### PR TITLE
Use interval intersect to slice slices to the exact range of the area selection when performing aggregations

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14898,6 +14898,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/time/conversion.sql",
         "src/trace_processor/perfetto_sql/stdlib/traced/stats.sql",
         "src/trace_processor/perfetto_sql/stdlib/v8/jit.sql",
+        "src/trace_processor/perfetto_sql/stdlib/viz/aggregation.sql",
         "src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql",
         "src/trace_processor/perfetto_sql/stdlib/viz/slices.sql",
         "src/trace_processor/perfetto_sql/stdlib/viz/summary/counters.sql",

--- a/BUILD
+++ b/BUILD
@@ -3503,6 +3503,7 @@ perfetto_filegroup(
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_viz_viz",
     srcs = [
+        "src/trace_processor/perfetto_sql/stdlib/viz/aggregation.sql",
         "src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql",
         "src/trace_processor/perfetto_sql/stdlib/viz/slices.sql",
         "src/trace_processor/perfetto_sql/stdlib/viz/threads.sql",

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,8 @@ Unreleased:
       much faster in the Perfetto UI and the trace processor.
   UI:
     * Improved JSON loading performance. See `Trace Processor` section above.
+    * Improved duration based slice aggregators - slices are now trimmed to the
+      width of the area selection.
   SDK:
     *
 

--- a/src/trace_processor/perfetto_sql/stdlib/viz/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/BUILD.gn
@@ -16,6 +16,7 @@ import("../../../../../gn/perfetto_sql.gni")
 
 perfetto_sql_source_set("viz") {
   sources = [
+    "aggregation.sql",
     "flamegraph.sql",
     "slices.sql",
     "threads.sql",

--- a/src/trace_processor/perfetto_sql/stdlib/viz/aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/aggregation.sql
@@ -1,0 +1,52 @@
+--
+-- Copyright 2025 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+INCLUDE PERFETTO MODULE intervals.intersect;
+
+-- This macro is basically interval_intersect_single! but it returns instants
+-- within the time range too. Returns all the original columns from the table or
+-- subquery + ii_dur which is the duration of the slice that lies within the
+-- provided bounds.
+-- Incomplete slices (dur < 0) are utterly ignored.
+-- Useful for aggregations.
+CREATE PERFETTO MACRO _intersect_slices(
+    ts Expr,
+    dur Expr,
+    t TableOrSubquery
+)
+RETURNS TableOrSubquery AS
+(
+  SELECT
+    slices.*,
+    ii.dur AS ii_dur
+  FROM _interval_intersect_single!(
+    $ts,
+    $dur,
+    (SELECT * FROM ($t) WHERE dur > 0)
+  ) AS ii
+  JOIN (
+    $t
+  ) AS slices
+    USING (id)
+  UNION ALL
+  SELECT
+    *,
+    dur AS ii_dur
+  FROM (
+    $t
+  )
+  WHERE
+    dur = 0 AND ts >= $ts AND ts < $ts + $dur
+);

--- a/src/trace_processor/perfetto_sql/stdlib/viz/aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/aggregation.sql
@@ -15,12 +15,10 @@
 
 INCLUDE PERFETTO MODULE intervals.intersect;
 
--- This macro is basically interval_intersect_single! but it returns instants
--- within the time range too. Returns all the original columns from the table or
--- subquery + ii_dur which is the duration of the slice that lies within the
--- provided bounds.
--- Incomplete slices (dur < 0) are utterly ignored.
--- Useful for aggregations.
+-- Extends `interval_intersect_single!` to handle instants within a time range.
+-- Returns all original columns from the input table/subquery, plus `ii_dur`:
+-- the duration of the slice segment within the specified bounds.
+-- Slices with `dur < 0` are ignored. Useful for aggregations.
 CREATE PERFETTO MACRO _intersect_slices(
     ts Expr,
     dur Expr,

--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -142,6 +142,10 @@ export class Time {
     return a - b;
   }
 
+  static durationBetween(a: time, b: time): duration {
+    return a >= b ? a - b : b - a;
+  }
+
   static min(a: time, b: time): time {
     return Time.fromRaw(BigintMath.min(a, b));
   }

--- a/ui/src/components/selection_aggregation_manager.ts
+++ b/ui/src/components/selection_aggregation_manager.ts
@@ -14,12 +14,13 @@
 
 import {AsyncLimiter} from '../base/async_limiter';
 import {isString} from '../base/object_utils';
+import {Time} from '../base/time';
 import {AggregateData, Column, ColumnDef, Sorting} from '../public/aggregation';
 import {AreaSelection, AreaSelectionAggregator} from '../public/selection';
 import {Track} from '../public/track';
-import {Dataset, UnionDataset} from '../trace_processor/dataset';
+import {Dataset, SourceDataset, UnionDataset} from '../trace_processor/dataset';
 import {Engine} from '../trace_processor/engine';
-import {NUM} from '../trace_processor/query_result';
+import {LONG, NUM} from '../trace_processor/query_result';
 
 export class SelectionAggregationManager {
   private readonly limiter = new AsyncLimiter();
@@ -90,7 +91,34 @@ export class SelectionAggregationManager {
     area: AreaSelection,
   ): Promise<AggregateData | undefined> {
     const aggr = this.aggregator;
-    const dataset = this.createDatasetForAggregator(aggr, area.tracks);
+    let dataset = this.createDatasetForAggregator(aggr, area.tracks);
+
+    await this.engine.query('INCLUDE PERFETTO MODULE viz.aggregation');
+
+    const duration = Time.durationBetween(area.start, area.end);
+
+    // The dataset must contain ts, dur, and id columns for interval
+    // intersection.
+    if (
+      duration > 0n &&
+      dataset &&
+      dataset.implements({id: NUM, ts: LONG, dur: LONG})
+    ) {
+      dataset = new SourceDataset({
+        src: `
+          SELECT
+            ii_dur as dur,
+            *
+          FROM _intersect_slices!(
+            ${area.start},
+            ${duration},
+            (${dataset.query()})
+          )
+        `,
+        schema: dataset.schema,
+      });
+    }
+
     const viewExists = await aggr.createAggregateView(
       this.engine,
       area,

--- a/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
@@ -32,7 +32,7 @@ export class FrameSelectionAggregator implements AreaSelectionAggregator {
 
   async createAggregateView(
     engine: Engine,
-    area: AreaSelection,
+    _area: AreaSelection,
     dataset?: Dataset,
   ) {
     if (!dataset) return false;
@@ -46,8 +46,6 @@ export class FrameSelectionAggregator implements AreaSelectionAggregator {
         avg(dur) as meanDur,
         max(dur) as maxDur
       from (${dataset.query()})
-      where ts + dur > ${area.start}
-        AND ts < ${area.end}
       group by jank_type
     `);
     return true;

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
@@ -19,6 +19,7 @@ import {Engine} from '../../trace_processor/engine';
 import {AreaSelectionAggregator} from '../../public/selection';
 import {LONG, NUM} from '../../trace_processor/query_result';
 import {Dataset} from '../../trace_processor/dataset';
+import {Time} from '../../base/time';
 
 export class CpuSliceSelectionAggregator implements AreaSelectionAggregator {
   readonly id = 'cpu_aggregation';
@@ -36,22 +37,30 @@ export class CpuSliceSelectionAggregator implements AreaSelectionAggregator {
   ) {
     if (!dataset) return false;
 
+    const duration = Time.durationBetween(area.start, area.end);
+    if (duration <= 0n) {
+      return false;
+    }
+
     await engine.query(`
+      INCLUDE PERFETTO MODULE viz.aggregation;
+
       create or replace perfetto table ${this.id} as
       select
         process.name as process_name,
         pid,
         thread.name as thread_name,
         tid,
-        sum(dur) AS total_dur,
-        sum(dur) / count() as avg_dur,
+        sum(ii_dur) AS total_dur,
+        sum(ii_dur) / count() as avg_dur,
         count() as occurrences
       from process
       join thread using (upid)
-      join (${dataset.query()}) as sched using (utid)
-      where
-        sched.ts + sched.dur > ${area.start}
-        and sched.ts < ${area.end}
+      join _intersect_slices!(
+        ${area.start},
+        ${duration},
+        (${dataset.query()})
+      ) AS sched using (utid)
       group by utid
     `);
     return true;

--- a/ui/src/public/selection.ts
+++ b/ui/src/public/selection.ts
@@ -155,7 +155,8 @@ export interface AreaSelectionAggregator {
    * @param engine - The query engine used to execute queries.
    * @param area - The currently selected area to aggregate.
    * @param dataset - The dataset representing a union of the data in the
-   * selected tracks.
+   * selected tracks sliced by the intersection of the area assuming datasets
+   * have a `dur` column. If no tracks have a dataset, this will be undefined.
    */
   createAggregateView(
     engine: Engine,


### PR DESCRIPTION
Use interval intersect to intersect slices by the exact area selection range when doing aggregations.

Any panels that use the area selection aggregator adapter (`createAggregationToTabAdaptor()`) will now be passed the pre-intersected dataset if the selected datasets implement a ts, dur and id columns.