### PR TITLE
Add rough log slice sketch

### DIFF
--- a/ui/src/assets/details.scss
+++ b/ui/src/assets/details.scss
@@ -271,6 +271,28 @@ table.half-width {
   }
 }
 
+
+.log-slice-panel {
+  &-container {
+    margin: 5px;
+  }
+  &-row {
+    display: flex;
+  }
+  &-time {
+    width: 110px;
+    padding-right: 20px;
+  }
+  &-indent-box {
+    margin-left: 3px;
+    border-left: 1px solid lightgray;
+    width: 20px;
+  }
+  &-name {
+    margin-bottom: 3px;
+  }
+}
+
 .log-panel {
   width: 100%;
   height: 100%;

--- a/ui/src/controller/globals.ts
+++ b/ui/src/controller/globals.ts
@@ -23,7 +23,7 @@ import {ControllerAny} from './controller';
 type PublishKinds = 'OverviewData'|'TrackData'|'Threads'|'QueryResult'|
     'LegacyTrace'|'SliceDetails'|'CounterDetails'|'HeapProfileDetails'|
     'HeapProfileFlamegraph'|'FileDownload'|'Loading'|'Search'|'BufferUsage'|
-    'RecordingLog'|'SearchResult'|'AggregateData';
+    'RecordingLog'|'SearchResult'|'AggregateData'|'LogSlices';
 
 export interface App {
   state: State;

--- a/ui/src/controller/log_slices_controller.ts
+++ b/ui/src/controller/log_slices_controller.ts
@@ -1,0 +1,131 @@
+// Copyright (C) 2019 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import {Engine} from '../common/engine';
+import {TimestampedAreaSelection} from '../common/state';
+import {fromNs, toNs} from '../common/time';
+import {SliceDetails} from '../frontend/globals';
+import {Config, SLICE_TRACK_KIND} from '../tracks/chrome_slices/common';
+
+import {Controller} from './controller';
+import {globals} from './globals';
+
+export interface LogSlicesControllerArgs {
+  engine: Engine;
+}
+
+export class LogSlicesController extends Controller<'main'> {
+  private previousArea: TimestampedAreaSelection = {lastUpdate: 0};
+  private requestingData = false;
+  private queuedRequest = false;
+
+  constructor(private args: LogSlicesControllerArgs) {
+    super('main');
+  }
+
+  run() {
+    const selectedArea = globals.state.frontendLocalState.selectedArea;
+
+    const areaChanged = this.previousArea.lastUpdate < selectedArea.lastUpdate;
+    if (!areaChanged) return;
+
+    if (this.requestingData) {
+      this.queuedRequest = true;
+    } else {
+      this.requestingData = true;
+      this.previousArea = selectedArea;
+      this.getLogSlices(areaChanged)
+          .then(slices => globals.publish('LogSlices', slices))
+          .catch(reason => {
+            console.error(reason);
+          })
+          .finally(() => {
+            this.requestingData = false;
+            if (this.queuedRequest) {
+              this.queuedRequest = false;
+              this.run();
+            }
+          });
+    }
+  }
+
+  private static ColumnNames =
+      ['ts', 'dur', 'name', 'cat', 'id', 'depth', 'arg_set_id', 'track_id'];
+
+  private static PropertyNames =
+      LogSlicesController.ColumnNames.map((colName: string) => {
+        return colName.replace(/_(\w)/g, ((m: string) => m[1].toUpperCase()));
+      });
+
+  async getLogSlices(areaChanged: boolean): Promise<SliceDetails[]> {
+    const selectedArea = globals.state.frontendLocalState.selectedArea;
+
+    if (!areaChanged) {
+      return [];
+    }
+    const area = selectedArea.area;
+    if (area === undefined) {
+      return [];
+    }
+
+    const trackIds = [];
+    for (const trackId of area.tracks) {
+      const track = globals.state.tracks[trackId];
+      // Track will be undefined for track groups.
+      if (track !== undefined && track.kind === SLICE_TRACK_KIND) {
+        trackIds.push((track.config as Config).trackId);
+      }
+    }
+    if (trackIds.length === 0) {
+      return [];
+    }
+
+    const query = `SELECT ${LogSlicesController.ColumnNames.join(',')}
+      FROM slice
+      WHERE slice.track_id IN (${trackIds.join(',')}) AND
+      slice.ts + slice.dur > ${toNs(area.startSec)} AND
+      slice.ts < ${toNs(area.endSec)}
+      ORDER BY ts ASC`;
+
+    const result = await this.args.engine.query(query);
+    const numRows = +result.numRecords;
+
+    const cols = result.columns;
+    const slices = [];
+    for (let row = 0; row < numRows; row++) {
+      const slicePojo: {[key: string]: string|number} = {};
+      for (let col = 0; col < LogSlicesController.ColumnNames.length; col++) {
+        if (cols[col].stringValues && cols[col].stringValues!.length > 0) {
+          slicePojo[LogSlicesController.PropertyNames[col]] =
+              cols[col].stringValues![row];
+        } else if (cols[col].longValues && cols[col].longValues!.length > 0) {
+          slicePojo[LogSlicesController.PropertyNames[col]] =
+              cols[col].longValues![row] as number;
+        } else if (
+            cols[col].doubleValues && cols[col].doubleValues!.length > 0) {
+          slicePojo[LogSlicesController.PropertyNames[col]] =
+              cols[col].doubleValues![row];
+        }
+      }
+      const slice = slicePojo as SliceDetails;
+      slice.ts =
+          fromNs(slice.ts ? slice.ts : globals.state.traceTime.startSec) -
+          globals.state.traceTime.startSec;
+      slices.push(slice);
+    }
+
+    return slices;
+  }
+}

--- a/ui/src/controller/trace_controller.ts
+++ b/ui/src/controller/trace_controller.ts
@@ -62,6 +62,7 @@ import {
   HeapProfileControllerArgs
 } from './heap_profile_controller';
 import {LoadingManager} from './loading_manager';
+import {LogSlicesController} from './log_slices_controller';
 import {LogsController} from './logs_controller';
 import {QueryController, QueryControllerArgs} from './query_controller';
 import {SearchController} from './search_controller';
@@ -167,6 +168,8 @@ export class TraceController extends Controller<States> {
             'thread_aggregation',
             ThreadAggregationController,
             {engine, kind: 'thread_state_aggregation'}));
+        childControllers.push(
+            Child('log_slices', LogSlicesController, {engine}));
         childControllers.push(Child('search', SearchController, {
           engine,
           app: globals,

--- a/ui/src/frontend/details_panel.ts
+++ b/ui/src/frontend/details_panel.ts
@@ -22,6 +22,7 @@ import {CounterDetailsPanel} from './counter_panel';
 import {DragGestureHandler} from './drag_gesture_handler';
 import {globals} from './globals';
 import {HeapProfileDetailsPanel} from './heap_profile_panel';
+import {LogSlicesPanel} from './log_slices_panel';
 import {LogPanel} from './logs_panel';
 import {NotesEditorPanel} from './notes_panel';
 import {AnyAttrsVnode, PanelContainer} from './panel_container';
@@ -218,6 +219,11 @@ export class DetailsPanel implements m.ClassComponent {
         detailsPanels.set(
             value.tabName, m(AggregationPanel, {kind: key, data: value}));
       }
+    }
+
+    if (globals.logSlices.length > 0) {
+      detailsPanels.set(
+          'Log Slices', m(LogSlicesPanel, {slices: globals.logSlices}));
     }
 
     const wasShowing = this.showDetailsPanel;

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -41,6 +41,8 @@ export interface SliceDetails {
   category?: string;
   name?: string;
   args?: Args;
+  depth?: number;
+  trackId?: number;
 }
 
 export interface CounterDetails {
@@ -96,6 +98,7 @@ class Globals {
   private _queryResults?: QueryResultsStore = undefined;
   private _overviewStore?: OverviewStore = undefined;
   private _aggregateDataStore?: AggregateDataStore = undefined;
+  private _logSlices?: SliceDetails[] = undefined;
   private _threadMap?: ThreadMap = undefined;
   private _sliceDetails?: SliceDetails = undefined;
   private _counterDetails?: CounterDetails = undefined;
@@ -136,6 +139,7 @@ class Globals {
     this._queryResults = new Map<string, {}>();
     this._overviewStore = new Map<string, QuantizedLoad[]>();
     this._aggregateDataStore = new Map<string, AggregateData>();
+    this._logSlices = [];
     this._threadMap = new Map<number, ThreadDesc>();
     this._sliceDetails = {};
     this._counterDetails = {};
@@ -203,6 +207,10 @@ class Globals {
     return assertExists(this._aggregateDataStore);
   }
 
+  get logSlices(): SliceDetails[] {
+    return assertExists(this._logSlices);
+  }
+
   get heapProfileDetails() {
     return assertExists(this._heapProfileDetails);
   }
@@ -249,6 +257,10 @@ class Globals {
 
   setAggregateData(kind: string, data: AggregateData) {
     this.aggregateDataStore.set(kind, data);
+  }
+
+  setLogSlices(slices: SliceDetails[]) {
+    this._logSlices = slices;
   }
 
   getCurResolution() {

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -180,6 +180,11 @@ class FrontendApi {
     this.redraw();
   }
 
+  publishLogSlices(args: SliceDetails[]) {
+    globals.setLogSlices(args);
+    this.redraw();
+  }
+
   private redraw(): void {
     if (globals.state.route &&
         globals.state.route !== this.router.getRouteFromHash()) {

--- a/ui/src/frontend/log_slices_panel.ts
+++ b/ui/src/frontend/log_slices_panel.ts
@@ -1,0 +1,50 @@
+// Copyright (C) 2019 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use size file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as m from 'mithril';
+
+import {SliceDetails} from './globals';
+import {Panel} from './panel';
+
+export class LogSlicesPanel extends Panel<{slices: SliceDetails[]}> {
+  view({attrs}: m.CVnode<{slices: SliceDetails[]}>) {
+    return m(
+        '.details-panel',
+        m('.log-slice-panel-container', this.getRows(attrs.slices)));
+  }
+
+  getRows(slices: SliceDetails[]) {
+    return slices.map(slice => {
+      const formattedTime =
+          (slice.ts ? slice.ts : 0).toFixed(6).padStart(12, '0');
+
+      const children = [m('.log-slice-panel-time', formattedTime)];
+      const indent = slice.depth ? slice.depth : 0;
+      for (let i = 0; i < indent; i++) {
+        children.push(m('.log-slice-panel-indent-box'));
+      }
+      children.push(m('.log-slice-panel-name', slice.name));
+
+      // TODO add hardwired warnings and error colors here
+      const hue = ((slice.trackId ? slice.trackId : 0) * 100) % 360;
+
+      return m(
+          '.log-slice-panel-row',
+          {style: `background:hsl(${hue}, 50%, 90%)`},
+          children);
+    });
+  }
+
+  renderCanvas() {}
+}


### PR DESCRIPTION
This is a rough sketch of displaying the selected slices in a log-oriented fashion, providing a view that can more effectively show longer log lines than traces typically generate. 

Current thoughts for where to go from here:
- eliminate current excessive updates
- page the list for performance
- include search criteria (text search, categories) in determining visible lines
- allow for navigation to other slices when there are outgoing flow events
- integrate with single selection, bidirectionally (clicking on a line here will select and maybe scroll in the tracks view)
- present a details popup/dropdown/side panel, showing additional information about the line, like trace event arguments (and adorn lines depending on the argument info, like a stack trace)
- integrate with instant events

To see it working, open the Chrome example, and select a few tracks worth of slices. You'll see a list of the slices, with their start time, indented by depth, and colored by thread.