### PR TITLE
CI: add 'opened' event to two reviewer check

### DIFF
--- a/.github/workflows/require-two-reviewers-for-fork-prs.yml
+++ b/.github/workflows/require-two-reviewers-for-fork-prs.yml
@@ -19,7 +19,7 @@ name: Enforce 2 collaborator reviews for fork PRs
 
 on:
   pull_request_target:
-    types: [synchronize, labeled, edited, auto_merge_enabled, auto_merge_disabled]
+    types: [opened, synchronize, labeled, edited, auto_merge_enabled, auto_merge_disabled]
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
I just realized that the latest changes can be confusing for googlers.
For them the check will never trigger if they don't upload a new
patchset or use auto-merge.
Add a trigger on creation, which will always pass for googlers.
