### PR TITLE
add entity_state_residency to sql standard library

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14569,6 +14569,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/android/device.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/dumpsys/show_map.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/dvfs.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/entity_state_residency.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/frames/jank_type.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/frames/per_frame_metrics.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql",

--- a/BUILD
+++ b/BUILD
@@ -3191,6 +3191,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/android/desktop_mode.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/device.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/dvfs.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/entity_state_residency.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/freezer.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/garbage_collection.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/input.sql",

--- a/src/trace_processor/perfetto_sql/stdlib/android/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/android/BUILD.gn
@@ -39,6 +39,7 @@ perfetto_sql_source_set("android") {
     "desktop_mode.sql",
     "device.sql",
     "dvfs.sql",
+    "entity_state_residency.sql",
     "freezer.sql",
     "garbage_collection.sql",
     "input.sql",

--- a/src/trace_processor/perfetto_sql/stdlib/android/entity_state_residency.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/entity_state_residency.sql
@@ -1,0 +1,91 @@
+--
+-- Copyright 2025 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+-- Android entity state residency samples.
+-- For details see: https://perfetto.dev/docs/reference/trace-config-proto#AndroidPowerConfig
+CREATE PERFETTO TABLE android_entity_state_residency (
+  -- `counter.id`
+  id ID(counter.id),
+  -- Timestamp of the residency sample.
+  ts TIMESTAMP,
+  -- Time until the next residency sample.
+  dur DURATION,
+  -- Entity or subsytem name.
+  entity_name STRING,
+  -- State name
+  state_name STRING,
+  -- Raw name (alias of counter.name)
+  raw_name STRING,
+  -- Time the entity or subsystem spent in the state since boot
+  state_time_since_boot DURATION,
+  -- Time the entity or subsystem spent in the state since boot on the next
+  -- sample
+  state_time_since_boot_at_end DURATION,
+  -- ratio of the time the entity or subsystem spend in the state out of the
+  -- elapsed time of the sample period. A value of 1 typically means the 100%
+  -- of time was spent in the state, and a value of 0 means no time was spent.
+  state_time_ratio DOUBLE,
+  -- entity + state track id. Alias of `counter_track.id`.
+  track_id JOINID(track.id)
+) AS
+WITH
+  filtered_track_info AS (
+    SELECT
+      id,
+      name AS raw_name,
+      iif(
+        name GLOB 'Entity residency: *' AND name GLOB '* is *',
+        replace(substr(name, 0, instr(name, ' is ')), 'Entity residency: ', ''),
+        NULL
+      ) AS entity_name,
+      iif(
+        name GLOB 'Entity residency: *' AND name GLOB '* is *',
+        substr(name, instr(name, ' is ') + length(' is ')),
+        NULL
+      ) AS state_name
+    FROM counter_track
+    WHERE
+      type = 'entity_state'
+  ),
+  partial_results AS (
+    SELECT
+      c.id,
+      c.ts,
+      lead(c.ts) OVER (PARTITION BY track_id ORDER BY c.ts) - c.ts AS dur,
+      t.entity_name,
+      t.state_name,
+      t.raw_name,
+      CAST(c.value * 1e6 AS INTEGER) AS state_time_since_boot,
+      CAST(lead(c.value) OVER (PARTITION BY track_id ORDER BY c.ts) * 1e6 AS INTEGER) AS state_time_since_boot_at_end,
+      c.track_id
+    FROM counter AS c
+    JOIN filtered_track_info AS t
+      ON c.track_id = t.id
+  )
+SELECT
+  id,
+  ts,
+  dur,
+  entity_name,
+  state_name,
+  raw_name,
+  state_time_since_boot,
+  state_time_since_boot_at_end,
+  (
+    state_time_since_boot_at_end - state_time_since_boot
+  ) * 1.0 / dur AS state_time_ratio,
+  track_id
+FROM partial_results;

--- a/test/trace_processor/diff_tests/parser/power/tests_entity_state_residency.py
+++ b/test/trace_processor/diff_tests/parser/power/tests_entity_state_residency.py
@@ -39,3 +39,24 @@ class EntityStateResidency(TestSuite):
         1,"Entity residency: PCIe-Modem is DOWN",20000
         2,"Entity residency: PCIe-Modem is DOWN",40000
         """))
+
+  def test_standard_library(self):
+    return DiffTestBlueprint(
+        trace=Path('entity_state_residency.textproto'),
+        query="""
+        INCLUDE PERFETTO MODULE android.entity_state_residency;
+        select
+          ts, entity_name, state_name, state_time_since_boot
+        from android_entity_state_residency
+        """,
+        out=Csv("""
+        "ts","entity_name","state_name","state_time_since_boot"
+        1,"Bluetooth","Idle",1000000000
+        2,"Bluetooth","Idle",3000000000
+        1,"Bluetooth","Active",2000000000
+        2,"Bluetooth","Active",4000000000
+        1,"PCIe-Modem","UP",10000000000
+        2,"PCIe-Modem","UP",30000000000
+        1,"PCIe-Modem","DOWN",20000000000
+        2,"PCIe-Modem","DOWN",40000000000
+        """))


### PR DESCRIPTION
Add the entity_states_residency data to sql standard library so that it can be more easily queried by plugins later.

this implementation was inspired by the existing
android_power_rails_counters API and implementation, but deliberately diverges in a few ways:
- It does not use counter_leading_intervals, since merging counter intervals can negatively impact average time in state computations.
- It omits the delta value since it can be confusing and potentially result in bugs since it references the previous sample unlike every thing else in the API which gives data relative to the next sample. See https://github.com/google/perfetto/pull/1455 for context.

Bug: https://github.com/google/perfetto/issues/1321
