### PR TITLE
Perfetto Android Java SDK: extract 'PerfettoTrackEventBuilder'.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16320,6 +16320,7 @@ android_library {
     name: "perfetto_trace_lib",
     srcs: [
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java",
     ],
     manifest: "src/android_sdk/java/main/AndroidManifest.xml",

--- a/BUILD
+++ b/BUILD
@@ -4471,6 +4471,7 @@ perfetto_android_library(
     name = "src_android_sdk_java_main_perfetto_trace_lib",
     srcs = [
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",
+        "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java",
     ],
     manifest = "src/android_sdk/java/main/AndroidManifest.xml",

--- a/src/android_sdk/java/main/BUILD.gn
+++ b/src/android_sdk/java/main/BUILD.gn
@@ -6,6 +6,7 @@ assert(enable_perfetto_android_java_sdk)
 perfetto_android_library("perfetto_trace_lib") {
   sources = [
     "dev/perfetto/sdk/PerfettoTrace.java",
+    "dev/perfetto/sdk/PerfettoTrackEventBuilder.java",
     "dev/perfetto/sdk/PerfettoTrackEventExtra.java",
   ]
   deps = [ "../../jni:libperfetto_jni" ]

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -38,7 +38,7 @@ public final class PerfettoTrace {
   private static final int PERFETTO_TE_TYPE_INSTANT = 3;
   private static final int PERFETTO_TE_TYPE_COUNTER = 4;
 
-  private static boolean isDebug = false;
+  private static boolean sIsDebug = false;
 
   static class NativeAllocationRegistry {
     public static NativeAllocationRegistry createMalloced(
@@ -198,7 +198,7 @@ public final class PerfettoTrace {
    * @param eventName The event name to appear in the trace.
    */
   public static PerfettoTrackEventBuilder instant(Category category, String eventName) {
-    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_INSTANT, category, isDebug)
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_INSTANT, category, sIsDebug)
         .setEventName(eventName);
   }
 
@@ -209,7 +209,7 @@ public final class PerfettoTrace {
    * @param eventName The event name to appear in the trace.
    */
   public static PerfettoTrackEventBuilder begin(Category category, String eventName) {
-    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_SLICE_BEGIN, category, isDebug)
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_SLICE_BEGIN, category, sIsDebug)
         .setEventName(eventName);
   }
 
@@ -219,7 +219,7 @@ public final class PerfettoTrace {
    * @param category The perfetto category.
    */
   public static PerfettoTrackEventBuilder end(Category category) {
-    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_SLICE_END, category, isDebug);
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_SLICE_END, category, sIsDebug);
   }
 
   /**
@@ -229,7 +229,7 @@ public final class PerfettoTrace {
    * @param value The value of the counter.
    */
   public static PerfettoTrackEventBuilder counter(Category category, long value) {
-    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_COUNTER, category, isDebug)
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_COUNTER, category, sIsDebug)
         .setCounter(value);
   }
 
@@ -251,7 +251,7 @@ public final class PerfettoTrace {
    * @param value The value of the counter.
    */
   public static PerfettoTrackEventBuilder counter(Category category, double value) {
-    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_COUNTER, category, isDebug)
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_COUNTER, category, sIsDebug)
         .setCounter(value);
   }
 
@@ -299,7 +299,7 @@ public final class PerfettoTrace {
 
   /** Registers the process with Perfetto and enable additional debug checks on the Java side. */
   public static void registerWithDebugChecks(boolean isBackendInProcess) {
-    isDebug = true;
+    sIsDebug = true;
     register(isBackendInProcess);
   }
 }

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -38,6 +38,8 @@ public final class PerfettoTrace {
   private static final int PERFETTO_TE_TYPE_INSTANT = 3;
   private static final int PERFETTO_TE_TYPE_COUNTER = 4;
 
+  private static boolean isDebug = false;
+
   static class NativeAllocationRegistry {
     public static NativeAllocationRegistry createMalloced(
         ClassLoader classLoader, long freeFunction) {
@@ -195,9 +197,8 @@ public final class PerfettoTrace {
    * @param category The perfetto category.
    * @param eventName The event name to appear in the trace.
    */
-  public static PerfettoTrackEventExtra.Builder instant(Category category, String eventName) {
-    return PerfettoTrackEventExtra.builder(category.isEnabled())
-        .init(PERFETTO_TE_TYPE_INSTANT, category)
+  public static PerfettoTrackEventBuilder instant(Category category, String eventName) {
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_INSTANT, category, isDebug)
         .setEventName(eventName);
   }
 
@@ -207,9 +208,8 @@ public final class PerfettoTrace {
    * @param category The perfetto category.
    * @param eventName The event name to appear in the trace.
    */
-  public static PerfettoTrackEventExtra.Builder begin(Category category, String eventName) {
-    return PerfettoTrackEventExtra.builder(category.isEnabled())
-        .init(PERFETTO_TE_TYPE_SLICE_BEGIN, category)
+  public static PerfettoTrackEventBuilder begin(Category category, String eventName) {
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_SLICE_BEGIN, category, isDebug)
         .setEventName(eventName);
   }
 
@@ -218,9 +218,8 @@ public final class PerfettoTrace {
    *
    * @param category The perfetto category.
    */
-  public static PerfettoTrackEventExtra.Builder end(Category category) {
-    return PerfettoTrackEventExtra.builder(category.isEnabled())
-        .init(PERFETTO_TE_TYPE_SLICE_END, category);
+  public static PerfettoTrackEventBuilder end(Category category) {
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_SLICE_END, category, isDebug);
   }
 
   /**
@@ -229,9 +228,8 @@ public final class PerfettoTrace {
    * @param category The perfetto category.
    * @param value The value of the counter.
    */
-  public static PerfettoTrackEventExtra.Builder counter(Category category, long value) {
-    return PerfettoTrackEventExtra.builder(category.isEnabled())
-        .init(PERFETTO_TE_TYPE_COUNTER, category)
+  public static PerfettoTrackEventBuilder counter(Category category, long value) {
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_COUNTER, category, isDebug)
         .setCounter(value);
   }
 
@@ -242,8 +240,7 @@ public final class PerfettoTrace {
    * @param value The value of the counter.
    * @param trackName The trackName for the event.
    */
-  public static PerfettoTrackEventExtra.Builder counter(
-      Category category, long value, String trackName) {
+  public static PerfettoTrackEventBuilder counter(Category category, long value, String trackName) {
     return counter(category, value).usingProcessCounterTrack(trackName);
   }
 
@@ -253,9 +250,8 @@ public final class PerfettoTrace {
    * @param category The perfetto category.
    * @param value The value of the counter.
    */
-  public static PerfettoTrackEventExtra.Builder counter(Category category, double value) {
-    return PerfettoTrackEventExtra.builder(category.isEnabled())
-        .init(PERFETTO_TE_TYPE_COUNTER, category)
+  public static PerfettoTrackEventBuilder counter(Category category, double value) {
+    return PerfettoTrackEventBuilder.newEvent(PERFETTO_TE_TYPE_COUNTER, category, isDebug)
         .setCounter(value);
   }
 
@@ -266,7 +262,7 @@ public final class PerfettoTrace {
    * @param value The value of the counter.
    * @param trackName The trackName for the event.
    */
-  public static PerfettoTrackEventExtra.Builder counter(
+  public static PerfettoTrackEventBuilder counter(
       Category category, double value, String trackName) {
     return counter(category, value).usingProcessCounterTrack(trackName);
   }
@@ -299,5 +295,11 @@ public final class PerfettoTrace {
   /** Registers the process with Perfetto. */
   public static void register(boolean isBackendInProcess) {
     native_register(isBackendInProcess);
+  }
+
+  /** Registers the process with Perfetto and enable additional debug checks on the Java side. */
+  public static void registerWithDebugChecks(boolean isBackendInProcess) {
+    isDebug = true;
+    register(isBackendInProcess);
   }
 }

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
@@ -160,14 +160,14 @@ public final class PerfettoTrackEventBuilder {
       return;
     }
     if (parent == null) {
-      // Crete a root builder, saved into thread-local variable.
+      // We are creating a root builder which will be saved in thread local storage.
       mParent = null;
       mChildBuildersCache = new Pool<>(DEFAULT_EXTRA_CACHE_SIZE);
       mObjectsPool = new ObjectsPool(DEFAULT_EXTRA_CACHE_SIZE);
       mObjectsCache = new ObjectsCache(DEFAULT_EXTRA_CACHE_SIZE);
       mLazyInitObjects = new LazyInitObjects();
     } else {
-      // Create a child builder for proto fields, read all cache fields from the parent.
+      // We are create a child builder for proto fields, read all cache fields from the parent.
       mParent = parent;
       readAllCacheFieldsFromParent(parent);
     }

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
@@ -1,0 +1,679 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.perfetto.sdk;
+
+import dev.perfetto.sdk.PerfettoTrace.Category;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.ArgBool;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.ArgDouble;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.ArgInt64;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.ArgString;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.CounterDouble;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.CounterInt64;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.CounterTrack;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.FieldContainer;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.FieldDouble;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.FieldInt64;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.FieldNested;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.FieldString;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.Flow;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.NamedTrack;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.PerfettoPointer;
+import dev.perfetto.sdk.PerfettoTrackEventExtra.Proto;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+/** Builder for Perfetto track event extras. */
+public final class PerfettoTrackEventBuilder {
+  private static final int DEFAULT_EXTRA_CACHE_SIZE = 5;
+
+  private PerfettoTrackEventExtra mExtra;
+
+  private int mTraceType = -1;
+  private Category mCategory = null;
+  private String mEventName = null;
+  private boolean mIsBuilt = false;
+  private boolean mIsDebug = false;
+
+  private PerfettoTrackEventBuilder mParent;
+  private FieldContainer mCurrentContainer;
+
+  private static final class ObjectsPool {
+    public final Pool<FieldInt64> mFieldInt64Pool;
+    public final Pool<FieldDouble> mFieldDoublePool;
+    public final Pool<FieldString> mFieldStringPool;
+    public final Pool<FieldNested> mFieldNestedPool;
+    public final Pool<Proto> mProtoPool;
+
+    public ObjectsPool(int capacity) {
+      mFieldInt64Pool = new Pool<>(capacity);
+      mFieldDoublePool = new Pool<>(capacity);
+      mFieldStringPool = new Pool<>(capacity);
+      mFieldNestedPool = new Pool<>(capacity);
+      mProtoPool = new Pool<>(capacity);
+    }
+
+    public void reset() {
+      mFieldInt64Pool.reset();
+      mFieldDoublePool.reset();
+      mFieldStringPool.reset();
+      mFieldNestedPool.reset();
+      mProtoPool.reset();
+    }
+  }
+
+  private static final class ObjectsCache {
+    public final RingBuffer<NamedTrack> mNamedTrackCache;
+    public final RingBuffer<CounterTrack> mCounterTrackCache;
+    public final RingBuffer<ArgInt64> mArgInt64Cache;
+    public final RingBuffer<ArgBool> mArgBoolCache;
+    public final RingBuffer<ArgDouble> mArgDoubleCache;
+    public final RingBuffer<ArgString> mArgStringCache;
+
+    public ObjectsCache(int capacity) {
+      mNamedTrackCache = new RingBuffer<>(capacity);
+      mCounterTrackCache = new RingBuffer<>(capacity);
+      mArgInt64Cache = new RingBuffer<>(capacity);
+      mArgBoolCache = new RingBuffer<>(capacity);
+      mArgDoubleCache = new RingBuffer<>(capacity);
+      mArgStringCache = new RingBuffer<>(capacity);
+    }
+  }
+
+  private static final class LazyInitObjects {
+    private CounterInt64 mCounterInt64 = null;
+    private CounterDouble mCounterDouble = null;
+    private Flow mFlow = null;
+    private Flow mTerminatingFlow = null;
+
+    public CounterInt64 getCounterInt64() {
+      if (mCounterInt64 == null) {
+        mCounterInt64 = new CounterInt64();
+      }
+      return mCounterInt64;
+    }
+
+    public CounterDouble getCounterDouble() {
+      if (mCounterDouble == null) {
+        mCounterDouble = new CounterDouble();
+      }
+      return mCounterDouble;
+    }
+
+    public Flow getFlow() {
+      if (mFlow == null) {
+        mFlow = new Flow();
+      }
+      return mFlow;
+    }
+
+    public Flow getTerminatingFlow() {
+      if (mTerminatingFlow == null) {
+        mTerminatingFlow = new Flow();
+      }
+      return mTerminatingFlow;
+    }
+  }
+
+  private Pool<PerfettoTrackEventBuilder> mChildBuildersCache;
+  private ObjectsPool mObjectsPool;
+  private ObjectsCache mObjectsCache;
+  private LazyInitObjects mLazyInitObjects;
+
+  private final boolean mIsCategoryEnabled;
+
+  private List<PerfettoPointer> mPendingPointers;
+
+  private static final PerfettoTrackEventBuilder NO_OP_BUILDER =
+      new PerfettoTrackEventBuilder(/* isCategoryEnabled= */ false, /* parent= */ null);
+
+  public static final ThreadLocal<PerfettoTrackEventBuilder> sThreadLocalBuilder =
+      ThreadLocal.withInitial(
+          () -> new PerfettoTrackEventBuilder(/* isCategoryEnabled= */ true, /* parent= */ null));
+
+  public static PerfettoTrackEventBuilder newEvent(
+      int traceType, Category category, boolean isDebug) {
+    if (category.isEnabled()) {
+      return sThreadLocalBuilder.get().initNewEvent(traceType, category, isDebug);
+    }
+    return NO_OP_BUILDER;
+  }
+
+  private PerfettoTrackEventBuilder(boolean isCategoryEnabled, PerfettoTrackEventBuilder parent) {
+    mIsCategoryEnabled = isCategoryEnabled;
+    if (!mIsCategoryEnabled) {
+      // No fields of this builder will be used, no need to initialize them.
+      return;
+    }
+    if (parent == null) {
+      // Crete a root builder, saved into thread-local variable.
+      mParent = null;
+      mChildBuildersCache = new Pool<>(DEFAULT_EXTRA_CACHE_SIZE);
+      mObjectsPool = new ObjectsPool(DEFAULT_EXTRA_CACHE_SIZE);
+      mObjectsCache = new ObjectsCache(DEFAULT_EXTRA_CACHE_SIZE);
+      mLazyInitObjects = new LazyInitObjects();
+    } else {
+      // Create a child builder for proto fields, read all cache fields from the parent.
+      mParent = parent;
+      readAllCacheFieldsFromParent(parent);
+    }
+
+    mExtra = new PerfettoTrackEventExtra();
+    mPendingPointers = new ArrayList<>();
+  }
+
+  /** Emits the track event. */
+  public void emit() {
+    if (!mIsCategoryEnabled) {
+      return;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+
+    mIsBuilt = true;
+    PerfettoTrackEventExtra.native_emit(
+        mTraceType, mCategory.getPtr(), mEventName, mExtra.getPtr());
+  }
+
+  /** Initialize the builder for a new trace event. */
+  private PerfettoTrackEventBuilder initNewEvent(
+      int traceType, Category category, boolean isDebug) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    mIsBuilt = false;
+    mParent = null;
+    mIsDebug = isDebug;
+    mTraceType = traceType;
+    mCategory = category;
+    mEventName = "";
+
+    mExtra.reset();
+    mChildBuildersCache.reset();
+    mObjectsPool.reset();
+    mPendingPointers.clear();
+    mCurrentContainer = null;
+
+    return this;
+  }
+
+  private PerfettoTrackEventBuilder initChildBuilderForProto(
+      PerfettoTrackEventBuilder parent, FieldContainer fieldContainer) {
+    mIsBuilt = false;
+    mParent = parent;
+    mIsDebug = parent.mIsDebug;
+
+    readAllCacheFieldsFromParent(parent);
+
+    mCurrentContainer = fieldContainer;
+    return this;
+  }
+
+  private void readAllCacheFieldsFromParent(PerfettoTrackEventBuilder parent) {
+    mChildBuildersCache = parent.mChildBuildersCache;
+    mObjectsPool = parent.mObjectsPool;
+    mObjectsCache = parent.mObjectsCache;
+    mLazyInitObjects = parent.mLazyInitObjects;
+  }
+
+  /** Sets the event name for the track event. */
+  public PerfettoTrackEventBuilder setEventName(String eventName) {
+    mEventName = eventName;
+    return this;
+  }
+
+  /** Adds a debug arg with key {@code name} and value {@code val}. */
+  public PerfettoTrackEventBuilder addArg(String name, long val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    ArgInt64 arg = mObjectsCache.mArgInt64Cache.get(name.hashCode());
+    if (arg == null || !arg.getName().equals(name)) {
+      arg = new ArgInt64(name);
+      mObjectsCache.mArgInt64Cache.put(name.hashCode(), arg);
+    }
+    arg.setValue(val);
+    addPerfettoPointerToExtra(arg);
+    return this;
+  }
+
+  /** Adds a debug arg with key {@code name} and value {@code val}. */
+  public PerfettoTrackEventBuilder addArg(String name, boolean val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    ArgBool arg = mObjectsCache.mArgBoolCache.get(name.hashCode());
+    if (arg == null || !arg.getName().equals(name)) {
+      arg = new ArgBool(name);
+      mObjectsCache.mArgBoolCache.put(name.hashCode(), arg);
+    }
+    arg.setValue(val);
+    addPerfettoPointerToExtra(arg);
+    return this;
+  }
+
+  /** Adds a debug arg with key {@code name} and value {@code val}. */
+  public PerfettoTrackEventBuilder addArg(String name, double val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    ArgDouble arg = mObjectsCache.mArgDoubleCache.get(name.hashCode());
+    if (arg == null || !arg.getName().equals(name)) {
+      arg = new ArgDouble(name);
+      mObjectsCache.mArgDoubleCache.put(name.hashCode(), arg);
+    }
+    arg.setValue(val);
+    addPerfettoPointerToExtra(arg);
+    return this;
+  }
+
+  /** Adds a debug arg with key {@code name} and value {@code val}. */
+  public PerfettoTrackEventBuilder addArg(String name, String val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    ArgString arg = mObjectsCache.mArgStringCache.get(name.hashCode());
+    if (arg == null || !arg.getName().equals(name)) {
+      arg = new ArgString(name);
+      mObjectsCache.mArgStringCache.put(name.hashCode(), arg);
+    }
+    arg.setValue(val);
+    addPerfettoPointerToExtra(arg);
+    return this;
+  }
+
+  /** Adds a flow with {@code id}. */
+  public PerfettoTrackEventBuilder setFlow(long id) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    Flow flow = mLazyInitObjects.getFlow();
+    flow.setProcessFlow(id);
+    addPerfettoPointerToExtra(flow);
+    return this;
+  }
+
+  /** Adds a terminating flow with {@code id}. */
+  public PerfettoTrackEventBuilder setTerminatingFlow(long id) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    Flow terminatingFlow = mLazyInitObjects.getTerminatingFlow();
+    terminatingFlow.setProcessTerminatingFlow(id);
+    addPerfettoPointerToExtra(terminatingFlow);
+    return this;
+  }
+
+  /** Adds the events to a named track instead of the thread track where the event occurred. */
+  public PerfettoTrackEventBuilder usingNamedTrack(long parentUuid, String name) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+
+    NamedTrack track = mObjectsCache.mNamedTrackCache.get(name.hashCode());
+    if (track == null || !track.getName().equals(name)) {
+      track = new NamedTrack(name, parentUuid);
+      mObjectsCache.mNamedTrackCache.put(name.hashCode(), track);
+    }
+    addPerfettoPointerToExtra(track);
+    return this;
+  }
+
+  /**
+   * Adds the events to a process scoped named track instead of the thread track where the event
+   * occurred.
+   */
+  public PerfettoTrackEventBuilder usingProcessNamedTrack(String name) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    return usingNamedTrack(PerfettoTrace.getProcessTrackUuid(), name);
+  }
+
+  /**
+   * Adds the events to a thread scoped named track instead of the thread track where the event
+   * occurred.
+   */
+  public PerfettoTrackEventBuilder usingThreadNamedTrack(long tid, String name) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    return usingNamedTrack(PerfettoTrace.getThreadTrackUuid(tid), name);
+  }
+
+  /** Adds the events to a counter track instead. This is required for setting counter values. */
+  public PerfettoTrackEventBuilder usingCounterTrack(long parentUuid, String name) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+
+    CounterTrack track = mObjectsCache.mCounterTrackCache.get(name.hashCode());
+    if (track == null || !track.getName().equals(name)) {
+      track = new CounterTrack(name, parentUuid);
+      mObjectsCache.mCounterTrackCache.put(name.hashCode(), track);
+    }
+    addPerfettoPointerToExtra(track);
+    return this;
+  }
+
+  /**
+   * Adds the events to a process scoped counter track instead. This is required for setting counter
+   * values.
+   */
+  public PerfettoTrackEventBuilder usingProcessCounterTrack(String name) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    return usingCounterTrack(PerfettoTrace.getProcessTrackUuid(), name);
+  }
+
+  /**
+   * Adds the events to a thread scoped counter track instead. This is required for setting counter
+   * values.
+   */
+  public PerfettoTrackEventBuilder usingThreadCounterTrack(long tid, String name) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    return usingCounterTrack(PerfettoTrace.getThreadTrackUuid(tid), name);
+  }
+
+  /** Sets a long counter value on the event. */
+  public PerfettoTrackEventBuilder setCounter(long val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    CounterInt64 counterInt64 = mLazyInitObjects.getCounterInt64();
+    counterInt64.setValue(val);
+    addPerfettoPointerToExtra(counterInt64);
+    return this;
+  }
+
+  /** Sets a double counter value on the event. */
+  public PerfettoTrackEventBuilder setCounter(double val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+
+    CounterDouble counterDouble = mLazyInitObjects.getCounterDouble();
+    counterDouble.setValue(val);
+    addPerfettoPointerToExtra(counterDouble);
+    return this;
+  }
+
+  /** Adds a proto field with field id {@code id} and value {@code val}. */
+  public PerfettoTrackEventBuilder addField(long id, long val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkBuildingProto();
+    }
+    FieldInt64 field = mObjectsPool.mFieldInt64Pool.get(FieldInt64::new);
+    field.setValue(id, val);
+    addFieldToContainer(field);
+    return this;
+  }
+
+  /** Adds a proto field with field id {@code id} and value {@code val}. */
+  public PerfettoTrackEventBuilder addField(long id, double val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkBuildingProto();
+    }
+    FieldDouble field = mObjectsPool.mFieldDoublePool.get(FieldDouble::new);
+    field.setValue(id, val);
+    addFieldToContainer(field);
+    return this;
+  }
+
+  /** Adds a proto field with field id {@code id} and value {@code val}. */
+  public PerfettoTrackEventBuilder addField(long id, String val) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkBuildingProto();
+    }
+    FieldString field = mObjectsPool.mFieldStringPool.get(FieldString::new);
+    field.setValue(id, val);
+    addFieldToContainer(field);
+    return this;
+  }
+
+  /**
+   * Begins a proto field. Fields can be added from this point and there must be a corresponding
+   * {@link #endProto}.
+   *
+   * <p>The proto field is a singleton and all proto fields get added inside the one {@code
+   * beginProto} and {@code endProto} within the {@link PerfettoTrackEventBuilder}.
+   */
+  public PerfettoTrackEventBuilder beginProto() {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkNotBuildingProto();
+    }
+    Proto proto = mObjectsPool.mProtoPool.get(Proto::new);
+    proto.clearFields();
+    addPerfettoPointerToExtra(proto);
+    return mChildBuildersCache
+        .get(() -> new PerfettoTrackEventBuilder(true, this))
+        .initChildBuilderForProto(this, proto);
+  }
+
+  /** Ends a proto field. */
+  public PerfettoTrackEventBuilder endProto() {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkMatchingBeginProto();
+    }
+    return mParent;
+  }
+
+  /**
+   * Begins a nested proto field with field id {@code id}. Fields can be added from this point and
+   * there must be a corresponding {@link #endNested}.
+   */
+  public PerfettoTrackEventBuilder beginNested(long id) {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+    if (mIsDebug) {
+      checkBuildingProto();
+    }
+    FieldNested field = mObjectsPool.mFieldNestedPool.get(FieldNested::new);
+    field.setId(id);
+    addFieldToContainer(field);
+    return mChildBuildersCache
+        .get(() -> new PerfettoTrackEventBuilder(true, this))
+        .initChildBuilderForProto(this, field);
+  }
+
+  /** Ends a nested proto field. */
+  public PerfettoTrackEventBuilder endNested() {
+    if (!mIsCategoryEnabled) {
+      return this;
+    }
+
+    if (mIsDebug) {
+      checkMatchingBeginNested();
+    }
+
+    return mParent;
+  }
+
+  private void addFieldToContainer(PerfettoPointer field) {
+    // Keep reference to the java object, `mCurrentContainer` uses a native part of the field
+    // object.
+    mPendingPointers.add(field);
+    mCurrentContainer.addField(field);
+  }
+
+  private void addPerfettoPointerToExtra(PerfettoPointer arg) {
+    // Keep reference to the java object, `mCurrentContainer` uses a native part of the field
+    // object.
+    mPendingPointers.add(arg);
+    mExtra.addPerfettoPointer(arg);
+  }
+
+  /**
+   * RingBuffer implemented on top of a SparseArray.
+   *
+   * <p>Bounds a SparseArray with a FIFO algorithm.
+   */
+  private static final class RingBuffer<T> {
+    private final int mCapacity;
+    private final int[] mKeyArray;
+    private final T[] mValueArray;
+    private int mWriteEnd = 0;
+
+    RingBuffer(int capacity) {
+      mCapacity = capacity;
+      mKeyArray = new int[capacity];
+      mValueArray = (T[]) new Object[capacity];
+    }
+
+    public void put(int key, T value) {
+      mKeyArray[mWriteEnd] = key;
+      mValueArray[mWriteEnd] = value;
+      mWriteEnd = (mWriteEnd + 1) % mCapacity;
+    }
+
+    public T get(int key) {
+      for (int i = 0; i < mCapacity; i++) {
+        if (mKeyArray[i] == key) {
+          return mValueArray[i];
+        }
+      }
+      return null;
+    }
+  }
+
+  private static final class Pool<T> {
+    private final int mCapacity;
+    private final T[] mValueArray;
+    private int mIdx = 0;
+
+    Pool(int capacity) {
+      mCapacity = capacity;
+      mValueArray = (T[]) new Object[capacity];
+    }
+
+    public void reset() {
+      mIdx = 0;
+    }
+
+    public T get(Supplier<T> supplier) {
+      if (mIdx >= mCapacity) {
+        return supplier.get();
+      }
+      if (mValueArray[mIdx] == null) {
+        mValueArray[mIdx] = supplier.get();
+      }
+      return mValueArray[mIdx++];
+    }
+  }
+
+  private void checkState() {
+    if (mIsBuilt) {
+      throw new IllegalStateException(
+          "This builder has already been used. Create a new builder for another event.");
+    }
+  }
+
+  private boolean isBuildingTopLevelExtra() {
+    return mParent == null && mCurrentContainer == null;
+  }
+
+  private boolean isBuildingProto() {
+    return (mParent != null && mParent.isBuildingTopLevelExtra()) && mCurrentContainer != null;
+  }
+
+  private boolean isBuildingNestedProto() {
+    return (mParent != null && (mParent.isBuildingProtoOrNestedProto()))
+        && mCurrentContainer != null;
+  }
+
+  private boolean isBuildingProtoOrNestedProto() {
+    return isBuildingProto() || isBuildingNestedProto();
+  }
+
+  private void checkNotBuildingProto() {
+    checkState();
+    if (isBuildingProtoOrNestedProto()) {
+      throw new IllegalStateException("Operation not supported for proto.");
+    }
+  }
+
+  private void checkBuildingProto() {
+    checkState();
+    if (isBuildingTopLevelExtra()) {
+      throw new IllegalStateException("Field operations must be within beginProto/endProto block.");
+    }
+  }
+
+  private void checkMatchingBeginNested() {
+    checkState();
+    if (!isBuildingNestedProto()) {
+      throw new IllegalStateException("No matching beginNested call.");
+    }
+  }
+
+  private void checkMatchingBeginProto() {
+    checkState();
+    if (!isBuildingProto()) {
+      throw new IllegalStateException("No matching beginProto call.");
+    }
+  }
+}

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
@@ -18,42 +18,15 @@ package dev.perfetto.sdk;
 
 import dalvik.annotation.optimization.CriticalNative;
 import dalvik.annotation.optimization.FastNative;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
 
 /**
  * Holds extras to be passed to Perfetto track events in {@link PerfettoTrace}.
  *
  * @hide
  */
-public final class PerfettoTrackEventExtra {
-  private static final boolean DEBUG = false;
-  private static final int DEFAULT_EXTRA_CACHE_SIZE = 5;
-  private static final Builder NO_OP_BUILDER =
-      new Builder(/* extra= */ null, /* isCategoryEnabled= */ false);
-  private static final ThreadLocal<PerfettoTrackEventExtra> sTrackEventExtra =
-      new ThreadLocal<PerfettoTrackEventExtra>() {
-        @Override
-        protected PerfettoTrackEventExtra initialValue() {
-          return new PerfettoTrackEventExtra();
-        }
-      };
+final class PerfettoTrackEventExtra {
   private static final AtomicLong sNamedTrackId = new AtomicLong();
-  private static final Supplier<Flow> sFlowSupplier = Flow::new;
-  private static final Supplier<Builder> sBuilderSupplier = Builder::new;
-  private static final Supplier<FieldInt64> sFieldInt64Supplier = FieldInt64::new;
-  private static final Supplier<FieldDouble> sFieldDoubleSupplier = FieldDouble::new;
-  private static final Supplier<FieldString> sFieldStringSupplier = FieldString::new;
-  private static final Supplier<FieldNested> sFieldNestedSupplier = FieldNested::new;
-
-  private final List<PerfettoPointer> mPendingPointers = new ArrayList<>();
-  private CounterInt64 mCounterInt64;
-  private CounterDouble mCounterDouble;
-  private Proto mProto;
-  private Flow mFlow;
-  private Flow mTerminatingFlow;
 
   static class NativeAllocationRegistry {
     public static NativeAllocationRegistry createMalloced(
@@ -67,542 +40,13 @@ public final class PerfettoTrackEventExtra {
     }
   }
 
-  /** Represents a native pointer to a Perfetto C SDK struct. E.g. PerfettoTeHlExtra. */
-  public interface PerfettoPointer {
-    /** Returns the perfetto struct native pointer. */
-    long getPtr();
-  }
-
-  /** Container for {@link Field} instances. */
-  public interface FieldContainer {
-    /** Add {@link Field} to the container. */
-    void addField(PerfettoPointer field);
-  }
-
-  /**
-   * RingBuffer implemented on top of a SparseArray.
-   *
-   * <p>Bounds a SparseArray with a FIFO algorithm.
-   */
-  private static final class RingBuffer<T> {
-    private final int mCapacity;
-    private final int[] mKeyArray;
-    private final T[] mValueArray;
-    private int mWriteEnd = 0;
-
-    RingBuffer(int capacity) {
-      mCapacity = capacity;
-      mKeyArray = new int[capacity];
-      mValueArray = (T[]) new Object[capacity];
-    }
-
-    public void put(int key, T value) {
-      mKeyArray[mWriteEnd] = key;
-      mValueArray[mWriteEnd] = value;
-      mWriteEnd = (mWriteEnd + 1) % mCapacity;
-    }
-
-    public T get(int key) {
-      for (int i = 0; i < mCapacity; i++) {
-        if (mKeyArray[i] == key) {
-          return mValueArray[i];
-        }
-      }
-      return null;
-    }
-  }
-
-  private static final class Pool<T> {
-    private final int mCapacity;
-    private final T[] mValueArray;
-    private int mIdx = 0;
-
-    Pool(int capacity) {
-      mCapacity = capacity;
-      mValueArray = (T[]) new Object[capacity];
-    }
-
-    public void reset() {
-      mIdx = 0;
-    }
-
-    public T get(Supplier<T> supplier) {
-      if (mIdx >= mCapacity) {
-        return supplier.get();
-      }
-      if (mValueArray[mIdx] == null) {
-        mValueArray[mIdx] = supplier.get();
-      }
-      return mValueArray[mIdx++];
-    }
-  }
-
-  /** Builder for Perfetto track event extras. */
-  public static final class Builder {
-    // For performance reasons, we hold a reference to mExtra as a holder for
-    // perfetto pointers being added. This way, we avoid an additional list to hold
-    // the pointers in Java and we can pass them down directly to native code.
-    private final PerfettoTrackEventExtra mExtra;
-
-    private int mTraceType;
-    private PerfettoTrace.Category mCategory;
-    private String mEventName;
-    private boolean mIsBuilt;
-
-    private Builder mParent;
-    private FieldContainer mCurrentContainer;
-
-    private final boolean mIsCategoryEnabled;
-    private final CounterInt64 mCounterInt64;
-    private final CounterDouble mCounterDouble;
-    private final Proto mProto;
-    private final Flow mFlow;
-    private final Flow mTerminatingFlow;
-
-    private final RingBuffer<NamedTrack> mNamedTrackCache;
-    private final RingBuffer<CounterTrack> mCounterTrackCache;
-    private final RingBuffer<ArgInt64> mArgInt64Cache;
-    private final RingBuffer<ArgBool> mArgBoolCache;
-    private final RingBuffer<ArgDouble> mArgDoubleCache;
-    private final RingBuffer<ArgString> mArgStringCache;
-
-    private final Pool<FieldInt64> mFieldInt64Cache;
-    private final Pool<FieldDouble> mFieldDoubleCache;
-    private final Pool<FieldString> mFieldStringCache;
-    private final Pool<FieldNested> mFieldNestedCache;
-    private final Pool<Builder> mBuilderCache;
-
-    private Builder() {
-      this(sTrackEventExtra.get(), true);
-    }
-
-    public Builder(PerfettoTrackEventExtra extra, boolean isCategoryEnabled) {
-      mIsCategoryEnabled = isCategoryEnabled;
-      mExtra = extra;
-      mNamedTrackCache = mExtra == null ? null : mExtra.mNamedTrackCache;
-      mCounterTrackCache = mExtra == null ? null : mExtra.mCounterTrackCache;
-      mArgInt64Cache = mExtra == null ? null : mExtra.mArgInt64Cache;
-      mArgDoubleCache = mExtra == null ? null : mExtra.mArgDoubleCache;
-      mArgBoolCache = mExtra == null ? null : mExtra.mArgBoolCache;
-      mArgStringCache = mExtra == null ? null : mExtra.mArgStringCache;
-      mFieldInt64Cache = mExtra == null ? null : mExtra.mFieldInt64Cache;
-      mFieldDoubleCache = mExtra == null ? null : mExtra.mFieldDoubleCache;
-      mFieldStringCache = mExtra == null ? null : mExtra.mFieldStringCache;
-      mFieldNestedCache = mExtra == null ? null : mExtra.mFieldNestedCache;
-      mBuilderCache = mExtra == null ? null : mExtra.mBuilderCache;
-
-      mCounterInt64 = mExtra == null ? null : mExtra.getCounterInt64();
-      mCounterDouble = mExtra == null ? null : mExtra.getCounterDouble();
-      mProto = mExtra == null ? null : mExtra.getProto();
-      mFlow = mExtra == null ? null : mExtra.getFlow();
-      mTerminatingFlow = mExtra == null ? null : mExtra.getTerminatingFlow();
-    }
-
-    /** Emits the track event. */
-    public void emit() {
-      if (!mIsCategoryEnabled) {
-        return;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-
-      mIsBuilt = true;
-      native_emit(mTraceType, mCategory.getPtr(), mEventName, mExtra.getPtr());
-    }
-
-    /** Initialize the builder for a new trace event. */
-    public Builder init(int traceType, PerfettoTrace.Category category) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-
-      mTraceType = traceType;
-      mCategory = category;
-      mEventName = "";
-      mFieldInt64Cache.reset();
-      mFieldDoubleCache.reset();
-      mFieldStringCache.reset();
-      mFieldNestedCache.reset();
-      mBuilderCache.reset();
-
-      mExtra.reset();
-      // Reset after on init in case the thread created builders without calling emit
-      return initInternal(this, null);
-    }
-
-    /** Sets the event name for the track event. */
-    public Builder setEventName(String eventName) {
-      mEventName = eventName;
-      return this;
-    }
-
-    /** Adds a debug arg with key {@code name} and value {@code val}. */
-    public Builder addArg(String name, long val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      ArgInt64 arg = mArgInt64Cache.get(name.hashCode());
-      if (arg == null || !arg.getName().equals(name)) {
-        arg = new ArgInt64(name);
-        mArgInt64Cache.put(name.hashCode(), arg);
-      }
-      arg.setValue(val);
-      mExtra.addPerfettoPointer(arg);
-      return this;
-    }
-
-    /** Adds a debug arg with key {@code name} and value {@code val}. */
-    public Builder addArg(String name, boolean val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      ArgBool arg = mArgBoolCache.get(name.hashCode());
-      if (arg == null || !arg.getName().equals(name)) {
-        arg = new ArgBool(name);
-        mArgBoolCache.put(name.hashCode(), arg);
-      }
-      arg.setValue(val);
-      mExtra.addPerfettoPointer(arg);
-      return this;
-    }
-
-    /** Adds a debug arg with key {@code name} and value {@code val}. */
-    public Builder addArg(String name, double val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      ArgDouble arg = mArgDoubleCache.get(name.hashCode());
-      if (arg == null || !arg.getName().equals(name)) {
-        arg = new ArgDouble(name);
-        mArgDoubleCache.put(name.hashCode(), arg);
-      }
-      arg.setValue(val);
-      mExtra.addPerfettoPointer(arg);
-      return this;
-    }
-
-    /** Adds a debug arg with key {@code name} and value {@code val}. */
-    public Builder addArg(String name, String val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      ArgString arg = mArgStringCache.get(name.hashCode());
-      if (arg == null || !arg.getName().equals(name)) {
-        arg = new ArgString(name);
-        mArgStringCache.put(name.hashCode(), arg);
-      }
-      arg.setValue(val);
-      mExtra.addPerfettoPointer(arg);
-      return this;
-    }
-
-    /** Adds a flow with {@code id}. */
-    public Builder setFlow(long id) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      mFlow.setProcessFlow(id);
-      mExtra.addPerfettoPointer(mFlow);
-      return this;
-    }
-
-    /** Adds a terminating flow with {@code id}. */
-    public Builder setTerminatingFlow(long id) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      mTerminatingFlow.setProcessTerminatingFlow(id);
-      mExtra.addPerfettoPointer(mTerminatingFlow);
-      return this;
-    }
-
-    /** Adds the events to a named track instead of the thread track where the event occurred. */
-    public Builder usingNamedTrack(long parentUuid, String name) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-
-      NamedTrack track = mNamedTrackCache.get(name.hashCode());
-      if (track == null || !track.getName().equals(name)) {
-        track = new NamedTrack(name, parentUuid);
-        mNamedTrackCache.put(name.hashCode(), track);
-      }
-      mExtra.addPerfettoPointer(track);
-      return this;
-    }
-
-    /**
-     * Adds the events to a process scoped named track instead of the thread track where the event
-     * occurred.
-     */
-    public Builder usingProcessNamedTrack(String name) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      return usingNamedTrack(PerfettoTrace.getProcessTrackUuid(), name);
-    }
-
-    /**
-     * Adds the events to a thread scoped named track instead of the thread track where the event
-     * occurred.
-     */
-    public Builder usingThreadNamedTrack(long tid, String name) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      return usingNamedTrack(PerfettoTrace.getThreadTrackUuid(tid), name);
-    }
-
-    /** Adds the events to a counter track instead. This is required for setting counter values. */
-    public Builder usingCounterTrack(long parentUuid, String name) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-
-      CounterTrack track = mCounterTrackCache.get(name.hashCode());
-      if (track == null || !track.getName().equals(name)) {
-        track = new CounterTrack(name, parentUuid);
-        mCounterTrackCache.put(name.hashCode(), track);
-      }
-      mExtra.addPerfettoPointer(track);
-      return this;
-    }
-
-    /**
-     * Adds the events to a process scoped counter track instead. This is required for setting
-     * counter values.
-     */
-    public Builder usingProcessCounterTrack(String name) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      return usingCounterTrack(PerfettoTrace.getProcessTrackUuid(), name);
-    }
-
-    /**
-     * Adds the events to a thread scoped counter track instead. This is required for setting
-     * counter values.
-     */
-    public Builder usingThreadCounterTrack(long tid, String name) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      return usingCounterTrack(PerfettoTrace.getThreadTrackUuid(tid), name);
-    }
-
-    /** Sets a long counter value on the event. */
-    public Builder setCounter(long val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      mCounterInt64.setValue(val);
-      mExtra.addPerfettoPointer(mCounterInt64);
-      return this;
-    }
-
-    /** Sets a double counter value on the event. */
-    public Builder setCounter(double val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      mCounterDouble.setValue(val);
-      mExtra.addPerfettoPointer(mCounterDouble);
-      return this;
-    }
-
-    /** Adds a proto field with field id {@code id} and value {@code val}. */
-    public Builder addField(long id, long val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkContainer();
-      }
-      FieldInt64 field = mFieldInt64Cache.get(sFieldInt64Supplier);
-      field.setValue(id, val);
-      mExtra.addPerfettoPointer(mCurrentContainer, field);
-      return this;
-    }
-
-    /** Adds a proto field with field id {@code id} and value {@code val}. */
-    public Builder addField(long id, double val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkContainer();
-      }
-      FieldDouble field = mFieldDoubleCache.get(sFieldDoubleSupplier);
-      field.setValue(id, val);
-      mExtra.addPerfettoPointer(mCurrentContainer, field);
-      return this;
-    }
-
-    /** Adds a proto field with field id {@code id} and value {@code val}. */
-    public Builder addField(long id, String val) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkContainer();
-      }
-      FieldString field = mFieldStringCache.get(sFieldStringSupplier);
-      field.setValue(id, val);
-      mExtra.addPerfettoPointer(mCurrentContainer, field);
-      return this;
-    }
-
-    /**
-     * Begins a proto field. Fields can be added from this point and there must be a corresponding
-     * {@link endProto}.
-     *
-     * <p>The proto field is a singleton and all proto fields get added inside the one {@link
-     * beginProto} and {@link endProto} within the {@link Builder}.
-     */
-    public Builder beginProto() {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkParent();
-      }
-      mProto.clearFields();
-      mExtra.addPerfettoPointer(mProto);
-      return mBuilderCache.get(sBuilderSupplier).initInternal(this, mProto);
-    }
-
-    /** Ends a proto field. */
-    public Builder endProto() {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (mParent == null || mCurrentContainer == null) {
-        throw new IllegalStateException("No proto to end");
-      }
-      return mParent;
-    }
-
-    /**
-     * Begins a nested proto field with field id {@code id}. Fields can be added from this point and
-     * there must be a corresponding {@link endNested}.
-     */
-    public Builder beginNested(long id) {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (DEBUG) {
-        checkContainer();
-      }
-      FieldNested field = mFieldNestedCache.get(sFieldNestedSupplier);
-      field.setId(id);
-      mExtra.addPerfettoPointer(mCurrentContainer, field);
-      return mBuilderCache.get(sBuilderSupplier).initInternal(this, field);
-    }
-
-    /** Ends a nested proto field. */
-    public Builder endNested() {
-      if (!mIsCategoryEnabled) {
-        return this;
-      }
-      if (mParent == null || mCurrentContainer == null) {
-        throw new IllegalStateException("No nested field to end");
-      }
-      return mParent;
-    }
-
-    private Builder initInternal(Builder parent, FieldContainer field) {
-      mParent = parent;
-      mCurrentContainer = field;
-      mIsBuilt = false;
-
-      return this;
-    }
-
-    private void checkState() {
-      if (mIsBuilt) {
-        throw new IllegalStateException(
-            "This builder has already been used. Create a new builder for another event.");
-      }
-    }
-
-    private void checkParent() {
-      checkState();
-      if (!this.equals(mParent)) {
-        throw new IllegalStateException("Operation not supported for proto");
-      }
-    }
-
-    private void checkContainer() {
-      checkState();
-      if (mCurrentContainer == null) {
-        throw new IllegalStateException(
-            "Field operations must be within beginProto/endProto block");
-      }
-    }
-  }
-
-  /** Start a {@link Builder} to build a {@link PerfettoTrackEventExtra}. */
-  public static Builder builder(boolean isCategoryEnabled) {
-    if (isCategoryEnabled) {
-      return sTrackEventExtra.get().mBuilderCache.get(sBuilderSupplier).initInternal(null, null);
-    }
-    return NO_OP_BUILDER;
-  }
-
-  private final RingBuffer<NamedTrack> mNamedTrackCache = new RingBuffer(DEFAULT_EXTRA_CACHE_SIZE);
-  private final RingBuffer<CounterTrack> mCounterTrackCache =
-      new RingBuffer(DEFAULT_EXTRA_CACHE_SIZE);
-
-  private final RingBuffer<ArgInt64> mArgInt64Cache = new RingBuffer(DEFAULT_EXTRA_CACHE_SIZE);
-  private final RingBuffer<ArgBool> mArgBoolCache = new RingBuffer(DEFAULT_EXTRA_CACHE_SIZE);
-  private final RingBuffer<ArgDouble> mArgDoubleCache = new RingBuffer(DEFAULT_EXTRA_CACHE_SIZE);
-  private final RingBuffer<ArgString> mArgStringCache = new RingBuffer(DEFAULT_EXTRA_CACHE_SIZE);
-
-  private final Pool<FieldInt64> mFieldInt64Cache = new Pool(DEFAULT_EXTRA_CACHE_SIZE);
-  private final Pool<FieldDouble> mFieldDoubleCache = new Pool(DEFAULT_EXTRA_CACHE_SIZE);
-  private final Pool<FieldString> mFieldStringCache = new Pool(DEFAULT_EXTRA_CACHE_SIZE);
-  private final Pool<FieldNested> mFieldNestedCache = new Pool(DEFAULT_EXTRA_CACHE_SIZE);
-  private final Pool<Builder> mBuilderCache = new Pool(DEFAULT_EXTRA_CACHE_SIZE);
-
   private static final NativeAllocationRegistry sRegistry =
       NativeAllocationRegistry.createMalloced(
           PerfettoTrackEventExtra.class.getClassLoader(), native_delete());
 
   private final long mPtr;
-  private static final String TAG = "PerfettoTrackEventExtra";
 
-  private PerfettoTrackEventExtra() {
+  PerfettoTrackEventExtra() {
     mPtr = native_init();
   }
 
@@ -614,57 +58,41 @@ public final class PerfettoTrackEventExtra {
   /** Adds a pointer representing a track event parameter. */
   public void addPerfettoPointer(PerfettoPointer extra) {
     native_add_arg(mPtr, extra.getPtr());
-    mPendingPointers.add(extra);
-  }
-
-  /** Adds a pointer representing a track event parameter to the {@code container}. */
-  public void addPerfettoPointer(FieldContainer container, PerfettoPointer extra) {
-    container.addField(extra);
-    mPendingPointers.add(extra);
   }
 
   /** Resets the track event extra. */
   public void reset() {
     native_clear_args(mPtr);
-    mPendingPointers.clear();
   }
 
-  private CounterInt64 getCounterInt64() {
-    if (mCounterInt64 == null) {
-      mCounterInt64 = new CounterInt64();
-    }
-    return mCounterInt64;
+  @CriticalNative
+  private static native long native_init();
+
+  @CriticalNative
+  private static native long native_delete();
+
+  @CriticalNative
+  private static native void native_add_arg(long ptr, long extraPtr);
+
+  @CriticalNative
+  private static native void native_clear_args(long ptr);
+
+  @FastNative
+  public static native void native_emit(int type, long tag, String name, long ptr);
+
+  /** Represents a native pointer to a Perfetto C SDK struct. E.g. PerfettoTeHlExtra. */
+  interface PerfettoPointer {
+    /** Returns the perfetto struct native pointer. */
+    long getPtr();
   }
 
-  private CounterDouble getCounterDouble() {
-    if (mCounterDouble == null) {
-      mCounterDouble = new CounterDouble();
-    }
-    return mCounterDouble;
+  /** Container for {@link Field} instances. */
+  interface FieldContainer {
+    /** Add {@link Field} to the container. */
+    void addField(PerfettoPointer field);
   }
 
-  private Proto getProto() {
-    if (mProto == null) {
-      mProto = new Proto();
-    }
-    return mProto;
-  }
-
-  private Flow getFlow() {
-    if (mFlow == null) {
-      mFlow = new Flow();
-    }
-    return mFlow;
-  }
-
-  private Flow getTerminatingFlow() {
-    if (mTerminatingFlow == null) {
-      mTerminatingFlow = new Flow();
-    }
-    return mTerminatingFlow;
-  }
-
-  private static final class Flow implements PerfettoPointer {
+  static final class Flow implements PerfettoPointer {
     private final long mPtr;
     private final long mExtraPtr;
 
@@ -703,7 +131,7 @@ public final class PerfettoTrackEventExtra {
     private static native long native_get_extra_ptr(long ptr);
   }
 
-  private static class NamedTrack implements PerfettoPointer {
+  static final class NamedTrack implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(NamedTrack.class.getClassLoader(), native_delete());
 
@@ -737,7 +165,7 @@ public final class PerfettoTrackEventExtra {
     private static native long native_get_extra_ptr(long ptr);
   }
 
-  private static final class CounterTrack implements PerfettoPointer {
+  static final class CounterTrack implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(
             CounterTrack.class.getClassLoader(), native_delete());
@@ -772,7 +200,7 @@ public final class PerfettoTrackEventExtra {
     private static native long native_get_extra_ptr(long ptr);
   }
 
-  private static final class CounterInt64 implements PerfettoPointer {
+  static final class CounterInt64 implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(
             CounterInt64.class.getClassLoader(), native_delete());
@@ -808,7 +236,7 @@ public final class PerfettoTrackEventExtra {
     private static native long native_get_extra_ptr(long ptr);
   }
 
-  private static final class CounterDouble implements PerfettoPointer {
+  static final class CounterDouble implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(
             CounterDouble.class.getClassLoader(), native_delete());
@@ -844,7 +272,7 @@ public final class PerfettoTrackEventExtra {
     private static native long native_get_extra_ptr(long ptr);
   }
 
-  private static final class ArgInt64 implements PerfettoPointer {
+  static final class ArgInt64 implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(ArgInt64.class.getClassLoader(), native_delete());
 
@@ -889,7 +317,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_set_value(long ptr, long val);
   }
 
-  private static final class ArgBool implements PerfettoPointer {
+  static final class ArgBool implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(ArgBool.class.getClassLoader(), native_delete());
 
@@ -934,7 +362,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_set_value(long ptr, boolean val);
   }
 
-  private static final class ArgDouble implements PerfettoPointer {
+  static final class ArgDouble implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(ArgDouble.class.getClassLoader(), native_delete());
 
@@ -979,7 +407,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_set_value(long ptr, double val);
   }
 
-  private static final class ArgString implements PerfettoPointer {
+  static final class ArgString implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(ArgString.class.getClassLoader(), native_delete());
 
@@ -1024,7 +452,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_set_value(long ptr, String val);
   }
 
-  private static final class Proto implements PerfettoPointer, FieldContainer {
+  static final class Proto implements PerfettoPointer, FieldContainer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(Proto.class.getClassLoader(), native_delete());
 
@@ -1070,7 +498,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_clear_fields(long ptr);
   }
 
-  private static final class FieldInt64 implements PerfettoPointer {
+  static final class FieldInt64 implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(FieldInt64.class.getClassLoader(), native_delete());
 
@@ -1108,7 +536,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_set_value(long ptr, long id, long val);
   }
 
-  private static final class FieldDouble implements PerfettoPointer {
+  static final class FieldDouble implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(
             FieldDouble.class.getClassLoader(), native_delete());
@@ -1147,7 +575,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_set_value(long ptr, long id, double val);
   }
 
-  private static final class FieldString implements PerfettoPointer {
+  static final class FieldString implements PerfettoPointer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(
             FieldString.class.getClassLoader(), native_delete());
@@ -1186,7 +614,7 @@ public final class PerfettoTrackEventExtra {
     private static native void native_set_value(long ptr, long id, String val);
   }
 
-  private static final class FieldNested implements PerfettoPointer, FieldContainer {
+  static final class FieldNested implements PerfettoPointer, FieldContainer {
     private static final NativeAllocationRegistry sRegistry =
         NativeAllocationRegistry.createMalloced(
             FieldNested.class.getClassLoader(), native_delete());
@@ -1232,19 +660,4 @@ public final class PerfettoTrackEventExtra {
     @CriticalNative
     private static native void native_set_id(long ptr, long id);
   }
-
-  @CriticalNative
-  private static native long native_init();
-
-  @CriticalNative
-  private static native long native_delete();
-
-  @CriticalNative
-  private static native void native_add_arg(long ptr, long extraPtr);
-
-  @CriticalNative
-  private static native void native_clear_args(long ptr);
-
-  @FastNative
-  private static native void native_emit(int type, long tag, String name, long ptr);
 }

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -76,7 +76,7 @@ public class PerfettoTraceTest {
 
   @Before
   public void setUp() {
-    PerfettoTrace.register(true);
+    PerfettoTrace.registerWithDebugChecks(true);
     // 'var unused' suppress error-prone warning
     var unused = FOO_CATEGORY.register();
 


### PR DESCRIPTION
We decouple the event builder from the native object wrappers, that simplifies the code and allows us to enable the debug asserts in builder at runtime.

Tested:
```
tools/bazel test //:src_android_sdk_java_test_perfetto_trace_instrumentation_test
```