### PR TITLE
tp: fallback to old way of binding httpd for localhost

### DIFF
--- a/include/perfetto/ext/base/http/http_server.h
+++ b/include/perfetto/ext/base/http/http_server.h
@@ -159,7 +159,6 @@ class HttpServer : public UnixSocket::EventListener {
  public:
   HttpServer(TaskRunner*, HttpRequestHandler*);
   ~HttpServer() override;
-  void Start(int port);
   void Start(const std::string& listen_ip, int port);
   void AddAllowedOrigin(const std::string&);
 

--- a/src/base/http/http_server_unittest.cc
+++ b/src/base/http/http_server_unittest.cc
@@ -91,7 +91,9 @@ class HttpCli {
 
 class HttpServerTest : public ::testing::Test {
  public:
-  HttpServerTest() : srv_(&task_runner_, &handler_) { srv_.Start(kTestPort); }
+  HttpServerTest() : srv_(&task_runner_, &handler_) {
+    srv_.Start("localhost", kTestPort);
+  }
 
   TestTaskRunner task_runner_;
   MockHttpHandler handler_;

--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -99,18 +99,15 @@ Httpd::Httpd(std::unique_ptr<TraceProcessor> preloaded_instance)
 Httpd::~Httpd() = default;
 
 void Httpd::Run(const std::string& listen_ip, int port) {
-  PERFETTO_ILOG("[HTTP] Starting RPC server on ip=%s  port=%d",
-                listen_ip.c_str(), port);
-  PERFETTO_LOG(
-      "[HTTP] This server can be used by reloading https://ui.perfetto.dev and "
-      "clicking on YES on the \"Trace Processor native acceleration\" dialog "
-      "or through the Python API (see "
-      "https://perfetto.dev/docs/analysis/trace-processor#python-api).");
-
   for (const auto& kAllowedCORSOrigin : kAllowedCORSOrigins) {
     http_srv_.AddAllowedOrigin(kAllowedCORSOrigin);
   }
   http_srv_.Start(listen_ip, port);
+  PERFETTO_ILOG(
+      "[HTTP] This server can be used by reloading https://ui.perfetto.dev and "
+      "clicking on YES on the \"Trace Processor native acceleration\" dialog "
+      "or through the Python API (see "
+      "https://perfetto.dev/docs/analysis/trace-processor#python-api).");
   task_runner_.Run();
 }
 
@@ -266,8 +263,9 @@ void RunHttpRPCServer(std::unique_ptr<TraceProcessor> preloaded_instance,
                       const std::string& port_number) {
   Httpd srv(std::move(preloaded_instance));
   std::optional<int> port_opt = base::StringToInt32(port_number);
+  std::string ip = listen_ip.empty() ? "localhost" : listen_ip;
   int port = port_opt.has_value() ? *port_opt : kBindPort;
-  srv.Run(listen_ip, port);
+  srv.Run(ip, port);
 }
 
 void Httpd::ServeHelpPage(const base::HttpRequest& req) {

--- a/src/websocket_bridge/websocket_bridge.cc
+++ b/src/websocket_bridge/websocket_bridge.cc
@@ -97,7 +97,7 @@ void WSBridge::Main(int, char**) {
   srv.AddAllowedOrigin("http://127.0.0.1:10000");
   srv.AddAllowedOrigin("https://ui.perfetto.dev");
 
-  srv.Start(kWebsocketPort);
+  srv.Start("localhost", kWebsocketPort);
   PERFETTO_LOG("[WSBridge] Listening on 127.0.0.1:%d", kWebsocketPort);
   task_runner_.Run();
 }


### PR DESCRIPTION
Seems like using getaddrinfo can fail in some contexts for
reasons which are not quite clear. Hardcode the IP mapping until
we understand why.

Bug: 411365664
