### PR TITLE
protobuf: Use generator_visibility arg for some proto_library targets

### DIFF
--- a/gn/perfetto_cc_proto_descriptor.gni
+++ b/gn/perfetto_cc_proto_descriptor.gni
@@ -33,7 +33,11 @@ template("perfetto_cc_proto_descriptor") {
       descriptor_file_path =
           get_label_info(invoker.descriptor_target, "target_gen_dir") +
           "/${invoker.descriptor_name}"
-      deps = [ invoker.descriptor_target ]
+      if (build_with_chromium) {
+        deps = [ "${invoker.descriptor_target}_gen" ]
+      } else {
+        deps = [ invoker.descriptor_target ]
+      }
     } else {
       descriptor_file_path = invoker.descriptor_path
       deps = []
@@ -52,9 +56,7 @@ template("perfetto_cc_proto_descriptor") {
         invoker.namespace,
       ]
     }
-    args += [
-      rebase_path(descriptor_file_path, root_build_dir),
-    ]
+    args += [ rebase_path(descriptor_file_path, root_build_dir) ]
     inputs = [ descriptor_file_path ]
     outputs = [ generated_header ]
     public_configs = [ ":${target_name}_config" ]

--- a/gn/proto_library.gni
+++ b/gn/proto_library.gni
@@ -350,6 +350,7 @@ template("perfetto_proto_library") {
                                "visibility",
                                "testonly",
                                "exclude_imports",
+                               "generator_visibility",
                              ])
     }
   }

--- a/gn/standalone/proto_library.gni
+++ b/gn/standalone/proto_library.gni
@@ -24,7 +24,11 @@ template("proto_library") {
   assert(defined(invoker.sources))
 
   # This is used in chromium build.
-  not_needed(invoker, [ "proto_deps" ])
+  not_needed(invoker,
+             [
+               "generator_visibility",
+               "proto_deps",
+             ])
 
   proto_sources = invoker.sources
 

--- a/protos/perfetto/config/BUILD.gn
+++ b/protos/perfetto/config/BUILD.gn
@@ -50,5 +50,7 @@ perfetto_proto_library("@TYPE@") {
   ]
 
   generate_descriptor = "config.descriptor"
+  generator_visibility =
+      [ "../../../src/trace_config_utils:gen_cc_config_descriptor" ]
   descriptor_root_source = "trace_config.proto"
 }

--- a/protos/perfetto/metrics/BUILD.gn
+++ b/protos/perfetto/metrics/BUILD.gn
@@ -23,6 +23,8 @@ perfetto_proto_library("@TYPE@") {
   ]
   sources = [ "metrics.proto" ]
   generate_descriptor = "metrics.descriptor"
+  generator_visibility =
+      [ "../../../src/trace_processor/metrics:gen_cc_metrics_descriptor" ]
   descriptor_root_source = "metrics.proto"
 }
 

--- a/protos/perfetto/metrics/chrome/BUILD.gn
+++ b/protos/perfetto/metrics/chrome/BUILD.gn
@@ -42,5 +42,6 @@ perfetto_proto_library("@TYPE@") {
     "user_event_hashes.proto",
   ]
   generate_descriptor = "all_chrome_metrics.descriptor"
+  generator_visibility = [ "../../../../src/trace_processor/metrics:gen_cc_all_chrome_metrics_descriptor" ]
   descriptor_root_source = "all_chrome_metrics.proto"
 }

--- a/protos/perfetto/metrics/webview/BUILD.gn
+++ b/protos/perfetto/metrics/webview/BUILD.gn
@@ -23,5 +23,6 @@ perfetto_proto_library("@TYPE@") {
   ]
   deps = [ "..:@TYPE@" ]
   generate_descriptor = "all_webview_metrics.descriptor"
+  generator_visibility = [ "../../../../src/trace_processor/metrics:gen_cc_all_webview_metrics_descriptor" ]
   descriptor_root_source = "all_webview_metrics.proto"
 }

--- a/protos/perfetto/perfetto_sql/BUILD.gn
+++ b/protos/perfetto/perfetto_sql/BUILD.gn
@@ -18,5 +18,6 @@ import("../../../gn/proto_library.gni")
 perfetto_proto_library("@TYPE@") {
   sources = [ "structured_query.proto" ]
   generate_descriptor = "perfettosql.descriptor"
+  generator_visibility = [ "../../../src/trace_processor/perfetto_sql/generator:gen_cc_perfetto_sql_descriptor" ]
   descriptor_root_source = "structured_query.proto"
 }

--- a/protos/perfetto/trace/BUILD.gn
+++ b/protos/perfetto/trace/BUILD.gn
@@ -112,6 +112,8 @@ perfetto_proto_library("@TYPE@") {
   deps = [ ":non_minimal_@TYPE@" ]
   sources = []
   generate_descriptor = "trace.descriptor"
+  generator_visibility =
+      [ "../../../src/trace_processor/importers/proto:gen_cc_trace_descriptor" ]
   descriptor_root_source = "trace.proto"
 }
 

--- a/protos/perfetto/trace/android/BUILD.gn
+++ b/protos/perfetto/trace/android/BUILD.gn
@@ -124,6 +124,7 @@ perfetto_proto_library("winscope_@TYPE@") {
   ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   generate_descriptor = "winscope.descriptor"
+  generator_visibility = [ "../../../../src/trace_processor/importers/proto/winscope:gen_cc_winscope_descriptor" ]
   descriptor_root_source = "winscope.proto"
 }
 
@@ -131,7 +132,7 @@ perfetto_proto_library("winscope_@TYPE@") {
 perfetto_proto_library("android_track_event_@TYPE@") {
   sources = [ "android_track_event.proto" ]
   public_deps = [ "../track_event:@TYPE@" ]
-
+  generator_visibility = [ "../../../../src/trace_processor/importers/proto:gen_cc_android_track_event_descriptor" ]
   generate_descriptor = "android_track_event.descriptor"
   descriptor_root_source = "android_track_event.proto"
 

--- a/protos/perfetto/trace/track_event/BUILD.gn
+++ b/protos/perfetto/trace/track_event/BUILD.gn
@@ -45,5 +45,6 @@ perfetto_proto_library("@TYPE@") {
     "track_event.proto",
   ]
   generate_descriptor = "track_event.descriptor"
+  generator_visibility = [ "../../../../src/trace_processor/importers/proto:gen_cc_track_event_descriptor" ]
   descriptor_root_source = "track_event.proto"
 }

--- a/protos/perfetto/trace_summary/BUILD.gn
+++ b/protos/perfetto/trace_summary/BUILD.gn
@@ -22,5 +22,6 @@ perfetto_proto_library("@TYPE@") {
   ]
   deps = [ "../perfetto_sql:@TYPE@" ]
   generate_descriptor = "trace_summary.descriptor"
+  generator_visibility = [ "../../../src/trace_processor/trace_summary:gen_cc_trace_summary_descriptor" ]
   descriptor_root_source = "file.proto"
 }

--- a/protos/third_party/chromium/BUILD.gn
+++ b/protos/third_party/chromium/BUILD.gn
@@ -7,6 +7,7 @@ perfetto_proto_library("@TYPE@") {
   public_deps = [ "../../perfetto/trace/track_event:@TYPE@" ]
 
   generate_descriptor = "chrome_track_event.descriptor"
+  generator_visibility = [ "../../../src/trace_processor/importers/proto:gen_cc_chrome_track_event_descriptor" ]
   descriptor_root_source = "chrome_track_event.proto"
 
   # When rolled into Chrome, extension descriptor is going to be linked into

--- a/src/protozero/BUILD.gn
+++ b/src/protozero/BUILD.gn
@@ -105,6 +105,8 @@ perfetto_proto_library("testing_messages_@TYPE@") {
     "test/example_proto/upper_import.proto",
   ]
   generate_descriptor = "test_messages.descriptor"
+  generator_visibility =
+      [ "../trace_processor:gen_cc_test_messages_descriptor" ]
   descriptor_root_source = "test/example_proto/test_messages.proto"
   proto_path = perfetto_root_path
 }


### PR DESCRIPTION
This is necessary to change public_deps to deps in proto_library template so that we can remove unnecessary inputs dependency from ninja build files.

See https://crrev.com/c/6414530 and https://crrev.com/c/6414089 for more references.

Bug: http://b/issues/402356473