### PR TITLE
Improve Randomness for Thread Naming and Thread Safety

### DIFF
--- a/src/tools/busy_threads/busy_threads.cc
+++ b/src/tools/busy_threads/busy_threads.cc
@@ -20,6 +20,9 @@
 #include <cinttypes>
 #include <thread>
 
+#include <pthread.h>
+#include <random>
+
 #include "perfetto/base/logging.h"
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/file_utils.h"
@@ -44,8 +47,10 @@ namespace {
 
 void SetRandomThreadName(uint32_t thread_name_count) {
 #if PERFETTO_HAVE_PTHREADS
-  base::StackString<16> name("busy-%" PRIu32,
-                             static_cast<uint32_t>(rand()) % thread_name_count);
+  thread_local std::random_device rd;
+  thread_local std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0, thread_name_count - 1);
+  base::StackString<16> name("busy-%" PRIu32, static_cast<uint32_t>(dis(gen)));
   pthread_setname_np(pthread_self(), name.c_str());
 #endif
 }


### PR DESCRIPTION
This pull request improves the randomness for thread naming in the SetRandomThreadName function and enhances thread safety. Key changes include:

- Introduced a thread-local random device and Mersenne Twister engine for generating random numbers.
- Replaced the previous usage of rand() with a more robust and thread-safe random number generator.