### PR TITLE
Added optional bool call_notify_end_of_file to ReadTrace method

### DIFF
--- a/include/perfetto/trace_processor/read_trace.h
+++ b/include/perfetto/trace_processor/read_trace.h
@@ -32,8 +32,8 @@ class TraceProcessor;
 base::Status PERFETTO_EXPORT_COMPONENT ReadTrace(
     TraceProcessor* tp,
     const char* filename,
-    const std::function<void(uint64_t parsed_size)>& progress_callback =
-        [](uint64_t) {});
+    const std::function<void(uint64_t parsed_size)>& progress_callback = {},
+    bool call_notify_end_of_file = true);
 
 base::Status PERFETTO_EXPORT_COMPONENT
 DecompressTrace(const uint8_t* data, size_t size, std::vector<uint8_t>* output);

--- a/src/trace_processor/read_trace.cc
+++ b/src/trace_processor/read_trace.cc
@@ -76,9 +76,12 @@ class SerializingProtoTraceReader : public ChunkedTraceReader {
 base::Status ReadTrace(
     TraceProcessor* tp,
     const char* filename,
-    const std::function<void(uint64_t parsed_size)>& progress_callback) {
-  RETURN_IF_ERROR(ReadTraceUnfinalized(tp, filename, progress_callback));
-  return tp->NotifyEndOfFile();
+    const std::function<void(uint64_t parsed_size)>& progress_callback,
+    bool call_notify_end_of_file) {
+  ReadTraceUnfinalized(tp, filename, progress_callback);
+  if (call_notify_end_of_file)
+    tp->NotifyEndOfFile();
+  return util::OkStatus();
 }
 
 base::Status DecompressTrace(const uint8_t* data,


### PR DESCRIPTION
Introduces an optional parameter to `ReadTrace()` for explicit management of `NotifyEndOfFile()` execution, supporting flexible parsing workflows.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
