### PR TITLE
Trace Redaction - Remove empty ftrace events

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15167,6 +15167,7 @@ filegroup {
         "src/trace_redaction/collect_frame_cookies.cc",
         "src/trace_redaction/collect_system_info.cc",
         "src/trace_redaction/collect_timeline_events.cc",
+        "src/trace_redaction/drop_empty_ftrace_events.cc",
         "src/trace_redaction/filtering.cc",
         "src/trace_redaction/find_package_uid.cc",
         "src/trace_redaction/merge_threads.cc",

--- a/src/trace_redaction/BUILD.gn
+++ b/src/trace_redaction/BUILD.gn
@@ -36,6 +36,8 @@ source_set("trace_redaction") {
     "collect_system_info.h",
     "collect_timeline_events.cc",
     "collect_timeline_events.h",
+    "drop_empty_ftrace_events.cc",
+    "drop_empty_ftrace_events.h",
     "filtering.cc",
     "filtering.h",
     "find_package_uid.cc",

--- a/src/trace_redaction/drop_empty_ftrace_events.cc
+++ b/src/trace_redaction/drop_empty_ftrace_events.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_redaction/drop_empty_ftrace_events.h"
+
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "perfetto/protozero/scattered_heap_buffer.h"
+#include "protos/perfetto/trace/ftrace/ftrace_event.pbzero.h"
+#include "protos/perfetto/trace/ftrace/ftrace_event_bundle.pbzero.h"
+#include "src/trace_redaction/proto_util.h"
+#include "src/trace_redaction/trace_redaction_framework.h"
+
+namespace perfetto::trace_redaction {
+namespace {
+constexpr auto kPidFieldNumber = protos::pbzero::FtraceEvent::kPidFieldNumber;
+constexpr auto kTimestampFieldNumber =
+    protos::pbzero::FtraceEvent::kTimestampFieldNumber;
+constexpr auto kEventFieldNumber =
+    protos::pbzero::FtraceEventBundle::kEventFieldNumber;
+constexpr auto kFtraceEventsFieldNumber =
+    protos::pbzero::TracePacket::kFtraceEventsFieldNumber;
+
+// Look at a FtraceEvent and determine if it has more than a pid and a
+// timestamp. If the event only has a pid and timestamp, it is considered empty
+// and should be removed.
+bool IsFtraceEventEmpty(protozero::ConstBytes bytes) {
+  protozero::ProtoDecoder decoder(bytes);
+
+  for (auto field = decoder.ReadField(); field.valid();
+       field = decoder.ReadField()) {
+    const auto id = field.id();
+
+    if (id != kPidFieldNumber && id != kTimestampFieldNumber) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Look at every field in a ftrace event bundle and remove any empty ftrace
+// event messages. It's possible for every ftrace event to be removed. When
+// that happens, the ftrace event bundle should be removed. That is out of
+// scope for this primitive and should be handled elsewhere.
+void OnFtraceEventBundle(
+    protozero::ConstBytes bytes,
+    protos::pbzero::FtraceEventBundle* ftrace_event_bundle) {
+  protozero::ProtoDecoder decoder(bytes);
+
+  for (auto field = decoder.ReadField(); field.valid();
+       field = decoder.ReadField()) {
+    const auto id = field.id();
+
+    if (id == kEventFieldNumber && IsFtraceEventEmpty(field.as_bytes())) {
+      continue;
+    }
+
+    proto_util::AppendField(field, ftrace_event_bundle);
+  }
+}
+
+}  // namespace
+
+base::Status DropEmptyFtraceEvents::Transform(const Context&,
+                                              std::string* packet) const {
+  protozero::ProtoDecoder decoder(*packet);
+  protozero::HeapBuffered<protos::pbzero::TracePacket> packet_message;
+
+  for (auto field = decoder.ReadField(); field.valid();
+       field = decoder.ReadField()) {
+    if (field.id() == kFtraceEventsFieldNumber) {
+      OnFtraceEventBundle(field.as_bytes(),
+                          packet_message->set_ftrace_events());
+    } else {
+      proto_util::AppendField(field, packet_message.get());
+    }
+  }
+
+  packet->assign(packet_message.SerializeAsString());
+  return base::OkStatus();
+}
+
+}  // namespace perfetto::trace_redaction

--- a/src/trace_redaction/drop_empty_ftrace_events.h
+++ b/src/trace_redaction/drop_empty_ftrace_events.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_REDACTION_DROP_EMPTY_FTRACE_EVENTS_H_
+#define SRC_TRACE_REDACTION_DROP_EMPTY_FTRACE_EVENTS_H_
+
+#include <string>
+
+#include "perfetto/base/status.h"
+#include "src/trace_redaction/trace_redaction_framework.h"
+
+namespace perfetto::trace_redaction {
+
+// Looks at every ftrace event and if the event is empty (only contains a pid
+// and timestamp value), it will be dropped (not copied to the new packet).
+// After removing ftrace events, it is possible for a ftrace event bundle to be
+// empty. It is easier to drop ftrace event bundles in its own primitive that
+// must run after this primitive.
+class DropEmptyFtraceEvents final : public TransformPrimitive {
+ public:
+  base::Status Transform(const Context& context,
+                         std::string* packet) const override;
+
+ private:
+  void OnPackageList(const Context& context,
+                     protozero::ConstBytes bytes,
+                     protos::pbzero::PackagesList* message) const;
+};
+
+}  // namespace perfetto::trace_redaction
+
+#endif  // SRC_TRACE_REDACTION_DROP_EMPTY_FTRACE_EVENTS_H_

--- a/src/trace_redaction/drop_empty_ftrace_events_unittest.cc
+++ b/src/trace_redaction/drop_empty_ftrace_events_unittest.cc
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_redaction/drop_empty_ftrace_events.h"
+#include "protos/perfetto/trace/ftrace/ftrace.gen.h"
+#include "protos/perfetto/trace/ftrace/ftrace_event.gen.h"
+#include "protos/perfetto/trace/ftrace/ftrace_event_bundle.gen.h"
+#include "test/gtest_and_gmock.h"
+
+#include "protos/perfetto/trace/trace_packet.gen.h"
+
+// After other transformations are done running, empty ftrace packets may be
+// left behind. A ftrace packet is considered empty when there is no more than
+// a pid and timestamp.
+//
+// If an event (ftrace packet) is empty, it should be removed from the ftrace
+// list (ftrace_events). If ftrace_events is empty (only contains a cpu), it
+// should be removed from the packet.
+//
+//  packet: {
+//    ftrace_events: {
+//      cpu  : 0x00000003
+//      event: {
+//        timestamp : 0x0000001d5d0ce35d
+//        pid       : 0x00400005
+//      }
+//      event: {
+//        timestamp : 0x0000001d5d0d7314
+//        pid       : 0x00400005
+//      }
+//    }
+//  }
+
+namespace perfetto::trace_redaction {
+namespace {
+constexpr auto kPid = 1u;
+constexpr auto kTimes = std::array<uint64_t, 2>{1000, 2000};
+}  // namespace
+
+// Each event has a payload (print message) and should not be dropped.
+//
+//  packet: {
+//    ftrace_events: {
+//      cpu  : 0x00000003
+//      event: {
+//        timestamp : 0x0000001d5d0ce35d
+//        pid       : 0x00400005
+//        print     : {
+//          buf: "TEXT A"
+//        }
+//      }
+//      event: {
+//        timestamp : 0x0000001d5d0d7314
+//        pid       : 0x00400005
+//        print     : {
+//          buf: "TEXT B"
+//        }
+//      }
+//    }
+//  }
+TEST(DropEmptyFtraceEvents, DropsNothing) {
+  auto sourcePacket = protos::gen::TracePacket();
+
+  auto* ftrace_events = sourcePacket.mutable_ftrace_events();
+  ftrace_events->set_cpu(0);
+
+  {
+    auto* event = ftrace_events->add_event();
+    event->set_timestamp(kTimes[0]);
+    event->set_pid(kPid);
+
+    auto* print = event->mutable_print();
+    print->set_buf("TEXT A");
+  }
+
+  {
+    auto* event = ftrace_events->add_event();
+    event->set_timestamp(kTimes[1]);
+    event->set_pid(kPid);
+
+    auto* print = event->mutable_print();
+    print->set_buf("TEXT B");
+  }
+
+  ASSERT_EQ(ftrace_events->event_size(), 2);
+
+  Context context;
+  auto inputBuffer = sourcePacket.SerializeAsString();
+
+  DropEmptyFtraceEvents transform;
+  ASSERT_TRUE(transform.Transform(context, &inputBuffer).ok());
+
+  auto packet = protos::gen::TracePacket();
+  packet.ParseFromString(inputBuffer);
+
+  ASSERT_EQ(packet.ftrace_events().event_size(), 2);
+}
+
+// The first event is not empty (it has a print event). However, the second
+// event does not have a body, and should be removed.
+//
+//  packet: {
+//    ftrace_events: {
+//      cpu  : 0x00000003
+//      event: {
+//        timestamp : 0x0000001d5d0ce35d
+//        pid       : 0x00400005
+//        print     : {
+//          buf: "TEXT A"
+//        }
+//      }
+//      event: {
+//        timestamp : 0x0000001d5d0d7314
+//        pid       : 0x00400005
+//      }
+//    }
+//  }
+TEST(DropEmptyFtraceEvents, DropsEvent) {
+  auto sourcePacket = protos::gen::TracePacket();
+
+  auto* ftrace_events = sourcePacket.mutable_ftrace_events();
+  ftrace_events->set_cpu(0);
+
+  {
+    auto* event = ftrace_events->add_event();
+    event->set_timestamp(kTimes[0]);
+    event->set_pid(kPid);
+
+    auto* print = event->mutable_print();
+    print->set_buf("TEXT A");
+  }
+
+  {
+    auto* event = ftrace_events->add_event();
+    event->set_timestamp(kTimes[1]);
+    event->set_pid(kPid);
+  }
+
+  ASSERT_EQ(ftrace_events->event_size(), 2);
+
+  Context context;
+  auto inputBuffer = sourcePacket.SerializeAsString();
+
+  DropEmptyFtraceEvents transform;
+  ASSERT_TRUE(transform.Transform(context, &inputBuffer).ok());
+
+  auto packet = protos::gen::TracePacket();
+  packet.ParseFromString(inputBuffer);
+
+  ASSERT_EQ(packet.ftrace_events().event_size(), 1);
+  ASSERT_TRUE(packet.ftrace_events().event()[0].has_print());
+}
+
+// Because all events have no bodies (only timestamp and pid), not only should
+// they should they be removed, the whole ftrace_events should be removed.
+//
+//  packet: {
+//    ftrace_events: {
+//      cpu  : 0x00000003
+//      event: {
+//        timestamp     : 0x0000001d5d0ce35d
+//        pid  : 0x00400005
+//      }
+//      event: {
+//        timestamp     : 0x0000001d5d0d7314
+//        pid  : 0x00400005
+//      }
+//    }
+//  }
+TEST(DropEmptyFtraceEvents, DropsFtraceEvents) {
+  auto sourcePacket = protos::gen::TracePacket();
+
+  auto* ftrace_events = sourcePacket.mutable_ftrace_events();
+  ftrace_events->set_cpu(0);
+
+  {
+    auto* event = ftrace_events->add_event();
+    event->set_timestamp(kTimes[0]);
+    event->set_pid(kPid);
+  }
+
+  {
+    auto* event = ftrace_events->add_event();
+    event->set_timestamp(kTimes[1]);
+    event->set_pid(kPid);
+  }
+
+  ASSERT_EQ(ftrace_events->event_size(), 2);
+
+  Context context;
+  auto inputBuffer = sourcePacket.SerializeAsString();
+
+  DropEmptyFtraceEvents transform;
+  ASSERT_TRUE(transform.Transform(context, &inputBuffer).ok());
+
+  auto packet = protos::gen::TracePacket();
+  packet.ParseFromString(inputBuffer);
+
+  ASSERT_EQ(packet.ftrace_events().event_size(), 0);
+}
+
+}  // namespace perfetto::trace_redaction

--- a/src/trace_redaction/trace_redactor.cc
+++ b/src/trace_redaction/trace_redactor.cc
@@ -32,6 +32,7 @@
 #include "src/trace_redaction/collect_frame_cookies.h"
 #include "src/trace_redaction/collect_system_info.h"
 #include "src/trace_redaction/collect_timeline_events.h"
+#include "src/trace_redaction/drop_empty_ftrace_events.h"
 #include "src/trace_redaction/find_package_uid.h"
 #include "src/trace_redaction/merge_threads.h"
 #include "src/trace_redaction/populate_allow_lists.h"
@@ -266,6 +267,15 @@ std::unique_ptr<TraceRedactor> TraceRedactor::CreateInstance(
     auto* primitive = redactor->emplace_transform<RedactProcessTrees>();
     primitive->emplace_modifier<ProcessTreeCreateSynthThreads>();
     primitive->emplace_filter<ConnectedToPackage>();
+  }
+
+  // Optimizations:
+  //
+  // This block of transforms should be registered last. They clean-up after the
+  // other transforms. The most common function will be to remove empty
+  // messages.
+  {
+    redactor->emplace_transform<DropEmptyFtraceEvents>();
   }
 
   return redactor;


### PR DESCRIPTION
Some transform primitives, can produce empty ftrace events. Because ftrace events make-up the bulk of a trace, these empty events waste a lot of space. For one sample we saw,

  - 11 MB before removing empty ftrace events
  -  6 MB after removing empty ftrace events

To avoid every transform from cleaning up after itself, we introduce a transform that looks for and removes empty ftrace events. 

However, this new transform does not fully solve the problem, but rather moves it up one level of abstraction, instead of empty ftrace events, we need to worry about empty ftrace bundles.

Bug: 399223002
Bug: 400076815