### PR TITLE
tracing: New stall buffer exhausted policy

### DIFF
--- a/include/perfetto/public/abi/data_source_abi.h
+++ b/include/perfetto/public/abi/data_source_abi.h
@@ -221,8 +221,12 @@ enum PerfettoDsBufferExhaustedPolicy {
   PERFETTO_DS_BUFFER_EXHAUSTED_POLICY_DROP = 0,
   // If the data source runs out of space when trying to acquire a new chunk,
   // it will stall, retry and eventually abort if a free chunk is not acquired
-  // after a while.
+  // after a few seconds.
   PERFETTO_DS_BUFFER_EXHAUSTED_POLICY_STALL_AND_ABORT = 1,
+  // If the data source runs out of space when trying to acquire a new chunk,
+  // it will stall, retry and eventually drop data if a free chunk is not
+  // acquired after a few seconds.
+  PERFETTO_DS_BUFFER_EXHAUSTED_POLICY_STALL_AND_DROP = 2,
 };
 
 // If the data source doesn't find an empty chunk when trying to emit tracing

--- a/include/perfetto/tracing/buffer_exhausted_policy.h
+++ b/include/perfetto/tracing/buffer_exhausted_policy.h
@@ -26,7 +26,8 @@ enum class BufferExhaustedPolicy {
   // available and wait for the tracing service to free one. Note that this
   // requires that messages the arbiter sends to the tracing service (from any
   // TraceWriter thread) will be received by it, even if all TraceWriter threads
-  // are stalled.
+  // are stalled. If no free SMB chunk becomes available after a few seconds,
+  // the process will be aborted.
   kStall,
 
   // SharedMemoryArbiterImpl::GetNewChunk() will return an invalid chunk if no
@@ -34,6 +35,15 @@ enum class BufferExhaustedPolicy {
   // to a garbage chunk and drop written data until acquiring a future chunk
   // succeeds again.
   kDrop,
+
+  // SharedMemoryArbiterImpl::GetNewChunk() will stall if no free SMB chunk is
+  // available and wait for the tracing service to free one. Note that this
+  // requires that messages the arbiter sends to the tracing service (from any
+  // TraceWriter thread) will be received by it, even if all TraceWriter threads
+  // are stalled. If no free SMB chunk becomes available after a few seconds,
+  // SharedMemoryArbiterImpl::GetNewChunk() will return an invalid chunk and
+  // data will be lost.
+  kStallThenDrop,
 
   // Deprecated alias. Do not use.
   kDefault = kStall

--- a/src/shared_lib/data_source.cc
+++ b/src/shared_lib/data_source.cc
@@ -320,6 +320,10 @@ bool PerfettoDsSetBufferExhaustedPolicy(struct PerfettoDsImpl* ds_impl,
       ds_impl->buffer_exhausted_policy =
           perfetto::BufferExhaustedPolicy::kStall;
       return true;
+    case PERFETTO_DS_BUFFER_EXHAUSTED_POLICY_STALL_AND_DROP:
+      ds_impl->buffer_exhausted_policy =
+          perfetto::BufferExhaustedPolicy::kStallThenDrop;
+      return true;
   }
   return false;
 }


### PR DESCRIPTION
The new policy is useful where the data source wants to avoid data loss as much as possible, but doesn't want to crash the process if the tracing service is not responsive.

Tested: unsubmitted (it wastes 20 seconds) integration test