### PR TITLE
Await loadJson() in dev.perfetto.SqlModules plugin

### DIFF
--- a/ui/src/plugins/dev.perfetto.SqlModules/index.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/index.ts
@@ -26,7 +26,7 @@ export default class implements PerfettoPlugin {
   private tables?: string[];
 
   async onTraceLoad(ctx: Trace) {
-    this.loadJson(ctx);
+    await this.loadJson(ctx);
   }
 
   private async loadJson(ctx: Trace) {


### PR DESCRIPTION
Fixes: https://buganizer.corp.google.com/issues/413722658

We have guard rails in place to stop traces from loading simultaneously, but these guard rails are only good if the plugins doo all their loading within their onTraceLoad() function. The SqlModules plugin starts a fetch from the server and immediately returns, indicating to the core that it's done loading while the fetch completes some time later.

When two traces are loaded in quick succession, we can end up with two loadJson() functions running concurrently. When they resolve they both try to add the same command to the command registry resulting in an error as seen in the bug report.

This patch fixes the immediate problem by awaiting the fetch within the plugin's onTraceLoad() function.

