### PR TITLE
tp: remove "sort if repeated queries" optimization

### DIFF
--- a/src/trace_processor/db/table.h
+++ b/src/trace_processor/db/table.h
@@ -180,9 +180,6 @@ class Table {
   // Returns an error if index doesn't exist.
   base::Status DropIndex(const std::string& name);
 
-  // Sorts the table using the specified order by constraints.
-  Table Sort(const std::vector<Order>&) const;
-
   // Returns an iterator over the rows in this table.
   Iterator IterateRows() const { return Iterator(this); }
 

--- a/src/trace_processor/sqlite/db_sqlite_table.h
+++ b/src/trace_processor/sqlite/db_sqlite_table.h
@@ -96,15 +96,6 @@ struct DbSqliteModule : public sqlite::Module<DbSqliteModule> {
 
     bool eof = true;
 
-    // Stores a sorted version of |db_table| sorted on a repeated equals
-    // constraint. This allows speeding up repeated subqueries in joins
-    // significantly.
-    std::optional<Table> sorted_cache_table;
-
-    // Stores the count of repeated equality queries to decide whether it is
-    // wortwhile to sort |db_table| to create |sorted_cache_table|.
-    uint32_t repeated_cache_count = 0;
-
     Mode mode = Mode::kSingleRow;
 
     int last_idx_num = -1;

--- a/src/trace_processor/sqlite/db_sqlite_table_unittest.cc
+++ b/src/trace_processor/sqlite/db_sqlite_table_unittest.cc
@@ -109,31 +109,6 @@ TEST(DbSqliteModule, IdEqCheaperThatOtherConstraint) {
   ASSERT_LT(id_cost.rows, a_cost.rows);
 }
 
-TEST(DbSqliteModule, SingleEqCheaperThanMultipleConstraint) {
-  auto schema = CreateSchema();
-  constexpr uint32_t kRowCount = 1234;
-
-  auto c = CreateConstraint(1, SQLITE_INDEX_CONSTRAINT_EQ);
-  auto u = CreateUsage();
-  auto info = CreateCsIndexInfo(1, &c, &u);
-
-  auto single_cost =
-      DbSqliteModule::EstimateCost(schema, kRowCount, &info, {0u}, {});
-
-  std::array c2{CreateConstraint(1, SQLITE_INDEX_CONSTRAINT_EQ),
-                CreateConstraint(2, SQLITE_INDEX_CONSTRAINT_EQ)};
-  std::array u2{CreateUsage(), CreateUsage()};
-  auto info2 = CreateCsIndexInfo(c2.size(), c2.data(), u2.data());
-
-  auto multi_cost =
-      DbSqliteModule::EstimateCost(schema, kRowCount, &info2, {0u, 1u}, {});
-
-  // The cost of the single filter should be cheaper (because of our special
-  // handling of single equality). But the number of rows should be greater.
-  ASSERT_LT(single_cost.cost, multi_cost.cost);
-  ASSERT_GT(single_cost.rows, multi_cost.rows);
-}
-
 TEST(DbSqliteModule, MultiSortedEqCheaperThanMultiUnsortedEq) {
   auto schema = CreateSchema();
   constexpr uint32_t kRowCount = 1234;


### PR DESCRIPTION
This optimization has outlived its usefulness as we've made progress
towards making O(1) id lookups actually fast. With dataframe, we won't
have anything like this so remove it from table module also to act as a
canary for any problems.
