### PR TITLE
Add track descriptions

### DIFF
--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -637,6 +637,8 @@ function renderTrackDetailsMenu(node: TrackNode, descriptor?: Track) {
       }),
       m(TreeNode, {left: 'Path', right: fullPath}),
       m(TreeNode, {left: 'Title', right: node.title}),
+      descriptor &&
+        m(TreeNode, {left: 'Description', right: descriptor?.description}),
       m(TreeNode, {
         left: 'Workspace',
         right: node.workspace?.title ?? '[no workspace]',

--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -59,6 +59,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title,
+        description: 'Android log messages',
         tags: {kind: ANDROID_LOGS_TRACK_KIND},
         track: createAndroidLogTrack(ctx, uri),
       });

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -105,20 +105,27 @@ export interface Track {
   // A unique identifier for this track.
   readonly uri: string;
 
-  // A factory function returning a new track instance.
+  // Describes how to render the track.
   readonly track: TrackRenderer;
 
   // Human readable title. Always displayed.
   readonly title: string;
 
-  // Human readable subtitle. Sometimes displayed if there is room.
+  // Optional: A human readable description of the track.
+  readonly description?: string;
+
+  // Optional: Human readable subtitle. Sometimes displayed if there is room.
   readonly subtitle?: string;
 
-  // Optional: A list of tags used for sorting, grouping and "chips".
+  // Optional: A list of tags which provide additional metadata about the track.
+  // Used mainly for legacy purposes that predate dataset.
   readonly tags?: TrackTags;
 
+  // Optional: A list of strings which are displayed as "chips" in the track
+  // shell.
   readonly chips?: ReadonlyArray<string>;
 
+  // Filled in by the core.
   readonly pluginId?: string;
 }
 


### PR DESCRIPTION
This PR adds track descriptions to track definitions.

Plugins can attach descriptions (short strings of text) that are displayed in the track details popup.

In the future we could make this style of help text more visible and more consistent throughout the UI, but for now this change provides the plumbing to allow plugins to specify descriptions.

![image](https://github.com/user-attachments/assets/2eafd89b-41c2-4fdf-a1a2-7c68b246f253)
