### PR TITLE
ui: fix graceful dialog on downloadPprof

### DIFF
--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -490,6 +490,7 @@ async function downloadPprof(trace: Trace, upid: number, ts: time) {
       title: 'Download not supported',
       content: m('div', 'This trace file does not support downloads'),
     });
+    return;
   }
   const blob = await trace.getTraceFile();
   convertTraceToPprofAndDownload(blob, pid.firstRow({pid: NUM}).pid, ts);


### PR DESCRIPTION
A missing return was invalidating the dialog and
falling through anyways.
