### PR TITLE
Allow users of DatasetSliceTrack to entirely override what's shown on the tooltip

### DIFF
--- a/ui/src/assets/viewer_page.scss
+++ b/ui/src/assets/viewer_page.scss
@@ -92,4 +92,5 @@
 .pf-track__tooltip {
   font-size: 14px;
   opacity: 0.8;
+  font-weight: 300;
 }

--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -204,9 +204,6 @@ export abstract class BaseSliceTrack<
   private charWidth = -1;
   protected hoveredSlice?: SliceT;
 
-  // Bunch of lines to render on the tooltip.
-  private hoverTooltip?: string[];
-
   private maxDataDepth = 0;
 
   // Computed layout.
@@ -251,6 +248,12 @@ export abstract class BaseSliceTrack<
   // TODO(stevegolton): If we merge BST with DST, this abstraction can be
   // avoided.
   abstract getJoinSqlSource(): string;
+
+  // Override me if you want to define what is rendered on the tooltip. Called
+  // every DOM render cycle. The raw slice data is passed to this function
+  protected renderTooltipForSlice(_: SliceT): m.Children {
+    return undefined;
+  }
 
   onSliceOver(_args: OnSliceOverArgs<SliceT>): void {}
   onSliceOut(_args: OnSliceOutArgs<SliceT>): void {}
@@ -660,7 +663,11 @@ export abstract class BaseSliceTrack<
   }
 
   renderTooltip() {
-    return this.hoverTooltip && [this.hoverTooltip.map((line) => m('', line))];
+    const hoveredSlice = this.hoveredSlice;
+    if (hoveredSlice) {
+      return this.renderTooltipForSlice(hoveredSlice);
+    }
+    return undefined;
   }
 
   // This method figures out if the visible window is outside the bounds of
@@ -839,12 +846,10 @@ export abstract class BaseSliceTrack<
     if (this.hoveredSlice === undefined) {
       this.trace.timeline.highlightedSliceId = undefined;
       this.onSliceOut({slice: assertExists(lastHoveredSlice)});
-      this.hoverTooltip = undefined;
     } else {
       const args: OnSliceOverArgs<SliceT> = {slice: this.hoveredSlice};
       this.trace.timeline.highlightedSliceId = this.hoveredSlice.id;
       this.onSliceOver(args);
-      this.hoverTooltip = args.tooltip;
     }
   }
 

--- a/ui/src/plugins/dev.perfetto.AndroidLog/logs_track.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/logs_track.ts
@@ -77,7 +77,7 @@ export function createAndroidLogTrack(trace: Trace, uri: string) {
     colorizer: (row) => DEPTH_TO_COLOR[row.depth],
     // It would be nice to show the message on the tooltip too, but loading a
     // message for each event may balloon memory, so we just show the tag.
-    tooltip: (row) => (row.tag === null ? [] : [row.tag]),
+    tooltip: (slice) => slice.row.tag,
     // All log events are instant events, render them as a little box rather
     // than the default chevron.
     instantStyle: {

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -51,8 +51,6 @@ export function createHeapProfileTrack(
         ts,
       );
     },
-    tooltip: (row) => {
-      return [row.type];
-    },
+    tooltip: (slice) => slice.row.type,
   });
 }

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
@@ -14,8 +14,12 @@
 
 import {BigintMath as BIMath} from '../../base/bigint_math';
 import {clamp} from '../../base/math_utils';
+import {exists} from '../../base/utils';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {
+  DatasetSliceTrack,
+  renderTooltip,
+} from '../../components/tracks/dataset_slice_track';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -25,6 +29,7 @@ import {
   NUM,
   STR_NULL,
 } from '../../trace_processor/query_result';
+import m from 'mithril';
 
 export interface TraceProcessorSliceTrackAttrs {
   readonly trace: Trace;
@@ -52,6 +57,7 @@ export function createTraceProcessorSliceTrack({
         name: STR_NULL,
         depth: NUM,
         thread_dur: LONG_NULL,
+        category: STR_NULL,
       },
       src: 'slice',
       filter: {
@@ -69,6 +75,13 @@ export function createTraceProcessorSliceTrack({
       } else {
         return 1;
       }
+    },
+    tooltip: (slice) => {
+      return renderTooltip(trace, slice, {
+        title: slice.title,
+        extras:
+          exists(slice.row.category) && m('', 'Category: ', slice.row.category),
+      });
     },
     detailsPanel: detailsPanel
       ? (row) => detailsPanel(row)
@@ -91,7 +104,8 @@ function getDepthProvider(trackIds: ReadonlyArray<number>) {
         dur,
         layout_depth as depth,
         name,
-        thread_dur
+        thread_dur,
+        category
       from experimental_slice_layout
       where filter_track_ids = '${trackIds.join(',')}'
     `;


### PR DESCRIPTION
Allow users of DatasetSliceTrack to entirely override what's shown on the tooltip & add `category` if not null