### PR TITLE
Fix import rules

### DIFF
--- a/python/tools/check_imports.py
+++ b/python/tools/check_imports.py
@@ -97,7 +97,7 @@ DEPS_ALLOWLIST = [
     # Misc legitimate deps.
     ('/frontend/index', ['/gen/*']),
     ('/traceconv/index', '/gen/traceconv'),
-    ('/engine/wasm_bridge', '/gen/trace_processor'),
+    ('/engine/wasm_bridge', '/gen/trace_processor_memory*'),
     ('/trace_processor/sql_utils/*', '/trace_processor/*'),
     ('/protos/index', '/gen/protos'),
 


### PR DESCRIPTION
Allow engine/* to import from gen/trace_processor_memory*.
