### PR TITLE
WIP: Port: Dump type from DisplayInfo

### DIFF
--- a/protos/perfetto/trace/android/view/displayinfo.proto
+++ b/protos/perfetto/trace/android/view/displayinfo.proto
@@ -32,4 +32,5 @@ message DisplayInfoProto {
   optional string name = 5;
   optional int32 flags = 6;
   optional DisplayCutoutProto cutout = 7;
+  optional int32 type = 8;
 }


### PR DESCRIPTION
Port of internal commit.

**Original commit message:**
Subject: Dump type from DisplayInfo

This can be used to distinguish between the main display and the virtual display.

This CL is a port of ag/28185252 into external/perfetto.

Flag: NONE dumping new field to proto
Bug: 351162994
Test: adb shell dumpsys window --proto
Change-Id: Ic731e2143fe8c4ba57c48cced141cbb910fefe2e

---
Original internal commit hash: d95cff731af8a511a0be86f0080310cbe8542e6a
Cherry-picked with `-x`.
This PR is part of a stack. Base branch: dev/ada6248a1f
