### PR TITLE
Renamed SettingsPage -> SettingsShell

### DIFF
--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -50,7 +50,7 @@
 @import "widgets/section";
 @import "widgets/segmented_buttons";
 @import "widgets/select";
-@import "widgets/settings_page";
+@import "widgets/settings_shell";
 @import "widgets/spinner";
 @import "widgets/split_panel";
 @import "widgets/sql_table";

--- a/ui/src/assets/widgets/settings_shell.scss
+++ b/ui/src/assets/widgets/settings_shell.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.pf-settings-page {
+.pf-settings-shell {
   overflow: auto;
 
   &__header {

--- a/ui/src/core_plugins/flags_page/plugins_page.ts
+++ b/ui/src/core_plugins/flags_page/plugins_page.ts
@@ -23,7 +23,7 @@ import {Card, CardList} from '../../widgets/card';
 import {Chip} from '../../widgets/chip';
 import {Intent} from '../../widgets/common';
 import {MenuItem, PopupMenu} from '../../widgets/menu';
-import {SettingsPage} from '../../widgets/settings_page';
+import {SettingsShell} from '../../widgets/settings_shell';
 import {Switch} from '../../widgets/switch';
 
 enum SortOrder {
@@ -86,7 +86,7 @@ export class PluginsPage implements m.ClassComponent {
     });
     const sorted = sortPlugins(registeredPlugins);
     return m(
-      SettingsPage,
+      SettingsShell,
       {
         title: 'Plugins',
         stickyHeaderContent: m(

--- a/ui/src/widgets/settings_shell.ts
+++ b/ui/src/widgets/settings_shell.ts
@@ -16,50 +16,50 @@ import m from 'mithril';
 import {HTMLAttrs} from './common';
 import {assertExists} from '../base/logging';
 
-export interface SettingsPageAttrs extends HTMLAttrs {
+export interface SettingsShellAttrs extends HTMLAttrs {
   readonly title: string;
   readonly stickyHeaderContent?: m.Children;
 }
 
-export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
+export class SettingsShell implements m.ClassComponent<SettingsShellAttrs> {
   private observer?: IntersectionObserver;
 
-  view(vnode: m.Vnode<SettingsPageAttrs>) {
+  view(vnode: m.Vnode<SettingsShellAttrs>) {
     const {
       title,
       stickyHeaderContent: headerContent,
       ...htmlAttrs
     } = vnode.attrs;
     return m(
-      '.pf-settings-page',
+      '.pf-settings-shell',
       htmlAttrs,
       m(
-        '.pf-settings-page__title',
-        m('.pf-settings-page__centred', m('h1', title)),
+        '.pf-settings-shell__title',
+        m('.pf-settings-shell__centred', m('h1', title)),
       ),
       m(
-        '.pf-settings-page__header',
-        m('.pf-settings-page__centred', headerContent),
+        '.pf-settings-shell__header',
+        m('.pf-settings-shell__centred', headerContent),
       ),
       m(
-        '.pf-settings-page__content',
-        m('.pf-settings-page__centred', vnode.children),
+        '.pf-settings-shell__content',
+        m('.pf-settings-shell__centred', vnode.children),
       ),
     );
   }
 
-  oncreate(vnode: m.VnodeDOM<SettingsPageAttrs, this>) {
+  oncreate(vnode: m.VnodeDOM<SettingsShellAttrs, this>) {
     const canary = assertExists(
-      vnode.dom.querySelector('.pf-settings-page__title'),
+      vnode.dom.querySelector('.pf-settings-shell__title'),
     );
     const header = assertExists(
-      vnode.dom.querySelector('.pf-settings-page__header'),
+      vnode.dom.querySelector('.pf-settings-shell__header'),
     );
 
     this.observer = new IntersectionObserver(
       ([entry]) => {
         header.classList.toggle(
-          'pf-settings-page__header--stuck',
+          'pf-settings-shell__header--stuck',
           !entry.isIntersecting,
         );
       },


### PR DESCRIPTION
The widget `SettingsPage` was badly named, and will collide with the upcoming (actual) settings page!

This PR just renames this widget to `SettingsShell` which more accurately describes what the widget does and will cause less confusion when we have a real settings page.