### PR TITLE
Remove default argument from ProducerEndpoint::CreateTraceWriter

### DIFF
--- a/include/perfetto/ext/tracing/core/tracing_service.h
+++ b/include/perfetto/ext/tracing/core/tracing_service.h
@@ -114,8 +114,7 @@ class PERFETTO_EXPORT_COMPONENT ProducerEndpoint {
   // DataSourceConfig.target_buffer().
   virtual std::unique_ptr<TraceWriter> CreateTraceWriter(
       BufferID target_buffer,
-      BufferExhaustedPolicy buffer_exhausted_policy =
-          BufferExhaustedPolicy::kDefault) = 0;
+      BufferExhaustedPolicy buffer_exhausted_policy) = 0;
 
   // TODO(eseckler): Also expose CreateStartupTraceWriter() ?
 

--- a/src/profiling/perf/perf_producer.cc
+++ b/src/profiling/perf/perf_producer.cc
@@ -37,6 +37,7 @@
 #include "perfetto/ext/tracing/core/tracing_service.h"
 #include "perfetto/ext/tracing/ipc/producer_ipc_client.h"
 #include "perfetto/public/compiler.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "src/profiling/common/callstack_trie.h"
@@ -489,7 +490,8 @@ void PerfProducer::StartDataSource(DataSourceInstanceID ds_id,
   }
 
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
-  auto writer = endpoint_->CreateTraceWriter(buffer_id);
+  auto writer =
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall);
 
   // Construct the data source instance.
   std::map<DataSourceInstanceID, DataSourceState>::iterator ds_it;
@@ -1275,7 +1277,8 @@ std::optional<ProcessSharding> PerfProducer::GetOrChooseCallstackProcessShard(
 
 void PerfProducer::StartMetatraceSource(DataSourceInstanceID ds_id,
                                         BufferID target_buffer) {
-  auto writer = endpoint_->CreateTraceWriter(target_buffer);
+  auto writer = endpoint_->CreateTraceWriter(target_buffer,
+                                             BufferExhaustedPolicy::kStall);
 
   auto it_and_inserted = metatrace_writers_.emplace(
       std::piecewise_construct, std::make_tuple(ds_id), std::make_tuple());

--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -27,6 +27,7 @@
 #include "perfetto/ext/base/weak_ptr.h"
 #include "perfetto/ext/tracing/core/basic_types.h"
 #include "perfetto/ext/tracing/ipc/producer_ipc_client.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "perfetto/tracing/core/forward_decls.h"
@@ -131,7 +132,7 @@ ProbesProducer::CreateDSInstance<FtraceDataSource>(
   const BufferID buffer_id = static_cast<BufferID>(config.target_buffer());
   std::unique_ptr<FtraceDataSource> data_source(new FtraceDataSource(
       ftrace_->GetWeakPtr(), session_id, std::move(ftrace_config),
-      endpoint_->CreateTraceWriter(buffer_id)));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall)));
   if (!ftrace_->AddDataSource(data_source.get())) {
     PERFETTO_ELOG("Failed to setup ftrace");
     return nullptr;
@@ -151,7 +152,7 @@ ProbesProducer::CreateDSInstance<InodeFileDataSource>(
     CreateStaticDeviceToInodeMap("/system", &system_inodes_);
   return std::make_unique<InodeFileDataSource>(
       source_config, task_runner_, session_id, &system_inodes_, &cache_,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -161,7 +162,8 @@ ProbesProducer::CreateDSInstance<ProcessStatsDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<ProcessStatsDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id),
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
       config);
 }
 
@@ -172,7 +174,8 @@ ProbesProducer::CreateDSInstance<StatsdBinderDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<StatsdBinderDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id),
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
       config);
 }
 
@@ -184,7 +187,7 @@ ProbesProducer::CreateDSInstance<AndroidPowerDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidPowerDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -195,7 +198,7 @@ ProbesProducer::CreateDSInstance<LinuxPowerSysfsDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<LinuxPowerSysfsDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -206,7 +209,7 @@ ProbesProducer::CreateDSInstance<AndroidKernelWakelocksDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidKernelWakelocksDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -217,7 +220,7 @@ ProbesProducer::CreateDSInstance<AndroidLogDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidLogDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -227,7 +230,8 @@ ProbesProducer::CreateDSInstance<PackagesListDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<PackagesListDataSource>(
-      config, session_id, endpoint_->CreateTraceWriter(buffer_id));
+      config, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -237,7 +241,8 @@ ProbesProducer::CreateDSInstance<AndroidGameInterventionListDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidGameInterventionListDataSource>(
-      config, session_id, endpoint_->CreateTraceWriter(buffer_id));
+      config, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -247,8 +252,9 @@ ProbesProducer::CreateDSInstance<SysStatsDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<SysStatsDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id), config,
-      std::make_unique<CpuFreqInfo>());
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
+      config, std::make_unique<CpuFreqInfo>());
 }
 
 template <>
@@ -258,7 +264,8 @@ ProbesProducer::CreateDSInstance<MetatraceDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<MetatraceDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id));
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -268,7 +275,8 @@ ProbesProducer::CreateDSInstance<SystemInfoDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<SystemInfoDataSource>(
-      session_id, endpoint_->CreateTraceWriter(buffer_id),
+      session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
       std::make_unique<CpuFreqInfo>());
 }
 
@@ -280,7 +288,7 @@ ProbesProducer::CreateDSInstance<InitialDisplayStateDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<InitialDisplayStateDataSource>(
       task_runner_, config, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -291,7 +299,7 @@ ProbesProducer::CreateDSInstance<AndroidSystemPropertyDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidSystemPropertyDataSource>(
       task_runner_, config, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 // Another anonymous namespace. This cannot be moved into the anonymous

--- a/src/traced/service/builtin_producer.cc
+++ b/src/traced/service/builtin_producer.cc
@@ -28,6 +28,7 @@
 #include "perfetto/ext/tracing/core/client_identity.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"
 #include "perfetto/ext/tracing/core/tracing_service.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "src/tracing/service/metatrace_writer.h"
@@ -227,7 +228,8 @@ void BuiltinProducer::StartDataSource(DataSourceInstanceID ds_id,
   // enabling metatrace early (relative to producers that are notified via IPC).
   if (ds_config.name() == MetatraceWriter::kDataSourceName) {
     auto writer = endpoint_->CreateTraceWriter(
-        static_cast<BufferID>(ds_config.target_buffer()));
+        static_cast<BufferID>(ds_config.target_buffer()),
+        BufferExhaustedPolicy::kStall);
 
     auto it_and_inserted = metatrace_.writers.emplace(
         std::piecewise_construct, std::make_tuple(ds_id), std::make_tuple());

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -3038,8 +3038,8 @@ TEST_F(TracingServiceImplTest, CommitToForbiddenBufferIsDiscarded) {
   BufferID buf1 = ds2->target_buffer;
 
   // Try to write to the correct buffer.
-  std::unique_ptr<TraceWriter> writer =
-      producer->endpoint()->CreateTraceWriter(buf0);
+  std::unique_ptr<TraceWriter> writer = producer->endpoint()->CreateTraceWriter(
+      buf0, BufferExhaustedPolicy::kStall);
   {
     auto tp = writer->NewTracePacket();
     tp->set_for_testing()->set_str("good_payload");
@@ -3060,7 +3060,8 @@ TEST_F(TracingServiceImplTest, CommitToForbiddenBufferIsDiscarded) {
   ASSERT_TRUE(flush_request.WaitForReply());
 
   // Try to write to the wrong buffer.
-  writer = producer->endpoint()->CreateTraceWriter(buf1);
+  writer = producer->endpoint()->CreateTraceWriter(
+      buf1, BufferExhaustedPolicy::kStall);
   {
     auto tp = writer->NewTracePacket();
     tp->set_for_testing()->set_str("bad_payload");

--- a/src/tracing/test/proxy_producer_endpoint.h
+++ b/src/tracing/test/proxy_producer_endpoint.h
@@ -46,8 +46,7 @@ class ProxyProducerEndpoint : public ProducerEndpoint {
   size_t shared_buffer_page_size_kb() const override;
   std::unique_ptr<TraceWriter> CreateTraceWriter(
       BufferID target_buffer,
-      BufferExhaustedPolicy buffer_exhausted_policy =
-          BufferExhaustedPolicy::kDefault) override;
+      BufferExhaustedPolicy buffer_exhausted_policy) override;
   SharedMemoryArbiter* MaybeSharedMemoryArbiter() override;
   bool IsShmemProvidedByProducer() const override;
   void NotifyFlushComplete(FlushRequestID) override;

--- a/src/tracing/test/tracing_integration_test.cc
+++ b/src/tracing/test/tracing_integration_test.cc
@@ -257,8 +257,8 @@ TEST_F(TracingIntegrationTest, WithIPCTransport) {
   // Now let the data source fill some pages within the same task.
   // Doing so should accumulate a bunch of chunks that will be notified by the
   // a future task in one batch.
-  std::unique_ptr<TraceWriter> writer =
-      producer_endpoint_->CreateTraceWriter(global_buf_id);
+  std::unique_ptr<TraceWriter> writer = producer_endpoint_->CreateTraceWriter(
+      global_buf_id, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(writer);
 
   const size_t kNumPackets = 10;
@@ -390,8 +390,8 @@ TEST_F(TracingIntegrationTest, WriteIntoFile) {
       }));
   task_runner_->RunUntilCheckpoint("on_create_ds_instance");
 
-  std::unique_ptr<TraceWriter> writer =
-      producer_endpoint_->CreateTraceWriter(global_buf_id);
+  std::unique_ptr<TraceWriter> writer = producer_endpoint_->CreateTraceWriter(
+      global_buf_id, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(writer);
 
   const size_t kNumPackets = 10;
@@ -481,8 +481,8 @@ TEST_F(TracingIntegrationTestWithSMBScrapingProducer, ScrapeOnFlush) {
 
   // Create writer, which will post a task to register the writer with the
   // service.
-  std::unique_ptr<TraceWriter> writer =
-      producer_endpoint_->CreateTraceWriter(global_buf_id);
+  std::unique_ptr<TraceWriter> writer = producer_endpoint_->CreateTraceWriter(
+      global_buf_id, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(writer);
 
   // Wait for the writer to be registered.

--- a/test/end_to_end_shared_memory_fuzzer.cc
+++ b/test/end_to_end_shared_memory_fuzzer.cc
@@ -80,7 +80,8 @@ class FakeProducer : public Producer {
   void StartDataSource(DataSourceInstanceID,
                        const DataSourceConfig& source_config) override {
     auto trace_writer = endpoint_->CreateTraceWriter(
-        static_cast<BufferID>(source_config.target_buffer()));
+        static_cast<BufferID>(source_config.target_buffer()),
+        BufferExhaustedPolicy::kStall);
     {
       auto packet = trace_writer->NewTracePacket();
       packet->AppendRawProtoBytes(data_, size_);

--- a/test/fake_producer.cc
+++ b/test/fake_producer.cc
@@ -26,6 +26,7 @@
 #include "perfetto/ext/tracing/core/shared_memory_arbiter.h"
 #include "perfetto/ext/tracing/core/trace_packet.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "src/ipc/client_impl.h"
 #include "src/tracing/ipc/producer/producer_ipc_client_impl.h"
@@ -96,7 +97,8 @@ void FakeProducer::StartDataSource(DataSourceInstanceID,
   } else {
     // Common case: Start tracing now.
     trace_writer_ = endpoint_->CreateTraceWriter(
-        static_cast<BufferID>(source_config.target_buffer()));
+        static_cast<BufferID>(source_config.target_buffer()),
+        BufferExhaustedPolicy::kStall);
     SetupFromConfig(source_config.for_testing());
   }
   if (source_config.for_testing().send_batch_on_register()) {


### PR DESCRIPTION
Default arguments are banned in virtual functions by the Google C++ style.

I didn't find any use of the default argument outside of the perfetto repo.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
