### PR TITLE
Trace Redaction - Share common package name in tests

### DIFF
--- a/src/trace_redaction/filter_sched_waking_events_integrationtest.cc
+++ b/src/trace_redaction/filter_sched_waking_events_integrationtest.cc
@@ -38,9 +38,6 @@
 namespace perfetto::trace_redaction {
 namespace {
 
-constexpr std::string_view kPackageName =
-    "com.Unity.com.unity.multiplayer.samples.coop";
-
 class RedactSchedWakingIntegrationTest
     : public testing::Test,
       protected TraceRedactionIntegrationFixure {
@@ -54,7 +51,7 @@ class RedactSchedWakingIntegrationTest
     redact_sched_events->emplace_modifier<ClearComms>();
     redact_sched_events->emplace_waking_filter<ConnectedToPackage>();
 
-    context_.package_name = kPackageName;
+    context_.package_name = kSomePackageName;
   }
 
   Context context_;

--- a/src/trace_redaction/filter_task_rename_integrationtest.cc
+++ b/src/trace_redaction/filter_task_rename_integrationtest.cc
@@ -50,7 +50,7 @@ class RenameEventsTraceRedactorIntegrationTest
     redact->emplace_filter<ConnectedToPackage>();
     redact->emplace_modifier<DoNothing>();
 
-    context_.package_name = "com.Unity.com.unity.multiplayer.samples.coop";
+    context_.package_name = kSomePackageName;
   }
 
   void GetRenamedPids(

--- a/src/trace_redaction/process_thread_timeline_integrationtest.cc
+++ b/src/trace_redaction/process_thread_timeline_integrationtest.cc
@@ -38,7 +38,7 @@ class ProcessThreadTimelineIntegrationTest
       protected TraceRedactionIntegrationFixure {
  protected:
   void SetUp() override {
-    context_.package_name = "com.Unity.com.unity.multiplayer.samples.coop";
+    context_.package_name = kSomePackageName;
 
     trace_redactor_.emplace_collect<FindPackageUid>();
     trace_redactor_.emplace_collect<CollectTimelineEvents>();

--- a/src/trace_redaction/prune_package_list_integrationtest.cc
+++ b/src/trace_redaction/prune_package_list_integrationtest.cc
@@ -36,22 +36,12 @@
 
 namespace perfetto::trace_redaction {
 
-namespace {
-
-// Set the package name to "just some package name". If a specific package name
-// is needed, the test it should overwrite this value.
-constexpr std::string_view kPackageName =
-    "com.Unity.com.unity.multiplayer.samples.coop";
-constexpr uint64_t kPackageUid = 10252;
-
-}  // namespace
-
 class PrunePackageListIntegrationTest
     : public testing::Test,
       protected TraceRedactionIntegrationFixure {
  protected:
   void SetUp() override {
-    context_.package_name = kPackageName;
+    context_.package_name = kSomePackageName;
 
     trace_redactor_.emplace_collect<FindPackageUid>();
     trace_redactor_.emplace_transform<PrunePackageList>();
@@ -109,7 +99,7 @@ TEST_F(PrunePackageListIntegrationTest, FindsPackageAndFiltersPackageList) {
   ASSERT_OK(after_raw_trace) << after_raw_trace.status().message();
 
   ASSERT_TRUE(context_.package_uid.has_value());
-  ASSERT_EQ(*context_.package_uid, kPackageUid);
+  ASSERT_EQ(*context_.package_uid, kSomePackageUid);
 
   protos::pbzero::Trace::Decoder redacted_trace(after_raw_trace.value());
   auto packages = GetPackageInfo(redacted_trace);
@@ -118,10 +108,10 @@ TEST_F(PrunePackageListIntegrationTest, FindsPackageAndFiltersPackageList) {
 
   for (const auto& package : packages) {
     ASSERT_TRUE(package.has_name());
-    ASSERT_EQ(package.name(), kPackageName);
+    ASSERT_EQ(package.name(), kSomePackageName);
 
     ASSERT_TRUE(package.has_uid());
-    ASSERT_EQ(NormalizeUid(package.uid()), kPackageUid);
+    ASSERT_EQ(NormalizeUid(package.uid()), kSomePackageUid);
   }
 }
 

--- a/src/trace_redaction/redact_process_trees_integrationtest.cc
+++ b/src/trace_redaction/redact_process_trees_integrationtest.cc
@@ -15,7 +15,6 @@
  */
 
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include "src/base/test/status_matchers.h"
@@ -32,13 +31,6 @@
 #include "protos/perfetto/trace/trace.pbzero.h"
 
 namespace perfetto::trace_redaction {
-
-namespace {
-
-constexpr std::string_view kProcessName =
-    "com.Unity.com.unity.multiplayer.samples.coop";
-
-}  // namespace
 
 class RedactProcessTreesIntegrationTest
     : public testing::Test,
@@ -59,7 +51,7 @@ class RedactProcessTreesIntegrationTest
     process_tree->emplace_filter<ConnectedToPackage>();
 
     // In this case, the process and package have the same name.
-    context_.package_name = kProcessName;
+    context_.package_name = kSomePackageName;
   }
 
   std::unordered_set<int32_t> GetPids(const std::string& bytes) const {

--- a/src/trace_redaction/redact_sched_events_integrationtest.cc
+++ b/src/trace_redaction/redact_sched_events_integrationtest.cc
@@ -99,7 +99,7 @@ class RedactSchedSwitchIntegrationTest
     redact_sched_events->emplace_modifier<ClearComms>();
     redact_sched_events->emplace_waking_filter<AllowAll>();
 
-    context_.package_name = "com.Unity.com.unity.multiplayer.samples.coop";
+    context_.package_name = kSomePackageName;
   }
 
   std::unordered_map<int32_t, std::string> expected_names_ = {

--- a/src/trace_redaction/scrub_process_stats_integrationtest.cc
+++ b/src/trace_redaction/scrub_process_stats_integrationtest.cc
@@ -41,8 +41,7 @@ class ScrubProcessStatsTest : public testing::Test,
     auto* scrub = trace_redactor_.emplace_transform<ScrubProcessStats>();
     scrub->emplace_filter<ConnectedToPackage>();
 
-    // Package "com.Unity.com.unity.multiplayer.samples.coop";
-    context_.package_uid = 10252;
+    context_.package_uid = kSomePackageUid;
   }
 
   // Gets pids from all process_stats messages in the trace (bytes).

--- a/src/trace_redaction/trace_redaction_integration_fixture.h
+++ b/src/trace_redaction/trace_redaction_integration_fixture.h
@@ -40,6 +40,12 @@ class TraceRedactionIntegrationFixure {
 
   base::StatusOr<std::string> LoadRedacted() const;
 
+  // Set the package name to "just some package name". If a specific package
+  // name is needed, the test it should overwrite this value.
+  static constexpr auto kSomePackageName =
+      "com.Unity.com.unity.multiplayer.samples.coop";
+  static constexpr auto kSomePackageUid = 10252u;
+
  private:
   base::StatusOr<std::string> ReadRawTrace(const std::string& path) const;
 


### PR DESCRIPTION
Many integration tests used the same package names. Each test would declare the same package name/uid. This CL moves the name and uid into the text fixture.
