### PR TITLE
tp: use dedicated args tracker for power rails

### DIFF
--- a/src/trace_processor/importers/proto/android_probes_parser.h
+++ b/src/trace_processor/importers/proto/android_probes_parser.h
@@ -24,6 +24,7 @@
 
 namespace perfetto::trace_processor {
 
+class ArgsTracker;
 class TraceProcessorContext;
 
 class AndroidProbesParser {
@@ -47,6 +48,7 @@ class AndroidProbesParser {
 
  private:
   TraceProcessorContext* const context_;
+  std::unique_ptr<ArgsTracker> power_rails_args_tracker_;
 
   const StringId battery_status_id_;
   const StringId plug_type_id_;


### PR DESCRIPTION
Use a dedicated args tracker for power rails parsing in order to workaround non-linear parsing performance. This should result in significant parse time improvements for traces with O(10 million) power samples and above.

Bug: https://github.com/google/perfetto/issues/1323
