### PR TITLE
Add number-related attributes to HTMLInputAttrs

### DIFF
--- a/ui/src/widgets/common.ts
+++ b/ui/src/widgets/common.ts
@@ -48,8 +48,10 @@ export interface HTMLInputAttrs extends HTMLFocusableAttrs {
   readonly oninput?: (e: KeyboardEvent) => void;
   readonly onkeydown?: (e: KeyboardEvent) => void;
   readonly onkeyup?: (e: KeyboardEvent) => void;
-  readonly value?: string;
+  readonly value?: string | number;
   readonly placeholder?: string;
+  readonly min?: number;
+  readonly max?: number;
 }
 
 export interface HTMLCheckboxAttrs extends HTMLInputAttrs {


### PR DESCRIPTION
This allows the TextInput widget to be used more conveniently when type=number.