### PR TITLE
Report failures on Windows in gn, ninja and pnpm

### DIFF
--- a/tools/run_buildtools_binary.py
+++ b/tools/run_buildtools_binary.py
@@ -56,10 +56,12 @@ def run_buildtools_binary(args):
   if sys_name == 'windows':
     # execl() behaves oddly on Windows: the spawned process doesn't seem to
     # receive CTRL+C. Use subprocess instead.
-    return subprocess.call([exe_path] + args)
+    exit_code = subprocess.call([exe_path] + args)
+    # exit from here to behave the same as when using os.execl
+    sys.exit(exit_code)
   else:
     os.execl(exe_path, os.path.basename(exe_path), *args)
 
 
 if __name__ == '__main__':
-  sys.exit(run_buildtools_binary(sys.argv[1:]))
+  run_buildtools_binary(sys.argv[1:])


### PR DESCRIPTION
Change the behavior of the run_buildtools_binary function to behave on Windows as it does on other operating systems, to not return an error code.
The callers in ninja, gn and pnpm did not forward the exit code, hence any compilation failure on Windows was not reported further.

Please do not submit a Pull Request via GitHub.
Our project makes use of Gerrit for patch submission and review.

For more details please see
https://perfetto.dev/docs/contributing/getting-started

