### PR TITLE
CI: change downscaling strategy to avoid interruptions

### DIFF
--- a/infra/ci/Makefile
+++ b/infra/ci/Makefile
@@ -80,7 +80,7 @@ clean:
 		--maintenance-policy=MIGRATE \
 		--service-account=gce-ci-worker@${PROJECT}.iam.gserviceaccount.com \
 		--scopes=${GCE_SCOPES} \
-		--image=projects/cos-cloud/global/images/cos-117-18613-164-81 \
+		--image=projects/cos-cloud/global/images/cos-121-18867-90-23 \
 		--boot-disk-size=100GB \
 		--boot-disk-type=pd-ssd \
 		--boot-disk-device-name=${GCE_TEMPLATE} \
@@ -101,13 +101,16 @@ gcloud compute --project=${PROJECT} \
 	--region=$1 \
 	--base-instance-name=${GCE_GROUP_NAME}-$1 \
 	--template=${GCE_TEMPLATE} \
-	--size=1
+	--standby-policy-mode=scale-out-pool \
+	--standby-policy-initial-delay=10 \
+	--size 0
 gcloud compute --quiet --project=$(PROJECT) \
 	instance-groups managed set-autoscaling ${GCE_GROUP_NAME}-$1 \
 	--region=$1 \
 	--min-num-replicas=${AUTOSCALER_MIN} \
 	--max-num-replicas=${MAX_VMS_PER_REGION} \
-	--cool-down-period=1800 \
+	--cool-down-period=300 \
+	--mode=only-scale-out \
 	--stackdriver-metric-filter="resource.type = \"global\"" \
 	--update-stackdriver-metric="custom.googleapis.com/$(PROJECT)/ci_job_queue_len" \
 	--stackdriver-metric-single-instance-assignment=${NUM_WORKERS_PER_VM}
@@ -120,7 +123,6 @@ start-workers: .deps/gce-template
 define stop-workers-for-region
 gcloud compute --quiet --project=${PROJECT} \
 	instance-groups managed delete ${GCE_GROUP_NAME}-$1 --region=$1 || true
-
 endef
 
 .PHONY: stop-workers

--- a/infra/ci/config.py
+++ b/infra/ci/config.py
@@ -41,10 +41,10 @@ LOGS_TTL_DAYS = 15
 TRUSTED_EMAILS = '^.*@google.com$'
 
 GCE_REGIONS = 'us-west1'
-GCE_VM_NAME = 'gh-worker'
+GCE_VM_NAME = 'ci-worker'
 GCE_VM_TYPE = 'c2d-standard-32'
-GCE_TEMPLATE = 'gh-worker-template'
-GCE_GROUP_NAME = 'gh'
+GCE_TEMPLATE = 'ci-worker-template'
+GCE_GROUP_NAME = 'ci'
 MAX_VMS_PER_REGION = 8
 NUM_WORKERS_PER_VM = 4
 AUTOSCALER_MIN = 0

--- a/infra/ci/worker/sandbox_runner.py
+++ b/infra/ci/worker/sandbox_runner.py
@@ -29,6 +29,7 @@ import sys
 
 from config import SANDBOX_IMG, GITHUB_REPO, SANDBOX_SVC_ACCOUNT
 from common_utils import get_github_registration_token
+from pathlib import Path
 
 CUR_DIR = os.path.dirname(__file__)
 
@@ -71,6 +72,10 @@ def main():
 
   signal.signal(signal.SIGTERM, sig_handler)
   signal.signal(signal.SIGINT, sig_handler)
+
+  # Update the mtime of perfetto_ci_lastrun. This is used to shutdown the
+  # GCE vm when idle for too long.
+  Path('/tmp/perfetto_ci_lastrun').touch()
 
   # Remove stale sandbox from previous runs, if any.
   subprocess.call(['docker', 'rm', '-f', SANDBOX_NAME],


### PR DESCRIPTION
The current design (before this CL) uses the MIG autoscaler to scale up and down.
That creates the problem that the autoscaler can shutdown a VM that has sandboxes
running, if they pick up the job late. This CL changes it to a new strategy where:
- The autoscaler only scales up
- Each GCE VM self-shutdowns after all sandbozes are idle for 90 mins.

This should reduce the possible race significantly and avoid interrupted jobs.

Bug: b/417658206
