### PR TITLE
Remove TRACE_EVENT_OBJECT_SNAPSHOT_WITH_ID_AND_TIMESTAMP

### DIFF
--- a/include/perfetto/tracing/track_event_legacy.h
+++ b/include/perfetto/tracing/track_event_legacy.h
@@ -941,13 +941,6 @@ ConvertThreadId(const PerfettoLegacyCurrentThreadId&);
       TRACE_EVENT_PHASE_SNAPSHOT_OBJECT, category_group, name, id,    \
       TRACE_EVENT_FLAG_NONE, "snapshot", snapshot)
 
-#define TRACE_EVENT_OBJECT_SNAPSHOT_WITH_ID_AND_TIMESTAMP(                 \
-    category_group, name, id, timestamp, snapshot)                         \
-  INTERNAL_TRACE_EVENT_ADD_WITH_ID_TID_AND_TIMESTAMP(                      \
-      TRACE_EVENT_PHASE_SNAPSHOT_OBJECT, category_group, name, id,         \
-      TRACE_EVENT_API_CURRENT_THREAD_ID, timestamp, TRACE_EVENT_FLAG_NONE, \
-      "snapshot", snapshot)
-
 #define TRACE_EVENT_OBJECT_DELETED_WITH_ID(category_group, name, id) \
   INTERNAL_TRACE_EVENT_ADD_WITH_ID(TRACE_EVENT_PHASE_DELETE_OBJECT,  \
                                    category_group, name, id,         \


### PR DESCRIPTION
Its last usage was removed in https://crrev.com/c/6197645.

I am also going to send CLs to Chromium & V8 to remove the other remaining usages
(https://source.chromium.org/search?q=TRACE_EVENT_OBJECT_SNAPSHOT_WITH_ID_AND_TIMESTAMP&ss=chromium).

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
