### PR TITLE
Remove redundant Track.title and rename TrackNode.title -> name

### DIFF
--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -294,7 +294,7 @@ export class BreakdownTracks {
     for (const iter = res.iter({}); iter.valid(); iter.next()) {
       const colRaw = iter.get(currColName);
       const colValue = colRaw === null ? 'NULL' : colRaw.toString();
-      const title = colValue;
+      const name = colValue;
 
       const newFilters = [
         ...filters,
@@ -311,7 +311,7 @@ export class BreakdownTracks {
 
       switch (trackType) {
         case BreakdownTrackType.AGGREGATION:
-          currNode = await this.createCounterTrackNode(title, newFilters);
+          currNode = await this.createCounterTrackNode(name, newFilters);
           if (this.props.slice && colIndex === columns.length - 1) {
             nextTrackType = BreakdownTrackType.SLICE;
             nextColIndex = 0;
@@ -320,7 +320,7 @@ export class BreakdownTracks {
           break;
         case BreakdownTrackType.SLICE:
           currNode = await this.createSliceTrackNode(
-            title,
+            name,
             newFilters,
             colIndex,
             sqlInfo,
@@ -334,7 +334,7 @@ export class BreakdownTracks {
           break;
         default:
           currNode = await this.createSliceTrackNode(
-            title,
+            name,
             newFilters,
             colIndex,
             sqlInfo,
@@ -411,9 +411,9 @@ export class BreakdownTracks {
     return maxValue === null ? 0 : maxValue;
   }
 
-  private async createCounterTrackNode(title: string, newFilters: Filter[]) {
+  private async createCounterTrackNode(name: string, newFilters: Filter[]) {
     return await this.createTrackNode(
-      title,
+      name,
       newFilters,
       (uri: string, filtersClause: string) => {
         return createQueryCounterTrack({
@@ -436,7 +436,7 @@ export class BreakdownTracks {
   }
 
   private async createTrackNode(
-    title: string,
+    name: string,
     filters: Filter[],
     createTrack: (
       uri: string,
@@ -460,14 +460,13 @@ export class BreakdownTracks {
 
     this.props.trace.tracks.registerTrack({
       uri,
-      title,
       renderer,
     });
 
     const sortOrder = await getSortOrder?.(filtersClause);
 
     return new TrackNode({
-      title,
+      name,
       uri,
       sortOrder: sortOrder !== undefined ? -sortOrder : undefined,
     });

--- a/ui/src/components/tracks/debug_tracks.ts
+++ b/ui/src/components/tracks/debug_tracks.ts
@@ -166,11 +166,10 @@ async function addPivotedSliceTracks(
   for (const iter = result.iter({}); iter.valid(); iter.next()) {
     const uri = `${uriBase}_${trackCount++}`;
     const pivotValue = iter.get('pivot');
-    const title = `${titleBase}: ${pivotColName} = ${sqlValueToReadableString(pivotValue)}`;
+    const name = `${titleBase}: ${pivotColName} = ${sqlValueToReadableString(pivotValue)}`;
 
     trace.tracks.registerTrack({
       uri,
-      title,
       renderer: new DatasetSliceTrack({
         trace,
         uri,
@@ -193,7 +192,7 @@ async function addPivotedSliceTracks(
       }),
     });
 
-    const trackNode = new TrackNode({uri, title, removable: true});
+    const trackNode = new TrackNode({uri, name, removable: true});
     trace.workspace.pinnedTracksNode.addChildLast(trackNode);
   }
 }
@@ -201,12 +200,11 @@ async function addPivotedSliceTracks(
 function addSingleSliceTrack(
   trace: Trace,
   tableName: string,
-  title: string,
+  name: string,
   uri: string,
 ) {
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new DatasetSliceTrack({
       trace,
       uri,
@@ -225,7 +223,7 @@ function addSingleSliceTrack(
     }),
   });
 
-  const trackNode = new TrackNode({uri, title, removable: true});
+  const trackNode = new TrackNode({uri, name, removable: true});
   trace.workspace.pinnedTracksNode.addChildLast(trackNode);
 }
 
@@ -334,11 +332,10 @@ async function addPivotedCounterTracks(
   for (const iter = result.iter({}); iter.valid(); iter.next()) {
     const uri = `${uriBase}_${trackCount++}`;
     const pivotValue = iter.get('pivot');
-    const title = `${titleBase}: ${pivotColName} = ${sqlValueToReadableString(pivotValue)}`;
+    const name = `${titleBase}: ${pivotColName} = ${sqlValueToReadableString(pivotValue)}`;
 
     trace.tracks.registerTrack({
       uri,
-      title,
       renderer: new SqlTableCounterTrack(
         trace,
         uri,
@@ -350,7 +347,7 @@ async function addPivotedCounterTracks(
       ),
     });
 
-    const trackNode = new TrackNode({uri, title, removable: true});
+    const trackNode = new TrackNode({uri, name, removable: true});
     trace.workspace.pinnedTracksNode.addChildLast(trackNode);
   }
 }
@@ -358,15 +355,14 @@ async function addPivotedCounterTracks(
 function addSingleCounterTrack(
   trace: Trace,
   tableName: string,
-  title: string,
+  name: string,
   uri: string,
 ) {
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new SqlTableCounterTrack(trace, uri, tableName),
   });
 
-  const trackNode = new TrackNode({uri, title, removable: true});
+  const trackNode = new TrackNode({uri, name, removable: true});
   trace.workspace.pinnedTracksNode.addChildLast(trackNode);
 }

--- a/ui/src/components/tracks/visualized_args_tracks.ts
+++ b/ui/src/components/tracks/visualized_args_tracks.ts
@@ -67,7 +67,6 @@ export async function addVisualizedArgTracks(trace: Trace, argName: string) {
     const uri = `${VISUALIZED_ARGS_SLICE_TRACK_URI_PREFIX}#${uuidv4()}`;
     trace.tracks.registerTrack({
       uri,
-      title: argName,
       chips: ['arg'],
       renderer: await createVisualizedArgsTrack({
         trace,
@@ -96,7 +95,7 @@ export async function addVisualizedArgTracks(trace: Trace, argName: string) {
 
     const parentGroup = threadSliceTrack?.parent;
     if (parentGroup) {
-      const newTrack = new TrackNode({uri, title: argName});
+      const newTrack = new TrackNode({uri, name: argName});
       parentGroup.addChildBefore(newTrack, threadSliceTrack);
       addedTracks.push(newTrack);
     }

--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -263,7 +263,7 @@ export class SearchManagerImpl {
     for (const track of workspace.flatTracksOrdered) {
       // We don't support searching for tracks that don't have a URI.
       if (!track.uri) continue;
-      if (track.title.toLowerCase().indexOf(lowerSearch) === -1) {
+      if (track.name.toLowerCase().indexOf(lowerSearch) === -1) {
         continue;
       }
       searchResults.totalResults++;

--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -80,8 +80,8 @@ export class SelectionManagerImpl implements SelectionManager {
     this.selectTrackEventInternal(trackUri, eventId, opts);
   }
 
-  selectTrack(trackUri: string, opts?: SelectionOpts) {
-    this.setSelection({kind: 'track', trackUri}, opts);
+  selectTrack(uri: string, opts?: SelectionOpts) {
+    this.setSelection({kind: 'track', trackUri: uri}, opts);
   }
 
   selectNote(args: {id: string}, opts?: SelectionOpts) {
@@ -384,7 +384,7 @@ export class SelectionManagerImpl implements SelectionManager {
     const range = this.findTimeRangeOfSelection();
     this.scrollHelper.scrollTo({
       time: range ? {...range} : undefined,
-      track: uri ? {uri: uri, expandGroup: true} : undefined,
+      track: uri ? {uri, expandGroup: true} : undefined,
     });
   }
 

--- a/ui/src/core/track_manager.ts
+++ b/ui/src/core/track_manager.ts
@@ -256,7 +256,7 @@ export function trackMatchesFilter(
       .filter((s) => s !== '');
 
     // At least one of the name filter terms must match.
-    const trackTitleLower = track.title.toLowerCase();
+    const trackTitleLower = track.name.toLowerCase();
     if (
       !nameFilters.some((nameFilter) =>
         trackTitleLower.includes(nameFilter.toLowerCase()),

--- a/ui/src/core/track_manager_unittest.ts
+++ b/ui/src/core/track_manager_unittest.ts
@@ -58,7 +58,6 @@ beforeEach(() => {
   mockTrack = makeMockTrack();
   td = {
     uri: 'test',
-    title: 'foo',
     renderer: mockTrack,
   };
   trackManager = new TrackManagerImpl();

--- a/ui/src/core_plugins/track_utils/index.ts
+++ b/ui/src/core_plugins/track_utils/index.ts
@@ -111,7 +111,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
         ) as ReadonlyArray<RequiredField<TrackNode, 'uri'>>;
         const track = await ctx.omnibox.prompt('Choose a track...', {
           values: tracksWithUris,
-          getName: (track) => track.title,
+          getName: (track) => track.name,
         });
         track && track.pin();
       },

--- a/ui/src/frontend/viewer_page/current_selection_tab.ts
+++ b/ui/src/frontend/viewer_page/current_selection_tab.ts
@@ -156,7 +156,7 @@ export class CurrentSelectionTab
     if (track) {
       return m(
         DetailsShell,
-        {title: 'Track', description: track.title},
+        {title: 'Track', description: track.uri},
         m(
           GridLayout,
           m(
@@ -166,7 +166,6 @@ export class CurrentSelectionTab
               {title: 'Details'},
               m(
                 Tree,
-                m(TreeNode, {left: 'Name', right: track.title}),
                 m(TreeNode, {left: 'URI', right: track.uri}),
                 m(TreeNode, {left: 'Plugin ID', right: track.pluginId}),
                 m(

--- a/ui/src/frontend/viewer_page/notes_panel.ts
+++ b/ui/src/frontend/viewer_page/notes_panel.ts
@@ -329,7 +329,7 @@ export class NotesPanel {
       onclick: async () => {
         const result = await this.trace.omnibox.prompt('Group name...');
         if (result) {
-          const group = new TrackNode({title: result, isSummary: true});
+          const group = new TrackNode({name: result, isSummary: true});
           this.trace.workspace.addChildLast(group);
         }
       },

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -153,7 +153,7 @@ export class TrackView {
       TrackShell,
       {
         id: node.id,
-        title: node.title,
+        title: node.name,
         subtitle: renderer?.desc.subtitle,
         ref: node.fullPath.join('/'),
         heightPx: height,
@@ -637,7 +637,7 @@ function renderTrackDetailsMenu(node: TrackNode, descriptor?: Track) {
         right: node.sortOrder ?? '0 (undefined)',
       }),
       m(TreeNode, {left: 'Path', right: fullPath}),
-      m(TreeNode, {left: 'Title', right: node.title}),
+      m(TreeNode, {left: 'Name', right: node.name}),
       descriptor &&
         m(TreeNode, {left: 'Description', right: descriptor?.description}),
       m(TreeNode, {

--- a/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
@@ -52,7 +52,7 @@ export default class implements PerfettoPlugin {
   }
 
   async createTargetVmTrack(ctx: Trace, targetUtid: number) {
-    const title = `Avf VM CPU Timeline utid:${targetUtid}`;
+    const name = `Avf VM CPU Timeline utid:${targetUtid}`;
     const uri = `com.android.AvfVmCpuTimeline#AvfVmCpuTimeline${targetUtid}`;
 
     this.validTargets.delete(targetUtid);
@@ -76,7 +76,6 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: new DatasetSliceTrack({
         trace: ctx,
         uri,
@@ -103,7 +102,7 @@ export default class implements PerfettoPlugin {
       }),
     });
 
-    const trackNode = new TrackNode({uri, title, sortOrder: -90});
+    const trackNode = new TrackNode({uri, name, sortOrder: -90});
     ctx.workspace.addChildInOrder(trackNode);
   }
 

--- a/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
+++ b/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
@@ -69,7 +69,6 @@ export default class implements PerfettoPlugin {
       });
       ctx.tracks.registerTrack({
         uri,
-        title: packageName,
         tags: {
           trackIds: [trackId],
           kind: SLICE_TRACK_KIND,
@@ -79,13 +78,13 @@ export default class implements PerfettoPlugin {
       let workPeriod = workPeriodByGpu.get(gpuId);
       if (workPeriod === undefined) {
         workPeriod = new TrackNode({
-          title: `GPU Work Period (GPU ${gpuId})`,
+          name: `GPU Work Period (GPU ${gpuId})`,
           isSummary: true,
         });
         workPeriodByGpu.set(gpuId, workPeriod);
         ctx.workspace.addChildInOrder(workPeriod);
       }
-      workPeriod.addChildInOrder(new TrackNode({title: packageName, uri}));
+      workPeriod.addChildInOrder(new TrackNode({name: packageName, uri: uri}));
     }
   }
 }

--- a/ui/src/plugins/com.android.InputEvents/index.ts
+++ b/ui/src/plugins/com.android.InputEvents/index.ts
@@ -45,7 +45,6 @@ export default class implements PerfettoPlugin {
 
     await ctx.engine.query('INCLUDE PERFETTO MODULE android.input;');
     const uri = 'com.android.InputEvents#InputEventsTrack';
-    const title = 'Input Events';
     const track = await createQuerySliceTrack({
       trace: ctx,
       uri,
@@ -55,10 +54,9 @@ export default class implements PerfettoPlugin {
     });
     ctx.tracks.registerTrack({
       uri,
-      title: title,
       renderer: track,
     });
-    const node = new TrackNode({uri, title});
+    const node = new TrackNode({uri, name: 'Input Events'});
     const group = ctx.plugins
       .getPlugin(StandardGroupsPlugin)
       .getOrCreateStandardGroup(ctx.workspace, 'USER_INTERACTION');

--- a/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
@@ -23,8 +23,6 @@ export default class implements PerfettoPlugin {
   static readonly id = 'com.android.TrustyTeeCpuTimeline';
 
   async onTraceLoad(ctx: Trace): Promise<void> {
-    const title = 'Trusty Tee CPU Timeline';
-
     const uri = `com.android.TrustyTeeCpuTimeline#TrustyTeeCpuTimeline`;
     const query = `
       SELECT
@@ -45,7 +43,6 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: new DatasetSliceTrack({
         trace: ctx,
         uri,
@@ -69,7 +66,11 @@ export default class implements PerfettoPlugin {
       }),
     });
 
-    const trackNode = new TrackNode({uri, title, sortOrder: -100});
+    const trackNode = new TrackNode({
+      uri,
+      name: 'Trusty Tee CPU Timeline',
+      sortOrder: -100,
+    });
     ctx.workspace.addChildInOrder(trackNode);
   }
 }

--- a/ui/src/plugins/com.example.Tracks/index.ts
+++ b/ui/src/plugins/com.example.Tracks/index.ts
@@ -66,12 +66,10 @@ async function createDummyData(trace: Trace) {
 
 // Example 1: A basic slice track showing all data from the table.
 async function addBasicSliceTrack(trace: Trace): Promise<void> {
-  const title = 'All Example Events';
   const uri = `com.example.Tracks#BasicSliceTrack`;
 
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
@@ -88,17 +86,18 @@ async function addBasicSliceTrack(trace: Trace): Promise<void> {
   });
 
   // Add to workspace
-  trace.workspace.addChildInOrder(new TrackNode({uri, title}));
+  trace.workspace.addChildInOrder(
+    new TrackNode({uri, name: 'All Example Events'}),
+  );
 }
 
 // Example 2: A simple slice track filtering data from an existing table.
 async function addFilteredSliceTrack(trace: Trace): Promise<void> {
-  const title = 'Slices starting with "B"';
+  const name = 'Slices starting with "B"';
   const uri = `com.example.Tracks#FilteredSliceTrack`;
 
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
@@ -123,17 +122,16 @@ async function addFilteredSliceTrack(trace: Trace): Promise<void> {
   });
 
   // Add to workspace
-  trace.workspace.addChildInOrder(new TrackNode({uri, title}));
+  trace.workspace.addChildInOrder(new TrackNode({uri, name}));
 }
 
 // Example 3: A slice track using a custom colorizer based on arguments.
 async function addSliceTrackWithCustomColorizer(trace: Trace): Promise<void> {
-  const title = 'Slices colorized by arg';
+  const name = 'Slices colorized by arg';
   const uri = `com.example.Tracks#SliceTrackColorized`;
 
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
@@ -155,17 +153,16 @@ async function addSliceTrackWithCustomColorizer(trace: Trace): Promise<void> {
   });
 
   // Add to workspace
-  trace.workspace.addChildInOrder(new TrackNode({uri, title}));
+  trace.workspace.addChildInOrder(new TrackNode({uri, name}));
 }
 
 // Example 4: An instant track (no durations).
 async function addInstantTrack(trace: Trace): Promise<void> {
-  const title = 'Instant Events';
+  const name = 'Instant Events';
   const uri = `com.example.Tracks#InstantTrack`;
 
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
@@ -182,17 +179,16 @@ async function addInstantTrack(trace: Trace): Promise<void> {
   });
 
   // Add to workspace
-  trace.workspace.addChildInOrder(new TrackNode({uri, title}));
+  trace.workspace.addChildInOrder(new TrackNode({uri, name}));
 }
 
 // Example 5: A slice track with explicit depth (rendered flat).
 async function addFlatSliceTrack(trace: Trace): Promise<void> {
-  const title = 'Flat Slices (Depth 0)';
+  const name = 'Flat Slices (Depth 0)';
   const uri = `com.example.Tracks#FlatSliceTrack`;
 
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
@@ -211,17 +207,16 @@ async function addFlatSliceTrack(trace: Trace): Promise<void> {
   });
 
   // Add to workspace
-  trace.workspace.addChildInOrder(new TrackNode({uri, title}));
+  trace.workspace.addChildInOrder(new TrackNode({uri, name}));
 }
 
 // Example 6: A slice track with a fixed color scheme.
 async function addFixedColorSliceTrack(trace: Trace): Promise<void> {
-  const title = 'Fixed Color Slices (Red)';
+  const name = 'Fixed Color Slices (Red)';
   const uri = `com.example.Tracks#FixedColorSliceTrack`;
 
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: new DatasetSliceTrack({
       trace: trace,
       uri,
@@ -240,7 +235,7 @@ async function addFixedColorSliceTrack(trace: Trace): Promise<void> {
   });
 
   // Add to workspace
-  trace.workspace.addChildInOrder(new TrackNode({uri, title}));
+  trace.workspace.addChildInOrder(new TrackNode({uri, name}));
 }
 
 // Example 7: Creating a nested group of tracks in the workspace.
@@ -252,31 +247,31 @@ async function addNestedTrackGroup(trace: Trace): Promise<void> {
 
   // Create track nodes for the hierarchy
   const trackRoot = new TrackNode({
-    title: 'Nested Track Group',
+    name: 'Nested Track Group',
   });
   const track1 = new TrackNode({
     uri: trackUri,
-    title: 'Nested 1',
+    name: 'Nested 1',
   });
   const track2 = new TrackNode({
     uri: trackUri,
-    title: 'Nested 2',
+    name: 'Nested 2',
   });
   const track11 = new TrackNode({
     uri: trackUri,
-    title: 'Nested 1.1',
+    name: 'Nested 1.1',
   });
   const track12 = new TrackNode({
     uri: trackUri,
-    title: 'Nested 1.2',
+    name: 'Nested 1.2',
   });
   const track121 = new TrackNode({
     uri: trackUri,
-    title: 'Nested 1.2.1',
+    name: 'Nested 1.2.1',
   });
   const track21 = new TrackNode({
     uri: trackUri,
-    title: 'Nested 2.1',
+    name: 'Nested 2.1',
   });
 
   // Build the hierarchy

--- a/ui/src/plugins/com.google.PixelCpmTrace/index.ts
+++ b/ui/src/plugins/com.google.PixelCpmTrace/index.ts
@@ -24,7 +24,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const group = new TrackNode({
-      title: 'Central Power Manager',
+      name: 'Central Power Manager',
       isSummary: true,
     });
 
@@ -57,14 +57,13 @@ export default class implements PerfettoPlugin {
       });
       ctx.tracks.registerTrack({
         uri,
-        title: trackName,
         tags: {
           kind: COUNTER_TRACK_KIND,
           trackIds: [trackId],
         },
         renderer: track,
       });
-      group.addChildInOrder(new TrackNode({uri, title: trackName}));
+      group.addChildInOrder(new TrackNode({uri, name: trackName}));
       if (!groupAdded) {
         ctx.workspace.addChildInOrder(group);
         groupAdded = true;

--- a/ui/src/plugins/com.google.android.GoogleCamera/index.ts
+++ b/ui/src/plugins/com.google.android.GoogleCamera/index.ts
@@ -53,7 +53,7 @@ export default class implements PerfettoPlugin {
   private pinTracks(ctx: Trace, trackNames: ReadonlyArray<string>) {
     ctx.workspace.flatTracks.forEach((track) => {
       trackNames.forEach((trackName) => {
-        if (track.title.match(trackName)) {
+        if (track.name.match(trackName)) {
           track.pin();
         }
       });

--- a/ui/src/plugins/dev.perfetto.AndroidCounterTracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidCounterTracks/index.ts
@@ -57,10 +57,9 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: track,
     });
 
-    return new TrackNode({title, uri, sortOrder: -7});
+    return new TrackNode({name: title, uri, sortOrder: -7});
   }
 }

--- a/ui/src/plugins/dev.perfetto.AndroidDesktopMode/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidDesktopMode/index.ts
@@ -57,13 +57,12 @@ export default class implements PerfettoPlugin {
     });
     ctx.tracks.registerTrack({
       uri: TRACK_URI,
-      title: TRACK_NAME,
       renderer: track,
     });
   }
 
   private addSimpleTrack(ctx: Trace) {
-    const trackNode = new TrackNode({uri: TRACK_URI, title: TRACK_NAME});
+    const trackNode = new TrackNode({uri: TRACK_URI, name: TRACK_NAME});
     ctx.workspace.addChildInOrder(trackNode);
     trackNode.pin();
   }

--- a/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
@@ -39,7 +39,6 @@ async function registerAllocsTrack(
   });
   ctx.tracks.registerTrack({
     uri,
-    title: `dmabuf allocs`,
     renderer: track,
   });
 }
@@ -77,7 +76,7 @@ export default class implements PerfettoPlugin {
         ctx.plugins
           .getPlugin(ProcessThreadGroupsPlugin)
           .getGroupForProcess(it.upid)
-          ?.addChildInOrder(new TrackNode({uri, title: 'dmabuf allocs'}));
+          ?.addChildInOrder(new TrackNode({uri, name: 'dmabuf allocs'}));
       } else if (it.utid != null) {
         const uri = `/android_process_dmabuf_utid_${it.utid}`;
         const config: SqlDataSource = {
@@ -88,7 +87,7 @@ export default class implements PerfettoPlugin {
         ctx.plugins
           .getPlugin(ProcessThreadGroupsPlugin)
           .getGroupForThread(it.utid)
-          ?.addChildInOrder(new TrackNode({uri, title: 'dmabuf allocs'}));
+          ?.addChildInOrder(new TrackNode({uri, name: 'dmabuf allocs'}));
       }
     }
     const memoryGroupFn = () => {
@@ -117,7 +116,6 @@ async function addGlobalCounter(ctx: Trace, parent: () => TrackNode) {
   const uri = `/android_dmabuf_counter`;
   ctx.tracks.registerTrack({
     uri,
-    title,
     tags: {
       kind: COUNTER_TRACK_KIND,
       trackIds: [id],
@@ -126,7 +124,7 @@ async function addGlobalCounter(ctx: Trace, parent: () => TrackNode) {
   });
   const node = new TrackNode({
     uri,
-    title,
+    name: title,
   });
   parent().addChildInOrder(node);
   return node;
@@ -148,7 +146,6 @@ async function addGlobalAllocs(ctx: Trace, parent: () => TrackNode) {
   const ids = trackIds.split(',').map((x) => Number(x));
   ctx.tracks.registerTrack({
     uri,
-    title,
     tags: {
       kind: SLICE_TRACK_KIND,
       trackIds: ids,
@@ -161,7 +158,7 @@ async function addGlobalAllocs(ctx: Trace, parent: () => TrackNode) {
   });
   const node = new TrackNode({
     uri,
-    title,
+    name: title,
   });
   parent().addChildInOrder(node);
 }

--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -72,16 +72,17 @@ export default class implements PerfettoPlugin {
     );
     const logCount = result.firstRow({cnt: NUM}).cnt;
     const uri = 'perfetto.AndroidLog';
-    const title = 'Android logs';
     if (logCount > 0) {
       ctx.tracks.registerTrack({
         uri,
-        title,
         description: 'Android log messages',
         tags: {kind: ANDROID_LOGS_TRACK_KIND},
         renderer: createAndroidLogTrack(ctx, uri),
       });
-      const track = new TrackNode({title, uri});
+      const track = new TrackNode({
+        name: 'Android logs',
+        uri,
+      });
       ctx.workspace.addChildInOrder(track);
     }
 

--- a/ui/src/plugins/dev.perfetto.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLongBatteryTracing/index.ts
@@ -848,7 +848,7 @@ export default class implements PerfettoPlugin {
         existingGroup.addChildInOrder(track);
       } else {
         const group = new TrackNode({
-          title: groupName,
+          name: groupName,
           isSummary: true,
           collapsed: groupCollapsed,
         });
@@ -881,10 +881,9 @@ export default class implements PerfettoPlugin {
     });
     ctx.tracks.registerTrack({
       uri,
-      title: name,
       renderer: track,
     });
-    const trackNode = new TrackNode({uri, title: name});
+    const trackNode = new TrackNode({uri, name});
     this.addTrack(ctx, trackNode, groupName, groupCollapsed);
   }
 
@@ -908,10 +907,9 @@ export default class implements PerfettoPlugin {
     });
     ctx.tracks.registerTrack({
       uri,
-      title: name,
       renderer: track,
     });
-    const trackNode = new TrackNode({uri, title: name});
+    const trackNode = new TrackNode({uri, name});
     this.addTrack(ctx, trackNode, groupName, groupCollapsed);
   }
 

--- a/ui/src/plugins/dev.perfetto.AndroidStartup/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidStartup/index.ts
@@ -82,10 +82,9 @@ export default class implements PerfettoPlugin {
     });
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: track,
     });
     // Needs a sort order lower than 'Ftrace Events' so that it is prioritized in the UI.
-    return new TrackNode({title, uri, sortOrder: -6});
+    return new TrackNode({name: title, uri, sortOrder: -6});
   }
 }

--- a/ui/src/plugins/dev.perfetto.AndroidStartup/optimizations.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidStartup/optimizations.ts
@@ -113,10 +113,9 @@ export async function optimizationsTrack(
     .join('UNION ALL '); // The trailing space is important.
 
   const uri = '/android_startups_optimization_status';
-  const title = 'Optimization Status';
   const track = await createQuerySliceTrack({
     trace: trace,
-    uri: uri,
+    uri,
     data: {
       sqlSource: sqlSource,
       columns: ['ts', 'dur', 'name', 'details'],
@@ -125,10 +124,9 @@ export async function optimizationsTrack(
   });
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: track,
   });
-  const trackNode = new TrackNode({title, uri});
+  const trackNode = new TrackNode({name: 'Optimization Status', uri});
   for await (const classLoadingTrack of classLoadingTracks) {
     trackNode.addChildLast(classLoadingTrack);
   }
@@ -145,10 +143,9 @@ async function classLoadingTrack(
       WHERE startup_id = ${startup.id}
   `;
   const uri = `/android_startups/${startup.id}/classloading`;
-  const title = `Unoptimized Class Loading in (${startup.package})`;
   const track = await createQuerySliceTrack({
     trace: trace,
-    uri: uri,
+    uri,
     data: {
       sqlSource: sqlSource,
       columns: ['ts', 'dur', 'name'],
@@ -156,10 +153,12 @@ async function classLoadingTrack(
   });
   trace.tracks.registerTrack({
     uri,
-    title,
     renderer: track,
   });
-  return new TrackNode({title, uri});
+  return new TrackNode({
+    name: `Unoptimized Class Loading in (${startup.package})`,
+    uri,
+  });
 }
 
 function buildName(startup: Startup): string {

--- a/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/index.ts
@@ -87,17 +87,19 @@ export default class implements PerfettoPlugin {
         };
 
         const uri = `/cpu_freq_cpu${cpu.ucpu}`;
-        const title = `Cpu ${cpu.toString()} Frequency`;
         ctx.tracks.registerTrack({
           uri,
-          title,
           tags: {
             kind: CPU_FREQ_TRACK_KIND,
             cpu: cpu.ucpu,
           },
           renderer: new CpuFreqTrack(config, ctx),
         });
-        const trackNode = new TrackNode({uri, title, sortOrder: -40});
+        const trackNode = new TrackNode({
+          uri,
+          name: `Cpu ${cpu.toString()} Frequency`,
+          sortOrder: -40,
+        });
         ctx.workspace.addChildInOrder(trackNode);
       }
     }

--- a/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
@@ -59,10 +59,8 @@ export default class implements PerfettoPlugin {
       const upid = it.upid;
       const threadName = it.threadName;
       const uri = `${getThreadUriPrefix(upid, utid)}_cpu_samples`;
-      const title = `${threadName} (CPU Stack Samples)`;
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: CPU_PROFILE_TRACK_KIND,
           utid,
@@ -73,7 +71,11 @@ export default class implements PerfettoPlugin {
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForThread(utid);
-      const track = new TrackNode({uri, title, sortOrder: -40});
+      const track = new TrackNode({
+        uri,
+        name: `${threadName} (CPU Stack Samples)`,
+        sortOrder: -40,
+      });
       group?.addChildInOrder(track);
     }
 

--- a/ui/src/plugins/dev.perfetto.CpuidleTimeInState/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuidleTimeInState/index.ts
@@ -44,10 +44,9 @@ export default class implements PerfettoPlugin {
     });
     ctx.tracks.registerTrack({
       uri,
-      title: name,
       renderer: track,
     });
-    const node = new TrackNode({uri, title: name});
+    const node = new TrackNode({uri, name});
     group.addChildInOrder(node);
   }
 
@@ -94,7 +93,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const group = new TrackNode({
-      title: 'CPU Idle Time In State',
+      name: 'CPU Idle Time In State',
       isSummary: true,
     });
 
@@ -116,7 +115,7 @@ export default class implements PerfettoPlugin {
     }
 
     const perCpuGroup = new TrackNode({
-      title: 'CPU Idle Per Cpu Time In State',
+      name: 'CPU Idle Per Cpu Time In State',
       isSummary: true,
     });
 

--- a/ui/src/plugins/dev.perfetto.EntityStateResidency/index.ts
+++ b/ui/src/plugins/dev.perfetto.EntityStateResidency/index.ts
@@ -59,14 +59,14 @@ export default class implements PerfettoPlugin {
         const powerGroup = ctx.plugins
           .getPlugin(StandardGroupsPlugin)
           .getOrCreateStandardGroup(ctx.workspace, 'POWER');
-        entityResidencyGroup = new TrackNode({title: 'Entity Residency'});
+        entityResidencyGroup = new TrackNode({name: 'Entity Residency'});
         powerGroup.addChildInOrder(entityResidencyGroup);
       }
 
       // Create a track group for the current entity if it does not already
       // exist.
-      if (currentGroup?.title !== it.entity) {
-        currentGroup = new TrackNode({title: it.entity, isSummary: true});
+      if (currentGroup?.name !== it.entity) {
+        currentGroup = new TrackNode({name: it.entity, isSummary: true});
         entityResidencyGroup.addChildInOrder(currentGroup);
       }
 
@@ -96,7 +96,6 @@ export default class implements PerfettoPlugin {
 
       ctx.tracks.registerTrack({
         uri,
-        title: name,
         tags: {
           kind: COUNTER_TRACK_KIND,
           trackIds: [it.trackId],
@@ -104,7 +103,7 @@ export default class implements PerfettoPlugin {
         },
         renderer: track,
       });
-      currentGroup.addChildInOrder(new TrackNode({uri, title: name}));
+      currentGroup.addChildInOrder(new TrackNode({uri, name}));
     }
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_controller.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_controller.ts
@@ -53,7 +53,7 @@ export function columnControllerRowFromName(
   return {
     id: name,
     checked,
-    column: {name: name, type: {name: 'NA', shortName: 'NA'}},
+    column: {name, type: {name: 'NA', shortName: 'NA'}},
   };
 }
 

--- a/ui/src/plugins/dev.perfetto.Frames/index.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/index.ts
@@ -74,11 +74,9 @@ export default class implements PerfettoPlugin {
       const trackIds = rawTrackIds.split(',').map((v) => Number(v));
       const maxDepth = it.maxDepth;
 
-      const title = 'Expected Timeline';
       const uri = makeUri(upid, 'expected_frames');
       ctx.tracks.registerTrack({
         uri,
-        title,
         renderer: createExpectedFramesTrack(ctx, uri, maxDepth, trackIds),
         tags: {
           trackIds,
@@ -88,7 +86,11 @@ export default class implements PerfettoPlugin {
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForProcess(upid);
-      const track = new TrackNode({uri, title, sortOrder: -50});
+      const track = new TrackNode({
+        uri,
+        name: 'Expected Timeline',
+        sortOrder: -50,
+      });
       group?.addChildInOrder(track);
     }
   }
@@ -124,11 +126,9 @@ export default class implements PerfettoPlugin {
       const trackIds = rawTrackIds.split(',').map((v) => Number(v));
       const maxDepth = it.maxDepth;
 
-      const title = 'Actual Timeline';
       const uri = makeUri(upid, 'actual_frames');
       ctx.tracks.registerTrack({
         uri,
-        title,
         renderer: createActualFramesTrack(ctx, uri, maxDepth, trackIds),
         tags: {
           upid,
@@ -139,7 +139,11 @@ export default class implements PerfettoPlugin {
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForProcess(upid);
-      const track = new TrackNode({uri, title, sortOrder: -50});
+      const track = new TrackNode({
+        uri,
+        name: 'Actual Timeline',
+        sortOrder: -50,
+      });
       group?.addChildInOrder(track);
     }
   }

--- a/ui/src/plugins/dev.perfetto.Ftrace/index.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/index.ts
@@ -57,18 +57,16 @@ export default class implements PerfettoPlugin {
 
     const cpus = await this.lookupCpuCores(ctx);
     const group = new TrackNode({
-      title: 'Ftrace Events',
+      name: 'Ftrace Events',
       sortOrder: -5,
       isSummary: true,
     });
 
     for (const cpu of cpus) {
       const uri = `/ftrace/cpu${cpu.ucpu}`;
-      const title = `Ftrace Track for CPU ${cpu.toString()}`;
 
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           cpu: cpu.cpu,
           groupName: 'Ftrace Events',
@@ -76,7 +74,10 @@ export default class implements PerfettoPlugin {
         renderer: createFtraceTrack(ctx, uri, cpu, filterStore),
       });
 
-      const track = new TrackNode({uri, title});
+      const track = new TrackNode({
+        uri,
+        name: `Ftrace Track for CPU ${cpu.toString()}`,
+      });
       group.addChildInOrder(track);
     }
 

--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -58,10 +58,8 @@ export default class implements PerfettoPlugin {
       }
 
       const uri = `dev.perfetto.GpuByProcess#${upid}`;
-      const title = `GPU ${processName}`;
       ctx.tracks.registerTrack({
         uri,
-        title,
         renderer: new DatasetSliceTrack({
           trace: ctx,
           uri,
@@ -83,7 +81,10 @@ export default class implements PerfettoPlugin {
           detailsPanel: () => new ThreadSliceDetailsPanel(ctx),
         }),
       });
-      const track = new TrackNode({uri, title});
+      const track = new TrackNode({
+        uri,
+        name: `GPU ${processName}`,
+      });
       ctx.workspace.addChildInOrder(track);
     }
   }

--- a/ui/src/plugins/dev.perfetto.GpuFreq/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuFreq/index.ts
@@ -37,14 +37,13 @@ export default class implements PerfettoPlugin {
       const name = `Gpu ${it.gpuId} Frequency`;
       ctx.tracks.registerTrack({
         uri,
-        title: name,
         tags: {
           kind: COUNTER_TRACK_KIND,
           trackIds: [it.id],
         },
         renderer: new TraceProcessorCounterTrack(ctx, uri, {}, it.id, name),
       });
-      const track = new TrackNode({uri, title: name, sortOrder: -20});
+      const track = new TrackNode({uri, name, sortOrder: -20});
       ctx.workspace.addChildInOrder(track);
     }
   }

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -82,11 +82,9 @@ export default class implements PerfettoPlugin {
     for (const it = result.iter({upid: NUM}); it.valid(); it.next()) {
       const upid = it.upid;
       const uri = `/process_${upid}/heap_profile`;
-      const title = 'Heap Profile';
 
       const track: Track = {
         uri,
-        title,
         tags: {
           kind: HEAP_PROFILE_TRACK_KIND,
           upid,
@@ -104,7 +102,11 @@ export default class implements PerfettoPlugin {
       this.trackMap.set(upid, track);
 
       const group = trackGroupsPlugin.getGroupForProcess(upid);
-      const trackNode = new TrackNode({uri, title, sortOrder: -30});
+      const trackNode = new TrackNode({
+        uri,
+        name: 'Heap Profile',
+        sortOrder: -30,
+      });
       group?.addChildInOrder(trackNode);
     }
   }

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/index.ts
@@ -54,10 +54,8 @@ export default class implements PerfettoPlugin {
     for (const it = pResult.iter({upid: NUM}); it.valid(); it.next()) {
       const upid = it.upid;
       const uri = makeUriForProc(upid);
-      const title = `Process Callstacks`;
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: INSTRUMENTS_SAMPLES_PROFILE_TRACK_KIND,
           upid,
@@ -67,7 +65,11 @@ export default class implements PerfettoPlugin {
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForProcess(upid);
-      const track = new TrackNode({uri, title, sortOrder: -40});
+      const track = new TrackNode({
+        uri,
+        name: 'Process Callstacks',
+        sortOrder: -40,
+      });
       group?.addChildInOrder(track);
     }
     const tResult = await ctx.engine.query(`
@@ -91,14 +93,13 @@ export default class implements PerfettoPlugin {
       it.next()
     ) {
       const {threadName, utid, tid, upid} = it;
-      const title =
+      const name =
         threadName === null
           ? `Thread Callstacks ${tid}`
           : `${threadName} Callstacks ${tid}`;
       const uri = `${getThreadUriPrefix(upid, utid)}_instruments_samples_profile`;
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: INSTRUMENTS_SAMPLES_PROFILE_TRACK_KIND,
           utid,
@@ -109,7 +110,7 @@ export default class implements PerfettoPlugin {
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForThread(utid);
-      const track = new TrackNode({uri, title, sortOrder: -50});
+      const track = new TrackNode({uri, name, sortOrder: -50});
       group?.addChildInOrder(track);
     }
 

--- a/ui/src/plugins/dev.perfetto.Io/index.ts
+++ b/ui/src/plugins/dev.perfetto.Io/index.ts
@@ -25,13 +25,13 @@ export default class implements PerfettoPlugin {
     await ctx.engine.query(`INCLUDE PERFETTO MODULE linux.block_io`);
     const devices = await this.lookupDevices(ctx.engine);
     const group = new TrackNode({
-      title: 'Queued IO requests',
+      name: 'Queued IO requests',
       sortOrder: -5,
       isSummary: true,
     });
     for (const device of devices) {
       const uri = `/queued_io_request_count/device_${device['id']}`;
-      const title = `dev major:${device['major']} minor:${device['minor']}`;
+      const name = `dev major:${device['major']} minor:${device['minor']}`;
       const track = await createQueryCounterTrack({
         trace: ctx,
         uri,
@@ -45,14 +45,13 @@ export default class implements PerfettoPlugin {
       });
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           device: device['id'],
           groupName: 'Queued IO requests',
         },
         renderer: track,
       });
-      const node = new TrackNode({uri, title});
+      const node = new TrackNode({uri, name});
       group.addChildInOrder(node);
     }
     if (group.children.length) {

--- a/ui/src/plugins/dev.perfetto.LargeScreensPerf/index.ts
+++ b/ui/src/plugins/dev.perfetto.LargeScreensPerf/index.ts
@@ -24,16 +24,16 @@ export default class implements PerfettoPlugin {
       callback: () => {
         ctx.workspace.flatTracks.forEach((track) => {
           if (
-            !!track.title.includes('UnfoldTransition') ||
-            track.title.includes('Screen on blocked') ||
-            track.title.includes('hingeAngle') ||
-            track.title.includes('UnfoldLightRevealOverlayAnimation') ||
-            track.title.startsWith('waitForAllWindowsDrawn') ||
-            track.title.endsWith('UNFOLD_ANIM>') ||
-            track.title.endsWith('UNFOLD>') ||
-            track.title == 'Waiting for KeyguardDrawnCallback#onDrawn' ||
-            track.title == 'FoldedState' ||
-            track.title == 'FoldUpdate'
+            !!track.name.includes('UnfoldTransition') ||
+            track.name.includes('Screen on blocked') ||
+            track.name.includes('hingeAngle') ||
+            track.name.includes('UnfoldLightRevealOverlayAnimation') ||
+            track.name.startsWith('waitForAllWindowsDrawn') ||
+            track.name.endsWith('UNFOLD_ANIM>') ||
+            track.name.endsWith('UNFOLD>') ||
+            track.name == 'Waiting for KeyguardDrawnCallback#onDrawn' ||
+            track.name == 'FoldedState' ||
+            track.name == 'FoldUpdate'
           ) {
             track.pin();
           }

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
@@ -76,10 +76,8 @@ export default class implements PerfettoPlugin {
       const upid = it.upid;
       const uri = makeUriForProc(upid);
       trackUris.push(uri);
-      const title = `Process Callstacks`;
       trace.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: PERF_SAMPLES_PROFILE_TRACK_KIND,
           upid,
@@ -89,7 +87,11 @@ export default class implements PerfettoPlugin {
       const group = trace.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForProcess(upid);
-      const track = new TrackNode({uri, title, sortOrder: -40});
+      const track = new TrackNode({
+        uri,
+        name: 'Process Callstacks',
+        sortOrder: -40,
+      });
       group?.addChildInOrder(track);
     }
 
@@ -137,7 +139,6 @@ export default class implements PerfettoPlugin {
       const uri = `${getThreadUriPrefix(upid, utid)}_perf_samples_profile`;
       trace.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: PERF_SAMPLES_PROFILE_TRACK_KIND,
           utid,
@@ -148,14 +149,14 @@ export default class implements PerfettoPlugin {
       const group = trace.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForThread(utid);
-      const track = new TrackNode({uri, title, sortOrder: -50});
+      const track = new TrackNode({uri, name: title, sortOrder: -50});
       group?.addChildInOrder(track);
     }
   }
 
   private async addPerfCounterTracks(trace: Trace) {
     const perfCountersGroup = new TrackNode({
-      title: 'Perf Counters',
+      name: 'Perf Counters',
       isSummary: true,
     });
 
@@ -184,7 +185,6 @@ export default class implements PerfettoPlugin {
 
       trace.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: COUNTER_TRACK_KIND,
           trackIds: [trackId],
@@ -203,7 +203,7 @@ export default class implements PerfettoPlugin {
       });
       const trackNode = new TrackNode({
         uri,
-        title,
+        name: title,
       });
       perfCountersGroup.addChildLast(trackNode);
     }

--- a/ui/src/plugins/dev.perfetto.PinSysUITracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.PinSysUITracks/index.ts
@@ -57,9 +57,7 @@ export default class implements PerfettoPlugin {
           // Ensure we only grab tracks that are in the SysUI process group
           if (!track.uri.startsWith(`/process_${sysuiUpid}`)) return;
           if (
-            !TRACKS_TO_PIN.some((trackName) =>
-              track.title.startsWith(trackName),
-            )
+            !TRACKS_TO_PIN.some((trackName) => track.name.startsWith(trackName))
           ) {
             return;
           }
@@ -68,7 +66,7 @@ export default class implements PerfettoPlugin {
 
         // expand the sysui process tracks group
         ctx.workspace.flatTracks.forEach((track) => {
-          if (track.hasChildren && track.title.startsWith(SYSTEM_UI_PROCESS)) {
+          if (track.hasChildren && track.name.startsWith(SYSTEM_UI_PROCESS)) {
             track.expand();
           }
         });

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/index.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/index.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {maybeMachineLabel} from '../../base/multi_machine_trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {getThreadOrProcUri} from '../../public/utils';
@@ -161,8 +160,6 @@ export default class implements PerfettoPlugin {
       // for additional details.
       isBootImageProfiling && chips.push('boot image profiling');
 
-      const machineLabel = maybeMachineLabel(machine);
-
       if (hasSched) {
         const config: ProcessSchedulingTrackConfig = {
           pidForColor,
@@ -173,7 +170,6 @@ export default class implements PerfettoPlugin {
         const cpuCount = cpuCountByMachine[machine] ?? 0;
         ctx.tracks.registerTrack({
           uri,
-          title: `${upid === null ? tid : pid}${machineLabel} schedule`,
           tags: {
             kind: PROCESS_SCHEDULING_TRACK_KIND,
           },
@@ -190,7 +186,6 @@ export default class implements PerfettoPlugin {
 
         ctx.tracks.registerTrack({
           uri,
-          title: `${upid === null ? tid : pid}${machineLabel} summary`,
           tags: {
             kind: PROCESS_SUMMARY_TRACK,
           },
@@ -249,7 +244,6 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri: '/kernel',
-      title: `Kernel thread summary`,
       tags: {
         kind: PROCESS_SUMMARY_TRACK,
       },

--- a/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessThreadGroups/index.ts
@@ -123,7 +123,7 @@ export default class implements PerfettoPlugin {
     // but creating a dedicated track type is out of scope at the time of
     // writing.
     const kernelThreadsGroup = new TrackNode({
-      title: 'Kernel threads',
+      name: 'Kernel threads',
       uri: '/kernel',
       sortOrder: 50,
       isSummary: true,
@@ -136,7 +136,7 @@ export default class implements PerfettoPlugin {
 
       const threadGroup = new TrackNode({
         uri: `thread${utid}`,
-        title: `Thread ${utid}`,
+        name: `Thread ${utid}`,
         isSummary: true,
         headless: true,
       });
@@ -265,7 +265,7 @@ export default class implements PerfettoPlugin {
         const displayName = getProcessDisplayName(name ?? undefined, id);
         const group = new TrackNode({
           uri: `/process_${uid}`,
-          title: displayName,
+          name: displayName,
           isSummary: true,
           sortOrder: 50,
         });
@@ -282,7 +282,7 @@ export default class implements PerfettoPlugin {
         const displayName = getThreadDisplayName(name ?? undefined, id);
         const group = new TrackNode({
           uri: `/thread_${uid}`,
-          title: displayName,
+          name: displayName,
           isSummary: true,
           sortOrder: 50,
         });
@@ -351,7 +351,7 @@ export default class implements PerfettoPlugin {
 
       const group = new TrackNode({
         uri: `/thread_${utid}`,
-        title: getThreadDisplayName(threadName ?? undefined, tid),
+        name: getThreadDisplayName(threadName ?? undefined, tid),
         isSummary: true,
         headless: true,
       });

--- a/ui/src/plugins/dev.perfetto.RestorePinnedTracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.RestorePinnedTracks/index.ts
@@ -315,7 +315,7 @@ export default class implements PerfettoPlugin {
 
     return {
       groupName: groupName(trackNode),
-      trackName: trackNode.title,
+      trackName: trackNode.name,
       pluginId: track?.pluginId,
       kind: track?.tags?.kind,
       isMainThread: track?.chips?.includes('main thread') || false,
@@ -358,7 +358,7 @@ function addOrReplaceNamedPinnedTracks({name, tracks}: SavedNamedPinnedTracks) {
 // Return the displayname of the containing group
 // If the track is a child of a workspace, return undefined...
 function groupName(track: TrackNode): string | undefined {
-  return track.parent?.title;
+  return track.parent?.name;
 }
 
 const SAVED_PINNED_TRACK_SCHEMA = z

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -88,14 +88,13 @@ export default class implements PerfettoPlugin {
 
       ctx.tracks.registerTrack({
         uri,
-        title: name,
         tags: {
           kind: CPU_SLICE_TRACK_KIND,
           cpu: cpu.ucpu,
         },
         renderer: new CpuSliceTrack(ctx, uri, cpu, threads),
       });
-      const trackNode = new TrackNode({uri, title: name, sortOrder: -50});
+      const trackNode = new TrackNode({uri, name, sortOrder: -50});
       ctx.workspace.addChildInOrder(trackNode);
     }
 
@@ -186,7 +185,6 @@ export default class implements PerfettoPlugin {
       const uri = uriForThreadStateTrack(upid, utid);
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: THREAD_STATE_TRACK_KIND,
           utid,
@@ -202,7 +200,7 @@ export default class implements PerfettoPlugin {
       const group = ctx.plugins
         .getPlugin(ProcessThreadGroupsPlugin)
         .getGroupForThread(utid);
-      const track = new TrackNode({uri, title, sortOrder: 10});
+      const track = new TrackNode({uri, name: title, sortOrder: 10});
       group?.addChildInOrder(track);
     }
   }

--- a/ui/src/plugins/dev.perfetto.SchedSummary/index.ts
+++ b/ui/src/plugins/dev.perfetto.SchedSummary/index.ts
@@ -27,7 +27,6 @@ export default class implements PerfettoPlugin {
     const runnableThreadCountUri = `/runnable_thread_count`;
     ctx.tracks.registerTrack({
       uri: runnableThreadCountUri,
-      title: 'Runnable thread count',
       renderer: new RunnableThreadCountTrack(ctx, runnableThreadCountUri),
     });
     ctx.commands.registerCommand({
@@ -40,7 +39,6 @@ export default class implements PerfettoPlugin {
     const uninterruptibleSleepThreadCountUri = `/uninterruptible_sleep_thread_count`;
     ctx.tracks.registerTrack({
       uri: uninterruptibleSleepThreadCountUri,
-      title: 'Uninterruptible Sleep thread count',
       renderer: new UninterruptibleSleepThreadCountTrack(
         ctx,
         uninterruptibleSleepThreadCountUri,
@@ -58,31 +56,29 @@ export default class implements PerfettoPlugin {
     });
 
     const uri = uriForActiveCPUCountTrack();
-    const title = 'Active CPU count';
+    const name = 'Active CPU count';
     ctx.tracks.registerTrack({
       uri,
-      title: title,
       renderer: new ActiveCPUCountTrack({trackUri: uri}, ctx),
     });
     ctx.commands.registerCommand({
       id: 'dev.perfetto.Sched.AddActiveCPUCountTrackCommand',
       name: 'Add track: active CPU count',
-      callback: () => addPinnedTrack(ctx, uri, title),
+      callback: () => addPinnedTrack(ctx, uri, name),
     });
 
     for (const cpuType of Object.values(CPUType)) {
       const uri = uriForActiveCPUCountTrack(cpuType);
-      const title = `Active ${cpuType} CPU count`;
+      const name = `Active ${cpuType} CPU count`;
       ctx.tracks.registerTrack({
         uri,
-        title: title,
         renderer: new ActiveCPUCountTrack({trackUri: uri}, ctx, cpuType),
       });
 
       ctx.commands.registerCommand({
         id: `dev.perfetto.Sched.AddActiveCPUCountTrackCommand.${cpuType}`,
         name: `Add track: active ${cpuType} CPU count`,
-        callback: () => addPinnedTrack(ctx, uri, title),
+        callback: () => addPinnedTrack(ctx, uri, name),
       });
     }
   }
@@ -97,8 +93,8 @@ function uriForActiveCPUCountTrack(cpuType?: CPUType): string {
   }
 }
 
-function addPinnedTrack(ctx: Trace, uri: string, title: string) {
-  const track = new TrackNode({uri, title});
+function addPinnedTrack(ctx: Trace, uri: string, name: string) {
+  const track = new TrackNode({uri, name});
   // Add track to the top of the stack
   ctx.workspace.addChildFirst(track);
   track.pin();

--- a/ui/src/plugins/dev.perfetto.Screenshots/index.ts
+++ b/ui/src/plugins/dev.perfetto.Screenshots/index.ts
@@ -30,14 +30,16 @@ export default class implements PerfettoPlugin {
     const {count} = res.firstRow({count: NUM});
 
     if (count > 0) {
-      const title = 'Screenshots';
       const uri = '/screenshots';
       ctx.tracks.registerTrack({
         uri,
-        title,
         renderer: createScreenshotsTrack(ctx, uri),
       });
-      const trackNode = new TrackNode({uri, title, sortOrder: -60});
+      const trackNode = new TrackNode({
+        uri,
+        name: 'Screenshots',
+        sortOrder: -60,
+      });
       ctx.workspace.addChildInOrder(trackNode);
     }
   }

--- a/ui/src/plugins/dev.perfetto.StandardGroups/index.ts
+++ b/ui/src/plugins/dev.perfetto.StandardGroups/index.ts
@@ -67,6 +67,6 @@ export default class implements PerfettoPlugin {
   }
 }
 
-function makeGroupNode(title: string, collapsed = true) {
-  return new TrackNode({title, isSummary: true, collapsed});
+function makeGroupNode(name: string, collapsed = true) {
+  return new TrackNode({name, isSummary: true, collapsed});
 }

--- a/ui/src/plugins/dev.perfetto.SysUIWorkspace/index.ts
+++ b/ui/src/plugins/dev.perfetto.SysUIWorkspace/index.ts
@@ -144,7 +144,7 @@ class ProcessWorkspaceFactory {
     const tracks = this.getTracksContaining(titleSubstring);
     if (tracks.length == 0) return;
     if (tracks.length >= minSizeToGroup) {
-      const newGroup = new TrackNode({title: titleSubstring, isSummary: true});
+      const newGroup = new TrackNode({name: titleSubstring, isSummary: true});
       this.ws.addChildLast(newGroup);
       tracks.forEach((track) => newGroup.addChildLast(track.clone()));
     } else {
@@ -154,7 +154,7 @@ class ProcessWorkspaceFactory {
 
   private getTracksContaining(titleSubstring: string): TrackNode[] {
     return this.processTracks.filter((track) =>
-      track.title.includes(titleSubstring),
+      track.name.includes(titleSubstring),
     );
   }
 
@@ -201,9 +201,9 @@ class ProcessWorkspaceFactory {
       return utid != undefined && uiThreadUtidsSet.has(utid);
     });
     toPin.sort((a, b) => {
-      return a.title.localeCompare(b.title);
+      return a.name.localeCompare(b.name);
     });
-    const uiThreadTrack = new TrackNode({title: 'UI Threads', isSummary: true});
+    const uiThreadTrack = new TrackNode({name: 'UI Threads', isSummary: true});
     this.ws.addChildLast(uiThreadTrack);
     toPin.forEach((track) => uiThreadTrack.addChildLast(track.clone()));
   }
@@ -217,16 +217,16 @@ class ProcessWorkspaceFactory {
     const trackGroups = new Map<string, TrackNode>();
 
     this.processTracks.forEach((track) => {
-      const match = track.title.match(groupRegex);
+      const match = track.name.match(groupRegex);
       if (!match?.groups) return;
 
       const {groupName, trackName} = match.groups;
 
       const newTrack = track.clone();
-      newTrack.title = trackName;
+      newTrack.name = trackName;
 
       if (!trackGroups.has(groupName)) {
-        const newGroup = new TrackNode({title: groupName, isSummary: true});
+        const newGroup = new TrackNode({name: groupName, isSummary: true});
         this.ws.addChildLast(newGroup);
         trackGroups.set(groupName, newGroup);
       }

--- a/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
@@ -46,7 +46,6 @@ export default class implements PerfettoPlugin {
       return;
     }
     const uri = `/clock_snapshots`;
-    const title = 'Clock Snapshots';
     const track = new DatasetSliceTrack({
       trace,
       uri,
@@ -132,10 +131,9 @@ export default class implements PerfettoPlugin {
     });
     trace.tracks.registerTrack({
       uri,
-      title,
       renderer: track,
     });
-    const trackNode = new TrackNode({uri, title});
+    const trackNode = new TrackNode({uri, name: 'Clock Snapshots'});
     const group = trace.plugins
       .getPlugin(StandardGroupsPlugin)
       .getOrCreateStandardGroup(trace.workspace, 'SYSTEM');

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -129,7 +129,7 @@ export default class implements PerfettoPlugin {
         continue;
       }
       const {group, topLevelGroup} = schema;
-      const title = getTrackName({
+      const trackName = getTrackName({
         name,
         tid,
         threadName,
@@ -143,7 +143,6 @@ export default class implements PerfettoPlugin {
       const uri = `/counter_${trackId}`;
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: COUNTER_TRACK_KIND,
           trackIds: [trackId],
@@ -164,7 +163,7 @@ export default class implements PerfettoPlugin {
             unit: unit ?? undefined,
           },
           trackId,
-          title,
+          trackName,
         ),
       });
       this.addTrack(
@@ -175,7 +174,7 @@ export default class implements PerfettoPlugin {
         utid,
         new TrackNode({
           uri,
-          title,
+          name: trackName,
           sortOrder: utid !== undefined || upid !== undefined ? 30 : 0,
         }),
       );
@@ -255,7 +254,7 @@ export default class implements PerfettoPlugin {
       }
       const trackIds = rawTrackIds.split(',').map((v) => Number(v));
       const {group, topLevelGroup} = schema;
-      const title = getTrackName({
+      const trackName = getTrackName({
         name,
         tid,
         threadName,
@@ -269,7 +268,6 @@ export default class implements PerfettoPlugin {
       const uri = `/slice_${trackIds[0]}`;
       ctx.tracks.registerTrack({
         uri,
-        title,
         tags: {
           kind: SLICE_TRACK_KIND,
           trackIds: trackIds,
@@ -296,7 +294,7 @@ export default class implements PerfettoPlugin {
         utid,
         new TrackNode({
           uri,
-          title,
+          name: trackName,
           sortOrder: utid !== undefined || upid !== undefined ? 20 : 0,
         }),
       );
@@ -368,7 +366,7 @@ export default class implements PerfettoPlugin {
     const newGroup = new TrackNode({
       uri: `/${group}`,
       isSummary: true,
-      title: name,
+      name,
       collapsed: !expanded,
     });
     node.addChildInOrder(newGroup);

--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -105,7 +105,7 @@ export default class implements PerfettoPlugin {
 
       const kind = isCounter ? COUNTER_TRACK_KIND : SLICE_TRACK_KIND;
       const trackIds = rawTrackIds.split(',').map((v) => Number(v));
-      const title = getTrackName({
+      const trackName = getTrackName({
         name,
         utid,
         upid,
@@ -126,7 +126,6 @@ export default class implements PerfettoPlugin {
         const trackId = trackIds[0];
         ctx.tracks.registerTrack({
           uri,
-          title,
           tags: {
             kind,
             trackIds: [trackIds[0]],
@@ -140,13 +139,12 @@ export default class implements PerfettoPlugin {
               unit: unit ?? undefined,
             },
             trackId,
-            title,
+            trackName,
           ),
         });
       } else if (hasData) {
         ctx.tracks.registerTrack({
           uri,
-          title,
           tags: {
             kind,
             trackIds: trackIds,
@@ -170,10 +168,10 @@ export default class implements PerfettoPlugin {
         hasChildren,
       );
       const node = new TrackNode({
-        title,
+        name: trackName,
         sortOrder: orderId,
         isSummary: hasData === 0,
-        uri: uri,
+        uri,
       });
       parent.addChildInOrder(node);
       trackIdToTrackNode.set(trackIds[0], node);
@@ -205,7 +203,7 @@ export default class implements PerfettoPlugin {
     let node = this.parentTrackNodes.get(id);
     if (node === undefined) {
       node = new TrackNode({
-        title: 'Global Track Events',
+        name: 'Global Track Events',
         isSummary: true,
       });
       ctx.workspace.addChildInOrder(node);

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/index.ts
@@ -30,7 +30,7 @@ export default class implements PerfettoPlugin {
       callback: () => {
         const track = new TrackNode({
           uri,
-          title: 'Chrome Interactions',
+          name: 'Chrome Interactions',
         });
         ctx.workspace.addChildInOrder(track);
         track.pin();
@@ -39,7 +39,6 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title: 'Chrome Interactions',
       renderer: createCriticalUserInteractionTrack(ctx, uri),
     });
   }

--- a/ui/src/plugins/org.chromium.ChromeNavigation/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeNavigation/index.ts
@@ -52,7 +52,7 @@ export default class implements PerfettoPlugin {
       name: 'Chrome Navigation: Pin relevant tracks',
       callback: () => {
         trace.workspace.flatTracks
-          .filter((t) => PIN_TRACK_NAME_PATTERNS.some((p) => t.title.match(p)))
+          .filter((t) => PIN_TRACK_NAME_PATTERNS.some((p) => t.name.match(p)))
           .forEach((t) => t.pin());
       },
     });
@@ -83,7 +83,7 @@ export default class implements PerfettoPlugin {
         // Find all tracks that we want to be visible.
         trace.workspace.flatTracks
           .filter((t) =>
-            INTERESTING_TRACKS_NAME_PATTERNS.some((p) => t.title.match(p)),
+            INTERESTING_TRACKS_NAME_PATTERNS.some((p) => t.name.match(p)),
           )
           .forEach((e) => flatIds.add(e.id));
 
@@ -100,7 +100,7 @@ export default class implements PerfettoPlugin {
           // We need to create a new node if we have added any children
           // or this track itself should be copied because the name matches.
           const nameMatch = INTERESTING_TRACKS_NAME_PATTERNS.some((p) =>
-            track.title.match(p),
+            track.name.match(p),
           );
           if (children.length === 0 && !nameMatch) {
             return undefined;

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
@@ -41,7 +41,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const group = new TrackNode({
-      title: 'Chrome Scroll Jank',
+      name: 'Chrome Scroll Jank',
       sortOrder: -30,
       isSummary: true,
     });
@@ -70,11 +70,10 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: createTopLevelScrollTrack(ctx, uri),
     });
 
-    const track = new TrackNode({uri, title});
+    const track = new TrackNode({uri, name: title});
     group.addChildInOrder(track);
   }
 
@@ -179,11 +178,10 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: createEventLatencyTrack(ctx, uri, baseTable),
     });
 
-    const track = new TrackNode({uri, title});
+    const track = new TrackNode({uri, name: title});
     group.addChildInOrder(track);
   }
 
@@ -200,11 +198,10 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: createScrollJankV3Track(ctx, uri),
     });
 
-    const track = new TrackNode({uri, title});
+    const track = new TrackNode({uri, name: title});
     group.addChildInOrder(track);
   }
 
@@ -221,11 +218,10 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: createScrollTimelineTrack(ctx, model),
     });
 
-    const track = new TrackNode({uri, title});
+    const track = new TrackNode({uri, name: title});
     group.addChildInOrder(track);
   }
 
@@ -253,9 +249,8 @@ export default class implements PerfettoPlugin {
         argColumns: ['id', 'track_id', 'ts', 'dur'],
         uri,
       });
-      const title = 'Chrome VSync';
-      ctx.tracks.registerTrack({uri, title, renderer: track});
-      group.addChildInOrder(new TrackNode({uri, title}));
+      ctx.tracks.registerTrack({uri, renderer: track});
+      group.addChildInOrder(new TrackNode({uri, name: 'Chrome VSync'}));
     }
 
     {
@@ -266,9 +261,8 @@ export default class implements PerfettoPlugin {
         uri,
         `(SELECT id, ts, LEAD(ts) OVER (ORDER BY ts) - ts as dur FROM ${vsyncTable})`,
       );
-      const title = 'Chrome VSync delta';
-      ctx.tracks.registerTrack({uri, title, renderer: track});
-      group.addChildInOrder(new TrackNode({uri, title}));
+      ctx.tracks.registerTrack({uri, renderer: track});
+      group.addChildInOrder(new TrackNode({uri, name: 'Chrome VSync delta'}));
     }
 
     {
@@ -284,9 +278,8 @@ export default class implements PerfettoPlugin {
         FROM chrome_scroll_update_info
         WHERE generation_ts IS NOT NULL)`,
       );
-      const title = 'Chrome input delta';
-      ctx.tracks.registerTrack({uri, title, renderer: track});
-      group.addChildInOrder(new TrackNode({uri, title}));
+      ctx.tracks.registerTrack({uri, renderer: track});
+      group.addChildInOrder(new TrackNode({uri, name: 'Chrome input delta'}));
     }
 
     {
@@ -342,8 +335,8 @@ export default class implements PerfettoPlugin {
           }),
           detailsPanel: () => new ThreadSliceDetailsPanel(ctx),
         });
-        ctx.tracks.registerTrack({uri, title: step.name, renderer: track});
-        group.addChildInOrder(new TrackNode({uri, title: step.name}));
+        ctx.tracks.registerTrack({uri, renderer: track});
+        group.addChildInOrder(new TrackNode({uri, name: step.name}));
       }
     }
   }

--- a/ui/src/plugins/org.chromium.ChromeTasks/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeTasks/index.ts
@@ -79,17 +79,16 @@ export default class implements PerfettoPlugin {
       utid: NUM,
     });
 
-    const group = new TrackNode({title: 'Chrome Tasks', isSummary: true});
+    const group = new TrackNode({name: 'Chrome Tasks', isSummary: true});
     for (; it.valid(); it.next()) {
       const utid = it.utid;
       const uri = `org.chromium.ChromeTasks#thread.${utid}`;
-      const title = `${it.threadName} ${it.tid}`;
+      const name = `${it.threadName} ${it.tid}`;
       ctx.tracks.registerTrack({
         uri,
         renderer: createChromeTasksThreadTrack(ctx, uri, asUtid(utid)),
-        title,
       });
-      const track = new TrackNode({uri, title});
+      const track = new TrackNode({uri, name});
       group.addChildInOrder(track);
       ctx.workspace.addChildInOrder(group);
     }

--- a/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
+++ b/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
@@ -27,7 +27,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     const kernel = new TrackNode({
-      title: 'Linux Kernel',
+      name: 'Linux Kernel',
       isSummary: true,
     });
     const rpm = await this.addRpmTracks(ctx);
@@ -55,17 +55,15 @@ export default class implements PerfettoPlugin {
       trackId: NUM,
     });
     const rpm = new TrackNode({
-      title: 'Runtime Power Management',
+      name: 'Runtime Power Management',
       isSummary: true,
     });
     for (; it.valid(); it.next()) {
       const trackId = it.trackId;
-      const title = it.deviceName ?? `${trackId}`;
-
-      const uri = `/linux/rpm/${title}`;
+      const name = it.deviceName ?? `${trackId}`;
+      const uri = `/linux/rpm/${name}`;
       ctx.tracks.registerTrack({
         uri,
-        title,
         renderer: await createTraceProcessorSliceTrack({
           trace: ctx,
           uri,
@@ -77,7 +75,7 @@ export default class implements PerfettoPlugin {
           groupName: `Linux Kernel Devices`,
         },
       });
-      const track = new TrackNode({uri, title});
+      const track = new TrackNode({uri, name: name});
       rpm.addChildInOrder(track);
     }
     return rpm;

--- a/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
+++ b/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
@@ -62,10 +62,8 @@ export default class implements PerfettoPlugin {
     const maxDepth = it.maxDepth;
 
     const uri = `/suspend_resume_latency`;
-    const displayName = `Suspend/Resume Latency`;
     ctx.tracks.registerTrack({
       uri,
-      title: displayName,
       tags: {
         trackIds,
         kind: SLICE_TRACK_KIND,
@@ -80,7 +78,7 @@ export default class implements PerfettoPlugin {
     });
 
     // Display the track in the UI.
-    const track = new TrackNode({uri, title: displayName});
+    const track = new TrackNode({uri, name: 'Suspend/Resume Latency'});
     ctx.workspace.addChildInOrder(track);
   }
 }

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -44,7 +44,7 @@ export default class implements PerfettoPlugin {
     // Short circuit if Wattson is not supported for this Perfetto trace
     if (!(markersSupported || cpuSupported || gpuSupported)) return;
 
-    const group = new TrackNode({title: 'Wattson', isSummary: true});
+    const group = new TrackNode({name: 'Wattson', isSummary: true});
     ctx.workspace.addChildInOrder(group);
 
     if (markersSupported) {
@@ -141,7 +141,6 @@ async function hasWattsonGpuSupport(engine: Engine): Promise<boolean> {
 
 async function addWattsonMarkersElements(ctx: Trace, group: TrackNode) {
   const uri = `/wattson/markers_window`;
-  const title = `Wattson markers window`;
   const track = await createQuerySliceTrack({
     trace: ctx,
     uri,
@@ -151,13 +150,12 @@ async function addWattsonMarkersElements(ctx: Trace, group: TrackNode) {
   });
   ctx.tracks.registerTrack({
     uri,
-    title,
     tags: {
       kind: SLICE_TRACK_KIND,
     },
     renderer: track,
   });
-  group.addChildInOrder(new TrackNode({uri, title}));
+  group.addChildInOrder(new TrackNode({uri, name: 'Wattson markers window'}));
 }
 
 async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
@@ -180,10 +178,8 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
   for (const cpu of cpus) {
     const queryKey = `cpu${cpu.ucpu}_mw`;
     const uri = `/wattson/cpu_subsystem_estimate_cpu${cpu.ucpu}`;
-    const title = `Cpu${cpu.toString()} Estimate`;
     ctx.tracks.registerTrack({
       uri,
-      title,
       renderer: new WattsonSubsystemEstimateTrack(
         ctx,
         uri,
@@ -196,14 +192,18 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
         groupName: `Wattson`,
       },
     });
-    group.addChildInOrder(new TrackNode({uri, title}));
+    group.addChildInOrder(
+      new TrackNode({
+        uri,
+        name: `Cpu${cpu.toString()} Estimate`,
+      }),
+    );
   }
 
   const uri = `/wattson/cpu_subsystem_estimate_dsu_scu`;
   const title = `DSU/SCU Estimate`;
   ctx.tracks.registerTrack({
     uri,
-    title,
     renderer: new WattsonSubsystemEstimateTrack(
       ctx,
       uri,
@@ -216,7 +216,7 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
       groupName: `Wattson`,
     },
   });
-  group.addChildInOrder(new TrackNode({uri, title}));
+  group.addChildInOrder(new TrackNode({uri, name: title}));
 
   // Register selection aggregators.
   // NOTE: the registration order matters because the laste two aggregators
@@ -248,14 +248,12 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
 }
 
 async function addWattsonGpuElements(ctx: Trace, group: TrackNode) {
-  const uri = `/wattson/gpu_subsystem_estimate`;
-  const title = `GPU Estimate`;
+  const id = `/wattson/gpu_subsystem_estimate`;
   ctx.tracks.registerTrack({
-    uri,
-    title,
+    uri: id,
     renderer: new WattsonSubsystemEstimateTrack(
       ctx,
-      uri,
+      id,
       `gpu_mw`,
       `GpuSubsystem`,
     ),
@@ -265,5 +263,5 @@ async function addWattsonGpuElements(ctx: Trace, group: TrackNode) {
       groupName: `Wattson`,
     },
   });
-  group.addChildInOrder(new TrackNode({uri, title}));
+  group.addChildInOrder(new TrackNode({uri: id, name: `GPU Estimate`}));
 }

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -117,9 +117,6 @@ export interface Track {
   // Describes how to render the track.
   readonly renderer: TrackRenderer;
 
-  // Human readable title. Always displayed.
-  readonly title: string;
-
   // Optional: A human readable description of the track.
   readonly description?: string;
 

--- a/ui/src/public/workspace.ts
+++ b/ui/src/public/workspace.ts
@@ -64,7 +64,7 @@ function createSessionUniqueId(): string {
  */
 
 export interface TrackNodeArgs {
-  title: string;
+  name: string;
   uri: string;
   headless: boolean;
   sortOrder: number;
@@ -86,13 +86,13 @@ export class TrackNode {
   // A human readable string for this track - displayed in the track shell.
   // TODO(stevegolton): Make this optional, so that if we implement a string for
   // this track then we can implement it here as well.
-  public title: string;
+  public name: string;
 
   // The URI of the track content to display here.
   public uri?: string;
 
   // Optional sort order, which workspaces may or may not take advantage of for
-  // sorting when displaying the workspace.
+  // sorting when displaying the workspace. Higher numbers appear first.
   public sortOrder?: number;
 
   // Don't show the header at all for this track, just show its un-nested
@@ -126,7 +126,7 @@ export class TrackNode {
 
   constructor(args?: Partial<TrackNodeArgs>) {
     const {
-      title = '',
+      name = '',
       uri,
       headless = false,
       sortOrder,
@@ -138,7 +138,7 @@ export class TrackNode {
     this.id = createSessionUniqueId();
     this.uri = uri;
     this.headless = headless;
-    this.title = title;
+    this.name = name;
     this.sortOrder = sortOrder;
     this.isSummary = isSummary;
     this._collapsed = collapsed;
@@ -277,12 +277,12 @@ export class TrackNode {
    * omitted.
    */
   get fullPath(): ReadonlyArray<string> {
-    let fullPath = [this.title];
+    let fullPath = [this.name];
     let parent = this.parent;
     while (parent) {
       // Ignore headless containers as they don't appear in the tree...
-      if (!parent.headless && parent.title !== '') {
-        fullPath = [parent.title, ...fullPath];
+      if (!parent.headless && parent.name !== '') {
+        fullPath = [parent.name, ...fullPath];
       }
       parent = parent.parent;
     }
@@ -575,7 +575,7 @@ export class Workspace {
     // Make a lightweight clone of this track - just the uri and the title.
     const cloned = new TrackNode({
       uri: track.uri,
-      title: track.title,
+      name: track.name,
       removable: track.removable,
     });
     this.pinnedTracksNode.addChildLast(cloned);

--- a/ui/src/public/workspace_unittest.ts
+++ b/ui/src/public/workspace_unittest.ts
@@ -238,7 +238,7 @@ test('TrackNode::clone', () => {
   expect(cloned.id).not.toBe(root.id); // id should be different
   expect(cloned.uri).toBe(root.uri);
   expect(cloned.expanded).toBe(root.expanded);
-  expect(cloned.title).toBe(root.title);
+  expect(cloned.name).toBe(root.name);
   expect(cloned.headless).toBe(root.headless);
   expect(cloned.isSummary).toBe(root.isSummary);
   expect(cloned.removable).toBe(root.removable);
@@ -258,15 +258,15 @@ test('TrackNode::clone(deep)', () => {
   expect(cloned.id).not.toBe(root.id); // id should be different
   expect(cloned.uri).toBe(root.uri);
   expect(cloned.expanded).toBe(root.expanded);
-  expect(cloned.title).toBe(root.title);
+  expect(cloned.name).toBe(root.name);
   expect(cloned.headless).toBe(root.headless);
   expect(cloned.isSummary).toBe(root.isSummary);
   expect(cloned.removable).toBe(root.removable);
   expect(cloned.children).toHaveLength(2);
 
-  expect(cloned.children[0].title).toBe(childA.title);
+  expect(cloned.children[0].name).toBe(childA.name);
   expect(cloned.children[0].uri).toBe(childA.uri);
 
-  expect(cloned.children[1].title).toBe(childB.title);
+  expect(cloned.children[1].name).toBe(childB.name);
   expect(cloned.children[1].uri).toBe(childB.uri);
 });


### PR DESCRIPTION
This patch removes the redundant 'title' property on the Track objects. It's redundant because the string that's actually displayed on the a track in the UI is the title property on the TrackNode, not the Track, so the Track.title is basically unused. All it does it force plugin developers to define this value twice.

Rationale: Why use TrackNode.title instead of Track.title?

Track 'titles' typically only make sense within the context of the track's containing groups. For example the 'Actual Frames' track titles make little sense outside the context of their containing process group. Since groups are in the domain of TrackNodes, it makes sense to locate this property here.

This patch also renames TrackNode.title -> name, as 'track name' is a much more natural name for this concept.