### PR TITLE
Reapply "probes: don't assume boot clock when preserve_ftrace_buffer is set (#1722)" (#1823)

### DIFF
--- a/src/traced/probes/ftrace/ftrace_config_muxer.cc
+++ b/src/traced/probes/ftrace/ftrace_config_muxer.cc
@@ -25,18 +25,32 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
+#include "perfetto/base/flat_set.h"
+#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/utils.h"
+#include "perfetto/public/compiler.h"
 #include "protos/perfetto/config/ftrace/ftrace_config.gen.h"
 #include "protos/perfetto/trace/ftrace/generic.pbzero.h"
+#include "src/kernel_utils/syscall_table.h"
 #include "src/traced/probes/ftrace/atrace_wrapper.h"
 #include "src/traced/probes/ftrace/compact_sched.h"
+#include "src/traced/probes/ftrace/event_info_constants.h"
 #include "src/traced/probes/ftrace/ftrace_config_utils.h"
+#include "src/traced/probes/ftrace/ftrace_print_filter.h"
+#include "src/traced/probes/ftrace/ftrace_procfs.h"
 #include "src/traced/probes/ftrace/ftrace_stats.h"
-#include "src/traced/probes/ftrace/predefined_tracepoints.h"
 
 #include "protos/perfetto/trace/ftrace/ftrace_event.pbzero.h"
+#include "src/traced/probes/ftrace/proto_translation_table.h"
 
 namespace perfetto {
 namespace {
@@ -393,13 +407,17 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
       ftrace_->ClearTrace();
     }
 
+    // Setup the clock: note that we still need to read the clock from ftrace
+    // and set current_state_.ftrace_clock, even if preserve_ftrace_buffer is
+    // false. Note that the clock is not changed if this option is set though.
+    SetupClock(request);
+
     // Set up the rest of the tracefs state, without starting it.
     // Notes:
     // * resizing buffers can be quite slow (up to hundreds of ms).
     // * resizing buffers may truncate existing contents if the new size is
     // smaller, which matters to the preserve_ftrace_buffer option.
     if (!request.preserve_ftrace_buffer()) {
-      SetupClock(request);
       SetupBufferSize(request);
     }
   }
@@ -774,22 +792,25 @@ const FtraceDataSourceConfig* FtraceConfigMuxer::GetDataSourceConfig(
 
 void FtraceConfigMuxer::SetupClock(const FtraceConfig& config) {
   std::string current_clock = ftrace_->GetClock();
-  std::set<std::string> clocks = ftrace_->AvailableClocks();
 
-  if (config.has_use_monotonic_raw_clock() &&
-      config.use_monotonic_raw_clock() && clocks.count(kClockMonoRaw)) {
-    ftrace_->SetClock(kClockMonoRaw);
-    current_clock = kClockMonoRaw;
-  } else {
-    for (size_t i = 0; i < base::ArraySize(kClocks); i++) {
-      std::string clock = std::string(kClocks[i]);
-      if (!clocks.count(clock))
-        continue;
-      if (current_clock == clock)
+  if (!config.preserve_ftrace_buffer()) {
+    std::set<std::string> clocks = ftrace_->AvailableClocks();
+
+    if (config.has_use_monotonic_raw_clock() &&
+        config.use_monotonic_raw_clock() && clocks.count(kClockMonoRaw)) {
+      ftrace_->SetClock(kClockMonoRaw);
+      current_clock = kClockMonoRaw;
+    } else {
+      for (size_t i = 0; i < base::ArraySize(kClocks); i++) {
+        std::string clock = std::string(kClocks[i]);
+        if (!clocks.count(clock))
+          continue;
+        if (current_clock == clock)
+          break;
+        ftrace_->SetClock(clock);
+        current_clock = clock;
         break;
-      ftrace_->SetClock(clock);
-      current_clock = clock;
-      break;
+      }
     }
   }
 


### PR DESCRIPTION
Now that https://github.com/google/perfetto/pull/1824 and https://github.com/google/perfetto/pull/1825 have fixes, we can safely reenable this again. We should land the prebuilt for https://github.com/google/perfetto/pull/1825 in Android though before we land this.

This reverts commit fbed4ffaccc0e754779134993ae8212091582aa9.
