### PR TITLE
Update extractor to return LayerDecoder.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor.h
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor.h
@@ -19,19 +19,19 @@
 
 #include <unordered_map>
 #include <vector>
-#include "perfetto/protozero/field.h"
 #include "protos/perfetto/trace/android/surfaceflinger_layers.pbzero.h"
 
 namespace perfetto::trace_processor::winscope::surfaceflinger_layers {
 
-using ConstBytes = protozero::ConstBytes;
+namespace {
 using LayersDecoder = protos::pbzero::LayersProto::Decoder;
 using LayerDecoder = protos::pbzero::LayerProto::Decoder;
+}  // namespace
 
-std::unordered_map<int, ConstBytes> ExtractLayersById(
+std::unordered_map<int, LayerDecoder> ExtractLayersById(
     const LayersDecoder& layers_decoder);
 
-std::vector<ConstBytes> ExtractLayersTopToBottom(
+std::vector<LayerDecoder> ExtractLayersTopToBottom(
     const LayersDecoder& layers_decoder);
 
 }  // namespace perfetto::trace_processor::winscope::surfaceflinger_layers

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
@@ -137,8 +137,9 @@ inline Rect GetBounds(const LayerDecoder& layer) {
 
 // Returns the screen bounds of a layer, cropped by the size of the crop rect if
 // provided, usually given as the layer's associated display.
-inline std::optional<Rect> GetCroppedScreenBounds(const LayerDecoder& layer,
-                                                  Rect* crop) {
+inline std::optional<geometry::Rect> GetCroppedScreenBounds(
+    const LayerDecoder& layer,
+    std::optional<geometry::Rect> crop) {
   if (!layer.has_screen_bounds()) {
     return std::nullopt;
   }
@@ -146,8 +147,8 @@ inline std::optional<Rect> GetCroppedScreenBounds(const LayerDecoder& layer,
       protos::pbzero::FloatRectProto::Decoder(layer.screen_bounds());
   auto screen_bounds_rect = Rect(screen_bounds);
 
-  if (crop && !(crop->IsEmpty())) {
-    screen_bounds_rect = screen_bounds_rect.CropRect(*crop);
+  if (crop.has_value() && !(crop->IsEmpty())) {
+    screen_bounds_rect = screen_bounds_rect.CropRect(crop.value());
   }
   return screen_bounds_rect;
 }


### PR DESCRIPTION
LayerDecoder provides greater clarity than ConstBytes. Also use optional Rect instead of pointer in GetCroppedScreenBounds.

Bug: 411363817
Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell
