### PR TITLE
tprobes: clang-tidy/readability cleanups

### DIFF
--- a/src/tools/ftrace_proto_gen/ftrace_proto_gen.cc
+++ b/src/tools/ftrace_proto_gen/ftrace_proto_gen.cc
@@ -16,14 +16,9 @@
 
 #include "src/tools/ftrace_proto_gen/ftrace_proto_gen.h"
 
-#include <algorithm>
 #include <fstream>
-#include <regex>
+#include <vector>
 
-#include "perfetto/base/logging.h"
-#include "perfetto/ext/base/file_utils.h"
-#include "perfetto/ext/base/pipe.h"
-#include "perfetto/ext/base/string_splitter.h"
 #include "perfetto/ext/base/string_utils.h"
 
 namespace perfetto {

--- a/src/tools/ftrace_proto_gen/ftrace_proto_gen.h
+++ b/src/tools/ftrace_proto_gen/ftrace_proto_gen.h
@@ -18,9 +18,7 @@
 #define SRC_TOOLS_FTRACE_PROTO_GEN_FTRACE_PROTO_GEN_H_
 
 #include <google/protobuf/descriptor.h>
-#include <map>
 #include <set>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -42,7 +40,7 @@ void GenerateFtraceEventProto(const std::vector<FtraceEventName>& raw_eventlist,
                               std::ostream* fout);
 std::string SingleEventInfo(perfetto::Proto proto,
                             const std::string& group,
-                            const uint32_t proto_field_id);
+                            uint32_t proto_field_id);
 void GenerateEventInfo(const std::vector<std::string>& events_info,
                        std::ostream* fout);
 std::string ProtoHeader();

--- a/src/tools/ftrace_proto_gen/main.cc
+++ b/src/tools/ftrace_proto_gen/main.cc
@@ -18,9 +18,7 @@
 #include <fstream>
 #include <map>
 #include <memory>
-#include <regex>
 #include <set>
-#include <sstream>
 #include <string>
 
 #include <google/protobuf/descriptor.h>

--- a/src/tools/ftrace_proto_gen/proto_gen_utils.cc
+++ b/src/tools/ftrace_proto_gen/proto_gen_utils.cc
@@ -17,13 +17,10 @@
 #include "src/tools/ftrace_proto_gen/proto_gen_utils.h"
 
 #include <algorithm>
-#include <fstream>
 #include <regex>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/file_utils.h"
-#include "perfetto/ext/base/pipe.h"
-#include "perfetto/ext/base/string_splitter.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/subprocess.h"
 

--- a/src/tools/ftrace_proto_gen/proto_gen_utils.h
+++ b/src/tools/ftrace_proto_gen/proto_gen_utils.h
@@ -18,7 +18,6 @@
 #define SRC_TOOLS_FTRACE_PROTO_GEN_PROTO_GEN_UTILS_H_
 
 #include <map>
-#include <set>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -93,7 +92,6 @@ struct Proto {
 
 std::string ToCamelCase(const std::string& s);
 ProtoType GetCommon(ProtoType one, ProtoType other);
-std::string ProtoHeader();
 ProtoType InferProtoType(const FtraceEvent::Field& field);
 
 }  // namespace perfetto

--- a/src/traced/probes/ftrace/atrace_hal_wrapper.h
+++ b/src/traced/probes/ftrace/atrace_hal_wrapper.h
@@ -21,8 +21,6 @@
 #include <string>
 #include <vector>
 
-#include "perfetto/ext/base/scoped_file.h"
-
 namespace perfetto {
 
 class AtraceHalWrapper {

--- a/src/traced/probes/ftrace/compact_sched.h
+++ b/src/traced/probes/ftrace/compact_sched.h
@@ -79,7 +79,7 @@ CompactSchedEventFormat InvalidCompactSchedEventFormatForTesting();
 
 // Compact encoding configuration used at ftrace reading & parsing time.
 struct CompactSchedConfig {
-  CompactSchedConfig(bool _enabled) : enabled(_enabled) {}
+  explicit CompactSchedConfig(bool _enabled) : enabled(_enabled) {}
 
   // If true, and sched_switch and/or sched_waking events are enabled, encode
   // them in a compact format instead of the normal form.
@@ -109,7 +109,7 @@ class CompactSchedSwitchBuffer {
     return timestamp_.size();
   }
 
-  inline void AppendTimestamp(uint64_t timestamp) {
+  void AppendTimestamp(uint64_t timestamp) {
     timestamp_.Append(timestamp - last_timestamp_);
     last_timestamp_ = timestamp;
   }
@@ -145,7 +145,7 @@ class CompactSchedWakingBuffer {
     return timestamp_.size();
   }
 
-  inline void AppendTimestamp(uint64_t timestamp) {
+  void AppendTimestamp(uint64_t timestamp) {
     timestamp_.Append(timestamp - last_timestamp_);
     last_timestamp_ = timestamp;
   }

--- a/src/traced/probes/ftrace/cpu_stats_parser_unittest.cc
+++ b/src/traced/probes/ftrace/cpu_stats_parser_unittest.cc
@@ -16,7 +16,6 @@
 
 #include "src/traced/probes/ftrace/cpu_stats_parser.h"
 
-#include "src/traced/probes/ftrace/ftrace_controller.h"
 #include "src/traced/probes/ftrace/ftrace_stats.h"
 #include "test/gtest_and_gmock.h"
 

--- a/src/traced/probes/ftrace/event_info.h
+++ b/src/traced/probes/ftrace/event_info.h
@@ -19,7 +19,6 @@
 
 #include <vector>
 
-#include "perfetto/base/logging.h"
 #include "src/traced/probes/ftrace/event_info_constants.h"
 
 namespace perfetto {

--- a/src/traced/probes/ftrace/event_info_constants.h
+++ b/src/traced/probes/ftrace/event_info_constants.h
@@ -19,7 +19,6 @@
 
 #include <stdint.h>
 
-#include <string>
 #include <vector>
 
 #include "perfetto/base/logging.h"

--- a/src/traced/probes/ftrace/format_parser/format_parser.cc
+++ b/src/traced/probes/ftrace/format_parser/format_parser.cc
@@ -21,13 +21,11 @@
 #include <cctype>
 #include <iosfwd>
 #include <iostream>
-#include <memory>
 #include <string>
 #include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/string_splitter.h"
-#include "perfetto/ext/base/utils.h"
 
 namespace perfetto {
 namespace {

--- a/src/traced/probes/ftrace/format_parser/format_parser.h
+++ b/src/traced/probes/ftrace/format_parser/format_parser.h
@@ -22,7 +22,6 @@
 
 #include <iosfwd>
 #include <iostream>
-#include <string>
 #include <tuple>
 #include <vector>
 

--- a/src/traced/probes/ftrace/ftrace_controller.h
+++ b/src/traced/probes/ftrace/ftrace_controller.h
@@ -73,6 +73,9 @@ class FtraceController {
   static std::unique_ptr<FtraceController> Create(base::TaskRunner*, Observer*);
   virtual ~FtraceController();
 
+  FtraceController(const FtraceController&) = delete;
+  FtraceController& operator=(const FtraceController&) = delete;
+
   bool AddDataSource(FtraceDataSource*) PERFETTO_WARN_UNUSED_RESULT;
   bool StartDataSource(FtraceDataSource*);
   void RemoveDataSource(FtraceDataSource*);
@@ -131,9 +134,6 @@ class FtraceController {
   friend class TestFtraceController;
   enum class PollSupport { kUntested, kSupported, kUnsupported };
 
-  FtraceController(const FtraceController&) = delete;
-  FtraceController& operator=(const FtraceController&) = delete;
-
   // Periodic task that reads all per-cpu ftrace buffers. Global across tracefs
   // instances.
   void ReadTick(int generation);
@@ -142,7 +142,7 @@ class FtraceController {
   // Optional: additional reads based on buffer capacity. Per tracefs instance.
   void UpdateBufferWatermarkWatches(FtraceInstanceState* instance,
                                     const std::string& instance_name);
-  void OnBufferPastWatermark(std::string instance_name,
+  void OnBufferPastWatermark(const std::string& instance_name,
                              size_t cpu,
                              bool repoll_watermark);
   void RemoveBufferWatermarkWatches(FtraceInstanceState* instance);
@@ -189,7 +189,7 @@ class FtraceController {
   base::WeakPtrFactory<FtraceController> weak_factory_;  // Keep last.
 };
 
-bool DumpKprobeStats(const std::string& text, FtraceStats* ftrace_stats);
+bool DumpKprobeStats(std::string text, FtraceStats* ftrace_stats);
 
 }  // namespace perfetto
 

--- a/src/traced/probes/ftrace/ftrace_data_source.h
+++ b/src/traced/probes/ftrace/ftrace_data_source.h
@@ -20,14 +20,11 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <utility>
 
 #include "perfetto/base/flat_set.h"
-#include "perfetto/ext/base/scoped_file.h"
 #include "perfetto/ext/base/weak_ptr.h"
 #include "perfetto/ext/tracing/core/basic_types.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"
-#include "perfetto/protozero/message_handle.h"
 #include "src/traced/probes/ftrace/ftrace_config_utils.h"
 #include "src/traced/probes/ftrace/ftrace_metadata.h"
 #include "src/traced/probes/ftrace/ftrace_stats.h"

--- a/src/traced/probes/ftrace/ftrace_print_filter.cc
+++ b/src/traced/probes/ftrace/ftrace_print_filter.cc
@@ -137,7 +137,7 @@ std::optional<FtracePrintFilterConfig> FtracePrintFilterConfig::Create(
 }
 
 FtracePrintFilterConfig::FtracePrintFilterConfig(FtracePrintFilter filter)
-    : filter_(filter) {}
+    : filter_(std::move(filter)) {}
 
 bool FtracePrintFilterConfig::IsEventInteresting(const uint8_t* start,
                                                  const uint8_t* end) const {

--- a/src/traced/probes/ftrace/ftrace_stats.h
+++ b/src/traced/probes/ftrace/ftrace_stats.h
@@ -27,7 +27,6 @@ namespace protos {
 namespace pbzero {
 class FtraceStats;
 class FtraceCpuStats;
-class FtraceKprobeStats;
 }  // namespace pbzero
 }  // namespace protos
 

--- a/src/traced/probes/ftrace/proto_translation_table.h
+++ b/src/traced/probes/ftrace/proto_translation_table.h
@@ -28,9 +28,7 @@
 #include <string>
 #include <vector>
 
-#include "perfetto/ext/base/scoped_file.h"
 #include "src/traced/probes/ftrace/compact_sched.h"
-#include "src/traced/probes/ftrace/event_info.h"
 #include "src/traced/probes/ftrace/format_parser/format_parser.h"
 #include "src/traced/probes/ftrace/printk_formats_parser.h"
 
@@ -97,6 +95,9 @@ class ProtoTranslationTable {
       std::vector<Field> common_fields);
   virtual ~ProtoTranslationTable();
 
+  ProtoTranslationTable(const ProtoTranslationTable&) = delete;
+  ProtoTranslationTable& operator=(const ProtoTranslationTable&) = delete;
+
   ProtoTranslationTable(const FtraceProcfs* ftrace_procfs,
                         const std::vector<Event>& events,
                         std::vector<Field> common_fields,
@@ -152,7 +153,7 @@ class ProtoTranslationTable {
   // Returns the size in bytes of the "size" field in the ftrace header. This
   // usually matches sizeof(void*) in the kernel (which can be != sizeof(void*)
   // of user space on 32bit-user + 64-bit-kernel configurations).
-  inline uint16_t page_header_size_len() const {
+  uint16_t page_header_size_len() const {
     // TODO(fmayer): Do kernel deepdive to double check this.
     return ftrace_page_header_spec_.size.size;
   }
@@ -187,9 +188,6 @@ class ProtoTranslationTable {
   }
 
  private:
-  ProtoTranslationTable(const ProtoTranslationTable&) = delete;
-  ProtoTranslationTable& operator=(const ProtoTranslationTable&) = delete;
-
   // Store strings so they can be read when writing the trace output.
   const char* InternString(const std::string& str);
 
@@ -219,10 +217,13 @@ class ProtoTranslationTable {
 // to be consumed by CpuReader.
 class EventFilter {
  public:
-  EventFilter();
-  ~EventFilter();
+  EventFilter() = default;
+  ~EventFilter() = default;
+  // move-only
   EventFilter(EventFilter&&) = default;
   EventFilter& operator=(EventFilter&&) = default;
+  EventFilter(const EventFilter&) = delete;
+  EventFilter& operator=(const EventFilter&) = delete;
 
   void AddEnabledEvent(size_t ftrace_event_id);
   void DisableEvent(size_t ftrace_event_id);
@@ -231,9 +232,6 @@ class EventFilter {
   void EnableEventsFrom(const EventFilter&);
 
  private:
-  EventFilter(const EventFilter&) = delete;
-  EventFilter& operator=(const EventFilter&) = delete;
-
   std::vector<bool> enabled_ids_;
 };
 

--- a/src/traced/probes/ftrace/test/cpu_reader_support.cc
+++ b/src/traced/probes/ftrace/test/cpu_reader_support.cc
@@ -16,14 +16,15 @@
 
 #include "src/traced/probes/ftrace/test/cpu_reader_support.h"
 
-#include "perfetto/ext/base/utils.h"
-#include "src/base/test/utils.h"
-#include "src/traced/probes/ftrace/ftrace_procfs.h"
-
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include "perfetto/ext/base/utils.h"
+#include "src/base/test/utils.h"
+#include "src/traced/probes/ftrace/event_info.h"
+#include "src/traced/probes/ftrace/ftrace_procfs.h"
 
 namespace perfetto {
 namespace {

--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -25,15 +25,11 @@
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/base/watchdog.h"
 #include "perfetto/ext/base/weak_ptr.h"
-#include "perfetto/ext/traced/traced.h"
 #include "perfetto/ext/tracing/core/basic_types.h"
-#include "perfetto/ext/tracing/core/trace_packet.h"
 #include "perfetto/ext/tracing/ipc/producer_ipc_client.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "perfetto/tracing/core/forward_decls.h"
-#include "perfetto/tracing/core/trace_config.h"
-#include "src/android_stats/statsd_logging_helper.h"
 #include "src/traced/probes/android_game_intervention_list/android_game_intervention_list_data_source.h"
 #include "src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.h"
 #include "src/traced/probes/android_log/android_log_data_source.h"
@@ -523,7 +519,7 @@ void ProbesProducer::Flush(FlushRequestID flush_request_id,
     if (it == data_sources_.end() || !it->second->started)
       continue;
     pending_flushes_.emplace(flush_request_id, ds_id);
-    ds_to_flush.emplace_back(std::make_pair(ds_id, it->second.get()));
+    ds_to_flush.emplace_back(ds_id, it->second.get());
   }
 
   // If there is nothing to flush, ack immediately.

--- a/src/traced/probes/probes_producer.h
+++ b/src/traced/probes/probes_producer.h
@@ -26,11 +26,11 @@
 #include "perfetto/ext/base/watchdog.h"
 #include "perfetto/ext/base/weak_ptr.h"
 #include "perfetto/ext/tracing/core/producer.h"
-#include "perfetto/ext/tracing/core/trace_writer.h"
 #include "perfetto/ext/tracing/core/tracing_service.h"
-#include "src/traced/probes/filesystem/inode_file_data_source.h"
+#include "src/traced/probes/filesystem/lru_inode_cache.h"
 #include "src/traced/probes/ftrace/ftrace_controller.h"
 #include "src/traced/probes/ftrace/ftrace_metadata.h"
+#include "src/traced/probes/probes_data_source.h"
 
 namespace perfetto {
 

--- a/src/traced_relay/relay_service_integrationtest.cc
+++ b/src/traced_relay/relay_service_integrationtest.cc
@@ -17,8 +17,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "perfetto/ext/base/unix_socket.h"
-#include "protos/perfetto/trace/remote_clock_sync.gen.h"
+#include "perfetto/tracing/core/data_source_config.h"
 #include "src/traced_relay/relay_service.h"
 
 #include "src/base/test/test_task_runner.h"
@@ -27,6 +28,7 @@
 
 #include "protos/perfetto/config/test_config.gen.h"
 #include "protos/perfetto/config/trace_config.gen.h"
+#include "protos/perfetto/trace/remote_clock_sync.gen.h"
 #include "protos/perfetto/trace/test_event.gen.h"
 
 namespace perfetto {

--- a/test/android_integrationtest.cc
+++ b/test/android_integrationtest.cc
@@ -28,12 +28,15 @@
 #include "perfetto/ext/tracing/core/trace_packet.h"
 #include "perfetto/ext/tracing/core/tracing_service.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/tracing/core/data_source_config.h"
 #include "src/base/test/test_task_runner.h"
 #include "src/base/test/utils.h"
 #include "test/gtest_and_gmock.h"
 #include "test/test_helper.h"
 
+#include "protos/perfetto/common/sys_stats_counters.gen.h"
 #include "protos/perfetto/config/power/android_power_config.pbzero.h"
+#include "protos/perfetto/config/sys_stats/sys_stats_config.gen.h"
 #include "protos/perfetto/config/test_config.gen.h"
 #include "protos/perfetto/config/trace_config.gen.h"
 #include "protos/perfetto/trace/ftrace/ftrace.gen.h"
@@ -42,15 +45,12 @@
 #include "protos/perfetto/trace/ftrace/ftrace_stats.gen.h"
 #include "protos/perfetto/trace/perfetto/tracing_service_event.gen.h"
 #include "protos/perfetto/trace/power/battery_counters.gen.h"
+#include "protos/perfetto/trace/sys_stats/sys_stats.gen.h"
 #include "protos/perfetto/trace/test_event.gen.h"
 #include "protos/perfetto/trace/trace.gen.h"
 #include "protos/perfetto/trace/trace_packet.gen.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "protos/perfetto/trace/trigger.gen.h"
-
-#include "protos/perfetto/common/sys_stats_counters.gen.h"
-#include "protos/perfetto/config/sys_stats/sys_stats_config.gen.h"
-#include "protos/perfetto/trace/sys_stats/sys_stats.gen.h"
 
 namespace perfetto {
 

--- a/test/cmdline_integrationtest.cc
+++ b/test/cmdline_integrationtest.cc
@@ -25,6 +25,7 @@
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/traced/traced.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/tracing_service_state.h"
 #include "src/base/test/test_task_runner.h"
 #include "src/base/test/utils.h"

--- a/test/end_to_end_benchmark.cc
+++ b/test/end_to_end_benchmark.cc
@@ -19,6 +19,7 @@
 #include "perfetto/base/time.h"
 #include "perfetto/ext/traced/traced.h"
 #include "perfetto/ext/tracing/core/trace_packet.h"
+#include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/trace_config.h"
 #include "src/base/test/test_task_runner.h"
 #include "test/gtest_and_gmock.h"

--- a/test/ftrace_integrationtest.cc
+++ b/test/ftrace_integrationtest.cc
@@ -31,6 +31,7 @@
 #include "perfetto/ext/tracing/core/trace_packet.h"
 #include "perfetto/ext/tracing/core/tracing_service.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/tracing_service_state.h"
 #include "src/base/test/test_task_runner.h"
 #include "src/base/test/utils.h"

--- a/test/traced_integrationtest.cc
+++ b/test/traced_integrationtest.cc
@@ -30,6 +30,7 @@
 #include "perfetto/ext/tracing/core/trace_packet.h"
 #include "perfetto/ext/tracing/core/tracing_service.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/tracing_service_state.h"
 #include "src/base/test/test_task_runner.h"
 #include "src/base/test/utils.h"


### PR DESCRIPTION
Small cleanups separated from an upcoming feature in ftrace code. Mostly
to get clangd off my back, and in retrospect I'm just disabling most of
the tidy checks locally until presubmit.