### PR TITLE
luci: Avoid installing python venv

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -508,9 +508,12 @@ config("android_liblog") {
 
 # Checks that tools/install-build-deps has been run since it last changed.
 perfetto_check_build_deps("check_build_deps") {
-  args = []
+  args = [ "--no-dev-tools" ]
 }
 
 perfetto_check_build_deps("check_build_deps_android") {
-  args = [ "--android" ]
+  args = [
+    "--no-dev-tools",
+    "--android",
+  ]
 }

--- a/infra/luci/recipes/perfetto.expected/ci_win.json
+++ b/infra/luci/recipes/perfetto.expected/ci_win.json
@@ -138,7 +138,8 @@
   {
     "cmd": [
       "python3",
-      "tools/install-build-deps"
+      "tools/install-build-deps",
+      "--no-dev-tools"
     ],
     "cwd": "[CACHE]\\builder\\perfetto",
     "infra_step": true,

--- a/infra/luci/recipes/perfetto.py
+++ b/infra/luci/recipes/perfetto.py
@@ -194,6 +194,8 @@ def RunSteps(api, repository):
     elif api.platform.is_linux:
       # Pull the cross-toolchains for building for linux-arm{,64}.
       extra_args += ['--linux-arm']
+    elif api.platform.is_win:
+      extra_args += ['--no-dev-tools']
     api.step('build-deps', ['python3', 'tools/install-build-deps'] + extra_args)
 
   if api.platform.is_win:

--- a/tools/install-build-deps
+++ b/tools/install-build-deps
@@ -771,6 +771,10 @@ def Main():
   parser.add_argument(
       '--no-toolchain', help='Do not download toolchain', action='store_true')
   parser.add_argument(
+      '--no-dev-tools',
+      help='Some tools are required exclusively when changing the source code (they are not required when just building it, e.g. in CI). Do not install those tools',
+      action='store_true')
+  parser.add_argument(
       '--build-os',
       default=system().lower(),
       choices=['windows', 'darwin', 'linux'],
@@ -906,12 +910,13 @@ def Main():
     else:
       InstallNodeModules(force_clean=nodejs_updated)
 
-  # Check the python venv
-  venv_needs_update = not CheckPythonVenv()
-  if args.check_only:
-    deps_updated |= venv_needs_update
-  elif venv_needs_update:
-    InstallPythonVenv()
+  if not args.no_dev_tools:
+    # Check the python venv
+    venv_needs_update = not CheckPythonVenv()
+    if args.check_only:
+      deps_updated |= venv_needs_update
+    elif venv_needs_update:
+      InstallPythonVenv()
 
   # Install the pre-push hook if the .git/hooks directory exists and it's a
   # non check-only invocation. Not on windows (symlinks are not supported


### PR DESCRIPTION
It doesn't work on windows. Luckily the venv is not required for building, only when changing the source code.

Partially autogenerated by running
`cd infra/luci && ./recipes.py test train`.
