### PR TITLE
Fix run_presubmit in repo_checks

### DIFF
--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -48,13 +48,14 @@ jobs:
         with:
           install-flags: --ui
 
-      - name: Run tools/presubmits
+      - name: Run tools/run_presubmit
         # base_ref is "" in post-submit, skip the presubmit check in postsubmit
         # as there is nothing do diff against.
         if: ${{ github.base_ref != '' }}
-        run: tools/run_presubmit \
-                --merge-base origin/${{ github.base_ref }} \
-                --skip-formatters=eslint,prettier
+        run: |
+          tools/run_presubmit \
+            --skip-formatters "eslint,prettier" \
+            --merge-base origin/${{ github.base_ref }}
 
       - name: Check merged protos (tools/gen_all)
         run: |


### PR DESCRIPTION
Poor YAML escaping was causing the --skip-formatters argument to be ignored
