### PR TITLE
Add plugin to handle entity state residency aggregation

### DIFF
--- a/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
@@ -1,0 +1,124 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Duration} from '../../base/time';
+import {ColumnDef, Sorting} from '../../public/aggregation';
+import {AreaSelection} from '../../public/selection';
+import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
+import {Engine} from '../../trace_processor/engine';
+import {AreaSelectionAggregator} from '../../public/selection';
+import {LONG, NUM} from '../../trace_processor/query_result';
+
+export class EntityStateResidencySelectionAggregator
+  implements AreaSelectionAggregator
+{
+  readonly id = 'entity_state_residency_aggregation';
+
+  // This just describes which counters we match, we don't actually use the
+  // resulting datasets, but it's a useful too to show what we actually match.
+  readonly trackKind = COUNTER_TRACK_KIND;
+  readonly schema = {
+    id: NUM,
+    ts: LONG,
+    value: NUM,
+  };
+
+  async createAggregateView(engine: Engine, area: AreaSelection) {
+    const trackIds: (string | number)[] = [];
+    for (const trackInfo of area.tracks) {
+      if (
+        trackInfo?.tags?.kind === COUNTER_TRACK_KIND &&
+        trackInfo?.tags?.type === 'entity_state'
+      ) {
+        trackInfo.tags?.trackIds && trackIds.push(...trackInfo.tags.trackIds);
+      }
+    }
+    if (trackIds.length === 0) return false;
+    const duration = area.end - area.start;
+    const durationSec = Duration.toSeconds(duration);
+
+    const query = `INCLUDE PERFETTO MODULE android.entity_state_residency;
+      CREATE OR REPLACE PERFETTO TABLE ${this.id} AS
+        WITH aggregated AS (
+          SELECT
+            track_id,
+            entity_name,
+            state_name,
+            COUNT(state_time_since_boot) AS count,
+            value_at_max_ts(-ts, state_time_since_boot) AS first,
+            value_at_max_ts(ts, state_time_since_boot) AS last
+          FROM android_entity_state_residency
+          WHERE track_id in (${trackIds})
+            AND ts BETWEEN ${area.start} AND ${area.end}
+          GROUP BY track_id, entity_name, state_name
+        )
+        SELECT
+          entity_name,
+          state_name,
+          count,
+          (last - first) / 1e6 AS delta_value,
+          ROUND((last - first)/(${durationSec} * 1e9) * 100, 2) AS rate_percent
+        FROM aggregated
+        GROUP BY track_id, entity_name, state_name`;
+    await engine.query(query);
+    return true;
+  }
+
+  getColumnDefinitions(): ColumnDef[] {
+    return [
+      {
+        title: 'Entity',
+        kind: 'STRING',
+        columnConstructor: Uint16Array,
+        columnId: 'entity_name',
+      },
+      {
+        title: 'State',
+        kind: 'STRING',
+        columnConstructor: Uint16Array,
+        columnId: 'state_name',
+      },
+      {
+        title: 'Time in state (ms)',
+        kind: 'NUMBER',
+        columnConstructor: Float64Array,
+        columnId: 'delta_value',
+        sum: true,
+      },
+      {
+        title: 'Time in state (%)',
+        kind: 'Number',
+        columnConstructor: Float64Array,
+        columnId: 'rate_percent',
+        sum: true,
+      },
+      {
+        title: 'Sample Count',
+        kind: 'Number',
+        columnConstructor: Float64Array,
+        columnId: 'count',
+      },
+    ];
+  }
+
+  async getExtra() {}
+
+  getTabName() {
+    return 'Entity State Residency';
+  }
+
+  getDefaultSorting(): Sorting {
+    return {column: 'entity_name', direction: 'DESC'};
+  }
+}

--- a/ui/src/plugins/dev.perfetto.EntityStateResidency/index.ts
+++ b/ui/src/plugins/dev.perfetto.EntityStateResidency/index.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {createAggregationToTabAdaptor} from '../../components/aggregation_adapter';
+import {PerfettoPlugin} from '../../public/plugin';
+import {Trace} from '../../public/trace';
+import {EntityStateResidencySelectionAggregator} from './entity_state_residency_selection_aggregator';
+
+/**
+ * This plugin handles the aggregations for entity state residency counter tracks.
+ */
+export default class implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.EntityStateResidency';
+
+  async onTraceLoad(ctx: Trace): Promise<void> {
+    ctx.selection.registerAreaSelectionTab(
+      createAggregationToTabAdaptor(
+        ctx,
+        new EntityStateResidencySelectionAggregator(),
+        200,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add a plugin to handle entity state residency. This plugin aims to present existing aggregation data in a more user-friendly manner, as well a remove aggregations that do not make sense. This is similar in concept to https://github.com/google/perfetto/pull/1211

This commit DOES NOT aim to fix any existing errors in computation like is mentioned in https://github.com/google/perfetto/issues/1478 and instead just aims to focus on better labeling for existing data

BUG: https://github.com/google/perfetto/issues/1321

## Before:

![image](https://github.com/user-attachments/assets/f3d81da6-5511-4817-a835-1c897960af83)


## After:

![image](https://github.com/user-attachments/assets/e32506d7-87d7-4bda-9f66-d7c5809756a0)

