### PR TITLE
Add layer support in DatasetSliceTrack & BaseSliceTrack

### DIFF
--- a/ui/src/components/colorizer.ts
+++ b/ui/src/components/colorizer.ts
@@ -109,7 +109,15 @@ const GRAY = makeColorScheme(new HSLColor([0, 0, 62]));
 const DESAT_RED = makeColorScheme(new HSLColor([3, 30, 49]));
 const DARK_GREEN = makeColorScheme(new HSLColor([120, 44, 34]));
 const LIME_GREEN = makeColorScheme(new HSLColor([75, 55, 47]));
-const TRANSPARENT_WHITE = makeColorScheme(new HSLColor([0, 1, 97], 0.55));
+const TRANSLUCENT_GRAY = {
+  base: new HSLColor([0, 1, 50], 0),
+  variant: new HSLColor([0, 1, 50], 0.2),
+  disabled: GRAY_COLOR,
+  // Make the text invisible
+  textBase: new HSLColor([0, 0, 0], 0),
+  textVariant: new HSLColor([0, 0, 0], 0),
+  textDisabled: new HSLColor([0, 0, 0], 0),
+};
 const ORANGE = makeColorScheme(new HSLColor([36, 100, 50]));
 const INDIGO = makeColorScheme(new HSLColor([231, 48, 48]));
 
@@ -168,7 +176,7 @@ export function colorForState(state: string): ColorScheme {
   } else if (state.includes('Dead')) {
     return GRAY;
   } else if (state.includes('Sleeping') || state.includes('Idle')) {
-    return TRANSPARENT_WHITE;
+    return TRANSLUCENT_GRAY;
   }
   return INDIGO;
 }

--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -320,7 +320,7 @@ export abstract class BaseSliceTrack<
       (
         await this.engine.query(`
           SELECT
-            depth + 1 AS rowCount
+            ifnull(depth, 0) + 1 AS rowCount
           FROM (${this.getSqlSource()})
           ORDER BY depth DESC
           LIMIT 1

--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -314,13 +314,16 @@ export abstract class BaseSliceTrack<
     const result = await this.onInit();
     result && this.trash.use(result);
 
-    // Calc the number of rows based on the depth parameter.
+    // Calc the number of rows based on the depth col.
     const rowCount = assertExists(
+      // `ORDER BY .. LIMIT 1` is faster than `MAX(depth)`
       (
         await this.engine.query(`
           SELECT
-            MAX(depth) + 1 as rowCount
+            depth + 1 AS rowCount
           FROM (${this.getSqlSource()})
+          ORDER BY depth DESC
+          LIMIT 1
         `)
       ).maybeFirstRow({rowCount: NUM})?.rowCount,
     );

--- a/ui/src/components/tracks/dataset_slice_track.ts
+++ b/ui/src/components/tracks/dataset_slice_track.ts
@@ -133,21 +133,6 @@ export interface DatasetSliceTrackAttrs<T extends DatasetSchema> {
   readonly instantStyle?: InstantStyle;
 
   /**
-   * This function can optionally be used to override the query that is
-   * generated for querying the slices rendered on the track. This is typically
-   * used to provide a non-standard depth value, but can be used as an escape
-   * hatch to completely override the query if required.
-   *
-   * The returned query must be in the form of a select statement or table name
-   * with the following columns:
-   * - id: NUM
-   * - ts: LONG
-   * - dur: LONG
-   * - depth: NUM
-   */
-  queryGenerator?(dataset: SourceDataset): string;
-
-  /**
    * An optional function to override the color scheme for each event.
    * If omitted, the default slice color scheme is used.
    */
@@ -216,7 +201,7 @@ export class DatasetSliceTrack<T extends ROW_SCHEMA> extends BaseSliceTrack<
       attrs.initialMaxDepth,
       attrs.instantStyle?.width,
     );
-    const {dataset, queryGenerator} = attrs;
+    const {dataset} = attrs;
 
     // This is the minimum viable implementation that the source dataset must
     // implement for the track to work properly. Typescript should enforce this
@@ -224,8 +209,7 @@ export class DatasetSliceTrack<T extends ROW_SCHEMA> extends BaseSliceTrack<
     // Better to error out early.
     assertTrue(this.attrs.dataset.implements(rowSchema));
 
-    this.sqlSource =
-      queryGenerator?.(dataset) ?? this.generateRenderQuery(dataset);
+    this.sqlSource = this.generateRenderQuery(dataset);
     this.rootTableName = attrs.rootTableName;
   }
 

--- a/ui/src/components/tracks/dataset_slice_track.ts
+++ b/ui/src/components/tracks/dataset_slice_track.ts
@@ -95,9 +95,6 @@ export interface DatasetSliceTrackAttrs<T extends DatasetSchema> {
    * - `layer` (NUM): This layer value influences the mipmap function. Slices in
    *   different layers will be mipmapped independency of each other, and the
    *   buckets of higher layers will be rendered on top of lower layers.
-   *   Warning: While using layers, depth values must be kept under 16 (see
-   *   LAYER_MULTIPLIER in base_slice_track.ts), otherwise we could run into
-   *   issues.
    */
   readonly dataset: SourceDataset<T>;
 

--- a/ui/src/components/tracks/dataset_slice_track.ts
+++ b/ui/src/components/tracks/dataset_slice_track.ts
@@ -23,7 +23,6 @@ import {Slice} from '../../public/track';
 import {DatasetSchema, SourceDataset} from '../../trace_processor/dataset';
 import {ColumnType, LONG, NUM} from '../../trace_processor/query_result';
 import {getColorForSlice} from '../colorizer';
-import {generateSqlWithInternalLayout} from '../sql_utils/layout';
 import {formatDuration} from '../time_utils';
 import {
   BASE_ROW,
@@ -35,6 +34,7 @@ import {
 } from './base_slice_track';
 import {Point2D, Size2D} from '../../base/geom';
 import {exists} from '../../base/utils';
+import {removeFalsyValues} from '../../base/array_utils';
 
 export interface InstantStyle {
   /**
@@ -92,6 +92,12 @@ export interface DatasetSliceTrackAttrs<T extends DatasetSchema> {
    *   width corresponds to the duration of the slice.
    * - `depth` (NUM): Depth of each event, used for vertical arrangement. Higher
    *   depth values are rendered lower down on the track.
+   * - `layer` (NUM): This layer value influences the mipmap function. Slices in
+   *   different layers will be mipmapped independency of each other, and the
+   *   buckets of higher layers will be rendered on top of lower layers.
+   *   Warning: While using layers, depth values must be kept under 16 (see
+   *   LAYER_MULTIPLIER in base_slice_track.ts), otherwise we could run into
+   *   issues.
    */
   readonly dataset: SourceDataset<T>;
 
@@ -245,26 +251,34 @@ export class DatasetSliceTrack<T extends ROW_SCHEMA> extends BaseSliceTrack<
 
   // Generate a query to use for generating slices to be rendered
   private generateRenderQuery(dataset: SourceDataset<T>) {
-    if (dataset.implements({dur: LONG, depth: NUM})) {
-      // Both depth and dur provided, we can use the dataset as-is.
+    const hasLayer = dataset.implements({layer: NUM});
+    const hasDepth = dataset.implements({depth: NUM});
+    const hasDur = dataset.implements({dur: LONG});
+
+    const cols = removeFalsyValues([
+      // If we have no layer, assume flat layering.
+      !hasLayer && '0 as layer',
+
+      // If we have dur but no depth, automatically calculate layout.
+      !hasDepth &&
+        hasDur &&
+        `
+          internal_layout(ts, dur) OVER (
+            ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS depth
+        `,
+
+      // If we have no dur or depth, use a flat layout.
+      !hasDepth && !hasDur && '0 as depth',
+
+      // If no dur, assume instant slices.
+      !hasDur && '0 as dur',
+    ]);
+
+    if (cols.length === 0) {
       return dataset.query();
-    } else if (dataset.implements({depth: NUM})) {
-      // Depth provided but no dur, assume each event is an instant event by
-      // hard coding dur to 0.
-      return `select 0 as dur, * from (${dataset.query()})`;
-    } else if (dataset.implements({dur: LONG})) {
-      // Dur provided but no depth, automatically calculate the depth using
-      // internal_layout().
-      return generateSqlWithInternalLayout({
-        columns: ['*'],
-        source: dataset.query(),
-        ts: 'ts',
-        dur: 'dur',
-        orderByClause: 'ts',
-      });
     } else {
-      // No depth nor dur provided, use 0 for both.
-      return `select 0 as dur, 0 as depth, * from (${dataset.query()})`;
+      return `select ${cols.join(', ')}, * from (${dataset.query()})`;
     }
   }
 

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
@@ -32,13 +32,13 @@ export function createThreadStateTrack(
         id: NUM,
         ts: LONG,
         dur: LONG,
-        depth: NUM,
         layer: NUM,
         cpu: NUM_NULL,
         state: STR,
         io_wait: NUM_NULL,
         utid: NUM,
         name: STR,
+        depth: NUM,
       },
       src: `
         SELECT
@@ -50,12 +50,12 @@ export function createThreadStateTrack(
           io_wait,
           utid,
           sched_state_io_to_human_readable_string(state, io_wait) AS name,
-          -- Move sleeping and idle threads to the back layer
-          case
-            when state in ('S', 'I') then 0
-            else 1
-          end as layer,
-          0 as depth
+          -- Move sleeping and idle slices to the back layer, others on top
+          CASE
+            WHEN state IN ('S', 'I') THEN 0
+            ELSE 1
+          END AS layer,
+          0 AS depth
         FROM thread_state
       `,
       filter: {


### PR DESCRIPTION
This allows tracks to separate slices onto different layers where each layer is mipmapped independently.

Very short but important slices which would normally be swamped by any longer but less important slices if they were on the same layer. By moving them onto separate layers, we can mipmap the separately making sure the more important slices show up on the track.

This patch also modifies the 'thread slice' track to take advantage of the layer functionality to ensure non-idle slices are displayed above idle ones.