### PR TITLE
tp: optimize min_ts_per_track query

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/viz/summary/track_event.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/summary/track_event.sql
@@ -43,6 +43,8 @@ SELECT
   track_id AS id,
   min(ts) AS min_ts
 FROM counter
+JOIN _track_event_tracks_unordered AS t
+  ON counter.track_id = t.id
 GROUP BY
   track_id
 UNION ALL
@@ -50,6 +52,8 @@ SELECT
   track_id AS id,
   min(ts) AS min_ts
 FROM slice
+JOIN _track_event_tracks_unordered AS t
+  ON slice.track_id = t.id
 GROUP BY
   track_id;
 


### PR DESCRIPTION
Optimize the min_ts_per_track query for tracks with large numbers of samples by limiting the results of the query to only contain timestamps for track event tracks and not power rail tracks.

This query change is essentially @LalitMaganti's suggestion from https://github.com/google/perfetto/issues/1323 with some minor formatting fixes.

Testing:
- Validate example Android and Chrome trace open (there is a very minor ~20 ms perf penalty from on loading these traces)
- Validate that power rail trace from https://github.com/google/perfetto/issues/1323 now shows negligible time spent loading plugins (now much less than 1 sec, previously ~10 sec)

Bug: https://github.com/google/perfetto/issues/1323

