### PR TITLE
Fix some questionable TypeScript import gymnastics

### DIFF
--- a/ui/src/components/details/process_details_tab.ts
+++ b/ui/src/components/details/process_details_tab.ts
@@ -18,8 +18,7 @@ import {Upid} from '../sql_utils/core_types';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
-import {Details, DetailsSchema} from '../widgets/sql/details/details';
-import d = DetailsSchema;
+import {Details, DetailsSchema as d} from '../widgets/sql/details/details';
 import {Trace} from '../../public/trace';
 
 export class ProcessDetailsTab implements Tab {

--- a/ui/src/components/details/thread_details_tab.ts
+++ b/ui/src/components/details/thread_details_tab.ts
@@ -18,8 +18,7 @@ import {Utid} from '../sql_utils/core_types';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
-import {Details, DetailsSchema} from '../widgets/sql/details/details';
-import d = DetailsSchema;
+import {Details, DetailsSchema as d} from '../widgets/sql/details/details';
 import {Trace} from '../../public/trace';
 
 export class ThreadDetailsTab implements Tab {

--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -22,7 +22,7 @@ import {
 import {createQuerySliceTrack} from '../../components/tracks/query_slice_track';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {ColumnType, NUM_NULL} from '../../trace_processor/query_result';
+import {SqlValue, NUM_NULL} from '../../trace_processor/query_result';
 
 /**
  * Aggregation types for the BreakdownTracks.
@@ -480,7 +480,7 @@ function buildFilterSqlClause(filters: Filter[]) {
 function filterToSql(filter: Filter) {
   const {columnName, value} = filter;
 
-  const filterValue: ColumnType | undefined = toSqlValue(value);
+  const filterValue: SqlValue | undefined = toSqlValue(value);
   return `${columnName} = ${filterValue === undefined ? '' : filterValue}`;
 }
 

--- a/ui/src/components/tracks/dataset_slice_track.ts
+++ b/ui/src/components/tracks/dataset_slice_track.ts
@@ -20,7 +20,7 @@ import {TrackEventDetails, TrackEventSelection} from '../../public/selection';
 import {Trace} from '../../public/trace';
 import {Slice} from '../../public/track';
 import {DatasetSchema, SourceDataset} from '../../trace_processor/dataset';
-import {ColumnType, LONG, NUM} from '../../trace_processor/query_result';
+import {SqlValue, LONG, NUM} from '../../trace_processor/query_result';
 import {getColorForSlice} from '../colorizer';
 import {formatDuration} from '../time_utils';
 import {
@@ -323,7 +323,7 @@ export class DatasetSliceTrack<T extends ROW_SCHEMA> extends BaseSliceTrack<
     if (!row.valid()) return undefined;
 
     // Pull the fields out from the results
-    const data: {[key: string]: ColumnType} = {};
+    const data: {[key: string]: SqlValue} = {};
     for (const col of result.columns()) {
       data[col] = row.get(col);
     }

--- a/ui/src/components/tracks/debug_slice_track_details_panel.ts
+++ b/ui/src/components/tracks/debug_slice_track_details_panel.ts
@@ -21,7 +21,7 @@ import {getThreadState, ThreadState} from '../sql_utils/thread_state';
 import {DurationWidget} from '../widgets/duration';
 import {Timestamp} from '../widgets/timestamp';
 import {
-  ColumnType,
+  SqlValue,
   durationFromSql,
   LONG,
   STR,
@@ -43,13 +43,13 @@ import {renderSliceArguments} from '../details/slice_args';
 
 export const ARG_PREFIX = 'arg_';
 
-function sqlValueToNumber(value?: ColumnType): number | undefined {
+function sqlValueToNumber(value?: SqlValue): number | undefined {
   if (typeof value === 'bigint') return Number(value);
   if (typeof value !== 'number') return undefined;
   return value;
 }
 
-function sqlValueToUtid(value?: ColumnType): Utid | undefined {
+function sqlValueToUtid(value?: SqlValue): Utid | undefined {
   if (typeof value === 'bigint') return Number(value) as Utid;
   if (typeof value !== 'number') return undefined;
   return value as Utid;
@@ -74,7 +74,7 @@ export class DebugSliceTrackDetailsPanel implements TrackEventDetailsPanel {
     name: string;
     ts: time;
     dur: duration;
-    args: {[key: string]: ColumnType};
+    args: {[key: string]: SqlValue};
   };
   // We will try to interpret the arguments as references into well-known
   // tables. These values will be set if the relevant columns exist and
@@ -201,7 +201,7 @@ export class DebugSliceTrackDetailsPanel implements TrackEventDetailsPanel {
     for (const key of Object.keys(row)) {
       if (key.startsWith(ARG_PREFIX)) {
         this.data.args[key.substr(ARG_PREFIX.length)] = (
-          row as {[key: string]: ColumnType}
+          row as {[key: string]: SqlValue}
         )[key];
       }
     }

--- a/ui/src/components/widgets/sql/details/details.ts
+++ b/ui/src/components/widgets/sql/details/details.ts
@@ -18,11 +18,8 @@ import {Time} from '../../../../base/time';
 import {exists} from '../../../../base/utils';
 import {raf} from '../../../../core/raf_scheduler';
 import {Engine} from '../../../../trace_processor/engine';
-import {Row} from '../../../../trace_processor/query_result';
-import {
-  SqlValue,
-  sqlValueToReadableString,
-} from '../../../../trace_processor/sql_utils';
+import {Row, SqlValue} from '../../../../trace_processor/query_result';
+import {sqlValueToReadableString} from '../../../../trace_processor/sql_utils';
 import {Arg, getArgs} from '../../../sql_utils/args';
 import {asArgSetId} from '../../../sql_utils/core_types';
 import {Anchor} from '../../../../widgets/anchor';

--- a/ui/src/components/widgets/sql/pivot_table/aggregations.ts
+++ b/ui/src/components/widgets/sql/pivot_table/aggregations.ts
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Row} from '../../../../trace_processor/query_result';
-import {SqlValue} from '../../../../trace_processor/sql_utils';
+import {Row, SqlValue} from '../../../../trace_processor/query_result';
 import {TableColumn} from '../table/table_column';
 import {aggregationId} from './ids';
 

--- a/ui/src/components/widgets/sql/pivot_table/pivot_tree_node.ts
+++ b/ui/src/components/widgets/sql/pivot_table/pivot_tree_node.ts
@@ -17,8 +17,7 @@ import {
   assertDefined,
   assertTrue,
 } from '../../../../base/logging';
-import {Row} from '../../../../trace_processor/query_result';
-import {SqlValue} from '../../../../trace_processor/sql_utils';
+import {Row, SqlValue} from '../../../../trace_processor/query_result';
 import {Filter, StandardFilters} from '../table/filters';
 import {TableColumn} from '../table/table_column';
 import {

--- a/ui/src/components/widgets/sql/table/filters.ts
+++ b/ui/src/components/widgets/sql/table/filters.ts
@@ -16,10 +16,8 @@ import m from 'mithril';
 import {Button, ButtonBar, ButtonVariant} from '../../../../widgets/button';
 import {Intent} from '../../../../widgets/common';
 import {isSqlColumnEqual, SqlColumn, sqlColumnId} from './sql_column';
-import {
-  SqlValue,
-  sqlValueToSqliteString,
-} from '../../../../trace_processor/sql_utils';
+import {sqlValueToSqliteString} from '../../../../trace_processor/sql_utils';
+import {SqlValue} from '../../../../trace_processor/query_result';
 
 // A filter which can be applied to the table.
 export interface Filter {

--- a/ui/src/components/widgets/sql/table/table.ts
+++ b/ui/src/components/widgets/sql/table/table.ts
@@ -17,11 +17,7 @@ import {MenuDivider, MenuItem, PopupMenu} from '../../../../widgets/menu';
 import {buildSqlQuery} from './query_builder';
 import {Icons} from '../../../../base/semantic_icons';
 import {sqliteString} from '../../../../base/string_utils';
-import {
-  ColumnType,
-  Row,
-  SqlValue,
-} from '../../../../trace_processor/query_result';
+import {Row, SqlValue} from '../../../../trace_processor/query_result';
 import {Anchor} from '../../../../widgets/anchor';
 import {BasicTable} from '../../../../widgets/basic_table';
 import {Spinner} from '../../../../widgets/spinner';
@@ -166,7 +162,7 @@ class ColumnFilter implements m.ClassComponent<ColumnFilterAttrs> {
               // checked matters: string, number (floating), and bigint.
               if (this.inputValue === '') return;
 
-              let filterValue: ColumnType;
+              let filterValue: SqlValue;
 
               if (Number.isNaN(Number.parseFloat(this.inputValue))) {
                 filterValue = sqliteString(this.inputValue);

--- a/ui/src/core/dataset_search.ts
+++ b/ui/src/core/dataset_search.ts
@@ -18,7 +18,6 @@ import {Track} from '../public/track';
 import {SourceDataset} from '../trace_processor/dataset';
 import {Engine} from '../trace_processor/engine';
 import {
-  ColumnType,
   LONG,
   NUM,
   SqlValue,
@@ -40,7 +39,7 @@ type PartitionMap = Map<string, Map<SqlValue, Track[]>>;
 // to find the corresponding track.
 export interface TrackGroup {
   readonly src: string;
-  readonly schema: Record<string, ColumnType>;
+  readonly schema: Record<string, SqlValue>;
   readonly nonPartitioned: Track[];
   readonly partitioned: PartitionMap;
 }

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/generic_slice_details_tab.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/generic_slice_details_tab.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
-import {ColumnType} from '../../trace_processor/query_result';
+import {SqlValue} from '../../trace_processor/query_result';
 import {sqlValueToReadableString} from '../../trace_processor/sql_utils';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout} from '../../widgets/grid_layout';
@@ -35,7 +35,7 @@ export type Columns = {
 // and renders it according to the provided config, specifying which columns
 // need to be rendered and how.
 export class GenericSliceDetailsTab implements TrackEventDetailsPanel {
-  private data?: {[key: string]: ColumnType};
+  private data?: {[key: string]: SqlValue};
 
   constructor(
     private readonly trace: Trace,

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/page_load_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/page_load_details_panel.ts
@@ -15,13 +15,12 @@
 import m from 'mithril';
 import {
   Details,
-  DetailsSchema,
+  DetailsSchema as d,
 } from '../../components/widgets/sql/details/details';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
-import d = DetailsSchema;
 
 export class PageLoadDetailsPanel implements TrackEventDetailsPanel {
   private data: Details;

--- a/ui/src/plugins/org.chromium.ChromeTasks/details.ts
+++ b/ui/src/plugins/org.chromium.ChromeTasks/details.ts
@@ -15,13 +15,12 @@
 import m from 'mithril';
 import {
   Details,
-  DetailsSchema,
+  DetailsSchema as d,
 } from '../../components/widgets/sql/details/details';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
-import d = DetailsSchema;
 
 export class ChromeTasksDetailsPanel implements TrackEventDetailsPanel {
   private readonly data: Details;

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -14,7 +14,7 @@
 
 import {assertUnreachable} from '../base/logging';
 import {getOrCreate} from '../base/utils';
-import {checkExtends, ColumnType, SqlValue, unionTypes} from './query_result';
+import {checkExtends, SqlValue, unionTypes} from './query_result';
 import {sqlValueToSqliteString} from './sql_utils';
 
 /**
@@ -105,7 +105,7 @@ export interface Dataset<T extends DatasetSchema = DatasetSchema> {
  * Defines a list of columns and types that define the shape of the data
  * represented by a dataset.
  */
-export type DatasetSchema = Readonly<Record<string, ColumnType>>;
+export type DatasetSchema = Readonly<Record<string, SqlValue>>;
 
 /**
  * A filter used to express that a column must equal a value.
@@ -207,14 +207,14 @@ export class UnionDataset implements Dataset {
   get schema(): DatasetSchema {
     // Find the minimal set of columns that are supported by all datasets of
     // the union
-    let unionSchema: Record<string, ColumnType> | undefined = undefined;
+    let unionSchema: Record<string, SqlValue> | undefined = undefined;
     this.union.forEach((ds) => {
       const dsSchema = ds.schema;
       if (unionSchema === undefined) {
         // First time just use this one
         unionSchema = dsSchema;
       } else {
-        const newSch: Record<string, ColumnType> = {};
+        const newSch: Record<string, SqlValue> = {};
         for (const [key, value] of Object.entries(unionSchema)) {
           if (key in dsSchema) {
             const commonType = unionTypes(value, dsSchema[key]);

--- a/ui/src/trace_processor/sql_utils.ts
+++ b/ui/src/trace_processor/sql_utils.ts
@@ -157,8 +157,6 @@ export async function getTableRowCount(
   }).count;
 }
 
-export {SqlValue};
-
 /**
  * Asynchronously creates a 'perfetto' table using the given engine and returns
  * an disposable object to handle its cleanup.


### PR DESCRIPTION
- Remove `ColumnType` type - an alias of `SqlValue` - just use `SqlValue` instead.
- Replace `import d = DetailsSchema;` with `import {DetailsSchema as d} from ...`.
- Remove `export {SqlValue};` in the middle of `sql_utils.ts` which was being used in various files.