### PR TITLE
Fix bug where ftrace track filters were not being applied correctly

### DIFF
--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_track.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_track.ts
@@ -30,15 +30,15 @@ export function createFtraceTrack(
   cpu: Cpu,
   store: Store<FtraceFilter>,
 ) {
-  const excludeList = store.state.excludeList;
   return new DatasetSliceTrack({
     trace,
     uri,
-    dataset: () =>
+    dataset: () => {
       // This dataset can change depending on the filter settings, so we pass a
       // function in here instead of a static dataset. This function is called
       // every render cycle by the track to see if the dataset has changed.
-      new SourceDataset({
+      const excludeList = store.state.excludeList;
+      return new SourceDataset({
         src: `
           SELECT *
           FROM ftrace_event
@@ -55,7 +55,8 @@ export function createFtraceTrack(
           col: 'ucpu',
           eq: cpu.ucpu,
         },
-      }),
+      });
+    },
     colorizer: (row) => materialColorScheme(row.name),
     instantStyle: {
       width: FTRACE_INSTANT_WIDTH_PX,


### PR DESCRIPTION
Fixes bug in #1644 where we hold onto an old version of the track filters when re-evaluating the dataset, so the ftrace tracks were never updated when the ftrace filter changes.
