### PR TITLE
tools/roll-prebuilts: Avoid calling yapf

### DIFF
--- a/tools/roll-prebuilts
+++ b/tools/roll-prebuilts
@@ -131,7 +131,6 @@ def update_manifest(git_revision, tool_name, archs):
 
   with open(out_file + '.tmp', 'w') as f:
     f.write(content)
-  subprocess.check_call(['yapf', '-i', out_file + '.tmp'])
   os.rename(out_file + '.tmp', out_file)
   os.chmod(out_file, 0o755)
 


### PR DESCRIPTION
yapf is not assumed to be on the PATH anymore. python code should be formatted later (after gen_amalgamated_python_tools) with tools/format-python-sources.
