### PR TITLE
Print timezone on the UI

### DIFF
--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -177,6 +177,16 @@ export class Time {
   static toTimecode(time: time): Timecode {
     return new Timecode(time);
   }
+
+  static formatTimezone(minutes: number): string {
+    const sign = minutes >= 0 ? '+' : '-';
+    const absMins = Math.abs(minutes);
+    const hours = Math.floor(absMins / 60);
+    const mins = absMins % 60;
+    const hoursStr = String(hours).padStart(2, '0');
+    const minsStr = String(mins).padStart(2, '0');
+    return `UTC${sign}${hoursStr}:${minsStr}`;
+  }
 }
 
 // Format `value` to `n` significant digits.

--- a/ui/src/components/widgets/timestamp_format_menu.ts
+++ b/ui/src/components/widgets/timestamp_format_menu.ts
@@ -16,6 +16,7 @@ import m from 'mithril';
 import {MenuItem} from '../../widgets/menu';
 import {Trace} from '../../public/trace';
 import {TimestampFormat} from '../../public/timeline';
+import {Time} from '../../base/time';
 
 interface TimestampFormatMenuItemAttrs {
   trace: Trace;
@@ -35,6 +36,8 @@ export class TimestampFormatMenuItem
       });
     }
 
+    const timeZone = Time.formatTimezone(attrs.trace.traceInfo.tzOffMin);
+
     return m(
       MenuItem,
       {
@@ -42,7 +45,10 @@ export class TimestampFormatMenuItem
       },
       renderMenuItem(TimestampFormat.Timecode, 'Timecode'),
       renderMenuItem(TimestampFormat.UTC, 'Realtime (UTC)'),
-      renderMenuItem(TimestampFormat.TraceTz, 'Realtime (Trace TZ)'),
+      renderMenuItem(
+        TimestampFormat.TraceTz,
+        `Realtime (Trace TZ - ${timeZone})`,
+      ),
       renderMenuItem(TimestampFormat.Seconds, 'Seconds'),
       renderMenuItem(TimestampFormat.Milliseconds, 'Milliseconds'),
       renderMenuItem(TimestampFormat.Microseconds, 'Microseconds'),

--- a/ui/src/core/fake_trace_impl.ts
+++ b/ui/src/core/fake_trace_impl.ts
@@ -47,6 +47,7 @@ export function createFakeTraceImpl(args: FakeTraceImplArgs = {}) {
     realtimeOffset: Time.ZERO,
     utcOffset: Time.ZERO,
     traceTzOffset: Time.ZERO,
+    tzOffMin: 0,
     cpus: [],
     importErrors: 0,
     traceType: 'proto',

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -464,6 +464,7 @@ async function getTraceInfo(
     ...traceTime,
     traceTitle,
     traceUrl,
+    tzOffMin,
     realtimeOffset,
     utcOffset,
     traceTzOffset,

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -47,6 +47,7 @@ import {
 import {featureFlags} from '../core/feature_flags';
 import {trackMatchesFilter} from '../core/track_manager';
 import {renderStatusBar} from './statusbar';
+import {Time} from '../base/time';
 
 const showStatusBarFlag = featureFlags.register({
   id: 'Enable status bar',
@@ -116,11 +117,12 @@ export class UiMainPerTrace implements m.ClassComponent {
         name: 'Set timestamp and duration format',
         callback: async () => {
           const TF = TimestampFormat;
+          const timeZone = Time.formatTimezone(trace.traceInfo.tzOffMin);
           const result = await app.omnibox.prompt('Select format...', {
             values: [
               {format: TF.Timecode, name: 'Timecode'},
               {format: TF.UTC, name: 'Realtime (UTC)'},
-              {format: TF.TraceTz, name: 'Realtime (Trace TZ)'},
+              {format: TF.TraceTz, name: `Realtime (Trace TZ - ${timeZone})`},
               {format: TF.Seconds, name: 'Seconds'},
               {format: TF.Milliseconds, name: 'Milliseconds'},
               {format: TF.Microseconds, name: 'Microseconds'},

--- a/ui/src/frontend/viewer_page/time_axis_panel.ts
+++ b/ui/src/frontend/viewer_page/time_axis_panel.ts
@@ -83,7 +83,9 @@ export class TimeAxisPanel {
           this.trace.traceInfo.realtimeOffset,
         );
         const dateTzStr = toISODateOnly(offsetTzDate);
-        ctx.fillText(dateTzStr, 6, 10);
+        const tzOffsetMins = this.trace.traceInfo.tzOffMin;
+        const timeZone = Time.formatTimezone(tzOffsetMins);
+        ctx.fillText(`${dateTzStr} ${timeZone}`, 6, 10);
         break;
       default:
         assertUnreachable(timestampFormat);

--- a/ui/src/public/trace_info.ts
+++ b/ui/src/public/trace_info.ts
@@ -35,6 +35,8 @@ export interface TraceInfo {
   // recorded into the trace, to show timestamps in the device local time.
   readonly traceTzOffset: time;
 
+  readonly tzOffMin: number;
+
   // The list of CPUs in the trace
   readonly cpus: Cpu[];
 


### PR DESCRIPTION
The PR adds a printout of the timezone in various places in the UI:

- In the top-left of the timeline next to the timestamp offset:
<img width="153" alt="image" src="https://github.com/user-attachments/assets/7860ac7c-3d91-49a8-97a6-d1758d408a67" />

- In the timestamp selection menus
<img width="260" alt="image" src="https://github.com/user-attachments/assets/b54e3e2b-6969-4178-869e-20829de93050" />


