### PR TITLE
Update winscope transactions tables.

### DIFF
--- a/src/trace_processor/importers/common/args_tracker.h
+++ b/src/trace_processor/importers/common/args_tracker.h
@@ -160,6 +160,11 @@ class ArgsTracker {
         context_->storage->mutable_surfaceflinger_transactions_table(), id);
   }
 
+  BoundInserter AddArgsTo(tables::SurfaceFlingerTransactionTable::Id id) {
+    return AddArgsTo(
+        context_->storage->mutable_surfaceflinger_transaction_table(), id);
+  }
+
   BoundInserter AddArgsTo(tables::ViewCaptureTable::Id id) {
     return AddArgsTo(context_->storage->mutable_viewcapture_table(), id);
   }

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -813,6 +813,24 @@ class TraceStorage {
     return &surfaceflinger_transactions_table_;
   }
 
+  const tables::SurfaceFlingerTransactionTable&
+  surfaceflinger_transaction_table() const {
+    return surfaceflinger_transaction_table_;
+  }
+  tables::SurfaceFlingerTransactionTable*
+  mutable_surfaceflinger_transaction_table() {
+    return &surfaceflinger_transaction_table_;
+  }
+
+  const tables::SurfaceFlingerTransactionFlagTable&
+  surfaceflinger_transaction_flag_table() const {
+    return surfaceflinger_transaction_flag_table_;
+  }
+  tables::SurfaceFlingerTransactionFlagTable*
+  mutable_surfaceflinger_transaction_flag_table() {
+    return &surfaceflinger_transaction_flag_table_;
+  }
+
   const tables::ViewCaptureTable& viewcapture_table() const {
     return viewcapture_table_;
   }
@@ -1138,6 +1156,10 @@ class TraceStorage {
   tables::SurfaceFlingerLayerTable surfaceflinger_layer_table_{&string_pool_};
   tables::SurfaceFlingerTransactionsTable surfaceflinger_transactions_table_{
       &string_pool_};
+  tables::SurfaceFlingerTransactionTable surfaceflinger_transaction_table_{
+      &string_pool_};
+  tables::SurfaceFlingerTransactionFlagTable
+      surfaceflinger_transaction_flag_table_{&string_pool_};
   tables::ViewCaptureTable viewcapture_table_{&string_pool_};
   tables::ViewCaptureViewTable viewcapture_view_table_{&string_pool_};
   tables::ViewCaptureInternedDataTable viewcapture_interned_data_table_{

--- a/src/trace_processor/tables/table_destructors.cc
+++ b/src/trace_processor/tables/table_destructors.cc
@@ -141,6 +141,9 @@ SurfaceFlingerLayersSnapshotTable::~SurfaceFlingerLayersSnapshotTable() =
     default;
 SurfaceFlingerLayerTable::~SurfaceFlingerLayerTable() = default;
 SurfaceFlingerTransactionsTable::~SurfaceFlingerTransactionsTable() = default;
+SurfaceFlingerTransactionTable::~SurfaceFlingerTransactionTable() = default;
+SurfaceFlingerTransactionFlagTable::~SurfaceFlingerTransactionFlagTable() =
+    default;
 ViewCaptureTable::~ViewCaptureTable() = default;
 ViewCaptureViewTable::~ViewCaptureViewTable() = default;
 ViewCaptureInternedDataTable::~ViewCaptureInternedDataTable() = default;

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -121,6 +121,7 @@ SURFACE_FLINGER_TRANSACTIONS_TABLE = Table(
         C('ts', CppInt64(), ColumnFlag.SORTED),
         C('arg_set_id', CppOptional(CppUint32())),
         C('base64_proto_id', CppOptional(CppUint32())),
+        C('vsync_id', CppOptional(CppInt64())),
     ],
     tabledoc=TableDoc(
         doc='SurfaceFlinger transactions. Each row contains a set of ' +
@@ -130,6 +131,67 @@ SURFACE_FLINGER_TRANSACTIONS_TABLE = Table(
             'ts': 'Timestamp of the transactions commit',
             'arg_set_id': 'Extra args parsed from the proto message',
             'base64_proto_id': 'String id for raw proto message',
+            'vsync_id': 'Vsync id taken from raw proto message',
+        }))
+
+SURFACE_FLINGER_TRANSACTION_TABLE = Table(
+    python_module=__file__,
+    class_name='SurfaceFlingerTransactionTable',
+    sql_name='__intrinsic_surfaceflinger_transaction',
+    columns=[
+        C('snapshot_id', CppTableId(SURFACE_FLINGER_TRANSACTIONS_TABLE)),
+        C('arg_set_id', CppOptional(CppUint32())),
+        C('base64_proto_id', CppOptional(CppUint32())),
+        C('transaction_id', CppOptional(CppInt64())),
+        C('pid', CppOptional(CppUint32())),
+        C('uid', CppOptional(CppUint32())),
+        C('layer_id', CppOptional(CppUint32())),
+        C('display_id', CppOptional(CppUint32())),
+        C('flags_id', CppOptional(CppUint32())),
+        C('transaction_type', CppOptional(CppString())),
+    ],
+    tabledoc=TableDoc(
+        doc='SurfaceFlinger transaction',
+        group='Winscope',
+        columns={
+            'snapshot_id':
+                'The snapshot that generated this transaction',
+            'arg_set_id':
+                'Extra args parsed from the proto message',
+            'base64_proto_id':
+                'String id for raw proto message',
+            'transaction_id':
+                'Transaction id taken from raw proto message',
+            'pid':
+                'Pid taken from raw proto message',
+            'uid':
+                'Uid taken from raw proto message',
+            'layer_id':
+                'Layer id taken from raw proto message',
+            'display_id':
+                'Display id taken from raw proto message',
+            'flags_id':
+                'Flags id used to retrieve associated flags from __intrinsic_surfaceflinger_transaction_flag',
+            'transaction_type':
+                'Transaction type'
+        }))
+
+SURFACE_FLINGER_TRANSACTION_FLAG_TABLE = Table(
+    python_module=__file__,
+    class_name='SurfaceFlingerTransactionFlagTable',
+    sql_name='__intrinsic_surfaceflinger_transaction_flag',
+    columns=[
+        C('flags_id', CppOptional(CppUint32())),
+        C('flag', CppOptional(CppString())),
+    ],
+    tabledoc=TableDoc(
+        doc='SurfaceFlinger transaction',
+        group='Winscope',
+        columns={
+            'flags_id':
+                'The flags_id corresponding to a row in __intrinsic_surfaceflinger_transaction',
+            'flag':
+                'The translated flag string',
         }))
 
 VIEWCAPTURE_TABLE = Table(
@@ -298,6 +360,8 @@ ALL_TABLES = [
     SURFACE_FLINGER_LAYERS_SNAPSHOT_TABLE,
     SURFACE_FLINGER_LAYER_TABLE,
     SURFACE_FLINGER_TRANSACTIONS_TABLE,
+    SURFACE_FLINGER_TRANSACTION_TABLE,
+    SURFACE_FLINGER_TRANSACTION_FLAG_TABLE,
     VIEWCAPTURE_TABLE,
     VIEWCAPTURE_VIEW_TABLE,
     VIEWCAPTURE_INTERNED_DATA_TABLE,

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -1189,6 +1189,8 @@ void TraceProcessorImpl::InitPerfettoSqlEngine() {
   RegisterStaticTable(storage->mutable_surfaceflinger_layers_snapshot_table());
   RegisterStaticTable(storage->mutable_surfaceflinger_layer_table());
   RegisterStaticTable(storage->mutable_surfaceflinger_transactions_table());
+  RegisterStaticTable(storage->mutable_surfaceflinger_transaction_table());
+  RegisterStaticTable(storage->mutable_surfaceflinger_transaction_flag_table());
 
   RegisterStaticTable(storage->mutable_viewcapture_table());
   RegisterStaticTable(storage->mutable_viewcapture_view_table());


### PR DESCRIPTION
Transactions table extended to provide vsync id, taken from raw proto message.

Individual transactions extracted into separate tables SurfaceFlingerTransactionTable and SurfaceFlingerTransactionFlagTable. These provide additional proto properties for faster querying in Winscope.

Bug: 411363817
Test: tools/diff_test_trace_processor.py