### PR TITLE
MSVC: Fix build with disabled logging

### DIFF
--- a/include/perfetto/base/logging.h
+++ b/include/perfetto/base/logging.h
@@ -147,7 +147,7 @@ inline void MaybeSerializeLastLogsForCrashReporting() {}
                           __LINE__, ##__VA_ARGS__);                           \
   } while (0)
 #elif defined(PERFETTO_DISABLE_LOG)
-#define PERFETTO_XLOG(...) ::perfetto::base::ignore_result(__VA_ARGS__)
+#define PERFETTO_XLOG(level, fmt, ...) ::perfetto::base::ignore_result(##__VA_ARGS__)
 #else
 #define PERFETTO_XLOG(level, fmt, ...)                                      \
   ::perfetto::base::LogMessage(level, ::perfetto::base::Basename(__FILE__), \


### PR DESCRIPTION
Windows build fails due to specific implementation
of __VA_ARGS__ in MSVC compiler

This leads to ",);" string after unwrapping
variadic macro. It's not enough to replace
__VA_ARGS__ by ##__VA_ARGS__ and indeed
only prepending parameters fix the problem

Fixes #216 

Please do not submit a Pull Request via GitHub.
Our project makes use of Gerrit for patch submission and review.

For more details please see
https://perfetto.dev/docs/contributing/getting-started


