### PR TITLE
tp: don't require single sequence emission for incremental counter tracks (#2002)

### DIFF
--- a/src/trace_processor/importers/proto/packet_sequence_state_generation.h
+++ b/src/trace_processor/importers/proto/packet_sequence_state_generation.h
@@ -213,6 +213,12 @@ class PacketSequenceStateGeneration : public RefCounted {
         .IncrementAndGetTrackEventThreadInstructionCount(delta);
   }
 
+  double IncrementAndGetCounterValue(uint64_t counter_track_uuid,
+                                     double value) {
+    return track_event_sequence_state_.IncrementAndGetCounterValue(
+        counter_track_uuid, value);
+  }
+
   bool track_event_timestamps_valid() const {
     return track_event_sequence_state_.timestamps_valid();
   }

--- a/src/trace_processor/importers/proto/track_event_module.cc
+++ b/src/trace_processor/importers/proto/track_event_module.cc
@@ -102,10 +102,6 @@ void TrackEventModule::ParseTracePacketData(const TracePacket::Decoder& decoder,
   }
 }
 
-void TrackEventModule::OnIncrementalStateCleared(uint32_t packet_sequence_id) {
-  track_event_tracker_->OnIncrementalStateCleared(packet_sequence_id);
-}
-
 void TrackEventModule::OnFirstPacketOnSequence(uint32_t packet_sequence_id) {
   track_event_tracker_->OnFirstPacketOnSequence(packet_sequence_id);
 }

--- a/src/trace_processor/importers/proto/track_event_module.h
+++ b/src/trace_processor/importers/proto/track_event_module.h
@@ -49,8 +49,6 @@ class TrackEventModule : public ProtoImporterModule {
                             const TracePacketData& data,
                             uint32_t field_id) override;
 
-  void OnIncrementalStateCleared(uint32_t) override;
-
   void OnFirstPacketOnSequence(uint32_t) override;
 
   void ParseTrackEventData(const protos::pbzero::TracePacket::Decoder& decoder,

--- a/src/trace_processor/importers/proto/track_event_sequence_state.h
+++ b/src/trace_processor/importers/proto/track_event_sequence_state.h
@@ -19,6 +19,7 @@
 
 #include <utility>
 
+#include "perfetto/ext/base/flat_hash_map.h"
 #include "protos/perfetto/trace/track_event/thread_descriptor.pbzero.h"
 
 namespace perfetto {
@@ -61,6 +62,14 @@ class TrackEventSequenceState {
     return thread_instruction_count_;
   }
 
+  double IncrementAndGetCounterValue(uint64_t counter_track_uuid,
+                                     double value) {
+    auto [it, inserted] =
+        incremental_counter_values_.Insert(counter_track_uuid, 0.0);
+    *it += value;
+    return *it;
+  }
+
   void SetThreadDescriptor(const protos::pbzero::ThreadDescriptor::Decoder&);
 
  private:
@@ -89,6 +98,9 @@ class TrackEventSequenceState {
   int64_t timestamp_ns_ = 0;
   int64_t thread_timestamp_ns_ = 0;
   int64_t thread_instruction_count_ = 0;
+
+  base::FlatHashMap<uint64_t /* uuid */, double /* value */>
+      incremental_counter_values_;
 
   PersistentState persistent_state_;
 };

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -44,7 +44,7 @@
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/proto_trace_reader.h"
 #include "src/trace_processor/importers/proto/track_event_tracker.h"
-#include "src/trace_processor/sorter/trace_sorter.h"
+#include "src/trace_processor/sorter/trace_sorter.h"  // IWYU pragma: keep
 #include "src/trace_processor/storage/metadata.h"
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -256,9 +256,6 @@ ModuleResult TrackEventTokenizer::TokenizeTrackDescriptorPacket(
     }
 
     // Incrementally encoded counters are only valid on a single sequence.
-    if (counter.is_incremental()) {
-      counter_details.packet_sequence_id = packet.trusted_packet_sequence_id();
-    }
     track_event_tracker_->ReserveDescriptorTrack(track.uuid(), reservation);
 
     return ModuleResult::Ignored();
@@ -429,12 +426,10 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     std::optional<double> value;
     if (event.has_counter_value()) {
       value = track_event_tracker_->ConvertToAbsoluteCounterValue(
-          track_uuid, packet.trusted_packet_sequence_id(),
-          static_cast<double>(event.counter_value()));
+          state.get(), track_uuid, static_cast<double>(event.counter_value()));
     } else {
       value = track_event_tracker_->ConvertToAbsoluteCounterValue(
-          track_uuid, packet.trusted_packet_sequence_id(),
-          event.double_counter_value());
+          state.get(), track_uuid, event.double_counter_value());
     }
 
     if (!value) {
@@ -450,8 +445,8 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
   size_t index = 0;
   const protozero::RepeatedFieldIterator<uint64_t> kEmptyIterator;
   auto result = AddExtraCounterValues(
-      data, index, packet.trusted_packet_sequence_id(),
-      event.extra_counter_values(), event.extra_counter_track_uuids(),
+      *state, data, index, event.extra_counter_values(),
+      event.extra_counter_track_uuids(),
       defaults ? defaults->extra_counter_track_uuids() : kEmptyIterator);
   if (!result.ok()) {
     PERFETTO_DLOG("%s", result.c_message());
@@ -459,8 +454,7 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
     return ModuleResult::Handled();
   }
   result = AddExtraCounterValues(
-      data, index, packet.trusted_packet_sequence_id(),
-      event.extra_double_counter_values(),
+      *state, data, index, event.extra_double_counter_values(),
       event.extra_double_counter_track_uuids(),
       defaults ? defaults->extra_double_counter_track_uuids() : kEmptyIterator);
   if (!result.ok()) {
@@ -476,9 +470,9 @@ ModuleResult TrackEventTokenizer::TokenizeTrackEventPacket(
 
 template <typename T>
 base::Status TrackEventTokenizer::AddExtraCounterValues(
+    PacketSequenceStateGeneration& state,
     TrackEventData& data,
     size_t& index,
-    uint32_t trusted_packet_sequence_id,
     protozero::RepeatedFieldIterator<T> value_it,
     protozero::RepeatedFieldIterator<uint64_t> packet_track_uuid_it,
     protozero::RepeatedFieldIterator<uint64_t> default_track_uuid_it) {
@@ -511,8 +505,7 @@ base::Status TrackEventTokenizer::AddExtraCounterValues(
     }
     std::optional<double> abs_value =
         track_event_tracker_->ConvertToAbsoluteCounterValue(
-            *track_uuid_it, trusted_packet_sequence_id,
-            static_cast<double>(*value_it));
+            &state, *track_uuid_it, static_cast<double>(*value_it));
     if (!abs_value) {
       return base::ErrStatus(
           "Ignoring TrackEvent with invalid extra counter track");

--- a/src/trace_processor/importers/proto/track_event_tokenizer.h
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.h
@@ -73,9 +73,9 @@ class TrackEventTokenizer {
       const protos::pbzero::ThreadDescriptor_Decoder&);
   template <typename T>
   base::Status AddExtraCounterValues(
+      PacketSequenceStateGeneration& state,
       TrackEventData& data,
       size_t& index,
-      uint32_t trusted_packet_sequence_id,
       protozero::RepeatedFieldIterator<T> value_it,
       protozero::RepeatedFieldIterator<uint64_t> packet_track_uuid_it,
       protozero::RepeatedFieldIterator<uint64_t> default_track_uuid_it);

--- a/src/trace_processor/importers/proto/track_event_tracker.cc
+++ b/src/trace_processor/importers/proto/track_event_tracker.cc
@@ -436,8 +436,8 @@ TrackEventTracker::ResolveDescriptorTrack(
 }
 
 std::optional<double> TrackEventTracker::ConvertToAbsoluteCounterValue(
+    PacketSequenceStateGeneration* packet_sequence_state,
     uint64_t counter_track_uuid,
-    uint32_t packet_sequence_id,
     double value) {
   auto* reservation_ptr = reserved_descriptor_tracks_.Find(counter_track_uuid);
   if (!reservation_ptr) {
@@ -455,44 +455,17 @@ std::optional<double> TrackEventTracker::ConvertToAbsoluteCounterValue(
   if (!reservation.counter_details) {
     PERFETTO_FATAL("Counter tracks require `counter_details`.");
   }
+
   DescriptorTrackReservation::CounterDetails& c_details =
       *reservation.counter_details;
-
-  if (c_details.unit_multiplier > 0)
+  if (c_details.unit_multiplier > 0) {
     value *= static_cast<double>(c_details.unit_multiplier);
-
+  }
   if (c_details.is_incremental) {
-    if (c_details.packet_sequence_id != packet_sequence_id) {
-      PERFETTO_DLOG(
-          "Incremental counter track with uuid %" PRIu64
-          " was updated from the wrong packet sequence (expected: %" PRIu32
-          " got:%" PRIu32 ")",
-          counter_track_uuid, c_details.packet_sequence_id, packet_sequence_id);
-      return std::nullopt;
-    }
-
-    c_details.latest_value += value;
-    value = c_details.latest_value;
+    value = packet_sequence_state->IncrementAndGetCounterValue(
+        counter_track_uuid, value);
   }
   return value;
-}
-
-void TrackEventTracker::OnIncrementalStateCleared(uint32_t packet_sequence_id) {
-  // TODO(eseckler): Improve on the runtime complexity of this. At O(hundreds)
-  // of packet sequences, incremental state clearing at O(trace second), and
-  // total number of tracks in O(thousands), a linear scan through all tracks
-  // here might not be fast enough.
-  for (auto it = reserved_descriptor_tracks_.GetIterator(); it; ++it) {
-    DescriptorTrackReservation& reservation = it.value();
-    // Only consider incremental counter tracks for current sequence.
-    if (!reservation.is_counter || !reservation.counter_details ||
-        !reservation.counter_details->is_incremental ||
-        reservation.counter_details->packet_sequence_id != packet_sequence_id) {
-      continue;
-    }
-    // Reset their value to 0, see CounterDescriptor's |is_incremental|.
-    reservation.counter_details->latest_value = 0;
-  }
 }
 
 void TrackEventTracker::OnFirstPacketOnSequence(uint32_t packet_sequence_id) {

--- a/test/trace_processor/diff_tests/parser/track_event/incremental_counter_sequences.textproto
+++ b/test/trace_processor/diff_tests/parser/track_event/incremental_counter_sequences.textproto
@@ -1,0 +1,77 @@
+# Test that incremental counters are correctly handled on a per-sequence basis.
+
+# Sequence 1, with incremental counter track uuid 10.
+packet {
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  incremental_state_cleared: true
+  track_descriptor {
+    uuid: 10
+    name: "MyIncrementalCounter"
+    counter {
+      is_incremental: true
+    }
+  }
+}
+
+# Sequence 2, also with incremental counter track uuid 10.
+packet {
+  trusted_packet_sequence_id: 2
+  timestamp: 0
+  incremental_state_cleared: true
+  track_descriptor {
+    uuid: 10
+    name: "MyIncrementalCounter"
+    counter {
+      is_incremental: true
+    }
+  }
+}
+
+# Event on sequence 1.
+packet {
+  trusted_packet_sequence_id: 1
+  sequence_flags: 2 # SEQ_NEEDS_INCREMENTAL_STATE
+  timestamp: 100
+  track_event {
+    type: 4 # TYPE_COUNTER
+    track_uuid: 10
+    counter_value: 100
+  }
+}
+
+# Event on sequence 2. Should not be affected by sequence 1.
+packet {
+  trusted_packet_sequence_id: 2
+  sequence_flags: 2 # SEQ_NEEDS_INCREMENTAL_STATE
+  timestamp: 150
+  track_event {
+    type: 4 # TYPE_COUNTER
+    track_uuid: 10
+    counter_value: 50
+  }
+}
+
+# Another event on sequence 1.
+packet {
+  trusted_packet_sequence_id: 1
+  sequence_flags: 2 # SEQ_NEEDS_INCREMENTAL_STATE
+  timestamp: 200
+  track_event {
+    type: 4 # TYPE_COUNTER
+    track_uuid: 10
+    counter_value: 10
+  }
+}
+
+# Another event on sequence 2.
+packet {
+  trusted_packet_sequence_id: 2
+  sequence_flags: 2 # SEQ_NEEDS_INCREMENTAL_STATE
+  timestamp: 250
+  track_event {
+    type: 4 # TYPE_COUNTER
+    track_uuid: 10
+    counter_value: 5
+  }
+}

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -620,6 +620,27 @@ class TrackEvent(TestSuite):
         "MyDoubleCounter","[NULL]","[NULL]","[NULL]","[NULL]",4500,2.718280
         """))
 
+  def test_incremental_counter_sequences(self):
+    return DiffTestBlueprint(
+        trace=Path('incremental_counter_sequences.textproto'),
+        query="""
+        SELECT
+          ts,
+          value
+        FROM counter
+        JOIN track ON counter.track_id = track.id
+        WHERE
+          track.name = 'MyIncrementalCounter'
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "ts","value"
+        100,100.000000
+        150,50.000000
+        200,110.000000
+        250,55.000000
+        """))
+
   # Clock handling
   def test_track_event_monotonic_trace_clock_slices(self):
     return DiffTestBlueprint(


### PR DESCRIPTION
We were forcing incremental counter tracks to come from the same
sequence as incrementality does not make sense across sequences.
However, it's perfectly legit for two threads to have their own view of
the same counter: for example for thread timestamps.

This happens in practice when multiple libraries are independently using
the sdk and enabling chrome timestamps (e.g. webview + cronet).

Fix this by allowing for multiple sequences to contribute to the same
track with independent incremental values.