### PR TITLE
tp: Consider objects from zygote and boot image as roots

### DIFF
--- a/src/trace_processor/importers/proto/heap_graph_tracker.h
+++ b/src/trace_processor/importers/proto/heap_graph_tracker.h
@@ -178,6 +178,7 @@ class HeapGraphTracker : public Destructible {
     protos::pbzero::HeapGraphObject::HeapType last_heap_type =
         protos::pbzero::HeapGraphObject::HEAP_TYPE_UNKNOWN;
     std::vector<SourceRoot> current_roots;
+    std::vector<uint64_t> internal_vm_roots;
 
     // Note: the below maps are a mix of std::map and base::FlatHashMap because
     // of the incremental evolution of this code (i.e. when the code was written

--- a/test/trace_processor/diff_tests/parser/profiling/heap_graph_flamegraph.out
+++ b/test/trace_processor/diff_tests/parser/profiling/heap_graph_flamegraph.out
@@ -2,3 +2,4 @@
 0,0,"FactoryProducerDelegateImplActor [ROOT_JAVA_FRAME]","JAVA",1,2,64,96,"[NULL]"
 1,1,"Foo","JAVA",1,1,32,32,0
 2,0,"DeobfuscatedA[] [ROOT_JAVA_FRAME]","JAVA",1,1,256,256,"[NULL]"
+3,0,"android.os.Parcel [ROOT_VM_INTERNAL]","JAVA",1,1,256,256,"[NULL]"

--- a/test/trace_processor/diff_tests/parser/profiling/tests_heap_graph.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests_heap_graph.py
@@ -221,7 +221,7 @@ class ProfilingHeapGraph(TestSuite):
           3,2,10,1024,3,0,"HEAP_TYPE_APP","a","DeobfuscatedA","[NULL]"
           4,2,10,256,"[NULL]",1,"HEAP_TYPE_APP","a[]","DeobfuscatedA[]","ROOT_JAVA_FRAME"
           5,2,10,256,"[NULL]",0,"HEAP_TYPE_APP","java.lang.Class<a[]>","java.lang.Class<DeobfuscatedA[]>","[NULL]"
-          6,2,10,256,"[NULL]",0,"HEAP_TYPE_ZYGOTE","android.os.Parcel","[NULL]","[NULL]"
+          6,2,10,256,"[NULL]",1,"HEAP_TYPE_ZYGOTE","android.os.Parcel","[NULL]","ROOT_VM_INTERNAL"
         '''))
 
   def test_heap_graph_object_reference_set_id(self):


### PR DESCRIPTION
This matches what the ART GC does: it will never try to free them.
