### PR TITLE
tp: fix duplicate detection for all negative column

### DIFF
--- a/src/trace_processor/dataframe/adhoc_dataframe_builder.h
+++ b/src/trace_processor/dataframe/adhoc_dataframe_builder.h
@@ -605,7 +605,7 @@ class AdhocDataframeBuilder {
   // Returns true if the value is a definite duplicate.
   PERFETTO_ALWAYS_INLINE bool CheckDuplicate(int64_t value, size_t size) {
     if (value < 0) {
-      return false;
+      return true;
     }
     if (PERFETTO_UNLIKELY(value >=
                           static_cast<int64_t>(duplicate_bit_vector_.size()))) {

--- a/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
+++ b/src/trace_processor/dataframe/runtime_dataframe_builder_unittest.cc
@@ -470,6 +470,18 @@ TEST_F(DataframeBuilderTest, DuplicateState_Int_HasDuplicates_NonNull) {
                   ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
 }
 
+TEST_F(DataframeBuilderTest, DuplicateState_Int_NegativeConsideredDuplicate) {
+  base::StatusOr<Dataframe> df_status =
+      BuildDf({"col_int"}, {{int64_t{-10}}, {int64_t{-20}}, {int64_t{-10}}});
+  ASSERT_OK(df_status.status());
+  Dataframe df = std::move(df_status.value());
+  auto spec = df.CreateSpec();
+  ASSERT_THAT(
+      spec.column_specs,
+      ElementsAre(ColumnSpec{Int32{}, NonNull{}, Unsorted{}, HasDuplicates{}},
+                  ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
+}
+
 TEST_F(DataframeBuilderTest, DuplicateState_Int_NullableBecomesHasDuplicates) {
   base::StatusOr<Dataframe> df_status =
       BuildDf({"col_int"}, {{int64_t{10}}, {std::nullopt}, {int64_t{30}}});


### PR DESCRIPTION
We were accidentally saying column has no dupes when we cannot know
that.
