### PR TITLE
ui: add command to zoom in on selection

### DIFF
--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -113,6 +113,7 @@ export class TraceContext implements Disposable {
 
     this.selectionMgr = new SelectionManagerImpl(
       this.engine,
+      this.timeline,
       this.trackMgr,
       this.noteMgr,
       this.scrollHelper,

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -223,6 +223,11 @@ export class UiMainPerTrace implements m.ClassComponent {
         defaultHotkey: 'F',
       },
       {
+        id: 'perfetto.ZoomOnInstant',
+        name: 'Zoom in on current selection',
+        callback: () => trace.selection.zoomOnSelection(),
+      },
+      {
         id: 'perfetto.Deselect',
         name: 'Deselect',
         callback: () => {


### PR DESCRIPTION
Add a new command to zoom in on selection. This is conceptually similar to focusing on events but also works on instant events.
