### PR TITLE
ui: Enable vega hover event processing

### DIFF
--- a/ui/src/components/widgets/vega_view.ts
+++ b/ui/src/components/widgets/vega_view.ts
@@ -343,6 +343,7 @@ class VegaWrapper {
       this.view = new vega.View(runtime, {
         loader: new EngineLoader(this._engine),
       });
+      this.view.hover();
       this.view.initialize(this.dom);
       for (const [key, value] of Object.entries(this._data)) {
         this.view.data(key, value);


### PR DESCRIPTION
This gets the hover encoding working in the vega example on the widgets page.

See: https://vega.github.io/vega/docs/api/view/#view_hover
