### PR TITLE
[TrackEvent] Add tests for upcoming API changes

### DIFF
--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -1691,20 +1691,23 @@ TEST_P(PerfettoApiTest, TrackEventDescriptor) {
 
   // Check that the advertised categories match PERFETTO_DEFINE_CATEGORIES (see
   // above).
-  EXPECT_EQ(7, desc.available_categories_size());
+  EXPECT_EQ(9, desc.available_categories_size());
   EXPECT_EQ("test", desc.available_categories()[0].name());
   EXPECT_EQ("This is a test category",
             desc.available_categories()[0].description());
   EXPECT_EQ("tag", desc.available_categories()[0].tags()[0]);
-  EXPECT_EQ("foo", desc.available_categories()[1].name());
-  EXPECT_EQ("bar", desc.available_categories()[2].name());
-  EXPECT_EQ("cat", desc.available_categories()[3].name());
-  EXPECT_EQ("slow", desc.available_categories()[3].tags()[0]);
-  EXPECT_EQ("cat.verbose", desc.available_categories()[4].name());
-  EXPECT_EQ("debug", desc.available_categories()[4].tags()[0]);
-  EXPECT_EQ("cat-with-dashes", desc.available_categories()[5].name());
-  EXPECT_EQ("disabled-by-default-cat", desc.available_categories()[6].name());
-  EXPECT_EQ("slow", desc.available_categories()[6].tags()[0]);
+  EXPECT_EQ("test.verbose", desc.available_categories()[1].name());
+  EXPECT_EQ("foo", desc.available_categories()[2].name());
+  EXPECT_EQ("bar", desc.available_categories()[3].name());
+  EXPECT_EQ("cat", desc.available_categories()[4].name());
+  EXPECT_EQ("slow", desc.available_categories()[4].tags()[0]);
+  EXPECT_EQ("cat.verbose", desc.available_categories()[5].name());
+  EXPECT_EQ("debug", desc.available_categories()[5].tags()[0]);
+  EXPECT_EQ("cat-with-dashes", desc.available_categories()[6].name());
+  EXPECT_EQ("slow_category", desc.available_categories()[7].name());
+  EXPECT_EQ("slow", desc.available_categories()[7].tags()[0]);
+  EXPECT_EQ("disabled-by-default-cat", desc.available_categories()[8].name());
+  EXPECT_EQ("slow", desc.available_categories()[8].tags()[0]);
 }
 
 TEST_P(PerfettoApiTest, TrackEventSharedIncrementalState) {

--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -4067,17 +4067,6 @@ TEST_P(PerfettoApiTest, TrackEventConfig) {
                     "B:$dynamic,$bar.DynamicGroupBarEvent"));
   }
 
-  // Enable explicit category with no wildcard.
-  // TODO(crbug.com/260418655): Fix once API changes are announced.
-  {
-    perfetto::protos::gen::TrackEventConfig te_cfg;
-    te_cfg.add_enabled_categories("foo");
-    run_config(te_cfg, []() {
-      EXPECT_TRUE(TRACE_EVENT_CATEGORY_ENABLED("foo"));
-      EXPECT_TRUE(TRACE_EVENT_CATEGORY_ENABLED("bar"));
-    });
-  }
-
   // Disable explicit category.
   {
     perfetto::protos::gen::TrackEventConfig te_cfg;
@@ -4117,6 +4106,7 @@ TEST_P(PerfettoApiTest, TrackEventConfig) {
     perfetto::protos::gen::TrackEventConfig te_cfg;
     te_cfg.add_disabled_categories("slow_category");
     te_cfg.add_enabled_tags("slow");
+    te_cfg.add_disabled_categories("*");
     run_config(te_cfg, []() {
       EXPECT_TRUE(TRACE_EVENT_CATEGORY_ENABLED("slow_category"));
     });
@@ -4128,6 +4118,7 @@ TEST_P(PerfettoApiTest, TrackEventConfig) {
     perfetto::protos::gen::TrackEventConfig te_cfg;
     te_cfg.add_enabled_tags("tag");
     te_cfg.add_disabled_tags("slow");
+    te_cfg.add_disabled_categories("*");
     run_config(te_cfg, []() {
       EXPECT_TRUE(TRACE_EVENT_CATEGORY_ENABLED("test"));
       EXPECT_TRUE(TRACE_EVENT_CATEGORY_ENABLED("test.verbose"));


### PR DESCRIPTION
This adds TrackEvent tests in preparation for API changes in
https://github.com/google/perfetto/pull/1432

Bug: chromium:260418655