### PR TITLE
Add dispatch time as ts even if present in first message.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
@@ -48,11 +48,6 @@ void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
   // Track transition args as the come in through different packets
   auto transition_tracker = ShellTransitionsTracker::GetOrCreate(context_);
 
-  if (transition.has_dispatch_time_ns()) {
-    transition_tracker->SetTimestamp(transition.id(),
-                                     transition.dispatch_time_ns());
-  }
-
   auto inserter = transition_tracker->AddArgsTo(transition.id());
   ArgsParser writer(/*timestamp=*/0, inserter, *context_->storage.get());
   base::Status status = args_parser_.ParseMessage(
@@ -64,6 +59,11 @@ void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
   if (!status.ok()) {
     context_->storage->IncrementStats(
         stats::winscope_shell_transitions_parse_errors);
+  }
+
+  if (transition.has_dispatch_time_ns()) {
+    transition_tracker->SetTimestamp(transition.id(),
+                                     transition.dispatch_time_ns());
   }
 }
 

--- a/test/trace_processor/diff_tests/parser/android/shell_transitions.textproto
+++ b/test/trace_processor/diff_tests/parser/android/shell_transitions.textproto
@@ -18,6 +18,7 @@ packet {
   trusted_pid: 1305
   shell_transition {
     id: 10
+    dispatch_time_ns: 77899001013
     create_time_ns: 77854865352
     send_time_ns: 77894307328
     start_transaction_id: 5604932322158
@@ -56,10 +57,7 @@ packet {
   previous_packet_dropped: true
   trusted_pid: 1305
   first_packet_on_sequence: true
-  shell_transition {
-    id: 7
-    starting_window_remove_time_ns: 77706603918
-  }
+  shell_transition { id: 7 starting_window_remove_time_ns: 77706603918 }
 }
 packet {
   trusted_uid: 1000
@@ -79,19 +77,13 @@ packet {
   trusted_uid: 1000
   trusted_packet_sequence_id: 5
   trusted_pid: 1305
-  shell_transition {
-    id: 9
-    finish_time_ns: 77873935462
-  }
+  shell_transition { id: 9 finish_time_ns: 77873935462 }
 }
 packet {
   trusted_uid: 1000
   trusted_packet_sequence_id: 5
   trusted_pid: 1305
-  shell_transition {
-    id: 10
-    finish_time_ns: 78621610429
-  }
+  shell_transition { id: 10 finish_time_ns: 78621610429 }
 }
 packet {
   trusted_uid: 10241
@@ -99,69 +91,41 @@ packet {
   previous_packet_dropped: true
   trusted_pid: 2528
   first_packet_on_sequence: true
-  shell_transition {
-    id: 7
-    dispatch_time_ns: 76879063147
-    handler: 2
-  }
+  shell_transition { id: 7 dispatch_time_ns: 76879063147 handler: 2 }
 }
 packet {
   trusted_uid: 10241
   trusted_packet_sequence_id: 6
   trusted_pid: 2528
-  shell_transition {
-    id: 8
-    merge_time_ns: 77278725500
-    merge_target: 7
-  }
+  shell_transition { id: 8 merge_time_ns: 77278725500 merge_target: 7 }
 }
 packet {
   trusted_uid: 10241
   trusted_packet_sequence_id: 6
   trusted_pid: 2528
-  shell_transition {
-    id: 8
-    dispatch_time_ns: 77320527177
-    handler: 3
-  }
+  shell_transition { id: 8 dispatch_time_ns: 77320527177 handler: 3 }
 }
 packet {
   trusted_uid: 10241
   trusted_packet_sequence_id: 6
   trusted_pid: 2528
-  shell_transition {
-    id: 9
-    dispatch_time_ns: 77876414832
-    handler: 3
-  }
+  shell_transition { id: 9 dispatch_time_ns: 77876414832 handler: 3 }
 }
 packet {
   trusted_uid: 10241
   trusted_packet_sequence_id: 6
   trusted_pid: 2528
-  shell_transition {
-    id: 10
-    dispatch_time_ns: 77899001013
-    handler: 4
-  }
+  shell_transition { id: 10 handler: 4 }
 }
 packet {
   trusted_uid: 10241
   trusted_packet_sequence_id: 6
   trusted_pid: 2528
-  shell_transition {
-    id: 11
-    dispatch_time_ns: 82536817137
-    handler: 2
-  }
+  shell_transition { id: 11 dispatch_time_ns: 82536817137 handler: 2 }
 }
 packet {
   trusted_uid: 10241
   trusted_packet_sequence_id: 6
   trusted_pid: 2528
-  shell_transition {
-    id: 12
-    merge_time_ns: 82697060749
-    merge_target: 11
-  }
+  shell_transition { id: 12 merge_time_ns: 82697060749 merge_target: 11 }
 }

--- a/test/trace_processor/diff_tests/parser/android/tests_shell_transitions.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_shell_transitions.py
@@ -26,18 +26,19 @@ class ShellTransitions(TestSuite):
         trace=Path('shell_transitions.textproto'),
         query="""
         SELECT
-          id, transition_id
+          id, ts, transition_id
         FROM
-          window_manager_shell_transitions;
+          window_manager_shell_transitions
+        ORDER BY id;
         """,
         out=Csv("""
-        "id","transition_id"
-        0,7
-        1,10
-        2,11
-        3,8
-        4,9
-        5,12
+        "id","ts","transition_id"
+        0,76879063147,7
+        1,77899001013,10
+        2,82536817137,11
+        3,77320527177,8
+        4,77876414832,9
+        5,0,12
         """))
 
   def test_has_expected_transition_args(self):

--- a/test/trace_processor/diff_tests/syntax/table_tests.py
+++ b/test/trace_processor/diff_tests/syntax/table_tests.py
@@ -615,7 +615,7 @@ class PerfettoTable(TestSuite):
         query="""
           SELECT key, int_value, real_value FROM __intrinsic_winscope_proto_to_args_with_defaults('__intrinsic_window_manager_shell_transition_protos') as tbl
           ORDER BY tbl.base64_proto_id, key
-          LIMIT 53
+          LIMIT 54
           """,
         out=Csv("""
           "key","int_value","real_value"
@@ -633,6 +633,7 @@ class PerfettoTable(TestSuite):
           "type",0,"[NULL]"
           "wm_abort_time_ns",0,"[NULL]"
           "create_time_ns",77854865352,"[NULL]"
+          "dispatch_time_ns",77899001013,"[NULL]"
           "finish_transaction_id",5604932322159,"[NULL]"
           "flags",0,"[NULL]"
           "merge_request_time_ns",0,"[NULL]"


### PR DESCRIPTION
A previous bug prevented dispatch time from being added to the table as a timestamp if it was present in a first message, due to the row only existing after being added to the args table.

Bug: 411363817
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="ShellTransitions"