### PR TITLE
Include Psapi.h after Windows.h

### DIFF
--- a/src/base/test/vm_test_utils.cc
+++ b/src/base/test/vm_test_utils.cc
@@ -27,8 +27,10 @@
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <vector>
 
-#include <Psapi.h>
+// clang-format off
 #include <Windows.h>
+#include <Psapi.h>
+// clang-format on
 #else  // PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <sys/mman.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Some of the chromium bots were not happy after the headers inclusion order was changed after clang-format.

Reverting back the orders in which the headers are added, and turning off clang format for the block where headers are added.

Bug: b/409239273
