### PR TITLE
Deprecate BufferExhaustedPolicy::kDefault enum alias

### DIFF
--- a/include/perfetto/ext/tracing/core/shared_memory_arbiter.h
+++ b/include/perfetto/ext/tracing/core/shared_memory_arbiter.h
@@ -55,8 +55,7 @@ class PERFETTO_EXPORT_COMPONENT SharedMemoryArbiter {
   // only BufferExhaustedPolicy::kDrop is supported.
   virtual std::unique_ptr<TraceWriter> CreateTraceWriter(
       BufferID target_buffer,
-      BufferExhaustedPolicy buffer_exhausted_policy =
-          BufferExhaustedPolicy::kDefault) = 0;
+      BufferExhaustedPolicy buffer_exhausted_policy) = 0;
 
   // Creates a TraceWriter that will commit to the target buffer with the given
   // reservation ID (creating a new reservation for this ID if none exists yet).

--- a/include/perfetto/ext/tracing/core/tracing_service.h
+++ b/include/perfetto/ext/tracing/core/tracing_service.h
@@ -114,8 +114,7 @@ class PERFETTO_EXPORT_COMPONENT ProducerEndpoint {
   // DataSourceConfig.target_buffer().
   virtual std::unique_ptr<TraceWriter> CreateTraceWriter(
       BufferID target_buffer,
-      BufferExhaustedPolicy buffer_exhausted_policy =
-          BufferExhaustedPolicy::kDefault) = 0;
+      BufferExhaustedPolicy buffer_exhausted_policy) = 0;
 
   // TODO(eseckler): Also expose CreateStartupTraceWriter() ?
 

--- a/include/perfetto/tracing/buffer_exhausted_policy.h
+++ b/include/perfetto/tracing/buffer_exhausted_policy.h
@@ -35,8 +35,7 @@ enum class BufferExhaustedPolicy {
   // succeeds again.
   kDrop,
 
-  // TODO(eseckler): Switch to kDrop by default and change the Android code to
-  // explicitly request kStall instead.
+  // Deprecated alias. Do not use.
   kDefault = kStall
 };
 

--- a/src/profiling/perf/perf_producer.cc
+++ b/src/profiling/perf/perf_producer.cc
@@ -37,6 +37,7 @@
 #include "perfetto/ext/tracing/core/tracing_service.h"
 #include "perfetto/ext/tracing/ipc/producer_ipc_client.h"
 #include "perfetto/public/compiler.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "src/profiling/common/callstack_trie.h"
@@ -489,7 +490,8 @@ void PerfProducer::StartDataSource(DataSourceInstanceID ds_id,
   }
 
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
-  auto writer = endpoint_->CreateTraceWriter(buffer_id);
+  auto writer =
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall);
 
   // Construct the data source instance.
   std::map<DataSourceInstanceID, DataSourceState>::iterator ds_it;
@@ -1275,7 +1277,8 @@ std::optional<ProcessSharding> PerfProducer::GetOrChooseCallstackProcessShard(
 
 void PerfProducer::StartMetatraceSource(DataSourceInstanceID ds_id,
                                         BufferID target_buffer) {
-  auto writer = endpoint_->CreateTraceWriter(target_buffer);
+  auto writer = endpoint_->CreateTraceWriter(target_buffer,
+                                             BufferExhaustedPolicy::kStall);
 
   auto it_and_inserted = metatrace_writers_.emplace(
       std::piecewise_construct, std::make_tuple(ds_id), std::make_tuple());

--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -27,6 +27,7 @@
 #include "perfetto/ext/base/weak_ptr.h"
 #include "perfetto/ext/tracing/core/basic_types.h"
 #include "perfetto/ext/tracing/ipc/producer_ipc_client.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "perfetto/tracing/core/forward_decls.h"
@@ -131,7 +132,7 @@ ProbesProducer::CreateDSInstance<FtraceDataSource>(
   const BufferID buffer_id = static_cast<BufferID>(config.target_buffer());
   std::unique_ptr<FtraceDataSource> data_source(new FtraceDataSource(
       ftrace_->GetWeakPtr(), session_id, std::move(ftrace_config),
-      endpoint_->CreateTraceWriter(buffer_id)));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall)));
   if (!ftrace_->AddDataSource(data_source.get())) {
     PERFETTO_ELOG("Failed to setup ftrace");
     return nullptr;
@@ -151,7 +152,7 @@ ProbesProducer::CreateDSInstance<InodeFileDataSource>(
     CreateStaticDeviceToInodeMap("/system", &system_inodes_);
   return std::make_unique<InodeFileDataSource>(
       source_config, task_runner_, session_id, &system_inodes_, &cache_,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -161,7 +162,8 @@ ProbesProducer::CreateDSInstance<ProcessStatsDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<ProcessStatsDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id),
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
       config);
 }
 
@@ -172,7 +174,8 @@ ProbesProducer::CreateDSInstance<StatsdBinderDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<StatsdBinderDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id),
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
       config);
 }
 
@@ -184,7 +187,7 @@ ProbesProducer::CreateDSInstance<AndroidPowerDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidPowerDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -195,7 +198,7 @@ ProbesProducer::CreateDSInstance<LinuxPowerSysfsDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<LinuxPowerSysfsDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -206,7 +209,7 @@ ProbesProducer::CreateDSInstance<AndroidKernelWakelocksDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidKernelWakelocksDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -217,7 +220,7 @@ ProbesProducer::CreateDSInstance<AndroidLogDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidLogDataSource>(
       config, task_runner_, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -227,7 +230,8 @@ ProbesProducer::CreateDSInstance<PackagesListDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<PackagesListDataSource>(
-      config, session_id, endpoint_->CreateTraceWriter(buffer_id));
+      config, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -237,7 +241,8 @@ ProbesProducer::CreateDSInstance<AndroidGameInterventionListDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidGameInterventionListDataSource>(
-      config, session_id, endpoint_->CreateTraceWriter(buffer_id));
+      config, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -247,8 +252,9 @@ ProbesProducer::CreateDSInstance<SysStatsDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<SysStatsDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id), config,
-      std::make_unique<CpuFreqInfo>());
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
+      config, std::make_unique<CpuFreqInfo>());
 }
 
 template <>
@@ -258,7 +264,8 @@ ProbesProducer::CreateDSInstance<MetatraceDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<MetatraceDataSource>(
-      task_runner_, session_id, endpoint_->CreateTraceWriter(buffer_id));
+      task_runner_, session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -268,7 +275,8 @@ ProbesProducer::CreateDSInstance<SystemInfoDataSource>(
     const DataSourceConfig& config) {
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<SystemInfoDataSource>(
-      session_id, endpoint_->CreateTraceWriter(buffer_id),
+      session_id,
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall),
       std::make_unique<CpuFreqInfo>());
 }
 
@@ -280,7 +288,7 @@ ProbesProducer::CreateDSInstance<InitialDisplayStateDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<InitialDisplayStateDataSource>(
       task_runner_, config, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 template <>
@@ -291,7 +299,7 @@ ProbesProducer::CreateDSInstance<AndroidSystemPropertyDataSource>(
   auto buffer_id = static_cast<BufferID>(config.target_buffer());
   return std::make_unique<AndroidSystemPropertyDataSource>(
       task_runner_, config, session_id,
-      endpoint_->CreateTraceWriter(buffer_id));
+      endpoint_->CreateTraceWriter(buffer_id, BufferExhaustedPolicy::kStall));
 }
 
 // Another anonymous namespace. This cannot be moved into the anonymous

--- a/src/traced/service/builtin_producer.cc
+++ b/src/traced/service/builtin_producer.cc
@@ -28,6 +28,7 @@
 #include "perfetto/ext/tracing/core/client_identity.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"
 #include "perfetto/ext/tracing/core/tracing_service.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/core/data_source_descriptor.h"
 #include "src/tracing/service/metatrace_writer.h"
@@ -227,7 +228,8 @@ void BuiltinProducer::StartDataSource(DataSourceInstanceID ds_id,
   // enabling metatrace early (relative to producers that are notified via IPC).
   if (ds_config.name() == MetatraceWriter::kDataSourceName) {
     auto writer = endpoint_->CreateTraceWriter(
-        static_cast<BufferID>(ds_config.target_buffer()));
+        static_cast<BufferID>(ds_config.target_buffer()),
+        BufferExhaustedPolicy::kStall);
 
     auto it_and_inserted = metatrace_.writers.emplace(
         std::piecewise_construct, std::make_tuple(ds_id), std::make_tuple());

--- a/src/tracing/core/shared_memory_arbiter_impl.h
+++ b/src/tracing/core/shared_memory_arbiter_impl.h
@@ -165,7 +165,7 @@ class SharedMemoryArbiterImpl : public SharedMemoryArbiter {
   // See include/perfetto/tracing/core/shared_memory_arbiter.h for comments.
   std::unique_ptr<TraceWriter> CreateTraceWriter(
       BufferID target_buffer,
-      BufferExhaustedPolicy = BufferExhaustedPolicy::kDefault) override;
+      BufferExhaustedPolicy) override;
   std::unique_ptr<TraceWriter> CreateStartupTraceWriter(
       uint16_t target_buffer_reservation_id) override;
   void BindToProducerEndpoint(TracingService::ProducerEndpoint*,

--- a/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
@@ -141,7 +141,7 @@ TEST_P(SharedMemoryArbiterImplTest, BatchCommits) {
   // Batching period is 0s - chunks are being committed as soon as they are
   // returned.
   SharedMemoryABI::Chunk chunk =
-      arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kDefault);
+      arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(chunk.is_valid());
   EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _)).Times(1);
   PatchList ignored;
@@ -159,7 +159,7 @@ TEST_P(SharedMemoryArbiterImplTest, BatchCommits) {
 
   // First chunk that will be batched. CommitData should not be called
   // immediately this time.
-  chunk = arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kDefault);
+  chunk = arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(chunk.is_valid());
   EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _)).Times(0);
   // We'll pretend that the chunk needs patching. This is done in order to
@@ -175,7 +175,7 @@ TEST_P(SharedMemoryArbiterImplTest, BatchCommits) {
 
   // Add a second chunk to the batch. This should also not trigger an immediate
   // call to CommitData.
-  chunk = arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kDefault);
+  chunk = arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(chunk.is_valid());
   EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _)).Times(0);
   arbiter_->ReturnCompletedChunk(std::move(chunk), 2, &ignored);
@@ -225,7 +225,7 @@ TEST_P(SharedMemoryArbiterImplTest, UseShmemEmulation) {
 
   // Test returning a completed chunk.
   SharedMemoryABI::Chunk chunk =
-      arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kDefault);
+      arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kStall);
   std::tie(page_idx, chunk_idx) = abi->GetPageAndChunkIndex(chunk);
   ASSERT_TRUE(chunk.is_valid());
   EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _)).Times(1);
@@ -243,7 +243,7 @@ TEST_P(SharedMemoryArbiterImplTest, UseShmemEmulation) {
   arbiter_->SetDirectSMBPatchingSupportedByService();
   ASSERT_TRUE(arbiter_->EnableDirectSMBPatching());
 
-  chunk = arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kDefault);
+  chunk = arbiter_->GetNewChunk({}, BufferExhaustedPolicy::kStall);
   std::tie(page_idx, chunk_idx) = abi->GetPageAndChunkIndex(chunk);
   ASSERT_TRUE(chunk.is_valid());
   EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _))

--- a/src/tracing/core/trace_writer_impl_unittest.cc
+++ b/src/tracing/core/trace_writer_impl_unittest.cc
@@ -263,7 +263,8 @@ INSTANTIATE_TEST_SUITE_P(PageSize, TraceWriterImplTest, ValuesIn(kPageSizes));
 
 TEST_P(TraceWriterImplTest, NewTracePacket) {
   const BufferID kBufId = 42;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
   const size_t kNumPackets = 32;
   for (size_t i = 0; i < kNumPackets; i++) {
     auto packet = writer->NewTracePacket();
@@ -292,7 +293,8 @@ TEST_P(TraceWriterImplTest, NewTracePacket) {
 TEST_P(TraceWriterImplTest, NewTracePacketLargePackets) {
   const BufferID kBufId = 42;
   const size_t chunk_size = page_size() / 4;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
   {
     auto packet = writer->NewTracePacket();
     packet->set_for_testing()->set_str(std::string("PACKET_1") +
@@ -331,7 +333,8 @@ constexpr char kFirstPacketOnSequenceFlagPrefix[] = {static_cast<char>(0xB8),
 
 TEST_P(TraceWriterImplTest, NewTracePacketTakeWriter) {
   const BufferID kBufId = 42;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
   const size_t kNumPackets = 32;
   for (size_t i = 0; i < kNumPackets; i++) {
     ScatteredStreamWriter* sw = writer->NewTracePacket().TakeStreamWriter();
@@ -365,7 +368,8 @@ INSTANTIATE_TEST_SUITE_P(PageSize,
 
 TEST_P(TraceWriterImplDeathTest, NewTracePacketTakeWriterNoFinish) {
   const BufferID kBufId = 42;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   TraceWriterImpl::TracePacketHandle handle = writer->NewTracePacket();
 
@@ -385,7 +389,8 @@ TEST_P(TraceWriterImplDeathTest, NewTracePacketTakeWriterNoFinish) {
 
 TEST_P(TraceWriterImplTest, AnnotatePatch) {
   const BufferID kBufId = 42;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
   ScatteredStreamWriter* sw = writer->NewTracePacket().TakeStreamWriter();
   std::string raw_proto_bytes = std::string("RAW_PROTO_BYTES");
   sw->WriteBytes(reinterpret_cast<const uint8_t*>(raw_proto_bytes.data()),
@@ -474,7 +479,8 @@ TEST_P(TraceWriterImplTest, MixManualTakeAndMessage) {
   const size_t chunk_size = page_size() / 4;
   const std::string large_string(chunk_size, 'x');
 
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   {
     ScatteredStreamWriter* sw = writer->NewTracePacket().TakeStreamWriter();
@@ -559,7 +565,8 @@ TEST_P(TraceWriterImplTest, MixManualTakeAndMessage) {
 TEST_P(TraceWriterImplTest, MessageHandleDestroyedPacketScrapable) {
   const BufferID kBufId = 42;
 
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   auto packet = writer->NewTracePacket();
   packet->set_for_testing()->set_str("packet1");
@@ -597,7 +604,8 @@ TEST_P(TraceWriterImplTest, MessageHandleDestroyedPacketScrapable) {
 TEST_P(TraceWriterImplTest, FinishTracePacketScrapable) {
   const BufferID kBufId = 42;
 
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   {
     protos::pbzero::TestEvent test_event;
@@ -658,7 +666,8 @@ TEST_P(TraceWriterImplTest,
        MessageHandleDestroyedAndFinishTracePacketScrapable) {
   const BufferID kBufId = 42;
 
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   auto packet = writer->NewTracePacket();
   packet->set_for_testing()->set_str("packet1");
@@ -704,7 +713,8 @@ TEST_P(TraceWriterImplTest,
 TEST_P(TraceWriterImplTest, MessageHandleDestroyedPacketFullChunk) {
   const BufferID kBufId = 42;
 
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   auto packet = writer->NewTracePacket();
   protos::pbzero::TestEvent* test_event = packet->set_for_testing();
@@ -742,7 +752,8 @@ TEST_P(TraceWriterImplTest, MessageHandleDestroyedPacketFullChunk) {
 TEST_P(TraceWriterImplTest, FinishTracePacketFullChunk) {
   const BufferID kBufId = 42;
 
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   {
     protos::pbzero::TestEvent test_event;
@@ -792,7 +803,8 @@ TEST_P(TraceWriterImplTest, FinishTracePacketFullChunk) {
 
 TEST_P(TraceWriterImplTest, FragmentingPacketWithProducerAndServicePatching) {
   const BufferID kBufId = 42;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   // Write a packet that's guaranteed to span more than a single chunk, but
   // less than two chunks.
@@ -883,7 +895,8 @@ TEST_P(TraceWriterImplTest, FragmentingPacketWithoutEnablingProducerPatching) {
   arbiter_->SetBatchCommitsDuration(UINT32_MAX);
 
   const BufferID kBufId = 42;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   // Write a packet that's guaranteed to span more than a single chunk.
   auto packet = writer->NewTracePacket();
@@ -1268,7 +1281,8 @@ TEST_P(TraceWriterImplTest, Flush) {
   MockFunction<void()> flush_cb;
 
   const BufferID kBufId = 42;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
   {
     auto packet = writer->NewTracePacket();
     packet->set_for_testing()->set_str("foobar");
@@ -1287,7 +1301,8 @@ TEST_P(TraceWriterImplTest, NestedMsgsPatches) {
   const uint32_t kNestedFieldId = 1;
   const uint32_t kStringFieldId = 2;
   const uint32_t kIntFieldId = 3;
-  std::unique_ptr<TraceWriter> writer = arbiter_->CreateTraceWriter(kBufId);
+  std::unique_ptr<TraceWriter> writer =
+      arbiter_->CreateTraceWriter(kBufId, BufferExhaustedPolicy::kStall);
 
   size_t chunk_size = page_size() / 4;
   std::string large_string(chunk_size, 'x');

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -3038,8 +3038,8 @@ TEST_F(TracingServiceImplTest, CommitToForbiddenBufferIsDiscarded) {
   BufferID buf1 = ds2->target_buffer;
 
   // Try to write to the correct buffer.
-  std::unique_ptr<TraceWriter> writer =
-      producer->endpoint()->CreateTraceWriter(buf0);
+  std::unique_ptr<TraceWriter> writer = producer->endpoint()->CreateTraceWriter(
+      buf0, BufferExhaustedPolicy::kStall);
   {
     auto tp = writer->NewTracePacket();
     tp->set_for_testing()->set_str("good_payload");
@@ -3060,7 +3060,8 @@ TEST_F(TracingServiceImplTest, CommitToForbiddenBufferIsDiscarded) {
   ASSERT_TRUE(flush_request.WaitForReply());
 
   // Try to write to the wrong buffer.
-  writer = producer->endpoint()->CreateTraceWriter(buf1);
+  writer = producer->endpoint()->CreateTraceWriter(
+      buf1, BufferExhaustedPolicy::kStall);
   {
     auto tp = writer->NewTracePacket();
     tp->set_for_testing()->set_str("bad_payload");

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -3288,8 +3288,8 @@ TEST_F(TracingServiceImplTest, ScrapeBuffersOnProducerDisconnect) {
 
   const auto* ds_inst = producer->GetDataSourceInstance("data_source");
   ASSERT_NE(nullptr, ds_inst);
-  std::unique_ptr<TraceWriter> writer =
-      shmem_arbiter->CreateTraceWriter(ds_inst->target_buffer);
+  std::unique_ptr<TraceWriter> writer = shmem_arbiter->CreateTraceWriter(
+      ds_inst->target_buffer, BufferExhaustedPolicy::kStall);
   // Wait for the TraceWriter to be registered.
   task_runner.RunUntilIdle();
 
@@ -3417,7 +3417,8 @@ class TracingServiceImplScrapingWithSmbTest : public TracingServiceImplTest {
 
     target_buffer_ = ds->target_buffer;
 
-    writer_ = arbiter_->CreateTraceWriter(target_buffer_);
+    writer_ = arbiter_->CreateTraceWriter(target_buffer_,
+                                          BufferExhaustedPolicy::kStall);
     // Wait for the writer to be registered.
     task_runner.RunUntilIdle();
   }

--- a/src/tracing/test/mock_producer.h
+++ b/src/tracing/test/mock_producer.h
@@ -76,7 +76,7 @@ class MockProducer : public Producer {
   std::unique_ptr<TraceWriter> CreateTraceWriter(
       const std::string& data_source_name,
       BufferExhaustedPolicy buffer_exhausted_policy =
-          BufferExhaustedPolicy::kDefault);
+          BufferExhaustedPolicy::kStall);
 
   // Expect a flush. Flushes |writer_to_flush| if non-null. If |reply| is true,
   // replies to the flush request, otherwise ignores it and doesn't reply.

--- a/src/tracing/test/proxy_producer_endpoint.h
+++ b/src/tracing/test/proxy_producer_endpoint.h
@@ -46,8 +46,7 @@ class ProxyProducerEndpoint : public ProducerEndpoint {
   size_t shared_buffer_page_size_kb() const override;
   std::unique_ptr<TraceWriter> CreateTraceWriter(
       BufferID target_buffer,
-      BufferExhaustedPolicy buffer_exhausted_policy =
-          BufferExhaustedPolicy::kDefault) override;
+      BufferExhaustedPolicy buffer_exhausted_policy) override;
   SharedMemoryArbiter* MaybeSharedMemoryArbiter() override;
   bool IsShmemProvidedByProducer() const override;
   void NotifyFlushComplete(FlushRequestID) override;

--- a/src/tracing/test/tracing_integration_test.cc
+++ b/src/tracing/test/tracing_integration_test.cc
@@ -257,8 +257,8 @@ TEST_F(TracingIntegrationTest, WithIPCTransport) {
   // Now let the data source fill some pages within the same task.
   // Doing so should accumulate a bunch of chunks that will be notified by the
   // a future task in one batch.
-  std::unique_ptr<TraceWriter> writer =
-      producer_endpoint_->CreateTraceWriter(global_buf_id);
+  std::unique_ptr<TraceWriter> writer = producer_endpoint_->CreateTraceWriter(
+      global_buf_id, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(writer);
 
   const size_t kNumPackets = 10;
@@ -390,8 +390,8 @@ TEST_F(TracingIntegrationTest, WriteIntoFile) {
       }));
   task_runner_->RunUntilCheckpoint("on_create_ds_instance");
 
-  std::unique_ptr<TraceWriter> writer =
-      producer_endpoint_->CreateTraceWriter(global_buf_id);
+  std::unique_ptr<TraceWriter> writer = producer_endpoint_->CreateTraceWriter(
+      global_buf_id, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(writer);
 
   const size_t kNumPackets = 10;
@@ -481,8 +481,8 @@ TEST_F(TracingIntegrationTestWithSMBScrapingProducer, ScrapeOnFlush) {
 
   // Create writer, which will post a task to register the writer with the
   // service.
-  std::unique_ptr<TraceWriter> writer =
-      producer_endpoint_->CreateTraceWriter(global_buf_id);
+  std::unique_ptr<TraceWriter> writer = producer_endpoint_->CreateTraceWriter(
+      global_buf_id, BufferExhaustedPolicy::kStall);
   ASSERT_TRUE(writer);
 
   // Wait for the writer to be registered.

--- a/test/end_to_end_shared_memory_fuzzer.cc
+++ b/test/end_to_end_shared_memory_fuzzer.cc
@@ -80,7 +80,8 @@ class FakeProducer : public Producer {
   void StartDataSource(DataSourceInstanceID,
                        const DataSourceConfig& source_config) override {
     auto trace_writer = endpoint_->CreateTraceWriter(
-        static_cast<BufferID>(source_config.target_buffer()));
+        static_cast<BufferID>(source_config.target_buffer()),
+        BufferExhaustedPolicy::kStall);
     {
       auto packet = trace_writer->NewTracePacket();
       packet->AppendRawProtoBytes(data_, size_);

--- a/test/fake_producer.cc
+++ b/test/fake_producer.cc
@@ -26,6 +26,7 @@
 #include "perfetto/ext/tracing/core/shared_memory_arbiter.h"
 #include "perfetto/ext/tracing/core/trace_packet.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "src/ipc/client_impl.h"
 #include "src/tracing/ipc/producer/producer_ipc_client_impl.h"
@@ -96,7 +97,8 @@ void FakeProducer::StartDataSource(DataSourceInstanceID,
   } else {
     // Common case: Start tracing now.
     trace_writer_ = endpoint_->CreateTraceWriter(
-        static_cast<BufferID>(source_config.target_buffer()));
+        static_cast<BufferID>(source_config.target_buffer()),
+        BufferExhaustedPolicy::kStall);
     SetupFromConfig(source_config.for_testing());
   }
   if (source_config.for_testing().send_batch_on_register()) {


### PR DESCRIPTION
The default in the SDK data sources is actually kDrop. As the TODO says, we always wanted to change it.

Let's mark the alias as deprecated.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
