### PR TITLE
Winscope rect and transform trackers

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14208,6 +14208,8 @@ filegroup {
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
         "src/trace_processor/importers/proto/winscope/winscope_geometry.cc",
         "src/trace_processor/importers/proto/winscope/winscope_module.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.cc",
     ],
 }
 

--- a/BUILD
+++ b/BUILD
@@ -2268,6 +2268,10 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/winscope/winscope_geometry.h",
         "src/trace_processor/importers/proto/winscope/winscope_module.cc",
         "src/trace_processor/importers/proto/winscope/winscope_module.h",
+        "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.h",
+        "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.h",
     ],
 )
 

--- a/src/trace_processor/importers/proto/winscope/BUILD.gn
+++ b/src/trace_processor/importers/proto/winscope/BUILD.gn
@@ -41,6 +41,10 @@ source_set("full") {
     "winscope_geometry.h",
     "winscope_module.cc",
     "winscope_module.h",
+    "winscope_rect_tracker.cc",
+    "winscope_rect_tracker.h",
+    "winscope_transform_tracker.cc",
+    "winscope_transform_tracker.h",
   ]
   deps = [
     ":gen_cc_winscope_descriptor",

--- a/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
@@ -24,7 +24,7 @@
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 
-namespace perfetto::trace_processor {
+namespace perfetto::trace_processor::winscope {
 
 ProtoLogMessageDecoder::ProtoLogMessageDecoder(TraceProcessorContext* context)
     : context_(context) {}
@@ -148,4 +148,4 @@ void ProtoLogMessageDecoder::TrackMessage(
                            TrackedMessage{level, group_id, message, location});
 }
 
-}  // namespace perfetto::trace_processor
+}  // namespace perfetto::trace_processor::winscope

--- a/src/trace_processor/importers/proto/winscope/protolog_message_decoder.h
+++ b/src/trace_processor/importers/proto/winscope/protolog_message_decoder.h
@@ -27,7 +27,7 @@
 #include "src/trace_processor/tables/winscope_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto::trace_processor {
+namespace perfetto::trace_processor::winscope {
 
 enum ProtoLogLevel : int32_t {
   DEBUG = 1,
@@ -81,6 +81,6 @@ class ProtoLogMessageDecoder {
   base::FlatHashMap<uint64_t, TrackedMessage> tracked_messages_;
 };
 
-}  // namespace perfetto::trace_processor
+}  // namespace perfetto::trace_processor::winscope
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_PROTOLOG_MESSAGE_DECODER_H_

--- a/src/trace_processor/importers/proto/winscope/protolog_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.cc
@@ -42,7 +42,11 @@
 
 namespace perfetto::trace_processor {
 
-ProtoLogParser::ProtoLogParser(WinscopeContext* context)
+namespace {
+using ProtoLogLevel = winscope::ProtoLogLevel;
+}
+
+ProtoLogParser::ProtoLogParser(winscope::WinscopeContext* context)
     : context_(context),
       args_parser_{*context->trace_processor_context_->descriptor_pool_},
       log_level_debug_string_id_(
@@ -148,7 +152,7 @@ void ProtoLogParser::ParseAndAddViewerConfigToMessageDecoder(
     protozero::ConstBytes blob) {
   protos::pbzero::ProtoLogViewerConfig::Decoder protolog_viewer_config(blob);
 
-  ProtoLogMessageDecoder& protolog_message_decoder =
+  winscope::ProtoLogMessageDecoder& protolog_message_decoder =
       context_->protolog_message_decoder_;
 
   for (auto it = protolog_viewer_config.groups(); it; ++it) {

--- a/src/trace_processor/importers/proto/winscope/protolog_parser.h
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.h
@@ -34,7 +34,7 @@ class TraceProcessorContext;
 
 class ProtoLogParser {
  public:
-  explicit ProtoLogParser(WinscopeContext*);
+  explicit ProtoLogParser(winscope::WinscopeContext*);
   void ParseProtoLogMessage(PacketSequenceStateGeneration* sequence_state,
                             protozero::ConstBytes,
                             int64_t timestamp);
@@ -42,13 +42,13 @@ class ProtoLogParser {
 
  private:
   void PopulateReservedRowWithMessage(tables::ProtoLogTable::Id table_row_id,
-                                      ProtoLogLevel level,
+                                      winscope::ProtoLogLevel level,
                                       std::string& group_tag,
                                       std::string& formatted_message,
                                       std::optional<StringId> stacktrace,
                                       std::optional<std::string>& location);
 
-  WinscopeContext* context_;
+  winscope::WinscopeContext* context_;
   util::ProtoToArgsParser args_parser_;
 
   const StringId log_level_debug_string_id_;

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
@@ -31,7 +31,8 @@
 namespace perfetto {
 namespace trace_processor {
 
-ShellTransitionsParser::ShellTransitionsParser(WinscopeContext* context)
+ShellTransitionsParser::ShellTransitionsParser(
+    winscope::WinscopeContext* context)
     : context_(context),
       args_parser_{*context->trace_processor_context_->descriptor_pool_} {}
 
@@ -51,7 +52,7 @@ void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
   storage->mutable_window_manager_shell_transition_protos_table()->Insert(row);
 
   // Track transition args as the come in through different packets
-  ShellTransitionsTracker& transition_tracker =
+  winscope::ShellTransitionsTracker& transition_tracker =
       context_->shell_transitions_tracker_;
   auto inserter = transition_tracker.AddArgsTo(transition.id());
   ArgsParser writer(/*timestamp=*/0, inserter, *storage.get());

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_parser.h
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_parser.h
@@ -29,12 +29,12 @@ class TraceProcessorContext;
 
 class ShellTransitionsParser {
  public:
-  explicit ShellTransitionsParser(WinscopeContext*);
+  explicit ShellTransitionsParser(winscope::WinscopeContext*);
   void ParseTransition(protozero::ConstBytes);
   void ParseHandlerMappings(protozero::ConstBytes);
 
  private:
-  WinscopeContext* context_;
+  winscope::WinscopeContext* context_;
   util::ProtoToArgsParser args_parser_;
 };
 }  // namespace trace_processor

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.cc
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.cc
@@ -18,8 +18,7 @@
 #include <cstdint>
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor::winscope {
 
 ShellTransitionsTracker::ShellTransitionsTracker(TraceProcessorContext* context)
     : context_(context) {}
@@ -153,5 +152,4 @@ ShellTransitionsTracker::GetRowReference(int32_t transition_id) {
   return window_manager_shell_transitions_table->FindById(pos->second.row_id);
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor::winscope

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
@@ -25,8 +25,7 @@
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/winscope_proto_mapping.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor::winscope {
 
 // Tracks information in the transition table.
 class ShellTransitionsTracker {
@@ -64,7 +63,6 @@ class ShellTransitionsTracker {
   std::unordered_map<int32_t, TransitionInfo> transitions_infos_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor::winscope
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_SHELL_TRANSITIONS_TRACKER_H_

--- a/src/trace_processor/importers/proto/winscope/winscope_context.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_context.h
@@ -19,24 +19,28 @@
 
 #include "src/trace_processor/importers/proto/winscope/protolog_message_decoder.h"
 #include "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor::winscope {
 
 class WinscopeContext {
  public:
   explicit WinscopeContext(TraceProcessorContext* context)
       : trace_processor_context_(context),
         shell_transitions_tracker_(context),
-        protolog_message_decoder_(context) {}
+        protolog_message_decoder_(context),
+        rect_tracker_(context),
+        transform_tracker_(context) {}
 
   TraceProcessorContext* trace_processor_context_;
   ShellTransitionsTracker shell_transitions_tracker_;
   ProtoLogMessageDecoder protolog_message_decoder_;
+  WinscopeRectTracker rect_tracker_;
+  WinscopeTransformTracker transform_tracker_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor::winscope
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_CONTEXT_H_

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.h
@@ -39,6 +39,7 @@ struct Size {
 // visibilities. These rects are added to the __intrinsic_winscope_rect table.
 class Rect {
  public:
+  explicit Rect();
   explicit Rect(const protos::pbzero::RectProto::Decoder& rect);
   explicit Rect(const protos::pbzero::FloatRectProto::Decoder& rect);
   Rect(double left, double top, double right, double bottom);

--- a/src/trace_processor/importers/proto/winscope/winscope_module.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_module.h
@@ -62,7 +62,7 @@ class WinscopeModule : public ProtoImporterModule {
                                    protozero::ConstBytes blob);
   void ParseWindowManagerData(int64_t timestamp, protozero::ConstBytes blob);
 
-  WinscopeContext context_;
+  winscope::WinscopeContext context_;
   util::ProtoToArgsParser args_parser_;
 
   SurfaceFlingerLayersParser surfaceflinger_layers_parser_;

--- a/src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.h"
+
+#include <algorithm>
+#include "src/trace_processor/storage/trace_storage.h"
+
+namespace perfetto::trace_processor::winscope {
+
+const tables::WinscopeRectTable::Id& WinscopeRectTracker::GetOrInsertRow(
+    geometry::Rect& rect) {
+  auto* existing_row_id = rows_.Find(rect);
+  if (existing_row_id) {
+    return *existing_row_id;
+  }
+
+  tables::WinscopeRectTable::Row row;
+  row.x = rect.x;
+  row.y = rect.y;
+  row.w = rect.w;
+  row.h = rect.h;
+  auto id = context_->storage->mutable_winscope_rect_table()->Insert(row).id;
+
+  return *rows_.Insert(rect, id).first;
+}
+
+}  // namespace perfetto::trace_processor::winscope

--- a/src/trace_processor/importers/proto/winscope/winscope_rect_tracker.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_rect_tracker.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_RECT_TRACKER_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_RECT_TRACKER_H_
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/hash.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry.h"
+#include "src/trace_processor/tables/winscope_tables_py.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor::winscope {
+
+struct RectHasher {
+  size_t operator()(const geometry::Rect& r) const {
+    perfetto::base::Hasher hasher;
+    hasher.Update(r.x);
+    hasher.Update(r.y);
+    hasher.Update(r.w);
+    hasher.Update(r.h);
+    return static_cast<size_t>(hasher.digest());
+  }
+};
+
+class WinscopeRectTracker {
+ public:
+  explicit WinscopeRectTracker(TraceProcessorContext* context)
+      : context_(context) {}
+  TraceProcessorContext* context_;
+
+  const tables::WinscopeRectTable::Id& GetOrInsertRow(geometry::Rect& rect);
+
+ private:
+  base::FlatHashMap<geometry::Rect, tables::WinscopeRectTable::Id, RectHasher>
+      rows_;
+};
+
+}  // namespace perfetto::trace_processor::winscope
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_RECT_TRACKER_H_

--- a/src/trace_processor/importers/proto/winscope/winscope_transform_tracker.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_transform_tracker.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.h"
+
+#include <algorithm>
+#include "src/trace_processor/storage/trace_storage.h"
+
+namespace perfetto::trace_processor::winscope {
+
+const tables::WinscopeTransformTable::Id&
+WinscopeTransformTracker::GetOrInsertRow(geometry::TransformMatrix& matrix) {
+  auto* existing_row_id = rows_.Find(matrix);
+  if (existing_row_id) {
+    return *existing_row_id;
+  }
+
+  tables::WinscopeTransformTable::Row row;
+  row.dsdx = matrix.dsdx;
+  row.dtdx = matrix.dtdx;
+  row.dsdy = matrix.dsdy;
+  row.dtdy = matrix.dtdy;
+  row.tx = matrix.tx;
+  row.ty = matrix.ty;
+  auto id =
+      context_->storage->mutable_winscope_transform_table()->Insert(row).id;
+
+  return *rows_.Insert(matrix, id).first;
+}
+
+}  // namespace perfetto::trace_processor::winscope

--- a/src/trace_processor/importers/proto/winscope/winscope_transform_tracker.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_transform_tracker.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_TRANSFORM_TRACKER_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_TRANSFORM_TRACKER_H_
+
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry.h"
+#include "src/trace_processor/tables/winscope_tables_py.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor::winscope {
+
+struct TransformMatrixHasher {
+  size_t operator()(const geometry::TransformMatrix& r) const {
+    base::Hasher hasher;
+    hasher.Update(r.dsdx);
+    hasher.Update(r.dtdx);
+    hasher.Update(r.tx);
+    hasher.Update(r.dsdy);
+    hasher.Update(r.dtdy);
+    hasher.Update(r.ty);
+    return static_cast<size_t>(hasher.digest());
+  }
+};
+
+class WinscopeTransformTracker {
+ public:
+  explicit WinscopeTransformTracker(TraceProcessorContext* context)
+      : context_(context) {}
+  TraceProcessorContext* context_;
+
+  const tables::WinscopeTransformTable::Id& GetOrInsertRow(
+      geometry::TransformMatrix& matrix);
+
+ private:
+  base::FlatHashMap<geometry::TransformMatrix,
+                    tables::WinscopeTransformTable::Id,
+                    TransformMatrixHasher>
+      rows_;
+};
+
+}  // namespace perfetto::trace_processor::winscope
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_TRANSFORM_TRACKER_H_


### PR DESCRIPTION
Winscope rect and transform trackers.
    
For parsing SF/VC/WM data into rect tables.
    
Bug: 411363817
Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell

