### PR TITLE
Update index.ts

### DIFF
--- a/test/trace_processor/diff_tests/metrics/graphics/composer_execution.py
+++ b/test/trace_processor/diff_tests/metrics/graphics/composer_execution.py
@@ -30,7 +30,7 @@ trace.add_thread(15000, 10335, "worker thread")
 trace.add_ftrace_packet(1)
 
 # unskipped validation
-trace.add_atrace_begin(ts=100, tid=10335, pid=10335, buf="onMessageRefresh")
+trace.add_atrace_begin(ts=100, tid=10335, pid=10335, buf="CompositionEngine::present")
 trace.add_atrace_begin(
     ts=200, tid=10335, pid=10335, buf="HwcPresentOrValidateDisplay 0")
 trace.add_atrace_end(ts=300, tid=10335, pid=10335)
@@ -59,7 +59,7 @@ trace.add_atrace_end(ts=2_800, tid=10335, pid=10335)
 
 # skipped validation
 trace.add_atrace_begin(ts=3_100, tid=10335, pid=10335, buf="AnotherFunction")
-trace.add_atrace_begin(ts=3_200, tid=10335, pid=10335, buf="onMessageRefresh")
+trace.add_atrace_begin(ts=3_200, tid=10335, pid=10335, buf="CompositionEngine::present")
 trace.add_atrace_begin(
     ts=3_300, tid=10335, pid=10335, buf="HwcPresentOrValidateDisplay 0")
 trace.add_atrace_end(ts=3_400, tid=10335, pid=10335)

--- a/ui/src/plugins/dev.perfetto.PinSysUITracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.PinSysUITracks/index.ts
@@ -20,7 +20,7 @@ import {PerfettoPlugin} from '../../public/plugin';
 const TRACKS_TO_PIN: string[] = [
   'Actual Timeline',
   'Expected Timeline',
-  'ndroid.systemui',
+  'Android.systemui',
   'IKeyguardService',
   'Transition:',
   'L<',


### PR DESCRIPTION
Complete perfetto internal systemui name

Because the underlying AndroidRuntime::setArgv0 will truncate thread names longer than 15 to keep 15, so this is probably intentional. Because the underlying setArgv0 is consistent with the kernel thread name length, this modification is to keep the first letter capitalized with other variables in TRACKS_TO_PIN, and to make the code clearer after completion, and easier for users to understand.

Signed-off-by:
Shuangxi Xiang <xiangshuangxi@xiaomi.corp-partner.google.com>