### PR TITLE
Fix android_kernel_wakelocks.

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/kernel_wakelocks.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/kernel_wakelocks.sql
@@ -76,7 +76,7 @@ WITH
       sum(iif(power_state = 'awake', dur, 0)) AS awake_dur
     FROM _android_kernel_wakelocks_joined
     GROUP BY
-      ts,
+      original_ts,
       name,
       type,
       held_dur


### PR DESCRIPTION
https://github.com/google/perfetto/pull/1554 was broken due to last minute cleanup. ts gets renamed in the query and the GROUP BY was applied to the wrong one (pre rename not post rename).

Bug: http://b/418182182
