### PR TITLE
ui: Fix  go to next slice hotkey not working on AZERTY

### DIFF
--- a/ui/src/base/hotkeys.ts
+++ b/ui/src/base/hotkeys.ts
@@ -126,6 +126,8 @@ const shiftExceptions = [
   '!',
   '[',
   ']',
+  '.',
+  ',',
 ];
 
 const macModifierStrings: ReadonlyMap<Modifier, string> = new Map<


### PR DESCRIPTION
The hotkey for "Go to next slice" is ".", but the "." key cannot be pressed without holding shift on AZERTY keyboards. Perfetto doesn't recognize the hotkey because "Shift+." is a different hotkey.

A while ago we set up a fix for this scenario, by listing a bunch of keys that cannot be pressed either with or without holding the shift key. In this scenario we ignore the shift key. This PR simply adds "." and "," to this list.

Fixes #1113