### PR TITLE
Render slice tooltips to the DOM (instead of to the canvas)

### DIFF
--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -60,6 +60,7 @@
 @import "widgets/text_input";
 @import "widgets/text_paragraph";
 @import "widgets/timestamp";
+@import "widgets/tooltip";
 @import "widgets/track_shell";
 @import "widgets/tree";
 @import "widgets/treetable";

--- a/ui/src/assets/viewer_page.scss
+++ b/ui/src/assets/viewer_page.scss
@@ -86,3 +86,10 @@
     font-size: 11px;
   }
 }
+
+// Just make the tooltip font a bit smaller, which helps keep the style in line
+// with the tracks.
+.pf-track__tooltip {
+  font-size: 14px;
+  opacity: 0.8;
+}

--- a/ui/src/assets/widgets/tooltip.scss
+++ b/ui/src/assets/widgets/tooltip.scss
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import "theme";
+
+.pf-cursor-tooltip {
+  position: absolute;
+  background: white;
+
+  font-family: $pf-font;
+  z-index: 10;
+  padding: 2px 6px;
+  border-radius: $pf-border-radius;
+  border: solid 1px $pf-minimal-border;
+  box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+}

--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -12,29 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
+import {drawIncompleteSlice} from '../../base/canvas_utils';
+import {colorCompare} from '../../base/color';
+import {AsyncDisposableStack} from '../../base/disposable_stack';
+import {VerticalBounds} from '../../base/geom';
 import {assertExists} from '../../base/logging';
 import {clamp, floatEqual} from '../../base/math_utils';
+import {cropText} from '../../base/string_utils';
 import {Time, time} from '../../base/time';
 import {exists} from '../../base/utils';
-import {
-  drawIncompleteSlice,
-  drawTrackHoverTooltip,
-} from '../../base/canvas_utils';
-import {cropText} from '../../base/string_utils';
-import {colorCompare} from '../../base/color';
-import {UNEXPECTED_PINK} from '../colorizer';
+import {uuidv4Sql} from '../../base/uuid';
 import {featureFlags} from '../../core/feature_flags';
 import {raf} from '../../core/raf_scheduler';
-import {TrackRenderer} from '../../public/track';
-import {Slice} from '../../public/track';
+import {Trace} from '../../public/trace';
+import {
+  Slice,
+  TrackMouseEvent,
+  TrackRenderContext,
+  TrackRenderer,
+} from '../../public/track';
 import {LONG, NUM} from '../../trace_processor/query_result';
 import {checkerboardExcept} from '../checkerboard';
+import {UNEXPECTED_PINK} from '../colorizer';
 import {BUCKETS_PER_PIXEL, CacheKey} from './timeline_cache';
-import {uuidv4Sql} from '../../base/uuid';
-import {AsyncDisposableStack} from '../../base/disposable_stack';
-import {TrackMouseEvent, TrackRenderContext} from '../../public/track';
-import {Point2D, VerticalBounds} from '../../base/geom';
-import {Trace} from '../../public/trace';
 
 // The common class that underpins all tracks drawing slices.
 
@@ -201,9 +202,11 @@ export abstract class BaseSliceTrack<
   private extraSqlColumns: string[];
 
   private charWidth = -1;
-  private hoverPos?: Point2D;
   protected hoveredSlice?: SliceT;
-  private hoverTooltip: string[] = [];
+
+  // Bunch of lines to render on the tooltip.
+  private hoverTooltip?: string[];
+
   private maxDataDepth = 0;
 
   // Computed layout.
@@ -650,24 +653,17 @@ export abstract class BaseSliceTrack<
     // have some abstraction for that arrow (ideally the same we'd use for
     // flows).
     this.drawSchedLatencyArrow(ctx, this.selectedSlice);
-
-    // If a slice is hovered, draw the tooltip.
-    const tooltip = this.hoverTooltip;
-    if (
-      this.hoveredSlice !== undefined &&
-      tooltip.length > 0 &&
-      this.hoverPos !== undefined
-    ) {
-      if (tooltip.length === 1) {
-        drawTrackHoverTooltip(ctx, this.hoverPos, size, tooltip[0]);
-      } else {
-        drawTrackHoverTooltip(ctx, this.hoverPos, size, tooltip[0], tooltip[1]);
-      }
-    } // if (hoveredSlice)
   }
 
   async onDestroy(): Promise<void> {
     await this.trash.asyncDispose();
+  }
+
+  renderTooltip() {
+    return (
+      this.hoverTooltip &&
+      m('.pf-track__tooltip', [this.hoverTooltip.map((line) => m('', line))])
+    );
   }
 
   // This method figures out if the visible window is outside the bounds of
@@ -826,15 +822,9 @@ export abstract class BaseSliceTrack<
   }
 
   onMouseMove(event: TrackMouseEvent): void {
-    const {x, y} = event;
-    this.hoverPos = {x, y};
     this.updateHoveredSlice(this.findSlice(event));
 
-    // We need to do a full redraw in order to update the hovered slice properly
-    // due to the way this system is plumbed together right now, despite the
-    // fact that changing the hovered slice SHOULD only require a canvas redraw.
-    //
-    // TODO(stevegolton): Fix this.
+    // Maybe do this in the caller?
     this.trace.raf.scheduleFullRedraw();
   }
 
@@ -852,13 +842,12 @@ export abstract class BaseSliceTrack<
     if (this.hoveredSlice === undefined) {
       this.trace.timeline.highlightedSliceId = undefined;
       this.onSliceOut({slice: assertExists(lastHoveredSlice)});
-      this.hoverTooltip = [];
-      this.hoverPos = undefined;
+      this.hoverTooltip = undefined;
     } else {
       const args: OnSliceOverArgs<SliceT> = {slice: this.hoveredSlice};
       this.trace.timeline.highlightedSliceId = this.hoveredSlice.id;
       this.onSliceOver(args);
-      this.hoverTooltip = args.tooltip || [];
+      this.hoverTooltip = args.tooltip;
     }
   }
 

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -76,6 +76,8 @@ export interface TrackViewAttrs {
   readonly depth: number;
   readonly stickyTop: number;
   readonly collapsible: boolean;
+  onTrackMouseOver(): void;
+  onTrackMouseOut(): void;
 }
 
 /**
@@ -178,10 +180,12 @@ export class TrackView {
             timescale,
           });
           raf.scheduleCanvasRedraw();
+          attrs.onTrackMouseOver();
         },
         onTrackContentMouseOut: () => {
           renderer?.track.onMouseOut?.();
           raf.scheduleCanvasRedraw();
+          attrs.onTrackMouseOut();
         },
         onTrackContentClick: (pos, bounds) => {
           const timescale = this.getTimescaleForBounds(bounds);

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -61,6 +61,7 @@ import {VirtualOverlayCanvas} from '../../widgets/virtual_overlay_canvas';
 import {SplitPanel} from '../../widgets/split_panel';
 import {TabbedSplitPanel} from '../../widgets/tabbed_split_panel';
 import {parseAndPrintTree} from '../../base/perfetto_sql_lang/language';
+import {CursorTooltip} from '../../widgets/cursor_tooltip';
 
 const DATA_ENGLISH_LETTER_FREQUENCY = {
   table: [
@@ -1022,6 +1023,11 @@ export class WidgetsPage implements m.ClassComponent<PageAttrs> {
         },
       }),
       m(WidgetShowcase, {
+        label: 'CursorTooltip',
+        description: 'A tooltip that follows the mouse around.',
+        renderWidget: () => m(CursorTooltipShowcase),
+      }),
+      m(WidgetShowcase, {
         label: 'Spinner',
         description: `Simple spinner, rotates forever.
             Width and height match the font size.`,
@@ -1559,6 +1565,32 @@ export class WidgetsPage implements m.ClassComponent<PageAttrs> {
       }),
     );
   }
+}
+
+function CursorTooltipShowcase() {
+  let show = false;
+  return {
+    view() {
+      return m(
+        '',
+        {
+          style: {
+            width: '150px',
+            height: '150px',
+            border: '1px dashed gray',
+            userSelect: 'none',
+            color: 'gray',
+            textAlign: 'center',
+            lineHeight: '150px',
+          },
+          onmouseover: () => (show = true),
+          onmouseout: () => (show = false),
+        },
+        'Hover here...',
+        show && m(CursorTooltip, 'Hi!'),
+      );
+    },
+  };
 }
 
 class ModalShowcase implements m.ClassComponent {

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -217,6 +217,10 @@ export interface TrackRenderer {
   // event selection. This is called each time the selection is changed (and the
   // selection is relevant to this track).
   detailsPanel?(sel: TrackEventSelection): TrackEventDetailsPanel | undefined;
+
+  // Optional: Returns tooltip content if available. If the return value is
+  // falsy, no tooltip is rendered.
+  renderTooltip?(): m.Children;
 }
 
 // An set of key/value pairs describing a given track. These are used for

--- a/ui/src/widgets/cursor_tooltip.ts
+++ b/ui/src/widgets/cursor_tooltip.ts
@@ -1,0 +1,94 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Portal} from './portal';
+import {bindEventListener} from '../base/dom_utils';
+import {DisposableStack} from '../base/disposable_stack';
+import {HTMLAttrs} from './common';
+import {
+  createPopper,
+  Instance as PopperInstance,
+  VirtualElement,
+} from '@popperjs/core';
+import {classNames} from '../base/classnames';
+
+export interface CursorTooltipAttrs extends HTMLAttrs {}
+
+class VElement implements VirtualElement {
+  private x = 0;
+  private y = 0;
+
+  getBoundingClientRect() {
+    return new DOMRect(this.x, this.y, 0, 0);
+  }
+
+  setPosition(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+/**
+ * Provides a little tooltip that's permanently attached to the mouse.
+ *
+ * Any children are rendered inside - the tooltip is displayed to the bottom
+ * right if there is room.
+ */
+export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
+  private readonly trash = new DisposableStack();
+  private readonly virtualElement = new VElement();
+  private popper?: PopperInstance;
+
+  view({children, attrs}: m.Vnode<CursorTooltipAttrs>) {
+    const {className, ...rest} = attrs;
+    return m(
+      Portal,
+      {
+        ...rest,
+        className: classNames('pf-cursor-tooltip', className),
+        onContentMount: (portal) => {
+          this.popper = createPopper(this.virtualElement, portal, {
+            placement: 'right-start',
+            modifiers: [
+              {
+                name: 'offset',
+                options: {
+                  offset: [8, 8], // Shift away from cursor
+                },
+              },
+            ],
+          });
+        },
+        onContentUnmount: () => {
+          this.popper?.destroy();
+        },
+      },
+      children,
+    );
+  }
+
+  oncreate(_: m.VnodeDOM<CursorTooltipAttrs>) {
+    this.trash.use(
+      bindEventListener(document, 'mousemove', (e) => {
+        this.virtualElement.setPosition(e.clientX, e.clientY);
+        this.popper?.update();
+      }),
+    );
+  }
+
+  onremove(_: m.VnodeDOM<CursorTooltipAttrs, this>) {
+    this.trash.dispose();
+  }
+}


### PR DESCRIPTION
Using the DOM for tooltips has the following benefits:
- Tooltips can be larger than the track
- Can add more detailed information
- Much easier to style

These tooltips use a new widget called `CursorTooltip`, which uses `popper.js` to automatically flip sides to keep the tooltip visible - just like the `Popup` widget does.
