### PR TITLE
Remove non UTF-8 characters in systrace parser

### DIFF
--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -193,6 +193,8 @@ std::string Uint64ToHexStringNoPrefix(uint64_t number);
 std::string ReplaceAll(std::string str,
                        const std::string& to_replace,
                        const std::string& replacement);
+std::string RemoveInvalidUTF8(const std::string& str);
+bool IsValidUTF8(const std::string& str);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 bool WideToUTF8(const std::wstring& source, std::string& output);

--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -193,7 +193,14 @@ std::string Uint64ToHexStringNoPrefix(uint64_t number);
 std::string ReplaceAll(std::string str,
                        const std::string& to_replace,
                        const std::string& replacement);
-void RemoveInvalidUTF8(base::StringView str, std::string& output);
+
+// Checks if all characters in the input string view `str` are ASCII.
+//
+// If so, the function returns true and `output` is not modified.
+// If `str` contains non-ASCII characters, the function returns false,
+// removes invalid UTF-8 characters from `str`, and stores the result in
+// `output`.
+bool RemoveInvalidUTF8AndCheckASCII(base::StringView str, std::string& output);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 bool WideToUTF8(const std::wstring& source, std::string& output);

--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -200,7 +200,7 @@ std::string ReplaceAll(std::string str,
 // If `str` contains non-ASCII characters, the function returns false,
 // removes invalid UTF-8 characters from `str`, and stores the result in
 // `output`.
-bool RemoveInvalidUTF8AndCheckASCII(base::StringView str, std::string& output);
+bool CheckASCIIAndRemoveInvalidUTF8(base::StringView str, std::string& output);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 bool WideToUTF8(const std::wstring& source, std::string& output);

--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -200,7 +200,7 @@ std::string ReplaceAll(std::string str,
 // If `str` contains non-ASCII characters, the function returns false,
 // removes invalid UTF-8 characters from `str`, and stores the result in
 // `output`.
-bool CheckASCIIAndRemoveInvalidUTF8(base::StringView str, std::string& output);
+bool CheckAsciiAndRemoveInvalidUTF8(base::StringView str, std::string& output);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 bool WideToUTF8(const std::wstring& source, std::string& output);

--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -193,8 +193,7 @@ std::string Uint64ToHexStringNoPrefix(uint64_t number);
 std::string ReplaceAll(std::string str,
                        const std::string& to_replace,
                        const std::string& replacement);
-std::string RemoveInvalidUTF8(const std::string& str);
-bool IsValidUTF8(const std::string& str);
+void RemoveInvalidUTF8(base::StringView str, std::string& output);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 bool WideToUTF8(const std::wstring& source, std::string& output);

--- a/src/base/string_utils.cc
+++ b/src/base/string_utils.cc
@@ -219,7 +219,14 @@ std::string ReplaceAll(std::string str,
   return str;
 }
 
-void RemoveInvalidUTF8(base::StringView str, std::string& output) {
+bool RemoveInvalidUTF8AndCheckASCII(base::StringView str, std::string& output) {
+  bool isASCII = std::all_of(str.begin(), str.end(), [](char c) {
+    return (static_cast<unsigned char>(c) & 0b10000000) == 0b00000000;
+  });
+  if (isASCII) {
+    return true;
+  }
+
   // https://www.rfc-editor.org/rfc/rfc3629.txt
   output.clear();
   output.reserve(str.size());
@@ -286,6 +293,7 @@ void RemoveInvalidUTF8(base::StringView str, std::string& output) {
 
     i += numBytes;
   }
+  return false;
 }
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)

--- a/src/base/string_utils.cc
+++ b/src/base/string_utils.cc
@@ -219,7 +219,7 @@ std::string ReplaceAll(std::string str,
   return str;
 }
 
-bool CheckASCIIAndRemoveInvalidUTF8(base::StringView str, std::string& output) {
+bool CheckAsciiAndRemoveInvalidUTF8(base::StringView str, std::string& output) {
   bool is_ascii = std::all_of(str.begin(), str.end(), [](char c) {
     return (static_cast<unsigned char>(c) & 0b10000000) == 0b00000000;
   });

--- a/src/base/string_utils_unittest.cc
+++ b/src/base/string_utils_unittest.cc
@@ -397,78 +397,78 @@ TEST(StringUtilsTest, ReplaceAll) {
   EXPECT_EQ(ReplaceAll("abc", "c", "bbb"), "abbbb");
 }
 
-TEST(StringUtilsTest, CheckASCIIAndRemoveInvalidUTF8) {
+TEST(StringUtilsTest, CheckAsciiAndRemoveInvalidUTF8) {
   std::string output;
   // ASCII string "hello"
-  EXPECT_TRUE(CheckASCIIAndRemoveInvalidUTF8("hello", output));
+  EXPECT_TRUE(CheckAsciiAndRemoveInvalidUTF8("hello", output));
   EXPECT_TRUE(output.empty());
 
   // Mixed string with invalid 2-byte sequence 11000000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("hello\xc0\x80world", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("hello\xc0\x80world", output));
   EXPECT_EQ(output, "helloworld");
 
   // Mixed string with valid 2-byte sequence ɸ (11000000 10000000)
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("hello\xc9\xb8world", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("hello\xc9\xb8world", output));
   EXPECT_EQ(output, "hello\xc9\xb8world");
 
   // Valid 2-byte UTF-8 sequence - ɸ
   // 11001001 10111000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xc9\xb8", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xc9\xb8", output));
   EXPECT_EQ(output, "\xc9\xb8");
 
   // Valid 3-byte UTF-8 sequence - ✓
   // 11100010 10011100 10010011
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xe2\x9c\x93", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xe2\x9c\x93", output));
   EXPECT_EQ(output, "\xe2\x9c\x93");
 
   // Valid 4-byte UTF-8 sequence - Grinning face emoji
   // 11110000 10011111 10011000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf0\x9f\x98\x80", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xf0\x9f\x98\x80", output));
   EXPECT_EQ(output, "\xf0\x9f\x98\x80");
 
   // Invalid 5+ byte sequence (truncated to 1 byte)
   // 11111000 10000000 10000000 10000000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf8\x80\x80\x80\x80", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xf8\x80\x80\x80\x80", output));
   EXPECT_EQ(output, "");
 
   // Invalid continuation byte in 2 byte sequence
   // 11010000 10110000 (invalid continuation byte)
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xd0\xc0", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xd0\xc0", output));
   EXPECT_TRUE(output.empty());
 
   // Invalid continuation byte in 3 byte sequence
   // 11100000 10100100 11000000 (invalid continuation byte)
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xe0\xa4\xc0", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xe0\xa4\xc0", output));
   EXPECT_TRUE(output.empty());
 
   // Invalid continuation byte in 4 byte sequence
   // 11110000 10011111 10011000 11000000 (invalid continuation byte)
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf0\x9f\x98\xc0", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xf0\x9f\x98\xc0", output));
   EXPECT_TRUE(output.empty());
 
   // Overlong 2-byte sequence of NULL char
   // 11000000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xc0\x80", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xc0\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Overlong 3-byte sequence of NULL char
   // 11100000 10000000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xe0\x80\x80", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xe0\x80\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Overlong 4-byte sequence of NULL char
   // 11110000 10000000 10000000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf0\x80\x80\x80", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xf0\x80\x80\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Surrogate
   // 11101101 10100000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xed\xa0\x80", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xed\xa0\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Out of range
   // 11110100 10010000 10000000 10000000
-  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf4\x90\x80\x80", output));
+  EXPECT_FALSE(CheckAsciiAndRemoveInvalidUTF8("\xf4\x90\x80\x80", output));
   EXPECT_TRUE(output.empty());
 }
 

--- a/src/base/string_utils_unittest.cc
+++ b/src/base/string_utils_unittest.cc
@@ -397,78 +397,78 @@ TEST(StringUtilsTest, ReplaceAll) {
   EXPECT_EQ(ReplaceAll("abc", "c", "bbb"), "abbbb");
 }
 
-TEST(StringUtilsTest, RemoveInvalidUTF8AndCheckASCII) {
+TEST(StringUtilsTest, CheckASCIIAndRemoveInvalidUTF8) {
   std::string output;
   // ASCII string "hello"
-  EXPECT_TRUE(RemoveInvalidUTF8AndCheckASCII("hello", output));
+  EXPECT_TRUE(CheckASCIIAndRemoveInvalidUTF8("hello", output));
   EXPECT_TRUE(output.empty());
 
   // Mixed string with invalid 2-byte sequence 11000000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("hello\xc0\x80world", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("hello\xc0\x80world", output));
   EXPECT_EQ(output, "helloworld");
 
   // Mixed string with valid 2-byte sequence ɸ (11000000 10000000)
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("hello\xc9\xb8world", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("hello\xc9\xb8world", output));
   EXPECT_EQ(output, "hello\xc9\xb8world");
 
   // Valid 2-byte UTF-8 sequence - ɸ
   // 11001001 10111000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xc9\xb8", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xc9\xb8", output));
   EXPECT_EQ(output, "\xc9\xb8");
 
   // Valid 3-byte UTF-8 sequence - ✓
   // 11100010 10011100 10010011
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xe2\x9c\x93", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xe2\x9c\x93", output));
   EXPECT_EQ(output, "\xe2\x9c\x93");
 
   // Valid 4-byte UTF-8 sequence - Grinning face emoji
   // 11110000 10011111 10011000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf0\x9f\x98\x80", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf0\x9f\x98\x80", output));
   EXPECT_EQ(output, "\xf0\x9f\x98\x80");
 
   // Invalid 5+ byte sequence (truncated to 1 byte)
   // 11111000 10000000 10000000 10000000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf8\x80\x80\x80\x80", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf8\x80\x80\x80\x80", output));
   EXPECT_EQ(output, "");
 
   // Invalid continuation byte in 2 byte sequence
   // 11010000 10110000 (invalid continuation byte)
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xd0\xc0", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xd0\xc0", output));
   EXPECT_TRUE(output.empty());
 
   // Invalid continuation byte in 3 byte sequence
   // 11100000 10100100 11000000 (invalid continuation byte)
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xe0\xa4\xc0", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xe0\xa4\xc0", output));
   EXPECT_TRUE(output.empty());
 
   // Invalid continuation byte in 4 byte sequence
   // 11110000 10011111 10011000 11000000 (invalid continuation byte)
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf0\x9f\x98\xc0", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf0\x9f\x98\xc0", output));
   EXPECT_TRUE(output.empty());
 
   // Overlong 2-byte sequence of NULL char
   // 11000000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xc0\x80", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xc0\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Overlong 3-byte sequence of NULL char
   // 11100000 10000000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xe0\x80\x80", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xe0\x80\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Overlong 4-byte sequence of NULL char
   // 11110000 10000000 10000000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf0\x80\x80\x80", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf0\x80\x80\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Surrogate
   // 11101101 10100000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xed\xa0\x80", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xed\xa0\x80", output));
   EXPECT_TRUE(output.empty());
 
   // Out of range
   // 11110100 10010000 10000000 10000000
-  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf4\x90\x80\x80", output));
+  EXPECT_FALSE(CheckASCIIAndRemoveInvalidUTF8("\xf4\x90\x80\x80", output));
   EXPECT_TRUE(output.empty());
 }
 

--- a/src/base/string_utils_unittest.cc
+++ b/src/base/string_utils_unittest.cc
@@ -397,6 +397,81 @@ TEST(StringUtilsTest, ReplaceAll) {
   EXPECT_EQ(ReplaceAll("abc", "c", "bbb"), "abbbb");
 }
 
+TEST(StringUtilsTest, RemoveInvalidUTF8AndCheckASCII) {
+  std::string output;
+  // ASCII string "hello"
+  EXPECT_TRUE(RemoveInvalidUTF8AndCheckASCII("hello", output));
+  EXPECT_TRUE(output.empty());
+
+  // Mixed string with invalid 2-byte sequence 11000000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("hello\xc0\x80world", output));
+  EXPECT_EQ(output, "helloworld");
+
+  // Mixed string with valid 2-byte sequence ɸ (11000000 10000000)
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("hello\xc9\xb8world", output));
+  EXPECT_EQ(output, "hello\xc9\xb8world");
+
+  // Valid 2-byte UTF-8 sequence - ɸ
+  // 11001001 10111000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xc9\xb8", output));
+  EXPECT_EQ(output, "\xc9\xb8");
+
+  // Valid 3-byte UTF-8 sequence - ✓
+  // 11100010 10011100 10010011
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xe2\x9c\x93", output));
+  EXPECT_EQ(output, "\xe2\x9c\x93");
+
+  // Valid 4-byte UTF-8 sequence - Grinning face emoji
+  // 11110000 10011111 10011000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf0\x9f\x98\x80", output));
+  EXPECT_EQ(output, "\xf0\x9f\x98\x80");
+
+  // Invalid 5+ byte sequence (truncated to 1 byte)
+  // 11111000 10000000 10000000 10000000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf8\x80\x80\x80\x80", output));
+  EXPECT_EQ(output, "");
+
+  // Invalid continuation byte in 2 byte sequence
+  // 11010000 10110000 (invalid continuation byte)
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xd0\xc0", output));
+  EXPECT_TRUE(output.empty());
+
+  // Invalid continuation byte in 3 byte sequence
+  // 11100000 10100100 11000000 (invalid continuation byte)
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xe0\xa4\xc0", output));
+  EXPECT_TRUE(output.empty());
+
+  // Invalid continuation byte in 4 byte sequence
+  // 11110000 10011111 10011000 11000000 (invalid continuation byte)
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf0\x9f\x98\xc0", output));
+  EXPECT_TRUE(output.empty());
+
+  // Overlong 2-byte sequence of NULL char
+  // 11000000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xc0\x80", output));
+  EXPECT_TRUE(output.empty());
+
+  // Overlong 3-byte sequence of NULL char
+  // 11100000 10000000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xe0\x80\x80", output));
+  EXPECT_TRUE(output.empty());
+
+  // Overlong 4-byte sequence of NULL char
+  // 11110000 10000000 10000000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf0\x80\x80\x80", output));
+  EXPECT_TRUE(output.empty());
+
+  // Surrogate
+  // 11101101 10100000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xed\xa0\x80", output));
+  EXPECT_TRUE(output.empty());
+
+  // Out of range
+  // 11110100 10010000 10000000 10000000
+  EXPECT_FALSE(RemoveInvalidUTF8AndCheckASCII("\xf4\x90\x80\x80", output));
+  EXPECT_TRUE(output.empty());
+}
+
 TEST(StringUtilsTest, StringCopy) {
   // Nothing should be written when |dst_size| = 0.
   {

--- a/src/trace_processor/importers/systrace/systrace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser.cc
@@ -51,8 +51,9 @@ void SystraceParser::ParsePrintEvent(int64_t ts,
                                      uint32_t pid,
                                      base::StringView event) {
   systrace_utils::SystraceTracePoint point{};
-  base::RemoveInvalidUTF8(event, temp_string_utf8_);
-  switch (ParseSystraceTracePoint(temp_string_utf8_.c_str(), &point)) {
+  bool isASCII = base::RemoveInvalidUTF8AndCheckASCII(event, temp_string_utf8_);
+  base::StringView event_utf8 = isASCII ? event : temp_string_utf8_.c_str();
+  switch (ParseSystraceTracePoint(event_utf8, &point)) {
     case systrace_utils::SystraceParseResult::kSuccess:
       ParseSystracePoint(ts, pid, point);
       break;

--- a/src/trace_processor/importers/systrace/systrace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser.cc
@@ -51,7 +51,7 @@ void SystraceParser::ParsePrintEvent(int64_t ts,
                                      uint32_t pid,
                                      base::StringView event) {
   systrace_utils::SystraceTracePoint point{};
-  bool isASCII = base::RemoveInvalidUTF8AndCheckASCII(event, temp_string_utf8_);
+  bool isASCII = base::CheckASCIIAndRemoveInvalidUTF8(event, temp_string_utf8_);
   base::StringView event_utf8 = isASCII ? event : temp_string_utf8_.c_str();
   switch (ParseSystraceTracePoint(event_utf8, &point)) {
     case systrace_utils::SystraceParseResult::kSuccess:

--- a/src/trace_processor/importers/systrace/systrace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser.cc
@@ -51,8 +51,8 @@ void SystraceParser::ParsePrintEvent(int64_t ts,
                                      uint32_t pid,
                                      base::StringView event) {
   systrace_utils::SystraceTracePoint point{};
-  std::string tmp = base::RemoveInvalidUTF8(event.ToStdString());
-  switch (ParseSystraceTracePoint(tmp.c_str(), &point)) {
+  base::RemoveInvalidUTF8(event, temp_string_utf8_);
+  switch (ParseSystraceTracePoint(temp_string_utf8_.c_str(), &point)) {
     case systrace_utils::SystraceParseResult::kSuccess:
       ParseSystracePoint(ts, pid, point);
       break;

--- a/src/trace_processor/importers/systrace/systrace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser.cc
@@ -51,7 +51,8 @@ void SystraceParser::ParsePrintEvent(int64_t ts,
                                      uint32_t pid,
                                      base::StringView event) {
   systrace_utils::SystraceTracePoint point{};
-  switch (ParseSystraceTracePoint(event, &point)) {
+  std::string tmp = base::RemoveInvalidUTF8(event.ToStdString());
+  switch (ParseSystraceTracePoint(tmp.c_str(), &point)) {
     case systrace_utils::SystraceParseResult::kSuccess:
       ParseSystracePoint(ts, pid, point);
       break;

--- a/src/trace_processor/importers/systrace/systrace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser.cc
@@ -51,8 +51,10 @@ void SystraceParser::ParsePrintEvent(int64_t ts,
                                      uint32_t pid,
                                      base::StringView event) {
   systrace_utils::SystraceTracePoint point{};
-  bool isASCII = base::CheckASCIIAndRemoveInvalidUTF8(event, temp_string_utf8_);
-  base::StringView event_utf8 = isASCII ? event : temp_string_utf8_.c_str();
+  bool is_ascii =
+      base::CheckAsciiAndRemoveInvalidUTF8(event, temp_string_utf8_);
+  base::StringView event_utf8 =
+      is_ascii ? event : base::StringView(temp_string_utf8_);
   switch (ParseSystraceTracePoint(event_utf8, &point)) {
     case systrace_utils::SystraceParseResult::kSuccess:
       ParseSystracePoint(ts, pid, point);

--- a/src/trace_processor/importers/systrace/systrace_parser.h
+++ b/src/trace_processor/importers/systrace/systrace_parser.h
@@ -154,10 +154,6 @@ inline SystraceParseResult ParseSystraceTracePoint(
       break;
   }
   base::StringView str = str_untrimmed.substr(0, len);
-  if (PERFETTO_UNLIKELY(!base::IsValidUTF8(str.ToStdString()))) {
-    return SystraceParseResult::kFailure;
-  }
-
   size_t off = 0;
 
   // This function reads the next field up to the next '|', '\0' or end(). It
@@ -327,6 +323,7 @@ class SystraceParser : public Destructible {
   const StringId cookie_id_;
   const StringId utid_id_;
   const StringId end_utid_id_;
+  std::string temp_string_utf8_;
 };
 
 }  // namespace trace_processor

--- a/src/trace_processor/importers/systrace/systrace_parser.h
+++ b/src/trace_processor/importers/systrace/systrace_parser.h
@@ -154,6 +154,9 @@ inline SystraceParseResult ParseSystraceTracePoint(
       break;
   }
   base::StringView str = str_untrimmed.substr(0, len);
+  if (PERFETTO_UNLIKELY(!base::IsValidUTF8(str.ToStdString()))) {
+    return SystraceParseResult::kFailure;
+  }
 
   size_t off = 0;
 

--- a/src/trace_processor/importers/systrace/systrace_parser.h
+++ b/src/trace_processor/importers/systrace/systrace_parser.h
@@ -323,6 +323,7 @@ class SystraceParser : public Destructible {
   const StringId cookie_id_;
   const StringId utid_id_;
   const StringId end_utid_id_;
+  // temp string used to store trace events after removing non UTF-8 chars
   std::string temp_string_utf8_;
 };
 

--- a/src/trace_processor/importers/systrace/systrace_parser_unittest.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser_unittest.cc
@@ -106,6 +106,9 @@ TEST(SystraceParserTest, SystraceEvent) {
   ASSERT_EQ(ParseSystraceTracePoint("trace_event_clock_sync: realtime_ts=123\n",
                                     &result),
             Result::kUnsupported);
+
+  ASSERT_EQ(ParseSystraceTracePoint("S|123|invalid\xa0\xa1|456", &result),
+            Result::kFailure);
 }
 
 TEST(SystraceParserTest, AsyncTrackEvents) {

--- a/src/trace_processor/importers/systrace/systrace_parser_unittest.cc
+++ b/src/trace_processor/importers/systrace/systrace_parser_unittest.cc
@@ -106,9 +106,6 @@ TEST(SystraceParserTest, SystraceEvent) {
   ASSERT_EQ(ParseSystraceTracePoint("trace_event_clock_sync: realtime_ts=123\n",
                                     &result),
             Result::kUnsupported);
-
-  ASSERT_EQ(ParseSystraceTracePoint("S|123|invalid\xa0\xa1|456", &result),
-            Result::kFailure);
 }
 
 TEST(SystraceParserTest, AsyncTrackEvents) {


### PR DESCRIPTION
Remove non UTF-8 characters in systrace parser

A trace can contain some "bytes" in "print" ftrace events which are not valid UTF8. sqlite expects strings to be UTF-8.

Tested via
```
tools/ninja -C out/linux_clang_debug && out/linux_clang_debug/perfetto_unittests &&  tools/diff_test_trace_processor.py  out/linux_clang_debug/trace_processor_shell
```