### PR TITLE
stdlib: Exclude dur==0 in Wattson freq/idle tables

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_freq.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_freq.sql
@@ -29,6 +29,8 @@ WITH
     FROM cpu_frequency_counters AS cf
     JOIN _dev_cpu_policy_map AS d_map
       ON cf.ucpu = d_map.cpu
+    WHERE
+      dur > 0
   ),
   -- Get first freq transition per CPU
   first_cpu_freq_slices AS (

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_idle.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_idle.sql
@@ -48,6 +48,8 @@ WITH
     )) AS cli
     JOIN cpu_counter_track AS cct
       ON cli.track_id = cct.id
+    WHERE
+      dur > 0
   ),
   -- Adjusted ts if applicable, which makes the current active state longer if
   -- it is coming from an idle exit.


### PR DESCRIPTION
Exclude slices with duration of 0 in the initial freq and idle tables used during Wattson calculation. Removing the dur==0 slices is necessary since a requirement for interval_intersect() is that the input have non-zero slices duration.

A dur==0 freq or idle slice can occur in the rare case when a trace has a freq or idle ftrace event at the same timestamp as trace_end().

Bug: 408009977
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter '.*wattson.*'
