### PR TITLE
ci: run small jobs on GitHub's pool rather than ours

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -38,7 +38,13 @@ concurrency:
 
 jobs:
   analyze:
-    runs-on: self-hosted
+    # Unlike other workflows, this runs on the Github ubuntu-latest pool.
+    # This is deliberate: (1) this workflow doesn't need anything special from
+    # our 'sandbox' docker container, and GitHub's pool is just faster.
+    # (2) when our CI autoscaler ramps down, it can take a long time until we
+    # have some capacity to run this. In turn, delaying analyze.yml further
+    # delays in scaling-up because we didn't queue the child jobs.
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
       TRIVIAL_CHANGE: ${{ steps.trivial.outputs.TRIVIAL_CHANGE }}

--- a/.github/workflows/pr-branch-check.yml
+++ b/.github/workflows/pr-branch-check.yml
@@ -27,7 +27,9 @@ on:
 jobs:
   pr-branch-check:
     if: startsWith(github.base_ref, 'dev/')
-    runs-on: self-hosted
+    # Deliberately run on GitHub's ubuntu-latest pool as it's faster for small
+    # job like this.
+    runs-on: ubuntu-latest
     steps:
       - name: Prevent accidental merge PRs into dev branches
         run: |

--- a/.github/workflows/require-two-reviewers-for-fork-prs.yml
+++ b/.github/workflows/require-two-reviewers-for-fork-prs.yml
@@ -30,7 +30,9 @@ concurrency:
 
 jobs:
   enforce-reviews:
-    runs-on: self-hosted
+    # Deliberately run on GitHub's ubuntu-latest pool as it's faster for small
+    # job like this.
+    runs-on: ubuntu-latest
     steps:
       - name: Check if PR is from a fork
         id: fork_check


### PR DESCRIPTION
My theory is that we can make the CI more responsive by moving
the small jobs that don't require our sandbox on GitHub's pool.
This is particularly important for analyze.yml, which is an
input for the autoscale: if that doesn't run, the autoscaler
won't scale up much as it sees only one job (it will only scale
up after analyze.yml has run). This should reduce queue times
when the CI is idle.