### PR TITLE
Limited the existence of a TID to one at a time

### DIFF
--- a/src/trace_processor/export_json_unittest.cc
+++ b/src/trace_processor/export_json_unittest.cc
@@ -876,7 +876,8 @@ TEST_F(ExportJsonTest, DuplicatePidAndTid) {
       ThreadNamePriority::kTrackDescriptor);
   UniqueTid utid1a = context_.process_tracker->UpdateThread(1, 1);
   UniqueTid utid1b = context_.process_tracker->UpdateThread(2, 1);
-  UniqueTid utid1c = context_.process_tracker->StartNewThread(std::nullopt, 2);
+  context_.process_tracker->ClearThread(2);
+  UniqueTid utid1c = context_.process_tracker->GetOrCreateThread(2);
   // Associate the new thread with its process.
   ASSERT_EQ(utid1c, context_.process_tracker->UpdateThread(2, 1));
 

--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -68,28 +68,6 @@ ProcessTracker::ProcessTracker(TraceProcessorContext* context)
 
 ProcessTracker::~ProcessTracker() = default;
 
-UniqueTid ProcessTracker::StartNewThread(std::optional<int64_t> timestamp,
-                                         int64_t tid) {
-  tables::ThreadTable::Row row;
-  row.tid = tid;
-  row.start_ts = timestamp;
-  row.machine_id = context_->machine_id();
-
-  auto* thread_table = context_->storage->mutable_thread_table();
-  UniqueTid new_utid = thread_table->Insert(row).row;
-  tids_[tid].emplace_back(new_utid);
-
-  if (PERFETTO_UNLIKELY(thread_name_priorities_.size() <= new_utid)) {
-    // This condition can happen in a multi-machine tracing session:
-    // Machine 1 gets utid 0, 1
-    // Machine 2 gets utid 2, 3
-    // Machine 1 gets utid 4: where thread_name_priorities_.size() == 2.
-    thread_name_priorities_.resize(new_utid + 1);
-  }
-  thread_name_priorities_[new_utid] = ThreadNamePriority::kOther;
-  return new_utid;
-}
-
 void ProcessTracker::EndThread(int64_t timestamp, int64_t tid) {
   auto& thread_table = *context_->storage->mutable_thread_table();
   auto& process_table = *context_->storage->mutable_process_table();
@@ -138,7 +116,33 @@ std::optional<UniqueTid> ProcessTracker::GetThreadOrNull(int64_t tid) {
 
 UniqueTid ProcessTracker::GetOrCreateThread(int64_t tid) {
   auto utid = GetThreadOrNull(tid);
-  return utid ? *utid : StartNewThread(std::nullopt, tid);
+  if (utid) {
+    return *utid;
+  }
+
+  tables::ThreadTable::Row row;
+  row.tid = tid;
+  row.machine_id = context_->machine_id();
+
+  auto* thread_table = context_->storage->mutable_thread_table();
+  UniqueTid new_utid = thread_table->Insert(row).row;
+  tids_[tid].emplace_back(new_utid);
+
+  if (PERFETTO_UNLIKELY(thread_name_priorities_.size() <= new_utid)) {
+    // This condition can happen in a multi-machine tracing session:
+    // Machine 1 gets utid 0, 1
+    // Machine 2 gets utid 2, 3
+    // Machine 1 gets utid 4: where thread_name_priorities_.size() == 2.
+    thread_name_priorities_.resize(new_utid + 1);
+  }
+  thread_name_priorities_[new_utid] = ThreadNamePriority::kOther;
+  return new_utid;
+}
+
+void ProcessTracker::SetThreadStartTs(UniqueTid utid, int64_t timestamp) {
+  auto& thread_table = *context_->storage->mutable_thread_table();
+  auto td = thread_table[utid];
+  td.set_start_ts(timestamp);
 }
 
 void ProcessTracker::UpdateThreadName(UniqueTid utid,
@@ -237,7 +241,7 @@ UniqueTid ProcessTracker::UpdateThread(int64_t tid, int64_t pid) {
   std::optional<UniqueTid> opt_utid = GetThreadOrNull(tid, pid);
 
   // If no matching thread was found, create a new one.
-  UniqueTid utid = opt_utid ? *opt_utid : StartNewThread(std::nullopt, tid);
+  UniqueTid utid = opt_utid ? *opt_utid : GetOrCreateThread(tid);
   auto rr = thread_table[utid];
   PERFETTO_DCHECK(rr.tid() == tid);
   // Ensure that the thread's machine ID matches the context's machine ID.
@@ -249,6 +253,33 @@ UniqueTid ProcessTracker::UpdateThread(int64_t tid, int64_t pid) {
   }
   ResolvePendingAssociations(utid, *rr.upid());
   return utid;
+}
+
+void ProcessTracker::ClearThread(int64_t tid) {
+  std::optional<UniqueTid> opt_utid = GetThreadOrNull(tid);
+  if (!opt_utid)
+    return;
+
+  // Remove the tid completely
+  tids_.Erase(tid);
+
+  auto& thread_table = *context_->storage->mutable_thread_table();
+  auto& process_table = *context_->storage->mutable_process_table();
+
+  auto td = thread_table[*opt_utid];
+  auto opt_upid = td.upid();
+  if (!opt_upid) {
+    return;
+  }
+  auto ps = process_table[*opt_upid];
+  if (ps.pid() != tid) {
+    return;
+  }
+
+  // If the process pid and thread tid are equal then, as is the main thread
+  // of the process, we should also finish the process itself.
+  PERFETTO_DCHECK(*td.is_main_thread());
+  pids_.Erase(tid);
 }
 
 void ProcessTracker::UpdateTrustedPid(int64_t trusted_pid, uint64_t uuid) {
@@ -298,15 +329,13 @@ UniquePid ProcessTracker::StartNewProcess(std::optional<int64_t> timestamp,
                                           int64_t pid,
                                           StringId main_thread_name,
                                           ThreadNamePriority priority) {
-  pids_.Erase(pid);
-  // TODO(eseckler): Consider erasing all old entries in |tids_| that match the
-  // |pid| (those would be for an older process with the same pid). Right now,
-  // we keep them in |tids_| (if they weren't erased by EndThread()), but ignore
-  // them in GetThreadOrNull().
+  // Clear the old UTIDs, so we don't end up reusing an old entry in case of
+  // TID recycling.
+  ClearThread(/*tid=*/pid);
 
-  // Create a new UTID for the main thread, so we don't end up reusing an old
-  // entry in case of TID recycling.
-  UniqueTid utid = StartNewThread(timestamp, /*tid=*/pid);
+  UniqueTid utid = GetOrCreateThread(/*tid=*/pid);
+  if (timestamp.has_value())
+    SetThreadStartTs(utid, *timestamp);
   UpdateThreadName(utid, main_thread_name, priority);
 
   // Note that we erased the pid above so this should always return a new
@@ -435,10 +464,10 @@ UniquePid ProcessTracker::GetOrCreateProcess(int64_t pid) {
   UniquePid upid = process_table.Insert(row).row;
   *it_and_ins.first = upid;  // Update the newly inserted hashmap entry.
 
-  // Create an entry for the main thread.
-  // We cannot call StartNewThread() here, because threads for this process
-  // (including the main thread) might have been seen already prior to this
-  // call. This call usually comes from the ProcessTree dump which is delayed.
+  // Create an entry for the main thread if it doesn't already exists.
+  // The threads for this process (including the main thread) might have been
+  // seen already prior to this call. This call usually comes from the
+  // ProcessTree dump which is delayed.
   UpdateThread(/*tid=*/pid, pid);
   return upid;
 }

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -66,10 +66,6 @@ class ProcessTracker {
   // implemented. This will include passing timestamps into the below methods
   // to ensure the correct upid/utid is found.
 
-  // Called when a task_newtask is observed. This force the tracker to start
-  // a new UTID for the thread, which is needed for TID-recycling resolution.
-  UniqueTid StartNewThread(std::optional<int64_t> timestamp, int64_t tid);
-
   // Returns whether a thread is considered alive by the process tracker.
   bool IsThreadAlive(UniqueTid utid);
 
@@ -83,6 +79,9 @@ class ProcessTracker {
   // Returns the thread utid (or creates a new entry if not present)
   UniqueTid GetOrCreateThread(int64_t tid);
 
+  // Assigns the start timestamp to a thread identified by utid.
+  void SetThreadStartTs(UniqueTid utid, int64_t timestamp);
+
   // Assigns the given name to the thread if the new name has a higher priority
   // than the existing one. The thread is identified by utid.
   virtual void UpdateThreadName(UniqueTid utid,
@@ -93,6 +92,12 @@ class ProcessTracker {
   // for the tid and the matching upid for the tgid and stores both.
   // Virtual for testing.
   virtual UniqueTid UpdateThread(int64_t tid, int64_t pid);
+
+  // Clears any thread associated with the provided tid. Mostly used in cases
+  // where data loss is apparent and a new thread with same tid needs to be
+  // created. For properly marking the end of a thread, use the EndThread
+  // method.
+  void ClearThread(int64_t tid);
 
   // Associates trusted_pid with track UUID.
   void UpdateTrustedPid(int64_t trusted_pid, uint64_t uuid);

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -2403,6 +2403,8 @@ void FtraceParser::ParseTaskNewTask(int64_t timestamp,
     return;
   }
 
+  proc_tracker->ClearThread(new_tid);
+
   // If the process is a fork, start a new process.
   if ((clone_flags & kCloneThread) == 0) {
     // This is a plain-old fork() or equivalent.
@@ -2420,7 +2422,8 @@ void FtraceParser::ParseTaskNewTask(int64_t timestamp,
   // This is a pthread_create or similar. Bind the two threads together, so
   // they get resolved to the same process.
   auto source_utid = proc_tracker->GetOrCreateThread(source_tid);
-  auto new_utid = proc_tracker->StartNewThread(timestamp, new_tid);
+  auto new_utid = proc_tracker->GetOrCreateThread(new_tid);
+  proc_tracker->SetThreadStartTs(new_utid, timestamp);
   proc_tracker->UpdateThreadName(new_utid, new_comm,
                                  ThreadNamePriority::kFtrace);
   proc_tracker->AssociateThreads(source_utid, new_utid);

--- a/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
+++ b/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
@@ -146,7 +146,8 @@ std::optional<UniqueTid> GenericKernelParser::GetUtidForState(int64_t ts,
             stats::generic_task_state_invalid_order);
         return std::nullopt;
       }
-      UniqueTid utid = context_->process_tracker->StartNewThread(ts, tid);
+      UniqueTid utid = context_->process_tracker->GetOrCreateThread(tid);
+      context_->process_tracker->SetThreadStartTs(utid, ts);
       context_->process_tracker->UpdateThreadName(
           utid, comm_id, ThreadNamePriority::kGenericKernelTask);
       return utid;

--- a/src/trace_processor/importers/proto/track_event_tracker.cc
+++ b/src/trace_processor/importers/proto/track_event_tracker.cc
@@ -271,11 +271,9 @@ TrackEventTracker::ResolveDescriptorTrack(
                     reservation.min_timestamp);
 
       // Associate the new thread with its process.
-      utid = context_->process_tracker->StartNewThread(std::nullopt,
-                                                       *reservation.tid);
-      UniqueTid updated_utid = context_->process_tracker->UpdateThread(
-          *reservation.tid, *reservation.pid);
-      PERFETTO_CHECK(updated_utid == utid);
+      context_->process_tracker->ClearThread(*reservation.tid);
+      utid = context_->process_tracker->UpdateThread(*reservation.tid,
+                                                     *reservation.pid);
     }
 
     TrackId id;


### PR DESCRIPTION
ProcessTracker permitted the creation of multiple threads with same TID but different UTIDs, mainly to address data loss scenarios. Refactored the code to have better semantics to address these cases. The ClearThread method removes all preexisting UTIDs from the active thread map, acting as a barrier point from which a new thread can be created for a preexisting TID.

Also, updated the API so that GetOrCreateThread becomes the primary thread creation method, forcing a single TID and thread association at any point in time.

Bug: 425694654
