### PR TITLE
ci: fix UI presubmit bugs

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -63,15 +63,15 @@ jobs:
 
       - name: Build Perfetto UI
         run: |
-          ui/build --out out/dist
-          cp -a out/dist/ui/dist/ "$PERFETTO_ARTIFACTS_DIR/ui"
+          ui/build --out out/ui
+          cp -a out/ui/ui/dist/ "$PERFETTO_ARTIFACTS_DIR/ui"
 
       - name: Print ccache stats
         run: ccache --show-stats
 
 
       - name: UI unittests
-        run: ui/run-unittests --out out/dist --no-build
+        run: ui/run-unittests --out out/ui --no-build
 
       - name: Install Chrome
         run: |
@@ -82,7 +82,7 @@ jobs:
           dpkg-deb -x chrome.deb  .
 
       - name: UI integrationtests
-        run: ui/run-integrationtests --out out/dist --no-build
+        run: ui/run-integrationtests --out out/ui --no-build
 
         # UI code formatting checks must be done here, rather than repo-checks,
         # because they need a out/ui build.
@@ -95,8 +95,8 @@ jobs:
       - name: Upload artifacts to GCS
         if: ${{ always() }}
         run: |
-          if [ -d out/dist/ui-test-artifacts ]; then
-            cp -a out/dist/ui-test-artifacts "$PERFETTO_ARTIFACTS_DIR/ui-test-artifacts"
+          if [ -d out/ui/ui-test-artifacts ]; then
+            cp -a out/ui/ui-test-artifacts "$PERFETTO_ARTIFACTS_DIR/ui-test-artifacts"
           fi
           /opt/ci/artifacts_uploader.py --rm ${{ env.PERFETTO_ARTIFACTS_ROOT }}
           echo "UI integration test report with screnshots:"


### PR DESCRIPTION
presubmits expect the UI to be built under out/ui
(because that's what ui/build and run-dev-server use).
The GitHub Action workflows was using out/dist instead.

