### PR TITLE
Android.bp: support generation of 'defaults' for 'java_' and 'cc_' targets.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1175,7 +1175,6 @@ cc_library_shared {
     name: "libperfetto_jni",
     defaults: [
         "libperfetto_jni_defaults",
-        "perfetto_defaults",
     ],
 }
 
@@ -1197,6 +1196,9 @@ cc_defaults {
     shared_libs: [
         "liblog",
         "libperfetto_c",
+    ],
+    defaults: [
+        "perfetto_defaults",
     ],
     header_libs: [
         "jni_headers",

--- a/Android.bp
+++ b/Android.bp
@@ -1173,6 +1173,15 @@ cc_library_static {
 // GN: //src/android_sdk/jni:libperfetto_jni
 cc_library_shared {
     name: "libperfetto_jni",
+    defaults: [
+        "libperfetto_jni_defaults",
+        "perfetto_defaults",
+    ],
+}
+
+// GN: //src/android_sdk/jni:libperfetto_jni
+cc_defaults {
+    name: "libperfetto_jni_defaults",
     srcs: [
         ":perfetto_include_perfetto_public_abi_base",
         ":perfetto_include_perfetto_public_abi_public",
@@ -1188,9 +1197,6 @@ cc_library_shared {
     shared_libs: [
         "liblog",
         "libperfetto_c",
-    ],
-    defaults: [
-        "perfetto_defaults",
     ],
     header_libs: [
         "jni_headers",
@@ -16685,6 +16691,14 @@ android_library {
 // GN: //src/android_sdk/java/main:perfetto_trace_lib
 java_library {
     name: "perfetto_trace_lib_java",
+    defaults: [
+        "perfetto_trace_lib_java_defaults",
+    ],
+}
+
+// GN: //src/android_sdk/java/main:perfetto_trace_lib
+java_defaults {
+    name: "perfetto_trace_lib_java_defaults",
     srcs: [
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoNativeMemoryCleaner.java",
         "src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java",

--- a/gn/perfetto_android_sdk.gni
+++ b/gn/perfetto_android_sdk.gni
@@ -23,6 +23,7 @@ template("perfetto_android_jni_library") {
     "deps",
     "binary_name",
     "bazel_linkopts",
+    "android_bp_extract_defaults",
     "testonly",
     "visibility",
   ]
@@ -32,6 +33,9 @@ template("perfetto_android_jni_library") {
       perfetto_custom_target_type = [ "perfetto_android_jni_library" ]
       perfetto_argument_binary_name = [ binary_name ]
       perfetto_bazel_argument_linkopts = [ bazel_linkopts ]
+      if (defined(android_bp_extract_defaults)) {
+        perfetto_android_bp_extract_defaults = [ android_bp_extract_defaults ]
+      }
     }
   }
 }
@@ -42,6 +46,7 @@ template("perfetto_android_library") {
     "deps",
     "manifest",
     "android_bp_generate_java_target",
+    "android_bp_extract_defaults",
     "testonly",
     "visibility",
   ]
@@ -65,6 +70,9 @@ template("perfetto_android_library") {
       if (defined(android_bp_generate_java_target)) {
         perfetto_android_library_android_bp_generate_java_target =
             [ android_bp_generate_java_target ]
+      }
+      if (defined(android_bp_extract_defaults)) {
+        perfetto_android_bp_extract_defaults = [ android_bp_extract_defaults ]
       }
     }
   }

--- a/src/android_sdk/java/main/BUILD.gn
+++ b/src/android_sdk/java/main/BUILD.gn
@@ -13,6 +13,7 @@ perfetto_android_library("perfetto_trace_lib") {
   deps = [ "../../jni:libperfetto_jni" ]
   manifest = "AndroidManifest.xml"
   android_bp_generate_java_target = true
+  android_bp_extract_defaults = true
 }
 
 perfetto_android_app("perfetto_trace_app") {

--- a/src/android_sdk/jni/BUILD.gn
+++ b/src/android_sdk/jni/BUILD.gn
@@ -28,4 +28,5 @@ perfetto_android_jni_library("libperfetto_jni") {
   ]
   binary_name = "libperfetto_jni.so"
   bazel_linkopts = "-llog"
+  android_bp_extract_defaults = true
 }

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -1226,11 +1226,11 @@ def extract_defaults(module: Module, blueprint: Blueprint):
                            module.gn_target)
   items_copy = dict(module.__dict__)
   for k, v in items_copy.items():
-    if k not in ('type', 'name', 'comment', 'defaults'):
+    if k not in ('type', 'name', 'comment'):
       defaults_module.__dict__[k] = v
       module.__dict__[k] = None
   blueprint.add_module(defaults_module)
-  module.defaults.add(defaults_module.name)
+  module.defaults = {defaults_module.name}
 
 
 def _get_cflags(target: GnParser.Target):

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -1133,6 +1133,9 @@ class AndroidJavaSDKModulesGenerator:
 
       self.blueprint.add_module(java_module)
 
+      if target.android_bp_extract_defaults:
+        extract_defaults(java_module, self.blueprint)
+
       module.static_libs.add(java_library_module_name)
     else:
       module.srcs = [gn_utils.label_to_path(src) for src in target.sources]
@@ -1209,6 +1212,25 @@ class AndroidJavaSDKModulesGenerator:
     visited.add(target)
     for d in target.non_proto_or_source_set_deps():
       self._collect_all_transitive_deps(d, visited)
+
+
+def extract_defaults(module: Module, blueprint: Blueprint):
+  if module.type.startswith('cc_library') or module.type.startswith(
+      'cc_binary'):
+    defaults_type = 'cc_defaults'
+  elif module.type == 'java_library':
+    defaults_type = 'java_defaults'
+  else:
+    raise Error('Unsupported module type: {}'.format(module.type))
+  defaults_module = Module(defaults_type, module.name + '_defaults',
+                           module.gn_target)
+  items_copy = dict(module.__dict__)
+  for k, v in items_copy.items():
+    if k not in ('type', 'name', 'comment', 'defaults'):
+      defaults_module.__dict__[k] = v
+      module.__dict__[k] = None
+  blueprint.add_module(defaults_module)
+  module.defaults.add(defaults_module.name)
 
 
 def _get_cflags(target: GnParser.Target):
@@ -1419,6 +1441,9 @@ def create_modules_from_target(blueprint: Blueprint, gn: GnParser,
     else:
       raise Error('Unknown dep %s (%s) for target %s' %
                   (dep_module.name, dep_module.type, module.name))
+
+  if target.android_bp_extract_defaults:
+    extract_defaults(module, blueprint)
 
   return module
 

--- a/tools/gn_utils.py
+++ b/tools/gn_utils.py
@@ -351,6 +351,7 @@ class GnParser(object):
       self.resource_files: Optional[str] = None
       # Used only when custom_action_type == 'perfetto_android_app'
       self.instruments: Optional[str] = None
+      self.android_bp_extract_defaults = False
       # Used only when custom_action_type == 'perfetto_android_library'
       self.android_bp_generate_java_target = False
       # Used only when
@@ -529,6 +530,11 @@ class GnParser(object):
           'perfetto_android_a_i_t_android_bp_test_config')
       target.a_i_t_android_bp_test_config = a_i_t_android_bp_test_config[
           0] if a_i_t_android_bp_test_config else None
+
+    extract_defaults = target.metadata.get(
+        'perfetto_android_bp_extract_defaults')
+    if extract_defaults:
+      target.android_bp_extract_defaults = bool(extract_defaults[0])
 
     # Default for 'public' is //* - all headers in 'sources' are public.
     # TODO(primiano): if a 'public' section is specified (even if empty), then


### PR DESCRIPTION
We need this to generate almost identical build targets. E.g.: for 'libperfetto_jni' we want to generate the '3p' and 'framework' targets which differ only by the 'jarjar' config.

Tested in android tree:
`m perfetto_trace_lib`
