### PR TITLE
Add a missing include for replace_numbers_function.h

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.h
@@ -18,6 +18,7 @@
 #define SRC_TRACE_PROCESSOR_PERFETTO_SQL_INTRINSICS_FUNCTIONS_REPLACE_NUMBERS_FUNCTION_H_
 
 #include <sqlite3.h>
+#include <stdint.h>
 
 #include "perfetto/base/status.h"
 


### PR DESCRIPTION
Include <stdint.h> is for int64_t.
