### PR TITLE
tp: bail out of linear scan of elements after 16 tries

### DIFF
--- a/src/trace_processor/dataframe/impl/bytecode_interpreter_impl.h
+++ b/src/trace_processor/dataframe/impl/bytecode_interpreter_impl.h
@@ -503,14 +503,14 @@ class InterpreterImpl {
 
       // Scan 16 rows: it's often the case that we have just a very small number
       // of equal rows, so we can avoid a binary search.
-      const DataType* eq_end_limit = std::min(end, eq_start + 16);
+      const DataType* eq_end_limit = eq_start + 16;
       for (;; ++eq_end) {
+        if (eq_end == end) {
+          break;
+        }
         if (eq_end == eq_end_limit) {
           eq_end =
               std::upper_bound(eq_start, end, val, GetUbComparator<DataType>());
-          break;
-        }
-        if (eq_end == end) {
           break;
         }
         if (std::not_equal_to<>()(*eq_end, cmp_value)) {

--- a/src/trace_processor/dataframe/impl/bytecode_interpreter_impl.h
+++ b/src/trace_processor/dataframe/impl/bytecode_interpreter_impl.h
@@ -500,7 +500,19 @@ class InterpreterImpl {
       const DataType* eq_start =
           std::lower_bound(begin, end, val, GetLbComprarator<DataType>());
       const DataType* eq_end = eq_start;
-      for (; eq_end != end; ++eq_end) {
+
+      // Scan 16 rows: it's often the case that we have just a very small number
+      // of equal rows, so we can avoid a binary search.
+      const DataType* eq_end_limit = std::min(end, eq_start + 16);
+      for (;; ++eq_end) {
+        if (eq_end == eq_end_limit) {
+          eq_end =
+              std::upper_bound(eq_start, end, val, GetUbComparator<DataType>());
+          break;
+        }
+        if (eq_end == end) {
+          break;
+        }
         if (std::not_equal_to<>()(*eq_end, cmp_value)) {
           break;
         }


### PR DESCRIPTION
Ensures we don't get caught in a O(n) scan in a O(logn) codepath
