### PR TITLE
UI: add support for triple-backtick code blocks

### DIFF
--- a/ui/src/assets/record.scss
+++ b/ui/src/assets/record.scss
@@ -730,6 +730,15 @@
       line-height: 20px;
     }
 
+    code {
+      background: #eee;
+      display: block;
+      padding: 5px;
+      margin: 5px 0;
+      border: 1px dotted #999;
+      white-space: pre-wrap;
+    }
+
     // .probe-config is showed only when the probe is enabled.
     .probe-config {
       @include transition(0.3s);

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/probe_renderer.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/probe_renderer.ts
@@ -71,7 +71,7 @@ export class Probe implements m.ClassComponent<ProbeAttrs> {
             `div${probe.image ? '' : '.extended-desc'}`,
             m(
               'div',
-              probe.description,
+              formatDescription(probe.description),
               probe.docsLink && m(DocsChip, {href: probe.docsLink}),
             ),
             m(
@@ -83,4 +83,36 @@ export class Probe implements m.ClassComponent<ProbeAttrs> {
           ),
     );
   }
+}
+
+/** Formats the probe.description turning ``` blocks into code snippets */
+function formatDescription(input: string | undefined): m.Children {
+  if (input === undefined) return [];
+
+  const result: m.Children = [];
+  const regex = /```(.*?)```/gs;
+  let lastIndex = 0;
+
+  for (const match of input.matchAll(regex)) {
+    const [fullMatch, codeContent] = match;
+    const matchStart = match.index ?? 0;
+
+    // Add preceding plain text
+    if (matchStart > lastIndex) {
+      const text = input.slice(lastIndex, matchStart);
+      result.push(m('div', text));
+    }
+
+    // Add code block
+    result.push(m('code', codeContent));
+
+    lastIndex = matchStart + fullMatch.length;
+  }
+
+  // Add remaining text after last match
+  if (lastIndex < input.length) {
+    result.push(m('div', input.slice(lastIndex)));
+  }
+
+  return result;
 }


### PR DESCRIPTION
Allows to add ``` code blocks ``` in the probe description.
Needed for https://github.com/google/perfetto/pull/1510

![image](https://github.com/user-attachments/assets/fdca93a7-bd9c-48d8-8b66-85f7e5e1f940)
