### PR TITLE
Make timestamp & duration format settings available all the time, not just when a trace is loaded

### DIFF
--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -12,43 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists, assertTrue} from '../base/logging';
-import {App} from '../public/app';
-import {TraceContext, TraceImpl} from './trace_impl';
-import {CommandManagerImpl} from './command_manager';
-import {OmniboxManagerImpl} from './omnibox_manager';
-import {raf} from './raf_scheduler';
-import {SidebarManagerImpl} from './sidebar_manager';
-import {PluginManagerImpl} from './plugin_manager';
-import {NewEngineMode} from '../trace_processor/engine';
-import {RouteArgs} from '../public/route_schema';
-import {SqlPackage} from '../public/extra_sql_packages';
-import {SerializedAppState} from './state_serialization_schema';
-import {PostedTrace, TraceSource} from './trace_source';
-import {loadTrace} from './load_trace';
-import {CORE_PLUGIN_ID} from './plugin_manager';
-import {Router} from './router';
-import {AnalyticsInternal, initAnalytics} from './analytics_impl';
-import {createProxy, getOrCreate} from '../base/utils';
-import {PageManagerImpl} from './page_manager';
-import {PageHandler} from '../public/page';
-import {PerfManager} from './perf_manager';
-import {ServiceWorkerController} from '../frontend/service_worker_controller';
-import {FeatureFlagManager, FlagSettings} from '../public/feature_flag';
-import {featureFlags} from './feature_flags';
-import {Raf} from '../public/raf';
 import {AsyncLimiter} from '../base/async_limiter';
-import {
-  PERFETTO_SETTINGS_STORAGE_KEY,
-  SettingsManagerImpl,
-} from './settings_manager';
-import {SettingsManager} from '../public/settings';
-import {LocalStorage} from './local_storage';
+import {assertExists, assertTrue} from '../base/logging';
+import {createProxy, getOrCreate} from '../base/utils';
+import {ServiceWorkerController} from '../frontend/service_worker_controller';
+import {App} from '../public/app';
+import {SqlPackage} from '../public/extra_sql_packages';
+import {FeatureFlagManager, FlagSettings} from '../public/feature_flag';
+import {PageHandler} from '../public/page';
+import {Raf} from '../public/raf';
+import {RouteArgs} from '../public/route_schema';
+import {Setting, SettingsManager} from '../public/settings';
+import {DurationPrecision, TimestampFormat} from '../public/timeline';
+import {NewEngineMode} from '../trace_processor/engine';
+import {AnalyticsInternal, initAnalytics} from './analytics_impl';
+import {CommandManagerImpl} from './command_manager';
+import {featureFlags} from './feature_flags';
+import {loadTrace} from './load_trace';
+import {OmniboxManagerImpl} from './omnibox_manager';
+import {PageManagerImpl} from './page_manager';
+import {PerfManager} from './perf_manager';
+import {CORE_PLUGIN_ID, PluginManagerImpl} from './plugin_manager';
+import {raf} from './raf_scheduler';
+import {Router} from './router';
+import {SettingsManagerImpl} from './settings_manager';
+import {SidebarManagerImpl} from './sidebar_manager';
+import {SerializedAppState} from './state_serialization_schema';
+import {TraceContext, TraceImpl} from './trace_impl';
+import {PostedTrace, TraceSource} from './trace_source';
 
 // The args that frontend/index.ts passes when calling AppImpl.initialize().
 // This is to deal with injections that would otherwise cause circular deps.
 export interface AppInitArgs {
-  initialRouteArgs: RouteArgs;
+  readonly initialRouteArgs: RouteArgs;
+  readonly settingsManager: SettingsManagerImpl;
+  readonly timestampFormatSetting: Setting<TimestampFormat>;
+  readonly durationPrecisionSetting: Setting<DurationPrecision>;
 }
 
 /**
@@ -80,9 +79,7 @@ export class AppContext {
   readonly embeddedMode: boolean;
   readonly testingMode: boolean;
   readonly openTraceAsyncLimiter = new AsyncLimiter();
-  readonly settingsManager = new SettingsManagerImpl(
-    new LocalStorage(PERFETTO_SETTINGS_STORAGE_KEY),
-  );
+  readonly settingsManager: SettingsManagerImpl;
 
   // This is normally empty and is injected with extra google-internal packages
   // via is_internal_user.js
@@ -102,9 +99,15 @@ export class AppContext {
     return assertExists(AppContext._instance);
   }
 
+  readonly timestampFormat: Setting<TimestampFormat>;
+  readonly durationPrecision: Setting<DurationPrecision>;
+
   // This constructor is invoked only once, when frontend/index.ts invokes
   // AppMainImpl.initialize().
   private constructor(initArgs: AppInitArgs) {
+    this.timestampFormat = initArgs.timestampFormatSetting;
+    this.durationPrecision = initArgs.durationPrecisionSetting;
+    this.settingsManager = initArgs.settingsManager;
     this.initArgs = initArgs;
     this.initialRouteArgs = initArgs.initialRouteArgs;
     this.serviceWorkerController = new ServiceWorkerController();

--- a/ui/src/core/fake_trace_impl.ts
+++ b/ui/src/core/fake_trace_impl.ts
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import z from 'zod';
 import {Time} from '../base/time';
 import {EngineBase} from '../trace_processor/engine';
 import {AppImpl} from './app_impl';
+import {InMemoryStorage} from './in_memory_storage';
+import {SettingsManagerImpl} from './settings_manager';
 import {TraceImpl} from './trace_impl';
 import {TraceInfoImpl} from './trace_info_impl';
+import {DurationPrecision, TimestampFormat} from '../public/timeline';
 
 export interface FakeTraceImplArgs {
   // If true suppresses exceptions when trying to issue a query. This is to
@@ -30,7 +34,26 @@ let appImplInitialized = false;
 export function initializeAppImplForTesting(): AppImpl {
   if (!appImplInitialized) {
     appImplInitialized = true;
-    AppImpl.initialize({initialRouteArgs: {}});
+
+    const settingsManager = new SettingsManagerImpl(new InMemoryStorage());
+    AppImpl.initialize({
+      initialRouteArgs: {},
+      settingsManager,
+      timestampFormatSetting: settingsManager.register({
+        id: 'timestampFormat',
+        name: 'Timestamp Format',
+        description: '',
+        defaultValue: TimestampFormat.Timecode,
+        schema: z.nativeEnum(TimestampFormat),
+      }),
+      durationPrecisionSetting: settingsManager.register({
+        id: 'durationPrecision',
+        name: 'Duration Precision',
+        description: '',
+        defaultValue: DurationPrecision.Full,
+        schema: z.nativeEnum(DurationPrecision),
+      }),
+    });
   }
   return AppImpl.instance;
 }

--- a/ui/src/core/in_memory_storage.ts
+++ b/ui/src/core/in_memory_storage.ts
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Storage} from './storage';
+
+export class InMemoryStorage implements Storage {
+  private storage: Record<string, unknown> = {};
+
+  load(): Record<string, unknown> {
+    return this.storage;
+  }
+
+  save(value: Record<string, unknown>): void {
+    this.storage = value;
+  }
+}

--- a/ui/src/core/timeline.ts
+++ b/ui/src/core/timeline.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import z from 'zod';
 import {assertUnreachable} from '../base/logging';
 import {Time, time, TimeSpan} from '../base/time';
 import {HighPrecisionTimeSpan} from '../base/high_precision_time_span';
@@ -20,7 +19,7 @@ import {raf} from './raf_scheduler';
 import {HighPrecisionTime} from '../base/high_precision_time';
 import {DurationPrecision, Timeline, TimestampFormat} from '../public/timeline';
 import {TraceInfo} from '../public/trace_info';
-import {Setting, SettingsManager} from '../public/settings';
+import {Setting} from '../public/settings';
 
 const MIN_DURATION = 10;
 
@@ -84,33 +83,15 @@ export class TimelineImpl implements Timeline {
     raf.scheduleCanvasRedraw();
   }
 
-  private readonly _timestampFormat: Setting<TimestampFormat>;
-  private readonly _durationPrecision: Setting<DurationPrecision>;
-
   constructor(
     private readonly traceInfo: TraceInfo,
-    settings: SettingsManager,
+    private readonly _timestampFormat: Setting<TimestampFormat>,
+    private readonly _durationPrecision: Setting<DurationPrecision>,
   ) {
     this._visibleWindow = HighPrecisionTimeSpan.fromTime(
       traceInfo.start,
       traceInfo.end,
     );
-
-    this._timestampFormat = settings.register({
-      id: 'timestampFormat',
-      name: 'Timestamp format',
-      description: 'The format of timestamps throughout Perfetto.',
-      schema: z.nativeEnum(TimestampFormat),
-      defaultValue: TimestampFormat.Timecode,
-    });
-
-    this._durationPrecision = settings.register({
-      id: 'durationPrecision',
-      name: 'Duration precision',
-      description: 'The precision of durations throughout Perfetto.',
-      schema: z.nativeEnum(DurationPrecision),
-      defaultValue: DurationPrecision.Full,
-    });
   }
 
   // TODO: there is some redundancy in the fact that both |visibleWindowTime|

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -95,18 +95,11 @@ export class TraceContext implements Disposable {
     this.trash.use(engine);
     this.traceInfo = traceInfo;
 
-    // Wrap the core settings manager in a proxy which removes registered
-    // settings when the trace is disposed.
-    // TODO(stevegolton): Dedupe this with the one in TraceImpl.
-    const settingsManagerProxy = createProxy(gctx.settingsManager, {
-      register: <T>(setting: SettingDescriptor<T>): Setting<T> => {
-        const settingInstance = gctx.settingsManager.register(setting);
-        this.trash.use(settingInstance);
-        return settingInstance;
-      },
-    });
-
-    this.timeline = new TimelineImpl(traceInfo, settingsManagerProxy);
+    this.timeline = new TimelineImpl(
+      traceInfo,
+      this.appCtx.timestampFormat,
+      this.appCtx.durationPrecision,
+    );
 
     this.scrollHelper = new ScrollHelper(
       this.traceInfo,

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // Keep this import first.
+import z from 'zod';
 import '../base/disposable_polyfill';
 import '../base/static_initializers';
 import NON_CORE_PLUGINS from '../gen/all_plugins';
@@ -50,6 +51,12 @@ import {
 import {addVisualizedArgTracks} from '../components/tracks/visualized_args_tracks';
 import {addQueryResultsTab} from '../components/query_table/query_result_tab';
 import {assetSrc, initAssets} from '../base/assets';
+import {
+  PERFETTO_SETTINGS_STORAGE_KEY,
+  SettingsManagerImpl,
+} from '../core/settings_manager';
+import {LocalStorage} from '../core/local_storage';
+import {DurationPrecision, TimestampFormat} from '../public/timeline';
 
 const CSP_WS_PERMISSIVE_PORT = featureFlags.register({
   id: 'cspAllowAnyWebsocketPort',
@@ -143,8 +150,34 @@ function main() {
   // Setup content security policy before anything else.
   setupContentSecurityPolicy();
   initAssets();
+
+  // Create settings Manager
+  const settingsManager = new SettingsManagerImpl(
+    new LocalStorage(PERFETTO_SETTINGS_STORAGE_KEY),
+  );
+
+  // Initialize core settings...
+  const timestampFormatSetting = settingsManager.register({
+    id: 'timestampFormat',
+    name: 'Timestamp format',
+    description: 'The format of timestamps throughout Perfetto.',
+    schema: z.nativeEnum(TimestampFormat),
+    defaultValue: TimestampFormat.Timecode,
+  });
+
+  const durationPrecisionSetting = settingsManager.register({
+    id: 'durationPrecision',
+    name: 'Duration precision',
+    description: 'The precision of durations throughout Perfetto.',
+    schema: z.nativeEnum(DurationPrecision),
+    defaultValue: DurationPrecision.Full,
+  });
+
   AppImpl.initialize({
     initialRouteArgs: Router.parseUrl(window.location.href).args,
+    settingsManager,
+    timestampFormatSetting,
+    durationPrecisionSetting,
   });
 
   // Load the css. The load is asynchronous and the CSS is not ready by the time


### PR DESCRIPTION
Currently it's a bit odd that the timestamp & duration settings are only available when a trace is loaded. This patch moves them from trace load to app startup, so that they are available always.
