### PR TITLE
Fix build error due to missing cstdint with gcc-15

### DIFF
--- a/include/perfetto/ext/tracing/core/slice.h
+++ b/include/perfetto/ext/tracing/core/slice.h
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "perfetto/base/logging.h"
 


### PR DESCRIPTION
  * Add missing cstdint include to fix build error with gcc-15

  * To fix the error with gcc-15. http://errors.yoctoproject.org/Errors/Details/851189/ ../git/include/perfetto/ext/tracing/core/slice.h:47:46: error: 'uint8_t' was not declared in this scope
    47 |   static Slice TakeOwnership(std::unique_ptr<uint8_t[]> buf, size_t size) {
        |                                              ^~~~~~~
    ../git/include/perfetto/ext/tracing/core/slice.h:25:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    24 | #include <string>
    +++ |+#include <cstdint>

  * See also: https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
