### PR TITLE
Fix memory corruption for TAR files >4GB on browser

### DIFF
--- a/src/trace_processor/importers/archive/tar_trace_reader.cc
+++ b/src/trace_processor/importers/archive/tar_trace_reader.cc
@@ -259,6 +259,18 @@ base::StatusOr<TarTraceReader::ParseResult> TarTraceReader::ParseMetadata() {
                            size.status().message().c_str());
   }
 
+  // Ensure the size fits within `size_t` to prevent issues on 32-bit platforms
+  // (e.g., in-browser environments) where `size_t` is smaller than `uint64_t`.
+  // `metadata_->size` is a `uint64_t`, but passing it to methods like
+  // `buffer_.SliceOff` (which take `size_t`) may cause overflow if it exceeds
+  // the max representable `size_t` value.
+  const uint64_t max_size = std::numeric_limits<size_t>::max();
+  if ((size.value() & (~(max_size))) != 0) {
+    // Return this specific message to ensure it is captured by the error
+    // dialog.
+    return base::ErrStatus("out of memory");
+  }
+
   metadata_.emplace();
   metadata_->size = size.value();
   metadata_->type_flag = *header.type_flag;

--- a/src/trace_processor/importers/archive/tar_trace_reader.cc
+++ b/src/trace_processor/importers/archive/tar_trace_reader.cc
@@ -265,7 +265,7 @@ base::StatusOr<TarTraceReader::ParseResult> TarTraceReader::ParseMetadata() {
   // `buffer_.SliceOff` (which take `size_t`) may cause overflow if it exceeds
   // the max representable `size_t` value.
   const uint64_t max_size = std::numeric_limits<size_t>::max();
-  if ((size.value() & (~(max_size))) != 0) {
+  if (std::greater<>()(size.value(), max_size)) {
     // Return this specific message to ensure it is captured by the error
     // dialog.
     return base::ErrStatus("out of memory");


### PR DESCRIPTION
Add a size validation to ensure file sizes do not exceed the maximum value of `size_t`,
preventing overflows and incorrect calculations in 32-bit environments.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
