### PR TITLE
Fix SQL table in time_in_state.sql

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/slices/time_in_state.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/slices/time_in_state.sql
@@ -49,7 +49,7 @@ CREATE PERFETTO TABLE thread_slice_time_in_state (
   -- If in uninterruptible sleep (D), the kernel function on which was blocked.
   -- Only available on userdebug Android builds when
   -- `sched/sched_blocked_reason` ftrace tracepoint is enabled.
-  blocked_function LONG,
+  blocked_function STRING,
   -- The duration of time the threads slice spent for each
   -- (state, io_wait, blocked_function) tuple.
   dur DURATION


### PR DESCRIPTION
In src/trace_processor/perfetto_sql/stdlib/slices/time_in_state.sql,
the blocked_function is defined LONG type, but it is actually STRING type.

There is only a need to make the simple modification to set it as STRING.

Related to https://github.com/google/perfetto/issues/1142