### PR TITLE
tp: Make DebugAnnotationParser iterative

### DIFF
--- a/src/trace_processor/util/debug_annotation_parser.cc
+++ b/src/trace_processor/util/debug_annotation_parser.cc
@@ -19,24 +19,25 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <string>
 
-#include "perfetto/base/build_config.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/small_vector.h"
+#include "perfetto/ext/base/status_macros.h"
 #include "perfetto/protozero/field.h"
 #include "perfetto/public/compiler.h"
-#include "protos/perfetto/trace/interned_data/interned_data.pbzero.h"
-
-#include "protos/perfetto/trace/profiling/profile_common.pbzero.h"
-#include "protos/perfetto/trace/track_event/debug_annotation.pbzero.h"
 #include "src/trace_processor/util/proto_to_args_parser.h"
+
+#include "protos/perfetto/trace/interned_data/interned_data.pbzero.h"
+#include "protos/perfetto/trace/profiling/profile_common.pbzero.h"
 
 namespace perfetto::trace_processor::util {
 
 namespace {
 
-std::string SanitizeDebugAnnotationName(const std::string& raw_name) {
-  std::string result = raw_name;
+std::string SanitizeDebugAnnotationName(std::string_view raw_name) {
+  std::string result(raw_name);
   std::replace(result.begin(), result.end(), '.', '_');
   std::replace(result.begin(), result.end(), '[', '_');
   std::replace(result.begin(), result.end(), ']', '_');
@@ -59,191 +60,320 @@ base::Status DebugAnnotationParser::ParseDebugAnnotationName(
     if (!decoder)
       return base::ErrStatus("Debug annotation with invalid name_iid");
 
-    result = SanitizeDebugAnnotationName(decoder->name().ToStdString());
+    result = SanitizeDebugAnnotationName(decoder->name().ToStdStringView());
   } else if (annotation.has_name()) {
-    result = SanitizeDebugAnnotationName(annotation.name().ToStdString());
+    result = SanitizeDebugAnnotationName(annotation.name().ToStdStringView());
   } else {
     return base::ErrStatus("Debug annotation without name");
   }
   return base::OkStatus();
 }
 
-DebugAnnotationParser::ParseResult
-DebugAnnotationParser::ParseDebugAnnotationValue(
-    protos::pbzero::DebugAnnotation::Decoder& annotation,
-    ProtoToArgsParser::Delegate& delegate,
-    const ProtoToArgsParser::Key& context_name) {
-  if (annotation.has_bool_value()) {
-    delegate.AddBoolean(context_name, annotation.bool_value());
-  } else if (annotation.has_uint_value()) {
-    delegate.AddUnsignedInteger(context_name, annotation.uint_value());
-  } else if (annotation.has_int_value()) {
-    delegate.AddInteger(context_name, annotation.int_value());
-  } else if (annotation.has_double_value()) {
-    delegate.AddDouble(context_name, annotation.double_value());
-  } else if (annotation.has_string_value()) {
-    delegate.AddString(context_name, annotation.string_value());
-  } else if (annotation.has_string_value_iid()) {
-    auto* decoder = delegate.GetInternedMessage(
-        protos::pbzero::InternedData::kDebugAnnotationStringValues,
-        annotation.string_value_iid());
-    if (!decoder) {
-      return {base::ErrStatus("Debug annotation with invalid string_value_iid"),
-              false};
-    }
-    delegate.AddString(context_name, decoder->str().ToStdString());
-  } else if (annotation.has_pointer_value()) {
-    delegate.AddPointer(context_name, annotation.pointer_value());
-  } else if (annotation.has_dict_entries()) {
-    bool added_entry = false;
-    for (auto it = annotation.dict_entries(); it; ++it) {
-      protos::pbzero::DebugAnnotation::Decoder key_value(*it);
-      std::string key;
-      base::Status key_parse_result =
-          ParseDebugAnnotationName(key_value, delegate, key);
-      if (!key_parse_result.ok())
-        return {key_parse_result, added_entry};
-
-      auto nested_key = proto_to_args_parser_.EnterDictionary(key);
-      ParseResult value_parse_result =
-          ParseDebugAnnotationValue(key_value, delegate, nested_key.key());
-      added_entry |= value_parse_result.added_entry;
-      if (!value_parse_result.status.ok())
-        return {value_parse_result.status, added_entry};
-    }
-  } else if (annotation.has_array_values()) {
-    size_t index = delegate.GetArrayEntryIndex(context_name.key);
-    bool added_entry = false;
-    for (auto it = annotation.array_values(); it; ++it) {
-      std::string array_key = context_name.key;
-      protos::pbzero::DebugAnnotation::Decoder value(*it);
-
-      auto nested_key = proto_to_args_parser_.EnterArray(index);
-      ParseResult value_parse_result =
-          ParseDebugAnnotationValue(value, delegate, nested_key.key());
-
-      if (value_parse_result.added_entry) {
-        index = delegate.IncrementArrayEntryIndex(array_key);
-        added_entry = true;
-      }
-      if (!value_parse_result.status.ok())
-        return {value_parse_result.status, added_entry};
-    }
-  } else if (annotation.has_legacy_json_value()) {
-    bool added_entry =
-        delegate.AddJson(context_name, annotation.legacy_json_value());
-    return {base::ErrStatus("Failed to parse JSON"), added_entry};
-  } else if (annotation.has_nested_value()) {
-    return ParseNestedValueArgs(annotation.nested_value(), context_name,
-                                delegate);
-  } else if (annotation.has_proto_value()) {
-    std::string type_name;
-    if (annotation.has_proto_type_name()) {
-      type_name = annotation.proto_type_name().ToStdString();
-    } else if (annotation.has_proto_type_name_iid()) {
-      auto* interned_name = delegate.GetInternedMessage(
-          protos::pbzero::InternedData::kDebugAnnotationValueTypeNames,
-          annotation.proto_type_name_iid());
-      if (!interned_name)
-        return {base::ErrStatus("Interned proto type name not found"), false};
-      type_name = interned_name->name().ToStdString();
-    } else {
-      return {base::ErrStatus("DebugAnnotation has proto_value, but doesn't "
-                              "have proto type name"),
-              false};
-    }
-    return {proto_to_args_parser_.ParseMessage(annotation.proto_value(),
-                                               type_name, nullptr, delegate),
-            true};
-  } else {
-    return {base::OkStatus(), /*added_entry=*/false};
-  }
-
-  return {base::OkStatus(), /*added_entry=*/true};
-}
-
 // static
 base::Status DebugAnnotationParser::Parse(
     protozero::ConstBytes data,
     ProtoToArgsParser::Delegate& delegate) {
-  protos::pbzero::DebugAnnotation::Decoder annotation(data);
+  // This function parses a tree of debug annotations iteratively using a work
+  // stack. A recursive approach is not used to avoid stack overflows when
+  // parsing deeply nested annotations.
+  struct WorkItem {
+    // The decoder for the current annotation node.
+    protos::pbzero::DebugAnnotation::Decoder decoder;
+    // The key context for the current annotation node.
+    ProtoToArgsParser::ScopedNestedKeyContext key;
+    // The index of the current array entry.
+    std::optional<size_t> array_index = {};
+    // The number of entries in the current array or dictionary.
+    uint32_t nested_count = 0;
+    // The current position in the array or dictionary.
+    uint32_t nested_current = 0;
+    // Whether an entry has been added to the delegate.
+    bool added_entry = false;
+    // Whether this is the first pass through the dictionary or array.
+    bool first_pass_done = false;
+  };
 
-  std::string name;
-  base::Status name_parse_result =
-      ParseDebugAnnotationName(annotation, delegate, name);
-  if (!name_parse_result.ok())
-    return name_parse_result;
+  // The work stack for the iterative parsing.
+  base::SmallVector<WorkItem, 4> work_stack;
+  base::SmallVector<protozero::ConstBytes, 64> nested_storage;
+  {
+    protos::pbzero::DebugAnnotation::Decoder root(data);
+    std::string name;
+    RETURN_IF_ERROR(ParseDebugAnnotationName(root, delegate, name));
+    work_stack.emplace_back(
+        WorkItem{std::move(root), proto_to_args_parser_.EnterDictionary(name)});
+  }
+  while (!work_stack.empty()) {
+    WorkItem& item = work_stack.back();
 
-  auto context = proto_to_args_parser_.EnterDictionary(name);
-
-  return ParseDebugAnnotationValue(annotation, delegate, context.key()).status;
+    // Dictionaries are parsed by adding each entry to the work stack.
+    if (item.decoder.has_dict_entries()) {
+      // First time seeing this dictionary, add them to the nested storage.
+      if (!item.first_pass_done) {
+        item.nested_current = static_cast<uint32_t>(nested_storage.size());
+        uint32_t count = 0;
+        for (auto res = item.decoder.dict_entries(); res; ++res, ++count) {
+          nested_storage.emplace_back(*res);
+        }
+        item.nested_count = count;
+        item.first_pass_done = true;
+      }
+      // If there are remaining entries, pop one and add it to the work stack.
+      if (item.nested_current < nested_storage.size()) {
+        protos::pbzero::DebugAnnotation::Decoder key_value(
+            nested_storage[item.nested_current++]);
+        std::string key;
+        RETURN_IF_ERROR(ParseDebugAnnotationName(key_value, delegate, key));
+        work_stack.emplace_back(WorkItem{
+            std::move(key_value),
+            proto_to_args_parser_.EnterDictionary(key),
+        });
+        continue;
+      }
+      // If we are here, we have processed all entries in the dictionary.
+      for (uint32_t i = 0; i < item.nested_count; ++i) {
+        nested_storage.pop_back();
+      }
+      item.added_entry = true;
+    } else if (item.decoder.has_array_values()) {
+      // First time seeing this array, add them to the nested storage.
+      if (!item.first_pass_done) {
+        item.nested_current = static_cast<uint32_t>(nested_storage.size());
+        uint32_t count = 0;
+        for (auto res = item.decoder.array_values(); res; ++res, ++count) {
+          nested_storage.emplace_back(*res);
+        }
+        item.nested_count = count;
+        item.array_index = delegate.GetArrayEntryIndex(item.key.key().key);
+        item.first_pass_done = true;
+      }
+      // If there are remaining array, pop one and add it to the work stack.
+      if (item.nested_current < nested_storage.size()) {
+        work_stack.emplace_back(WorkItem{
+            protos::pbzero::DebugAnnotation::Decoder(
+                nested_storage[item.nested_current++]),
+            proto_to_args_parser_.EnterArray(*item.array_index),
+        });
+        continue;
+      }
+      // If we are here, we have processed all entries in the dictionary.
+      for (uint32_t i = 0; i < item.nested_count; ++i) {
+        nested_storage.pop_back();
+      }
+    } else if (item.decoder.has_bool_value()) {
+      delegate.AddBoolean(item.key.key(), item.decoder.bool_value());
+      item.added_entry = true;
+    } else if (item.decoder.has_uint_value()) {
+      delegate.AddUnsignedInteger(item.key.key(), item.decoder.uint_value());
+      item.added_entry = true;
+    } else if (item.decoder.has_int_value()) {
+      delegate.AddInteger(item.key.key(), item.decoder.int_value());
+      item.added_entry = true;
+    } else if (item.decoder.has_double_value()) {
+      delegate.AddDouble(item.key.key(), item.decoder.double_value());
+      item.added_entry = true;
+    } else if (item.decoder.has_string_value()) {
+      delegate.AddString(item.key.key(), item.decoder.string_value());
+      item.added_entry = true;
+    } else if (item.decoder.has_string_value_iid()) {
+      auto* decoder = delegate.GetInternedMessage(
+          protos::pbzero::InternedData::kDebugAnnotationStringValues,
+          item.decoder.string_value_iid());
+      if (!decoder) {
+        return base::ErrStatus(
+            "Debug annotation with invalid string_value_iid");
+      }
+      delegate.AddString(item.key.key(), decoder->str().ToStdString());
+      item.added_entry = true;
+    } else if (item.decoder.has_pointer_value()) {
+      delegate.AddPointer(item.key.key(), item.decoder.pointer_value());
+      item.added_entry = true;
+    } else if (item.decoder.has_legacy_json_value()) {
+      delegate.AddJson(item.key.key(), item.decoder.legacy_json_value());
+      item.added_entry = true;
+    } else if (item.decoder.has_proto_value()) {
+      std::string type_name;
+      if (item.decoder.has_proto_type_name()) {
+        type_name = item.decoder.proto_type_name().ToStdString();
+      } else if (item.decoder.has_proto_type_name_iid()) {
+        auto* interned_name = delegate.GetInternedMessage(
+            protos::pbzero::InternedData::kDebugAnnotationValueTypeNames,
+            item.decoder.proto_type_name_iid());
+        if (!interned_name) {
+          return base::ErrStatus("Interned proto type name not found");
+        }
+        type_name = interned_name->name().ToStdString();
+      } else {
+        return base::ErrStatus(
+            "DebugAnnotation has proto_value, but doesn't "
+            "have proto type name");
+      }
+      RETURN_IF_ERROR(proto_to_args_parser_.ParseMessage(
+          item.decoder.proto_value(), type_name, nullptr, delegate));
+      item.added_entry = true;
+    } else if (item.decoder.has_nested_value()) {
+      auto res = ParseNestedValueArgs(item.decoder.nested_value(),
+                                      item.key.key(), delegate);
+      RETURN_IF_ERROR(res.status);
+      item.added_entry = res.added_entry;
+    }
+    // We are done with this item, pop it from the stack.
+    bool added_entry = item.added_entry;
+    work_stack.pop_back();
+    if (!work_stack.empty()) {
+      auto& back = work_stack.back();
+      if (added_entry && back.array_index) {
+        back.array_index =
+            delegate.IncrementArrayEntryIndex(back.key.key().key);
+      }
+      back.added_entry = back.added_entry || added_entry;
+    }
+  }
+  return base::OkStatus();
 }
 
 DebugAnnotationParser::ParseResult DebugAnnotationParser::ParseNestedValueArgs(
     protozero::ConstBytes nested_value,
     const ProtoToArgsParser::Key& context_name,
     ProtoToArgsParser::Delegate& delegate) {
-  protos::pbzero::DebugAnnotation::NestedValue::Decoder value(nested_value);
-  switch (value.nested_type()) {
-    case protos::pbzero::DebugAnnotation::NestedValue::UNSPECIFIED: {
-      // Leaf value.
-      if (value.has_bool_value()) {
-        delegate.AddBoolean(context_name, value.bool_value());
-        return {base::OkStatus(), true};
-      }
-      if (value.has_int_value()) {
-        delegate.AddInteger(context_name, value.int_value());
-        return {base::OkStatus(), true};
-      }
-      if (value.has_double_value()) {
-        delegate.AddDouble(context_name, value.double_value());
-        return {base::OkStatus(), true};
-      }
-      if (value.has_string_value()) {
-        delegate.AddString(context_name, value.string_value());
-        return {base::OkStatus(), true};
-      }
-      return {base::OkStatus(), false};
+  // This function parses a tree of nested debug annotations iteratively using a
+  // work stack. A recursive approach is not used to avoid stack overflows when
+  // parsing deeply nested annotations.
+  struct WorkItem {
+    // The decoder for the current annotation node.
+    protos::pbzero::DebugAnnotation::NestedValue::Decoder decoder;
+    // The key context for the current annotation node.
+    std::optional<ProtoToArgsParser::ScopedNestedKeyContext> key;
+    // The index of the current array entry.
+    std::optional<size_t> array_index = 0;
+    // The number of entries in the current array or dictionary.
+    uint32_t nested_count = 0;
+    // The current position in the array or dictionary.
+    uint32_t nested_current = 0;
+    // Whether an entry has been added to the delegate.
+    bool added_entry = false;
+    // Whether this is the first pass through the dictionary or array.
+    bool first_pass_done = false;
+  };
+  struct NestedItem {
+    std::string key;
+    protozero::ConstBytes nested_value;
+  };
+
+  auto key = [&](const WorkItem& item) -> const ProtoToArgsParser::Key& {
+    if (item.key) {
+      return item.key->key();
     }
-    case protos::pbzero::DebugAnnotation::NestedValue::DICT: {
-      bool added_entry = false;
-      auto key_it = value.dict_keys();
-      auto value_it = value.dict_values();
-      for (; key_it && value_it; ++key_it, ++value_it) {
-        std::string child_name =
-            SanitizeDebugAnnotationName((*key_it).ToStdString());
-        auto nested_key = proto_to_args_parser_.EnterDictionary(child_name);
-        ParseResult result =
-            ParseNestedValueArgs(*value_it, nested_key.key(), delegate);
-        added_entry |= result.added_entry;
-        if (!result.status.ok())
-          return {result.status, added_entry};
-      }
-      return {base::OkStatus(), true};
-    }
+    return context_name;
+  };
 
-    case protos::pbzero::DebugAnnotation::NestedValue::ARRAY: {
-      std::string array_key = context_name.key;
-      size_t array_index = delegate.GetArrayEntryIndex(context_name.key);
-      bool added_entry = false;
+  // The work stack for the iterative parsing.
+  base::SmallVector<WorkItem, 4> work_stack;
+  base::SmallVector<NestedItem, 64> nested_storage;
+  bool added_entry = false;
+  work_stack.emplace_back(WorkItem{
+      protos::pbzero::DebugAnnotation::NestedValue::Decoder(nested_value),
+      std::nullopt,
+  });
 
-      for (auto value_it = value.array_values(); value_it; ++value_it) {
-        auto nested_key = proto_to_args_parser_.EnterArray(array_index);
-        ParseResult result =
-            ParseNestedValueArgs(*value_it, nested_key.key(), delegate);
+  while (!work_stack.empty()) {
+    WorkItem& item = work_stack.back();
 
-        if (result.added_entry) {
-          ++array_index;
-          delegate.IncrementArrayEntryIndex(array_key);
-          added_entry = true;
+    switch (item.decoder.nested_type()) {
+      case protos::pbzero::DebugAnnotation::NestedValue::UNSPECIFIED: {
+        // Leaf value.
+        if (item.decoder.has_bool_value()) {
+          delegate.AddBoolean(key(item), item.decoder.bool_value());
+          item.added_entry = true;
+        } else if (item.decoder.has_int_value()) {
+          delegate.AddInteger(key(item), item.decoder.int_value());
+          item.added_entry = true;
+        } else if (item.decoder.has_double_value()) {
+          delegate.AddDouble(key(item), item.decoder.double_value());
+          item.added_entry = true;
+        } else if (item.decoder.has_string_value()) {
+          delegate.AddString(key(item), item.decoder.string_value());
+          item.added_entry = true;
         }
-        if (!result.status.ok())
-          return {result.status, added_entry};
+        break;
       }
-      return {base::OkStatus(), added_entry};
+      case protos::pbzero::DebugAnnotation::NestedValue::DICT: {
+        // First time seeing this dictionary, add them to the nested storage.
+        if (!item.first_pass_done) {
+          item.nested_current = static_cast<uint32_t>(nested_storage.size());
+          uint32_t count = 0;
+          auto keys = item.decoder.dict_keys();
+          auto values = item.decoder.dict_values();
+          for (; keys; ++keys, ++values, ++count) {
+            PERFETTO_DCHECK(values);
+            protozero::ConstChars k = *keys;
+            nested_storage.emplace_back(NestedItem{
+                SanitizeDebugAnnotationName(k.ToStdStringView()),
+                *values,
+            });
+          }
+          item.nested_count = count;
+          item.first_pass_done = true;
+        }
+        // If there are remaining entries, pop one and add it to the work stack.
+        if (item.nested_current < nested_storage.size()) {
+          const auto& nested_item = nested_storage[item.nested_current++];
+          work_stack.emplace_back(WorkItem{
+              protos::pbzero::DebugAnnotation::NestedValue::Decoder(
+                  nested_item.nested_value),
+              proto_to_args_parser_.EnterDictionary(nested_item.key),
+          });
+          continue;
+        }
+        // If we are here, we have processed all entries in the dictionary.
+        for (uint32_t i = 0; i < item.nested_count; ++i) {
+          nested_storage.pop_back();
+        }
+        item.added_entry = true;
+        break;
+      }
+      case protos::pbzero::DebugAnnotation::NestedValue::ARRAY: {
+        // First time seeing this array, add them to the nested storage.
+        if (!item.first_pass_done) {
+          item.nested_current = static_cast<uint32_t>(nested_storage.size());
+          uint32_t count = 0;
+          for (auto res = item.decoder.array_values(); res; ++res, ++count) {
+            nested_storage.emplace_back(NestedItem{"", *res});
+          }
+          item.nested_count = count;
+          item.array_index = delegate.GetArrayEntryIndex(key(item).key);
+          item.first_pass_done = true;
+        }
+        // If there are remaining array, pop one and add it to the work stack.
+        if (item.nested_current < nested_storage.size()) {
+          work_stack.emplace_back(WorkItem{
+              protos::pbzero::DebugAnnotation::NestedValue::Decoder(
+                  nested_storage[item.nested_current++].nested_value),
+              proto_to_args_parser_.EnterArray(*item.array_index),
+          });
+          continue;
+        }
+        // If we are here, we have processed all entries in the dictionary.
+        for (uint32_t i = 0; i < item.nested_count; ++i) {
+          nested_storage.pop_back();
+        }
+        break;
+      }
+    }
+
+    // We are done with this item, pop it from the stack.
+    bool just_added_entry = item.added_entry;
+    added_entry = added_entry || just_added_entry;
+    work_stack.pop_back();
+    if (!work_stack.empty()) {
+      auto& back = work_stack.back();
+      if (just_added_entry && back.array_index) {
+        back.array_index = delegate.IncrementArrayEntryIndex(key(back).key);
+      }
+      back.added_entry = back.added_entry || just_added_entry;
     }
   }
-  return {base::OkStatus(), false};
+  return {base::OkStatus(), added_entry};
 }
 
 }  // namespace perfetto::trace_processor::util

--- a/src/trace_processor/util/debug_annotation_parser.h
+++ b/src/trace_processor/util/debug_annotation_parser.h
@@ -17,6 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_UTIL_DEBUG_ANNOTATION_PARSER_H_
 #define SRC_TRACE_PROCESSOR_UTIL_DEBUG_ANNOTATION_PARSER_H_
 
+#include <optional>
 #include <string>
 
 #include "perfetto/base/status.h"
@@ -51,10 +52,6 @@ class DebugAnnotationParser {
       protos::pbzero::DebugAnnotation::Decoder& annotation,
       ProtoToArgsParser::Delegate& delegate,
       std::string& result);
-  ParseResult ParseDebugAnnotationValue(
-      protos::pbzero::DebugAnnotation::Decoder& annotation,
-      ProtoToArgsParser::Delegate& delegate,
-      const ProtoToArgsParser::Key& context_name);
   ParseResult ParseNestedValueArgs(protozero::ConstBytes nested_value,
                                    const ProtoToArgsParser::Key& context_name,
                                    ProtoToArgsParser::Delegate& delegate);


### PR DESCRIPTION
Refactored the `ParseNestedValueArgs` function in `DebugAnnotationParser`
to be iterative instead of recursive. This avoids stack overflow issues
with deeply nested annotations.
