### PR TITLE
Fix a ui track crash when a counter is the last event

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -889,7 +889,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
         min_value as minDisplayValue,
         max_value as maxDisplayValue
       from ${this.getTableName()}(
-        trace_start(), trace_end(), trace_dur()
+        trace_start(), trace_end() + 1, trace_dur() + 1
       );
     `);
 


### PR DESCRIPTION
It can be reproduced with the following txt trace:

```
  HwBinder:640_1-721   (  640) [000] ...1 6824711.854000: tracing_mark_write: I|640|event
  HwBinder:640_1-721   (  640) [000] ...1 6824711.854890: tracing_mark_write: C|640|counter|1
```

Bug: https://b.corp.google.com/issues/419524104
