### PR TITLE
tp: fix invalid state on preloaded TP

### DIFF
--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -99,8 +99,13 @@ void Response::Send(Rpc::RpcResponseFunction send_fn) {
 
 Rpc::Rpc(std::unique_ptr<TraceProcessor> preloaded_instance)
     : trace_processor_(std::move(preloaded_instance)) {
-  if (!trace_processor_)
+  if (trace_processor_) {
+    // If the trace processor is preloaded, we need to reset the trace
+    // processor on any further Parse() calls.
+    eof_ = true;
+  } else {
     ResetTraceProcessorInternal(Config());
+  }
 }
 
 Rpc::Rpc() : Rpc(nullptr) {}

--- a/src/trace_processor/trace_processor_storage_impl.h
+++ b/src/trace_processor/trace_processor_storage_impl.h
@@ -45,6 +45,7 @@ class TraceProcessorStorageImpl : public TraceProcessorStorage {
   base::Hasher trace_hash_;
   TraceProcessorContext context_;
   bool unrecoverable_parse_error_ = false;
+  bool eof_ = false;
   size_t hash_input_size_remaining_ = 4096;
   ForwardingTraceParser* parser_ = nullptr;
 };


### PR DESCRIPTION
Preloaded instances are passed being in an EOF state (i.e. with trace
already full loaded). Not having this leads to TP ending up in an
inconsistent state.
