### PR TITLE
Detect, ignore, and log weird results from SuspendControlService.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -581,6 +581,7 @@ cc_library_shared {
         ":perfetto_src_ipc_common",
         ":perfetto_src_ipc_host",
         ":perfetto_src_kallsyms_kallsyms",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_protozero_filtering_bytecode_common",
         ":perfetto_src_protozero_filtering_bytecode_parser",
@@ -1763,6 +1764,7 @@ cc_library_static {
         ":perfetto_src_ipc_host",
         ":perfetto_src_ipc_perfetto_ipc",
         ":perfetto_src_kallsyms_kallsyms",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_protozero_filtering_bytecode_common",
         ":perfetto_src_protozero_filtering_bytecode_generator",
@@ -2078,6 +2080,7 @@ cc_library_static {
         ":perfetto_src_ipc_host",
         ":perfetto_src_ipc_perfetto_ipc",
         ":perfetto_src_kallsyms_kallsyms",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_protozero_filtering_bytecode_common",
         ":perfetto_src_protozero_filtering_bytecode_parser",
@@ -2650,6 +2653,7 @@ cc_test {
         ":perfetto_src_ipc_host",
         ":perfetto_src_ipc_perfetto_ipc",
         ":perfetto_src_kallsyms_kallsyms",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_perfetto_cmd_bugreport_path",
         ":perfetto_src_profiling_common_callstack_trie",
@@ -12082,6 +12086,11 @@ filegroup {
     ],
 }
 
+// GN: //src/kernel_utils:kernel_wakelock_errors
+filegroup {
+    name: "perfetto_src_kernel_utils_kernel_wakelock_errors",
+}
+
 // GN: //src/kernel_utils:syscall_table
 filegroup {
     name: "perfetto_src_kernel_utils_syscall_table",
@@ -16640,6 +16649,7 @@ cc_test {
         ":perfetto_src_ipc_unittests",
         ":perfetto_src_kallsyms_kallsyms",
         ":perfetto_src_kallsyms_unittests",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_kernel_utils_unittests",
         ":perfetto_src_perfetto_cmd_bugreport_path",
@@ -17203,6 +17213,7 @@ cc_library_static {
         ":perfetto_src_ipc_host",
         ":perfetto_src_ipc_perfetto_ipc",
         ":perfetto_src_kallsyms_kallsyms",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_protozero_filtering_bytecode_common",
         ":perfetto_src_protozero_filtering_bytecode_parser",
@@ -17528,6 +17539,7 @@ cc_binary {
         ":perfetto_src_base_http_http",
         ":perfetto_src_base_unix_socket",
         ":perfetto_src_base_version",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_profiling_deobfuscator",
         ":perfetto_src_profiling_symbolizer_symbolize_database",
@@ -17974,6 +17986,7 @@ cc_binary_host {
         ":perfetto_src_base_base",
         ":perfetto_src_base_clock_snapshots",
         ":perfetto_src_base_version",
+        ":perfetto_src_kernel_utils_kernel_wakelock_errors",
         ":perfetto_src_kernel_utils_syscall_table",
         ":perfetto_src_profiling_deobfuscator",
         ":perfetto_src_profiling_symbolizer_symbolize_database",

--- a/BUILD
+++ b/BUILD
@@ -325,6 +325,7 @@ perfetto_cc_binary(
 perfetto_cc_library(
     name = "trace_processor_rpc",
     srcs = [
+        ":src_kernel_utils_kernel_wakelock_errors",
         ":src_kernel_utils_syscall_table",
         ":src_protozero_proto_ring_buffer",
         ":src_protozero_text_to_proto_text_to_proto",
@@ -685,6 +686,7 @@ perfetto_cc_library(
             ":src_android_internal_headers",
             ":src_android_internal_lazy_library_loader",
             ":src_kallsyms_kallsyms",
+            ":src_kernel_utils_kernel_wakelock_errors",
             ":src_kernel_utils_syscall_table",
             ":src_protozero_proto_ring_buffer",
             ":src_traced_probes_android_game_intervention_list_android_game_intervention_list",
@@ -1425,6 +1427,14 @@ perfetto_filegroup(
         "src/kallsyms/kernel_symbol_map.h",
         "src/kallsyms/lazy_kernel_symbolizer.cc",
         "src/kallsyms/lazy_kernel_symbolizer.h",
+    ],
+)
+
+# GN target: //src/kernel_utils:kernel_wakelock_errors
+perfetto_filegroup(
+    name = "src_kernel_utils_kernel_wakelock_errors",
+    srcs = [
+        "src/kernel_utils/kernel_wakelock_errors.h",
     ],
 )
 
@@ -7250,6 +7260,7 @@ perfetto_cc_binary(
 perfetto_cc_library(
     name = "trace_processor",
     srcs = [
+        ":src_kernel_utils_kernel_wakelock_errors",
         ":src_kernel_utils_syscall_table",
         ":src_protozero_text_to_proto_text_to_proto",
         ":src_trace_processor_dataframe_dataframe",
@@ -7472,6 +7483,7 @@ perfetto_cc_binary(
         ":include_perfetto_trace_processor_basic_types",
         ":include_perfetto_trace_processor_storage",
         ":include_perfetto_trace_processor_trace_processor",
+        ":src_kernel_utils_kernel_wakelock_errors",
         ":src_kernel_utils_syscall_table",
         ":src_profiling_deobfuscator",
         ":src_profiling_symbolizer_symbolize_database",
@@ -7687,6 +7699,7 @@ perfetto_cc_binary(
         ":include_perfetto_trace_processor_basic_types",
         ":include_perfetto_trace_processor_storage",
         ":include_perfetto_trace_processor_trace_processor",
+        ":src_kernel_utils_kernel_wakelock_errors",
         ":src_kernel_utils_syscall_table",
         ":src_profiling_deobfuscator",
         ":src_profiling_symbolizer_symbolize_database",

--- a/protos/perfetto/trace/android/kernel_wakelock_data.proto
+++ b/protos/perfetto/trace/android/kernel_wakelock_data.proto
@@ -48,4 +48,6 @@ message KernelWakelockData {
   // the wakelock has been held.
   // If not, it's a delta from the last time we saw it.
   repeated uint64 time_held_millis = 3 [packed = true];
+
+  optional uint64 error_flags = 4;
 }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -5496,6 +5496,8 @@ message KernelWakelockData {
   // the wakelock has been held.
   // If not, it's a delta from the last time we saw it.
   repeated uint64 time_held_millis = 3 [packed = true];
+
+  optional uint64 error_flags = 4;
 }
 
 // End of protos/perfetto/trace/android/kernel_wakelock_data.proto

--- a/src/kernel_utils/BUILD.gn
+++ b/src/kernel_utils/BUILD.gn
@@ -26,6 +26,12 @@ source_set("syscall_table") {
   ]
 }
 
+source_set("kernel_wakelock_errors") {
+  sources = [
+    "kernel_wakelock_errors.h",
+  ]
+}
+
 perfetto_unittest_source_set("unittests") {
   testonly = true
   deps = [

--- a/src/kernel_utils/kernel_wakelock_errors.h
+++ b/src/kernel_utils/kernel_wakelock_errors.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_KERNEL_UTILS_KERNEL_WAKELOCK_ERRORS_H_
+#define SRC_KERNEL_UTILS_KERNEL_WAKELOCK_ERRORS_H_
+
+#include <cinttypes>
+
+constexpr uint64_t kKernelWakelockErrorZeroValue = 1;
+constexpr uint64_t kKernelWakelockErrorNonMonotonicValue = 2;
+
+#endif  // SRC_KERNEL_UTILS_KERNEL_WAKELOCK_ERRORS_H_

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -194,6 +194,7 @@ source_set("full") {
     "../../../../protos/perfetto/trace/system_info:zero",
     "../../../../protos/perfetto/trace/translation:zero",
     "../../../base",
+    "../../../kernel_utils:kernel_wakelock_errors",
     "../../../kernel_utils:syscall_table",
     "../../../protozero",
     "../../containers",

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -108,6 +108,13 @@ namespace perfetto::trace_processor::stats {
        "Duplicated interning ID seen. Should never happen."),                  \
   F(kernel_wakelock_unknown_id,           kSingle,  kError,    kAnalysis,      \
        "Interning ID not found. Should never happen."),                        \
+  F(kernel_wakelock_zero_value_reported,  kSingle,  kDataLoss, kTrace,         \
+       "Zero value received from SuspendControlService. Indicates a transient "\
+       "error in SuspendControlService."),                                     \
+  F(kernel_wakelock_non_monotonic_value_reported,                              \
+                                          kSingle,  kDataLoss, kTrace,         \
+       "Decreased value received from SuspendControlService. Indicates a "     \
+       "transient error in SuspendControlService."),                           \
   F(app_wakelock_parse_error,             kSingle,  kError,    kAnalysis,      \
        "Parsing packed repeated field. Should never happen."),                 \
   F(app_wakelock_unknown_id,              kSingle,  kError,    kAnalysis,      \

--- a/src/traced/probes/android_kernel_wakelocks/BUILD.gn
+++ b/src/traced/probes/android_kernel_wakelocks/BUILD.gn
@@ -25,6 +25,7 @@ source_set("android_kernel_wakelocks") {
     "../../../../protos/perfetto/trace:zero",
     "../../../../protos/perfetto/trace/android:zero",
     "../../../android_internal:lazy_library_loader",
+    "../../../kernel_utils:kernel_wakelock_errors",
     "../../../base",
   ]
   sources = [

--- a/src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.cc
+++ b/src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.cc
@@ -173,10 +173,10 @@ void AndroidKernelWakelocksDataSource::WriteKernelWakelocks() {
     uint64_t last_value = info->last_value;
 
     if (total == 0) {
-      error_flags &= kKernelWakelockErrorZeroValue;
+      error_flags |= kKernelWakelockErrorZeroValue;
       continue;
     } else if (total < last_value) {
-      error_flags &= kKernelWakelockErrorNonMonotonicValue;
+      error_flags |= kKernelWakelockErrorNonMonotonicValue;
       continue;
     }
     if (total != last_value) {

--- a/src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.cc
+++ b/src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.cc
@@ -29,6 +29,7 @@
 #include "perfetto/tracing/core/data_source_config.h"
 #include "src/android_internal/lazy_library_loader.h"
 #include "src/android_internal/suspend_control_service.h"
+#include "src/kernel_utils/kernel_wakelock_errors.h"
 
 #include "protos/perfetto/common/android_energy_consumer_descriptor.pbzero.h"
 #include "protos/perfetto/config/android/kernel_wakelocks_config.pbzero.h"
@@ -140,6 +141,7 @@ void AndroidKernelWakelocksDataSource::WriteKernelWakelocks() {
   base::FlatHashMap<std::string, uint64_t> totals;
 
   auto* proto = packet->set_kernel_wakelock_data();
+  uint64_t error_flags = 0;
 
   std::vector<android_internal::KernelWakelock> wakelocks =
       lib_->GetKernelWakelocks();
@@ -167,10 +169,17 @@ void AndroidKernelWakelocksDataSource::WriteKernelWakelocks() {
 
   for (auto it = totals.GetIterator(); it; ++it) {
     KernelWakelockInfo* info = wakelocks_.Find(it.key());
-
     uint64_t total = it.value();
-    if (it.value() != info->last_value) {
-      uint64_t last_value = info->last_value;
+    uint64_t last_value = info->last_value;
+
+    if (total == 0) {
+      error_flags &= kKernelWakelockErrorZeroValue;
+      continue;
+    } else if (total < last_value) {
+      error_flags &= kKernelWakelockErrorNonMonotonicValue;
+      continue;
+    }
+    if (total != last_value) {
       info->last_value = total;
       wakelock_id.Append(info->id);
       time_held_millis.Append(total - last_value);
@@ -179,6 +188,10 @@ void AndroidKernelWakelocksDataSource::WriteKernelWakelocks() {
 
   proto->set_wakelock_id(wakelock_id);
   proto->set_time_held_millis(time_held_millis);
+
+  if (error_flags != 0) {
+    proto->set_error_flags(error_flags);
+  }
 }
 
 void AndroidKernelWakelocksDataSource::Flush(FlushRequestID,


### PR DESCRIPTION
Bug: 404239369

We're seeing rare, strange results in traces that are consistent with SuspendControlService rolling back values or returning 0. If we see this occurring, ignore what it told us and increment a counter.
