### PR TITLE
Tidy up page registration

### DIFF
--- a/ui/src/base/mithril_utils.ts
+++ b/ui/src/base/mithril_utils.ts
@@ -75,39 +75,6 @@ export class Gate implements m.ClassComponent<GateAttrs> {
   }
 }
 
-/**
- * Utility function to pre-bind some mithril attrs of a component, and leave
- * the others unbound and passed at run-time.
- * Example use case: the Page API Passes to the registered page a PageAttrs,
- * which is {subpage:string}. Imagine you write a MyPage component that takes
- * some extra input attrs (e.g. the App object) and you want to bind them
- * onActivate(). The results looks like this:
- *
- * interface MyPageAttrs extends PageAttrs { app: App; }
- *
- * class MyPage extends m.classComponent<MyPageAttrs> {... view() {...} }
- *
- * onActivate(app: App) {
- *   pages.register(... bindMithrilApps(MyPage, {app: app});
- * }
- *
- * The return value of bindMithrilApps is a mithril component that takes in
- * input only a {subpage: string} and passes down to MyPage the combination
- * of pre-bound and runtime attrs, that is {subpage, app}.
- */
-export function bindMithrilAttrs<BaseAttrs, Attrs>(
-  component: m.ComponentTypes<Attrs>,
-  boundArgs: Omit<Attrs, keyof BaseAttrs>,
-): m.Component<BaseAttrs> {
-  return {
-    view(vnode: m.Vnode<BaseAttrs>) {
-      const attrs = {...vnode.attrs, ...boundArgs} as Attrs;
-      const emptyAttrs: m.CommonAttributes<Attrs, {}> = {}; // Keep tsc happy.
-      return m<Attrs, {}>(component, {...attrs, ...emptyAttrs});
-    },
-  };
-}
-
 export type MithrilEvent<T extends Event = Event> = T & {redraw: boolean};
 
 /**

--- a/ui/src/core/page_manager.ts
+++ b/ui/src/core/page_manager.ts
@@ -15,30 +15,18 @@
 import m from 'mithril';
 import {assertExists, assertTrue} from '../base/logging';
 import {Registry} from '../base/registry';
-import {PageAttrs, PageHandler, PageWithTraceAttrs} from '../public/page';
+import {PageHandler} from '../public/page';
 import {Router} from './router';
-import {TraceImpl} from './trace_impl';
 import {Gate} from '../base/mithril_utils';
 
-export interface PageWithTraceImplAttrs extends PageAttrs {
-  trace: TraceImpl;
-}
-
-// This is to allow internal core classes to get a TraceImpl injected rather
-// than just a Trace.
-type PageHandlerInternal = PageHandler<
-  | m.ComponentTypes<PageWithTraceAttrs>
-  | m.ComponentTypes<PageWithTraceImplAttrs>
->;
-
 export class PageManagerImpl {
-  private readonly registry = new Registry<PageHandlerInternal>((x) => x.route);
+  private readonly registry = new Registry<PageHandler>((x) => x.route);
   private readonly previousPages = new Map<
     string,
     {page: string; subpage: string}
   >();
 
-  registerPage(pageHandler: PageHandlerInternal): Disposable {
+  registerPage(pageHandler: PageHandler): Disposable {
     assertTrue(/^\/\w*$/.exec(pageHandler.route) !== null);
     // The pluginId is injected by the proxy in AppImpl / TraceImpl. If this is
     // undefined somebody (tests) managed to call this method without proxy.
@@ -47,7 +35,7 @@ export class PageManagerImpl {
   }
 
   // Called by index.ts upon the main frame redraw callback.
-  renderPageForCurrentRoute(trace: TraceImpl | undefined): m.Children {
+  renderPageForCurrentRoute(): m.Children {
     const route = Router.parseFragment(location.hash);
     this.previousPages.set(route.page, {
       page: route.page,
@@ -61,12 +49,11 @@ export class PageManagerImpl {
     // such as the viewer page.
     return Array.from(this.previousPages.entries())
       .map(([key, {page, subpage}]) => {
-        const maybeRenderedPage = this.renderPageForRoute(trace, page, subpage);
+        const maybeRenderedPage = this.renderPageForRoute(page, subpage);
         // If either the route doesn't exist or requires a trace but the trace
         // is not loaded, fall back on the default route.
         const renderedPage =
-          maybeRenderedPage ??
-          assertExists(this.renderPageForRoute(trace, '/', ''));
+          maybeRenderedPage ?? assertExists(this.renderPageForRoute('/', ''));
         return [key, renderedPage];
       })
       .map(([key, page]) => {
@@ -76,27 +63,11 @@ export class PageManagerImpl {
 
   // Will return undefined if either: (1) the route does not exist; (2) the
   // route exists, it requires a trace, but there is no trace loaded.
-  private renderPageForRoute(
-    coreTrace: TraceImpl | undefined,
-    page: string,
-    subpage: string,
-  ) {
+  private renderPageForRoute(page: string, subpage: string) {
     const handler = this.registry.tryGet(page);
     if (handler === undefined) {
       return undefined;
     }
-    const pluginId = assertExists(handler?.pluginId);
-    const trace = coreTrace?.forkForPlugin(pluginId);
-    const traceRequired = !handler?.traceless;
-    if (traceRequired && trace === undefined) {
-      return undefined;
-    }
-    if (traceRequired) {
-      return m(handler.page as m.ComponentTypes<PageWithTraceImplAttrs>, {
-        subpage,
-        trace: assertExists(trace),
-      });
-    }
-    return m(handler.page, {subpage, trace});
+    return handler.render(subpage);
   }
 }

--- a/ui/src/core/router.ts
+++ b/ui/src/core/router.ts
@@ -15,7 +15,6 @@
 import m from 'mithril';
 import {assertTrue} from '../base/logging';
 import {RouteArgs, ROUTE_SCHEMA} from '../public/route_schema';
-import {PageAttrs} from '../public/page';
 
 export const ROUTE_PREFIX = '#!';
 
@@ -48,10 +47,6 @@ export interface Route {
   subpage: string;
   fragment: string;
   args: RouteArgs;
-}
-
-export interface RoutesMap {
-  [key: string]: m.ComponentTypes<PageAttrs>;
 }
 
 // This router does two things:

--- a/ui/src/core_plugins/flags_page/flags_page.ts
+++ b/ui/src/core_plugins/flags_page/flags_page.ts
@@ -16,7 +16,6 @@ import m from 'mithril';
 import {channelChanged, getNextChannel, setChannel} from '../../core/channels';
 import {featureFlags} from '../../core/feature_flags';
 import {Flag, OverrideState} from '../../public/feature_flag';
-import {PageAttrs} from '../../public/page';
 import {Router} from '../../core/router';
 
 const RELEASE_PROCESS_URL =
@@ -99,7 +98,11 @@ class FlagWidget implements m.ClassComponent<FlagWidgetAttrs> {
   }
 }
 
-export class FlagsPage implements m.ClassComponent<PageAttrs> {
+export interface FlagsPageAttrs {
+  readonly subpage?: string;
+}
+
+export class FlagsPage implements m.ClassComponent<FlagsPageAttrs> {
   view() {
     const needsReload = channelChanged();
     return m(
@@ -160,7 +163,7 @@ export class FlagsPage implements m.ClassComponent<PageAttrs> {
     );
   }
 
-  oncreate(vnode: m.VnodeDOM<PageAttrs>) {
+  oncreate(vnode: m.VnodeDOM<FlagsPageAttrs>) {
     const flagId = /[/](\w+)/.exec(vnode.attrs.subpage ?? '')?.slice(1, 2)[0];
     if (flagId) {
       const flag = vnode.dom.querySelector(`#${flagId}`);

--- a/ui/src/core_plugins/flags_page/index.ts
+++ b/ui/src/core_plugins/flags_page/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {AppImpl} from '../../core/app_impl';
 import {PerfettoPlugin} from '../../public/plugin';
 import {FlagsPage} from './flags_page';
@@ -24,8 +25,7 @@ export default class implements PerfettoPlugin {
     // Flags page
     app.pages.registerPage({
       route: '/flags',
-      page: FlagsPage,
-      traceless: true,
+      render: (subpage) => m(FlagsPage, {subpage}),
     });
     app.sidebar.addMenuItem({
       section: 'support',
@@ -35,11 +35,10 @@ export default class implements PerfettoPlugin {
       icon: 'emoji_flags',
     });
 
-    // Plugins page.
+    // Plugins page
     app.pages.registerPage({
       route: '/plugins',
-      page: PluginsPage,
-      traceless: true,
+      render: () => m(PluginsPage),
     });
     app.sidebar.addMenuItem({
       section: 'support',

--- a/ui/src/core_plugins/flags_page/plugins_page.ts
+++ b/ui/src/core_plugins/flags_page/plugins_page.ts
@@ -18,7 +18,6 @@ import {assertUnreachable} from '../../base/logging';
 import {exists} from '../../base/utils';
 import {AppImpl} from '../../core/app_impl';
 import {PluginWrapper} from '../../core/plugin_manager';
-import {PageAttrs} from '../../public/page';
 import {Button, ButtonBar, ButtonVariant} from '../../widgets/button';
 import {Card, CardList} from '../../widgets/card';
 import {Chip} from '../../widgets/chip';
@@ -75,7 +74,7 @@ function sortText(sortOrder: SortOrder) {
   }
 }
 
-export class PluginsPage implements m.ClassComponent<PageAttrs> {
+export class PluginsPage implements m.ClassComponent {
   view() {
     const pluginManager = AppImpl.instance.plugins;
     const registeredPlugins = pluginManager.getAllPlugins();

--- a/ui/src/frontend/home_page.ts
+++ b/ui/src/frontend/home_page.ts
@@ -16,7 +16,6 @@ import m from 'mithril';
 import {channelChanged, getNextChannel, setChannel} from '../core/channels';
 import {Anchor} from '../widgets/anchor';
 import {HotkeyGlyphs} from '../widgets/hotkey_glyphs';
-import {PageAttrs} from '../public/page';
 import {assetSrc} from '../base/assets';
 
 export class Hints implements m.ClassComponent {
@@ -66,7 +65,7 @@ export class Hints implements m.ClassComponent {
   }
 }
 
-export class HomePage implements m.ClassComponent<PageAttrs> {
+export class HomePage implements m.ClassComponent {
   view() {
     return m(
       '.page.home-page',

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -35,7 +35,7 @@ import {postMessageHandler} from './post_message_handler';
 import {Route, Router} from '../core/router';
 import {CheckHttpRpcConnection} from './rpc_http_dialog';
 import {maybeOpenTraceFromRoute} from './trace_url_handler';
-import {ViewerPage} from './viewer_page/viewer_page';
+import {renderViewerPage} from './viewer_page/viewer_page';
 import {HttpRpcEngine} from '../trace_processor/http_rpc_engine';
 import {showModal} from '../widgets/modal';
 import {IdleDetector} from './idle_detector';
@@ -216,9 +216,8 @@ function onCssLoaded() {
   document.body.innerHTML = '';
 
   const pages = AppImpl.instance.pages;
-  const traceless = true;
-  pages.registerPage({route: '/', traceless, page: HomePage});
-  pages.registerPage({route: '/viewer', page: ViewerPage});
+  pages.registerPage({route: '/', render: () => m(HomePage)});
+  pages.registerPage({route: '/viewer', render: () => renderViewerPage()});
   const router = new Router();
   router.onRouteChanged = routeChange;
 

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -799,7 +799,7 @@ export class UiMainPerTrace implements m.ClassComponent {
           omnibox: this.renderOmnibox(),
           trace: this.trace,
         }),
-        app.pages.renderPageForCurrentRoute(app.trace),
+        app.pages.renderPageForCurrentRoute(),
         m(CookieConsent),
         maybeRenderFullscreenModalDialog(),
         app.perfDebugging.renderPerfStats(),

--- a/ui/src/frontend/viewer_page/viewer_page.ts
+++ b/ui/src/frontend/viewer_page/viewer_page.ts
@@ -19,7 +19,6 @@ import {Rect2D} from '../../base/geom';
 import {TimeScale} from '../../base/time_scale';
 import {AppImpl} from '../../core/app_impl';
 import {featureFlags} from '../../core/feature_flags';
-import {PageWithTraceImplAttrs} from '../../core/page_manager';
 import {raf} from '../../core/raf_scheduler';
 import {OverviewTimeline} from './overview_timeline_panel';
 import {TabPanel} from './tab_panel';
@@ -27,6 +26,7 @@ import {TimelineHeader} from './timeline_header';
 import {TrackTreeView} from './track_tree_view';
 import {KeyboardNavigationHandler} from './wasd_navigation_handler';
 import {trackMatchesFilter} from '../../core/track_manager';
+import {TraceImpl} from '../../core/trace_impl';
 
 const OVERVIEW_PANEL_FLAG = featureFlags.register({
   id: 'overviewVisible',
@@ -35,13 +35,26 @@ const OVERVIEW_PANEL_FLAG = featureFlags.register({
   defaultValue: true,
 });
 
-export class ViewerPage implements m.ClassComponent<PageWithTraceImplAttrs> {
+export function renderViewerPage() {
+  // Only render if a trace is loaded
+  const trace = AppImpl.instance.trace;
+  if (trace) {
+    return m(ViewerPage, {trace});
+  } else {
+    return undefined;
+  }
+}
+
+interface ViewerPageAttrs {
+  readonly trace: TraceImpl;
+}
+
+class ViewerPage implements m.ClassComponent<ViewerPageAttrs> {
   private readonly trash = new DisposableStack();
   private timelineBounds?: Rect2D;
 
-  view({attrs}: m.CVnode<PageWithTraceImplAttrs>) {
+  view({attrs}: m.CVnode<ViewerPageAttrs>) {
     const {trace} = attrs;
-
     return m(
       '.pf-viewer-page.page',
       m(
@@ -84,7 +97,7 @@ export class ViewerPage implements m.ClassComponent<PageWithTraceImplAttrs> {
     );
   }
 
-  oncreate(vnode: m.VnodeDOM<PageWithTraceImplAttrs>) {
+  oncreate(vnode: m.VnodeDOM<ViewerPageAttrs>) {
     const {attrs, dom} = vnode;
 
     // Handles WASD keybindings to pan & zoom
@@ -114,7 +127,7 @@ export class ViewerPage implements m.ClassComponent<PageWithTraceImplAttrs> {
     this.onupdate(vnode);
   }
 
-  onupdate({attrs}: m.VnodeDOM<PageWithTraceImplAttrs>) {
+  onupdate({attrs}: m.VnodeDOM<ViewerPageAttrs>) {
     // TODO(stevegolton): It's assumed that the TrackStacks will call into
     // trace.tracks.getTrackRenderer() in their view() functions which will mark
     // track renderers as used. We call flushOldTracks() here as it's guaranteed

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -15,7 +15,6 @@
 import m from 'mithril';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
 
-import {PageWithTraceAttrs} from '../../public/page';
 import {DataVisualiser} from './data_visualiser/data_visualiser';
 import {QueryBuilder} from './query_builder/builder';
 import {Button, ButtonVariant} from '../../widgets/button';
@@ -41,6 +40,7 @@ import {
   SqlSourceAttrs,
   SqlSourceNode,
 } from './query_builder/sources/sql_source';
+import {Trace} from '../../public/trace';
 
 export interface ExplorePageState {
   rootNodes: QueryNode[];
@@ -59,7 +59,8 @@ export const ExplorePageModeToLabel: Record<ExplorePageModes, string> = {
   [ExplorePageModes.DATA_VISUALISER]: 'Visualise Data',
 };
 
-interface ExplorePageAttrs extends PageWithTraceAttrs {
+interface ExplorePageAttrs {
+  readonly trace: Trace;
   readonly sqlModulesPlugin: SqlModulesPlugin;
   readonly state: ExplorePageState;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
@@ -33,13 +33,12 @@ export default class implements PerfettoPlugin {
   async onTraceLoad(trace: Trace): Promise<void> {
     trace.pages.registerPage({
       route: '/explore',
-      page: {
-        view: ({attrs}) =>
-          m(ExplorePage, {
-            ...attrs,
-            state: this.state,
-            sqlModulesPlugin: attrs.trace.plugins.getPlugin(SqlModulesPlugin),
-          }),
+      render: () => {
+        return m(ExplorePage, {
+          trace,
+          state: this.state,
+          sqlModulesPlugin: trace.plugins.getPlugin(SqlModulesPlugin),
+        });
       },
     });
     trace.sidebar.addMenuItem({

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -14,7 +14,6 @@
 
 import m from 'mithril';
 
-import {PageWithTraceAttrs} from '../../../public/page';
 import {Button, ButtonVariant} from '../../../widgets/button';
 import {SqlModules, SqlTable} from '../../dev.perfetto.SqlModules/sql_modules';
 import {ColumnControllerRow} from './column_controller';
@@ -24,6 +23,7 @@ import {DataSourceViewer} from './data_source_viewer';
 import {PopupMenu} from '../../../widgets/menu';
 import {Icons} from '../../../base/semantic_icons';
 import {Intent} from '../../../widgets/common';
+import {Trace} from '../../../public/trace';
 
 export interface QueryBuilderTable {
   name: string;
@@ -32,7 +32,9 @@ export interface QueryBuilderTable {
   sql: string;
 }
 
-export interface QueryBuilderAttrs extends PageWithTraceAttrs {
+export interface QueryBuilderAttrs {
+  readonly trace: Trace;
+
   readonly sqlModules: SqlModules;
   readonly rootNodes: QueryNode[];
   readonly selectedNode?: QueryNode;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_source_viewer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_source_viewer.ts
@@ -14,7 +14,6 @@
 
 import m from 'mithril';
 
-import {PageWithTraceAttrs} from '../../../public/page';
 import {TextParagraph} from '../../../widgets/text_paragraph';
 import {QueryTable} from '../../../components/query_table/query_table';
 import {runQueryForQueryTable} from '../../../components/query_table/queries';
@@ -29,8 +28,10 @@ import protos from '../../../protos';
 import {copyToClipboard} from '../../../base/clipboard';
 import {Button} from '../../../widgets/button';
 import {Icons} from '../../../base/semantic_icons';
+import {Trace} from '../../../public/trace';
 
-export interface DataSourceAttrs extends PageWithTraceAttrs {
+export interface DataSourceAttrs {
+  readonly trace: Trace;
   readonly queryNode: QueryNode;
 }
 

--- a/ui/src/plugins/dev.perfetto.InsightsPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.InsightsPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {InsightsPage} from './insights_page';
@@ -20,7 +21,10 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.InsightsPage';
 
   async onTraceLoad(trace: Trace): Promise<void> {
-    trace.pages.registerPage({route: '/insights', page: InsightsPage});
+    trace.pages.registerPage({
+      route: '/insights',
+      render: () => m(InsightsPage, {trace}),
+    });
     trace.sidebar.addMenuItem({
       section: 'current_trace',
       text: 'Insights',

--- a/ui/src/plugins/dev.perfetto.InsightsPage/insights_page.ts
+++ b/ui/src/plugins/dev.perfetto.InsightsPage/insights_page.ts
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {PageWithTraceAttrs} from '../../public/page';
 
-export class InsightsPage implements m.ClassComponent<PageWithTraceAttrs> {
+export class InsightsPage implements m.ClassComponent {
   view() {
     return m('.insights-page');
   }

--- a/ui/src/plugins/dev.perfetto.MetricsPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {MetricsPage} from './metrics_page';
@@ -20,7 +21,10 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.MetricsPage';
 
   async onTraceLoad(trace: Trace): Promise<void> {
-    trace.pages.registerPage({route: '/metrics', page: MetricsPage});
+    trace.pages.registerPage({
+      route: '/metrics',
+      render: () => m(MetricsPage, {trace}),
+    });
     trace.sidebar.addMenuItem({
       section: 'current_trace',
       text: 'Metrics',

--- a/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
@@ -20,7 +20,6 @@ import {STR} from '../../trace_processor/query_result';
 import {Select} from '../../widgets/select';
 import {Spinner} from '../../widgets/spinner';
 import {VegaView} from '../../components/widgets/vega_view';
-import {PageWithTraceAttrs} from '../../public/page';
 import {assertExists} from '../../base/logging';
 import {Trace} from '../../public/trace';
 
@@ -229,10 +228,14 @@ class MetricVizView implements m.ClassComponent<MetricVizViewAttrs> {
   }
 }
 
-export class MetricsPage implements m.ClassComponent<PageWithTraceAttrs> {
+export interface MetricsPageAttrs {
+  readonly trace: Trace;
+}
+
+export class MetricsPage implements m.ClassComponent<MetricsPageAttrs> {
   private controller?: MetricsController;
 
-  oninit({attrs}: m.Vnode<PageWithTraceAttrs>) {
+  oninit({attrs}: m.Vnode<MetricsPageAttrs>) {
     this.controller = new MetricsController(attrs.trace);
   }
 

--- a/ui/src/plugins/dev.perfetto.QueryPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {QueryPage} from './query_page';
@@ -20,7 +21,10 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.QueryPage';
 
   async onTraceLoad(trace: Trace): Promise<void> {
-    trace.pages.registerPage({route: '/query', page: QueryPage});
+    trace.pages.registerPage({
+      route: '/query',
+      render: () => m(QueryPage, {trace}),
+    });
     trace.sidebar.addMenuItem({
       section: 'current_trace',
       text: 'Query (SQL)',

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -21,7 +21,6 @@ import {
 } from '../../components/query_table/queries';
 import {Callout} from '../../widgets/callout';
 import {Editor} from '../../widgets/editor';
-import {PageWithTraceAttrs} from '../../public/page';
 import {QueryHistoryComponent, queryHistoryStorage} from './query_history';
 import {Trace, TraceAttrs} from '../../public/trace';
 import {addQueryResultsTab} from '../../components/query_table/query_result_tab';
@@ -106,8 +105,12 @@ class QueryInput implements m.ClassComponent<QueryInputAttrs> {
   }
 }
 
-export class QueryPage implements m.ClassComponent<PageWithTraceAttrs> {
-  view({attrs}: m.CVnode<PageWithTraceAttrs>) {
+export interface QueryPageAttrs {
+  readonly trace: Trace;
+}
+
+export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
+  view({attrs}: m.CVnode<QueryPageAttrs>) {
     return m(
       '.query-page',
       m(Callout, 'Enter query and press Cmd/Ctrl + Enter'),

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {bindMithrilAttrs} from '../../base/mithril_utils';
 import {App} from '../../public/app';
 import {PerfettoPlugin} from '../../public/plugin';
 import {AdbWebsocketTargetProvider} from './adb/websocket/adb_websocket_target_provider';
@@ -34,7 +33,7 @@ import {RecordingManager} from './recording_manager';
 import {TracedWebsocketTargetProvider} from './traced_over_websocket/traced_websocket_provider';
 import {savedConfigsPage} from './pages/saved_configs';
 import {WebDeviceProxyTargetProvider} from './adb/web_device_proxy/wdp_target_provider';
-
+import m from 'mithril';
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.RecordTraceV2';
   private static recordingMgr?: RecordingManager;
@@ -49,10 +48,13 @@ export default class implements PerfettoPlugin {
     });
     app.pages.registerPage({
       route: '/record',
-      traceless: true,
-      page: bindMithrilAttrs(RecordPageV2, {
-        getRecordingManager: this.getRecordingManager.bind(this, app),
-      }),
+      render: (subpage) => {
+        return m(RecordPageV2, {
+          subpage,
+          app,
+          getRecordingManager: () => this.getRecordingManager(app),
+        });
+      },
     });
   }
 

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {PageAttrs} from '../../../public/page';
 import {RecordingManager} from '../recording_manager';
 import {Icon} from '../../../widgets/icon';
 import {RecordSubpage, supportsPlatform} from '../config/config_interfaces';
@@ -25,10 +24,13 @@ import {BUCKET_NAME} from '../../../base/gcs_uploader';
 import {RecordingTarget} from '../interfaces/recording_target';
 import {exists} from '../../../base/utils';
 import {SHARE_SUBPAGE, shareRecordConfig} from '../config/config_sharing';
+import {App} from '../../../public/app';
 
-export type RecordPageAttrs = PageAttrs & {
-  getRecordingManager: () => RecordingManager;
-};
+export interface RecordPageAttrs {
+  readonly app: App;
+  readonly subpage?: string;
+  readonly getRecordingManager: () => RecordingManager;
+}
 
 const DEFAULT_SUBPAGE = 'target';
 const PERSIST_EVERY_MS = 1000;

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TraceInfoPage} from './trace_info_page';
@@ -20,7 +21,10 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.TraceInfoPage';
 
   async onTraceLoad(trace: Trace): Promise<void> {
-    trace.pages.registerPage({route: '/info', page: TraceInfoPage});
+    trace.pages.registerPage({
+      route: '/info',
+      render: () => m(TraceInfoPage, {trace}),
+    });
     trace.sidebar.addMenuItem({
       section: 'current_trace',
       text: 'Info and stats',

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
@@ -16,8 +16,7 @@ import m from 'mithril';
 import {Engine, EngineAttrs} from '../../trace_processor/engine';
 import {QueryResult, UNKNOWN} from '../../trace_processor/query_result';
 import {assertExists} from '../../base/logging';
-import {TraceAttrs} from '../../public/trace';
-import {PageWithTraceAttrs} from '../../public/page';
+import {Trace, TraceAttrs} from '../../public/trace';
 
 /**
  * Extracts and copies fields from a source object based on the keys present in
@@ -420,14 +419,18 @@ class PackageListSection implements m.ClassComponent<EngineAttrs> {
   }
 }
 
-export class TraceInfoPage implements m.ClassComponent<PageWithTraceAttrs> {
+export interface TraceInfoPageAttrs {
+  readonly trace: Trace;
+}
+
+export class TraceInfoPage implements m.ClassComponent<TraceInfoPageAttrs> {
   private engine?: Engine;
 
-  oninit({attrs}: m.CVnode<PageWithTraceAttrs>) {
+  oninit({attrs}: m.CVnode<TraceInfoPageAttrs>) {
     this.engine = attrs.trace.engine.getProxy('TraceInfoPage');
   }
 
-  view({attrs}: m.CVnode<PageWithTraceAttrs>) {
+  view({attrs}: m.CVnode<TraceInfoPageAttrs>) {
     const engine = assertExists(this.engine);
     return m(
       '.trace-info-page',

--- a/ui/src/plugins/dev.perfetto.VizPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.VizPage/index.ts
@@ -23,15 +23,14 @@ export default class implements PerfettoPlugin {
   async onTraceLoad(trace: Trace): Promise<void> {
     trace.pages.registerPage({
       route: '/viz',
-      page: {
-        view: ({attrs}) =>
-          m(VizPage, {
-            ...attrs,
-            spec: this.spec,
-            setSpec: (spec) => {
-              this.spec = spec;
-            },
-          }),
+      render: () => {
+        return m(VizPage, {
+          trace,
+          spec: this.spec,
+          setSpec: (spec) => {
+            this.spec = spec;
+          },
+        });
       },
     });
     trace.sidebar.addMenuItem({

--- a/ui/src/plugins/dev.perfetto.VizPage/viz_page.ts
+++ b/ui/src/plugins/dev.perfetto.VizPage/viz_page.ts
@@ -15,12 +15,13 @@
 import m from 'mithril';
 import {Editor} from '../../widgets/editor';
 import {VegaView} from '../../components/widgets/vega_view';
-import {PageWithTraceAttrs} from '../../public/page';
 import {Engine} from '../../trace_processor/engine';
+import {Trace} from '../../public/trace';
 
-export interface VizPageAttrs extends PageWithTraceAttrs {
-  spec: string;
-  setSpec: (spec: string) => void;
+export interface VizPageAttrs {
+  readonly trace: Trace;
+  readonly spec: string;
+  readonly setSpec: (spec: string) => void;
 }
 
 export class VizPage implements m.ClassComponent<VizPageAttrs> {

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {App} from '../../public/app';
 import {PerfettoPlugin} from '../../public/plugin';
 import {WidgetsPage} from './widgets_page';
@@ -22,8 +23,7 @@ export default class implements PerfettoPlugin {
   static onActivate(app: App): void {
     app.pages.registerPage({
       route: '/widgets',
-      page: WidgetsPage,
-      traceless: true,
+      render: () => m(WidgetsPage, {app}),
     });
     app.sidebar.addMenuItem({
       section: 'navigation',

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -42,7 +42,6 @@ import {TextInput} from '../../widgets/text_input';
 import {MultiParagraphText, TextParagraph} from '../../widgets/text_paragraph';
 import {LazyTreeNode, Tree, TreeNode} from '../../widgets/tree';
 import {VegaView} from '../../components/widgets/vega_view';
-import {PageAttrs} from '../../public/page';
 import {TableShowcase} from './table_showcase';
 import {TreeTable, TreeTableAttrs} from '../../components/widgets/treetable';
 import {Intent} from '../../widgets/common';
@@ -667,7 +666,7 @@ function SegmentedButtonsDemo({attrs}: {attrs: {}}) {
   };
 }
 
-export class WidgetsPage implements m.ClassComponent<PageAttrs> {
+export class WidgetsPage implements m.ClassComponent {
   view() {
     return m(
       '.widgets-page',

--- a/ui/src/public/page.ts
+++ b/ui/src/public/page.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {Trace} from './trace';
 
 /**
  * Allows to register custom page endpoints that response to given routes, e.g.
@@ -34,38 +33,24 @@ export interface PageManager {
   registerPage(pageHandler: PageHandler): Disposable;
 }
 
-/**
- * Mithril attrs for pages that don't require a Trace object. These pages are
- * always accessible, even before a trace is loaded.
- */
-export interface PageAttrs {
-  subpage?: string;
-  trace?: Trace;
-}
+export interface PageHandler {
+  /**
+   * The route path this page handler responds to (e.g., '/', '/viewer').
+   * This will be used to match the URL path when routing requests.
+   */
+  readonly route: string;
 
-/**
- * Mithril attrs for pages that require a Trace object. These pages are
- * reachable only after a trace is loaded. Trying to access the route without a
- * trace loaded results in the HomePage (route: '/') to be displayed instead.
- */
-export interface PageWithTraceAttrs extends PageAttrs {
-  trace: Trace;
-}
+  /**
+   * The ID of the plugin that registered this page handler.
+   * This field is automatically populated by the internal implementation.
+   */
+  readonly pluginId?: string;
 
-export type PageHandler<PWT = m.ComponentTypes<PageWithTraceAttrs>> = {
-  route: string; // e.g. '/' (default route), '/viewer'
-  pluginId?: string; // Not needed, the internal impl will fill it.
-} & (
-  | {
-      // If true, the route will be available even when there is no trace
-      // loaded. The component needs to deal with a possibly undefined attr.
-      traceless: true;
-      page: m.ComponentTypes<PageAttrs>;
-    }
-  | {
-      // If is omitted, the route will be available only when a trace is loaded.
-      // The component is guarranteed to get a defined Trace in its attrs.
-      traceless?: false;
-      page: PWT;
-    }
-);
+  /**
+   * Renders the page content.
+   * Called during each Mithril render cycle.
+   *
+   * @param subpage Optional subpage path segment after the main route
+   */
+  readonly render: (subpage: string | undefined) => m.Children;
+}


### PR DESCRIPTION
In order to register a page plugins currently need to provide a component whose attributes extend the `PageWithTraceAttrs` interface, unless the magic `traceless` flag is passed at which point they need only pass a component whose attributes extend the `PageAttrs` interface.

This is confusing for a number of reasons. How is the trace passed in to the page? What about the app? How do I pass my own arguments into my page?

Consider tracks and tabs for example, Any Mithril rendering done by those entities is described using functions, which are simply called every render cycle (when relevant). Usage of a function allows crucial arguments such as trace/app/etc to be captured using a closure, and any 'this' context to be captured simply by using an arrow function. 

The page API, however, takes a Mithril component rather than a function, which makes it very unclear on how to inject other arguments, and mysteriously hides how or if the trace is injected. Oh and if you get the attributes type wrong on your component, good luck de cyphering the TS error message.

Anna and Lydia both already got immediately stung by the issue of injecting extra arguments form their plugin into the page component when working on the explore page, so this is a real problem. The provided `bindMithrilAttrs` function, which was supposed to solve this problem, doesn't help as it's a very confusing templated function which, combined with Mithril's uneasy TypeScript integration, just makes the situation even worse.

I'd argue that one of the biggest issues is that it's just inconsistent with the rest of the other APIs, causing unnecessary friction when trying to write plugins.

In addition it pushes the onus of pulling out plugin-contextualized trace context objects onto the router, which is redundant as we have already solved the problem elegantly several times in the other APIs without those subsystems having to know anything about plugins - by just having the plugin inject in the trace object that was passed to it in its onTraceLoad hook.

Finally, this architecture promotes the proliferation of the pointless PageWithTraceAttrs, PageWithTraceImplAttrs interfaces which don't really prevent any boilerplate and just add unnecessary abstraction and coupling. When using a Mithril component, there is an unwritten convention that its attributes interface is listed in full above it so we can easily see how to use the component. The proliferation of PageWithTraceAttrs and friends just hides a couple of these attributes, and makes the code confusing to read.

This PR fixes things up by changing the page subsystem to take a render function instead of a component. This makes the API much cleaner and more consistent with the rest of the API.

New API:
```ts
trace.pages.registerPage({
  route: '/foo',

  // The render function is passed the subpage from the router, which can always be ignored
  render: (subpage) => m(FooPage, {subpage, trace, foo, bar, baz}),
});
```

Changes:
- Removed PageAttrs and PageWithTraceAttrs interfaces to simplify page attribute management.
- Updated page registration to use render functions instead of page components directly.
- Adjusted various page components to align with the new attribute structure.
- Reduce coupling and enhance code readability by defining trace attributes where necessary.
