### PR TITLE
Rename track.track -> track.renderer

### DIFF
--- a/ui/src/components/selection_aggregation_manager.ts
+++ b/ui/src/components/selection_aggregation_manager.ts
@@ -202,7 +202,7 @@ export class SelectionAggregationManager {
         (td) =>
           aggr.trackKind === undefined || aggr.trackKind === td.tags?.kind,
       )
-      .map((td) => td.track.getDataset?.())
+      .map((td) => td.renderer.getDataset?.())
       .filter((dataset) => dataset !== undefined)
       .filter(
         (dataset) =>

--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -456,12 +456,12 @@ export class BreakdownTracks {
       filters.length > 0 ? `\nWHERE ${buildFilterSqlClause(filters)}` : '';
     const uri = `${this.uri}_${uuidv4()}`;
 
-    const track = await createTrack(uri, filtersClause);
+    const renderer = await createTrack(uri, filtersClause);
 
     this.props.trace.tracks.registerTrack({
       uri,
       title,
-      track,
+      renderer,
     });
 
     const sortOrder = await getSortOrder?.(filtersClause);

--- a/ui/src/components/tracks/debug_tracks.ts
+++ b/ui/src/components/tracks/debug_tracks.ts
@@ -171,7 +171,7 @@ async function addPivotedSliceTracks(
     trace.tracks.registerTrack({
       uri,
       title,
-      track: new DatasetSliceTrack({
+      renderer: new DatasetSliceTrack({
         trace,
         uri,
         dataset: new SourceDataset({
@@ -207,7 +207,7 @@ function addSingleSliceTrack(
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new DatasetSliceTrack({
+    renderer: new DatasetSliceTrack({
       trace,
       uri,
       dataset: new SourceDataset({
@@ -339,7 +339,7 @@ async function addPivotedCounterTracks(
     trace.tracks.registerTrack({
       uri,
       title,
-      track: new SqlTableCounterTrack(
+      renderer: new SqlTableCounterTrack(
         trace,
         uri,
         `
@@ -364,7 +364,7 @@ function addSingleCounterTrack(
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new SqlTableCounterTrack(trace, uri, tableName),
+    renderer: new SqlTableCounterTrack(trace, uri, tableName),
   });
 
   const trackNode = new TrackNode({uri, title, removable: true});

--- a/ui/src/components/tracks/visualized_args_tracks.ts
+++ b/ui/src/components/tracks/visualized_args_tracks.ts
@@ -69,7 +69,7 @@ export async function addVisualizedArgTracks(trace: Trace, argName: string) {
       uri,
       title: argName,
       chips: ['arg'],
-      track: await createVisualizedArgsTrack({
+      renderer: await createVisualizedArgsTrack({
         trace,
         uri,
         trackId,

--- a/ui/src/core/dataset_search.ts
+++ b/ui/src/core/dataset_search.ts
@@ -81,7 +81,7 @@ function buildTrackGroups(
 ): Map<string, TrackGroup> {
   const trackGroups = new Map<string, TrackGroup>();
   for (const track of tracks) {
-    const dataset = track.track.getDataset?.();
+    const dataset = track.renderer.getDataset?.();
     if (dataset) {
       const src = dataset.src;
       const trackGroup = getOrCreate(trackGroups, src, () => ({

--- a/ui/src/core/flow_manager.ts
+++ b/ui/src/core/flow_manager.ts
@@ -373,7 +373,7 @@ export class FlowManager {
       //
       // TODO(stevegolton): We can remove this check entirely once flows are
       // made more generic.
-      const rootTableName = trackInfo.track.rootTableName;
+      const rootTableName = trackInfo.renderer.rootTableName;
       if (rootTableName === 'slice') {
         if (trackInfo?.tags?.trackIds) {
           for (const trackId of trackInfo.tags.trackIds) {
@@ -463,7 +463,7 @@ export class FlowManager {
 
     if (
       selection.kind === 'track_event' &&
-      this.trackMgr.getTrack(selection.trackUri)?.track.rootTableName ===
+      this.trackMgr.getTrack(selection.trackUri)?.renderer.rootTableName ===
         'slice'
     ) {
       this.sliceSelected(selection.eventId);

--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -240,9 +240,9 @@ export class SelectionManagerImpl implements SelectionManager {
 
     this.trackManager
       .getAllTracks()
-      .filter((track) => track.track.rootTableName === sqlTableName)
+      .filter((track) => track.renderer.rootTableName === sqlTableName)
       .map((track) => {
-        const dataset = track.track.getDataset?.();
+        const dataset = track.renderer.getDataset?.();
         if (!dataset) return undefined;
         return [dataset, track] as const;
       })
@@ -401,7 +401,7 @@ export class SelectionManagerImpl implements SelectionManager {
       );
     }
 
-    const trackRenderer = track.track;
+    const trackRenderer = track.renderer;
     if (!trackRenderer.getSelectionDetails) {
       throw new Error(
         `Unable to resolve selection details: Track ${trackUri} does not support selection details`,
@@ -433,7 +433,7 @@ export class SelectionManagerImpl implements SelectionManager {
     if (!td) {
       return;
     }
-    const panel = td.track.detailsPanel?.(selection);
+    const panel = td.renderer.detailsPanel?.(selection);
     if (!panel) {
       return;
     }

--- a/ui/src/core/track_manager.ts
+++ b/ui/src/core/track_manager.ts
@@ -236,7 +236,7 @@ class TrackFSMImpl implements TrackWithFSM {
   }
 
   get track(): TrackRenderer {
-    return this.desc.track;
+    return this.desc.renderer;
   }
 }
 

--- a/ui/src/core/track_manager_unittest.ts
+++ b/ui/src/core/track_manager_unittest.ts
@@ -59,7 +59,7 @@ beforeEach(() => {
   td = {
     uri: 'test',
     title: 'foo',
-    track: mockTrack,
+    renderer: mockTrack,
   };
   trackManager = new TrackManagerImpl();
   trackManager.registerTrack(td);

--- a/ui/src/core_plugins/track_utils/index.ts
+++ b/ui/src/core_plugins/track_utils/index.ts
@@ -149,7 +149,7 @@ async function selectAdjacentTrackEvent(
   if (selection.kind !== 'track_event') return;
 
   const td = ctx.tracks.getTrack(selection.trackUri);
-  const dataset = td?.track.getDataset?.();
+  const dataset = td?.renderer.getDataset?.();
   if (!dataset || !dataset.implements({id: NUM, ts: LONG})) return;
 
   const windowFunc = direction === 'next' ? 'LEAD' : 'LAG';

--- a/ui/src/frontend/viewer_page/flow_events_renderer.ts
+++ b/ui/src/frontend/viewer_page/flow_events_renderer.ts
@@ -147,7 +147,7 @@ export function renderFlows(
       const trackRect = trackPanel.verticalBounds;
       const sliceRectRaw = trace.tracks
         .getTrack(trackUri)
-        ?.track.getSliceVerticalBounds?.(depth);
+        ?.renderer.getSliceVerticalBounds?.(depth);
       if (sliceRectRaw) {
         const sliceRect = {
           top: sliceRectRaw.top + trackRect.top,

--- a/ui/src/frontend/viewer_page/track_tree_view.ts
+++ b/ui/src/frontend/viewer_page/track_tree_view.ts
@@ -290,7 +290,7 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
     const track = trackNode.uri
       ? this.trace.tracks.getTrack(trackNode.uri)
       : undefined;
-    const tooltipNodes = track?.track.renderTooltip?.();
+    const tooltipNodes = track?.renderer.renderTooltip?.();
     if (!Boolean(tooltipNodes)) {
       return;
     }

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -619,7 +619,7 @@ function copyToWorkspace(trace: Trace, node: TrackNode, ws?: Workspace) {
 
 function renderTrackDetailsMenu(node: TrackNode, descriptor?: Track) {
   const fullPath = node.fullPath.join(' \u2023 ');
-  const query = descriptor?.track.getDataset?.()?.query();
+  const query = descriptor?.renderer.getDataset?.()?.query();
 
   return m(
     '.pf-track__track-details-popup',

--- a/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
@@ -77,7 +77,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track: new DatasetSliceTrack({
+      renderer: new DatasetSliceTrack({
         trace: ctx,
         uri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
+++ b/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
@@ -74,7 +74,7 @@ export default class implements PerfettoPlugin {
           trackIds: [trackId],
           kind: SLICE_TRACK_KIND,
         },
-        track,
+        renderer: track,
       });
       let workPeriod = workPeriodByGpu.get(gpuId);
       if (workPeriod === undefined) {

--- a/ui/src/plugins/com.android.InputEvents/index.ts
+++ b/ui/src/plugins/com.android.InputEvents/index.ts
@@ -56,7 +56,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title: title,
-      track,
+      renderer: track,
     });
     const node = new TrackNode({uri, title});
     const group = ctx.plugins

--- a/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
@@ -46,7 +46,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track: new DatasetSliceTrack({
+      renderer: new DatasetSliceTrack({
         trace: ctx,
         uri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.example.Tracks/index.ts
+++ b/ui/src/plugins/com.example.Tracks/index.ts
@@ -72,7 +72,7 @@ async function addBasicSliceTrack(trace: Trace): Promise<void> {
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new DatasetSliceTrack({
+    renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -99,7 +99,7 @@ async function addFilteredSliceTrack(trace: Trace): Promise<void> {
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new DatasetSliceTrack({
+    renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -134,7 +134,7 @@ async function addSliceTrackWithCustomColorizer(trace: Trace): Promise<void> {
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new DatasetSliceTrack({
+    renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -166,7 +166,7 @@ async function addInstantTrack(trace: Trace): Promise<void> {
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new DatasetSliceTrack({
+    renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -193,7 +193,7 @@ async function addFlatSliceTrack(trace: Trace): Promise<void> {
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new DatasetSliceTrack({
+    renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -222,7 +222,7 @@ async function addFixedColorSliceTrack(trace: Trace): Promise<void> {
   trace.tracks.registerTrack({
     uri,
     title,
-    track: new DatasetSliceTrack({
+    renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/com.google.PixelCpmTrace/index.ts
+++ b/ui/src/plugins/com.google.PixelCpmTrace/index.ts
@@ -62,7 +62,7 @@ export default class implements PerfettoPlugin {
           kind: COUNTER_TRACK_KIND,
           trackIds: [trackId],
         },
-        track,
+        renderer: track,
       });
       group.addChildInOrder(new TrackNode({uri, title: trackName}));
       if (!groupAdded) {

--- a/ui/src/plugins/dev.perfetto.AndroidCounterTracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidCounterTracks/index.ts
@@ -58,7 +58,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track,
+      renderer: track,
     });
 
     return new TrackNode({title, uri, sortOrder: -7});

--- a/ui/src/plugins/dev.perfetto.AndroidDesktopMode/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidDesktopMode/index.ts
@@ -58,7 +58,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri: TRACK_URI,
       title: TRACK_NAME,
-      track,
+      renderer: track,
     });
   }
 

--- a/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
@@ -40,7 +40,7 @@ async function registerAllocsTrack(
   ctx.tracks.registerTrack({
     uri,
     title: `dmabuf allocs`,
-    track: track,
+    renderer: track,
   });
 }
 
@@ -122,7 +122,7 @@ async function addGlobalCounter(ctx: Trace, parent: () => TrackNode) {
       kind: COUNTER_TRACK_KIND,
       trackIds: [id],
     },
-    track: new TraceProcessorCounterTrack(ctx, uri, {}, id, title),
+    renderer: new TraceProcessorCounterTrack(ctx, uri, {}, id, title),
   });
   const node = new TrackNode({
     uri,
@@ -153,7 +153,7 @@ async function addGlobalAllocs(ctx: Trace, parent: () => TrackNode) {
       kind: SLICE_TRACK_KIND,
       trackIds: ids,
     },
-    track: await createTraceProcessorSliceTrack({
+    renderer: await createTraceProcessorSliceTrack({
       trace: ctx,
       uri,
       trackIds: ids,

--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -79,7 +79,7 @@ export default class implements PerfettoPlugin {
         title,
         description: 'Android log messages',
         tags: {kind: ANDROID_LOGS_TRACK_KIND},
-        track: createAndroidLogTrack(ctx, uri),
+        renderer: createAndroidLogTrack(ctx, uri),
       });
       const track = new TrackNode({title, uri});
       ctx.workspace.addChildInOrder(track);

--- a/ui/src/plugins/dev.perfetto.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLongBatteryTracing/index.ts
@@ -882,7 +882,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title: name,
-      track,
+      renderer: track,
     });
     const trackNode = new TrackNode({uri, title: name});
     this.addTrack(ctx, trackNode, groupName, groupCollapsed);
@@ -909,7 +909,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title: name,
-      track,
+      renderer: track,
     });
     const trackNode = new TrackNode({uri, title: name});
     this.addTrack(ctx, trackNode, groupName, groupCollapsed);

--- a/ui/src/plugins/dev.perfetto.AndroidStartup/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidStartup/index.ts
@@ -83,7 +83,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track,
+      renderer: track,
     });
     // Needs a sort order lower than 'Ftrace Events' so that it is prioritized in the UI.
     return new TrackNode({title, uri, sortOrder: -6});

--- a/ui/src/plugins/dev.perfetto.AndroidStartup/optimizations.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidStartup/optimizations.ts
@@ -126,7 +126,7 @@ export async function optimizationsTrack(
   trace.tracks.registerTrack({
     uri,
     title,
-    track,
+    renderer: track,
   });
   const trackNode = new TrackNode({title, uri});
   for await (const classLoadingTrack of classLoadingTracks) {
@@ -157,7 +157,7 @@ async function classLoadingTrack(
   trace.tracks.registerTrack({
     uri,
     title,
-    track,
+    renderer: track,
   });
   return new TrackNode({title, uri});
 }

--- a/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
@@ -95,7 +95,7 @@ export default class implements PerfettoPlugin {
             kind: CPU_FREQ_TRACK_KIND,
             cpu: cpu.ucpu,
           },
-          track: new CpuFreqTrack(config, ctx),
+          renderer: new CpuFreqTrack(config, ctx),
         });
         const trackNode = new TrackNode({uri, title, sortOrder: -40});
         ctx.workspace.addChildInOrder(trackNode);

--- a/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
@@ -68,7 +68,7 @@ export default class implements PerfettoPlugin {
           utid,
           ...(exists(upid) && {upid}),
         },
-        track: createCpuProfileTrack(ctx, uri, utid),
+        renderer: createCpuProfileTrack(ctx, uri, utid),
       });
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)

--- a/ui/src/plugins/dev.perfetto.CpuidleTimeInState/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuidleTimeInState/index.ts
@@ -45,7 +45,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title: name,
-      track,
+      renderer: track,
     });
     const node = new TrackNode({uri, title: name});
     group.addChildInOrder(node);

--- a/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
@@ -139,7 +139,7 @@ async function getUtid(trace: Trace): Promise<Utid | undefined> {
     return asUtid(track.tags.utid);
   }
 
-  const dataset = track.track.getDataset?.();
+  const dataset = track.renderer.getDataset?.();
   if (dataset === undefined) return undefined;
   if (!dataset.implements({utid: NUM})) return undefined;
 

--- a/ui/src/plugins/dev.perfetto.EntityStateResidency/index.ts
+++ b/ui/src/plugins/dev.perfetto.EntityStateResidency/index.ts
@@ -102,7 +102,7 @@ export default class implements PerfettoPlugin {
           trackIds: [it.trackId],
           type: 'entity_state',
         },
-        track,
+        renderer: track,
       });
       currentGroup.addChildInOrder(new TrackNode({uri, title: name}));
     }

--- a/ui/src/plugins/dev.perfetto.Frames/index.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/index.ts
@@ -79,7 +79,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title,
-        track: createExpectedFramesTrack(ctx, uri, maxDepth, trackIds),
+        renderer: createExpectedFramesTrack(ctx, uri, maxDepth, trackIds),
         tags: {
           trackIds,
           upid,
@@ -129,7 +129,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title,
-        track: createActualFramesTrack(ctx, uri, maxDepth, trackIds),
+        renderer: createActualFramesTrack(ctx, uri, maxDepth, trackIds),
         tags: {
           upid,
           trackIds,

--- a/ui/src/plugins/dev.perfetto.Ftrace/index.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/index.ts
@@ -73,7 +73,7 @@ export default class implements PerfettoPlugin {
           cpu: cpu.cpu,
           groupName: 'Ftrace Events',
         },
-        track: createFtraceTrack(ctx, uri, cpu, filterStore),
+        renderer: createFtraceTrack(ctx, uri, cpu, filterStore),
       });
 
       const track = new TrackNode({uri, title});

--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -62,7 +62,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title,
-        track: new DatasetSliceTrack({
+        renderer: new DatasetSliceTrack({
           trace: ctx,
           uri,
           dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.GpuFreq/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuFreq/index.ts
@@ -42,7 +42,7 @@ export default class implements PerfettoPlugin {
           kind: COUNTER_TRACK_KIND,
           trackIds: [it.id],
         },
-        track: new TraceProcessorCounterTrack(ctx, uri, {}, it.id, name),
+        renderer: new TraceProcessorCounterTrack(ctx, uri, {}, it.id, name),
       });
       const track = new TrackNode({uri, title: name, sortOrder: -20});
       ctx.workspace.addChildInOrder(track);

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -91,7 +91,7 @@ export default class implements PerfettoPlugin {
           kind: HEAP_PROFILE_TRACK_KIND,
           upid,
         },
-        track: createHeapProfileTrack(
+        renderer: createHeapProfileTrack(
           trace,
           uri,
           EVENT_TABLE_NAME,

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/index.ts
@@ -62,7 +62,7 @@ export default class implements PerfettoPlugin {
           kind: INSTRUMENTS_SAMPLES_PROFILE_TRACK_KIND,
           upid,
         },
-        track: createProcessInstrumentsSamplesProfileTrack(ctx, uri, upid),
+        renderer: createProcessInstrumentsSamplesProfileTrack(ctx, uri, upid),
       });
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
@@ -104,7 +104,7 @@ export default class implements PerfettoPlugin {
           utid,
           upid: upid ?? undefined,
         },
-        track: createThreadInstrumentsSamplesProfileTrack(ctx, uri, utid),
+        renderer: createThreadInstrumentsSamplesProfileTrack(ctx, uri, utid),
       });
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)

--- a/ui/src/plugins/dev.perfetto.Io/index.ts
+++ b/ui/src/plugins/dev.perfetto.Io/index.ts
@@ -50,7 +50,7 @@ export default class implements PerfettoPlugin {
           device: device['id'],
           groupName: 'Queued IO requests',
         },
-        track,
+        renderer: track,
       });
       const node = new TrackNode({uri, title});
       group.addChildInOrder(node);

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
@@ -84,7 +84,7 @@ export default class implements PerfettoPlugin {
           kind: PERF_SAMPLES_PROFILE_TRACK_KIND,
           upid,
         },
-        track: createProcessPerfSamplesProfileTrack(trace, uri, upid),
+        renderer: createProcessPerfSamplesProfileTrack(trace, uri, upid),
       });
       const group = trace.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
@@ -143,7 +143,7 @@ export default class implements PerfettoPlugin {
           utid,
           upid: upid ?? undefined,
         },
-        track: createThreadPerfSamplesProfileTrack(trace, uri, utid),
+        renderer: createThreadPerfSamplesProfileTrack(trace, uri, utid),
       });
       const group = trace.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
@@ -190,7 +190,7 @@ export default class implements PerfettoPlugin {
           trackIds: [trackId],
           cpu,
         },
-        track: new TraceProcessorCounterTrack(
+        renderer: new TraceProcessorCounterTrack(
           trace,
           uri,
           {

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/index.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/index.ts
@@ -178,7 +178,7 @@ export default class implements PerfettoPlugin {
             kind: PROCESS_SCHEDULING_TRACK_KIND,
           },
           chips,
-          track: new ProcessSchedulingTrack(ctx, config, cpuCount, threads),
+          renderer: new ProcessSchedulingTrack(ctx, config, cpuCount, threads),
           subtitle,
         });
       } else {
@@ -195,7 +195,7 @@ export default class implements PerfettoPlugin {
             kind: PROCESS_SUMMARY_TRACK,
           },
           chips,
-          track: new ProcessSummaryTrack(ctx.engine, config),
+          renderer: new ProcessSummaryTrack(ctx.engine, config),
           subtitle,
         });
       }
@@ -253,7 +253,7 @@ export default class implements PerfettoPlugin {
       tags: {
         kind: PROCESS_SUMMARY_TRACK,
       },
-      track: new ProcessSummaryTrack(ctx.engine, config),
+      renderer: new ProcessSummaryTrack(ctx.engine, config),
     });
   }
 }

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -93,7 +93,7 @@ export default class implements PerfettoPlugin {
           kind: CPU_SLICE_TRACK_KIND,
           cpu: cpu.ucpu,
         },
-        track: new CpuSliceTrack(ctx, uri, cpu, threads),
+        renderer: new CpuSliceTrack(ctx, uri, cpu, threads),
       });
       const trackNode = new TrackNode({uri, title: name, sortOrder: -50});
       ctx.workspace.addChildInOrder(trackNode);
@@ -196,7 +196,7 @@ export default class implements PerfettoPlugin {
         chips: removeFalsyValues([
           isKernelThread === 0 && isMainThread === 1 && 'main thread',
         ]),
-        track: createThreadStateTrack(ctx, uri, utid),
+        renderer: createThreadStateTrack(ctx, uri, utid),
       });
 
       const group = ctx.plugins

--- a/ui/src/plugins/dev.perfetto.SchedSummary/index.ts
+++ b/ui/src/plugins/dev.perfetto.SchedSummary/index.ts
@@ -28,7 +28,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri: runnableThreadCountUri,
       title: 'Runnable thread count',
-      track: new RunnableThreadCountTrack(ctx, runnableThreadCountUri),
+      renderer: new RunnableThreadCountTrack(ctx, runnableThreadCountUri),
     });
     ctx.commands.registerCommand({
       id: 'dev.perfetto.Sched.AddRunnableThreadCountTrackCommand',
@@ -41,7 +41,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri: uninterruptibleSleepThreadCountUri,
       title: 'Uninterruptible Sleep thread count',
-      track: new UninterruptibleSleepThreadCountTrack(
+      renderer: new UninterruptibleSleepThreadCountTrack(
         ctx,
         uninterruptibleSleepThreadCountUri,
       ),
@@ -62,7 +62,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title: title,
-      track: new ActiveCPUCountTrack({trackUri: uri}, ctx),
+      renderer: new ActiveCPUCountTrack({trackUri: uri}, ctx),
     });
     ctx.commands.registerCommand({
       id: 'dev.perfetto.Sched.AddActiveCPUCountTrackCommand',
@@ -76,7 +76,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title: title,
-        track: new ActiveCPUCountTrack({trackUri: uri}, ctx, cpuType),
+        renderer: new ActiveCPUCountTrack({trackUri: uri}, ctx, cpuType),
       });
 
       ctx.commands.registerCommand({

--- a/ui/src/plugins/dev.perfetto.Screenshots/index.ts
+++ b/ui/src/plugins/dev.perfetto.Screenshots/index.ts
@@ -35,7 +35,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title,
-        track: createScreenshotsTrack(ctx, uri),
+        renderer: createScreenshotsTrack(ctx, uri),
       });
       const trackNode = new TrackNode({uri, title, sortOrder: -60});
       ctx.workspace.addChildInOrder(trackNode);

--- a/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
@@ -133,7 +133,7 @@ export default class implements PerfettoPlugin {
     trace.tracks.registerTrack({
       uri,
       title,
-      track,
+      renderer: track,
     });
     const trackNode = new TrackNode({uri, title});
     const group = trace.plugins

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -155,7 +155,7 @@ export default class implements PerfettoPlugin {
         chips: removeFalsyValues([
           isKernelThread === 0 && isMainThread === 1 && 'main thread',
         ]),
-        track: new TraceProcessorCounterTrack(
+        renderer: new TraceProcessorCounterTrack(
           ctx,
           uri,
           {
@@ -281,7 +281,7 @@ export default class implements PerfettoPlugin {
         chips: removeFalsyValues([
           isKernelThread === 0 && isMainThread === 1 && 'main thread',
         ]),
-        track: await createTraceProcessorSliceTrack({
+        renderer: await createTraceProcessorSliceTrack({
           trace: ctx,
           uri,
           maxDepth,

--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -133,7 +133,7 @@ export default class implements PerfettoPlugin {
             upid: upid ?? undefined,
             utid: utid ?? undefined,
           },
-          track: new TraceProcessorCounterTrack(
+          renderer: new TraceProcessorCounterTrack(
             ctx,
             uri,
             {
@@ -153,7 +153,7 @@ export default class implements PerfettoPlugin {
             upid: upid ?? undefined,
             utid: utid ?? undefined,
           },
-          track: await createTraceProcessorSliceTrack({
+          renderer: await createTraceProcessorSliceTrack({
             trace: ctx,
             uri,
             trackIds,

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/index.ts
@@ -40,7 +40,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title: 'Chrome Interactions',
-      track: createCriticalUserInteractionTrack(ctx, uri),
+      renderer: createCriticalUserInteractionTrack(ctx, uri),
     });
   }
 }

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
@@ -71,7 +71,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track: createTopLevelScrollTrack(ctx, uri),
+      renderer: createTopLevelScrollTrack(ctx, uri),
     });
 
     const track = new TrackNode({uri, title});
@@ -180,7 +180,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track: createEventLatencyTrack(ctx, uri, baseTable),
+      renderer: createEventLatencyTrack(ctx, uri, baseTable),
     });
 
     const track = new TrackNode({uri, title});
@@ -201,7 +201,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track: createScrollJankV3Track(ctx, uri),
+      renderer: createScrollJankV3Track(ctx, uri),
     });
 
     const track = new TrackNode({uri, title});
@@ -222,7 +222,7 @@ export default class implements PerfettoPlugin {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track: createScrollTimelineTrack(ctx, model),
+      renderer: createScrollTimelineTrack(ctx, model),
     });
 
     const track = new TrackNode({uri, title});
@@ -254,7 +254,7 @@ export default class implements PerfettoPlugin {
         uri,
       });
       const title = 'Chrome VSync';
-      ctx.tracks.registerTrack({uri, title, track});
+      ctx.tracks.registerTrack({uri, title, renderer: track});
       group.addChildInOrder(new TrackNode({uri, title}));
     }
 
@@ -267,7 +267,7 @@ export default class implements PerfettoPlugin {
         `(SELECT id, ts, LEAD(ts) OVER (ORDER BY ts) - ts as dur FROM ${vsyncTable})`,
       );
       const title = 'Chrome VSync delta';
-      ctx.tracks.registerTrack({uri, title, track});
+      ctx.tracks.registerTrack({uri, title, renderer: track});
       group.addChildInOrder(new TrackNode({uri, title}));
     }
 
@@ -285,7 +285,7 @@ export default class implements PerfettoPlugin {
         WHERE generation_ts IS NOT NULL)`,
       );
       const title = 'Chrome input delta';
-      ctx.tracks.registerTrack({uri, title, track});
+      ctx.tracks.registerTrack({uri, title, renderer: track});
       group.addChildInOrder(new TrackNode({uri, title}));
     }
 
@@ -342,7 +342,7 @@ export default class implements PerfettoPlugin {
           }),
           detailsPanel: () => new ThreadSliceDetailsPanel(ctx),
         });
-        ctx.tracks.registerTrack({uri, title: step.name, track});
+        ctx.tracks.registerTrack({uri, title: step.name, renderer: track});
         group.addChildInOrder(new TrackNode({uri, title: step.name}));
       }
     }

--- a/ui/src/plugins/org.chromium.ChromeTasks/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeTasks/index.ts
@@ -86,7 +86,7 @@ export default class implements PerfettoPlugin {
       const title = `${it.threadName} ${it.tid}`;
       ctx.tracks.registerTrack({
         uri,
-        track: createChromeTasksThreadTrack(ctx, uri, asUtid(utid)),
+        renderer: createChromeTasksThreadTrack(ctx, uri, asUtid(utid)),
         title,
       });
       const track = new TrackNode({uri, title});

--- a/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
+++ b/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
@@ -66,7 +66,7 @@ export default class implements PerfettoPlugin {
       ctx.tracks.registerTrack({
         uri,
         title,
-        track: await createTraceProcessorSliceTrack({
+        renderer: await createTraceProcessorSliceTrack({
           trace: ctx,
           uri,
           trackIds: [trackId],

--- a/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
+++ b/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
@@ -70,7 +70,7 @@ export default class implements PerfettoPlugin {
         trackIds,
         kind: SLICE_TRACK_KIND,
       },
-      track: await createTraceProcessorSliceTrack({
+      renderer: await createTraceProcessorSliceTrack({
         trace: ctx,
         uri,
         maxDepth,

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -155,7 +155,7 @@ async function addWattsonMarkersElements(ctx: Trace, group: TrackNode) {
     tags: {
       kind: SLICE_TRACK_KIND,
     },
-    track,
+    renderer: track,
   });
   group.addChildInOrder(new TrackNode({uri, title}));
 }
@@ -184,7 +184,7 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
     ctx.tracks.registerTrack({
       uri,
       title,
-      track: new WattsonSubsystemEstimateTrack(
+      renderer: new WattsonSubsystemEstimateTrack(
         ctx,
         uri,
         queryKey,
@@ -204,7 +204,7 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
   ctx.tracks.registerTrack({
     uri,
     title,
-    track: new WattsonSubsystemEstimateTrack(
+    renderer: new WattsonSubsystemEstimateTrack(
       ctx,
       uri,
       `dsu_scu_mw`,
@@ -253,7 +253,7 @@ async function addWattsonGpuElements(ctx: Trace, group: TrackNode) {
   ctx.tracks.registerTrack({
     uri,
     title,
-    track: new WattsonSubsystemEstimateTrack(
+    renderer: new WattsonSubsystemEstimateTrack(
       ctx,
       uri,
       `gpu_mw`,

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -115,7 +115,7 @@ export interface Track {
   readonly uri: string;
 
   // Describes how to render the track.
-  readonly track: TrackRenderer;
+  readonly renderer: TrackRenderer;
 
   // Human readable title. Always displayed.
   readonly title: string;


### PR DESCRIPTION
For legacy reasons, `Track` has a field called `track` which is of type 'TrackRenderer'. This PR renames this field to `renderer` to avoid confusion.