### PR TITLE
Make CI actually run on dev branches

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -29,7 +29,7 @@ on:
     types: [opened, synchronize]
     branches:
       - main
-      - dev/*
+      - dev/**/*
 
 # If a new commit is pushed, cancel previous jobs for the same PR / branch.
 concurrency:


### PR DESCRIPTION
The existing glob was not sufficient as `/` is not matched.
