### PR TITLE
Cherrypick: Fix UI hang when loading data for 0 or negative canvas sizes (#1563)

### DIFF
--- a/ui/src/frontend/viewer_page/resolution.ts
+++ b/ui/src/frontend/viewer_page/resolution.ts
@@ -14,27 +14,36 @@
 
 import {BigintMath} from '../../base/bigint_math';
 import {HighPrecisionTimeSpan} from '../../base/high_precision_time_span';
+import {errResult, okResult, Result} from '../../base/result';
 import {duration} from '../../base/time';
 
 /**
  * Work out an appropriate "resolution" for a given time span stretched over a
- * given number of pixels.
- *
- * The returned value will be rounded down to the nearest power of 2, and will
- * always be >= 1.
+ * given number of pixels, rounded down to the nearest power of 2.
  *
  * @param timeSpan The span of time to represent.
  * @param widthPx How many pixels we have to represent the time span.
- * @returns The resultant resolution.
+ * @returns The resultant resolution, or an error if the input parameters are
+ * invalid.
  */
 export function calculateResolution(
   timeSpan: HighPrecisionTimeSpan,
   widthPx: number,
-): duration {
-  // Work out how much time corresponds to one pixel
-  const timePerPixel = Number(timeSpan.duration) / widthPx;
+): Result<duration> {
+  if (widthPx <= 0) {
+    return errResult('Parameter "widthPx" must be greater than 0.');
+  }
 
-  // Round down to the nearest power of 2, noting that the smallest value this
-  // function can return is 1
-  return BigintMath.bitFloor(BigInt(Math.floor(timePerPixel)));
+  const dur = timeSpan.duration;
+  if (dur <= 0) {
+    return errResult(
+      'The duration of the "timeSpan" parameter must be greater than 0.',
+    );
+  }
+
+  // Work out how much time corresponds to one pixel.
+  const timePerPixel = Number(dur) / widthPx;
+
+  // Convert to a bigint and round down to the nearest power of 2.
+  return okResult(BigintMath.bitFloor(BigInt(Math.floor(timePerPixel))));
 }

--- a/ui/src/frontend/viewer_page/search_overview_track.ts
+++ b/ui/src/frontend/viewer_page/search_overview_track.ts
@@ -51,7 +51,7 @@ export class SearchOverviewTrack implements AsyncDisposable {
   }
 
   render(ctx: CanvasRenderingContext2D, size: Size2D) {
-    this.maybeUpdate(size);
+    this.maybeUpdate(size.width);
     this.renderSearchOverview(ctx, size);
   }
 
@@ -151,7 +151,7 @@ export class SearchOverviewTrack implements AsyncDisposable {
     return summary;
   }
 
-  private maybeUpdate(size: Size2D) {
+  private maybeUpdate(timelineWidth: number) {
     const searchManager = this.trace.search;
     const timeline = this.trace.timeline;
     if (!searchManager.hasResults) {
@@ -159,7 +159,11 @@ export class SearchOverviewTrack implements AsyncDisposable {
     }
     const newSpan = timeline.visibleWindow;
     const newSearchGeneration = searchManager.searchGeneration;
-    const newResolution = calculateResolution(newSpan, size.width);
+    const maybeNewResolution = calculateResolution(newSpan, timelineWidth);
+    if (!maybeNewResolution.ok) {
+      return;
+    }
+    const newResolution = maybeNewResolution.value;
     const newTimeSpan = newSpan.toTimeSpan();
     if (
       this.previousSpan?.containsSpan(newTimeSpan.start, newTimeSpan.end) &&

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -275,14 +275,21 @@ export class TrackView {
       right: trackRect.width,
     });
 
-    const start = performance.now();
+    const maybeNewResolution = calculateResolution(
+      visibleWindow,
+      trackRect.width,
+    );
+    if (!maybeNewResolution.ok) {
+      return;
+    }
 
+    const start = performance.now();
     node.uri &&
       renderer?.render({
         trackUri: node.uri,
         visibleWindow,
         size: trackRect,
-        resolution: calculateResolution(visibleWindow, trackRect.width),
+        resolution: maybeNewResolution.value,
         ctx,
         timescale,
       });


### PR DESCRIPTION
The `calculateResolution` function is used to work out the horizontal resolution at which data should be loaded for a given timespan and horizontal width (e.g. of a canvas) in px. If either of these values are 0 or negative, this function currently returns 1n. This causes issues as loading data at a resolution of 1 is rarely what you actually want to do in this instance, and it usually produces very slow queries which can cause the UI to hang and generally become unresponsive.

This patch makes `calculateResolution` return a `Result<bigint>` type instead, and returns an error value when the inputs are 0 or negative. Using a `Result<T>` type rather than throwing an error forces callers to handle the error case at the callsite so it cannot be ignored. In this case, if resolution cannot be caulculate then it's safe to skip rendering, and the callsites have been modified to do so.

Fixes: https://b.corp.google.com/issues/418232042
