### PR TITLE
Fix counter hover in log mode

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -560,7 +560,11 @@ export abstract class BaseCounterTrack implements TrackRenderer {
 
     const hover = this.hover;
     if (hover !== undefined) {
-      let text = `${hover.lastDisplayValue.toLocaleString()}`;
+      const value =
+        this.options?.yDisplay === 'log'
+          ? Math.exp(hover.lastDisplayValue)
+          : hover.lastDisplayValue;
+      let text = `${value.toLocaleString()}`;
 
       const unit = this.unit;
       switch (options.yMode) {


### PR DESCRIPTION
Fix counter hover in log mode; we were previously showing the log value in the hover.