### PR TITLE
get.perfetto.dev: remove base64 encoding

### DIFF
--- a/infra/perfetto-get.appspot.com/main.py
+++ b/infra/perfetto-get.appspot.com/main.py
@@ -62,7 +62,7 @@ def fetch_artifact(resource):
     if req.status_code != 200:
       err_str = 'http error %d while fetching %s' % (req.status_code, url)
       return make_response(err_str, req.status_code, hdrs)
-    contents = base64.b64decode(req.text)
+    contents = req.text
     cache[url] = CacheEntry(contents, time.time() + CACHE_TTL)
   hdrs = {'Content-Disposition': 'attachment; filename="%s"' % resource}
   return make_response(contents, 200, hdrs)


### PR DESCRIPTION
In a previous patch the script was pointed to GitHub (good).
However the previous code was dealing with the fact that Gerrit used to
return data base64-encoded. Github does not. the b64 decode,
therefore, is not needed.
