### PR TITLE
Add command to close the current trace

### DIFF
--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -453,6 +453,10 @@ export class TraceImpl implements Trace {
     this.appImpl.openTraceFromBuffer(args);
   }
 
+  closeCurrentTrace(): void {
+    this.appImpl.closeCurrentTrace();
+  }
+
   get onTraceReady() {
     return this.traceCtx.onTraceReady;
   }

--- a/ui/src/core_plugins/commands/index.ts
+++ b/ui/src/core_plugins/commands/index.ts
@@ -163,6 +163,14 @@ export default class implements PerfettoPlugin {
         icon: 'filter_none',
       });
     }
+
+    ctx.commands.registerCommand({
+      id: 'perfetto.closeTrace',
+      name: 'Close trace',
+      callback: () => {
+        ctx.closeCurrentTrace();
+      },
+    });
   }
 
   async onTraceLoad(ctx: Trace): Promise<void> {

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -77,4 +77,5 @@ export interface App {
     title: string;
     fileName: string;
   }): void;
+  closeCurrentTrace(): void;
 }


### PR DESCRIPTION
This change adds a new command that disposes the current trace and removes it from the global AppImpl object. Mainly for testing.