### PR TITLE
Rename from prepare_seq_id to buffer_seq_id

### DIFF
--- a/protos/perfetto/trace/android/server/windowmanagerservice.proto
+++ b/protos/perfetto/trace/android/server/windowmanagerservice.proto
@@ -464,7 +464,7 @@ message WindowStateProto {
   repeated InsetsSourceProto mergedLocalInsetsSources = 47;
   optional int32 requested_visible_types = 48;
   optional RectProto dim_bounds = 49;
-  optional int32 prepare_sync_seq_id = 50;
+  optional int32 buffer_seq_id = 50;
   optional int32 sync_seq_id = 51;
 }
 


### PR DESCRIPTION
Port of internal commit.

**Original commit message:**
Subject: Rename from prepare_seq_id to buffer_seq_id

This proto entry usage is becoming a little more general
than just prepare. Rename it to communicate that it is
specific to the buffer-sync to avoid confusion.

Bug: 385976595
Test: N/A
Flag: EXEMPT rename
Change-Id: I5881a8d8e4e2c53ca24b26b38ec50b941c55ad14

---
Original internal commit hash: d43d282acb04132a039c142f27893803cc3a2e46
Cherry-picked with `-x`.
This PR is part of a stack. Base branch: main
