### PR TITLE
Record package_list when network tracing is enabled

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/android.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/android.ts
@@ -167,6 +167,8 @@ function netTracing(): RecordProbe {
       tc.addDataSource('android.network_packets').networkPacketTraceConfig = {
         pollMs: settings.pollMs.value,
       };
+      // Allows mapping packet uids to package names.
+      tc.addDataSource('android.packages_list');
     },
   };
 }


### PR DESCRIPTION
This ensures the package_list is recored when network tracing is enabled in the record V2 ui. This is the typical use case, to ensure that the packets are reported with their associated package name.
