### PR TITLE
tracing_service_impl: Only emit clone_snapshot_trigger once

### DIFF
--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -3923,6 +3923,9 @@ void TracingServiceImpl::MaybeEmitRemoteClockSync(
 void TracingServiceImpl::MaybeEmitCloneTrigger(
     TracingSession* tracing_session,
     std::vector<TracePacket>* packets) {
+  if (tracing_session->did_emit_initial_packets)
+    return;
+
   if (tracing_session->clone_trigger.has_value()) {
     protozero::HeapBuffered<protos::pbzero::TracePacket> packet;
     auto* trigger = packet->set_clone_snapshot_trigger();

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -5709,6 +5709,13 @@ TEST_F(TracingServiceImplTest, CloneSessionEmitsTrigger) {
   EXPECT_EQ(trigger.producer_name(), kCloneTriggerProducerName);
   EXPECT_EQ(trigger.trusted_producer_uid(),
             static_cast<int32_t>(kCloneTriggerProducerUid));
+
+  // A second ReadBuffers() should not reemit the clone_snapshot_trigger.
+  cloned_packets = consumer2->ReadBuffers();
+  EXPECT_THAT(
+      cloned_packets,
+      Not(Contains(Property(
+          &protos::gen::TracePacket::has_clone_snapshot_trigger, Eq(true)))));
 }
 
 TEST_F(TracingServiceImplTest, InvalidBufferSizes) {


### PR DESCRIPTION
Reading a cloned trace with a trigger we found many (many) absolutely identical packets like:

```
packet {
  trusted_uid: 9999
  timestamp: 223437728327805
  trusted_packet_sequence_id: 1
  clone_snapshot_trigger {
    trigger_name: "..."
    producer_name: "perfetto_cmd_producer"
    trusted_producer_uid: 10134
  }
}
```

It turns out TracingServiceImpl is emitting them on every ReadBuffers(). This is not required, let'd to like we do it MaybeEmitTraceConfig().

Bug: 406599194