### PR TITLE
Redaction - Use ftrace event `pid` with rename events

### DIFF
--- a/src/trace_redaction/filtering.cc
+++ b/src/trace_redaction/filtering.cc
@@ -36,4 +36,10 @@ bool AllowAll::Includes(const Context&, protozero::Field) const {
   return true;
 }
 
+MatchesPid::MatchesPid(int32_t pid) : pid_(pid) {}
+
+bool MatchesPid::Includes(const Context&, uint64_t, int32_t pid) const {
+  return pid == pid_;
+}
+
 }  // namespace perfetto::trace_redaction

--- a/src/trace_redaction/filtering.h
+++ b/src/trace_redaction/filtering.h
@@ -53,6 +53,15 @@ class AllowAll : public PidFilter, public FtraceEventFilter {
   bool Includes(const Context& context, protozero::Field event) const override;
 };
 
+class MatchesPid : public PidFilter {
+ public:
+  explicit MatchesPid(int32_t pid);
+  bool Includes(const Context&, uint64_t, int32_t pid) const override;
+
+ private:
+  int32_t pid_;
+};
+
 }  // namespace perfetto::trace_redaction
 
 #endif  // SRC_TRACE_REDACTION_FILTERING_H_

--- a/src/trace_redaction/redact_process_events.cc
+++ b/src/trace_redaction/redact_process_events.cc
@@ -306,6 +306,8 @@ base::Status RedactProcessEvents::OnProcessRename(
   // support backwards compatibility but assume the ftrace event's pid can be
   // used, the rename task's pid will be used if it is present, otherwise it'll
   // use the ftrace event's pid.
+  //
+  // https://b.corp.google.com/issues/407810213
   auto nearest_pid = decoder.has_pid() ? decoder.pid() : pid;
 
   PERFETTO_DCHECK(filter_);

--- a/src/trace_redaction/redact_process_events.h
+++ b/src/trace_redaction/redact_process_events.h
@@ -59,6 +59,11 @@ class RedactProcessEvents : public TransformPrimitive {
     filter_ = std::make_unique<Filter>();
   }
 
+  template <class Filter>
+  void emplace_filter(std::unique_ptr<Filter> filter) {
+    filter_ = std::move(filter);
+  }
+
  private:
   base::Status OnFtraceEvents(const Context& context,
                               protozero::ConstBytes bytes,
@@ -88,6 +93,7 @@ class RedactProcessEvents : public TransformPrimitive {
       const Context& context,
       uint64_t ts,
       int32_t cpu,
+      int32_t pid,
       protozero::ConstBytes bytes,
       std::string* shared_comm,
       protos::pbzero::FtraceEvent* parent_message) const;


### PR DESCRIPTION
Before this, redaction relied on the `pid` value in the rename task and asserted its presence. This broke when Perfetto stopped emitted the field. The field was removed because the rename task's `pid` would match the ftrace event's `pid`.

To safely remove the assertion, redaction will now use:

```
return rename_task.has_pid() ? rename_task.pid() : ftrace_event.pid()
```