### PR TITLE
Update TransitionsTracker to use own ArgsTracker instances

### DIFF
--- a/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
@@ -34,28 +34,25 @@ ShellTransitionsParser::ShellTransitionsParser(TraceProcessorContext* context)
 void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
   protos::pbzero::ShellTransition::Decoder transition(blob);
 
-  auto row_id =
-      ShellTransitionsTracker::GetOrCreate(context_)->InternTransition(
-          transition.id());
-
-  auto* window_manager_shell_transitions_table =
-      context_->storage->mutable_window_manager_shell_transitions_table();
-  auto row = window_manager_shell_transitions_table->FindById(row_id).value();
-
-  if (transition.has_dispatch_time_ns()) {
-    row.set_ts(transition.dispatch_time_ns());
-  }
-
-  tables::WindowManagerShellTransitionProtosTable::Row protos;
-  protos.transition_id = transition.id();
-  protos.base64_proto_id = context_->storage->mutable_string_pool()
+  // Store the raw proto and its ID in a separate table to handle
+  // transitions received over multiple packets for Winscope trace search.
+  tables::WindowManagerShellTransitionProtosTable::Row row;
+  row.transition_id = transition.id();
+  row.base64_proto_id = context_->storage->mutable_string_pool()
                                ->InternString(base::StringView(
                                    base::Base64Encode(blob.data, blob.size)))
                                .raw_id();
   context_->storage->mutable_window_manager_shell_transition_protos_table()
-      ->Insert(protos);
+      ->Insert(row);
 
-  auto inserter = context_->args_tracker->AddArgsTo(row_id);
+  // Track transition args as the come in through different packets
+  auto transition_tracker = ShellTransitionsTracker::GetOrCreate(context_);
+
+  if (transition.has_dispatch_time_ns()) {
+        transition_tracker->SetTimestamp(transition.id(), transition.dispatch_time_ns());
+  }
+
+  auto inserter = transition_tracker->AddArgsTo(transition.id());
   ArgsParser writer(/*timestamp=*/0, inserter, *context_->storage.get());
   base::Status status = args_parser_.ParseMessage(
       blob,

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.cc
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.cc
@@ -28,11 +28,34 @@ ShellTransitionsTracker::ShellTransitionsTracker(TraceProcessorContext* context)
 
 ShellTransitionsTracker::~ShellTransitionsTracker() = default;
 
-tables::WindowManagerShellTransitionsTable::Id
-ShellTransitionsTracker::InternTransition(int32_t transition_id) {
-  auto pos = transition_id_to_row_mapping_.find(transition_id);
-  if (pos != transition_id_to_row_mapping_.end()) {
-    return pos->second;
+ArgsTracker::BoundInserter ShellTransitionsTracker::AddArgsTo(int32_t transition_id) {
+  auto* transition_info = GetOrInsertTransition(transition_id);
+
+  return transition_info->args_tracker.AddArgsTo(transition_info->row_id);
+}
+
+void ShellTransitionsTracker::SetTimestamp(int32_t transition_id, int64_t timestamp_ns) {
+  auto pos = transitions_infos_.find(transition_id);
+  if (pos == transitions_infos_.end()) {
+    context_->storage->IncrementStats(
+        stats::winscope_shell_transitions_parse_errors);
+    return;
+  }
+
+  auto* window_manager_shell_transitions_table =
+    context_->storage->mutable_window_manager_shell_transitions_table();
+  window_manager_shell_transitions_table->FindById(pos->second.row_id).value().set_ts(timestamp_ns);
+}
+
+void ShellTransitionsTracker::Flush() {
+  // The destructor of ArgsTracker will flush the args to the tables.
+  transitions_infos_.clear();
+}
+
+ShellTransitionsTracker::TransitionInfo* ShellTransitionsTracker::GetOrInsertTransition(int32_t transition_id) {
+  auto pos = transitions_infos_.find(transition_id);
+  if (pos != transitions_infos_.end()) {
+    return &pos->second;
   }
 
   auto* window_manager_shell_transitions_table =
@@ -42,9 +65,11 @@ ShellTransitionsTracker::InternTransition(int32_t transition_id) {
   row.transition_id = transition_id;
   auto row_id = window_manager_shell_transitions_table->Insert(row).id;
 
-  transition_id_to_row_mapping_.insert({transition_id, row_id});
+  transitions_infos_.insert({transition_id, TransitionInfo{row_id, ArgsTracker(context_)}});
 
-  return row_id;
+  pos = transitions_infos_.find(transition_id);
+  return &pos->second;
 }
+
 }  // namespace trace_processor
 }  // namespace perfetto

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
@@ -21,6 +21,7 @@
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/winscope_proto_mapping.h"
+#include "src/trace_processor/importers/common/args_tracker.h"
 
 namespace perfetto {
 namespace trace_processor {
@@ -40,13 +41,22 @@ class ShellTransitionsTracker : public Destructible {
         context->shell_transitions_tracker.get());
   }
 
-  tables::WindowManagerShellTransitionsTable::Id InternTransition(
-      int32_t transition_id);
+  ArgsTracker::BoundInserter AddArgsTo(int32_t transition_id);
+
+  void SetTimestamp(int32_t transition_id, int64_t timestamp_ns);
+
+  void Flush();
 
  private:
+  struct TransitionInfo {
+    tables::WindowManagerShellTransitionsTable::Id row_id;
+    ArgsTracker args_tracker;
+  };
+
+  TransitionInfo* GetOrInsertTransition(int32_t transition_id);
+
   TraceProcessorContext* context_;
-  std::unordered_map<int32_t, tables::WindowManagerShellTransitionsTable::Id>
-      transition_id_to_row_mapping_;
+  std::unordered_map<int32_t, TransitionInfo> transitions_infos_;
 };
 
 }  // namespace trace_processor

--- a/src/trace_processor/importers/proto/winscope/winscope_module.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_module.cc
@@ -36,6 +36,7 @@
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/tables/winscope_tables_py.h"
 #include "src/trace_processor/util/winscope_proto_mapping.h"
+#include "winscope_module.h"
 
 namespace perfetto::trace_processor {
 
@@ -244,6 +245,10 @@ void WinscopeModule::ParseWindowManagerData(int64_t timestamp,
     context_->storage->IncrementStats(
         stats::winscope_windowmanager_parse_errors);
   }
+}
+
+void WinscopeModule::NotifyEndOfFile() {
+  ShellTransitionsTracker::GetOrCreate(context_)->Flush();
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/winscope/winscope_module.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_module.h
@@ -27,6 +27,7 @@
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.h"
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.h"
 #include "src/trace_processor/importers/proto/winscope/viewcapture_parser.h"
+#include "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
@@ -48,6 +49,8 @@ class WinscopeModule : public ProtoImporterModule {
                             int64_t ts,
                             const TracePacketData&,
                             uint32_t field_id) override;
+
+  void NotifyEndOfFile() override;
 
  private:
   void ParseWinscopeExtensionsData(protozero::ConstBytes blob,

--- a/test/trace_processor/diff_tests/parser/android/args_table_issue.textproto
+++ b/test/trace_processor/diff_tests/parser/android/args_table_issue.textproto
@@ -1,0 +1,100 @@
+packet {
+  ftrace_events {
+    cpu: 1
+    previous_bundle_end_timestamp: 7527500607990
+    event {
+      timestamp: 7527503966842
+      pid: 20578
+      task_rename {
+        pid: 20578
+        oldcomm: "binder:19699_2"
+        newcomm: "Thread-236"
+        oom_score_adj: -950
+      }
+    }
+  }
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 3
+  trusted_pid: 688
+}
+packet {
+  ftrace_events {
+    cpu: 2
+    previous_bundle_end_timestamp: 7527490894972
+    event {
+      timestamp: 7527501668984
+      pid: 643
+      print {
+        buf: "C|643|binder_proxies|442\n"
+      }
+    }
+    event {
+      timestamp: 7527503926737
+      pid: 20579
+      task_rename {
+        pid: 20579
+        oldcomm: "binder:19699_2"
+        newcomm: "Thread-237"
+        oom_score_adj: -950
+      }
+    }
+  }
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 3
+  trusted_pid: 688
+}
+packet {
+  first_packet_on_sequence: true
+  shell_transition {
+    id: 729
+    targets {
+      flags: 1048577
+    }
+  }
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 6
+  trusted_pid: 932
+  previous_packet_dropped: true
+}
+packet {
+  first_packet_on_sequence: true
+  timestamp: 7527511238900
+  protolog_viewer_config {
+  }
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 10
+  trusted_pid: 932
+  previous_packet_dropped: true
+}
+packet {
+  first_packet_on_sequence: true
+  shell_transition {
+    id: 729
+    handler: 2
+  }
+  trusted_uid: 10222
+  trusted_packet_sequence_id: 12
+  trusted_pid: 6295
+  previous_packet_dropped: true
+}
+packet {
+  first_packet_on_sequence: true
+  shell_handler_mappings {
+    mapping {
+      id: 2
+      name: "com.android.wm.shell.recents.RecentsTransitionHandler"
+    }
+    mapping {
+      id: 3
+      name: "com.android.wm.shell.transition.RemoteTransitionHandler"
+    }
+    mapping {
+      id: 1
+      name: "com.android.wm.shell.transition.DefaultTransitionHandler"
+    }
+  }
+  trusted_uid: 10222
+  trusted_packet_sequence_id: 13
+  trusted_pid: 6295
+  previous_packet_dropped: true
+}

--- a/test/trace_processor/diff_tests/parser/android/tests_shell_transitions.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_shell_transitions.py
@@ -113,3 +113,20 @@ class ShellTransitions(TestSuite):
         "COUNT(*)"
         3
         """))
+
+  def test_handles_weird_args_table_issue(self):
+    return DiffTestBlueprint(
+        trace=Path('args_table_issue.textproto'),
+        query="""
+        SELECT
+          args.key, args.display_value
+        FROM
+          window_manager_shell_transitions JOIN args ON window_manager_shell_transitions.arg_set_id = args.arg_set_id
+        ORDER BY args.key;
+        """,
+        out=Csv("""
+        "key","display_value"
+        "handler","2"
+        "id","729"
+        "targets[0].flags","1048577"
+        """))


### PR DESCRIPTION
This is to fix an issue where ShellTransition data was not being correctly parsed by the parser resulting in missing data in the transitions in Flicker and Winscope. The was due to a misuse of the ArgsTracker interface in the ShellTransitionsParser, where the args were being overwritten with new arg sets due to the flushing of the `context->args_tracker` that was happening every once in a while. We should now be accumulating the args correctly and fully before flushing them to storage, ensuring we don't miss any args in the trace tables.

Bug: 406973318
Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell --name-filter=".*Transition.*"
Change-Id: I74728cb062066468dd80f5aa6315e7e15316343e
