### PR TITLE
tp: make ProtoToArgsParser iterative

### DIFF
--- a/src/trace_processor/util/proto_to_args_parser.cc
+++ b/src/trace_processor/util/proto_to_args_parser.cc
@@ -102,6 +102,29 @@ ProtoToArgsParser::ProtoToArgsParser(const DescriptorPool& pool) : pool_(pool) {
   key_prefix_.flat_key.reserve(kDefaultSize);
 }
 
+struct ProtoToArgsParser::WorkItem {
+  // The decoder for the current message. Its internal state marks our
+  // progress through this message's fields.
+  protozero::ProtoDecoder decoder;
+
+  // The descriptor for the current message type.
+  const ProtoDescriptor* descriptor;
+
+  // A map to track the index of repeated fields *at this nesting level*.
+  std::unordered_map<size_t, int> repeated_field_index;
+
+  // The set of fields seen in this message, for handling defaults.
+  std::unordered_set<std::string_view> existing_fields;
+
+  // The RAII context for the current message's key. Its destructor will be
+  // called automatically when this WorkItem is popped from the stack,
+  // ensuring the key prefix is correctly managed.
+  ScopedNestedKeyContext key_context;
+
+  // Set to false as soon as any field is parsed for this message.
+  bool empty_message = true;
+};
+
 base::Status ProtoToArgsParser::ParseMessage(
     const protozero::ConstBytes& cb,
     const std::string& type,
@@ -109,144 +132,141 @@ base::Status ProtoToArgsParser::ParseMessage(
     Delegate& delegate,
     int* unknown_extensions,
     bool add_defaults) {
-  ScopedNestedKeyContext key_context(key_prefix_);
-  return ParseMessageInternal(key_context, cb, type, allowed_fields, delegate,
-                              unknown_extensions, add_defaults);
-}
+  std::vector<WorkItem> work_stack;
 
-base::Status ProtoToArgsParser::ParseMessageInternal(
-    ScopedNestedKeyContext& key_context,
-    const protozero::ConstBytes& cb,
-    const std::string& type,
-    const std::vector<uint32_t>* allowed_fields,
-    Delegate& delegate,
-    int* unknown_extensions,
-    bool add_defaults) {
-  if (auto override_result =
-          MaybeApplyOverrideForType(type, key_context, cb, delegate)) {
-    return override_result.value();
+  {
+    ScopedNestedKeyContext key_context(key_prefix_);
+    if (auto override_result =
+            MaybeApplyOverrideForType(type, key_context, cb, delegate)) {
+      return override_result.value();
+    }
+
+    auto idx = pool_.FindDescriptorIdx(type);
+    if (!idx) {
+      return base::Status("Failed to find proto descriptor for " + type);
+    }
+    auto* proto_descriptor = &pool_.descriptors()[*idx];
+    work_stack.emplace_back(WorkItem{protozero::ProtoDecoder(cb),
+                                     proto_descriptor,
+                                     {},
+                                     {},
+                                     std::move(key_context),
+                                     true});
   }
 
-  auto idx = pool_.FindDescriptorIdx(type);
-  if (!idx) {
-    return base::Status("Failed to find proto descriptor");
-  }
+  while (!work_stack.empty()) {
+    WorkItem& item = work_stack.back();
 
-  const auto& descriptor = pool_.descriptors()[*idx];
-
-  std::unordered_map<size_t, int> repeated_field_index;
-  bool empty_message = true;
-  protozero::ProtoDecoder decoder(cb);
-  std::unordered_set<std::string_view> existing_fields;
-  for (protozero::Field f = decoder.ReadField(); f.valid();
-       f = decoder.ReadField()) {
-    empty_message = false;
-    const auto* field = descriptor.FindFieldByTag(f.id());
-    if (!field) {
-      if (unknown_extensions != nullptr) {
-        (*unknown_extensions)++;
-      }
-      // Unknown field, possibly an unknown extension.
-      continue;
-    }
-
-    if (add_defaults) {
-      existing_fields.insert(field->name());
-    }
-
-    if (!IsFieldAllowed(*field, allowed_fields)) {
-      // Field is neither an extension, nor is allowed to be
-      // reflected.
-      continue;
-    }
-
-    // Packed fields need to be handled specially because
-    if (field->is_packed()) {
-      RETURN_IF_ERROR(ParsePackedField(*field, repeated_field_index, f,
-                                       delegate, unknown_extensions,
-                                       add_defaults));
-      continue;
-    }
-
-    RETURN_IF_ERROR(ParseField(*field, repeated_field_index[f.id()], f,
-                               delegate, unknown_extensions, add_defaults));
-    if (field->is_repeated()) {
-      repeated_field_index[f.id()]++;
-    }
-  }
-
-  if (empty_message) {
-    delegate.AddNull(key_prefix_);
-  } else if (add_defaults) {
-    for (const auto& [id, field] : descriptor.fields()) {
-      if (!IsFieldAllowed(field, allowed_fields)) {
+    protozero::Field field = item.decoder.ReadField();
+    if (field.valid()) {
+      item.empty_message = false;
+      const auto* field_descriptor =
+          item.descriptor->FindFieldByTag(field.id());
+      if (!field_descriptor) {
+        if (unknown_extensions != nullptr) {
+          (*unknown_extensions)++;
+        }
+        // Unknown field, possibly an unknown extension.
         continue;
       }
-      const std::string& field_name = field.name();
-      bool field_exists =
-          existing_fields.find(field_name) != existing_fields.cend();
-      if (field_exists) {
+
+      if (add_defaults) {
+        item.existing_fields.insert(field_descriptor->name());
+      }
+
+      if (!IsFieldAllowed(*field_descriptor, allowed_fields)) {
+        // Field is neither an extension, nor is allowed to be
+        // reflected.
         continue;
       }
-      ScopedNestedKeyContext key_context_default(key_prefix_);
-      AppendProtoType(key_prefix_.flat_key, field_name);
-      AppendProtoType(key_prefix_.key, field_name);
-      RETURN_IF_ERROR(AddDefault(field, delegate));
+
+      // Packed fields need to be handled specially because
+      if (field_descriptor->is_packed()) {
+        RETURN_IF_ERROR(ParsePackedField(
+            *field_descriptor, item.repeated_field_index, field, delegate));
+        continue;
+      }
+
+      std::string prefix_part = field_descriptor->name();
+      if (field_descriptor->is_repeated()) {
+        int& index = item.repeated_field_index[field.id()];
+        std::string number = std::to_string(index);
+        prefix_part.reserve(prefix_part.length() + number.length() + 2);
+        prefix_part.append("[");
+        prefix_part.append(number);
+        prefix_part.append("]");
+        index++;
+      }
+
+      ScopedNestedKeyContext field_key_context(key_prefix_);
+      AppendProtoType(key_prefix_.flat_key, field_descriptor->name());
+      AppendProtoType(key_prefix_.key, prefix_part);
+
+      if (std::optional<base::Status> status =
+              MaybeApplyOverrideForField(field, delegate)) {
+        RETURN_IF_ERROR(*status);
+        continue;
+      }
+
+      if (field_descriptor->type() ==
+          protos::pbzero::FieldDescriptorProto::TYPE_MESSAGE) {
+        if (auto override_result = MaybeApplyOverrideForType(
+                field_descriptor->resolved_type_name(), field_key_context,
+                field.as_bytes(), delegate)) {
+          RETURN_IF_ERROR(override_result.value());
+          continue;
+        }
+        auto desc_idx =
+            pool_.FindDescriptorIdx(field_descriptor->resolved_type_name());
+        if (!desc_idx) {
+          return base::ErrStatus(
+              "Failed to find proto descriptor for %s",
+              field_descriptor->resolved_type_name().c_str());
+        }
+        auto* proto_descriptor = &pool_.descriptors()[*desc_idx];
+        work_stack.emplace_back(
+            WorkItem{protozero::ProtoDecoder(field.as_bytes()),
+                     proto_descriptor,
+                     {},
+                     {},
+                     std::move(field_key_context),
+                     true});
+      } else {
+        RETURN_IF_ERROR(ParseSimpleField(*field_descriptor, field, delegate));
+      }
+      continue;
     }
+
+    if (item.empty_message) {
+      delegate.AddNull(item.key_context.key());
+    } else if (add_defaults) {
+      for (const auto& [id, field_desc] : item.descriptor->fields()) {
+        if (!IsFieldAllowed(field_desc, allowed_fields)) {
+          continue;
+        }
+        const std::string& field_name = field_desc.name();
+        bool field_exists = item.existing_fields.find(field_name) !=
+                            item.existing_fields.cend();
+        if (field_exists) {
+          continue;
+        }
+        ScopedNestedKeyContext key_context_default(key_prefix_);
+        AppendProtoType(key_prefix_.flat_key, field_name);
+        AppendProtoType(key_prefix_.key, field_name);
+        RETURN_IF_ERROR(AddDefault(field_desc, delegate));
+      }
+    }
+    work_stack.pop_back();
   }
 
   return base::OkStatus();
-}
-
-base::Status ProtoToArgsParser::ParseField(
-    const FieldDescriptor& field_descriptor,
-    int repeated_field_number,
-    protozero::Field field,
-    Delegate& delegate,
-    int* unknown_extensions,
-    bool add_defaults) {
-  std::string prefix_part = field_descriptor.name();
-  if (field_descriptor.is_repeated()) {
-    std::string number = std::to_string(repeated_field_number);
-    prefix_part.reserve(prefix_part.length() + number.length() + 2);
-    prefix_part.append("[");
-    prefix_part.append(number);
-    prefix_part.append("]");
-  }
-
-  // In the args table we build up message1.message2.field1 as the column
-  // name. This will append the ".field1" suffix to |key_prefix| and then
-  // remove it when it goes out of scope.
-  ScopedNestedKeyContext key_context(key_prefix_);
-  AppendProtoType(key_prefix_.flat_key, field_descriptor.name());
-  AppendProtoType(key_prefix_.key, prefix_part);
-
-  // If we have an override parser then use that instead and move onto the
-  // next loop.
-  if (std::optional<base::Status> status =
-          MaybeApplyOverrideForField(field, delegate)) {
-    return *status;
-  }
-
-  // If this is not a message we can just immediately add the column name and
-  // get the value out of |field|. However if it is a message we need to
-  // recurse into it.
-  if (field_descriptor.type() ==
-      protos::pbzero::FieldDescriptorProto::TYPE_MESSAGE) {
-    return ParseMessageInternal(key_context, field.as_bytes(),
-                                field_descriptor.resolved_type_name(), nullptr,
-                                delegate, unknown_extensions, add_defaults);
-  }
-  return ParseSimpleField(field_descriptor, field, delegate);
 }
 
 base::Status ProtoToArgsParser::ParsePackedField(
     const FieldDescriptor& field_descriptor,
     std::unordered_map<size_t, int>& repeated_field_index,
     protozero::Field field,
-    Delegate& delegate,
-    int* unknown_extensions,
-    bool add_defaults) {
+    Delegate& delegate) {
   using FieldDescriptorProto = protos::pbzero::FieldDescriptorProto;
   using PWT = protozero::proto_utils::ProtoWireType;
 
@@ -263,8 +283,25 @@ base::Status ProtoToArgsParser::ParsePackedField(
   auto parse = [&](uint64_t new_value, PWT wire_type) {
     protozero::Field f;
     f.initialize(field.id(), static_cast<uint8_t>(wire_type), new_value, 0);
-    return ParseField(field_descriptor, repeated_field_index[field.id()]++, f,
-                      delegate, unknown_extensions, add_defaults);
+
+    std::string prefix_part = field_descriptor.name();
+    int& index = repeated_field_index[field.id()];
+    std::string number = std::to_string(index);
+    prefix_part.reserve(prefix_part.length() + number.length() + 2);
+    prefix_part.append("[");
+    prefix_part.append(number);
+    prefix_part.append("]");
+    index++;
+
+    ScopedNestedKeyContext key_context(key_prefix_);
+    AppendProtoType(key_prefix_.flat_key, field_descriptor.name());
+    AppendProtoType(key_prefix_.key, prefix_part);
+
+    if (std::optional<base::Status> status =
+            MaybeApplyOverrideForField(f, delegate)) {
+      return *status;
+    }
+    return ParseSimpleField(field_descriptor, f, delegate);
   };
 
   const uint8_t* data = field.as_bytes().data;

--- a/src/trace_processor/util/proto_to_args_parser.h
+++ b/src/trace_processor/util/proto_to_args_parser.h
@@ -257,20 +257,13 @@ class ProtoToArgsParser {
                                  ParsingOverrideForType parsing_override);
 
  private:
-  base::Status ParseField(const FieldDescriptor& field_descriptor,
-                          int repeated_field_number,
-                          protozero::Field field,
-                          Delegate& delegate,
-                          int* unknown_extensions,
-                          bool add_defaults);
+  struct WorkItem;
 
   base::Status ParsePackedField(
       const FieldDescriptor& field_descriptor,
       std::unordered_map<size_t, int>& repeated_field_index,
       protozero::Field field,
-      Delegate& delegate,
-      int* unknown_extensions,
-      bool add_defaults);
+      Delegate& delegate);
 
   std::optional<base::Status> MaybeApplyOverrideForField(
       const protozero::Field&,
@@ -281,16 +274,6 @@ class ProtoToArgsParser {
       ScopedNestedKeyContext& key,
       const protozero::ConstBytes& data,
       Delegate& delegate);
-
-  // A type override can call |key.RemoveFieldSuffix()| if it wants to exclude
-  // the overridden field's name from the parsed args' keys.
-  base::Status ParseMessageInternal(ScopedNestedKeyContext& key,
-                                    const protozero::ConstBytes& cb,
-                                    const std::string& type,
-                                    const std::vector<uint32_t>* fields,
-                                    Delegate& delegate,
-                                    int* unknown_extensions,
-                                    bool add_defaults = false);
 
   base::Status ParseSimpleField(const FieldDescriptor& descriptor,
                                 const protozero::Field& field,


### PR DESCRIPTION
For deeply nested messages, we are getting stack overflows for this. Fix by changing the implementation to be iterative instead.