### PR TITLE
Revert "thermal: perfetto/ftrace: Disable parsing param_set_value_cpm"

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -1344,11 +1344,10 @@ base::Status FtraceParser::ParseFtraceEvent(uint32_t cpu,
         ParseKprobe(ts, pid, fld_bytes);
         break;
       }
-      // TODO(b/407000648): Re-enable once param_set_value_cpm timestamp is
-      // fixed. case FtraceEvent::kParamSetValueCpmFieldNumber: {
-      //   ParseParamSetValueCpm(fld_bytes);
-      //   break;
-      // }
+      case FtraceEvent::kParamSetValueCpmFieldNumber: {
+        ParseParamSetValueCpm(fld_bytes);
+        break;
+      }
       case FtraceEvent::kBlockIoStartFieldNumber: {
         ParseBlockIoStart(ts, fld_bytes);
         break;

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
@@ -280,14 +280,12 @@ void FtraceTokenizer::TokenizeFtraceEvent(
     TokenizeFtraceThermalExynosAcpmBulk(cpu, std::move(event),
                                         std::move(state));
     return;
+  } else if (PERFETTO_UNLIKELY(event_id ==
+                               protos::pbzero::FtraceEvent::
+                                   kParamSetValueCpmFieldNumber)) {
+    TokenizeFtraceParamSetValueCpm(cpu, std::move(event), std::move(state));
+    return;
   }
-  // TODO(b/407000648): Re-enable once param_set_value_cpm timestamp is fixed.
-  // else if (PERFETTO_UNLIKELY(event_id ==
-  //                              protos::pbzero::FtraceEvent::
-  //                                  kParamSetValueCpmFieldNumber)) {
-  //   TokenizeFtraceParamSetValueCpm(cpu, std::move(event), std::move(state));
-  //   return;
-  // }
 
   auto timestamp = context_->clock_tracker->ToTraceTime(
       clock_id, static_cast<int64_t>(raw_timestamp));


### PR DESCRIPTION
This reverts commit c9f2646bd3fa0dfabfc8968fc83a712b6e04998a.

With issue fixed in b/407752170, reenable cpm tracepoints.