### PR TITLE
tp: fix parsing of Chrome Devtools/NodeJS CPU profiling data

### DIFF
--- a/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h
+++ b/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/flat_hash_map.h"
@@ -44,12 +45,14 @@ class LegacyV8CpuProfileTracker {
 
   // Adds the callsite with for the given session and pid and given raw callsite
   // id.
-  base::Status AddCallsite(uint64_t session_id,
-                           uint32_t pid,
-                           uint32_t raw_callsite_id,
-                           std::optional<uint32_t> parent_raw_callsite_id,
-                           base::StringView script_url,
-                           base::StringView function_name);
+  base::Status AddCallsite(
+      uint64_t session_id,
+      uint32_t pid,
+      uint32_t raw_callsite_id,
+      std::optional<uint32_t> parent_raw_callsite_id,
+      base::StringView script_url,
+      base::StringView function_name,
+      const std::vector<uint32_t>& raw_children_callsite_ids);
 
   // Increments the current timestamp for the given session and pid by
   // |delta_ts| and returns the resulting full timestamp.
@@ -69,6 +72,7 @@ class LegacyV8CpuProfileTracker {
   struct State {
     int64_t ts;
     base::FlatHashMap<uint32_t, CallsiteId> callsites;
+    base::FlatHashMap<uint32_t, uint32_t> callsite_inferred_parents;
     DummyMemoryMapping* mapping;
   };
   struct Hasher {

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -567,7 +567,7 @@ base::Status TrackEventTokenizer::TokenizeLegacySampleEvent(
       base::Status status =
           context_->legacy_v8_cpu_profile_tracker->AddCallsite(
               legacy.unscoped_id(), static_cast<uint32_t>(state.pid()), node_id,
-              parent_node_id, url, function_name);
+              parent_node_id, url, function_name, {});
       if (!status.ok()) {
         context_->storage->IncrementStats(
             stats::legacy_v8_cpu_profile_invalid_callsite);

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -469,11 +469,13 @@ namespace perfetto::trace_processor::stats {
       "An invalid Mali GPU MCU state ID was detected."),                       \
   F(pixel_modem_negative_timestamp,       kSingle,  kError,   kAnalysis,       \
       "A negative timestamp was received from a Pixel modem event."),          \
-  F(legacy_v8_cpu_profile_invalid_callsite, kSingle,  kInfo,  kAnalysis,       \
-      "Indicates a callsite in legacy v8 CPU profiling is invalid."),          \
-  F(legacy_v8_cpu_profile_invalid_sample, kSingle,  kError,  kAnalysis,        \
+  F(legacy_v8_cpu_profile_invalid_callsite, kSingle, kError,  kTrace,          \
+      "Indicates a callsite in legacy v8 CPU profiling is invalid. This is "   \
+      "a sign that the trace is malformed."),                                  \
+  F(legacy_v8_cpu_profile_invalid_sample, kSingle,  kError,  kTrace,           \
       "Indicates a sample in legacy v8 CPU profile is invalid. This will "     \
-      "cause CPU samples to be missing in the UI."),                           \
+      "cause CPU samples to be missing in the UI. This is a sign that the "    \
+      "trace is malformed."),                                                  \
   F(config_write_into_file_no_flush,      kSingle,  kError,  kTrace,           \
       "The trace was collected with the `write_into_file` option set but "     \
       "*without* `flush_period_ms` being set. This will cause the trace to "   \


### PR DESCRIPTION
Turns out they use a separate format to V8 with a more standardised
system [1]. Since supporting it is quite simple, just do it.

See discussion at https://github.com/google/perfetto/issues/275 for what prompted this.

[1] https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#type-ProfileNode
