### PR TITLE
Clarify reference to Debian Rodete in docs

### DIFF
--- a/docs/contributing/build-instructions.md
+++ b/docs/contributing/build-instructions.md
@@ -154,7 +154,7 @@ Android.bp file. If you are adding a new target, add a new entry to the
 
 ## Supported platforms
 
-**Linux desktop** (Debian Rodete)
+**Linux desktop** (Debian Testing/Rodete)
 
 - Hermetic clang + libcxx toolchain (both following chromium's revisions)
 - GCC-7 and libstdc++ 6


### PR DESCRIPTION
Debian Rodete (ROlling DEbian TEsting) is an internal Google codename for what is essentially Debian Testing, and therefore there is no public release of it. To lessen any confusion, it seems advisable to point external users to the closest publicly available release while also leaving in Rodete if any internal Googlers are reading the docs and do not understand the origin of Rodete.

Please do not submit a Pull Request via GitHub.
Our project makes use of Gerrit for patch submission and review.

For more details please see
https://perfetto.dev/docs/contributing/getting-started

