### PR TITLE
Show args on debug track details panel

### DIFF
--- a/ui/src/components/details/sql_table_tab.ts
+++ b/ui/src/components/details/sql_table_tab.ts
@@ -115,10 +115,8 @@ class LegacySqlTableTab implements Tab {
       },
       m(AddDebugTrackMenu, {
         trace: this.state.trace,
-        dataSource: {
-          sqlSource: `SELECT ${debugTrackColumns.join(', ')} FROM (${selectStatement})`,
-          columns: debugTrackColumns,
-        },
+        query: `SELECT ${debugTrackColumns.join(', ')} FROM (${selectStatement})`,
+        availableColumns: debugTrackColumns,
       }),
     );
     return [

--- a/ui/src/components/query_table/query_result_tab.ts
+++ b/ui/src/components/query_table/query_result_tab.ts
@@ -105,10 +105,8 @@ export class QueryResultTab implements Tab {
               },
               m(AddDebugTrackMenu, {
                 trace: this.trace,
-                dataSource: {
-                  sqlSource: `select * from ${this.sqlViewName}`,
-                  columns: assertExists(this.queryResponse).columns,
-                },
+                query: `select * from ${this.sqlViewName}`,
+                availableColumns: assertExists(this.queryResponse).columns,
               }),
             ),
       ],

--- a/ui/src/components/tracks/add_debug_track_menu.ts
+++ b/ui/src/components/tracks/add_debug_track_menu.ts
@@ -20,58 +20,66 @@ import {Form, FormLabel} from '../../widgets/form';
 import {Select} from '../../widgets/select';
 import {TextInput} from '../../widgets/text_input';
 import {addDebugCounterTrack, addDebugSliceTrack} from './debug_tracks';
-import {SqlDataSource} from './query_slice_track';
 
 interface AddDebugTrackMenuAttrs {
-  dataSource: Required<SqlDataSource>;
-  trace: Trace;
+  readonly trace: Trace; // Required for adding new tracks and modifying the workspace.
+  // A list of available columns in the query results - used to work out sensible defaults for each field.
+  readonly availableColumns: ReadonlyArray<string>;
+  // The actual query used to define the debug track.
+  readonly query: string;
 }
 
 const TRACK_NAME_FIELD_REF = 'TRACK_NAME_FIELD';
 
+function chooseDefaultColumn(
+  columns: ReadonlyArray<string>,
+  name: string,
+): string {
+  // Search for exact match
+  const exactMatch = columns.find((col) => col === name);
+  if (exactMatch) return exactMatch;
+
+  // Search for partial match
+  const partialMatch = columns.find((col) => col.endsWith(`_${name}`));
+  if (partialMatch) return partialMatch;
+
+  // Debug tracks support data without dur, in which case it's treated as 0.
+  if (name === 'dur') {
+    return '0';
+  }
+
+  return '';
+}
+
+type TrackType = 'slice' | 'counter';
+const trackTypes: ReadonlyArray<TrackType> = ['slice', 'counter'];
+
+interface ConfigurationOptions {
+  ts: string;
+  dur: string;
+  name: string;
+  value: string;
+  argSetId: string;
+  pivot: string;
+}
+
 export class AddDebugTrackMenu
   implements m.ClassComponent<AddDebugTrackMenuAttrs>
 {
-  readonly columns: string[];
+  private trackName = '';
+  private trackType: TrackType = 'slice';
+  private readonly options: ConfigurationOptions;
 
-  name: string = '';
-  trackType: 'slice' | 'counter' = 'slice';
-  // Names of columns which will be used as data sources for rendering.
-  // We store the config for all possible columns used for rendering (i.e.
-  // 'value' for slice and 'name' for counter) and then just don't the values
-  // which don't match the currently selected track type (so changing track type
-  // from A to B and back to A is a no-op).
-  renderParams: {
-    ts: string;
-    dur: string;
-    name: string;
-    value: string;
-    pivot: string;
-  };
+  constructor({attrs}: m.Vnode<AddDebugTrackMenuAttrs>) {
+    const columns = attrs.availableColumns;
 
-  constructor(vnode: m.Vnode<AddDebugTrackMenuAttrs>) {
-    this.columns = [...vnode.attrs.dataSource.columns];
-
-    const chooseDefaultOption = (name: string) => {
-      for (const column of this.columns) {
-        if (column === name) return column;
-      }
-      for (const column of this.columns) {
-        if (column.endsWith(`_${name}`)) return column;
-      }
-      // Debug tracks support data without dur, in which case it's treated as
-      // 0.
-      if (name === 'dur') {
-        return '0';
-      }
-      return this.columns[0];
-    };
-
-    this.renderParams = {
-      ts: chooseDefaultOption('ts'),
-      dur: chooseDefaultOption('dur'),
-      name: chooseDefaultOption('name'),
-      value: chooseDefaultOption('value'),
+    // Initialize the settings to some sensible defaults.
+    this.options = {
+      ts: chooseDefaultColumn(columns, 'ts'),
+      dur: chooseDefaultColumn(columns, 'dur'),
+      name: chooseDefaultColumn(columns, 'name'),
+      value: chooseDefaultColumn(columns, 'value'),
+      argSetId: chooseDefaultColumn(columns, 'arg_set_id'),
       pivot: '',
     };
   }
@@ -89,137 +97,148 @@ export class AddDebugTrackMenu
     }
   }
 
-  private renderTrackTypeSelect() {
-    const options = [];
-    for (const type of ['slice', 'counter']) {
-      options.push(
-        m(
-          'option',
-          {
-            value: type,
-            selected: this.trackType === type ? true : undefined,
+  view({attrs}: m.Vnode<AddDebugTrackMenuAttrs>) {
+    return m(
+      Form,
+      {
+        onSubmit: () => this.createTracks(attrs),
+        submitLabel: 'Add Track',
+      },
+      m(FormLabel, {for: 'track_name'}, 'Track name'),
+      m(
+        TextInput,
+        {
+          id: 'track_name',
+          ref: TRACK_NAME_FIELD_REF,
+          onkeydown: (e: KeyboardEvent) => {
+            // Allow Esc to close popup.
+            if (e.key === 'Escape') return;
           },
-          type,
-        ),
-      );
-    }
+          oninput: (e: KeyboardEvent) => {
+            if (!e.target) return;
+            this.trackName = (e.target as HTMLInputElement).value;
+          },
+        },
+        this.trackName,
+      ),
+      m(FormLabel, {for: 'track_type'}, 'Track type'),
+      this.renderTrackTypeSelect(),
+      this.renderOptions(attrs.availableColumns),
+    );
+  }
+
+  private renderTrackTypeSelect() {
     return m(
       Select,
       {
         id: 'track_type',
         oninput: (e: Event) => {
           if (!e.target) return;
-          this.trackType = (e.target as HTMLSelectElement).value as
-            | 'slice'
-            | 'counter';
+          this.trackType = (e.target as HTMLSelectElement).value as TrackType;
         },
       },
-      options,
-    );
-  }
-
-  view(vnode: m.Vnode<AddDebugTrackMenuAttrs>) {
-    const renderSelect = (name: 'ts' | 'dur' | 'name' | 'value' | 'pivot') => {
-      const options = [];
-
-      if (name === 'pivot') {
-        options.push(
-          m(
-            'option',
-            {selected: this.renderParams[name] === '' ? true : undefined},
-            m('i', ''),
-          ),
-        );
-      }
-      for (const column of this.columns) {
-        options.push(
-          m(
-            'option',
-            {selected: this.renderParams[name] === column ? true : undefined},
-            column,
-          ),
-        );
-      }
-      if (name === 'dur') {
-        options.push(
-          m(
-            'option',
-            {selected: this.renderParams[name] === '0' ? true : undefined},
-            m('i', '0'),
-          ),
-        );
-      }
-      return [
-        m(FormLabel, {for: name}, name),
+      trackTypes.map((value) =>
         m(
-          Select,
+          'option',
           {
-            id: name,
-            oninput: (e: Event) => {
-              if (!e.target) return;
-              this.renderParams[name] = (e.target as HTMLSelectElement).value;
-            },
+            value: value,
+            selected: this.trackType === value,
           },
-          options,
+          value,
         ),
-      ];
-    };
-
-    return m(
-      Form,
-      {
-        onSubmit: () => this.createDebugTracks(vnode.attrs),
-        submitLabel: 'Show',
-      },
-      m(FormLabel, {for: 'track_name'}, 'Track name'),
-      m(TextInput, {
-        id: 'track_name',
-        ref: TRACK_NAME_FIELD_REF,
-        onkeydown: (e: KeyboardEvent) => {
-          // Allow Esc to close popup.
-          if (e.key === 'Escape') return;
-        },
-        oninput: (e: KeyboardEvent) => {
-          if (!e.target) return;
-          this.name = (e.target as HTMLInputElement).value;
-        },
-      }),
-      m(FormLabel, {for: 'track_type'}, 'Track type'),
-      this.renderTrackTypeSelect(),
-      renderSelect('ts'),
-      this.trackType === 'slice' && renderSelect('dur'),
-      this.trackType === 'slice' && renderSelect('name'),
-      this.trackType === 'counter' && renderSelect('value'),
-      renderSelect('pivot'),
+      ),
     );
   }
 
-  private createDebugTracks(attrs: AddDebugTrackMenuAttrs) {
+  private renderOptions(availableColumns: ReadonlyArray<string>) {
+    switch (this.trackType) {
+      case 'slice':
+        return this.renderSliceOptions(availableColumns);
+      case 'counter':
+        return this.renderCounterTrackOptions(availableColumns);
+      default:
+        assertUnreachable(this.trackType);
+    }
+  }
+
+  private renderSliceOptions(availableColumns: ReadonlyArray<string>) {
+    return [
+      this.renderFormSelectInput('ts', 'ts', availableColumns),
+      this.renderFormSelectInput('dur', 'dur', ['0', ...availableColumns]),
+      this.renderFormSelectInput('name', 'name', availableColumns),
+      this.renderFormSelectInput('arg_set_id', 'argSetId', [
+        '',
+        ...availableColumns,
+      ]),
+      this.renderFormSelectInput('pivot', 'pivot', ['', ...availableColumns]),
+    ];
+  }
+
+  private renderCounterTrackOptions(availableColumns: ReadonlyArray<string>) {
+    return [
+      this.renderFormSelectInput('ts', 'ts', availableColumns),
+      this.renderFormSelectInput('value', 'value', availableColumns),
+      this.renderFormSelectInput('pivot', 'pivot', ['', ...availableColumns]),
+    ];
+  }
+
+  private renderFormSelectInput<K extends keyof ConfigurationOptions>(
+    name: string,
+    optionKey: K,
+    options: ReadonlyArray<string>,
+  ) {
+    return [
+      m(FormLabel, {for: name}, name),
+      m(
+        Select,
+        {
+          id: name,
+          oninput: (e: Event) => {
+            if (!e.target) return;
+            this.options[optionKey] = (e.target as HTMLSelectElement).value;
+          },
+          value: this.options[optionKey],
+        },
+        options.map((opt) =>
+          m('option', {selected: this.options[optionKey] === opt}, opt),
+        ),
+      ),
+    ];
+  }
+
+  private createTracks(attrs: AddDebugTrackMenuAttrs) {
     switch (this.trackType) {
       case 'slice':
         addDebugSliceTrack({
           trace: attrs.trace,
-          data: attrs.dataSource,
-          title: this.name,
-          columns: {
-            ts: this.renderParams.ts,
-            dur: this.renderParams.dur,
-            name: this.renderParams.name,
+          data: {
+            sqlSource: attrs.query,
+            columns: attrs.availableColumns,
           },
-          argColumns: this.columns,
-          pivotOn: this.renderParams.pivot,
+          title: this.trackName,
+          columns: {
+            ts: this.options.ts,
+            dur: this.options.dur,
+            name: this.options.name,
+          },
+          argSetIdColumn: this.options.argSetId,
+          argColumns: attrs.availableColumns,
+          pivotOn: this.options.pivot,
         });
         break;
       case 'counter':
         addDebugCounterTrack({
           trace: attrs.trace,
-          data: attrs.dataSource,
-          title: this.name,
-          columns: {
-            ts: this.renderParams.ts,
-            value: this.renderParams.value,
+          data: {
+            sqlSource: attrs.query,
+            columns: attrs.availableColumns,
           },
-          pivotOn: this.renderParams.pivot,
+          title: this.trackName,
+          columns: {
+            ts: this.options.ts,
+            value: this.options.value,
+          },
+          pivotOn: this.options.pivot,
         });
         break;
       default:

--- a/ui/src/components/tracks/debug_tracks.ts
+++ b/ui/src/components/tracks/debug_tracks.ts
@@ -24,7 +24,7 @@ import {
 } from '../../trace_processor/sql_utils';
 import {DatasetSliceTrack} from './dataset_slice_track';
 import {
-  ARG_PREFIX,
+  RAW_PREFIX,
   DebugSliceTrackDetailsPanel,
 } from './debug_slice_track_details_panel';
 import {
@@ -44,8 +44,9 @@ export interface DebugSliceTrackArgs {
   readonly data: SqlDataSource;
   readonly title?: string;
   readonly columns?: Partial<SliceColumnMapping>;
-  readonly argColumns?: string[];
+  readonly argColumns?: ReadonlyArray<string>;
   readonly pivotOn?: string;
+  readonly argSetIdColumn?: string;
 }
 
 /**
@@ -88,6 +89,7 @@ export async function addDebugSliceTrack(args: DebugSliceTrackArgs) {
     args.columns,
     args.argColumns,
     args.pivotOn,
+    args.argSetIdColumn,
   );
 
   if (args.pivotOn) {
@@ -99,7 +101,13 @@ export async function addDebugSliceTrack(args: DebugSliceTrackArgs) {
       args.pivotOn,
     );
   } else {
-    addSingleSliceTrack(args.trace, tableName, titleBase, uriBase);
+    addSingleSliceTrack(
+      args.trace,
+      tableName,
+      titleBase,
+      uriBase,
+      args.argSetIdColumn,
+    );
   }
 }
 
@@ -108,8 +116,9 @@ async function createTableForSliceTrack(
   tableName: string,
   data: SqlDataSource,
   columns: Partial<SliceColumnMapping> = {},
-  argColumns?: string[],
+  argColumns?: ReadonlyArray<string>,
   pivotCol?: string,
+  argSetIdColumn?: string,
 ) {
   const {ts = 'ts', dur = 'dur', name = 'name'} = columns;
 
@@ -124,8 +133,9 @@ async function createTableForSliceTrack(
     `${ts} as ts`,
     `ifnull(cast(${dur} as int), -1) as dur`,
     `printf('%s', ${name}) as name`,
-    argColumns && argColumns.map((c) => `${c} as ${ARG_PREFIX}${c}`),
+    argColumns && argColumns.map((c) => `${c} as ${RAW_PREFIX}${c}`),
     pivotCol && `${pivotCol} as pivot`,
+    argSetIdColumn && `${argSetIdColumn} as arg_set_id`,
   ]
     .flat() // Convert to flattened list
     .filter(Boolean) // Remove falsy values
@@ -202,6 +212,7 @@ function addSingleSliceTrack(
   tableName: string,
   name: string,
   uri: string,
+  argSetIdCol?: string,
 ) {
   trace.tracks.registerTrack({
     uri,
@@ -218,7 +229,12 @@ function addSingleSliceTrack(
         src: tableName,
       }),
       detailsPanel: (row) => {
-        return new DebugSliceTrackDetailsPanel(trace, tableName, row.id);
+        return new DebugSliceTrackDetailsPanel(
+          trace,
+          tableName,
+          row.id,
+          argSetIdCol,
+        );
       },
     }),
   });

--- a/ui/src/components/tracks/query_slice_track.ts
+++ b/ui/src/components/tracks/query_slice_track.ts
@@ -14,7 +14,7 @@
 
 import {DatasetSliceTrack} from './dataset_slice_track';
 import {
-  ARG_PREFIX,
+  RAW_PREFIX,
   DebugSliceTrackDetailsPanel,
 } from './debug_slice_track_details_panel';
 import {createPerfettoTable} from '../../trace_processor/sql_utils';
@@ -51,7 +51,7 @@ export interface SqlDataSource {
   // If omitted, original column names from the query are used instead.
   // The caller is responsible for ensuring that the number of items in this
   // list matches the number of columns returned by sqlSource.
-  readonly columns?: string[];
+  readonly columns?: ReadonlyArray<string>;
 }
 
 export interface SliceColumnMapping {
@@ -131,7 +131,7 @@ async function createPerfettoTableForTrack(
         ifnull(cast(${dur} as int), -1) as dur,
         printf('%s', ${name}) as name
         ${argColumns.length > 0 ? ',' : ''}
-        ${argColumns.map((c) => `${c} as ${ARG_PREFIX}${c}`).join(',\n')}
+        ${argColumns.map((c) => `${c} as ${RAW_PREFIX}${c}`).join(',\n')}
       from data
     )
     select


### PR DESCRIPTION
- Add a new option to the 'add debug track' menu to select a column to use as the arg set id.
- Move the existing 'args' in the details panels (which are really just a printout of the raw columns from the source query), to the left panel and call them 'Raw Columns', and print the real args is present into the right hand panel.
