### PR TITLE
TraceProcessor library not working with Pyinstaller exe

### DIFF
--- a/python/perfetto/trace_processor/shell.py
+++ b/python/perfetto/trace_processor/shell.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import shutil
 from typing import List, Optional
 from urllib import request, error
 
@@ -41,8 +42,15 @@ def load_shell(bin_path: str,
   url = f'{addr}:{str(port)}'
 
   shell_path = platform_delegate.get_shell_path(bin_path=bin_path)
+
+  # get Python interpreter path
+  if not getattr(sys, 'frozen', False):
+    python_executable_path = sys.executable
+  else:
+    python_executable_path = shutil.which('python')
+
   if os.name == 'nt' and not shell_path.endswith('.exe'):
-    tp_exec = [sys.executable, shell_path]
+    tp_exec = [python_executable_path, shell_path]
   else:
     tp_exec = [shell_path]
 


### PR DESCRIPTION
This PR addresses an issue where the TraceProcessor library fails to function correctly when bundled into an executable using Pyinstaller.

Currently, the `shell.py` script within the TraceProcessor library utilizes `sys.executable` to determine the Python interpreter's path on Windows systems. When an application is packaged with Pyinstaller, `sys.executable` returns the path of the generated executable itself, rather than the actual Python interpreter, leading to the library's malfunction.

This change modifies how `sys.executable` is used, ensuring that the TraceProcessor library can correctly locate the Python interpreter path, even within Pyinstaller-packaged applications.

Related to issue: https://github.com/google/perfetto/issues/512