### PR TITLE
Dump attached insets in InsetsSource

### DIFF
--- a/protos/perfetto/trace/android/view/insetssource.proto
+++ b/protos/perfetto/trace/android/view/insetssource.proto
@@ -27,4 +27,5 @@ message InsetsSourceProto {
   optional RectProto visible_frame = 3;
   optional bool visible = 4;
   optional int32 type_number = 5;
+  optional RectProto attached_insets = 6;
 }


### PR DESCRIPTION
This is necessary to let CTS support relative insets. Also the information can be used for debugging.

Test: CTS: SplashscreenTests
Bug: 277292497
Change-Id: I94b15644ef1efa58d3b8d5c851bfecb569e7b8ad