### PR TITLE
Fixed data source index assert checking against wrong constant.

### DIFF
--- a/src/tracing/internal/tracing_muxer_impl.cc
+++ b/src/tracing/internal/tracing_muxer_impl.cc
@@ -798,7 +798,7 @@ void TracingMuxerImpl::UpdateDataSourcesOnAllBackends() {
       if (!backend.producer->connected_)
         continue;
 
-      PERFETTO_DCHECK(rds.static_state->index < kMaxDataSourceInstances);
+      PERFETTO_DCHECK(rds.static_state->index < kMaxDataSources);
       if (backend.producer->registered_data_sources_.test(
               rds.static_state->index))
         continue;


### PR DESCRIPTION
This PR contains a small assert fix. The data source index is wrongfully checked against kMaxDataSourceInstances. This leads to perfetto not working with more than 8 data source registrations, although 32 should be allowed following the kMaxDataSource constant definition. Thus, kMaxDataSourceInstances is replaced with kMaxDataSources as the checked constant.