### PR TITLE
protos: remove unused import (profile_common.proto)

### DIFF
--- a/protos/perfetto/trace/chrome/chrome_trace_packet.proto
+++ b/protos/perfetto/trace/chrome/chrome_trace_packet.proto
@@ -32,7 +32,6 @@ import "protos/perfetto/trace/chrome/chrome_trigger.proto";
 import "protos/perfetto/trace/clock_snapshot.proto";
 import "protos/perfetto/trace/interned_data/interned_data.proto";
 import "protos/perfetto/trace/profiling/profile_packet.proto";
-import "protos/perfetto/trace/profiling/profile_common.proto";
 import "protos/perfetto/trace/track_event/process_descriptor.proto";
 import "protos/perfetto/trace/track_event/thread_descriptor.proto";
 import "protos/perfetto/trace/track_event/track_event.proto";


### PR DESCRIPTION
We didn't catch this because we don't build the chrome protos (.../trace/chrome:minimal_complete_lite). Let's consider putting that in presubmit, but I wanted to keep this patch minimal

Fixes: 94a1b58c6e ("protos: remove ProfiledFrameSymbols")
Bug: 406928883