### PR TITLE
Add error stats for consecutive running state events for same TID

### DIFF
--- a/protos/perfetto/trace/generic_kernel/generic_task_state.proto
+++ b/protos/perfetto/trace/generic_kernel/generic_task_state.proto
@@ -40,6 +40,9 @@ message GenericKernelTaskStateEvent {
   // These states are a generic representation of the actual thread state and
   // don't necessarily map one-to-one to the states the actual OS kernel
   // tracks internally.
+  //
+  // Note: Consecutive TASK_STATE_RUNNING states for the same TID is considered
+  // an error resulting in potential data loss.
   enum TaskStateEnum {
     TASK_STATE_UNKNOWN = 0;
     TASK_STATE_CREATED = 1;

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -12495,6 +12495,9 @@ message GenericKernelTaskStateEvent {
   // These states are a generic representation of the actual thread state and
   // don't necessarily map one-to-one to the states the actual OS kernel
   // tracks internally.
+  //
+  // Note: Consecutive TASK_STATE_RUNNING states for the same TID is considered
+  // an error resulting in potential data loss.
   enum TaskStateEnum {
     TASK_STATE_UNKNOWN = 0;
     TASK_STATE_CREATED = 1;


### PR DESCRIPTION
When a TID's last state event was TASK_STATE_RUNNING the next event for that TID cannot be running. This indicates data loss in the kernel.

Bug: 424815014
