### PR TITLE
[chrome] Add scenario description string

### DIFF
--- a/protos/perfetto/config/chrome/scenario_config.proto
+++ b/protos/perfetto/config/chrome/scenario_config.proto
@@ -97,6 +97,8 @@ message ScenarioConfig {
   // Scenario name, unique within the whole field tracing config.
   optional string scenario_name = 1;
 
+  optional string scenario_description = 9;
+
   // When triggered, this scenario becomes active. Initializes a tracing session
   // and starts recording data sources. This activates `upload_rules` and
   // `stop_rules`.

--- a/protos/perfetto/config/chrome/scenario_config.proto
+++ b/protos/perfetto/config/chrome/scenario_config.proto
@@ -97,6 +97,7 @@ message ScenarioConfig {
   // Scenario name, unique within the whole field tracing config.
   optional string scenario_name = 1;
 
+  // Short scenario description, displayed in Chrome internal UI.
   optional string scenario_description = 9;
 
   // When triggered, this scenario becomes active. Initializes a tracing session


### PR DESCRIPTION
This PR adds a description string field to ScenarioConfig, which will be displayed in Chrome internal UI.
