### PR TITLE
ui: Add docs for track help text / descriptions.

### DIFF
--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -59,7 +59,7 @@ function getTrackHeight(node: TrackNode, track?: TrackRenderer) {
   // compact to save space.
   if (node.isSummary && node.expanded) return TRACK_HEIGHT_DEFAULT_PX;
 
-  const trackHeight = track?.getHeight();
+  const trackHeight = track?.getHeight?.();
   if (trackHeight === undefined) return TRACK_HEIGHT_DEFAULT_PX;
 
   // Limit the minimum height of a track, and also round up to the nearest

--- a/ui/src/plugins/com.example.Tracks/index.ts
+++ b/ui/src/plugins/com.example.Tracks/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {TrackNode} from '../../public/workspace';
@@ -35,6 +36,7 @@ export default class implements PerfettoPlugin {
     await addFlatSliceTrack(trace);
     await addFixedColorSliceTrack(trace);
     await addNestedTrackGroup(trace);
+    addTracksWithHelpText(trace);
   }
 }
 
@@ -305,4 +307,56 @@ async function addNestedTrackGroup(trace: Trace): Promise<void> {
       trace.workspaces.switchWorkspace(ws);
     },
   });
+}
+
+function addTracksWithHelpText(trace: Trace) {
+  const uri = `com.example.Tracks#TrackWithHelpText`;
+
+  trace.tracks.registerTrack({
+    uri,
+    renderer: new DatasetSliceTrack({
+      trace: trace,
+      uri,
+      dataset: new SourceDataset({
+        src: 'example_events', // Use the whole dummy table
+        schema: {
+          id: NUM,
+          ts: LONG,
+          dur: LONG,
+          name: STR,
+        },
+      }),
+    }),
+    description: () => [
+      'This track demonstrates how to add help text.',
+      m('br'),
+      'Use Mithril vnodes for formatting.',
+    ],
+  });
+
+  const groupNode = addGroupWithHelpText(trace);
+
+  // Add to workspace
+  groupNode.addChildLast(new TrackNode({uri, name: 'Track with Help Text'}));
+}
+
+function addGroupWithHelpText(trace: Trace) {
+  const uri = `com.example.Tracks#GroupWithHelpText`;
+
+  trace.tracks.registerTrack({
+    uri,
+    renderer: {
+      render: () => {},
+    },
+    description: () => [
+      'This is a group track with some help text.',
+      m('br'),
+      'Use Mithril vnodes for formatting.',
+    ],
+  });
+
+  // Add to workspace
+  const groupNode = new TrackNode({uri, name: 'Group with Help Text'});
+  trace.workspace.addChildInOrder(groupNode);
+  return groupNode;
 }

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -210,7 +210,7 @@ export interface TrackRenderer {
    * track uses.
    */
   getSliceVerticalBounds?(depth: number): VerticalBounds | undefined;
-  getHeight(): number;
+  getHeight?(): number;
   getTrackShellButtons?(): m.Children;
   onMouseMove?(event: TrackMouseEvent): void;
   onMouseClick?(event: TrackMouseEvent): boolean;


### PR DESCRIPTION
Also make `Track::getHeight()` optional to make it easier to define dummy renderers.
