### PR TITLE
Fix duration in android_kernel_wakelocks table.

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/kernel_wakelocks.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/kernel_wakelocks.sql
@@ -54,6 +54,8 @@ CREATE PERFETTO TABLE android_kernel_wakelocks (
   ts TIMESTAMP,
   -- Duration.
   dur DURATION,
+  -- Duration spent awake.
+  awake_dur DURATION,
   -- Kernel or native wakelock name.
   name STRING,
   -- 'kernel' or 'native'.
@@ -73,8 +75,6 @@ WITH
       sum(dur) AS dur,
       sum(iif(power_state = 'awake', dur, 0)) AS awake_dur
     FROM _android_kernel_wakelocks_joined
-    WHERE
-      power_state = 'awake'
     GROUP BY
       1,
       2,
@@ -84,6 +84,7 @@ WITH
 SELECT
   ts,
   dur,
+  awake_dur,
   name,
   type,
   cast_int!(held_dur) AS held_dur,

--- a/src/trace_processor/perfetto_sql/stdlib/android/kernel_wakelocks.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/kernel_wakelocks.sql
@@ -76,10 +76,10 @@ WITH
       sum(iif(power_state = 'awake', dur, 0)) AS awake_dur
     FROM _android_kernel_wakelocks_joined
     GROUP BY
-      1,
-      2,
-      3,
-      4
+      ts,
+      name,
+      type,
+      held_dur
   )
 SELECT
   ts,


### PR DESCRIPTION
We accidentally had an extra `WHERE` clause that meant we were only counting awake time towards `dur`. Fix that, and expose `awake_dur` in case anyone actually wants that.
