### PR TITLE
Add "R" hotkey to create area selection from event selection

### DIFF
--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -307,7 +307,7 @@ export class UiMainPerTrace implements m.ClassComponent {
       },
       {
         id: 'perfetto.ConvertSelectionToArea',
-        name: 'Convert the current selection to an area selection',
+        name: 'Convert selection to area selection',
         callback: () => {
           const selection = trace.selection.selection;
           const range = trace.selection.findTimeRangeOfSelection();
@@ -319,8 +319,7 @@ export class UiMainPerTrace implements m.ClassComponent {
             });
           }
         },
-        // TODO(stevegolton): Decide on a sensible hotkey.
-        // defaultHotkey: 'L',
+        defaultHotkey: 'R',
       },
       {
         id: 'perfetto.ToggleDrawer',


### PR DESCRIPTION
This operation is actually what most people want when they use 'M' to create an annotation. They don't want to create an annotation at all, they just want to convert a the selected slice to an area selection so that they can perform aggregations over that time range.

'R' is a good choice for this hotkey because:
- You can press it with your left hand while mousing with your right (assuming right handed users using a QWERTY/AZERTY layout).
- It doesn't collide with the WASD key equivalents in DVORAK/AZERTY layout.
- It's one of the letters in the word 'aRea'.