### PR TITLE
Fix crash in heap profile auto-selection at trace load time

### DIFF
--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -394,12 +394,25 @@ export class SelectionManagerImpl implements SelectionManager {
     opts?: SelectionOpts,
     serializedDetailsPanel?: unknown,
   ) {
-    const details = await this.trackManager
-      .getTrack(trackUri)
-      ?.track.getSelectionDetails?.(eventId);
+    const track = this.trackManager.getTrack(trackUri);
+    if (!track) {
+      throw new Error(
+        `Unable to resolve selection details: Track ${trackUri} not found`,
+      );
+    }
 
+    const trackRenderer = track.track;
+    if (!trackRenderer.getSelectionDetails) {
+      throw new Error(
+        `Unable to resolve selection details: Track ${trackUri} does not support selection details`,
+      );
+    }
+
+    const details = await trackRenderer.getSelectionDetails(eventId);
     if (!exists(details)) {
-      throw new Error('Unable to resolve selection details');
+      throw new Error(
+        `Unable to resolve selection details: Track ${trackUri} returned no details for event ${eventId}`,
+      );
     }
 
     const selection: TrackEventSelection = {

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -39,6 +39,10 @@ export function createHeapProfileTrack(
         type: STR,
         id: NUM,
       },
+      filter: {
+        col: 'upid',
+        eq: upid,
+      },
     }),
     detailsPanel: (row) => {
       const ts = Time.fromRaw(row.ts);

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -15,91 +15,74 @@
 import {HEAP_PROFILE_TRACK_KIND} from '../../public/track_kinds';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
-import {LONG, NUM} from '../../trace_processor/query_result';
+import {NUM} from '../../trace_processor/query_result';
 import {createHeapProfileTrack} from './heap_profile_track';
 import {TrackNode} from '../../public/workspace';
 import {createPerfettoTable} from '../../trace_processor/sql_utils';
 import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
 import {Track} from '../../public/track';
 
-function getUriForTrack(upid: number): string {
-  return `/process_${upid}/heap_profile`;
-}
-
-interface TrackReference {
-  readonly tableName: string;
-  readonly track: Track;
-}
+const EVENT_TABLE_NAME = 'heap_profile_events';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.HeapProfile';
   static readonly dependencies = [ProcessThreadGroupsPlugin];
 
-  private readonly tracks: TrackReference[] = [];
+  private readonly trackMap = new Map<number, Track>();
 
   async onTraceLoad(trace: Trace): Promise<void> {
+    await this.createHeapProfileTable(trace);
+    await this.addProcessTracks(trace);
+
+    trace.onTraceReady.addListener(async () => {
+      await this.selectFirstHeapProfile(trace);
+    });
+  }
+
+  private async createHeapProfileTable(trace: Trace) {
+    await createPerfettoTable(
+      trace.engine,
+      EVENT_TABLE_NAME,
+      `
+        SELECT
+          MIN(id) as id,
+          graph_sample_ts AS ts,
+          upid,
+          0 AS dur,
+          0 AS depth,
+          'graph' AS type
+        FROM heap_graph_object
+        GROUP BY graph_sample_ts, upid
+
+        UNION ALL
+
+        SELECT
+          MIN(id) as id,
+          ts,
+          upid,
+          0 AS dur,
+          0 AS depth,
+          'heap_profile:' || GROUP_CONCAT(DISTINCT heap_name) AS type
+        FROM heap_profile_allocation
+        GROUP BY ts, upid
+      `,
+    );
+  }
+
+  private async addProcessTracks(trace: Trace) {
+    const trackGroupsPlugin = trace.plugins.getPlugin(
+      ProcessThreadGroupsPlugin,
+    );
     const incomplete = await this.getIncomplete(trace);
-    const upids = await this.getUniqueUpids(trace);
-
-    for (const upid of upids) {
-      const uri = getUriForTrack(upid);
+    const result = await trace.engine.query(`
+      SELECT DISTINCT 
+        upid
+      FROM ${EVENT_TABLE_NAME}
+    `);
+    for (const it = result.iter({upid: NUM}); it.valid(); it.next()) {
+      const upid = it.upid;
+      const uri = `/process_${upid}/heap_profile`;
       const title = 'Heap Profile';
-      const tableName = `_heap_profile_${upid}`;
-
-      createPerfettoTable(
-        trace.engine,
-        tableName,
-        `
-          WITH
-            heaps AS (
-              SELECT
-                group_concat(DISTINCT heap_name) AS h
-              FROM heap_profile_allocation
-              WHERE upid = ${upid}
-            ),
-            allocation_tses AS (
-              SELECT DISTINCT
-                ts
-              FROM heap_profile_allocation
-              WHERE upid = ${upid}
-            ),
-            graph_tses AS (
-              SELECT DISTINCT
-                graph_sample_ts
-              FROM heap_graph_object
-              WHERE upid = ${upid}
-            )
-          SELECT
-            *,
-            0 AS dur,
-            0 AS depth
-          FROM (
-            SELECT
-              (
-                SELECT a.id
-                FROM heap_profile_allocation a
-                WHERE a.ts = t.ts
-                ORDER BY a.id
-                LIMIT 1
-              ) AS id,
-              ts,
-              'heap_profile:' || (SELECT h FROM heaps) AS type
-            FROM allocation_tses t
-            UNION ALL
-            SELECT
-              (
-                SELECT o.id
-                FROM heap_graph_object o
-                WHERE o.graph_sample_ts = g.graph_sample_ts
-                ORDER BY o.id
-                LIMIT 1
-              ) AS id,
-              graph_sample_ts AS ts,
-              'graph' AS type
-            FROM graph_tses g
-          )
-        `,
-      );
 
       const track: Track = {
         uri,
@@ -108,71 +91,51 @@ export default class implements PerfettoPlugin {
           kind: HEAP_PROFILE_TRACK_KIND,
           upid,
         },
-        track: createHeapProfileTrack(trace, uri, tableName, upid, incomplete),
+        track: createHeapProfileTrack(
+          trace,
+          uri,
+          EVENT_TABLE_NAME,
+          upid,
+          incomplete,
+        ),
       };
 
-      this.tracks.push({tableName, track});
       trace.tracks.registerTrack(track);
+      this.trackMap.set(upid, track);
 
-      const group = trace.plugins
-        .getPlugin(ProcessThreadGroupsPlugin)
-        .getGroupForProcess(upid);
+      const group = trackGroupsPlugin.getGroupForProcess(upid);
       const trackNode = new TrackNode({uri, title, sortOrder: -30});
       group?.addChildInOrder(trackNode);
     }
-
-    trace.onTraceReady.addListener(async () => {
-      await this.selectFirstHeapProfile(trace);
-    });
   }
 
   private async getIncomplete(trace: Trace): Promise<boolean> {
     const it = await trace.engine.query(`
-      SELECT value FROM stats
+      SELECT value
+      FROM stats
       WHERE name = 'heap_graph_non_finalized_graph'
     `);
     const incomplete = it.firstRow({value: NUM}).value > 0;
     return incomplete;
   }
 
-  async getUniqueUpids(trace: Trace): Promise<number[]> {
-    const result = await trace.engine.query(`
-      SELECT DISTINCT upid FROM heap_profile_allocation
-      UNION
-      SELECT DISTINCT upid FROM heap_graph_object
-    `);
-    const upids: number[] = [];
-    for (const it = result.iter({upid: NUM}); it.valid(); it.next()) {
-      upids.push(it.upid);
-    }
-    return upids;
-  }
-
-  async selectFirstHeapProfile(ctx: Trace) {
-    const samples: {trackUri: string; eventId: number; ts: bigint}[] = [];
-
+  private async selectFirstHeapProfile(ctx: Trace) {
     // Select the first sample from each track
-    for (const {tableName, track} of this.tracks) {
-      const result = await ctx.engine.query(`
-        SELECT id, ts
-        FROM ${tableName}
+    const result = await ctx.engine.query(`
+        SELECT
+          id,
+          upid
+        FROM ${EVENT_TABLE_NAME}
         ORDER BY ts
         LIMIT 1
       `);
 
-      for (const it = result.iter({id: NUM, ts: LONG}); it.valid(); it.next()) {
-        samples.push({
-          trackUri: track.uri,
-          eventId: it.id,
-          ts: it.ts,
-        });
-      }
-    }
+    const iter = result.maybeFirstRow({id: NUM, upid: NUM});
+    if (!iter) return;
 
-    // Sort samples by timestamp and select the first one
-    samples.sort((a, b) => Number(a.ts - b.ts));
-    if (samples.length === 0) return;
-    const firstSample = samples[0];
-    ctx.selection.selectTrackEvent(firstSample.trackUri, firstSample.eventId);
+    const track = this.trackMap.get(iter.upid);
+    if (!track) return;
+
+    ctx.selection.selectTrackEvent(track.uri, iter.id);
   }
 }


### PR DESCRIPTION
https://buganizer.corp.google.com/issues/416190258

When loading a trace with heap profile tracks, we automatically select the earliest heap profile sample on trace load.
    
We currently assume that this event has id = 0, but this is not necessarily the case.
    
This change refactors the queries in the heap profile plugin to make things a lot clearer, as it was getting out of control, and also fixes the bug so that it works out the necessary event id properly.
    
This change also refactors the selection logic in SelectionManager a little to make the error message clearer and to ease debugging in the future.
