### PR TITLE
ui: make pan and zoom independent of keyboard layout

### DIFF
--- a/ui/src/frontend/pan_and_zoom_handler.ts
+++ b/ui/src/frontend/pan_and_zoom_handler.ts
@@ -52,9 +52,8 @@ enum Pan {
   Right = 1
 }
 function keyToPan(e: KeyboardEvent): Pan {
-  const key = e.key.toLowerCase();
-  if (['a'].includes(key)) return Pan.Left;
-  if (['d', 'e'].includes(key)) return Pan.Right;
+  if (e.code == "KeyA") return Pan.Left;
+  if (e.code == "KeyD") return Pan.Right;
   return Pan.None;
 }
 
@@ -64,9 +63,8 @@ enum Zoom {
   Out = -1
 }
 function keyToZoom(e: KeyboardEvent): Zoom {
-  const key = e.key.toLowerCase();
-  if (['w', ','].includes(key)) return Zoom.In;
-  if (['s', 'o'].includes(key)) return Zoom.Out;
+  if (e.code == "KeyW") return Zoom.In;
+  if (e.code == "KeyS") return Zoom.Out;
   return Zoom.None;
 }
 


### PR DESCRIPTION

Hello,
I'm using an azerty keyboard, and pan and zoom is impracticable with the current shortcuts.
It can be fixed buy using event code instead of event key as explained in this page. https://www.bram.us/2022/03/31/wasd-controls-on-the-web/
