### PR TITLE
Add transaction to table only after flags decoded.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc
@@ -324,9 +324,6 @@ void SurfaceFlingerTransactionsParser::ParseDisplayState(
           ->InternString(
               base::StringView(base::Base64Encode(blob.data, blob.size)))
           .raw_id();
-  auto row_id = context_->storage->mutable_surfaceflinger_transaction_table()
-                    ->Insert(transaction)
-                    .id;
 
   if (state_decoder.has_what()) {
     auto what = state_decoder.what();
@@ -355,6 +352,10 @@ void SurfaceFlingerTransactionsParser::ParseDisplayState(
       AddFlags(translated, transaction.flags_id.value());
     }
   }
+
+  auto row_id = context_->storage->mutable_surfaceflinger_transaction_table()
+                    ->Insert(transaction)
+                    .id;
 
   AddArgs(timestamp, blob, row_id, ".perfetto.protos.DisplayState");
 }

--- a/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_transactions.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_transactions.py
@@ -183,7 +183,7 @@ class SurfaceFlingerTransactions(TestSuite):
         """,
         out=Csv("""
         "snapshot_id","arg_set_id","transaction_id","pid","uid","layer_id","display_id","flags_id"
-        2,42,10518374908660,3,415,"[NULL]",1234,"[NULL]"
+        2,42,10518374908660,3,415,"[NULL]",1234,1
         """))
 
   def test_surfaceflinger_transaction_display_change_args(self):
@@ -306,7 +306,7 @@ class SurfaceFlingerTransactions(TestSuite):
         """,
         out=Csv("""
         "snapshot_id","arg_set_id","transaction_id","pid","uid","layer_id","display_id","flags_id"
-        2,46,"[NULL]","[NULL]","[NULL]","[NULL]",5678,"[NULL]"
+        2,46,"[NULL]","[NULL]","[NULL]","[NULL]",5678,2
         """))
 
   def test_surfaceflinger_transaction_added_layer_args(self):


### PR DESCRIPTION
Transaction flags_id was not being set for changed/added displays.

Bug: 411363817
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="SurfaceFlingerTransactions"
