### PR TITLE
presubmit: let clang-format handle tabs in cpp sources

### DIFF
--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -240,9 +240,11 @@ def CheckDoNotSubmit(changed_files: List[str]) -> List[str]:
 
 def CheckChangeHasNoTabs(changed_files: List[str]) -> List[str]:
   errors = []
-  # Basic filter: skip common binary/data files where tabs might be ok
+  # Basic filter: skip common binary/data files where tabs might be ok,
+  #               c++ files are already handled by clang-format.
   files_to_check_list = filter_files(
-      changed_files, files_to_skip=['*.pb', '*.png', '*.jpg', '*/test/data/*'])
+      changed_files,
+      files_to_skip=['*.cc', '*.h', '*.pb', '*.png', '*.jpg', '*/test/data/*'])
 
   for f_path in files_to_check_list:
     content = read_file_content(f_path)


### PR DESCRIPTION
I've found myself fighting this presubmit in ftrace sources because we have cases with tabs inside test strings (as extracted from tracefs).

Since we're now enforcing formatting, and clang-format covers tabs in cpp sources, exclude them from this presubmit check.