### PR TITLE
ci: fix postsubmit

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -60,24 +60,27 @@ jobs:
       # Fetch the upstream branch as well, so we can diff and see the list of
       # changed files.
       - name: Fetch upstream branch
+        if: ${{ github.base_ref != '' }}
         run: git fetch origin ${{ github.base_ref }} --depth=1
 
       - name: Check if the change is trivial (docs/infra only)
         id: trivial
         run: |
-          if !(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep -qv '^(docs|infra|tools|test/data|[.]github)/'); then
-          echo "TRIVIAL_CHANGE=1" | tee -a $GITHUB_OUTPUT
-          else
+          # In postsubmit (cron) github.base_ref is ""
+          if [ -z "${{ github.base_ref }}" ] || git diff --name-only origin/${{ github.base_ref }} HEAD | egrep -qv '^(docs|infra|tools|test/data|[.]github)/'; then
           echo "TRIVIAL_CHANGE=0" | tee -a $GITHUB_OUTPUT
+          else
+          echo "TRIVIAL_CHANGE=1" | tee -a $GITHUB_OUTPUT
           fi
 
       - name: Check if the change is UI only (skip linux/android tests)
         id: ui_only
         run: |
-          if !(git diff --name-only origin/${{ github.base_ref }} HEAD | egrep -qv '^(ui|test/data/ui-screenshots)/'); then
-          echo "UI_ONLY_CHANGE=1" | tee -a $GITHUB_OUTPUT
-          else
+          # In postsubmit (cron) github.base_ref is ""
+          if [ -z "${{ github.base_ref }}" ] || git diff --name-only origin/${{ github.base_ref }} HEAD | egrep -qv '^(ui|test/data/ui-screenshots)/'; then
           echo "UI_ONLY_CHANGE=0" | tee -a $GITHUB_OUTPUT
+          else
+          echo "UI_ONLY_CHANGE=1" | tee -a $GITHUB_OUTPUT
           fi
 
   linux:

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -36,8 +36,9 @@ jobs:
           fetch-depth: 1
 
       # Fetch the upstream branch as well, so we can diff and see the list of
-      # changed files.
+      # changed files (unless this is a post-submit test).
       - name: Fetch upstream branch
+        if: ${{ github.base_ref != '' }}
         run: git fetch origin ${{ github.base_ref }} --depth=1
 
       - name: Setup ccache
@@ -48,6 +49,9 @@ jobs:
           install-flags: --ui
 
       - name: Run tools/presubmits
+        # base_ref is "" in post-submit, skip the presubmit check in postsubmit
+        # as there is nothing do diff against.
+        if: ${{ github.base_ref != '' }}
         run: tools/run_presubmit --merge-base origin/${{ github.base_ref }}
 
       - name: Check merged protos (tools/gen_all)


### PR DESCRIPTION
Mask out the tests that depend on diffing the CL against the merge base.
They make no sense in post-submit, as we want to check the state of the repo as-is.
