### PR TITLE
Filter out frame_id = -1 in _get_frame_table_with_id 

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
@@ -54,8 +54,9 @@ SELECT
   *
 FROM all_found
 -- Casting string to int returns 0 if the string can't be cast.
+-- frame_id is -1 indicating an invalid vsync id
 WHERE
-  frame_id != 0;
+  frame_id != 0 AND frame_id != -1;
 
 -- All of the `Choreographer#doFrame` slices with their frame id.
 CREATE PERFETTO TABLE android_frames_choreographer_do_frame (


### PR DESCRIPTION
Choreographer#doFrame and DrawFrame can have frame_id of -1, indicating an invalid vsync id according to Android Open Source. If the trace file contains data with frame_id = -1, it results in Cartesian product when joining the android_frames_chore_do_frame,_frames_draw_frame, and fallback tables in srctrace_processor/perfetto_sql/stdlib/frames/timeline.sql.

For example, there are 100 rows with frame_id =1, the JOIN operation produces 100 100 * 100 = 1,,000 rows, leading to wasm OOM issues.

This commit includes the following changes:
1. Modified _get_frame_table_with_id function to filter out slices with frame_id = -1.

Bug: https://github.com/google/perfetto/issues/1390
