### PR TITLE
add buildtools/cpp-httplib to gitignore

### DIFF
--- a/buildtools/.gitignore
+++ b/buildtools/.gitignore
@@ -11,6 +11,7 @@
 /catapult_trace_viewer/
 /clang_format/
 /clang/
+/cpp-httplib/
 /expat/src/
 /d8/
 /debian_sid_arm-sysroot/


### PR DESCRIPTION
This file should have been added to .gitignore in 2024
when the optional install-build-dep entry was introduced.
I think we never noticed until now because bigtrace was not used in the CI.
This is now causing some CI errors.

