### PR TITLE
gn: Don't set -fno-rtti when is_ubsan is true

### DIFF
--- a/buildtools/BUILD.gn
+++ b/buildtools/BUILD.gn
@@ -663,7 +663,7 @@ if (use_custom_libcxx) {
     configs -= [
       "//gn/standalone:extra_warnings",
       "//gn/standalone:no_exceptions",
-      "//gn/standalone:no_rtti",
+      "//gn/standalone:rtti_cflags",
 
       # When building with msan, libunwind itself triggers memory violations
       # that causes msan to get stuck into an infinite loop. Just don't
@@ -749,7 +749,7 @@ if (use_custom_libcxx) {
     configs -= [
       "//gn/standalone:extra_warnings",
       "//gn/standalone:no_exceptions",
-      "//gn/standalone:no_rtti",
+      "//gn/standalone:rtti_cflags",
       "//gn/standalone:c++17",
     ]
     configs += [
@@ -868,7 +868,7 @@ if (use_custom_libcxx) {
     configs -= [
       "//gn/standalone:extra_warnings",
       "//gn/standalone:no_exceptions",
-      "//gn/standalone:no_rtti",
+      "//gn/standalone:rtti_cflags",
       "//gn/standalone:c++17",
     ]
     if ((is_android || is_mac) && !custom_libcxx_is_static) {
@@ -1704,7 +1704,7 @@ if (enable_perfetto_etm_importer) {
     configs -= [
       "//gn/standalone:extra_warnings",
       "//gn/standalone:no_exceptions",
-      "//gn/standalone:no_rtti",
+      "//gn/standalone:rtti_cflags",
     ]
     include_dirs = [ "open_csd/decoder/include" ]
     public_configs = [ ":open_csd_config" ]

--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -147,11 +147,17 @@ config("no_exceptions") {
   }
 }
 
-config("no_rtti") {
-  if (is_win) {
-    cflags_cc = [ "/GR-" ]
-  } else {
-    cflags_cc = [ "-fno-rtti" ]
+config("rtti_cflags") {
+  # Generally, we want -fno-rtti. However, this is compatible with some ubsan
+  # configurations (specifically, those that use -fsanitize=vptr). Since we
+  # don't know if anyone linking in perfetto will use -fsanitize=vptr, don't
+  # pass -fno-rtti when is_ubsan is true.
+  if (!is_ubsan) {
+    if (is_win) {
+      cflags_cc = [ "/GR-" ]
+    } else {
+      cflags_cc = [ "-fno-rtti" ]
+    }
   }
 }
 

--- a/gn/standalone/BUILDCONFIG.gn
+++ b/gn/standalone/BUILDCONFIG.gn
@@ -69,7 +69,7 @@ default_configs = [
   "//gn/standalone:default",
   "//gn/standalone:extra_warnings",
   "//gn/standalone:no_exceptions",
-  "//gn/standalone:no_rtti",
+  "//gn/standalone:rtti_cflags",
   "//gn/standalone:visibility_hidden",
   "//gn/standalone/libc++:config",
   "//gn/standalone/sanitizers:sanitizers_cflags",


### PR DESCRIPTION
Generally, we build perfetto with -fno-rtti. However, this is incompatible with some UBSAN configurations, notably -fsanitize=vptr. Since we don't know if someone downstream will use -fsanitize=vptr, don't pass -fno-rtti when is_ubsan is true. This produces code which is compatible with clients using -fsanitize=vptr.

Bug: 422542836
Test: In ChromeOS chroot:
Test:     USE=ubsan emerge-$BOARD perfetto vulkan-shader-profiler

Change-Id: I1bf8950af457a708c93a30f6eefee1bff519cf4c
