### PR TITLE
tp: add support for sorting dataframes

### DIFF
--- a/src/trace_processor/dataframe/dataframe.cc
+++ b/src/trace_processor/dataframe/dataframe.cc
@@ -20,7 +20,6 @@
 #include <utility>
 #include <vector>
 
-#include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_or.h"
 #include "src/trace_processor/dataframe/impl/query_plan.h"
 #include "src/trace_processor/dataframe/specs.h"
@@ -30,9 +29,11 @@ namespace perfetto::trace_processor::dataframe {
 
 base::StatusOr<Dataframe::QueryPlan> Dataframe::PlanQuery(
     std::vector<FilterSpec>& specs,
+    const std::vector<SortSpec>& sort_specs,
     uint64_t cols_used) const {
-  ASSIGN_OR_RETURN(auto plan, impl::QueryPlanBuilder::Build(
-                                  row_count_, columns_, specs, cols_used));
+  ASSIGN_OR_RETURN(auto plan,
+                   impl::QueryPlanBuilder::Build(row_count_, columns_, specs,
+                                                 sort_specs, cols_used));
   return QueryPlan(std::move(plan));
 }
 

--- a/src/trace_processor/dataframe/dataframe.h
+++ b/src/trace_processor/dataframe/dataframe.h
@@ -92,13 +92,15 @@ class Dataframe {
   // and column selection.
   //
   // Parameters:
-  //   specs:            Filter predicates to apply to the data.
+  //   filter_specs:     Filter predicates to apply to the data.
+  //   sort_specs:       Sort specifications defining the desired row order.
   //   cols_used_bitmap: Bitmap where each bit corresponds to a column that may
   //                     be requested. Only columns with set bits can be
   //                     fetched.
   // Returns:
   //   A StatusOr containing the QueryPlan or an error status.
-  base::StatusOr<QueryPlan> PlanQuery(std::vector<FilterSpec>& specs,
+  base::StatusOr<QueryPlan> PlanQuery(std::vector<FilterSpec>& filter_specs,
+                                      const std::vector<SortSpec>& sort_specs,
                                       uint64_t cols_used_bitmap) const;
 
   // Prepares a cursor for executing the query plan. The template parameter

--- a/src/trace_processor/dataframe/impl/bytecode_core.h
+++ b/src/trace_processor/dataframe/impl/bytecode_core.h
@@ -33,6 +33,7 @@
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/dataframe/impl/bytecode_registers.h"
 #include "src/trace_processor/dataframe/impl/types.h"
+#include "src/trace_processor/dataframe/specs.h"
 
 namespace perfetto::trace_processor::dataframe::impl::bytecode {
 
@@ -102,7 +103,7 @@ PERFETTO_NO_INLINE inline base::StackString<64> ArgToString(
 }
 
 PERFETTO_NO_INLINE inline base::StackString<64> ArgToString(NonNullOp value) {
-  return base::StackString<64>("NonNullOp(%d)", value.index());
+  return base::StackString<64>("NonNullOp(%u)", value.index());
 }
 
 PERFETTO_NO_INLINE inline base::StackString<64> ArgToString(
@@ -112,7 +113,18 @@ PERFETTO_NO_INLINE inline base::StackString<64> ArgToString(
 
 PERFETTO_NO_INLINE inline base::StackString<64> ArgToString(
     impl::BoundModifier bound) {
-  return base::StackString<64>("BoundModifier(%d)", bound.index());
+  return base::StackString<64>("BoundModifier(%u)", bound.index());
+}
+
+PERFETTO_NO_INLINE inline base::StackString<64> ArgToString(
+    SortDirection direction) {
+  return base::StackString<64>("SortDirection(%u)",
+                               static_cast<uint32_t>(direction));
+}
+
+PERFETTO_NO_INLINE inline base::StackString<64> ArgToString(
+    NullsLocation location) {
+  return base::StackString<64>("NullsLocation(%u)", location.index());
 }
 
 PERFETTO_NO_INLINE inline void BytecodeFieldToString(

--- a/src/trace_processor/dataframe/impl/bytecode_interpreter_unittest.cc
+++ b/src/trace_processor/dataframe/impl/bytecode_interpreter_unittest.cc
@@ -252,6 +252,25 @@ Bytecode ParseBytecode(const std::string& bytecode_str) {
   return bc;
 }
 
+template <typename T, typename U>
+Column CreateNonNullUnsortedColumn(std::string name,
+                                   std::initializer_list<U> data,
+                                   StringPool* pool = nullptr) {
+  impl::FlexVector<T> vec;
+  if constexpr (std::is_same_v<T, StringPool::Id>) {
+    PERFETTO_CHECK(pool);
+    for (const auto& str_like : data) {
+      vec.push_back(pool->InternString(str_like));
+    }
+  } else {
+    for (const U& val : data) {
+      vec.push_back(val);
+    }
+  }
+  return impl::Column{std::move(name), impl::Storage{std::move(vec)},
+                      impl::Overlay::NoOverlay{}, Unsorted{}};
+}
+
 template <typename T>
 FlexVector<T> CreateFlexVectorForTesting(std::initializer_list<T> values) {
   FlexVector<T> vec;
@@ -264,16 +283,21 @@ FlexVector<T> CreateFlexVectorForTesting(std::initializer_list<T> values) {
 class BytecodeInterpreterTest : public testing::Test {
  protected:
   template <typename... Ts>
-  void SetRegistersAndExecute(const std::string& bytecode, Ts... value) {
+  void SetRegistersAndExecute(const std::string& bytecode_str, Ts... value) {
     BytecodeVector bytecode_vector;
-    bytecode_vector.emplace_back(ParseBytecode(bytecode));
-    interpreter_ = std::make_unique<Interpreter<Fetcher>>(
-        std::move(bytecode_vector), column_.get(), &spool_);
+    bytecode_vector.emplace_back(ParseBytecode(bytecode_str));
+    SetupInterpreterWithBytecode(std::move(bytecode_vector));
+
     uint32_t i = 0;
     (interpreter_->SetRegisterValueForTesting(reg::WriteHandle<Ts>(i++),
                                               std::move(value)),
      ...);
     interpreter_->Execute(fetcher_);
+  }
+
+  void SetupInterpreterWithBytecode(BytecodeVector bytecode) {
+    interpreter_ = std::make_unique<Interpreter<Fetcher>>(
+        std::move(bytecode), columns_vec_.data(), &spool_);
   }
 
   template <typename T>
@@ -285,7 +309,7 @@ class BytecodeInterpreterTest : public testing::Test {
 
   Fetcher fetcher_;
   StringPool spool_;
-  std::unique_ptr<Column> column_;
+  std::vector<Column> columns_vec_;
   std::unique_ptr<Interpreter<Fetcher>> interpreter_;
 };
 
@@ -723,8 +747,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32Eq) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
-                                 Sorted{}});
+  columns_vec_.emplace_back(
+      impl::Column{"foo", std::move(values), Overlay::NoOverlay{}, Sorted{}});
   {
     // Test case 1: Value exists in range
     SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
@@ -754,8 +778,9 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32LowerBound) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  column_.reset(new impl::Column{"foo", Storage{std::move(values)},
-                                 Overlay{Overlay::NoOverlay{}}, Sorted{}});
+  columns_vec_.emplace_back(impl::Column{"foo", Storage{std::move(values)},
+                                         Overlay{Overlay::NoOverlay{}},
+                                         Sorted{}});
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
                          Range{3u, 8u});
@@ -775,8 +800,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32UpperBound) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
-                                 Sorted{}});
+  columns_vec_.emplace_back(
+      impl::Column{"foo", std::move(values), Overlay::NoOverlay{}, Sorted{}});
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
                          Range{3u, 7u});
@@ -824,8 +849,8 @@ TEST_F(BytecodeInterpreterTest, FilterUint32Eq) {
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({4u, 49u, 392u, 4u, 49u, 4u, 391u});
-  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
-                                 Unsorted{}});
+  columns_vec_.emplace_back(
+      impl::Column{"foo", std::move(values), Overlay::NoOverlay{}, Unsorted{}});
 
   std::vector<uint32_t> indices_spec = {3, 3, 4, 5, 0, 6, 0};
   {
@@ -874,8 +899,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterString) {
   // Sorted string data: ["apple", "banana", "banana", "cherry", "date"]
   auto values = CreateFlexVectorForTesting<StringPool::Id>(
       {apple_id, banana_id, banana_id, cherry_id, date_id});
-  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
-                                 Sorted{}});
+  columns_vec_.emplace_back(
+      impl::Column{"foo", std::move(values), Overlay::NoOverlay{}, Sorted{}});
 
   // --- Sub-test for EqualRange (Eq) ---
   {
@@ -927,8 +952,8 @@ TEST_F(BytecodeInterpreterTest, StringFilter) {
   // Index:    0        1      2      3        4       5        6
   auto values = CreateFlexVectorForTesting<StringPool::Id>(
       {cherry_id, apple_id, empty_id, banana_id, apple_id, date_id, durian_id});
-  column_.reset(new impl::Column{"foo", std::move(values), Overlay::NoOverlay{},
-                                 Unsorted{}});
+  columns_vec_.emplace_back(
+      impl::Column{"foo", std::move(values), Overlay::NoOverlay{}, Unsorted{}});
 
   // Initial indices {0, 1, 2, 3, 4, 5, 6} pointing to the data
   const std::vector<uint32_t> source_indices = {0, 1, 2, 3, 4, 5, 6};
@@ -995,7 +1020,7 @@ TEST_F(BytecodeInterpreterTest, NullFilter) {
 
   // Create a dummy column with a DenseNull overlay using the BitVector
   // (SparseNull would work identically for this specific test)
-  column_ = std::make_unique<impl::Column>(impl::Column{
+  columns_vec_.emplace_back(impl::Column{
       "foo",
       Storage{Storage::Uint32{}},  // Storage type doesn't matter for NullFilter
       Overlay{Overlay::DenseNull{std::move(bv)}}, Unsorted{}});
@@ -1051,7 +1076,7 @@ TEST_F(BytecodeInterpreterTest, PrefixPopcount) {
   bv.set(160);  // Word 2
   bv.set(200);  // Word 3
 
-  column_ = std::make_unique<impl::Column>(impl::Column{
+  columns_vec_.emplace_back(impl::Column{
       "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
       Overlay{Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
   SetRegistersAndExecute("PrefixPopcount: [col=0, dest_register=Register(0)]");
@@ -1100,7 +1125,7 @@ TEST_F(BytecodeInterpreterTest, TranslateSparseNullIndices) {
   bv.set(160);  // Word 2
   bv.set(200);  // Word 3
 
-  column_ = std::make_unique<impl::Column>(impl::Column{
+  columns_vec_.emplace_back(impl::Column{
       "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
       Overlay{Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
 
@@ -1156,7 +1181,7 @@ TEST_F(BytecodeInterpreterTest, StrideTranslateAndCopySparseNullIndices) {
   popcount_slab[3] = 9;
 
   // Create a dummy column with the BitVector (SparseNull overlay)
-  column_ = std::make_unique<impl::Column>(impl::Column{
+  columns_vec_.emplace_back(impl::Column{
       "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
       Overlay{Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
 
@@ -1225,7 +1250,7 @@ TEST_F(BytecodeInterpreterTest, StrideCopyDenseNullIndices) {
   bv.set(200);  // Word 3
 
   // Create a dummy column with the BitVector (DenseNull overlay)
-  column_ = std::make_unique<impl::Column>(impl::Column{
+  columns_vec_.emplace_back(impl::Column{
       "foo", Storage{Storage::Uint32{}},  // Storage type doesn't matter
       Overlay{Overlay::DenseNull{std::move(bv)}}, Unsorted{}});
 
@@ -1279,7 +1304,7 @@ TEST_F(BytecodeInterpreterTest, StrideCopyDenseNullIndices) {
 TEST_F(BytecodeInterpreterTest, NonStringFilterInPlace) {
   // Column data: {5, 10, 5, 15, 10, 20}
   auto values = CreateFlexVectorForTesting<uint32_t>({5, 10, 5, 15, 10, 20});
-  column_ = std::make_unique<impl::Column>(impl::Column{
+  columns_vec_.emplace_back(impl::Column{
       "foo", std::move(values), Overlay{Overlay::NoOverlay{}}, Unsorted{}});
 
   // Source indices (imagine these are translated storage indices for data
@@ -1316,7 +1341,7 @@ TEST_F(BytecodeInterpreterTest, Uint32SetIdSortedEq) {
   // 7  7  10
   auto values = CreateFlexVectorForTesting<uint32_t>(
       {0u, 0u, 0u, 3u, 3u, 5u, 5u, 7u, 7u, 7u, 10u});
-  column_ = std::make_unique<impl::Column>(impl::Column{
+  columns_vec_.emplace_back(impl::Column{
       "foo", std::move(values), Overlay{Overlay::NoOverlay{}}, SetIdSorted{}});
 
   std::string bytecode =
@@ -1386,6 +1411,157 @@ TEST_F(BytecodeInterpreterTest, Uint32SetIdSortedEq) {
     EXPECT_EQ(result.b, full_range.b);
     EXPECT_EQ(result.e, full_range.e);
   }
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteSortUint32Asc) {
+  columns_vec_.emplace_back(
+      CreateNonNullUnsortedColumn<uint32_t>("col", {50u, 10u, 30u, 20u, 40u}));
+
+  std::vector<uint32_t> initial_indices = {0, 1, 2, 3, 4};
+  SetRegistersAndExecute(
+      "StableSortIndices<Uint32>: [col=0, direction=SortDirection(0), "
+      "update_register=Register(0)]",
+      GetSpan(initial_indices));
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1, 3, 2, 4, 0));
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteSortDoubleDesc) {
+  columns_vec_.emplace_back(
+      CreateNonNullUnsortedColumn<double>("col", {1.1, 5.5, 2.2, 4.4, 3.3}));
+
+  std::vector<uint32_t> initial_indices = {0, 1, 2, 3, 4};
+  SetRegistersAndExecute(
+      "StableSortIndices<Double>: [col=0, direction=SortDirection(1), "
+      "update_register=Register(0)]",
+      GetSpan(initial_indices));
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1, 3, 4, 2, 0));
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteSortStringAsc) {
+  columns_vec_.clear();
+  columns_vec_.emplace_back(CreateNonNullUnsortedColumn<StringPool::Id>(
+      "col", {"banana", "apple", "cherry", "date"}, &spool_));
+
+  std::vector<uint32_t> initial_indices = {0, 1, 2, 3};
+  SetRegistersAndExecute(
+      "StableSortIndices<String>: [col=0, direction=SortDirection(0), "
+      "update_register=Register(0)]",
+      GetSpan(initial_indices));
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1, 0, 2, 3));
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteSortIdAsc) {
+  columns_vec_.emplace_back(
+      impl::Column{"id_col", impl::Storage{impl::Storage::Id{5}},
+                   impl::Overlay::NoOverlay{}, IdSorted{}});
+
+  std::vector<uint32_t> initial_indices = {3, 0, 4, 1, 2};
+  SetRegistersAndExecute(
+      "StableSortIndices<Id>: [col=0, direction=SortDirection(0), "
+      "update_register=Register(0)]",
+      GetSpan(initial_indices));
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 1, 2, 3, 4));
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteStableSort) {
+  columns_vec_.emplace_back(
+      CreateNonNullUnsortedColumn<int64_t>("col_I", {10, 20, 10, 20, 10}));
+  columns_vec_.emplace_back(CreateNonNullUnsortedColumn<StringPool::Id>(
+      "col_S", {"c", "e", "a", "d", "b"}, &spool_));
+
+  BytecodeVector bytecode;
+  bytecode.emplace_back(ParseBytecode(
+      "StableSortIndices<String>: [col=1, direction=SortDirection(1), "
+      "update_register=Register(0)]"));
+  bytecode.emplace_back(ParseBytecode(
+      "StableSortIndices<Int64>: [col=0, direction=SortDirection(0), "
+      "update_register=Register(0)]"));
+
+  SetupInterpreterWithBytecode(std::move(bytecode));
+
+  std::vector<uint32_t> initial_indices = {0, 1, 2, 3, 4};
+  interpreter_->SetRegisterValueForTesting(reg::WriteHandle<Span<uint32_t>>(0),
+                                           GetSpan(initial_indices));
+
+  interpreter_->Execute(fetcher_);
+
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 4, 2, 1, 3));
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteNullPartitionNullsAtStart) {
+  auto data_vec = CreateFlexVectorForTesting<uint32_t>({100, 300, 400, 600});
+  auto bv = BitVector::CreateWithSize(7);
+  bv.set(1);
+  bv.set(3);
+  bv.set(4);
+  bv.set(6);
+  columns_vec_.push_back(impl::Column{
+      "col", impl::Storage{std::move(data_vec)},
+      impl::Overlay{impl::Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
+
+  std::vector<uint32_t> initial_indices = {0, 1, 2, 3, 4, 5, 6};
+  SetRegistersAndExecute(
+      "NullIndicesStablePartition: [col=0, nulls_location=NullsLocation(0), "
+      "partition_register=Register(0), dest_non_null_register=Register(1)]",
+      GetSpan(initial_indices), impl::Span<uint32_t>{nullptr, nullptr});
+
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 2, 5, 1, 3, 4, 6));
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(1), ElementsAre(1, 3, 4, 6));
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteNullPartitionNullsAtEnd) {
+  auto data_vec = CreateFlexVectorForTesting<uint32_t>({100, 300, 400, 600});
+  auto bv = BitVector::CreateWithSize(7);
+  bv.set(1);
+  bv.set(3);
+  bv.set(4);
+  bv.set(6);
+  columns_vec_.push_back(impl::Column{
+      "col", impl::Storage{std::move(data_vec)},
+      impl::Overlay{impl::Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
+
+  std::vector<uint32_t> initial_indices = {0, 1, 2, 3, 4, 5, 6};
+  SetRegistersAndExecute(
+      "NullIndicesStablePartition: [col=0, nulls_location=NullsLocation(1), "
+      "partition_register=Register(0), dest_non_null_register=Register(1)]",
+      GetSpan(initial_indices), impl::Span<uint32_t>{nullptr, nullptr});
+
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1, 3, 4, 6, 0, 2, 5));
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(1), ElementsAre(1, 3, 4, 6));
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteNullPartitionAllNulls) {
+  auto data_vec = CreateFlexVectorForTesting<uint32_t>({});
+  auto bv = BitVector::CreateWithSize(3);
+  columns_vec_.push_back(impl::Column{
+      "col", impl::Storage{std::move(data_vec)},
+      impl::Overlay{impl::Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
+
+  std::vector<uint32_t> initial_indices = {0, 1, 2};
+  SetRegistersAndExecute(
+      "NullIndicesStablePartition: [col=0, nulls_location=NullsLocation(0), "
+      "partition_register=Register(0), dest_non_null_register=Register(1)]",
+      GetSpan(initial_indices), impl::Span<uint32_t>{nullptr, nullptr});
+
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 1, 2));
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(1), ElementsAre());
+}
+
+TEST_F(BytecodeInterpreterTest, ExecuteNullPartitionEmptyInput) {
+  auto data_vec = CreateFlexVectorForTesting<uint32_t>({});
+  auto bv = BitVector::CreateWithSize(0);
+  columns_vec_.push_back(impl::Column{
+      "col", impl::Storage{std::move(data_vec)},
+      impl::Overlay{impl::Overlay::SparseNull{std::move(bv)}}, Unsorted{}});
+
+  std::vector<uint32_t> initial_indices = {};
+  SetRegistersAndExecute(
+      "NullIndicesStablePartition: [col=0, nulls_location=NullsLocation(0), "
+      "partition_register=Register(0), dest_non_null_register=Register(1)]",
+      GetSpan(initial_indices), impl::Span<uint32_t>{nullptr, nullptr});
+
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre());
+  EXPECT_THAT(GetRegister<Span<uint32_t>>(1), ElementsAre());
 }
 
 }  // namespace

--- a/src/trace_processor/dataframe/impl/query_plan.h
+++ b/src/trace_processor/dataframe/impl/query_plan.h
@@ -131,12 +131,15 @@ struct QueryPlan {
 // needed to execute a query.
 class QueryPlanBuilder {
  public:
-  static base::StatusOr<QueryPlan> Build(uint32_t row_count,
-                                         const std::vector<Column>& columns,
-                                         std::vector<FilterSpec>& specs,
-                                         uint64_t cols_used) {
+  static base::StatusOr<QueryPlan> Build(
+      uint32_t row_count,
+      const std::vector<Column>& columns,
+      std::vector<FilterSpec>& specs,
+      const std::vector<SortSpec>& sort_specs,
+      uint64_t cols_used) {
     QueryPlanBuilder builder(row_count, columns);
     RETURN_IF_ERROR(builder.Filter(specs));
+    builder.Sort(sort_specs);
     builder.Output(cols_used);
     return std::move(builder).Build();
   }
@@ -157,6 +160,10 @@ class QueryPlanBuilder {
   // Adds filter operations to the query plan based on filter specifications.
   // Optimizes the order of filters for efficiency.
   base::Status Filter(std::vector<FilterSpec>& specs);
+
+  // Adds sort operations to the query plan based on sort specifications.
+  // Sorts are applied after filters, in reverse order of specification.
+  void Sort(const std::vector<SortSpec>& sort_specs);
 
   // Configures output handling for the filtered rows.
   // |cols_used_bitmap| is a bitmap with bits set for columns that will be

--- a/src/trace_processor/dataframe/impl/types.h
+++ b/src/trace_processor/dataframe/impl/types.h
@@ -91,6 +91,17 @@ struct UpperBound {};
 using EqualRangeLowerBoundUpperBound =
     TypeSet<EqualRange, LowerBound, UpperBound>;
 
+// Type tag indicating nulls should be placed at the start during
+// partitioning/sorting.
+struct NullsAtStart {};
+
+// Type tag indicating nulls should be placed at the end during
+// partitioning/sorting.
+struct NullsAtEnd {};
+
+// TypeSet defining the possible placement locations for nulls.
+using NullsLocation = TypeSet<NullsAtStart, NullsAtEnd>;
+
 // Storage implementation for column data. Provides physical storage
 // for different types of column content.
 class Storage {
@@ -98,6 +109,8 @@ class Storage {
   // Storage representation for Id columns.
   struct Id {
     uint32_t size;  // Number of rows in the column
+
+    static const void* data() { return nullptr; }
   };
   using Uint32 = FlexVector<uint32_t>;
   using Int32 = FlexVector<int32_t>;

--- a/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
+++ b/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
@@ -155,7 +155,8 @@ class DataframeBuilderTest : public ::testing::Test {
     std::vector<FilterSpec> filter_specs;
     auto num_cols_selected =
         static_cast<uint32_t>(PERFETTO_POPCOUNT(cols_bitmap));
-    ASSERT_OK_AND_ASSIGN(auto plan, df.PlanQuery(filter_specs, cols_bitmap));
+    ASSERT_OK_AND_ASSIGN(auto plan,
+                         df.PlanQuery(filter_specs, {}, cols_bitmap));
 
     TestRowFetcher execute_fetcher;
     std::optional<Cursor<TestRowFetcher>> cursor;

--- a/src/trace_processor/dataframe/specs.h
+++ b/src/trace_processor/dataframe/specs.h
@@ -129,7 +129,7 @@ using Nullability = TypeSet<NonNull, SparseNull, DenseNull>;
 // This is used to generate query plans for filtering rows.
 struct FilterSpec {
   // Index of the column in the dataframe to filter.
-  uint32_t column_index;
+  uint32_t col;
 
   // Original index from the client query (used for tracking).
   uint32_t source_index;
@@ -140,6 +140,25 @@ struct FilterSpec {
   // Output parameter: index for the filter value in query execution.
   // This is populated during query planning.
   std::optional<uint32_t> value_index;
+};
+
+// -----------------------------------------------------------------------------
+// Sort Specifications
+// -----------------------------------------------------------------------------
+
+// Defines the direction for sorting.
+enum class SortDirection : uint32_t {
+  kAscending,
+  kDescending,
+};
+
+// Specifies a sort operation to be applied to the dataframe rows.
+struct SortSpec {
+  // Index of the column in the dataframe to sort by.
+  uint32_t col;
+
+  // Direction of the sort (ascending or descending).
+  SortDirection direction;
 };
 
 }  // namespace perfetto::trace_processor::dataframe


### PR DESCRIPTION
This PR adds end to end support for sorting dataframes; all the way from
SQLite to the interpreter.
