### PR TITLE
[ui] Extend trusted origin to support *.proxy.googlers.com hostnames

### DIFF
--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -53,6 +53,7 @@ export function isTrustedOrigin(origin: string): boolean {
   const hostname = new URL(origin).hostname;
   if (hostname.endsWith('.corp.google.com')) return true;
   if (hostname.endsWith('.c.googlers.com')) return true;
+  if (hostname.endsWith('.proxy.googlers.com')) return true;
   if (
     hostname === 'localhost' ||
     hostname === '127.0.0.1' ||

--- a/ui/src/frontend/post_message_handler_unittest.ts
+++ b/ui/src/frontend/post_message_handler_unittest.ts
@@ -42,6 +42,8 @@ describe('postMessageHandler', () => {
     expect(isTrustedOrigin('http://broccoliman.c.googlers.com')).toBeTruthy();
     expect(isTrustedOrigin('https://broccolimancorp.google.com')).toBeFalsy();
     expect(isTrustedOrigin('https://broccolimanc.googlers.com')).toBeFalsy();
+    expect(isTrustedOrigin('https://b1234567890abcdef.proxy.googlers.com')).toBeTruthy();
+    expect(isTrustedOrigin('https://b1234567890abcdefproxy.googlers.com')).toBeFalsy();
     expect(isTrustedOrigin('https://localhost')).toBeTruthy();
     expect(isTrustedOrigin('http://localhost')).toBeTruthy();
     expect(isTrustedOrigin('https://127.0.0.1')).toBeTruthy();


### PR DESCRIPTION
This builds on f2511be5e0c05976ccb5233edfa8ee2141923731 to extend support for trusted origins to `*.proxy.googlers.com` hostnames, which are used in addition to `*.c.googlers.com` hostnames.

I extended the unit tests to cover this and confirmed the tests pass with `./ui/run-unittests`.

Bug: http://b/402495918
