### PR TITLE
Don't call startTrackingUidTimes().

### DIFF
--- a/src/android_internal/cpu_time_in_state.cc
+++ b/src/android_internal/cpu_time_in_state.cc
@@ -28,10 +28,6 @@
 namespace perfetto {
 namespace android_internal {
 
-bool EnsureCpuTimesAvailable() {
-  return android::bpf::startTrackingUidTimes();
-}
-
 bool GetCpuTimes(CpuTime* cpu_times,
                  size_t* size_of_arr,
                  uint64_t* last_update_ns) {

--- a/src/android_internal/cpu_time_in_state.h
+++ b/src/android_internal/cpu_time_in_state.h
@@ -39,8 +39,6 @@ extern "C" {
 
 // These functions are not thread safe unless specified otherwise.
 
-bool __attribute__((visibility("default"))) EnsureCpuTimesAvailable();
-
 bool __attribute__((visibility("default")))
 GetCpuTimes(CpuTime* cpu_times, size_t* size_of_arr, uint64_t* last_update_ns);
 

--- a/src/traced/probes/android_cpu_per_uid/android_cpu_per_uid_data_source.cc
+++ b/src/traced/probes/android_cpu_per_uid/android_cpu_per_uid_data_source.cc
@@ -73,17 +73,7 @@ const ProbesDataSource::Descriptor AndroidCpuPerUidDataSource::descriptor = {
 // Dynamically loads the libperfetto_android_internal.so library which
 // allows to proxy calls to android hwbinder in in-tree builds.
 struct AndroidCpuPerUidDataSource::DynamicLibLoader {
-  PERFETTO_LAZY_LOAD(android_internal::EnsureCpuTimesAvailable,
-                     ensure_cpu_times_available_);
   PERFETTO_LAZY_LOAD(android_internal::GetCpuTimes, get_cpu_times_);
-
-  bool EnsureCpuTimesAvailable() {
-    if (!ensure_cpu_times_available_) {
-      return false;
-    }
-
-    return ensure_cpu_times_available_();
-  }
 
   std::vector<android_internal::CpuTime> GetCpuTimes(uint64_t* last_update_ns) {
     if (!get_cpu_times_) {
@@ -128,11 +118,7 @@ AndroidCpuPerUidDataSource::~AndroidCpuPerUidDataSource() = default;
 
 void AndroidCpuPerUidDataSource::Start() {
   lib_.reset(new DynamicLibLoader());
-  if (lib_->EnsureCpuTimesAvailable()) {
-    Tick();
-  } else {
-    PERFETTO_ELOG("Could not enable CPU per UID data source");
-  }
+  Tick();
 }
 
 void AndroidCpuPerUidDataSource::Tick() {


### PR DESCRIPTION
System server does this for us and doing so requires a bunch of permissions we don't have.

Bug: http://b/b422976190
