### PR TITLE
tp: reduce performance cost of duplicate checking

### DIFF
--- a/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
+++ b/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
@@ -101,9 +101,9 @@ TEST_F(DataframeBuilderTest, AddSingleRowSimple) {
               ElementsAre("int_col", "double_col", "str_col", "_auto_id"));
   ASSERT_THAT(
       spec.column_specs,
-      ElementsAre(ColumnSpec{Uint32{}, NonNull{}, Sorted{}, NoDuplicates{}},
-                  ColumnSpec{Double{}, NonNull{}, Sorted{}, NoDuplicates{}},
-                  ColumnSpec{String{}, NonNull{}, Sorted{}, NoDuplicates{}},
+      ElementsAre(ColumnSpec{Uint32{}, NonNull{}, Sorted{}, HasDuplicates{}},
+                  ColumnSpec{Double{}, NonNull{}, Sorted{}, HasDuplicates{}},
+                  ColumnSpec{String{}, NonNull{}, Sorted{}, HasDuplicates{}},
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
   VerifyData(*df, 7,
              Rows(Row(uint32_t{123}, 45.6, NullTermStringView{"hello"})));
@@ -118,7 +118,7 @@ TEST_F(DataframeBuilderTest, AddMultipleRowsConsistentTypes) {
   ASSERT_THAT(
       spec.column_specs,
       ElementsAre(ColumnSpec{Uint32{}, NonNull{}, Unsorted{}, NoDuplicates{}},
-                  ColumnSpec{String{}, NonNull{}, Sorted{}, NoDuplicates{}},
+                  ColumnSpec{String{}, NonNull{}, Sorted{}, HasDuplicates{}},
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
   VerifyData(*df, 3,
              Rows(Row(uint32_t{10}, NullTermStringView{"A"}),
@@ -142,7 +142,7 @@ TEST_F(DataframeBuilderTest, AddRowsWithNulls) {
       ElementsAre(
           ColumnSpec{Uint32{}, SparseNull{}, Unsorted{}, HasDuplicates{}},
           ColumnSpec{String{}, SparseNull{}, Unsorted{}, HasDuplicates{}},
-          ColumnSpec{Double{}, NonNull{}, Sorted{}, NoDuplicates{}},
+          ColumnSpec{Double{}, NonNull{}, Sorted{}, HasDuplicates{}},
           ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
   VerifyData(*df, 7,
              Rows(Row(uint32_t{1}, nullptr, 1.1),
@@ -262,7 +262,7 @@ TEST_F(DataframeBuilderTest, AddRowPromoteIntColumnToDouble) {
   ASSERT_THAT(spec.column_names, ElementsAre("col_a", "_auto_id"));
   ASSERT_THAT(
       spec.column_specs,
-      ElementsAre(ColumnSpec{Double{}, NonNull{}, Sorted{}, NoDuplicates{}},
+      ElementsAre(ColumnSpec{Double{}, NonNull{}, Sorted{}, HasDuplicates{}},
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
   VerifyData(*df, 1, Rows(Row(100.0), Row(200.5)));
 }
@@ -290,7 +290,7 @@ TEST_F(DataframeBuilderTest, AddRowConvertNewIntToDoubleInDoubleColumn) {
   ASSERT_THAT(spec.column_names, ElementsAre("col_a", "_auto_id"));
   ASSERT_THAT(
       spec.column_specs,
-      ElementsAre(ColumnSpec{Double{}, NonNull{}, Sorted{}, NoDuplicates{}},
+      ElementsAre(ColumnSpec{Double{}, NonNull{}, Sorted{}, HasDuplicates{}},
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
   VerifyData(*df, 1, Rows(Row(100.5), Row(200.0)));
 }
@@ -309,9 +309,9 @@ TEST_F(DataframeBuilderTest, BuildIntegerDowncasting) {
                           "should_be_int64", "_auto_id"));
   ASSERT_THAT(
       spec.column_specs,
-      ElementsAre(ColumnSpec{Uint32{}, NonNull{}, Unsorted{}, NoDuplicates{}},
-                  ColumnSpec{Int32{}, NonNull{}, Unsorted{}, NoDuplicates{}},
-                  ColumnSpec{Int64{}, NonNull{}, Unsorted{}, NoDuplicates{}},
+      ElementsAre(ColumnSpec{Uint32{}, NonNull{}, Unsorted{}, HasDuplicates{}},
+                  ColumnSpec{Int32{}, NonNull{}, Unsorted{}, HasDuplicates{}},
+                  ColumnSpec{Int64{}, NonNull{}, Unsorted{}, HasDuplicates{}},
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
 }
 
@@ -393,7 +393,7 @@ TEST_F(DataframeBuilderTest, BuildIntegerNoDowncast) {
   ASSERT_THAT(
       spec.column_specs,
       ElementsAre(
-          ColumnSpec{Int64{}, NonNull{}, Unsorted{}, NoDuplicates{}},
+          ColumnSpec{Int64{}, NonNull{}, Unsorted{}, HasDuplicates{}},
           ColumnSpec{Uint32{}, SparseNull{}, Unsorted{}, HasDuplicates{}},
           ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
 }
@@ -504,7 +504,7 @@ TEST_F(DataframeBuilderTest, DuplicateState_Double_NoDuplicates_NonNull) {
   auto spec = df.CreateSpec();
   ASSERT_THAT(
       spec.column_specs,
-      ElementsAre(ColumnSpec{Double{}, NonNull{}, Sorted{}, NoDuplicates{}},
+      ElementsAre(ColumnSpec{Double{}, NonNull{}, Sorted{}, HasDuplicates{}},
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
 }
 
@@ -555,7 +555,7 @@ TEST_F(DataframeBuilderTest, DuplicateState_String_NoDuplicates_NonNull) {
   auto spec = df.CreateSpec();
   ASSERT_THAT(
       spec.column_specs,
-      ElementsAre(ColumnSpec{String{}, NonNull{}, Sorted{}, NoDuplicates{}},
+      ElementsAre(ColumnSpec{String{}, NonNull{}, Sorted{}, HasDuplicates{}},
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
 }
 


### PR DESCRIPTION
Doing a hashset add on every call was just too bad in terms of
performance. I tried using flathashmap and even wrote a custom optimized
hashset implementation and nothing worked.

In practice, the main case we care about duplicates is to build the
special side data structure for ids. Because of this, switch to using a
bitvector based implementation which is much more efficient.

On a represenative query, this takes the time taken to build the table
from 2.1s to 1.3s with the duplicate checking cost being ~zero
