### PR TITLE
Add more options for button widget styling

### DIFF
--- a/ui/src/assets/widgets/button.scss
+++ b/ui/src/assets/widgets/button.scss
@@ -14,13 +14,34 @@
 
 @import "theme";
 
+@mixin filled-color-scheme($intent-color, $text-color) {
+  color: $text-color;
+  background: $intent-color;
+
+  &:hover {
+    background: lighten($intent-color, 5%);
+  }
+
+  &:active,
+  &.pf-active {
+    background: darken($intent-color, 5%);
+  }
+
+  &[disabled] {
+    &:hover {
+      background: $intent-color;
+    }
+
+    &.pf-active {
+      background: darken($intent-color, 5%);
+    }
+  }
+}
+
 .pf-button {
   font-family: $pf-font;
   line-height: 1;
   user-select: none;
-  transition:
-    background $pf-anim-timing,
-    box-shadow $pf-anim-timing;
   border-radius: $pf-border-radius;
   padding: 4px 8px;
   white-space: nowrap;
@@ -46,47 +67,6 @@
     @include focus;
   }
 
-  background: $pf-minimal-background;
-  color: inherit;
-
-  &:hover {
-    background: $pf-minimal-background-hover;
-  }
-
-  &:active,
-  &.pf-active {
-    background: $pf-minimal-background-active;
-  }
-
-  &[disabled] {
-    color: $pf-minimal-foreground-disabled;
-    background: $pf-minimal-background-disabled;
-    cursor: not-allowed;
-  }
-
-  // Remove default background in minimal mode, showing only the text
-  &.pf-intent-primary {
-    color: $pf-primary-foreground;
-    background: $pf-primary-background;
-
-    &:hover {
-      background: $pf-primary-background-hover;
-    }
-
-    &:active,
-    &.pf-active {
-      transition: none;
-      background: $pf-primary-background-active;
-      box-shadow: inset 1px 1px 4px #00000040;
-    }
-    &[disabled] {
-      background: $pf-primary-background-disabled;
-      color: $pf-primary-foreground-disabled;
-      box-shadow: none;
-      cursor: not-allowed;
-    }
-  }
-
   // Reduce padding when compact
   &.pf-compact {
     padding: 2px 4px;
@@ -109,6 +89,93 @@
 
     &.pf-compact {
       padding: 0;
+    }
+  }
+
+  &[disabled] {
+    filter: opacity(50%);
+    cursor: not-allowed;
+  }
+
+  // From here on in we just describe the colours
+  &--filled {
+    background: rgba(gray, 20%);
+
+    &:hover {
+      background: rgba(gray, 30%);
+    }
+
+    &.pf-active,
+    &:active {
+      background: rgba(gray, 40%);
+    }
+
+    &[disabled] {
+      &:hover {
+        background: rgba(gray, 20%); // Reset to the default background
+      }
+
+      &.pf-active {
+        background: rgba(gray, 40%);
+      }
+    }
+
+    &.pf-intent-primary {
+      @include filled-color-scheme($color-primary, white);
+    }
+
+    &.pf-intent-success {
+      @include filled-color-scheme($color-success, white);
+    }
+
+    &.pf-intent-danger {
+      @include filled-color-scheme($color-danger, white);
+    }
+
+    &.pf-intent-warning {
+      @include filled-color-scheme($color-warning, black);
+    }
+  }
+
+  &--outlined {
+    border: 1px solid color-mix(in srgb, currentColor 50%, transparent);
+  }
+
+  &--minimal,
+  &--outlined {
+    &:hover {
+      background: color-mix(in srgb, currentColor 10%, transparent);
+    }
+
+    &:active,
+    &.pf-active {
+      background: color-mix(in srgb, currentColor 20%, transparent);
+    }
+
+    &.pf-intent-primary {
+      color: $pf-primary-background;
+    }
+
+    &.pf-intent-success {
+      color: $color-success;
+    }
+
+    &.pf-intent-danger {
+      color: $color-danger;
+    }
+
+    &.pf-intent-warning {
+      color: $color-warning;
+    }
+
+    &[disabled] {
+      &:hover {
+        background: unset;
+      }
+
+      &.pf-active {
+        background: color-mix(in srgb, currentColor 20%, transparent);
+      }
     }
   }
 }

--- a/ui/src/assets/widgets/theme.scss
+++ b/ui/src/assets/widgets/theme.scss
@@ -42,6 +42,11 @@ $pf-minimal-background-hover: #0001;
 $pf-minimal-background-active: #0002;
 $pf-minimal-background-disabled: none;
 
+$color-primary: #3d5688;
+$color-danger: #912929;
+$color-success: #3c832b;
+$color-warning: #dca612;
+
 $pf-colour-thin-border: #aaa;
 
 @mixin focus {

--- a/ui/src/components/widgets/sql/table/filters.ts
+++ b/ui/src/components/widgets/sql/table/filters.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {Button, ButtonBar} from '../../../../widgets/button';
+import {Button, ButtonBar, ButtonVariant} from '../../../../widgets/button';
 import {Intent} from '../../../../widgets/common';
 import {isSqlColumnEqual, SqlColumn, sqlColumnId} from './sql_column';
 import {
@@ -120,6 +120,7 @@ export function renderFilters(filters: Filters): m.Children {
         label: filterTitle(filter),
         icon: 'close',
         intent: Intent.Primary,
+        variant: ButtonVariant.Filled,
         onclick: () => filters.removeFilter(filter),
       }),
     ),

--- a/ui/src/core_plugins/flags_page/plugins_page.ts
+++ b/ui/src/core_plugins/flags_page/plugins_page.ts
@@ -19,7 +19,7 @@ import {exists} from '../../base/utils';
 import {AppImpl} from '../../core/app_impl';
 import {PluginWrapper} from '../../core/plugin_manager';
 import {PageAttrs} from '../../public/page';
-import {Button, ButtonBar} from '../../widgets/button';
+import {Button, ButtonBar, ButtonVariant} from '../../widgets/button';
 import {Card, CardList} from '../../widgets/card';
 import {Chip} from '../../widgets/chip';
 import {Intent} from '../../widgets/common';
@@ -187,6 +187,7 @@ function reloadButton() {
     icon: 'refresh',
     label: 'Reload required',
     intent: Intent.Primary,
+    variant: ButtonVariant.Filled,
     title: 'Click here to reload the page',
     onclick: () => location.reload(),
   });

--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -21,7 +21,7 @@ import {getCurrentModalKey, showModal} from '../widgets/modal';
 import {globals} from './globals';
 import {AppImpl} from '../core/app_impl';
 import {Router} from '../core/router';
-import {Button} from '../widgets/button';
+import {Button, ButtonVariant} from '../widgets/button';
 import {Intent} from '../widgets/common';
 
 const MODAL_KEY = 'crash_modal';
@@ -226,6 +226,7 @@ class ErrorDialogComponent implements m.ClassComponent<ErrorDetails> {
         m(Button, {
           onclick: () => this.fileBug(err),
           intent: Intent.Primary,
+          variant: ButtonVariant.Filled,
           label: 'File a bug (Googlers only)',
         }),
       ),

--- a/ui/src/frontend/viewer_page/current_selection_tab.ts
+++ b/ui/src/frontend/viewer_page/current_selection_tab.ts
@@ -13,21 +13,21 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {raf} from '../../core/raf_scheduler';
-import {TraceImpl} from '../../core/trace_impl';
-import {DetailsShell} from '../../widgets/details_shell';
-import {EmptyState} from '../../widgets/empty_state';
-import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
-import {Section} from '../../widgets/section';
-import {Tree, TreeNode} from '../../widgets/tree';
+import { raf } from '../../core/raf_scheduler';
+import { TraceImpl } from '../../core/trace_impl';
+import { DetailsShell } from '../../widgets/details_shell';
+import { EmptyState } from '../../widgets/empty_state';
+import { GridLayout, GridLayoutColumn } from '../../widgets/grid_layout';
+import { Section } from '../../widgets/section';
+import { Tree, TreeNode } from '../../widgets/tree';
 import {
   AreaSelection,
   NoteSelection,
   TrackSelection,
 } from '../../public/selection';
-import {assertUnreachable} from '../../base/logging';
-import {Button, ButtonBar} from '../../widgets/button';
-import {NoteEditor} from '../note_editor';
+import { assertUnreachable } from '../../base/logging';
+import { Button, ButtonBar } from '../../widgets/button';
+import { NoteEditor } from '../note_editor';
 
 export interface CurrentSelectionTabAttrs {
   readonly trace: TraceImpl;

--- a/ui/src/frontend/viewer_page/notes_panel.ts
+++ b/ui/src/frontend/viewer_page/notes_panel.ts
@@ -13,26 +13,26 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {canvasClip} from '../../base/canvas_utils';
-import {currentTargetOffset, findRef} from '../../base/dom_utils';
-import {Size2D} from '../../base/geom';
-import {assertUnreachable} from '../../base/logging';
-import {Icons} from '../../base/semantic_icons';
-import {TimeScale} from '../../base/time_scale';
-import {randomColor} from '../../components/colorizer';
-import {raf} from '../../core/raf_scheduler';
-import {TraceImpl} from '../../core/trace_impl';
-import {Note, SpanNote} from '../../public/note';
-import {Button, ButtonBar} from '../../widgets/button';
-import {MenuDivider, MenuItem, PopupMenu} from '../../widgets/menu';
-import {Select} from '../../widgets/select';
-import {TRACK_SHELL_WIDTH} from '../css_constants';
-import {generateTicks, getMaxMajorTicks, TickType} from './gridline_helper';
-import {TextInput} from '../../widgets/text_input';
-import {Popup} from '../../widgets/popup';
-import {TrackNode, Workspace} from '../../public/workspace';
-import {AreaSelection, Selection} from '../../public/selection';
-import {MultiSelectOption, PopupMultiSelect} from '../../widgets/multiselect';
+import { canvasClip } from '../../base/canvas_utils';
+import { currentTargetOffset, findRef } from '../../base/dom_utils';
+import { Size2D } from '../../base/geom';
+import { assertUnreachable } from '../../base/logging';
+import { Icons } from '../../base/semantic_icons';
+import { TimeScale } from '../../base/time_scale';
+import { randomColor } from '../../components/colorizer';
+import { raf } from '../../core/raf_scheduler';
+import { TraceImpl } from '../../core/trace_impl';
+import { Note, SpanNote } from '../../public/note';
+import { Button, ButtonBar } from '../../widgets/button';
+import { MenuDivider, MenuItem, PopupMenu } from '../../widgets/menu';
+import { Select } from '../../widgets/select';
+import { TRACK_SHELL_WIDTH } from '../css_constants';
+import { generateTicks, getMaxMajorTicks, TickType } from './gridline_helper';
+import { TextInput } from '../../widgets/text_input';
+import { Popup } from '../../widgets/popup';
+import { TrackNode, Workspace } from '../../public/workspace';
+import { AreaSelection, Selection } from '../../public/selection';
+import { MultiSelectOption, PopupMultiSelect } from '../../widgets/multiselect';
 
 const FLAG_WIDTH = 16;
 const AREA_TRIANGLE_WIDTH = 10;

--- a/ui/src/frontend/viewer_page/track_tree_view.ts
+++ b/ui/src/frontend/viewer_page/track_tree_view.ts
@@ -62,7 +62,7 @@ import {TrackView} from './track_view';
 import {drawVerticalLineAtTime} from './vertical_line_helper';
 import {featureFlags} from '../../core/feature_flags';
 import {EmptyState} from '../../widgets/empty_state';
-import {Button} from '../../widgets/button';
+import {Button, ButtonVariant} from '../../widgets/button';
 import {Intent} from '../../widgets/common';
 
 const VIRTUAL_TRACK_SCROLLING = featureFlags.register({
@@ -222,6 +222,7 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
           },
           m(Button, {
             intent: Intent.Primary,
+            variant: ButtonVariant.Filled,
             label: 'Clear track filter',
             onclick: () => trace.tracks.filters.clearAll(),
           }),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -18,7 +18,7 @@ import SqlModulesPlugin from '../dev.perfetto.SqlModules';
 import {PageWithTraceAttrs} from '../../public/page';
 import {DataVisualiser} from './data_visualiser/data_visualiser';
 import {QueryBuilder} from './query_builder/builder';
-import {Button} from '../../widgets/button';
+import {Button, ButtonVariant} from '../../widgets/button';
 import {Intent} from '../../widgets/common';
 import {NodeType, QueryNode} from './query_node';
 import {MenuItem} from '../../widgets/menu';
@@ -159,6 +159,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
                     label: 'Add new node',
                     icon: Icons.Add,
                     intent: Intent.Primary,
+                    variant: ButtonVariant.Filled,
                   }),
                 },
                 addSourcePopupMenu(attrs),
@@ -166,6 +167,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
               m(Button, {
                 label: 'Clear All Query Nodes',
                 intent: Intent.Primary,
+                variant: ButtonVariant.Filled,
                 onclick: () => {
                   state.rootNodes = [];
                   state.selectedNode = undefined;
@@ -176,6 +178,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
           : m(Button, {
               label: 'Back to Query Builder',
               intent: Intent.Primary,
+              variant: ButtonVariant.Filled,
               onclick: () => {
                 state.mode = ExplorePageModes.QUERY_BUILDER;
               },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 
 import {PageWithTraceAttrs} from '../../../public/page';
-import {Button} from '../../../widgets/button';
+import {Button, ButtonVariant} from '../../../widgets/button';
 import {SqlModules, SqlTable} from '../../dev.perfetto.SqlModules/sql_modules';
 import {ColumnControllerRow} from './column_controller';
 import {QueryNode} from '../query_node';
@@ -105,6 +105,7 @@ export class QueryBuilder implements m.ClassComponent<QueryBuilderAttrs> {
                 trigger: m(Button, {
                   icon: Icons.Add,
                   intent: Intent.Primary,
+                  variant: ButtonVariant.Filled,
                   style: {
                     height: '100px',
                     width: '100px',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/sources/stdlib_table.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/sources/stdlib_table.ts
@@ -32,7 +32,7 @@ import {
 import protos from '../../../../protos';
 import {TextParagraph} from '../../../../widgets/text_paragraph';
 import {Trace} from '../../../../public/trace';
-import {Button} from '../../../../widgets/button';
+import {Button, ButtonVariant} from '../../../../widgets/button';
 import {closeModal} from '../../../../widgets/modal';
 import {
   createFiltersProto,
@@ -162,6 +162,7 @@ export class StdlibTableSource implements m.ClassComponent<StdlibTableAttrs> {
       m(Button, {
         label: attrs.sqlTable ? 'Change table' : 'Select table',
         intent: Intent.Primary,
+        variant: ButtonVariant.Filled,
         onclick: async () => {
           this.onTableSelect(attrs);
         },

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -32,7 +32,7 @@ import {
 } from '../../public/details_panel';
 import {Trace} from '../../public/trace';
 import {NUM} from '../../trace_processor/query_result';
-import {Button} from '../../widgets/button';
+import {Button, ButtonVariant} from '../../widgets/button';
 import {Intent} from '../../widgets/common';
 import {DetailsShell} from '../../widgets/details_shell';
 import {Icon} from '../../widgets/icon';
@@ -133,6 +133,7 @@ export class HeapProfileFlamegraphDetailsPanel
               m(Button, {
                 icon: 'file_download',
                 intent: Intent.Primary,
+                variant: ButtonVariant.Filled,
                 onclick: () => {
                   downloadPprof(this.trace, this.upid, ts);
                 },

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
@@ -18,7 +18,7 @@ import {SegmentedButtons} from '../../../widgets/segmented_buttons';
 import {TARGET_PLATFORMS} from '../interfaces/target_platform';
 import {RecordingTargetProvider} from '../interfaces/recording_target_provider';
 import {Icon} from '../../../widgets/icon';
-import {Button} from '../../../widgets/button';
+import {Button, ButtonBar, ButtonVariant} from '../../../widgets/button';
 import {Intent} from '../../../widgets/common';
 import {getOrCreate} from '../../../base/utils';
 import {PreflightCheckRenderer} from './preflight_check_renderer';
@@ -210,6 +210,7 @@ class TargetSelector implements m.ClassComponent<TargetSelectorAttrs> {
             label: 'Connect new device',
             icon: 'add',
             intent: Intent.Primary,
+            variant: ButtonVariant.Filled,
             onclick: async () => {
               const target = await attrs.provider.pairNewTarget!();
               target && recMgr.setTarget(target);
@@ -264,7 +265,7 @@ class SessionMgmtRenderer implements m.ClassComponent<SessionMgmtAttrs> {
     return [
       m('header', 'Tracing session'),
       m(
-        'div',
+        ButtonBar,
         m(Button, {
           label: 'Start tracing',
           icon: 'not_started',

--- a/ui/src/plugins/dev.perfetto.ThreadState/thread_state_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.ThreadState/thread_state_details_panel.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {Anchor} from '../../widgets/anchor';
-import {Button} from '../../widgets/button';
+import {Button, ButtonVariant} from '../../widgets/button';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
@@ -312,6 +312,7 @@ export class ThreadStateDetailsPanel implements TrackEventDetailsPanel {
         m(Button, {
           label: 'Critical path lite',
           intent: Intent.Primary,
+          variant: ButtonVariant.Filled,
           onclick: () => {
             this.trace.commands.runCommand(
               CRITICAL_PATH_LITE_CMD,

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -18,7 +18,7 @@ import {Hotkey, Platform} from '../../base/hotkeys';
 import {isString} from '../../base/object_utils';
 import {Icons} from '../../base/semantic_icons';
 import {Anchor} from '../../widgets/anchor';
-import {Button} from '../../widgets/button';
+import {Button, ButtonBar, ButtonVariant} from '../../widgets/button';
 import {Callout} from '../../widgets/callout';
 import {Checkbox} from '../../widgets/checkbox';
 import {Editor} from '../../widgets/editor';
@@ -310,7 +310,6 @@ function PortalButton() {
       return [
         m(Button, {
           label: 'Toggle Portal',
-          intent: Intent.Primary,
           onclick: () => {
             portalOpen = !portalOpen;
           },
@@ -674,14 +673,38 @@ export class WidgetsPage implements m.ClassComponent<PageAttrs> {
       m('h1', 'Widgets'),
       m(WidgetShowcase, {
         label: 'Button',
-        renderWidget: ({label, icon, rightIcon, ...rest}) =>
-          m(Button, {
-            icon: arg(icon, 'send'),
-            rightIcon: arg(rightIcon, 'arrow_forward'),
-            label: arg(label, 'Button', ''),
-            onclick: () => alert('button pressed'),
-            ...rest,
-          }),
+        renderWidget: ({label, icon, rightIcon, showAsGrid, ...rest}) =>
+          Boolean(showAsGrid)
+            ? m(
+                '',
+                {
+                  style: {
+                    display: 'grid',
+                    gridTemplateColumns: 'auto auto auto',
+                    gap: '4px',
+                  },
+                },
+                Object.values(Intent).map((intent) => {
+                  return Object.values(ButtonVariant).map((variant) => {
+                    return m(Button, {
+                      style: {
+                        width: '80px',
+                      },
+                      ...rest,
+                      label: variant,
+                      variant,
+                      intent,
+                    });
+                  });
+                }),
+              )
+            : m(Button, {
+                icon: arg(icon, 'send'),
+                rightIcon: arg(rightIcon, 'arrow_forward'),
+                label: arg(label, 'Button', ''),
+                onclick: () => alert('button pressed'),
+                ...rest,
+              }),
         initialOpts: {
           label: true,
           icon: true,
@@ -691,6 +714,11 @@ export class WidgetsPage implements m.ClassComponent<PageAttrs> {
           active: false,
           compact: false,
           loading: false,
+          variant: new EnumOption(
+            ButtonVariant.Filled,
+            Object.values(ButtonVariant),
+          ),
+          showAsGrid: false,
         },
       }),
       m(WidgetShowcase, {
@@ -1089,18 +1117,20 @@ export class WidgetsPage implements m.ClassComponent<PageAttrs> {
             {
               trigger: m(Button, {label: 'Open the popup'}),
             },
-            m(
-              PopupMenu,
-              {
-                trigger: m(Button, {label: 'Select an option'}),
-              },
-              m(MenuItem, {label: 'Option 1'}),
-              m(MenuItem, {label: 'Option 2'}),
-            ),
-            m(Button, {
-              label: 'Done',
-              dismissPopup: true,
-            }),
+            m(ButtonBar, [
+              m(
+                PopupMenu,
+                {
+                  trigger: m(Button, {label: 'Select an option'}),
+                },
+                m(MenuItem, {label: 'Option 1'}),
+                m(MenuItem, {label: 'Option 2'}),
+              ),
+              m(Button, {
+                label: 'Done',
+                dismissPopup: true,
+              }),
+            ]),
           ),
       }),
       m(WidgetShowcase, {
@@ -1539,7 +1569,6 @@ class ModalShowcase implements m.ClassComponent {
               '',
               `Counter value: ${counter}`,
               m(Button, {
-                intent: Intent.Primary,
                 label: 'Increment Counter',
                 onclick: () => ++counter,
               }),

--- a/ui/src/widgets/button.ts
+++ b/ui/src/widgets/button.ts
@@ -18,6 +18,13 @@ import {HTMLAttrs, HTMLButtonAttrs, Intent, classForIntent} from './common';
 import {Icon} from './icon';
 import {Popup} from './popup';
 import {Spinner} from './spinner';
+import {assertUnreachable} from '../base/logging';
+
+export enum ButtonVariant {
+  Filled = 'Filled',
+  Outlined = 'Outlined',
+  Minimal = 'Minimal',
+}
 
 interface CommonAttrs extends HTMLButtonAttrs {
   // Always show the button as if the "active" pseudo class were applied, which
@@ -42,9 +49,16 @@ interface CommonAttrs extends HTMLButtonAttrs {
   // Whether to use a filled icon
   // Defaults to false;
   iconFilled?: boolean;
-  // Indicate button colouring by intent.
+  // Indicate the intent of the button using color.
   // Defaults to undefined aka "None"
   intent?: Intent;
+  // Choose what style the button should have.
+  // - Filled: The button has a background - used for standalone buttons.
+  // - Text: The button has no visible background - used for when many buttons
+  //   appear together and styling on each one would be too visually busy e.g.
+  //   on toolbars.
+  // Defaults to Filled.
+  variant?: ButtonVariant;
 }
 
 interface IconButtonAttrs extends CommonAttrs {
@@ -72,16 +86,19 @@ export class Button implements m.ClassComponent<ButtonAttrs> {
       dismissPopup,
       iconFilled,
       intent = Intent.None,
+      variant = ButtonVariant.Minimal,
       ...htmlAttrs
     } = attrs;
 
     const label = 'label' in attrs ? attrs.label : undefined;
+    const iconOnly = Boolean(icon && !label);
 
     const classes = classNames(
       active && 'pf-active',
       compact && 'pf-compact',
+      classForVariant(variant),
       classForIntent(intent),
-      icon && !label && 'pf-icon-only',
+      iconOnly && 'pf-icon-only',
       dismissPopup && Popup.DISMISS_POPUP_GROUP_CLASS,
       className,
     );
@@ -113,6 +130,19 @@ export class Button implements m.ClassComponent<ButtonAttrs> {
     } else {
       return undefined;
     }
+  }
+}
+
+function classForVariant(variant: ButtonVariant) {
+  switch (variant) {
+    case ButtonVariant.Filled:
+      return 'pf-button--filled';
+    case ButtonVariant.Outlined:
+      return 'pf-button--outlined';
+    case ButtonVariant.Minimal:
+      return 'pf-button--minimal';
+    default:
+      assertUnreachable(variant);
   }
 }
 

--- a/ui/src/widgets/common.ts
+++ b/ui/src/widgets/common.ts
@@ -68,8 +68,11 @@ export interface HTMLLabelAttrs extends HTMLAttrs {
 }
 
 export enum Intent {
-  None = 'none',
-  Primary = 'primary',
+  None = 'None',
+  Primary = 'Primary',
+  Success = 'Success',
+  Danger = 'Danger',
+  Warning = 'Warning',
 }
 
 export function classForIntent(intent: Intent): string | undefined {
@@ -78,6 +81,12 @@ export function classForIntent(intent: Intent): string | undefined {
       return undefined;
     case Intent.Primary:
       return 'pf-intent-primary';
+    case Intent.Success:
+      return 'pf-intent-success';
+    case Intent.Danger:
+      return 'pf-intent-danger';
+    case Intent.Warning:
+      return 'pf-intent-warning';
     default:
       return assertUnreachable(intent);
   }

--- a/ui/src/widgets/form.ts
+++ b/ui/src/widgets/form.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {Button} from './button';
+import {Button, ButtonVariant} from './button';
 import {HTMLAttrs, HTMLLabelAttrs} from './common';
 import {Popup} from './popup';
 import {Intent} from '../widgets/common';
@@ -74,6 +74,7 @@ export class Form implements m.ClassComponent<FormAttrs> {
           rightIcon: submitIcon,
           className: Popup.DISMISS_POPUP_GROUP_CLASS,
           intent: Intent.Primary,
+          variant: ButtonVariant.Filled,
           onclick: (e: Event) => {
             preventDefault && e.preventDefault();
             onSubmit();
@@ -84,12 +85,14 @@ export class Form implements m.ClassComponent<FormAttrs> {
           m(Button, {
             type: 'button',
             label: cancelLabel,
+            variant: ButtonVariant.Filled,
             className: Popup.DISMISS_POPUP_GROUP_CLASS,
           }),
         // This reset button just clears the form.
         resetLabel &&
           m(Button, {
             label: resetLabel,
+            variant: ButtonVariant.Filled,
             type: 'reset',
           }),
       ),

--- a/ui/src/widgets/modal.ts
+++ b/ui/src/widgets/modal.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {defer} from '../base/deferred';
 import {Icon} from './icon';
-import {Button} from './button';
+import {Button, ButtonVariant} from './button';
 import {Intent} from './common';
 
 // This module deals with modal dialogs. Unlike most components, here we want to
@@ -129,6 +129,7 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
       buttons.push(
         m(Button, {
           intent: button.primary ? Intent.Primary : Intent.None,
+          variant: ButtonVariant.Filled,
           id: button.id,
           onclick: () => {
             closeModal(attrs.key);

--- a/ui/src/widgets/split_panel.ts
+++ b/ui/src/widgets/split_panel.ts
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {DisposableStack} from '../base/disposable_stack';
-import {toHTMLElement} from '../base/dom_utils';
-import {DragGestureHandler} from '../base/drag_gesture_handler';
-import {assertExists, assertUnreachable} from '../base/logging';
-import {Button, ButtonBar} from './button';
+import { DisposableStack } from '../base/disposable_stack';
+import { toHTMLElement } from '../base/dom_utils';
+import { DragGestureHandler } from '../base/drag_gesture_handler';
+import { assertExists, assertUnreachable } from '../base/logging';
+import { Button, ButtonBar } from './button';
 
 export enum SplitPanelDrawerVisibility {
   VISIBLE,

--- a/ui/src/widgets/track_shell.ts
+++ b/ui/src/widgets/track_shell.ts
@@ -21,7 +21,7 @@ import {assertExists} from '../base/logging';
 import {clamp} from '../base/math_utils';
 import {hasChildren, MithrilEvent} from '../base/mithril_utils';
 import {Icons} from '../base/semantic_icons';
-import {Button, ButtonBar} from './button';
+import {Button, ButtonBar, ButtonVariant} from './button';
 import {Chip, ChipBar} from './chip';
 import {HTMLAttrs, Intent} from './common';
 import {MiddleEllipsis} from './middle_ellipsis';
@@ -441,6 +441,7 @@ function renderCrashButton(error: Error, pluginId: string | undefined) {
       m(Button, {
         label: 'View & Report Crash',
         intent: Intent.Primary,
+        variant: ButtonVariant.Filled,
         className: Popup.DISMISS_POPUP_GROUP_CLASS,
         onclick: () => {
           throw error;


### PR DESCRIPTION
This change adds more variants for styling buttons. This change is aimed to ultimately help provide a better UX.

Buttons currently default to 'minimal' which styles the text the same color as the surrounding text, which makes them difficult to distinguish from the surrounding text.

This change adds the following variants and intents:

Variants (style):
- Filled
- Outlined
- Minimal

Intents (color):
- Primary
- Danger
- Success
- Warning

This change keeps the default variant as 'minimal', which matches what the vast majority of buttons are in the UI currently, as to not introduce too many changes in this change. However, folks should really prefer using 'filled' or 'outlined' in the future to improve UX.