### PR TITLE
Use calculated thread state consistently in thread state track datasets & aggregators

### DIFF
--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
@@ -15,13 +15,7 @@
 import {ColumnDef, Sorting, BarChartData} from '../../public/aggregation';
 import {AreaSelection} from '../../public/selection';
 import {Engine} from '../../trace_processor/engine';
-import {
-  LONG,
-  NUM,
-  NUM_NULL,
-  STR,
-  STR_NULL,
-} from '../../trace_processor/query_result';
+import {LONG, NUM, STR, STR_NULL} from '../../trace_processor/query_result';
 import {AreaSelectionAggregator} from '../../public/selection';
 import {Dataset} from '../../trace_processor/dataset';
 import {colorForThreadState} from './common';
@@ -31,7 +25,6 @@ export class ThreadStateSelectionAggregator implements AreaSelectionAggregator {
 
   readonly schema = {
     dur: LONG,
-    io_wait: NUM_NULL,
     state: STR,
     utid: NUM,
   } as const;
@@ -50,14 +43,14 @@ export class ThreadStateSelectionAggregator implements AreaSelectionAggregator {
         process.pid,
         thread.name as thread_name,
         thread.tid,
-        tstate.state || ',' || ifnull(tstate.io_wait, 'NULL') as concat_state,
+        tstate.state as state,
         sum(tstate.dur) AS total_dur,
         sum(tstate.dur) / count() as avg_dur,
         count() as occurrences
       from (${dataset.query()}) tstate
       join thread using (utid)
       left join process using (upid)
-      group by utid, concat_state
+      group by utid, state
     `);
 
     return true;
@@ -72,22 +65,22 @@ export class ThreadStateSelectionAggregator implements AreaSelectionAggregator {
 
     const query = `
       select
-        sched_state_io_to_human_readable_string(state, io_wait) AS name,
+        tstate.state as state,
         sum(dur) as totalDur
       from (${dataset.query()}) tstate
       join thread using (utid)
-      group by tstate.name
+      group by tstate.state
     `;
     const result = await engine.query(query);
 
     const it = result.iter({
-      name: STR_NULL,
+      state: STR_NULL,
       totalDur: NUM,
     });
 
     const states: BarChartData[] = [];
     for (let i = 0; it.valid(); ++i, it.next()) {
-      const name = it.name ?? 'Unknown';
+      const name = it.state ?? 'Unknown';
       const ms = it.totalDur / 1000000;
       states.push({
         name,
@@ -126,9 +119,9 @@ export class ThreadStateSelectionAggregator implements AreaSelectionAggregator {
       },
       {
         title: 'State',
-        kind: 'STATE',
+        kind: 'STRING',
         columnConstructor: Uint16Array,
-        columnId: 'concat_state',
+        columnId: 'state',
       },
       {
         title: 'Wall duration (ms)',

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
@@ -46,10 +46,8 @@ export function createThreadStateTrack(
         dur: LONG,
         layer: NUM,
         cpu: NUM_NULL,
-        state: STR,
-        io_wait: NUM_NULL,
         utid: NUM,
-        name: STR,
+        state: STR,
         depth: NUM,
       },
       src: `
@@ -58,10 +56,8 @@ export function createThreadStateTrack(
           ts,
           dur,
           cpu,
-          state,
-          io_wait,
           utid,
-          sched_state_io_to_human_readable_string(state, io_wait) AS name,
+          sched_state_io_to_human_readable_string(state, io_wait) AS state,
           -- Move sleeping and idle slices to the back layer, others on top
           CASE
             WHEN state IN ('S', 'I') THEN 0
@@ -80,10 +76,10 @@ export function createThreadStateTrack(
       sliceHeight: 12,
       titleSizePx: 10,
     },
-    sliceName: (row) => row.name,
+    sliceName: (row) => row.state,
     colorizer: (row): ColorScheme => {
-      const colorForState = colorForThreadState(row.name);
-      if (row.name.includes('Sleeping') || row.name.includes('Idle')) {
+      const colorForState = colorForThreadState(row.state);
+      if (row.state.includes('Sleeping') || row.state.includes('Idle')) {
         // For sleeping/idle slices, return a transparent color scheme with
         // transparent text + a subtle gray variant displayed when hovering the
         // slice.


### PR DESCRIPTION
Fixes the hodge-podge of io_wait, state, name fields in the thread state tracks datasets.

This change creates one single state field (the result of sched_state_io_to_human_readable_string(state, io_wait))which is used for naming the slices and grouping for aggregations.

This patch doesn't aim to improve aggregation performance, it just simplifies the dataset and reduces unnecessary fields.
