### PR TITLE
presubmit: minor fixes

### DIFF
--- a/python/tools/code_format_ui.py
+++ b/python/tools/code_format_ui.py
@@ -35,6 +35,8 @@ class Prettier(CodeFormatterBase):
   def filter_files(self, files):
     # Filter based on extension first.
     filtered = super().filter_files(files)
+    # Filter out changes outside of ui/
+    filtered = [f for f in filtered if f.startswith('ui/')]
     with open('ui/.prettierignore', 'r') as fd:
       ignorelist = fd.read().strip().split('\n')
       filtered = [
@@ -62,6 +64,13 @@ class Eslint(CodeFormatterBase):
 
   def __init__(self):
     super().__init__(name='eslint', exts=['.ts', '.js'])
+
+  def filter_files(self, files):
+    # Filter based on extension first.
+    filtered = super().filter_files(files)
+    # Filter out changes outside of ui/
+    filtered = [f for f in filtered if f.startswith('ui/')]
+    return filtered
 
   def run_formatter(self, repo_root: str, check_only: bool, files: list[str]):
     tool = 'node_modules/.bin/eslint'

--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -244,7 +244,9 @@ def CheckChangeHasNoTabs(changed_files: List[str]) -> List[str]:
   #               c++ files are already handled by clang-format.
   files_to_check_list = filter_files(
       changed_files,
-      files_to_skip=['*.cc', '*.h', '*.pb', '*.png', '*.jpg', '*/test/data/*'])
+      files_to_skip=[
+          '*.cc', '*.h', '*.pb', '*.png', '*.jpg', '*/test/data/*', 'Makefile'
+      ])
 
   for f_path in files_to_check_list:
     content = read_file_content(f_path)


### PR DESCRIPTION
- Don't run eslint/prettier outside of ui/. Thei fail with a warning if you try because they assume ui/ as root.
- Allow tabs in Makefile because they are load bearing

