### PR TITLE
Handle CREATED, DEAD, and DESTROYED events in GenericTaskStateEvents

### DIFF
--- a/src/trace_processor/importers/common/thread_state_tracker.cc
+++ b/src/trace_processor/importers/common/thread_state_tracker.cc
@@ -240,6 +240,15 @@ void ThreadStateTracker::UpdatePendingState(
   }
 }
 
+StringId ThreadStateTracker::GetPrevEndState(UniqueTid utid) {
+  if (!HasPreviousRowNumbersForUtid(utid))
+    return kNullStringId;
+
+  auto row_ref = RowNumToRef(prev_row_numbers_for_thread_[utid]->last_row);
+
+  return row_ref.state();
+}
+
 bool ThreadStateTracker::IsRunning(StringId state) {
   return state == running_string_id_;
 }

--- a/src/trace_processor/importers/common/thread_state_tracker.h
+++ b/src/trace_processor/importers/common/thread_state_tracker.h
@@ -81,6 +81,7 @@ class ThreadStateTracker : public Destructible {
   //
   // - PushThreadState
   // - UpdatePendingState
+  // - GetPrevEndState
   //
   // To update the thread state track accordingly. Updating pending state is
   // necessary in this scenario because single thread state change events don't
@@ -97,6 +98,8 @@ class ThreadStateTracker : public Destructible {
                           std::optional<uint16_t> cpu = std::nullopt,
                           std::optional<UniqueTid> waker_utid = std::nullopt,
                           std::optional<uint16_t> common_flags = std::nullopt);
+
+  StringId GetPrevEndState(UniqueTid utid);
 
  private:
   void AddOpenState(int64_t ts,

--- a/src/trace_processor/importers/generic_kernel/generic_kernel_parser.h
+++ b/src/trace_processor/importers/generic_kernel/generic_kernel_parser.h
@@ -77,7 +77,10 @@ class GenericKernelParser {
   std::vector<std::optional<SchedEventState::PendingSchedInfo>>
       pending_state_per_utid_;
 
+  StringId created_string_id_;
   StringId running_string_id_;
+  StringId dead_string_id_;
+  StringId destroyed_string_id_;
   const std::vector<StringId> task_states_;
 };
 

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -96,6 +96,8 @@ namespace perfetto::trace_processor::stats {
   F(fuchsia_invalid_event_arg_name,       kSingle,  kError,    kAnalysis, ""), \
   F(fuchsia_unknown_event_arg,            kSingle,  kError,    kAnalysis, ""), \
   F(fuchsia_invalid_string_ref,           kSingle,  kError,    kAnalysis, ""), \
+  F(generic_task_state_invalid_order,     kSingle,  kError,    kAnalysis,      \
+       "Invalid order of generic task state events. Should never happen."),    \
   F(gpu_counters_invalid_spec,            kSingle,  kError,    kAnalysis, ""), \
   F(gpu_counters_missing_spec,            kSingle,  kError,    kAnalysis, ""), \
   F(gpu_render_stage_parser_errors,       kSingle,  kError,    kAnalysis, ""), \

--- a/test/trace_processor/diff_tests/parser/generic_kernel/tests.py
+++ b/test/trace_processor/diff_tests/parser/generic_kernel/tests.py
@@ -411,7 +411,45 @@ class GenericKernelParser(TestSuite):
         362831239274,-1,"[NULL]",3,"S","[NULL]"
         """))
 
-  def test_thread_state_created(self):
+  def test_thread_state_created_and_dead(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 360831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_CREATED
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 361831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_DEAD
+            prio: 100
+          }
+        }
+        """),
+        query="""
+        select
+          ts,
+          dur,
+          cpu,
+          utid,
+          state,
+          ucpu
+        from thread_state
+        """,
+        out=Csv("""
+        "ts","dur","cpu","utid","state","ucpu"
+        360831239274,1000000000,"[NULL]",1,"Created","[NULL]"
+        361831239274,-1,"[NULL]",1,"Z","[NULL]"
+        """))
+
+  def test_thread_created_and_dead(self):
     return DiffTestBlueprint(
         trace=TextProto(r"""
         packet {
@@ -420,7 +458,75 @@ class GenericKernelParser(TestSuite):
             cpu: 0
             comm: "task1"
             tid: 101
-            state: 1
+            state: TASK_STATE_CREATED
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 361831239274
+          generic_kernel_task_state_event {
+            cpu: 0
+            comm: "task2"
+            tid: 102
+            state: TASK_STATE_CREATED
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 362831239274
+          generic_kernel_task_state_event {
+            cpu: 0
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_DEAD
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 363831239274
+          generic_kernel_task_state_event {
+            cpu: 0
+            comm: "task2"
+            tid: 102
+            state: TASK_STATE_DEAD
+            prio: 100
+          }
+        }
+        """),
+        query="""
+        select
+          utid,
+          tid,
+          name,
+          start_ts,
+          end_ts
+        from thread
+        """,
+        out=Csv("""
+        "utid","tid","name","start_ts","end_ts"
+        0,0,"swapper","[NULL]","[NULL]"
+        1,101,"task1",360831239274,362831239274
+        2,102,"task2",361831239274,363831239274
+        """))
+
+  def test_thread_state_created_and_destroyed(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 360831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_CREATED
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 361831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_DESTROYED
             prio: 100
           }
         }
@@ -437,10 +543,11 @@ class GenericKernelParser(TestSuite):
         """,
         out=Csv("""
         "ts","dur","cpu","utid","state","ucpu"
-        360831239274,-1,"[NULL]",1,"Created","[NULL]"
+        360831239274,1000000000,"[NULL]",1,"Created","[NULL]"
+        361831239274,-1,"[NULL]",1,"X","[NULL]"
         """))
 
-  def test_thread_name(self):
+  def test_thread_created_and_destroyed(self):
     return DiffTestBlueprint(
         trace=TextProto(r"""
         packet {
@@ -449,7 +556,7 @@ class GenericKernelParser(TestSuite):
             cpu: 0
             comm: "task1"
             tid: 101
-            state: 1
+            state: TASK_STATE_CREATED
             prio: 100
           }
         }
@@ -457,9 +564,9 @@ class GenericKernelParser(TestSuite):
           timestamp: 361831239274
           generic_kernel_task_state_event {
             cpu: 0
-            comm: "task2"
-            tid: 102
-            state: 1
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_DESTROYED
             prio: 100
           }
         }
@@ -468,12 +575,237 @@ class GenericKernelParser(TestSuite):
         select
           utid,
           tid,
-          name
+          name,
+          start_ts,
+          end_ts
         from thread
         """,
         out=Csv("""
-        "utid","tid","name"
-        0,0,"swapper"
-        1,101,"task1"
-        2,102,"task2"
+        "utid","tid","name","start_ts","end_ts"
+        0,0,"swapper","[NULL]","[NULL]"
+        1,101,"task1",360831239274,"[NULL]"
+        """))
+
+  def test_thread_only_destroyed_or_dead(self):
+    # The DESTROYED event should be ignored
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 360831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_DEAD
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 361831239274
+          generic_kernel_task_state_event {
+            comm: "task2"
+            tid: 102
+            state: TASK_STATE_DESTROYED
+            prio: 100
+          }
+        }
+        """),
+        query="""
+        select
+          utid,
+          tid,
+          name,
+          start_ts,
+          end_ts
+        from thread
+        """,
+        out=Csv("""
+        "utid","tid","name","start_ts","end_ts"
+        0,0,"swapper","[NULL]","[NULL]"
+        1,101,"task1","[NULL]",360831239274
+        """))
+
+  def test_thread_state_only_destroyed_or_dead(self):
+    # The DESTROYED event should be ignored
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 360831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_DEAD
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 361831239274
+          generic_kernel_task_state_event {
+            comm: "task2"
+            tid: 102
+            state: TASK_STATE_DESTROYED
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 362831239274
+          generic_kernel_task_state_event {
+            cpu: 0
+            comm: "task1"
+            tid: 101
+            state: TASK_STATE_RUNNING
+            prio: 100
+          }
+        }
+        """),
+        query="""
+        select
+          ts,
+          dur,
+          cpu,
+          utid,
+          state,
+          ucpu
+        from thread_state
+        """,
+        out=Csv("""
+        "ts","dur","cpu","utid","state","ucpu"
+        360831239274,-1,"[NULL]",1,"Z","[NULL]"
+        362831239274,-1,0,2,"Running",0
+        """))
+
+  def test_thread_state_destroyed_after_dead(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 359831239274
+          generic_kernel_task_state_event {
+            cpu: 0
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_RUNNING
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 360831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_DEAD
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 361831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_DESTROYED
+            prio: 100
+          }
+        }
+        """),
+        query="""
+        select
+          ts,
+          dur,
+          cpu,
+          utid,
+          state,
+          ucpu
+        from thread_state
+        """,
+        out=Csv("""
+        "ts","dur","cpu","utid","state","ucpu"
+        359831239274,1000000000,0,1,"Running",0
+        360831239274,-1,"[NULL]",1,"Z","[NULL]"
+        """))
+
+  def test_error_stats_created_after_running(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 359831239274
+          generic_kernel_task_state_event {
+            cpu: 0
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_RUNNING
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 360831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_CREATED
+            prio: 100
+          }
+        }
+        """),
+        query="""
+        select
+          name,
+          severity,
+          source,
+          value,
+          description
+        from stats
+        where name = "generic_task_state_invalid_order"
+        """,
+        out=Csv(
+            """
+        "name","severity","source","value","description"
+        "generic_task_state_invalid_order","error","analysis",1,""" +
+            """"Invalid order of generic task state events. Should never happen."
+        """))
+
+  def test_error_stats_dead_after_destroyed(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          timestamp: 359831239274
+          generic_kernel_task_state_event {
+            cpu: 0
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_RUNNING
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 360831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_DESTROYED
+            prio: 100
+          }
+        }
+        packet {
+          timestamp: 361831239274
+          generic_kernel_task_state_event {
+            comm: "task1"
+            tid: 1
+            state: TASK_STATE_DEAD
+            prio: 100
+          }
+        }
+        """),
+        query="""
+        select
+          name,
+          severity,
+          source,
+          value,
+          description
+        from stats
+        where name = "generic_task_state_invalid_order"
+        """,
+        out=Csv(
+            """
+        "name","severity","source","value","description"
+        "generic_task_state_invalid_order","error","analysis",1,""" +
+            """"Invalid order of generic task state events. Should never happen."
         """))


### PR DESCRIPTION
The thread table is populated with a start_ts when a CREATED event is received for a non-existing thread. If any other state is received for a non-existing thread, then the start_ts is left NULL (since we don't know when the thread was actually created).

Now, threads are only ended when a DEAD event is received. The DESTROYED event is only considered if its received before a DEAD event. If no utid exists associated to a DESTROYED event, then the event is simply ignored.

Also, we introduce a new error stat: generic_task_state_invalid_order, to cover error cases in which events are received in an inproper sequence. For example, the error stat is incremented if a CREATED event is received for an already existing thread or if a DEAD event is received after a DESTROYED event for the same thread.

Bug: 420976270