### PR TITLE
Cache async track depths before at creation time.

### DIFF
--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -230,25 +230,6 @@ export abstract class BaseSliceTrack<
   // `select id, ts, dur, 0 as depth from foo where bar = 'baz'`
   abstract getSqlSource(): string;
 
-  // This should return a fast sql select statement or table name with slightly
-  // relaxed constraints compared to getSqlSource(). It's the query used to join
-  // the results of the mipmap table in order to fetch the real `ts` and `dur`
-  // from the quantized slices.
-  //
-  // This query only needs to provide `ts`, `dur` and `id` columns (no depth
-  // required), and it doesn't even need to be filtered (because it's just used
-  // in the join), it just needs to be fast! This means that most of the time
-  // this can just be the root table of wherever this track comes from (e.g. the
-  // slice table).
-  //
-  // If in doubt, this can just return the same query as getSqlSource(), which
-  // is perfectly valid, however you may be leaving some performance on the
-  // table.
-  //
-  // TODO(stevegolton): If we merge BST with DST, this abstraction can be
-  // avoided.
-  abstract getJoinSqlSource(): string;
-
   // Override me if you want to define what is rendered on the tooltip. Called
   // every DOM render cycle. The raw slice data is passed to this function
   protected renderTooltipForSlice(_: SliceT): m.Children {
@@ -708,7 +689,7 @@ export abstract class BaseSliceTrack<
         ${slicesKey.end},
         ${resolution}
       ) z
-      CROSS JOIN (${this.getJoinSqlSource()}) s using (id)
+      CROSS JOIN (${this.getSqlSource()}) s using (id)
     `);
 
     const it = queryRes.iter(this.rowSpec);

--- a/ui/src/components/tracks/dataset_slice_track.ts
+++ b/ui/src/components/tracks/dataset_slice_track.ts
@@ -284,28 +284,6 @@ export class DatasetSliceTrack<T extends ROW_SCHEMA> extends BaseSliceTrack<
     return this.sqlSource;
   }
 
-  override getJoinSqlSource(): string {
-    // This is a little performance optimization. Internally BST joins the
-    // results of the mipmap table query with the sqlSource in order to get the
-    // original ts, dur and id. However this sqlSource can sometimes be a
-    // contrived, slow query, usually to calculate the depth (e.g. something
-    // based on experimental_slice_layout).
-    //
-    // We don't actually need a depth value at this point, so calculating it is
-    // worthless. We only need ts, id, and dur. We don't even need this query to
-    // be correctly filtered, as we are merely joining on this table. We do
-    // however need it to be fast.
-    //
-    // In conclusion, if the dataset source has a dur column present (ts, and id
-    // are mandatory), then we can take a shortcut and just use this much
-    // simpler query to join on.
-    if (this.attrs.dataset.implements({dur: LONG})) {
-      return this.attrs.dataset.src;
-    } else {
-      return this.sqlSource;
-    }
-  }
-
   getDataset() {
     return this.attrs.dataset;
   }

--- a/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
@@ -153,7 +153,11 @@ async function addGlobalAllocs(ctx: Trace, parent: () => TrackNode) {
       kind: SLICE_TRACK_KIND,
       trackIds: ids,
     },
-    track: createTraceProcessorSliceTrack({trace: ctx, uri, trackIds: ids}),
+    track: await createTraceProcessorSliceTrack({
+      trace: ctx,
+      uri,
+      trackIds: ids,
+    }),
   });
   const node = new TrackNode({
     uri,

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -281,7 +281,7 @@ export default class implements PerfettoPlugin {
         chips: removeFalsyValues([
           isKernelThread === 0 && isMainThread === 1 && 'main thread',
         ]),
-        track: createTraceProcessorSliceTrack({
+        track: await createTraceProcessorSliceTrack({
           trace: ctx,
           uri,
           maxDepth,

--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -153,7 +153,11 @@ export default class implements PerfettoPlugin {
             upid: upid ?? undefined,
             utid: utid ?? undefined,
           },
-          track: createTraceProcessorSliceTrack({trace: ctx, uri, trackIds}),
+          track: await createTraceProcessorSliceTrack({
+            trace: ctx,
+            uri,
+            trackIds,
+          }),
         });
       }
       const parent = this.findParentTrackNode(

--- a/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
+++ b/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
@@ -66,7 +66,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title,
-        track: createTraceProcessorSliceTrack({
+        track: await createTraceProcessorSliceTrack({
           trace: ctx,
           uri,
           trackIds: [trackId],

--- a/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
+++ b/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
@@ -70,7 +70,7 @@ export default class implements PerfettoPlugin {
         trackIds,
         kind: SLICE_TRACK_KIND,
       },
-      track: createTraceProcessorSliceTrack({
+      track: await createTraceProcessorSliceTrack({
         trace: ctx,
         uri,
         maxDepth,


### PR DESCRIPTION
Async track depths are calculated using `experimental_slice_layout` which, when passed verbatim to BaseSliceTrack, can be very slow when cross joining on the result of the mipmap table. Currently we avoid this by allowing the cross join to operate directly on the slice table, because depths are not required anyway, but this is a hack and makes the code hard to reason about and leaves rough edges for users of DatasetSliceTrack.

This patch makes it so that the track depths are calculated up front when an async slice track is created. This is much more efficient that trying to cross join on it even once, and only happens one on startup, leaving the cross joins to be fast.

This also means we can remove the getSqlJoinSource() hack in BaseSliceTrack, which has been removed in this CL.
