### PR TITLE
ui: change ui_builder_entrypoint to reference GitHub

### DIFF
--- a/infra/perfetto.dev/cloud_build_entrypoint.sh
+++ b/infra/perfetto.dev/cloud_build_entrypoint.sh
@@ -16,20 +16,11 @@
 set -exu
 
 # This script will be run in /workspace after the Cloud Build environment has
-# pulled the GitHub repo in shallow mode. We want to build off the official
-# AOSP repo, not the GitHub mirror though, hence why the clone below.
-# GitHub is used only as a trigger. This is because Google Cloud Build doesn't
-# support yet triggering from Gerrit.
-# See go/perfetto-ui-autopush for more details.
+# pulled the GitHub repo in shallow mode.
 
 # The cd is really a safeguard against people running this script on their
 # workstation and hitting the rm -rf.
 cd /workspace/
-ls -A1 | xargs rm -rf
-UPSTREAM="https://android.googlesource.com/platform/external/perfetto.git"
-git clone --depth 1 $UPSTREAM upstream
-
-cd upstream/
 git rev-parse HEAD
 
 # Install only NodeJS, gn and ninja no need to install the other toolchains.

--- a/infra/ui.perfetto.dev/builder/Dockerfile
+++ b/infra/ui.perfetto.dev/builder/Dockerfile
@@ -37,6 +37,6 @@ RUN set -ex; \
     rm -rf /builder/google-cloud-sdk/.install/.backup;
 
 ADD ui_builder_entrypoint.sh /ui_builder_entrypoint.sh
-RUN chmod 755 /ui_builder_entrypoint.sh
+RUN chmod 755 /ui_builder_entrypoint.sh;
 
 ENTRYPOINT [ "tini", "-g", "--" ]

--- a/infra/ui.perfetto.dev/builder/ui_builder_entrypoint.sh
+++ b/infra/ui.perfetto.dev/builder/ui_builder_entrypoint.sh
@@ -22,19 +22,13 @@ pwd
 mount
 
 # This script will be run in /workspace after the Cloud Build environment has
-# pulled the GitHub repo in shallow mode. We want to build off the official
-# AOSP repo, not the GitHub mirror though, hence why the clone below.
-# GitHub is used only as a trigger. This is because Google Cloud Build doesn't
-# support yet triggering from Gerrit.
+# pulled the GitHub repo in shallow mode.
 
 cd /workspace/
 mkdir /workspace/tmp
 
-ls -A1 | xargs rm -rf
-UPSTREAM="https://android.googlesource.com/platform/external/perfetto.git"
-git clone $UPSTREAM upstream
-
-cd upstream/
+git config --global init.defaultBranch main;
+git fetch --unshallow
 
 # infra/ui.perfetto.dev/cloudbuild_release.yaml sets $1 to the branch
 # name when triggering from a release branch. Otherwise $1 is "" when triggering


### PR DESCRIPTION
Remove the old code that was using GitHub only as a trigger and then pulling from AOSP.

Bug: b/406181088


