### PR TITLE
[ui] prioritize display of power-specifc aggregation

### DIFF
--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -30,11 +30,12 @@ import {SelectionAggregationManager} from './selection_aggregation_manager';
 export function createAggregationToTabAdaptor(
   trace: Trace,
   aggregator: AreaSelectionAggregator,
+  tabPriorityOverride?: number,
 ): AreaSelectionTab {
   const schemaSpecificity =
     (aggregator.schema && Object.keys(aggregator.schema).length) ?? 0;
   const kindRating = aggregator.trackKind === undefined ? 0 : 100;
-  const priority = kindRating + schemaSpecificity;
+  const priority = tabPriorityOverride ?? kindRating + schemaSpecificity;
   const aggMan = new SelectionAggregationManager(trace.engine, aggregator);
   let currentSelection: AreaSelection | undefined;
 

--- a/ui/src/plugins/dev.perfetto.PowerAggregations/index.ts
+++ b/ui/src/plugins/dev.perfetto.PowerAggregations/index.ts
@@ -25,7 +25,11 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.selection.registerAreaSelectionTab(
-      createAggregationToTabAdaptor(ctx, new PowerCounterSelectionAggregator()),
+      createAggregationToTabAdaptor(
+        ctx,
+        new PowerCounterSelectionAggregator(),
+        200,
+      ),
     );
   }
 }


### PR DESCRIPTION
Display the power-specific aggregation by default instead of the
generic aggregation tab in order provide the user a better UX when
aggregating over power rail tracks.

example: 
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/21610f4e-5c44-406a-a82d-43358b32d12f" />


Bug: https://github.com/google/perfetto/issues/910
