### PR TITLE
Add a missing include for unix_socket.h

### DIFF
--- a/include/perfetto/ext/base/unix_socket.h
+++ b/include/perfetto/ext/base/unix_socket.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/compiler.h"


### PR DESCRIPTION
This is to fix module build in chromium.