### PR TITLE
tp: _interval_interesect supports instant events

### DIFF
--- a/src/trace_processor/containers/interval_intersector_unittest.cc
+++ b/src/trace_processor/containers/interval_intersector_unittest.cc
@@ -85,6 +85,27 @@ TEST(IntervalIntersector, IntervalTree_NoOverlap) {
   EXPECT_THAT(overlaps, IsEmpty());
 }
 
+TEST(IntervalIntersector, IntervalTree_InstantIntervals) {
+  auto intervals = CreateIntervals({{10, 10}, {20, 20}});
+  IntervalIntersector intersector(intervals,
+                                  IntervalIntersector::kIntervalTree);
+
+  // Test case 1: Overlap with first instant
+  std::vector<Id> overlaps;
+  intersector.FindOverlaps(5, 15, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0));
+
+  // Test case 2: Overlap with second instant
+  overlaps.clear();
+  intersector.FindOverlaps(15, 25, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(1));
+
+  // Test case 3: Query is an instant
+  overlaps.clear();
+  intersector.FindOverlaps(10, 10, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0));
+}
+
 // Tests for kBinarySearch Mode
 
 TEST(IntervalIntersector, BinarySearch_EmptyInput) {
@@ -124,6 +145,27 @@ TEST(IntervalIntersector, BinarySearch_NoOverlap) {
   EXPECT_THAT(overlaps, IsEmpty());
 }
 
+TEST(IntervalIntersector, BinarySearch_InstantIntervals) {
+  auto intervals = CreateIntervals({{10, 10}, {20, 20}});
+  IntervalIntersector intersector(intervals,
+                                  IntervalIntersector::kBinarySearch);
+
+  // Test case 1: Overlap with first instant
+  std::vector<Id> overlaps;
+  intersector.FindOverlaps(5, 15, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0));
+
+  // Test case 2: Overlap with second instant
+  overlaps.clear();
+  intersector.FindOverlaps(15, 25, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(1));
+
+  // Test case 3: Query is an instant
+  overlaps.clear();
+  intersector.FindOverlaps(10, 10, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0));
+}
+
 // Tests for kLinearScan Mode
 
 TEST(IntervalIntersector, LinearScan_EmptyInput) {
@@ -156,6 +198,50 @@ TEST(IntervalIntersector, LinearScan_NoOverlap) {
   std::vector<Id> overlaps;
   intersector.FindOverlaps(6, 9, overlaps);
   EXPECT_THAT(overlaps, IsEmpty());
+}
+TEST(IntervalIntersector, OverlapTests) {
+  auto intervals = CreateIntervals({{10, 20}, {30, 40}, {15, 25}});
+  IntervalIntersector intersector(intervals, IntervalIntersector::kLinearScan);
+
+  // Test case 1: No overlap
+  std::vector<Id> overlaps;
+  intersector.FindOverlaps(0, 5, overlaps);
+  EXPECT_THAT(overlaps, IsEmpty());
+
+  // Test case 2: Single overlap
+  overlaps.clear();
+  intersector.FindOverlaps(18, 22, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0, 2));
+
+  // Test case 3: Multiple overlaps
+  overlaps.clear();
+  intersector.FindOverlaps(12, 35, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0, 1, 2));
+
+  // Test case 4: Query is an instant
+  overlaps.clear();
+  intersector.FindOverlaps(17, 17, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0, 2));
+}
+
+TEST(IntervalIntersector, InstantIntervals) {
+  auto intervals = CreateIntervals({{10, 10}, {20, 20}});
+  IntervalIntersector intersector(intervals, IntervalIntersector::kLinearScan);
+
+  // Test case 1: Overlap with first instant
+  std::vector<Id> overlaps;
+  intersector.FindOverlaps(5, 15, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0));
+
+  // Test case 2: Overlap with second instant
+  overlaps.clear();
+  intersector.FindOverlaps(15, 25, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(1));
+
+  // Test case 3: Query is an instant
+  overlaps.clear();
+  intersector.FindOverlaps(10, 10, overlaps);
+  EXPECT_THAT(overlaps, UnorderedElementsAre(0));
 }
 
 }  // namespace

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc
@@ -330,13 +330,16 @@ struct IntervalTreeIntervalsAgg
           ctx, "Interval intersect requires intervals to be sorted by ts.");
       return;
     }
-    agg_ctx.last_interval_start = interval.start;
     int64_t dur = sqlite::value::Int64(argv[2]);
-    if (dur < 1) {
-      sqlite::result::Error(
-          ctx, "Interval intersect only works on intervals with dur > 0");
+
+    if (dur < 0) {
+      sqlite::result::Error(ctx,
+                            "Interval intersect only works on intervals with "
+                            "non negative duration.");
       return;
     }
+
+    agg_ctx.last_interval_start = interval.start;
     interval.end = interval.start + static_cast<uint64_t>(dur);
 
     // Fast path for no partitions.

--- a/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
@@ -328,13 +328,6 @@ class IntervalsIntersect(TestSuite):
         query="""
         INCLUDE PERFETTO MODULE intervals.intersect;
 
-        CREATE PERFETTO TABLE A AS
-          WITH data(id, ts, dur) AS (
-            VALUES
-            (0, 1, 6)
-          )
-          SELECT * FROM data;
-
         CREATE PERFETTO TABLE B AS
           WITH data(id, ts, dur) AS (
             VALUES
@@ -353,6 +346,254 @@ class IntervalsIntersect(TestSuite):
         0,1,1
         1,3,2
         2,6,1
+        """))
+
+  def test_overlap_start_and_end(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 1, 1)
+          )
+          SELECT * FROM data;
+
+        SELECT *
+        FROM _interval_intersect_single!(2, 1, A)
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "id","ts","dur"
+        """))
+
+  def test_instants(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        #      0 1 2 3 4 5 6 7
+        # A:   _ - - - - - - _
+        # B:   - - _ _ _ _ - -
+        # res: _ - _ - - _ - _
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 0, 2),
+            (1, 3, 0),
+            (2, 6, 2)
+          )
+          SELECT * FROM data;
+
+        SELECT *
+        FROM _interval_intersect_single!(1, 6, A)
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "id","ts","dur"
+        0,1,1
+        1,3,0
+        2,6,1
+        """))
+
+  def test_instants_intersect_interval(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        #      0 1 2 3 4 5 6 7
+        # A:   _ _ _ . _ _ _ _ (instant at ts=3, dur=0)
+        # B:   _ - - - - - - _
+        # res: _ _ _ . _ _ _ _
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 3, 0)
+          )
+          SELECT * FROM data;
+
+        CREATE PERFETTO TABLE B AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (10, 1, 6)
+          )
+          SELECT * FROM data;
+
+        SELECT ts, dur, id_0, id_1
+        FROM _interval_intersect!((A, B), ())
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "ts","dur","id_0","id_1"
+        3,0,0,10
+        """))
+
+  def test_instants_intersect_interval_outside(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        #      0 1 2 3 4 5 6 7
+        # A:   . _ _ _ _ _ _ _ (instant at ts=0, dur=0)
+        # B:   _ - - - - - - _
+        # res: _ _ _ _ _ _ _ _
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 0, 0)
+          )
+          SELECT * FROM data;
+
+        CREATE PERFETTO TABLE B AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (10, 1, 6)
+          )
+          SELECT * FROM data;
+
+        SELECT ts, dur, id_0, id_1
+        FROM _interval_intersect!((A, B), ())
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "ts","dur","id_0","id_1"
+        """))
+
+  def test_two_instants_intersect(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        #      0 1 2 3 4 5 6 7
+        # A:   _ _ _ . _ _ _ _ (instant at ts=3, dur=0)
+        # B:   _ _ _ . _ _ _ _ (instant at ts=3, dur=0)
+        # res: _ _ _ . _ _ _ _
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 3, 0)
+          )
+          SELECT * FROM data;
+
+        CREATE PERFETTO TABLE B AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (10, 3, 0)
+          )
+          SELECT * FROM data;
+
+        SELECT ts, dur, id_0, id_1
+        FROM _interval_intersect!((A, B), ())
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "ts","dur","id_0","id_1"
+        3,0,0,10
+        """))
+
+  def test_two_instants_no_intersect(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        #      0 1 2 3 4 5 6 7
+        # A:   _ _ . _ _ _ _ _ (instant at ts=2, dur=0)
+        # B:   _ _ _ . _ _ _ _ (instant at ts=3, dur=0)
+        # res: _ _ _ _ _ _ _ _
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 2, 0)
+          )
+          SELECT * FROM data;
+
+        CREATE PERFETTO TABLE B AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (10, 3, 0)
+          )
+          SELECT * FROM data;
+
+        SELECT ts, dur, id_0, id_1
+        FROM _interval_intersect!((A, B), ())
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "ts","dur","id_0","id_1"
+        """))
+
+  def test_instant_intersect_multiple_intervals(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        #      0 1 2 3 4 5 6 7
+        # A:   _ _ _ . _ _ _ _ (instant at ts=3, dur=0)
+        # B:   - - _ - - _ - -
+        # res: _ _ _ . _ _ _ _
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 3, 0)
+          )
+          SELECT * FROM data;
+
+        CREATE PERFETTO TABLE B AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (1, 0, 2),
+            (2, 3, 2),
+            (3, 6, 2)
+          )
+          SELECT * FROM data;
+
+        SELECT ts, dur, id_0, id_1
+        FROM _interval_intersect!((A, B), ())
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "ts","dur","id_0","id_1"
+        3,0,0,2
+        """))
+
+  def test_multiple_instants_intersect_interval_single_func(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        #      0 1 2 3 4 5 6 7
+        # A:   _ - - - - - - _
+        # B:   . _ . . _ . _ .
+        # res: _ _ . . _ . _ _
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE B_instants AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 0, 0),
+            (1, 2, 0),
+            (2, 3, 0),
+            (3, 5, 0),
+            (4, 7, 0)
+          )
+          SELECT * FROM data;
+
+        SELECT *
+        FROM _interval_intersect_single!(1, 6, B_instants)
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "id","ts","dur"
+        1,2,0
+        2,3,0
+        3,5,0
         """))
 
   def test_ii_wrong_partition(self):
@@ -625,35 +866,6 @@ class IntervalsIntersect(TestSuite):
         70731196731,196563,4,4,5
         70731435690,22916,6,6,7
         70730062200,125364,0,0,1
-        """))
-
-  def test_sanity_multiple_tables_and_partitions(self):
-    return DiffTestBlueprint(
-        trace=DataPath('example_android_trace_30s.pb'),
-        query="""
-        INCLUDE PERFETTO MODULE intervals.intersect;
-
-        SELECT * FROM _interval_intersect!(
-          (
-            (SELECT id, ts, dur, utid, cpu FROM sched WHERE dur > 0 LIMIT 10),
-            (SELECT id, ts, dur, utid, cpu FROM sched WHERE dur > 0 LIMIT 10),
-            (SELECT id, ts, dur, utid, cpu FROM sched WHERE dur > 0 LIMIT 10)
-          ),
-          (utid, cpu)
-        );
-        """,
-        out=Csv("""
-        "ts","dur","id_0","id_1","id_2","utid","cpu"
-        70730062200,125364,0,0,0,1,0
-        70730187564,20297242,1,1,1,0,0
-        70731483398,24583,9,9,9,10,3
-        70731458606,24792,8,8,8,9,3
-        70731393294,42396,5,5,5,6,3
-        70731435690,22916,6,6,6,7,3
-        70731161731,35000,3,3,3,4,3
-        70731196731,196563,4,4,4,5,3
-        70731438502,55261,7,7,7,8,6
-        70731135898,25833,2,2,2,2,3
         """))
 
   def test_sanity_multiple_tables_and_partitions(self):

--- a/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
@@ -373,9 +373,9 @@ class IntervalsIntersect(TestSuite):
     return DiffTestBlueprint(
         trace=TextProto(""),
         #      0 1 2 3 4 5 6 7
-        # A:   _ - - - - - - _
-        # B:   - - _ _ _ _ - -
-        # res: _ - _ - - _ - _
+        # A:   _ _ - * - - _ _
+        # B:   - _ _ _ _ _ _ -
+        # res: - _ - * - - _ -
         query="""
         INCLUDE PERFETTO MODULE intervals.intersect;
 


### PR DESCRIPTION
_interval_intersect macro will now return instants if there are instant results. Removed the dur > 0 check and added tests. If the interval (ts, dur) is (0, 10) it will return instant when it's inside it, (5, 0), but the ends are excluded, so there is no overlap with (10, 2).
