### PR TITLE
WIP: Port: Adding RemoteInsetsControlTarget to proto dump

### DIFF
--- a/protos/perfetto/trace/android/server/windowmanagerservice.proto
+++ b/protos/perfetto/trace/android/server/windowmanagerservice.proto
@@ -231,6 +231,7 @@ message DisplayContentProto {
   optional IdentifierProto input_method_input_target_identifier = 41;
   optional IdentifierProto input_method_control_target_identifier = 42;
   optional IdentifierProto current_focus_identifier = 43;
+  optional RemoteInsetsControlTargetProto remote_insets_control_target = 44;
 }
 
 // represents DisplayArea object
@@ -465,6 +466,13 @@ message WindowStateProto {
   optional RectProto dim_bounds = 49;
   optional int32 prepare_sync_seq_id = 50;
   optional int32 sync_seq_id = 51;
+}
+
+// represents RemoteInsetsControlTarget
+message RemoteInsetsControlTargetProto {
+  optional IdentifierProto identifier = 1;
+  optional int32 requested_visible_types = 2;
+  optional int32 animating_types = 3;
 }
 
 message IdentifierProto {


### PR DESCRIPTION
Port of internal commit.

**Original commit message:**
Subject: Adding RemoteInsetsControlTarget to proto dump

This CL is a port of ag/33553569 into external/perfetto.

Fix: 399856349
Test: adb shell dumpsys window --proto
Flag: EXEMPT proto only
Change-Id: I235f6190ab19b11f532a9b26548f994aae7333c4

---
Original internal commit hash: 1e93a96ab097de402a1bc60fb9644f03ca5f37c0
Cherry-picked with `-x`.
This PR is part of a stack. Base branch: dev/3aecc22684
