### PR TITLE
Add machine id column to AndroidLog panel

### DIFF
--- a/ui/src/plugins/dev.perfetto.AndroidLog/logs_panel.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/logs_panel.ts
@@ -179,7 +179,7 @@ export class LogPanel implements m.ClassComponent<LogPanelAttrs> {
           this.entries.isHighlighted[i] && 'pf-highlighted',
         ),
         cells: [
-          ...(hasMachineIds ? [machineIds[i] || ''] : []),
+          ...(hasMachineIds ? [machineIds[i]] : []),
           m(Timestamp, {ts}),
           priorityLetter || '?',
           tags[i],


### PR DESCRIPTION
In multi-VM traces, it is valuable to differentiate from which machine each Android log is coming from. For this we added a machine id column to the table in the AndroidLog panel. This columns is conditional to there being more than one machine, if not then the log panel behaves the same way as before.

Test: ui/run-unittests
Bug: 406061688
