### PR TITLE
IME proto: add prevent_ime_startup_unless_text_editor

### DIFF
--- a/protos/perfetto/trace/android/server/inputmethod/inputmethodmanagerservice.proto
+++ b/protos/perfetto/trace/android/server/inputmethod/inputmethodmanagerservice.proto
@@ -47,4 +47,5 @@ message InputMethodManagerServiceProto {
   optional bool show_ime_with_hard_keyboard = 23;
   optional bool accessibility_requesting_no_soft_keyboard = 24;
   optional bool concurrent_multi_user_mode_enabled = 25;
+  optional bool prevent_ime_startup_unless_text_editor = 26;
 }


### PR DESCRIPTION
config_preventImeStartupUnlessTextEditor is an Android configuration option that, when enabled, prevents the InputMethodManagerService from starting up the input method (keyboard) unless a text editor is focused.

This configuration is used in many CtsInputMethodTestCases tests (like CtsInputMethodTestCases:KeyboardVisibilityControlTest). Understanding its value is essential for effective test debugging.

This CL is a port of ag/33261804 into external/perfetto