### PR TITLE
Add ability to set a custom timezone

### DIFF
--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -449,15 +449,14 @@ export class TimeSpan {
  *
  * @param date The original JavaScript `Date` object to format.
  * @param options An optional configuration object.
- * @param {number} [options.tzOffsetMins=0] - The timezone offset in minutes
- * from UTC. For example, -420 for UTC-7 or 330 for UTC+5:30. Defaults to 0
- * (UTC).
- * @param {boolean} [options.printDate=true] - Whether to include the date part
+ * @param {number} [options.tzOffsetMins] - The timezone offset in minutes from
+ * UTC. For example, -420 for UTC-7 or 330 for UTC+5:30. Defaults to 0 (UTC).
+ * @param {boolean} [options.printDate] - Whether to include the date part
  * (`YYYY-MM-DD`).
- * @param {boolean} [options.printTime=true] - Whether to include the time part
+ * @param {boolean} [options.printTime] - Whether to include the time part
  * (`HH:mm:ss.SSS`).
- * @param {boolean} [options.printTimezone=true] - Whether to include the
- * timezone offset.
+ * @param {boolean} [options.printTimezone] - Whether to include the timezone
+ * offset.
  *
  * @returns A formatted string representing the date and time in the specified
  * timezone.

--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -543,3 +543,48 @@ export function formatTimezone(tzOffsetMins: number): string {
   const minsStr = String(mins).padStart(2, '0');
   return `UTC${sign}${hoursStr}:${minsStr}`;
 }
+
+/**
+ * A TypeScript Map that pairs user-friendly timezone descriptions
+ * with their corresponding UTC offset in minutes.
+ */
+export const timezoneOffsetMap: {[key: string]: number} = {
+  '(UTC-12:00) International Date Line West': -720,
+  '(UTC-11:00) Coordinated Universal Time-11': -660,
+  '(UTC-10:00) Hawaii': -600,
+  '(UTC-09:30) Marquesas Islands': -570,
+  '(UTC-09:00) Alaska': -540,
+  '(UTC-08:00) Pacific Time (US & Canada)': -480,
+  '(UTC-07:00) Mountain Time (US & Canada)': -420,
+  '(UTC-06:00) Central Time (US & Canada), Mexico City': -360,
+  '(UTC-05:00) Eastern Time (US & Canada), Bogota, Lima': -300,
+  '(UTC-04:00) Atlantic Time (Canada), La Paz': -240,
+  '(UTC-03:30) Newfoundland': -210,
+  '(UTC-03:00) Buenos Aires, São Paulo': -180,
+  '(UTC-02:00) Coordinated Universal Time-02': -120,
+  '(UTC-01:00) Azores, Cape Verde Is.': -60,
+  '(UTC+00:00) London, Dublin, Lisbon, Casablanca': 0,
+  '(UTC+01:00) Amsterdam, Berlin, Paris, Rome, Madrid': 60,
+  '(UTC+02:00) Athens, Cairo, Johannesburg, Helsinki': 120,
+  '(UTC+03:00) Moscow, Istanbul, Riyadh, Nairobi': 180,
+  '(UTC+03:30) Tehran': 210,
+  '(UTC+04:00) Dubai, Abu Dhabi, Muscat, Baku': 240,
+  '(UTC+04:30) Kabul': 270,
+  '(UTC+05:00) Karachi, Tashkent': 300,
+  '(UTC+05:30) Mumbai, New Delhi, Kolkata, Colombo': 330,
+  '(UTC+05:45) Kathmandu': 345,
+  '(UTC+06:00) Almaty, Dhaka': 360,
+  '(UTC+06:30) Yangon (Rangoon)': 390,
+  '(UTC+07:00) Bangkok, Hanoi, Jakarta': 420,
+  '(UTC+08:00) Beijing, Hong Kong, Singapore, Taipei, Perth': 480,
+  '(UTC+08:45) Eucla': 525,
+  '(UTC+09:00) Tokyo, Seoul, Osaka, Sapporo': 540,
+  '(UTC+09:30) Adelaide, Darwin': 570,
+  '(UTC+10:00) Sydney, Melbourne, Brisbane, Guam': 600,
+  '(UTC+10:30) Lord Howe Island': 630,
+  '(UTC+11:00) Solomon Is., New Caledonia': 660,
+  '(UTC+12:00) Auckland, Wellington, Fiji': 720,
+  '(UTC+12:45) Chatham Islands': 765,
+  "(UTC+13:00) Nuku'alofa": 780,
+  '(UTC+14:00) Kiritimati': 840,
+};

--- a/ui/src/components/time_utils.ts
+++ b/ui/src/components/time_utils.ts
@@ -35,6 +35,7 @@ export function formatDuration(trace: Trace, dur: duration): string {
     case TimestampFormat.UTC:
     case TimestampFormat.TraceTz:
     case TimestampFormat.Timecode:
+    case TimestampFormat.CustomTimezone:
       return renderFormattedDuration(trace, dur);
     case TimestampFormat.TraceNs:
       return dur.toString();

--- a/ui/src/components/widgets/timestamp.ts
+++ b/ui/src/components/widgets/timestamp.ts
@@ -81,6 +81,7 @@ export class Timestamp implements m.ClassComponent<TimestampAttrs> {
       case TimestampFormat.UTC:
       case TimestampFormat.TraceTz:
       case TimestampFormat.Timecode:
+      case TimestampFormat.CustomTimezone:
         return renderTimecode(time);
       case TimestampFormat.TraceNs:
         return time.toString();

--- a/ui/src/components/widgets/timestamp_format_menu.ts
+++ b/ui/src/components/widgets/timestamp_format_menu.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {MenuItem} from '../../widgets/menu';
 import {Trace} from '../../public/trace';
 import {TimestampFormat} from '../../public/timeline';
-import {formatTimezone} from '../../base/time';
+import {formatTimezone, timezoneOffsetMap} from '../../base/time';
 
 interface TimestampFormatMenuItemAttrs {
   trace: Trace;
@@ -26,36 +26,50 @@ export class TimestampFormatMenuItem
   implements m.ClassComponent<TimestampFormatMenuItemAttrs>
 {
   view({attrs}: m.Vnode<TimestampFormatMenuItemAttrs>) {
+    const timeline = attrs.trace.timeline;
     function renderMenuItem(value: TimestampFormat, label: string) {
       return m(MenuItem, {
         label,
-        active: value === attrs.trace.timeline.timestampFormat,
+        active: value === timeline.timestampFormat,
         onclick: () => {
-          attrs.trace.timeline.timestampFormat = value;
+          timeline.timestampFormat = value;
         },
       });
     }
 
     const timeZone = formatTimezone(attrs.trace.traceInfo.tzOffMin);
+    const TF = TimestampFormat;
 
     return m(
       MenuItem,
       {
         label: 'Time format',
       },
-      renderMenuItem(TimestampFormat.Timecode, 'Timecode'),
-      renderMenuItem(TimestampFormat.UTC, 'Realtime (UTC)'),
-      renderMenuItem(
-        TimestampFormat.TraceTz,
-        `Realtime (Trace TZ - ${timeZone})`,
-      ),
-      renderMenuItem(TimestampFormat.Seconds, 'Seconds'),
-      renderMenuItem(TimestampFormat.Milliseconds, 'Milliseconds'),
-      renderMenuItem(TimestampFormat.Microseconds, 'Microseconds'),
-      renderMenuItem(TimestampFormat.TraceNs, 'Raw'),
-      renderMenuItem(
-        TimestampFormat.TraceNsLocale,
-        'Raw (with locale-specific formatting)',
+      renderMenuItem(TF.Timecode, 'Timecode'),
+      renderMenuItem(TF.UTC, 'Realtime (UTC)'),
+      renderMenuItem(TF.TraceTz, `Realtime (Trace TZ - ${timeZone})`),
+      renderMenuItem(TF.Seconds, 'Seconds'),
+      renderMenuItem(TF.Milliseconds, 'Milliseconds'),
+      renderMenuItem(TF.Microseconds, 'Microseconds'),
+      renderMenuItem(TF.TraceNs, 'Raw'),
+      renderMenuItem(TF.TraceNsLocale, 'Raw (with locale-specific formatting)'),
+      m(
+        MenuItem,
+        {
+          label: 'Custom',
+          active: TF.CustomTimezone === timeline.timestampFormat,
+        },
+        Object.keys(timezoneOffsetMap).map((tz) => {
+          const customTz = timeline.timezoneOverride;
+          return m(MenuItem, {
+            label: tz,
+            active: tz === customTz.get(),
+            onclick: () => {
+              timeline.timestampFormat = TF.CustomTimezone;
+              customTz.set(tz);
+            },
+          });
+        }),
       ),
     );
   }

--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -48,6 +48,7 @@ export interface AppInitArgs {
   readonly settingsManager: SettingsManagerImpl;
   readonly timestampFormatSetting: Setting<TimestampFormat>;
   readonly durationPrecisionSetting: Setting<DurationPrecision>;
+  readonly timezoneOverrideSetting: Setting<string>;
 }
 
 /**
@@ -101,12 +102,14 @@ export class AppContext {
 
   readonly timestampFormat: Setting<TimestampFormat>;
   readonly durationPrecision: Setting<DurationPrecision>;
+  readonly timezoneOverride: Setting<string>;
 
   // This constructor is invoked only once, when frontend/index.ts invokes
   // AppMainImpl.initialize().
   private constructor(initArgs: AppInitArgs) {
     this.timestampFormat = initArgs.timestampFormatSetting;
     this.durationPrecision = initArgs.durationPrecisionSetting;
+    this.timezoneOverride = initArgs.timezoneOverrideSetting;
     this.settingsManager = initArgs.settingsManager;
     this.initArgs = initArgs;
     this.initialRouteArgs = initArgs.initialRouteArgs;

--- a/ui/src/core/fake_trace_impl.ts
+++ b/ui/src/core/fake_trace_impl.ts
@@ -53,6 +53,13 @@ export function initializeAppImplForTesting(): AppImpl {
         defaultValue: DurationPrecision.Full,
         schema: z.nativeEnum(DurationPrecision),
       }),
+      timezoneOverrideSetting: settingsManager.register({
+        id: 'timezoneOverride',
+        name: 'Timezone Override',
+        description: 'What timezone to use for displaying timestamps.',
+        schema: z.enum(['dummy']),
+        defaultValue: 'dummy',
+      }),
     });
   }
   return AppImpl.instance;

--- a/ui/src/core/timeline.ts
+++ b/ui/src/core/timeline.ts
@@ -87,7 +87,7 @@ export class TimelineImpl implements Timeline {
     private readonly traceInfo: TraceInfo,
     private readonly _timestampFormat: Setting<TimestampFormat>,
     private readonly _durationPrecision: Setting<DurationPrecision>,
-    private readonly _timezoneOverride: Setting<string>,
+    readonly timezoneOverride: Setting<string>,
   ) {
     this._visibleWindow = HighPrecisionTimeSpan.fromTime(
       traceInfo.start,
@@ -209,7 +209,7 @@ export class TimelineImpl implements Timeline {
         return getTraceMidnightInTimezone(
           this.traceInfo.start,
           this.traceInfo.unixOffset,
-          timezoneOffsetMap[this._timezoneOverride.get()],
+          timezoneOffsetMap[this.timezoneOverride.get()],
         );
       case TimestampFormat.TraceTz:
         return getTraceMidnightInTimezone(
@@ -244,7 +244,7 @@ export class TimelineImpl implements Timeline {
   }
 
   get customTimezoneOffset(): number {
-    return timezoneOffsetMap[this._timezoneOverride.get()];
+    return timezoneOffsetMap[this.timezoneOverride.get()];
   }
 }
 

--- a/ui/src/core/timeline.ts
+++ b/ui/src/core/timeline.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {assertUnreachable} from '../base/logging';
-import {Time, time, TimeSpan} from '../base/time';
+import {Time, time, TimeSpan, timezoneOffsetMap} from '../base/time';
 import {HighPrecisionTimeSpan} from '../base/high_precision_time_span';
 import {raf} from './raf_scheduler';
 import {HighPrecisionTime} from '../base/high_precision_time';
@@ -87,6 +87,7 @@ export class TimelineImpl implements Timeline {
     private readonly traceInfo: TraceInfo,
     private readonly _timestampFormat: Setting<TimestampFormat>,
     private readonly _durationPrecision: Setting<DurationPrecision>,
+    private readonly _timezoneOverride: Setting<string>,
   ) {
     this._visibleWindow = HighPrecisionTimeSpan.fromTime(
       traceInfo.start,
@@ -204,6 +205,12 @@ export class TimelineImpl implements Timeline {
           this.traceInfo.unixOffset,
           0, // UTC
         );
+      case TimestampFormat.CustomTimezone:
+        return getTraceMidnightInTimezone(
+          this.traceInfo.start,
+          this.traceInfo.unixOffset,
+          timezoneOffsetMap[this._timezoneOverride.get()],
+        );
       case TimestampFormat.TraceTz:
         return getTraceMidnightInTimezone(
           this.traceInfo.start,
@@ -234,6 +241,10 @@ export class TimelineImpl implements Timeline {
 
   set durationPrecision(precision: DurationPrecision) {
     this._durationPrecision.set(precision);
+  }
+
+  get customTimezoneOffset(): number {
+    return timezoneOffsetMap[this._timezoneOverride.get()];
   }
 }
 

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -101,6 +101,7 @@ export class TraceContext implements Disposable {
       traceInfo,
       this.appCtx.timestampFormat,
       this.appCtx.durationPrecision,
+      this.appCtx.timezoneOverride,
     );
 
     this.scrollHelper = new ScrollHelper(

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -57,6 +57,7 @@ import {
 } from '../core/settings_manager';
 import {LocalStorage} from '../core/local_storage';
 import {DurationPrecision, TimestampFormat} from '../public/timeline';
+import {timezoneOffsetMap} from '../base/time';
 
 const CSP_WS_PERMISSIVE_PORT = featureFlags.register({
   id: 'cspAllowAnyWebsocketPort',
@@ -165,6 +166,14 @@ function main() {
     defaultValue: TimestampFormat.Timecode,
   });
 
+  const timezoneOverrideSetting = settingsManager.register({
+    id: 'timezoneOverride',
+    name: 'Timezone Override',
+    description: 'What timezone to use for displaying timestamps.',
+    schema: z.enum(Object.keys(timezoneOffsetMap) as [string, ...string[]]),
+    defaultValue: '(UTC+00:00) London, Dublin, Lisbon, Casablanca', // UTC by default.
+  });
+
   const durationPrecisionSetting = settingsManager.register({
     id: 'durationPrecision',
     name: 'Duration precision',
@@ -178,6 +187,7 @@ function main() {
     settingsManager,
     timestampFormatSetting,
     durationPrecisionSetting,
+    timezoneOverrideSetting,
   });
 
   // Load the css. The load is asynchronous and the CSS is not ready by the time

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -122,6 +122,7 @@ export class UiMainPerTrace implements m.ClassComponent {
             values: [
               {format: TF.Timecode, name: 'Timecode'},
               {format: TF.UTC, name: 'Realtime (UTC)'},
+              {format: TF.CustomTimezone, name: 'Custom Timezone'},
               {format: TF.TraceTz, name: `Realtime (Trace TZ - ${timeZone})`},
               {format: TF.Seconds, name: 'Seconds'},
               {format: TF.Milliseconds, name: 'Milliseconds'},

--- a/ui/src/frontend/viewer_page/minimap.ts
+++ b/ui/src/frontend/viewer_page/minimap.ts
@@ -268,6 +268,7 @@ function renderTimestamp(
     case TimestampFormat.UTC:
     case TimestampFormat.TraceTz:
     case TimestampFormat.Timecode:
+    case TimestampFormat.CustomTimezone:
       renderTimecode(ctx, time, x, y, minWidth);
       break;
     case TimestampFormat.TraceNs:

--- a/ui/src/frontend/viewer_page/time_axis_panel.ts
+++ b/ui/src/frontend/viewer_page/time_axis_panel.ts
@@ -85,6 +85,20 @@ export class TimeAxisPanel {
           ctx.fillText(originDate, 6, 10);
         }
         break;
+      case TimestampFormat.CustomTimezone:
+        {
+          const originAsDate = Time.toDate(
+            timeAxisOrigin,
+            this.trace.traceInfo.unixOffset,
+          );
+          const tzOffsetMins = this.trace.timeline.customTimezoneOffset;
+          const originDate = formatDate(originAsDate, {
+            tzOffsetMins,
+            printTime: false,
+          });
+          ctx.fillText(originDate, 6, 10);
+        }
+        break;
       case TimestampFormat.TraceTz:
         {
           const originAsDate = Time.toDate(
@@ -144,6 +158,7 @@ export class TimeAxisPanel {
     const fmt = this.trace.timeline.timestampFormat;
     switch (fmt) {
       case TimestampFormat.UTC:
+      case TimestampFormat.CustomTimezone:
       case TimestampFormat.TraceTz:
       case TimestampFormat.Timecode:
         return renderTimecode(ctx, time, x, y, minWidth);

--- a/ui/src/frontend/viewer_page/time_selection_panel.ts
+++ b/ui/src/frontend/viewer_page/time_selection_panel.ts
@@ -264,6 +264,7 @@ export class TimeSelectionPanel {
     const fmt = this.trace.timeline.timestampFormat;
     switch (fmt) {
       case TimestampFormat.UTC:
+      case TimestampFormat.CustomTimezone:
       case TimestampFormat.TraceTz:
       case TimestampFormat.Timecode:
         const THIN_SPACE = '\u2009';

--- a/ui/src/public/timeline.ts
+++ b/ui/src/public/timeline.ts
@@ -23,6 +23,7 @@ export enum TimestampFormat {
   Milliseconds = 'milliseconds',
   Microseconds = 'microseconds',
   UTC = 'utc',
+  CustomTimezone = 'customTimezone',
   TraceTz = 'traceTz',
 }
 
@@ -64,4 +65,5 @@ export interface Timeline {
   // These control how timestamps and durations are formatted throughout the UI
   timestampFormat: TimestampFormat;
   durationPrecision: DurationPrecision;
+  customTimezoneOffset: number;
 }

--- a/ui/src/public/timeline.ts
+++ b/ui/src/public/timeline.ts
@@ -14,6 +14,7 @@
 
 import {HighPrecisionTimeSpan} from '../base/high_precision_time_span';
 import {time} from '../base/time';
+import {Setting} from './settings';
 
 export enum TimestampFormat {
   Timecode = 'timecode',
@@ -66,4 +67,5 @@ export interface Timeline {
   timestampFormat: TimestampFormat;
   durationPrecision: DurationPrecision;
   customTimezoneOffset: number;
+  timezoneOverride: Setting<string>;
 }


### PR DESCRIPTION
This patch adds a new entry in the timestamp format setting + a new setting to control the timezone when this setting is applied.
![image](https://github.com/user-attachments/assets/8441ff2b-adb9-44fa-b1f5-07d065097ac2)

It also includes a new entry in the timestamp dropdown menu, showing the available timezones:
![image](https://github.com/user-attachments/assets/0c6bb013-e583-440c-8063-780a4368b1c3)



