### PR TITLE
PinAndroidPerfMetrics: Add support to pin notifications_blocking metrics

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
@@ -93,3 +93,19 @@ SELECT
 FROM android_binder_txns AS tx
 WHERE
   NOT aidl_name IS NULL AND is_sync = 1;
+
+CREATE PERFETTO FUNCTION _is_relevant_notifications_blocking_call(
+    name STRING,
+    dur LONG
+)
+RETURNS BOOL AS
+SELECT
+  $name = 'NotificationStackScrollLayout#onMeasure'
+  AND $dur > 0
+  AND (
+    $name GLOB 'NotificationStackScrollLayout#onMeasure'
+    OR $name GLOB 'NotificationToplineView#onMeasure'
+    OR $name GLOB 'ExpNotRow#*'
+    OR $name GLOB 'NotificationShadeWindowView#onMeasure'
+    OR $name GLOB 'ImageFloatingTextView#onMeasure'
+  );

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/handlerRegistry.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/handlerRegistry.ts
@@ -14,6 +14,7 @@
 
 import {MetricHandler} from './metricUtils';
 import {pinBlockingCallHandlerInstance} from './pinBlockingCall';
+import {pinNotificationsBlockingCallHandlerInstance} from './pinNotificationsBlockingCall';
 import {pinCujScopedJankInstance} from './pinCujScoped';
 import {pinFullTraceJankInstance} from './fullTraceJankMetricHandler';
 import {pinCujInstance} from './pinCujMetricHandler';
@@ -23,5 +24,6 @@ export const METRIC_HANDLERS: MetricHandler[] = [
   pinCujInstance,
   pinCujScopedJankInstance,
   pinBlockingCallHandlerInstance,
+  pinNotificationsBlockingCallHandlerInstance,
   pinFullTraceJankInstance,
 ];

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/metricUtils.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/metricUtils.ts
@@ -60,6 +60,19 @@ export interface BlockingCallMetricData {
   aggregation: string;
 }
 
+/**
+ * Represents data for a Notifications Blocking Call metric
+ * Eg.- perfetto_android_notifications_blocking_call-blocking_calls-name-NotificationStackScrollLayout#onMeasure-cnt
+ * Eg.- perfetto_android_notifications_blocking_call-blocking_calls-name-ExpNotRow#onLayout(nostyle)-total_dur_ns
+ */
+export interface NotificationsBlockingCallMetricData {
+  /** Notification name (e.g., NotificationStackScrollLayout) */
+  notificationName: string;
+
+  /** aggregation type (e.g., total_dur_ms) */
+  aggregation: string;
+}
+
 /** Represents a cuj to be pinned. */
 export interface CujMetricData {
   cujName: string;
@@ -70,6 +83,7 @@ export type MetricData =
   | FullTraceMetricData
   | CujScopedMetricData
   | BlockingCallMetricData
+  | NotificationsBlockingCallMetricData
   | CujMetricData;
 
 // Common JankType for cujScoped and fullTrace metrics

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinNotificationsBlockingCall.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinNotificationsBlockingCall.ts
@@ -1,0 +1,96 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  NotificationsBlockingCallMetricData,
+  MetricHandler,
+} from './metricUtils';
+import {Trace} from '../../../public/trace';
+import {addDebugSliceTrack} from '../../../components/tracks/debug_tracks';
+
+class BlockingCallMetricHandler implements MetricHandler {
+  /**
+   * Matches metric key for notifications blocking call metrics & return parsed data if successful.
+   *
+   * @param {string} metricKey The metric key to match.
+   * @returns {NotificationsBlockingCallMetricData | undefined} Parsed data or undefined if no match.
+   */
+  public match(
+    metricKey: string,
+  ): NotificationsBlockingCallMetricData | undefined {
+    const matcher =
+      /perfetto_android_notifications_blocking_call-blocking_calls-name-(?<blockingCallName>([^\-]*))-(?<aggregation>.*)/;
+    const match = matcher.exec(metricKey);
+    if (!match?.groups) {
+      return undefined;
+    }
+    const metricData: NotificationsBlockingCallMetricData = {
+      notificationName: match.groups.blockingCallName,
+      aggregation: match.groups.aggregation,
+    };
+    return metricData;
+  }
+
+  /**
+   * Adds the debug tracks for Notifications Blocking Call metrics
+   *
+   * @param {NotificationsBlockingCallMetricData} metricData Parsed metric data
+   * @param {Trace} ctx PluginContextTrace for trace related properties and methods
+   * @returns {void} Adds one track for Notifications Blocking Call slice of metric
+   */
+  public addMetricTrack(
+    metricData: NotificationsBlockingCallMetricData,
+    ctx: Trace,
+  ): void {
+    const config = this.notificationsBlockingCallTrackConfig(metricData);
+    addDebugSliceTrack({trace: ctx, ...config});
+  }
+
+  private notificationsBlockingCallTrackConfig(
+    metricData: NotificationsBlockingCallMetricData,
+  ) {
+    const notificationName = metricData.notificationName;
+
+    // Avoid use of android_sysui_notifications_blocking_calls_metric.sql, in favour of stdlib migration
+    // The query below is derived from android_sysui_notifications_blocking_calls_metric.sql
+    // See table "android_sysui_notifications_blocking_calls"
+    const notificationsBlockingCallsQuery = `
+SELECT
+    s.name name,
+    s.ts ts,
+    s.dur dur
+FROM slice s
+    JOIN thread_track ON s.track_id = thread_track.id
+    JOIN thread USING (utid)
+WHERE
+    thread.is_main_thread AND
+    _is_relevant_notifications_blocking_call(s.name, s.dur)
+GROUP BY s.name
+  `;
+
+    const trackName = notificationName + ' blocking calls';
+    return {
+      data: {
+        sqlSource: notificationsBlockingCallsQuery,
+        columns: ['name', 'ts', 'dur'],
+      },
+      columns: {ts: 'ts', dur: 'dur', name: 'name'},
+      argColumns: ['name', 'ts', 'dur'],
+      title: trackName,
+    };
+  }
+}
+
+export const pinNotificationsBlockingCallHandlerInstance =
+  new BlockingCallMetricHandler();

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinNotificationsBlockingCall_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinNotificationsBlockingCall_unittest.ts
@@ -1,0 +1,89 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {NotificationsBlockingCallMetricData} from './metricUtils';
+import {pinNotificationsBlockingCallHandlerInstance} from './pinNotificationsBlockingCall';
+
+const validMetricsTest: {
+  inputMetric: string;
+  expectedOutput: NotificationsBlockingCallMetricData;
+}[] = [
+  {
+    inputMetric:
+      'perfetto_android_notifications_blocking_call-blocking_calls-name-NotificationStackScrollLayout#onMeasure-total_dur_ms-mean',
+    expectedOutput: {
+      notificationName: 'NotificationStackScrollLayout#onMeasure',
+      aggregation: 'total_dur_ms-mean',
+    },
+  },
+  {
+    inputMetric:
+      'perfetto_android_notifications_blocking_call-blocking_calls-name-NotificationToplineView#onMeasure-cnt',
+    expectedOutput: {
+      notificationName: 'NotificationToplineView#onMeasure',
+      aggregation: 'cnt',
+    },
+  },
+  {
+    inputMetric:
+      'perfetto_android_notifications_blocking_call-blocking_calls-name-ExpNotRow#onNotifUpdated (leaf)-total_dur_ns',
+    expectedOutput: {
+      notificationName: 'ExpNotRow#onNotifUpdated (leaf)',
+      aggregation: 'total_dur_ns',
+    },
+  },
+  {
+    inputMetric:
+      'perfetto_android_notifications_blocking_call-blocking_calls-name-NotificationShadeWindowView#onMeasure-total_dur_ns-mean',
+    expectedOutput: {
+      notificationName: 'NotificationShadeWindowView#onMeasure',
+      aggregation: 'total_dur_ns-mean',
+    },
+  },
+  {
+    inputMetric:
+      'perfetto_android_notifications_blocking_call-blocking_calls-name-ImageFloatingTextView#onMeasure-total_dur_ns-mean',
+    expectedOutput: {
+      notificationName: 'ImageFloatingTextView#onMeasure',
+      aggregation: 'total_dur_ns-mean',
+    },
+  },
+];
+
+const invalidMetricsTest: string[] = [
+  'perfetto_android_blocking_call-cuj-name-com.google.android.apps.nexuslauncher-name-TASKBAR_EXPAND-blocking_calls-name-animation-total_dur_ms-mean',
+  'perfetto_cuj_launcher-RECENTS_SCROLLING-counter_metrics-missed_sf_frames-mean',
+];
+
+const tester = pinNotificationsBlockingCallHandlerInstance;
+
+describe('testMetricParser_match', () => {
+  it('parses metrics and returns expected data', () => {
+    for (const testCase of validMetricsTest) {
+      const parsedData = tester.match(testCase.inputMetric);
+      // without this explicit check, undefined also passes the test
+      expect(parsedData).toBeDefined();
+      if (parsedData) {
+        expect(parsedData).toEqual(testCase.expectedOutput);
+      }
+    }
+  });
+  it('parses metrics and returns undefined', () => {
+    for (const testCase of invalidMetricsTest) {
+      const parsedData = tester.match(testCase);
+
+      expect(parsedData).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
- Metrics prefixed `perfetto_android_notifications_blocking_call-blocking_calls-name-` are now handled by `dev.perfetto.PinAndroidPerfMetrics` plugin.
- This is already tracked and visualized by other tools. This CL allows perfetto to pin such metrics in the timeline.
- Other tools build the table in `android_sysui_notifications_blocking_calls_metric.sql` and use the value from the table 'android_sysui_notifications_blocking_calls'
- This CL however does not make use of it, to prevent use of `RUN_METRIC` in light of stdlib migration.

Bug: 352266918
Test: `./ui/run-unittests`
Test: Manual - load traces from b/379219510, pin metric "perfetto_android_notifications_blocking_call-blocking_calls-name-ExpNotRow#onNotifUpdated (leaf)-total_dur_ns-mean"
Change-Id: I9827d5726c9ff5133ad9295ce0343125591f9399
