### PR TITLE
ci: use git diff A B not A...B for change detection

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Check if the change is trivial (docs/infra only)
         id: trivial
         run: |
-          if !(git diff --name-only origin/${{ github.base_ref }}...HEAD | egrep -qv '^(docs|infra|tools|test/data|[.]github)/'); then
+          if !(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep -qv '^(docs|infra|tools|test/data|[.]github)/'); then
           echo "TRIVIAL_CHANGE=1" | tee -a $GITHUB_OUTPUT
           else
           echo "TRIVIAL_CHANGE=0" | tee -a $GITHUB_OUTPUT
@@ -74,7 +74,7 @@ jobs:
       - name: Check if the change is UI only (skip linux/android tests)
         id: ui_only
         run: |
-          if !(git diff --name-only origin/${{ github.base_ref }}...HEAD | egrep -qv '^(ui|test/data/ui-screenshots)/'); then
+          if !(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep -qv '^(ui|test/data/ui-screenshots)/'); then
           echo "UI_ONLY_CHANGE=1" | tee -a $GITHUB_OUTPUT
           else
           echo "UI_ONLY_CHANGE=0" | tee -a $GITHUB_OUTPUT

--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -88,8 +88,7 @@ def get_changed_files(merge_base: Optional[str]) -> List[str]:
       ]
 
       diff_result = run_command([
-          'git', 'diff', '--name-only', '--diff-filter=crd',
-          f'{merge_base}...HEAD'
+          'git', 'diff', '--name-only', '--diff-filter=crd', merge_base, 'HEAD'
       ])
       diff_files = diff_result.stdout.splitlines()
 


### PR DESCRIPTION
Problem: A...B means git diff $(git merge-base A B) B
1) This is not what we want
2) This breaks due to shallow checkouts in some cases
3) When 2 happens, it creates false-positives in the trivial/skip detection
    (e.g. https://screenshot.googleplex.com/AnTCRA629ejZxn3)