### PR TITLE
Add usb group to predefined tracepoints

### DIFF
--- a/src/traced/probes/ftrace/predefined_tracepoints.cc
+++ b/src/traced/probes/ftrace/predefined_tracepoints.cc
@@ -379,6 +379,24 @@ base::FlatSet<GroupAndName> GenerateCameraTracePoints(
   return events;
 }
 
+base::FlatSet<GroupAndName> GenerateUsbTracePoints() {
+  base::FlatSet<GroupAndName> events;
+  InsertEvent("dwc3", "dwc3_alloc_request", &events);
+  InsertEvent("dwc3", "dwc3_complete_trb", &events);
+  InsertEvent("dwc3", "dwc3_ctrl_req", &events);
+  InsertEvent("dwc3", "dwc3_ep_dequeue", &events);
+  InsertEvent("dwc3", "dwc3_ep_queue", &events);
+  InsertEvent("dwc3", "dwc3_event", &events);
+  InsertEvent("dwc3", "dwc3_free_request", &events);
+  InsertEvent("dwc3", "dwc3_gadget_ep_cmd", &events);
+  InsertEvent("dwc3", "dwc3_gadget_ep_disable", &events);
+  InsertEvent("dwc3", "dwc3_gadget_ep_enable", &events);
+  InsertEvent("dwc3", "dwc3_gadget_generic_cmd", &events);
+  InsertEvent("dwc3", "dwc3_gadget_giveback", &events);
+  InsertEvent("dwc3", "dwc3_prepare_trb", &events);
+  return events;
+}
+
 std::map<std::string, base::FlatSet<GroupAndName>>
 GeneratePredefinedTracePoints(const ProtoTranslationTable* table,
                               FtraceProcfs* ftrace) {
@@ -412,6 +430,7 @@ GeneratePredefinedTracePoints(const ProtoTranslationTable* table,
   tracepoints["memory"] = GenerateMemoryTracePoints(ftrace);
   tracepoints["thermal"] = GenerateThermalTracePoints();
   tracepoints["camera"] = GenerateCameraTracePoints(table);
+  tracepoints["usb"] = GenerateUsbTracePoints();
   return tracepoints;
 }
 }  // namespace


### PR DESCRIPTION
Create a usb group for DWC3 ftrace events.
DWC3 USB controller is a widely adopted SNPS IP, with linux upstream support and extensitve use by companies like QCOM, Samsung and Google. This would be helpful in debugging usb issues and analyzing usb performance.
The counterpart in atrace is in ag/34015648.

Bug: 396043704
Test: out/android/perfetto_unittests
Test: capture and validate the trace