### PR TITLE
winscope_geometry: Make member operator== const

### DIFF
--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
@@ -58,7 +58,7 @@ Rect::Rect(double left, double top, double right, double bottom) {
   h = bottom - top;
 }
 
-bool Rect::IsEmpty() {
+bool Rect::IsEmpty() const {
   const bool null_value_present = IsFloatEqual(x, -1) || IsFloatEqual(y, -1) ||
                                   IsFloatEqual(x + w, -1) ||
                                   IsFloatEqual(y + h, -1);
@@ -66,7 +66,7 @@ bool Rect::IsEmpty() {
   return null_value_present || null_h_or_w;
 }
 
-Rect Rect::CropRect(const Rect& other) {
+Rect Rect::CropRect(const Rect& other) const {
   const auto max_left = std::max(x, other.x);
   const auto min_right = std::min(x + w, other.x + other.w);
   const auto max_top = std::max(y, other.y);
@@ -74,12 +74,12 @@ Rect Rect::CropRect(const Rect& other) {
   return Rect(max_left, max_top, min_right, min_bottom);
 }
 
-bool Rect::ContainsRect(const Rect& other) {
+bool Rect::ContainsRect(const Rect& other) const {
   return (w > 0 && h > 0 && x <= other.x && y <= other.y &&
           (x + w >= other.x + other.w) && (y + h >= other.y + other.h));
 }
 
-bool Rect::IntersectsRect(const Rect& other) {
+bool Rect::IntersectsRect(const Rect& other) const {
   if (x < other.x + other.w && other.x < x + w && y <= other.y + other.h &&
       other.y <= y + h) {
     auto new_x = x;
@@ -104,30 +104,30 @@ bool Rect::IntersectsRect(const Rect& other) {
   return false;
 }
 
-bool Rect::operator==(const Rect& other) {
+bool Rect::operator==(const Rect& other) const {
   return IsFloatEqual(x, other.x) && IsFloatEqual(y, other.y) &&
          IsFloatEqual(w, other.w) && IsFloatEqual(h, other.h);
 }
 
-bool Rect::IsAlmostEqual(const Rect& other) {
+bool Rect::IsAlmostEqual(const Rect& other) const {
   return (IsFloatClose(x, other.x) && IsFloatClose(y, other.y) &&
           IsFloatClose(w, other.w) && IsFloatClose(h, other.h));
 }
 
-bool TransformMatrix::operator==(const TransformMatrix& other) {
+bool TransformMatrix::operator==(const TransformMatrix& other) const {
   return IsFloatEqual(dsdx, other.dsdx) && IsFloatEqual(dsdy, other.dsdy) &&
          IsFloatEqual(dtdx, other.dtdx) && IsFloatEqual(dtdy, other.dtdy) &&
          IsFloatEqual(tx, other.tx) && IsFloatEqual(ty, other.ty);
 }
 
-Point TransformMatrix::TransformPoint(Point point) {
+Point TransformMatrix::TransformPoint(Point point) const {
   return {
       dsdx * point.x + dtdx * point.y + tx,
       dtdy * point.x + dsdy * point.y + ty,
   };
 }
 
-Rect TransformMatrix::TransformRect(const Rect& r) {
+Rect TransformMatrix::TransformRect(const Rect& r) const {
   const auto lt_prime = TransformMatrix::TransformPoint({r.x, r.y});
   const auto rb_prime = TransformMatrix::TransformPoint({r.x + r.w, r.y + r.h});
   const auto x = std::min(lt_prime.x, rb_prime.x);
@@ -136,7 +136,7 @@ Rect TransformMatrix::TransformRect(const Rect& r) {
               std::max(lt_prime.y, rb_prime.y));
 }
 
-Region TransformMatrix::TransformRegion(Region region) {
+Region TransformMatrix::TransformRegion(Region region) const {
   std::vector<Rect> rects;
   for (const auto& rect : region.rects) {
     rects.push_back(TransformMatrix::TransformRect(rect));
@@ -144,7 +144,7 @@ Region TransformMatrix::TransformRegion(Region region) {
   return Region{rects};
 }
 
-TransformMatrix TransformMatrix::Inverse() {
+TransformMatrix TransformMatrix::Inverse() const {
   const auto ident = 1.0 / TransformMatrix::Det();
   TransformMatrix inverse = TransformMatrix{
       dsdy * ident, -dtdx * ident, 0, -dtdy * ident, dsdx * ident, 0,
@@ -158,11 +158,11 @@ TransformMatrix TransformMatrix::Inverse() {
   return inverse;
 }
 
-bool TransformMatrix::IsValid() {
+bool TransformMatrix::IsValid() const {
   return !IsFloatEqual(dsdx * dsdy, dtdx * dtdy);
 }
 
-double TransformMatrix::Det() {
+double TransformMatrix::Det() const {
   return dsdx * dsdy - dtdx * dtdy;
 }
 

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.h
@@ -44,13 +44,13 @@ class Rect {
   explicit Rect(const protos::pbzero::FloatRectProto::Decoder& rect);
   Rect(double left, double top, double right, double bottom);
 
-  bool operator==(const Rect& other);
+  bool operator==(const Rect& other) const;
 
-  bool IsAlmostEqual(const Rect& other);
-  bool IsEmpty();
-  Rect CropRect(const Rect& other);
-  bool ContainsRect(const Rect& other);
-  bool IntersectsRect(const Rect& other);
+  bool IsAlmostEqual(const Rect& other) const;
+  bool IsEmpty() const;
+  Rect CropRect(const Rect& other) const;
+  bool ContainsRect(const Rect& other) const;
+  bool IntersectsRect(const Rect& other) const;
 
   double x = 0;
   double y = 0;
@@ -67,13 +67,13 @@ struct Region {
 // These transforms are added to the __intrinsic_winscope_transform table.
 class TransformMatrix {
  public:
-  bool operator==(const TransformMatrix& other);
+  bool operator==(const TransformMatrix& other) const;
 
-  Point TransformPoint(Point point);
-  Rect TransformRect(const Rect& r);
-  Region TransformRegion(Region region);
-  TransformMatrix Inverse();
-  bool IsValid();
+  Point TransformPoint(Point point) const;
+  Rect TransformRect(const Rect& r) const;
+  Region TransformRegion(Region region) const;
+  TransformMatrix Inverse() const;
+  bool IsValid() const;
 
   double dsdx = 1;
   double dtdx = 0;
@@ -83,7 +83,7 @@ class TransformMatrix {
   double ty = 0;
 
  private:
-  double Det();
+  double Det() const;
 };
 
 }  // namespace perfetto::trace_processor::winscope::geometry


### PR DESCRIPTION
Otherwise we get a warning in C++20.

```
external/perfetto/include/perfetto/ext/base/flat_hash_map.h:214:42: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'perfetto::trace_processor::winscope::geometry::Rect' and 'perfetto::trace_processor::winscope::geometry::Rect') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
  214 |         if (tag_idx == tag && keys_[idx] == key) {
      |                               ~~~~~~~~~~ ^  ~~~
external/perfetto/src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc:38:17: note: in instantiation of member function 'perfetto::base::FlatHashMap<perfetto::trace_processor::winscope::geometry::Rect, perfetto::trace_processor::tables::WinscopeRectTable::Id, perfetto::trace_processor::winscope::RectHasher>::Insert' requested here
   38 |   return *rows_.Insert(rect, id).first;
      |                 ^
external/perfetto/src/trace_processor/importers/proto/winscope/winscope_geometry.h:47:8: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
   47 |   bool operator==(const Rect& other);
      |        ^
external/perfetto/src/trace_processor/importers/proto/winscope/winscope_geometry.h:47:8: note: mark 'operator==' as const or add a matching 'operator!=' to resolve the ambiguity
1 error generated.
```

Android in-tree builds are done with C++20 now.

Also, mark other related methods as const.
