### PR TITLE
tp: py_api: Provide TraceSummarySpec as bytes

### DIFF
--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -175,7 +175,8 @@ class TraceProcessor:
     an error.
 
     Args:
-      specs: A list of textproto/bytes specs to be used for the summary
+      specs: A list of textproto (as str) or binary proto (as bytes) specs to be
+        used for the summary
       metric_ids: Optional list of metric IDs as defined in TraceMetrics. 
         If `None` all metrics will be executed.
       metadata_query_id: Optional query ID for metadata

--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -14,7 +14,7 @@
 
 import dataclasses as dc
 from urllib.parse import urlparse
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from perfetto.common.exceptions import PerfettoException
 from perfetto.common.query_result_iterator import QueryResultIterator
@@ -167,7 +167,7 @@ class TraceProcessor:
     return metrics
 
   def trace_summary(self,
-                    specs: List[str],
+                    specs: List[Union[str, bytes]],
                     metric_ids: Optional[List[str]] = None,
                     metadata_query_id: Optional[str] = None):
     """Returns the trace summary data corresponding to the passed in metric
@@ -175,8 +175,9 @@ class TraceProcessor:
     an error.
 
     Args:
-      metric_ids: A list of metric IDs as defined in TraceMetrics
-      specs: A list of textproto specs to be used for the summary
+      specs: A list of textproto/bytes specs to be used for the summary
+      metric_ids: Optional list of metric IDs as defined in TraceMetrics. 
+        If `None` all metrics will be executed.
       metadata_query_id: Optional query ID for metadata
 
     Returns:

--- a/python/perfetto/trace_processor/http.py
+++ b/python/perfetto/trace_processor/http.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import http.client
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from perfetto.trace_processor.protos import ProtoFactory
 
@@ -46,15 +46,24 @@ class TraceProcessorHttp:
       return result
 
   def trace_summary(self,
-                    specs: List[str],
+                    specs: List[Union[str, bytes]],
                     metric_ids: Optional[List[str]] = None,
                     metadata_query_id: Optional[str] = None):
     args = self.protos.TraceSummaryArgs()
-    args.textproto_specs.extend(specs)
+
     if (metric_ids is None):
       args.computation_spec.run_all_metrics = True
     elif (len(metric_ids) > 0):
       args.computation_spec.metric_ids.extend(metric_ids)
+
+    if (specs is not None and len(specs) > 0):
+      for spec in specs:
+        if isinstance(spec, str):
+          args.textproto_specs.append(spec)
+        elif isinstance(spec, bytes):
+          proto_spec = self.protos.TraceSummarySpec()
+          proto_spec.ParseFromString(spec)
+          args.proto_specs.append(proto_spec)
 
     if (metadata_query_id is not None):
       args.computation_spec.metadata_query_id = metadata_query_id

--- a/python/perfetto/trace_processor/protos.py
+++ b/python/perfetto/trace_processor/protos.py
@@ -65,6 +65,10 @@ class ProtoFactory:
     self.QueryResult = create_message_factory('perfetto.protos.QueryResult')
     self.TraceMetrics = create_message_factory('perfetto.protos.TraceMetrics')
     self.TraceSummary = create_message_factory('perfetto.protos.TraceSummary')
+    self.TraceSummarySpec = create_message_factory(
+        'perfetto.protos.TraceSummarySpec')
+    self.TraceMetricV2Spec = create_message_factory(
+        'perfetto.protos.TraceMetricV2Spec')
     self.DisableAndReadMetatraceResult = create_message_factory(
         'perfetto.protos.DisableAndReadMetatraceResult')
     self.CellsBatch = create_message_factory(

--- a/python/test/api_integrationtest.py
+++ b/python/test/api_integrationtest.py
@@ -26,6 +26,7 @@ from perfetto.batch_trace_processor.api import BatchTraceProcessorConfig
 from perfetto.batch_trace_processor.api import FailureHandling
 from perfetto.batch_trace_processor.api import Metadata
 from perfetto.batch_trace_processor.api import TraceListReference
+from perfetto.trace_processor.protos import ProtoFactory
 from perfetto.trace_processor.api import PLATFORM_DELEGATE
 from perfetto.trace_processor.api import TraceProcessor
 from perfetto.trace_processor.api import TraceProcessorException
@@ -425,6 +426,63 @@ class TestApi(unittest.TestCase):
       """
     tp = create_tp(trace=example_android_trace_path())
     trace_summary = tp.trace_summary([metric_spec_1, metric_spec_2])
+    self.assertEqual(len(trace_summary.metric), 2)
+    self.assertIn(trace_summary.metric[0].spec.id, ['metric_one', 'metric_two'])
+    self.assertIn(trace_summary.metric[1].spec.id, ['metric_one', 'metric_two'])
+    tp.close()
+
+  def test_trace_summary_specs_as_bytes(self):
+    platform_delegate = PLATFORM_DELEGATE()
+    protos = ProtoFactory(platform_delegate)
+
+    metric_spec_1 = protos.TraceSummarySpec()
+    metric_1 = protos.TraceMetricV2Spec()
+    metric_1.id = 'metric_one'
+    metric_1.value = 'dur'
+    metric_1.query.simple_slices.process_name_glob = 'ab*'
+    metric_spec_1.metric_spec.extend([metric_1])
+    metric_spec_1_bytes = metric_spec_1.SerializeToString()
+
+    metric_spec_2 = protos.TraceSummarySpec()
+    metric_2 = protos.TraceMetricV2Spec()
+    metric_2.id = 'metric_two'
+    metric_2.value = 'ts'
+    metric_2.query.simple_slices.process_name_glob = 'cd*'
+    metric_spec_2.metric_spec.extend([metric_2])
+    metric_spec_2_bytes = metric_spec_2.SerializeToString()
+
+    tp = create_tp(trace=example_android_trace_path())
+    trace_summary = tp.trace_summary([metric_spec_1_bytes, metric_spec_2_bytes])
+    self.assertEqual(len(trace_summary.metric), 2)
+    self.assertIn(trace_summary.metric[0].spec.id, ['metric_one', 'metric_two'])
+    self.assertIn(trace_summary.metric[1].spec.id, ['metric_one', 'metric_two'])
+    tp.close()
+
+  def test_trace_summary_specs_as_bytes_and_text(self):
+    platform_delegate = PLATFORM_DELEGATE()
+    protos = ProtoFactory(platform_delegate)
+
+    metric_spec_1 = protos.TraceSummarySpec()
+    metric_1 = protos.TraceMetricV2Spec()
+    metric_1.id = 'metric_one'
+    metric_1.value = 'dur'
+    metric_1.query.simple_slices.process_name_glob = 'ab*'
+    metric_spec_1.metric_spec.extend([metric_1])
+    metric_spec_1_bytes = metric_spec_1.SerializeToString()
+
+    metric_spec_2 = """metric_spec: {
+        id: "metric_two"
+        value: "ts"
+        query: {
+          simple_slices {
+            process_name_glob: "cd*"
+          }
+        }
+      }
+      """
+
+    tp = create_tp(trace=example_android_trace_path())
+    trace_summary = tp.trace_summary([metric_spec_1_bytes, metric_spec_2])
     self.assertEqual(len(trace_summary.metric), 2)
     self.assertIn(trace_summary.metric[0].spec.id, ['metric_one', 'metric_two'])
     self.assertIn(trace_summary.metric[1].spec.id, ['metric_one', 'metric_two'])


### PR DESCRIPTION
Extend tp python API to also support bytes (proto) alongside textproto