### PR TITLE
tp: change growth factor of flexvector to 1.5x

### DIFF
--- a/src/trace_processor/dataframe/impl/flex_vector.h
+++ b/src/trace_processor/dataframe/impl/flex_vector.h
@@ -46,7 +46,6 @@ namespace perfetto::trace_processor::dataframe::impl {
 // - Simple API similar to std::vector but for trivially copyable types only
 //
 // Performance characteristics:
-// - Ensures power-of-two capacity for efficient modulo operations
 // - Uses aligned memory for better memory access patterns
 // - Provides fast element access with bounds checking in debug mode
 //
@@ -55,17 +54,22 @@ namespace perfetto::trace_processor::dataframe::impl {
 //   for (int i = 0; i < 20; ++i) {
 //     vec.push_back(i);  // Will automatically resize when needed
 //   }
-template <typename T, uint64_t kAlignment = std::max<uint64_t>(alignof(T), 64)>
+template <typename T>
 class FlexVector {
  public:
+  // The capacity should alwauys be a multiple of this value to ensure
+  // proper alignment and memory access patterns.
+  static constexpr size_t kCapacityMultiple = 64;
+
+  // The growth factor when the vector runs out of capacity.
+  // This is set to 1.5x to avoid excessive memory usage while still
+  // providing a reasonable growth rate.
+  static constexpr double kGrowthFactor = 1.5;
+
   static_assert(std::is_trivially_destructible_v<T>,
                 "FlexVector elements must be trivially destructible");
   static_assert(std::is_trivially_copyable_v<T>,
                 "FlexVector elements must be trivially copyable");
-  static_assert(alignof(T) <= kAlignment,
-                "Alignment must be at least as strict as element alignment");
-  static_assert(internal::IsPowerOfTwo(kAlignment),
-                "Alignment must be a power of two");
 
   using value_type = T;
   using size_type = uint64_t;
@@ -83,8 +87,8 @@ class FlexVector {
   // Allocates a new FlexVector with the specified initial capacity.
   //
   // capacity: Initial capacity (number of elements).
-  static FlexVector<T, kAlignment> CreateWithCapacity(uint64_t capacity) {
-    return FlexVector(base::AlignUp(capacity, kAlignment), 0);
+  static FlexVector<T> CreateWithCapacity(uint64_t capacity) {
+    return FlexVector(base::AlignUp(capacity, kCapacityMultiple), 0);
   }
 
   // Allocates a new FlexVector with the specified initial size. The values
@@ -92,13 +96,13 @@ class FlexVector {
   // std::vector.
   //
   // size: Initial size (number of elements).
-  static FlexVector<T, kAlignment> CreateWithSize(uint64_t size) {
-    return FlexVector(base::AlignUp(size, kAlignment), size);
+  static FlexVector<T> CreateWithSize(uint64_t size) {
+    return FlexVector(base::AlignUp(size, kCapacityMultiple), size);
   }
 
   // Adds `value` to the end of the vector.
   PERFETTO_ALWAYS_INLINE void push_back(T value) {
-    PERFETTO_DCHECK(capacity() % kAlignment == 0);
+    PERFETTO_DCHECK(capacity() % kCapacityMultiple == 0);
     PERFETTO_DCHECK(size_ <= capacity());
     if (PERFETTO_UNLIKELY(size_ == capacity())) {
       IncreaseCapacity();
@@ -108,7 +112,7 @@ class FlexVector {
 
   // Adds `count` elements of `value` to the end of the vector.
   PERFETTO_ALWAYS_INLINE void push_back_multiple(T value, uint64_t count) {
-    PERFETTO_DCHECK(capacity() % kAlignment == 0);
+    PERFETTO_DCHECK(capacity() % kCapacityMultiple == 0);
     PERFETTO_DCHECK(size_ <= capacity());
     while (PERFETTO_UNLIKELY(size_ + count > capacity())) {
       IncreaseCapacity();
@@ -144,10 +148,10 @@ class FlexVector {
   // still maintaining the invariants of the class.
   void shrink_to_fit() {
     if (size_ == 0) {
-      slab_ = Slab<T, kAlignment>::Alloc(0);
+      slab_ = Slab<T>::Alloc(0);
     } else {
-      Slab<T, kAlignment> new_slab =
-          Slab<T, kAlignment>::Alloc(base::AlignUp(size_, kAlignment));
+      Slab<T> new_slab =
+          Slab<T>::Alloc(base::AlignUp(size_, kCapacityMultiple));
       memcpy(new_slab.data(), slab_.data(), size_ * sizeof(T));
       slab_ = std::move(new_slab);
     }
@@ -180,12 +184,15 @@ class FlexVector {
  private:
   // Constructor used by Alloc.
   explicit FlexVector(uint64_t capacity, uint64_t size)
-      : slab_(Slab<T, kAlignment>::Alloc(capacity)), size_(size) {}
+      : slab_(Slab<T>::Alloc(capacity)), size_(size) {}
 
   PERFETTO_NO_INLINE void IncreaseCapacity() {
-    // Grow by doubling, at least to alignment capacity.
-    uint64_t new_capacity = std::max<uint64_t>(capacity() * 2, kAlignment);
-    Slab<T, kAlignment> new_slab = Slab<T, kAlignment>::Alloc(new_capacity);
+    uint64_t new_capacity = std::max<uint64_t>(
+        base::AlignUp(static_cast<size_t>(static_cast<double>(capacity()) *
+                                          kGrowthFactor),
+                      kCapacityMultiple),
+        kCapacityMultiple);
+    Slab<T> new_slab = Slab<T>::Alloc(new_capacity);
     if (slab_.size() > 0) {
       // Copy from the original slab data
       memcpy(new_slab.data(), slab_.data(), size_ * sizeof(T));
@@ -194,7 +201,7 @@ class FlexVector {
   }
 
   // The underlying memory slab.
-  Slab<T, kAlignment> slab_;
+  Slab<T> slab_;
 
   // Current number of elements.
   uint64_t size_ = 0;

--- a/src/trace_processor/dataframe/impl/flex_vector_unittest.cc
+++ b/src/trace_processor/dataframe/impl/flex_vector_unittest.cc
@@ -17,9 +17,7 @@
 #include "src/trace_processor/dataframe/impl/flex_vector.h"
 
 #include <cstddef>
-#include <cstdint>
 
-#include "src/trace_processor/dataframe/impl/slab.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto::trace_processor::dataframe::impl {
@@ -184,17 +182,6 @@ TEST(FlexVectorTest, DataAccessor) {
   // Modify through data()
   data[1] = 42;
   EXPECT_EQ(vec[1], 42);
-}
-
-// Test with custom alignment
-TEST(FlexVectorTest, CustomAlignment) {
-  // Use 128-byte alignment
-  constexpr size_t kCustomAlignment = 128;
-  auto vec = FlexVector<double, kCustomAlignment>::CreateWithCapacity(256);
-
-  // The data pointer should be aligned to kCustomAlignment
-  auto ptr_value = reinterpret_cast<uintptr_t>(vec.data());
-  EXPECT_EQ(ptr_value % kCustomAlignment, 0u);
 }
 
 }  // namespace

--- a/src/trace_processor/dataframe/impl/slab.h
+++ b/src/trace_processor/dataframe/impl/slab.h
@@ -17,7 +17,6 @@
 #ifndef SRC_TRACE_PROCESSOR_DATAFRAME_IMPL_SLAB_H_
 #define SRC_TRACE_PROCESSOR_DATAFRAME_IMPL_SLAB_H_
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -38,25 +37,19 @@ static constexpr bool IsPowerOfTwo(size_t n) {
 //
 // This class enforces several important constraints:
 // - Elements must be trivially constructible and destructible
-// - The alignment must be at least as strict as the element's alignment
-// - The alignment must be a power of two
 //
 // Usage example:
 //   auto slab = Slab<float>::Alloc(1024);  // Allocates space for 1024 floats
 //   for (size_t i = 0; i < slab.size(); ++i) {
 //     slab[i] = static_cast<float>(i);
 //   }
-template <typename T, size_t kAlignment = std::max<size_t>(alignof(T), 64)>
+template <typename T>
 class Slab {
  public:
   static_assert(std::is_trivially_constructible_v<T>,
                 "Slab elements must be trivially constructible");
   static_assert(std::is_trivially_destructible_v<T>,
                 "Slab elements must be trivially destructible");
-  static_assert(alignof(T) <= kAlignment,
-                "Alignment must be at least as strict as element alignment");
-  static_assert(internal::IsPowerOfTwo(kAlignment),
-                "Alignment must be a power of two");
 
   using value_type = T;
   using const_iterator = const T*;
@@ -76,9 +69,9 @@ class Slab {
   //
   // size: Number of elements to allocate space for.
   // Returns a new Slab object with the requested capacity.
-  static Slab<T, kAlignment> Alloc(uint64_t size) {
+  static Slab<T> Alloc(uint64_t size) {
     return Slab(
-        static_cast<T*>(base::AlignedAlloc(kAlignment, size * sizeof(T))),
+        static_cast<T*>(base::AlignedAlloc(alignof(T), size * sizeof(T))),
         size);
   }
 

--- a/src/trace_processor/dataframe/impl/slab_unittest.cc
+++ b/src/trace_processor/dataframe/impl/slab_unittest.cc
@@ -128,17 +128,6 @@ TEST(SlabTest, RangeBasedForLoop) {
   EXPECT_EQ(sum, 15);
 }
 
-// Test with custom alignment
-TEST(SlabTest, CustomAlignment) {
-  // Use 128-byte alignment
-  constexpr size_t kCustomAlignment = 128;
-  auto slab = Slab<double, kCustomAlignment>::Alloc(10);
-
-  // The data pointer should be aligned to kCustomAlignment
-  auto ptr_value = reinterpret_cast<uintptr_t>(slab.data());
-  EXPECT_EQ(ptr_value % kCustomAlignment, 0u);
-}
-
 // Test with different data types
 TEST(SlabTest, DifferentDataTypes) {
   // Test with a larger type


### PR DESCRIPTION
2x was causing very high memory use when parsing large heap dumps. Use
1.5x instead which is what also folly's vector uses to be a bit more
reasonable.

Also remove a bunch of confusing code where alignment and capacity
multiples were mixed up. We were not actually using custom alignment
capability in prod so remove it and simplify.
