### PR TITLE
[traceconv] Allow passing pid/timestamps to java_heap_profile format

### DIFF
--- a/src/traceconv/main.cc
+++ b/src/traceconv/main.cc
@@ -164,11 +164,13 @@ int Main(int argc, char** argv) {
 
   std::string format(positional_args[0]);
 
-  if ((format != "profile" && format != "hprof") &&
+  if ((format != "profile" &&
+       format != "hprof" &&
+       format != "java_heap_profile") &&
       (pid != 0 || !timestamps.empty())) {
     PERFETTO_ELOG(
-        "--pid and --timestamps are supported only for profile "
-        "formats.");
+        "--pid and --timestamps are supported only for profile, hprof, "
+        "and java_heap_profile formats.");
     return 1;
   }
   if (perf_profile && format != "profile") {


### PR DESCRIPTION
Currently, traceconv fails when trying to specify either of these arguments when using `java_heap_profile`, but this subcommand support them. Also updated the error message to mention 'hprof' format too.

Tested by running: `traceconv java_heap_profile --timestamps 14335729096436 --pid 16437` and checked that it output a valid profile.