### PR TITLE
tp: don't emit hard errors if there are no frames in the sample

### DIFF
--- a/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
+++ b/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
@@ -131,9 +131,9 @@ base::Status PerfTextTraceTokenizer::Parse(TraceBlobView blob) {
           mapping->InternDummyFrame(symbol_name, base::StringView()));
     }
     if (frames.empty()) {
-      return base::ErrStatus(
-          "Perf text parser: no frames in sample (context: '%s')",
-          std::string(first_line).c_str());
+      context_->storage->IncrementStats(
+          storage::stats::perf_text_importer_sample_no_frames);
+      continue;
     }
 
     std::optional<CallsiteId> parent_callsite;

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -558,7 +558,11 @@ namespace perfetto::trace_processor::stats {
       "slice. This can happen e.g. in JSON traces using X events or in other " \
       "cases where a duration is part of the trace. To solve this problem "    \
       "make sure that your X events do not overlap on the same track (e.g. "   \
-      "thread/process) ")
+      "thread/process)"),                                                      \
+  F(perf_text_importer_sample_no_frames,        kSingle,  kError,  kTrace,     \
+      "A perf sample was encountered that has no frames. This can happen "     \
+      "if the kernel is unable to unwind the stack while sampling. Check "     \
+      "Linux kernel documentation for causes of this and potential fixes.")
 // clang-format on
 
 enum Type {


### PR DESCRIPTION
This can happen in legit cases and does not mean the rest of the trace
is useless. Just increment a stat and move on.
