### PR TITLE
Fix bug where ftrace and counter details panel args has context menu items relevant only to slice table.

### DIFF
--- a/ui/src/components/details/args.ts
+++ b/ui/src/components/details/args.ts
@@ -1,0 +1,137 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {isString} from '../../base/object_utils';
+import {Icons} from '../../base/semantic_icons';
+import {exists} from '../../base/utils';
+import {ArgNode, convertArgsToTree, Key} from './slice_args_parser';
+import {Anchor} from '../../widgets/anchor';
+import {MenuItem, PopupMenu} from '../../widgets/menu';
+import {TreeNode} from '../../widgets/tree';
+import {Arg} from '../sql_utils/args';
+import {Trace} from '../../public/trace';
+
+// Renders slice arguments (key/value pairs) as a subtree.
+export function renderArguments(
+  trace: Trace,
+  args: ReadonlyArray<Arg>,
+  extraMenuItems?: (arg: Arg) => m.Children,
+): m.Children {
+  if (args.length > 0) {
+    const tree = convertArgsToTree(args);
+    return renderArgTreeNodes(trace, tree, extraMenuItems);
+  } else {
+    return undefined;
+  }
+}
+
+export function hasArgs(args?: Arg[]): args is Arg[] {
+  return exists(args) && args.length > 0;
+}
+
+function renderArgTreeNodes(
+  trace: Trace,
+  args: ArgNode<Arg>[],
+  extraMenuItems?: (arg: Arg) => m.Children,
+): m.Children {
+  return args.map((arg) => {
+    const {key, value, children} = arg;
+    if (children && children.length === 1) {
+      // If we only have one child, collapse into self and combine keys
+      const child = children[0];
+      const compositeArg = {
+        ...child,
+        key: stringifyKey(key, child.key),
+      };
+      return renderArgTreeNodes(trace, [compositeArg], extraMenuItems);
+    } else {
+      return m(
+        TreeNode,
+        {
+          left: renderArgKey(stringifyKey(key), value, extraMenuItems),
+          right: exists(value) && renderArgValue(value),
+          summary: children && renderSummary(children),
+        },
+        children && renderArgTreeNodes(trace, children, extraMenuItems),
+      );
+    }
+  });
+}
+
+function renderArgKey(
+  key: string,
+  value: Arg | undefined,
+  extraMenuItems?: (arg: Arg) => m.Children,
+): m.Children {
+  if (value === undefined) {
+    return key;
+  } else {
+    const {key: fullKey} = value;
+    return m(
+      PopupMenu,
+      {trigger: m(Anchor, {icon: Icons.ContextMenu}, key)},
+      m(MenuItem, {
+        label: 'Copy full key',
+        icon: 'content_copy',
+        onclick: () => navigator.clipboard.writeText(fullKey),
+      }),
+      extraMenuItems?.(value),
+    );
+  }
+}
+
+function renderArgValue({value}: Arg): m.Children {
+  if (isWebLink(value)) {
+    return renderWebLink(value);
+  } else {
+    return `${value}`;
+  }
+}
+
+function renderSummary(children: ArgNode<Arg>[]): m.Children {
+  const summary = children
+    .slice(0, 2)
+    .map(({key}) => key)
+    .join(', ');
+  const remaining = children.length - 2;
+  if (remaining > 0) {
+    return `{${summary}, ... (${remaining} more items)}`;
+  } else {
+    return `{${summary}}`;
+  }
+}
+
+function stringifyKey(...key: Key[]): string {
+  return key
+    .map((element, index) => {
+      if (typeof element === 'number') {
+        return `[${element}]`;
+      } else {
+        return (index === 0 ? '' : '.') + element;
+      }
+    })
+    .join('');
+}
+
+function isWebLink(value: unknown): value is string {
+  return (
+    isString(value) &&
+    (value.startsWith('http://') || value.startsWith('https://'))
+  );
+}
+
+function renderWebLink(url: string): m.Children {
+  return m(Anchor, {href: url, target: '_blank', icon: 'open_in_new'}, url);
+}

--- a/ui/src/components/details/slice_args.ts
+++ b/ui/src/components/details/slice_args.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 The Android Open Source Project
+// Copyright (C) 2025 The Android Open Source Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,75 +13,22 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {isString} from '../../base/object_utils';
-import {Icons} from '../../base/semantic_icons';
-import {sqliteString} from '../../base/string_utils';
-import {exists} from '../../base/utils';
-import {ArgNode, convertArgsToTree, Key} from './slice_args_parser';
-import {Anchor} from '../../widgets/anchor';
-import {MenuItem, PopupMenu} from '../../widgets/menu';
-import {TreeNode} from '../../widgets/tree';
+import {MenuItem} from '../../widgets/menu';
 import {Arg} from '../sql_utils/args';
+import {Trace} from '../../public/trace';
+import {renderArguments} from './args';
+import {extensions} from '../extensions';
 import {assertExists} from '../../base/logging';
 import {getSqlTableDescription} from '../widgets/sql/table/sql_table_registry';
-import {Trace} from '../../public/trace';
-import {extensions} from '../extensions';
+import {sqliteString} from '../../base/string_utils';
 
 // Renders slice arguments (key/value pairs) as a subtree.
-export function renderArguments(
+export function renderSliceArguments(
   trace: Trace,
   args: ReadonlyArray<Arg>,
 ): m.Children {
-  if (args.length > 0) {
-    const tree = convertArgsToTree(args);
-    return renderArgTreeNodes(trace, tree);
-  } else {
-    return undefined;
-  }
-}
-
-export function hasArgs(args?: Arg[]): args is Arg[] {
-  return exists(args) && args.length > 0;
-}
-
-function renderArgTreeNodes(trace: Trace, args: ArgNode<Arg>[]): m.Children {
-  return args.map((arg) => {
-    const {key, value, children} = arg;
-    if (children && children.length === 1) {
-      // If we only have one child, collapse into self and combine keys
-      const child = children[0];
-      const compositeArg = {
-        ...child,
-        key: stringifyKey(key, child.key),
-      };
-      return renderArgTreeNodes(trace, [compositeArg]);
-    } else {
-      return m(
-        TreeNode,
-        {
-          left: renderArgKey(trace, stringifyKey(key), value),
-          right: exists(value) && renderArgValue(value),
-          summary: children && renderSummary(children),
-        },
-        children && renderArgTreeNodes(trace, children),
-      );
-    }
-  });
-}
-
-function renderArgKey(trace: Trace, key: string, value?: Arg): m.Children {
-  if (value === undefined) {
-    return key;
-  } else {
-    const {key: fullKey, displayValue} = value;
-    return m(
-      PopupMenu,
-      {trigger: m(Anchor, {icon: Icons.ContextMenu}, key)},
-      m(MenuItem, {
-        label: 'Copy full key',
-        icon: 'content_copy',
-        onclick: () => navigator.clipboard.writeText(fullKey),
-      }),
+  return renderArguments(trace, args, (arg) => {
+    return [
       m(MenuItem, {
         label: 'Find slices with same arg value',
         icon: 'search',
@@ -90,7 +37,7 @@ function renderArgKey(trace: Trace, key: string, value?: Arg): m.Children {
             table: assertExists(getSqlTableDescription('slice')),
             filters: [
               {
-                op: (cols) => `${cols[0]} = ${sqliteString(displayValue)}`,
+                op: (cols) => `${cols[0]} = ${sqliteString(arg.displayValue)}`,
                 columns: [
                   {
                     column: 'display_value',
@@ -98,7 +45,7 @@ function renderArgKey(trace: Trace, key: string, value?: Arg): m.Children {
                       table: 'args',
                       joinOn: {
                         arg_set_id: 'arg_set_id',
-                        key: sqliteString(fullKey),
+                        key: sqliteString(arg.flatKey),
                       },
                     },
                   },
@@ -112,53 +59,9 @@ function renderArgKey(trace: Trace, key: string, value?: Arg): m.Children {
         label: 'Visualize argument values',
         icon: 'query_stats',
         onclick: () => {
-          extensions.addVisualizedArgTracks(trace, fullKey);
+          extensions.addVisualizedArgTracks(trace, arg.flatKey);
         },
       }),
-    );
-  }
-}
-
-function renderArgValue({value}: Arg): m.Children {
-  if (isWebLink(value)) {
-    return renderWebLink(value);
-  } else {
-    return `${value}`;
-  }
-}
-
-function renderSummary(children: ArgNode<Arg>[]): m.Children {
-  const summary = children
-    .slice(0, 2)
-    .map(({key}) => key)
-    .join(', ');
-  const remaining = children.length - 2;
-  if (remaining > 0) {
-    return `{${summary}, ... (${remaining} more items)}`;
-  } else {
-    return `{${summary}}`;
-  }
-}
-
-function stringifyKey(...key: Key[]): string {
-  return key
-    .map((element, index) => {
-      if (typeof element === 'number') {
-        return `[${element}]`;
-      } else {
-        return (index === 0 ? '' : '.') + element;
-      }
-    })
-    .join('');
-}
-
-function isWebLink(value: unknown): value is string {
-  return (
-    isString(value) &&
-    (value.startsWith('http://') || value.startsWith('https://'))
-  );
-}
-
-function renderWebLink(url: string): m.Children {
-  return m(Anchor, {href: url, target: '_blank', icon: 'open_in_new'}, url);
+    ];
+  });
 }

--- a/ui/src/components/details/thread_slice_details_tab.ts
+++ b/ui/src/components/details/thread_slice_details_tab.ts
@@ -24,7 +24,7 @@ import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {Section} from '../../widgets/section';
 import {Tree} from '../../widgets/tree';
 import {Flow, FlowPoint} from '../../core/flow_types';
-import {hasArgs, renderArguments} from './slice_args';
+import {hasArgs} from './args';
 import {renderDetails} from './slice_details';
 import {getSlice, SliceDetails} from '../sql_utils/slice';
 import {
@@ -42,6 +42,7 @@ import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {TrackEventSelection} from '../../public/selection';
 import {extensions} from '../extensions';
 import {TraceImpl} from '../../core/trace_impl';
+import {renderSliceArguments} from './slice_args';
 
 interface ContextMenuItem {
   name: string;
@@ -261,7 +262,7 @@ export class ThreadSliceDetailsPanel implements TrackEventDetailsPanel {
       m(
         Section,
         {title: 'Arguments'},
-        m(Tree, renderArguments(trace, slice.args)),
+        m(Tree, renderSliceArguments(trace, slice.args)),
       );
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (precFlows ?? followingFlows ?? args) {

--- a/ui/src/components/sql_utils/args.ts
+++ b/ui/src/components/sql_utils/args.ts
@@ -102,8 +102,7 @@ function parseValue(
     case 'string':
       return value.stringValue;
     case 'bool':
-      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      return !!value.intValue;
+      return value.intValue === null ? null : value.intValue !== 0n;
     case 'real':
       return value.realValue;
     case 'null':

--- a/ui/src/components/tracks/debug_slice_track_details_panel.ts
+++ b/ui/src/components/tracks/debug_slice_track_details_panel.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {duration, Time, time} from '../../base/time';
-import {hasArgs, renderArguments} from '../details/slice_args';
+import {hasArgs} from '../details/args';
 import {getSlice, SliceDetails} from '../sql_utils/slice';
 import {asSliceSqlId, Utid} from '../sql_utils/core_types';
 import {getThreadState, ThreadState} from '../sql_utils/thread_state';
@@ -39,6 +39,7 @@ import {sliceRef} from '../widgets/slice';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
 import {SqlRef} from '../../widgets/sql_ref';
+import {renderSliceArguments} from '../details/slice_args';
 
 export const ARG_PREFIX = 'arg_';
 
@@ -176,7 +177,7 @@ export class DebugSliceTrackDetailsPanel implements TrackEventDetailsPanel {
           {
             left: 'Args',
           },
-          renderArguments(this.trace, this.slice.args),
+          renderSliceArguments(this.trace, this.slice.args),
         ),
     );
   }

--- a/ui/src/components/widgets/sql/details/details.ts
+++ b/ui/src/components/widgets/sql/details/details.ts
@@ -29,11 +29,12 @@ import {Anchor} from '../../../../widgets/anchor';
 import {renderError} from '../../../../widgets/error';
 import {SqlRef} from '../../../../widgets/sql_ref';
 import {Tree, TreeNode} from '../../../../widgets/tree';
-import {hasArgs, renderArguments} from '../../../details/slice_args';
+import {hasArgs} from '../../../details/args';
 import {DurationWidget} from '../../../widgets/duration';
 import {Timestamp as TimestampWidget} from '../../../widgets/timestamp';
 import {sqlIdRegistry} from './sql_ref_renderer_registry';
 import {Trace} from '../../../../public/trace';
+import {renderSliceArguments} from '../../../details/slice_args';
 
 // This file contains the helper to render the details tree (based on Tree
 // widget) for an object represented by a SQL row in some table. The user passes
@@ -811,7 +812,7 @@ function renderValue(
           {
             left: key,
           },
-          renderArguments(trace, args),
+          renderSliceArguments(trace, args),
         )
       );
     case 'array': {

--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_details_panel.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {assertUnreachable} from '../../base/logging';
 import {Time} from '../../base/time';
-import {renderArguments} from '../../components/details/slice_args';
+import {renderArguments} from '../../components/details/args';
 import {Arg, ArgValue, ArgValueType} from '../../components/sql_utils/args';
 import {asArgId} from '../../components/sql_utils/core_types';
 import {Timestamp} from '../../components/widgets/timestamp';

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_details_panel.ts
@@ -30,7 +30,7 @@ import {Tree, TreeNode} from '../../widgets/tree';
 import {Timestamp} from '../../components/widgets/timestamp';
 import {DurationWidget} from '../../components/widgets/duration';
 import {TrackEventSelection} from '../../public/selection';
-import {hasArgs, renderArguments} from '../../components/details/slice_args';
+import {hasArgs, renderArguments} from '../../components/details/args';
 import {asArgSetId} from '../../components/sql_utils/core_types';
 import {Arg, getArgs} from '../../components/sql_utils/args';
 

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_details_panel.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {Duration, duration, Time, time} from '../../base/time';
-import {hasArgs, renderArguments} from '../../components/details/slice_args';
+import {hasArgs} from '../../components/details/args';
 import {renderDetails} from '../../components/details/slice_details';
 import {
   getDescendantSliceTree,
@@ -48,6 +48,7 @@ import {sliceRef} from '../../components/widgets/slice';
 import {JANKS_TRACK_URI, renderSliceRef} from './utils';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
+import {renderSliceArguments} from '../../components/details/slice_args';
 
 // Given a node in the slice tree, return a path from root to it.
 function getPath(slice: SliceTreeNode): string[] {
@@ -530,7 +531,7 @@ export class EventLatencySliceDetailsPanel implements TrackEventDetailsPanel {
               m(
                 Section,
                 {title: 'Arguments'},
-                m(Tree, renderArguments(this.trace, slice.args)),
+                m(Tree, renderSliceArguments(this.trace, slice.args)),
               ),
           ),
           m(GridLayoutColumn, rightSideWidgets),


### PR DESCRIPTION
The options "Show slices with same arg value" and "Visualize argument" don't apply to ftrace/counter tracks, yet these options were being supplied by the generic renderArguments() function, which was being used for both of these.

This patch maked renderArguments() much more generic, allowing extra menu items to be injected in from the caller via a callback. For convenience, another helper function renderSliceArguments() has been created which called renderArguments() with the extra context menu items, and this is used everywhere where slice arguments are actually required whereas renderArguments() is used for ftrace and counter details panels.