### PR TITLE
Add "mini" query page tab

### DIFF
--- a/ui/src/plugins/dev.perfetto.QueryPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/index.ts
@@ -13,12 +13,31 @@
 // limitations under the License.
 
 import m from 'mithril';
+import {
+  QueryResponse,
+  runQueryForQueryTable,
+} from '../../components/query_table/queries';
+import {QueryTable} from '../../components/query_table/query_table';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
+import {Editor} from '../../widgets/editor';
 import {QueryPage} from './query_page';
+import {App} from '../../public/app';
+import {Flag} from '../../public/feature_flag';
 
-export default class implements PerfettoPlugin {
+export default class QueryPagePlugin implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.QueryPage';
+  static flag: Flag;
+
+  static onActivate(app: App) {
+    QueryPagePlugin.flag = app.featureFlags.register({
+      id: 'dev.perfetto.QueryPage',
+      name: 'Enable mini query page tab',
+      defaultValue: false,
+      description:
+        'Enables a tab version of the query page that allows query tab - like functionality in the tab drawer',
+    });
+  }
 
   async onTraceLoad(trace: Trace): Promise<void> {
     trace.pages.registerPage({
@@ -32,5 +51,51 @@ export default class implements PerfettoPlugin {
       icon: 'database',
       sortOrder: 1,
     });
+
+    if (QueryPagePlugin.flag.get()) {
+      trace.tabs.registerTab({
+        uri: 'dev.perfetto.QueryPage',
+        isEphemeral: false,
+        content: {
+          render() {
+            return m(QueryPageMini, {trace});
+          },
+          getTitle() {
+            return 'QueryPage Mini';
+          },
+        },
+      });
+    }
+  }
+}
+
+interface QueryPageMiniAttrs {
+  readonly trace: Trace;
+}
+
+class QueryPageMini implements m.ClassComponent<QueryPageMiniAttrs> {
+  private executedQuery?: string;
+  private queryResult?: QueryResponse;
+
+  view({attrs}: m.CVnode<QueryPageMiniAttrs>) {
+    return m(
+      '.pf-query-page-mini',
+      m(Editor, {
+        language: 'perfetto-sql',
+        onExecute: async (query) => {
+          this.executedQuery = query;
+          const result = await runQueryForQueryTable(query, attrs.trace.engine);
+          this.queryResult = result;
+        },
+      }),
+      this.executedQuery === undefined
+        ? null
+        : m(QueryTable, {
+            trace: attrs.trace,
+            query: this.executedQuery,
+            resp: this.queryResult,
+            fillParent: false,
+          }),
+    );
   }
 }


### PR DESCRIPTION
Add a new 'mini' query page tab which displays a mini version of the query page in a tab on the viewer page. This is useful for quickly modifying queries and seeing the results, while being able to compare results against the timeline.

This tab is behind a flag initially as it's very rough and still needs some polish.

Going forward, this tab should sync with the query page itself, taking the place of the 'Standalone Query' tab that's created on the viewer page whenever a query is run on the query page.
