### PR TITLE
Improve dataset search efficiency

### DIFF
--- a/ui/src/core/dataset_search.ts
+++ b/ui/src/core/dataset_search.ts
@@ -1,0 +1,207 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Time, time} from '../base/time';
+import {getOrCreate} from '../base/utils';
+import {Track} from '../public/track';
+import {SourceDataset} from '../trace_processor/dataset';
+import {Engine} from '../trace_processor/engine';
+import {
+  ColumnType,
+  LONG,
+  NUM,
+  SqlValue,
+  STR_NULL,
+  UNKNOWN,
+} from '../trace_processor/query_result';
+import {escapeSearchQuery} from '../trace_processor/query_utils';
+
+// Type alias for search results
+export type SearchResult = {
+  id: number;
+  ts: time;
+  track: Track;
+};
+
+type PartitionMap = Map<string, Map<SqlValue, Track[]>>;
+
+// Defines a group of tracks that use the same dataset source, including a LUT
+// to find the corresponding track.
+export interface TrackGroup {
+  readonly src: string;
+  readonly schema: Record<string, ColumnType>;
+  readonly nonPartitioned: Track[];
+  readonly partitioned: PartitionMap;
+}
+
+// Searches for a given searchTerm within all tracks that have a name column.
+export async function searchTrackEvents(
+  engine: Engine,
+  tracks: ReadonlyArray<Track>,
+  searchTerm: string,
+): Promise<SearchResult[]> {
+  const trackGroups = buildTrackGroups(tracks);
+  const searchLiteral = escapeSearchQuery(searchTerm);
+  // TODO(stevegolton): We currently only search for names but in the future we
+  // will allow more search facets to be defined.
+  return await searchNames(trackGroups, searchLiteral, engine);
+}
+
+function buildTrackGroups(
+  tracks: ReadonlyArray<Track>,
+): Map<string, TrackGroup> {
+  const trackGroups = new Map<string, TrackGroup>();
+  for (const track of tracks) {
+    const dataset = track.track.getDataset?.();
+    if (dataset) {
+      const src = dataset.src;
+      const trackGroup = getOrCreate(trackGroups, src, () => ({
+        src,
+        schema: {},
+        nonPartitioned: [],
+        partitioned: new Map(),
+      }));
+      addTrackToTrackGroup(trackGroup, track, dataset);
+    }
+  }
+  return trackGroups;
+}
+
+function addTrackToTrackGroup(
+  trackGroup: TrackGroup,
+  track: Track,
+  dataset: SourceDataset,
+): void {
+  const filter = dataset.filter;
+  const schema = dataset.schema;
+
+  // Combine schemas from all datasets in the group.
+  for (const [col, type] of Object.entries(schema)) {
+    // TODO(stevegolton): This is a bit of a hack as the data types could
+    // conflict. In the future we will probably switch to a centralized
+    // datasource approach which tracks will point to that has its own schema.
+    trackGroup.schema[col] = type;
+  }
+
+  if (filter === undefined) {
+    trackGroup.nonPartitioned.push(track);
+  } else {
+    const partitions = getOrCreate(
+      trackGroup.partitioned,
+      filter.col,
+      () => new Map<SqlValue, Track[]>(),
+    );
+    const addTrackToPartition = (value: SqlValue) => {
+      const key = normalizeMapKey(value);
+      const partition = getOrCreate(partitions, key, () => []);
+      partition.push(track);
+    };
+
+    if ('eq' in filter) {
+      addTrackToPartition(filter.eq);
+    } else {
+      for (const value of filter.in) {
+        addTrackToPartition(value);
+      }
+    }
+  }
+}
+
+// Normalizes values used as keys in the partition map.
+// This is necessary because SQL queries might return integer values as BigInts
+// (e.g., for LONG types), while filter definitions might use standard numbers.
+// This ensures consistent key types (BigInt for integers, others as-is)
+// for reliable lookups in the JavaScript Map.
+function normalizeMapKey(value: SqlValue): SqlValue {
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    return BigInt(value);
+  } else {
+    return value;
+  }
+}
+
+async function searchNames(
+  trackGroups: Map<string, TrackGroup>,
+  searchLiteral: string,
+  engine: Engine,
+): Promise<SearchResult[]> {
+  const searchResults: SearchResult[] = [];
+
+  // Process each track group
+  for (const trackGroup of trackGroups.values()) {
+    // Only search track groups that implement the required schema
+    // The schema check ensures 'id', 'ts', and 'name' columns exist.
+    const groupDataset = new SourceDataset({
+      src: trackGroup.src,
+      schema: trackGroup.schema,
+    });
+    if (groupDataset.implements({id: NUM, ts: LONG, name: STR_NULL})) {
+      const results = await searchTrackGroup(trackGroup, searchLiteral, engine);
+      searchResults.push(...results);
+    }
+  }
+
+  return searchResults;
+}
+
+async function searchTrackGroup(
+  trackGroup: TrackGroup,
+  searchLiteral: string,
+  engine: Engine,
+): Promise<SearchResult[]> {
+  const results: SearchResult[] = [];
+  const partitionCols = Array.from(trackGroup.partitioned.keys());
+  const partitionColSchema = Object.fromEntries(
+    partitionCols.map((key) => [key, UNKNOWN]),
+  );
+
+  // Ensure required columns plus any partition columns are selected.
+  const schema = {id: NUM, ts: LONG, ...partitionColSchema};
+  const selectCols = ['id', 'ts', ...partitionCols];
+
+  // Build and execute search query
+  const query = `
+    SELECT
+      ${selectCols.join(', ')}
+    FROM (${trackGroup.src})
+    WHERE name GLOB ${searchLiteral}
+  `;
+  const result = await engine.query(query);
+
+  // Process query results
+  for (const iter = result.iter(schema); iter.valid(); iter.next()) {
+    const id = iter.id;
+    const ts = Time.fromRaw(iter.ts);
+
+    // Add results for matching partitioned tracks
+    for (const colName of partitionCols) {
+      const partitionValue = iter.get(colName);
+      const tracks = trackGroup.partitioned.get(colName)?.get(partitionValue);
+
+      if (tracks) {
+        for (const track of tracks) {
+          results.push({id, ts, track});
+        }
+      }
+    }
+
+    // Add results for non-partitioned tracks (they match any row from the
+    // source)
+    for (const track of trackGroup.nonPartitioned) {
+      results.push({id, ts, track});
+    }
+  }
+
+  return results;
+}

--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -1,31 +1,17 @@
-// Copyright (C) 2024 The Android Open Source Project
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 import {AsyncLimiter} from '../base/async_limiter';
 import {sqliteString} from '../base/string_utils';
 import {Time} from '../base/time';
 import {exists} from '../base/utils';
-import {ResultStepEventHandler} from '../public/search';
+import {ResultStepEventHandler} from '../public/search'; // Added SearchResult import
 import {
   ANDROID_LOGS_TRACK_KIND,
   CPU_SLICE_TRACK_KIND,
 } from '../public/track_kinds';
 import {Workspace} from '../public/workspace';
-import {SourceDataset, UnionDataset} from '../trace_processor/dataset';
 import {Engine} from '../trace_processor/engine';
 import {LONG, NUM, STR} from '../trace_processor/query_result';
 import {escapeSearchQuery} from '../trace_processor/query_utils';
+import {searchTrackEvents} from './dataset_search';
 import {featureFlags} from './feature_flags';
 import {raf} from './raf_scheduler';
 import {SearchSource} from './search_data';
@@ -91,11 +77,16 @@ export class SearchManagerImpl {
     if (text !== '') {
       this._searchInProgress = true;
       this._limiter.schedule(async () => {
+        const startTime = performance.now();
         if (DATASET_SEARCH.get()) {
           await this.executeDatasetSearch();
         } else {
           await this.executeSearch();
         }
+        const timeTaken = performance.now() - startTime;
+        console.log(
+          `Search returned ${this._results?.eventIds.length} results in ${timeTaken}ms`,
+        );
         this._searchInProgress = false;
         raf.scheduleFullRedraw();
       });
@@ -166,6 +157,7 @@ export class SearchManagerImpl {
     return this._searchInProgress;
   }
 
+  // --- Legacy Search Method ---
   private async executeSearch() {
     const search = this._searchText;
     const searchLiteral = escapeSearchQuery(this._searchText);
@@ -349,91 +341,55 @@ export class SearchManagerImpl {
     }
 
     const generation = this._searchGeneration;
-    const searchLiteral = escapeSearchQuery(this._searchText);
 
-    const datasets = trackManager
-      .getAllTracks()
-      .map((t) => {
-        const dataset = t.track.getDataset?.();
-        if (dataset) {
-          return [dataset, t.uri] as const;
-        } else {
-          return undefined;
-        }
-      })
-      .filter(exists)
-      .filter(([dataset]) => dataset.implements({id: NUM, ts: LONG, name: STR}))
-      .map(
-        ([dataset, uri]) =>
-          new SourceDataset({
-            src: `
-              select
-                id,
-                ts,
-                name,
-                '${uri}' as uri
-              from (${dataset.query()})`,
-            schema: {id: NUM, ts: LONG, name: STR, uri: STR},
-          }),
-      );
+    const allResults = await searchTrackEvents(
+      engine,
+      trackManager.getAllTracks(),
+      this._searchText,
+    );
 
-    const union = new UnionDataset(datasets);
-    const result = await engine.query(`
-      select
-        id,
-        uri,
-        ts
-      from (${union.query()})
-      where name glob ${searchLiteral}
-    `);
-
-    const numRows = result.numRows();
+    const numRows = allResults.length;
     const searchResults: SearchResults = {
       eventIds: new Float64Array(numRows),
       tses: new BigInt64Array(numRows),
-      utids: new Float64Array(numRows),
+      utids: new Float64Array(numRows).fill(-1), // Fill with -1 as utid is unknown
       sources: [],
       trackUris: [],
       totalResults: numRows,
     };
 
-    let i = 0;
-    for (
-      const iter = result.iter({id: NUM, ts: LONG, uri: STR});
-      iter.valid();
-      iter.next()
-    ) {
-      searchResults.eventIds[i] = iter.id;
-      searchResults.tses[i] = iter.ts;
-      searchResults.utids[i] = -1; // We don't know anything about utids.
+    for (let i = 0; i < numRows; i++) {
+      const {id, ts, track} = allResults[i];
+      searchResults.eventIds[i] = id;
+      searchResults.tses[i] = ts;
+      searchResults.trackUris.push(track.uri);
+      // Assuming all results from datasets correspond to 'event' type search
       searchResults.sources.push('event');
-      searchResults.trackUris.push(iter.uri);
-      ++i;
     }
 
     if (generation !== this._searchGeneration) {
-      // We arrived too late. By the time we computed results the user issued
-      // another search.
+      // We arrived too late.
       return;
     }
     this._results = searchResults;
 
-    // We have changed the search results - try and find the first result that's
-    // after the start of this visible window.
+    // Find first result after the start of the visible window
     const visibleWindow = this._timeline?.visibleWindow.toTimeSpan();
-    if (visibleWindow) {
-      const foundIndex = this._results.tses.findIndex(
-        (ts) => ts >= visibleWindow.start,
-      );
-      if (foundIndex === -1) {
-        this._resultIndex = -1;
-      } else {
-        // Store the value before the found one, so that when the user presses
-        // enter we navigate to the correct one.
-        this._resultIndex = foundIndex - 1;
+    if (visibleWindow && this._results.totalResults > 0) {
+      let foundIndex = -1;
+      for (let i = 0; i < this._results.tses.length; i++) {
+        if (this._results.tses[i] >= visibleWindow.start) {
+          foundIndex = i;
+          break;
+        }
       }
+      // Store the index *before* the found one, so the first step lands on it.
+      this._resultIndex = foundIndex === -1 ? -1 : foundIndex - 1;
     } else {
       this._resultIndex = -1;
     }
+
+    // Trigger redraw if needed (assuming _searchInProgress was handled outside)
+    raf.scheduleFullRedraw();
   }
 }

--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -1,8 +1,22 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {AsyncLimiter} from '../base/async_limiter';
 import {sqliteString} from '../base/string_utils';
 import {Time} from '../base/time';
 import {exists} from '../base/utils';
-import {ResultStepEventHandler} from '../public/search'; // Added SearchResult import
+import {ResultStepEventHandler} from '../public/search';
 import {
   ANDROID_LOGS_TRACK_KIND,
   CPU_SLICE_TRACK_KIND,
@@ -77,16 +91,11 @@ export class SearchManagerImpl {
     if (text !== '') {
       this._searchInProgress = true;
       this._limiter.schedule(async () => {
-        const startTime = performance.now();
         if (DATASET_SEARCH.get()) {
           await this.executeDatasetSearch();
         } else {
           await this.executeSearch();
         }
-        const timeTaken = performance.now() - startTime;
-        console.log(
-          `Search returned ${this._results?.eventIds.length} results in ${timeTaken}ms`,
-        );
         this._searchInProgress = false;
         raf.scheduleFullRedraw();
       });
@@ -157,7 +166,6 @@ export class SearchManagerImpl {
     return this._searchInProgress;
   }
 
-  // --- Legacy Search Method ---
   private async executeSearch() {
     const search = this._searchText;
     const searchLiteral = escapeSearchQuery(this._searchText);
@@ -388,8 +396,5 @@ export class SearchManagerImpl {
     } else {
       this._resultIndex = -1;
     }
-
-    // Trigger redraw if needed (assuming _searchInProgress was handled outside)
-    raf.scheduleFullRedraw();
   }
 }


### PR DESCRIPTION
This change improves efficiency of the dataset search algorithm by grouping together batches of tracks that have the same dataset `src` running one query per group, rather than a big union all of all tracks.

In addition, rather than embedding the track URI in the query, we resolve the owning track for each event by doing a reverse lookup of the track's partition (filter).

This leads to much more efficient query(s), despite having to run more than one query (one per track group).
