### PR TITLE
stdlib: Add IRQ power attribution for Wattson

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15025,7 +15025,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/wattson/gpu/freq_idle.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/attribution.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql",
-        "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql",
+        "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/task_slices.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/ui/continuous_estimates.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql",
     ],

--- a/BUILD
+++ b/BUILD
@@ -3446,7 +3446,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/wattson/gpu/freq_idle.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/attribution.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql",
-        "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql",
+        "src/trace_processor/perfetto_sql/stdlib/wattson/tasks/task_slices.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/ui/continuous_estimates.sql",
         "src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql",
     ],

--- a/src/trace_processor/metrics/sql/android/wattson_app_startup_threads.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_app_startup_threads.sql
@@ -15,7 +15,7 @@
 
 INCLUDE PERFETTO MODULE android.startup.startups;
 INCLUDE PERFETTO MODULE wattson.estimates;
-INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
 DROP VIEW IF EXISTS _app_startup_window;
 CREATE PERFETTO VIEW _app_startup_window AS

--- a/src/trace_processor/metrics/sql/android/wattson_atrace_apps_threads.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_atrace_apps_threads.sql
@@ -15,7 +15,7 @@
 
 INCLUDE PERFETTO MODULE android.startup.startups;
 INCLUDE PERFETTO MODULE wattson.estimates;
-INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
 -- Create the base table (`android_jank_cuj`) containing all completed CUJs
 -- found in the trace.

--- a/src/trace_processor/metrics/sql/android/wattson_markers_threads.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_markers_threads.sql
@@ -14,7 +14,7 @@
 -- limitations under the License.
 
 INCLUDE PERFETTO MODULE wattson.estimates;
-INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 INCLUDE PERFETTO MODULE wattson.utils;
 
 DROP VIEW IF EXISTS _wattson_period_window;

--- a/src/trace_processor/metrics/sql/android/wattson_trace_threads.sql
+++ b/src/trace_processor/metrics/sql/android/wattson_trace_threads.sql
@@ -14,7 +14,7 @@
 -- limitations under the License.
 
 INCLUDE PERFETTO MODULE wattson.estimates;
-INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
 -- This metric is defined to be for entire trace duration
 DROP VIEW IF EXISTS _wattson_period_window;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/BUILD.gn
@@ -34,7 +34,7 @@ perfetto_sql_source_set("wattson") {
     "gpu/freq_idle.sql",
     "tasks/attribution.sql",
     "tasks/idle_transitions_attribution.sql",
-    "tasks/threads_w_processes.sql",
+    "tasks/task_slices.sql",
     "ui/continuous_estimates.sql",
     "utils.sql",
   ]

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/attribution.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/attribution.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
 INCLUDE PERFETTO MODULE wattson.ui.continuous_estimates;
 
@@ -164,11 +164,11 @@ SELECT
 FROM _interval_intersect!(
   (
     _ii_subquery!(_unioned_wattson_estimates_mw),
-    _ii_subquery!(_sched_w_thread_process_package_summary)
+    _ii_subquery!(_wattson_task_slices)
   ),
   (cpu)
 ) AS ii
 JOIN _unioned_wattson_estimates_mw AS uw
   ON uw._auto_id = id_0
-JOIN _sched_w_thread_process_package_summary AS s
+JOIN _wattson_task_slices AS s
   ON s._auto_id = id_1;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql
@@ -21,16 +21,6 @@ INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
 INCLUDE PERFETTO MODULE wattson.utils;
 
--- Get slice info of tasks/processes
-CREATE PERFETTO TABLE _task_slices AS
-SELECT
-  ts,
-  dur,
-  cpu,
-  utid,
-  upid
-FROM _wattson_task_slices;
-
 -- Gets the slices where the CPU transitions from deep idle to active, and the
 -- associated task that causes the idle exit
 CREATE PERFETTO TABLE _idle_w_tasks AS
@@ -45,13 +35,15 @@ WITH
       id_1 AS idle_group
     FROM _interval_intersect!(
     (
-      _ii_subquery!(_task_slices),
+      _ii_subquery!(_wattson_task_slices),
       _ii_subquery!(_idle_exits)
     ),
     (cpu)
   ) AS ii
-    JOIN _task_slices AS tasks
+    JOIN _wattson_task_slices AS tasks
       ON tasks._auto_id = id_0
+    ORDER BY
+      ii.ts ASC
   ),
   -- Since sorted by time, MIN() is fast aggregate function that will return the
   -- first time slice, which will be the utid = 0 slice immediately succeeding the

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql
@@ -17,45 +17,45 @@ INCLUDE PERFETTO MODULE intervals.intersect;
 
 INCLUDE PERFETTO MODULE wattson.estimates;
 
-INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
 INCLUDE PERFETTO MODULE wattson.utils;
 
--- Get slice info of threads/processes
-CREATE PERFETTO TABLE _thread_process_slices AS
+-- Get slice info of tasks/processes
+CREATE PERFETTO TABLE _task_slices AS
 SELECT
   ts,
   dur,
   cpu,
   utid,
   upid
-FROM _sched_w_thread_process_package_summary;
+FROM _wattson_task_slices;
 
 -- Gets the slices where the CPU transitions from deep idle to active, and the
--- associated thread that causes the idle exit
-CREATE PERFETTO TABLE _idle_w_threads AS
+-- associated task that causes the idle exit
+CREATE PERFETTO TABLE _idle_w_tasks AS
 WITH
-  _ii_idle_threads AS (
+  _ii_idle_tasks AS (
     SELECT
       ii.ts,
       ii.dur,
       ii.cpu,
-      threads.utid,
-      threads.upid,
+      tasks.utid,
+      tasks.upid,
       id_1 AS idle_group
     FROM _interval_intersect!(
     (
-      _ii_subquery!(_thread_process_slices),
+      _ii_subquery!(_task_slices),
       _ii_subquery!(_idle_exits)
     ),
     (cpu)
   ) AS ii
-    JOIN _thread_process_slices AS threads
-      ON threads._auto_id = id_0
+    JOIN _task_slices AS tasks
+      ON tasks._auto_id = id_0
   ),
   -- Since sorted by time, MIN() is fast aggregate function that will return the
   -- first time slice, which will be the utid = 0 slice immediately succeeding the
-  -- idle to active transition, and immediately preceding the active thread
+  -- idle to active transition, and immediately preceding the active task
   first_swapper_slice AS (
     SELECT
       ts,
@@ -63,12 +63,12 @@ WITH
       cpu,
       idle_group,
       min(ts) AS min
-    FROM _ii_idle_threads
+    FROM _ii_idle_tasks
     GROUP BY
       idle_group
   ),
-  -- MIN() here will give the first active thread immediately succeeding the idle
-  -- to active transition slice, which means this the the thread that causes the
+  -- MIN() here will give the first active task immediately succeeding the idle
+  -- to active transition slice, which means this the the task that causes the
   -- idle exit
   first_non_swapper_slice AS (
     SELECT
@@ -77,7 +77,7 @@ WITH
       upid,
       min(ts) AS min,
       min(ts) + dur AS next_ts
-    FROM _ii_idle_threads
+    FROM _ii_idle_tasks
     WHERE
       NOT utid IN (
         SELECT
@@ -98,7 +98,7 @@ WITH
       cpu,
       idle_group,
       max(ts) AS min
-    FROM _ii_idle_threads
+    FROM _ii_idle_tasks
     GROUP BY
       idle_group
   )
@@ -106,24 +106,24 @@ SELECT
   swapper_info.ts,
   swapper_info.dur,
   swapper_info.cpu,
-  thread_info.utid,
-  thread_info.upid
-FROM first_non_swapper_slice AS thread_info
+  task_info.utid,
+  task_info.upid
+FROM first_non_swapper_slice AS task_info
 JOIN first_swapper_slice AS swapper_info
   USING (idle_group)
 UNION ALL
 -- Adds the last slice to idle transition attribution IF this is a singleton
--- thread wakeup. This is true if there is only one thread between swapper idle
--- exits/wakeups. For example, groups with order of swapper, thread X, swapper
--- will be included. Entries that have multiple thread between swappers, such as
--- swapper, thread X, thread Y, swapper will not be included.
+-- task wakeup. This is true if there is only one task between swapper idle
+-- exits/wakeups. For example, groups with order of swapper, task X, swapper
+-- will be included. Entries that have multiple task between swappers, such as
+-- swapper, task X, task Y, swapper will not be included.
 SELECT
   swapper_info.ts,
   swapper_info.dur,
   swapper_info.cpu,
-  thread_info.utid,
-  thread_info.upid
-FROM first_non_swapper_slice AS thread_info
+  task_info.utid,
+  task_info.upid
+FROM first_non_swapper_slice AS task_info
 JOIN last_swapper_slice AS swapper_info
   USING (idle_group)
 WHERE
@@ -135,10 +135,10 @@ CREATE PERFETTO TABLE _idle_transition_cost AS
 SELECT
   ii.ts,
   ii.dur,
-  threads.cpu,
-  threads.utid,
-  threads.upid,
-  CASE threads.cpu
+  tasks.cpu,
+  tasks.utid,
+  tasks.upid,
+  CASE tasks.cpu
     WHEN 0
     THEN power.cpu0_mw
     WHEN 1
@@ -159,13 +159,13 @@ SELECT
   END AS estimated_mw
 FROM _interval_intersect!(
   (
-    _ii_subquery!(_idle_w_threads),
+    _ii_subquery!(_idle_w_tasks),
     _ii_subquery!(_system_state_mw)
   ),
   ()
 ) AS ii
-JOIN _idle_w_threads AS threads
-  ON threads._auto_id = id_0
+JOIN _idle_w_tasks AS tasks
+  ON tasks._auto_id = id_0
 JOIN _system_state_mw AS power
   ON power._auto_id = id_1;
 
@@ -178,7 +178,7 @@ CREATE PERFETTO FUNCTION _filter_idle_attribution(
 )
 RETURNS TABLE (
   idle_cost_mws LONG,
-  utid JOINID(thread.id),
+  utid JOINID(task.id),
   upid JOINID(process.id),
   cpu JOINID(cpu.id)
 ) AS

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/idle_transitions_attribution.sql
@@ -31,17 +31,6 @@ SELECT
   upid
 FROM _sched_w_thread_process_package_summary;
 
--- Get slices only where there is transition from deep idle to active
-CREATE PERFETTO TABLE _idle_exits AS
-SELECT
-  ts,
-  dur,
-  cpu,
-  idle
-FROM _adjusted_deep_idle
-WHERE
-  idle = -1 AND dur > 0;
-
 -- Gets the slices where the CPU transitions from deep idle to active, and the
 -- associated thread that causes the idle exit
 CREATE PERFETTO TABLE _idle_w_threads AS

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/task_slices.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/task_slices.sql
@@ -37,7 +37,7 @@ FROM _adjusted_deep_idle
 WHERE
   idle = -1 AND dur > 0;
 
--- Establish relationships between thread/process/package
+-- Establish relationships between tasks, such as thread/process/package
 CREATE PERFETTO TABLE _task_wo_irq_infos AS
 SELECT
   sched.ts,
@@ -225,7 +225,7 @@ CREATE PERFETTO INDEX _task_causing_idle_exit_idx ON _task_causing_idle_exit(idl
 --- and replaced with swapper. The previous table, _active_state_w_tasks, has
 --- many groups of "islands", of which the gaps need to be filled back in with
 --- the swapper task.
-CREATE PERFETTO TABLE _sched_w_thread_process_package_summary AS
+CREATE PERFETTO TABLE _wattson_task_slices AS
 WITH
   base_tasks AS (
     SELECT

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql
@@ -23,7 +23,8 @@ SELECT
   ts,
   dur,
   cpu,
-  idle
+  idle,
+  _auto_id AS group_id
 FROM _adjusted_deep_idle
 WHERE
   idle = -1 AND dur > 0;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql
@@ -15,6 +15,10 @@
 
 INCLUDE PERFETTO MODULE android.process_metadata;
 
+INCLUDE PERFETTO MODULE intervals.overlap;
+
+INCLUDE PERFETTO MODULE linux.irqs;
+
 INCLUDE PERFETTO MODULE wattson.cpu.idle;
 
 -- Get slices only where there is transition from deep idle to active
@@ -52,3 +56,108 @@ LEFT JOIN android_process_metadata AS package
   USING (upid)
 WHERE
   dur > 0;
+
+-- Flatten hard IRQs, since they can preempt each other. Only hard IRQs can use
+-- the built-in ancestor_slice() and interval functions
+CREATE PERFETTO VIEW _hard_irq_flattened_slices AS
+WITH
+  root_slices AS (
+    SELECT
+      id,
+      ts,
+      dur
+    FROM linux_hard_irqs
+    WHERE
+      parent_id IS NULL
+  ),
+  child_slices AS (
+    SELECT
+      anc.id AS root_id,
+      irq.id,
+      irq.parent_id,
+      irq.ts,
+      irq.dur
+    FROM linux_hard_irqs AS irq, ancestor_slice(irq.id) AS anc
+    WHERE
+      irq.parent_id IS NOT NULL
+  )
+SELECT
+  intervals.ts,
+  intervals.dur,
+  slices.name AS hard_irq_name,
+  slices.stack_id AS hard_irq_stack_id,
+  cpu_track.cpu
+FROM _intervals_flatten!(_intervals_merge_root_and_children!(root_slices, child_slices)) AS intervals
+JOIN slices
+  USING (id)
+JOIN cpu_track
+  ON cpu_track.id = slices.track_id;
+
+-- Softirqs run with other softirqs disabled, so will not be preempted by each
+-- other, and thus do not need to be flattened like hard IRQs do.
+CREATE PERFETTO VIEW _soft_irq_slices AS
+SELECT
+  linux_soft_irqs.ts,
+  linux_soft_irqs.dur,
+  slices.name AS soft_irq_name,
+  slices.stack_id AS soft_irq_stack_id,
+  cpu_track.cpu
+FROM linux_soft_irqs
+JOIN slices
+  USING (id)
+JOIN cpu_track
+  ON cpu_track.id = slices.track_id;
+
+CREATE VIRTUAL TABLE _all_irqs_combined_slices USING SPAN_OUTER_JOIN (
+  _soft_irq_slices PARTITIONED cpu,
+  _hard_irq_flattened_slices PARTITIONED cpu
+);
+
+-- Replace soft IRQs with hard IRQs if hard IRQs are present. Hard IRQs could
+-- preempt soft IRQs, but not the other way around.
+CREATE PERFETTO VIEW _all_irqs_flattened_slices AS
+WITH
+  base_name AS (
+    SELECT
+      ts,
+      dur,
+      cpu,
+      coalesce(hard_irq_name, soft_irq_name) AS irq_name,
+      coalesce(hard_irq_stack_id, soft_irq_stack_id) AS stack_id
+    FROM _all_irqs_combined_slices
+  )
+SELECT
+  ts,
+  dur,
+  cpu,
+  irq_name,
+  -- Create a synthetic irq_id such that IRQ slices have the same
+  -- properties/columns as thread slices, which allows us to fit IRQ slices into
+  -- the existing framework of attributing power to tasks.
+  hash(irq_name) AS irq_id
+FROM base_name;
+
+-- SPAN_OUTER_JOIN needed because IRQ table do not have contiguous slices,
+-- whereas tasks table will be contiguous
+CREATE VIRTUAL TABLE _irq_w_tasks_info USING SPAN_OUTER_JOIN (
+  _sched_w_thread_process_package_summary PARTITIONED cpu,
+  _all_irqs_flattened_slices PARTITIONED cpu
+);
+
+-- Replace nominal tasks with IRQ if the IRQ slice is present. IRQs could
+-- preempt tasks, but not the other way around.
+CREATE PERFETTO TABLE _all_tasks_flattened_slices AS
+SELECT
+  ts,
+  dur,
+  cpu,
+  coalesce(irq_id, utid) AS utid,
+  coalesce(irq_id, upid) AS upid,
+  coalesce(irq_id, tid) AS tid,
+  coalesce(irq_id, pid) AS pid,
+  coalesce(irq_id, uid) AS uid,
+  coalesce(irq_name, thread_name) AS thread_name,
+  coalesce(irq_name, process_name) AS process_name,
+  coalesce(irq_name, package_name) AS package_name,
+  NOT irq_id IS NULL AS is_irq
+FROM _irq_w_tasks_info;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/tasks/threads_w_processes.sql
@@ -15,6 +15,19 @@
 
 INCLUDE PERFETTO MODULE android.process_metadata;
 
+INCLUDE PERFETTO MODULE wattson.cpu.idle;
+
+-- Get slices only where there is transition from deep idle to active
+CREATE PERFETTO TABLE _idle_exits AS
+SELECT
+  ts,
+  dur,
+  cpu,
+  idle
+FROM _adjusted_deep_idle
+WHERE
+  idle = -1 AND dur > 0;
+
 -- Establish relationships between thread/process/package
 CREATE PERFETTO TABLE _sched_w_thread_process_package_summary AS
 SELECT

--- a/test/trace_processor/diff_tests/stdlib/wattson/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/wattson/tests.py
@@ -418,3 +418,30 @@ class WattsonStdlib(TestSuite):
             1,250118842121,137102890041
             1,387221732162,2321209555
             """))
+
+  # Tests that IRQ stacks are properly flattened and have unique IDs
+  def test_wattson_irq_flattening(self):
+    return DiffTestBlueprint(
+        trace=DataPath('wattson_irq_gpu_markers.pb'),
+        query="""
+        INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+
+        SELECT
+          SUM(dur) AS total_dur, irq_name, irq_id
+        FROM  _all_irqs_flattened_slices
+        GROUP BY irq_name
+        LIMIT 10
+        """,
+        out=Csv("""
+          "total_dur","irq_name","irq_id"
+          1118451,"BLOCK",-7563548160659491326
+          1701414,"IRQ (100a0000.BIG)",-8960469306195608742
+          769330,"IRQ (100a0000.LITTLE)",2595235052520049942
+          741289,"IRQ (100a0000.MID)",709594339438163430
+          2179935,"IRQ (10840000.pinctrl)",6369664009351169759
+          1192993,"IRQ (10970000.hsi2c)",-1238860297262945668
+          7840694,"IRQ (176a0000.mbox)",442503679933451729
+          2110993,"IRQ (1c0b0000.drmdpp)",3108582083943637163
+          2132254,"IRQ (1c0b1000.drmdpp)",2330704911466106250
+          1187454,"IRQ (1c0b2000.drmdpp)",-4397375750993244671
+          """))

--- a/test/trace_processor/diff_tests/stdlib/wattson/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/wattson/tests.py
@@ -445,3 +445,33 @@ class WattsonStdlib(TestSuite):
           2132254,"IRQ (1c0b1000.drmdpp)",2330704911466106250
           1187454,"IRQ (1c0b2000.drmdpp)",-4397375750993244671
           """))
+
+  # Tests that all tasks are correct after accounting for preemption and idle
+  # exits
+  def test_wattson_all_tasks_flattening_and_idle_exits(self):
+    return DiffTestBlueprint(
+        trace=DataPath('wattson_irq_gpu_markers.pb'),
+        query="""
+        INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+
+        SELECT
+          SUM(dur) AS dur,
+          thread_name
+        FROM _sched_w_thread_process_package_summary
+        GROUP BY thread_name
+        ORDER BY dur DESC
+        LIMIT 10
+        """,
+        out=Csv("""
+          "dur","thread_name"
+          80559339989,"swapper"
+          1617087785,"Runner: gl_tess"
+          800487950,"mali-cmar-backe"
+          469271586,"mali_jd_thread"
+          426019439,"surfaceflinger"
+          326858956,"IRQ (exynos-mct)"
+          323531361,"s.nexuslauncher"
+          312153973,"RenderThread"
+          251889143,"50000.corporate"
+          241043219,"traced_probes"
+          """))

--- a/test/trace_processor/diff_tests/stdlib/wattson/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/wattson/tests.py
@@ -424,7 +424,7 @@ class WattsonStdlib(TestSuite):
     return DiffTestBlueprint(
         trace=DataPath('wattson_irq_gpu_markers.pb'),
         query="""
-        INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+        INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
         SELECT
           SUM(dur) AS total_dur, irq_name, irq_id
@@ -452,12 +452,12 @@ class WattsonStdlib(TestSuite):
     return DiffTestBlueprint(
         trace=DataPath('wattson_irq_gpu_markers.pb'),
         query="""
-        INCLUDE PERFETTO MODULE wattson.tasks.threads_w_processes;
+        INCLUDE PERFETTO MODULE wattson.tasks.task_slices;
 
         SELECT
           SUM(dur) AS dur,
           thread_name
-        FROM _sched_w_thread_process_package_summary
+        FROM _wattson_task_slices
         GROUP BY thread_name
         ORDER BY dur DESC
         LIMIT 10


### PR DESCRIPTION
In addition to threads/processes/packages, add IRQs as a potential task
for Wattson to attribute power for. This handles cases where tasks may
preempt another task, including for soft IRQs and hard IRQs.


Test: tools/diff_test_trace_processor.py out/linux/trace_processor_shell --name-filter '.*wattson.*'
Bug: 422478917
Signed-off-by: Samuel Wu <wusamuel@google.com>