### PR TITLE
Add machine id to global Meminfo and CPU tracks

### DIFF
--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -72,6 +72,7 @@ export default class implements PerfettoPlugin {
           ct.name,
           ct.id,
           ct.unit,
+          ct.machine_id as machine,
           extract_arg(ct.dimension_arg_set_id, 'utid') as utid,
           extract_arg(ct.dimension_arg_set_id, 'upid') as upid
         from counter_track ct
@@ -108,6 +109,7 @@ export default class implements PerfettoPlugin {
       pid: NUM_NULL,
       isMainThread: NUM,
       isKernelThread: NUM,
+      machine: NUM_NULL,
     });
     for (; it.valid(); it.next()) {
       const {
@@ -123,6 +125,7 @@ export default class implements PerfettoPlugin {
         pid,
         isMainThread,
         isKernelThread,
+        machine,
       } = it;
       const schema = schemas.get(type);
       if (schema === undefined) {
@@ -139,6 +142,7 @@ export default class implements PerfettoPlugin {
         utid,
         kind: COUNTER_TRACK_KIND,
         threadTrack: utid !== undefined,
+        machine,
       });
       const uri = `/counter_${trackId}`;
       ctx.tracks.registerTrack({

--- a/ui/src/public/utils.ts
+++ b/ui/src/public/utils.ts
@@ -75,6 +75,8 @@ export function getTrackName(
     return `${name} (${userName})`;
   } else if (isUidTrack && hasName && hasUid) {
     return `${name} ${uid}`;
+  } else if (hasName && !hasUpid && !hasUtid) {
+    return `${name}${machineLabel}`;
   } else if (hasName) {
     return `${name}`;
   } else if (hasThreadName && hasTid) {


### PR DESCRIPTION
When visualizing unified traces that contain global Meminfo and CPU tracks, you end up with two tracks with the same name. For example, you end up with two MemFree tracks and there is no way of distinguishing which track belongs to which machine. Added the machine id to the track name to disambiguate to which machine the track belongs to.

Bug: 421946530
