### PR TITLE
feat(ui): add feature flag to enable editing in default workspace

### DIFF
--- a/ui/src/core/workspace_manager.ts
+++ b/ui/src/core/workspace_manager.ts
@@ -14,8 +14,16 @@
 
 import {assertTrue} from '../base/logging';
 import {Workspace, WorkspaceManager} from '../public/workspace';
+import {featureFlags} from './feature_flags';
 
 const DEFAULT_WORKSPACE_NAME = 'Default Workspace';
+const DEFAULT_WORKSPACE_EDITABLE_FLAG = featureFlags.register({
+  id: 'defaultWorkspaceEditable',
+  name: 'Enable Default Workspace Editing',
+  description:
+    'Allows tracks within the default workspace to be removed and rearranged using drag-and-drop operations.',
+  defaultValue: false,
+});
 
 export class WorkspaceManagerImpl implements WorkspaceManager {
   readonly defaultWorkspace = new Workspace();
@@ -24,7 +32,7 @@ export class WorkspaceManagerImpl implements WorkspaceManager {
 
   constructor() {
     this.defaultWorkspace.title = DEFAULT_WORKSPACE_NAME;
-    this.defaultWorkspace.userEditable = false;
+    this.defaultWorkspace.userEditable = DEFAULT_WORKSPACE_EDITABLE_FLAG.get();
     this._currentWorkspace = this.defaultWorkspace;
   }
 


### PR DESCRIPTION
- Add 'defaultWorkspaceEditable' feature flag to control workspace editability
- Allow track removal and reordering when flag is enabled
- Maintain default workspace read-only state when flag is disabled


More discussion
https://github.com/google/perfetto/discussions/1343
