### PR TITLE
Decentralize dataset-search into plugins

### DIFF
--- a/ui/src/core/dataset_search.ts
+++ b/ui/src/core/dataset_search.ts
@@ -63,19 +63,22 @@ export async function searchTrackEvents(
   const resultsById = await searchIds(trackGroups, searchTerm, engine);
   results = results.concat(resultsById);
 
-  // // Remove duplicates
-  // const uniqueResults = new Map<string, SearchResult>();
-  // for (const result of results) {
-  //   const key = `${result.id}-${result.ts}`;
-  //   if (!uniqueResults.has(key)) {
-  //     uniqueResults.set(key, result);
-  //   }
-  // }
+  // Remove duplicates
+  const uniqueResults = new Map<string, SearchResult>();
+  for (const result of results) {
+    // Use a combination of id and track URI to ensure uniqueness.
+    const key = `${result.id}-${result.track.uri}`;
+    if (!uniqueResults.has(key)) {
+      uniqueResults.set(key, result);
+    }
+  }
 
   // Sort the results by timestamp
-  results.sort((a, b) => Number(a.ts - b.ts));
+  const sortedResults = Array.from(uniqueResults.values()).sort((a, b) =>
+    Number(a.ts - b.ts),
+  );
 
-  return results;
+  return sortedResults;
 }
 
 async function searchTracksUsingProvider(

--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -69,7 +69,7 @@ export class SearchManagerImpl implements SearchManager {
   private _limiter = new AsyncLimiter();
   private _onResultStep?: ResultStepEventHandler;
 
-  private readonly providers: SearchProvider[] = [];
+  private readonly _providers: SearchProvider[] = [];
 
   constructor(args?: {
     timeline: TimelineImpl;
@@ -86,7 +86,7 @@ export class SearchManagerImpl implements SearchManager {
   }
 
   registerSearchProvider(provider: SearchProvider): void {
-    this.providers.push(provider);
+    this._providers.push(provider);
   }
 
   search(text: string) {
@@ -363,7 +363,7 @@ export class SearchManagerImpl implements SearchManager {
     const allResults = await searchTrackEvents(
       engine,
       trackManager.getAllTracks(),
-      this.providers,
+      this._providers,
       this._searchText,
     );
 

--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -16,7 +16,11 @@ import {AsyncLimiter} from '../base/async_limiter';
 import {sqliteString} from '../base/string_utils';
 import {Time} from '../base/time';
 import {exists} from '../base/utils';
-import {ResultStepEventHandler} from '../public/search';
+import {
+  ResultStepEventHandler,
+  SearchManager,
+  SearchProvider,
+} from '../public/search';
 import {
   ANDROID_LOGS_TRACK_KIND,
   CPU_SLICE_TRACK_KIND,
@@ -49,7 +53,7 @@ export interface SearchResults {
   totalResults: number;
 }
 
-export class SearchManagerImpl {
+export class SearchManagerImpl implements SearchManager {
   private _searchGeneration = 0;
   private _searchText = '';
   private _results?: SearchResults;
@@ -65,6 +69,8 @@ export class SearchManagerImpl {
   private _limiter = new AsyncLimiter();
   private _onResultStep?: ResultStepEventHandler;
 
+  private readonly providers: SearchProvider[] = [];
+
   constructor(args?: {
     timeline: TimelineImpl;
     trackManager: TrackManagerImpl;
@@ -77,6 +83,10 @@ export class SearchManagerImpl {
     this._engine = args?.engine;
     this._workspace = args?.workspace;
     this._onResultStep = args?.onResultStep;
+  }
+
+  registerSearchProvider(provider: SearchProvider): void {
+    this.providers.push(provider);
   }
 
   search(text: string) {
@@ -353,6 +363,7 @@ export class SearchManagerImpl {
     const allResults = await searchTrackEvents(
       engine,
       trackManager.getAllTracks(),
+      this.providers,
       this._searchText,
     );
 

--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -130,7 +130,9 @@ export default class implements PerfettoPlugin {
           );
       },
       async getSearchFilter(searchTerm) {
-        return `msg GLOB ${escapeSearchQuery(searchTerm)}`;
+        return {
+          where: `msg GLOB ${escapeSearchQuery(searchTerm)}`,
+        };
       },
     });
   }

--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -18,10 +18,11 @@ import {ANDROID_LOGS_TRACK_KIND} from '../../public/track_kinds';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Engine} from '../../trace_processor/engine';
-import {NUM, NUM_NULL} from '../../trace_processor/query_result';
+import {NUM, NUM_NULL, STR_NULL} from '../../trace_processor/query_result';
 import {createAndroidLogTrack} from './logs_track';
 import {exists} from '../../base/utils';
 import {TrackNode} from '../../public/workspace';
+import {escapeSearchQuery} from '../../trace_processor/query_utils';
 
 const VERSION = 1;
 
@@ -116,6 +117,20 @@ export default class implements PerfettoPlugin {
       name: 'Show android logs tab',
       callback: () => {
         ctx.tabs.showTab(androidLogsTabUri);
+      },
+    });
+
+    ctx.search.registerSearchProvider({
+      name: 'Android logs',
+      selectTracks(tracks) {
+        return tracks
+          .filter((track) => track.tags?.kind === ANDROID_LOGS_TRACK_KIND)
+          .filter((t) =>
+            t.renderer.getDataset?.()?.implements({msg: STR_NULL}),
+          );
+      },
+      async getSearchFilter(searchTerm) {
+        return `msg GLOB ${escapeSearchQuery(searchTerm)}`;
       },
     });
   }

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -95,7 +95,9 @@ export default class implements PerfettoPlugin {
         for (const it = utidRes.iter({utid: NUM}); it.valid(); it.next()) {
           utids.push(it.utid);
         }
-        return `utid IN (${utids.join()})`;
+        return {
+          where: `utid IN (${utids.join()})`,
+        };
       },
     });
   }

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -71,7 +71,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.search.registerSearchProvider({
-      name: 'Scheduler Slices',
+      name: 'Sched Slices',
       selectTracks(tracks) {
         return tracks
           .filter((t) => t.tags?.kind === CPU_SLICE_TRACK_KIND)

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -63,7 +63,7 @@ export default class implements PerfettoPlugin {
     this.addMinimapContentProvider(ctx);
 
     ctx.search.registerSearchProvider({
-      name: 'Slices',
+      name: 'Slices by name',
       selectTracks(tracks) {
         return tracks
           .filter((t) => t.tags?.kind === SLICE_TRACK_KIND)
@@ -72,7 +72,9 @@ export default class implements PerfettoPlugin {
           );
       },
       async getSearchFilter(searchTerm) {
-        return `name GLOB ${escapeSearchQuery(searchTerm)}`;
+        return {
+          where: `name GLOB ${escapeSearchQuery(searchTerm)}`,
+        };
       },
     });
 
@@ -87,21 +89,28 @@ export default class implements PerfettoPlugin {
       },
       async getSearchFilter(searchTerm) {
         const searchLiteral = escapeSearchQuery(searchTerm);
-        const argSetIdsResult = await ctx.engine.query(`
-          SELECT arg_set_id as argSetId
-          FROM args
-          WHERE
-            string_value GLOB ${searchLiteral} OR key GLOB ${searchLiteral}
-        `);
-        const argSetIds = [];
-        for (
-          const it = argSetIdsResult.iter({argSetId: NUM});
-          it.valid();
-          it.next()
-        ) {
-          argSetIds.push(it.argSetId);
-        }
-        return `arg_set_id IN (${argSetIds.join()})`;
+        // const argSetIdsResult = await ctx.engine.query(`
+        //   SELECT arg_set_id as argSetId
+        //   FROM args
+        //   WHERE
+        //     string_value GLOB ${searchLiteral} OR key GLOB ${searchLiteral}
+        // `);
+        // const argSetIds = [];
+        // for (
+        //   const it = argSetIdsResult.iter({argSetId: NUM});
+        //   it.valid();
+        //   it.next()
+        // ) {
+        //   argSetIds.push(it.argSetId);
+        // }
+        return {
+          join: `args USING(arg_set_id)`,
+          where: `
+            args.string_value GLOB ${searchLiteral}
+            OR
+            args.key GLOB ${searchLiteral}
+          `,
+        };
       },
     });
   }

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -89,20 +89,6 @@ export default class implements PerfettoPlugin {
       },
       async getSearchFilter(searchTerm) {
         const searchLiteral = escapeSearchQuery(searchTerm);
-        // const argSetIdsResult = await ctx.engine.query(`
-        //   SELECT arg_set_id as argSetId
-        //   FROM args
-        //   WHERE
-        //     string_value GLOB ${searchLiteral} OR key GLOB ${searchLiteral}
-        // `);
-        // const argSetIds = [];
-        // for (
-        //   const it = argSetIdsResult.iter({argSetId: NUM});
-        //   it.valid();
-        //   it.next()
-        // ) {
-        //   argSetIds.push(it.argSetId);
-        // }
         return {
           join: `args USING(arg_set_id)`,
           where: `

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
@@ -30,6 +30,7 @@ import {
   LONG,
   LONG_NULL,
   NUM,
+  NUM_NULL,
   STR_NULL,
 } from '../../trace_processor/query_result';
 import m from 'mithril';
@@ -51,6 +52,7 @@ const schema = {
   thread_dur: LONG_NULL,
   category: STR_NULL,
   correlation_id: STR_NULL,
+  arg_set_id: NUM_NULL,
 };
 
 export async function createTraceProcessorSliceTrack({
@@ -112,7 +114,8 @@ async function getDataset(engine: Engine, trackIds: ReadonlyArray<number>) {
           thread_dur,
           track_id,
           category,
-          extract_arg(arg_set_id, 'correlation_id') as correlation_id
+          extract_arg(arg_set_id, 'correlation_id') as correlation_id,
+          arg_set_id
         from slice
       `,
       filter: {
@@ -148,7 +151,8 @@ async function getDataset(engine: Engine, trackIds: ReadonlyArray<number>) {
           thread_dur,
           track_id,
           category,
-          extract_arg(arg_set_id, 'correlation_id') as correlation_id
+          extract_arg(arg_set_id, 'correlation_id') as correlation_id,
+          arg_set_id
         from slice
         join ${tableName} d using (id)
       `,

--- a/ui/src/public/search.ts
+++ b/ui/src/public/search.ts
@@ -26,6 +26,11 @@ export interface SearchResult {
 
 export type ResultStepEventHandler = (r: SearchResult) => void;
 
+export interface FilterExpression {
+  readonly where: string;
+  readonly join?: string;
+}
+
 export interface SearchProvider {
   readonly name: string;
 
@@ -44,7 +49,7 @@ export interface SearchProvider {
    * This function is async because it may need to query some data using the
    * search term before it can return a filter expression.
    */
-  getSearchFilter(searchTerm: string): Promise<string>;
+  getSearchFilter(searchTerm: string): Promise<FilterExpression>;
 }
 
 export interface SearchManager {

--- a/ui/src/public/search.ts
+++ b/ui/src/public/search.ts
@@ -27,18 +27,30 @@ export interface SearchResult {
 export type ResultStepEventHandler = (r: SearchResult) => void;
 
 export interface FilterExpression {
+  /**
+   * A SQL WHERE clause that filters the events in the selected tracks. The
+   * 'where' keyword is added automatically.
+   */
   readonly where: string;
+
+  /**
+   * An optional SQL JOIN clause that can be used to join with other tables. The
+   * 'join' keyword is added automatically.
+   */
   readonly join?: string;
 }
 
 export interface SearchProvider {
+  /**
+   * A human-readable name for this search provider. This is not currently used
+   * but it will be used to identify the provider in the UI and logs.
+   */
   readonly name: string;
 
   /**
    * Returns a set of tracks that this provider is interested in.
-   * @param tracks - A list of all tracks we are searching in.
-   * @returns A subset of tracks that this provider is interested in. If empty,
-   *          the provider will not be used.
+   * @param tracks - A list of all tracks we want to search inside.
+   * @returns A subset of tracks that this provider is interested in.
    */
   selectTracks(tracks: ReadonlyArray<Track>): ReadonlyArray<Track>;
 
@@ -48,6 +60,10 @@ export interface SearchProvider {
    *
    * This function is async because it may need to query some data using the
    * search term before it can return a filter expression.
+   *
+   * @param searchTerm - The raw search term entered by the user.
+   * @returns A promise that resolves to a FilterExpression that is compiled into
+   * the resulting SQL query.
    */
   getSearchFilter(searchTerm: string): Promise<FilterExpression>;
 }

--- a/ui/src/public/search.ts
+++ b/ui/src/public/search.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {time} from '../base/time';
+import {Track} from './track';
 
 export type SearchSource = 'cpu' | 'log' | 'slice' | 'track' | 'event';
 
@@ -24,3 +25,28 @@ export interface SearchResult {
 }
 
 export type ResultStepEventHandler = (r: SearchResult) => void;
+
+export interface SearchProvider {
+  readonly name: string;
+
+  /**
+   * Returns a set of tracks that this provider is interested in.
+   * @param tracks - A list of all tracks we are searching in.
+   * @returns A subset of tracks that this provider is interested in. If empty,
+   *          the provider will not be used.
+   */
+  selectTracks(tracks: ReadonlyArray<Track>): ReadonlyArray<Track>;
+
+  /**
+   * Returns a where clause filter given a search term. This describes how to
+   * search for events in the selected tracks.
+   *
+   * This function is async because it may need to query some data using the
+   * search term before it can return a filter expression.
+   */
+  getSearchFilter(searchTerm: string): Promise<string>;
+}
+
+export interface SearchManager {
+  registerSearchProvider(provider: SearchProvider): void;
+}

--- a/ui/src/public/trace.ts
+++ b/ui/src/public/trace.ts
@@ -27,6 +27,7 @@ import {DisposableStack} from '../base/disposable_stack';
 import {Evt} from '../base/events';
 import {StatusbarManager} from './statusbar';
 import {MinimapManager} from './minimap';
+import {SearchManager} from './search';
 
 // Lists all the possible event listeners using the key as the event name and
 // the type as the type of the callback.
@@ -54,6 +55,7 @@ export interface Trace extends App {
   readonly traceInfo: TraceInfo;
   readonly statusbar: StatusbarManager;
   readonly minimap: MinimapManager;
+  readonly search: SearchManager;
 
   // Events.
   onTraceReady: Evt<void>;


### PR DESCRIPTION
This patch introduces a new concept of 'search providers', which provide a way for plugins to extend the search interface subsystem.

This patch also includes modifications to plugins in order to bring the functionality of the dataset search mechanism in line with the functionality of the original search.

That is to say we search:
  - cpu slices by process or thread name
  - slices by name, id or arg string/key
  - android logs by message
 