### PR TITLE
ui: Make SegmentedButton inline

### DIFF
--- a/ui/src/assets/widgets/segmented_buttons.scss
+++ b/ui/src/assets/widgets/segmented_buttons.scss
@@ -15,7 +15,7 @@
 @import "theme";
 
 .pf-segmented-buttons {
-  display: flex;
+  display: inline-flex;
   flex-direction: row;
 
   .pf-button {

--- a/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
@@ -348,17 +348,20 @@ export class MetricsPage implements m.ClassComponent<MetricsPageAttrs> {
     const json = v1Controller.resultAsJson;
     return m(
       '.metrics-page',
-      m(SegmentedButtons, {
-        options: [{label: 'Metric v1'}, {label: 'Metric v2'}],
-        selectedOption: this.mode === 'V1' ? 0 : 1,
-        onOptionSelected: (num) => {
-          if (num === 0) {
-            this.mode = 'V1';
-          } else {
-            this.mode = 'V2';
-          }
-        },
-      }),
+      m(
+        '',
+        m(SegmentedButtons, {
+          options: [{label: 'Metric v1'}, {label: 'Metric v2'}],
+          selectedOption: this.mode === 'V1' ? 0 : 1,
+          onOptionSelected: (num) => {
+            if (num === 0) {
+              this.mode = 'V1';
+            } else {
+              this.mode = 'V2';
+            }
+          },
+        }),
+      ),
       this.mode === 'V1' &&
         m(MetricV1Fetcher, {
           controller: v1Controller,


### PR DESCRIPTION
SegmentedButton is similar to a buttons and inputs, so it makes sense that it has inline styling rather than block so that it can live side by side with other elements.
