### PR TITLE
Show per-machine system info in Info and Stats page

### DIFF
--- a/ui/src/assets/trace_info_page.scss
+++ b/ui/src/assets/trace_info_page.scss
@@ -44,6 +44,14 @@
     }
 
     h3 {
+      font-size: 1.5rem;
+      font-weight: 400;
+      margin-top: 1.25rem;
+      margin-bottom: 1rem;
+      color: #333;
+    }
+
+    h4 {
       font-size: 0.9rem;
       font-weight: 400;
       line-height: 1.25rem;

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
@@ -126,7 +126,7 @@ class StatsSection implements m.ClassComponent<StatsSectionAttrs> {
     return m(
       `section${attrs.cssClass}`,
       m('h2', attrs.title),
-      m('h3', attrs.subTitle),
+      m('h4', attrs.subTitle),
       m(
         'table',
         m('thead', m('tr', m('td', 'Name'), m('td', 'Value'), m('td', 'Type'))),
@@ -143,7 +143,7 @@ class LoadingErrors implements m.ClassComponent<TraceAttrs> {
     return m(
       `section.errors`,
       m('h2', `Loading errors`),
-      m('h3', `The following errors were encountered while loading the trace:`),
+      m('h4', `The following errors were encountered while loading the trace:`),
       m('pre.metric-error', errors.join('\n')),
     );
   }
@@ -211,6 +211,103 @@ class TraceMetadata implements m.ClassComponent<EngineAttrs> {
         m('thead', m('tr', m('td', 'Name'), m('td', 'Value'))),
         m('tbody', tableRows),
       ),
+    );
+  }
+}
+
+const machineRowSpec = {
+  id: UNKNOWN,
+  rawId: UNKNOWN,
+  sysname: UNKNOWN,
+  release: UNKNOWN,
+  version: UNKNOWN,
+  arch: UNKNOWN,
+  numCpus: UNKNOWN,
+  androidBuildFingerprint: UNKNOWN,
+  androidDeviceManufacturer: UNKNOWN,
+  androidSdkVersion: UNKNOWN,
+};
+
+type MachineRow = typeof machineRowSpec;
+
+class MachineListSection implements m.ClassComponent<EngineAttrs> {
+  private data?: MachineRow[];
+
+  oncreate({attrs}: m.CVnodeDOM<EngineAttrs>) {
+    const engine = attrs.engine;
+    const query = `
+      select
+        id,
+        raw_id as rawId,
+        sysname,
+        release,
+        version,
+        arch,
+        num_cpus as numCpus,
+        android_build_fingerprint as androidBuildFingerprint,
+        android_device_manufacturer as androidDeviceManufacturer,
+        android_sdk_version as androidSdkVersion
+      from machine
+    `;
+
+    engine.query(query).then((resp: QueryResult) => {
+      const tableRows: MachineRow[] = [];
+      const it = resp.iter(machineRowSpec);
+      for (; it.valid(); it.next()) {
+        tableRows.push(pickFields(it, machineRowSpec));
+      }
+      this.data = tableRows;
+    });
+  }
+
+  view() {
+    const data = this.data;
+    if (data === undefined || data.length <= 1) {
+      return undefined;
+    }
+
+    const machineTables = data.map((row) => {
+      const tableRows = [
+        m('tr', m('td.name', 'id'), m('td', `${row.id}`)),
+        m('tr', m('td.name', 'rawId'), m('td', `${row.rawId}`)),
+        m('tr', m('td.name', 'sysname'), m('td', `${row.sysname}`)),
+        m('tr', m('td.name', 'release'), m('td', `${row.release}`)),
+        m('tr', m('td.name', 'version'), m('td', `${row.version}`)),
+        m('tr', m('td.name', 'arch'), m('td', `${row.arch}`)),
+        m('tr', m('td.name', 'num_cpus'), m('td', `${row.numCpus}`)),
+        m(
+          'tr',
+          m('td.name', 'android_build_fingerprint'),
+          m('td', `${row.androidBuildFingerprint}`),
+        ),
+        m(
+          'tr',
+          m('td.name', 'android_device_manufacturer'),
+          m('td', `${row.androidDeviceManufacturer}`),
+        ),
+        m(
+          'tr',
+          m('td.name', 'android_sdk_version'),
+          m('td', `${row.androidSdkVersion}`),
+        ),
+      ];
+
+      return m(
+        '',
+        m('h3', `Machine ${row.id}`),
+        m(
+          'table',
+          m('thead', m('tr', m('td', 'Name'), m('td', 'Value'))),
+          m('tbody', tableRows),
+        ),
+      );
+    });
+
+    return m(
+      'section',
+      m('h2', 'Machines'),
+      m('h4', 'System information of the machines involved in the trace.'),
+      machineTables,
     );
   }
 }
@@ -456,6 +553,7 @@ export class TraceInfoPage implements m.ClassComponent<TraceInfoPageAttrs> {
         sqlConstraints: `severity = 'data_loss' and value > 0`,
       }),
       m(TraceMetadata, {engine}),
+      m(MachineListSection, {engine}),
       m(PackageListSection, {engine}),
       m(AndroidGameInterventionList, {engine}),
       m(StatsSection, {


### PR DESCRIPTION
In unified traces it is very valuable to know the system information of each machine. This allows you to reason about the source of the tracing data.

Bug: 406278549
