### PR TITLE
Add missing #include <optional>

### DIFF
--- a/src/traced/probes/sys_stats/sys_stats_data_source.h
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.h
@@ -21,6 +21,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "perfetto/ext/base/paged_memory.h"


### PR DESCRIPTION
optional is used on line 75  virtual std::optional<uint64_t> ReadFileToUInt64(const std::string& path);

Could work on some compilers as indirect dependency. Without this fix failed to build with clang-16 on Linux as dependency for AGI
Error:
In file included from external/perfetto/src/traced/probes/sys_stats/sys_stats_data_source.cc:17:
external/perfetto/src/traced/probes/sys_stats/sys_stats_data_source.h:74:16: error: 'optional' in namespace 'std' does not name a template type
   74 |   virtual std::optional<uint64_t> ReadFileToUInt64(const std::string& path);
