### PR TITLE
tracing_service_impl: Record stop_delay_ms for TracePacket.trigger

### DIFF
--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -15991,6 +15991,8 @@ message Trigger {
   optional string producer_name = 2;
   // The verified UID of the producer.
   optional int32 trusted_producer_uid = 3;
+  // The value of stop_delay_ms from the configuration.
+  optional uint64 stop_delay_ms = 4;
 }
 
 // End of protos/perfetto/trace/trigger.proto

--- a/protos/perfetto/trace/trigger.proto
+++ b/protos/perfetto/trace/trigger.proto
@@ -28,4 +28,6 @@ message Trigger {
   optional string producer_name = 2;
   // The verified UID of the producer.
   optional int32 trusted_producer_uid = 3;
+  // The value of stop_delay_ms from the configuration.
+  optional uint64 stop_delay_ms = 4;
 }

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -1731,7 +1731,8 @@ void TracingServiceImpl::ActivateTriggers(
       const bool triggers_already_received =
           !tracing_session.received_triggers.empty();
       const TriggerInfo trigger = {static_cast<uint64_t>(now_ns), iter->name(),
-                                   producer->name_, producer->uid()};
+                                   producer->name_, producer->uid(),
+                                   iter->stop_delay_ms()};
       MaybeSnapshotClocksIntoRingBuffer(&tracing_session);
       tracing_session.received_triggers.push_back(trigger);
       switch (trigger_mode) {
@@ -3955,6 +3956,7 @@ void TracingServiceImpl::MaybeEmitReceivedTriggers(
     trigger->set_trigger_name(info.trigger_name);
     trigger->set_producer_name(info.producer_name);
     trigger->set_trusted_producer_uid(static_cast<int32_t>(info.producer_uid));
+    trigger->set_stop_delay_ms(info.trigger_delay_mono_ms);
 
     packet->set_timestamp(info.boot_time_ns);
     packet->set_trusted_uid(static_cast<int32_t>(uid_));

--- a/src/tracing/service/tracing_service_impl.h
+++ b/src/tracing/service/tracing_service_impl.h
@@ -478,6 +478,7 @@ class TracingServiceImpl : public TracingService {
     std::string trigger_name;
     std::string producer_name;
     uid_t producer_uid = 0;
+    uint64_t trigger_delay_mono_ms = 0;
   };
 
   struct PendingClone {


### PR DESCRIPTION
`stop_delay_ms` is mirrored from the config. We shouldn't read the config from trace_processor.
