### PR TITLE
ui: Add option to connect to custom consumer socket

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_platform_checks.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_platform_checks.ts
@@ -17,6 +17,7 @@ import {errResult, okResult, Result} from '../../../base/result';
 import {PreflightCheck} from '../interfaces/connection_check';
 import {AdbDevice} from './adb_device';
 import {getAdbTracingServiceState} from './adb_tracing_session';
+import {RecordTraceV2Settings} from '../settings';
 
 /**
  * Common pre-flight checks for Android targets. This function is used by
@@ -26,6 +27,7 @@ import {getAdbTracingServiceState} from './adb_tracing_session';
  */
 export async function* checkAndroidTarget(
   adbDevice: AdbDevice,
+  settings: RecordTraceV2Settings,
 ): AsyncGenerator<PreflightCheck> {
   yield {
     name: 'Android version',
@@ -53,7 +55,7 @@ export async function* checkAndroidTarget(
       );
     })(),
   };
-  const svcStatus = await getAdbTracingServiceState(adbDevice);
+  const svcStatus = await getAdbTracingServiceState(adbDevice, settings);
   yield {
     name: 'Traced version',
     status: await (async (): Promise<Result<string>> => {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_tracing_session.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_tracing_session.ts
@@ -18,15 +18,15 @@ import {TracingProtocol} from '../tracing_protocol/tracing_protocol';
 import {errResult, okResult, Result} from '../../../base/result';
 import {exists} from '../../../base/utils';
 import {ConsumerIpcTracingSession} from '../tracing_protocol/consumer_ipc_tracing_session';
-
-export const CONSUMER_SOCKET = '/dev/socket/traced_consumer';
+import {RecordTraceV2Settings} from '../settings';
 
 export async function createAdbTracingSession(
   adbDevice: AdbDevice,
   traceConfig: protos.ITraceConfig,
+  settings: RecordTraceV2Settings,
 ): Promise<Result<ConsumerIpcTracingSession>> {
   const streamStatus = await adbDevice.createStream(
-    `localfilesystem:${CONSUMER_SOCKET}`,
+    settings.getTracedConsumerSocketAddressForAdb(),
   );
   if (!streamStatus.ok) return streamStatus;
   const stream = streamStatus.value;
@@ -37,11 +37,15 @@ export async function createAdbTracingSession(
 
 export async function getAdbTracingServiceState(
   adbDevice: AdbDevice,
+  settings: RecordTraceV2Settings,
 ): Promise<Result<protos.ITracingServiceState>> {
-  const sock = CONSUMER_SOCKET;
-  const status = await adbDevice.createStream(`localfilesystem:${sock}`);
+  const status = await adbDevice.createStream(
+    settings.getTracedConsumerSocketAddressForAdb(),
+  );
   if (!status.ok) {
-    return errResult(`Failed to connect to ${sock}: ${status.error}`);
+    return errResult(
+      `Failed to connect to ${settings.getTracedConsumerSocketAddress()}: ${status.error}`,
+    );
   }
   const stream = status.value;
   using consumerPort = await TracingProtocol.create(stream);

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_target.ts
@@ -27,6 +27,7 @@ import {AsyncLazy} from '../../../../base/async_lazy';
 import {WdpDevice} from './wdp_schema';
 import {showPopupWindow} from '../../../../base/popup_window';
 import {defer} from '../../../../base/deferred';
+import {RecordTraceV2Settings} from '../../settings';
 
 export class WebDeviceProxyTarget implements RecordingTarget {
   readonly kind = 'LIVE_RECORDING';
@@ -38,6 +39,7 @@ export class WebDeviceProxyTarget implements RecordingTarget {
   constructor(
     private wsUrl: string,
     private devJson: WdpDevice,
+    private readonly settings: RecordTraceV2Settings,
   ) {
     this.id = this.devJson.serialNumber;
     this.updateWdpState(devJson);
@@ -91,7 +93,7 @@ export class WebDeviceProxyTarget implements RecordingTarget {
       status: this.deviceReady(),
     };
     if (this.adbDevice.value === undefined) return;
-    yield* checkAndroidTarget(this.adbDevice.value);
+    yield* checkAndroidTarget(this.adbDevice.value, this.settings);
   }
 
   private async connectIfNeeded(): Promise<Result<AdbWebsocketDevice>> {
@@ -141,7 +143,7 @@ export class WebDeviceProxyTarget implements RecordingTarget {
     if (this.adbDevice.value === undefined) {
       return errResult('WebSocket transport disconnected');
     }
-    return getAdbTracingServiceState(this.adbDevice.value);
+    return getAdbTracingServiceState(this.adbDevice.value, this.settings);
   }
 
   async startTracing(
@@ -149,6 +151,10 @@ export class WebDeviceProxyTarget implements RecordingTarget {
   ): Promise<Result<ConsumerIpcTracingSession>> {
     const adbDeviceStatus = await this.connectIfNeeded();
     if (!adbDeviceStatus.ok) return adbDeviceStatus;
-    return await createAdbTracingSession(adbDeviceStatus.value, traceConfig);
+    return await createAdbTracingSession(
+      adbDeviceStatus.value,
+      traceConfig,
+      this.settings,
+    );
   }
 }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_target_provider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_target_provider.ts
@@ -26,6 +26,7 @@ import {
 } from './wdp_schema';
 import {disposeWebsocket} from '../../websocket/websocket_utils';
 import {AsyncLazy} from '../../../../base/async_lazy';
+import {RecordTraceV2Settings} from '../../settings';
 
 const WDP_URL = 'https://tools.google.com/dlpage/android_web_device_proxy';
 
@@ -43,6 +44,8 @@ export class WebDeviceProxyTargetProvider implements RecordingTargetProvider {
   readonly supportedPlatforms = ['ANDROID'] as const;
   readonly onTargetsChanged = new EvtSource<void>();
   private targets = new Map<string, WdpDeviceProxyTarget>();
+
+  constructor(private readonly settings: RecordTraceV2Settings) {}
 
   // Wraps the websocket listening for device changes on /track-devices.json.
   private trackDevicesConn = new AsyncLazy<TrackDevicesConnection>();
@@ -172,7 +175,11 @@ export class WebDeviceProxyTargetProvider implements RecordingTargetProvider {
         existingDevice.updateWdpState(devJson);
       } else {
         const wsUrl = 'ws://127.0.0.1:9167/adb-json';
-        const newTarget = new WdpDeviceProxyTarget(wsUrl, devJson);
+        const newTarget = new WdpDeviceProxyTarget(
+          wsUrl,
+          devJson,
+          this.settings,
+        );
         this.targets.set(serial, newTarget);
       }
     }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_target.ts
@@ -24,6 +24,7 @@ import {
 } from '../adb_tracing_session';
 import {AdbWebsocketDevice} from './adb_websocket_device';
 import {AsyncLazy} from '../../../../base/async_lazy';
+import {RecordTraceV2Settings} from '../../settings';
 
 export class AdbWebsocketTarget implements RecordingTarget {
   readonly kind = 'LIVE_RECORDING';
@@ -36,6 +37,7 @@ export class AdbWebsocketTarget implements RecordingTarget {
     private wsUrl: string,
     private serial: string,
     private model: string,
+    private readonly settings: RecordTraceV2Settings,
   ) {}
 
   get id(): string {
@@ -60,7 +62,7 @@ export class AdbWebsocketTarget implements RecordingTarget {
       })(),
     };
     if (this.adbDevice.value === undefined) return;
-    yield* checkAndroidTarget(this.adbDevice.value);
+    yield* checkAndroidTarget(this.adbDevice.value, this.settings);
   }
 
   private async connectIfNeeded(): Promise<Result<AdbWebsocketDevice>> {
@@ -82,7 +84,7 @@ export class AdbWebsocketTarget implements RecordingTarget {
     if (this.adbDevice.value === undefined) {
       return errResult('WebSocket transport disconnected');
     }
-    return getAdbTracingServiceState(this.adbDevice.value);
+    return getAdbTracingServiceState(this.adbDevice.value, this.settings);
   }
 
   async startTracing(
@@ -90,6 +92,10 @@ export class AdbWebsocketTarget implements RecordingTarget {
   ): Promise<Result<ConsumerIpcTracingSession>> {
     const adbDeviceStatus = await this.connectIfNeeded();
     if (!adbDeviceStatus.ok) return adbDeviceStatus;
-    return await createAdbTracingSession(adbDeviceStatus.value, traceConfig);
+    return await createAdbTracingSession(
+      adbDeviceStatus.value,
+      traceConfig,
+      this.settings,
+    );
   }
 }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_target_provider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_target_provider.ts
@@ -21,6 +21,7 @@ import {AdbWebsocketTarget} from './adb_websocket_target';
 import {adbCmdAndWait} from './adb_websocket_utils';
 import {EvtSource} from '../../../../base/events';
 import {websocketInstructions} from '../../websocket/websocket_utils';
+import {RecordTraceV2Settings} from '../../settings';
 
 export class AdbWebsocketTargetProvider implements RecordingTargetProvider {
   readonly id = 'adb_websocket';
@@ -33,6 +34,8 @@ export class AdbWebsocketTargetProvider implements RecordingTargetProvider {
   private readonly wsHost = '127.0.0.1:8037';
   readonly onTargetsChanged = new EvtSource<void>();
   private targets = new Map<string, AdbWebsocketTarget>();
+
+  constructor(private readonly settings: RecordTraceV2Settings) {}
 
   async *runPreflightChecks(): AsyncGenerator<PreflightCheck> {
     yield {
@@ -66,7 +69,12 @@ export class AdbWebsocketTargetProvider implements RecordingTargetProvider {
     // Find new devices.
     for (const [serial, model] of adbDevices.entries()) {
       if (this.targets.has(serial)) continue; // We already have a target.
-      const newTarget = new AdbWebsocketTarget(this.wsUrl, serial, model);
+      const newTarget = new AdbWebsocketTarget(
+        this.wsUrl,
+        serial,
+        model,
+        this.settings,
+      );
       this.targets.set(serial, newTarget);
     }
   }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_target.ts
@@ -26,6 +26,7 @@ import {errResult, okResult, Result} from '../../../../base/result';
 import {checkAndroidTarget} from '../adb_platform_checks';
 import {ConsumerIpcTracingSession} from '../../tracing_protocol/consumer_ipc_tracing_session';
 import {AsyncLazy} from '../../../../base/async_lazy';
+import {RecordTraceV2Settings} from '../../settings';
 
 export class AdbWebusbTarget implements RecordingTarget {
   readonly kind = 'LIVE_RECORDING';
@@ -36,6 +37,7 @@ export class AdbWebusbTarget implements RecordingTarget {
   constructor(
     private usbiface: AdbUsbInterface,
     private adbKeyMgr: AdbKeyManager,
+    private readonly settings: RecordTraceV2Settings,
   ) {}
 
   async *runPreflightChecks(): AsyncGenerator<PreflightCheck> {
@@ -50,7 +52,7 @@ export class AdbWebusbTarget implements RecordingTarget {
     };
 
     if (this.adbDevice.value === undefined) return;
-    yield* checkAndroidTarget(this.adbDevice.value);
+    yield* checkAndroidTarget(this.adbDevice.value, this.settings);
   }
 
   async connectIfNeeded(): Promise<Result<AdbWebusbDevice>> {
@@ -76,7 +78,7 @@ export class AdbWebusbTarget implements RecordingTarget {
     if (this.adbDevice.value === undefined) {
       return errResult('WebUSB transport disconnected');
     }
-    return getAdbTracingServiceState(this.adbDevice.value);
+    return getAdbTracingServiceState(this.adbDevice.value, this.settings);
   }
 
   async startTracing(
@@ -84,7 +86,11 @@ export class AdbWebusbTarget implements RecordingTarget {
   ): Promise<Result<ConsumerIpcTracingSession>> {
     const adbDeviceStatus = await this.connectIfNeeded();
     if (!adbDeviceStatus.ok) return adbDeviceStatus;
-    return await createAdbTracingSession(adbDeviceStatus.value, traceConfig);
+    return await createAdbTracingSession(
+      adbDeviceStatus.value,
+      traceConfig,
+      this.settings,
+    );
   }
 
   disconnect(): void {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_target_provider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_target_provider.ts
@@ -25,6 +25,7 @@ import {errResult} from '../../../../base/result';
 import {RecordingTargetProvider} from '../../interfaces/recording_target_provider';
 import {AdbWebusbTarget} from './adb_webusb_target';
 import {EvtSource} from '../../../../base/events';
+import {RecordTraceV2Settings} from '../../settings';
 
 export class AdbWebusbTargetProvider implements RecordingTargetProvider {
   readonly id = 'adb_webusb';
@@ -40,7 +41,7 @@ export class AdbWebusbTargetProvider implements RecordingTargetProvider {
   private targets = new Map<string, AdbWebusbTarget>();
   readonly onTargetsChanged = new EvtSource<void>();
 
-  constructor() {
+  constructor(private readonly settings: RecordTraceV2Settings) {
     if (!exists(navigator.usb)) return;
     navigator.usb.addEventListener('disconnect', () => this.refreshTargets());
     navigator.usb.addEventListener('connect', () => this.refreshTargets());
@@ -73,7 +74,11 @@ export class AdbWebusbTargetProvider implements RecordingTargetProvider {
 
     // If the user re-pairs the same device, remove it from the list and keep
     // the new one.
-    const newTarget = new AdbWebusbTarget(usbiface, this.adbKeyMgr);
+    const newTarget = new AdbWebusbTarget(
+      usbiface,
+      this.adbKeyMgr,
+      this.settings,
+    );
     this.targets.set(key, newTarget);
     this.onTargetsChanged.notify();
     return newTarget;
@@ -101,7 +106,11 @@ export class AdbWebusbTargetProvider implements RecordingTargetProvider {
     }
     for (const [key, usbiface] of usbDevices.entries()) {
       if (this.targets.has(key)) continue; // We already have this target.
-      const newTarget = new AdbWebusbTarget(usbiface, this.adbKeyMgr);
+      const newTarget = new AdbWebusbTarget(
+        usbiface,
+        this.adbKeyMgr,
+        this.settings,
+      );
       this.targets.set(key, newTarget);
       triggerOnTrgetsChanged = true;
     }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/index.ts
@@ -35,11 +35,16 @@ import {RecordingManager} from './recording_manager';
 import {TracedWebsocketTargetProvider} from './traced_over_websocket/traced_websocket_provider';
 import {WebDeviceProxyTargetProvider} from './adb/web_device_proxy/wdp_target_provider';
 import m from 'mithril';
+import {RecordTraceV2Settings} from './settings';
+
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.RecordTraceV2';
   private static recordingMgr?: RecordingManager;
 
   static onActivate(app: App) {
+    const settings = new RecordTraceV2Settings();
+    settings.registerSettings(app.settings);
+
     app.sidebar.addMenuItem({
       section: 'trace_files',
       text: 'Record new trace',
@@ -53,7 +58,7 @@ export default class implements PerfettoPlugin {
         return m(RecordPageV2, {
           subpage,
           app,
-          getRecordingManager: () => this.getRecordingManager(app),
+          getRecordingManager: () => this.getRecordingManager(app, settings),
         });
       },
     });
@@ -61,7 +66,7 @@ export default class implements PerfettoPlugin {
       id: 'dev.perfetto.RecordTraceV2.disconnectTarget',
       name: 'Disconnect the current device',
       callback: () => {
-        const recMgr = this.getRecordingManager(app);
+        const recMgr = this.getRecordingManager(app, settings);
         if (recMgr.currentTarget) {
           recMgr.currentTarget.disconnect();
         }
@@ -72,13 +77,18 @@ export default class implements PerfettoPlugin {
   // Lazily initialize the RecordingManager at first call. This is to prevent
   // providers to connect to sockets / devtools (which in turn can trigger
   // security UX in the browser) before the user has even done anything.
-  private static getRecordingManager(app: App): RecordingManager {
+  private static getRecordingManager(
+    app: App,
+    settings: RecordTraceV2Settings,
+  ): RecordingManager {
     if (this.recordingMgr === undefined) {
-      const recMgr = new RecordingManager(app);
+      const recMgr = new RecordingManager(app, settings);
       this.recordingMgr = recMgr;
-      recMgr.registerProvider(new AdbWebusbTargetProvider());
-      recMgr.registerProvider(new AdbWebsocketTargetProvider());
-      recMgr.registerProvider(new WebDeviceProxyTargetProvider());
+      recMgr.registerProvider(new AdbWebusbTargetProvider(recMgr.settings));
+      recMgr.registerProvider(new AdbWebsocketTargetProvider(recMgr.settings));
+      recMgr.registerProvider(
+        new WebDeviceProxyTargetProvider(recMgr.settings),
+      );
 
       const chromeProvider = new ChromeExtensionTargetProvider();
       recMgr.registerProvider(chromeProvider);

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/recording_manager.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/recording_manager.ts
@@ -35,6 +35,7 @@ import {Time, Timecode} from '../../base/time';
 import {base64Decode, base64Encode} from '../../base/string_utils';
 
 import {getPresetsForPlatform} from './presets';
+import {RecordTraceV2Settings} from './settings';
 
 const LOCALSTORAGE_KEY = 'recordPlugin';
 
@@ -63,7 +64,10 @@ export class RecordingManager {
   private _customTraceConfig?: protos.TraceConfig;
   private _customConfigFileName?: string;
 
-  constructor(readonly app: App) {}
+  constructor(
+    readonly app: App,
+    readonly settings: RecordTraceV2Settings,
+  ) {}
 
   registerPage(...pages: RecordSubpage[]) {
     for (const page of pages) {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/settings.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/settings.ts
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import z from 'zod';
+import {
+  Setting,
+  SettingDescriptor,
+  SettingsManager,
+} from '../../public/settings';
+
+// This class holds all the setting offered by the RecordTraceV2 plugin.
+// It is registered at plugin activation time.
+export class RecordTraceV2Settings {
+  static readonly baseId = 'dev.perfetto.RecordTraceV2#';
+  static readonly socketAddressDescriptor: SettingDescriptor<string> = {
+    id: 'dev.perfetto.TracedConsumerSocketAddress',
+    name: 'Traced socket address',
+    description: `The recording plugin communicates with traced using a socket. This setting specifies the address the UI connects to.
+    To use a socket in the abstract namespace, prefix its name with "@".`,
+    schema: z.string(),
+    defaultValue: '/dev/socket/traced_consumer',
+    requiresReload: false,
+  };
+  private socketAddressValue?: Setting<string>;
+
+  // Register all the settings of the RecordTraceV2 plugin
+  registerSettings(settingsManager: SettingsManager) {
+    this.socketAddressValue = settingsManager.register(
+      RecordTraceV2Settings.socketAddressDescriptor,
+    );
+  }
+
+  // Return the fully formed ADB socket address according to the settings
+  // The address is of the form <type>:<address>
+  getTracedConsumerSocketAddressForAdb() {
+    const address = this.getTracedConsumerSocketAddress();
+    if (address.startsWith('@')) {
+      return `localabstract:${address.slice(1)}`;
+    }
+    return `localfilesystem:${address}`;
+  }
+
+  // Return the address value in the setting
+  getTracedConsumerSocketAddress() {
+    if (this.socketAddressValue === undefined) {
+      return RecordTraceV2Settings.socketAddressDescriptor.defaultValue;
+    }
+    return this.socketAddressValue.get();
+  }
+}


### PR DESCRIPTION
Testing changes in traced and related probes from the UI requires rebuilding Android or manually replacing system Perfetto binaries, which is cumbersome.

This commit introduces a new option allowing the UI to connect to an alternative tracing service running on the target system, instead of the default Perfetto daemon.

When the feature flag connectToLocalAbstractTraceboxSocket is enabled, the recording plugin connects via a local abstract socket named "@tracebox_traced_consumer". To use this feature, start tracebox and websocket_bridge with the environment variable
PERFETTO_CONSUMER_SOCK_NAME=@tracebox_traced_consumer set.

--- 

Note:

My team regularly updates `traced` and works primarily with Android devices that have root access but a read-only system partition. Historically, we maintained internal code that automatically pushed tracebox to the device and started it as part of the recording process whenever a new binary was available. While this made distributing "complete" versions of Perfetto convenient internally, it is impractical for external sharing or upstreaming.

Having a straightforward method to connect to an alternative tracing service directly from the UI would significantly ease the workflow for testing UI changes dependent on updates to `traced`. Hence this proposed change.

Regarding the implementation in this PR, I'm not entirely satisfied. Initially, I tried following the approach used in the [QueryPage plugin](https://github.com/google/perfetto/blob/main/ui/src/plugins/dev.perfetto.QueryPage/index.ts#L33). Unfortunately, `adb_tracing_session.ts` cannot reference `index.ts` without creating circular dependencies. Passing the flag through multiple function layers down to `createAdbTracingSession` seemed excessive. To avoid this, I introduced `local_flag.ts` to centrally store the local flag without circular dependencies—but this solution feels out of place. Guidance or suggestions on a cleaner approach would be greatly appreciated.





