### PR TITLE
Remove depth check for filtering frame slices.

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
@@ -45,16 +45,16 @@ WITH
       upid,
       ts
     FROM thread_slice
-    -- Mostly the frame slice is at depth 0. Though it could be pushed to depth 1 while users
-    -- enable low layer trace e.g. atrace_app.
     WHERE
-      name GLOB $glob_str AND depth IN (0, 1)
+      name GLOB $glob_str
   )
 SELECT
   *
 FROM all_found
--- Casting string to int returns 0 if the string can't be cast.
--- frame_id is -1 indicating an invalid vsync id
+-- Casting string to int returns 0 if the string can't be cast. This eliminates the Choreographer resynced slices
+-- with the format "Choreographer#doFrame - resynced to 1234 in 20.0ms". The stdlib table is to only list the top
+-- level Choreographer#doFrame slices, hence the 'resynced' slices are ignored.
+-- frame_id is -1 indicating an invalid vsync id.
 WHERE
   frame_id != 0 AND frame_id != -1;
 

--- a/test/trace_processor/diff_tests/metrics/graphics/android_doframe_depth.py
+++ b/test/trace_processor/diff_tests/metrics/graphics/android_doframe_depth.py
@@ -120,6 +120,7 @@ add_frame_from_depth(
     ts_end_do_frame=65_000_000,
     ts_draw_frame=65_00_000,
     ts_end_draw_frame=70_000_000,
+    resync=True,
     depth=2)
 
 add_frame_from_depth(

--- a/test/trace_processor/diff_tests/stdlib/android/frames_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/frames_tests.py
@@ -34,6 +34,8 @@ class Frames(TestSuite):
         "frame_id","name","depth"
         10,"Choreographer#doFrame 10",0
         11,"Choreographer#doFrame 11",1
+        12,"Choreographer#doFrame 12",4
+        13,"Choreographer#doFrame 13",3
         """))
 
   def test_android_frames_choreographer_do_frame(self):


### PR DESCRIPTION
Current depth check limits filtering Choreographer#doFrame slices to be at depth 0 and 1. There are cases where the frame slice can be at level 2(eg. b/413987043). The depth check was kept earlier to eliminate resynced slices. This check is not required as the current table logic eliminates these slices with the integer cast.

Bug: 413987043
Test: tools/diff_test_trace_processor.py --name-filter ".*frames.*" out/linux_clang_debug/trace_processor_shell

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
