### PR TITLE
Dev/wusamuel/markers_track_and_misc_cleanup

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14516,6 +14516,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/wattson/curves/w_dsu_dependence.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/system_state.sql",
+        "src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql",
     ],
     cmd: "$(location tools/gen_amalgamated_sql.py) --namespace=stdlib --cpp-out=$(out) $(in)",
     out: [

--- a/BUILD
+++ b/BUILD
@@ -3475,6 +3475,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/wattson/curves/w_dsu_dependence.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/system_state.sql",
+        "src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql",
     ],
 )
 

--- a/src/trace_processor/metrics/sql/android/wattson_markers_rails.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_markers_rails.sql
@@ -14,15 +14,16 @@
 -- limitations under the License.
 
 INCLUDE PERFETTO MODULE wattson.curves.estimates;
+INCLUDE PERFETTO MODULE wattson.utils;
 
 DROP VIEW IF EXISTS _wattson_period_windows;
 CREATE PERFETTO VIEW _wattson_period_windows AS
 SELECT
   -- Requirement is there is exactly one pair of start/stop
-  (SELECT ts FROM slice WHERE name == 'wattson_start') as ts,
-  (SELECT ts FROM slice WHERE name == 'wattson_stop')
-  - (SELECT ts FROM slice WHERE name == 'wattson_start') as dur,
-  1 as period_id;
+  ts,
+  dur,
+  1 as period_id
+FROM _wattson_markers_window;
 
 SELECT RUN_METRIC(
   'android/wattson_rail_relations.sql',

--- a/src/trace_processor/metrics/sql/android/wattson_markers_threads.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_markers_threads.sql
@@ -14,16 +14,17 @@
 -- limitations under the License.
 
 INCLUDE PERFETTO MODULE wattson.curves.estimates;
+INCLUDE PERFETTO MODULE wattson.utils;
 INCLUDE PERFETTO MODULE viz.summary.threads_w_processes;
 
 DROP VIEW IF EXISTS _wattson_period_window;
 CREATE PERFETTO VIEW _wattson_period_window AS
 SELECT
   -- Requirement is there is exactly one pair of start/stop
-  (SELECT ts FROM slice WHERE name == 'wattson_start') as ts,
-  (SELECT ts FROM slice WHERE name == 'wattson_stop')
-  - (SELECT ts FROM slice WHERE name == 'wattson_start') as dur,
-  1 as period_id;
+  ts,
+  dur,
+  1 as period_id
+FROM _wattson_markers_window;
 
 SELECT RUN_METRIC(
   'android/wattson_tasks_attribution.sql',

--- a/src/trace_processor/metrics/sql/android/wattson_rail_relations.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_rail_relations.sql
@@ -17,6 +17,7 @@
 -- and subrails as well as the hierarchical power estimates of each rail
 
 INCLUDE PERFETTO MODULE wattson.curves.estimates;
+INCLUDE PERFETTO MODULE wattson.utils;
 
 -- The most basic rail components that form the "building blocks" from which all
 -- other rails and components are derived. Average power over the entire trace

--- a/src/trace_processor/metrics/sql/android/wattson_rail_relations.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_rail_relations.sql
@@ -43,7 +43,7 @@ SELECT
   SUM(ii.dur * ss.cpu7_mw) / SUM(ii.dur) as cpu7_mw,
   SUM(ii.dur * ss.dsu_scu_mw) / SUM(ii.dur) as dsu_scu_mw,
   SUM(ii.dur) as period_dur,
-  w.period_id
+  ii.id_0 as period_id
 FROM _interval_intersect!(
   (
     (SELECT period_id AS id, * FROM {{window_table}}),
@@ -51,9 +51,8 @@ FROM _interval_intersect!(
   ),
   ()
 ) ii
-JOIN {{window_table}} AS w ON w.period_id = id_0
 JOIN _system_state_mw AS ss ON ss._auto_id = id_1
-GROUP BY w.period_id;
+GROUP BY period_id;
 
 -- Macro that filters out CPUs that are unrelated to the policy of the table
 -- passed in, and does some bookkeeping to put data in expected format

--- a/src/trace_processor/metrics/sql/android/wattson_tasks_attribution.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_tasks_attribution.sql
@@ -15,6 +15,7 @@
 
 INCLUDE PERFETTO MODULE wattson.curves.estimates;
 INCLUDE PERFETTO MODULE wattson.curves.idle_attribution;
+INCLUDE PERFETTO MODULE wattson.utils;
 INCLUDE PERFETTO MODULE viz.summary.threads_w_processes;
 
 -- Take only the Wattson estimations that are in the window of interest

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/BUILD.gn
@@ -30,5 +30,6 @@ perfetto_sql_source_set("wattson") {
     "curves/w_dsu_dependence.sql",
     "device_infos.sql",
     "system_state.sql",
+    "utils.sql",
   ]
 }

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_freq_idle.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_freq_idle.sql
@@ -25,17 +25,7 @@ INCLUDE PERFETTO MODULE wattson.curves.utils;
 
 INCLUDE PERFETTO MODULE wattson.device_infos;
 
--- Helper macro for using Perfetto table with interval intersect
-CREATE PERFETTO MACRO _ii_subquery(
-    tab TableOrSubquery
-)
-RETURNS TableOrSubquery AS
-(
-  SELECT
-    _auto_id AS id,
-    *
-  FROM $tab
-);
+INCLUDE PERFETTO MODULE wattson.utils;
 
 -- Wattson estimation is valid from when first CPU0 frequency appears
 CREATE PERFETTO TABLE _valid_window AS

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_split.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu_split.sql
@@ -27,6 +27,8 @@ INCLUDE PERFETTO MODULE wattson.curves.utils;
 
 INCLUDE PERFETTO MODULE wattson.device_infos;
 
+INCLUDE PERFETTO MODULE wattson.utils;
+
 -- Helper macro to do pivot function without policy information
 CREATE PERFETTO MACRO _stats_wo_policy_subquery(
     cpu Expr,

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/estimates.sql
@@ -23,6 +23,8 @@ INCLUDE PERFETTO MODULE wattson.curves.w_dsu_dependence;
 
 INCLUDE PERFETTO MODULE wattson.device_infos;
 
+INCLUDE PERFETTO MODULE wattson.utils;
+
 -- One of the two tables will be empty, depending on whether the device is
 -- dependent on devfreq or a different CPU's frequency
 CREATE PERFETTO VIEW _curves_w_dependencies (

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/w_dsu_dependence.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/w_dsu_dependence.sql
@@ -23,6 +23,8 @@ INCLUDE PERFETTO MODULE wattson.curves.utils;
 
 INCLUDE PERFETTO MODULE wattson.device_infos;
 
+INCLUDE PERFETTO MODULE wattson.utils;
+
 CREATE PERFETTO TABLE _cpu_curves AS
 SELECT
   ts,

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
@@ -1,0 +1,31 @@
+--
+-- Copyright 2025 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Creates slice that defines the user inserted Wattson markers. This table will
+-- provide the proper Wattson markers slice if user inserts only one pair of
+-- Wattson markers, which is the pre-defined agreement.
+CREATE PERFETTO TABLE _wattson_markers_window AS
+SELECT
+  min(ts) FILTER(WHERE
+    name = 'wattson_start') AS ts,
+  max(ts) FILTER(WHERE
+    name = 'wattson_stop') - min(ts) FILTER(WHERE
+    name = 'wattson_start') AS dur,
+  'Markers window' AS name
+FROM slice
+WHERE
+  name IN ('wattson_start', 'wattson_stop')
+HAVING
+  ts IS NOT NULL;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
@@ -29,3 +29,15 @@ WHERE
   name IN ('wattson_start', 'wattson_stop')
 HAVING
   ts IS NOT NULL;
+
+-- Helper macro for using Perfetto table with interval intersect
+CREATE PERFETTO MACRO _ii_subquery(
+    tab TableOrSubquery
+)
+RETURNS TableOrSubquery AS
+(
+  SELECT
+    _auto_id AS id,
+    *
+  FROM $tab
+);

--- a/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ColumnDef, Sorting} from '../../public/aggregation';
-import {Area, AreaSelection} from '../../public/selection';
+import {
+  Area,
+  AreaSelection,
+  AreaSelectionAggregator,
+} from '../../public/selection';
 import {Engine} from '../../trace_processor/engine';
-import {CPUSS_ESTIMATE_TRACK_KIND} from '../../public/track_kinds';
-import {AreaSelectionAggregator} from '../../public/selection';
 import {exists} from '../../base/utils';
+import {ColumnDef, Sorting} from '../../public/aggregation';
+import {CPUSS_ESTIMATE_TRACK_KIND} from '../../public/track_kinds';
 
 export class WattsonEstimateSelectionAggregator
   implements AreaSelectionAggregator

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -16,21 +16,21 @@ import {
   BaseCounterTrack,
   CounterOptions,
 } from '../../components/tracks/base_counter_track';
-import {Trace} from '../../public/trace';
-import {PerfettoPlugin} from '../../public/plugin';
 import {
   CPUSS_ESTIMATE_TRACK_KIND,
   SLICE_TRACK_KIND,
 } from '../../public/track_kinds';
+import {createWattsonAggregationToTabAdaptor} from './aggregation_panel';
+import {createQuerySliceTrack} from '../../components/tracks/query_slice_track';
+import {Engine} from '../../trace_processor/engine';
+import {NUM} from '../../trace_processor/query_result';
+import {PerfettoPlugin} from '../../public/plugin';
+import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
 import {WattsonEstimateSelectionAggregator} from './estimate_aggregator';
 import {WattsonPackageSelectionAggregator} from './package_aggregator';
 import {WattsonProcessSelectionAggregator} from './process_aggregator';
 import {WattsonThreadSelectionAggregator} from './thread_aggregator';
-import {Engine} from '../../trace_processor/engine';
-import {NUM} from '../../trace_processor/query_result';
-import {createWattsonAggregationToTabAdaptor} from './aggregation_panel';
-import {createQuerySliceTrack} from '../../components/tracks/query_slice_track';
 
 export default class implements PerfettoPlugin {
   static readonly id = `org.kernel.Wattson`;

--- a/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {exists} from '../../base/utils';
+import {AreaSelection, AreaSelectionAggregator} from '../../public/selection';
 import {ColumnDef, Sorting} from '../../public/aggregation';
-import {AreaSelection} from '../../public/selection';
-import {Engine} from '../../trace_processor/engine';
-import {NUM} from '../../trace_processor/query_result';
 import {CPU_SLICE_TRACK_KIND} from '../../public/track_kinds';
-import {AreaSelectionAggregator} from '../../public/selection';
+import {Engine} from '../../trace_processor/engine';
+import {exists} from '../../base/utils';
+import {NUM} from '../../trace_processor/query_result';
 
 export class WattsonPackageSelectionAggregator
   implements AreaSelectionAggregator

--- a/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {exists} from '../../base/utils';
-import {ColumnDef, Sorting} from '../../public/aggregation';
 import {AreaSelection, AreaSelectionAggregator} from '../../public/selection';
+import {ColumnDef, Sorting} from '../../public/aggregation';
 import {CPU_SLICE_TRACK_KIND} from '../../public/track_kinds';
 import {Engine} from '../../trace_processor/engine';
+import {exists} from '../../base/utils';
 
 export class WattsonProcessSelectionAggregator
   implements AreaSelectionAggregator

--- a/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {exists} from '../../base/utils';
+import {AreaSelection, AreaSelectionAggregator} from '../../public/selection';
 import {ColumnDef, Sorting} from '../../public/aggregation';
-import {AreaSelection} from '../../public/selection';
-import {Engine} from '../../trace_processor/engine';
 import {CPU_SLICE_TRACK_KIND} from '../../public/track_kinds';
-import {AreaSelectionAggregator} from '../../public/selection';
+import {Engine} from '../../trace_processor/engine';
+import {exists} from '../../base/utils';
 
 export class WattsonThreadSelectionAggregator
   implements AreaSelectionAggregator


### PR DESCRIPTION
ui: Add Wattson markers slice track and misc cleanup

Add a track under Wattson that displays the Wattson markers slice. This
slice occurs frequently enough that it would be an efficiency
improvement for end users of Wattson.

Additionally, cleanup metrics and ui code related to the newly added
Wattson markers slice track for readability.

Bug: 410030831
Signed-off-by: Samuel Wu <wusamuel@google.com>