### PR TITLE
Replace the deprecated onMessageRefresh with present

### DIFF
--- a/test/trace_processor/diff_tests/metrics/graphics/composer_execution.py
+++ b/test/trace_processor/diff_tests/metrics/graphics/composer_execution.py
@@ -30,7 +30,7 @@ trace.add_thread(15000, 10335, "worker thread")
 trace.add_ftrace_packet(1)
 
 # unskipped validation
-trace.add_atrace_begin(ts=100, tid=10335, pid=10335, buf="onMessageRefresh")
+trace.add_atrace_begin(ts=100, tid=10335, pid=10335, buf="CompositionEngine::present")
 trace.add_atrace_begin(
     ts=200, tid=10335, pid=10335, buf="HwcPresentOrValidateDisplay 0")
 trace.add_atrace_end(ts=300, tid=10335, pid=10335)
@@ -59,7 +59,7 @@ trace.add_atrace_end(ts=2_800, tid=10335, pid=10335)
 
 # skipped validation
 trace.add_atrace_begin(ts=3_100, tid=10335, pid=10335, buf="AnotherFunction")
-trace.add_atrace_begin(ts=3_200, tid=10335, pid=10335, buf="onMessageRefresh")
+trace.add_atrace_begin(ts=3_200, tid=10335, pid=10335, buf="CompositionEngine::present")
 trace.add_atrace_begin(
     ts=3_300, tid=10335, pid=10335, buf="HwcPresentOrValidateDisplay 0")
 trace.add_atrace_end(ts=3_400, tid=10335, pid=10335)


### PR DESCRIPTION
Remove the abandoned onMessageRefresh in old Android versions

In Android T and higher, the atrace event of SurfaceFlinger::onMessageRefresh() is indeed deprecated, so the logic of these test codes needs to be adjusted. If the test is only for Android T+, it is recommended to directly delete all onMessageRefresh related Trace events, because the function has been removed from the code base and its Trace events are no longer generated. In addition, the function of onMessageRefresh has been refactored and optimized in Android T, and its core logic has been integrated into the new process of CompositionEngine. It is recommended to replace onMessageRefresh here with the Trace event of the new function (such as CompositionEngine::present()).

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
