### PR TITLE
tp: table tests for SF parser changes

### DIFF
--- a/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
+++ b/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
@@ -1,30 +1,12 @@
 packet {
   clock_snapshot {
     primary_trace_clock: BUILTIN_CLOCK_BOOTTIME
-    clocks {
-      clock_id: 6
-      timestamp: 0
-    }
-    clocks {
-      clock_id: 2
-      timestamp: 1682359234732002451
-    }
-    clocks {
-      clock_id: 4
-      timestamp: 0
-    }
-    clocks {
-      clock_id: 1
-      timestamp: 1682359234732002451
-    }
-    clocks {
-      clock_id: 3
-      timestamp: 0
-    }
-    clocks {
-      clock_id: 5
-      timestamp: 0
-    }
+    clocks { clock_id: 6 timestamp: 0 }
+    clocks { clock_id: 2 timestamp: 1682359234732002451 }
+    clocks { clock_id: 4 timestamp: 0 }
+    clocks { clock_id: 1 timestamp: 1682359234732002451 }
+    clocks { clock_id: 3 timestamp: 0 }
+    clocks { clock_id: 5 timestamp: 0 }
   }
   trusted_uid: 9999
   trusted_packet_sequence_id: 1
@@ -50,33 +32,17 @@ packet {
         children: 87
         layer_stack: 0
         z: 0
-        crop {
-          right: -1
-          bottom: -1
-        }
+        z_order_relative_of: 5
+        crop { right: -1 bottom: -1 }
         is_opaque: false
         invalidate: true
         dataspace: "BT709 sRGB Full range"
         pixel_format: "Unknown/None"
-        color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
-        requested_color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
+        color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
+        requested_color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
         flags: 2
-        transform {
-          type: 0
-        }
-        requested_transform {
-          type: 0
-        }
+        transform { type: 0 }
+        requested_transform { type: 0 }
         queued_frames: 0
         is_protected: false
         curr_frame: 0
@@ -105,12 +71,7 @@ packet {
         owner_uid: 1000
         is_trusted_overlay: false
         requested_corner_radius: 0.000000
-        destination_frame {
-          left: 0
-          top: 0
-          right: -1
-          bottom: -1
-        }
+        destination_frame { left: 0 top: 0 right: -1 bottom: -1 }
       }
       layers {
         id: 4
@@ -129,25 +90,11 @@ packet {
         invalidate: true
         dataspace: "BT709 sRGB Full range"
         pixel_format: "Unknown/None"
-        color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
-        requested_color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
+        color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
+        requested_color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
         flags: 0
-        transform {
-          type: 0
-        }
-        requested_transform {
-          type: 0
-        }
+        transform { type: 0 }
+        requested_transform { type: 0 }
         parent: 3
         queued_frames: 0
         is_protected: false
@@ -177,12 +124,7 @@ packet {
         owner_uid: 1000
         is_trusted_overlay: false
         requested_corner_radius: 0.000000
-        destination_frame {
-          left: 0
-          top: 0
-          right: -1
-          bottom: -1
-        }
+        destination_frame { left: 0 top: 0 right: -1 bottom: -1 }
       }
     }
     hwc_blob: "\n\nlastUeventTime(01:00:00.000) lastTimestamp(0)\nlastEnableVsyncTime(10:33:30.061)\nlastDisableVsyncTime(10:33:30.180)\nlastValidateTime(10:33:30.065)\nlastPresentTime(10:33:30.076)\n\nResource Manager:\n[RGB Restrictions]\nHW-Node 1-1:\n    maxDownScale = 1, maxUpscale = 1\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 1, fullHeightAlign = 1\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 16, minCropHeight = 16\n    cropXAlign = 1, cropYAlign = 1\n    cropWidthAlign = 1, cropHeightAlign = 1\n\nHW-Node 1-2:\nSame as above\n\nHW-Node 7-1:\n    maxDownScale = 2, maxUpscale = 8\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 1, fullHeightAlign = 1\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 16, minCropHeight = 16\n    cropXAlign = 1, cropYAlign = 1\n    cropWidthAlign = 1, cropHeightAlign = 1\n\nHW-Node 7-2:\nSame as above\n\nHW-Node 10-1:\n    maxDownScale = 4, maxUpscale = 8\n    maxFullWidth = 8192, maxFullHeight = 8192\n    minFullWidth = 1, minFullHeight = 1\n    fullWidthAlign = 1, fullHeightAlign = 1\n    maxCropWidth = 8192, maxCropHeight = 8192\n    minCropWidth = 1, minCropHeight = 1\n    cropXAlign = 1, cropYAlign = 1\n    cropWidthAlign = 1, cropHeightAlign = 1\n\nHW-Node 10-2:\nSame as above\n\n[YUV Restrictions]\nHW-Node 1-1:\n    maxDownScale = 1, maxUpscale = 1\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 2, fullHeightAlign = 2\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 32, minCropHeight = 32\n    cropXAlign = 2, cropYAlign = 2\n    cropWidthAlign = 2, cropHeightAlign = 2\n\nHW-Node 1-2:\nSame as above\n\nHW-Node 7-1:\n    maxDownScale = 2, maxUpscale = 8\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 2, fullHeightAlign = 2\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 32, minCropHeight = 32\n    cropXAlign = 2, cropYAlign = 2\n    cropWidthAlign = 2, cropHeightAlign = 2\n\nHW-Node 7-2:\nSame as above\n\nHW-Node 10-1:\n    maxDownScale = 4, maxUpscale = 8\n    maxFullWidth = 8192, maxFullHeight = 8192\n    minFullWidth = 1, minFullHeight = 1\n    fullWidthAlign = 2, fullHeightAlign = 2\n    maxCropWidth = 8192, maxCropHeight = 8192\n    minCropWidth = 1, minCropHeight = 1\n    cropXAlign = 2, cropYAlign = 2\n    cropWidthAlign = 2, cropHeightAlign = 2\n\nHW-Node 10-2:\nSame as above\n\nspecial plane num: 0:\n\n[PrimaryDisplay] display information size: 1080 x 2400, vsyncState: 2, colorMode: 9, colorTransformHint: 0, orientation 0\nCompositionInfo (1)\nmHasCompositionLayer(0)\n\tinternal_format: 0x1, afbc: 1\n\nCompositionInfo (2)\nmHasCompositionLayer(0)\n\nPanelGammaSource (0)\n\n============================== dump layers ===========================================\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   0    |    1     | 0xb4000076722154f0 | 71, 72, -1 |  1   | RGBA_8888 | 0x8810000 |    0    |  0x1  |     1      | 0.0764324 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n|    sourceCrop    |    dispFrame     | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 2400 | 0, 0, 1080, 2400 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tassignedMPP: DPP_GF0\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 2400, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(1), transform(0x 0), afbc(0)\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   1    |    1     | 0xb40000767220fcf0 | 60, 64, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     1      | 0.0683864 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n|   sourceCrop    |    dispFrame    | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 128 | 0, 0, 1080, 128 | 0, 0, 0, 0 | 0x0 |      1      |  2   |     2      |      2       |     0x0     |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tassignedMPP: DPP_GF1\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 128, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   2    |    1     | 0xb40000767220f350 | 37, 40, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     1      | 0.0763385 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n|    sourceCrop    |    dispFrame     | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 2400 | 0, 0, 1080, 2400 | 0, 0, 0, 0 | 0x0 |      2      |  2   |     2      |      2       |     0x0     |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tassignedMPP: DPP_GF2\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 2400, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n\n============================== dump ignore layers ===========================================\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   3    |    1     | 0xb40000767220e2d0 | 51, 52, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     0      | 0.0911009 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n|   sourceCrop    |    dispFrame    | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 128 | 0, 0, 1080, 128 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tresource is not assigned.\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 128, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+--------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |  fps   |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+--------+\n|   4    |    1     | 0xb40000767220f090 | 54, 55, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     0      | 90.849 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+--------+\n+----------------+---------------------+------------+-----+-------------+------+------------+--------------+-------------+\n|   sourceCrop   |      dispFrame      | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+----------------+---------------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 74 | 0, 2326, 1080, 2400 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+----------------+---------------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tresource is not assigned.\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 2326, w: 1080, h: 74, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n\nBrightnessController:\n\tsysfs support 1, max 4095, valid brightness table 1, lhbm supported 1, ghbm supported 1\n\trequests: enhance hbm 0, lhbm 0, brightness 0.060924, instant hbm 0, DimBrightness 0\n\tstates: brighntess level 205, ghbm 0, dimming 1, lhbm 0\thdr layer state 0, unchecked lhbm request 0(0), unchecked ghbm request 0(0)\n\tdimming usage 0, hbm dimming 0, time us 5000000\n\twhite point nits current 2.000000, previous 2.000000\n\tcabc supported 0, cabcMode 0\n\nDisplay idle timer: disabled\n\t[0] vote to 0 ns\n\t[1] vote to 0 ns\nMin idle refresh rate: 0\nRefresh rate delay: 0 ns\n\t[0] vote to 0 ns\n\t[1] vote to 0 ns\n\t[2] vote to 0 ns\n"
@@ -190,19 +132,9 @@ packet {
       id: 4619827677550801152
       name: "Common Panel"
       layer_stack: 0
-      size {
-        w: 1080
-        h: 2400
-      }
-      layer_stack_space_rect {
-        left: 0
-        top: 0
-        right: 1080
-        bottom: 2400
-      }
-      transform {
-        type: 0
-      }
+      size { w: 1080 h: 2400 }
+      layer_stack_space_rect { left: 0 top: 0 right: 1080 bottom: 2400 }
+      transform { type: 0 }
       is_virtual: false
     }
     vsync_id: 24766
@@ -233,35 +165,16 @@ packet {
         type: "Layer"
         layer_stack: 0
         z: 0
-        crop {
-          left: 0
-          top: 0
-          right: -1
-          bottom: -1
-        }
+        crop { left: 0 top: 0 right: -1 bottom: -1 }
         is_opaque: false
         invalidate: true
         dataspace: "BT709 sRGB Full range"
         pixel_format: "Unknown/None"
-        color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
-        requested_color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
+        color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
+        requested_color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
         flags: 2
-        transform {
-          type: 0
-        }
-        requested_transform {
-          type: 0
-        }
+        transform { type: 0 }
+        requested_transform { type: 0 }
         queued_frames: 0
         is_protected: false
         curr_frame: 0
@@ -290,12 +203,7 @@ packet {
         owner_uid: 1000
         is_trusted_overlay: false
         requested_corner_radius: 0.000000
-        destination_frame {
-          left: 0
-          top: 0
-          right: -1
-          bottom: -1
-        }
+        destination_frame { left: 0 top: 0 right: -1 bottom: -1 }
       }
       layers {
         id: 4
@@ -314,25 +222,11 @@ packet {
         invalidate: true
         dataspace: "BT709 sRGB Full range"
         pixel_format: "Unknown/None"
-        color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
-        requested_color {
-          r: -1.000000
-          g: -1.000000
-          b: -1.000000
-          a: 1.000000
-        }
+        color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
+        requested_color { r: -1.000000 g: -1.000000 b: -1.000000 a: 1.000000 }
         flags: 0
-        transform {
-          type: 0
-        }
-        requested_transform {
-          type: 0
-        }
+        transform { type: 0 }
+        requested_transform { type: 0 }
         parent: 3
         queued_frames: 0
         is_protected: false
@@ -351,10 +245,10 @@ packet {
           bottom: 24000.000000
         }
         screen_bounds {
-          left: -10800.000000
-          top: -24000.000000
-          right: 10800.000000
-          bottom: 24000.000000
+          left: -1080.000000
+          top: -2400.000000
+          right: 1080.000000
+          bottom: 2400.000000
         }
         shadow_radius: 0.000000
         is_relative_of: false
@@ -362,12 +256,7 @@ packet {
         owner_uid: 1000
         is_trusted_overlay: false
         requested_corner_radius: 0.000000
-        destination_frame {
-          left: 0
-          top: 0
-          right: -1
-          bottom: -1
-        }
+        destination_frame { left: 0 top: 0 right: -1 bottom: -1 }
       }
     }
     hwc_blob: "\n\nlastUeventTime(01:00:00.000) lastTimestamp(0)\nlastEnableVsyncTime(10:33:59.440)\nlastDisableVsyncTime(10:33:30.180)\nlastValidateTime(10:33:59.446)\nlastPresentTime(10:33:59.446)\n\nResource Manager:\n[RGB Restrictions]\nHW-Node 1-1:\n    maxDownScale = 1, maxUpscale = 1\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 1, fullHeightAlign = 1\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 16, minCropHeight = 16\n    cropXAlign = 1, cropYAlign = 1\n    cropWidthAlign = 1, cropHeightAlign = 1\n\nHW-Node 1-2:\nSame as above\n\nHW-Node 7-1:\n    maxDownScale = 2, maxUpscale = 8\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 1, fullHeightAlign = 1\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 16, minCropHeight = 16\n    cropXAlign = 1, cropYAlign = 1\n    cropWidthAlign = 1, cropHeightAlign = 1\n\nHW-Node 7-2:\nSame as above\n\nHW-Node 10-1:\n    maxDownScale = 4, maxUpscale = 8\n    maxFullWidth = 8192, maxFullHeight = 8192\n    minFullWidth = 1, minFullHeight = 1\n    fullWidthAlign = 1, fullHeightAlign = 1\n    maxCropWidth = 8192, maxCropHeight = 8192\n    minCropWidth = 1, minCropHeight = 1\n    cropXAlign = 1, cropYAlign = 1\n    cropWidthAlign = 1, cropHeightAlign = 1\n\nHW-Node 10-2:\nSame as above\n\n[YUV Restrictions]\nHW-Node 1-1:\n    maxDownScale = 1, maxUpscale = 1\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 2, fullHeightAlign = 2\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 32, minCropHeight = 32\n    cropXAlign = 2, cropYAlign = 2\n    cropWidthAlign = 2, cropHeightAlign = 2\n\nHW-Node 1-2:\nSame as above\n\nHW-Node 7-1:\n    maxDownScale = 2, maxUpscale = 8\n    maxFullWidth = 8190, maxFullHeight = 8190\n    minFullWidth = 16, minFullHeight = 16\n    fullWidthAlign = 2, fullHeightAlign = 2\n    maxCropWidth = 4096, maxCropHeight = 4096\n    minCropWidth = 32, minCropHeight = 32\n    cropXAlign = 2, cropYAlign = 2\n    cropWidthAlign = 2, cropHeightAlign = 2\n\nHW-Node 7-2:\nSame as above\n\nHW-Node 10-1:\n    maxDownScale = 4, maxUpscale = 8\n    maxFullWidth = 8192, maxFullHeight = 8192\n    minFullWidth = 1, minFullHeight = 1\n    fullWidthAlign = 2, fullHeightAlign = 2\n    maxCropWidth = 8192, maxCropHeight = 8192\n    minCropWidth = 1, minCropHeight = 1\n    cropXAlign = 2, cropYAlign = 2\n    cropWidthAlign = 2, cropHeightAlign = 2\n\nHW-Node 10-2:\nSame as above\n\nspecial plane num: 0:\n\n[PrimaryDisplay] display information size: 1080 x 2400, vsyncState: 1, colorMode: 9, colorTransformHint: 0, orientation 0\nCompositionInfo (1)\nmHasCompositionLayer(0)\n\tinternal_format: 0x1, afbc: 1\n\nCompositionInfo (2)\nmHasCompositionLayer(0)\n\nPanelGammaSource (0)\n\n============================== dump layers ===========================================\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   0    |    1     | 0xb400007672210ed0 | 47, 88, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     1      | 0.0323772 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n|    sourceCrop    |    dispFrame     | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 2400 | 0, 0, 1080, 2400 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tassignedMPP: DPP_GF0\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 2400, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n\n============================== dump ignore layers ===========================================\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   3    |    1     | 0xb40000767220e2d0 | 51, 52, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     0      | 0.0911009 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n|   sourceCrop    |    dispFrame    | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 128 | 0, 0, 1080, 128 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tresource is not assigned.\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 128, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+--------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |  fps   |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+--------+\n|   4    |    1     | 0xb40000767220f090 | 54, 55, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     0      | 90.849 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+--------+\n+----------------+---------------------+------------+-----+-------------+------+------------+--------------+-------------+\n|   sourceCrop   |      dispFrame      | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+----------------+---------------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 74 | 0, 2326, 1080, 2400 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+----------------+---------------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tresource is not assigned.\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 2326, w: 1080, h: 74, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   1    |    1     | 0xb40000767220fcf0 | 60, 64, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     0      | 0.0683864 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n|   sourceCrop    |    dispFrame    | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 128 | 0, 0, 1080, 128 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+-----------------+-----------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tresource is not assigned.\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 128, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n| zOrder | priority |       handle       |     fd     | AFBC |  format   | dataSpace | colorTr | blend | planeAlpha |    fps    |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n|   2    |    1     | 0xb400007672211710 | 63, 65, -1 |  1   | RGBA_8888 | 0x88a0000 |    0    |  0x2  |     0      | 0.0323941 |\n+--------+----------+--------------------+------------+------+-----------+-----------+---------+-------+------------+-----------+\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n|    sourceCrop    |    dispFrame     | blockRect  | tr  | windowIndex | type | exynosType | validateType | overlayInfo |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n| 0, 0, 1080, 2400 | 0, 0, 1080, 2400 | 0, 0, 0, 0 | 0x0 |      0      |  2   |     2      |      2       |     0x0     |\n+------------------+------------------+------------+-----+-------------+------+------------+--------------+-------------+\n+---------+-----------+\n| MPPFlag | dim ratio |\n+---------+-----------+\n| 0x6042  |     1     |\n+---------+-----------+\nMPPFlags for otfMPP\n[DPP_GF0: 0x0] [DPP_GF1: 0x0] [DPP_GF2: 0x0] [DPP_VGRFS0: 0x0] [DPP_VGRFS1: 0x0] [DPP_VGRFS2: 0x0] \nMPPFlags for m2mMPP\n[G2D0-YUV_PRI: 0x80] [G2D0-YUV_PRI: 0x80] [G2D0-YUV_EXT: 0x80] [G2D0-RGB_PRI: 0x0] [G2D0-RGB_EXT: 0x0] \n[G2D0-COMBO_VIR: 0x0] \nacquireFence: -1\n\tresource is not assigned.\n\tdump midImg\n\tbufferHandle: 0x0, fullWidth: 1080, fullHeight: 2400, x: 0, y: 0, w: 1080, h: 2400, format: RGBA_8888\n\tusageFlags: 0xb00, layerFlags: 0x       0, acquireFenceFd: -1, releaseFenceFd: -1\n\tdataSpace(143261696), blending(2), transform(0x 0), afbc(0)\n\nBrightnessController:\n\tsysfs support 1, max 4095, valid brightness table 1, lhbm supported 1, ghbm supported 1\n\trequests: enhance hbm 0, lhbm 0, brightness 0.060924, instant hbm 0, DimBrightness 0\n\tstates: brighntess level 205, ghbm 0, dimming 1, lhbm 0\thdr layer state 0, unchecked lhbm request 0(0), unchecked ghbm request 0(0)\n\tdimming usage 0, hbm dimming 0, time us 5000000\n\twhite point nits current 2.000000, previous 2.000000\n\tcabc supported 0, cabcMode 0\n\nDisplay idle timer: disabled\n\t[0] vote to 0 ns\n\t[1] vote to 0 ns\nMin idle refresh rate: 0\nRefresh rate delay: 0 ns\n\t[0] vote to 0 ns\n\t[1] vote to 0 ns\n\t[2] vote to 0 ns\n"
@@ -375,32 +264,274 @@ packet {
       id: 4619827677550801152
       name: "Common Panel"
       layer_stack: 0
-      size {
-        w: 1080
-        h: 2400
-      }
-      layer_stack_space_rect {
-        left: 0
-        top: 0
-        right: 1080
-        bottom: 2400
-      }
-      transform {
-        type: 0
-      }
-      is_virtual: false
+      size { w: 1080 h: 2400 }
+      layer_stack_space_rect { left: 0 top: 0 right: 1080 bottom: 2400 }
+      transform { type: 0 }
+      is_virtual: true
     }
     displays {
       id: 4619827677550801153
       name: "Common Panel"
-      size {
-        w: 1080
-        h: 2400
+      size { w: 1080 h: 2400 }
+      layer_stack_space_rect { right: 1080 bottom: 2400 }
+    }
+    vsync_id: 24767
+  }
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 2
+  trusted_pid: 592
+}
+
+packet {
+  timestamp: 2749700000000
+  timestamp_clock_id: 3
+  surfaceflinger_layers_snapshot {
+    elapsed_realtime_nanos: 2749700000000
+    excludes_composition_state: true
+    layers {
+      layers { parent: -1 }
+      layers {
+        id: 1
+        name: "layer1"
+        layer_stack: 0
+        is_opaque: true
+        z: 0
+        bounds { left: 0 top: 0 right: 1 bottom: 1 }
+        screen_bounds { left: 0 top: 0 right: 1 bottom: 1 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 0 top: 0 right: 1 bottom: 1 } }
+        input_window_info {
+          input_config: 16384
+          frame { left: 0 top: 0 right: 1 bottom: 1 }
+          visible: true
+        }
+        corner_radius: 1
+        hwc_composition_type: 2
       }
-      layer_stack_space_rect {
-        right: 1080
-        bottom: 2400
+      layers {
+        id: 2
+        name: "layer2"
+        layer_stack: 0
+        is_opaque: true
+        z: 0
+        bounds { left: 0 top: 0 right: 2 bottom: 2 }
+        screen_bounds { left: 0 top: 0 right: 2 bottom: 2 }
+        color { a: 1 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 0 top: 0 right: 2 bottom: 2 } }
+        input_window_info {
+          input_config: 0
+          frame { left: 0 top: 0 right: 2 bottom: 2 }
+          visible: false
+        }
       }
+      layers {
+        id: 3
+        name: "layer3"
+        layer_stack: 0
+        is_opaque: true
+        z: 0
+        bounds { left: 0 top: 0 right: 2 bottom: 2 }
+        screen_bounds { left: 0 top: 0 right: 2 bottom: 2 }
+        color { a: 0.5 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 0 top: 0 right: 2 bottom: 2 } }
+        input_window_info {
+          input_config: 64
+          frame { left: -999, top: -999, right: 999, bottom: 999 }
+          visible: true
+        }
+      }
+      layers {
+        id: 4
+        name: "layer4"
+        layer_stack: 1
+        is_opaque: true
+        z: 0
+        color { a: 1 }
+        bounds { left: 0 top: 0 right: 1 bottom: 1 }
+        screen_bounds { left: 0 top: 0 right: 1 bottom: 1 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 0 top: 0 right: 1 bottom: 1 } }
+        input_window_info {
+          frame { left: 0 top: 0 right: 5 bottom: 5 }
+          visible: true
+        }
+      }
+      layers {
+        id: 5
+        name: "layer5"
+        layer_stack: 0
+        is_opaque: true
+        z: 0
+        color { a: 1 }
+        bounds { left: 0 top: 0 right: 1 bottom: 1 }
+        screen_bounds { left: 0 top: 0 right: 1 bottom: 1 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 0 top: 0 right: 1 bottom: 1 } }
+      }
+      layers {
+        id: 6
+        name: "layer6"
+        layer_stack: 0
+        is_opaque: true
+        z: 0
+        color { a: 1 }
+        bounds { left: 2 top: 2 right: 3 bottom: 3 }
+        screen_bounds { left: 2 top: 2 right: 3 bottom: 3 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 2 top: 2 right: 3 bottom: 3 } }
+        input_window_info {
+          input_config: 8
+          frame { left: 0 top: 0 right: 5 bottom: 5 }
+        }
+      }
+      layers {
+        id: 7
+        name: "layer7"
+        layer_stack: 0
+        is_opaque: false
+        z: 0
+        color { a: 1 }
+        bounds { left: 2 top: 2 right: 3 bottom: 3 }
+        screen_bounds { left: 2 top: 2 right: 3 bottom: 3 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 2 top: 2 right: 3 bottom: 3 } }
+        input_window_info {
+          input_config: 0
+          frame { left: 0 top: 0 right: 5 bottom: 5 }
+          touchable_region {
+            rect { left: 0 top: 0 right: 2 bottom: 2 }
+            rect { left: 2 top: 2 right: 3 bottom: 3 }
+          }
+        }
+      }
+      layers {
+        id: 8
+        name: "layer8"
+        layer_stack: 1
+        is_opaque: false
+        z: 0
+        color { a: 1 }
+        bounds { left: 2 top: 2 right: 3 bottom: 3 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: 2 top: 2 right: 3 bottom: 3 } }
+        input_window_info {
+          input_config: 0
+          frame { left: 0 top: 0 right: 5 bottom: 5 }
+          touchable_region { rect { left: 0 top: 0 right: 2 bottom: 2 } }
+        }
+      }
+      layers {
+        id: 9
+        name: "layer9"
+        layer_stack: 2
+        is_opaque: false
+        z: 0
+        color { a: 1 }
+        bounds { left: -50 top: -100 right: 50 bottom: 100 }
+        screen_bounds { left: -50 top: -100 right: 50 bottom: 100 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: -50 top: -100 right: 50 bottom: 100 } }
+        input_window_info {
+          input_config: 0
+          frame: {}
+          touchable_region {
+            rect { left: -999 top: -999 right: 999 bottom: 999 }
+          }
+        }
+      }
+      layers {
+        id: 10
+        name: "layer10"
+        layer_stack: 0
+        is_opaque: false
+        z: 0
+        bounds { left: -50 top: -100 right: 50 bottom: 100 }
+        screen_bounds { left: -50 top: -100 right: 50 bottom: 100 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: -50 top: -100 right: 50 bottom: 100 } }
+      }
+      layers {
+        id: 11
+        name: "layer11"
+        layer_stack: 0
+        is_opaque: false
+        z: 0
+        bounds { left: -50 top: -100 right: 50 bottom: 100 }
+        screen_bounds { left: -49.991 top: -100 right: 50 bottom: 100 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: -50 top: -100 right: 50 bottom: 100 } }
+      }
+      layers {
+        id: 12
+        name: "layer12"
+        layer_stack: 0
+        is_opaque: false
+        z: 0
+        bounds { left: -50000 top: -50000 right: 50000 bottom: 50000 }
+        screen_bounds { left: -50000 top: -50000 right: 50000 bottom: 50000 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region {
+          rect { left: -50000 top: -50000 right: 50000 bottom: 50000 }
+        }
+      }
+      layers {
+        id: 13
+        name: "layer13"
+        layer_stack: 0
+        is_opaque: false
+        z: 0
+        bounds { left: -100 top: -50 right: 100 bottom: 50 }
+        screen_bounds { left: -100 top: -50 right: 100 bottom: 50 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: -100 top: -50 right: 100 bottom: 50 } }
+      }
+      layers {
+        id: 14
+        name: "layer14"
+        layer_stack: 0
+        is_opaque: false
+        z: 0
+        bounds { left: -100 top: -100 right: 100 bottom: 100 }
+        screen_bounds { left: -100 top: -100 right: 100 bottom: 100 }
+        active_buffer { width: 1 height: 1 stride: 1 format: 1 }
+        visible_region { rect { left: -100 top: -100 right: 100 bottom: 100 } }
+      }
+    }
+    displays {
+      id: 1
+      layer_stack: 0
+      size { w: 1 h: 1 }
+      layer_stack_space_rect { left: 0 top: 0 right: 5 bottom: 5 }
+    }
+    displays {
+      id: 2
+      layer_stack: 1
+      name: "Display2"
+      size { w: 2 h: 2 }
+    }
+    displays {
+      id: 3
+      layer_stack: 2
+      name: "Display3"
+      size { w: 5 h: 10 }
+      transform { type: 1024 }
+    }
+    displays {
+      id: 4
+      layer_stack: 3
+      name: "Display4"
+      size { w: 5 h: 10 }
+      layer_stack_space_rect { right: 5 bottom: 10 }
+    }
+    displays {
+      id: 5
+      layer_stack: 2
+      name: "Display5"
+      size { w: 5 h: 10 }
+      layer_stack_space_rect { right: 5 bottom: 10 }
+      transform { type: 1024 }
     }
     vsync_id: 24767
   }

--- a/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
@@ -28,7 +28,7 @@ class SurfaceFlingerLayers(TestSuite):
         SELECT
           id, ts
         FROM
-          surfaceflinger_layers_snapshot;
+          surfaceflinger_layers_snapshot LIMIT 2;
         """,
         out=Csv("""
         "id","ts"
@@ -65,21 +65,70 @@ class SurfaceFlingerLayers(TestSuite):
         "where","visibleRegionsDirty"
         """))
 
+  def test_displays_table(self):
+    return DiffTestBlueprint(
+        trace=Path('surfaceflinger_layers.textproto'),
+        query="""
+        INCLUDE PERFETTO MODULE android.winscope.surfaceflinger;
+        INCLUDE PERFETTO MODULE android.winscope.rect;
+
+        SELECT
+          dis.id,
+          dis.snapshot_id,
+          dis.is_on,
+          dis.is_virtual,
+          dis.display_id,
+          dis.display_name,
+          RR.x,
+          RR.y,
+          RR.w,
+          RR.h
+        FROM android_surfaceflinger_display as dis
+          inner join android_winscope_trace_rect as TR
+          on TR.id = dis.trace_rect_id
+          inner join android_winscope_rect as RR
+          on RR.id = TR.rect_id
+          LIMIT 5;
+        """,
+        out=Csv("""
+        "id","snapshot_id","is_on","is_virtual","display_id","display_name","x","y","w","h"
+        0,0,1,0,4619827677550801152,"Common Panel",0.000000,0.000000,1080.000000,2400.000000
+        1,1,1,1,4619827677550801152,"Common Panel",0.000000,0.000000,1080.000000,2400.000000
+        2,1,0,0,4619827677550801153,"Common Panel",0.000000,0.000000,1080.000000,2400.000000
+        3,2,1,0,1,"[NULL]",0.000000,0.000000,5.000000,5.000000
+        4,2,1,0,2,"Display2",0.000000,0.000000,2.000000,2.000000
+        """))
+
   def test_layer_table(self):
     return DiffTestBlueprint(
         trace=Path('surfaceflinger_layers.textproto'),
         query="""
         SELECT
-          id, snapshot_id
+          id,
+          snapshot_id,
+          layer_id,
+          layer_name,
+          parent,
+          corner_radius,
+          hwc_composition_type,
+          z_order_relative_of,
+          is_missing_z_parent,
+          is_visible,
+          layer_rect_id,
+          input_rect_id
         FROM
-          surfaceflinger_layer;
+          surfaceflinger_layer
+        LIMIT 7;
         """,
         out=Csv("""
-        "id","snapshot_id"
-        0,0
-        1,0
-        2,1
-        3,1
+        "id","snapshot_id","layer_id","layer_name","parent","corner_radius","hwc_composition_type","z_order_relative_of","is_missing_z_parent","is_visible","layer_rect_id","input_rect_id"
+        0,0,3,"Display 0 name="Built-in Screen"#3","[NULL]",0.000000,"[NULL]",5,1,0,"[NULL]","[NULL]"
+        1,0,4,"WindowedMagnification:0:31#4",3,0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        2,1,3,"Display 0 name="Built-in Screen"#3","[NULL]",0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        3,1,4,"WindowedMagnification:0:31#4",3,0.000000,"[NULL]","[NULL]",0,0,3,"[NULL]"
+        4,2,"[NULL]","[NULL]",-1,"[NULL]","[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        5,2,1,"layer1","[NULL]",1.000000,2,"[NULL]",0,0,9,10
+        6,2,2,"layer2","[NULL]","[NULL]","[NULL]","[NULL]",0,1,11,12
         """))
 
   def test_tables_have_raw_protos(self):
@@ -94,6 +143,146 @@ class SurfaceFlingerLayers(TestSuite):
         """,
         out=Csv("""
         "COUNT(*)"
-        2
-        4
+        3
+        19
+        """))
+
+  def test_layer_args(self):
+    return DiffTestBlueprint(
+        trace=Path('surfaceflinger_layers.textproto'),
+        query="""
+        SELECT
+          args.key, args.display_value
+        FROM
+          surfaceflinger_layer AS sfl JOIN args ON sfl.arg_set_id = args.arg_set_id
+        WHERE sfl.id = 2 and (key like "screen_bounds%" or key like "visibility_reason%")
+        ORDER BY args.key
+        """,
+        out=Csv("""
+        "key","display_value"
+        "screen_bounds.bottom","24000.0"
+        "screen_bounds.left","-10800.0"
+        "screen_bounds.right","10800.0"
+        "screen_bounds.top","-24000.0"
+        "visibility_reason[0]","buffer is empty"
+        "visibility_reason[1]","does not have color fill, shadow or blur"
+        """))
+
+  def test_layer_rects(self):
+    # gives group_id 1 for 4 and resets depth due to different layer stack
+    # ignores 8 as missing screen bounds
+    # makes 9 as invalid bounds but visible rect
+    # ignores 10 as invalid screen bounds from display 3
+    # ignores 11 as invalid screen bounds from display 3 (float not exactly equal)
+    # ignores 12 as invalid screen bounds from platform default
+    # ignores 13 as invalid screen bounds from display 4 (rotated)
+    # ignores 14 as invalid screen bounds from max of all available displays
+    return DiffTestBlueprint(
+        trace=Path('surfaceflinger_layers.textproto'),
+        query="""
+        INCLUDE PERFETTO MODULE android.winscope.surfaceflinger;
+        INCLUDE PERFETTO MODULE android.winscope.rect;
+
+        SELECT
+          sfl.layer_id, wtr.group_id, wtr.depth, wtr.is_visible, wtr.opacity, rect.x, rect.y, rect.w, rect.h
+        FROM surfaceflinger_layer AS sfl
+        INNER JOIN android_winscope_trace_rect AS wtr
+          ON sfl.layer_rect_id = wtr.id
+          AND sfl.snapshot_id = 2
+        INNER JOIN android_winscope_rect AS rect
+          ON rect.id = wtr.rect_id
+        """,
+        out=Csv("""
+        "layer_id","group_id","depth","is_visible","opacity","x","y","w","h"
+        1,0,1,0,"[NULL]",0.000000,0.000000,1.000000,1.000000
+        2,0,2,1,1.000000,0.000000,0.000000,2.000000,2.000000
+        3,0,3,1,0.500000,0.000000,0.000000,2.000000,2.000000
+        4,1,1,1,1.000000,0.000000,0.000000,1.000000,1.000000
+        5,0,4,1,1.000000,0.000000,0.000000,1.000000,1.000000
+        6,0,5,1,1.000000,2.000000,2.000000,1.000000,1.000000
+        7,0,6,1,1.000000,2.000000,2.000000,1.000000,1.000000
+        9,2,1,1,1.000000,-50.000000,-100.000000,100.000000,200.000000
+        """))
+
+  def test_display_rects(self):
+    # makes display rects from stack space rect if available
+    # sets group id from layer stack
+    # rotates rect based on transform
+    return DiffTestBlueprint(
+        trace=Path('surfaceflinger_layers.textproto'),
+        query="""
+        INCLUDE PERFETTO MODULE android.winscope.surfaceflinger;
+        INCLUDE PERFETTO MODULE android.winscope.rect;
+
+        SELECT
+          sfd.display_id, wtr.group_id, wtr.depth, wtr.is_visible, wtr.opacity, rect.x, rect.y, rect.w, rect.h
+        FROM android_surfaceflinger_display AS sfd
+        INNER JOIN android_winscope_trace_rect AS wtr
+          ON sfd.trace_rect_id = wtr.id
+          AND sfd.snapshot_id = 2
+        INNER JOIN android_winscope_rect AS rect
+          ON rect.id = wtr.rect_id
+        """,
+        out=Csv("""
+        "display_id","group_id","depth","is_visible","opacity","x","y","w","h"
+        1,0,0,0,"[NULL]",0.000000,0.000000,5.000000,5.000000
+        2,1,1,0,"[NULL]",0.000000,0.000000,2.000000,2.000000
+        3,2,2,0,"[NULL]",0.000000,0.000000,10.000000,5.000000
+        4,3,3,0,"[NULL]",0.000000,0.000000,5.000000,10.000000
+        5,2,4,0,"[NULL]",0.000000,0.000000,5.000000,10.000000
+        """))
+
+  def test_input_rects(self):
+    # makes 1 as visible spy window
+    # makes 2 as non-visible non-spy window
+    # crops 3 to display bounds
+    # makes 4 as visible window despite layer rect being non-visible
+    # ignore 5 as no input rect
+    # makes 6 with empty fill region
+    # makes 7 with fill region
+    # makes 8 with fill region in different layer stack
+    # makes 9 with fill region despite no frame
+    return DiffTestBlueprint(
+        trace=Path('surfaceflinger_layers.textproto'),
+        query="""
+        INCLUDE PERFETTO MODULE android.winscope.surfaceflinger;
+        INCLUDE PERFETTO MODULE android.winscope.rect;
+
+        SELECT
+          sfl.layer_id,
+          wtr.group_id,
+          wtr.depth,
+          wtr.is_visible,
+          wtr.is_spy,
+          rect.x,
+          rect.y,
+          rect.w,
+          rect.h,
+          fill_region_rect.x as fr_x,
+          fill_region_rect.y as fr_y,
+          fill_region_rect.w as fr_w,
+          fill_region_rect.h as fr_h
+        FROM surfaceflinger_layer AS sfl
+        INNER JOIN android_winscope_trace_rect AS wtr
+          ON sfl.input_rect_id = wtr.id
+        INNER JOIN android_winscope_rect AS rect
+          ON rect.id = wtr.rect_id
+        LEFT JOIN android_winscope_fill_region AS fill_region
+          ON fill_region.trace_rect_id = sfl.input_rect_id
+        LEFT JOIN android_winscope_rect AS fill_region_rect
+          ON fill_region_rect.id = fill_region.rect_id
+
+        WHERE sfl.snapshot_id = 2
+        """,
+        out=Csv("""
+        "layer_id","group_id","depth","is_visible","is_spy","x","y","w","h","fr_x","fr_y","fr_w","fr_h"
+        1,0,1,1,1,0.000000,0.000000,1.000000,1.000000,"[NULL]","[NULL]","[NULL]","[NULL]"
+        2,0,2,0,0,0.000000,0.000000,2.000000,2.000000,"[NULL]","[NULL]","[NULL]","[NULL]"
+        3,0,3,1,0,0.000000,0.000000,5.000000,5.000000,"[NULL]","[NULL]","[NULL]","[NULL]"
+        4,1,1,1,0,0.000000,0.000000,5.000000,5.000000,"[NULL]","[NULL]","[NULL]","[NULL]"
+        6,0,4,1,0,0.000000,0.000000,5.000000,5.000000,0.000000,0.000000,0.000000,0.000000
+        7,0,5,1,0,0.000000,0.000000,5.000000,5.000000,0.000000,0.000000,2.000000,2.000000
+        7,0,5,1,0,0.000000,0.000000,5.000000,5.000000,2.000000,2.000000,1.000000,1.000000
+        8,1,2,1,0,0.000000,0.000000,5.000000,5.000000,0.000000,0.000000,2.000000,2.000000
+        9,2,1,1,0,0.000000,10.000000,0.000000,0.000000,0.000000,0.000000,5.000000,10.000000
         """))

--- a/test/trace_processor/diff_tests/syntax/table_tests.py
+++ b/test/trace_processor/diff_tests/syntax/table_tests.py
@@ -575,7 +575,7 @@ class PerfettoTable(TestSuite):
         "visible_region","visible_region","[NULL]","[NULL]","[NULL]"
         "window_type","window_type",0,"[NULL]","[NULL]"
         "z","z",0,"[NULL]","[NULL]"
-        "z_order_relative_of","z_order_relative_of",0,"[NULL]","[NULL]"
+        "z_order_relative_of","z_order_relative_of",5,"[NULL]","[NULL]"
         "active_buffer","active_buffer","[NULL]","[NULL]","[NULL]"
         """))
 
@@ -592,40 +592,40 @@ class PerfettoTable(TestSuite):
         "flat_key","key","int_value","string_value","real_value"
         "displays.dpi_x","displays[0].dpi_x","[NULL]","[NULL]",0.000000
         "displays.dpi_y","displays[0].dpi_y","[NULL]","[NULL]",0.000000
-        "displays.id","displays[0].id",4619827677550801152,"[NULL]","[NULL]"
+        "displays.id","displays[0].id",1,"[NULL]","[NULL]"
         "displays.is_virtual","displays[0].is_virtual",0,"[NULL]","[NULL]"
         "displays.layer_stack","displays[0].layer_stack",0,"[NULL]","[NULL]"
-        "displays.layer_stack_space_rect.bottom","displays[0].layer_stack_space_rect.bottom",2400,"[NULL]","[NULL]"
+        "displays.layer_stack_space_rect.bottom","displays[0].layer_stack_space_rect.bottom",5,"[NULL]","[NULL]"
         "displays.layer_stack_space_rect.left","displays[0].layer_stack_space_rect.left",0,"[NULL]","[NULL]"
-        "displays.layer_stack_space_rect.right","displays[0].layer_stack_space_rect.right",1080,"[NULL]","[NULL]"
+        "displays.layer_stack_space_rect.right","displays[0].layer_stack_space_rect.right",5,"[NULL]","[NULL]"
         "displays.layer_stack_space_rect.top","displays[0].layer_stack_space_rect.top",0,"[NULL]","[NULL]"
-        "displays.name","displays[0].name","[NULL]","Common Panel","[NULL]"
-        "displays.size.h","displays[0].size.h",2400,"[NULL]","[NULL]"
-        "displays.size.w","displays[0].size.w",1080,"[NULL]","[NULL]"
-        "displays.transform.dsdx","displays[0].transform.dsdx","[NULL]","[NULL]",0.000000
-        "displays.transform.dsdy","displays[0].transform.dsdy","[NULL]","[NULL]",0.000000
-        "displays.transform.dtdx","displays[0].transform.dtdx","[NULL]","[NULL]",0.000000
-        "displays.transform.dtdy","displays[0].transform.dtdy","[NULL]","[NULL]",0.000000
-        "displays.transform.type","displays[0].transform.type",0,"[NULL]","[NULL]"
+        "displays.name","displays[0].name","[NULL]","[NULL]","[NULL]"
+        "displays.size.h","displays[0].size.h",1,"[NULL]","[NULL]"
+        "displays.size.w","displays[0].size.w",1,"[NULL]","[NULL]"
+        "displays.transform","displays[0].transform","[NULL]","[NULL]","[NULL]"
         "displays.dpi_x","displays[1].dpi_x","[NULL]","[NULL]",0.000000
         "displays.dpi_y","displays[1].dpi_y","[NULL]","[NULL]",0.000000
-        "displays.id","displays[1].id",4619827677550801153,"[NULL]","[NULL]"
+        "displays.id","displays[1].id",2,"[NULL]","[NULL]"
         "displays.is_virtual","displays[1].is_virtual",0,"[NULL]","[NULL]"
-        "displays.layer_stack","displays[1].layer_stack",0,"[NULL]","[NULL]"
-        "displays.layer_stack_space_rect.bottom","displays[1].layer_stack_space_rect.bottom",2400,"[NULL]","[NULL]"
-        "displays.layer_stack_space_rect.left","displays[1].layer_stack_space_rect.left",0,"[NULL]","[NULL]"
-        "displays.layer_stack_space_rect.right","displays[1].layer_stack_space_rect.right",1080,"[NULL]","[NULL]"
-        "displays.layer_stack_space_rect.top","displays[1].layer_stack_space_rect.top",0,"[NULL]","[NULL]"
-        "displays.name","displays[1].name","[NULL]","Common Panel","[NULL]"
-        "displays.size.h","displays[1].size.h",2400,"[NULL]","[NULL]"
-        "displays.size.w","displays[1].size.w",1080,"[NULL]","[NULL]"
+        "displays.layer_stack","displays[1].layer_stack",1,"[NULL]","[NULL]"
+        "displays.layer_stack_space_rect","displays[1].layer_stack_space_rect","[NULL]","[NULL]","[NULL]"
+        "displays.name","displays[1].name","[NULL]","Display2","[NULL]"
+        "displays.size.h","displays[1].size.h",2,"[NULL]","[NULL]"
+        "displays.size.w","displays[1].size.w",2,"[NULL]","[NULL]"
         "displays.transform","displays[1].transform","[NULL]","[NULL]","[NULL]"
-        "elapsed_realtime_nanos","elapsed_realtime_nanos",2749500341063,"[NULL]","[NULL]"
-        "excludes_composition_state","excludes_composition_state",0,"[NULL]","[NULL]"
-        "missed_entries","missed_entries",0,"[NULL]","[NULL]"
-        "vsync_id","vsync_id",24767,"[NULL]","[NULL]"
-        "where","where","[NULL]","bufferLatched","[NULL]"
-        "displays.dpi_x","displays[0].dpi_x","[NULL]","[NULL]",0.000000
+        "displays.dpi_x","displays[2].dpi_x","[NULL]","[NULL]",0.000000
+        "displays.dpi_y","displays[2].dpi_y","[NULL]","[NULL]",0.000000
+        "displays.id","displays[2].id",3,"[NULL]","[NULL]"
+        "displays.is_virtual","displays[2].is_virtual",0,"[NULL]","[NULL]"
+        "displays.layer_stack","displays[2].layer_stack",2,"[NULL]","[NULL]"
+        "displays.layer_stack_space_rect","displays[2].layer_stack_space_rect","[NULL]","[NULL]","[NULL]"
+        "displays.name","displays[2].name","[NULL]","Display3","[NULL]"
+        "displays.size.h","displays[2].size.h",10,"[NULL]","[NULL]"
+        "displays.size.w","displays[2].size.w",5,"[NULL]","[NULL]"
+        "displays.transform.dsdx","displays[2].transform.dsdx","[NULL]","[NULL]",0.000000
+        "displays.transform.dsdy","displays[2].transform.dsdy","[NULL]","[NULL]",0.000000
+        "displays.transform.dtdx","displays[2].transform.dtdx","[NULL]","[NULL]",0.000000
+        "displays.transform.dtdy","displays[2].transform.dtdy","[NULL]","[NULL]",0.000000
         """))
 
   def test_winscope_proto_to_args_with_defaults_with_multiple_packets_per_proto(


### PR DESCRIPTION
Test rect computation at the table level, since it returns table ids and we want to check what data it actually added to the various Winscope tables.

Bug: 411363817
Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell