### PR TITLE
tp: fix internal syntax error in v2 metric using shared query

### DIFF
--- a/src/trace_processor/trace_summary/summary.cc
+++ b/src/trace_processor/trace_summary/summary.cc
@@ -103,7 +103,7 @@ base::Status CreateQueriesAndComputeMetrics(
     const TraceSummaryOutputSpec& output_spec) {
   for (const auto& query : queries) {
     auto it = processor->ExecuteQuery("CREATE PERFETTO TABLE " +
-                                      query.table_name + " " + query.sql);
+                                      query.table_name + " AS " + query.sql);
     PERFETTO_CHECK(!it.Next());
     if (!it.Status().ok()) {
       return base::ErrStatus("Error while executing shared query %s: %s",


### PR DESCRIPTION
Tested using the chrome_histogram_metrics.textproto:
```
query {
  id: "chrome_histogram_summaries"
  sql: {
      column_names: "histogram_name"
      column_names: "average"
      column_names: "sum"
      column_names: "max"
      column_names: "min"
      column_names: "count"
      sql:
        "
with chrome_histogram_slices as
(
  select
    *,
    extract_arg(arg_set_id, 'chrome_histogram_sample.name') as histogram_name,
    extract_arg(arg_set_id, 'chrome_histogram_sample.sample') as histogram_sample
  from slice
  where category = 'disabled-by-default-histogram_samples'
)
select
  process.name as process_name,
  pid,
  histogram_name,
  count(1) as count,
  sum(histogram_sample) as sum,
  max(histogram_sample) as max,
  min(histogram_sample) as min,
  avg(histogram_sample) as average
from chrome_histogram_slices _cslice
  join thread_track on _cslice.track_id = thread_track.id
  join thread using (utid)
  join process using (upid)
group by histogram_name, upid
order by histogram_name, upid"
    }
}

metric_spec: {
  id: "chrome_histogram_average"
  dimensions: "histogram_name"
  value: "averate"
  query: {
    inner_query {
      inner_query_id: "chrome_histogram_summaries"
    }
    select_columns: {
      column_name: "histogram_name"
    }
    select_columns: {
      column_name: "average"
    }
  }
}

```

Bug: 409432195
Test: trace_processor_shell --summary --summary-spec chrome_histograms_metrics.textproto --summary-metrics-v2 chrome_histogram_average cuj_perf_trace_data.pb
Change-Id: I856eb2d4b867423d552405e644ff4e43113e90b8

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
