### PR TITLE
Fix: failure of trace processing due to nullptr

### DIFF
--- a/src/trace_processor/trace_processor_storage_impl.cc
+++ b/src/trace_processor/trace_processor_storage_impl.cc
@@ -142,6 +142,10 @@ void TraceProcessorStorageImpl::DestroyContext() {
   TraceProcessorContext context;
   context.storage = std::move(context_.storage);
 
+  // Fix for nullptr exception in forwarding_trace_parser (b/366266937)
+  context.reader_registry = std::move(context_.reader_registry);
+  context.process_tracker = std::move(context_.process_tracker);
+
   // TODO(b/309623584): Decouple from storage and remove from here. This
   // function should only move storage and delete everything else.
   context.heap_graph_tracker = std::move(context_.heap_graph_tracker);


### PR DESCRIPTION
DestoryContext doesn't re-initialise reader_registry and process_tracker which leads to nullptr exception while using them in forwarding_trace_parser and leading tofailure of processing the trace.

[Bug: 366266937]

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
