### PR TITLE
Remove TraceWriter from EventContext

### DIFF
--- a/include/perfetto/tracing/event_context.h
+++ b/include/perfetto/tracing/event_context.h
@@ -140,8 +140,7 @@ class PERFETTO_EXPORT_COMPONENT EventContext {
   using TracePacketHandle =
       ::protozero::MessageHandle<protos::pbzero::TracePacket>;
 
-  EventContext(TraceWriterBase* trace_writer,
-               TracePacketHandle,
+  EventContext(TracePacketHandle,
                internal::TrackEventIncrementalState*,
                internal::TrackEventTlsState*);
   EventContext(const EventContext&) = delete;
@@ -150,7 +149,6 @@ class PERFETTO_EXPORT_COMPONENT EventContext {
   protos::pbzero::DebugAnnotation* AddDebugAnnotation(
       ::perfetto::DynamicString name);
 
-  TraceWriterBase* trace_writer_ = nullptr;
   TracePacketHandle trace_packet_;
   protos::pbzero::TrackEvent* event_;
   internal::TrackEventIncrementalState* incremental_state_;

--- a/src/tracing/event_context.cc
+++ b/src/tracing/event_context.cc
@@ -23,12 +23,10 @@
 namespace perfetto {
 
 EventContext::EventContext(
-    TraceWriterBase* trace_writer,
     EventContext::TracePacketHandle trace_packet,
     internal::TrackEventIncrementalState* incremental_state,
     internal::TrackEventTlsState* tls_state)
-    : trace_writer_(trace_writer),
-      trace_packet_(std::move(trace_packet)),
+    : trace_packet_(std::move(trace_packet)),
       event_(trace_packet_->set_track_event()),
       incremental_state_(incremental_state),
       tls_state_(tls_state) {}

--- a/src/tracing/internal/track_event_internal.cc
+++ b/src/tracing/internal/track_event_internal.cc
@@ -557,7 +557,7 @@ EventContext TrackEventInternal::WriteEvent(
     bool on_current_thread_track) {
   PERFETTO_DCHECK(!incr_state->was_cleared);
   auto packet = NewTracePacket(trace_writer, incr_state, tls_state, timestamp);
-  EventContext ctx(trace_writer, std::move(packet), incr_state, &tls_state);
+  EventContext ctx(std::move(packet), incr_state, &tls_state);
 
   auto track_event = ctx.event();
   if (type != protos::pbzero::TrackEvent::TYPE_UNSPECIFIED)


### PR DESCRIPTION
It was used temporarily in https://r.android.com/2864782 and it could have been removed since https://r.android.com/2714981.
