### PR TITLE
Introduce winscope context.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2261,6 +2261,7 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.h",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.h",
+        "src/trace_processor/importers/proto/winscope/winscope_context.h",
         "src/trace_processor/importers/proto/winscope/winscope_module.cc",
         "src/trace_processor/importers/proto/winscope/winscope_module.h",
     ],

--- a/src/trace_processor/importers/proto/winscope/BUILD.gn
+++ b/src/trace_processor/importers/proto/winscope/BUILD.gn
@@ -36,6 +36,7 @@ source_set("full") {
     "viewcapture_args_parser.h",
     "viewcapture_parser.cc",
     "viewcapture_parser.h",
+    "winscope_context.h",
     "winscope_module.cc",
     "winscope_module.h",
   ]

--- a/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
@@ -28,7 +28,6 @@ namespace perfetto::trace_processor {
 
 ProtoLogMessageDecoder::ProtoLogMessageDecoder(TraceProcessorContext* context)
     : context_(context) {}
-ProtoLogMessageDecoder::~ProtoLogMessageDecoder() = default;
 
 std::optional<DecodedMessage> ProtoLogMessageDecoder::Decode(
     uint64_t message_id,

--- a/src/trace_processor/importers/proto/winscope/protolog_message_decoder.h
+++ b/src/trace_processor/importers/proto/winscope/protolog_message_decoder.h
@@ -25,7 +25,6 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/winscope_tables_py.h"
-#include "src/trace_processor/types/destructible.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto::trace_processor {
@@ -57,19 +56,9 @@ struct TrackedMessage {
   std::optional<std::string> location;
 };
 
-class ProtoLogMessageDecoder : public Destructible {
+class ProtoLogMessageDecoder {
  public:
-  explicit ProtoLogMessageDecoder(TraceProcessorContext* context);
-  virtual ~ProtoLogMessageDecoder() override;
-
-  static ProtoLogMessageDecoder* GetOrCreate(TraceProcessorContext* context) {
-    if (!context->protolog_message_decoder) {
-      context->protolog_message_decoder.reset(
-          new ProtoLogMessageDecoder(context));
-    }
-    return static_cast<ProtoLogMessageDecoder*>(
-        context->protolog_message_decoder.get());
-  }
+  explicit ProtoLogMessageDecoder(TraceProcessorContext*);
 
   std::optional<DecodedMessage> Decode(
       uint64_t message_id,

--- a/src/trace_processor/importers/proto/winscope/protolog_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.cc
@@ -42,16 +42,23 @@
 
 namespace perfetto::trace_processor {
 
-ProtoLogParser::ProtoLogParser(TraceProcessorContext* context)
+ProtoLogParser::ProtoLogParser(WinscopeContext* context)
     : context_(context),
-      args_parser_{*context_->descriptor_pool_},
-      log_level_debug_string_id_(context->storage->InternString("DEBUG")),
-      log_level_verbose_string_id_(context->storage->InternString("VERBOSE")),
-      log_level_info_string_id_(context->storage->InternString("INFO")),
-      log_level_warn_string_id_(context->storage->InternString("WARN")),
-      log_level_error_string_id_(context->storage->InternString("ERROR")),
-      log_level_wtf_string_id_(context->storage->InternString("WTF")),
-      log_level_unknown_string_id_(context_->storage->InternString("UNKNOWN")) {
+      args_parser_{*context->trace_processor_context_->descriptor_pool_},
+      log_level_debug_string_id_(
+          context->trace_processor_context_->storage->InternString("DEBUG")),
+      log_level_verbose_string_id_(
+          context->trace_processor_context_->storage->InternString("VERBOSE")),
+      log_level_info_string_id_(
+          context->trace_processor_context_->storage->InternString("INFO")),
+      log_level_warn_string_id_(
+          context->trace_processor_context_->storage->InternString("WARN")),
+      log_level_error_string_id_(
+          context->trace_processor_context_->storage->InternString("ERROR")),
+      log_level_wtf_string_id_(
+          context->trace_processor_context_->storage->InternString("WTF")),
+      log_level_unknown_string_id_(
+          context->trace_processor_context_->storage->InternString("UNKNOWN")) {
 }
 
 void ProtoLogParser::ParseProtoLogMessage(
@@ -75,6 +82,8 @@ void ProtoLogParser::ParseProtoLogMessage(
     boolean_params.emplace_back(*it);
   }
 
+  auto storage = context_->trace_processor_context_->storage;
+
   std::vector<std::string> string_params;
   if (protolog_message.has_str_param_iids()) {
     for (auto it = protolog_message.str_param_iids(); it; ++it) {
@@ -85,7 +94,7 @@ void ProtoLogParser::ParseProtoLogMessage(
         // This shouldn't happen since we already checked the incremental
         // state is valid.
         string_params.emplace_back("<ERROR>");
-        context_->storage->IncrementStats(
+        storage->IncrementStats(
             stats::winscope_protolog_missing_interned_arg_parse_errors);
         continue;
       }
@@ -103,24 +112,21 @@ void ProtoLogParser::ParseProtoLogMessage(
       // This shouldn't happen since we already checked the incremental
       // state is valid.
       string_params.emplace_back("<ERROR>");
-      context_->storage->IncrementStats(
+      storage->IncrementStats(
           stats::winscope_protolog_missing_interned_stacktrace_parse_errors);
     } else {
-      stacktrace = context_->storage->InternString(
+      stacktrace = storage->InternString(
           base::StringView(stacktrace_decoder->str().ToStdString()));
     }
   }
 
-  auto* protolog_table = context_->storage->mutable_protolog_table();
+  auto* protolog_table = storage->mutable_protolog_table();
 
   tables::ProtoLogTable::Row row;
   row.ts = timestamp;
   auto row_id = protolog_table->Insert(row).id;
 
-  auto* protolog_message_decoder =
-      ProtoLogMessageDecoder::GetOrCreate(context_);
-
-  auto decoded_message_opt = protolog_message_decoder->Decode(
+  auto decoded_message_opt = context_->protolog_message_decoder_.Decode(
       protolog_message.message_id(), sint64_params, double_params,
       boolean_params, string_params);
   if (decoded_message_opt.has_value()) {
@@ -134,8 +140,7 @@ void ProtoLogParser::ParseProtoLogMessage(
     // This shouldn't happen since we should have processed all viewer config
     // messages in the tokenization state, and process the protolog messages
     // only in the parsing state.
-    context_->storage->IncrementStats(
-        stats::winscope_protolog_message_decoding_failed);
+    storage->IncrementStats(stats::winscope_protolog_message_decoding_failed);
   }
 }
 
@@ -143,12 +148,12 @@ void ProtoLogParser::ParseAndAddViewerConfigToMessageDecoder(
     protozero::ConstBytes blob) {
   protos::pbzero::ProtoLogViewerConfig::Decoder protolog_viewer_config(blob);
 
-  auto* protolog_message_decoder =
-      ProtoLogMessageDecoder::GetOrCreate(context_);
+  ProtoLogMessageDecoder& protolog_message_decoder =
+      context_->protolog_message_decoder_;
 
   for (auto it = protolog_viewer_config.groups(); it; ++it) {
     protos::pbzero::ProtoLogViewerConfig::Group::Decoder group(*it);
-    protolog_message_decoder->TrackGroup(group.id(), group.tag().ToStdString());
+    protolog_message_decoder.TrackGroup(group.id(), group.tag().ToStdString());
   }
 
   for (auto it = protolog_viewer_config.messages(); it; ++it) {
@@ -160,7 +165,7 @@ void ProtoLogParser::ParseAndAddViewerConfigToMessageDecoder(
       location = message_data.location().ToStdString();
     }
 
-    protolog_message_decoder->TrackMessage(
+    protolog_message_decoder.TrackMessage(
         message_data.message_id(),
         static_cast<ProtoLogLevel>(message_data.level()),
         message_data.group_id(), message_data.message().ToStdString(),
@@ -175,7 +180,8 @@ void ProtoLogParser::PopulateReservedRowWithMessage(
     std::string& message,
     std::optional<StringId> stacktrace,
     std::optional<std::string>& location) {
-  auto* protolog_table = context_->storage->mutable_protolog_table();
+  auto storage = context_->trace_processor_context_->storage;
+  auto* protolog_table = storage->mutable_protolog_table();
   auto row = protolog_table->FindById(table_row_id).value();
 
   StringPool::Id level;
@@ -201,11 +207,10 @@ void ProtoLogParser::PopulateReservedRowWithMessage(
   }
   row.set_level(level);
 
-  auto tag = context_->storage->InternString(base::StringView(group_tag));
+  auto tag = storage->InternString(base::StringView(group_tag));
   row.set_tag(tag);
 
-  auto message_string_id =
-      context_->storage->InternString(base::StringView(message));
+  auto message_string_id = storage->InternString(base::StringView(message));
   row.set_message(message_string_id);
 
   if (stacktrace.has_value()) {
@@ -214,7 +219,7 @@ void ProtoLogParser::PopulateReservedRowWithMessage(
 
   if (location.has_value()) {
     auto location_string_id =
-        context_->storage->InternString(base::StringView(location.value()));
+        storage->InternString(base::StringView(location.value()));
     row.set_location(location_string_id);
   }
 }

--- a/src/trace_processor/importers/proto/winscope/protolog_parser.h
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.h
@@ -23,6 +23,7 @@
 
 #include "protos/perfetto/trace/android/protolog.pbzero.h"
 #include "src/trace_processor/importers/proto/winscope/protolog_message_decoder.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_context.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/util/descriptors.h"
 #include "src/trace_processor/util/proto_to_args_parser.h"
@@ -33,7 +34,7 @@ class TraceProcessorContext;
 
 class ProtoLogParser {
  public:
-  explicit ProtoLogParser(TraceProcessorContext*);
+  explicit ProtoLogParser(WinscopeContext*);
   void ParseProtoLogMessage(PacketSequenceStateGeneration* sequence_state,
                             protozero::ConstBytes,
                             int64_t timestamp);
@@ -47,7 +48,7 @@ class ProtoLogParser {
                                       std::optional<StringId> stacktrace,
                                       std::optional<std::string>& location);
 
-  TraceProcessorContext* const context_;
+  WinscopeContext* context_;
   util::ProtoToArgsParser args_parser_;
 
   const StringId log_level_debug_string_id_;

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc
@@ -16,12 +16,13 @@
 
 #include "src/trace_processor/importers/proto/winscope/shell_transitions_parser.h"
 #include <optional>
-#include "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h"
 
 #include "perfetto/ext/base/base64.h"
 #include "protos/perfetto/trace/android/shell_transition.pbzero.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/proto/args_parser.h"
+#include "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_context.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/winscope_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
@@ -30,28 +31,30 @@
 namespace perfetto {
 namespace trace_processor {
 
-ShellTransitionsParser::ShellTransitionsParser(TraceProcessorContext* context)
-    : context_(context), args_parser_{*context->descriptor_pool_} {}
+ShellTransitionsParser::ShellTransitionsParser(WinscopeContext* context)
+    : context_(context),
+      args_parser_{*context->trace_processor_context_->descriptor_pool_} {}
 
 void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
   protos::pbzero::ShellTransition::Decoder transition(blob);
+
+  auto storage = context_->trace_processor_context_->storage;
 
   // Store the raw proto and its ID in a separate table to handle
   // transitions received over multiple packets for Winscope trace search.
   tables::WindowManagerShellTransitionProtosTable::Row row;
   row.transition_id = transition.id();
-  row.base64_proto_id = context_->storage->mutable_string_pool()
+  row.base64_proto_id = storage->mutable_string_pool()
                             ->InternString(base::StringView(
                                 base::Base64Encode(blob.data, blob.size)))
                             .raw_id();
-  context_->storage->mutable_window_manager_shell_transition_protos_table()
-      ->Insert(row);
+  storage->mutable_window_manager_shell_transition_protos_table()->Insert(row);
 
   // Track transition args as the come in through different packets
-  auto transition_tracker = ShellTransitionsTracker::GetOrCreate(context_);
-
-  auto inserter = transition_tracker->AddArgsTo(transition.id());
-  ArgsParser writer(/*timestamp=*/0, inserter, *context_->storage.get());
+  ShellTransitionsTracker& transition_tracker =
+      context_->shell_transitions_tracker_;
+  auto inserter = transition_tracker.AddArgsTo(transition.id());
+  ArgsParser writer(/*timestamp=*/0, inserter, *storage.get());
   base::Status status = args_parser_.ParseMessage(
       blob,
       *util::winscope_proto_mapping::GetProtoName(
@@ -59,41 +62,40 @@ void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
       nullptr /* parse all fields */, writer);
 
   if (!status.ok()) {
-    context_->storage->IncrementStats(
-        stats::winscope_shell_transitions_parse_errors);
+    storage->IncrementStats(stats::winscope_shell_transitions_parse_errors);
   }
 
   if (transition.has_type()) {
-    transition_tracker->SetTransitionType(transition.id(), transition.type());
+    transition_tracker.SetTransitionType(transition.id(), transition.type());
   }
 
   if (transition.has_dispatch_time_ns()) {
-    transition_tracker->SetDispatchTime(transition.id(),
-                                        transition.dispatch_time_ns());
-    transition_tracker->SetTimestamp(transition.id(),
-                                     transition.dispatch_time_ns());
+    transition_tracker.SetDispatchTime(transition.id(),
+                                       transition.dispatch_time_ns());
+    transition_tracker.SetTimestamp(transition.id(),
+                                    transition.dispatch_time_ns());
   }
 
   if (transition.has_send_time_ns()) {
-    transition_tracker->SetSendTime(transition.id(), transition.send_time_ns());
-    transition_tracker->SetTimestampIfEmpty(transition.id(),
-                                            transition.send_time_ns());
+    transition_tracker.SetSendTime(transition.id(), transition.send_time_ns());
+    transition_tracker.SetTimestampIfEmpty(transition.id(),
+                                           transition.send_time_ns());
   }
 
   if (transition.has_finish_time_ns()) {
     auto finish_time = transition.finish_time_ns();
-    transition_tracker->TrySetDurationFromFinishTime(transition.id(),
-                                                     finish_time);
+    transition_tracker.TrySetDurationFromFinishTime(transition.id(),
+                                                    finish_time);
 
     if (finish_time > 0) {
-      transition_tracker->SetStatus(
+      transition_tracker.SetStatus(
           transition.id(),
-          context_->storage->mutable_string_pool()->InternString("played"));
+          storage->mutable_string_pool()->InternString("played"));
     }
   }
 
   if (transition.has_handler()) {
-    transition_tracker->SetHandler(transition.id(), transition.handler());
+    transition_tracker.SetHandler(transition.id(), transition.handler());
   }
 
   auto shell_aborted = transition.has_shell_abort_time_ns() &&
@@ -102,29 +104,28 @@ void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
       transition.has_wm_abort_time_ns() && transition.wm_abort_time_ns() > 0;
 
   if (shell_aborted || wm_aborted) {
-    transition_tracker->SetStatus(
+    transition_tracker.SetStatus(
         transition.id(),
-        context_->storage->mutable_string_pool()->InternString("aborted"));
+        storage->mutable_string_pool()->InternString("aborted"));
   }
 
   auto merged =
       transition.has_merge_time_ns() && transition.merge_time_ns() > 0;
   if (merged) {
-    transition_tracker->SetStatus(
+    transition_tracker.SetStatus(
         transition.id(),
-        context_->storage->mutable_string_pool()->InternString("merged"));
+        storage->mutable_string_pool()->InternString("merged"));
   }
 
   // set flags id and flags
   if (transition.has_flags()) {
-    transition_tracker->SetFlags(transition.id(), transition.flags());
+    transition_tracker.SetFlags(transition.id(), transition.flags());
   }
 
   // update participants
   if (transition.has_targets()) {
     auto* participants_table =
-        context_->storage
-            ->mutable_window_manager_shell_transition_participants_table();
+        storage->mutable_window_manager_shell_transition_participants_table();
     for (auto it = transition.targets(); it; ++it) {
       tables::WindowManagerShellTransitionParticipantsTable::Row
           participant_row;
@@ -142,9 +143,10 @@ void ShellTransitionsParser::ParseTransition(protozero::ConstBytes blob) {
 }
 
 void ShellTransitionsParser::ParseHandlerMappings(protozero::ConstBytes blob) {
+  auto storage = context_->trace_processor_context_->storage;
+
   auto* shell_handlers_table =
-      context_->storage
-          ->mutable_window_manager_shell_transition_handlers_table();
+      storage->mutable_window_manager_shell_transition_handlers_table();
 
   protos::pbzero::ShellHandlerMappings::Decoder handler_mappings(blob);
   for (auto it = handler_mappings.mapping(); it; ++it) {
@@ -152,9 +154,9 @@ void ShellTransitionsParser::ParseHandlerMappings(protozero::ConstBytes blob) {
 
     tables::WindowManagerShellTransitionHandlersTable::Row row;
     row.handler_id = mapping.id();
-    row.handler_name = context_->storage->InternString(
-        base::StringView(mapping.name().ToStdString()));
-    row.base64_proto_id = context_->storage->mutable_string_pool()
+    row.handler_name =
+        storage->InternString(base::StringView(mapping.name().ToStdString()));
+    row.base64_proto_id = storage->mutable_string_pool()
                               ->InternString(base::StringView(
                                   base::Base64Encode(blob.data, blob.size)))
                               .raw_id();

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_parser.h
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_parser.h
@@ -17,6 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_SHELL_TRANSITIONS_PARSER_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_SHELL_TRANSITIONS_PARSER_H_
 
+#include "src/trace_processor/importers/proto/winscope/winscope_context.h"
 #include "src/trace_processor/util/descriptors.h"
 #include "src/trace_processor/util/proto_to_args_parser.h"
 
@@ -28,12 +29,12 @@ class TraceProcessorContext;
 
 class ShellTransitionsParser {
  public:
-  explicit ShellTransitionsParser(TraceProcessorContext*);
+  explicit ShellTransitionsParser(WinscopeContext*);
   void ParseTransition(protozero::ConstBytes);
   void ParseHandlerMappings(protozero::ConstBytes);
 
  private:
-  TraceProcessorContext* const context_;
+  WinscopeContext* context_;
   util::ProtoToArgsParser args_parser_;
 };
 }  // namespace trace_processor

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.cc
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.cc
@@ -24,8 +24,6 @@ namespace trace_processor {
 ShellTransitionsTracker::ShellTransitionsTracker(TraceProcessorContext* context)
     : context_(context) {}
 
-ShellTransitionsTracker::~ShellTransitionsTracker() = default;
-
 ArgsTracker::BoundInserter ShellTransitionsTracker::AddArgsTo(
     int32_t transition_id) {
   auto* transition_info = GetOrInsertTransition(transition_id);

--- a/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
@@ -29,19 +29,9 @@ namespace perfetto {
 namespace trace_processor {
 
 // Tracks information in the transition table.
-class ShellTransitionsTracker : public Destructible {
+class ShellTransitionsTracker {
  public:
   explicit ShellTransitionsTracker(TraceProcessorContext*);
-  virtual ~ShellTransitionsTracker() override;
-
-  static ShellTransitionsTracker* GetOrCreate(TraceProcessorContext* context) {
-    if (!context->shell_transitions_tracker) {
-      context->shell_transitions_tracker.reset(
-          new ShellTransitionsTracker(context));
-    }
-    return static_cast<ShellTransitionsTracker*>(
-        context->shell_transitions_tracker.get());
-  }
 
   ArgsTracker::BoundInserter AddArgsTo(int32_t transition_id);
 

--- a/src/trace_processor/importers/proto/winscope/winscope_context.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_context.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_CONTEXT_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_CONTEXT_H_
+
+#include "src/trace_processor/importers/proto/winscope/protolog_message_decoder.h"
+#include "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto {
+namespace trace_processor {
+
+class WinscopeContext {
+ public:
+  explicit WinscopeContext(TraceProcessorContext* context)
+      : trace_processor_context_(context),
+        shell_transitions_tracker_(context),
+        protolog_message_decoder_(context) {}
+
+  TraceProcessorContext* trace_processor_context_;
+  ShellTransitionsTracker shell_transitions_tracker_;
+  ProtoLogMessageDecoder protolog_message_decoder_;
+};
+
+}  // namespace trace_processor
+}  // namespace perfetto
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_CONTEXT_H_

--- a/src/trace_processor/importers/proto/winscope/winscope_module.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_module.h
@@ -18,18 +18,16 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_MODULE_H_
 
 #include <cstdint>
-#include "perfetto/base/build_config.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/winscope/android_input_event_parser.h"
 #include "src/trace_processor/importers/proto/winscope/protolog_parser.h"
 #include "src/trace_processor/importers/proto/winscope/shell_transitions_parser.h"
-#include "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h"
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.h"
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.h"
 #include "src/trace_processor/importers/proto/winscope/viewcapture_parser.h"
-
-#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_context.h"
 
 namespace perfetto {
 namespace trace_processor {
@@ -64,7 +62,7 @@ class WinscopeModule : public ProtoImporterModule {
                                    protozero::ConstBytes blob);
   void ParseWindowManagerData(int64_t timestamp, protozero::ConstBytes blob);
 
-  TraceProcessorContext* const context_;
+  WinscopeContext context_;
   util::ProtoToArgsParser args_parser_;
 
   SurfaceFlingerLayersParser surfaceflinger_layers_parser_;

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -168,11 +168,6 @@ class TraceProcessorContext {
   std::unique_ptr<Destructible> etm_tracker;                            // EtmTracker
   std::unique_ptr<Destructible> elf_tracker;                            // ElfTracker
   std::unique_ptr<Destructible> file_tracker;                           // FileTracker
-
-#if PERFETTO_BUILDFLAG(PERFETTO_ENABLE_WINSCOPE)
-  std::unique_ptr<Destructible> shell_transitions_tracker;              // ShellTransitionsTracker
-  std::unique_ptr<Destructible> protolog_message_decoder;               // ProtoLogMessageDecoder
-#endif
   // clang-format on
 
   std::unique_ptr<ProtoTraceParser> proto_trace_parser;


### PR DESCRIPTION
For pointers to winscope-specific trackers that were previously in TraceProcessorContext.

In a separate WinscopeContext class to prevent circular dependencies with WinscopeModule and the constituent parsers.

Bug: 411363817
Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell
