### PR TITLE
tp: Reduce the number of trace_bounds calculations.

### DIFF
--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -589,8 +589,6 @@ base::Status TraceProcessorImpl::Parse(TraceBlobView blob) {
 
 void TraceProcessorImpl::Flush() {
   TraceProcessorStorageImpl::Flush();
-  BuildBoundsTable(engine_->sqlite_engine()->db(),
-                   GetTraceTimestampBoundsNs(*context_.storage));
 }
 
 base::Status TraceProcessorImpl::NotifyEndOfFile() {
@@ -1405,8 +1403,6 @@ std::unique_ptr<PerfettoSqlEngine> TraceProcessorImpl::InitPerfettoSqlEngine(
     }
   }
 
-  // Fill trace bounds table.
-  BuildBoundsTable(db, GetTraceTimestampBoundsNs(*storage));
   return engine;
 }
 


### PR DESCRIPTION
Currently, there is redundancy in the calculation of `trace_bounds`, which is computed multiple times. 
Take `TraceProcessorImpl::Flush` and `TraceProcessorImpl::NotifyEndOfFile()` as examples: 

both functions construct `trace_bounds` by calling `BuildBoundsTable`. The step of `GetTraceTimestampBoundsNs`
is relatively time-consuming as it internally iterates over numerous tables. When dealing with
excessively large trace files, this time consumption becomes particularly noticeable.

```c++
base::Status LoadTrace(const std::string& trace_file_path, double* size_mb) {
  base::Status read_status = ReadTraceUnfinalized(
      g_tp, trace_file_path.c_str(), [&size_mb](size_t parsed_size) {
        *size_mb = static_cast<double>(parsed_size) / 1E6;
        fprintf(stderr, "\rLoading trace: %.2f MB\r", *size_mb);
      });
  g_tp->Flush();

  ......

  return g_tp->NotifyEndOfFile();
}
```


Within the `Flush` method, `BuildBoundsTable` is invoked. Additionally, `NotifyEndOfFile` calls
`BuildBoundsTable` twice (since `NotifyEndOfFile` internally triggers `Flush`).

Perhaps we could retain only the `BuildBoundsTable` call within `NotifyEndOfFile`, calculating
`trace_bounds` just once at the end. This approach would eliminate two invocations of
`GetTraceTimestampBoundsNs`, thereby reducing processing time.

Taking the loading of 25.33MB and 268.26MB trace files via trace_processor_shell as examples,
the execution times before and after optimization are as follows:

**25.33MB**

before
Trace loaded: 25.33 MB in 6.21s (4.1 MB/s)
Trace loaded: 25.33 MB in 6.22s (4.1 MB/s)
Trace loaded: 25.33 MB in 6.20s (4.1 MB/s)
Trace loaded: 25.33 MB in 6.23s (4.1 MB/s)
Trace loaded: 25.33 MB in 6.24s (4.1 MB/s)

after
Trace loaded: 25.33 MB in 5.94s (4.3 MB/s)
Trace loaded: 25.33 MB in 5.95s (4.3 MB/s)
Trace loaded: 25.33 MB in 5.92s (4.3 MB/s)
Trace loaded: 25.33 MB in 5.90s (4.3 MB/s)
Trace loaded: 25.33 MB in 5.89s (4.3 MB/s)



**268.26MB**

before
Trace loaded: 268.26 MB in 76.01s (3.5 MB/s)
Trace loaded: 268.26 MB in 76.56s (3.5 MB/s)
Trace loaded: 268.26 MB in 77.01s (3.5 MB/s)
Trace loaded: 268.26 MB in 76.74s (3.5 MB/s)
Trace loaded: 268.26 MB in 76.91s (3.5 MB/s)

after
Trace loaded: 268.26 MB in 70.89s (3.8 MB/s)
Trace loaded: 268.26 MB in 71.24s (3.8 MB/s)
Trace loaded: 268.26 MB in 71.39s (3.8 MB/s)
Trace loaded: 268.26 MB in 71.30s (3.8 MB/s)
Trace loaded: 268.26 MB in 71.22s (3.8 MB/s)
