### PR TITLE
Improve wasm64 support

### DIFF
--- a/gn/standalone/toolchain/BUILD.gn
+++ b/gn/standalone/toolchain/BUILD.gn
@@ -423,24 +423,29 @@ gcc_like_toolchain("gcc_like_host") {
                                  ])
 }
 
-gcc_like_toolchain("wasm") {
-  # emsdk_dir and em_config are defined in wasm.gni.
-  cpu = host_cpu
-  os = host_os
-  ar = "$emsdk_dir/emscripten/emar --em-config $em_config"
-  cc = "$emsdk_dir/emscripten/emcc --em-config $em_config"
-  cxx = "$emsdk_dir/emscripten/em++ --em-config $em_config"
-  strip = ""
+# The 32 and 64 bit wasm toolchains are configured identically, but differ in
+# the fact that is_wasm_memory64=true (in gn_vars.gni, which looks at the
+# current_toolchain) conditions cflags and ldflags. We actually need different
+# toolchains because the same .cc files will be build twice for each wasm
+# bitness, and they need different output paths.
+template("wasm_toolchain") {
+  gcc_like_toolchain(target_name) {
+    forward_variables_from(invoker, "*")
+
+    # emsdk_dir and em_config are defined in wasm.gni.
+    cpu = host_cpu
+    os = host_os
+    ar = "$emsdk_dir/emscripten/emar --em-config $em_config"
+    cc = "$emsdk_dir/emscripten/emcc --em-config $em_config"
+    cxx = "$emsdk_dir/emscripten/em++ --em-config $em_config"
+    strip = ""
+  }
 }
 
-gcc_like_toolchain("wasm_memory64") {
-  # emsdk_dir and em_config are defined in wasm.gni.
-  cpu = host_cpu
-  os = host_os
-  ar = "$emsdk_dir/emscripten/emar --em-config $em_config"
-  cc = "$emsdk_dir/emscripten/emcc --em-config $em_config"
-  cxx = "$emsdk_dir/emscripten/em++ --em-config $em_config"
-  strip = ""
+# Istantiates both wasm toolchains.
+wasm_toolchain("wasm") {
+}
+wasm_toolchain("wasm_memory64") {
 }
 
 # This is used both for MSVC anc clang-cl. clang-cl cmdline interface pretends

--- a/gn/standalone/wasm.gni
+++ b/gn/standalone/wasm.gni
@@ -34,6 +34,7 @@ template("wasm_lib") {
   # If the name is foo the target_name must be foo_wasm.
   assert(invoker.name + "_wasm" == target_name)
   _lib_name = invoker.name
+  _is_memory64 = defined(invoker.is_memory64) && invoker.is_memory64
   if (is_wasm) {
     _exports = "['ccall', 'callMain', 'addFunction', 'FS', 'HEAPU8']"
     _target_ldflags = [
@@ -114,21 +115,20 @@ template("wasm_lib") {
 
     executable("${_lib_name}.js") {
       forward_variables_from(invoker, _vars_to_forward)
-      ldflags = _target_ldflags + [
-                  "-s",
-                  "MAXIMUM_MEMORY=4GB",
-                ]
-      output_extension = ""
-    }
-    executable("${_lib_name}_memory64.js") {
-      forward_variables_from(invoker, _vars_to_forward)
-      ldflags = _target_ldflags + [
-                  "-s",
-                  "MEMORY64=1",
-                  "-s",
-                  "MAXIMUM_MEMORY=16GB",
-                  "-mwasm64",
-                ]
+      if (_is_memory64) {
+        ldflags = _target_ldflags + [
+                    "-s",
+                    "MEMORY64=1",
+                    "-s",
+                    "MAXIMUM_MEMORY=16GB",
+                    "-mwasm64",
+                  ]
+      } else {
+        ldflags = _target_ldflags + [
+                    "-s",
+                    "MAXIMUM_MEMORY=4GB",
+                  ]
+      }
       output_extension = ""
     }
 
@@ -147,41 +147,24 @@ template("wasm_lib") {
       args = [ "--noop" ]
       script = "//gn/standalone/build_tool_wrapper.py"
     }
-    action("${_lib_name}_memory64.wasm") {
-      inputs = []
-      deps = [ ":${_lib_name}_memory64.js" ]
-      outputs = [ "$root_out_dir/${_lib_name}_memory64.wasm" ]
-      if (is_debug) {
-        outputs += [ "$root_out_dir/${_lib_name}_memory64.wasm.map" ]
-      }
-      args = [ "--noop" ]
-      script = "//gn/standalone/build_tool_wrapper.py"
-    }
-
     copy("${_lib_name}.d.ts") {
       sources = [ "//gn/standalone/wasm_typescript_declaration.d.ts" ]
       outputs = [ "$root_out_dir/$_lib_name.d.ts" ]
-    }
-    copy("${_lib_name}_memory64.d.ts") {
-      sources = [ "//gn/standalone/wasm_typescript_declaration.d.ts" ]
-      outputs = [ "$root_out_dir/${_lib_name}_memory64.d.ts" ]
     }
   } else {  # is_wasm
     not_needed(invoker, "*")
   }
 
   group(target_name) {
+    if (_is_memory64) {
+      _wasm_32_or_64_toolchain = wasm_memory64_toolchain
+    } else {
+      _wasm_32_or_64_toolchain = wasm_toolchain
+    }
     deps = [
-      ":${_lib_name}.d.ts($wasm_toolchain)",
-      ":${_lib_name}.js($wasm_toolchain)",
-      ":${_lib_name}.wasm($wasm_toolchain)",
-    ]
-  }
-  group(invoker.name + "_memory64_wasm") {
-    deps = [
-      ":${_lib_name}_memory64.d.ts($wasm_memory64_toolchain)",
-      ":${_lib_name}_memory64.wasm($wasm_memory64_toolchain)",
-      ":${_lib_name}_memory64.js($wasm_memory64_toolchain)",
+      ":${_lib_name}.d.ts($_wasm_32_or_64_toolchain)",
+      ":${_lib_name}.js($_wasm_32_or_64_toolchain)",
+      ":${_lib_name}.wasm($_wasm_32_or_64_toolchain)",
     ]
   }
 }  # template

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -32,14 +32,22 @@ if (enable_perfetto_trace_processor_sqlite) {
 }
 
 if (enable_perfetto_ui) {
+  trace_processor_wasm_deps = [
+    ":lib",
+    "../../gn:default_deps",
+    "../base",
+    "rpc:wasm_bridge",
+  ]
+
   wasm_lib("trace_processor_wasm") {
     name = "trace_processor"
-    deps = [
-      ":lib",
-      "../../gn:default_deps",
-      "../base",
-      "rpc:wasm_bridge",
-    ]
+    deps = trace_processor_wasm_deps
+  }
+
+  wasm_lib("trace_processor_memory64_wasm") {
+    name = "trace_processor_memory64"
+    is_memory64 = true
+    deps = trace_processor_wasm_deps
   }
 }
 

--- a/ui/config/rollup.config.js
+++ b/ui/config/rollup.config.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const { uglify } = require('rollup-plugin-uglify');
+const {uglify} = require('rollup-plugin-uglify');
 const commonjs = require('@rollup/plugin-commonjs');
 const nodeResolve = require('@rollup/plugin-node-resolve');
 const path = require('path');
@@ -34,12 +34,15 @@ function defBundle(tsRoot, bundle, distDir) {
     },
     plugins: [
       replace({
-        patterns: [
-          {
-            test: /__IS_MEMORY64_ONLY__/g,
-            replace: JSON.stringify(process.env['IS_MEMORY64_ONLY'] == 'true'),
-          },
-        ],
+        patterns:
+          process.env['IS_MEMORY64_ONLY'] != 'true'
+            ? [
+                {
+                  test: './trace_processor_32_stub',
+                  replace: '../gen/trace_processor',
+                },
+              ]
+            : [],
       }),
 
       nodeResolve({
@@ -56,12 +59,12 @@ function defBundle(tsRoot, bundle, distDir) {
         patterns: [
           // Protobufjs's inquire() uses eval but that's not really needed in
           // the browser. https://github.com/protobufjs/protobuf.js/issues/593
-          { test: /eval\(.*\(moduleName\);/g, replace: 'undefined;' },
+          {test: /eval\(.*\(moduleName\);/g, replace: 'undefined;'},
 
           // Immer entry point has a if (process.env.NODE_ENV === 'production')
           // but |process| is not defined in the browser. Bypass.
           // https://github.com/immerjs/immer/issues/557
-          { test: /process\.env\.NODE_ENV/g, replace: "'production'" },
+          {test: /process\.env\.NODE_ENV/g, replace: "'production'"},
         ],
       }),
 
@@ -113,7 +116,7 @@ function maybeUglify() {
   const minifyEnv = process.env['MINIFY_JS'];
   if (!minifyEnv) return [];
   const opts =
-    minifyEnv === 'preserve_comments' ? { output: { comments: 'all' } } : undefined;
+    minifyEnv === 'preserve_comments' ? {output: {comments: 'all'}} : undefined;
   return [uglify(opts)];
 }
 

--- a/ui/src/engine/index.ts
+++ b/ui/src/engine/index.ts
@@ -13,66 +13,22 @@
 // limitations under the License.
 
 import {WasmBridge} from './wasm_bridge';
-import memory64, {InitWasm} from '../gen/trace_processor_memory64';
-import {base64Decode} from '../base/string_utils';
 
 const selfWorker = self as {} as Worker;
+const wasmBridge = new WasmBridge();
 
-// For manual testing of the Memory32 build, we can disable the Memory64 check.
-const DISABLE_MEMORY64_FOR_MANUAL_TEST = false;
+// There are two message handlers here:
+// 1. The Worker (self.onmessage) handler.
+// 2. The MessagePort handler.
+// The sequence of actions is the following:
+// 1. The frontend does one postMessage({port: MessagePort}) on the Worker
+//    scope. This message transfers the MessagePort.
+//    This is the only postMessage we'll ever receive here.
+// 2. All the other messages (i.e. the TraceProcessor RPC binary pipe) will be
+//    received on the MessagePort.
 
-// Checks if the current environment supports Memory64.
-async function hasMemory64Support() {
-  if (DISABLE_MEMORY64_FOR_MANUAL_TEST) {
-    return false;
-  }
-  try {
-    // Compiled version of WAT program `(module (memory i64 0))` to WASM.
-    await WebAssembly.compile(base64Decode('AGFzbQEAAAAFAwEEAAAIBG5hbWUCAQA='));
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
-// This variable will be replaced by rollup at build time based on the
-// existence of gen/trace_processor; we don't unconditionally build that.
-declare const __IS_MEMORY64_ONLY__: string | undefined;
-
-async function createTraceProcessor(): Promise<InitWasm> {
-  if (await hasMemory64Support()) {
-    return memory64;
-  }
-  // See comment on __IS_MEMORY64_ONLY__ above.
-  if (!__IS_MEMORY64_ONLY__) {
-    // @ts-ignore: TS2307. This module is optional and may not exist. Rollup
-    // correctly ensures this code is not included in the final bundle.
-    return [(await import('../gen/trace_processor')).default, '32'];
-  }
-  throw new Error(
-    `Unable to load trace processor: running a browser without Memory64 ` +
-      `support and with no memory32 build.`,
-  );
-}
-
-async function init() {
-  const wasmBridge = new WasmBridge(await createTraceProcessor());
-
-  // There are two message handlers here:
-  // 1. The Worker (self.onmessage) handler.
-  // 2. The MessagePort handler.
-  // The sequence of actions is the following:
-  // 1. The frontend does one postMessage({port: MessagePort}) on the Worker
-  //    scope. This message transfers the MessagePort.
-  //    This is the only postMessage we'll ever receive here.
-  // 2. All the other messages (i.e. the TraceProcessor RPC binary pipe) will be
-  //    received on the MessagePort.
-
-  // Receives the boostrap message from the frontend with the MessagePort.
-  selfWorker.onmessage = (msg: MessageEvent) => {
-    const port = msg.data as MessagePort;
-    wasmBridge.initialize(port);
-  };
-}
-
-init();
+// Receives the boostrap message from the frontend with the MessagePort.
+selfWorker.onmessage = (msg: MessageEvent) => {
+  const port = msg.data as MessagePort;
+  wasmBridge.initialize(port);
+};

--- a/ui/src/engine/trace_processor_32_stub.ts
+++ b/ui/src/engine/trace_processor_32_stub.ts
@@ -1,0 +1,22 @@
+// Copyright (C) 2018 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default (() => {
+  throw new Error(
+    'Unable to load the 32-bit trace_processor.wasm. ' +
+      'This is because you are running in a browser that does NOT support ' +
+      'Memory64 but passed --only-wasm-memory64 to ui/build ' +
+      '(run-dev-server does that)',
+  );
+}) as never;

--- a/ui/src/engine/wasm_bridge.ts
+++ b/ui/src/engine/wasm_bridge.ts
@@ -14,7 +14,19 @@
 
 import {defer} from '../base/deferred';
 import {assertExists, assertTrue} from '../base/logging';
-import {Module, InitWasm} from '../gen/trace_processor_memory64';
+
+// The 64-bit variant of TraceProcessor wasm is always built in all build
+// configurations and we can depend on it from typescript.
+import TraceProcessor64 from '../gen/trace_processor_memory64';
+
+// The 32-bit variant may or may not be part of the build, depending on whether
+// the user passes --only-wasm-memory64 to ui/build.js. When we are building
+// also the 32-bit (e.g., in production builds) the import below will be
+// redirected by rollup to '../gen/trace_processor' (The 32-bit module).
+import TraceProcessor32 from './trace_processor_32_stub';
+
+// For manual testing of the Memory32 build, we can disable the Memory64 check.
+const DISABLE_MEMORY64_FOR_MANUAL_TEST = false;
 
 // The Initialize() call will allocate a buffer of REQ_BUF_SIZE bytes which
 // will be used to copy the input request data. This is to avoid passing the
@@ -33,32 +45,35 @@ const REQ_BUF_SIZE = 32 * 1024 * 1024;
 //             - [JS] onReply() (this file)
 //               - [JS] postMessage() (this file)
 export class WasmBridge {
-  // When this promise has resolved it is safe to call callWasm.
-  whenInitialized: Promise<void>;
-
   private aborted: boolean;
-  private connection: Module;
-  private reqBufferAddr = BigInt(0);
+  private connection: TraceProcessor64.Module;
+  private reqBufferAddr = 0;
   private lastStderr: string[] = [];
   private messagePort?: MessagePort;
+  private useMemory64: boolean;
 
-  constructor(init: InitWasm) {
+  constructor() {
     this.aborted = false;
     const deferredRuntimeInitialized = defer<void>();
-    this.connection = init({
+    this.useMemory64 = hasMemory64Support();
+    const initModule = this.useMemory64 ? TraceProcessor64 : TraceProcessor32;
+    this.connection = initModule({
       locateFile: (s: string) => s,
       print: (line: string) => console.log(line),
       printErr: (line: string) => this.appendAndLogErr(line),
       onRuntimeInitialized: () => deferredRuntimeInitialized.resolve(),
     });
-    this.whenInitialized = deferredRuntimeInitialized.then(() => {
+
+    deferredRuntimeInitialized.then(() => {
       const fn = this.connection.addFunction(this.onReply.bind(this), 'vpi');
-      this.reqBufferAddr = this.connection.ccall(
-        'trace_processor_rpc_init',
-        /* return=*/ 'pointer',
-        /* args=*/ ['pointer', 'number'],
-        [fn, REQ_BUF_SIZE],
-      ) as unknown as bigint;
+      this.reqBufferAddr = this.wasmPtrCast(
+        this.connection.ccall(
+          'trace_processor_rpc_init',
+          /* return=*/ 'pointer',
+          /* args=*/ ['pointer', 'number'],
+          [fn, REQ_BUF_SIZE],
+        ),
+      );
     });
   }
 
@@ -84,7 +99,7 @@ export class WasmBridge {
     while (wrSize < data.length) {
       const sliceLen = Math.min(data.length - wrSize, REQ_BUF_SIZE);
       const dataSlice = data.subarray(wrSize, wrSize + sliceLen);
-      this.connection.HEAPU8.set(dataSlice, Number(this.reqBufferAddr));
+      this.connection.HEAPU8.set(dataSlice, this.reqBufferAddr);
       wrSize += sliceLen;
       try {
         this.connection.ccall(
@@ -107,11 +122,9 @@ export class WasmBridge {
 
   // This function is bound and passed to Initialize and is called by the C++
   // code while in the ccall(trace_processor_on_rpc_request).
-  private onReply(heapPtr: bigint, size: number) {
-    const data = this.connection.HEAPU8.slice(
-      Number(heapPtr),
-      Number(heapPtr) + size,
-    );
+  private onReply(heapPtrArg: bigint | number, size: number) {
+    const heapPtr = this.wasmPtrCast(heapPtrArg);
+    const data = this.connection.HEAPU8.slice(heapPtr, heapPtr + size);
     assertExists(this.messagePort).postMessage(data, [data.buffer]);
   }
 
@@ -122,5 +135,42 @@ export class WasmBridge {
     if (this.lastStderr.length > 512) {
       this.lastStderr.shift();
     }
+  }
+
+  // Takes a wasm pointer and converts it into a positive number < 2**53.
+  // When using memory64 pointer args are passed as BigInt, but they are
+  // guaranteed to be < 2**53 anyways.
+  // When using memory32, pointer args are passed as numbers. However, because
+  // they can be between 2GB and 4GB, we need to remove the negative sign.
+  private wasmPtrCast(val: number | bigint): number {
+    if (this.useMemory64) {
+      return Number(val);
+    }
+    // Force heapPtr to be a positive using an unsigned right shift.
+    // The issue here is the following: the matching code in wasm_bridge.cc
+    // invokes this function passing  arguments as uint32_t. However, in the
+    // wasm<>JS interop bindings, the uint32 args become Js numbers. If the
+    // pointer is > 2GB, this number will be negative, which causes the wrong
+    // behaviour when used as an offset on HEAP8U.
+    assertTrue(typeof val === 'number');
+    return Number(val) >>> 0; // static_cast<uint32_t>
+  }
+}
+
+// Checks if the current environment supports Memory64.
+function hasMemory64Support() {
+  if (DISABLE_MEMORY64_FOR_MANUAL_TEST) {
+    return false;
+  }
+  // Compiled version of WAT program `(module (memory i64 0))` to WASM.
+  const memory64DetectProgram = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x05, 0x03, 0x01, 0x04,
+    0x00, 0x00, 0x08, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x02, 0x01, 0x00,
+  ]);
+  try {
+    new WebAssembly.Module(memory64DetectProgram);
+    return true;
+  } catch (e) {
+    return false;
   }
 }


### PR DESCRIPTION
- Reduce duplication in .gni files
- Make 64-bit detection synchronous. The async adds extra complexity that can be avoided.
- Change the way 64-bit-only is passed. I am not a an of the "async import" as that
  IMHO creates unnecessary risks and makes the code even more complicate due to
  an unnecessary async. Instad use a stub import + rollup to redirect to the real import.
- Rollback some of the changes to engine.ts. I don't like the extra layers introduced by
  #1458. I think the previous model where wasm_bridge.ts does everything is cleaner.
- Fix a bug which #1458 accidentally re-introduced on wasm32, where addresses that are
 between 2GB and 4GB accidentally become negative offsets.

I tested it both on Chrome (which supports wasm64) and an older Firefox (which doesn't)