### PR TITLE
PinAndroidPerfMetrics: Fix trackName on debug tracks

### DIFF
--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/fullTraceJankMetricHandler.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/fullTraceJankMetricHandler.ts
@@ -118,7 +118,7 @@ class FullTraceJankMetricHandler implements MetricHandler {
       },
       columns: {ts: 'ts', dur: 'dur', name: 'name'},
       argColumns: fullTraceJankColumns,
-      tableName: trackName,
+      title: trackName,
     };
   }
 }

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
@@ -100,7 +100,7 @@ class BlockingCallMetricHandler implements MetricHandler {
       },
       columns: {ts: 'ts', dur: 'dur', name: 'name'},
       argColumns: ['name', 'ts', 'dur'],
-      trackName,
+      title: trackName,
     };
   }
 }

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinCujScoped.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinCujScoped.ts
@@ -115,7 +115,7 @@ class PinCujScopedJank implements MetricHandler {
       },
       columns: {ts: 'ts', dur: 'dur', name: 'id'},
       argColumns: ['id', 'ts', 'dur'],
-      trackName,
+      title: trackName,
     };
 
     return {


### PR DESCRIPTION
- Previously, several pin commands would yield in seemingly randomly named tracks as such - "Debug Slice Track N"
- This is because slice's object passed to addDebugSliceTrack doesn't set trackName as "title"

Bug: 429513544
Test: Manual | Pin CUJ Scoped, FT or Blocking call metric (eg. perfetto_ft_systemui-missed_sf_frames) and check track name
Change-Id: I73ac01af9293fa14ae7d3bb8a2191048e057603a
