### PR TITLE
Add machine id filter to AndroidLog

### DIFF
--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -77,7 +77,7 @@ export default class implements PerfettoPlugin {
     );
 
     const cache: LogPanelCache = {
-      uMachineIds: [],
+      uniqueMachineIds: null,
     };
 
     ctx.tabs.registerTab({

--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {LogFilteringCriteria, LogPanel} from './logs_panel';
+import {LogFilteringCriteria, LogPanelCache, LogPanel} from './logs_panel';
 import {ANDROID_LOGS_TRACK_KIND} from '../../public/track_kinds';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
@@ -32,6 +32,7 @@ const DEFAULT_STATE: AndroidLogPluginState = {
     tags: [],
     textEntry: '',
     hideNonMatching: true,
+    machineExcludeList: [],
   },
 };
 
@@ -75,11 +76,15 @@ export default class implements PerfettoPlugin {
       (x) => x as LogFilteringCriteria,
     );
 
+    const cache: LogPanelCache = {
+      uMachineIds: [],
+    };
+
     ctx.tabs.registerTab({
       isEphemeral: false,
       uri: androidLogsTabUri,
       content: {
-        render: () => m(LogPanel, {filterStore: filterStore, trace: ctx}),
+        render: () => m(LogPanel, {filterStore, cache, trace: ctx}),
         getTitle: () => 'Android Logs',
       },
     });

--- a/ui/src/plugins/dev.perfetto.AndroidLog/logs_panel.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/logs_panel.ts
@@ -117,8 +117,7 @@ export class LogPanel implements m.ClassComponent<LogPanelAttrs> {
       this.reloadData(attrs);
     }
 
-    const hasMachineIds =
-      this.entries && this.entries.machineIds.filter((id) => id).length > 0;
+    const hasMachineIds = attrs.cache.uMachineIds.length > 1;
     const hasProcessNames =
       this.entries &&
       this.entries.processName.filter((name) => name).length > 0;
@@ -317,6 +316,8 @@ interface LogsFiltersAttrs {
 
 export class LogsFilters implements m.ClassComponent<LogsFiltersAttrs> {
   view({attrs}: m.CVnode<LogsFiltersAttrs>) {
+    const hasMachineIds = attrs.cache.uMachineIds.length > 1;
+
     return [
       m('.log-label', 'Log Level'),
       m(LogPriorityWidget, {
@@ -360,7 +361,7 @@ export class LogsFilters implements m.ClassComponent<LogsFiltersAttrs> {
         },
         disabled: attrs.store.state.textEntry === '',
       }),
-      this.renderFilterPanel(attrs),
+      ...(hasMachineIds ? [this.renderFilterPanel(attrs)] : []),
     ];
   }
 


### PR DESCRIPTION
In multi-machine traces doing log analysis might be complicated given there could be thousands of logs from each machine in the same log table. To improve the log navigation, we added a multi-select filter which allows the user to select any subset of machines to only view their respective logs.

Test: ui/run-unittests
Bug: 406061688
