### PR TITLE
Improve 'Find track by name' command UX

### DIFF
--- a/ui/src/core_plugins/track_utils/index.ts
+++ b/ui/src/core_plugins/track_utils/index.ts
@@ -65,7 +65,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
         ) as ReadonlyArray<RequiredField<TrackNode, 'uri'>>;
         const track = await ctx.omnibox.prompt('Choose a track...', {
           values: tracksWithUris,
-          getName: (track) => track.title,
+          getName: (track) => track.fullPath.join(' \u2023 '),
         });
         track &&
           ctx.selection.selectTrack(track.uri, {

--- a/ui/src/core_plugins/track_utils/index.ts
+++ b/ui/src/core_plugins/track_utils/index.ts
@@ -72,6 +72,8 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
             scrollToSelection: true,
           });
       },
+      // This is analogous to the 'Find file' hotkey in VSCode.
+      defaultHotkey: '!Mod+P',
     });
 
     ctx.commands.registerCommand({

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -618,13 +618,7 @@ function copyToWorkspace(trace: Trace, node: TrackNode, ws?: Workspace) {
 }
 
 function renderTrackDetailsMenu(node: TrackNode, descriptor?: Track) {
-  let parent = node.parent;
-  let fullPath: m.ChildArray = [node.title];
-  while (parent && parent instanceof TrackNode) {
-    fullPath = [parent.title, ' \u2023 ', ...fullPath];
-    parent = parent.parent;
-  }
-
+  const fullPath = node.fullPath.join(' \u2023 ');
   const query = descriptor?.track.getDataset?.()?.query();
 
   return m(


### PR DESCRIPTION
This patch adds the following:
- Consistently apply the little arrow to join path elements when printing full track path names in the UI, including in the 'Find track by name' command dropdown (see attached image).
- Add 'Mod+P' hotkey to 'Find track by name', which is analogous to the 'Find file' hotkey in VSCode.

![image](https://github.com/user-attachments/assets/8f5ffef1-f406-4c54-ac49-cc796d52b9c2)
