### PR TITLE
Update SysUI persistent tracing flag name in comments

### DIFF
--- a/persistent_cfg.pbtxt
+++ b/persistent_cfg.pbtxt
@@ -1,5 +1,6 @@
 # Persistent tracing configuration. Only enabled on some devices for debugging
-# purposes when the property persist.debug.perfetto.persistent is set to 1.
+# purposes when the property
+# persist.debug.perfetto.persistent_sysui_tracing_for_bugreport is set to 1.
 
 bugreport_score: 5
 bugreport_filename: "sysui.pftrace"


### PR DESCRIPTION
The flag `persist.debug.perfetto.persistent` no longer exists and we now have `persist.debug.perfetto.persistent_sysui_tracing_for_bugreport` instead to be more descriptive. This PR updates the comments that mention this flag which is no longer used.