### PR TITLE
persistent_cfg: transactions with continuous mode

### DIFF
--- a/persistent_cfg.pbtxt
+++ b/persistent_cfg.pbtxt
@@ -39,7 +39,7 @@ data_sources: {
     name: "android.surfaceflinger.transactions"
     target_buffer: 0
     surfaceflinger_transactions_config: {
-      mode: MODE_ACTIVE
+      mode: MODE_CONTINUOUS
     }
   }
 }


### PR DESCRIPTION
Set android.surfaceflinger.transactions tracing mode to MODE_CONTINUOUS