### PR TITLE
Remove obsolete CheckBadCppPatterns from tools/run_presubmit

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -81,7 +81,6 @@ def CheckChange(input, output):
   results += RunAndReportIfLong(CheckMergedTraceConfigProto, input, output)
   results += RunAndReportIfLong(CheckProtoEventList, input, output)
   results += RunAndReportIfLong(CheckBannedCpp, input, output)
-  results += RunAndReportIfLong(CheckBadCppPatterns, input, output)
   results += RunAndReportIfLong(CheckSqlModules, input, output)
   results += RunAndReportIfLong(CheckSqlMetrics, input, output)
   results += RunAndReportIfLong(CheckTestData, input, output)
@@ -213,25 +212,6 @@ def CheckBannedCpp(input_api, output_api):
         if input_api.re.search(regex, line):
           errors.append(
               output_api.PresubmitError('Banned pattern:\n  {}:{} {}'.format(
-                  f.LocalPath(), line_number, message)))
-  return errors
-
-
-def CheckBadCppPatterns(input_api, output_api):
-  bad_patterns = [
-      (r'.*/tracing_service_impl[.]cc$', r'\btrigger_config\(\)',
-       'Use GetTriggerMode(session->config) rather than .trigger_config()'),
-  ]
-  errors = []
-  for file_regex, code_regex, message in bad_patterns:
-    filt = lambda x: input_api.FilterSourceFile(x, files_to_check=[file_regex])
-    for f in input_api.AffectedSourceFiles(filt):
-      for line_number, line in f.ChangedContents():
-        if input_api.re.search(r'^\s*//', line):
-          continue  # Skip comments
-        if input_api.re.search(code_regex, line):
-          errors.append(
-              output_api.PresubmitError('{}:{} {}'.format(
                   f.LocalPath(), line_number, message)))
   return errors
 

--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -682,34 +682,6 @@ def CheckBannedCpp(changed_files: List[str]) -> List[str]:
   return errors
 
 
-def CheckBadCppPatterns(changed_files: List[str]) -> List[str]:
-  # File Regex (for filtering), Code Regex (for checking), Message tuple
-  # File pattern needs to be fnmatch compatible
-  bad_patterns: List[Tuple[str, str, str]] = [
-      (
-          '*/tracing_service_impl.cc',
-          r'\btrigger_config\(\)',  # fnmatch pattern
-          'Use GetTriggerMode(session->config) rather than .trigger_config()'),
-  ]
-  errors = []
-  comment_pattern = re.compile(r'^\s*//')  # Regex is fine here
-
-  for file_pattern, code_regex_str, message in bad_patterns:
-    # Filter files using fnmatch pattern
-    files_to_check_list = filter_files(
-        changed_files, files_to_check=[file_pattern])
-    for f_path in files_to_check_list:
-      content = read_file_content(f_path)
-      if content:
-        for i, line in enumerate(content):
-          if comment_pattern.search(line):
-            continue  # Skip comments
-          # Check content using re.search
-          if re.search(code_regex_str, line):
-            errors.append(f'{f_path}:{i+1}: {message}')
-  return errors
-
-
 def CheckSqlModules(changed_files: List[str]) -> List[str]:
   if sys.platform == 'win32':
     return []
@@ -991,7 +963,6 @@ def main():
       (CheckMergedTraceConfigProto, [changed_files]),
       (CheckProtoEventList, [changed_files, merge_base]),  # Needs merge_base
       (CheckBannedCpp, [changed_files]),
-      (CheckBadCppPatterns, [changed_files]),
       (CheckSqlModules, [changed_files]),
       (CheckSqlMetrics, [changed_files]),
       (CheckTestData, [changed_files


### PR DESCRIPTION
This was introduced in 0fd92a9496e0("service: disallow ReadBuffers for CLONE_SNAPSHOT traces"), but it never worked.

I checked the current complaints and they're all false positives.

I'm also removing the check from PRESUBMIT.py, even though this should not be used anymore.