### PR TITLE
prevent tabnabbing attack with rel="noopener noreferrer"

### DIFF
--- a/ui/src/assets/bigtrace.html
+++ b/ui/src/assets/bigtrace.html
@@ -35,11 +35,11 @@ Please file a bug (details below) and try these remediation steps:
 
 * <a href="javascript:clearAllCaches();">Clear all the site storage and caches</a> and reload the page.
 
-* Clear the site data and caches from devtools, following <a target="_blank" href="https://developers.google.com/web/tools/chrome-devtools/storage/cache#deletecache">these instructions</a>.
+* Clear the site data and caches from devtools, following <a target="_blank" rel="noopener noreferrer" href="https://developers.google.com/web/tools/chrome-devtools/storage/cache#deletecache">these instructions</a>.
 
 In any case, **FILE A BUG** attaching logs and screenshots from devtools.
-  Googlers:      <a href="http://go/perfetto-ui-bug" target="_blank">go/perfetto-ui-bug</a>
-  Non-googlers:  <a href="https://github.com/google/perfetto/issues/new" target="_blank">github.com/google/perfetto/issues/new</a>
+  Googlers:      <a href="http://go/perfetto-ui-bug" target="_blank" rel="noopener noreferrer">go/perfetto-ui-bug</a>
+  Non-googlers:  <a href="https://github.com/google/perfetto/issues/new" target="_blank" rel="noopener noreferrer">github.com/google/perfetto/issues/new</a>
 
 <div id=app_load_failure_err></div>
 Technical Information:

--- a/ui/src/assets/index.html
+++ b/ui/src/assets/index.html
@@ -38,11 +38,11 @@ If the problem persists try these remediation steps:
 
 * <a href="javascript:clearAllCaches();">Clear all the site storage and caches</a> and reload the page.
 
-* Clear the site data and caches from devtools, following <a target="_blank" href="https://developers.google.com/web/tools/chrome-devtools/storage/cache#deletecache">these instructions</a>.
+* Clear the site data and caches from devtools, following <a target="_blank" rel="noopener noreferrer" href="https://developers.google.com/web/tools/chrome-devtools/storage/cache#deletecache">these instructions</a>.
 
 If none of this works, file a bug attaching logs and screenshots from devtools.
-  Googlers:      <a href="http://go/perfetto-ui-bug" target="_blank">go/perfetto-ui-bug</a>
-  Non-googlers:  <a href="https://github.com/google/perfetto/issues/new" target="_blank">github.com/google/perfetto/issues/new</a>
+  Googlers:      <a href="http://go/perfetto-ui-bug" target="_blank" rel="noopener noreferrer">go/perfetto-ui-bug</a>
+  Non-googlers:  <a href="https://github.com/google/perfetto/issues/new" target="_blank" rel="noopener noreferrer">github.com/google/perfetto/issues/new</a>
 
 <div id=app_load_failure_err></div>
 Technical Information:


### PR DESCRIPTION
Fix potential tabnabbing attack by adding `rel="noopener noreferrer"` to `a` tags with `target="_blank"`