### PR TITLE
Add bar chart support to the aggregation adapater

### DIFF
--- a/ui/src/components/colorizer.ts
+++ b/ui/src/components/colorizer.ts
@@ -66,9 +66,9 @@ const MD_PALETTE_RAW: Color[] = [
   new HSLColor({h: 54, s: 100, l: 62}),
 ];
 
-const WHITE_COLOR = new HSLColor([0, 0, 100]);
-const BLACK_COLOR = new HSLColor([0, 0, 0]);
-const GRAY_COLOR = new HSLColor([0, 0, 90]);
+export const WHITE_COLOR = new HSLColor([0, 0, 100]);
+export const BLACK_COLOR = new HSLColor([0, 0, 0]);
+export const GRAY_COLOR = new HSLColor([0, 0, 90]);
 
 const MD_PALETTE: ColorScheme[] = MD_PALETTE_RAW.map((color): ColorScheme => {
   const base = color.lighten(10, 60).desaturate(20);
@@ -105,21 +105,7 @@ export function makeColorScheme(base: Color, variant?: Color): ColorScheme {
   };
 }
 
-const GRAY = makeColorScheme(new HSLColor([0, 0, 62]));
-const DESAT_RED = makeColorScheme(new HSLColor([3, 30, 49]));
-const DARK_GREEN = makeColorScheme(new HSLColor([120, 44, 34]));
-const LIME_GREEN = makeColorScheme(new HSLColor([75, 55, 47]));
-const TRANSLUCENT_GRAY = {
-  base: new HSLColor([0, 1, 50], 0),
-  variant: new HSLColor([0, 1, 50], 0.2),
-  disabled: GRAY_COLOR,
-  // Make the text invisible
-  textBase: new HSLColor([0, 0, 0], 0),
-  textVariant: new HSLColor([0, 0, 0], 0),
-  textDisabled: new HSLColor([0, 0, 0], 0),
-};
-const ORANGE = makeColorScheme(new HSLColor([36, 100, 50]));
-const INDIGO = makeColorScheme(new HSLColor([231, 48, 48]));
+export const GRAY = makeColorScheme(new HSLColor([0, 0, 62]));
 
 // A piece of wisdom from a long forgotten blog post: "Don't make
 // colors you want to change something normal like grey."
@@ -161,24 +147,6 @@ function proceduralColorScheme(seed: string): ColorScheme {
 
     return colorScheme;
   }
-}
-
-export function colorForState(state: string): ColorScheme {
-  if (state === 'Running') {
-    return DARK_GREEN;
-  } else if (state.startsWith('Runnable')) {
-    return LIME_GREEN;
-  } else if (state.includes('Uninterruptible Sleep')) {
-    if (state.includes('non-IO')) {
-      return DESAT_RED;
-    }
-    return ORANGE;
-  } else if (state.includes('Dead')) {
-    return GRAY;
-  } else if (state.includes('Sleeping') || state.includes('Idle')) {
-    return TRANSLUCENT_GRAY;
-  }
-  return INDIGO;
 }
 
 export function colorForTid(tid: number): ColorScheme {

--- a/ui/src/components/selection_aggregation_manager.ts
+++ b/ui/src/components/selection_aggregation_manager.ts
@@ -118,14 +118,14 @@ export class SelectionAggregationManager {
     const columnSums = await Promise.all(
       defs.map((def) => this.getSum(aggr.id, def)),
     );
-    const extraData = await aggr.getExtra(this.engine, area);
+    const extraData = await aggr.getBarChartData?.(this.engine, area, dataset);
     const extra = extraData ? extraData : undefined;
     const data: AggregateData = {
       tabName: aggr.getTabName(),
       columns,
       columnSums,
       strings: [],
-      extra,
+      barChart: extra,
     };
 
     const stringIndexes = new Map<string, number>();

--- a/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
@@ -112,8 +112,6 @@ export class EntityStateResidencySelectionAggregator
     ];
   }
 
-  async getExtra() {}
-
   getTabName() {
     return 'Entity State Residency';
   }

--- a/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
@@ -57,8 +57,6 @@ export class FrameSelectionAggregator implements AreaSelectionAggregator {
     return 'Frames';
   }
 
-  async getExtra() {}
-
   getDefaultSorting(): Sorting {
     return {column: 'occurrences', direction: 'DESC'};
   }

--- a/ui/src/plugins/dev.perfetto.PowerAggregations/power_counter_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.PowerAggregations/power_counter_selection_aggregator.ts
@@ -101,8 +101,6 @@ export class PowerCounterSelectionAggregator
     ];
   }
 
-  async getExtra() {}
-
   getTabName() {
     return 'Power Counters';
   }

--- a/ui/src/plugins/dev.perfetto.Sched/common.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/common.ts
@@ -12,9 +12,46 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {HSLColor} from '../../base/color';
+import {ColorScheme} from '../../base/color_scheme';
+import {GRAY, GRAY_COLOR, makeColorScheme} from '../../components/colorizer';
+
 export const CPU_SLICE_URI_PREFIX = '/sched_cpu';
 
 // Helper function moved here as it's only used by the overlay.
 export function uriForSchedTrack(cpu: number): string {
   return `${CPU_SLICE_URI_PREFIX}${cpu}`;
+}
+
+const DESAT_RED = makeColorScheme(new HSLColor([3, 30, 49]));
+const DARK_GREEN = makeColorScheme(new HSLColor([120, 44, 34]));
+const LIME_GREEN = makeColorScheme(new HSLColor([75, 55, 47]));
+const TRANSLUCENT_GRAY = {
+  base: new HSLColor([0, 1, 50], 0),
+  variant: new HSLColor([0, 1, 50], 0.2),
+  disabled: GRAY_COLOR,
+  // Make the text invisible
+  textBase: new HSLColor([0, 0, 0], 0),
+  textVariant: new HSLColor([0, 0, 0], 0),
+  textDisabled: new HSLColor([0, 0, 0], 0),
+};
+const ORANGE = makeColorScheme(new HSLColor([36, 100, 50]));
+const INDIGO = makeColorScheme(new HSLColor([231, 48, 48]));
+
+export function colorForThreadState(state: string): ColorScheme {
+  if (state === 'Running') {
+    return DARK_GREEN;
+  } else if (state.startsWith('Runnable')) {
+    return LIME_GREEN;
+  } else if (state.includes('Uninterruptible Sleep')) {
+    if (state.includes('non-IO')) {
+      return DESAT_RED;
+    }
+    return ORANGE;
+  } else if (state.includes('Dead')) {
+    return GRAY;
+  } else if (state.includes('Sleeping') || state.includes('Idle')) {
+    return TRANSLUCENT_GRAY;
+  }
+  return INDIGO;
 }

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_by_process_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_by_process_selection_aggregator.ts
@@ -61,8 +61,6 @@ export class CpuSliceByProcessSelectionAggregator
     return 'CPU by process';
   }
 
-  async getExtra() {}
-
   getDefaultSorting(): Sorting {
     return {column: 'total_dur', direction: 'DESC'};
   }

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
@@ -61,8 +61,6 @@ export class CpuSliceSelectionAggregator implements AreaSelectionAggregator {
     return 'CPU by thread';
   }
 
-  async getExtra() {}
-
   getDefaultSorting(): Sorting {
     return {column: 'total_dur', direction: 'DESC'};
   }

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ColumnDef, Sorting, ThreadStateExtra} from '../../public/aggregation';
+import {ColumnDef, Sorting, BarChartData} from '../../public/aggregation';
 import {AreaSelection} from '../../public/selection';
 import {Engine} from '../../trace_processor/engine';
 import {
@@ -24,7 +24,7 @@ import {
 } from '../../trace_processor/query_result';
 import {AreaSelectionAggregator} from '../../public/selection';
 import {Dataset} from '../../trace_processor/dataset';
-import {translateState} from '../../components/sql_utils/thread_state';
+import {colorForThreadState} from './common';
 
 export class ThreadStateSelectionAggregator implements AreaSelectionAggregator {
   readonly id = 'thread_state_aggregation';
@@ -66,17 +66,16 @@ export class ThreadStateSelectionAggregator implements AreaSelectionAggregator {
     return true;
   }
 
-  async getExtra(
+  async getBarChartData(
     engine: Engine,
     area: AreaSelection,
     dataset?: Dataset,
-  ): Promise<ThreadStateExtra | void> {
-    if (dataset === undefined) return;
+  ): Promise<BarChartData[] | undefined> {
+    if (dataset === undefined) return undefined;
 
     const query = `
       select
-        state,
-        io_wait as ioWait,
+        sched_state_io_to_human_readable_string(state, io_wait) AS name,
         sum(dur) as totalDur
       from (${dataset.query()}) tstate
       join thread using (utid)
@@ -87,28 +86,21 @@ export class ThreadStateSelectionAggregator implements AreaSelectionAggregator {
     const result = await engine.query(query);
 
     const it = result.iter({
-      state: STR_NULL,
-      ioWait: NUM_NULL,
+      name: STR_NULL,
       totalDur: NUM,
     });
 
-    let totalMs = 0;
-    const values = new Float64Array(result.numRows());
-    const states = [];
+    const states: BarChartData[] = [];
     for (let i = 0; it.valid(); ++i, it.next()) {
-      const state = it.state == null ? undefined : it.state;
-      const ioWait = it.ioWait === null ? undefined : it.ioWait > 0;
-      states.push(translateState(state, ioWait));
+      const name = it.name ?? 'Unknown';
       const ms = it.totalDur / 1000000;
-      values[i] = ms;
-      totalMs += ms;
+      states.push({
+        name,
+        timeInStateMs: ms,
+        color: colorForThreadState(name),
+      });
     }
-    return {
-      kind: 'THREAD_STATE',
-      states,
-      values,
-      totalMs,
-    };
+    return states;
   }
 
   getColumnDefinitions(): ColumnDef[] {

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {colorForState} from '../../components/colorizer';
 import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
+import {colorForThreadState} from './common';
 import {ThreadStateDetailsPanel} from './thread_state_details_panel';
 
 export function createThreadStateTrack(
@@ -68,7 +68,7 @@ export function createThreadStateTrack(
       sliceHeight: 12,
       titleSizePx: 10,
     },
-    colorizer: (row) => colorForState(row.name),
+    colorizer: (row) => colorForThreadState(row.name),
     detailsPanel: (row) => new ThreadStateDetailsPanel(trace, row.id),
     rootTableName: 'thread_state',
   });

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_selection_aggregator.ts
@@ -186,8 +186,6 @@ export class CounterSelectionAggregator implements AreaSelectionAggregator {
     ];
   }
 
-  async getExtra() {}
-
   getTabName() {
     return 'Counters';
   }

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -56,8 +56,6 @@ export class SliceSelectionAggregator implements AreaSelectionAggregator {
     return 'Slices';
   }
 
-  async getExtra() {}
-
   getDefaultSorting(): Sorting {
     return {column: 'total_dur', direction: 'DESC'};
   }

--- a/ui/src/plugins/org.kernel.Wattson/aggregation_panel.ts
+++ b/ui/src/plugins/org.kernel.Wattson/aggregation_panel.ts
@@ -60,10 +60,6 @@ export class WattsonAggregationPanel
           },
           title: 'Select power units',
         }),
-        attrs.data.extra !== undefined &&
-          attrs.data.extra.kind === 'THREAD_STATE'
-          ? this.showStateSummary(attrs.data.extra)
-          : null,
         this.showTimeRange(),
         m(
           'table',

--- a/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
@@ -112,8 +112,6 @@ export class WattsonEstimateSelectionAggregator
     ];
   }
 
-  async getExtra() {}
-
   getTabName() {
     return 'Wattson estimates';
   }

--- a/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
@@ -99,8 +99,6 @@ export class WattsonPackageSelectionAggregator
     ];
   }
 
-  async getExtra() {}
-
   getTabName() {
     return 'Wattson by package';
   }

--- a/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
@@ -138,8 +138,6 @@ export class WattsonProcessSelectionAggregator
     ];
   }
 
-  async getExtra() {}
-
   getTabName() {
     return 'Wattson by process';
   }

--- a/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
@@ -227,8 +227,6 @@ export class WattsonThreadSelectionAggregator
     ];
   }
 
-  async getExtra() {}
-
   getTabName() {
     return 'Wattson by thread';
   }

--- a/ui/src/public/aggregation.ts
+++ b/ui/src/public/aggregation.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {ColorScheme} from '../base/color_scheme';
+
 export type Column = (
   | StringColumn
   | TimestampColumn
@@ -61,18 +63,17 @@ export interface AggregateData {
   // For string interning.
   readonly strings: string[];
   // Some aggregations will have extra info to display;
-  readonly extra?: ThreadStateExtra;
+  readonly barChart?: ReadonlyArray<BarChartData>;
 }
 
 export function isEmptyData(data: AggregateData) {
   return data.columns.length === 0 || data.columns[0].data.length === 0;
 }
 
-export interface ThreadStateExtra {
-  readonly kind: 'THREAD_STATE';
-  readonly states: string[];
-  readonly values: Float64Array;
-  readonly totalMs: number;
+export interface BarChartData {
+  readonly name: string;
+  readonly timeInStateMs: number;
+  readonly color: ColorScheme;
 }
 
 export interface Sorting {

--- a/ui/src/public/selection.ts
+++ b/ui/src/public/selection.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {duration, time, TimeSpan} from '../base/time';
 import {Dataset, DatasetSchema} from '../trace_processor/dataset';
 import {Engine} from '../trace_processor/engine';
-import {ColumnDef, Sorting, ThreadStateExtra} from './aggregation';
+import {ColumnDef, Sorting, BarChartData} from './aggregation';
 import {Track} from './track';
 import {arrayEquals} from '../base/array_utils';
 
@@ -162,11 +162,11 @@ export interface AreaSelectionAggregator {
     area: AreaSelection,
     dataset?: Dataset,
   ): Promise<boolean>;
-  getExtra(
+  getBarChartData?(
     engine: Engine,
     area: AreaSelection,
     dataset?: Dataset,
-  ): Promise<ThreadStateExtra | void>;
+  ): Promise<BarChartData[] | undefined>;
   getTabName(): string;
   getDefaultSorting(): Sorting;
   getColumnDefinitions(): ColumnDef[];


### PR DESCRIPTION
In the past, thread state aggregation tabs used to have a little bar chart at the top of the panel showing the proportions of thread states within the selected area. This was lost after a refactor.

The way this used to work was very hacky - there was a special case for the thread state tab that the core knew about.

This patch changes this special case to a more generic 'bar chart' interface, where aggregators can specify bar chart data, which the thread state aggregator makes use of to bring its bar chart back to life.

Removing this special case also means that we can remove the hard dependency on thread state structures and colors from the core, allowing us to remove anything thread state related into the 'Sched' plugin.
