### PR TITLE
CI: improve 2-reviewer check

### DIFF
--- a/.github/workflows/require-two-reviewers-for-fork-prs.yml
+++ b/.github/workflows/require-two-reviewers-for-fork-prs.yml
@@ -18,15 +18,15 @@
 name: Enforce 2 collaborator reviews for fork PRs
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited, review_requested]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   pull-requests: read
 
 jobs:
   enforce-reviews:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Check if PR is from a fork
         id: fork_check


### PR DESCRIPTION
Trigger on pull-request review activity, not on upload.
Also run on our bots, not on the communal quota.