### PR TITLE
stdlib: Combine all Wattson subsystem estimates

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14908,6 +14908,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/viz/summary/track_event.sql",
         "src/trace_processor/perfetto_sql/stdlib/viz/threads.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/arm_dsu.sql",
+        "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/freq.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/freq_idle.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/hotplug.sql",

--- a/BUILD
+++ b/BUILD
@@ -3512,6 +3512,7 @@ perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_wattson_wattson",
     srcs = [
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/arm_dsu.sql",
+        "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/freq.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/freq_idle.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/cpu/hotplug.sql",

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/BUILD.gn
@@ -17,6 +17,7 @@ import("../../../../../gn/perfetto_sql.gni")
 perfetto_sql_source_set("wattson") {
   sources = [
     "cpu/arm_dsu.sql",
+    "cpu/estimates.sql",
     "cpu/freq.sql",
     "cpu/freq_idle.sql",
     "cpu/hotplug.sql",

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
@@ -1,0 +1,152 @@
+--
+-- Copyright 2024 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+INCLUDE PERFETTO MODULE wattson.cpu.split;
+
+INCLUDE PERFETTO MODULE wattson.cpu.w_cpu_dependence;
+
+INCLUDE PERFETTO MODULE wattson.cpu.w_dsu_dependence;
+
+INCLUDE PERFETTO MODULE wattson.curves.utils;
+
+INCLUDE PERFETTO MODULE wattson.device_infos;
+
+INCLUDE PERFETTO MODULE wattson.utils;
+
+-- One of the two tables will be empty, depending on whether the device is
+-- dependent on devfreq or a different CPU's frequency
+CREATE PERFETTO VIEW _curves_w_dependencies (
+  ts TIMESTAMP,
+  dur DURATION,
+  freq_0 LONG,
+  idle_0 LONG,
+  freq_1 LONG,
+  idle_1 LONG,
+  freq_2 LONG,
+  idle_2 LONG,
+  freq_3 LONG,
+  idle_3 LONG,
+  cpu0_curve DOUBLE,
+  cpu1_curve DOUBLE,
+  cpu2_curve DOUBLE,
+  cpu3_curve DOUBLE,
+  cpu4_curve DOUBLE,
+  cpu5_curve DOUBLE,
+  cpu6_curve DOUBLE,
+  cpu7_curve DOUBLE,
+  l3_hit_count LONG,
+  l3_miss_count LONG,
+  suspended BOOL,
+  no_static LONG,
+  all_cpu_deep_idle LONG,
+  dependent_freq LONG,
+  dependent_policy LONG
+) AS
+-- Table that is dependent on differet CPU's frequency
+SELECT
+  *
+FROM _w_cpu_dependence
+UNION ALL
+-- Table that is dependent of devfreq frequency
+SELECT
+  *
+FROM _w_dsu_dependence;
+
+-- Final table showing the curves per CPU per slice
+CREATE PERFETTO TABLE _system_state_curves AS
+SELECT
+  base.ts,
+  base.dur,
+  -- base.cpu[0-3]_curve will be non-zero if CPU has 1D dependency
+  -- base.cpu[0-3]_curve will be zero if device is suspended or deep idle
+  -- base.cpu[0-3]_curve will be NULL if 2D dependency required
+  iif(suspended, 0.0, coalesce(base.cpu0_curve, lut0.curve_value)) AS cpu0_curve,
+  iif(suspended, 0.0, coalesce(base.cpu1_curve, lut1.curve_value)) AS cpu1_curve,
+  iif(suspended, 0.0, coalesce(base.cpu2_curve, lut2.curve_value)) AS cpu2_curve,
+  iif(suspended, 0.0, coalesce(base.cpu3_curve, lut3.curve_value)) AS cpu3_curve,
+  -- base.cpu[4-7]_curve will be non-zero if CPU has 1D dependency
+  -- base.cpu[4-7]_curve will be zero if device is suspended or deep idle
+  -- base.cpu[4-7]_curve will be NULL if CPU doesn't exist on device
+  iif(suspended, 0.0, coalesce(base.cpu4_curve, 0.0)) AS cpu4_curve,
+  iif(suspended, 0.0, coalesce(base.cpu5_curve, 0.0)) AS cpu5_curve,
+  iif(suspended, 0.0, coalesce(base.cpu6_curve, 0.0)) AS cpu6_curve,
+  iif(suspended, 0.0, coalesce(base.cpu7_curve, 0.0)) AS cpu7_curve,
+  iif(no_static = 1, 0.0, coalesce(static_1d.curve_value, static_2d.curve_value)) AS static_curve,
+  iif(all_cpu_deep_idle = 1, 0, base.l3_hit_count * l3_hit_lut.curve_value) AS l3_hit_value,
+  iif(all_cpu_deep_idle = 1, 0, base.l3_miss_count * l3_miss_lut.curve_value) AS l3_miss_value
+FROM _curves_w_dependencies AS base
+-- LUT for 2D dependencies
+LEFT JOIN _filtered_curves_2d AS lut0
+  ON lut0.freq_khz = base.freq_0
+  AND lut0.other_policy = base.dependent_policy
+  AND lut0.other_freq_khz = base.dependent_freq
+  AND lut0.idle = base.idle_0
+LEFT JOIN _filtered_curves_2d AS lut1
+  ON lut1.freq_khz = base.freq_1
+  AND lut1.other_policy = base.dependent_policy
+  AND lut1.other_freq_khz = base.dependent_freq
+  AND lut1.idle = base.idle_1
+LEFT JOIN _filtered_curves_2d AS lut2
+  ON lut2.freq_khz = base.freq_2
+  AND lut2.other_policy = base.dependent_policy
+  AND lut2.other_freq_khz = base.dependent_freq
+  AND lut2.idle = base.idle_2
+LEFT JOIN _filtered_curves_2d AS lut3
+  ON lut3.freq_khz = base.freq_3
+  AND lut3.other_policy = base.dependent_policy
+  AND lut3.other_freq_khz = base.dependent_freq
+  AND lut3.idle = base.idle_3
+-- LUT for static curve lookup
+LEFT JOIN _filtered_curves_2d AS static_2d
+  ON static_2d.freq_khz = base.freq_0
+  AND static_2d.other_policy = base.dependent_policy
+  AND static_2d.other_freq_khz = base.dependent_freq
+  AND static_2d.idle = 255
+LEFT JOIN _filtered_curves_1d AS static_1d
+  ON static_1d.policy = 0 AND static_1d.freq_khz = base.freq_0 AND static_1d.idle = 255
+-- LUT joins for L3 cache
+LEFT JOIN _filtered_curves_l3 AS l3_hit_lut
+  ON l3_hit_lut.freq_khz = base.freq_0
+  AND l3_hit_lut.other_policy = base.dependent_policy
+  AND l3_hit_lut.other_freq_khz = base.dependent_freq
+  AND l3_hit_lut.action = 'hit'
+LEFT JOIN _filtered_curves_l3 AS l3_miss_lut
+  ON l3_miss_lut.freq_khz = base.freq_0
+  AND l3_miss_lut.other_policy = base.dependent_policy
+  AND l3_miss_lut.other_freq_khz = base.dependent_freq
+  AND l3_miss_lut.action = 'miss';
+
+-- The most basic components of Wattson, all normalized to be in mW on a per
+-- system state basis
+CREATE PERFETTO TABLE _cpu_estimates_mw AS
+SELECT
+  ts,
+  dur,
+  cpu0_curve AS cpu0_mw,
+  cpu1_curve AS cpu1_mw,
+  cpu2_curve AS cpu2_mw,
+  cpu3_curve AS cpu3_mw,
+  cpu4_curve AS cpu4_mw,
+  cpu5_curve AS cpu5_mw,
+  cpu6_curve AS cpu6_mw,
+  cpu7_curve AS cpu7_mw,
+  -- LUT for l3 is scaled by 10^6 to save resolution and in units of kWs. Scale
+  -- this by 10^3 so when divided by ns, result is in units of mW
+  (
+    (
+      coalesce(l3_hit_value, 0) + coalesce(l3_miss_value, 0)
+    ) * 1000 / dur
+  ) + static_curve AS dsu_scu_mw
+FROM _system_state_curves;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/estimates.sql
@@ -1,5 +1,5 @@
 --
--- Copyright 2024 The Android Open Source Project
+-- Copyright 2025 The Android Open Source Project
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -13,143 +13,22 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-INCLUDE PERFETTO MODULE wattson.cpu.split;
+INCLUDE PERFETTO MODULE wattson.cpu.estimates;
 
-INCLUDE PERFETTO MODULE wattson.cpu.w_cpu_dependence;
-
-INCLUDE PERFETTO MODULE wattson.cpu.w_dsu_dependence;
-
-INCLUDE PERFETTO MODULE wattson.curves.utils;
-
-INCLUDE PERFETTO MODULE wattson.device_infos;
+INCLUDE PERFETTO MODULE wattson.gpu.estimates;
 
 INCLUDE PERFETTO MODULE wattson.utils;
 
--- One of the two tables will be empty, depending on whether the device is
--- dependent on devfreq or a different CPU's frequency
-CREATE PERFETTO VIEW _curves_w_dependencies (
-  ts TIMESTAMP,
-  dur DURATION,
-  freq_0 LONG,
-  idle_0 LONG,
-  freq_1 LONG,
-  idle_1 LONG,
-  freq_2 LONG,
-  idle_2 LONG,
-  freq_3 LONG,
-  idle_3 LONG,
-  cpu0_curve DOUBLE,
-  cpu1_curve DOUBLE,
-  cpu2_curve DOUBLE,
-  cpu3_curve DOUBLE,
-  cpu4_curve DOUBLE,
-  cpu5_curve DOUBLE,
-  cpu6_curve DOUBLE,
-  cpu7_curve DOUBLE,
-  l3_hit_count LONG,
-  l3_miss_count LONG,
-  suspended BOOL,
-  no_static LONG,
-  all_cpu_deep_idle LONG,
-  dependent_freq LONG,
-  dependent_policy LONG
-) AS
--- Table that is dependent on differet CPU's frequency
-SELECT
-  *
-FROM _w_cpu_dependence
-UNION ALL
--- Table that is dependent of devfreq frequency
-SELECT
-  *
-FROM _w_dsu_dependence;
-
--- Final table showing the curves per CPU per slice
-CREATE PERFETTO TABLE _system_state_curves AS
-SELECT
-  base.ts,
-  base.dur,
-  -- base.cpu[0-3]_curve will be non-zero if CPU has 1D dependency
-  -- base.cpu[0-3]_curve will be zero if device is suspended or deep idle
-  -- base.cpu[0-3]_curve will be NULL if 2D dependency required
-  iif(suspended, 0.0, coalesce(base.cpu0_curve, lut0.curve_value)) AS cpu0_curve,
-  iif(suspended, 0.0, coalesce(base.cpu1_curve, lut1.curve_value)) AS cpu1_curve,
-  iif(suspended, 0.0, coalesce(base.cpu2_curve, lut2.curve_value)) AS cpu2_curve,
-  iif(suspended, 0.0, coalesce(base.cpu3_curve, lut3.curve_value)) AS cpu3_curve,
-  -- base.cpu[4-7]_curve will be non-zero if CPU has 1D dependency
-  -- base.cpu[4-7]_curve will be zero if device is suspended or deep idle
-  -- base.cpu[4-7]_curve will be NULL if CPU doesn't exist on device
-  iif(suspended, 0.0, coalesce(base.cpu4_curve, 0.0)) AS cpu4_curve,
-  iif(suspended, 0.0, coalesce(base.cpu5_curve, 0.0)) AS cpu5_curve,
-  iif(suspended, 0.0, coalesce(base.cpu6_curve, 0.0)) AS cpu6_curve,
-  iif(suspended, 0.0, coalesce(base.cpu7_curve, 0.0)) AS cpu7_curve,
-  iif(no_static = 1, 0.0, coalesce(static_1d.curve_value, static_2d.curve_value)) AS static_curve,
-  iif(all_cpu_deep_idle = 1, 0, base.l3_hit_count * l3_hit_lut.curve_value) AS l3_hit_value,
-  iif(all_cpu_deep_idle = 1, 0, base.l3_miss_count * l3_miss_lut.curve_value) AS l3_miss_value
-FROM _curves_w_dependencies AS base
--- LUT for 2D dependencies
-LEFT JOIN _filtered_curves_2d AS lut0
-  ON lut0.freq_khz = base.freq_0
-  AND lut0.other_policy = base.dependent_policy
-  AND lut0.other_freq_khz = base.dependent_freq
-  AND lut0.idle = base.idle_0
-LEFT JOIN _filtered_curves_2d AS lut1
-  ON lut1.freq_khz = base.freq_1
-  AND lut1.other_policy = base.dependent_policy
-  AND lut1.other_freq_khz = base.dependent_freq
-  AND lut1.idle = base.idle_1
-LEFT JOIN _filtered_curves_2d AS lut2
-  ON lut2.freq_khz = base.freq_2
-  AND lut2.other_policy = base.dependent_policy
-  AND lut2.other_freq_khz = base.dependent_freq
-  AND lut2.idle = base.idle_2
-LEFT JOIN _filtered_curves_2d AS lut3
-  ON lut3.freq_khz = base.freq_3
-  AND lut3.other_policy = base.dependent_policy
-  AND lut3.other_freq_khz = base.dependent_freq
-  AND lut3.idle = base.idle_3
--- LUT for static curve lookup
-LEFT JOIN _filtered_curves_2d AS static_2d
-  ON static_2d.freq_khz = base.freq_0
-  AND static_2d.other_policy = base.dependent_policy
-  AND static_2d.other_freq_khz = base.dependent_freq
-  AND static_2d.idle = 255
-LEFT JOIN _filtered_curves_1d AS static_1d
-  ON static_1d.policy = 0 AND static_1d.freq_khz = base.freq_0 AND static_1d.idle = 255
--- LUT joins for L3 cache
-LEFT JOIN _filtered_curves_l3 AS l3_hit_lut
-  ON l3_hit_lut.freq_khz = base.freq_0
-  AND l3_hit_lut.other_policy = base.dependent_policy
-  AND l3_hit_lut.other_freq_khz = base.dependent_freq
-  AND l3_hit_lut.action = 'hit'
-LEFT JOIN _filtered_curves_l3 AS l3_miss_lut
-  ON l3_miss_lut.freq_khz = base.freq_0
-  AND l3_miss_lut.other_policy = base.dependent_policy
-  AND l3_miss_lut.other_freq_khz = base.dependent_freq
-  AND l3_miss_lut.action = 'miss';
+-- Need to use SPAN_OUTER_JOIN because depending on the trace points enabled,
+-- it's possible one of the tables is empty
+CREATE VIRTUAL TABLE _virtual_system_state_mw USING SPAN_OUTER_JOIN (_cpu_estimates_mw, _gpu_estimates_mw);
 
 -- The most basic components of Wattson, all normalized to be in mW on a per
 -- system state basis
 CREATE PERFETTO TABLE _system_state_mw AS
 SELECT
-  ts,
-  dur,
-  cpu0_curve AS cpu0_mw,
-  cpu1_curve AS cpu1_mw,
-  cpu2_curve AS cpu2_mw,
-  cpu3_curve AS cpu3_mw,
-  cpu4_curve AS cpu4_mw,
-  cpu5_curve AS cpu5_mw,
-  cpu6_curve AS cpu6_mw,
-  cpu7_curve AS cpu7_mw,
-  -- LUT for l3 is scaled by 10^6 to save resolution and in units of kWs. Scale
-  -- this by 10^3 so when divided by ns, result is in units of mW
-  (
-    (
-      coalesce(l3_hit_value, 0) + coalesce(l3_miss_value, 0)
-    ) * 1000 / dur
-  ) + static_curve AS dsu_scu_mw
-FROM _system_state_curves;
+  *
+FROM _virtual_system_state_mw;
 
 -- API to get power from each system state in an arbitrary time window
 CREATE PERFETTO FUNCTION _windowed_system_state_mw(
@@ -165,7 +44,8 @@ RETURNS TABLE (
   cpu5_mw DOUBLE,
   cpu6_mw DOUBLE,
   cpu7_mw DOUBLE,
-  dsu_scu_mw DOUBLE
+  dsu_scu_mw DOUBLE,
+  gpu_mw DOUBLE
 ) AS
 SELECT
   sum(ss.cpu0_mw * ss.dur) / sum(ss.dur) AS cpu0_mw,
@@ -176,7 +56,8 @@ SELECT
   sum(ss.cpu5_mw * ss.dur) / sum(ss.dur) AS cpu5_mw,
   sum(ss.cpu6_mw * ss.dur) / sum(ss.dur) AS cpu6_mw,
   sum(ss.cpu7_mw * ss.dur) / sum(ss.dur) AS cpu7_mw,
-  sum(ss.dsu_scu_mw * ss.dur) / sum(ss.dur) AS dsu_scu_mw
+  sum(ss.dsu_scu_mw * ss.dur) / sum(ss.dur) AS dsu_scu_mw,
+  sum(ss.gpu_mw * ss.dur) / sum(ss.dur) AS gpu_mw
 FROM _interval_intersect_single!($ts, $dur, _ii_subquery!(_system_state_mw)) AS ii
 JOIN _system_state_mw AS ss
   ON ss._auto_id = id;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/gpu/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/gpu/estimates.sql
@@ -16,7 +16,7 @@
 INCLUDE PERFETTO MODULE wattson.gpu.freq_idle;
 
 -- GPU power estimates in mW
-CREATE PERFETTO TABLE _gpu_estimates AS
+CREATE PERFETTO TABLE _gpu_estimates_mw AS
 SELECT
   gfi.ts,
   gfi.dur,

--- a/test/trace_processor/diff_tests/metrics/android/wattson_atrace_apps_threads.out
+++ b/test/trace_processor/diff_tests/metrics/android/wattson_atrace_apps_threads.out
@@ -6,7 +6,7 @@ wattson_atrace_apps_threads {
     period_name: "NOTIFICATION_SHADE_EXPAND_COLLAPSE::Expand"
     task_info {
       estimated_mws: 206.217712
-      estimated_mw: 52.570084
+      estimated_mw: 52.542408
       idle_transitions_mws: 4.957417
       total_mws: 211.175125
       thread_name: "RenderThread"
@@ -16,7 +16,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 173.102859
-      estimated_mw: 44.128277
+      estimated_mw: 44.105045
       idle_transitions_mws: 1.703194
       total_mws: 174.806061
       thread_name: "ndroid.systemui"
@@ -26,7 +26,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 98.270241
-      estimated_mw: 25.051556
+      estimated_mw: 25.038368
       idle_transitions_mws: -24.609318
       total_mws: 73.660919
       thread_name: "swapper"
@@ -36,7 +36,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 74.889847
-      estimated_mw: 19.091307
+      estimated_mw: 19.081257
       idle_transitions_mws: 0.033585
       total_mws: 74.923431
       thread_name: "heapprofdunwind"
@@ -46,7 +46,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 47.755604
-      estimated_mw: 12.174105
+      estimated_mw: 12.167697
       idle_transitions_mws: 0.364447
       total_mws: 48.120052
       thread_name: "surfaceflinger"
@@ -56,7 +56,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 41.309998
-      estimated_mw: 10.530957
+      estimated_mw: 10.525414
       idle_transitions_mws: 0.027102
       total_mws: 41.337097
       thread_name: "stack-unwinding"
@@ -66,7 +66,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 22.573942
-      estimated_mw: 5.754666
+      estimated_mw: 5.751636
       idle_transitions_mws: 0.007215
       total_mws: 22.581158
       thread_name: "binder:581_2"
@@ -76,7 +76,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 21.076130
-      estimated_mw: 5.372835
+      estimated_mw: 5.370007
       idle_transitions_mws: 0.192020
       total_mws: 21.268148
       thread_name: "RenderEngine"
@@ -86,7 +86,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 18.141607
-      estimated_mw: 4.624752
+      estimated_mw: 4.622318
       idle_transitions_mws: 0.678068
       total_mws: 18.819675
       thread_name: "heapprofd"
@@ -96,7 +96,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 15.645424
-      estimated_mw: 3.988412
+      estimated_mw: 3.986313
       idle_transitions_mws: 0.008242
       total_mws: 15.653665
       thread_name: "traced_probes"
@@ -106,7 +106,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 15.568545
-      estimated_mw: 3.968814
+      estimated_mw: 3.966725
       idle_transitions_mws: 0.043519
       total_mws: 15.612064
       thread_name: "mali-compiler"
@@ -116,7 +116,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 14.159061
-      estimated_mw: 3.609501
+      estimated_mw: 3.607601
       idle_transitions_mws: 1.647916
       total_mws: 15.806977
       thread_name: "mali_jd_thread"
@@ -126,7 +126,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 10.558540
-      estimated_mw: 2.691638
+      estimated_mw: 2.690221
       idle_transitions_mws: 0.220143
       total_mws: 10.778683
       thread_name: "binder:1423_D"
@@ -136,7 +136,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 9.821459
-      estimated_mw: 2.503737
+      estimated_mw: 2.502419
       idle_transitions_mws: 1.368331
       total_mws: 11.189790
       thread_name: "mali-cmar-backe"
@@ -146,7 +146,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 8.882938
-      estimated_mw: 2.264484
+      estimated_mw: 2.263292
       idle_transitions_mws: 0.309721
       total_mws: 9.192659
       thread_name: "s.nexuslauncher"
@@ -156,7 +156,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 8.269282
-      estimated_mw: 2.108048
+      estimated_mw: 2.106938
       idle_transitions_mws: 0.221031
       total_mws: 8.490312
       thread_name: "RenderThread"
@@ -166,7 +166,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.601047
-      estimated_mw: 1.682773
+      estimated_mw: 1.681887
       idle_transitions_mws: 0.020536
       total_mws: 6.621583
       thread_name: "Jit thread pool"
@@ -176,7 +176,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.485011
-      estimated_mw: 1.653192
+      estimated_mw: 1.652322
       idle_transitions_mws: 0.166026
       total_mws: 6.651037
       thread_name: "android.hardwar"
@@ -186,7 +186,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.353718
-      estimated_mw: 1.619723
+      estimated_mw: 1.618870
       idle_transitions_mws: 0.435055
       total_mws: 6.788774
       thread_name: "binder:15865_2"
@@ -196,7 +196,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.212472
-      estimated_mw: 1.583715
+      estimated_mw: 1.582882
       idle_transitions_mws: 0.147167
       total_mws: 6.359639
       thread_name: "binder:1423_19"
@@ -206,7 +206,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.929500
-      estimated_mw: 1.511579
+      estimated_mw: 1.510783
       idle_transitions_mws: 0.409743
       total_mws: 6.339243
       thread_name: "binder:578_4"
@@ -216,7 +216,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.732332
-      estimated_mw: 1.461316
+      estimated_mw: 1.460546
       idle_transitions_mws: 0.982419
       total_mws: 6.714750
       thread_name: "TimerDispatch"
@@ -226,7 +226,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.132700
-      estimated_mw: 1.308454
+      estimated_mw: 1.307766
       idle_transitions_mws: 0.005174
       total_mws: 5.137874
       thread_name: "traced"
@@ -236,7 +236,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.693400
-      estimated_mw: 1.196466
+      estimated_mw: 1.195836
       idle_transitions_mws: 0.464214
       total_mws: 5.157614
       thread_name: "decon0_kthread"
@@ -246,7 +246,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.472431
-      estimated_mw: 1.140135
+      estimated_mw: 1.139535
       idle_transitions_mws: 0.052865
       total_mws: 4.525296
       thread_name: "android.anim"
@@ -256,7 +256,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.468098
-      estimated_mw: 1.139031
+      estimated_mw: 1.138431
       idle_transitions_mws: 0.312739
       total_mws: 4.780837
       thread_name: "binder:578_1"
@@ -266,7 +266,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.264686
-      estimated_mw: 1.087176
+      estimated_mw: 1.086603
       idle_transitions_mws: 0.422902
       total_mws: 4.687588
       thread_name: "BckgrndExec HP"
@@ -276,7 +276,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.222947
-      estimated_mw: 1.076535
+      estimated_mw: 1.075969
       idle_transitions_mws: 0.069071
       total_mws: 4.292018
       thread_name: "binder:1423_20"
@@ -286,7 +286,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.102149
-      estimated_mw: 1.045741
+      estimated_mw: 1.045191
       idle_transitions_mws: 0.203898
       total_mws: 4.306047
       thread_name: "app"
@@ -296,7 +296,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.248730
-      estimated_mw: 0.828183
+      estimated_mw: 0.827747
       idle_transitions_mws: 0.181516
       total_mws: 3.430246
       thread_name: "binder:15865_5"
@@ -306,7 +306,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.144092
-      estimated_mw: 0.801508
+      estimated_mw: 0.801086
       idle_transitions_mws: 0.229577
       total_mws: 3.373669
       thread_name: "binder:8021_3"
@@ -316,7 +316,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.948840
-      estimated_mw: 0.751733
+      estimated_mw: 0.751338
       idle_transitions_mws: 0.075375
       total_mws: 3.024214
       thread_name: "kworker/u16:2"
@@ -326,7 +326,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.726243
-      estimated_mw: 0.694988
+      estimated_mw: 0.694622
       idle_transitions_mws: 0.248653
       total_mws: 2.974896
       thread_name: "kworker/u17:0"
@@ -336,7 +336,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.678242
-      estimated_mw: 0.682751
+      estimated_mw: 0.682392
       idle_transitions_mws: 0.230961
       total_mws: 2.909204
       thread_name: "kworker/u17:2"
@@ -346,7 +346,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.605286
-      estimated_mw: 0.664153
+      estimated_mw: 0.663803
       idle_transitions_mws: 0.103628
       total_mws: 2.708915
       thread_name: "system_server"
@@ -356,7 +356,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.298660
-      estimated_mw: 0.585986
+      estimated_mw: 0.585678
       idle_transitions_mws: 0.350597
       total_mws: 2.649256
       thread_name: "surfaceflinger"
@@ -366,7 +366,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.167596
-      estimated_mw: 0.552575
+      estimated_mw: 0.552284
       idle_transitions_mws: 0.188994
       total_mws: 2.356590
       thread_name: "binder:578_5"
@@ -376,7 +376,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.073512
-      estimated_mw: 0.528590
+      estimated_mw: 0.528312
       idle_transitions_mws: 0.097369
       total_mws: 2.170880
       thread_name: "mali-cmar-backe"
@@ -386,7 +386,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.948980
-      estimated_mw: 0.496844
+      estimated_mw: 0.496582
       idle_transitions_mws: 0.423332
       total_mws: 2.372312
       thread_name: "mali_apc_thread"
@@ -396,7 +396,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.875300
-      estimated_mw: 0.478061
+      estimated_mw: 0.477810
       idle_transitions_mws: 0.095768
       total_mws: 1.971068
       thread_name: "android.display"
@@ -406,7 +406,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.798275
-      estimated_mw: 0.458426
+      estimated_mw: 0.458184
       idle_transitions_mws: 0.033822
       total_mws: 1.832097
       thread_name: "SysUiBg"
@@ -416,7 +416,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.692667
-      estimated_mw: 0.431504
+      estimated_mw: 0.431276
       idle_transitions_mws: 0.057915
       total_mws: 1.750582
       thread_name: "roidJUnitRunner"
@@ -426,7 +426,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.639881
-      estimated_mw: 0.418047
+      estimated_mw: 0.417827
       idle_transitions_mws: 0.153495
       total_mws: 1.793376
       thread_name: "wmshell.main"
@@ -436,7 +436,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.625893
-      estimated_mw: 0.414481
+      estimated_mw: 0.414263
       idle_transitions_mws: 0.516872
       total_mws: 2.142765
       thread_name: "sugov:0"
@@ -446,7 +446,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.580663
-      estimated_mw: 0.402951
+      estimated_mw: 0.402739
       idle_transitions_mws: 0.214407
       total_mws: 1.795070
       thread_name: "SystemUIBg-8"
@@ -456,7 +456,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.516507
-      estimated_mw: 0.386596
+      estimated_mw: 0.386392
       idle_transitions_mws: 0.310487
       total_mws: 1.826994
       thread_name: "sugov:6"
@@ -466,7 +466,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.485770
-      estimated_mw: 0.378760
+      estimated_mw: 0.378561
       idle_transitions_mws: 0.066072
       total_mws: 1.551843
       thread_name: "traced_perf"
@@ -476,7 +476,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.428930
-      estimated_mw: 0.364270
+      estimated_mw: 0.364078
       idle_transitions_mws: 0.008858
       total_mws: 1.437788
       thread_name: "HwBinder:882_4"
@@ -486,7 +486,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.392551
-      estimated_mw: 0.354996
+      estimated_mw: 0.354810
       idle_transitions_mws: 0.003933
       total_mws: 1.396484
       thread_name: "logcat"
@@ -496,7 +496,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.344761
-      estimated_mw: 0.342813
+      estimated_mw: 0.342633
       idle_transitions_mws: 0.584814
       total_mws: 1.929575
       thread_name: "GPU completion"
@@ -506,7 +506,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.310533
-      estimated_mw: 0.334088
+      estimated_mw: 0.333912
       idle_transitions_mws: 0.161843
       total_mws: 1.472376
       thread_name: "SystemUIBg-2"
@@ -516,7 +516,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.281507
-      estimated_mw: 0.326688
+      estimated_mw: 0.326516
       idle_transitions_mws: 0.033634
       total_mws: 1.315141
       thread_name: "RegionSampling"
@@ -526,7 +526,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.256711
-      estimated_mw: 0.320367
+      estimated_mw: 0.320199
       idle_transitions_mws: 0.054090
       total_mws: 1.310801
       thread_name: "logd.writer"
@@ -536,7 +536,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.240996
-      estimated_mw: 0.316361
+      estimated_mw: 0.316195
       idle_transitions_mws: 0.144253
       total_mws: 1.385249
       thread_name: "SystemUIBg-5"
@@ -546,7 +546,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.188475
-      estimated_mw: 0.302972
+      estimated_mw: 0.302813
       idle_transitions_mws: 0.156376
       total_mws: 1.344851
       thread_name: "SystemUIBg-1"
@@ -556,7 +556,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.171181
-      estimated_mw: 0.298564
+      estimated_mw: 0.298406
       idle_transitions_mws: 0.128639
       total_mws: 1.299820
       thread_name: "SystemUIBg-7"
@@ -566,7 +566,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.104624
-      estimated_mw: 0.281596
+      estimated_mw: 0.281448
       idle_transitions_mws: 0.127727
       total_mws: 1.232351
       thread_name: "SystemUIBg-4"
@@ -576,7 +576,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.069360
-      estimated_mw: 0.272607
+      estimated_mw: 0.272463
       idle_transitions_mws: 0.020329
       total_mws: 1.089689
       thread_name: "CpuMonitorServi"
@@ -586,7 +586,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.043121
-      estimated_mw: 0.265918
+      estimated_mw: 0.265778
       idle_transitions_mws: 0.009673
       total_mws: 1.052794
       thread_name: "binder:1423_5"
@@ -596,7 +596,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.009034
-      estimated_mw: 0.257228
+      estimated_mw: 0.257093
       idle_transitions_mws: 0.082171
       total_mws: 1.091205
       thread_name: "UiAutomation"
@@ -606,7 +606,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.989256
-      estimated_mw: 0.252186
+      estimated_mw: 0.252053
       idle_transitions_mws: 0.056402
       total_mws: 1.045658
       thread_name: "binder:7309_7"
@@ -616,7 +616,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.977089
-      estimated_mw: 0.249085
+      estimated_mw: 0.248953
       idle_transitions_mws: 0.331602
       total_mws: 1.308691
       thread_name: "sugov:4"
@@ -626,7 +626,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.956713
-      estimated_mw: 0.243890
+      estimated_mw: 0.243762
       idle_transitions_mws: 0.000000
       total_mws: 0.956713
       thread_name: "rcuop/3"
@@ -636,7 +636,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.931130
-      estimated_mw: 0.237369
+      estimated_mw: 0.237244
       idle_transitions_mws: 0.676853
       total_mws: 1.607983
       thread_name: "HWC release"
@@ -646,7 +646,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.907067
-      estimated_mw: 0.231234
+      estimated_mw: 0.231112
       idle_transitions_mws: 0.028157
       total_mws: 0.935223
       thread_name: "logd.reader.per"
@@ -656,7 +656,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.868172
-      estimated_mw: 0.221319
+      estimated_mw: 0.221202
       idle_transitions_mws: 0.146257
       total_mws: 1.014428
       thread_name: "SystemUIBg-3"
@@ -666,7 +666,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.867149
-      estimated_mw: 0.221058
+      estimated_mw: 0.220942
       idle_transitions_mws: 0.009544
       total_mws: 0.876693
       thread_name: "rcuop/1"
@@ -676,7 +676,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.832127
-      estimated_mw: 0.212130
+      estimated_mw: 0.212018
       idle_transitions_mws: 0.022652
       total_mws: 0.854780
       thread_name: "OomAdjuster"
@@ -686,7 +686,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.761025
-      estimated_mw: 0.194004
+      estimated_mw: 0.193902
       idle_transitions_mws: 0.196124
       total_mws: 0.957149
       thread_name: "DisplayHints"
@@ -696,7 +696,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.752865
-      estimated_mw: 0.191924
+      estimated_mw: 0.191823
       idle_transitions_mws: 0.105885
       total_mws: 0.858750
       thread_name: "SystemUIBg-6"
@@ -706,7 +706,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.706055
-      estimated_mw: 0.179991
+      estimated_mw: 0.179896
       idle_transitions_mws: 0.025176
       total_mws: 0.731231
       thread_name: "appSf"
@@ -716,7 +716,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.703080
-      estimated_mw: 0.179233
+      estimated_mw: 0.179138
       idle_transitions_mws: 0.013204
       total_mws: 0.716284
       thread_name: "NodeLooperThrea"
@@ -726,7 +726,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.689877
-      estimated_mw: 0.175867
+      estimated_mw: 0.175774
       idle_transitions_mws: 0.063660
       total_mws: 0.753537
       thread_name: "BckgrndExec LP"
@@ -736,7 +736,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.677375
-      estimated_mw: 0.172680
+      estimated_mw: 0.172589
       idle_transitions_mws: 0.090316
       total_mws: 0.767691
       thread_name: "mali-cmar-backe"
@@ -746,7 +746,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.660832
-      estimated_mw: 0.168463
+      estimated_mw: 0.168374
       idle_transitions_mws: 0.049691
       total_mws: 0.710522
       thread_name: "hwuiTask1"
@@ -756,7 +756,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.615420
-      estimated_mw: 0.156886
+      estimated_mw: 0.156803
       idle_transitions_mws: 0.000000
       total_mws: 0.615420
       thread_name: "android.hardwar"
@@ -766,7 +766,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.606426
-      estimated_mw: 0.154593
+      estimated_mw: 0.154512
       idle_transitions_mws: 0.058519
       total_mws: 0.664945
       thread_name: "hwuiTask0"
@@ -776,7 +776,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.590458
-      estimated_mw: 0.150523
+      estimated_mw: 0.150443
       idle_transitions_mws: 0.013812
       total_mws: 0.604269
       thread_name: "android.bg"
@@ -786,7 +786,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.550448
-      estimated_mw: 0.140323
+      estimated_mw: 0.140249
       idle_transitions_mws: 0.257590
       total_mws: 0.808039
       thread_name: "binder:15865_2"
@@ -796,7 +796,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.543652
-      estimated_mw: 0.138591
+      estimated_mw: 0.138518
       idle_transitions_mws: 0.089873
       total_mws: 0.633525
       thread_name: "m.test.scenario"
@@ -806,7 +806,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.534760
-      estimated_mw: 0.136324
+      estimated_mw: 0.136252
       idle_transitions_mws: 0.051313
       total_mws: 0.586073
       thread_name: "binder:7309_5"
@@ -816,7 +816,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.502881
-      estimated_mw: 0.128197
+      estimated_mw: 0.128130
       idle_transitions_mws: 0.023637
       total_mws: 0.526518
       thread_name: "ImageWallpaper"
@@ -826,7 +826,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.431574
-      estimated_mw: 0.110019
+      estimated_mw: 0.109961
       idle_transitions_mws: 0.009131
       total_mws: 0.440704
       thread_name: "android.ui"
@@ -836,7 +836,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.422404
-      estimated_mw: 0.107681
+      estimated_mw: 0.107625
       idle_transitions_mws: 0.086889
       total_mws: 0.509294
       thread_name: "AudioOut_D"
@@ -846,7 +846,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.411673
-      estimated_mw: 0.104946
+      estimated_mw: 0.104891
       idle_transitions_mws: 0.010624
       total_mws: 0.422297
       thread_name: "binder:1423_1E"
@@ -856,7 +856,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.405716
-      estimated_mw: 0.103427
+      estimated_mw: 0.103373
       idle_transitions_mws: 0.014389
       total_mws: 0.420105
       thread_name: "binder:6316_3"
@@ -866,7 +866,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.389122
-      estimated_mw: 0.099197
+      estimated_mw: 0.099145
       idle_transitions_mws: 0.006769
       total_mws: 0.395890
       thread_name: "tworkPolicy.uid"
@@ -876,7 +876,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.384741
-      estimated_mw: 0.098080
+      estimated_mw: 0.098028
       idle_transitions_mws: 0.000000
       total_mws: 0.384741
       thread_name: "DefaultDispatch"
@@ -886,7 +886,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.358374
-      estimated_mw: 0.091358
+      estimated_mw: 0.091310
       idle_transitions_mws: 0.037765
       total_mws: 0.396139
       thread_name: "writer"
@@ -896,7 +896,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.346232
-      estimated_mw: 0.088263
+      estimated_mw: 0.088217
       idle_transitions_mws: 0.000000
       total_mws: 0.346232
       thread_name: "rcuop/2"
@@ -906,7 +906,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.332790
-      estimated_mw: 0.084837
+      estimated_mw: 0.084792
       idle_transitions_mws: 0.000000
       total_mws: 0.332790
       thread_name: "android.hardwar"
@@ -916,7 +916,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.318674
-      estimated_mw: 0.081238
+      estimated_mw: 0.081195
       idle_transitions_mws: 0.014411
       total_mws: 0.333085
       thread_name: "aocd"
@@ -926,7 +926,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.300057
-      estimated_mw: 0.076492
+      estimated_mw: 0.076452
       idle_transitions_mws: 0.042708
       total_mws: 0.342765
       thread_name: "FastMixer"
@@ -936,7 +936,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.276390
-      estimated_mw: 0.070459
+      estimated_mw: 0.070422
       idle_transitions_mws: 0.028807
       total_mws: 0.305197
       thread_name: "InputDispatcher"
@@ -946,7 +946,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.272877
-      estimated_mw: 0.069563
+      estimated_mw: 0.069527
       idle_transitions_mws: 0.018078
       total_mws: 0.290955
       thread_name: "batterystats-ha"
@@ -956,7 +956,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.267024
-      estimated_mw: 0.068071
+      estimated_mw: 0.068035
       idle_transitions_mws: 0.000000
       total_mws: 0.267024
       thread_name: "statsd.writer"
@@ -966,7 +966,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.255867
-      estimated_mw: 0.065227
+      estimated_mw: 0.065193
       idle_transitions_mws: 0.240626
       total_mws: 0.496493
       thread_name: "perf_mon_update"
@@ -976,7 +976,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.239514
-      estimated_mw: 0.061058
+      estimated_mw: 0.061026
       idle_transitions_mws: 0.022557
       total_mws: 0.262071
       thread_name: "HwcAsyncWorker"
@@ -986,7 +986,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.238083
-      estimated_mw: 0.060693
+      estimated_mw: 0.060662
       idle_transitions_mws: 0.068707
       total_mws: 0.306790
       thread_name: "RE Completion"
@@ -996,7 +996,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.227789
-      estimated_mw: 0.058069
+      estimated_mw: 0.058038
       idle_transitions_mws: 0.016385
       total_mws: 0.244173
       thread_name: "init"
@@ -1006,7 +1006,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.219400
-      estimated_mw: 0.055931
+      estimated_mw: 0.055901
       idle_transitions_mws: 0.020481
       total_mws: 0.239880
       thread_name: "statsd.reader"
@@ -1016,7 +1016,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.213416
-      estimated_mw: 0.054405
+      estimated_mw: 0.054377
       idle_transitions_mws: 0.035706
       total_mws: 0.249122
       thread_name: "adpf_handler0"
@@ -1026,7 +1026,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.203361
-      estimated_mw: 0.051842
+      estimated_mw: 0.051814
       idle_transitions_mws: 0.015670
       total_mws: 0.219031
       thread_name: "logd.klogd"
@@ -1036,7 +1036,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.200634
-      estimated_mw: 0.051147
+      estimated_mw: 0.051120
       idle_transitions_mws: 0.000000
       total_mws: 0.200634
       thread_name: "init"
@@ -1046,7 +1046,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.199431
-      estimated_mw: 0.050840
+      estimated_mw: 0.050813
       idle_transitions_mws: 0.000000
       total_mws: 0.199431
       thread_name: "ssioncontroller"
@@ -1056,7 +1056,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.180209
-      estimated_mw: 0.045940
+      estimated_mw: 0.045916
       idle_transitions_mws: 0.014000
       total_mws: 0.194210
       thread_name: "PowerManagerSer"
@@ -1066,7 +1066,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.169546
-      estimated_mw: 0.043221
+      estimated_mw: 0.043199
       idle_transitions_mws: 0.000000
       total_mws: 0.169546
       thread_name: "android.hardwar"
@@ -1076,7 +1076,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.165218
-      estimated_mw: 0.042118
+      estimated_mw: 0.042096
       idle_transitions_mws: 0.010544
       total_mws: 0.175762
       thread_name: "simpleinteracti"
@@ -1086,7 +1086,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.161399
-      estimated_mw: 0.041145
+      estimated_mw: 0.041123
       idle_transitions_mws: 0.010750
       total_mws: 0.172149
       thread_name: "TracingMuxer"
@@ -1096,7 +1096,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.157367
-      estimated_mw: 0.040117
+      estimated_mw: 0.040096
       idle_transitions_mws: 0.000000
       total_mws: 0.157367
       thread_name: "migration/5"
@@ -1106,7 +1106,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.152011
-      estimated_mw: 0.038751
+      estimated_mw: 0.038731
       idle_transitions_mws: 0.000000
       total_mws: 0.152011
       thread_name: "binder:2755_7"
@@ -1116,7 +1116,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.150989
-      estimated_mw: 0.038491
+      estimated_mw: 0.038471
       idle_transitions_mws: 0.019265
       total_mws: 0.170254
       thread_name: "binder:3175_3"
@@ -1126,7 +1126,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.134089
-      estimated_mw: 0.034183
+      estimated_mw: 0.034165
       idle_transitions_mws: 0.029327
       total_mws: 0.163415
       thread_name: "RegSampIdle"
@@ -1136,7 +1136,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.127224
-      estimated_mw: 0.032433
+      estimated_mw: 0.032416
       idle_transitions_mws: 0.032326
       total_mws: 0.159551
       thread_name: "GPU completion"
@@ -1146,7 +1146,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.124130
-      estimated_mw: 0.031644
+      estimated_mw: 0.031627
       idle_transitions_mws: 0.043462
       total_mws: 0.167592
       thread_name: "rcuog/0"
@@ -1156,7 +1156,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.118406
-      estimated_mw: 0.030185
+      estimated_mw: 0.030169
       idle_transitions_mws: 0.021201
       total_mws: 0.139606
       thread_name: "system_server"
@@ -1166,7 +1166,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.116829
-      estimated_mw: 0.029783
+      estimated_mw: 0.029767
       idle_transitions_mws: 0.001648
       total_mws: 0.118477
       thread_name: "eduling.default"
@@ -1176,7 +1176,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.113923
-      estimated_mw: 0.029042
+      estimated_mw: 0.029026
       idle_transitions_mws: 0.006637
       total_mws: 0.120560
       thread_name: "binder:960_5"
@@ -1186,7 +1186,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.111159
-      estimated_mw: 0.028337
+      estimated_mw: 0.028322
       idle_transitions_mws: 0.095302
       total_mws: 0.206460
       thread_name: "rcu_preempt"
@@ -1196,7 +1196,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.111032
-      estimated_mw: 0.028305
+      estimated_mw: 0.028290
       idle_transitions_mws: 0.007461
       total_mws: 0.118492
       thread_name: "binder:2189_8"
@@ -1206,7 +1206,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.108112
-      estimated_mw: 0.027561
+      estimated_mw: 0.027546
       idle_transitions_mws: 0.017058
       total_mws: 0.125170
       thread_name: "mali-mem-purge"
@@ -1216,7 +1216,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.105528
-      estimated_mw: 0.026902
+      estimated_mw: 0.026888
       idle_transitions_mws: 0.009394
       total_mws: 0.114922
       thread_name: "ScreenDecoratio"
@@ -1226,7 +1226,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.102268
-      estimated_mw: 0.026071
+      estimated_mw: 0.026057
       idle_transitions_mws: 0.022458
       total_mws: 0.124727
       thread_name: "migration/0"
@@ -1236,7 +1236,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.101387
-      estimated_mw: 0.025846
+      estimated_mw: 0.025832
       idle_transitions_mws: 0.003500
       total_mws: 0.104886
       thread_name: "rcuop/4"
@@ -1246,7 +1246,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.100266
-      estimated_mw: 0.025560
+      estimated_mw: 0.025547
       idle_transitions_mws: 0.004128
       total_mws: 0.104393
       thread_name: "lmkd"
@@ -1256,7 +1256,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.099188
-      estimated_mw: 0.025286
+      estimated_mw: 0.025272
       idle_transitions_mws: 0.021708
       total_mws: 0.120896
       thread_name: "surfaceflinger"
@@ -1266,7 +1266,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.091655
-      estimated_mw: 0.023365
+      estimated_mw: 0.023353
       idle_transitions_mws: 0.004706
       total_mws: 0.096361
       thread_name: "queued-work-loo"
@@ -1276,7 +1276,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.086655
-      estimated_mw: 0.022090
+      estimated_mw: 0.022079
       idle_transitions_mws: 0.012266
       total_mws: 0.098920
       thread_name: "binder:8021_4"
@@ -1286,7 +1286,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084793
-      estimated_mw: 0.021616
+      estimated_mw: 0.021605
       idle_transitions_mws: 0.000000
       total_mws: 0.084793
       thread_name: "RxSchedulerPurg"
@@ -1296,7 +1296,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084755
-      estimated_mw: 0.021606
+      estimated_mw: 0.021595
       idle_transitions_mws: 0.000000
       total_mws: 0.084755
       thread_name: "binder:6274_2"
@@ -1306,7 +1306,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084513
-      estimated_mw: 0.021544
+      estimated_mw: 0.021533
       idle_transitions_mws: 0.008854
       total_mws: 0.093367
       thread_name: "android.hardwar"
@@ -1316,7 +1316,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.083576
-      estimated_mw: 0.021306
+      estimated_mw: 0.021294
       idle_transitions_mws: 0.057310
       total_mws: 0.140885
       thread_name: "mali-mem-purge"
@@ -1326,7 +1326,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.080612
-      estimated_mw: 0.020550
+      estimated_mw: 0.020539
       idle_transitions_mws: 0.005383
       total_mws: 0.085995
       thread_name: "binder:6343_3"
@@ -1336,7 +1336,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.080195
-      estimated_mw: 0.020444
+      estimated_mw: 0.020433
       idle_transitions_mws: 0.002488
       total_mws: 0.082683
       thread_name: "binder:3195_7"
@@ -1346,7 +1346,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.079276
-      estimated_mw: 0.020209
+      estimated_mw: 0.020199
       idle_transitions_mws: 0.008015
       total_mws: 0.087291
       thread_name: "droid.bluetooth"
@@ -1356,7 +1356,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.072891
-      estimated_mw: 0.018582
+      estimated_mw: 0.018572
       idle_transitions_mws: 0.064386
       total_mws: 0.137277
       thread_name: "mali-mem-purge"
@@ -1366,7 +1366,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.071735
-      estimated_mw: 0.018287
+      estimated_mw: 0.018277
       idle_transitions_mws: 0.000000
       total_mws: 0.071735
       thread_name: "binder:2857_1"
@@ -1376,7 +1376,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.070477
-      estimated_mw: 0.017966
+      estimated_mw: 0.017957
       idle_transitions_mws: 0.009221
       total_mws: 0.079699
       thread_name: "migration/4"
@@ -1386,7 +1386,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.068423
-      estimated_mw: 0.017443
+      estimated_mw: 0.017434
       idle_transitions_mws: 0.007818
       total_mws: 0.076241
       thread_name: "ActivityManager"
@@ -1396,7 +1396,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.067514
-      estimated_mw: 0.017211
+      estimated_mw: 0.017202
       idle_transitions_mws: 0.000000
       total_mws: 0.067514
       thread_name: "binder:6749_10"
@@ -1406,7 +1406,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.067256
-      estimated_mw: 0.017145
+      estimated_mw: 0.017136
       idle_transitions_mws: 0.000000
       total_mws: 0.067256
       thread_name: "ndroid.calendar"
@@ -1416,7 +1416,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.064859
-      estimated_mw: 0.016534
+      estimated_mw: 0.016526
       idle_transitions_mws: 0.000000
       total_mws: 0.064859
       thread_name: "binder:2619_10"
@@ -1426,7 +1426,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.062248
-      estimated_mw: 0.015869
+      estimated_mw: 0.015860
       idle_transitions_mws: 0.005420
       total_mws: 0.067668
       thread_name: "binder:2224_3"
@@ -1436,7 +1436,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.059517
-      estimated_mw: 0.015172
+      estimated_mw: 0.015164
       idle_transitions_mws: 0.000000
       total_mws: 0.059517
       thread_name: "binder:6048_10"
@@ -1446,7 +1446,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.058541
-      estimated_mw: 0.014924
+      estimated_mw: 0.014916
       idle_transitions_mws: 0.002991
       total_mws: 0.061533
       thread_name: "AudioService"
@@ -1456,7 +1456,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.056259
-      estimated_mw: 0.014342
+      estimated_mw: 0.014334
       idle_transitions_mws: 0.006806
       total_mws: 0.063065
       thread_name: "ogle.android.as"
@@ -1466,7 +1466,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.056172
-      estimated_mw: 0.014320
+      estimated_mw: 0.014312
       idle_transitions_mws: 0.003180
       total_mws: 0.059352
       thread_name: "NDK MediaCodec_"
@@ -1476,7 +1476,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.056072
-      estimated_mw: 0.014294
+      estimated_mw: 0.014287
       idle_transitions_mws: 0.000000
       total_mws: 0.056072
       thread_name: "binder:3635_1"
@@ -1486,7 +1486,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.054885
-      estimated_mw: 0.013992
+      estimated_mw: 0.013984
       idle_transitions_mws: 0.003019
       total_mws: 0.057905
       thread_name: "binder:4580_4"
@@ -1496,7 +1496,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.054087
-      estimated_mw: 0.013788
+      estimated_mw: 0.013781
       idle_transitions_mws: 0.013196
       total_mws: 0.067283
       thread_name: "rcu_exp_gp_kthr"
@@ -1506,7 +1506,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.053467
-      estimated_mw: 0.013630
+      estimated_mw: 0.013623
       idle_transitions_mws: 0.003989
       total_mws: 0.057456
       thread_name: "GPU completion"
@@ -1516,7 +1516,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.053465
-      estimated_mw: 0.013630
+      estimated_mw: 0.013622
       idle_transitions_mws: 0.060083
       total_mws: 0.113548
       thread_name: "psimon"
@@ -1526,7 +1526,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.053385
-      estimated_mw: 0.013609
+      estimated_mw: 0.013602
       idle_transitions_mws: 0.000000
       total_mws: 0.053385
       thread_name: "binder:2729_C"
@@ -1536,7 +1536,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.053306
-      estimated_mw: 0.013589
+      estimated_mw: 0.013582
       idle_transitions_mws: 0.010632
       total_mws: 0.063938
       thread_name: "migration/1"
@@ -1546,7 +1546,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.050623
-      estimated_mw: 0.012905
+      estimated_mw: 0.012898
       idle_transitions_mws: 0.000000
       total_mws: 0.050623
       thread_name: "binder:7270_3"
@@ -1556,7 +1556,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.048496
-      estimated_mw: 0.012363
+      estimated_mw: 0.012356
       idle_transitions_mws: 0.000000
       total_mws: 0.048496
       thread_name: "binder:7503_10"
@@ -1566,7 +1566,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.047871
-      estimated_mw: 0.012204
+      estimated_mw: 0.012197
       idle_transitions_mws: 0.001470
       total_mws: 0.049341
       thread_name: "binder:3160_6"
@@ -1576,7 +1576,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.047314
-      estimated_mw: 0.012062
+      estimated_mw: 0.012055
       idle_transitions_mws: 0.000000
       total_mws: 0.047314
       thread_name: "rild_exynos"
@@ -1586,7 +1586,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.046395
-      estimated_mw: 0.011827
+      estimated_mw: 0.011821
       idle_transitions_mws: 0.000000
       total_mws: 0.046395
       thread_name: "binder:2387_1"
@@ -1596,7 +1596,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.044923
-      estimated_mw: 0.011452
+      estimated_mw: 0.011446
       idle_transitions_mws: 0.000000
       total_mws: 0.044923
       thread_name: "shortcut"
@@ -1606,7 +1606,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.043502
-      estimated_mw: 0.011090
+      estimated_mw: 0.011084
       idle_transitions_mws: 0.029942
       total_mws: 0.073443
       thread_name: "rcuog/4"
@@ -1616,7 +1616,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.042701
-      estimated_mw: 0.010886
+      estimated_mw: 0.010880
       idle_transitions_mws: 0.002188
       total_mws: 0.044889
       thread_name: "binder:568_6"
@@ -1626,7 +1626,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.042548
-      estimated_mw: 0.010847
+      estimated_mw: 0.010841
       idle_transitions_mws: 0.004161
       total_mws: 0.046709
       thread_name: "TelecomMetricsC"
@@ -1636,7 +1636,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.042310
-      estimated_mw: 0.010786
+      estimated_mw: 0.010780
       idle_transitions_mws: 0.026711
       total_mws: 0.069021
       thread_name: "android.io"
@@ -1646,7 +1646,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.042079
-      estimated_mw: 0.010727
+      estimated_mw: 0.010721
       idle_transitions_mws: 0.010993
       total_mws: 0.053072
       thread_name: "WifiHandlerThre"
@@ -1656,7 +1656,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.039287
-      estimated_mw: 0.010015
+      estimated_mw: 0.010010
       idle_transitions_mws: 0.007035
       total_mws: 0.046322
       thread_name: "android.fg"
@@ -1666,7 +1666,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.038659
-      estimated_mw: 0.009855
+      estimated_mw: 0.009850
       idle_transitions_mws: 0.000000
       total_mws: 0.038659
       thread_name: "RxSchedulerPurg"
@@ -1676,7 +1676,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.037910
-      estimated_mw: 0.009664
+      estimated_mw: 0.009659
       idle_transitions_mws: 0.000000
       total_mws: 0.037910
       thread_name: "FinalizerWatchd"
@@ -1686,7 +1686,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.036905
-      estimated_mw: 0.009408
+      estimated_mw: 0.009403
       idle_transitions_mws: 0.000000
       total_mws: 0.036905
       thread_name: "adbd"
@@ -1696,7 +1696,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.036214
-      estimated_mw: 0.009232
+      estimated_mw: 0.009227
       idle_transitions_mws: 0.000000
       total_mws: 0.036214
       thread_name: "RemoveFBsThread"
@@ -1706,7 +1706,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.034953
-      estimated_mw: 0.008910
+      estimated_mw: 0.008906
       idle_transitions_mws: 0.033149
       total_mws: 0.068102
       thread_name: "kworker/1:1"
@@ -1716,7 +1716,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.032915
-      estimated_mw: 0.008391
+      estimated_mw: 0.008387
       idle_transitions_mws: 0.002825
       total_mws: 0.035740
       thread_name: "InteractionJank"
@@ -1726,7 +1726,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.031200
-      estimated_mw: 0.007954
+      estimated_mw: 0.007949
       idle_transitions_mws: 0.003840
       total_mws: 0.035040
       thread_name: "SensorService"
@@ -1736,7 +1736,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.030959
-      estimated_mw: 0.007892
+      estimated_mw: 0.007888
       idle_transitions_mws: 0.000000
       total_mws: 0.030959
       thread_name: "adbd"
@@ -1746,7 +1746,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.030717
-      estimated_mw: 0.007831
+      estimated_mw: 0.007826
       idle_transitions_mws: 0.000000
       total_mws: 0.030717
       thread_name: "FinalizerWatchd"
@@ -1756,7 +1756,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.030581
-      estimated_mw: 0.007796
+      estimated_mw: 0.007792
       idle_transitions_mws: 0.000000
       total_mws: 0.030581
       thread_name: "migration/2"
@@ -1766,7 +1766,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.030195
-      estimated_mw: 0.007697
+      estimated_mw: 0.007693
       idle_transitions_mws: 0.000000
       total_mws: 0.030195
       thread_name: "kworker/4:1H"
@@ -1776,7 +1776,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.028423
-      estimated_mw: 0.007246
+      estimated_mw: 0.007242
       idle_transitions_mws: 0.000000
       total_mws: 0.028423
       thread_name: "kworker/u16:0"
@@ -1786,7 +1786,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.028020
-      estimated_mw: 0.007143
+      estimated_mw: 0.007139
       idle_transitions_mws: 0.002999
       total_mws: 0.031020
       thread_name: "aiai-notificati"
@@ -1796,7 +1796,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.027966
-      estimated_mw: 0.007129
+      estimated_mw: 0.007125
       idle_transitions_mws: 0.003243
       total_mws: 0.031209
       thread_name: "android.hardwar"
@@ -1806,7 +1806,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.027171
-      estimated_mw: 0.006927
+      estimated_mw: 0.006923
       idle_transitions_mws: 0.020618
       total_mws: 0.047790
       thread_name: "kworker/0:2"
@@ -1816,7 +1816,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.026046
-      estimated_mw: 0.006640
+      estimated_mw: 0.006636
       idle_transitions_mws: 0.048396
       total_mws: 0.074442
       thread_name: "UsfTransport"
@@ -1826,7 +1826,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.024438
-      estimated_mw: 0.006230
+      estimated_mw: 0.006227
       idle_transitions_mws: 0.001899
       total_mws: 0.026337
       thread_name: "aiai-pecan-0"
@@ -1836,7 +1836,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.023282
-      estimated_mw: 0.005935
+      estimated_mw: 0.005932
       idle_transitions_mws: 0.000000
       total_mws: 0.023282
       thread_name: "lhd"
@@ -1846,7 +1846,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.022890
-      estimated_mw: 0.005835
+      estimated_mw: 0.005832
       idle_transitions_mws: 0.015045
       total_mws: 0.037935
       thread_name: "kworker/3:12"
@@ -1856,7 +1856,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.022772
-      estimated_mw: 0.005805
+      estimated_mw: 0.005802
       idle_transitions_mws: 0.001083
       total_mws: 0.023855
       thread_name: "main"
@@ -1866,7 +1866,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.020180
-      estimated_mw: 0.005144
+      estimated_mw: 0.005142
       idle_transitions_mws: 0.020657
       total_mws: 0.040837
       thread_name: "binder:7309_2"
@@ -1876,7 +1876,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019641
-      estimated_mw: 0.005007
+      estimated_mw: 0.005004
       idle_transitions_mws: 0.000000
       total_mws: 0.019641
       thread_name: "heapprofd"
@@ -1886,7 +1886,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.018365
-      estimated_mw: 0.004682
+      estimated_mw: 0.004679
       idle_transitions_mws: 0.003448
       total_mws: 0.021813
       thread_name: "com.google.usf."
@@ -1896,7 +1896,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.018154
-      estimated_mw: 0.004628
+      estimated_mw: 0.004626
       idle_transitions_mws: 0.024148
       total_mws: 0.042302
       thread_name: "kworker/7:5"
@@ -1906,7 +1906,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.017792
-      estimated_mw: 0.004536
+      estimated_mw: 0.004533
       idle_transitions_mws: 0.015196
       total_mws: 0.032989
       thread_name: "migration/3"
@@ -1916,7 +1916,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.015546
-      estimated_mw: 0.003963
+      estimated_mw: 0.003961
       idle_transitions_mws: 0.021182
       total_mws: 0.036727
       thread_name: ".gms.persistent"
@@ -1926,7 +1926,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014990
-      estimated_mw: 0.003821
+      estimated_mw: 0.003819
       idle_transitions_mws: 0.000000
       total_mws: 0.014990
       thread_name: "binder:568_8"
@@ -1936,7 +1936,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014987
-      estimated_mw: 0.003821
+      estimated_mw: 0.003819
       idle_transitions_mws: 0.000000
       total_mws: 0.014987
       thread_name: "aiai-min-shared"
@@ -1946,7 +1946,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014632
-      estimated_mw: 0.003730
+      estimated_mw: 0.003728
       idle_transitions_mws: 0.000000
       total_mws: 0.014632
       thread_name: "ksoftirqd/2"
@@ -1956,7 +1956,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013179
-      estimated_mw: 0.003360
+      estimated_mw: 0.003358
       idle_transitions_mws: 0.000754
       total_mws: 0.013933
       thread_name: "android.imms"
@@ -1966,7 +1966,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012659
-      estimated_mw: 0.003227
+      estimated_mw: 0.003225
       idle_transitions_mws: 0.013610
       total_mws: 0.026269
       thread_name: "kworker/2:1"
@@ -1976,7 +1976,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.011318
-      estimated_mw: 0.002885
+      estimated_mw: 0.002884
       idle_transitions_mws: 0.017252
       total_mws: 0.028570
       thread_name: "binder:1158_2"
@@ -1986,7 +1986,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.010716
-      estimated_mw: 0.002732
+      estimated_mw: 0.002730
       idle_transitions_mws: 0.003928
       total_mws: 0.014644
       thread_name: "TimerThread"
@@ -1996,7 +1996,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.010560
-      estimated_mw: 0.002692
+      estimated_mw: 0.002691
       idle_transitions_mws: 0.000000
       total_mws: 0.010560
       thread_name: "rcuop/0"
@@ -2006,7 +2006,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.010537
-      estimated_mw: 0.002686
+      estimated_mw: 0.002685
       idle_transitions_mws: 0.036693
       total_mws: 0.047230
       thread_name: "kworker/4:3"
@@ -2016,7 +2016,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008739
-      estimated_mw: 0.002228
+      estimated_mw: 0.002227
       idle_transitions_mws: 0.000000
       total_mws: 0.008739
       thread_name: "binder:15865_6"
@@ -2026,7 +2026,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008457
-      estimated_mw: 0.002156
+      estimated_mw: 0.002155
       idle_transitions_mws: 0.000000
       total_mws: 0.008457
       thread_name: "UsfHalWorker"
@@ -2036,7 +2036,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.007635
-      estimated_mw: 0.001946
+      estimated_mw: 0.001945
       idle_transitions_mws: 0.000000
       total_mws: 0.007635
       thread_name: "IdleTimer"
@@ -2046,7 +2046,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.007634
-      estimated_mw: 0.001946
+      estimated_mw: 0.001945
       idle_transitions_mws: 0.003539
       total_mws: 0.011173
       thread_name: "binder:8021_5"
@@ -2056,7 +2056,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006824
-      estimated_mw: 0.001740
+      estimated_mw: 0.001739
       idle_transitions_mws: 0.000000
       total_mws: 0.006824
       thread_name: "binder:15865_4"
@@ -2066,7 +2066,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006397
-      estimated_mw: 0.001631
+      estimated_mw: 0.001630
       idle_transitions_mws: 0.000000
       total_mws: 0.006397
       thread_name: "binder:7503_F"
@@ -2076,7 +2076,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006389
-      estimated_mw: 0.001629
+      estimated_mw: 0.001628
       idle_transitions_mws: 0.000000
       total_mws: 0.006389
       thread_name: "kworker/6:0"
@@ -2086,7 +2086,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.005616
-      estimated_mw: 0.001432
+      estimated_mw: 0.001431
       idle_transitions_mws: 0.000000
       total_mws: 0.005616
       thread_name: "ksoftirqd/0"
@@ -2096,7 +2096,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.005558
-      estimated_mw: 0.001417
+      estimated_mw: 0.001416
       idle_transitions_mws: 0.000000
       total_mws: 0.005558
       thread_name: "migration/7"
@@ -2106,7 +2106,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.005013
-      estimated_mw: 0.001278
+      estimated_mw: 0.001277
       idle_transitions_mws: 0.000000
       total_mws: 0.005013
       thread_name: "migration/6"
@@ -2116,7 +2116,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.001062
-      estimated_mw: 0.000271
+      estimated_mw: 0.000270
       idle_transitions_mws: 0.004483
       total_mws: 0.005544
       thread_name: "kworker/5:33"
@@ -2140,7 +2140,7 @@ wattson_atrace_apps_threads {
     period_name: "NOTIFICATION_SHADE_QS_EXPAND_COLLAPSE"
     task_info {
       estimated_mws: 219.356796
-      estimated_mw: 55.919563
+      estimated_mw: 55.890129
       idle_transitions_mws: 4.015336
       total_mws: 223.372131
       thread_name: "ndroid.systemui"
@@ -2150,7 +2150,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 201.001511
-      estimated_mw: 51.240341
+      estimated_mw: 51.213367
       idle_transitions_mws: 5.232009
       total_mws: 206.233521
       thread_name: "RenderThread"
@@ -2160,7 +2160,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 99.220078
-      estimated_mw: 25.293694
+      estimated_mw: 25.280378
       idle_transitions_mws: -27.744040
       total_mws: 71.476036
       thread_name: "swapper"
@@ -2170,7 +2170,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 30.950077
-      estimated_mw: 7.889953
+      estimated_mw: 7.885800
       idle_transitions_mws: 0.168814
       total_mws: 31.118891
       thread_name: "surfaceflinger"
@@ -2180,7 +2180,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 16.193003
-      estimated_mw: 4.128004
+      estimated_mw: 4.125831
       idle_transitions_mws: 0.401085
       total_mws: 16.594088
       thread_name: "InputDispatcher"
@@ -2190,7 +2190,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 13.731295
-      estimated_mw: 3.500453
+      estimated_mw: 3.498610
       idle_transitions_mws: 0.231241
       total_mws: 13.962536
       thread_name: "s.nexuslauncher"
@@ -2200,7 +2200,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 13.093807
-      estimated_mw: 3.337941
+      estimated_mw: 3.336184
       idle_transitions_mws: 0.000000
       total_mws: 13.093807
       thread_name: "binder:581_2"
@@ -2210,7 +2210,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 12.729743
-      estimated_mw: 3.245132
+      estimated_mw: 3.243424
       idle_transitions_mws: 0.012038
       total_mws: 12.741781
       thread_name: "stack-unwinding"
@@ -2220,7 +2220,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 10.984733
-      estimated_mw: 2.800285
+      estimated_mw: 2.798811
       idle_transitions_mws: 0.019429
       total_mws: 11.004162
       thread_name: "traced_probes"
@@ -2230,7 +2230,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 9.265457
-      estimated_mw: 2.361998
+      estimated_mw: 2.360755
       idle_transitions_mws: 0.642519
       total_mws: 9.907976
       thread_name: "binder:1423_D"
@@ -2240,7 +2240,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 9.116576
-      estimated_mw: 2.324045
+      estimated_mw: 2.322821
       idle_transitions_mws: 0.000824
       total_mws: 9.117400
       thread_name: "ActivityManager"
@@ -2250,7 +2250,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 8.057963
-      estimated_mw: 2.054178
+      estimated_mw: 2.053096
       idle_transitions_mws: 1.035555
       total_mws: 9.093518
       thread_name: "mali-cmar-backe"
@@ -2260,7 +2260,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 7.928385
-      estimated_mw: 2.021145
+      estimated_mw: 2.020081
       idle_transitions_mws: 0.647915
       total_mws: 8.576300
       thread_name: "binder:578_1"
@@ -2270,7 +2270,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 7.752030
-      estimated_mw: 1.976187
+      estimated_mw: 1.975147
       idle_transitions_mws: 0.000698
       total_mws: 7.752728
       thread_name: "traced"
@@ -2280,7 +2280,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.517419
-      estimated_mw: 1.661454
+      estimated_mw: 1.660580
       idle_transitions_mws: 1.661456
       total_mws: 8.178876
       thread_name: "mali_jd_thread"
@@ -2290,7 +2290,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.235751
-      estimated_mw: 1.589650
+      estimated_mw: 1.588813
       idle_transitions_mws: 0.005741
       total_mws: 6.241493
       thread_name: "trigger_perfett"
@@ -2300,7 +2300,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.849003
-      estimated_mw: 1.491058
+      estimated_mw: 1.490273
       idle_transitions_mws: 0.313084
       total_mws: 6.162086
       thread_name: "binder:1423_5"
@@ -2310,7 +2310,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.474003
-      estimated_mw: 1.395461
+      estimated_mw: 1.394726
       idle_transitions_mws: 0.996487
       total_mws: 6.470490
       thread_name: "TimerDispatch"
@@ -2320,7 +2320,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.998270
-      estimated_mw: 1.274185
+      estimated_mw: 1.273514
       idle_transitions_mws: 0.292234
       total_mws: 5.290504
       thread_name: "binder:1423_19"
@@ -2330,7 +2330,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.667690
-      estimated_mw: 1.189912
+      estimated_mw: 1.189285
       idle_transitions_mws: 0.206536
       total_mws: 4.874226
       thread_name: "app"
@@ -2340,7 +2340,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.031611
-      estimated_mw: 1.027759
+      estimated_mw: 1.027218
       idle_transitions_mws: 0.068113
       total_mws: 4.099724
       thread_name: "android.ui"
@@ -2350,7 +2350,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.876612
-      estimated_mw: 0.988246
+      estimated_mw: 0.987726
       idle_transitions_mws: 0.077440
       total_mws: 3.954052
       thread_name: "kworker/u16:0"
@@ -2360,7 +2360,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.670668
-      estimated_mw: 0.935746
+      estimated_mw: 0.935253
       idle_transitions_mws: 0.629293
       total_mws: 4.299961
       thread_name: "decon0_kthread"
@@ -2370,7 +2370,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.638816
-      estimated_mw: 0.927626
+      estimated_mw: 0.927137
       idle_transitions_mws: 1.199599
       total_mws: 4.838415
       thread_name: "sugov:0"
@@ -2380,7 +2380,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.532295
-      estimated_mw: 0.900471
+      estimated_mw: 0.899997
       idle_transitions_mws: 0.001518
       total_mws: 3.533813
       thread_name: "SysUiBg"
@@ -2390,7 +2390,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.431310
-      estimated_mw: 0.874727
+      estimated_mw: 0.874267
       idle_transitions_mws: 0.125885
       total_mws: 3.557195
       thread_name: "RenderEngine"
@@ -2400,7 +2400,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.350341
-      estimated_mw: 0.854086
+      estimated_mw: 0.853637
       idle_transitions_mws: 0.137454
       total_mws: 3.487795
       thread_name: "roidJUnitRunner"
@@ -2410,7 +2410,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.303621
-      estimated_mw: 0.842176
+      estimated_mw: 0.841733
       idle_transitions_mws: 0.115430
       total_mws: 3.419051
       thread_name: "binder:7292_5"
@@ -2420,7 +2420,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.075752
-      estimated_mw: 0.784087
+      estimated_mw: 0.783674
       idle_transitions_mws: 0.082840
       total_mws: 3.158592
       thread_name: "android.hardwar"
@@ -2430,7 +2430,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.721846
-      estimated_mw: 0.693867
+      estimated_mw: 0.693502
       idle_transitions_mws: 0.005831
       total_mws: 2.727677
       thread_name: "Jit thread pool"
@@ -2440,7 +2440,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.590009
-      estimated_mw: 0.660258
+      estimated_mw: 0.659911
       idle_transitions_mws: 0.207711
       total_mws: 2.797720
       thread_name: "binder:15865_5"
@@ -2450,7 +2450,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.582274
-      estimated_mw: 0.658286
+      estimated_mw: 0.657940
       idle_transitions_mws: 0.143112
       total_mws: 2.725385
       thread_name: "kworker/u17:2"
@@ -2460,7 +2460,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.416878
-      estimated_mw: 0.616123
+      estimated_mw: 0.615799
       idle_transitions_mws: 0.195245
       total_mws: 2.612124
       thread_name: "binder:15865_2"
@@ -2470,7 +2470,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.339876
-      estimated_mw: 0.596493
+      estimated_mw: 0.596179
       idle_transitions_mws: 0.232481
       total_mws: 2.572356
       thread_name: "binder:578_5"
@@ -2480,7 +2480,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.147599
-      estimated_mw: 0.547477
+      estimated_mw: 0.547189
       idle_transitions_mws: 0.317868
       total_mws: 2.465467
       thread_name: "BckgrndExec HP"
@@ -2490,7 +2490,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.010603
-      estimated_mw: 0.512553
+      estimated_mw: 0.512284
       idle_transitions_mws: 0.139782
       total_mws: 2.150385
       thread_name: "system_server"
@@ -2500,7 +2500,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.000071
-      estimated_mw: 0.509868
+      estimated_mw: 0.509600
       idle_transitions_mws: 0.038967
       total_mws: 2.039038
       thread_name: "traced_perf"
@@ -2510,7 +2510,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.935477
-      estimated_mw: 0.493402
+      estimated_mw: 0.493142
       idle_transitions_mws: 0.416633
       total_mws: 2.352110
       thread_name: "binder:7292_4"
@@ -2520,7 +2520,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.742045
-      estimated_mw: 0.444091
+      estimated_mw: 0.443857
       idle_transitions_mws: 0.567846
       total_mws: 2.309891
       thread_name: "sugov:4"
@@ -2530,7 +2530,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.693529
-      estimated_mw: 0.431723
+      estimated_mw: 0.431496
       idle_transitions_mws: 0.000000
       total_mws: 1.693529
       thread_name: "android.hardwar"
@@ -2540,7 +2540,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.594189
-      estimated_mw: 0.406399
+      estimated_mw: 0.406185
       idle_transitions_mws: 0.084697
       total_mws: 1.678886
       thread_name: "binder:1423_1E"
@@ -2550,7 +2550,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.582279
-      estimated_mw: 0.403363
+      estimated_mw: 0.403150
       idle_transitions_mws: 0.469983
       total_mws: 2.052262
       thread_name: "sugov:6"
@@ -2560,7 +2560,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.565071
-      estimated_mw: 0.398976
+      estimated_mw: 0.398766
       idle_transitions_mws: 0.177839
       total_mws: 1.742910
       thread_name: "surfaceflinger"
@@ -2570,7 +2570,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.517351
-      estimated_mw: 0.386811
+      estimated_mw: 0.386607
       idle_transitions_mws: 0.116411
       total_mws: 1.633762
       thread_name: "binder:8021_3"
@@ -2580,7 +2580,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.148426
-      estimated_mw: 0.292763
+      estimated_mw: 0.292609
       idle_transitions_mws: 0.325698
       total_mws: 1.474124
       thread_name: "SystemUIBg-1"
@@ -2590,7 +2590,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.146216
-      estimated_mw: 0.292199
+      estimated_mw: 0.292045
       idle_transitions_mws: 0.040349
       total_mws: 1.186565
       thread_name: "RegionSampling"
@@ -2600,7 +2600,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.129025
-      estimated_mw: 0.287817
+      estimated_mw: 0.287665
       idle_transitions_mws: 0.319617
       total_mws: 1.448642
       thread_name: "SystemUIBg-4"
@@ -2610,7 +2610,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.101538
-      estimated_mw: 0.280810
+      estimated_mw: 0.280662
       idle_transitions_mws: 0.142086
       total_mws: 1.243623
       thread_name: "UiAutomation"
@@ -2620,7 +2620,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.100433
-      estimated_mw: 0.280528
+      estimated_mw: 0.280380
       idle_transitions_mws: 0.113671
       total_mws: 1.214105
       thread_name: "binder:7309_5"
@@ -2630,7 +2630,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.047979
-      estimated_mw: 0.267156
+      estimated_mw: 0.267015
       idle_transitions_mws: 0.007566
       total_mws: 1.055544
       thread_name: "mali-compiler"
@@ -2640,7 +2640,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.028903
-      estimated_mw: 0.262293
+      estimated_mw: 0.262155
       idle_transitions_mws: 0.348773
       total_mws: 1.377675
       thread_name: "SystemUIBg-8"
@@ -2650,7 +2650,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.008278
-      estimated_mw: 0.257035
+      estimated_mw: 0.256900
       idle_transitions_mws: 0.251555
       total_mws: 1.259833
       thread_name: "InputTracer"
@@ -2660,7 +2660,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.962402
-      estimated_mw: 0.245341
+      estimated_mw: 0.245211
       idle_transitions_mws: 0.394505
       total_mws: 1.356908
       thread_name: "SystemUIBg-5"
@@ -2670,7 +2670,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.935827
-      estimated_mw: 0.238566
+      estimated_mw: 0.238440
       idle_transitions_mws: 0.350992
       total_mws: 1.286818
       thread_name: "SystemUIBg-2"
@@ -2680,7 +2680,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.892046
-      estimated_mw: 0.227405
+      estimated_mw: 0.227285
       idle_transitions_mws: 0.239289
       total_mws: 1.131334
       thread_name: "SystemUIBg-7"
@@ -2690,7 +2690,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.865882
-      estimated_mw: 0.220735
+      estimated_mw: 0.220619
       idle_transitions_mws: 0.174156
       total_mws: 1.040038
       thread_name: "wmshell.main"
@@ -2700,7 +2700,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.848311
-      estimated_mw: 0.216256
+      estimated_mw: 0.216142
       idle_transitions_mws: 0.375854
       total_mws: 1.224165
       thread_name: "SystemUIBg-3"
@@ -2710,7 +2710,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.844309
-      estimated_mw: 0.215236
+      estimated_mw: 0.215122
       idle_transitions_mws: 0.179144
       total_mws: 1.023453
       thread_name: "SystemUIBg-6"
@@ -2720,7 +2720,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.827673
-      estimated_mw: 0.210995
+      estimated_mw: 0.210884
       idle_transitions_mws: 0.179125
       total_mws: 1.006799
       thread_name: "PowerStatsServi"
@@ -2730,7 +2730,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.790621
-      estimated_mw: 0.201549
+      estimated_mw: 0.201443
       idle_transitions_mws: 0.105249
       total_mws: 0.895870
       thread_name: "mali_apc_thread"
@@ -2740,7 +2740,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.779786
-      estimated_mw: 0.198787
+      estimated_mw: 0.198682
       idle_transitions_mws: 0.014243
       total_mws: 0.794029
       thread_name: "process reaper"
@@ -2750,7 +2750,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.767745
-      estimated_mw: 0.195718
+      estimated_mw: 0.195615
       idle_transitions_mws: 0.146388
       total_mws: 0.914133
       thread_name: "m.test.scenario"
@@ -2760,7 +2760,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.750545
-      estimated_mw: 0.191333
+      estimated_mw: 0.191232
       idle_transitions_mws: 0.028181
       total_mws: 0.778725
       thread_name: "kworker/u17:0"
@@ -2770,7 +2770,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.747688
-      estimated_mw: 0.190605
+      estimated_mw: 0.190504
       idle_transitions_mws: 0.363831
       total_mws: 1.111519
       thread_name: "GPU completion"
@@ -2780,7 +2780,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.740673
-      estimated_mw: 0.188816
+      estimated_mw: 0.188717
       idle_transitions_mws: 0.146008
       total_mws: 0.886681
       thread_name: "DisplayHints"
@@ -2790,7 +2790,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.720779
-      estimated_mw: 0.183745
+      estimated_mw: 0.183648
       idle_transitions_mws: 0.450580
       total_mws: 1.171358
       thread_name: "HWC release"
@@ -2800,7 +2800,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.718310
-      estimated_mw: 0.183115
+      estimated_mw: 0.183019
       idle_transitions_mws: 0.037584
       total_mws: 0.755895
       thread_name: "binder:15865_6"
@@ -2810,7 +2810,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.616128
-      estimated_mw: 0.157066
+      estimated_mw: 0.156984
       idle_transitions_mws: 0.024258
       total_mws: 0.640385
       thread_name: "logd.writer"
@@ -2820,7 +2820,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.519314
-      estimated_mw: 0.132386
+      estimated_mw: 0.132317
       idle_transitions_mws: 0.029821
       total_mws: 0.549136
       thread_name: "binder:15865_7"
@@ -2830,7 +2830,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.504188
-      estimated_mw: 0.128530
+      estimated_mw: 0.128463
       idle_transitions_mws: 0.038687
       total_mws: 0.542875
       thread_name: "BckgrndExec LP"
@@ -2840,7 +2840,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.441016
-      estimated_mw: 0.112426
+      estimated_mw: 0.112367
       idle_transitions_mws: 0.078692
       total_mws: 0.519708
       thread_name: "mali-cmar-backe"
@@ -2850,7 +2850,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.414641
-      estimated_mw: 0.105702
+      estimated_mw: 0.105647
       idle_transitions_mws: 0.082847
       total_mws: 0.497488
       thread_name: "binder:7309_2"
@@ -2860,7 +2860,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.395448
-      estimated_mw: 0.100810
+      estimated_mw: 0.100756
       idle_transitions_mws: 0.218582
       total_mws: 0.614029
       thread_name: "binder:15865_2"
@@ -2870,7 +2870,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.318815
-      estimated_mw: 0.081274
+      estimated_mw: 0.081231
       idle_transitions_mws: 0.000000
       total_mws: 0.318815
       thread_name: "logcat"
@@ -2880,7 +2880,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.290038
-      estimated_mw: 0.073938
+      estimated_mw: 0.073899
       idle_transitions_mws: 0.010375
       total_mws: 0.300413
       thread_name: "InteractionJank"
@@ -2890,7 +2890,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.284804
-      estimated_mw: 0.072604
+      estimated_mw: 0.072566
       idle_transitions_mws: 0.007497
       total_mws: 0.292301
       thread_name: "binder:7309_6"
@@ -2900,7 +2900,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.270404
-      estimated_mw: 0.068933
+      estimated_mw: 0.068896
       idle_transitions_mws: 0.001294
       total_mws: 0.271698
       thread_name: "Jit thread pool"
@@ -2910,7 +2910,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.241841
-      estimated_mw: 0.061651
+      estimated_mw: 0.061619
       idle_transitions_mws: 0.001656
       total_mws: 0.243496
       thread_name: "droid.apps.maps"
@@ -2920,7 +2920,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.230547
-      estimated_mw: 0.058772
+      estimated_mw: 0.058741
       idle_transitions_mws: 0.217516
       total_mws: 0.448063
       thread_name: "perf_mon_update"
@@ -2930,7 +2930,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.205438
-      estimated_mw: 0.052371
+      estimated_mw: 0.052344
       idle_transitions_mws: 0.033086
       total_mws: 0.238524
       thread_name: "vsync"
@@ -2940,7 +2940,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.203994
-      estimated_mw: 0.052003
+      estimated_mw: 0.051976
       idle_transitions_mws: 0.009086
       total_mws: 0.213080
       thread_name: "logd.reader.per"
@@ -2950,7 +2950,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.201298
-      estimated_mw: 0.051316
+      estimated_mw: 0.051289
       idle_transitions_mws: 0.038341
       total_mws: 0.239639
       thread_name: "adpf_handler0"
@@ -2960,7 +2960,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.189910
-      estimated_mw: 0.048413
+      estimated_mw: 0.048387
       idle_transitions_mws: 0.000000
       total_mws: 0.189910
       thread_name: "NodeLooperThrea"
@@ -2970,7 +2970,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.177258
-      estimated_mw: 0.045187
+      estimated_mw: 0.045164
       idle_transitions_mws: 0.016272
       total_mws: 0.193530
       thread_name: "HwBinder:578_1"
@@ -2980,7 +2980,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.164429
-      estimated_mw: 0.041917
+      estimated_mw: 0.041895
       idle_transitions_mws: 0.010174
       total_mws: 0.174602
       thread_name: "TracingMuxer"
@@ -2990,7 +2990,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.161933
-      estimated_mw: 0.041281
+      estimated_mw: 0.041259
       idle_transitions_mws: 0.001961
       total_mws: 0.163894
       thread_name: "main"
@@ -3000,7 +3000,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.159240
-      estimated_mw: 0.040594
+      estimated_mw: 0.040573
       idle_transitions_mws: 0.000000
       total_mws: 0.159240
       thread_name: "kworker/3:3H"
@@ -3010,7 +3010,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.152760
-      estimated_mw: 0.038942
+      estimated_mw: 0.038922
       idle_transitions_mws: 0.006517
       total_mws: 0.159277
       thread_name: "statsd.reader"
@@ -3020,7 +3020,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.149836
-      estimated_mw: 0.038197
+      estimated_mw: 0.038177
       idle_transitions_mws: 0.005029
       total_mws: 0.154866
       thread_name: "Background_17"
@@ -3030,7 +3030,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.138264
-      estimated_mw: 0.035247
+      estimated_mw: 0.035228
       idle_transitions_mws: 0.004283
       total_mws: 0.142547
       thread_name: "statsd.writer"
@@ -3040,7 +3040,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.132288
-      estimated_mw: 0.033724
+      estimated_mw: 0.033706
       idle_transitions_mws: 0.028129
       total_mws: 0.160417
       thread_name: "RegSampIdle"
@@ -3050,7 +3050,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.114687
-      estimated_mw: 0.029237
+      estimated_mw: 0.029221
       idle_transitions_mws: 0.000000
       total_mws: 0.114687
       thread_name: "migration/3"
@@ -3060,7 +3060,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.111031
-      estimated_mw: 0.028305
+      estimated_mw: 0.028290
       idle_transitions_mws: 0.000000
       total_mws: 0.111031
       thread_name: "heapprofd"
@@ -3070,7 +3070,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.108152
-      estimated_mw: 0.027571
+      estimated_mw: 0.027556
       idle_transitions_mws: 0.022336
       total_mws: 0.130488
       thread_name: "android.hardwar"
@@ -3080,7 +3080,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.102656
-      estimated_mw: 0.026170
+      estimated_mw: 0.026156
       idle_transitions_mws: 0.000000
       total_mws: 0.102656
       thread_name: "migration/0"
@@ -3090,7 +3090,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.091369
-      estimated_mw: 0.023292
+      estimated_mw: 0.023280
       idle_transitions_mws: 0.063324
       total_mws: 0.154694
       thread_name: "mali-mem-purge"
@@ -3100,7 +3100,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.088625
-      estimated_mw: 0.022593
+      estimated_mw: 0.022581
       idle_transitions_mws: 0.090680
       total_mws: 0.179305
       thread_name: "mali-mem-purge"
@@ -3110,7 +3110,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.087351
-      estimated_mw: 0.022268
+      estimated_mw: 0.022256
       idle_transitions_mws: 0.032640
       total_mws: 0.119991
       thread_name: "surfaceflinger"
@@ -3120,7 +3120,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084905
-      estimated_mw: 0.021644
+      estimated_mw: 0.021633
       idle_transitions_mws: 0.006671
       total_mws: 0.091575
       thread_name: "SensorService"
@@ -3130,7 +3130,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084199
-      estimated_mw: 0.021464
+      estimated_mw: 0.021453
       idle_transitions_mws: 0.008253
       total_mws: 0.092452
       thread_name: "-Executor] idle"
@@ -3139,7 +3139,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.077161
-      estimated_mw: 0.019670
+      estimated_mw: 0.019660
       idle_transitions_mws: 0.000000
       total_mws: 0.077161
       thread_name: "-Executor] idle"
@@ -3148,7 +3148,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.071234
-      estimated_mw: 0.018159
+      estimated_mw: 0.018150
       idle_transitions_mws: 0.012328
       total_mws: 0.083563
       thread_name: "queued-work-loo"
@@ -3158,7 +3158,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.068262
-      estimated_mw: 0.017402
+      estimated_mw: 0.017392
       idle_transitions_mws: 0.003502
       total_mws: 0.071763
       thread_name: "android.hardwar"
@@ -3168,7 +3168,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.061241
-      estimated_mw: 0.015612
+      estimated_mw: 0.015604
       idle_transitions_mws: 0.000000
       total_mws: 0.061241
       thread_name: "TouchTimer"
@@ -3178,7 +3178,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.059074
-      estimated_mw: 0.015059
+      estimated_mw: 0.015051
       idle_transitions_mws: 0.007234
       total_mws: 0.066308
       thread_name: "UsfTransport"
@@ -3188,7 +3188,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.058859
-      estimated_mw: 0.015005
+      estimated_mw: 0.014997
       idle_transitions_mws: 0.013913
       total_mws: 0.072772
       thread_name: "kworker/2:1"
@@ -3198,7 +3198,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.057819
-      estimated_mw: 0.014740
+      estimated_mw: 0.014732
       idle_transitions_mws: 0.002076
       total_mws: 0.059896
       thread_name: "-Executor] idle"
@@ -3207,7 +3207,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.056811
-      estimated_mw: 0.014483
+      estimated_mw: 0.014475
       idle_transitions_mws: 0.000000
       total_mws: 0.056811
       thread_name: "migration/1"
@@ -3217,7 +3217,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.051664
-      estimated_mw: 0.013170
+      estimated_mw: 0.013164
       idle_transitions_mws: 0.005213
       total_mws: 0.056877
       thread_name: "ScreenDecoratio"
@@ -3227,7 +3227,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.051403
-      estimated_mw: 0.013104
+      estimated_mw: 0.013097
       idle_transitions_mws: 0.064089
       total_mws: 0.115492
       thread_name: "psimon"
@@ -3237,7 +3237,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.051090
-      estimated_mw: 0.013024
+      estimated_mw: 0.013017
       idle_transitions_mws: 0.011517
       total_mws: 0.062607
       thread_name: "kworker/3:12"
@@ -3247,7 +3247,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.050942
-      estimated_mw: 0.012986
+      estimated_mw: 0.012980
       idle_transitions_mws: 0.004026
       total_mws: 0.054968
       thread_name: "-Executor] idle"
@@ -3256,7 +3256,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.049289
-      estimated_mw: 0.012565
+      estimated_mw: 0.012559
       idle_transitions_mws: 0.000000
       total_mws: 0.049289
       thread_name: "migration/2"
@@ -3266,7 +3266,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.047770
-      estimated_mw: 0.012178
+      estimated_mw: 0.012171
       idle_transitions_mws: 0.005397
       total_mws: 0.053167
       thread_name: "eduling.default"
@@ -3276,7 +3276,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.043262
-      estimated_mw: 0.011029
+      estimated_mw: 0.011023
       idle_transitions_mws: 0.004228
       total_mws: 0.047490
       thread_name: "-Executor] idle"
@@ -3285,7 +3285,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.038018
-      estimated_mw: 0.009692
+      estimated_mw: 0.009687
       idle_transitions_mws: 0.001732
       total_mws: 0.039750
       thread_name: "BroadcastRunnin"
@@ -3295,7 +3295,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.037081
-      estimated_mw: 0.009453
+      estimated_mw: 0.009448
       idle_transitions_mws: 0.014265
       total_mws: 0.051346
       thread_name: "-Executor] idle"
@@ -3304,7 +3304,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.034452
-      estimated_mw: 0.008783
+      estimated_mw: 0.008778
       idle_transitions_mws: 0.007819
       total_mws: 0.042271
       thread_name: "RE Completion"
@@ -3314,7 +3314,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.034110
-      estimated_mw: 0.008696
+      estimated_mw: 0.008691
       idle_transitions_mws: 0.001921
       total_mws: 0.036031
       thread_name: "binder:15865_1"
@@ -3324,7 +3324,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.033181
-      estimated_mw: 0.008459
+      estimated_mw: 0.008454
       idle_transitions_mws: 0.000000
       total_mws: 0.033181
       thread_name: "RxSchedulerPurg"
@@ -3334,7 +3334,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.031927
-      estimated_mw: 0.008139
+      estimated_mw: 0.008135
       idle_transitions_mws: 0.049831
       total_mws: 0.081758
       thread_name: "com.google.usf."
@@ -3344,7 +3344,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.029733
-      estimated_mw: 0.007580
+      estimated_mw: 0.007576
       idle_transitions_mws: 0.002042
       total_mws: 0.031775
       thread_name: "android.hardwar"
@@ -3354,7 +3354,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.027352
-      estimated_mw: 0.006973
+      estimated_mw: 0.006969
       idle_transitions_mws: 0.000921
       total_mws: 0.028273
       thread_name: "simpleinteracti"
@@ -3364,7 +3364,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.023126
-      estimated_mw: 0.005895
+      estimated_mw: 0.005892
       idle_transitions_mws: 0.003350
       total_mws: 0.026476
       thread_name: "otp-aiai-notifi"
@@ -3373,7 +3373,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.022468
-      estimated_mw: 0.005728
+      estimated_mw: 0.005725
       idle_transitions_mws: 0.003576
       total_mws: 0.026044
       thread_name: "binder:15865_3"
@@ -3383,7 +3383,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.022384
-      estimated_mw: 0.005706
+      estimated_mw: 0.005703
       idle_transitions_mws: 0.003920
       total_mws: 0.026304
       thread_name: "-Executor] idle"
@@ -3392,7 +3392,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.020308
-      estimated_mw: 0.005177
+      estimated_mw: 0.005174
       idle_transitions_mws: 0.000000
       total_mws: 0.020308
       thread_name: "android.hardwar"
@@ -3402,7 +3402,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019427
-      estimated_mw: 0.004952
+      estimated_mw: 0.004950
       idle_transitions_mws: 0.000000
       total_mws: 0.019427
       thread_name: "GoogleApiHandle"
@@ -3412,7 +3412,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019117
-      estimated_mw: 0.004873
+      estimated_mw: 0.004871
       idle_transitions_mws: 0.000000
       total_mws: 0.019117
       thread_name: "migration/5"
@@ -3422,7 +3422,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019070
-      estimated_mw: 0.004861
+      estimated_mw: 0.004859
       idle_transitions_mws: 0.003087
       total_mws: 0.022157
       thread_name: "-Executor] idle"
@@ -3431,7 +3431,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019025
-      estimated_mw: 0.004850
+      estimated_mw: 0.004847
       idle_transitions_mws: 0.006383
       total_mws: 0.025408
       thread_name: "UsfHalWorker"
@@ -3441,7 +3441,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.018090
-      estimated_mw: 0.004612
+      estimated_mw: 0.004609
       idle_transitions_mws: 0.002281
       total_mws: 0.020372
       thread_name: "kworker/5:3H"
@@ -3451,7 +3451,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.017385
-      estimated_mw: 0.004432
+      estimated_mw: 0.004429
       idle_transitions_mws: 0.000000
       total_mws: 0.017385
       thread_name: "kworker/6:7H"
@@ -3461,7 +3461,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.017028
-      estimated_mw: 0.004341
+      estimated_mw: 0.004339
       idle_transitions_mws: 0.028344
       total_mws: 0.045372
       thread_name: "kworker/6:0"
@@ -3471,7 +3471,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.015576
-      estimated_mw: 0.003971
+      estimated_mw: 0.003969
       idle_transitions_mws: 0.003187
       total_mws: 0.018763
       thread_name: "kworker/5:33"
@@ -3481,7 +3481,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014807
-      estimated_mw: 0.003775
+      estimated_mw: 0.003773
       idle_transitions_mws: 0.000000
       total_mws: 0.014807
       thread_name: "DefaultDispatch"
@@ -3491,7 +3491,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014612
-      estimated_mw: 0.003725
+      estimated_mw: 0.003723
       idle_transitions_mws: 0.000000
       total_mws: 0.014612
       thread_name: "lhd"
@@ -3501,7 +3501,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013996
-      estimated_mw: 0.003568
+      estimated_mw: 0.003566
       idle_transitions_mws: 0.002338
       total_mws: 0.016334
       thread_name: "system_server"
@@ -3511,7 +3511,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013689
-      estimated_mw: 0.003490
+      estimated_mw: 0.003488
       idle_transitions_mws: 0.000000
       total_mws: 0.013689
       thread_name: "RxSchedulerPurg"
@@ -3521,7 +3521,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013150
-      estimated_mw: 0.003352
+      estimated_mw: 0.003350
       idle_transitions_mws: 0.003143
       total_mws: 0.016292
       thread_name: "-Executor] idle"
@@ -3530,7 +3530,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013125
-      estimated_mw: 0.003346
+      estimated_mw: 0.003344
       idle_transitions_mws: 0.000000
       total_mws: 0.013125
       thread_name: "DefaultDispatch"
@@ -3540,7 +3540,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012955
-      estimated_mw: 0.003303
+      estimated_mw: 0.003301
       idle_transitions_mws: 0.000000
       total_mws: 0.012955
       thread_name: "migration/4"
@@ -3550,7 +3550,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012324
-      estimated_mw: 0.003142
+      estimated_mw: 0.003140
       idle_transitions_mws: 0.000000
       total_mws: 0.012324
       thread_name: "RxCachedWorkerP"
@@ -3560,7 +3560,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012290
-      estimated_mw: 0.003133
+      estimated_mw: 0.003131
       idle_transitions_mws: 0.000000
       total_mws: 0.012290
       thread_name: "-Executor] idle"
@@ -3570,7 +3570,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.011181
-      estimated_mw: 0.002850
+      estimated_mw: 0.002849
       idle_transitions_mws: 0.159340
       total_mws: 0.170521
       thread_name: "binder:15865_4"
@@ -3580,7 +3580,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.011101
-      estimated_mw: 0.002830
+      estimated_mw: 0.002829
       idle_transitions_mws: 0.000000
       total_mws: 0.011101
       thread_name: "DefaultDispatch"
@@ -3590,7 +3590,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.010968
-      estimated_mw: 0.002796
+      estimated_mw: 0.002795
       idle_transitions_mws: 0.000000
       total_mws: 0.010968
       thread_name: "DefaultDispatch"
@@ -3600,7 +3600,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.009375
-      estimated_mw: 0.002390
+      estimated_mw: 0.002389
       idle_transitions_mws: 0.002434
       total_mws: 0.011809
       thread_name: "RxCachedWorkerP"
@@ -3610,7 +3610,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008952
-      estimated_mw: 0.002282
+      estimated_mw: 0.002281
       idle_transitions_mws: 0.000000
       total_mws: 0.008952
       thread_name: "DefaultDispatch"
@@ -3620,7 +3620,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008763
-      estimated_mw: 0.002234
+      estimated_mw: 0.002233
       idle_transitions_mws: 0.001547
       total_mws: 0.010310
       thread_name: "DefaultDispatch"
@@ -3630,7 +3630,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008158
-      estimated_mw: 0.002080
+      estimated_mw: 0.002079
       idle_transitions_mws: 0.000000
       total_mws: 0.008158
       thread_name: "IdleTimer"
@@ -3640,7 +3640,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006398
-      estimated_mw: 0.001631
+      estimated_mw: 0.001630
       idle_transitions_mws: 0.015290
       total_mws: 0.021688
       thread_name: "kworker/0:2"
@@ -3650,7 +3650,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006367
-      estimated_mw: 0.001623
+      estimated_mw: 0.001622
       idle_transitions_mws: 0.005399
       total_mws: 0.011766
       thread_name: "GpsdWatchDog"
@@ -3660,7 +3660,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006244
-      estimated_mw: 0.001592
+      estimated_mw: 0.001591
       idle_transitions_mws: 0.003325
       total_mws: 0.009570
       thread_name: "binder:1423_20"
@@ -3670,7 +3670,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.005897
-      estimated_mw: 0.001503
+      estimated_mw: 0.001502
       idle_transitions_mws: 0.000000
       total_mws: 0.005897
       thread_name: "kworker/1:1H"
@@ -3690,7 +3690,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004890
-      estimated_mw: 0.001247
+      estimated_mw: 0.001246
       idle_transitions_mws: 0.004577
       total_mws: 0.009467
       thread_name: "-Executor] idle"
@@ -3700,7 +3700,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004727
-      estimated_mw: 0.001205
+      estimated_mw: 0.001204
       idle_transitions_mws: 0.000000
       total_mws: 0.004727
       thread_name: "f2fs_discard-25"
@@ -3710,7 +3710,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004593
-      estimated_mw: 0.001171
+      estimated_mw: 0.001170
       idle_transitions_mws: 0.002459
       total_mws: 0.007052
       thread_name: "kworker/7:5"
@@ -3730,7 +3730,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004244
-      estimated_mw: 0.001082
+      estimated_mw: 0.001081
       idle_transitions_mws: 0.000000
       total_mws: 0.004244
       thread_name: "ksoftirqd/0"
@@ -3760,7 +3760,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.003361
-      estimated_mw: 0.000857
+      estimated_mw: 0.000856
       idle_transitions_mws: 0.001746
       total_mws: 0.005108
       thread_name: "DefaultDispatch"
@@ -3770,7 +3770,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.003318
-      estimated_mw: 0.000846
+      estimated_mw: 0.000845
       idle_transitions_mws: 0.013897
       total_mws: 0.017214
       thread_name: "kworker/1:1"
@@ -3804,7 +3804,7 @@ wattson_atrace_apps_threads {
     period_name: "NOTIFICATION_SHADE_EXPAND_COLLAPSE::Collapse"
     task_info {
       estimated_mws: 219.389236
-      estimated_mw: 55.927834
+      estimated_mw: 55.898396
       idle_transitions_mws: 4.012363
       total_mws: 223.401596
       thread_name: "ndroid.systemui"
@@ -3814,7 +3814,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 201.001511
-      estimated_mw: 51.240341
+      estimated_mw: 51.213367
       idle_transitions_mws: 5.232009
       total_mws: 206.233521
       thread_name: "RenderThread"
@@ -3824,7 +3824,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 99.233765
-      estimated_mw: 25.297182
+      estimated_mw: 25.283867
       idle_transitions_mws: -27.745781
       total_mws: 71.487984
       thread_name: "swapper"
@@ -3834,7 +3834,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 30.950077
-      estimated_mw: 7.889953
+      estimated_mw: 7.885800
       idle_transitions_mws: 0.168814
       total_mws: 31.118891
       thread_name: "surfaceflinger"
@@ -3844,7 +3844,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 16.105377
-      estimated_mw: 4.105666
+      estimated_mw: 4.103505
       idle_transitions_mws: 0.401085
       total_mws: 16.506462
       thread_name: "InputDispatcher"
@@ -3854,7 +3854,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 13.725424
-      estimated_mw: 3.498956
+      estimated_mw: 3.497114
       idle_transitions_mws: 0.231241
       total_mws: 13.956665
       thread_name: "s.nexuslauncher"
@@ -3864,7 +3864,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 13.093807
-      estimated_mw: 3.337941
+      estimated_mw: 3.336184
       idle_transitions_mws: 0.000000
       total_mws: 13.093807
       thread_name: "binder:581_2"
@@ -3874,7 +3874,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 12.560343
-      estimated_mw: 3.201948
+      estimated_mw: 3.200262
       idle_transitions_mws: 0.012038
       total_mws: 12.572382
       thread_name: "stack-unwinding"
@@ -3884,7 +3884,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 10.984733
-      estimated_mw: 2.800285
+      estimated_mw: 2.798811
       idle_transitions_mws: 0.019429
       total_mws: 11.004162
       thread_name: "traced_probes"
@@ -3894,7 +3894,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 9.265457
-      estimated_mw: 2.361998
+      estimated_mw: 2.360755
       idle_transitions_mws: 0.642519
       total_mws: 9.907976
       thread_name: "binder:1423_D"
@@ -3904,7 +3904,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 9.116576
-      estimated_mw: 2.324045
+      estimated_mw: 2.322821
       idle_transitions_mws: 0.000824
       total_mws: 9.117400
       thread_name: "ActivityManager"
@@ -3914,7 +3914,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 8.057963
-      estimated_mw: 2.054178
+      estimated_mw: 2.053096
       idle_transitions_mws: 1.035555
       total_mws: 9.093518
       thread_name: "mali-cmar-backe"
@@ -3924,7 +3924,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 7.877838
-      estimated_mw: 2.008259
+      estimated_mw: 2.007202
       idle_transitions_mws: 0.645664
       total_mws: 8.523502
       thread_name: "binder:578_1"
@@ -3934,7 +3934,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 7.752030
-      estimated_mw: 1.976187
+      estimated_mw: 1.975147
       idle_transitions_mws: 0.000698
       total_mws: 7.752728
       thread_name: "traced"
@@ -3944,7 +3944,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.517419
-      estimated_mw: 1.661454
+      estimated_mw: 1.660580
       idle_transitions_mws: 1.661456
       total_mws: 8.178876
       thread_name: "mali_jd_thread"
@@ -3954,7 +3954,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.235751
-      estimated_mw: 1.589650
+      estimated_mw: 1.588813
       idle_transitions_mws: 0.005741
       total_mws: 6.241493
       thread_name: "trigger_perfett"
@@ -3964,7 +3964,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.849003
-      estimated_mw: 1.491058
+      estimated_mw: 1.490273
       idle_transitions_mws: 0.313084
       total_mws: 6.162086
       thread_name: "binder:1423_5"
@@ -3974,7 +3974,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.474003
-      estimated_mw: 1.395461
+      estimated_mw: 1.394726
       idle_transitions_mws: 0.996487
       total_mws: 6.470490
       thread_name: "TimerDispatch"
@@ -3984,7 +3984,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.997519
-      estimated_mw: 1.273993
+      estimated_mw: 1.273323
       idle_transitions_mws: 0.291548
       total_mws: 5.289067
       thread_name: "binder:1423_19"
@@ -3994,7 +3994,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.667690
-      estimated_mw: 1.189912
+      estimated_mw: 1.189285
       idle_transitions_mws: 0.206536
       total_mws: 4.874226
       thread_name: "app"
@@ -4004,7 +4004,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.031611
-      estimated_mw: 1.027759
+      estimated_mw: 1.027218
       idle_transitions_mws: 0.068113
       total_mws: 4.099724
       thread_name: "android.ui"
@@ -4014,7 +4014,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.876612
-      estimated_mw: 0.988246
+      estimated_mw: 0.987726
       idle_transitions_mws: 0.077440
       total_mws: 3.954052
       thread_name: "kworker/u16:0"
@@ -4024,7 +4024,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.670668
-      estimated_mw: 0.935746
+      estimated_mw: 0.935253
       idle_transitions_mws: 0.629293
       total_mws: 4.299961
       thread_name: "decon0_kthread"
@@ -4034,7 +4034,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.628442
-      estimated_mw: 0.924981
+      estimated_mw: 0.924494
       idle_transitions_mws: 1.195743
       total_mws: 4.824185
       thread_name: "sugov:0"
@@ -4044,7 +4044,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.532295
-      estimated_mw: 0.900471
+      estimated_mw: 0.899997
       idle_transitions_mws: 0.001518
       total_mws: 3.533813
       thread_name: "SysUiBg"
@@ -4054,7 +4054,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.431310
-      estimated_mw: 0.874727
+      estimated_mw: 0.874267
       idle_transitions_mws: 0.125885
       total_mws: 3.557195
       thread_name: "RenderEngine"
@@ -4064,7 +4064,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.350341
-      estimated_mw: 0.854086
+      estimated_mw: 0.853637
       idle_transitions_mws: 0.137454
       total_mws: 3.487795
       thread_name: "roidJUnitRunner"
@@ -4074,7 +4074,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.303621
-      estimated_mw: 0.842176
+      estimated_mw: 0.841733
       idle_transitions_mws: 0.115430
       total_mws: 3.419051
       thread_name: "binder:7292_5"
@@ -4084,7 +4084,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.075752
-      estimated_mw: 0.784087
+      estimated_mw: 0.783674
       idle_transitions_mws: 0.082840
       total_mws: 3.158592
       thread_name: "android.hardwar"
@@ -4094,7 +4094,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.721846
-      estimated_mw: 0.693867
+      estimated_mw: 0.693502
       idle_transitions_mws: 0.005831
       total_mws: 2.727677
       thread_name: "Jit thread pool"
@@ -4104,7 +4104,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.590009
-      estimated_mw: 0.660258
+      estimated_mw: 0.659911
       idle_transitions_mws: 0.207711
       total_mws: 2.797720
       thread_name: "binder:15865_5"
@@ -4114,7 +4114,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.582274
-      estimated_mw: 0.658286
+      estimated_mw: 0.657940
       idle_transitions_mws: 0.143112
       total_mws: 2.725385
       thread_name: "kworker/u17:2"
@@ -4124,7 +4124,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.416878
-      estimated_mw: 0.616123
+      estimated_mw: 0.615799
       idle_transitions_mws: 0.195245
       total_mws: 2.612124
       thread_name: "binder:15865_2"
@@ -4134,7 +4134,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.339876
-      estimated_mw: 0.596493
+      estimated_mw: 0.596179
       idle_transitions_mws: 0.232481
       total_mws: 2.572356
       thread_name: "binder:578_5"
@@ -4144,7 +4144,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.147599
-      estimated_mw: 0.547477
+      estimated_mw: 0.547189
       idle_transitions_mws: 0.317868
       total_mws: 2.465467
       thread_name: "BckgrndExec HP"
@@ -4154,7 +4154,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.010603
-      estimated_mw: 0.512553
+      estimated_mw: 0.512284
       idle_transitions_mws: 0.139782
       total_mws: 2.150385
       thread_name: "system_server"
@@ -4164,7 +4164,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.000071
-      estimated_mw: 0.509868
+      estimated_mw: 0.509600
       idle_transitions_mws: 0.038967
       total_mws: 2.039038
       thread_name: "traced_perf"
@@ -4174,7 +4174,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.935477
-      estimated_mw: 0.493402
+      estimated_mw: 0.493142
       idle_transitions_mws: 0.416633
       total_mws: 2.352110
       thread_name: "binder:7292_4"
@@ -4184,7 +4184,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.748154
-      estimated_mw: 0.445648
+      estimated_mw: 0.445414
       idle_transitions_mws: 0.570725
       total_mws: 2.318880
       thread_name: "sugov:4"
@@ -4194,7 +4194,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.693529
-      estimated_mw: 0.431723
+      estimated_mw: 0.431496
       idle_transitions_mws: 0.000000
       total_mws: 1.693529
       thread_name: "android.hardwar"
@@ -4204,7 +4204,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.594189
-      estimated_mw: 0.406399
+      estimated_mw: 0.406185
       idle_transitions_mws: 0.084697
       total_mws: 1.678886
       thread_name: "binder:1423_1E"
@@ -4214,7 +4214,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.582279
-      estimated_mw: 0.403363
+      estimated_mw: 0.403150
       idle_transitions_mws: 0.469983
       total_mws: 2.052262
       thread_name: "sugov:6"
@@ -4224,7 +4224,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.565071
-      estimated_mw: 0.398976
+      estimated_mw: 0.398766
       idle_transitions_mws: 0.177839
       total_mws: 1.742910
       thread_name: "surfaceflinger"
@@ -4234,7 +4234,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.517351
-      estimated_mw: 0.386811
+      estimated_mw: 0.386607
       idle_transitions_mws: 0.116411
       total_mws: 1.633762
       thread_name: "binder:8021_3"
@@ -4244,7 +4244,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.148426
-      estimated_mw: 0.292763
+      estimated_mw: 0.292609
       idle_transitions_mws: 0.325698
       total_mws: 1.474124
       thread_name: "SystemUIBg-1"
@@ -4254,7 +4254,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.146216
-      estimated_mw: 0.292199
+      estimated_mw: 0.292045
       idle_transitions_mws: 0.040349
       total_mws: 1.186565
       thread_name: "RegionSampling"
@@ -4264,7 +4264,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.129025
-      estimated_mw: 0.287817
+      estimated_mw: 0.287665
       idle_transitions_mws: 0.319617
       total_mws: 1.448642
       thread_name: "SystemUIBg-4"
@@ -4274,7 +4274,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.101538
-      estimated_mw: 0.280810
+      estimated_mw: 0.280662
       idle_transitions_mws: 0.142086
       total_mws: 1.243623
       thread_name: "UiAutomation"
@@ -4284,7 +4284,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.100433
-      estimated_mw: 0.280528
+      estimated_mw: 0.280380
       idle_transitions_mws: 0.113671
       total_mws: 1.214105
       thread_name: "binder:7309_5"
@@ -4294,7 +4294,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.047979
-      estimated_mw: 0.267156
+      estimated_mw: 0.267015
       idle_transitions_mws: 0.007566
       total_mws: 1.055544
       thread_name: "mali-compiler"
@@ -4304,7 +4304,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.028903
-      estimated_mw: 0.262293
+      estimated_mw: 0.262155
       idle_transitions_mws: 0.348773
       total_mws: 1.377675
       thread_name: "SystemUIBg-8"
@@ -4314,7 +4314,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.008278
-      estimated_mw: 0.257035
+      estimated_mw: 0.256900
       idle_transitions_mws: 0.251555
       total_mws: 1.259833
       thread_name: "InputTracer"
@@ -4324,7 +4324,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.962402
-      estimated_mw: 0.245341
+      estimated_mw: 0.245211
       idle_transitions_mws: 0.394505
       total_mws: 1.356908
       thread_name: "SystemUIBg-5"
@@ -4334,7 +4334,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.935827
-      estimated_mw: 0.238566
+      estimated_mw: 0.238440
       idle_transitions_mws: 0.350992
       total_mws: 1.286818
       thread_name: "SystemUIBg-2"
@@ -4344,7 +4344,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.892046
-      estimated_mw: 0.227405
+      estimated_mw: 0.227285
       idle_transitions_mws: 0.239289
       total_mws: 1.131334
       thread_name: "SystemUIBg-7"
@@ -4354,7 +4354,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.865882
-      estimated_mw: 0.220735
+      estimated_mw: 0.220619
       idle_transitions_mws: 0.174156
       total_mws: 1.040038
       thread_name: "wmshell.main"
@@ -4364,7 +4364,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.855968
-      estimated_mw: 0.218208
+      estimated_mw: 0.218093
       idle_transitions_mws: 0.179680
       total_mws: 1.035648
       thread_name: "SystemUIBg-6"
@@ -4374,7 +4374,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.848311
-      estimated_mw: 0.216256
+      estimated_mw: 0.216142
       idle_transitions_mws: 0.375854
       total_mws: 1.224165
       thread_name: "SystemUIBg-3"
@@ -4384,7 +4384,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.827673
-      estimated_mw: 0.210995
+      estimated_mw: 0.210884
       idle_transitions_mws: 0.179125
       total_mws: 1.006799
       thread_name: "PowerStatsServi"
@@ -4394,7 +4394,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.790621
-      estimated_mw: 0.201549
+      estimated_mw: 0.201443
       idle_transitions_mws: 0.105249
       total_mws: 0.895870
       thread_name: "mali_apc_thread"
@@ -4404,7 +4404,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.779786
-      estimated_mw: 0.198787
+      estimated_mw: 0.198682
       idle_transitions_mws: 0.014243
       total_mws: 0.794029
       thread_name: "process reaper"
@@ -4414,7 +4414,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.767745
-      estimated_mw: 0.195718
+      estimated_mw: 0.195615
       idle_transitions_mws: 0.146388
       total_mws: 0.914133
       thread_name: "m.test.scenario"
@@ -4424,7 +4424,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.750545
-      estimated_mw: 0.191333
+      estimated_mw: 0.191232
       idle_transitions_mws: 0.028181
       total_mws: 0.778725
       thread_name: "kworker/u17:0"
@@ -4434,7 +4434,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.747688
-      estimated_mw: 0.190605
+      estimated_mw: 0.190504
       idle_transitions_mws: 0.363831
       total_mws: 1.111519
       thread_name: "GPU completion"
@@ -4444,7 +4444,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.740673
-      estimated_mw: 0.188816
+      estimated_mw: 0.188717
       idle_transitions_mws: 0.146008
       total_mws: 0.886681
       thread_name: "DisplayHints"
@@ -4454,7 +4454,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.720779
-      estimated_mw: 0.183745
+      estimated_mw: 0.183648
       idle_transitions_mws: 0.450580
       total_mws: 1.171358
       thread_name: "HWC release"
@@ -4464,7 +4464,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.718310
-      estimated_mw: 0.183115
+      estimated_mw: 0.183019
       idle_transitions_mws: 0.037584
       total_mws: 0.755895
       thread_name: "binder:15865_6"
@@ -4474,7 +4474,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.616128
-      estimated_mw: 0.157066
+      estimated_mw: 0.156984
       idle_transitions_mws: 0.024258
       total_mws: 0.640385
       thread_name: "logd.writer"
@@ -4484,7 +4484,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.519314
-      estimated_mw: 0.132386
+      estimated_mw: 0.132317
       idle_transitions_mws: 0.029821
       total_mws: 0.549136
       thread_name: "binder:15865_7"
@@ -4494,7 +4494,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.495458
-      estimated_mw: 0.126305
+      estimated_mw: 0.126238
       idle_transitions_mws: 0.038687
       total_mws: 0.534145
       thread_name: "BckgrndExec LP"
@@ -4504,7 +4504,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.441016
-      estimated_mw: 0.112426
+      estimated_mw: 0.112367
       idle_transitions_mws: 0.078692
       total_mws: 0.519708
       thread_name: "mali-cmar-backe"
@@ -4514,7 +4514,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.414641
-      estimated_mw: 0.105702
+      estimated_mw: 0.105647
       idle_transitions_mws: 0.082847
       total_mws: 0.497488
       thread_name: "binder:7309_2"
@@ -4524,7 +4524,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.395448
-      estimated_mw: 0.100810
+      estimated_mw: 0.100756
       idle_transitions_mws: 0.218582
       total_mws: 0.614029
       thread_name: "binder:15865_2"
@@ -4534,7 +4534,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.318815
-      estimated_mw: 0.081274
+      estimated_mw: 0.081231
       idle_transitions_mws: 0.000000
       total_mws: 0.318815
       thread_name: "logcat"
@@ -4544,7 +4544,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.294023
-      estimated_mw: 0.074954
+      estimated_mw: 0.074914
       idle_transitions_mws: 0.012163
       total_mws: 0.306186
       thread_name: "InteractionJank"
@@ -4554,7 +4554,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.284804
-      estimated_mw: 0.072604
+      estimated_mw: 0.072566
       idle_transitions_mws: 0.007497
       total_mws: 0.292301
       thread_name: "binder:7309_6"
@@ -4564,7 +4564,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.270404
-      estimated_mw: 0.068933
+      estimated_mw: 0.068896
       idle_transitions_mws: 0.001294
       total_mws: 0.271698
       thread_name: "Jit thread pool"
@@ -4574,7 +4574,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.241841
-      estimated_mw: 0.061651
+      estimated_mw: 0.061619
       idle_transitions_mws: 0.001656
       total_mws: 0.243496
       thread_name: "droid.apps.maps"
@@ -4584,7 +4584,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.232584
-      estimated_mw: 0.059292
+      estimated_mw: 0.059260
       idle_transitions_mws: 0.223822
       total_mws: 0.456406
       thread_name: "perf_mon_update"
@@ -4594,7 +4594,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.205438
-      estimated_mw: 0.052371
+      estimated_mw: 0.052344
       idle_transitions_mws: 0.033086
       total_mws: 0.238524
       thread_name: "vsync"
@@ -4604,7 +4604,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.203994
-      estimated_mw: 0.052003
+      estimated_mw: 0.051976
       idle_transitions_mws: 0.009086
       total_mws: 0.213080
       thread_name: "logd.reader.per"
@@ -4614,7 +4614,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.201298
-      estimated_mw: 0.051316
+      estimated_mw: 0.051289
       idle_transitions_mws: 0.038341
       total_mws: 0.239639
       thread_name: "adpf_handler0"
@@ -4624,7 +4624,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.189910
-      estimated_mw: 0.048413
+      estimated_mw: 0.048387
       idle_transitions_mws: 0.000000
       total_mws: 0.189910
       thread_name: "NodeLooperThrea"
@@ -4634,7 +4634,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.177258
-      estimated_mw: 0.045187
+      estimated_mw: 0.045164
       idle_transitions_mws: 0.016272
       total_mws: 0.193530
       thread_name: "HwBinder:578_1"
@@ -4644,7 +4644,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.164429
-      estimated_mw: 0.041917
+      estimated_mw: 0.041895
       idle_transitions_mws: 0.010174
       total_mws: 0.174602
       thread_name: "TracingMuxer"
@@ -4654,7 +4654,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.161933
-      estimated_mw: 0.041281
+      estimated_mw: 0.041259
       idle_transitions_mws: 0.001961
       total_mws: 0.163894
       thread_name: "main"
@@ -4664,7 +4664,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.159240
-      estimated_mw: 0.040594
+      estimated_mw: 0.040573
       idle_transitions_mws: 0.000000
       total_mws: 0.159240
       thread_name: "kworker/3:3H"
@@ -4674,7 +4674,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.152760
-      estimated_mw: 0.038942
+      estimated_mw: 0.038922
       idle_transitions_mws: 0.006517
       total_mws: 0.159277
       thread_name: "statsd.reader"
@@ -4684,7 +4684,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.149836
-      estimated_mw: 0.038197
+      estimated_mw: 0.038177
       idle_transitions_mws: 0.005029
       total_mws: 0.154866
       thread_name: "Background_17"
@@ -4694,7 +4694,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.138264
-      estimated_mw: 0.035247
+      estimated_mw: 0.035228
       idle_transitions_mws: 0.004283
       total_mws: 0.142547
       thread_name: "statsd.writer"
@@ -4704,7 +4704,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.132288
-      estimated_mw: 0.033724
+      estimated_mw: 0.033706
       idle_transitions_mws: 0.028129
       total_mws: 0.160417
       thread_name: "RegSampIdle"
@@ -4714,7 +4714,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.114687
-      estimated_mw: 0.029237
+      estimated_mw: 0.029221
       idle_transitions_mws: 0.000000
       total_mws: 0.114687
       thread_name: "migration/3"
@@ -4724,7 +4724,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.111031
-      estimated_mw: 0.028305
+      estimated_mw: 0.028290
       idle_transitions_mws: 0.000000
       total_mws: 0.111031
       thread_name: "heapprofd"
@@ -4734,7 +4734,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.108152
-      estimated_mw: 0.027571
+      estimated_mw: 0.027556
       idle_transitions_mws: 0.022336
       total_mws: 0.130488
       thread_name: "android.hardwar"
@@ -4744,7 +4744,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.102656
-      estimated_mw: 0.026170
+      estimated_mw: 0.026156
       idle_transitions_mws: 0.000000
       total_mws: 0.102656
       thread_name: "migration/0"
@@ -4754,7 +4754,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.091369
-      estimated_mw: 0.023292
+      estimated_mw: 0.023280
       idle_transitions_mws: 0.063324
       total_mws: 0.154694
       thread_name: "mali-mem-purge"
@@ -4764,7 +4764,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.088625
-      estimated_mw: 0.022593
+      estimated_mw: 0.022581
       idle_transitions_mws: 0.090680
       total_mws: 0.179305
       thread_name: "mali-mem-purge"
@@ -4774,7 +4774,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.087351
-      estimated_mw: 0.022268
+      estimated_mw: 0.022256
       idle_transitions_mws: 0.032640
       total_mws: 0.119991
       thread_name: "surfaceflinger"
@@ -4784,7 +4784,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084905
-      estimated_mw: 0.021644
+      estimated_mw: 0.021633
       idle_transitions_mws: 0.006671
       total_mws: 0.091575
       thread_name: "SensorService"
@@ -4794,7 +4794,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084199
-      estimated_mw: 0.021464
+      estimated_mw: 0.021453
       idle_transitions_mws: 0.008253
       total_mws: 0.092452
       thread_name: "-Executor] idle"
@@ -4803,7 +4803,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.077161
-      estimated_mw: 0.019670
+      estimated_mw: 0.019660
       idle_transitions_mws: 0.000000
       total_mws: 0.077161
       thread_name: "-Executor] idle"
@@ -4812,7 +4812,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.071234
-      estimated_mw: 0.018159
+      estimated_mw: 0.018150
       idle_transitions_mws: 0.012328
       total_mws: 0.083563
       thread_name: "queued-work-loo"
@@ -4822,7 +4822,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.068262
-      estimated_mw: 0.017402
+      estimated_mw: 0.017392
       idle_transitions_mws: 0.003502
       total_mws: 0.071763
       thread_name: "android.hardwar"
@@ -4832,7 +4832,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.061241
-      estimated_mw: 0.015612
+      estimated_mw: 0.015604
       idle_transitions_mws: 0.000000
       total_mws: 0.061241
       thread_name: "TouchTimer"
@@ -4842,7 +4842,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.059074
-      estimated_mw: 0.015059
+      estimated_mw: 0.015051
       idle_transitions_mws: 0.007234
       total_mws: 0.066308
       thread_name: "UsfTransport"
@@ -4852,7 +4852,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.058859
-      estimated_mw: 0.015005
+      estimated_mw: 0.014997
       idle_transitions_mws: 0.013913
       total_mws: 0.072772
       thread_name: "kworker/2:1"
@@ -4862,7 +4862,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.057819
-      estimated_mw: 0.014740
+      estimated_mw: 0.014732
       idle_transitions_mws: 0.002076
       total_mws: 0.059896
       thread_name: "-Executor] idle"
@@ -4871,7 +4871,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.056811
-      estimated_mw: 0.014483
+      estimated_mw: 0.014475
       idle_transitions_mws: 0.000000
       total_mws: 0.056811
       thread_name: "migration/1"
@@ -4881,7 +4881,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.051664
-      estimated_mw: 0.013170
+      estimated_mw: 0.013164
       idle_transitions_mws: 0.005213
       total_mws: 0.056877
       thread_name: "ScreenDecoratio"
@@ -4891,7 +4891,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.051403
-      estimated_mw: 0.013104
+      estimated_mw: 0.013097
       idle_transitions_mws: 0.064089
       total_mws: 0.115492
       thread_name: "psimon"
@@ -4901,7 +4901,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.051090
-      estimated_mw: 0.013024
+      estimated_mw: 0.013017
       idle_transitions_mws: 0.011517
       total_mws: 0.062607
       thread_name: "kworker/3:12"
@@ -4911,7 +4911,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.050942
-      estimated_mw: 0.012986
+      estimated_mw: 0.012980
       idle_transitions_mws: 0.004026
       total_mws: 0.054968
       thread_name: "-Executor] idle"
@@ -4920,7 +4920,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.049289
-      estimated_mw: 0.012565
+      estimated_mw: 0.012559
       idle_transitions_mws: 0.000000
       total_mws: 0.049289
       thread_name: "migration/2"
@@ -4930,7 +4930,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.047770
-      estimated_mw: 0.012178
+      estimated_mw: 0.012171
       idle_transitions_mws: 0.005397
       total_mws: 0.053167
       thread_name: "eduling.default"
@@ -4940,7 +4940,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.043262
-      estimated_mw: 0.011029
+      estimated_mw: 0.011023
       idle_transitions_mws: 0.004228
       total_mws: 0.047490
       thread_name: "-Executor] idle"
@@ -4949,7 +4949,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.038018
-      estimated_mw: 0.009692
+      estimated_mw: 0.009687
       idle_transitions_mws: 0.001732
       total_mws: 0.039750
       thread_name: "BroadcastRunnin"
@@ -4959,7 +4959,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.037081
-      estimated_mw: 0.009453
+      estimated_mw: 0.009448
       idle_transitions_mws: 0.014265
       total_mws: 0.051346
       thread_name: "-Executor] idle"
@@ -4968,7 +4968,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.034452
-      estimated_mw: 0.008783
+      estimated_mw: 0.008778
       idle_transitions_mws: 0.007819
       total_mws: 0.042271
       thread_name: "RE Completion"
@@ -4978,7 +4978,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.034110
-      estimated_mw: 0.008696
+      estimated_mw: 0.008691
       idle_transitions_mws: 0.001921
       total_mws: 0.036031
       thread_name: "binder:15865_1"
@@ -4988,7 +4988,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.033181
-      estimated_mw: 0.008459
+      estimated_mw: 0.008454
       idle_transitions_mws: 0.000000
       total_mws: 0.033181
       thread_name: "RxSchedulerPurg"
@@ -4998,7 +4998,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.031927
-      estimated_mw: 0.008139
+      estimated_mw: 0.008135
       idle_transitions_mws: 0.049831
       total_mws: 0.081758
       thread_name: "com.google.usf."
@@ -5008,7 +5008,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.029733
-      estimated_mw: 0.007580
+      estimated_mw: 0.007576
       idle_transitions_mws: 0.002042
       total_mws: 0.031775
       thread_name: "android.hardwar"
@@ -5018,7 +5018,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.027352
-      estimated_mw: 0.006973
+      estimated_mw: 0.006969
       idle_transitions_mws: 0.000921
       total_mws: 0.028273
       thread_name: "simpleinteracti"
@@ -5028,7 +5028,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.023126
-      estimated_mw: 0.005895
+      estimated_mw: 0.005892
       idle_transitions_mws: 0.003350
       total_mws: 0.026476
       thread_name: "otp-aiai-notifi"
@@ -5037,7 +5037,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.022468
-      estimated_mw: 0.005728
+      estimated_mw: 0.005725
       idle_transitions_mws: 0.003576
       total_mws: 0.026044
       thread_name: "binder:15865_3"
@@ -5047,7 +5047,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.022384
-      estimated_mw: 0.005706
+      estimated_mw: 0.005703
       idle_transitions_mws: 0.003920
       total_mws: 0.026304
       thread_name: "-Executor] idle"
@@ -5056,7 +5056,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.020308
-      estimated_mw: 0.005177
+      estimated_mw: 0.005174
       idle_transitions_mws: 0.000000
       total_mws: 0.020308
       thread_name: "android.hardwar"
@@ -5066,7 +5066,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019427
-      estimated_mw: 0.004952
+      estimated_mw: 0.004950
       idle_transitions_mws: 0.000000
       total_mws: 0.019427
       thread_name: "GoogleApiHandle"
@@ -5076,7 +5076,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019117
-      estimated_mw: 0.004873
+      estimated_mw: 0.004871
       idle_transitions_mws: 0.000000
       total_mws: 0.019117
       thread_name: "migration/5"
@@ -5086,7 +5086,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019070
-      estimated_mw: 0.004861
+      estimated_mw: 0.004859
       idle_transitions_mws: 0.003087
       total_mws: 0.022157
       thread_name: "-Executor] idle"
@@ -5095,7 +5095,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.019025
-      estimated_mw: 0.004850
+      estimated_mw: 0.004847
       idle_transitions_mws: 0.006383
       total_mws: 0.025408
       thread_name: "UsfHalWorker"
@@ -5105,7 +5105,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.018090
-      estimated_mw: 0.004612
+      estimated_mw: 0.004609
       idle_transitions_mws: 0.002281
       total_mws: 0.020372
       thread_name: "kworker/5:3H"
@@ -5115,7 +5115,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.017385
-      estimated_mw: 0.004432
+      estimated_mw: 0.004429
       idle_transitions_mws: 0.000000
       total_mws: 0.017385
       thread_name: "kworker/6:7H"
@@ -5125,7 +5125,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.017028
-      estimated_mw: 0.004341
+      estimated_mw: 0.004339
       idle_transitions_mws: 0.028344
       total_mws: 0.045372
       thread_name: "kworker/6:0"
@@ -5135,7 +5135,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.015576
-      estimated_mw: 0.003971
+      estimated_mw: 0.003969
       idle_transitions_mws: 0.003187
       total_mws: 0.018763
       thread_name: "kworker/5:33"
@@ -5145,7 +5145,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014807
-      estimated_mw: 0.003775
+      estimated_mw: 0.003773
       idle_transitions_mws: 0.000000
       total_mws: 0.014807
       thread_name: "DefaultDispatch"
@@ -5155,7 +5155,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014612
-      estimated_mw: 0.003725
+      estimated_mw: 0.003723
       idle_transitions_mws: 0.000000
       total_mws: 0.014612
       thread_name: "lhd"
@@ -5165,7 +5165,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013996
-      estimated_mw: 0.003568
+      estimated_mw: 0.003566
       idle_transitions_mws: 0.002338
       total_mws: 0.016334
       thread_name: "system_server"
@@ -5175,7 +5175,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013689
-      estimated_mw: 0.003490
+      estimated_mw: 0.003488
       idle_transitions_mws: 0.000000
       total_mws: 0.013689
       thread_name: "RxSchedulerPurg"
@@ -5185,7 +5185,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013150
-      estimated_mw: 0.003352
+      estimated_mw: 0.003350
       idle_transitions_mws: 0.003143
       total_mws: 0.016292
       thread_name: "-Executor] idle"
@@ -5194,7 +5194,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013125
-      estimated_mw: 0.003346
+      estimated_mw: 0.003344
       idle_transitions_mws: 0.000000
       total_mws: 0.013125
       thread_name: "DefaultDispatch"
@@ -5204,7 +5204,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012955
-      estimated_mw: 0.003303
+      estimated_mw: 0.003301
       idle_transitions_mws: 0.000000
       total_mws: 0.012955
       thread_name: "migration/4"
@@ -5214,7 +5214,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012324
-      estimated_mw: 0.003142
+      estimated_mw: 0.003140
       idle_transitions_mws: 0.000000
       total_mws: 0.012324
       thread_name: "RxCachedWorkerP"
@@ -5224,7 +5224,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012290
-      estimated_mw: 0.003133
+      estimated_mw: 0.003131
       idle_transitions_mws: 0.000000
       total_mws: 0.012290
       thread_name: "-Executor] idle"
@@ -5234,7 +5234,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.011181
-      estimated_mw: 0.002850
+      estimated_mw: 0.002849
       idle_transitions_mws: 0.159340
       total_mws: 0.170521
       thread_name: "binder:15865_4"
@@ -5244,7 +5244,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.011101
-      estimated_mw: 0.002830
+      estimated_mw: 0.002829
       idle_transitions_mws: 0.000000
       total_mws: 0.011101
       thread_name: "DefaultDispatch"
@@ -5254,7 +5254,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.010968
-      estimated_mw: 0.002796
+      estimated_mw: 0.002795
       idle_transitions_mws: 0.000000
       total_mws: 0.010968
       thread_name: "DefaultDispatch"
@@ -5264,7 +5264,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.009375
-      estimated_mw: 0.002390
+      estimated_mw: 0.002389
       idle_transitions_mws: 0.002434
       total_mws: 0.011809
       thread_name: "RxCachedWorkerP"
@@ -5274,7 +5274,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008952
-      estimated_mw: 0.002282
+      estimated_mw: 0.002281
       idle_transitions_mws: 0.000000
       total_mws: 0.008952
       thread_name: "DefaultDispatch"
@@ -5284,7 +5284,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008763
-      estimated_mw: 0.002234
+      estimated_mw: 0.002233
       idle_transitions_mws: 0.001547
       total_mws: 0.010310
       thread_name: "DefaultDispatch"
@@ -5294,7 +5294,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008158
-      estimated_mw: 0.002080
+      estimated_mw: 0.002079
       idle_transitions_mws: 0.000000
       total_mws: 0.008158
       thread_name: "IdleTimer"
@@ -5304,7 +5304,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006398
-      estimated_mw: 0.001631
+      estimated_mw: 0.001630
       idle_transitions_mws: 0.015290
       total_mws: 0.021688
       thread_name: "kworker/0:2"
@@ -5314,7 +5314,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006367
-      estimated_mw: 0.001623
+      estimated_mw: 0.001622
       idle_transitions_mws: 0.005399
       total_mws: 0.011766
       thread_name: "GpsdWatchDog"
@@ -5324,7 +5324,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.006244
-      estimated_mw: 0.001592
+      estimated_mw: 0.001591
       idle_transitions_mws: 0.003325
       total_mws: 0.009570
       thread_name: "binder:1423_20"
@@ -5334,7 +5334,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.005897
-      estimated_mw: 0.001503
+      estimated_mw: 0.001502
       idle_transitions_mws: 0.000000
       total_mws: 0.005897
       thread_name: "kworker/1:1H"
@@ -5354,7 +5354,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004890
-      estimated_mw: 0.001247
+      estimated_mw: 0.001246
       idle_transitions_mws: 0.004577
       total_mws: 0.009467
       thread_name: "-Executor] idle"
@@ -5364,7 +5364,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004727
-      estimated_mw: 0.001205
+      estimated_mw: 0.001204
       idle_transitions_mws: 0.000000
       total_mws: 0.004727
       thread_name: "f2fs_discard-25"
@@ -5374,7 +5374,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004593
-      estimated_mw: 0.001171
+      estimated_mw: 0.001170
       idle_transitions_mws: 0.002459
       total_mws: 0.007052
       thread_name: "kworker/7:5"
@@ -5394,7 +5394,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.004244
-      estimated_mw: 0.001082
+      estimated_mw: 0.001081
       idle_transitions_mws: 0.000000
       total_mws: 0.004244
       thread_name: "ksoftirqd/0"
@@ -5424,7 +5424,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.003361
-      estimated_mw: 0.000857
+      estimated_mw: 0.000856
       idle_transitions_mws: 0.001746
       total_mws: 0.005108
       thread_name: "DefaultDispatch"
@@ -5434,7 +5434,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.003318
-      estimated_mw: 0.000846
+      estimated_mw: 0.000845
       idle_transitions_mws: 0.013897
       total_mws: 0.017214
       thread_name: "kworker/1:1"
@@ -5468,7 +5468,7 @@ wattson_atrace_apps_threads {
     period_name: "NOTIFICATION_SHADE_QS_EXPAND_COLLAPSE"
     task_info {
       estimated_mws: 214.173737
-      estimated_mw: 54.598274
+      estimated_mw: 54.569530
       idle_transitions_mws: 4.704501
       total_mws: 218.878235
       thread_name: "RenderThread"
@@ -5478,7 +5478,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 197.375793
-      estimated_mw: 50.316059
+      estimated_mw: 50.289570
       idle_transitions_mws: 2.544069
       total_mws: 199.919876
       thread_name: "ndroid.systemui"
@@ -5488,7 +5488,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 105.466507
-      estimated_mw: 26.886065
+      estimated_mw: 26.871912
       idle_transitions_mws: -26.366659
       total_mws: 79.099846
       thread_name: "swapper"
@@ -5498,7 +5498,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 35.544174
-      estimated_mw: 9.061104
+      estimated_mw: 9.056335
       idle_transitions_mws: 0.169810
       total_mws: 35.713985
       thread_name: "surfaceflinger"
@@ -5508,7 +5508,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 17.197294
-      estimated_mw: 4.384023
+      estimated_mw: 4.381715
       idle_transitions_mws: 0.000881
       total_mws: 17.198175
       thread_name: "binder:581_2"
@@ -5518,7 +5518,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 12.747731
-      estimated_mw: 3.249717
+      estimated_mw: 3.248007
       idle_transitions_mws: 2.993788
       total_mws: 15.741520
       thread_name: "mali_jd_thread"
@@ -5528,7 +5528,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 11.927473
-      estimated_mw: 3.040613
+      estimated_mw: 3.039012
       idle_transitions_mws: 1.160018
       total_mws: 13.087491
       thread_name: "mali-cmar-backe"
@@ -5538,7 +5538,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 10.639238
-      estimated_mw: 2.712209
+      estimated_mw: 2.710782
       idle_transitions_mws: 0.001341
       total_mws: 10.640579
       thread_name: "traced_probes"
@@ -5548,7 +5548,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 6.725314
-      estimated_mw: 1.714452
+      estimated_mw: 1.713549
       idle_transitions_mws: 0.839243
       total_mws: 7.564557
       thread_name: "binder:578_5"
@@ -5558,7 +5558,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.879081
-      estimated_mw: 1.498726
+      estimated_mw: 1.497937
       idle_transitions_mws: 1.205528
       total_mws: 7.084609
       thread_name: "TimerDispatch"
@@ -5568,7 +5568,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.632726
-      estimated_mw: 1.435924
+      estimated_mw: 1.435168
       idle_transitions_mws: 0.214282
       total_mws: 5.847008
       thread_name: "s.nexuslauncher"
@@ -5578,7 +5578,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 5.088638
-      estimated_mw: 1.297222
+      estimated_mw: 1.296539
       idle_transitions_mws: 0.178397
       total_mws: 5.267035
       thread_name: "binder:1423_1E"
@@ -5588,7 +5588,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.945695
-      estimated_mw: 1.260782
+      estimated_mw: 1.260118
       idle_transitions_mws: 0.833182
       total_mws: 5.778877
       thread_name: "decon0_kthread"
@@ -5598,7 +5598,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.779517
-      estimated_mw: 1.218419
+      estimated_mw: 1.217778
       idle_transitions_mws: 0.128440
       total_mws: 4.907957
       thread_name: "InputDispatcher"
@@ -5608,7 +5608,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.327768
-      estimated_mw: 1.103257
+      estimated_mw: 1.102676
       idle_transitions_mws: 0.422247
       total_mws: 4.750015
       thread_name: "binder:15865_6"
@@ -5618,7 +5618,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.234480
-      estimated_mw: 1.079475
+      estimated_mw: 1.078907
       idle_transitions_mws: 0.301274
       total_mws: 4.535754
       thread_name: "binder:15865_7"
@@ -5628,7 +5628,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 4.050001
-      estimated_mw: 1.032447
+      estimated_mw: 1.031904
       idle_transitions_mws: 0.152912
       total_mws: 4.202913
       thread_name: "android.hardwar"
@@ -5638,7 +5638,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.672807
-      estimated_mw: 0.936291
+      estimated_mw: 0.935798
       idle_transitions_mws: 0.092040
       total_mws: 3.764847
       thread_name: "RenderEngine"
@@ -5648,7 +5648,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.426552
-      estimated_mw: 0.873514
+      estimated_mw: 0.873054
       idle_transitions_mws: 0.185621
       total_mws: 3.612173
       thread_name: "app"
@@ -5658,7 +5658,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.343877
-      estimated_mw: 0.852438
+      estimated_mw: 0.851990
       idle_transitions_mws: 0.179517
       total_mws: 3.523394
       thread_name: "binder:1423_5"
@@ -5668,7 +5668,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.125882
-      estimated_mw: 0.796866
+      estimated_mw: 0.796446
       idle_transitions_mws: 0.203438
       total_mws: 3.329320
       thread_name: "kworker/u17:0"
@@ -5678,7 +5678,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.079918
-      estimated_mw: 0.785149
+      estimated_mw: 0.784735
       idle_transitions_mws: 0.488750
       total_mws: 3.568667
       thread_name: "BckgrndExec HP"
@@ -5688,7 +5688,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 3.034196
-      estimated_mw: 0.773493
+      estimated_mw: 0.773086
       idle_transitions_mws: 0.084653
       total_mws: 3.118849
       thread_name: "kworker/u16:0"
@@ -5698,7 +5698,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.802860
-      estimated_mw: 0.714520
+      estimated_mw: 0.714144
       idle_transitions_mws: 0.248476
       total_mws: 3.051337
       thread_name: "binder:578_4"
@@ -5708,7 +5708,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.321190
-      estimated_mw: 0.591730
+      estimated_mw: 0.591418
       idle_transitions_mws: 0.862690
       total_mws: 3.183880
       thread_name: "sugov:0"
@@ -5718,7 +5718,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.278841
-      estimated_mw: 0.580934
+      estimated_mw: 0.580628
       idle_transitions_mws: 0.215383
       total_mws: 2.494224
       thread_name: "binder:8021_3"
@@ -5728,7 +5728,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 2.111137
-      estimated_mw: 0.538182
+      estimated_mw: 0.537899
       idle_transitions_mws: 0.008546
       total_mws: 2.119683
       thread_name: "Jit thread pool"
@@ -5738,7 +5738,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.982057
-      estimated_mw: 0.505276
+      estimated_mw: 0.505010
       idle_transitions_mws: 0.085102
       total_mws: 2.067159
       thread_name: "binder:1423_D"
@@ -5748,7 +5748,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.829627
-      estimated_mw: 0.466418
+      estimated_mw: 0.466172
       idle_transitions_mws: 0.000000
       total_mws: 1.829627
       thread_name: "traced"
@@ -5758,7 +5758,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.712972
-      estimated_mw: 0.436680
+      estimated_mw: 0.436450
       idle_transitions_mws: 0.002095
       total_mws: 1.715067
       thread_name: "mali-compiler"
@@ -5768,7 +5768,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.590401
-      estimated_mw: 0.405433
+      estimated_mw: 0.405220
       idle_transitions_mws: 0.330927
       total_mws: 1.921329
       thread_name: "SystemUIBg-8"
@@ -5778,7 +5778,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.581537
-      estimated_mw: 0.403174
+      estimated_mw: 0.402961
       idle_transitions_mws: 0.101478
       total_mws: 1.683016
       thread_name: "roidJUnitRunner"
@@ -5788,7 +5788,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.580886
-      estimated_mw: 0.403008
+      estimated_mw: 0.402795
       idle_transitions_mws: 0.551884
       total_mws: 2.132769
       thread_name: "sugov:4"
@@ -5798,7 +5798,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.495272
-      estimated_mw: 0.381183
+      estimated_mw: 0.380982
       idle_transitions_mws: 0.034705
       total_mws: 1.529977
       thread_name: "binder:7292_4"
@@ -5808,7 +5808,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.476052
-      estimated_mw: 0.376283
+      estimated_mw: 0.376085
       idle_transitions_mws: 1.094565
       total_mws: 2.570617
       thread_name: "GPU completion"
@@ -5818,7 +5818,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.404948
-      estimated_mw: 0.358157
+      estimated_mw: 0.357968
       idle_transitions_mws: 0.401791
       total_mws: 1.806739
       thread_name: "SystemUIBg-1"
@@ -5828,7 +5828,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.402405
-      estimated_mw: 0.357508
+      estimated_mw: 0.357320
       idle_transitions_mws: 0.004212
       total_mws: 1.406617
       thread_name: "android.ui"
@@ -5838,7 +5838,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.352848
-      estimated_mw: 0.344875
+      estimated_mw: 0.344693
       idle_transitions_mws: 0.143022
       total_mws: 1.495870
       thread_name: "surfaceflinger"
@@ -5848,7 +5848,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.327123
-      estimated_mw: 0.338317
+      estimated_mw: 0.338139
       idle_transitions_mws: 0.293497
       total_mws: 1.620620
       thread_name: "SystemUIBg-2"
@@ -5858,7 +5858,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.222534
-      estimated_mw: 0.311655
+      estimated_mw: 0.311491
       idle_transitions_mws: 0.385088
       total_mws: 1.607622
       thread_name: "sugov:6"
@@ -5868,7 +5868,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.191472
-      estimated_mw: 0.303736
+      estimated_mw: 0.303576
       idle_transitions_mws: 0.293872
       total_mws: 1.485344
       thread_name: "SystemUIBg-4"
@@ -5878,7 +5878,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.139364
-      estimated_mw: 0.290453
+      estimated_mw: 0.290300
       idle_transitions_mws: 0.363230
       total_mws: 1.502594
       thread_name: "SystemUIBg-7"
@@ -5888,7 +5888,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.122272
-      estimated_mw: 0.286095
+      estimated_mw: 0.285945
       idle_transitions_mws: 0.031042
       total_mws: 1.153314
       thread_name: "RegionSampling"
@@ -5898,7 +5898,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.121161
-      estimated_mw: 0.285812
+      estimated_mw: 0.285662
       idle_transitions_mws: 0.292494
       total_mws: 1.413655
       thread_name: "SystemUIBg-6"
@@ -5908,7 +5908,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 1.105598
-      estimated_mw: 0.281845
+      estimated_mw: 0.281696
       idle_transitions_mws: 0.320302
       total_mws: 1.425900
       thread_name: "DisplayHints"
@@ -5918,7 +5918,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.972906
-      estimated_mw: 0.248018
+      estimated_mw: 0.247888
       idle_transitions_mws: 0.223148
       total_mws: 1.196054
       thread_name: "SystemUIBg-5"
@@ -5928,7 +5928,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.969671
-      estimated_mw: 0.247194
+      estimated_mw: 0.247063
       idle_transitions_mws: 0.139178
       total_mws: 1.108849
       thread_name: "wmshell.main"
@@ -5938,7 +5938,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.951728
-      estimated_mw: 0.242619
+      estimated_mw: 0.242492
       idle_transitions_mws: 0.249450
       total_mws: 1.201179
       thread_name: "SystemUIBg-3"
@@ -5948,7 +5948,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.912757
-      estimated_mw: 0.232685
+      estimated_mw: 0.232562
       idle_transitions_mws: 0.006823
       total_mws: 0.919580
       thread_name: "stack-unwinding"
@@ -5958,7 +5958,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.859854
-      estimated_mw: 0.219199
+      estimated_mw: 0.219083
       idle_transitions_mws: 0.672885
       total_mws: 1.532740
       thread_name: "HWC release"
@@ -5968,7 +5968,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.799569
-      estimated_mw: 0.203830
+      estimated_mw: 0.203723
       idle_transitions_mws: 0.053828
       total_mws: 0.853398
       thread_name: "system_server"
@@ -5978,7 +5978,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.688229
-      estimated_mw: 0.175447
+      estimated_mw: 0.175354
       idle_transitions_mws: 0.028179
       total_mws: 0.716408
       thread_name: "traced_perf"
@@ -5988,7 +5988,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.638692
-      estimated_mw: 0.162819
+      estimated_mw: 0.162733
       idle_transitions_mws: 0.079790
       total_mws: 0.718482
       thread_name: "BckgrndExec LP"
@@ -5998,7 +5998,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.574267
-      estimated_mw: 0.146395
+      estimated_mw: 0.146318
       idle_transitions_mws: 0.277560
       total_mws: 0.851827
       thread_name: "binder:15865_2"
@@ -6008,7 +6008,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.484049
-      estimated_mw: 0.123396
+      estimated_mw: 0.123331
       idle_transitions_mws: 0.038063
       total_mws: 0.522113
       thread_name: "binder:7309_5"
@@ -6018,7 +6018,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.481119
-      estimated_mw: 0.122649
+      estimated_mw: 0.122585
       idle_transitions_mws: 0.011302
       total_mws: 0.492421
       thread_name: "SysUiBg"
@@ -6028,7 +6028,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.478735
-      estimated_mw: 0.122042
+      estimated_mw: 0.121977
       idle_transitions_mws: 0.025871
       total_mws: 0.504606
       thread_name: "mali-cmar-backe"
@@ -6038,7 +6038,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.324511
-      estimated_mw: 0.082726
+      estimated_mw: 0.082682
       idle_transitions_mws: 0.007210
       total_mws: 0.331721
       thread_name: "TelecomMetricsC"
@@ -6048,7 +6048,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.323233
-      estimated_mw: 0.082400
+      estimated_mw: 0.082357
       idle_transitions_mws: 0.029109
       total_mws: 0.352342
       thread_name: "UiAutomation"
@@ -6058,7 +6058,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.312723
-      estimated_mw: 0.079721
+      estimated_mw: 0.079679
       idle_transitions_mws: 0.066640
       total_mws: 0.379363
       thread_name: "InputTracer"
@@ -6068,7 +6068,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.246190
-      estimated_mw: 0.062760
+      estimated_mw: 0.062727
       idle_transitions_mws: 0.016394
       total_mws: 0.262584
       thread_name: "TracingMuxer"
@@ -6078,7 +6078,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.240514
-      estimated_mw: 0.061313
+      estimated_mw: 0.061281
       idle_transitions_mws: 0.207098
       total_mws: 0.447613
       thread_name: "perf_mon_update"
@@ -6088,7 +6088,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.239018
-      estimated_mw: 0.060932
+      estimated_mw: 0.060900
       idle_transitions_mws: 0.069143
       total_mws: 0.308161
       thread_name: "mali_apc_thread"
@@ -6098,7 +6098,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.207460
-      estimated_mw: 0.052887
+      estimated_mw: 0.052859
       idle_transitions_mws: 0.000000
       total_mws: 0.207460
       thread_name: "android.hardwar"
@@ -6108,7 +6108,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.191767
-      estimated_mw: 0.048886
+      estimated_mw: 0.048860
       idle_transitions_mws: 0.015502
       total_mws: 0.207268
       thread_name: "vsync"
@@ -6118,7 +6118,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.183813
-      estimated_mw: 0.046858
+      estimated_mw: 0.046834
       idle_transitions_mws: 0.011727
       total_mws: 0.195540
       thread_name: "android.display"
@@ -6128,7 +6128,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.181545
-      estimated_mw: 0.046280
+      estimated_mw: 0.046256
       idle_transitions_mws: 0.042261
       total_mws: 0.223806
       thread_name: "m.test.scenario"
@@ -6138,7 +6138,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.176922
-      estimated_mw: 0.045102
+      estimated_mw: 0.045078
       idle_transitions_mws: 0.015713
       total_mws: 0.192635
       thread_name: "StateService"
@@ -6148,7 +6148,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.175924
-      estimated_mw: 0.044847
+      estimated_mw: 0.044824
       idle_transitions_mws: 0.036154
       total_mws: 0.212078
       thread_name: "NetworkPolicy"
@@ -6158,7 +6158,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.168071
-      estimated_mw: 0.042846
+      estimated_mw: 0.042823
       idle_transitions_mws: 0.027057
       total_mws: 0.195128
       thread_name: "SensorService"
@@ -6168,7 +6168,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.167810
-      estimated_mw: 0.042779
+      estimated_mw: 0.042757
       idle_transitions_mws: 0.027300
       total_mws: 0.195111
       thread_name: "android.hardwar"
@@ -6178,7 +6178,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.160484
-      estimated_mw: 0.040911
+      estimated_mw: 0.040890
       idle_transitions_mws: 0.000000
       total_mws: 0.160484
       thread_name: "logcat"
@@ -6188,7 +6188,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.158435
-      estimated_mw: 0.040389
+      estimated_mw: 0.040368
       idle_transitions_mws: 0.109778
       total_mws: 0.268213
       thread_name: "UsfTransport"
@@ -6198,7 +6198,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.146738
-      estimated_mw: 0.037407
+      estimated_mw: 0.037387
       idle_transitions_mws: 0.032827
       total_mws: 0.179565
       thread_name: "RE Completion"
@@ -6208,7 +6208,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.143858
-      estimated_mw: 0.036673
+      estimated_mw: 0.036654
       idle_transitions_mws: 0.002084
       total_mws: 0.145942
       thread_name: "logd.writer"
@@ -6218,7 +6218,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.141028
-      estimated_mw: 0.035952
+      estimated_mw: 0.035933
       idle_transitions_mws: 0.016135
       total_mws: 0.157163
       thread_name: "queued-work-loo"
@@ -6228,7 +6228,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.138227
-      estimated_mw: 0.035238
+      estimated_mw: 0.035219
       idle_transitions_mws: 0.010068
       total_mws: 0.148295
       thread_name: "binder:2380_1"
@@ -6238,7 +6238,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.137644
-      estimated_mw: 0.035089
+      estimated_mw: 0.035070
       idle_transitions_mws: 0.001887
       total_mws: 0.139530
       thread_name: "BG Thread #0"
@@ -6248,7 +6248,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.131759
-      estimated_mw: 0.033589
+      estimated_mw: 0.033571
       idle_transitions_mws: 0.005395
       total_mws: 0.137154
       thread_name: "statsd.writer"
@@ -6258,7 +6258,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.128342
-      estimated_mw: 0.032718
+      estimated_mw: 0.032700
       idle_transitions_mws: 0.086893
       total_mws: 0.215235
       thread_name: "com.google.usf."
@@ -6268,7 +6268,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.125158
-      estimated_mw: 0.031906
+      estimated_mw: 0.031889
       idle_transitions_mws: 0.009871
       total_mws: 0.135029
       thread_name: "adpf_handler0"
@@ -6278,7 +6278,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.119938
-      estimated_mw: 0.030575
+      estimated_mw: 0.030559
       idle_transitions_mws: 0.007516
       total_mws: 0.127454
       thread_name: "statsd.reader"
@@ -6288,7 +6288,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.108942
-      estimated_mw: 0.027772
+      estimated_mw: 0.027757
       idle_transitions_mws: 0.040663
       total_mws: 0.149605
       thread_name: "RegSampIdle"
@@ -6298,7 +6298,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.107226
-      estimated_mw: 0.027335
+      estimated_mw: 0.027320
       idle_transitions_mws: 0.008154
       total_mws: 0.115380
       thread_name: "HwBinder:578_1"
@@ -6308,7 +6308,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.100824
-      estimated_mw: 0.025703
+      estimated_mw: 0.025689
       idle_transitions_mws: 0.000000
       total_mws: 0.100824
       thread_name: "binder:5825_C"
@@ -6318,7 +6318,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.094869
-      estimated_mw: 0.024184
+      estimated_mw: 0.024172
       idle_transitions_mws: 0.009876
       total_mws: 0.104745
       thread_name: "batterystats-ha"
@@ -6328,7 +6328,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.091956
-      estimated_mw: 0.023442
+      estimated_mw: 0.023430
       idle_transitions_mws: 0.044297
       total_mws: 0.136253
       thread_name: "surfaceflinger"
@@ -6338,7 +6338,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.086083
-      estimated_mw: 0.021945
+      estimated_mw: 0.021933
       idle_transitions_mws: 0.045777
       total_mws: 0.131859
       thread_name: "mali-mem-purge"
@@ -6348,7 +6348,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.084972
-      estimated_mw: 0.021661
+      estimated_mw: 0.021650
       idle_transitions_mws: 0.000000
       total_mws: 0.084972
       thread_name: "rcuop/0"
@@ -6358,7 +6358,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.082966
-      estimated_mw: 0.021150
+      estimated_mw: 0.021139
       idle_transitions_mws: 0.121083
       total_mws: 0.204049
       thread_name: "mali-mem-purge"
@@ -6368,7 +6368,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.080994
-      estimated_mw: 0.020648
+      estimated_mw: 0.020637
       idle_transitions_mws: 0.013428
       total_mws: 0.094423
       thread_name: "PowerManagerSer"
@@ -6378,7 +6378,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.077395
-      estimated_mw: 0.019730
+      estimated_mw: 0.019720
       idle_transitions_mws: 0.003875
       total_mws: 0.081270
       thread_name: "migration/5"
@@ -6388,7 +6388,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.077355
-      estimated_mw: 0.019720
+      estimated_mw: 0.019709
       idle_transitions_mws: 0.027622
       total_mws: 0.104977
       thread_name: "NodeLooperThrea"
@@ -6398,7 +6398,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.068797
-      estimated_mw: 0.017538
+      estimated_mw: 0.017529
       idle_transitions_mws: 0.003383
       total_mws: 0.072180
       thread_name: "logd.reader.per"
@@ -6408,7 +6408,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.064020
-      estimated_mw: 0.016320
+      estimated_mw: 0.016312
       idle_transitions_mws: 0.033531
       total_mws: 0.097551
       thread_name: "UsfHalWorker"
@@ -6418,7 +6418,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.062769
-      estimated_mw: 0.016001
+      estimated_mw: 0.015993
       idle_transitions_mws: 0.000000
       total_mws: 0.062769
       thread_name: "RxSchedulerPurg"
@@ -6428,7 +6428,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.055253
-      estimated_mw: 0.014085
+      estimated_mw: 0.014078
       idle_transitions_mws: 0.004861
       total_mws: 0.060114
       thread_name: "TouchTimer"
@@ -6438,7 +6438,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.053773
-      estimated_mw: 0.013708
+      estimated_mw: 0.013701
       idle_transitions_mws: 0.000000
       total_mws: 0.053773
       thread_name: "rcuop/2"
@@ -6448,7 +6448,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.053545
-      estimated_mw: 0.013650
+      estimated_mw: 0.013643
       idle_transitions_mws: 0.008039
       total_mws: 0.061584
       thread_name: "android.hardwar"
@@ -6458,7 +6458,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.052824
-      estimated_mw: 0.013466
+      estimated_mw: 0.013459
       idle_transitions_mws: 0.000000
       total_mws: 0.052824
       thread_name: "migration/4"
@@ -6468,7 +6468,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.048480
-      estimated_mw: 0.012359
+      estimated_mw: 0.012352
       idle_transitions_mws: 0.001828
       total_mws: 0.050308
       thread_name: "BroadcastRunnin"
@@ -6478,7 +6478,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.047029
-      estimated_mw: 0.011989
+      estimated_mw: 0.011983
       idle_transitions_mws: 0.010203
       total_mws: 0.057232
       thread_name: "rcuog/0"
@@ -6488,7 +6488,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.046155
-      estimated_mw: 0.011766
+      estimated_mw: 0.011760
       idle_transitions_mws: 0.011323
       total_mws: 0.057478
       thread_name: "migration/3"
@@ -6498,7 +6498,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.045221
-      estimated_mw: 0.011528
+      estimated_mw: 0.011522
       idle_transitions_mws: 0.016679
       total_mws: 0.061900
       thread_name: "kworker/3:12"
@@ -6508,7 +6508,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.042764
-      estimated_mw: 0.010902
+      estimated_mw: 0.010896
       idle_transitions_mws: 0.000000
       total_mws: 0.042764
       thread_name: "migration/0"
@@ -6518,7 +6518,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.037096
-      estimated_mw: 0.009457
+      estimated_mw: 0.009452
       idle_transitions_mws: 0.002992
       total_mws: 0.040088
       thread_name: "Scheduler Threa"
@@ -6528,7 +6528,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.035010
-      estimated_mw: 0.008925
+      estimated_mw: 0.008920
       idle_transitions_mws: 0.000000
       total_mws: 0.035010
       thread_name: "BG Thread #1"
@@ -6538,7 +6538,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.034617
-      estimated_mw: 0.008825
+      estimated_mw: 0.008820
       idle_transitions_mws: 0.010964
       total_mws: 0.045580
       thread_name: "migration/2"
@@ -6548,7 +6548,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.033040
-      estimated_mw: 0.008423
+      estimated_mw: 0.008418
       idle_transitions_mws: 0.000000
       total_mws: 0.033040
       thread_name: "kworker/0:2"
@@ -6558,7 +6558,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.031045
-      estimated_mw: 0.007914
+      estimated_mw: 0.007910
       idle_transitions_mws: 0.002585
       total_mws: 0.033631
       thread_name: "ScreenDecoratio"
@@ -6568,7 +6568,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.028948
-      estimated_mw: 0.007380
+      estimated_mw: 0.007376
       idle_transitions_mws: 0.000000
       total_mws: 0.028948
       thread_name: "migration/1"
@@ -6578,7 +6578,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.027667
-      estimated_mw: 0.007053
+      estimated_mw: 0.007049
       idle_transitions_mws: 0.000000
       total_mws: 0.027667
       thread_name: "BG Thread #2"
@@ -6588,7 +6588,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.024507
-      estimated_mw: 0.006248
+      estimated_mw: 0.006244
       idle_transitions_mws: 0.003027
       total_mws: 0.027535
       thread_name: "system_server"
@@ -6598,7 +6598,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.023236
-      estimated_mw: 0.005923
+      estimated_mw: 0.005920
       idle_transitions_mws: 0.007415
       total_mws: 0.030651
       thread_name: "RxSchedulerPurg"
@@ -6608,7 +6608,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.017959
-      estimated_mw: 0.004578
+      estimated_mw: 0.004576
       idle_transitions_mws: 0.032022
       total_mws: 0.049980
       thread_name: "kworker/2:1"
@@ -6618,7 +6618,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.015647
-      estimated_mw: 0.003989
+      estimated_mw: 0.003987
       idle_transitions_mws: 0.025322
       total_mws: 0.040968
       thread_name: "kworker/4:3"
@@ -6628,7 +6628,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.014750
-      estimated_mw: 0.003760
+      estimated_mw: 0.003758
       idle_transitions_mws: 0.002760
       total_mws: 0.017510
       thread_name: "InteractionJank"
@@ -6638,7 +6638,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.013324
-      estimated_mw: 0.003397
+      estimated_mw: 0.003395
       idle_transitions_mws: 0.000000
       total_mws: 0.013324
       thread_name: "gle.android.gms"
@@ -6648,7 +6648,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.012413
-      estimated_mw: 0.003164
+      estimated_mw: 0.003163
       idle_transitions_mws: 0.007870
       total_mws: 0.020283
       thread_name: "rcu_preempt"
@@ -6658,7 +6658,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008817
-      estimated_mw: 0.002248
+      estimated_mw: 0.002246
       idle_transitions_mws: 0.004787
       total_mws: 0.013604
       thread_name: "binder:7309_6"
@@ -6668,7 +6668,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008487
-      estimated_mw: 0.002164
+      estimated_mw: 0.002162
       idle_transitions_mws: 0.004097
       total_mws: 0.012584
       thread_name: "kworker/7:5"
@@ -6678,7 +6678,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008153
-      estimated_mw: 0.002078
+      estimated_mw: 0.002077
       idle_transitions_mws: 0.030446
       total_mws: 0.038599
       thread_name: "migration/7"
@@ -6688,7 +6688,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.008152
-      estimated_mw: 0.002078
+      estimated_mw: 0.002077
       idle_transitions_mws: 0.000000
       total_mws: 0.008152
       thread_name: "migration/6"
@@ -6698,7 +6698,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.007198
-      estimated_mw: 0.001835
+      estimated_mw: 0.001834
       idle_transitions_mws: 0.001161
       total_mws: 0.008359
       thread_name: "hbox:interactor"
@@ -6708,7 +6708,7 @@ wattson_atrace_apps_threads {
     }
     task_info {
       estimated_mws: 0.005429
-      estimated_mw: 0.001384
+      estimated_mw: 0.001383
       idle_transitions_mws: 0.016815
       total_mws: 0.022244
       thread_name: "kworker/1:1"

--- a/test/trace_processor/diff_tests/stdlib/wattson/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/wattson/tests.py
@@ -267,7 +267,10 @@ class WattsonStdlib(TestSuite):
         trace=DataPath('wattson_dsu_pmu.pb'),
         query=("""
             INCLUDE PERFETTO MODULE wattson.estimates;
-              select * from _system_state_mw
+              SELECT
+                ts, dur, cpu0_mw, cpu1_mw, cpu2_mw, cpu3_mw, cpu4_mw, cpu5_mw,
+                cpu6_mw, cpu7_mw, dsu_scu_mw
+              FROM _system_state_mw
               WHERE ts > 359661672577
               ORDER by ts ASC
               LIMIT 10
@@ -387,7 +390,10 @@ class WattsonStdlib(TestSuite):
         trace=DataPath('wattson_tk4_pcmark.pb'),
         query=("""
             INCLUDE PERFETTO MODULE wattson.estimates;
-            SELECT * FROM _system_state_mw
+            SELECT
+               ts, dur, cpu0_mw, cpu1_mw, cpu2_mw, cpu3_mw, cpu4_mw, cpu5_mw,
+               cpu6_mw, cpu7_mw, dsu_scu_mw
+            FROM _system_state_mw
             WHERE ts > 4108586775197
             LIMIT 20
             """),

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -123,7 +123,7 @@ class GpuSubsystemEstimateTrack extends BaseCounterTrack {
   }
 
   getSqlSource() {
-    return `select ts, ${this.queryKey} as value from _gpu_estimates`;
+    return `select ts, ${this.queryKey} as value from _gpu_estimates_mw`;
   }
 }
 


### PR DESCRIPTION
Create a root estimates.sql that has the power estimates for all Wattson subsystems (e.g. CPU, GPU, etc.). This means moving the original CPU estimates into its own separate directory.

This change causes some inconsequential rounding errors, due to more slices being split up when the GPU estimates are SPAN_JOIN-ed. The slices with smaller time intervals may lose some precision when computing average power.

Bug: 419369871
