### PR TITLE
Increase fetch-depth in repo-checks

### DIFF
--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -33,7 +33,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # Fetches the merge commit and its parents, which is required for
+          # the presubmit script to parse the commit message (for
+          # CheckChromeStdlib in tools/run_presubmit).
+          fetch-depth: 2
 
       # Fetch the upstream branch as well, so we can diff and see the list of
       # changed files (unless this is a post-submit test).


### PR DESCRIPTION
This is to ensure that the presubmit script has access to the message of the commit under test. This should hopefully fix #1777.