### PR TITLE
Convert `thread_state.state` to a human readable value in SQL rather than JS

### DIFF
--- a/ui/src/plugins/dev.perfetto.ThreadState/index.ts
+++ b/ui/src/plugins/dev.perfetto.ThreadState/index.ts
@@ -42,6 +42,7 @@ export default class implements PerfettoPlugin {
     const result = await engine.query(`
       include perfetto module viz.threads;
       include perfetto module viz.summary.threads;
+      include perfetto module sched.states;
 
       select
         utid,


### PR DESCRIPTION
This change makes it so that the thread state tracks generate the slice titles using the stdlib function `sched_state_io_to_human_readable_string` in SQL rather than doing the conversion in JavaScript.
