### PR TITLE
Android Java SDK: rename 'perfetto_jni_lib' to 'perfetto_jni'.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1169,7 +1169,7 @@ cc_library_static {
 
 // GN: //src/android_sdk/jni:libperfetto_jni
 cc_library_shared {
-    name: "libperfetto_jni_lib",
+    name: "libperfetto_jni",
     srcs: [
         ":perfetto_include_perfetto_public_abi_base",
         ":perfetto_include_perfetto_public_abi_public",
@@ -16380,7 +16380,7 @@ android_test {
     ],
     test_config: "src/android_sdk/java/test/PerfettoAndroidSdkTest.xml",
     jni_libs: [
-        "libperfetto_jni_lib",
+        "libperfetto_jni",
     ],
     jni_uses_platform_apis: true,
 }

--- a/BUILD
+++ b/BUILD
@@ -4599,7 +4599,7 @@ perfetto_android_jni_library(
         ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
         ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
     ],
-    binary_name = "libperfetto_jni_lib.so",
+    binary_name = "libperfetto_jni.so",
     linkopts = [
         "-llog",
     ],

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -75,7 +75,7 @@ public class PerfettoTraceTest {
 
   @Before
   public void setUp() {
-    System.loadLibrary("perfetto_jni_lib");
+    System.loadLibrary("perfetto_jni");
     PerfettoTrace.registerWithDebugChecks(true);
     // 'var unused' suppress error-prone warning
     var unused = FOO_CATEGORY.register();

--- a/src/android_sdk/jni/BUILD.gn
+++ b/src/android_sdk/jni/BUILD.gn
@@ -26,6 +26,6 @@ perfetto_android_jni_library("libperfetto_jni") {
     "../../../gn:default_deps",
     "../../shared_lib:libperfetto_c",
   ]
-  binary_name = "libperfetto_jni_lib.so"
+  binary_name = "libperfetto_jni.so"
   bazel_linkopts = "-llog"
 }


### PR DESCRIPTION
In framework, we usually don't add '_lib' suffix for the native libs, so rename the perfetto native lib binary.

Tested:
```
tools/bazel test //:src_android_sdk_java_test_perfetto_trace_instrumentation_test
```