### PR TITLE
tprobes: generic events as self-describing protos (2/3)

### DIFF
--- a/protos/perfetto/config/ftrace/ftrace_config.proto
+++ b/protos/perfetto/config/ftrace/ftrace_config.proto
@@ -18,7 +18,7 @@ syntax = "proto2";
 
 package perfetto.protos;
 
-// Next id: 31
+// Next id: 33
 message FtraceConfig {
   // Ftrace events to record, example: "sched/sched_switch".
   repeated string ftrace_events = 1;
@@ -153,6 +153,12 @@ message FtraceConfig {
   //   need to deal with both cases.
   // For more context: go/rss-stat-throttled.
   optional bool throttle_rss_stat = 15;
+
+  // If true, use self-describing proto messages when writing events not known
+  // at compile time (aka generic events). Each event bundle will have a set of
+  // serialised proto descriptors for events within that bundle.
+  // Added in: perfetto v50.
+  optional bool denser_generic_event_encoding = 32;
 
   // If true, avoid enabling events that aren't statically known by
   // traced_probes. Otherwise, the default is to emit such events as

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -995,7 +995,7 @@ message EtwConfig {
 
 // Begin of protos/perfetto/config/ftrace/ftrace_config.proto
 
-// Next id: 31
+// Next id: 33
 message FtraceConfig {
   // Ftrace events to record, example: "sched/sched_switch".
   repeated string ftrace_events = 1;
@@ -1130,6 +1130,12 @@ message FtraceConfig {
   //   need to deal with both cases.
   // For more context: go/rss-stat-throttled.
   optional bool throttle_rss_stat = 15;
+
+  // If true, use self-describing proto messages when writing events not known
+  // at compile time (aka generic events). Each event bundle will have a set of
+  // serialised proto descriptors for events within that bundle.
+  // Added in: perfetto v50.
+  optional bool denser_generic_event_encoding = 32;
 
   // If true, avoid enabling events that aren't statically known by
   // traced_probes. Otherwise, the default is to emit such events as

--- a/protos/perfetto/trace/ftrace/ftrace_event.proto
+++ b/protos/perfetto/trace/ftrace/ftrace_event.proto
@@ -110,6 +110,9 @@ message FtraceEvent {
   // consider merging with common_preempt_count to avoid extra proto tags.
   optional uint32 common_flags = 5;
 
+  // Range reserved for self-describing messages.
+  reserved 65536 to 131072;
+
   oneof event {
     PrintFtraceEvent print = 3;
     SchedSwitchFtraceEvent sched_switch = 4;

--- a/protos/perfetto/trace/ftrace/ftrace_event_bundle.proto
+++ b/protos/perfetto/trace/ftrace/ftrace_event_bundle.proto
@@ -130,6 +130,17 @@ message FtraceEventBundle {
   // Added in: perfetto v47.
   optional uint64 previous_bundle_end_timestamp = 10;
 
+  // Describes the serialised |FtraceEvent| protos for events not known at
+  // compile time, when using the |denser_generic_event_encoding| option.
+  // Addded in: perfetto v50.
+  message GenericEventDescriptor {
+    // submessage id within FtraceEvent described by |descriptor|.
+    optional int32 field_id = 1;
+    // serialised DescriptorProto
+    optional bytes descriptor = 2;
+  }
+  repeated GenericEventDescriptor generic_event_descriptors = 11;
+
   // Written only on debuggable android builds if the config sets
   // |debug_ftrace_abi|. Contains the raw ring buffer tracing page that the
   // implementation could not parse.

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -995,7 +995,7 @@ message EtwConfig {
 
 // Begin of protos/perfetto/config/ftrace/ftrace_config.proto
 
-// Next id: 31
+// Next id: 33
 message FtraceConfig {
   // Ftrace events to record, example: "sched/sched_switch".
   repeated string ftrace_events = 1;
@@ -1130,6 +1130,12 @@ message FtraceConfig {
   //   need to deal with both cases.
   // For more context: go/rss-stat-throttled.
   optional bool throttle_rss_stat = 15;
+
+  // If true, use self-describing proto messages when writing events not known
+  // at compile time (aka generic events). Each event bundle will have a set of
+  // serialised proto descriptors for events within that bundle.
+  // Added in: perfetto v50.
+  optional bool denser_generic_event_encoding = 32;
 
   // If true, avoid enabling events that aren't statically known by
   // traced_probes. Otherwise, the default is to emit such events as
@@ -11218,6 +11224,9 @@ message FtraceEvent {
   // consider merging with common_preempt_count to avoid extra proto tags.
   optional uint32 common_flags = 5;
 
+  // Range reserved for self-describing messages.
+  reserved 65536 to 131072;
+
   oneof event {
     PrintFtraceEvent print = 3;
     SchedSwitchFtraceEvent sched_switch = 4;
@@ -12053,6 +12062,17 @@ message FtraceEventBundle {
   // oldest bundles can skew the first valid timestamp per cpu significantly.
   // Added in: perfetto v47.
   optional uint64 previous_bundle_end_timestamp = 10;
+
+  // Describes the serialised |FtraceEvent| protos for events not known at
+  // compile time, when using the |denser_generic_event_encoding| option.
+  // Addded in: perfetto v50.
+  message GenericEventDescriptor {
+    // submessage id within FtraceEvent described by |descriptor|.
+    optional int32 field_id = 1;
+    // serialised DescriptorProto
+    optional bytes descriptor = 2;
+  }
+  repeated GenericEventDescriptor generic_event_descriptors = 11;
 
   // Written only on debuggable android builds if the config sets
   // |debug_ftrace_abi|. Contains the raw ring buffer tracing page that the

--- a/src/tools/ftrace_proto_gen/ftrace_proto_gen.cc
+++ b/src/tools/ftrace_proto_gen/ftrace_proto_gen.cc
@@ -128,6 +128,9 @@ void GenerateFtraceEventProto(const std::vector<FtraceEventName>& raw_eventlist,
   // consider merging with common_preempt_count to avoid extra proto tags.
   optional uint32 common_flags = 5;
 
+  // Range reserved for self-describing messages.
+  reserved 65536 to 131072;
+
   oneof event {
 )";
 

--- a/src/traced/probes/ftrace/cpu_reader.cc
+++ b/src/traced/probes/ftrace/cpu_reader.cc
@@ -27,6 +27,7 @@
 #include "perfetto/ext/base/metatrace.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"
+#include "perfetto/protozero/proto_utils.h"
 #include "src/kallsyms/kernel_symbol_map.h"
 #include "src/kallsyms/lazy_kernel_symbolizer.h"
 #include "src/traced/probes/ftrace/ftrace_config_muxer.h"
@@ -35,6 +36,7 @@
 #include "src/traced/probes/ftrace/ftrace_print_filter.h"
 #include "src/traced/probes/ftrace/proto_translation_table.h"
 
+#include "protos/perfetto/common/descriptor.pbzero.h"
 #include "protos/perfetto/trace/ftrace/ftrace_event.pbzero.h"
 #include "protos/perfetto/trace/ftrace/ftrace_event_bundle.pbzero.h"
 #include "protos/perfetto/trace/ftrace/ftrace_stats.pbzero.h"  // FtraceParseStatus
@@ -49,6 +51,7 @@ namespace {
 using FtraceParseStatus = protos::pbzero::FtraceParseStatus;
 using protos::pbzero::GenericFtraceEvent;
 using protos::pbzero::KprobeEvent;
+using protozero::proto_utils::ProtoSchemaType;
 
 // If the compact_sched buffer accumulates more unique strings, the reader will
 // flush it to reset the interning state (and make it cheap again).
@@ -348,6 +351,23 @@ void CpuReader::Bundler::StartNewPacket(
   }
 }
 
+void CpuReader::Bundler::WriteGenericEventDescriptors() {
+  if (!bundle_)
+    return;
+
+  for (uint32_t proto_id : generic_descriptors_to_write_) {
+    PERFETTO_DCHECK(generic_pb_descriptors_->Find(proto_id));
+
+    std::vector<unsigned char>* pb_descriptor =
+        generic_pb_descriptors_->Find(proto_id);
+    if (pb_descriptor) {
+      auto* g = bundle_->add_generic_event_descriptors();
+      g->set_field_id(static_cast<int32_t>(proto_id));
+      g->set_descriptor(pb_descriptor->data(), pb_descriptor->size());
+    }
+  }
+}
+
 void CpuReader::Bundler::FinalizeAndRunSymbolizer() {
   if (!packet_) {
     return;
@@ -355,6 +375,10 @@ void CpuReader::Bundler::FinalizeAndRunSymbolizer() {
 
   if (compact_sched_enabled_) {
     compact_sched_buf_->WriteAndReset(bundle_);
+  }
+
+  if (!generic_descriptors_to_write_.empty()) {
+    WriteGenericEventDescriptors();
   }
 
   bundle_->Finalize();
@@ -441,7 +465,8 @@ bool CpuReader::ProcessPagesForDataSource(
   Bundler bundler(trace_writer, metadata,
                   ds_config->symbolize_ksyms ? symbolizer : nullptr, cpu,
                   ftrace_clock_snapshot, ftrace_clock, compact_sched_buf,
-                  ds_config->compact_sched.enabled, *bundle_end_timestamp);
+                  ds_config->compact_sched.enabled, *bundle_end_timestamp,
+                  table->generic_evt_pb_descriptors());
 
   bool success = true;
   size_t pages_parsed = 0;
@@ -690,7 +715,8 @@ protos::pbzero::FtraceParseStatus CpuReader::ParsePagePayload(
                   bundler->GetOrCreateBundle()->add_event();
               event->set_timestamp(timestamp);
               if (!ParseEvent(ftrace_event_id, start, next, table, ds_config,
-                              event, metadata)) {
+                              event, metadata,
+                              bundler->generic_descriptors_to_write())) {
                 return FtraceParseStatus::FTRACE_STATUS_INVALID_EVENT;
               }
             } else {  // print event did NOT pass the filter
@@ -702,7 +728,8 @@ protos::pbzero::FtraceParseStatus CpuReader::ParsePagePayload(
                 bundler->GetOrCreateBundle()->add_event();
             event->set_timestamp(timestamp);
             if (!ParseEvent(ftrace_event_id, start, next, table, ds_config,
-                            event, metadata)) {
+                            event, metadata,
+                            bundler->generic_descriptors_to_write())) {
               return FtraceParseStatus::FTRACE_STATUS_INVALID_EVENT;
             }
           }
@@ -722,15 +749,16 @@ protos::pbzero::FtraceParseStatus CpuReader::ParsePagePayload(
 
 // |start| is the start of the current event.
 // |end| is the end of the buffer.
-bool CpuReader::ParseEvent(uint16_t ftrace_event_id,
-                           const uint8_t* start,
-                           const uint8_t* end,
-                           const ProtoTranslationTable* table,
-                           const FtraceDataSourceConfig* ds_config,
-                           protozero::Message* message,
-                           FtraceMetadata* metadata) {
+bool CpuReader::ParseEvent(
+    uint16_t ftrace_event_id,
+    const uint8_t* start,
+    const uint8_t* end,
+    const ProtoTranslationTable* table,
+    const FtraceDataSourceConfig* ds_config,
+    protozero::Message* message,
+    FtraceMetadata* metadata,
+    base::FlatSet<uint32_t>* generic_descriptors_to_write) {
   PERFETTO_DCHECK(start < end);
-
   // The event must be enabled and known to reach here.
   const Event& info = *table->GetEventById(ftrace_event_id);
 
@@ -741,41 +769,59 @@ bool CpuReader::ParseEvent(uint16_t ftrace_event_id,
 
   bool success = true;
   const Field* common_pid_field = table->common_pid();
-  if (PERFETTO_LIKELY(common_pid_field))
+  if (PERFETTO_LIKELY(common_pid_field)) {
     success &=
         ParseField(*common_pid_field, start, end, table, message, metadata);
+  }
 
-  protozero::Message* nested =
-      message->BeginNestedMessage<protozero::Message>(info.proto_field_id);
+  auto begin_nested_message = [&message](uint32_t field_id) {
+    return message->BeginNestedMessage<protozero::Message>(field_id);
+  };
 
-  // Parse generic (not known at compile time) event.
-  if (PERFETTO_UNLIKELY(info.proto_field_id ==
-                        protos::pbzero::FtraceEvent::kGenericFieldNumber)) {
-    nested->AppendString(GenericFtraceEvent::kEventNameFieldNumber, info.name);
-    for (const Field& field : info.fields) {
-      auto* generic_field = nested->BeginNestedMessage<protozero::Message>(
-          GenericFtraceEvent::kFieldFieldNumber);
-      generic_field->AppendString(GenericFtraceEvent::Field::kNameFieldNumber,
-                                  field.ftrace_name);
-      success &= ParseField(field, start, end, table, generic_field, metadata);
+  using protos::pbzero::FtraceEvent;
+  if (PERFETTO_UNLIKELY(table->IsGenericEventProtoId(info.proto_field_id))) {
+    if (ds_config->write_generic_evt_descriptors) {
+      // Newer style encoding for generic (unknown at compile time) events.
+      // The encoding itself is the same as the common "else" branch at the
+      // bottom of this if-else chain. The only addition is remembering that we
+      // need to emit the descriptor.
+      generic_descriptors_to_write->insert(info.proto_field_id);
+      protozero::Message* nested = begin_nested_message(info.proto_field_id);
+      for (const Field& field : info.fields) {
+        success &= ParseField(field, start, end, table, nested, metadata);
+      }
+    } else {
+      // legacy encoding of generic events
+      protozero::Message* nested =
+          begin_nested_message(FtraceEvent::kGenericFieldNumber);
+      success &=
+          ParseGenericEventLegacy(info, start, end, table, nested, metadata);
     }
-  } else if (PERFETTO_UNLIKELY(
-                 info.proto_field_id ==
-                 protos::pbzero::FtraceEvent::kSysEnterFieldNumber)) {
+
+  } else if (PERFETTO_UNLIKELY(info.proto_field_id ==
+                               FtraceEvent::kSysEnterFieldNumber)) {
+    // syscall sys_enter
+    protozero::Message* nested = begin_nested_message(info.proto_field_id);
     success &= ParseSysEnter(info, start, end, nested);
-  } else if (PERFETTO_UNLIKELY(
-                 info.proto_field_id ==
-                 protos::pbzero::FtraceEvent::kSysExitFieldNumber)) {
+
+  } else if (PERFETTO_UNLIKELY(info.proto_field_id ==
+                               FtraceEvent::kSysExitFieldNumber)) {
+    // syscall sys_exit
+    protozero::Message* nested = begin_nested_message(info.proto_field_id);
     success &= ParseSysExit(info, start, end, ds_config, nested, metadata);
-  } else if (PERFETTO_UNLIKELY(
-                 info.proto_field_id ==
-                 protos::pbzero::FtraceEvent::kKprobeEventFieldNumber)) {
-    KprobeEvent::KprobeType* elem = ds_config->kprobes.Find(ftrace_event_id);
+
+  } else if (PERFETTO_UNLIKELY(info.proto_field_id ==
+                               FtraceEvent::kKprobeEventFieldNumber)) {
+    // kprobes
+    protozero::Message* nested = begin_nested_message(info.proto_field_id);
     nested->AppendString(KprobeEvent::kNameFieldNumber, info.name);
-    if (elem) {
-      nested->AppendVarInt(KprobeEvent::kTypeFieldNumber, *elem);
+    if (auto* type = ds_config->kprobes.Find(ftrace_event_id); type) {
+      nested->AppendVarInt(KprobeEvent::kTypeFieldNumber, *type);
     }
-  } else {  // Parse all other events.
+
+  } else {
+    // all other events
+    protozero::Message* nested = begin_nested_message(info.proto_field_id);
     for (const Field& field : info.fields) {
       success &= ParseField(field, start, end, table, nested, metadata);
     }
@@ -904,6 +950,37 @@ bool CpuReader::ParseField(const Field& field,
   // Shouldn't reach this since we only attempt to parse fields that were
   // validated by the proto translation table earlier.
   return false;
+}
+
+// static
+bool CpuReader::ParseGenericEventLegacy(const Event& info,
+                                        const uint8_t* start,
+                                        const uint8_t* end,
+                                        const ProtoTranslationTable* table,
+                                        protozero::Message* message,
+                                        FtraceMetadata* metadata) {
+  using PBFIELD = GenericFtraceEvent::Field;
+
+  bool success = true;
+  auto* generic = static_cast<GenericFtraceEvent*>(message);
+  generic->set_event_name(info.name);
+  for (const Field& field : info.fields) {
+    auto* pb_field = generic->add_field();
+    pb_field->set_name(field.ftrace_name);
+    // Proto translation table has an ascending order of proto field ids for the
+    // fields, but we need to encode them into a type-dependent oneof.
+    Field for_encoding = field;
+    if (field.proto_field_type == ProtoSchemaType::kInt64)
+      for_encoding.proto_field_id = PBFIELD::kIntValueFieldNumber;
+    else if (field.proto_field_type == ProtoSchemaType::kUint64)
+      for_encoding.proto_field_id = PBFIELD::kUintValueFieldNumber;
+    else if (field.proto_field_type == ProtoSchemaType::kString)
+      for_encoding.proto_field_id = PBFIELD::kStrValueFieldNumber;
+    else
+      return false;
+    success &= ParseField(for_encoding, start, end, table, pb_field, metadata);
+  }
+  return success;
 }
 
 // static

--- a/src/traced/probes/ftrace/cpu_reader.h
+++ b/src/traced/probes/ftrace/cpu_reader.h
@@ -23,6 +23,8 @@
 #include <optional>
 #include <set>
 
+#include "perfetto/base/flat_set.h"
+#include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/paged_memory.h"
 #include "perfetto/ext/base/scoped_file.h"
 #include "perfetto/ext/base/utils.h"
@@ -119,7 +121,9 @@ class CpuReader {
             protos::pbzero::FtraceClock ftrace_clock,
             CompactSchedBuffer* compact_sched_buf,
             bool compact_sched_enabled,
-            uint64_t previous_bundle_end_ts)
+            uint64_t previous_bundle_end_ts,
+            const base::FlatHashMap<uint32_t, std::vector<uint8_t>>*
+                generic_pb_descriptors)
         : trace_writer_(trace_writer),
           metadata_(metadata),
           symbolizer_(symbolizer),
@@ -128,7 +132,8 @@ class CpuReader {
           ftrace_clock_(ftrace_clock),
           compact_sched_enabled_(compact_sched_enabled),
           compact_sched_buf_(compact_sched_buf),
-          initial_previous_bundle_end_ts_(previous_bundle_end_ts) {
+          initial_previous_bundle_end_ts_(previous_bundle_end_ts),
+          generic_pb_descriptors_(generic_pb_descriptors) {
       if (compact_sched_enabled_)
         compact_sched_buf_->Reset();
     }
@@ -156,6 +161,12 @@ class CpuReader {
       return compact_sched_buf_;
     }
 
+    base::FlatSet<uint32_t>* generic_descriptors_to_write() {
+      return &generic_descriptors_to_write_;
+    }
+
+    void WriteGenericEventDescriptors();
+
    private:
     TraceWriter* const trace_writer_;         // Never nullptr.
     FtraceMetadata* const metadata_;          // Never nullptr.
@@ -166,6 +177,10 @@ class CpuReader {
     const bool compact_sched_enabled_;
     CompactSchedBuffer* const compact_sched_buf_;
     uint64_t initial_previous_bundle_end_ts_;
+    // Keyed by proto field id within |FtraceEvent|.
+    base::FlatSet<uint32_t> generic_descriptors_to_write_;
+    const base::FlatHashMap<uint32_t, std::vector<uint8_t>>*
+        generic_pb_descriptors_;
 
     TraceWriter::TracePacketHandle packet_;
     protos::pbzero::FtraceEventBundle* bundle_ = nullptr;
@@ -325,7 +340,8 @@ class CpuReader {
                          const ProtoTranslationTable* table,
                          const FtraceDataSourceConfig* ds_config,
                          protozero::Message* message,
-                         FtraceMetadata* metadata);
+                         FtraceMetadata* metadata,
+                         base::FlatSet<uint32_t>* generic_descriptors_to_write);
 
   static bool ParseField(const Field& field,
                          const uint8_t* start,
@@ -347,6 +363,13 @@ class CpuReader {
                            const FtraceDataSourceConfig* ds_config,
                            protozero::Message* message,
                            FtraceMetadata* metadata);
+
+  static bool ParseGenericEventLegacy(const Event& info,
+                                      const uint8_t* start,
+                                      const uint8_t* end,
+                                      const ProtoTranslationTable* table,
+                                      protozero::Message* message,
+                                      FtraceMetadata* metadata);
 
   // Parse a sched_switch event according to pre-validated format, and buffer
   // the individual fields in the given compact encoding batch.

--- a/src/traced/probes/ftrace/ftrace_config_muxer.h
+++ b/src/traced/probes/ftrace/ftrace_config_muxer.h
@@ -59,7 +59,10 @@ struct FtraceDataSourceConfig {
       bool symbolize_ksyms_in,
       uint32_t buffer_percent_in,
       base::FlatSet<int64_t> syscalls_returning_fd_in,
-      bool debug_ftrace_abi_in)
+      base::FlatHashMap<uint32_t, protos::pbzero::KprobeEvent::KprobeType>
+          kprobes_in,
+      bool debug_ftrace_abi_in,
+      bool write_generic_evt_descriptors_in)
       : event_filter(std::move(event_filter_in)),
         syscall_filter(std::move(syscall_filter_in)),
         compact_sched(compact_sched_in),
@@ -71,7 +74,9 @@ struct FtraceDataSourceConfig {
         symbolize_ksyms(symbolize_ksyms_in),
         buffer_percent(buffer_percent_in),
         syscalls_returning_fd(std::move(syscalls_returning_fd_in)),
-        debug_ftrace_abi(debug_ftrace_abi_in) {}
+        kprobes(std::move(kprobes_in)),
+        debug_ftrace_abi(debug_ftrace_abi_in),
+        write_generic_evt_descriptors(write_generic_evt_descriptors_in) {}
 
   // The event filter allows to quickly check if a certain ftrace event with id
   // x is enabled for this data source.
@@ -108,6 +113,9 @@ struct FtraceDataSourceConfig {
   // For development/debugging, serialise raw ring buffer pages if on a
   // debuggable android build.
   const bool debug_ftrace_abi;
+
+  // If true, use the newer format for generic events.
+  const bool write_generic_evt_descriptors;
 };
 
 // Ftrace is a bunch of globally modifiable persistent state.

--- a/src/traced/probes/ftrace/proto_translation_table.cc
+++ b/src/traced/probes/ftrace/proto_translation_table.cc
@@ -26,6 +26,7 @@
 #include "perfetto/protozero/proto_utils.h"
 #include "src/traced/probes/ftrace/ftrace_procfs.h"
 
+#include "protos/perfetto/common/descriptor.gen.h"
 #include "protos/perfetto/trace/ftrace/ftrace_event.pbzero.h"
 #include "protos/perfetto/trace/ftrace/ftrace_event_bundle.pbzero.h"
 #include "protos/perfetto/trace/ftrace/generic.pbzero.h"
@@ -209,27 +210,21 @@ bool Match(const char* string, const char* pattern) {
   return ret != REG_NOMATCH;
 }
 
-// Set proto field type and id based on the ftrace type.
-void SetProtoType(FtraceFieldType ftrace_type,
-                  ProtoSchemaType* proto_type,
-                  uint32_t* proto_field_id) {
+// TODO(rsavitski): consider using zigzag encoding for signed integers.
+ProtoSchemaType ToGenericProtoField(FtraceFieldType ftrace_type) {
   switch (ftrace_type) {
     case kFtraceCString:
     case kFtraceFixedCString:
     case kFtraceStringPtr:
     case kFtraceDataLoc:
-      *proto_type = ProtoSchemaType::kString;
-      *proto_field_id = GenericFtraceEvent::Field::kStrValueFieldNumber;
-      break;
+      return ProtoSchemaType::kString;
     case kFtraceInt8:
     case kFtraceInt16:
     case kFtraceInt32:
     case kFtracePid32:
     case kFtraceCommonPid32:
     case kFtraceInt64:
-      *proto_type = ProtoSchemaType::kInt64;
-      *proto_field_id = GenericFtraceEvent::Field::kIntValueFieldNumber;
-      break;
+      return ProtoSchemaType::kInt64;
     case kFtraceUint8:
     case kFtraceUint16:
     case kFtraceUint32:
@@ -241,13 +236,57 @@ void SetProtoType(FtraceFieldType ftrace_type,
     case kFtraceInode64:
     case kFtraceSymAddr32:
     case kFtraceSymAddr64:
-      *proto_type = ProtoSchemaType::kUint64;
-      *proto_field_id = GenericFtraceEvent::Field::kUintValueFieldNumber;
-      break;
+      return ProtoSchemaType::kUint64;
     case kInvalidFtraceFieldType:
-      PERFETTO_FATAL("Unexpected ftrace field type");
+      PERFETTO_DFATAL("Unexpected ftrace field type");
+      return ProtoSchemaType::kUnknown;
   }
 }
+
+protos::gen::FieldDescriptorProto::Type ToPbDescEnum(ProtoSchemaType v) {
+  using PB = protos::gen::FieldDescriptorProto;
+  switch (v) {
+    case (ProtoSchemaType::kDouble):
+      return PB::TYPE_DOUBLE;
+    case (ProtoSchemaType::kFloat):
+      return PB::TYPE_FLOAT;
+    case (ProtoSchemaType::kInt64):
+      return PB::TYPE_INT64;
+    case (ProtoSchemaType::kUint64):
+      return PB::TYPE_UINT64;
+    case (ProtoSchemaType::kInt32):
+      return PB::TYPE_INT32;
+    case (ProtoSchemaType::kFixed64):
+      return PB::TYPE_FIXED64;
+    case (ProtoSchemaType::kFixed32):
+      return PB::TYPE_FIXED32;
+    case (ProtoSchemaType::kBool):
+      return PB::TYPE_BOOL;
+    case (ProtoSchemaType::kString):
+      return PB::TYPE_STRING;
+    case (ProtoSchemaType::kGroup):
+      return PB::TYPE_GROUP;
+    case (ProtoSchemaType::kMessage):
+      return PB::TYPE_MESSAGE;
+    case (ProtoSchemaType::kBytes):
+      return PB::TYPE_BYTES;
+    case (ProtoSchemaType::kUint32):
+      return PB::TYPE_UINT32;
+    case (ProtoSchemaType::kEnum):
+      return PB::TYPE_ENUM;
+    case (ProtoSchemaType::kSfixed32):
+      return PB::TYPE_SFIXED32;
+    case (ProtoSchemaType::kSfixed64):
+      return PB::TYPE_SFIXED64;
+    case (ProtoSchemaType::kSint32):
+      return PB::TYPE_SINT32;
+    case (ProtoSchemaType::kSint64):
+      return PB::TYPE_SINT64;
+    case (ProtoSchemaType::kUnknown):
+      PERFETTO_DFATAL("Should never try to map an unknown proto field type.");
+      return PB::TYPE_BYTES;
+  }
+};
 
 }  // namespace
 
@@ -539,69 +578,129 @@ ProtoTranslationTable::ProtoTranslationTable(
   }
 }
 
-const Event* ProtoTranslationTable::CreateEventWithProtoId(
+const Event* ProtoTranslationTable::CreateGenericEvent(
+    const GroupAndName& group_and_name) {
+  if (const auto* existing = GetEvent(group_and_name); existing) {
+    PERFETTO_CHECK(IsGenericEventProtoId(existing->proto_field_id));
+    return existing;
+  }
+  auto proto_id = next_generic_evt_proto_id_++;
+  return CreateGenericEventInternal(group_and_name, proto_id,
+                                    /*keep_proto_descriptor=*/true);
+}
+
+// TODO(rsavitski): kprobes should eventually be migrated to generic events with
+// proto descriptors.
+const Event* ProtoTranslationTable::CreateKprobeEvent(
+    const GroupAndName& group_and_name) {
+  using protos::pbzero::FtraceEvent;
+  if (const auto* existing = GetEvent(group_and_name); existing) {
+    PERFETTO_DCHECK(existing->proto_field_id ==
+                    FtraceEvent::kKprobeEventFieldNumber);
+    return existing;
+  }
+  return CreateGenericEventInternal(group_and_name,
+                                    FtraceEvent::kKprobeEventFieldNumber,
+                                    /*keep_proto_descriptor=*/false);
+}
+
+const Event* ProtoTranslationTable::CreateGenericEventInternal(
     const GroupAndName& group_and_name,
-    uint32_t proto_field_id) {
-  // The ftrace event does not already exist so a new one will be created
-  // by parsing the format file.
+    uint32_t proto_field_id,
+    bool keep_proto_descriptor) {
   std::string contents = ftrace_procfs_->ReadEventFormat(group_and_name.group(),
                                                          group_and_name.name());
   if (contents.empty())
     return nullptr;
+
   FtraceEvent tracefs_event = {};
   ParseFtraceEvent(contents, &tracefs_event);
 
   if (tracefs_event.id >= events_.size()) {
     events_.resize(tracefs_event.id + 1);
   }
-
-  // Set known event variables
-  Event* e = &events_.at(tracefs_event.id);
-  e->ftrace_event_id = tracefs_event.id;
-  e->proto_field_id = proto_field_id;
-  e->name = InternString(group_and_name.name());
-  e->group = InternString(group_and_name.group());
+  Event* evt = &events_.at(tracefs_event.id);
+  evt->ftrace_event_id = tracefs_event.id;
+  evt->proto_field_id = proto_field_id;
+  evt->name = InternString(group_and_name.name());
+  evt->group = InternString(group_and_name.group());
 
   // Calculate size of common fields.
-  for (const FtraceEvent::Field& ftrace_field : tracefs_event.common_fields) {
-    uint16_t field_end = ftrace_field.offset + ftrace_field.size;
-    e->size = std::max(field_end, e->size);
+  for (const FtraceEvent::Field& tracefs_field : tracefs_event.common_fields) {
+    uint16_t field_end = tracefs_field.offset + tracefs_field.size;
+    evt->size = std::max(field_end, evt->size);
   }
 
-  // For every field in the ftrace event, make a field in the generic event.
-  for (const FtraceEvent::Field& ftrace_field : tracefs_event.fields)
-    e->size = std::max(CreateGenericEventField(ftrace_field, *e), e->size);
+  // TODO(rsavitski): consider mixing in the group into the name (while keeping
+  // it a valid C identifier).
+  protos::gen::DescriptorProto pb_descriptor;
+  pb_descriptor.set_name(group_and_name.name());
 
-  group_and_name_to_event_[group_and_name] = &events_.at(e->ftrace_event_id);
-  name_to_events_[e->name].push_back(&events_.at(e->ftrace_event_id));
-  group_to_events_[e->group].push_back(&events_.at(e->ftrace_event_id));
+  auto add_pb_desc_field = [&pb_descriptor](
+                               uint32_t id, const std::string& name,
+                               protos::gen::FieldDescriptorProto::Type type) {
+    auto* f = pb_descriptor.add_field();
+    f->set_number(static_cast<int32_t>(id));
+    f->set_name(name);
+    f->set_type(type);  // e.g. int32, fixed64
+  };
 
-  return e;
-}
+  // Create a transcoding mapping for the fields.
+  uint32_t submessage_field_proto_id = 1;
+  for (const FtraceEvent::Field& tracefs_field : tracefs_event.fields) {
+    uint16_t field_end = tracefs_field.offset + tracefs_field.size;
+    evt->size = std::max(field_end, evt->size);
 
-const Event* ProtoTranslationTable::GetOrCreateEvent(
-    const GroupAndName& group_and_name) {
-  const Event* event = GetEvent(group_and_name);
-  if (event)
-    return event;
-  return CreateEventWithProtoId(
-      group_and_name, protos::pbzero::FtraceEvent::kGenericFieldNumber);
-}
-
-const Event* ProtoTranslationTable::GetOrCreateKprobeEvent(
-    const GroupAndName& group_and_name) {
-  const Event* event = GetEvent(group_and_name);
-  const uint32_t proto_field_id =
-      protos::pbzero::FtraceEvent::kKprobeEventFieldNumber;
-  if (event) {
-    if (event->proto_field_id != proto_field_id) {
-      return nullptr;
+    std::string field_name =
+        GetNameFromTypeAndName(tracefs_field.type_and_name);
+    if (field_name.empty()) {
+      PERFETTO_DLOG("Couldn't extract name from %s.{%s}",
+                    group_and_name.ToString().c_str(),
+                    tracefs_field.type_and_name.c_str());
+      continue;
     }
-    return event;
+
+    FtraceFieldType tracefs_type{};
+    if (!InferFtraceType(tracefs_field.type_and_name, tracefs_field.size,
+                         tracefs_field.is_signed, &tracefs_type)) {
+      PERFETTO_DLOG("Couldn't extract type from %s.{%s}",
+                    group_and_name.ToString().c_str(),
+                    tracefs_field.type_and_name.c_str());
+      continue;
+    }
+
+    Field field{};
+    field.ftrace_offset = tracefs_field.offset;
+    field.ftrace_size = tracefs_field.size;
+    field.ftrace_type = tracefs_type;
+    field.ftrace_name = InternString(field_name);
+    field.proto_field_type = ToGenericProtoField(tracefs_type);
+    field.proto_field_id = submessage_field_proto_id++;
+    if (field.proto_field_type == ProtoSchemaType::kUnknown ||
+        !SetTranslationStrategy(field.ftrace_type, field.proto_field_type,
+                                &field.strategy)) {
+      continue;
+    }
+    add_pb_desc_field(field.proto_field_id, field_name,
+                      ToPbDescEnum(field.proto_field_type));
+
+    evt->fields.push_back(field);
   }
-  return CreateEventWithProtoId(group_and_name, proto_field_id);
+
+  if (keep_proto_descriptor) {
+    generic_evt_pb_descriptors_.Insert(evt->proto_field_id,
+                                       pb_descriptor.SerializeAsArray());
+  }
+
+  PERFETTO_DCHECK(evt == &events_.at(evt->ftrace_event_id));
+
+  group_and_name_to_event_[group_and_name] = evt;
+  name_to_events_[evt->name].push_back(evt);
+  group_to_events_[evt->group].push_back(evt);
+  return evt;
 }
 
+// Uncommon, used to handle removal temporary ftrace events, e.g. kprobes.
 void ProtoTranslationTable::RemoveEvent(const GroupAndName& group_and_name) {
   const std::string& group = group_and_name.group();
   const std::string& name = group_and_name.name();
@@ -635,41 +734,9 @@ const char* ProtoTranslationTable::InternString(const std::string& str) {
   return it_and_inserted.first->c_str();
 }
 
-uint16_t ProtoTranslationTable::CreateGenericEventField(
-    const FtraceEvent::Field& ftrace_field,
-    Event& event) {
-  uint16_t field_end = ftrace_field.offset + ftrace_field.size;
-  std::string field_name = GetNameFromTypeAndName(ftrace_field.type_and_name);
-  if (field_name.empty()) {
-    PERFETTO_DLOG("Field: %s could not be added to the generic event.",
-                  ftrace_field.type_and_name.c_str());
-    return field_end;
-  }
-  event.fields.emplace_back();
-  Field* field = &event.fields.back();
-  field->ftrace_name = InternString(field_name);
-  if (!InferFtraceType(ftrace_field.type_and_name, ftrace_field.size,
-                       ftrace_field.is_signed, &field->ftrace_type)) {
-    PERFETTO_DLOG(
-        "Failed to infer ftrace field type for \"%s.%s\" (type:\"%s\" "
-        "size:%d "
-        "signed:%d)",
-        event.name, field->ftrace_name, ftrace_field.type_and_name.c_str(),
-        ftrace_field.size, ftrace_field.is_signed);
-    event.fields.pop_back();
-    return field_end;
-  }
-  SetProtoType(field->ftrace_type, &field->proto_field_type,
-               &field->proto_field_id);
-  field->ftrace_offset = ftrace_field.offset;
-  field->ftrace_size = ftrace_field.size;
-  // Proto type is set based on ftrace type so all fields should have a
-  // translation strategy.
-  bool success = SetTranslationStrategy(
-      field->ftrace_type, field->proto_field_type, &field->strategy);
-  PERFETTO_DCHECK(success);
-  return field_end;
-}
+//
+// EventFilter:
+//
 
 void EventFilter::AddEnabledEvent(size_t ftrace_event_id) {
   if (ftrace_event_id >= enabled_ids_.size())

--- a/src/traced/probes/ftrace/proto_translation_table.h
+++ b/src/traced/probes/ftrace/proto_translation_table.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include "perfetto/ext/base/flat_hash_map.h"
 #include "src/traced/probes/ftrace/compact_sched.h"
 #include "src/traced/probes/ftrace/format_parser/format_parser.h"
 #include "src/traced/probes/ftrace/printk_formats_parser.h"
@@ -71,6 +72,8 @@ bool InferFtraceType(const std::string& type_and_name,
 
 class ProtoTranslationTable {
  public:
+  static constexpr uint32_t kGenericEvtProtoMinPbFieldId = 65536;
+
   struct FtracePageHeaderSpec {
     FtraceEvent::Field timestamp{};
     FtraceEvent::Field overwrite{};
@@ -148,15 +151,8 @@ class ProtoTranslationTable {
     return ftrace_page_header_spec_.size.size;
   }
 
-  // Retrieves the ftrace event from the proto translation
-  // table. If it does not exist, reads the format file and creates a
-  // new event with the proto id set to generic. Virtual for testing.
-  virtual const Event* GetOrCreateEvent(const GroupAndName&);
-
-  // Retrieves the ftrace event, that's going to be translated to a kprobe, from
-  // the proto translation table. If the event is already known and used for
-  // something other than a kprobe, returns nullptr.
-  virtual const Event* GetOrCreateKprobeEvent(const GroupAndName&);
+  virtual const Event* CreateGenericEvent(const GroupAndName&);
+  virtual const Event* CreateKprobeEvent(const GroupAndName&);
 
   // Removes the ftrace event from the proto translation table.
   virtual void RemoveEvent(const GroupAndName&);
@@ -179,16 +175,22 @@ class ProtoTranslationTable {
     return printk_formats_.at(address);
   }
 
+  bool IsGenericEventProtoId(uint32_t proto_field_id) const {
+    return proto_field_id >= kGenericEvtProtoMinPbFieldId;
+  }
+
+  const base::FlatHashMap<uint32_t, std::vector<uint8_t>>*
+  generic_evt_pb_descriptors() const {
+    return &generic_evt_pb_descriptors_;
+  }
+
  private:
   // Store strings so they can be read when writing the trace output.
   const char* InternString(const std::string& str);
 
-  // The event must not already exist.
-  const Event* CreateEventWithProtoId(const GroupAndName& group_and_name,
-                                      uint32_t proto_field_id);
-
-  uint16_t CreateGenericEventField(const FtraceEvent::Field& ftrace_field,
-                                   Event& event);
+  const Event* CreateGenericEventInternal(const GroupAndName& group_and_name,
+                                          uint32_t proto_field_id,
+                                          bool keep_proto_descriptor);
 
   const FtraceProcfs* ftrace_procfs_;
   std::set<std::string> interned_strings_;
@@ -201,6 +203,16 @@ class ProtoTranslationTable {
   FtracePageHeaderSpec ftrace_page_header_spec_{};
   CompactSchedEventFormat compact_sched_format_;
   PrintkMap printk_formats_;
+  // Used to assign proto field ids within "FtraceEvent" proto when serialising
+  // events not known at compile time.
+  uint32_t next_generic_evt_proto_id_ = kGenericEvtProtoMinPbFieldId;
+  // Keyed by proto id. Not garbage collected as the number of events is bounded
+  // unless someone is constantly recreating dynamic probes. This is acceptable
+  // since the proto translation table itself only lives for as long as tracing
+  // is active.
+  // TODO(rsavitski): double-check that tracefs doesn't reuse tracepoint ids for
+  // dynamic probes.
+  base::FlatHashMap<uint32_t, std::vector<uint8_t>> generic_evt_pb_descriptors_;
 };
 
 // Class for efficient 'is event with id x enabled?' checks.


### PR DESCRIPTION
The encoding of ftrace events that do not have a protobuf description in
the perfetto repo is very space inefficient. This is because every
GenericFtraceEvent proto has a string description of the field names and
added layers of proto nesting. This was good enough for local
exploration, but is often used by accident when configs use category
globs. Also, long-term it'd be nice to move away from requiring protos
to be checked into our repo outside of truly well-known cases.

This patch adds a feature flag to enable such generic events to be
serialised using self-describing protos, with the aim of being a bit
more space efficient. The FtraceEvent proto will have a submessage under
a field id not covered by the compile-time oneof fields (similar to
proto extensions). The FtraceEventBundle will have an
id->ProtoDescriptor map, once per generic event type.

Notes:
* every unknown event type will have its own proto field id, and a
  bundle-level proto descriptor.
* the mapping stays consistent within all bundles in  a tracing session.
* there is no global mapping of event->id across traces.
* we still use the FtraceEvent container proto, with the upsides of
  being able to do streaming serialisation of bundles, and the downsides
  of protobuf encoding overheads due to deep nesting (and extra missing
  bits like delta timestamps).
* we do not use incremental state, every bundle describes the generic
  events. The space cost is amortised by bundles being relatively
  infrequent.
* the new encoding is behind a flag, and the default case continues to
  be GenericFtraceEvent protos.

//////////////
For reviewers:

This might help visualise the proto structure:
  message FtraceEvent {
    optional uint64 timestamp = 1;
    optional uint32 pid = 2;

    oneof event {
      PrintFtraceEvent print = 3;
      SchedSwitchFtraceEvent sched_switch = 4;
      ...
    }

    // synthesised at runtime, similar to an extension range:
    optional GenericOne unknown_event_one = 65536;
    optional GenericTwo unknown_event_two = 65537;
  }

I started by reserving a high range of field ids within the FtraceEvent
proto for the synthesised-on-the-fly submesssages.  Would've been nice
to use something with one fewer byte for pb tags (e.g. 1k-2k), but that
is a bit too close to the compile-time proto range, which already goes
up to ~600. The field id range does matter since we use "id>65k" as a
way of quickly identifying that an event is generic within the
proto_translation_table and cpu_reader.

proto_translation_table: I changed the |events_| mapping (from ftrace id
to a struct describing the event) to generate proper per-field proto
descriptions of events, and moved the GenericFtraceEvent specifics to
cpu_reader's serialisation path.

cpu_reader::Bundler changes: when parsing, we need to remember the set
of referenced generic events to emit their descriptors.