### PR TITLE
[ui] Enable power aggregation tab plugin by default

### DIFF
--- a/ui/src/core/default_plugins.ts
+++ b/ui/src/core/default_plugins.ts
@@ -53,6 +53,7 @@ export const defaultPlugins = [
   'dev.perfetto.MetricsPage',
   'dev.perfetto.PinAndroidPerfMetrics',
   'dev.perfetto.PinSysUITracks',
+  'dev.perfetto.PowerAggregations',
   'dev.perfetto.Process',
   'dev.perfetto.ProcessSummary',
   'dev.perfetto.ProcessThreadGroups',


### PR DESCRIPTION
The power aggregations tab provides users a better UX when
aggregating over power rail. Enable this plugin by default so that
users get this better UX without having to enable the plugin
manually.
