### PR TITLE
Add support for dimension spec in metrics v2

### DIFF
--- a/protos/perfetto/trace_summary/v2_metric.proto
+++ b/protos/perfetto/trace_summary/v2_metric.proto
@@ -38,10 +38,7 @@ import "protos/perfetto/perfetto_sql/structured_query.proto";
 //
 // ```
 // id: "memory_per_process"
-// dimensions_specs: {
-//   name: "process_name"
-//   type: STRING
-// }
+// dimensions: "process_name"
 // value: "avg_rss_and_swap"
 // query: {
 //   table: {
@@ -69,14 +66,8 @@ import "protos/perfetto/perfetto_sql/structured_query.proto";
 //
 // ```
 // id: "memory_per_process_and_cuj"
-// dimensions_specs: {
-//  name: "process_name"
-//  type: STRING
-//}
-// dimensions_specs: {
-//  name: "cuj_name"
-//  type: STRING
-//}//
+// dimensions: "process_name"
+// dimensions: "cuj_name"
 // value: "avg_rss_and_swap"
 // query: {
 //   interval_intersect: {

--- a/protos/perfetto/trace_summary/v2_metric.proto
+++ b/protos/perfetto/trace_summary/v2_metric.proto
@@ -158,11 +158,14 @@ message TraceMetricV2Spec {
 
   message DimensionSpec {
     optional string name = 1;
+    // The type of the dimension. Must be specified.
     optional DimensionType type = 2;
   }
   // The columns from `query` which will act as the "dimensions" for the metric.
   // For a given set of dimensions, there must be exactly *one* value emitted.
   // Optional.
+  // If the `dimensions_specs` field is defined, then the type of each
+  // dimension must be specified.
   repeated DimensionSpec dimensions_specs = 5;
   // Either dimensions or dimensions_specs should be defined, but not both.
   repeated string dimensions = 2;

--- a/protos/perfetto/trace_summary/v2_metric.proto
+++ b/protos/perfetto/trace_summary/v2_metric.proto
@@ -38,7 +38,10 @@ import "protos/perfetto/perfetto_sql/structured_query.proto";
 //
 // ```
 // id: "memory_per_process"
-// dimensions: "process_name"
+// dimensions_specs: {
+//   name: "process_name"
+//   type: STRING
+// }
 // value: "avg_rss_and_swap"
 // query: {
 //   table: {
@@ -66,7 +69,14 @@ import "protos/perfetto/perfetto_sql/structured_query.proto";
 //
 // ```
 // id: "memory_per_process_and_cuj"
-// dimensions: "process_name"
+// dimensions_specs: {
+//  name: "process_name"
+//  type: STRING
+//}
+// dimensions_specs: {
+//  name: "cuj_name"
+//  type: STRING
+//}//
 // value: "avg_rss_and_swap"
 // query: {
 //   interval_intersect: {
@@ -148,10 +158,23 @@ message TraceMetricV2Spec {
   // Required.
   optional string id = 1;
 
+  enum DimensionType {
+    DIMENSION_TYPE_UNSPECIFIED = 0;
+    STRING = 1;
+    INT64 = 2;
+    DOUBLE = 3;
+  }
+
+  message DimensionSpec {
+    optional string name = 1;
+    optional DimensionType type = 2;
+  }
   // The columns from `query` which will act as the "dimensions" for the metric.
   // For a given set of dimensions, there must be exactly *one* value emitted.
   // Optional.
-  repeated string dimensions = 2;
+  repeated DimensionSpec dimensions_specs = 5;
+  // Deprecated, use dimensions_specs instead.
+  repeated string dimensions = 2 [deprecated = true];
 
   // The column from `query` which will act as the "value" for the metric. This
   // must be a column containing only integers/doubles/nulls. Strings are *not*
@@ -230,6 +253,9 @@ message TraceMetricV2 {
     // The dimensions that `value` should be associated with. The order of
     // dimensions matches precisely the order of dimension names given by the
     // `spec`.
+    // The type of the dimension is infered from the sql column type.
+    // In case dimensionSpec is specified, the dimension type must match the
+    // type specified in the spec.
     message Dimension {
       message Null {}
       oneof value_oneof {

--- a/protos/perfetto/trace_summary/v2_metric.proto
+++ b/protos/perfetto/trace_summary/v2_metric.proto
@@ -173,8 +173,8 @@ message TraceMetricV2Spec {
   // For a given set of dimensions, there must be exactly *one* value emitted.
   // Optional.
   repeated DimensionSpec dimensions_specs = 5;
-  // Deprecated, use dimensions_specs instead.
-  repeated string dimensions = 2 [deprecated = true];
+  // Either dimensions or dimensions_specs should be defined, but not both.
+  repeated string dimensions = 2;
 
   // The column from `query` which will act as the "value" for the metric. This
   // must be a column containing only integers/doubles/nulls. Strings are *not*

--- a/src/trace_processor/trace_summary/summary.cc
+++ b/src/trace_processor/trace_summary/summary.cc
@@ -125,13 +125,14 @@ base::Status CreateQueriesAndComputeMetrics(
     protos::pbzero::TraceMetricV2Spec::Decoder spec_decoder(m.value().spec);
 
     uint32_t col_count = it.ColumnCount();
-    base::FlatHashMap<std::string, uint32_t> column_name_to_index;
-    for (uint32_t i = 0; i < col_count; ++i) {
-      column_name_to_index.Insert(it.GetColumnName(i), i);
-    }
     std::string metric_value_column_name = spec_decoder.value().ToStdString();
-    auto* metric_value_index =
-        column_name_to_index.Find(metric_value_column_name);
+    std::optional<uint32_t> metric_value_index;
+    for (uint32_t i = 0; i < col_count; ++i) {
+      if (it.GetColumnName(i) == metric_value_column_name) {
+        metric_value_index = i;
+        break;
+      }
+    }
     if (!metric_value_index) {
       return base::ErrStatus(
           "Column %s not found in the query result for metric %s",
@@ -139,16 +140,53 @@ base::Status CreateQueriesAndComputeMetrics(
     }
 
     std::vector<protos::pbzero::TraceMetricV2Spec::DimensionSpec::Decoder>
-        dimension_specs;
-    for (auto dim_spec_it = spec_decoder.dimensions_specs(); dim_spec_it;
-         ++dim_spec_it) {
-      dimension_specs.emplace_back(*dim_spec_it);
-    }
-    if (dimension_specs.size() > 0 && spec_decoder.dimensions()) {
+        all_dimensions;
+    if (spec_decoder.dimensions_specs() && spec_decoder.dimensions()) {
       return base::ErrStatus(
           "Both dimensions and dimension_specs defined for metric %s. Only one "
           "is allowed",
           metric_name.c_str());
+    }
+    for (auto dim_spec_it = spec_decoder.dimensions_specs(); dim_spec_it;
+         ++dim_spec_it) {
+      protos::pbzero::TraceMetricV2Spec::DimensionSpec::Decoder dim_spec(
+          *dim_spec_it);
+      std::string dim_name = dim_spec.name().ToStdString();
+      protos::pbzero::TraceMetricV2Spec::DimensionType dimension_type =
+          static_cast<protos::pbzero::TraceMetricV2Spec::DimensionType>(
+              dim_spec.type());
+      if (dimension_type ==
+          protos::pbzero::TraceMetricV2Spec::DIMENSION_TYPE_UNSPECIFIED) {
+        return base::ErrStatus("Dimension %s in metric %s has unspecified type",
+                               dim_name.c_str(), metric_name.c_str());
+      }
+      all_dimensions.emplace_back(*dim_spec_it);
+    }
+    for (auto dim_name_it = spec_decoder.dimensions(); dim_name_it;
+         ++dim_name_it) {
+      protozero::HeapBuffered<protos::pbzero::TraceMetricV2Spec::DimensionSpec>
+          dim_spec_no_type;
+      dim_spec_no_type->set_name(dim_name_it->as_std_string());
+      all_dimensions.emplace_back(dim_spec_no_type.SerializeAsArray().data(),
+                                  dim_spec_no_type.SerializeAsArray().size());
+    }
+
+    std::vector<uint32_t> dimension_column_indices;
+    for (const auto& dim_spec : all_dimensions) {
+      std::string dim_name = dim_spec.name().ToStdString();
+      std::optional<uint32_t> dim_index;
+      for (uint32_t i = 0; i < col_count; ++i) {
+        if (it.GetColumnName(i) == dim_name) {
+          dim_index = i;
+          break;
+        }
+      }
+      if (!dim_index) {
+        return base::ErrStatus(
+            "Column %s not found in the query result for metric %s",
+            dim_name.c_str(), metric_name.c_str());
+      }
+      dimension_column_indices.push_back(*dim_index);
     }
 
     while (it.Next()) {
@@ -182,97 +220,63 @@ base::Status CreateQueriesAndComputeMetrics(
               metric_name.c_str());
       }
 
-      if (dimension_specs.empty()) {
-        // Dimensions are defined without an explicit type
-        // Infer the type from the sql value.
-        for (auto dim_name_it = spec_decoder.dimensions(); dim_name_it;
-             ++dim_name_it) {
-          protos::pbzero::TraceMetricV2::MetricRow::Dimension* dimension =
-              row->add_dimension();
-          auto* dim_index =
-              column_name_to_index.Find(dim_name_it->as_std_string());
-          if (!dim_index) {
-            return base::ErrStatus(
-                "Column %s not found in the query result for metric %s",
-                dim_name_it->as_std_string().c_str(), metric_name.c_str());
-          }
-          const auto& dimension_value = it.Get(*dim_index);
-          switch (dimension_value.type) {
-            case SqlValue::kNull:
+      // Read dimensions.
+      for (size_t i = 0; i < all_dimensions.size(); ++i) {
+        protos::pbzero::TraceMetricV2::MetricRow::Dimension* dimension =
+            row->add_dimension();
+
+        uint32_t dim_column_index = dimension_column_indices[i];
+        const auto& dimension_value = it.Get(dim_column_index);
+        if (dimension_value.is_null()) {
+          // Accept null value for all dimension types.
+          dimension->set_null_value();
+          continue;
+        }
+
+        protos::pbzero::TraceMetricV2Spec::DimensionType dimension_type =
+            static_cast<protos::pbzero::TraceMetricV2Spec::DimensionType>(
+                all_dimensions[i].type());
+        switch (dimension_type) {
+          case protos::pbzero::TraceMetricV2Spec::STRING:
+            if (dimension_value.type != SqlValue::kString) {
+              return base::ErrStatus(
+                  "Expected string for dimension %zu in metric %s, got %d", i,
+                  metric_name.c_str(), dimension_value.type);
+            }
+            dimension->set_string_value(dimension_value.AsString());
+            break;
+          case protos::pbzero::TraceMetricV2Spec::INT64:
+            if (dimension_value.type != SqlValue::kLong) {
+              return base::ErrStatus(
+                  "Expected int64 for dimension %zu in metric %s, got %d", i,
+                  metric_name.c_str(), dimension_value.type);
+            }
+            dimension->set_int64_value(dimension_value.AsLong());
+            break;
+          case protos::pbzero::TraceMetricV2Spec::DOUBLE:
+            if (dimension_value.type != SqlValue::kDouble) {
+              return base::ErrStatus(
+                  "Expected double for dimension %zu in metric %s, got %d", i,
+                  metric_name.c_str(), dimension_value.type);
+            }
+            dimension->set_double_value(dimension_value.AsDouble());
+            break;
+          case protos::pbzero::TraceMetricV2Spec::DIMENSION_TYPE_UNSPECIFIED:
+            if (dimension_value.type == SqlValue::kNull) {
               dimension->set_null_value();
-              break;
-            case SqlValue::kLong:
+            } else if (dimension_value.type == SqlValue::kLong) {
               dimension->set_int64_value(dimension_value.AsLong());
-              break;
-            case SqlValue::kDouble:
+            } else if (dimension_value.type == SqlValue::kDouble) {
               dimension->set_double_value(dimension_value.AsDouble());
-              break;
-            case SqlValue::kString:
+            } else if (dimension_value.type == SqlValue::kString) {
               dimension->set_string_value(dimension_value.AsString());
-              break;
-            case SqlValue::kBytes:
+            } else if (dimension_value.type == SqlValue::kBytes) {
               return base::ErrStatus(
                   "Received bytes for dimension in metric %s: this is not "
                   "supported",
                   metric_name.c_str());
-          }
-        }
-      } else {
-        for (uint32_t i = 0; i < dimension_specs.size(); ++i) {
-          protos::pbzero::TraceMetricV2::MetricRow::Dimension* dimension =
-              row->add_dimension();
-
-          const auto& dim_spec = dimension_specs[i];
-          std::string dim_name = dim_spec.name().ToStdString();
-          protos::pbzero::TraceMetricV2Spec::DimensionType dimension_type =
-              static_cast<protos::pbzero::TraceMetricV2Spec::DimensionType>(
-                  dim_spec.type());
-
-          auto* dim_index = column_name_to_index.Find(dim_name);
-          if (!dim_index) {
-            return base::ErrStatus(
-                "Column %s not found in the query result for metric %s",
-                dim_name.c_str(), metric_name.c_str());
-          }
-          const auto& dimension_value = it.Get(*dim_index);
-          if (dimension_value.is_null()) {
-            // Accept null value for all dimension types.
-            dimension->set_null_value();
-            continue;
-          }
-          switch (dimension_type) {
-            case protos::pbzero::TraceMetricV2Spec::STRING:
-              if (dimension_value.type != SqlValue::kString) {
-                return base::ErrStatus(
-                    "Expected string for dimension %s in metric %s, got %d",
-                    dim_name.c_str(), metric_name.c_str(),
-                    dimension_value.type);
-              }
-              dimension->set_string_value(dimension_value.AsString());
-              break;
-            case protos::pbzero::TraceMetricV2Spec::INT64:
-              if (dimension_value.type != SqlValue::kLong) {
-                return base::ErrStatus(
-                    "Expected int64 for dimension %s in metric %s, got %d",
-                    dim_name.c_str(), metric_name.c_str(),
-                    dimension_value.type);
-              }
-              dimension->set_int64_value(dimension_value.AsLong());
-              break;
-            case protos::pbzero::TraceMetricV2Spec::DOUBLE:
-              if (dimension_value.type != SqlValue::kDouble) {
-                return base::ErrStatus(
-                    "Expected double for dimension %s in metric %s, got %d",
-                    dim_name.c_str(), metric_name.c_str(),
-                    dimension_value.type);
-              }
-              dimension->set_double_value(dimension_value.AsDouble());
-              break;
-            case protos::pbzero::TraceMetricV2Spec::DIMENSION_TYPE_UNSPECIFIED:
-              return base::ErrStatus(
-                  "Unsupported dimension type %d for dimension %s in metric %s",
-                  dimension_type, dim_name.c_str(), metric_name.c_str());
-          }
+            }
+            break;
         }
       }
     }

--- a/src/trace_processor/trace_summary/summary.cc
+++ b/src/trace_processor/trace_summary/summary.cc
@@ -138,7 +138,7 @@ base::Status CreateQueriesAndComputeMetrics(
           metric_value_column_name.c_str(), metric_name.c_str());
     }
 
-    if (spec_decoder.dimensions_specs() && spec_decoder.dimensions()) {
+    if (spec_decoder.has_dimensions_specs() && spec_decoder.has_dimensions()) {
       return base::ErrStatus(
           "Both dimensions and dimension_specs defined for metric %s. Only one "
           "is allowed",

--- a/test/trace_processor/diff_tests/summary/metrics_v2_tests.py
+++ b/test/trace_processor/diff_tests/summary/metrics_v2_tests.py
@@ -44,3 +44,47 @@ class SummaryMetricsV2(TestSuite):
           }
         '''),
         out=Path('smoke_metric_v2.out'))
+
+  def test_simple_slices_metric_v2(self):
+    return DiffTestBlueprint(
+        trace=Path('synth_simple_slices.py'),
+        # Test reading dimensions in correct order
+        # Dimensions are intentionally defined in different order from the query
+        # Metric is defined to not be the last column in the query
+        query=MetricV2SpecTextproto('''
+              id: "max_duration"
+              dimensions_specs {
+                name: "thread_name"
+                type: STRING
+              }
+              dimensions_specs {
+                name: "slice_name"
+                type: STRING
+              }
+              value: "max_dur"
+              query {
+                simple_slices {
+                  slice_name_glob: "*"
+                }
+                group_by {
+                  column_names: "slice_name"
+                  column_names: "thread_name"
+                  aggregates {
+                    column_name: "dur"
+                    op: COUNT
+                    result_column_name: "count_dur"
+                  }
+                  aggregates {
+                    column_name: "dur"
+                    op: MAX
+                    result_column_name: "max_dur"
+                  }
+                  aggregates {
+                    column_name: "dur"
+                    op: SUM
+                    result_column_name: "sum_dur"
+                  }
+                }
+              }
+        '''),
+        out=Path('simple_slices_metric_v2.out'))

--- a/test/trace_processor/diff_tests/summary/simple_slices_metric_v2.out
+++ b/test/trace_processor/diff_tests/summary/simple_slices_metric_v2.out
@@ -1,0 +1,63 @@
+row {
+    value: 100.0
+    dimension {
+        null_value {}
+    }
+    dimension {
+        string_value: "ProcessSliceNoThread"
+    }
+}
+row {
+    value: 301.0
+    dimension {
+        string_value: "Thread"
+    }
+    dimension {
+        string_value: "ThreadSlice1"
+    }
+}
+row {
+    value: 199.0
+    dimension {
+        string_value: "Thread"
+    }
+    dimension {
+        string_value: "ThreadSlice2"
+    }
+}
+spec {
+    id: "max_duration"
+    value: "max_dur"
+    query {
+        simple_slices {
+            slice_name_glob: "*"
+        }
+        group_by {
+            column_names: "slice_name"
+            column_names: "thread_name"
+            aggregates {
+                column_name: "dur"
+                op: COUNT
+                result_column_name: "count_dur"
+            }
+            aggregates {
+                column_name: "dur"
+                op: MAX
+                result_column_name: "max_dur"
+            }
+            aggregates {
+                column_name: "dur"
+                op: SUM
+                result_column_name: "sum_dur"
+            }
+        }
+    }
+    dimensions_specs {
+        name: "thread_name"
+        type: STRING
+    }
+    dimensions_specs {
+        name: "slice_name"
+        type: STRING
+    }
+}

--- a/test/trace_processor/diff_tests/summary/synth_simple_slices.py
+++ b/test/trace_processor/diff_tests/summary/synth_simple_slices.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License a
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import sys
+
+import synth_common
+
+from synth_common import ms_to_ns
+
+trace = synth_common.create_trace()
+
+process_track = 1
+pid = 2
+thread_track = 3
+tid = 4
+
+trace.add_process_track_descriptor(
+    process_track, pid=pid, process_name="Process")
+trace.add_thread_track_descriptor(
+    process_track, thread_track, tid=tid, pid=pid, thread_name="Thread")
+
+trace.add_track_event_slice(
+    "ProcessSliceNoThread", ts=3, dur=100, track=process_track)
+trace.add_track_event_slice("ThreadSlice1", ts=5, dur=200, track=thread_track)
+trace.add_track_event_slice("ThreadSlice2", ts=6, dur=300, track=thread_track)
+
+trace.add_track_event_slice(
+    "ProcessSliceNoThread", ts=33, dur=10, track=process_track)
+trace.add_track_event_slice("ThreadSlice1", ts=35, dur=10, track=thread_track)
+trace.add_track_event_slice("ThreadSlice2", ts=36, dur=10, track=thread_track)
+
+sys.stdout.buffer.write(trace.trace.SerializeToString())


### PR DESCRIPTION
Add support for dimension spec in metrics v2

* Explicitly specify the expected type of the dimension in the metrics v2 output
* Accept null for all dimension types
* Continue supporting dimensions without explicit types being specified 
*  Read columns based on spec dimension/metric column names not based on order to 
    * Fix bug on wrong output produced in the case different dimension order between the query and the spec
     * Fix bug on wrong metric value emitted, incase of the metric column is not the last
* Add test for simple_slices in metrics v2

Bug: 415966029
Test: `tools/ninja -C out/linux_clang_debug  && tools/diff_test_trace_processor.py  out/linux_clang_debug/trace_processor_shell --name-filter=".*SummaryMetricsV2.*"`