### PR TITLE
Remove non UTF-8 characters in systrace parser

### DIFF
--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -193,6 +193,8 @@ std::string Uint64ToHexStringNoPrefix(uint64_t number);
 std::string ReplaceAll(std::string str,
                        const std::string& to_replace,
                        const std::string& replacement);
+std::string RemoveInvalidUTF8(const std::string& str);
+bool IsValidUTF8(const std::string& str);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 bool WideToUTF8(const std::wstring& source, std::string& output);

--- a/src/trace_processor/importers/systrace/systrace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser.cc
@@ -51,7 +51,8 @@ void SystraceParser::ParsePrintEvent(int64_t ts,
                                      uint32_t pid,
                                      base::StringView event) {
   systrace_utils::SystraceTracePoint point{};
-  switch (ParseSystraceTracePoint(event, &point)) {
+  std::string tmp = base::RemoveInvalidUTF8(event.ToStdString());
+  switch (ParseSystraceTracePoint(tmp.c_str(), &point)) {
     case systrace_utils::SystraceParseResult::kSuccess:
       ParseSystracePoint(ts, pid, point);
       break;

--- a/src/trace_processor/importers/systrace/systrace_parser.h
+++ b/src/trace_processor/importers/systrace/systrace_parser.h
@@ -154,6 +154,9 @@ inline SystraceParseResult ParseSystraceTracePoint(
       break;
   }
   base::StringView str = str_untrimmed.substr(0, len);
+  if (PERFETTO_UNLIKELY(!base::IsValidUTF8(str.ToStdString()))) {
+    return SystraceParseResult::kFailure;
+  }
 
   size_t off = 0;
 

--- a/src/trace_processor/importers/systrace/systrace_parser_unittest.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser_unittest.cc
@@ -106,6 +106,9 @@ TEST(SystraceParserTest, SystraceEvent) {
   ASSERT_EQ(ParseSystraceTracePoint("trace_event_clock_sync: realtime_ts=123\n",
                                     &result),
             Result::kUnsupported);
+
+  ASSERT_EQ(ParseSystraceTracePoint("S|123|invalid\xa0\xa1|456", &result),
+            Result::kFailure);
 }
 
 TEST(SystraceParserTest, AsyncTrackEvents) {


### PR DESCRIPTION
Remove non UTF-8 characters in systrace parser

A trace can contain some "bytes" in "print" ftrace events which are not valid UTF8. sqlite expects strings to be UTF-8.

Tested via 
```
tools/ninja -C out/linux_clang_debug && out/linux_clang_debug/perfetto_unittests &&  tools/diff_test_trace_processor.py  out/linux_clang_debug/trace_processor_shell
```