### PR TITLE
Consider unique frame_id when calculating per-frame metrics.

### DIFF
--- a/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_per_frame_metric.sql
+++ b/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_per_frame_metric.sql
@@ -87,7 +87,9 @@ WHERE
       OR
       -- frame end within cuj
       (frame.ts_end >= cuj.ts AND frame.ts_end <= cuj.ts_end)
-   );
+   )
+   -- This grouping is done to de-duplicate identical rows.
+   GROUP BY frame_id;
 
 -- Combine the above two tables to get blocking calls within frame within CUJ.
 DROP TABLE IF EXISTS blocking_calls_frame_cuj;


### PR DESCRIPTION
While extracting the frames in a CUJ, there are duplicate entries for a CUJ. This is because currently there is no way to associate an actual frame with a corresponding DrawFrame. At the metric level, this is an immediate fix to make sure that the correct number of frames are used for metric calculation.

Bug: 425562160
Test: tools/diff_test_trace_processor.py --name-filter ".*android_blocking_calls_cuj_per_frame.*" out/linux_clang_debug/trace_processor_shell