### PR TITLE
tp: StructuredQuery.sql supports multi select SQL field

### DIFF
--- a/protos/perfetto/perfetto_sql/structured_query.proto
+++ b/protos/perfetto/perfetto_sql/structured_query.proto
@@ -90,17 +90,17 @@ message PerfettoSqlStructuredQuery {
   message Sql {
     // The SQL string. Required.
     //
-    // Note: this string is currently required to be a single well-formed select
-    // statement. This means you cannot use CREATE PERFETTO TABLE/VIEW but *can*
-    // use WITH clauses, UNION and INTERSECT. This restriction may be dropped
-    // in the future.
+    // Note: We expect the last statement to be the only one to produce a
+    // result.
     optional string sql = 1;
 
     // The name of columns which will be returned by the SQL. Required.
     repeated string column_names = 2;
 
-    // SQL string that has to be run before running the SQL. Supports multi
-    // statement queries. Optional.
+    // DEPRECATED, as `sql` field supports multi-statement queries.
+    //
+    // SQL string that has to be run before running the SQL.
+    // Supports multi statement queries. Optional.
     optional string preamble = 3;
   }
 

--- a/protos/perfetto/perfetto_sql/structured_query.proto
+++ b/protos/perfetto/perfetto_sql/structured_query.proto
@@ -90,8 +90,13 @@ message PerfettoSqlStructuredQuery {
   message Sql {
     // The SQL string. Required.
     //
-    // Note: We expect the last statement to be the only one to produce a
-    // result.
+    // `sql` can contain multiple, semi-colon separated statements but must
+    // adhere to the following principles:
+    // 1) Only the final statement can return results (i.e. be a `SELECT`
+    // statement): every other statement must be a statement returning no output
+    // (e.g. INCLUDE PERFETTO MODULE, CREATE PERFETTO TABLE etc.).
+    // 2) The final statement *must* be a valid `SELECT` statement returning
+    // results with at least one column.
     optional string sql = 1;
 
     // The name of columns which will be returned by the SQL. Required.

--- a/python/generators/diff_tests/runner.py
+++ b/python/generators/diff_tests/runner.py
@@ -294,6 +294,9 @@ class TestCaseRunner:
       actual_summary = summary_message_factory()
       actual_summary.ParseFromString(stdout)
 
+      actual = text_format.MessageToString(actual_summary.metric[0]) if len(
+          actual_summary.metric) > 0 else ''
+
       os.remove(tmp_perf_file.name)
       if not keep_input:
         os.remove(tmp_spec_file.name)
@@ -303,7 +306,7 @@ class TestCaseRunner:
           trace_path,
           cmd,
           text_format.MessageToString(expected_summary.metric[0]),
-          text_format.MessageToString(actual_summary.metric[0]),
+          actual,
           stderr.decode('utf8'),
           tp.returncode,
           [line.decode('utf8') for line in tmp_perf_file.readlines()],

--- a/src/trace_processor/perfetto_sql/generator/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/generator/BUILD.gn
@@ -26,6 +26,7 @@ source_set("generator") {
     "../../../base",
     "../../../protozero",
     "../../util",
+    "../tokenizer",
   ]
 }
 
@@ -46,5 +47,6 @@ perfetto_unittest_source_set("unittests") {
     "../../../base",
     "../../../base:test_support",
     "../../../protozero/text_to_proto",
+    "../tokenizer",
   ]
 }

--- a/src/trace_processor/perfetto_sql/generator/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/generator/BUILD.gn
@@ -25,6 +25,7 @@ source_set("generator") {
     "../../../../protos/perfetto/perfetto_sql:zero",
     "../../../base",
     "../../../protozero",
+    "../../sqlite",
     "../../util",
     "../tokenizer",
   ]
@@ -47,6 +48,7 @@ perfetto_unittest_source_set("unittests") {
     "../../../base",
     "../../../base:test_support",
     "../../../protozero/text_to_proto",
+    "../../sqlite",
     "../tokenizer",
   ]
 }

--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
@@ -252,6 +252,31 @@ TEST(StructuredQueryGeneratorTest, SqlSourceWithPreamble) {
               UnorderedElementsAre("SELECT 1; SELECT 2;"));
 }
 
+TEST(StructuredQueryGeneratorTest, SqlSourceWithMultistatement) {
+  StructuredQueryGenerator gen;
+  auto proto = ToProto(R"(
+    sql: {
+      sql: "; ;SELECT 1; SELECT 2;; SELECT id, ts, dur FROM slice"
+      column_names: "id"
+      column_names: "ts"
+      column_names: "dur"
+    }
+  )");
+  auto ret = gen.Generate(proto.data(), proto.size());
+  ASSERT_OK_AND_ASSIGN(std::string res, ret);
+  ASSERT_THAT(res, EqualsIgnoringWhitespace(R"(
+    WITH sq_0 AS (
+      SELECT * FROM (
+        SELECT id, ts, dur
+        FROM (SELECT id, ts, dur FROM slice)
+      )
+    )
+    SELECT * FROM sq_0
+    )"));
+  ASSERT_THAT(gen.ComputePreambles(),
+              UnorderedElementsAre("SELECT 1; SELECT 2;; "));
+}
+
 TEST(StructuredQueryGeneratorTest, IntervalIntersectSource) {
   StructuredQueryGenerator gen;
   auto proto = ToProto(R"(

--- a/src/trace_processor/trace_summary/summary.cc
+++ b/src/trace_processor/trace_summary/summary.cc
@@ -114,7 +114,7 @@ base::Status CreateQueriesAndComputeMetrics(
   for (auto m = queries_per_metric.GetIterator(); m; ++m) {
     const std::string& metric_name = m.key();
     if (m.value().query.empty()) {
-      return base::ErrStatus("Metric %s was not found in any summary spec",
+      return base::ErrStatus("Metric '%s' was not found in any summary spec",
                              metric_name.c_str());
     }
     auto* metric = summary->add_metric();
@@ -135,14 +135,14 @@ base::Status CreateQueriesAndComputeMetrics(
     }
     if (!metric_value_index) {
       return base::ErrStatus(
-          "Column %s not found in the query result for metric %s",
+          "Column '%s' not found in the query result for metric '%s'",
           metric_value_column_name.c_str(), metric_name.c_str());
     }
 
     if (spec_decoder.has_dimensions_specs() && spec_decoder.has_dimensions()) {
       return base::ErrStatus(
-          "Both dimensions and dimension_specs defined for metric %s. Only one "
-          "is allowed",
+          "Both dimensions and dimension_specs defined for metric '%s'. Only "
+          "one is allowed",
           metric_name.c_str());
     }
     std::vector<uint32_t> dimension_column_indices;
@@ -160,7 +160,7 @@ base::Status CreateQueriesAndComputeMetrics(
         if (dimension_type ==
             protos::pbzero::TraceMetricV2Spec::DIMENSION_TYPE_UNSPECIFIED) {
           return base::ErrStatus(
-              "Dimension %s in metric %s has unspecified type",
+              "Dimension '%s' in metric '%s' has unspecified type",
               dim_name.c_str(), metric_name.c_str());
         }
         std::optional<uint32_t> dim_index;
@@ -172,7 +172,8 @@ base::Status CreateQueriesAndComputeMetrics(
         }
         if (!dim_index) {
           return base::ErrStatus(
-              "Column %s not found in the query result for metric %s",
+              "Dimensions column '%s' not found in the query result for metric "
+              "'%s'",
               dim_name.c_str(), metric_name.c_str());
         }
         dimension_column_indices.push_back(*dim_index);
@@ -191,7 +192,8 @@ base::Status CreateQueriesAndComputeMetrics(
         }
         if (!dim_index) {
           return base::ErrStatus(
-              "Column %s not found in the query result for metric %s",
+              "Dimensions column '%s' not found in the query result for metric "
+              "'%s'",
               dim_name.c_str(), metric_name.c_str());
         }
         dimension_column_indices.push_back(*dim_index);
@@ -221,12 +223,12 @@ base::Status CreateQueriesAndComputeMetrics(
           PERFETTO_FATAL("Null value should have been skipped");
         case SqlValue::kString:
           return base::ErrStatus(
-              "Received string for value column in metric %s: this is not "
+              "Received string for value column in metric '%s': this is not "
               "supported",
               metric_name.c_str());
         case SqlValue::kBytes:
           return base::ErrStatus(
-              "Received bytes for metric value in metric %s: this is not "
+              "Received bytes for metric value in metric '%s': this is not "
               "supported",
               metric_name.c_str());
       }
@@ -250,24 +252,24 @@ base::Status CreateQueriesAndComputeMetrics(
           case protos::pbzero::TraceMetricV2Spec::STRING:
             if (dimension_value.type != SqlValue::kString) {
               return base::ErrStatus(
-                  "Expected string for dimension %zu in metric %s, got %d", i,
-                  metric_name.c_str(), dimension_value.type);
+                  "Expected string for dimension '%zu' in metric '%s', got %d",
+                  i, metric_name.c_str(), dimension_value.type);
             }
             dimension->set_string_value(dimension_value.AsString());
             break;
           case protos::pbzero::TraceMetricV2Spec::INT64:
             if (dimension_value.type != SqlValue::kLong) {
               return base::ErrStatus(
-                  "Expected int64 for dimension %zu in metric %s, got %d", i,
-                  metric_name.c_str(), dimension_value.type);
+                  "Expected int64 for dimension '%zu' in metric '%s', got %d",
+                  i, metric_name.c_str(), dimension_value.type);
             }
             dimension->set_int64_value(dimension_value.AsLong());
             break;
           case protos::pbzero::TraceMetricV2Spec::DOUBLE:
             if (dimension_value.type != SqlValue::kDouble) {
               return base::ErrStatus(
-                  "Expected double for dimension %zu in metric %s, got %d", i,
-                  metric_name.c_str(), dimension_value.type);
+                  "Expected double for dimension '%zu' in metric '%s', got %d",
+                  i, metric_name.c_str(), dimension_value.type);
             }
             dimension->set_double_value(dimension_value.AsDouble());
             break;
@@ -282,7 +284,7 @@ base::Status CreateQueriesAndComputeMetrics(
               dimension->set_string_value(dimension_value.AsString());
             } else if (dimension_value.type == SqlValue::kBytes) {
               return base::ErrStatus(
-                  "Received bytes for dimension in metric %s: this is not "
+                  "Received bytes for dimension in metric '%s': this is not "
                   "supported",
                   metric_name.c_str());
             }
@@ -364,7 +366,7 @@ base::Status Summarize(TraceProcessor* processor,
         }
         if (queries_per_metric.Find(id)) {
           return base::ErrStatus(
-              "Duplicate definitions for metric %s received: this is not "
+              "Duplicate definitions for metric '%s' received: this is not "
               "allowed",
               id.c_str());
         }
@@ -372,7 +374,7 @@ base::Status Summarize(TraceProcessor* processor,
         base::StatusOr<std::string> query_or =
             generator.Generate(m.query().data, m.query().size);
         if (!query_or.ok()) {
-          return base::ErrStatus("Unable to build query for metric %s: %s",
+          return base::ErrStatus("Unable to build query for metric '%s': %s",
                                  id.c_str(), query_or.status().c_message());
         }
         metric.query = *query_or;
@@ -404,14 +406,14 @@ base::Status Summarize(TraceProcessor* processor,
         }
         if (!metric->query.empty()) {
           return base::ErrStatus(
-              "Duplicate definitions for metric %s received: this is not "
+              "Duplicate definitions for metric '%s' received: this is not "
               "allowed",
               id.c_str());
         }
         base::StatusOr<std::string> query_or =
             generator.Generate(m.query().data, m.query().size);
         if (!query_or.ok()) {
-          return base::ErrStatus("Unable to build query for metric %s: %s",
+          return base::ErrStatus("Unable to build query for metric '%s': %s",
                                  id.c_str(), query_or.status().c_message());
         }
         metric->query = *query_or;
@@ -428,6 +430,17 @@ base::Status Summarize(TraceProcessor* processor,
   if (computation.metadata_query_id) {
     ASSIGN_OR_RETURN(metadata_sql,
                      generator.GenerateById(*computation.metadata_query_id));
+  }
+
+  for (const auto& preamble : generator.ComputePreambles()) {
+    auto it = processor->ExecuteQuery(preamble);
+    if (it.Next()) {
+      return base::ErrStatus(
+          "Preamble query returned results. Preambles must not return. Only "
+          "the last statement of the `sql` field can return results.");
+    }
+    PERFETTO_CHECK(!it.Next());
+    RETURN_IF_ERROR(it.Status());
   }
 
   for (const auto& module : generator.ComputeReferencedModules()) {

--- a/test/trace_processor/diff_tests/summary/metrics_v2_tests.py
+++ b/test/trace_processor/diff_tests/summary/metrics_v2_tests.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from python.generators.diff_tests.testing import DataPath, Path
+from python.generators.diff_tests.testing import DataPath, Path, Csv
 from python.generators.diff_tests.testing import MetricV2SpecTextproto
 from python.generators.diff_tests.testing import DiffTestBlueprint
 from python.generators.diff_tests.testing import TestSuite
@@ -88,3 +88,181 @@ class SummaryMetricsV2(TestSuite):
               }
         '''),
         out=Path('simple_slices_metric_v2.out'))
+
+  def test_sql_no_preamble(self):
+    return DiffTestBlueprint(
+        trace=DataPath('android_postboot_unlock.pftrace'),
+        query=MetricV2SpecTextproto('''
+          id: "memory_per_process"
+          dimensions: "id"
+          value: "ts"
+          query: {
+            id: "sql_source"
+            sql {
+              sql: "SELECT id, ts FROM slice limit 2"
+              column_names: "id"
+              column_names: "ts"
+            }
+          }
+        '''),
+        out=Csv("""
+          row {
+            value: 37351104642.0
+            dimension {
+              int64_value: 0
+            }
+          }
+          row {
+            value: 37351520078.0
+            dimension {
+            int64_value: 1
+            }
+          }
+          spec {
+            id: "memory_per_process"
+            dimensions: "id"
+            value: "ts"
+            query {
+              id: "sql_source"
+              sql {
+                sql: "SELECT id, ts FROM slice limit 2"
+                column_names: "id"
+                column_names: "ts"
+              }
+            }
+          }
+        """))
+
+  def test_sql_miltistatements_in_sql(self):
+    return DiffTestBlueprint(
+        trace=DataPath('android_postboot_unlock.pftrace'),
+        query=MetricV2SpecTextproto('''
+          id: "memory_per_process"
+          dimensions: "id"
+          value: "ts"
+          query: {
+            id: "sql_source"
+            sql {
+              sql: "INCLUDE PERFETTO MODULE slices.with_context; SELECT id, ts FROM slice limit 2"
+              column_names: "id"
+              column_names: "ts"
+            }
+          }
+        '''),
+        out=Csv("""
+          row {
+            value: 37351104642.0
+            dimension {
+              int64_value: 0
+            }
+          }
+          row {
+            value: 37351520078.0
+            dimension {
+            int64_value: 1
+            }
+          }
+          spec {
+            id: "memory_per_process"
+            dimensions: "id"
+            value: "ts"
+            query {
+              id: "sql_source"
+              sql {
+                sql: "INCLUDE PERFETTO MODULE slices.with_context; SELECT id, ts FROM slice limit 2"
+                column_names: "id"
+                column_names: "ts"
+              }
+            }
+          }
+        """))
+
+  def test_sql_with_view_preamble(self):
+    return DiffTestBlueprint(
+        trace=DataPath('android_postboot_unlock.pftrace'),
+        query=MetricV2SpecTextproto('''
+          id: "preamble_view_metric"
+          dimensions: "id"
+          value: "ts"
+          query: {
+            id: "sql_source_with_view"
+            sql {
+              preamble: "CREATE PERFETTO VIEW sl AS SELECT id, ts FROM slice;"
+              sql: "SELECT id, ts FROM sl LIMIT 2"
+              column_names: "id"
+              column_names: "ts"
+            }
+          }
+        '''),
+        out=Csv("""
+          row {
+            value: 37351104642.0
+            dimension {
+              int64_value: 0
+            }
+          }
+          row {
+            value: 37351520078.0
+            dimension {
+            int64_value: 1
+            }
+          }
+          spec {
+            id: "preamble_view_metric"
+            dimensions: "id"
+            value: "ts"
+            query {
+              id: "sql_source_with_view"
+              sql {
+                preamble: "CREATE PERFETTO VIEW sl AS SELECT id, ts FROM slice;"
+                sql: "SELECT id, ts FROM sl LIMIT 2"
+                column_names: "id"
+                column_names: "ts"
+              }
+            }
+          }
+        """))
+
+  def test_sql_with_view_multistatement_view(self):
+    return DiffTestBlueprint(
+        trace=DataPath('android_postboot_unlock.pftrace'),
+        query=MetricV2SpecTextproto('''
+          id: "preamble_view_metric"
+          dimensions: "id"
+          value: "ts"
+          query: {
+            id: "sql_source_with_view"
+            sql {
+              sql: "CREATE PERFETTO VIEW sl AS SELECT id, ts FROM slice; SELECT id, ts FROM sl LIMIT 2"
+              column_names: "id"
+              column_names: "ts"
+            }
+          }
+        '''),
+        out=Csv("""
+          row {
+            value: 37351104642.0
+            dimension {
+              int64_value: 0
+            }
+          }
+          row {
+            value: 37351520078.0
+            dimension {
+            int64_value: 1
+            }
+          }
+          spec {
+            id: "preamble_view_metric"
+            dimensions: "id"
+            value: "ts"
+            query {
+              id: "sql_source_with_view"
+              sql {
+              sql: "CREATE PERFETTO VIEW sl AS SELECT id, ts FROM slice; SELECT id, ts FROM sl LIMIT 2"
+                column_names: "id"
+                column_names: "ts"
+              }
+            }
+          }
+        """))


### PR DESCRIPTION
Before we had to have preamble to state what queries were needed before executing the statement from the `sql`  field. Now we tokenize the `sql` field into statements and push all except the last one into the `preamble` (and validate that they don't produce any results) and push only the last one into the final query.