### PR TITLE
Make DOM tooltips smaller and align them to center right of cursor

### DIFF
--- a/ui/src/assets/viewer_page.scss
+++ b/ui/src/assets/viewer_page.scss
@@ -88,8 +88,7 @@
 }
 
 .pf-track__tooltip {
-  font-size: 14px; // Slightly smaller font - to match tracks.
+  font-size: 11px; // Slightly smaller font - to match previous tooltip size
   opacity: 0.8;
   font-weight: 300;
-  max-width: 500px; // Limit how wide the tooltip can be - keeps it readable.
 }

--- a/ui/src/assets/viewer_page.scss
+++ b/ui/src/assets/viewer_page.scss
@@ -89,6 +89,6 @@
 
 .pf-track__tooltip {
   font-size: 11px; // Slightly smaller font - to match previous tooltip size
-  opacity: 0.8;
+  opacity: 0.9;
   font-weight: 300;
 }

--- a/ui/src/widgets/cursor_tooltip.ts
+++ b/ui/src/widgets/cursor_tooltip.ts
@@ -67,12 +67,12 @@ export class CursorTooltip implements m.ClassComponent<CursorTooltipAttrs> {
         onContentMount: (portal) => {
           this.virtualElement.setPosition(globalMousePos);
           this.popper = createPopper(this.virtualElement, portal, {
-            placement: 'right-start',
+            placement: 'right',
             modifiers: [
               {
                 name: 'offset',
                 options: {
-                  offset: [8, 8], // Shift away from cursor
+                  offset: [0, 8], // Shift away from cursor
                 },
               },
             ],


### PR DESCRIPTION
This more closely resembles the previous canvas based tooltips, and keeps the tooltips out the way of neighboring tracks