### PR TITLE
tracing: Move buffer_exhausted_policy to instance state

### DIFF
--- a/include/perfetto/tracing/data_source.h
+++ b/include/perfetto/tracing/data_source.h
@@ -479,9 +479,10 @@ class DataSource : public DataSourceBase {
         DerivedDataSource::kRequiresCallbacksUnderLock;
     params.supports_multiple_instances =
         DerivedDataSource::kSupportsMultipleInstances;
+    params.default_buffer_exhausted_policy =
+        DerivedDataSource::kBufferExhaustedPolicy;
     return Helper::type().Register(
-        descriptor, factory, params, DerivedDataSource::kBufferExhaustedPolicy,
-        no_flush,
+        descriptor, factory, params, no_flush,
         GetCreateTlsFn(
             static_cast<typename DataSourceTraits::TlsStateType*>(nullptr)),
         GetCreateIncrementalStateFn(

--- a/include/perfetto/tracing/internal/data_source_internal.h
+++ b/include/perfetto/tracing/internal/data_source_internal.h
@@ -26,6 +26,7 @@
 #include <mutex>
 
 // No perfetto headers (other than tracing/api and protozero) should be here.
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "perfetto/tracing/internal/basic_types.h"
 #include "perfetto/tracing/trace_writer_base.h"
@@ -113,6 +114,10 @@ struct DataSourceState {
   // Whether this data source instance should call NotifyDataSourceStopped()
   // when it's stopped.
   bool will_notify_on_stop = false;
+
+  // The wanted behavior for this data source instance when a TraceWriter runs
+  // out of space in the shared memory buffer.
+  BufferExhaustedPolicy buffer_exhausted_policy = BufferExhaustedPolicy::kDrop;
 
   // Incremented whenever incremental state should be reset for this instance of
   // this data source.

--- a/include/perfetto/tracing/internal/data_source_type.h
+++ b/include/perfetto/tracing/internal/data_source_type.h
@@ -44,20 +44,16 @@ class PERFETTO_EXPORT_COMPONENT DataSourceType {
   // * `descriptor` is the data source protobuf descriptor.
   // * `factory` is a std::function used to create instances of the data source
   //   type.
-  // * `buffer_exhausted_policy` specifies what to do when the shared memory
-  //   buffer runs out of chunks.
   // * `create_custom_tls_fn` and `create_incremental_state_fn` are function
   //   pointers called to create custom state. They will receive `user_arg` as
   //   an extra param.
   bool Register(const DataSourceDescriptor& descriptor,
                 TracingMuxer::DataSourceFactory factory,
                 internal::DataSourceParams params,
-                BufferExhaustedPolicy buffer_exhausted_policy,
                 bool no_flush,
                 CreateCustomTlsFn create_custom_tls_fn,
                 CreateIncrementalStateFn create_incremental_state_fn,
                 void* user_arg) {
-    buffer_exhausted_policy_ = buffer_exhausted_policy;
     create_custom_tls_fn_ = create_custom_tls_fn;
     create_incremental_state_fn_ = create_incremental_state_fn;
     user_arg_ = user_arg;
@@ -302,7 +298,6 @@ class PERFETTO_EXPORT_COMPONENT DataSourceType {
   }
 
   DataSourceStaticState state_;
-  BufferExhaustedPolicy buffer_exhausted_policy_{};
   CreateCustomTlsFn create_custom_tls_fn_ = nullptr;
   CreateIncrementalStateFn create_incremental_state_fn_ = nullptr;
   // User defined pointer that carries extra content for the fn_ callbacks

--- a/include/perfetto/tracing/internal/tracing_muxer.h
+++ b/include/perfetto/tracing/internal/tracing_muxer.h
@@ -38,6 +38,8 @@ class TracingSession;
 namespace internal {
 
 struct DataSourceParams {
+  BufferExhaustedPolicy default_buffer_exhausted_policy =
+      BufferExhaustedPolicy::kDrop;
   bool supports_multiple_instances = true;
   bool requires_callbacks_under_lock = true;
 };

--- a/src/shared_lib/data_source.cc
+++ b/src/shared_lib/data_source.cc
@@ -360,10 +360,11 @@ bool PerfettoDsImplRegister(struct PerfettoDsImpl* ds_impl,
   perfetto::internal::DataSourceParams params;
   params.supports_multiple_instances = true;
   params.requires_callbacks_under_lock = false;
+  params.default_buffer_exhausted_policy =
+      data_source_type->buffer_exhausted_policy;
   bool success = data_source_type->cpp_type.Register(
-      dsd, factory, params, data_source_type->buffer_exhausted_policy,
-      data_source_type->on_flush_cb == nullptr, create_custom_tls_fn,
-      create_incremental_state_fn, cb_ctx);
+      dsd, factory, params, data_source_type->on_flush_cb == nullptr,
+      create_custom_tls_fn, create_incremental_state_fn, cb_ctx);
   if (!success) {
     return false;
   }

--- a/src/tracing/data_source.cc
+++ b/src/tracing/data_source.cc
@@ -74,8 +74,9 @@ void DataSourceType::PopulateTlsInst(
           std::memory_order_relaxed);
   tls_inst->data_source_instance_id = instance_state->data_source_instance_id;
   tls_inst->is_intercepted = instance_state->interceptor_id != 0;
-  tls_inst->trace_writer = tracing_impl->CreateTraceWriter(
-      &state_, instance_index, instance_state, buffer_exhausted_policy_);
+  tls_inst->trace_writer =
+      tracing_impl->CreateTraceWriter(&state_, instance_index, instance_state,
+                                      instance_state->buffer_exhausted_policy);
   if (create_incremental_state_fn_) {
     PERFETTO_DCHECK(!tls_inst->incremental_state);
     CreateIncrementalState(tls_inst, instance_index);

--- a/src/tracing/internal/tracing_muxer_impl.cc
+++ b/src/tracing/internal/tracing_muxer_impl.cc
@@ -1229,6 +1229,8 @@ static bool MaybeAdoptStartupTracingInDataSource(
         internal_state->data_source_instance_id = instance_id;
         internal_state->buffer_id =
             static_cast<internal::BufferId>(cfg.target_buffer());
+        internal_state->buffer_exhausted_policy =
+            rds.params.default_buffer_exhausted_policy;
         internal_state->config.reset(new DataSourceConfig(cfg));
 
         // TODO(eseckler): Should the data source config provided by the service
@@ -1350,6 +1352,8 @@ TracingMuxerImpl::FindDataSourceRes TracingMuxerImpl::SetupDataSourceImpl(
     internal_state->data_source_instance_id = instance_id;
     internal_state->buffer_id =
         static_cast<internal::BufferId>(cfg.target_buffer());
+    internal_state->buffer_exhausted_policy =
+        rds.params.default_buffer_exhausted_policy;
     internal_state->config.reset(new DataSourceConfig(cfg));
     internal_state->startup_session_id = startup_session_id;
     internal_state->data_source = rds.factory();


### PR DESCRIPTION
A future commit will allow configuring the buffer_exhausted_policy from the config. This is a prerequisite for that.