### PR TITLE
Dispose trace-scoped settings properly when the trace is disposed

### DIFF
--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -52,7 +52,8 @@ import {PostedTrace} from './trace_source';
 import {PerfManager} from './perf_manager';
 import {EvtSource} from '../base/events';
 import {Raf} from '../public/raf';
-import {SettingsManager} from '../public/settings';
+import {Setting, SettingDescriptor, SettingsManager} from '../public/settings';
+import {SettingsManagerImpl} from './settings_manager';
 
 /**
  * Handles the per-trace state of the UI
@@ -183,6 +184,7 @@ export class TraceImpl implements Trace {
   private readonly commandMgrProxy: CommandManagerImpl;
   private readonly sidebarProxy: SidebarManagerImpl;
   private readonly pageMgrProxy: PageManagerImpl;
+  private readonly settingsProxy: SettingsManagerImpl;
 
   // This is called by TraceController when loading a new trace, soon after the
   // engine has been set up. It obtains a new TraceImpl for the core. From that
@@ -248,6 +250,14 @@ export class TraceImpl implements Trace {
         });
         traceUnloadTrash.use(disposable);
         return disposable;
+      },
+    });
+
+    this.settingsProxy = createProxy(ctx.appCtx.settingsManager, {
+      register<T>(setting: SettingDescriptor<T>): Setting<T> {
+        const settingInstance = ctx.appCtx.settingsManager.register(setting);
+        traceUnloadTrash.use(settingInstance);
+        return settingInstance;
       },
     });
 
@@ -449,7 +459,7 @@ export class TraceImpl implements Trace {
   }
 
   get settings(): SettingsManager {
-    return this.appImpl.settings;
+    return this.settingsProxy;
   }
 }
 

--- a/ui/src/plugins/com.example.Settings/index.ts
+++ b/ui/src/plugins/com.example.Settings/index.ts
@@ -47,6 +47,8 @@ export default class implements PerfettoPlugin {
       },
     });
 
+    // This is how you register a string setting. The setting will appear on
+    // the settings page as a nubmer input.
     app.settings.register({
       id: 'com.example.Settings#numberSetting',
       name: 'Number Setting',
@@ -100,7 +102,15 @@ export default class implements PerfettoPlugin {
     });
   }
 
-  async onTraceLoad(_: Trace): Promise<void> {
-    // Nothing to do.
+  async onTraceLoad(trace: Trace): Promise<void> {
+    // Register a setting that is only available when a trace is loaded.
+    trace.settings.register({
+      id: 'com.example.Settings#booleanSettingWithTrace',
+      name: 'Boolean Setting (registered with the trace)',
+      description:
+        "A boolean setting that's registered with teh trace rather than the app.",
+      schema: z.boolean(),
+      defaultValue: false,
+    });
   }
 }

--- a/ui/src/public/settings.ts
+++ b/ui/src/public/settings.ts
@@ -56,7 +56,7 @@ export interface SettingDescriptor<T> {
  * with the setting's value and state.
  * @template T The type of the setting's value.
  */
-export interface Setting<T> extends SettingDescriptor<T> {
+export interface Setting<T> extends SettingDescriptor<T>, Disposable {
   // Returns true if this settings is currently set to the default value.
   readonly isDefault: boolean;
   // Get the current value of the setting.


### PR DESCRIPTION
Fixes a bug where settings added via the trace object (inside the onTraceLoad() function for example) are not removed when a second trace is loaded, and thus we run into a crash when the duplicate setting is added.