### PR TITLE
tracing: Test when perfetto is not initialized

### DIFF
--- a/src/shared_lib/test/api_integrationtest.cc
+++ b/src/shared_lib/test/api_integrationtest.cc
@@ -1209,6 +1209,23 @@ TEST_F(SharedLibProducerTest, ActivateTriggers) {
                           StringField("trigger1"))))))))));
 }
 
+TEST(SharedLibNonInitializedTest, DataSourceTrace) {
+  EXPECT_FALSE(PERFETTO_ATOMIC_LOAD(data_source_1.enabled));
+
+  bool executed = false;
+
+  PERFETTO_DS_TRACE(data_source_1, ctx) {
+    executed = true;
+  }
+
+  EXPECT_FALSE(executed);
+}
+
+TEST(SharedLibNonInitializedTest, TeMacro) {
+  EXPECT_FALSE(std::atomic_load(cat1.enabled));
+  PERFETTO_TE(cat1, PERFETTO_TE_INSTANT(""));
+}
+
 class SharedLibTrackEventTest : public testing::Test {
  protected:
   void SetUp() override {

--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -7156,6 +7156,30 @@ TEST_F(ConcurrentSessionTest, DisallowMultipleSessionBasic) {
   EXPECT_THAT(slices3, ElementsAre("B:test.DrawGame3"));
 }
 
+TEST(PerfettoApiInitTest, NonInitializedThreadTrackCurrent) {
+  ASSERT_FALSE(perfetto::Tracing::IsInitialized());
+
+  auto PERFETTO_UNUSED track = perfetto::ThreadTrack::Current();
+}
+
+TEST(PerfettoApiInitTest, NonInitializedDataSourceTrace) {
+  ASSERT_FALSE(perfetto::Tracing::IsInitialized());
+
+  CustomDataSource::Trace([](CustomDataSource::TraceContext ctx) {
+    {
+      auto packet = ctx.NewTracePacket();
+      packet->set_for_testing()->set_str("CustomDataSource.Main");
+    }
+    ctx.Flush();
+  });
+}
+
+TEST(PerfettoApiInitTest, NonInitializedTraceEventMacro) {
+  ASSERT_FALSE(perfetto::Tracing::IsInitialized());
+
+  TRACE_EVENT("cat", "Foo");
+}
+
 TEST(PerfettoApiInitTest, DisableSystemConsumer) {
   g_test_tracing_policy->should_allow_consumer_connection = true;
 


### PR DESCRIPTION
Coverage for e2b0047c1e67("Fix null dereference in v8 (#1388)"). One of the tests was able to reproduce the bug when run with GCC.