### PR TITLE
tp: support listening on specified ip

### DIFF
--- a/include/perfetto/ext/base/http/http_server.h
+++ b/include/perfetto/ext/base/http/http_server.h
@@ -160,6 +160,7 @@ class HttpServer : public UnixSocket::EventListener {
   HttpServer(TaskRunner*, HttpRequestHandler*);
   ~HttpServer() override;
   void Start(int port);
+  void Start(const std::string& listen_ip, int port);
   void AddAllowedOrigin(const std::string&);
 
  private:

--- a/include/perfetto/ext/base/http/http_server.h
+++ b/include/perfetto/ext/base/http/http_server.h
@@ -169,6 +169,9 @@ class HttpServer : public UnixSocket::EventListener {
   void HandleCorsPreflightRequest(const HttpRequest&);
   bool IsOriginAllowed(StringView);
 
+  void ListenOnIpV4(const std::string& ip_addr);
+  void ListenOnIpV6(const std::string& ip_addr);
+
   // UnixSocket::EventListener implementation.
   void OnNewIncomingConnection(UnixSocket*,
                                std::unique_ptr<UnixSocket>) override;

--- a/include/perfetto/ext/base/unix_socket.h
+++ b/include/perfetto/ext/base/unix_socket.h
@@ -74,7 +74,7 @@ enum class SockPeerCredMode {
 #endif
 };
 
-// Returns the socket family from the full addres that perfetto uses.
+// Returns the socket family from the full address that perfetto uses.
 // Addr can be:
 // - /path/to/socket : for linked AF_UNIX sockets.
 // - @abstract_name  : for abstract AF_UNIX sockets.
@@ -83,13 +83,22 @@ enum class SockPeerCredMode {
 // - vsock://-1:3000 : for VM sockets.
 SockFamily GetSockFamily(const char* addr);
 
+// NetAddrInfo is a wrapper for a full address and it's family
+// and type.
 struct NetAddrInfo {
   NetAddrInfo(const std::string& ip_port, SockFamily family, SockType type)
       : ip_port_(ip_port), family_(family), type_(type) {}
-  std::string ip_port_;
-  SockFamily family_;
-  SockType type_;
+  std::string ip_port_;  // full address with ip and port
+  SockFamily family_;    // socket family
+  SockType type_;        // socket type
 };
+
+// Returns a list of NetAddrInfo from ip and port which
+// ip can be an ipv4 or an ipv6 or a domain.
+// 127.0.0.1    : ipv4 address
+// localhost    : domain
+// ::1          : ipv6 address
+// port is a normal tcp port as string.
 std::vector<NetAddrInfo> GetNetAddrInfo(const std::string& ip,
                                         const std::string& port);
 

--- a/include/perfetto/ext/base/unix_socket.h
+++ b/include/perfetto/ext/base/unix_socket.h
@@ -83,6 +83,16 @@ enum class SockPeerCredMode {
 // - vsock://-1:3000 : for VM sockets.
 SockFamily GetSockFamily(const char* addr);
 
+struct NetAddrInfo {
+  NetAddrInfo(const std::string& ip_port, SockFamily family, SockType type)
+      : ip_port_(ip_port), family_(family), type_(type) {}
+  std::string ip_port_;
+  SockFamily family_;
+  SockType type_;
+};
+std::vector<NetAddrInfo> GetNetAddrInfo(const std::string& ip,
+                                        const std::string& port);
+
 // Returns whether inter-process shared memory is supported for the socket.
 inline bool SockShmemSupported(SockFamily sock_family) {
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)

--- a/src/base/http/http_server.cc
+++ b/src/base/http/http_server.cc
@@ -73,6 +73,38 @@ void HttpServer::Start(int port) {
   }
 }
 
+void HttpServer::Start(const std::string& listen_ip, int port) {
+  std::string ip = listen_ip;
+  if (listen_ip.empty()) {
+    ip = "0.0.0.0";
+  }
+  std::string port_str = std::to_string(port);
+  std::vector<NetAddrInfo> addr_infos = GetNetAddrInfo(ip, port_str);
+  for (NetAddrInfo& info : addr_infos) {
+    if (info.family_ == SockFamily::kInet) {
+      PERFETTO_ILOG("[HTTP] Starting HTTP server on %s", info.ip_port_.c_str());
+      sock4_ = UnixSocket::Listen(info.ip_port_, this, task_runner_,
+                                  SockFamily::kInet, SockType::kStream);
+      bool ipv4_listening = sock4_ && sock4_->is_listening();
+      if (!ipv4_listening) {
+        PERFETTO_PLOG("Failed to listen on IPv4 socket: \"%s\"",
+                      info.ip_port_.c_str());
+        sock4_.reset();
+      }
+    } else if (info.family_ == SockFamily::kInet6) {
+      PERFETTO_ILOG("[HTTP] Starting HTTP server on %s", info.ip_port_.c_str());
+      sock6_ = UnixSocket::Listen(info.ip_port_, this, task_runner_,
+                                  SockFamily::kInet6, SockType::kStream);
+      bool ipv6_listening = sock6_ && sock6_->is_listening();
+      if (!ipv6_listening) {
+        PERFETTO_PLOG("Failed to listen on IPv6 socket: \"%s\"",
+                      info.ip_port_.c_str());
+        sock6_.reset();
+      }
+    }
+  }
+}
+
 void HttpServer::AddAllowedOrigin(const std::string& origin) {
   allowed_origins_.emplace_back(origin);
 }

--- a/src/base/http/http_server.cc
+++ b/src/base/http/http_server.cc
@@ -81,10 +81,7 @@ void HttpServer::ListenOnIpV6(const std::string& ip_addr) {
 }
 
 void HttpServer::Start(const std::string& listen_ip, int port) {
-  std::string ip = listen_ip;
-  if (listen_ip.empty()) {
-    ip = "0.0.0.0";
-  }
+  std::string ip = listen_ip.empty() ? "localhost" : listen_ip;
   std::string port_str = std::to_string(port);
   std::vector<NetAddrInfo> addr_infos = GetNetAddrInfo(ip, port_str);
   for (NetAddrInfo& info : addr_infos) {

--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -54,7 +54,7 @@ class Httpd : public base::HttpRequestHandler {
  public:
   explicit Httpd(std::unique_ptr<TraceProcessor>);
   ~Httpd() override;
-  void Run(int port);
+  void Run(const std::string& listen_ip, int port);
 
  private:
   // HttpRequestHandler implementation.
@@ -98,8 +98,8 @@ Httpd::Httpd(std::unique_ptr<TraceProcessor> preloaded_instance)
       http_srv_(&task_runner_, this) {}
 Httpd::~Httpd() = default;
 
-void Httpd::Run(int port) {
-  PERFETTO_ILOG("[HTTP] Starting RPC server on localhost:%d", port);
+void Httpd::Run(const std::string &listen_ip, int port) {
+  PERFETTO_ILOG("[HTTP] Starting RPC server on ip=%s  port=%d", listen_ip.c_str(), port);
   PERFETTO_LOG(
       "[HTTP] This server can be used by reloading https://ui.perfetto.dev and "
       "clicking on YES on the \"Trace Processor native acceleration\" dialog "
@@ -109,7 +109,7 @@ void Httpd::Run(int port) {
   for (const auto& kAllowedCORSOrigin : kAllowedCORSOrigins) {
     http_srv_.AddAllowedOrigin(kAllowedCORSOrigin);
   }
-  http_srv_.Start(port);
+  http_srv_.Start(listen_ip, port);
   task_runner_.Run();
 }
 
@@ -261,11 +261,12 @@ void Httpd::OnWebsocketMessage(const base::WebsocketMessage& msg) {
 }  // namespace
 
 void RunHttpRPCServer(std::unique_ptr<TraceProcessor> preloaded_instance,
+                        const std::string& listen_ip,
                       const std::string& port_number) {
   Httpd srv(std::move(preloaded_instance));
   std::optional<int> port_opt = base::StringToInt32(port_number);
   int port = port_opt.has_value() ? *port_opt : kBindPort;
-  srv.Run(port);
+  srv.Run(listen_ip, port);
 }
 
 void Httpd::ServeHelpPage(const base::HttpRequest& req) {

--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -98,8 +98,9 @@ Httpd::Httpd(std::unique_ptr<TraceProcessor> preloaded_instance)
       http_srv_(&task_runner_, this) {}
 Httpd::~Httpd() = default;
 
-void Httpd::Run(const std::string &listen_ip, int port) {
-  PERFETTO_ILOG("[HTTP] Starting RPC server on ip=%s  port=%d", listen_ip.c_str(), port);
+void Httpd::Run(const std::string& listen_ip, int port) {
+  PERFETTO_ILOG("[HTTP] Starting RPC server on ip=%s  port=%d",
+                listen_ip.c_str(), port);
   PERFETTO_LOG(
       "[HTTP] This server can be used by reloading https://ui.perfetto.dev and "
       "clicking on YES on the \"Trace Processor native acceleration\" dialog "
@@ -261,7 +262,7 @@ void Httpd::OnWebsocketMessage(const base::WebsocketMessage& msg) {
 }  // namespace
 
 void RunHttpRPCServer(std::unique_ptr<TraceProcessor> preloaded_instance,
-                        const std::string& listen_ip,
+                      const std::string& listen_ip,
                       const std::string& port_number) {
   Httpd srv(std::move(preloaded_instance));
   std::optional<int> port_opt = base::StringToInt32(port_number);

--- a/src/trace_processor/rpc/httpd.h
+++ b/src/trace_processor/rpc/httpd.h
@@ -26,12 +26,15 @@ class TraceProcessor;
 
 // Starts a RPC server that handles requests using protobuf-over-HTTP.
 // It takes control of the calling thread and does not return.
-// The unique_ptr argument is optional. If non-null, the HTTP server will adopt
+// preloaded_instance is optional. If non-null, the HTTP server will adopt
 // an existing instance with a pre-loaded trace. If null, it will create a new
 // instance when pushing data into the /parse endpoint.
-void RunHttpRPCServer(std::unique_ptr<TraceProcessor>,
-                      const std::string&,
-                      const std::string&);
+// listen_ip is the ip address which http server will listen on,
+// it can be an ipv4 or an ipv6 or a domain.
+// port_number is the port which http server will listen on.
+void RunHttpRPCServer(std::unique_ptr<TraceProcessor> preloaded_instance,
+                      const std::string& listen_ip,
+                      const std::string& port_number);
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/rpc/httpd.h
+++ b/src/trace_processor/rpc/httpd.h
@@ -29,7 +29,7 @@ class TraceProcessor;
 // The unique_ptr argument is optional. If non-null, the HTTP server will adopt
 // an existing instance with a pre-loaded trace. If null, it will create a new
 // instance when pushing data into the /parse endpoint.
-void RunHttpRPCServer(std::unique_ptr<TraceProcessor>, const std::string&);
+void RunHttpRPCServer(std::unique_ptr<TraceProcessor>, const std::string&, const std::string&);
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/rpc/httpd.h
+++ b/src/trace_processor/rpc/httpd.h
@@ -29,7 +29,9 @@ class TraceProcessor;
 // The unique_ptr argument is optional. If non-null, the HTTP server will adopt
 // an existing instance with a pre-loaded trace. If null, it will create a new
 // instance when pushing data into the /parse endpoint.
-void RunHttpRPCServer(std::unique_ptr<TraceProcessor>, const std::string&, const std::string&);
+void RunHttpRPCServer(std::unique_ptr<TraceProcessor>,
+                      const std::string&,
+                      const std::string&);
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -1035,7 +1035,6 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
       continue;
     }
 
-
     if (option == OPT_STDIOD) {
       command_line_options.enable_stdiod = true;
       continue;

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -934,7 +934,7 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
 
       {"httpd", no_argument, nullptr, 'D'},
       {"http-port", required_argument, nullptr, OPT_HTTP_PORT},
-      {"http-ip", required_argument, nullptr, OPT_HTTP_IP},
+      {"http-ip-address", required_argument, nullptr, OPT_HTTP_IP},
       {"stdiod", no_argument, nullptr, OPT_STDIOD},
       {"interactive", no_argument, nullptr, 'i'},
 

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -697,6 +697,7 @@ struct CommandLineOptions {
 
   bool enable_httpd = false;
   std::string port_number;
+  std::string listen_ip;
   bool enable_stdiod = false;
   bool launch_shell = false;
 
@@ -750,6 +751,7 @@ General purpose:
 Behavioural:
  -D, --httpd                          Enables the HTTP RPC server.
  --http-port PORT                     Specify what port to run HTTP RPC server.
+ --http-ip ip                         Specify what ip to run HTTP RPC server.
  --stdiod                             Enables the stdio RPC server.
  -i, --interactive                    Starts interactive mode even after
                                       executing some other commands (-q, -Q,
@@ -894,6 +896,7 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
   CommandLineOptions command_line_options;
   enum LongOption {
     OPT_HTTP_PORT = 1000,
+    OPT_HTTP_IP,
     OPT_STDIOD,
 
     OPT_FORCE_FULL_SORT,
@@ -931,6 +934,7 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
 
       {"httpd", no_argument, nullptr, 'D'},
       {"http-port", required_argument, nullptr, OPT_HTTP_PORT},
+      {"http-ip", required_argument, nullptr, OPT_HTTP_IP},
       {"stdiod", no_argument, nullptr, OPT_STDIOD},
       {"interactive", no_argument, nullptr, 'i'},
 
@@ -1025,6 +1029,12 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
       command_line_options.port_number = optarg;
       continue;
     }
+
+    if (option == OPT_HTTP_IP) {
+      command_line_options.listen_ip = optarg;
+      continue;
+    }
+
 
     if (option == OPT_STDIOD) {
       command_line_options.enable_stdiod = true;
@@ -1965,7 +1975,7 @@ base::Status TraceProcessorMain(int argc, char** argv) {
 #endif
 
 #if PERFETTO_BUILDFLAG(PERFETTO_TP_HTTPD)
-    RunHttpRPCServer(std::move(tp), options.port_number);
+    RunHttpRPCServer(std::move(tp), options.listen_ip, options.port_number);
     PERFETTO_FATAL("Should never return");
 #else
     PERFETTO_FATAL("HTTP not available");

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -751,7 +751,7 @@ General purpose:
 Behavioural:
  -D, --httpd                          Enables the HTTP RPC server.
  --http-port PORT                     Specify what port to run HTTP RPC server.
- --http-ip ip                         Specify what ip address to run HTTP RPC server.
+ --http-ip-address ip                 Specify what ip address to run HTTP RPC server.
  --stdiod                             Enables the stdio RPC server.
  -i, --interactive                    Starts interactive mode even after
                                       executing some other commands (-q, -Q,

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -751,7 +751,7 @@ General purpose:
 Behavioural:
  -D, --httpd                          Enables the HTTP RPC server.
  --http-port PORT                     Specify what port to run HTTP RPC server.
- --http-ip ip                         Specify what ip to run HTTP RPC server.
+ --http-ip ip                         Specify what ip address to run HTTP RPC server.
  --stdiod                             Enables the stdio RPC server.
  -i, --interactive                    Starts interactive mode even after
                                       executing some other commands (-q, -Q,


### PR DESCRIPTION
make trace_processor_shell support listen on specific ip other than localhost.
issuse: https://github.com/google/perfetto/issues/1181

users can use --http-ip 0.0.0.0 to specific an ip or a hostname.  
trace_processor_shell will listen on 0.0.0.0 by default.
this make it can be accessed by localhost:9001 even trace_processor_shell is started at a docker container by port forward.

like this: docker run -it --rm   -p 9001:9001 image:tag trace_processor_shell -D --http-port 9001


