### PR TITLE
ui: Parse out any plugin specific route args and direct them to plugins

### DIFF
--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -400,6 +400,10 @@ export class TraceImpl implements Trace {
     return this.appImpl.initialRouteArgs;
   }
 
+  get initialPluginRouteArgs() {
+    return this.appImpl.initialPluginRouteArgs;
+  }
+
   get featureFlags(): FeatureFlagManager {
     return {
       register: (settings: FlagSettings) => featureFlags.register(settings),

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -48,6 +48,11 @@ export interface App {
   readonly initialRouteArgs: RouteArgs;
 
   /**
+   * Args in the URL bar that start with this plugin's id.
+   */
+  readonly initialPluginRouteArgs: {[key: string]: number | boolean | string};
+
+  /**
    * Returns the current trace object, if any. The instance being returned is
    * bound to the same plugin of App.pluginId.
    */

--- a/ui/src/public/route_schema.ts
+++ b/ui/src/public/route_schema.ts
@@ -67,6 +67,9 @@ export const ROUTE_SCHEMA = z
     visStart: z.string().optional().catch(undefined),
     visEnd: z.string().optional().catch(undefined),
   })
+
+  // Allow arbitrary values to pass through, these may be forwarded to plugins.
+  .catchall(z.union([z.number(), z.string(), z.boolean()]))
   // default({}) ensures at compile-time that every entry is either optional or
   // has a default value.
   .default({});


### PR DESCRIPTION
Any route args that are formatted like:

```
<pluginId>:<key>=<value>
```

will be redirected to the plugin with id `<pluginId>`.

Plugins can access their args via `app.initialPluginRouteArgs`.

https://b.corp.google.com/issues/406308446

