### PR TITLE
Make trace processor metatrace thread local, not global

### DIFF
--- a/src/trace_processor/tp_metatrace.cc
+++ b/src/trace_processor/tp_metatrace.cc
@@ -47,7 +47,7 @@ thread_local Category g_enabled_categories = Category::NONE;
 void Enable(MetatraceConfig config) {
   g_enabled_categories = MetatraceCategoriesToProtoEnum(config.categories);
   if (config.override_buffer_size) {
-    RingBuffer::GetInstance()->Resize(config.override_buffer_size);
+    RingBuffer::GetInstance().Resize(config.override_buffer_size);
   }
 }
 
@@ -55,7 +55,7 @@ void DisableAndReadBuffer(std::function<void(Record*)> fn) {
   g_enabled_categories = Category::NONE;
   if (!fn)
     return;
-  RingBuffer::GetInstance()->ReadAll(fn);
+  RingBuffer::GetInstance().ReadAll(fn);
 }
 
 RingBuffer::RingBuffer() : data_(kDefaultCapacity) {


### PR DESCRIPTION
This makes it possible to use metatrace in a multi-threaded context, as long as we are careful to only use each trace processor instance from a single thread.

Bug: [427909201](https://b.corp.google.com/427909201)
