### PR TITLE
Export 'android_track_event' proto as a separate target in BUILD and Android.bp.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16082,6 +16082,45 @@ filegroup {
     ],
 }
 
+// GN: [//protos/perfetto/trace/android:android_track_event_source_set]
+java_library {
+    name: "perfetto_trace_android_track_event_extension_java_protos",
+    srcs: [
+        "protos/perfetto/trace/android/android_track_event.proto",
+        "protos/perfetto/trace/track_event/chrome_active_processes.proto",
+        "protos/perfetto/trace/track_event/chrome_application_state_info.proto",
+        "protos/perfetto/trace/track_event/chrome_compositor_scheduler_state.proto",
+        "protos/perfetto/trace/track_event/chrome_content_settings_event_info.proto",
+        "protos/perfetto/trace/track_event/chrome_frame_reporter.proto",
+        "protos/perfetto/trace/track_event/chrome_histogram_sample.proto",
+        "protos/perfetto/trace/track_event/chrome_keyed_service.proto",
+        "protos/perfetto/trace/track_event/chrome_latency_info.proto",
+        "protos/perfetto/trace/track_event/chrome_legacy_ipc.proto",
+        "protos/perfetto/trace/track_event/chrome_message_pump.proto",
+        "protos/perfetto/trace/track_event/chrome_mojo_event_info.proto",
+        "protos/perfetto/trace/track_event/chrome_process_descriptor.proto",
+        "protos/perfetto/trace/track_event/chrome_renderer_scheduler_state.proto",
+        "protos/perfetto/trace/track_event/chrome_thread_descriptor.proto",
+        "protos/perfetto/trace/track_event/chrome_user_event.proto",
+        "protos/perfetto/trace/track_event/chrome_window_handle_event_info.proto",
+        "protos/perfetto/trace/track_event/counter_descriptor.proto",
+        "protos/perfetto/trace/track_event/debug_annotation.proto",
+        "protos/perfetto/trace/track_event/log_message.proto",
+        "protos/perfetto/trace/track_event/process_descriptor.proto",
+        "protos/perfetto/trace/track_event/range_of_interest.proto",
+        "protos/perfetto/trace/track_event/screenshot.proto",
+        "protos/perfetto/trace/track_event/source_location.proto",
+        "protos/perfetto/trace/track_event/task_execution.proto",
+        "protos/perfetto/trace/track_event/thread_descriptor.proto",
+        "protos/perfetto/trace/track_event/track_descriptor.proto",
+        "protos/perfetto/trace/track_event/track_event.proto",
+    ],
+    proto: {
+        type: "lite",
+        canonical_path_from_root: false,
+    },
+}
+
 // GN: //src/android_sdk/java/test:perfetto_trace_instrumentation_test
 android_test {
     name: "perfetto_trace_instrumentation_test",

--- a/BUILD
+++ b/BUILD
@@ -4532,6 +4532,7 @@ perfetto_android_library(
     manifest = "src/android_sdk/java/test/AndroidTestManifest.xml",
     deps = [
         ":src_android_sdk_java_main_perfetto_trace_lib",
+        ":trace_android_track_event_extension_java_proto_lite",
         ":trace_java_proto_lite",
     ] + PERFETTO_CONFIG.deps.android_test_common,
     tags = [
@@ -5093,6 +5094,47 @@ perfetto_py_proto_library(
     ],
     deps = [
         ":trace_summary_proto",
+    ],
+)
+
+# GN target: [//protos/perfetto/trace/android:android_track_event_source_set]
+perfetto_proto_library(
+    name = "trace_android_track_event_extension_proto",
+    deps = [
+        ":protos_perfetto_trace_android_android_track_event_protos",
+        ":protos_perfetto_trace_track_event_protos",
+    ],
+)
+
+# GN target: [//protos/perfetto/trace/android:android_track_event_source_set]
+perfetto_cc_proto_library(
+    name = "trace_android_track_event_extension_cc_proto",
+    deps = [
+        ":trace_android_track_event_extension_proto",
+    ],
+)
+
+# GN target: [//protos/perfetto/trace/android:android_track_event_source_set]
+perfetto_java_proto_library(
+    name = "trace_android_track_event_extension_java_proto",
+    deps = [
+        ":trace_android_track_event_extension_proto",
+    ],
+)
+
+# GN target: [//protos/perfetto/trace/android:android_track_event_source_set]
+perfetto_java_lite_proto_library(
+    name = "trace_android_track_event_extension_java_proto_lite",
+    deps = [
+        ":trace_android_track_event_extension_proto",
+    ],
+)
+
+# GN target: [//protos/perfetto/trace/android:android_track_event_source_set]
+perfetto_py_proto_library(
+    name = "trace_android_track_event_extension_py_pb2",
+    deps = [
+        ":trace_android_track_event_extension_proto",
     ],
 )
 

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -163,6 +163,12 @@ proto_groups = {
     'trace_summary': {
         'types': ['filegroup'],
         'targets': ['//protos/perfetto/trace_summary:source_set',]
+    },
+    'trace_android_track_event_extension': {
+        'types': ['lite'],
+        'targets': [
+            '//protos/perfetto/trace/android:android_track_event_source_set',
+        ]
     }
 }
 

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -156,6 +156,12 @@ proto_groups = {
         'sources': ['//protos/perfetto/trace_summary:source_set',],
         'visibility': ['//visibility:public'],
     },
+    'trace_android_track_event_extension': {
+        'sources': [
+            '//protos/perfetto/trace/android:android_track_event_source_set',
+        ],
+        'visibility': [],
+    }
 }
 
 # Path for the protobuf sources in the standalone build.
@@ -218,7 +224,8 @@ external_java_android_sdk_deps: Dict[str, List[str]] = {
 # Map from GN targets to the list of Bazel deps labels
 additional_java_android_sdk_deps: Dict[str, List[str]] = {
     '//src/android_sdk/java/test:perfetto_trace_test_lib': [
-        ':trace_java_proto_lite'
+        ':trace_java_proto_lite',
+        ':trace_android_track_event_extension_java_proto_lite',
     ],
 }
 


### PR DESCRIPTION
We need this to parse an 'AndroidMessageQueue' proto event in tests.
