### PR TITLE
Flame graph filtering by unaggregated properties 

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
@@ -113,7 +113,7 @@ RETURNS TableOrSubquery AS
     path_hash AS parent_path_hash,
     '[native] ' || x.name AS name,
     root_type,
-    'native' AS heap_type,
+    'HEAP_TYPE_NATIVE' AS heap_type,
     sum(x.self_native_count) AS self_count,
     sum(x.self_native_size) AS self_size
   FROM x


### PR DESCRIPTION
This is useful e.g. to filter by root type or by heap type (e.g. ss:
HEAP_TYPE_APP to avoid looking at boot / zygote classes for a heap dump)

Bug: 417266471