### PR TITLE
Fix android_power_rails_counters average power calculation

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -69,7 +69,9 @@ SELECT
   c.value AS energy_since_boot,
   c.next_value AS energy_since_boot_at_end,
   1e6 * (
-    c.delta_value / c.dur
+    (
+      c.next_value - c.value
+    ) / c.dur
   ) AS average_power,
   c.delta_value AS energy_delta,
   c.track_id,


### PR DESCRIPTION
"delta" value is defined as the elapsed energy since the PREVIOUS sample, however "dur" is defined as the elapsed time until the NEXT sample.

Whether we choose to use the next, or previous sample for this calculation, we should make sure we use the same for both the delta energy and delta time values.

Since the documentation indicated that average_power it should be the next sample, adjust the query to ensure we are using both delta energy and delta time relative to the next sample.

Since the sample period for energy samples is fairly uniform this doesn't impact the power values too much but does shift power values later by one sample period.