### PR TITLE
protos: remove redundant edge

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -5452,7 +5452,6 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_cpp_gen",
     srcs: [
-        ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_system_info_cpp",
     ],
     tools: [
@@ -5469,7 +5468,6 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_cpp_gen_headers",
     srcs: [
-        ":perfetto_protos_perfetto_common_cpp",
         ":perfetto_protos_perfetto_config_system_info_cpp",
     ],
     tools: [
@@ -5498,7 +5496,6 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_lite_gen",
     srcs: [
-        ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_system_info_lite",
     ],
     tools: [
@@ -5514,7 +5511,6 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_lite_gen_headers",
     srcs: [
-        ":perfetto_protos_perfetto_common_lite",
         ":perfetto_protos_perfetto_config_system_info_lite",
     ],
     tools: [
@@ -5542,7 +5538,6 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_zero_gen",
     srcs: [
-        ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_system_info_zero",
     ],
     tools: [
@@ -5559,7 +5554,6 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_system_info_zero_gen_headers",
     srcs: [
-        ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_system_info_zero",
     ],
     tools: [

--- a/BUILD
+++ b/BUILD
@@ -5601,7 +5601,6 @@ perfetto_cc_protozero_library(
 perfetto_cc_protocpp_library(
     name = "protos_perfetto_config_system_info_cpp",
     deps = [
-        ":protos_perfetto_common_cpp",
         ":protos_perfetto_config_system_info_protos",
     ],
 )
@@ -5615,16 +5614,12 @@ perfetto_proto_library(
     visibility = [
         PERFETTO_CONFIG.proto_library_visibility,
     ],
-    deps = [
-        ":protos_perfetto_common_protos",
-    ],
 )
 
 # GN target: //protos/perfetto/config/system_info:zero
 perfetto_cc_protozero_library(
     name = "protos_perfetto_config_system_info_zero",
     deps = [
-        ":protos_perfetto_common_zero",
         ":protos_perfetto_config_system_info_protos",
     ],
 )

--- a/protos/perfetto/config/system_info/BUILD.gn
+++ b/protos/perfetto/config/system_info/BUILD.gn
@@ -15,6 +15,5 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  deps = [ "../../common:@TYPE@" ]
   sources = [ "system_info_config.proto" ]
 }


### PR DESCRIPTION
This is not necessary as the system_info_config does not depend on
anything in common.
