### PR TITLE
Bump priority of thread state aggregation tab to show up before slices

### DIFF
--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -147,7 +147,11 @@ export default class implements PerfettoPlugin {
     const {engine} = ctx;
 
     ctx.selection.registerAreaSelectionTab(
-      createAggregationToTabAdaptor(ctx, new ThreadStateSelectionAggregator()),
+      createAggregationToTabAdaptor(
+        ctx,
+        new ThreadStateSelectionAggregator(),
+        10,
+      ),
     );
 
     const result = await engine.query(`


### PR DESCRIPTION
When selecting thread state tracks, the slice aggregation tab showed up before the thread state aggregation tab, which is usually not what we want.

Before:


After:
<img width="508" alt="image" src="https://github.com/user-attachments/assets/598ccf35-2815-4a2b-a595-c2dbee8ce64b" />

