### PR TITLE
Move feature flags `storage` abstraction to new file & make reusable

### DIFF
--- a/ui/src/core/feature_flags.ts
+++ b/ui/src/core/feature_flags.ts
@@ -18,11 +18,8 @@
 // into issues with initialization order which will be a pain.
 import {z} from 'zod';
 import {Flag, FlagSettings, OverrideState} from '../public/feature_flag';
-
-export interface FlagStore {
-  load(): object;
-  save(o: object): void;
-}
+import {LocalStorage} from './local_storage';
+import {Storage} from './storage';
 
 // Stored state for a number of flags.
 interface FlagOverrides {
@@ -30,11 +27,11 @@ interface FlagOverrides {
 }
 
 class Flags {
-  private store: FlagStore;
+  private store: Storage;
   private flags: Map<string, FlagImpl>;
   private overrides: FlagOverrides;
 
-  constructor(store: FlagStore) {
+  constructor(store: Storage) {
     this.store = store;
     this.flags = new Map();
     this.overrides = {};
@@ -156,28 +153,5 @@ class FlagImpl implements Flag {
   }
 }
 
-class LocalStorageStore implements FlagStore {
-  static KEY = 'perfettoFeatureFlags';
-
-  load(): object {
-    const s = localStorage.getItem(LocalStorageStore.KEY);
-    let parsed: object;
-    try {
-      parsed = JSON.parse(s ?? '{}');
-    } catch (e) {
-      return {};
-    }
-    if (typeof parsed !== 'object' || parsed === null) {
-      return {};
-    }
-    return parsed;
-  }
-
-  save(o: object): void {
-    const s = JSON.stringify(o);
-    localStorage.setItem(LocalStorageStore.KEY, s);
-  }
-}
-
 export const FlagsForTesting = Flags;
-export const featureFlags = new Flags(new LocalStorageStore());
+export const featureFlags = new Flags(new LocalStorage('perfettoFeatureFlags'));

--- a/ui/src/core/feature_flags_unittest.ts
+++ b/ui/src/core/feature_flags_unittest.ts
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {FlagsForTesting as Flags, FlagStore} from '../core/feature_flags';
+import {FlagsForTesting as Flags} from '../core/feature_flags';
+import {Storage} from './storage';
 
-class TestFlagStore implements FlagStore {
-  o: object = {};
+class TestFlagStore implements Storage {
+  o: Record<string, unknown> = {};
 
-  load(): object {
+  load(): Record<string, unknown> {
     return this.o;
   }
 
-  save(o: object): void {
+  save(o: Record<string, unknown>): void {
     this.o = o;
   }
 }
@@ -103,11 +104,11 @@ test('flags can be reset', () => {
 
 test('corrupt store is ignored', () => {
   class Store {
-    load(): object {
+    load(): Record<string, unknown> {
       return {foo: 'bad state'};
     }
 
-    save(_: object): void {}
+    save(_: Record<string, unknown>): void {}
   }
   const flags = new Flags(new Store());
   const foo = flags.register({

--- a/ui/src/core/local_storage.ts
+++ b/ui/src/core/local_storage.ts
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Storage} from './storage';
+
+export class LocalStorage implements Storage {
+  constructor(private readonly key: string) {}
+
+  load(): Record<string, unknown> {
+    const s = localStorage.getItem(this.key);
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(s ?? '{}');
+    } catch (e) {
+      return {};
+    }
+    if (typeof parsed !== 'object' || parsed === null) {
+      return {};
+    }
+    return parsed;
+  }
+
+  save(o: Record<string, unknown>): void {
+    const s = JSON.stringify(o);
+    localStorage.setItem(this.key, s);
+  }
+}

--- a/ui/src/core/storage.ts
+++ b/ui/src/core/storage.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface Storage {
+  load(): Record<string, unknown>;
+  save(o: Record<string, unknown>): void;
+}


### PR DESCRIPTION
- Move the `Storage` abstraction out of feature_flags.ts into its own file.
- Add ability to inject a local storage key into `LocalStorage` implementation, which allows it to be reused for other systems that require local storage, not just flags.
- Refactor feature flags & tests accordingly.