### PR TITLE
Disable some heapprofd cts tests for native bridge [cherry-pick]

### DIFF
--- a/test/cts/heapprofd_test_cts.cc
+++ b/test/cts/heapprofd_test_cts.cc
@@ -45,7 +45,25 @@ static_assert(kExpectedIndividualAllocSz > kTestSamplingInterval,
 // malloc(kExpectedIndividualAllocSz).
 static char kMallocActivity[] = "MainActivity";
 
+// Note that tests using AssertExpectedMallocsPresent are relying on the fact
+// that callstacks can provide information about which function called
+// malloc/free. This is not the case for apps running with native_bridge.
+//
+// For these there are 2 different stacks: native one - visible to perfetto;
+// and another one for emulated architecture. Perfetto currently does not
+// detect/report stack for emulated apps and the native stacktrace looks
+// similar for all memory allocations initiated from emulated code.
+//
+// Since having perfetto handle second callstack is not a trivial change
+// we disable these tests if ran on emulated architectures.
+//
+// See also http://b/411111586.
+#define SKIP_WITH_NATIVE_BRIDGE  \
+  if (RunningWithNativeBridge()) \
+  GTEST_SKIP()
+
 TEST(HeapprofdCtsTest, DebuggableAppRuntime) {
+  SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
   std::string app_name = "android.perfetto.cts.app.debuggable";
   const auto& packets = ProfileRuntime(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});
@@ -54,6 +72,7 @@ TEST(HeapprofdCtsTest, DebuggableAppRuntime) {
 }
 
 TEST(HeapprofdCtsTest, DebuggableAppStartup) {
+  SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
   std::string app_name = "android.perfetto.cts.app.debuggable";
   const auto& packets = ProfileStartup(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});
@@ -62,6 +81,7 @@ TEST(HeapprofdCtsTest, DebuggableAppStartup) {
 }
 
 TEST(HeapprofdCtsTest, ProfileableAppRuntime) {
+  SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
   std::string app_name = "android.perfetto.cts.app.profileable";
   const auto& packets = ProfileRuntime(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});
@@ -70,6 +90,7 @@ TEST(HeapprofdCtsTest, ProfileableAppRuntime) {
 }
 
 TEST(HeapprofdCtsTest, ProfileableAppStartup) {
+  SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
   std::string app_name = "android.perfetto.cts.app.profileable";
   const auto& packets = ProfileStartup(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});
@@ -78,6 +99,9 @@ TEST(HeapprofdCtsTest, ProfileableAppStartup) {
 }
 
 TEST(HeapprofdCtsTest, ReleaseAppRuntime) {
+  if (!IsUserBuild()) {
+    SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
+  }
   std::string app_name = "android.perfetto.cts.app.release";
   const auto& packets = ProfileRuntime(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});
@@ -90,6 +114,9 @@ TEST(HeapprofdCtsTest, ReleaseAppRuntime) {
 }
 
 TEST(HeapprofdCtsTest, ReleaseAppStartup) {
+  if (!IsUserBuild()) {
+    SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
+  }
   std::string app_name = "android.perfetto.cts.app.release";
   const auto& packets = ProfileStartup(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});
@@ -102,6 +129,9 @@ TEST(HeapprofdCtsTest, ReleaseAppStartup) {
 }
 
 TEST(HeapprofdCtsTest, NonProfileableAppRuntime) {
+  if (!IsUserBuild()) {
+    SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
+  }
   std::string app_name = "android.perfetto.cts.app.nonprofileable";
   const auto& packets = ProfileRuntime(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});
@@ -113,6 +143,9 @@ TEST(HeapprofdCtsTest, NonProfileableAppRuntime) {
 }
 
 TEST(HeapprofdCtsTest, NonProfileableAppStartup) {
+  if (!IsUserBuild()) {
+    SKIP_WITH_NATIVE_BRIDGE;  // http://b/411111586
+  }
   std::string app_name = "android.perfetto.cts.app.nonprofileable";
   const auto& packets = ProfileStartup(
       app_name, kMallocActivity, kTestSamplingInterval, /*heap_names=*/{});

--- a/test/cts/heapprofd_test_helper.cc
+++ b/test/cts/heapprofd_test_helper.cc
@@ -317,4 +317,25 @@ void AssertNoProfileContents(
   }
 }
 
+// Copied from
+// https://source.corp.google.com/h/googleplex-android/platform/superproject/main/+/main:system/libbase/include/android-base/macros.h;l=137
+// Current ABI string
+#if defined(__arm__)
+#define ABI_STRING "arm"
+#elif defined(__aarch64__)
+#define ABI_STRING "arm64"
+#elif defined(__i386__)
+#define ABI_STRING "x86"
+#elif defined(__riscv)
+#define ABI_STRING "riscv64"
+#elif defined(__x86_64__)
+#define ABI_STRING "x86_64"
+#endif
+
+bool RunningWithNativeBridge() {
+  static const prop_info* pi =
+      __system_property_find("ro.dalvik.vm.isa." ABI_STRING);
+  return pi != nullptr;
+}
+
 }  // namespace perfetto

--- a/test/cts/heapprofd_test_helper.h
+++ b/test/cts/heapprofd_test_helper.h
@@ -54,6 +54,8 @@ void AssertHasSampledAllocs(
 void AssertNoProfileContents(
     const std::vector<protos::gen::TracePacket>& packets);
 
+bool RunningWithNativeBridge();
+
 }  // namespace perfetto
 
 #endif  // TEST_CTS_HEAPPROFD_TEST_HELPER_H_


### PR DESCRIPTION
These tests are relying on the fact that callstacks can provide information about which function called malloc/free.

This is not the case for apps running with native_bridge. For these there exists 2 different stacks (native one - visible to perfetto) and another one for emulated architecture (to access which perfetto needs to read and unwind second, - guest stack).

The result is that as of now all native callstacks for memory allocations originated for emulated apps look the same and get aggregated together. And this is why test does not pass.

Bug: 411111586
Test: run heapprofd tests on Android Emulator under native bridge
Change-Id: I24499cd22095e3c0002bc426ff4c9d64dfb9b8e6
(cherry picked from commit ada6248a1f195ed278e2956602f2f161d1baed6c)
