### PR TITLE
Make dataframe::TypeSet constructor constexpr

### DIFF
--- a/src/trace_processor/dataframe/type_set.h
+++ b/src/trace_processor/dataframe/type_set.h
@@ -82,7 +82,7 @@ class TypeSet {
   TypeSet() = delete;
 
   template <typename T, typename = std::enable_if_t<Contains<T>()>>
-  TypeSet(T) : type_idx_(GetTypeIndex<T>()) {}
+  constexpr TypeSet(T) : type_idx_(GetTypeIndex<T>()) {}
 
   uint32_t index() const { return type_idx_; }
 


### PR DESCRIPTION
bytecode::SortedFilterBase::EstimateCost is constexpr and uses dataframe::TypeSet, which needs to have a constexpr constructor according to MSVC.
