### PR TITLE
[ui] Fix passing classes to input elements

### DIFF
--- a/ui/src/widgets/text_input.ts
+++ b/ui/src/widgets/text_input.ts
@@ -39,7 +39,9 @@ export class TextInput implements m.ClassComponent<TextInputAttrs> {
 
     return m(
       '.pf-text-input', // Add a wrapper div
-      className,
+      {
+        className,
+      },
       leftIcon &&
         m(Icon, {icon: leftIcon, className: 'pf-text-input__left-icon'}), // Conditionally render icon
       m('input.pf-text-input__input', {


### PR DESCRIPTION
Ensure that the class name is passed properly to a TextInput div
rather than being passed as a string child element.