### PR TITLE
Add metasql_unparenthesize module.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14662,6 +14662,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/linux/perf/samples.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/perf/spe.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/threads.sql",
+        "src/trace_processor/perfetto_sql/stdlib/metasql/unparenthesize.sql",
         "src/trace_processor/perfetto_sql/stdlib/pixel/camera.sql",
         "src/trace_processor/perfetto_sql/stdlib/pkvm/hypervisor.sql",
         "src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/casts.sql",

--- a/BUILD
+++ b/BUILD
@@ -3334,6 +3334,14 @@ perfetto_filegroup(
     ],
 )
 
+# GN target: //src/trace_processor/perfetto_sql/stdlib/metasql:metasql
+perfetto_filegroup(
+    name = "src_trace_processor_perfetto_sql_stdlib_metasql_metasql",
+    srcs = [
+        "src/trace_processor/perfetto_sql/stdlib/metasql/unparenthesize.sql",
+    ],
+)
+
 # GN target: //src/trace_processor/perfetto_sql/stdlib/pixel:pixel
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_pixel_pixel",
@@ -3520,6 +3528,7 @@ perfetto_cc_amalgamated_sql(
         ":src_trace_processor_perfetto_sql_stdlib_linux_linux",
         ":src_trace_processor_perfetto_sql_stdlib_linux_memory_memory",
         ":src_trace_processor_perfetto_sql_stdlib_linux_perf_perf",
+        ":src_trace_processor_perfetto_sql_stdlib_metasql_metasql",
         ":src_trace_processor_perfetto_sql_stdlib_pixel_pixel",
         ":src_trace_processor_perfetto_sql_stdlib_pkvm_pkvm",
         ":src_trace_processor_perfetto_sql_stdlib_prelude_after_eof_after_eof",

--- a/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
@@ -28,6 +28,7 @@ perfetto_amalgamated_sql_header("stdlib") {
     "graphs",
     "intervals",
     "linux",
+    "metasql",
     "pixel",
     "pkvm",
     "prelude",

--- a/src/trace_processor/perfetto_sql/stdlib/metasql/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/metasql/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../../gn/perfetto_sql.gni")
+
+perfetto_sql_source_set("metasql") {
+  sources = [ "unparenthesize.sql" ]
+}

--- a/src/trace_processor/perfetto_sql/stdlib/metasql/unparenthesize.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/metasql/unparenthesize.sql
@@ -1,0 +1,14 @@
+CREATE PERFETTO MACRO __unparenthesize_identity(
+    x ColumnName
+)
+RETURNS Expr AS
+$x;
+
+-- Removes parentheses from an expression. Typically used when you need to
+-- wrap parentheses around e.g. a column list.
+CREATE PERFETTO MACRO metasql_unparenthesize(
+    -- Argument to unparenthesize.
+    expr Expr
+)
+RETURNS Expr AS
+__intrinsic_token_apply!(__unparenthesize_identity, $expr);


### PR DESCRIPTION
This is a common requirement that currently needs `__intrinsic_token_apply`.

Isolate it here so that `__intrinsic_token_apply` can later be removed.
