### PR TITLE
tp: Optimize ClockTracker by caching the FindPath queue

### DIFF
--- a/src/trace_processor/importers/common/clock_tracker.cc
+++ b/src/trace_processor/importers/common/clock_tracker.cc
@@ -202,12 +202,11 @@ ClockTracker::ClockPath ClockTracker::FindPath(ClockId src, ClockId target) {
   // the full path to reach that node.
   // We assume the graph is acyclic, if it isn't the ClockPath::kMaxLen will
   // stop the search anyways.
-  std::queue<ClockPath> queue;
-  queue.emplace(src);
+  queue_find_path_cache_.emplace_back(src);
 
-  while (!queue.empty()) {
-    ClockPath cur_path = queue.front();
-    queue.pop();
+  while (!queue_find_path_cache_.empty()) {
+    ClockPath cur_path = queue_find_path_cache_.front();
+    queue_find_path_cache_.pop_front();
 
     const ClockId cur_clock_id = cur_path.last;
     if (cur_clock_id == target)
@@ -223,7 +222,8 @@ ClockTracker::ClockPath ClockTracker::FindPath(ClockId src, ClockId target) {
          it != graph_.end() && std::get<0>(*it) == cur_clock_id; ++it) {
       ClockId next_clock_id = std::get<1>(*it);
       SnapshotHash hash = std::get<2>(*it);
-      queue.push(ClockPath(cur_path, next_clock_id, hash));
+      queue_find_path_cache_.emplace_back(
+          ClockPath(cur_path, next_clock_id, hash));
     }
   }
   return ClockPath();  // invalid path.

--- a/src/trace_processor/importers/common/clock_tracker.h
+++ b/src/trace_processor/importers/common/clock_tracker.h
@@ -22,13 +22,16 @@
 #include <array>
 #include <cinttypes>
 #include <cstdint>
+#include <list>
 #include <map>
 #include <optional>
+#include <queue>
 #include <random>
 #include <set>
 #include <vector>
 
 #include "perfetto/base/logging.h"
+#include "perfetto/ext/base/circular_queue.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
@@ -388,6 +391,10 @@ class ClockTracker {
   bool trace_time_clock_id_used_for_conversion_ = false;
   base::FlatHashMap<ClockId, int64_t> clock_offsets_;
   std::optional<int64_t> timezone_offset_;
+
+  // A queue of paths to explore. Stored as a field to reduce allocations
+  // on every call to FindPath().
+  std::deque<ClockPath> queue_find_path_cache_;
 };
 
 }  // namespace trace_processor


### PR DESCRIPTION
Cached the queue in `FindPath` as a field in `ClockTracker` to avoid
reallocating it on every call. This improves performance by reducing
unnecessary allocations.
