### PR TITLE
Fix docs of InstrumentsXmlTokenizer regarding input XML

### DIFF
--- a/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
+++ b/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
@@ -59,11 +59,12 @@ std::string MakeTrimmed(const char* chars, int len) {
 //   xctrace export --input /path/to/profile.trace --xpath
 //     '//trace-toc/run/data/table[@schema="os-signpost and
 //        @category="PointsOfInterest"] |
-//      //trace-toc/run/data/table[@schema="time-sample"]'
+//      //trace-toc/run/data/table[@schema="cpu-profile"]'
 //
 // This exports two tables:
 //   1. Points of interest signposts
-//   2. Time samples
+//   2. CPU profile
+// You can also use time-profile instead of cpu-profile if needed.
 //
 // The first is used for clock synchronization -- perfetto emits signpost events
 // during tracing which allow synchronization of the xctrace clock (relative to


### PR DESCRIPTION
The tool expects an input XML that includes the cpu-profile or time-profile schemas. Not time-sample.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
