### PR TITLE
tp: add optimization for descending sort on ordered column

### DIFF
--- a/src/trace_processor/dataframe/dataframe_unittest.cc
+++ b/src/trace_processor/dataframe/dataframe_unittest.cc
@@ -867,7 +867,7 @@ TEST_F(DataframeBytecodeTest, SortOptimizationNotApplied_MultipleSpecs) {
                   /*cols_used=*/3);  // 0b11
 }
 
-TEST_F(DataframeBytecodeTest, SortOptimizationNotApplied_DescendingOrder) {
+TEST_F(DataframeBytecodeTest, SortOptimization_Reverse) {
   std::vector<impl::Column> cols = MakeColumnVector(
       impl::Column{impl::Storage::Uint32{}, impl::NullStorage::NonNull{},
                    Sorted{}, HasDuplicates{}});
@@ -877,9 +877,7 @@ TEST_F(DataframeBytecodeTest, SortOptimizationNotApplied_DescendingOrder) {
     InitRange: [size=0, dest_register=Register(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
-    AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    CopyToRowLayout<Uint32, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    SortRowLayout: [buffer_register=Register(3), total_row_stride=4, indices_register=Register(2)]
+    Reverse: [update_register=Register(2)]
   )",
                   /*cols_used=*/1);
 }

--- a/src/trace_processor/dataframe/impl/bytecode_instructions.h
+++ b/src/trace_processor/dataframe/impl/bytecode_instructions.h
@@ -608,6 +608,17 @@ struct In : InBase {
   static_assert(TS1::Contains<T>());
 };
 
+// Reverses the order of indices in the given register.
+struct Reverse : Bytecode {
+  // TODO(lalitm): while the cost type is legitimate, the cost estimate inside
+  // is plucked from thin air and has no real foundation. Fix this by creating
+  // benchmarks and backing it up with actual data.
+  static constexpr Cost kCost = LinearPerRowCost{2};
+
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_1(reg::RwHandle<Span<uint32_t>>,
+                                     update_register);
+};
+
 // List of all bytecode instruction types for variant definition.
 #define PERFETTO_DATAFRAME_BYTECODE_LIST(X)  \
   X(InitRange)                               \
@@ -754,7 +765,8 @@ struct In : InBase {
   X(In<Int32>)                               \
   X(In<Int64>)                               \
   X(In<Double>)                              \
-  X(In<String>)
+  X(In<String>)                              \
+  X(Reverse)
 
 #define PERFETTO_DATAFRAME_BYTECODE_VARIANT(...) __VA_ARGS__,
 

--- a/src/trace_processor/dataframe/impl/bytecode_interpreter_impl.h
+++ b/src/trace_processor/dataframe/impl/bytecode_interpreter_impl.h
@@ -432,6 +432,12 @@ class InterpreterImpl {
     return true;
   }
 
+  PERFETTO_ALWAYS_INLINE void Reverse(const bytecode::Reverse& r) {
+    using B = bytecode::Reverse;
+    auto& update = ReadFromRegister(r.arg<B::update_register>());
+    std::reverse(update.b, update.e);
+  }
+
   template <typename T, typename RangeOp>
   PERFETTO_ALWAYS_INLINE void SortedFilter(
       const bytecode::SortedFilterBase& f) {

--- a/src/trace_processor/dataframe/impl/bytecode_interpreter_unittest.cc
+++ b/src/trace_processor/dataframe/impl/bytecode_interpreter_unittest.cc
@@ -177,6 +177,19 @@ TEST_F(BytecodeInterpreterTest, Iota) {
   EXPECT_THAT(update, ElementsAreArray({5u, 6u, 7u, 8u, 9u}));
 }
 
+TEST_F(BytecodeInterpreterTest, Reverse) {
+  std::vector<uint32_t> res = {1, 2, 3, 4, 5};
+  SetRegistersAndExecute("Reverse: [update_register=Register(0)]",
+                         GetSpan(res));
+
+  const auto& update = GetRegister<Span<uint32_t>>(0);
+  ASSERT_THAT(update.b, AllOf(testing::Ge(res.data()),
+                              testing::Le(res.data() + res.size())));
+  ASSERT_THAT(update.e, AllOf(testing::Ge(res.data()),
+                              testing::Le(res.data() + res.size())));
+  EXPECT_THAT(update, ElementsAre(5, 4, 3, 2, 1));
+}
+
 using CastResult = CastFilterValueResult;
 
 struct CastTestCase {


### PR DESCRIPTION
Just reverse the vector. Speeds up some queries where SQLite does not
correctly propogate LIMIT 1 to us.
