### PR TITLE
ui: Add track help button

### DIFF
--- a/ui/src/assets/widgets/popup.scss
+++ b/ui/src/assets/widgets/popup.scss
@@ -35,12 +35,19 @@
   border: solid 1px $pf-colour-thin-border;
   border-radius: $pf-border-radius;
   box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.2);
+  max-width: 350px; // Sensible default width for most popups
 
   .pf-popup-content {
     // Ensures all content is rendered above the arrow
     position: relative;
     // Default padding set to some sensible value that works for most content
     padding: 4px;
+    overflow: hidden;
+  }
+
+  &--match-width {
+    // Width is handled in JS
+    max-width: unset;
   }
 }
 

--- a/ui/src/base/semantic_icons.ts
+++ b/ui/src/base/semantic_icons.ts
@@ -45,6 +45,7 @@ export class Icons {
   static readonly GoTo = 'arrow_forward';
   static readonly ContextMenuAlt = 'more_vert';
   static readonly Warning = 'warning';
+  static readonly Help = 'help';
 
   // Page control
   static readonly NextPage = 'chevron_right';

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -46,6 +46,7 @@ import {Trace} from '../../public/trace';
 import {Anchor} from '../../widgets/anchor';
 import {showModal} from '../../widgets/modal';
 import {copyToClipboard} from '../../base/clipboard';
+import {Popup} from '../../widgets/popup';
 
 const TRACK_HEIGHT_MIN_PX = 18;
 const TRACK_HEIGHT_DEFAULT_PX = 30;
@@ -122,10 +123,16 @@ export class TrackView {
     } = attrs;
     const {node, renderer, height} = this;
 
+    const description = renderer?.desc.description;
+
     const buttons = attrs.lite
       ? []
       : [
           renderer?.track.getTrackShellButtons?.(),
+          description !== undefined &&
+            this.renderHelpButton(
+              typeof description === 'function' ? description() : description,
+            ),
           (removable || node.removable) && this.renderCloseButton(),
           // We don't want summary tracks to be pinned as they rarely have
           // useful information.
@@ -335,6 +342,20 @@ export class TrackView {
       title: isPinned ? 'Unpin' : 'Pin to top',
       compact: true,
     });
+  }
+
+  private renderHelpButton(helpText: m.Children): m.Children {
+    return m(
+      Popup,
+      {
+        trigger: m(Button, {
+          className: classNames('pf-visible-on-hover'),
+          icon: Icons.Help,
+          compact: true,
+        }),
+      },
+      helpText,
+    );
   }
 
   private renderTrackMenuButton(): m.Children {
@@ -638,8 +659,6 @@ function renderTrackDetailsMenu(node: TrackNode, descriptor?: Track) {
       }),
       m(TreeNode, {left: 'Path', right: fullPath}),
       m(TreeNode, {left: 'Name', right: node.name}),
-      descriptor &&
-        m(TreeNode, {left: 'Description', right: descriptor?.description}),
       m(TreeNode, {
         left: 'Workspace',
         right: node.workspace?.title ?? '[no workspace]',

--- a/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLog/index.ts
@@ -23,6 +23,8 @@ import {createAndroidLogTrack} from './logs_track';
 import {exists} from '../../base/utils';
 import {TrackNode} from '../../public/workspace';
 import {escapeSearchQuery} from '../../trace_processor/query_utils';
+import {Anchor} from '../../widgets/anchor';
+import {Icons} from '../../base/semantic_icons';
 
 const VERSION = 1;
 
@@ -76,7 +78,21 @@ export default class implements PerfettoPlugin {
     if (logCount > 0) {
       ctx.tracks.registerTrack({
         uri,
-        description: 'Android log messages',
+        description: () => {
+          return m('', [
+            'Android log (logcat) messages.',
+            m('br'),
+            m(
+              Anchor,
+              {
+                href: 'https://perfetto.dev/docs/data-sources/android-log',
+                target: '_blank',
+                icon: Icons.ExternalLink,
+              },
+              'Documentation',
+            ),
+          ]);
+        },
         tags: {kind: ANDROID_LOGS_TRACK_KIND},
         renderer: createAndroidLogTrack(ctx, uri),
       });

--- a/ui/src/plugins/dev.perfetto.Ftrace/index.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/index.ts
@@ -67,6 +67,7 @@ export default class implements PerfettoPlugin {
 
       ctx.tracks.registerTrack({
         uri,
+        description: `Ftrace events for CPU ${cpu.toString()}`,
         tags: {
           cpu: cpu.cpu,
           groupName: 'Ftrace Events',

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -41,6 +41,9 @@ import {CpuSliceByProcessSelectionAggregator} from './cpu_slice_by_process_selec
 import {CpuSliceSelectionAggregator} from './cpu_slice_selection_aggregator';
 import {CpuSliceTrack} from './cpu_slice_track';
 import {WakerOverlay} from './waker_overlay';
+import m from 'mithril';
+import {Anchor} from '../../widgets/anchor';
+import {Icons} from '../../base/semantic_icons';
 
 function uriForThreadStateTrack(upid: number | null, utid: number): string {
   return `${getThreadUriPrefix(upid, utid)}_state`;
@@ -131,6 +134,21 @@ export default class implements PerfettoPlugin {
       const threads = ctx.plugins.getPlugin(ThreadPlugin).getThreadMap();
 
       ctx.tracks.registerTrack({
+        description: () => {
+          return m('', [
+            `Shows which threads were running on CPU ${cpu.toString()} over time.`,
+            m('br'),
+            m(
+              Anchor,
+              {
+                href: 'https://perfetto.dev/docs/data-sources/cpu-scheduling',
+                target: '_blank',
+                icon: Icons.ExternalLink,
+              },
+              'Documentation',
+            ),
+          ]);
+        },
         uri,
         tags: {
           kind: CPU_SLICE_TRACK_KIND,
@@ -229,6 +247,21 @@ export default class implements PerfettoPlugin {
       const uri = uriForThreadStateTrack(upid, utid);
       ctx.tracks.registerTrack({
         uri,
+        description: () => {
+          return m('', [
+            `Shows the scheduling state of the thread over time, e.g. Running, Runnable, Sleeping.`,
+            m('br'),
+            m(
+              Anchor,
+              {
+                href: 'https://perfetto.dev/docs/data-sources/cpu-scheduling',
+                target: '_blank',
+                icon: Icons.ExternalLink,
+              },
+              'Documentation',
+            ),
+          ]);
+        },
         tags: {
           kind: THREAD_STATE_TRACK_KIND,
           utid,

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -117,8 +117,9 @@ export interface Track {
   // Describes how to render the track.
   readonly renderer: TrackRenderer;
 
-  // Optional: A human readable description of the track.
-  readonly description?: string;
+  // Optional: A human readable description of the track. This can be a simple
+  // string or a render function that returns Mithril vnodes.
+  readonly description?: string | (() => m.Children);
 
   // Optional: Human readable subtitle. Sometimes displayed if there is room.
   readonly subtitle?: string;

--- a/ui/src/widgets/popup.ts
+++ b/ui/src/widgets/popup.ts
@@ -162,6 +162,7 @@ export class Popup implements m.ClassComponent<PopupAttrs> {
       createNewGroup = true,
       onPopupMount = () => {},
       onPopupUnMount = () => {},
+      matchWidth,
     } = attrs;
 
     const portalAttrs: PortalAttrs = {
@@ -213,6 +214,7 @@ export class Popup implements m.ClassComponent<PopupAttrs> {
           class: classNames(
             className,
             createNewGroup && Popup.POPUP_GROUP_CLASS,
+            matchWidth && 'pf-popup--match-width',
           ),
           ref: Popup.POPUP_REF,
         },


### PR DESCRIPTION
If a `description` is provided when the track is registered, the help button appears in the track shell featuring a popup containing the provided description.

The description can be either a simple string or a function returning Mithril components in order to display rich text such as hyperlinks.

Fixes: https://buganizer.corp.google.com/issues/424382932

Example: 
![image](https://github.com/user-attachments/assets/b2480cbb-e0d3-4a02-9626-9e44f8ce8421)
