### PR TITLE
fix android_power_rails_counters id column type

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -23,7 +23,7 @@ INCLUDE PERFETTO MODULE time.conversion;
 -- NOTE: Requires dedicated hardware - table is only populated on Pixels.
 CREATE PERFETTO TABLE android_power_rails_counters (
   -- `counter.id`
-  id LONG,
+  id ID(counter.id),
   -- Timestamp of the energy measurement.
   ts TIMESTAMP,
   -- Time until the next energy measurement.


### PR DESCRIPTION
Fix the type for the id column in android_power_rails_counters as the use of a long type was mentioned to be a bug in https://github.com/google/perfetto/pull/1457#discussion_r2085086053

