### PR TITLE
Color gpu events with the same render_pass_handle the same color

### DIFF
--- a/src/trace_processor/importers/proto/gpu_event_parser.cc
+++ b/src/trace_processor/importers/proto/gpu_event_parser.cc
@@ -457,6 +457,7 @@ void GpuEventParser::ParseGpuRenderStageEvent(
         render_pass_name.has_value()
             ? context_->storage->InternString(render_pass_name.value().c_str())
             : kNullStringId;
+
     auto command_buffer_name = FindDebugName(VK_OBJECT_TYPE_COMMAND_BUFFER,
                                              event.command_buffer_handle());
     auto command_buffer_name_id = command_buffer_name.has_value()
@@ -490,6 +491,15 @@ void GpuEventParser::ParseGpuRenderStageEvent(
               }
             }
           }
+
+          if (event.render_pass_handle()) {
+            base::StackString<512> id_str("rp:#%" PRIu64,
+                                          event.render_pass_handle());
+            inserter->AddArg(context_->storage->InternString("correlation_id"),
+                             Variadic::String(context_->storage->InternString(
+                                 id_str.string_view())));
+          }
+
           for (auto it = event.extra_data(); it; ++it) {
             protos::pbzero::GpuRenderStageEvent_ExtraData_Decoder datum(*it);
             StringId name_id = context_->storage->InternString(datum.name());

--- a/ui/src/components/colorizer.ts
+++ b/ui/src/components/colorizer.ts
@@ -184,8 +184,14 @@ export function randomColor(): string {
   }
 }
 
-export function getColorForSlice(sliceName: string): ColorScheme {
-  const name = sliceName.replace(/( )?\d+/g, '');
+export function getColorForSlice(
+  sliceName: string,
+  {stripTrailingDigits = true}: {stripTrailingDigits?: boolean} = {},
+): ColorScheme {
+  const name = stripTrailingDigits
+    ? sliceName.replace(/( )?\d+/g, '')
+    : sliceName;
+
   if (USE_CONSISTENT_COLORS.get()) {
     return materialColorScheme(name);
   } else {

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
@@ -86,7 +86,9 @@ export async function createTraceProcessorSliceTrack({
       : () => new ThreadSliceDetailsPanel(trace),
     colorizer: (row) => {
       if (row.correlation_id) {
-        return getColorForSlice(row.correlation_id);
+        return getColorForSlice(row.correlation_id, {
+          stripTrailingDigits: false,
+        });
       }
       if (row.name) {
         return getColorForSlice(row.name);


### PR DESCRIPTION
This is currently using the correlation_id arg that's picked up by `createTraceProcessorSliceTrack()` tracks, but it would be trivial to pull these tracks out into a separate GPU-specific plugin if we were to make correlation_id limited to track event tracks in the future. At that point we could do away with the correlation_id arg entirely and look purely at the `render_pass_handle` arg to correlate colours in the UI plugin.