### PR TITLE
trace_processor: Fix ODR violations

### DIFF
--- a/include/perfetto/ext/trace_processor/importers/memory_tracker/raw_memory_graph_node.h
+++ b/include/perfetto/ext/trace_processor/importers/memory_tracker/raw_memory_graph_node.h
@@ -102,16 +102,16 @@ class PERFETTO_EXPORT_COMPONENT RawMemoryGraphNode {
       std::vector<RawMemoryGraphNode::MemoryNodeEntry>&& entries);
 
   // Standard attribute |name|s for the AddScalar and AddString() methods.
-  static const char kNameSize[];         // To represent allocated space.
-  static const char kNameObjectCount[];  // To represent number of objects.
+  static constexpr char kNameSize[]= "size";         // To represent allocated space.
+  static constexpr char kNameObjectCount[]= "object_count";  // To represent number of objects.
 
   // Standard attribute |unit|s for the AddScalar and AddString() methods.
-  static const char kUnitsBytes[];    // Unit name to represent bytes.
-  static const char kUnitsObjects[];  // Unit name to represent #objects.
+  static constexpr char kUnitsBytes[] = "bytes";    // Unit name to represent bytes.
+  static constexpr char kUnitsObjects[] = "objects";  // Unit name to represent #objects.
 
   // Constants used only internally and by tests.
-  static const char kTypeScalar[];  // Type name for scalar attributes.
-  static const char kTypeString[];  // Type name for string attributes.
+  static constexpr char kTypeScalar[] = "scalar";  // Type name for scalar attributes.
+  static constexpr char kTypeString[] = "string";  // Type name for string attributes.
 
   // |id| is an optional global node identifier, unique across all processes
   // within the scope of a global node.

--- a/src/trace_processor/importers/memory_tracker/raw_memory_graph_node.cc
+++ b/src/trace_processor/importers/memory_tracker/raw_memory_graph_node.cc
@@ -19,13 +19,6 @@
 namespace perfetto {
 namespace trace_processor {
 
-const char RawMemoryGraphNode::kNameSize[] = "size";
-const char RawMemoryGraphNode::kNameObjectCount[] = "object_count";
-const char RawMemoryGraphNode::kTypeScalar[] = "scalar";
-const char RawMemoryGraphNode::kTypeString[] = "string";
-const char RawMemoryGraphNode::kUnitsBytes[] = "bytes";
-const char RawMemoryGraphNode::kUnitsObjects[] = "objects";
-
 RawMemoryGraphNode::MemoryNodeEntry::MemoryNodeEntry(const std::string& n,
                                                      const std::string& u,
                                                      uint64_t v)


### PR DESCRIPTION
In `RawMemoryGraphNode`, make some string constants `static constexpr`.

This is apparently only a problem in ASan component builds.

Bug: 408927257