### PR TITLE
Add pluginable overlay subsystem & use for waker lines for cpu tracks

### DIFF
--- a/ui/src/base/vertical_line_helper.ts
+++ b/ui/src/base/vertical_line_helper.ts
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {time} from '../../base/time';
-import {TimeScale} from '../../base/time_scale';
+import {time} from './time';
+import {TimeScale} from './time_scale';
 
 export function drawVerticalLineAtTime(
   ctx: CanvasRenderingContext2D,

--- a/ui/src/core/track_manager.ts
+++ b/ui/src/core/track_manager.ts
@@ -18,7 +18,7 @@ import {
   Track,
   TrackManager,
   TrackFilterCriteria,
-  TimelineOverlay,
+  Overlay,
 } from '../public/track';
 import {AsyncLimiter} from '../base/async_limiter';
 import {TrackRenderContext} from '../public/track';
@@ -73,7 +73,7 @@ export class TrackFilterState {
  */
 export class TrackManagerImpl implements TrackManager {
   private readonly tracks = new Registry<TrackFSMImpl>((x) => x.desc.uri);
-  private readonly _timelineOverlays: TimelineOverlay[] = [];
+  private readonly _overlays: Overlay[] = [];
 
   // This property is written by scroll_helper.ts and read&cleared by the
   // track_panel.ts. This exist for the following use case: the user wants to
@@ -95,13 +95,13 @@ export class TrackManagerImpl implements TrackManager {
     return this.tracks.register(new TrackFSMImpl(trackDesc));
   }
 
-  registerTimelineOverlay(overlay: TimelineOverlay): Disposable {
-    this._timelineOverlays.push(overlay);
+  registerOverlay(overlay: Overlay): Disposable {
+    this._overlays.push(overlay);
     return {
       [Symbol.dispose]: () => {
-        const index = this._timelineOverlays.indexOf(overlay);
+        const index = this._overlays.indexOf(overlay);
         if (index !== -1) {
-          this._timelineOverlays.splice(index, 1);
+          this._overlays.splice(index, 1);
         }
       },
     };
@@ -149,8 +149,8 @@ export class TrackManagerImpl implements TrackManager {
     return this.filterCriteria;
   }
 
-  get timelineOverlays(): ReadonlyArray<TimelineOverlay> {
-    return this._timelineOverlays;
+  get overlays(): ReadonlyArray<Overlay> {
+    return this._overlays;
   }
 }
 

--- a/ui/src/frontend/viewer_page/track_tree_view.ts
+++ b/ui/src/frontend/viewer_page/track_tree_view.ts
@@ -386,7 +386,7 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
     this.drawAreaSelection(ctx, timescale, size);
     this.updateInteractions(timelineRect, timescale, size, renderedTracks);
 
-    this.trace.tracks.timelineOverlays.forEach((overlay) => {
+    this.trace.tracks.overlays.forEach((overlay) => {
       overlay.render(ctx, timescale, size, renderedTracks);
     });
 

--- a/ui/src/frontend/viewer_page/track_tree_view.ts
+++ b/ui/src/frontend/viewer_page/track_tree_view.ts
@@ -59,7 +59,7 @@ import {
   wheelNavigationInteraction,
 } from './timeline_interactions';
 import {TrackView} from './track_view';
-import {drawVerticalLineAtTime} from './vertical_line_helper';
+import {drawVerticalLineAtTime} from '../../base/vertical_line_helper';
 import {featureFlags} from '../../core/feature_flags';
 import {EmptyState} from '../../widgets/empty_state';
 import {Button, ButtonVariant} from '../../widgets/button';
@@ -382,10 +382,13 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
     renderFlows(this.trace, ctx, size, renderedTracks, rootNode, timescale);
     this.drawHoveredNoteVertical(ctx, timescale, size);
     this.drawHoveredCursorVertical(ctx, timescale, size);
-    this.drawWakeupVertical(ctx, timescale, size);
     this.drawNoteVerticals(ctx, timescale, size);
     this.drawAreaSelection(ctx, timescale, size);
     this.updateInteractions(timelineRect, timescale, size, renderedTracks);
+
+    this.trace.tracks.timelineOverlays.forEach((overlay) => {
+      overlay.render(ctx, timescale, size, renderedTracks);
+    });
 
     const renderTime = performance.now() - start;
     this.updatePerfStats(renderTime, renderedTracks.length, tracksOnCanvas);
@@ -680,23 +683,6 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
         this.trace.timeline.hoveredNoteTimestamp,
         size.height,
         `#aaa`,
-      );
-    }
-  }
-
-  private drawWakeupVertical(
-    ctx: CanvasRenderingContext2D,
-    timescale: TimeScale,
-    size: Size2D,
-  ) {
-    const selection = this.trace.selection.selection;
-    if (selection.kind === 'track_event' && selection.wakeupTs) {
-      drawVerticalLineAtTime(
-        ctx,
-        timescale,
-        selection.wakeupTs,
-        size.height,
-        `black`,
       );
     }
   }

--- a/ui/src/plugins/dev.perfetto.CpuSlices/common.ts
+++ b/ui/src/plugins/dev.perfetto.CpuSlices/common.ts
@@ -1,0 +1,18 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Helper function moved here as it's only used by the overlay.
+export function uriForSchedTrack(cpu: number): string {
+  return `/sched_cpu${cpu}`;
+}

--- a/ui/src/plugins/dev.perfetto.CpuSlices/common.ts
+++ b/ui/src/plugins/dev.perfetto.CpuSlices/common.ts
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+export const CPU_SLICE_URI_PREFIX = '/sched_cpu';
+
 // Helper function moved here as it's only used by the overlay.
 export function uriForSchedTrack(cpu: number): string {
-  return `/sched_cpu${cpu}`;
+  return `${CPU_SLICE_URI_PREFIX}${cpu}`;
 }

--- a/ui/src/plugins/dev.perfetto.CpuSlices/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuSlices/index.ts
@@ -74,7 +74,7 @@ export default class implements PerfettoPlugin {
       ctx.workspace.addChildInOrder(trackNode);
     }
 
-    ctx.tracks.registerTimelineOverlay(new WakerOverlay(ctx));
+    ctx.tracks.registerOverlay(new WakerOverlay(ctx));
   }
 
   async getAndroidCpuClusterTypes(

--- a/ui/src/plugins/dev.perfetto.CpuSlices/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuSlices/index.ts
@@ -12,21 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {CPU_SLICE_TRACK_KIND} from '../../public/track_kinds';
-import {Engine} from '../../trace_processor/engine';
-import {Trace} from '../../public/trace';
-import {PerfettoPlugin} from '../../public/plugin';
-import {NUM, STR_NULL} from '../../trace_processor/query_result';
-import {CpuSliceTrack} from './cpu_slice_track';
-import {TrackNode} from '../../public/workspace';
-import {CpuSliceSelectionAggregator} from './cpu_slice_selection_aggregator';
-import {CpuSliceByProcessSelectionAggregator} from './cpu_slice_by_process_selection_aggregator';
-import ThreadPlugin from '../dev.perfetto.Thread';
 import {createAggregationToTabAdaptor} from '../../components/aggregation_adapter';
-
-function uriForSchedTrack(cpu: number): string {
-  return `/sched_cpu${cpu}`;
-}
+import {PerfettoPlugin} from '../../public/plugin';
+import {Trace} from '../../public/trace';
+import {CPU_SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {TrackNode} from '../../public/workspace';
+import {Engine} from '../../trace_processor/engine';
+import {NUM, STR_NULL} from '../../trace_processor/query_result';
+import ThreadPlugin from '../dev.perfetto.Thread';
+import {uriForSchedTrack} from './common';
+import {CpuSliceByProcessSelectionAggregator} from './cpu_slice_by_process_selection_aggregator';
+import {CpuSliceSelectionAggregator} from './cpu_slice_selection_aggregator';
+import {CpuSliceTrack} from './cpu_slice_track';
+import {WakerOverlay} from './waker_overlay';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.CpuSlices';
@@ -75,6 +73,8 @@ export default class implements PerfettoPlugin {
       const trackNode = new TrackNode({uri, title: name, sortOrder: -50});
       ctx.workspace.addChildInOrder(trackNode);
     }
+
+    ctx.tracks.registerTimelineOverlay(new WakerOverlay(ctx));
   }
 
   async getAndroidCpuClusterTypes(

--- a/ui/src/plugins/dev.perfetto.CpuSlices/waker_overlay.ts
+++ b/ui/src/plugins/dev.perfetto.CpuSlices/waker_overlay.ts
@@ -26,14 +26,14 @@ import {
 } from '../../components/sql_utils/sched';
 import {Selection} from '../../public/selection';
 import {Trace} from '../../public/trace';
-import {TimelineOverlay, TrackBounds} from '../../public/track';
+import {Overlay, TrackBounds} from '../../public/track';
 import {uriForSchedTrack} from './common';
 
 const MARGIN = 3;
 const DIAMOND_SIZE = 8;
 const ARROW_HEIGHT = 12;
 
-export class WakerOverlay implements TimelineOverlay {
+export class WakerOverlay implements Overlay {
   private readonly limiter = new AsyncLimiter();
   private readonly trace: Trace;
 

--- a/ui/src/plugins/dev.perfetto.CpuSlices/waker_overlay.ts
+++ b/ui/src/plugins/dev.perfetto.CpuSlices/waker_overlay.ts
@@ -1,0 +1,222 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {AsyncLimiter} from '../../base/async_limiter';
+import {canvasSave, drawDoubleHeadedArrow} from '../../base/canvas_utils';
+import {Size2D} from '../../base/geom';
+import {Duration, time} from '../../base/time';
+import {TimeScale} from '../../base/time_scale';
+import {drawVerticalLineAtTime} from '../../base/vertical_line_helper';
+import {asSchedSqlId} from '../../components/sql_utils/core_types';
+import {
+  getSched,
+  getSchedWakeupInfo,
+  SchedWakeupInfo,
+} from '../../components/sql_utils/sched';
+import {Selection} from '../../public/selection';
+import {Trace} from '../../public/trace';
+import {TimelineOverlay, TrackBounds} from '../../public/track';
+import {uriForSchedTrack} from './common';
+
+const MARGIN = 3;
+const DIAMOND_SIZE = 8;
+const ARROW_HEIGHT = 12;
+
+export class WakerOverlay implements TimelineOverlay {
+  private readonly limiter = new AsyncLimiter();
+  private readonly trace: Trace;
+
+  private currentSelection: Selection | undefined;
+  private wakeup: SchedWakeupInfo | undefined;
+  private wakedTrackUri: string | undefined;
+  private wakedSliceTs: time | undefined;
+
+  constructor(trace: Trace) {
+    this.trace = trace;
+  }
+
+  render(
+    canvasCtx: CanvasRenderingContext2D,
+    timescale: TimeScale,
+    size: Size2D,
+    renderedTracks: ReadonlyArray<TrackBounds>,
+  ): void {
+    // Update wakeup info asynchronously if selection changed
+    this.limiter.schedule(async () => await this.updateWakeupInfoIfNeeded());
+
+    // If we don't have valid wakeup info, bail out
+    if (!this.wakeup?.wakeupTs) {
+      return;
+    }
+
+    // Draw the vertical line at the wakeup timestamp
+    this.drawWakeupLine(
+      canvasCtx,
+      timescale,
+      size.height,
+      this.wakeup.wakeupTs,
+    );
+
+    // Draw the marker on the waker CPU track
+    if (this.wakeup.wakerCpu !== undefined) {
+      this.drawWakerMarker(
+        canvasCtx,
+        timescale,
+        renderedTracks,
+        this.wakeup.wakeupTs,
+        this.wakeup.wakerCpu,
+      );
+    }
+
+    // Draw the latency arrow on the waked track
+    if (this.wakedTrackUri && this.wakedSliceTs) {
+      this.drawLatencyArrow(
+        canvasCtx,
+        timescale,
+        renderedTracks,
+        this.wakeup.wakeupTs,
+        this.wakedTrackUri,
+        this.wakedSliceTs,
+      );
+    }
+  }
+
+  private async updateWakeupInfoIfNeeded(): Promise<void> {
+    const selection = this.trace.selection.selection;
+    if (this.currentSelection === selection) {
+      return;
+    }
+
+    this.currentSelection = selection;
+    if (selection.kind === 'track_event') {
+      const sched = await getSched(
+        this.trace.engine,
+        asSchedSqlId(selection.eventId),
+      );
+      if (sched === undefined) {
+        this.wakeup = undefined;
+        this.wakedTrackUri = undefined;
+        this.wakedSliceTs = undefined;
+        return;
+      }
+      this.wakeup = await getSchedWakeupInfo(this.trace.engine, sched);
+      this.wakedTrackUri = selection.trackUri;
+      this.wakedSliceTs = selection.ts;
+    } else {
+      this.wakeup = undefined;
+      this.wakedTrackUri = undefined;
+      this.wakedSliceTs = undefined;
+    }
+  }
+
+  private drawWakeupLine(
+    canvasCtx: CanvasRenderingContext2D,
+    timescale: TimeScale,
+    height: number,
+    wakeupTs: time,
+  ): void {
+    drawVerticalLineAtTime(canvasCtx, timescale, wakeupTs, height, `black`);
+  }
+
+  private drawWakerMarker(
+    canvasCtx: CanvasRenderingContext2D,
+    timescale: TimeScale,
+    renderedTracks: ReadonlyArray<TrackBounds>,
+    wakeupTs: time,
+    wakerCpu: number,
+  ): void {
+    const wakerCpuTrackUri = uriForSchedTrack(wakerCpu);
+    const wakerTrack = renderedTracks.find(
+      (track) => wakerCpuTrackUri === track.node.uri,
+    );
+
+    if (!wakerTrack) return;
+
+    const bounds = wakerTrack.verticalBounds;
+    const trackHeight = bounds.bottom - bounds.top;
+    const rectHeight = trackHeight - 2 * MARGIN;
+    const wakeupPosPx = Math.floor(timescale.timeToPx(wakeupTs));
+
+    using _ = canvasSave(canvasCtx);
+    canvasCtx.translate(0, bounds.top);
+    canvasCtx.beginPath();
+    const yCenter = MARGIN + rectHeight / 2;
+    canvasCtx.moveTo(wakeupPosPx, yCenter + DIAMOND_SIZE);
+    canvasCtx.fillStyle = 'black';
+    canvasCtx.lineTo(wakeupPosPx + DIAMOND_SIZE * 0.75, yCenter);
+    canvasCtx.lineTo(wakeupPosPx, yCenter - DIAMOND_SIZE);
+    canvasCtx.lineTo(wakeupPosPx - DIAMOND_SIZE * 0.75, yCenter);
+    canvasCtx.fill();
+    canvasCtx.closePath();
+  }
+
+  private drawLatencyArrow(
+    canvasCtx: CanvasRenderingContext2D,
+    timescale: TimeScale,
+    renderedTracks: ReadonlyArray<TrackBounds>,
+    wakeupTs: time,
+    wakedTrackUri: string,
+    wakedSliceTs: time,
+  ): void {
+    const wakedTrack = renderedTracks.find(
+      (track) => wakedTrackUri === track.node.uri,
+    );
+
+    if (!wakedTrack) return;
+
+    const bounds = wakedTrack.verticalBounds;
+    const trackHeight = bounds.bottom - bounds.top;
+    const rectHeight = trackHeight - 2 * MARGIN;
+    const wakeupPosPx = timescale.timeToPx(wakeupTs);
+    const wakedSliceStartPx = timescale.timeToPx(wakedSliceTs);
+    const latencyWidthPx = wakedSliceStartPx - wakeupPosPx;
+
+    using _ = canvasSave(canvasCtx);
+    canvasCtx.translate(0, bounds.top);
+
+    // Draw the double-headed arrow
+    drawDoubleHeadedArrow(
+      canvasCtx,
+      wakeupPosPx,
+      MARGIN + rectHeight,
+      latencyWidthPx,
+      latencyWidthPx >= 20, // Only draw arrow heads if width is sufficient
+    );
+
+    // Draw latency text if space permits
+    const latency = wakedSliceTs - wakeupTs;
+    const displayText = Duration.humanise(latency);
+    const measured = canvasCtx.measureText(displayText);
+    if (latencyWidthPx >= measured.width + 2) {
+      const textX = wakeupPosPx + latencyWidthPx / 2;
+      const textY = MARGIN + rectHeight - 1;
+      const textBgY = MARGIN + rectHeight - ARROW_HEIGHT;
+
+      // Semi-transparent background for text
+      canvasCtx.fillStyle = 'rgba(255,255,255,0.7)';
+      canvasCtx.fillRect(
+        textX - measured.width / 2 - 1,
+        textBgY,
+        measured.width + 2,
+        ARROW_HEIGHT - 1, // Height adjusted to fit within arrow bounds
+      );
+
+      // Latency text
+      canvasCtx.textBaseline = 'bottom';
+      canvasCtx.fillStyle = 'black';
+      canvasCtx.textAlign = 'center';
+      canvasCtx.fillText(displayText, textX, textY);
+    }
+  }
+}

--- a/ui/src/public/selection.ts
+++ b/ui/src/public/selection.ts
@@ -209,8 +209,6 @@ export interface TrackEventDetails {
   // Optional additional information.
   // TODO(stevegolton): Find an elegant way of moving this information out of
   // the core.
-  readonly wakeupTs?: time;
-  readonly wakerCpu?: number;
   readonly utid?: number;
 }
 

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -56,6 +56,15 @@ export interface TrackManager {
    * power to the user compared to e.g. purely filtering by name.
    */
   registerTrackFilterCriteria(filter: TrackFilterCriteria): void;
+
+  /**
+   * Register a timeline overlay renderer.
+   *
+   * Overlays are rendered on top of all tracks in the timeline view and can be
+   * used to draw annotations that span multiple tracks, such as flow arrows or
+   * vertical lines marking specific events.
+   */
+  registerTimelineOverlay(overlay: TimelineOverlay): void;
 }
 
 export interface TrackContext {
@@ -307,4 +316,18 @@ export interface Slice {
   subTitle: string;
   colorScheme: ColorScheme;
   isHighlighted: boolean;
+}
+
+export interface TrackBounds {
+  readonly node: TrackNode;
+  readonly verticalBounds: VerticalBounds;
+}
+
+export interface TimelineOverlay {
+  render(
+    ctx: CanvasRenderingContext2D,
+    timescale: TimeScale,
+    size: Size2D,
+    renderedTracks: ReadonlyArray<TrackBounds>,
+  ): void;
 }

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -64,7 +64,7 @@ export interface TrackManager {
    * used to draw annotations that span multiple tracks, such as flow arrows or
    * vertical lines marking specific events.
    */
-  registerTimelineOverlay(overlay: TimelineOverlay): void;
+  registerOverlay(overlay: Overlay): void;
 }
 
 export interface TrackContext {
@@ -318,16 +318,19 @@ export interface Slice {
   isHighlighted: boolean;
 }
 
+/**
+ * Contains a track and it's top and bottom coordinates in the timeline.
+ */
 export interface TrackBounds {
   readonly node: TrackNode;
   readonly verticalBounds: VerticalBounds;
 }
 
-export interface TimelineOverlay {
+export interface Overlay {
   render(
     ctx: CanvasRenderingContext2D,
     timescale: TimeScale,
     size: Size2D,
-    renderedTracks: ReadonlyArray<TrackBounds>,
+    tracks: ReadonlyArray<TrackBounds>,
   ): void;
 }


### PR DESCRIPTION
This change adds the following:
- A new overlay rendering subsystem which allows plugisn to render an overlay on top of the timeline (on top of tracks other tracks).
- The CpuSlices plugin uses this new overlay rendering mechanism to to render the waker the waker information over the top of the timeline when CPU slices are selected.
  - This moves a lot of the custom waker information from the core into the plugin, tidying up the core a lot.
