### PR TITLE
ci: add llvm-dev to sandbox ci

### DIFF
--- a/infra/ci/sandbox/Dockerfile
+++ b/infra/ci/sandbox/Dockerfile
@@ -54,6 +54,7 @@ RUN set -ex; \
         openjdk-11-jdk \
         clang-8 \
         libc++-8-dev \
+        llvm-dev \
         libc++abi-8-dev; \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1; \
     python3 -m pip install --no-cache-dir protobuf pandas grpcio; \


### PR DESCRIPTION
This PR adds llvm-dev package to install list of the Dockerfile for the sandbox CI.

This is necessary to test #2035 which requires that llvm package be installed.

Once this lands can someone please restart the CI?