### PR TITLE
protovm: fix missing include

### DIFF
--- a/src/protovm/error_handling.h
+++ b/src/protovm/error_handling.h
@@ -20,6 +20,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <memory>
+#include <new>
 #include <string>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
Add missing "#include <new>" to error_handling.h
