### PR TITLE
Avoid volatile increment in test

### DIFF
--- a/src/base/watchdog_unittest.cc
+++ b/src/base/watchdog_unittest.cc
@@ -25,6 +25,7 @@
 #include <signal.h>
 #include <time.h>
 
+#include <atomic>
 #include <condition_variable>
 #include <map>
 #include <memory>
@@ -105,7 +106,7 @@ TEST(WatchdogTest, CrashCpu) {
         TestWatchdog watchdog(1);
         watchdog.SetCpuLimit(10, 25);
         watchdog.Start();
-        volatile int x = 0;
+        std::atomic<int> x = 0;
         for (;;) {
           x++;
         }


### PR DESCRIPTION
It's deprecated in C++20.
