### PR TITLE
Kernel wakelocks: be even more defensive.

### DIFF
--- a/src/kernel_utils/kernel_wakelock_errors.h
+++ b/src/kernel_utils/kernel_wakelock_errors.h
@@ -21,5 +21,6 @@
 
 constexpr uint64_t kKernelWakelockErrorZeroValue = 1;
 constexpr uint64_t kKernelWakelockErrorNonMonotonicValue = 2;
+constexpr uint64_t kKernelWakelockErrorImplausiblyLargeValue = 4;
 
 #endif  // SRC_KERNEL_UTILS_KERNEL_WAKELOCK_ERRORS_H_

--- a/src/trace_processor/importers/proto/android_kernel_wakelocks_module.cc
+++ b/src/trace_processor/importers/proto/android_kernel_wakelocks_module.cc
@@ -112,6 +112,10 @@ void AndroidKernelWakelocksModule::ParseTracePacketData(
     context_->storage->IncrementStats(
         stats::kernel_wakelock_non_monotonic_value_reported);
   }
+  if (traced_errors & kKernelWakelockErrorImplausiblyLargeValue) {
+    context_->storage->IncrementStats(
+        stats::kernel_wakelock_implausibly_large_value_reported);
+  }
 
   // Anything we knew about but didn't see in this packet must not have
   // incremented.

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -115,6 +115,11 @@ namespace perfetto::trace_processor::stats {
                                           kSingle,  kDataLoss, kTrace,         \
        "Decreased value received from SuspendControlService. Indicates a "     \
        "transient error in SuspendControlService."),                           \
+  F(kernel_wakelock_implausibly_large_value_reported,                          \
+                                          kSingle,  kDataLoss, kTrace,         \
+       "Implausibly large increment to value received from "                   \
+       "SuspendControlService. Indicates a transient error in "                \
+       "SuspendControlService."),                                              \
   F(app_wakelock_parse_error,             kSingle,  kError,    kAnalysis,      \
        "Parsing packed repeated field. Should never happen."),                 \
   F(app_wakelock_unknown_id,              kSingle,  kError,    kAnalysis,      \

--- a/src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.h
+++ b/src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.h
@@ -58,6 +58,7 @@ class AndroidKernelWakelocksDataSource : public ProbesDataSource {
   base::WeakPtr<AndroidKernelWakelocksDataSource> GetWeakPtr() const;
 
   uint32_t poll_interval_ms_ = 0;
+  uint64_t max_plausible_diff_ms_ = 0;
   base::FlatHashMap<std::string, KernelWakelockInfo> wakelocks_;
   uint32_t next_id_ = 0;
 


### PR DESCRIPTION
We see very high values occasionally from SuspendControlService. If we do, ignore them and set an error flag.

Bug: http://b/404239369
