### PR TITLE
luci: Use python.exe instead of python3.exe on windows

### DIFF
--- a/infra/luci/recipes/perfetto.expected/ci_win.json
+++ b/infra/luci/recipes/perfetto.expected/ci_win.json
@@ -137,7 +137,7 @@
   },
   {
     "cmd": [
-      "python3",
+      "python",
       "tools/install-build-deps"
     ],
     "cwd": "[CACHE]\\builder\\perfetto",

--- a/infra/luci/recipes/perfetto.py
+++ b/infra/luci/recipes/perfetto.py
@@ -194,7 +194,10 @@ def RunSteps(api, repository):
     elif api.platform.is_linux:
       # Pull the cross-toolchains for building for linux-arm{,64}.
       extra_args += ['--linux-arm']
-    api.step('build-deps', ['python3', 'tools/install-build-deps'] + extra_args)
+    api.step('build-deps', [
+        'python3' if not api.platform.is_win else 'python',
+        'tools/install-build-deps'
+    ] + extra_args)
 
   if api.platform.is_win:
     BuildForPlatform(api, ctx, 'windows-amd64')


### PR DESCRIPTION
python3.exe doesn't exist on windows, expecially on venv.

Let's try if this works with just python.exe