### PR TITLE
PinAndroidPerfMetrics: Add default filter for "all" jankType

### DIFF
--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinCujScoped.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinCujScoped.ts
@@ -74,7 +74,7 @@ class PinCujScopedJank implements MetricHandler {
     metricData: CujScopedMetricData,
     ctx: Trace,
   ) {
-    let jankTypeFilter;
+    let jankTypeFilter = 'AND (app_missed > 0 OR sf_missed > 0)';
     let jankTypeDisplayName = 'all';
     if (metricData.jankType?.includes('app')) {
       jankTypeFilter = ' AND app_missed > 0';


### PR DESCRIPTION
- The regex allows for a metric with jankType as:
  1. missed_frames
  2. missed_sf_frames
  3. missed_app_frames
- "missed_frames" is accepted but leaves the jankTypeFilter unassigned
- This makes the query append "undefined", which causes a UI Error
- Fix this by or-ing app_missed and sf_missed conditions for filter

Bug: 417567195
Test: Open any trace, pin any missed_frames metric, check for UI Error
Change-Id: Id8d88fb794df5de2f02df3cd4ce062a1fb3a24d1
