### PR TITLE
df: add runtime builder class for building dataframes for unknown schemas

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -13234,6 +13234,7 @@ filegroup {
     name: "perfetto_src_trace_processor_dataframe_unittests",
     srcs: [
         "src/trace_processor/dataframe/dataframe_unittest.cc",
+        "src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc",
         "src/trace_processor/dataframe/type_set_unittest.cc",
     ],
 }

--- a/BUILD
+++ b/BUILD
@@ -1681,6 +1681,7 @@ perfetto_filegroup(
         "src/trace_processor/dataframe/cursor.h",
         "src/trace_processor/dataframe/dataframe.cc",
         "src/trace_processor/dataframe/dataframe.h",
+        "src/trace_processor/dataframe/runtime_dataframe_builder.h",
     ],
 )
 

--- a/src/trace_processor/dataframe/BUILD.gn
+++ b/src/trace_processor/dataframe/BUILD.gn
@@ -19,6 +19,7 @@ source_set("dataframe") {
     "cursor.h",
     "dataframe.cc",
     "dataframe.h",
+    "runtime_dataframe_builder.h",
   ]
   deps = [
     "../../../gn:default_deps",
@@ -48,6 +49,7 @@ perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
     "dataframe_unittest.cc",
+    "runtime_dataframe_builder_unittest.cc",
     "type_set_unittest.cc",
   ]
   deps = [

--- a/src/trace_processor/dataframe/impl/bit_vector.h
+++ b/src/trace_processor/dataframe/impl/bit_vector.h
@@ -51,13 +51,26 @@ struct BitVector {
   // Default constructor creates an empty bit vector.
   BitVector() = default;
 
+  // Movable but not copyable.
+  BitVector(BitVector&&) = default;
+  BitVector& operator=(BitVector&&) = default;
+  BitVector(const BitVector&) = delete;
+  BitVector& operator=(const BitVector&) = delete;
+
   // Allocates a new BitVector with `size` unset bits.
   //
   // size: Size for how many bits to add to the BitVector.
-  // Returns a BitVector with the given size and with all bits set to false.
-  static BitVector CreateWithSize(uint64_t size) {
+  // Returns a BitVector with the given size and with all bits set to ``value`.
+  static BitVector CreateWithSize(uint64_t size, bool value = false) {
+    if (size == 0) {
+      return {};
+    }
     auto words = FlexVector<uint64_t>::CreateWithSize((size + 63u) / 64u);
-    memset(words.data(), 0, words.size() * sizeof(uint64_t));
+    memset(words.data(), value ? 0xFF : 0, words.size() * sizeof(uint64_t));
+    // Clear any bits past `size`.
+    if (size % 64u != 0u) {
+      words.back() &= (1ull << (size % 64u)) - 1ull;
+    }
     PERFETTO_DCHECK(size <= words.size() * 64u);
     return BitVector(std::move(words), size);
   }

--- a/src/trace_processor/dataframe/impl/bit_vector.h
+++ b/src/trace_processor/dataframe/impl/bit_vector.h
@@ -60,7 +60,7 @@ struct BitVector {
   // Allocates a new BitVector with `size` unset bits.
   //
   // size: Size for how many bits to add to the BitVector.
-  // Returns a BitVector with the given size and with all bits set to ``value`.
+  // Returns a BitVector with the given size and with all bits set to `value`.
   static BitVector CreateWithSize(uint64_t size, bool value = false) {
     if (size == 0) {
       return {};

--- a/src/trace_processor/dataframe/impl/bit_vector_unittest.cc
+++ b/src/trace_processor/dataframe/impl/bit_vector_unittest.cc
@@ -32,13 +32,19 @@ TEST(BitVectorTest, DefaultConstructor) {
 }
 
 TEST(BitVectorTest, CreateWithSize) {
-  auto bits = BitVector::CreateWithSize(31);
-
-  EXPECT_EQ(bits.size(), 31u);
-
-  // All bits should be false since we pushed all false values
-  for (size_t i = 0; i < 31; ++i) {
-    EXPECT_FALSE(bits.is_set(i)) << "Bit " << i << " should be unset";
+  {
+    auto bits = BitVector::CreateWithSize(31);
+    EXPECT_EQ(bits.size(), 31u);
+    for (size_t i = 0; i < 31; ++i) {
+      EXPECT_FALSE(bits.is_set(i)) << "Bit " << i << " should be unset";
+    }
+  }
+  {
+    auto bits = BitVector::CreateWithSize(65, true);
+    EXPECT_EQ(bits.size(), 65u);
+    for (size_t i = 0; i < 65; ++i) {
+      EXPECT_TRUE(bits.is_set(i)) << "Bit " << i << " should be set";
+    }
   }
 }
 

--- a/src/trace_processor/dataframe/impl/bytecode_instructions.h
+++ b/src/trace_processor/dataframe/impl/bytecode_instructions.h
@@ -61,7 +61,7 @@ struct Iota : Bytecode {
 };
 
 // Base class for casting filter value operations.
-struct CastFilterValueBase : TemplatedBytecode1<ColumnType> {
+struct CastFilterValueBase : TemplatedBytecode1<StorageType> {
   PERFETTO_DATAFRAME_BYTECODE_IMPL_3(FilterValueHandle,
                                      fval_handle,
                                      reg::WriteHandle<CastFilterValueResult>,
@@ -78,7 +78,7 @@ struct CastFilterValue : CastFilterValueBase {
 
 // Base for operations on sorted data.
 struct SortedFilterBase
-    : TemplatedBytecode2<ColumnType, EqualRangeLowerBoundUpperBound> {
+    : TemplatedBytecode2<StorageType, EqualRangeLowerBoundUpperBound> {
   PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
                                      col,
                                      reg::ReadHandle<CastFilterValueResult>,

--- a/src/trace_processor/dataframe/impl/bytecode_interpreter.h
+++ b/src/trace_processor/dataframe/impl/bytecode_interpreter.h
@@ -252,7 +252,7 @@ class Interpreter {
         filter_value_fetcher_->GetValueType(handle.index);
 
     using ValueType =
-        ColumnType::VariantTypeAtIndex<T, CastFilterValueResult::Value>;
+        StorageType::VariantTypeAtIndex<T, CastFilterValueResult::Value>;
     CastFilterValueResult result;
     if constexpr (std::is_same_v<T, Id>) {
       auto op = *f.arg<B::op>().TryDowncast<NonStringOp>();
@@ -295,7 +295,7 @@ class Interpreter {
     if (!HandleInvalidCastFilterValueResult(value, update)) {
       return;
     }
-    using M = ColumnType::VariantTypeAtIndex<T, CastFilterValueResult::Value>;
+    using M = StorageType::VariantTypeAtIndex<T, CastFilterValueResult::Value>;
     M val = base::unchecked_get<M>(value.value);
     if constexpr (std::is_same_v<T, Id>) {
       uint32_t inner_val = val.value;
@@ -341,7 +341,7 @@ class Interpreter {
       return;
     }
     using ValueType =
-        ColumnType::VariantTypeAtIndex<Uint32, CastFilterValueResult::Value>;
+        StorageType::VariantTypeAtIndex<Uint32, CastFilterValueResult::Value>;
     auto val = base::unchecked_get<ValueType>(cast_result.value);
     const auto& col = columns_[bytecode.arg<B::col>()];
     const auto* storage = col.storage.template unchecked_data<Uint32>();
@@ -437,7 +437,7 @@ class Interpreter {
       return;
     }
     const auto& source = ReadFromRegister(nf.arg<B::source_register>());
-    using M = ColumnType::VariantTypeAtIndex<T, CastFilterValueResult::Value>;
+    using M = StorageType::VariantTypeAtIndex<T, CastFilterValueResult::Value>;
     if constexpr (std::is_same_v<T, Id>) {
       update.e = IdentityFilter(
           source.b, source.e, update.b,

--- a/src/trace_processor/dataframe/impl/bytecode_interpreter_unittest.cc
+++ b/src/trace_processor/dataframe/impl/bytecode_interpreter_unittest.cc
@@ -721,9 +721,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32Eq) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  column_.reset(new Column{ColumnSpec{"foo", Uint32(), Sorted(), NonNull()},
-                           Storage{std::move(values)},
-                           Overlay{Overlay::NoOverlay{}}});
+  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
+                                 Sorted{}});
   {
     // Test case 1: Value exists in range
     SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
@@ -753,9 +752,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32LowerBound) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  column_.reset(new Column{ColumnSpec{"foo", Uint32(), Sorted(), NonNull()},
-                           Storage{std::move(values)},
-                           Overlay{Overlay::NoOverlay{}}});
+  column_.reset(new impl::Column{"foo", Storage{std::move(values)},
+                                 Overlay{Overlay::NoOverlay{}}, Sorted{}});
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
                          Range{3u, 8u});
@@ -775,9 +773,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32UpperBound) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  column_.reset(new Column{ColumnSpec{"foo", Uint32(), Sorted(), NonNull()},
-                           Storage{std::move(values)},
-                           Overlay{Overlay::NoOverlay{}}});
+  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
+                                 Sorted{}});
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
                          Range{3u, 7u});
@@ -825,9 +822,8 @@ TEST_F(BytecodeInterpreterTest, FilterUint32Eq) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({4u, 49u, 392u, 4u, 49u, 4u, 391u});
-  column_.reset(new Column{ColumnSpec{"foo", Uint32(), Unsorted(), NonNull()},
-                           Storage{std::move(values)},
-                           Overlay{Overlay::NoOverlay{}}});
+  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
+                                 Unsorted{}});
 
   std::vector<uint32_t> indices_spec = {3, 3, 4, 5, 0, 6, 0};
   {
@@ -876,9 +872,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterString) {
   // Sorted string data: ["apple", "banana", "banana", "cherry", "date"]
   auto values = CreateFlexVectorForTesting<StringPool::Id>(
       {apple_id, banana_id, banana_id, cherry_id, date_id});
-  column_.reset(new Column{ColumnSpec{"col", String{}, Sorted{}, NonNull{}},
-                           Storage{std::move(values)},
-                           Overlay{Overlay::NoOverlay{}}});
+  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
+                                 Sorted{}});
 
   // --- Sub-test for EqualRange (Eq) ---
   {
@@ -930,9 +925,8 @@ TEST_F(BytecodeInterpreterTest, StringFilter) {
   // Index:    0        1      2      3        4       5        6
   auto values = CreateFlexVectorForTesting<StringPool::Id>(
       {cherry_id, apple_id, empty_id, banana_id, apple_id, date_id, durian_id});
-  column_.reset(new Column{ColumnSpec{"col", String{}, Unsorted{}, NonNull{}},
-                           Storage{std::move(values)},
-                           Overlay{Overlay::NoOverlay{}}});
+  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
+                                 Unsorted{}});
 
   // Initial indices {0, 1, 2, 3, 4, 5, 6} pointing to the data
   const std::vector<uint32_t> source_indices = {0, 1, 2, 3, 4, 5, 6};
@@ -999,10 +993,10 @@ TEST_F(BytecodeInterpreterTest, NullFilter) {
 
   // Create a dummy column with a DenseNull overlay using the BitVector
   // (SparseNull would work identically for this specific test)
-  column_ = std::make_unique<Column>(Column{
-      ColumnSpec{"col_nullable", Uint32{}, Unsorted{}, DenseNull{}},
+  column_ = std::make_unique<impl::Column>(impl::Column{
+      "foo",
       Storage{Storage::Uint32{}},  // Storage type doesn't matter for NullFilter
-      Overlay{Overlay::DenseNull{std::move(bv)}}});
+      Overlay{Overlay::DenseNull{std::move(bv)}}, Unsorted{}});
 
   std::vector<uint32_t> indices(kNumIndices);
   std::iota(indices.begin(), indices.end(), 0);
@@ -1055,10 +1049,9 @@ TEST_F(BytecodeInterpreterTest, PrefixPopcount) {
   bv.set(160);  // Word 2
   bv.set(200);  // Word 3
 
-  column_ = std::make_unique<Column>(
-      Column{ColumnSpec{"col_nullable", Uint32{}, Unsorted{}, SparseNull{}},
-             Storage{Storage::Uint32{}},  // Storage type doesn't matter
-             Overlay{Overlay::SparseNull{std::move(bv)}}});
+  column_ = std::make_unique<impl::Column>(impl::Column{
+      "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
+      Overlay{Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
   SetRegistersAndExecute("PrefixPopcount: [col=0, dest_register=Register(0)]");
 
   const auto& result_slab = GetRegister<Slab<uint32_t>>(0);
@@ -1105,10 +1098,9 @@ TEST_F(BytecodeInterpreterTest, TranslateSparseNullIndices) {
   bv.set(160);  // Word 2
   bv.set(200);  // Word 3
 
-  column_ = std::make_unique<Column>(
-      Column{ColumnSpec{"col_sparse", Uint32{}, Unsorted{}, SparseNull{}},
-             Storage{Storage::Uint32{}},  // Storage type doesn't matter
-             Overlay{Overlay::SparseNull{std::move(bv)}}});
+  column_ = std::make_unique<impl::Column>(impl::Column{
+      "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
+      Overlay{Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
 
   // Precomputed PrefixPopcount Slab (from previous test)
   auto popcount_slab = Slab<uint32_t>::Alloc(4);
@@ -1162,10 +1154,9 @@ TEST_F(BytecodeInterpreterTest, StrideTranslateAndCopySparseNullIndices) {
   popcount_slab[3] = 9;
 
   // Create a dummy column with the BitVector (SparseNull overlay)
-  column_ = std::make_unique<Column>(
-      Column{ColumnSpec{"col_sparse", Uint32{}, Unsorted{}, SparseNull{}},
-             Storage{Storage::Uint32{}},  // Storage type doesn't matter
-             Overlay{Overlay::SparseNull{std::move(bv)}}});
+  column_ = std::make_unique<impl::Column>(impl::Column{
+      "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
+      Overlay{Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
 
   // Input/Output buffer setup: Stride = 3, Offset for this column = 1
   // We pre-populate offset 0 with the original indices to simulate the state
@@ -1232,10 +1223,9 @@ TEST_F(BytecodeInterpreterTest, StrideCopyDenseNullIndices) {
   bv.set(200);  // Word 3
 
   // Create a dummy column with the BitVector (DenseNull overlay)
-  column_ = std::make_unique<Column>(
-      Column{ColumnSpec{"col_dense", Uint32{}, Unsorted{}, DenseNull{}},
-             Storage{Storage::Uint32{}},  // Storage type doesn't matter
-             Overlay{Overlay::DenseNull{std::move(bv)}}});
+  column_ = std::make_unique<impl::Column>(impl::Column{
+      "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
+      Overlay{Overlay::DenseNull{std::move(bv)}}, Unsorted{}});
 
   // Input/Output buffer setup: Stride = 2, Offset for this column = 1
   // Pre-populate offset 0 with the original indices.
@@ -1287,9 +1277,8 @@ TEST_F(BytecodeInterpreterTest, StrideCopyDenseNullIndices) {
 TEST_F(BytecodeInterpreterTest, NonStringFilterInPlace) {
   // Column data: {5, 10, 5, 15, 10, 20}
   auto values = CreateFlexVectorForTesting<uint32_t>({5, 10, 5, 15, 10, 20});
-  column_ = std::make_unique<Column>(
-      Column{ColumnSpec{"col", Uint32{}, Unsorted{}, NonNull{}},
-             Storage{std::move(values)}, Overlay{Overlay::NoOverlay{}}});
+  column_ = std::make_unique<impl::Column>(impl::Column{
+      "foo", std::move(values), Overlay{Overlay::NoOverlay{}}, Unsorted{}});
 
   // Source indices (imagine these are translated storage indices for data
   // lookup).
@@ -1325,9 +1314,8 @@ TEST_F(BytecodeInterpreterTest, Uint32SetIdSortedEq) {
   // 7  7  10
   auto values = CreateFlexVectorForTesting<uint32_t>(
       {0u, 0u, 0u, 3u, 3u, 5u, 5u, 7u, 7u, 7u, 10u});
-  column_ = std::make_unique<Column>(
-      Column{ColumnSpec{"col", Uint32(), SetIdSorted(), NonNull()},
-             Storage{std::move(values)}, Overlay{Overlay::NoOverlay{}}});
+  column_ = std::make_unique<impl::Column>(impl::Column{
+      "foo", std::move(values), Overlay{Overlay::NoOverlay{}}, SetIdSorted{}});
 
   std::string bytecode =
       "Uint32SetIdSortedEq: [col=0, val_register=Register(0), "

--- a/src/trace_processor/dataframe/impl/flex_vector.h
+++ b/src/trace_processor/dataframe/impl/flex_vector.h
@@ -69,9 +69,9 @@ class FlexVector {
 
   // Allocates a new FlexVector with the specified initial capacity.
   //
-  // capacity: Initial capacity (number of elements). Must be a power of two.
+  // capacity: Initial capacity (number of elements).
   static FlexVector<T, kAlignment> CreateWithCapacity(uint64_t capacity) {
-    return FlexVector(capacity, 0);
+    return FlexVector(capacity == 0 ? 0 : NextPowerOfTwo(capacity), 0);
   }
 
   // Allocates a new FlexVector with the specified initial size. The values
@@ -80,17 +80,7 @@ class FlexVector {
   //
   // size: Initial size (number of elements).
   static FlexVector<T, kAlignment> CreateWithSize(uint64_t size) {
-    static constexpr auto next_power_of_two = [](uint64_t x) {
-      uint64_t n = x - 1;
-      n |= n >> 1;
-      n |= n >> 2;
-      n |= n >> 4;
-      n |= n >> 8;
-      n |= n >> 16;
-      n |= n >> 32;
-      return n + 1;
-    };
-    return FlexVector(size == 0 ? 0 : next_power_of_two(size), size);
+    return FlexVector(size == 0 ? 0 : NextPowerOfTwo(size), size);
   }
 
   // Adds an element to the end of the vector, automatically resizing if needed.
@@ -134,6 +124,26 @@ class FlexVector {
   PERFETTO_ALWAYS_INLINE const T* end() const { return slab_.data() + size_; }
   PERFETTO_ALWAYS_INLINE T* begin() { return slab_.data(); }
   PERFETTO_ALWAYS_INLINE T* end() { return slab_.data() + size_; }
+
+  PERFETTO_ALWAYS_INLINE const T& back() const {
+    PERFETTO_DCHECK(!empty());
+    return slab_.data()[size_ - 1];
+  }
+  PERFETTO_ALWAYS_INLINE T& back() {
+    PERFETTO_DCHECK(!empty());
+    return slab_.data()[size_ - 1];
+  }
+
+  static constexpr uint64_t NextPowerOfTwo(uint64_t x) {
+    uint64_t n = x - 1;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    n |= n >> 32;
+    return n + 1;
+  }
 
   // Returns the current capacity (maximum size without reallocation).
   PERFETTO_ALWAYS_INLINE uint64_t capacity() const { return slab_.size(); }

--- a/src/trace_processor/dataframe/impl/query_plan.cc
+++ b/src/trace_processor/dataframe/impl/query_plan.cc
@@ -42,9 +42,10 @@ namespace {
 
 // Calculates filter preference score for ordering filters.
 // Lower scores are applied first for better efficiency.
-uint32_t FilterPreference(const FilterSpec& fs, const ColumnSpec& col) {
+uint32_t FilterPreference(const FilterSpec& fs, const impl::Column& col) {
   enum AbsolutePreference : uint8_t {
     kIdEq,                     // Most efficient: id equality check
+    kSetIdSortedEq,            // Set id sorted equality check
     kIdInequality,             // Id inequality check
     kNumericSortedEq,          // Numeric sorted equality check
     kNumericSortedInequality,  // Numeric inequality check
@@ -53,10 +54,14 @@ uint32_t FilterPreference(const FilterSpec& fs, const ColumnSpec& col) {
     kLeastPreferred,           // Least preferred
   };
   const auto& op = fs.op;
-  const auto& ct = col.column_type;
-  const auto& n = col.nullability;
+  const auto& ct = col.storage.type();
+  const auto& n = col.overlay.nullability();
   if (n.Is<NonNull>() && ct.Is<Id>() && op.Is<Eq>()) {
     return kIdEq;
+  }
+  if (n.Is<NonNull>() && ct.Is<Uint32>() && col.sort_state.Is<SetIdSorted>() &&
+      op.Is<Eq>()) {
+    return kSetIdSortedEq;
   }
   if (n.Is<NonNull>() && ct.Is<Id>() && op.IsAnyOf<InequalityOp>()) {
     return kIdInequality;
@@ -124,14 +129,14 @@ base::Status QueryPlanBuilder::Filter(std::vector<FilterSpec>& specs) {
                    [this](const FilterSpec& a, const FilterSpec& b) {
                      const auto& a_col = columns_[a.column_index];
                      const auto& b_col = columns_[b.column_index];
-                     return FilterPreference(a, a_col.spec) <
-                            FilterPreference(b, b_col.spec);
+                     return FilterPreference(a, a_col) <
+                            FilterPreference(b, b_col);
                    });
 
   // Apply each filter in the optimized order
   for (FilterSpec& c : specs) {
     const Column& col = columns_[c.column_index];
-    const auto& ct = col.spec.column_type;
+    StorageType ct = col.storage.type();
 
     // Get the non-null operation (all our ops are non-null at this point)
     auto non_null_op = c.op.TryDowncast<NonNullOp>();
@@ -190,7 +195,7 @@ void QueryPlanBuilder::Output(uint64_t cols_used) {
       continue;
     }
     const auto& col = columns_[i];
-    switch (col.spec.nullability.index()) {
+    switch (col.overlay.nullability().index()) {
       case Nullability::GetTypeIndex<SparseNull>():
       case Nullability::GetTypeIndex<DenseNull>():
         null_cols.emplace_back(ColAndOffset{i, plan_.params.output_per_row});
@@ -227,7 +232,7 @@ void QueryPlanBuilder::Output(uint64_t cols_used) {
     }
     for (auto [col, offset] : null_cols) {
       const auto& c = columns_[col];
-      switch (c.spec.nullability.index()) {
+      switch (c.overlay.nullability().index()) {
         case Nullability::GetTypeIndex<SparseNull>(): {
           using B = bytecode::StrideTranslateAndCopySparseNullIndices;
           auto reg = PrefixPopcountRegisterFor(col);
@@ -307,7 +312,9 @@ void QueryPlanBuilder::NullConstraint(const NullOp& op, FilterSpec& c) {
   // the caller (i.e. SQLite) knows that we are able to handle the constraint.
   c.value_index = plan_.params.filter_value_count++;
 
-  switch (columns_[c.column_index].spec.nullability.index()) {
+  const auto& col = columns_[c.column_index];
+  uint32_t nullability_type_index = col.overlay.nullability().index();
+  switch (nullability_type_index) {
     case Nullability::GetTypeIndex<SparseNull>():
     case Nullability::GetTypeIndex<DenseNull>(): {
       auto indices = EnsureIndicesAreInSlab();
@@ -333,12 +340,12 @@ void QueryPlanBuilder::NullConstraint(const NullOp& op, FilterSpec& c) {
 
 bool QueryPlanBuilder::TrySortedConstraint(
     const FilterSpec& fs,
-    const ColumnType& ct,
+    const StorageType& ct,
     const NonNullOp& op,
     const bytecode::reg::RwHandle<CastFilterValueResult>& result) {
   const auto& col = columns_[fs.column_index];
-  const auto& n = col.spec.nullability;
-  if (!n.Is<NonNull>() || col.spec.sort_state.Is<Unsorted>()) {
+  const auto& nullability = col.overlay.nullability();
+  if (!nullability.Is<NonNull>() || col.sort_state.Is<Unsorted>()) {
     return false;
   }
   auto range_op = op.TryDowncast<RangeOp>();
@@ -354,7 +361,7 @@ bool QueryPlanBuilder::TrySortedConstraint(
       base::unchecked_get<bytecode::reg::RwHandle<Range>>(indices_reg_);
 
   // Handle set id equality with a specialized opcode.
-  if (ct.Is<Uint32>() && col.spec.sort_state.Is<SetIdSorted>() && op.Is<Eq>()) {
+  if (ct.Is<Uint32>() && col.sort_state.Is<SetIdSorted>() && op.Is<Eq>()) {
     using B = bytecode::Uint32SetIdSortedEq;
     auto& bc = AddOpcode<B>();
     bc.arg<B::val_register>() = result;
@@ -378,7 +385,8 @@ bytecode::reg::RwHandle<Span<uint32_t>>
 QueryPlanBuilder::MaybeAddOverlayTranslation(const FilterSpec& c) {
   bytecode::reg::RwHandle<Span<uint32_t>> main = EnsureIndicesAreInSlab();
   const auto& col = columns_[c.column_index];
-  switch (col.spec.nullability.index()) {
+  uint32_t nullability_type_index = col.overlay.nullability().index();
+  switch (nullability_type_index) {
     case Nullability::GetTypeIndex<SparseNull>(): {
       bytecode::reg::RwHandle<Slab<uint32_t>> scratch_slab{register_count_++};
       bytecode::reg::RwHandle<Span<uint32_t>> scratch_span{register_count_++};

--- a/src/trace_processor/dataframe/impl/query_plan.h
+++ b/src/trace_processor/dataframe/impl/query_plan.h
@@ -186,7 +186,7 @@ class QueryPlanBuilder {
   // Returns true if the optimization was applied.
   bool TrySortedConstraint(
       const FilterSpec& fs,
-      const ColumnType& ct,
+      const StorageType& ct,
       const NonNullOp& op,
       const bytecode::reg::RwHandle<CastFilterValueResult>& result);
 

--- a/src/trace_processor/dataframe/runtime_dataframe_builder.h
+++ b/src/trace_processor/dataframe/runtime_dataframe_builder.h
@@ -1,0 +1,421 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_DATAFRAME_RUNTIME_DATAFRAME_BUILDER_H_
+#define SRC_TRACE_PROCESSOR_DATAFRAME_RUNTIME_DATAFRAME_BUILDER_H_
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/public/compiler.h"
+#include "src/trace_processor/containers/null_term_string_view.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/dataframe/dataframe.h"
+#include "src/trace_processor/dataframe/impl/bit_vector.h"
+#include "src/trace_processor/dataframe/impl/flex_vector.h"
+#include "src/trace_processor/dataframe/impl/types.h"
+#include "src/trace_processor/dataframe/specs.h"
+#include "src/trace_processor/dataframe/value_fetcher.h"
+#include "src/trace_processor/util/status_macros.h"
+
+namespace perfetto::trace_processor::dataframe {
+
+// Builds a Dataframe instance row by row at runtime.
+//
+// This class allows constructing a `Dataframe` incrementally. It infers
+// column types (`int64_t`, `double`, `StringPool::Id`) based on the first
+// non-null value encountered in each column. Null values are tracked
+// efficiently using a `BitVector` (created only if nulls exist), and the
+// underlying data storage only stores non-null values (SparseNull
+// representation).
+//
+// Upon calling `Build()`, the builder analyzes the collected data to:
+// - Determine the final optimal storage type for integer columns (downcasting
+//   `int64_t` to `uint32_t` or `int32_t` if possible, or using `Id` type).
+// - Determine the final sort state (`IdSorted`, `SetIdSorted`, `Sorted`,
+//   `Unsorted`) by analyzing the collected values. Nullable columns are always
+//   `Unsorted`.
+// - Construct the final `Dataframe` object.
+//
+// Usage Example:
+// ```cpp
+// // Assume MyFetcher inherits from ValueFetcher and provides data for rows.
+// struct MyFetcher : ValueFetcher {
+//   // ... implementation to fetch data for current row ...
+// };
+//
+// std::vector<std::string> col_names = {"ts", "value", "name"};
+// StringPool pool;
+// RuntimeDataframeBuilder builder(col_names, &pool);
+// for (MyFetcher fetcher; fetcher.Next();) {
+//   if (!builder.AddRow(&fetcher)) {
+//     // Handle error (e.g., type mismatch)
+//     PERFETTO_ELOG("Failed to add row: %s", builder.status().message());
+//     break;
+//   }
+// }
+//
+// base::StatusOr<Dataframe> df = std::move(builder).Build();
+// if (!df.ok()) {
+//   // Handle build error
+//   PERFETTO_ELOG("Failed to build dataframe: %s", df.status().message());
+// } else {
+//   // Use the dataframe *df...
+// }
+// ```
+class RuntimeDataframeBuilder {
+ public:
+  // Constructs a RuntimeDataframeBuilder.
+  //
+  // Args:
+  //   names: A vector of strings representing the names of the columns
+  //          to be built. The order determines the column order as well.
+  //   pool: A pointer to a `StringPool` instance used for interning
+  //         string values encountered during row addition. Must remain
+  //         valid for the lifetime of the builder and the resulting
+  //         Dataframe.
+  RuntimeDataframeBuilder(std::vector<std::string> names, StringPool* pool)
+      : string_pool_(pool),
+        column_names_(std::move(names)),
+        column_state_(column_names_.size()) {}
+  ~RuntimeDataframeBuilder() = default;
+
+  // Movable but not copyable
+  RuntimeDataframeBuilder(RuntimeDataframeBuilder&&) noexcept;
+  RuntimeDataframeBuilder& operator=(RuntimeDataframeBuilder&&) noexcept;
+  RuntimeDataframeBuilder(const RuntimeDataframeBuilder&) = delete;
+  RuntimeDataframeBuilder& operator=(const RuntimeDataframeBuilder&) = delete;
+
+  // Adds a row to the dataframe using data provided by the Fetcher.
+  //
+  // Template Args:
+  //   ValueFetcherImpl: A concrete class derived from `ValueFetcher` that
+  //                     provides methods like `GetValueType(col_idx)` and
+  //                     `GetInt64Value(col_idx)`, `GetDoubleValue(col_idx)`,
+  //                     `GetStringValue(col_idx)` for the current row.
+  // Args:
+  //   fetcher: A pointer to an instance of `ValueFetcherImpl`, configured
+  //            to provide data for the row being added. The fetcher only
+  //            needs to be valid for the duration of this call.
+  // Returns:
+  //   true: If the row was added successfully.
+  //   false: If an error occurred (e.g., type mismatch). Check `status()` for
+  //          details. The builder should not be used further if false is
+  //          returned.
+  //
+  // Implementation Notes:
+  // 1) Infers column types (int64_t, double, StringPool::Id) based on the first
+  //    non-null value encountered. Stores integer types smaller than int64_t
+  //    (i.e. Id, uint32_t, int32_t) initially as int64_t, with potential
+  //    downcasting occurring during Build().
+  // 2) Tracks null values sparsely: only non-null values are appended to the
+  //    internal data storage vectors. A BitVector is created and maintained
+  //    only if null values are encountered for a column.
+  // 3) Performs strict type checking against the inferred type for subsequent
+  //    rows. If a type mismatch occurs, sets an error status (retrievable via
+  //    status()) and returns false.
+  template <typename ValueFetcherImpl>
+  bool AddRow(ValueFetcherImpl* fetcher) {
+    static_assert(std::is_base_of_v<ValueFetcher, ValueFetcherImpl>,
+                  "ValueFetcherImpl must inherit from ValueFetcher");
+    PERFETTO_CHECK(current_status_.ok());
+
+    for (uint32_t i = 0; i < column_names_.size(); ++i) {
+      ColumnState& state = column_state_[i];
+      typename ValueFetcherImpl::Type fetched_type = fetcher->GetValueType(i);
+      switch (fetched_type) {
+        case ValueFetcherImpl::kInt64: {
+          auto* r = EnsureColumnType<int64_t>(i, state.data);
+          if (PERFETTO_UNLIKELY(!r)) {
+            return false;
+          }
+          r->push_back(fetcher->GetInt64Value(i));
+          break;
+        }
+        case ValueFetcherImpl::kDouble: {
+          auto* r = EnsureColumnType<double>(i, state.data);
+          if (PERFETTO_UNLIKELY(!r)) {
+            return false;
+          }
+          r->push_back(fetcher->GetDoubleValue(i));
+          break;
+        }
+        case ValueFetcherImpl::kString: {
+          auto* r = EnsureColumnType<StringPool::Id>(i, state.data);
+          if (PERFETTO_UNLIKELY(!r)) {
+            return false;
+          }
+          r->push_back(string_pool_->InternString(fetcher->GetStringValue(i)));
+          break;
+        }
+        case ValueFetcherImpl::kNull:
+          if (PERFETTO_UNLIKELY(!state.null_overlay)) {
+            state.null_overlay =
+                impl::BitVector::CreateWithSize(row_count_, true);
+          }
+          break;
+      }
+      if (PERFETTO_UNLIKELY(state.null_overlay)) {
+        state.null_overlay->push_back(fetched_type != ValueFetcherImpl::kNull);
+      }
+    }  // End column loop
+    row_count_++;
+    return true;
+  }
+
+  // Finalizes the builder and attempts to construct the Dataframe.
+  // This method consumes the builder (note the && qualifier).
+  //
+  // Returns:
+  //   StatusOr<Dataframe>: On success, contains the built `Dataframe`.
+  //                        On failure (e.g., if `AddRow` previously failed),
+  //                        contains an error status retrieved from `status()`.
+  //
+  // Implementation wise, the collected data for each column is analyzed to:
+  // - Determine the final optimal storage type (e.g., downcasting int64_t to
+  //   uint32_t/int32_t if possible, using Id type if applicable).
+  // - Determine the final nullability overlay (NonNull or SparseNull).
+  // - Determine the final sort state (IdSorted, SetIdSorted, Sorted, Unsorted)
+  //   by analyzing the collected non-null values.
+  // - Construct and return the final `Dataframe` instance.
+  base::StatusOr<Dataframe> Build() && {
+    RETURN_IF_ERROR(current_status_);
+    std::vector<impl::Column> columns;
+    for (uint32_t i = 0; i < column_names_.size(); ++i) {
+      auto& state = column_state_[i];
+      switch (state.data.index()) {
+        case base::variant_index<DataVariant, std::nullopt_t>():
+          columns.emplace_back(impl::Column{
+              std::move(column_names_[i]),
+              impl::Storage{impl::FlexVector<uint32_t>()},
+              CreateOverlayFromBitvector(std::move(state.null_overlay)),
+              Unsorted{}});
+          break;
+        case base::variant_index<DataVariant, impl::FlexVector<int64_t>>(): {
+          auto& data =
+              base::unchecked_get<impl::FlexVector<int64_t>>(state.data);
+          bool is_id_sorted = data.empty() || data[0] == 0;
+          bool is_setid_sorted = data.empty() || data[0] == 0;
+          bool is_sorted = true;
+          int64_t min = data.empty() ? 0 : data[0];
+          int64_t max = data.empty() ? 0 : data[0];
+          for (uint32_t j = 1; j < data.size(); ++j) {
+            is_id_sorted = is_id_sorted && (data[j] == j);
+            is_setid_sorted =
+                is_setid_sorted && (data[j] == data[j - 1] || data[j] == j);
+            is_sorted = is_sorted && data[j - 1] <= data[j];
+            min = std::min(min, data[j]);
+            max = std::max(max, data[j]);
+          }
+          bool is_nullable = state.null_overlay.has_value();
+          columns.emplace_back(impl::Column{
+              std::move(column_names_[i]),
+              CreateIntegerStorage(std::move(data), is_id_sorted, min, max),
+              CreateOverlayFromBitvector(std::move(state.null_overlay)),
+              GetIntegerSortStateFromProperties(is_nullable, is_id_sorted,
+                                                is_setid_sorted, is_sorted)});
+          break;
+        }
+        case base::variant_index<DataVariant, impl::FlexVector<double>>(): {
+          auto& data =
+              base::unchecked_get<impl::FlexVector<double>>(state.data);
+          SortState sort_state =
+              GetSortStateForDouble(state.null_overlay.has_value(), data);
+          columns.emplace_back(impl::Column{
+              std::move(column_names_[i]), impl::Storage{std::move(data)},
+              CreateOverlayFromBitvector(std::move(state.null_overlay)),
+              sort_state});
+          break;
+        }
+        case base::variant_index<DataVariant,
+                                 impl::FlexVector<StringPool::Id>>(): {
+          auto& data =
+              base::unchecked_get<impl::FlexVector<StringPool::Id>>(state.data);
+          SortState sort_state = GetStringSortState(
+              state.null_overlay.has_value(), data, string_pool_);
+          columns.emplace_back(impl::Column{
+              std::move(column_names_[i]), impl::Storage{std::move(data)},
+              CreateOverlayFromBitvector(std::move(state.null_overlay)),
+              sort_state});
+          break;
+        }
+      }
+    }
+    return Dataframe(std::move(columns), row_count_, string_pool_);
+  }
+
+  // Returns the current status of the builder.
+  //
+  // If `AddRow` returned `false`, this method can be used to retrieve the
+  // `base::Status` object containing the error details (e.g., type mismatch).
+  //
+  // Returns:
+  //   const base::Status&: The current status. `ok()` will be true unless
+  //                        an error occurred during a previous `AddRow` call.
+  const base::Status& status() const { return current_status_; }
+
+ private:
+  using DataVariant = std::variant<std::nullopt_t,
+                                   impl::FlexVector<int64_t>,
+                                   impl::FlexVector<double>,
+                                   impl::FlexVector<StringPool::Id>>;
+  struct ColumnState {
+    DataVariant data = std::nullopt;
+    std::optional<impl::BitVector> null_overlay;
+  };
+
+  template <typename T>
+  PERFETTO_ALWAYS_INLINE impl::FlexVector<T>* EnsureColumnType(
+      uint32_t i,
+      DataVariant& data) {
+    switch (data.index()) {
+      case base::variant_index<DataVariant, std::nullopt_t>():
+        data = impl::FlexVector<T>();
+        return &base::unchecked_get<impl::FlexVector<T>>(data);
+      case base::variant_index<DataVariant, impl::FlexVector<T>>():
+        return &base::unchecked_get<impl::FlexVector<T>>(data);
+      default:
+        current_status_ = base::ErrStatus(
+            "Type mismatch in column '%s' at row %u. Existing type != "
+            "fetched type.",
+            column_names_[i].c_str(), row_count_);
+        return nullptr;
+    }
+  }
+
+  static impl::Storage CreateIntegerStorage(impl::FlexVector<int64_t> data,
+                                            bool is_id_sorted,
+                                            int64_t min,
+                                            int64_t max) {
+    if (is_id_sorted) {
+      return impl::Storage{
+          impl::Storage::Id{static_cast<uint32_t>(data.size())}};
+    }
+    if (IsRangeFullyRepresentableByType<uint32_t>(min, max)) {
+      return impl::Storage{
+          impl::Storage::Uint32{DowncastFromInt64<uint32_t>(data)}};
+    }
+    if (IsRangeFullyRepresentableByType<int32_t>(min, max)) {
+      return impl::Storage{
+          impl::Storage::Int32{DowncastFromInt64<int32_t>(data)}};
+    }
+    return impl::Storage{impl::Storage::Int64{std::move(data)}};
+  }
+
+  static impl::Overlay CreateOverlayFromBitvector(
+      std::optional<impl::BitVector> bit_vector) {
+    if (bit_vector) {
+      return impl::Overlay{impl::Overlay::SparseNull{*std::move(bit_vector)}};
+    }
+    return impl::Overlay{impl::Overlay::NoOverlay{}};
+  }
+
+  template <typename T>
+  static bool IsRangeFullyRepresentableByType(int64_t min, int64_t max) {
+    // The <= for max is intentional because we're checking representability
+    // of min/max, not looping or similar.
+    PERFETTO_DCHECK(min <= max);
+    return min >= std::numeric_limits<T>::min() &&
+           max <= std::numeric_limits<T>::max();
+  }
+
+  template <typename T>
+  static impl::FlexVector<T> DowncastFromInt64(
+      const impl::FlexVector<int64_t>& data) {
+    auto res = impl::FlexVector<T>::CreateWithSize(data.size());
+    for (uint32_t i = 0; i < data.size(); ++i) {
+      PERFETTO_DCHECK(IsRangeFullyRepresentableByType<T>(data[i], data[i]));
+      res[i] = static_cast<T>(data[i]);
+    }
+    return res;
+  }
+
+  static SortState GetSortStateForDouble(bool is_nullable,
+                                         const impl::FlexVector<double>& data) {
+    if (is_nullable) {
+      return SortState{Unsorted{}};
+    }
+    for (uint32_t i = 1; i < data.size(); ++i) {
+      if (data[i - 1] > data[i]) {
+        return SortState{Unsorted{}};
+      }
+    }
+    return SortState{Sorted{}};
+  }
+
+  static SortState GetStringSortState(
+      bool is_nullable,
+      const impl::FlexVector<StringPool::Id>& data,
+      StringPool* pool) {
+    if (is_nullable) {
+      return SortState{Unsorted{}};
+    }
+    if (!data.empty()) {
+      NullTermStringView prev = pool->Get(data[0]);
+      for (uint32_t i = 1; i < data.size(); ++i) {
+        NullTermStringView curr = pool->Get(data[i]);
+        if (prev > curr) {
+          return SortState{Unsorted{}};
+        }
+        prev = curr;
+      }
+    }
+    return SortState{Sorted{}};
+  }
+
+  static SortState GetIntegerSortStateFromProperties(bool is_nullable,
+                                                     bool is_id_sorted,
+                                                     bool is_setid_sorted,
+                                                     bool is_sorted) {
+    if (is_nullable) {
+      return SortState{Unsorted{}};
+    }
+    if (is_id_sorted) {
+      PERFETTO_DCHECK(is_setid_sorted);
+      PERFETTO_DCHECK(is_sorted);
+      return SortState{IdSorted{}};
+    }
+    if (is_setid_sorted) {
+      PERFETTO_DCHECK(is_sorted);
+      return SortState{SetIdSorted{}};
+    }
+    if (is_sorted) {
+      return SortState{Sorted{}};
+    }
+    return SortState{Unsorted{}};
+  }
+
+  StringPool* string_pool_;
+  uint32_t row_count_ = 0;
+  std::vector<std::string> column_names_;
+  std::vector<ColumnState> column_state_;
+  base::Status current_status_ = base::OkStatus();
+};
+
+}  // namespace perfetto::trace_processor::dataframe
+
+#endif  // SRC_TRACE_PROCESSOR_DATAFRAME_RUNTIME_DATAFRAME_BUILDER_H_

--- a/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
+++ b/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
@@ -1,0 +1,408 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/dataframe/runtime_dataframe_builder.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <limits>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/base/test/status_matchers.h"
+#include "src/trace_processor/containers/null_term_string_view.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/dataframe/cursor.h"
+#include "src/trace_processor/dataframe/dataframe.h"
+#include "src/trace_processor/dataframe/specs.h"
+#include "src/trace_processor/dataframe/value_fetcher.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::dataframe {
+
+inline void PrintTo(const Dataframe::ColumnSpec& spec, std::ostream* os) {
+  *os << "\n  ColumnSpec{\n"
+      << "    name: \"" << spec.name << "\",\n"
+      << "    type: " << spec.type.ToString() << ",\n"
+      << "    nullability: " << spec.nullability.ToString() << ",\n"
+      << "    sort_state: " << spec.sort_state.ToString() << "\n"
+      << "  }";
+}
+
+inline bool operator==(const Dataframe::ColumnSpec& lhs,
+                       const Dataframe::ColumnSpec& rhs) {
+  return lhs.name == rhs.name && lhs.type == rhs.type &&
+         lhs.nullability == rhs.nullability && lhs.sort_state == rhs.sort_state;
+}
+
+namespace {
+
+using testing::ElementsAre;
+using testing::ElementsAreArray;
+using testing::IsEmpty;
+using testing::SizeIs;
+
+struct TestRowFetcher : ValueFetcher {
+  using Value = std::variant<std::nullopt_t, int64_t, double, const char*>;
+  enum Type : uint8_t {
+    kNull,
+    kInt64,
+    kDouble,
+    kString,
+  };
+
+  void SetRow(const std::vector<Value>& row_data) { current_row_ = &row_data; }
+
+  Type GetValueType(uint32_t index) {
+    PERFETTO_CHECK(current_row_ && index < current_row_->size());
+    const auto& var = (*current_row_)[index];
+    if (std::holds_alternative<std::nullopt_t>(var))
+      return Type::kNull;
+    if (std::holds_alternative<int64_t>(var))
+      return Type::kInt64;
+    if (std::holds_alternative<double>(var))
+      return Type::kDouble;
+    if (std::holds_alternative<const char*>(var))
+      return Type::kString;
+    PERFETTO_FATAL("Invalid variant state");
+  }
+
+  int64_t GetInt64Value(uint32_t index) {
+    PERFETTO_CHECK(current_row_ && index < current_row_->size());
+    return std::get<int64_t>((*current_row_)[index]);
+  }
+
+  double GetDoubleValue(uint32_t index) {
+    PERFETTO_CHECK(current_row_ && index < current_row_->size());
+    return std::get<double>((*current_row_)[index]);
+  }
+
+  const char* GetStringValue(uint32_t index) {
+    PERFETTO_CHECK(current_row_ && index < current_row_->size());
+    return std::get<const char*>((*current_row_)[index]);
+  }
+
+ private:
+  const std::vector<Value>* current_row_ = nullptr;
+};
+
+// Callback for verifying cell values from the cursor.
+// Stores visited values in variants for later checking.
+struct ValueVerifier : CellCallback {
+  using ValueVariant = std::variant<uint32_t,
+                                    int32_t,
+                                    int64_t,
+                                    double,
+                                    NullTermStringView,
+                                    nullptr_t>;
+
+  void Fetch(Cursor<TestRowFetcher>* cursor, uint32_t col_count) {
+    for (uint32_t i = 0; i < col_count; ++i) {
+      cursor->Cell(i, *this);
+    }
+  }
+  void OnCell(int64_t value) { values.emplace_back(value); }
+  void OnCell(double value) { values.emplace_back(value); }
+  void OnCell(NullTermStringView value) { values.emplace_back(value); }
+  void OnCell(nullptr_t) { values.emplace_back(nullptr); }
+  void OnCell(int32_t value) { values.emplace_back(value); }
+  void OnCell(uint32_t value) { values.emplace_back(value); }
+
+  std::vector<ValueVariant> values;
+};
+
+class DataframeBuilderTest : public ::testing::Test {
+ protected:
+  base::StatusOr<Dataframe> BuildDf(
+      const std::vector<std::string>& names,
+      const std::vector<std::vector<TestRowFetcher::Value>>& rows) {
+    RuntimeDataframeBuilder builder(names, &pool_);
+    TestRowFetcher fetcher;
+    for (const auto& row_data : rows) {
+      fetcher.SetRow(row_data);
+      if (!builder.AddRow(&fetcher)) {
+        return builder.status();
+      }
+    }
+    return std::move(builder).Build();
+  }
+
+  static void VerifyData(
+      Dataframe& df,
+      uint64_t cols_bitmap,
+      const std::vector<std::vector<ValueVerifier::ValueVariant>>& expected) {
+    std::vector<FilterSpec> filter_specs;
+    auto num_cols_selected =
+        static_cast<uint32_t>(PERFETTO_POPCOUNT(cols_bitmap));
+    ASSERT_OK_AND_ASSIGN(auto plan, df.PlanQuery(filter_specs, cols_bitmap));
+
+    TestRowFetcher execute_fetcher;
+    std::optional<Cursor<TestRowFetcher>> cursor;
+    df.PrepareCursor(std::move(plan), cursor);
+    cursor->Execute(execute_fetcher);
+
+    size_t row_index = 0;
+    for (const auto& row : expected) {
+      ValueVerifier verifier;
+      ASSERT_FALSE(cursor->Eof())
+          << "Cursor finished early at row " << row_index;
+      verifier.Fetch(&cursor.value(), num_cols_selected);
+      EXPECT_THAT(verifier.values, ElementsAreArray(row))
+          << "Mismatch in data for row " << row_index;
+      cursor->Next();
+      row_index++;
+    }
+    ASSERT_TRUE(cursor->Eof())
+        << "Cursor has more rows than expected. Expected " << expected.size()
+        << " rows.";
+    ASSERT_EQ(row_index, expected.size())
+        << "Mismatch in number of rows processed.";
+  }
+
+  StringPool pool_;
+};
+
+template <typename... Args>
+std::vector<ValueVerifier::ValueVariant> Row(Args&&... args) {
+  return std::vector<ValueVerifier::ValueVariant>{
+      ValueVerifier::ValueVariant(std::forward<Args>(args))...};
+}
+
+template <typename... Args>
+std::vector<std::vector<ValueVerifier::ValueVariant>> Rows(Args&&... rows) {
+  return std::vector<std::vector<ValueVerifier::ValueVariant>>{
+      std::forward<Args>(rows)...};
+}
+
+// Test building an empty dataframe with no columns and no rows.
+TEST_F(DataframeBuilderTest, BuildEmpty) {
+  RuntimeDataframeBuilder builder({}, &pool_);
+  base::StatusOr<Dataframe> df = std::move(builder).Build();
+  ASSERT_OK(df.status());
+
+  std::vector<Dataframe::ColumnSpec> specs = df->CreateColumnSpecs();
+  ASSERT_THAT(specs, IsEmpty());
+}
+
+TEST_F(DataframeBuilderTest, AddSingleRowSimple) {
+  base::StatusOr<Dataframe> df = BuildDf({"int_col", "double_col", "str_col"},
+                                         {{int64_t{123}, 45.6, "hello"}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(
+      df->CreateColumnSpecs(),
+      ElementsAre(
+          Dataframe::ColumnSpec{"int_col", Uint32{}, NonNull{}, Sorted{}},
+          Dataframe::ColumnSpec{"double_col", Double{}, NonNull{}, Sorted{}},
+          Dataframe::ColumnSpec{"str_col", String{}, NonNull{}, Sorted{}}));
+  VerifyData(*df, 7,
+             Rows(Row(uint32_t{123}, 45.6, NullTermStringView{"hello"})));
+}
+
+TEST_F(DataframeBuilderTest, AddMultipleRowsConsistentTypes) {
+  base::StatusOr<Dataframe> df = BuildDf(
+      {"a", "b"}, {{int64_t{10}, "A"}, {int64_t{20}, "B"}, {int64_t{5}, "C"}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(
+      df->CreateColumnSpecs(),
+      ElementsAre(Dataframe::ColumnSpec{"a", Uint32{}, NonNull{}, Unsorted{}},
+                  Dataframe::ColumnSpec{"b", String{}, NonNull{}, Sorted{}}));
+  VerifyData(*df, 3,
+             Rows(Row(uint32_t{10}, NullTermStringView{"A"}),
+                  Row(uint32_t{20}, NullTermStringView{"B"}),
+                  Row(uint32_t{5}, NullTermStringView{"C"})));
+}
+
+TEST_F(DataframeBuilderTest, AddRowsWithNulls) {
+  base::StatusOr<Dataframe> df =
+      BuildDf({"nullable_int", "nullable_str", "non_null"},
+              {{int64_t{1}, std::nullopt, 1.1},
+               {std::nullopt, "A", 2.2},
+               {int64_t{3}, "B", 3.3},
+               {int64_t{2}, std::nullopt, 4.4}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"nullable_int", Uint32{},
+                                                SparseNull{}, Unsorted{}},
+                          Dataframe::ColumnSpec{"nullable_str", String{},
+                                                SparseNull{}, Unsorted{}},
+                          Dataframe::ColumnSpec{"non_null", Double{}, NonNull{},
+                                                Sorted{}}));
+  VerifyData(*df, 7,
+             Rows(Row(uint32_t{1}, nullptr, 1.1),
+                  Row(nullptr, NullTermStringView{"A"}, 2.2),
+                  Row(uint32_t{3}, NullTermStringView{"B"}, 3.3),
+                  Row(uint32_t{2}, nullptr, 4.4)));
+}
+
+TEST_F(DataframeBuilderTest, AddRowTypeMismatch) {
+  RuntimeDataframeBuilder builder({"col_a"}, &pool_);
+  TestRowFetcher fetcher;
+
+  // Add first row - infers type as Int64
+  std::vector<TestRowFetcher::Value> row1 = {{{int64_t{100}}}};
+  fetcher.SetRow(row1);
+  ASSERT_TRUE(builder.AddRow(&fetcher));
+  ASSERT_TRUE(builder.status().ok());
+
+  // Add second row - attempt to add a double to the int64 column
+  std::vector<TestRowFetcher::Value> row2 = {{{200.5}}};
+  fetcher.SetRow(row2);
+  ASSERT_FALSE(builder.AddRow(&fetcher));
+  ASSERT_FALSE(builder.status().ok());
+
+  // Optional: Check error message content
+  EXPECT_THAT(builder.status().message(),
+              testing::HasSubstr("Type mismatch in column 'col_a'"));
+  EXPECT_THAT(builder.status().message(),
+              testing::HasSubstr("Existing type != fetched type"));
+
+  // Attempting to build after an error should also fail
+  base::StatusOr<Dataframe> df_status = std::move(builder).Build();
+  ASSERT_FALSE(df_status.ok());
+  EXPECT_THAT(df_status.status().message(),
+              testing::HasSubstr("Type mismatch in column 'col_a'"));
+}
+
+TEST_F(DataframeBuilderTest, BuildIntegerDowncasting) {
+  base::StatusOr<Dataframe> df = BuildDf(
+      {"should_be_uint32", "should_be_int32", "should_be_int64"},
+      {{int64_t{0}, int64_t{-10}, int64_t{3'000'000'000LL}},
+       {int64_t{100}, int64_t{0}, int64_t{4'000'000'000LL}},
+       {int64_t{4'000'000'000LL}, int64_t{1'000'000'000}, int64_t{10LL}},
+       {int64_t{50}, int64_t{-2'000'000'000}, int64_t{-5'000'000'000LL}}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"should_be_uint32", Uint32{},
+                                                NonNull{}, Unsorted{}},
+                          Dataframe::ColumnSpec{"should_be_int32", Int32{},
+                                                NonNull{}, Unsorted{}},
+                          Dataframe::ColumnSpec{"should_be_int64", Int64{},
+                                                NonNull{}, Unsorted{}}));
+}
+
+TEST_F(DataframeBuilderTest, BuildIdColumn) {
+  base::StatusOr<Dataframe> df = BuildDf(
+      {"id_col"}, {{int64_t{0}}, {int64_t{1}}, {int64_t{2}}, {int64_t{3}}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"id_col", Id{}, NonNull{},
+                                                IdSorted{}}));
+  VerifyData(*df, 1,
+             Rows(Row(uint32_t{0}), Row(uint32_t{1}), Row(uint32_t{2}),
+                  Row(uint32_t{3})));
+}
+
+TEST_F(DataframeBuilderTest, BuildSetIdSortedColumn) {
+  base::StatusOr<Dataframe> df = BuildDf({"setid_col"}, {{int64_t{0}},
+                                                         {int64_t{0}},
+                                                         {int64_t{2}},
+                                                         {int64_t{2}},
+                                                         {int64_t{2}},
+                                                         {int64_t{5}},
+                                                         {int64_t{5}},
+                                                         {int64_t{7}}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"setid_col", Uint32{},
+                                                NonNull{}, SetIdSorted{}}));
+}
+
+TEST_F(DataframeBuilderTest, BuildSetIdSortedViolated) {
+  base::StatusOr<Dataframe> df =
+      BuildDf({"not_setid_col"},
+              {{int64_t{0}}, {int64_t{0}}, {int64_t{2}}, {int64_t{1}}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"not_setid_col", Uint32{},
+                                                NonNull{}, Unsorted{}}));
+}
+
+TEST_F(DataframeBuilderTest, InferTypeAfterNull) {
+  base::StatusOr<Dataframe> df =
+      BuildDf({"int_col", "str_col"}, {{std::nullopt, std::nullopt},
+                                       {int64_t{999}, "world"},
+                                       {int64_t{888}, std::nullopt}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"int_col", Uint32{},
+                                                SparseNull{}, Unsorted{}},
+                          Dataframe::ColumnSpec{"str_col", String{},
+                                                SparseNull{}, Unsorted{}}));
+}
+
+TEST_F(DataframeBuilderTest, BuildIntegerNoDowncast) {
+  int64_t int32_max = std::numeric_limits<int32_t>::max();
+  int64_t int32_min = std::numeric_limits<int32_t>::min();
+  int64_t uint32_max = std::numeric_limits<uint32_t>::max();
+
+  base::StatusOr<Dataframe> df =
+      BuildDf({"col_a", "col_b"}, {{int64_t{int32_max + 1}, std::nullopt},
+                                   {int64_t{uint32_max + 1}, std::nullopt},
+                                   {int64_t{int32_min - 1}, std::nullopt}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(
+      df->CreateColumnSpecs(),
+      ElementsAre(
+          Dataframe::ColumnSpec{"col_a", Int64{}, NonNull{}, Unsorted{}},
+          Dataframe::ColumnSpec{"col_b", Uint32{}, SparseNull{}, Unsorted{}}));
+}
+
+TEST_F(DataframeBuilderTest, BuildAllNullColumn) {
+  base::StatusOr<Dataframe> df =
+      BuildDf({"non_null_col", "all_null_col"}, {{int64_t{0}, std::nullopt},
+                                                 {int64_t{1}, std::nullopt},
+                                                 {int64_t{2}, std::nullopt}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"non_null_col", Id{}, NonNull{},
+                                                IdSorted{}},
+                          Dataframe::ColumnSpec{"all_null_col", Uint32{},
+                                                SparseNull{}, Unsorted{}}));
+}
+
+TEST_F(DataframeBuilderTest, BuildSortStateUnsortedAfterNull) {
+  base::StatusOr<Dataframe> df =
+      BuildDf({"sorted_then_null"},
+              {{int64_t{10}}, {int64_t{20}}, {std::nullopt}, {int64_t{30}}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"sorted_then_null", Uint32{},
+                                                SparseNull{}, Unsorted{}}));
+}
+
+TEST_F(DataframeBuilderTest, BuildEmptyColumn) {
+  base::StatusOr<Dataframe> df =
+      BuildDf({"populated_col", "empty_col"}, {{int64_t{10}, std::nullopt},
+                                               {int64_t{20}, std::nullopt},
+                                               {int64_t{30}, std::nullopt}});
+  ASSERT_OK(df.status());
+  ASSERT_THAT(df->CreateColumnSpecs(),
+              ElementsAre(Dataframe::ColumnSpec{"populated_col", Uint32{},
+                                                NonNull{}, Sorted{}},
+                          Dataframe::ColumnSpec{"empty_col", Uint32{},
+                                                SparseNull{}, Unsorted{}}));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::dataframe

--- a/src/trace_processor/dataframe/specs.h
+++ b/src/trace_processor/dataframe/specs.h
@@ -4,7 +4,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
-#include <string>
 
 #include "src/trace_processor/dataframe/type_set.h"
 
@@ -35,8 +34,8 @@ struct Double {};
 // Represents values where the value is a string.
 struct String {};
 
-// TypeSet of all possible column value types.
-using ColumnType = TypeSet<Id, Uint32, Int32, Int64, Double, String>;
+// TypeSet of all possible storage value types.
+using StorageType = TypeSet<Id, Uint32, Int32, Int64, Double, String>;
 
 // -----------------------------------------------------------------------------
 // Operation Types
@@ -141,25 +140,6 @@ struct FilterSpec {
   // Output parameter: index for the filter value in query execution.
   // This is populated during query planning.
   std::optional<uint32_t> value_index;
-};
-
-// -----------------------------------------------------------------------------
-// Column Specifications
-// -----------------------------------------------------------------------------
-
-// Describes the properties of a dataframe column.
-struct ColumnSpec {
-  // Column name.
-  std::string name;
-
-  // Type of content stored in the column.
-  ColumnType column_type;
-
-  // Sort order of the column data.
-  SortState sort_state;
-
-  // Whether the column can contain NULL values.
-  Nullability nullability;
 };
 
 }  // namespace perfetto::trace_processor::dataframe

--- a/src/trace_processor/dataframe/type_set.h
+++ b/src/trace_processor/dataframe/type_set.h
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <tuple>
 #include <type_traits>
 #include <variant>
@@ -130,6 +131,18 @@ class TypeSet {
     uint32_t idx = GetTypeIndexUnchecked<T>();
     PERFETTO_CHECK(idx != static_cast<uint32_t>(-1));
     return idx;
+  }
+
+  // Equality operator for TypeSet.
+  constexpr bool operator==(const TypeSet<Ts...>& other) const {
+    return type_idx_ == other.type_idx_;
+  }
+
+  // Returns a string representation of the TypeSet.
+  std::string ToString() const {
+    std::string result = "TypeSet";
+    result += "[" + std::to_string(type_idx_) + "]";
+    return result;
   }
 
   // Gets the type at the same index in a variant as T is in this TypeSet.

--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.h
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 #include "src/trace_processor/containers/null_term_string_view.h"
 #include "src/trace_processor/containers/string_pool.h"
@@ -78,8 +79,7 @@ struct DataframeModule : sqlite::Module<DataframeModule> {
   };
   using DfCursor = dataframe::Cursor<SqliteValueFetcher>;
   struct Cursor : sqlite::Module<DataframeModule>::Cursor {
-    DfCursor* df_cursor() { return reinterpret_cast<DfCursor*>(cursor); }
-    alignas(DfCursor) char cursor[sizeof(DfCursor)];
+    std::optional<DfCursor> df_cursor;
     const char* last_idx_str = nullptr;
   };
 


### PR DESCRIPTION
This CL adds a builder class for building dataframes where the schema of the
dataframe is not known upfront and should be inferred from the inserted
rows. We try and always be as memory efficient as possible and infer as many
properties (i.e. sorted/id etc) as we can.
