### PR TITLE
ci: move UI code formatter checks to UI bot

### DIFF
--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -52,7 +52,9 @@ jobs:
         # base_ref is "" in post-submit, skip the presubmit check in postsubmit
         # as there is nothing do diff against.
         if: ${{ github.base_ref != '' }}
-        run: tools/run_presubmit --merge-base origin/${{ github.base_ref }}
+        run: tools/run_presubmit \
+                --merge-base origin/${{ github.base_ref }} \
+                --skip-formatters=eslint,prettier
 
       - name: Check merged protos (tools/gen_all)
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -78,6 +78,11 @@ jobs:
       - name: UI integrationtests
         run: ui/run-integrationtests --out out/dist --no-build
 
+        # UI code formatting checks must be done here, rather than repo-checks,
+        # because they need a out/ui build.
+      - name: Check UI code is formatted
+        run: ui/format-sources --check-only
+
       - name: Upload artifacts to GCS
         if: ${{ always() }}
         run: |

--- a/python/tools/code_format_ui.py
+++ b/python/tools/code_format_ui.py
@@ -73,6 +73,11 @@ class Eslint(CodeFormatterBase):
     return filtered
 
   def run_formatter(self, repo_root: str, check_only: bool, files: list[str]):
+    out_ui_dir = os.path.join(repo_root, 'out', 'ui')
+    if not os.path.exists(out_ui_dir):
+      # Unfortunately eslint requires a UI build to run.
+      print(f'Cannot run eslint because there is no UI build in {out_ui_dir}')
+      return 127
     tool = 'node_modules/.bin/eslint'
     ui_dir = os.path.join(repo_root, 'ui')
     if not os.path.exists(os.path.join(ui_dir, tool)):

--- a/python/tools/code_format_utils.py
+++ b/python/tools/code_format_utils.py
@@ -41,6 +41,11 @@ class CodeFormatterBase:
         action='store_true',
         help='Format all versioned sources, not just the changed ones')
     parser.add_argument('filelist', nargs='*')
+    parser.add_argument(
+        '--skip',
+        type=str,
+        default='',
+        help='Comma-separated list of formatter names to skip')
     return parser
 
   def add_custom_args(self, parser):
@@ -106,6 +111,8 @@ def run_code_formatters(formatters: list[CodeFormatterBase]):
   ]
   os.chdir(ROOT_DIR)
   files = CodeFormatterBase.build_file_list(args)
+  skip_list = set(args.skip.split(','))
+  formatters = [f for f in formatters if f.name not in skip_list]
   for formatter in formatters:
     files_to_check = formatter.filter_files(files)
     if not args.quiet:

--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -228,14 +228,15 @@ def CheckChangeHasNoTabs(changed_files: List[str]) -> List[str]:
   return errors
 
 
-def CheckCodeFormatted() -> List[str]:
+def CheckCodeFormatted(skip_formatters: str) -> List[str]:
   # NOTE: format-sources does its own invocation of git diff ... to detect
   # changed file. We use that, rather than passing the list here, to avoid
   # ending in a situation where run_presubmit fails, but then
   # tools/format_sources succeeds because they diverge in their diff logic.
   tool = os.path.join(REPO_ROOT, 'tools/format-sources')
   try:
-    run_command([tool, '--quiet', '--check-only'], stderr=subprocess.STDOUT)
+    run_command([tool, '--quiet', '--check-only', '--skip=' + skip_formatters],
+                stderr=subprocess.STDOUT)
   except subprocess.CalledProcessError:
     return [f'Please run {tool} to format sources.']
   return []
@@ -838,6 +839,10 @@ def CheckUiRatchet(changed_files: List[str]) -> List[str]:
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--merge-base', default='origin/main')
+  parser.add_argument(
+      '--skip-formatters',
+      default='',
+      help='Comma-separated list of code formatters to skip')
   # The pre-push hook passes extra cmdline arguments like 'origin git@...'.
   # Accept and ignore positional args.
   args, _ = parser.parse_known_args()
@@ -857,7 +862,7 @@ def main():
 
   # Use RunAndReportIfLong for all checks
   checks_to_run = [
-      (CheckCodeFormatted, []),
+      (CheckCodeFormatted, [args.skip_formatters]),
       (CheckDoNotSubmit, [changed_files]),
       (CheckChangeHasNoTabs, [changed_files]),
       (CheckIncludeGuards, [changed_files]),


### PR DESCRIPTION
Problem:
- eslint requires a UI build to run.
- We run the presubmits in a bot (repo_checks) that doesn't build anything.

Solution:
- Add a --skip argument to tools/format-sources (and recursively to run_presubmit)
- Skip UI formatters in the repo_checks bot
- Run UI formatters in the UI bot
