### PR TITLE
build: don't use gold on Linux standalone builds

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -454,7 +454,7 @@ config("release") {
       "-Wl,--gc-sections",
       "-Wl,-O1",
     ]
-  } else if (!is_win && !is_wasm) {
+  } else if (!is_wasm && (is_android || (is_linux && is_hermetic_clang))) {
     ldflags = [
       "-Wl,--gc-sections",
       "-Wl,--icf=all",

--- a/gn/standalone/toolchain/BUILD.gn
+++ b/gn/standalone/toolchain/BUILD.gn
@@ -55,11 +55,10 @@ declare_args() {
   sysroot = ""
   gcc_toolchain = ""
   ar = "ar"
-  linker = ""
+  linker = ""  # If left to "" uses the default linker (Linux:bfd, Mac:ld64).
   strip = ""
 
   if (is_linux_host) {
-    linker = "gold"
     if (linux_llvm_objcopy != "") {
       # If we are using the hermetic clang toolchain llvm-objcopy from there as
       # it works with Linux-arm cross toolchains. The |_llvm_strip_wrapper| is
@@ -174,11 +173,7 @@ declare_args() {
 
 declare_args() {
   target_strip = ""
-  if (is_linux || is_android) {
-    target_linker = "gold"
-  } else {
-    target_linker = ""
-  }
+  target_linker = ""
 
   if (!is_cross_compiling || is_perfetto_build_generator ||
       is_system_compiler) {

--- a/gn/standalone/toolchain/llvm.gni
+++ b/gn/standalone/toolchain/llvm.gni
@@ -38,7 +38,7 @@ if (is_linux_host) {
     _linux_llvm_dir = _find_llvm_out[0]
     linux_clang_bin = _find_llvm_out[1]
     linux_clangxx_bin = _find_llvm_out[2]
-    linux_clang_linker = "gold"
+    linux_clang_linker = "ld"  # Use the default system linker (bfd)
   }
 } else if (is_mac_host && is_clang && !is_system_compiler) {
   _mac_toolchain_dirs = exec_script("mac_find_llvm.py", [], "list lines")


### PR DESCRIPTION
On Linux, when NOT using clang, we used to depend on the gold linker. That linker is now going away, making this problematic. We realistically don't care about it, because all our reference builds (both on Android and linux) use the hermetic clang toolchain.

I tested that this change has only effect on the gcc build configs, as follows:
- Run tools/setup_all_configs.py --android
- cp -a out out.old
- Apply this patch
- cd out; for x in *; do gn gen $x; done
- git diff --no-index --word-diff=color --minimal out.old out

The only changes in ninja files are in the out/linux_gcc* dirs.  

Bug: b/410777878
