### PR TITLE
tp: ftrace: allow for "local" ftrace clock (#1928)

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.cc
@@ -15,6 +15,7 @@
  */
 
 #include "src/trace_processor/importers/ftrace/ftrace_tokenizer.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -32,11 +33,10 @@
 #include "perfetto/trace_processor/ref_counted.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
-#include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
-#include "src/trace_processor/sorter/trace_sorter.h"
+#include "src/trace_processor/sorter/trace_sorter.h"  // IWYU pragma: keep
 #include "src/trace_processor/storage/metadata.h"
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -49,8 +49,7 @@
 #include "protos/perfetto/trace/ftrace/power.pbzero.h"
 #include "protos/perfetto/trace/ftrace/thermal_exynos.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using protozero::ProtoDecoder;
 using protozero::proto_utils::MakeTagVarInt;
@@ -62,7 +61,7 @@ using protos::pbzero::FtraceEventBundle;
 
 namespace {
 
-static constexpr uint32_t kFtraceGlobalClockIdForOldKernels = 64;
+static constexpr uint32_t kSequenceScopedClockId = 64;
 
 // Fast path for parsing the event id of an ftrace event.
 // Speculate on the fact that, if the timestamp was found, the common pid
@@ -137,29 +136,13 @@ base::Status FtraceTokenizer::TokenizeFtraceBundle(
                                        static_cast<int>(cpu), 1);
   }
 
-  ClockTracker::ClockId clock_id;
-  switch (decoder.ftrace_clock()) {
-    case FtraceClock::FTRACE_CLOCK_UNSPECIFIED:
-      clock_id = BuiltinClock::BUILTIN_CLOCK_BOOTTIME;
-      break;
-    case FtraceClock::FTRACE_CLOCK_GLOBAL:
-      clock_id = ClockTracker::SequenceToGlobalClock(
-          packet_sequence_id, kFtraceGlobalClockIdForOldKernels);
-      break;
-    case FtraceClock::FTRACE_CLOCK_MONO_RAW:
-      clock_id = BuiltinClock::BUILTIN_CLOCK_MONOTONIC_RAW;
-      break;
-    case FtraceClock::FTRACE_CLOCK_LOCAL:
-      return base::ErrStatus("Unable to parse ftrace packets with local clock");
-    default:
-      return base::ErrStatus(
-          "Unable to parse ftrace packets with unknown clock");
-  }
-
-  if (decoder.has_ftrace_timestamp()) {
-    PERFETTO_DCHECK(clock_id != BuiltinClock::BUILTIN_CLOCK_BOOTTIME);
-    HandleFtraceClockSnapshot(decoder.ftrace_timestamp(),
-                              decoder.boot_timestamp(), packet_sequence_id);
+  // Deal with ftrace recorded using a clock that isn't our preferred default
+  // (boottime). Do a best-effort fit to the "primary trace clock" based on
+  // per-bundle timestamp snapshots.
+  ClockTracker::ClockId clock_id = BuiltinClock::BUILTIN_CLOCK_BOOTTIME;
+  if (decoder.has_ftrace_clock()) {
+    ASSIGN_OR_RETURN(clock_id,
+                     HandleFtraceClockSnapshot(decoder, packet_sequence_id));
   }
 
   if (decoder.has_compact_sched()) {
@@ -431,21 +414,52 @@ void FtraceTokenizer::TokenizeFtraceCompactSchedWaking(
     context_->storage->IncrementStats(stats::compact_sched_has_parse_errors);
 }
 
-void FtraceTokenizer::HandleFtraceClockSnapshot(int64_t ftrace_ts,
-                                                int64_t boot_ts,
-                                                uint32_t packet_sequence_id) {
-  // If we've already seen a snapshot at this timestamp, don't unnecessarily
-  // add another entry to the clock tracker.
-  if (latest_ftrace_clock_snapshot_ts_ == ftrace_ts)
-    return;
-  latest_ftrace_clock_snapshot_ts_ = ftrace_ts;
+base::StatusOr<ClockTracker::ClockId>
+FtraceTokenizer::HandleFtraceClockSnapshot(
+    protos::pbzero::FtraceEventBundle::Decoder& decoder,
+    uint32_t packet_sequence_id) {
+  // Convert from ftrace clock enum to a clock id for trace parsing.
+  ClockTracker::ClockId clock_id = BuiltinClock::BUILTIN_CLOCK_BOOTTIME;
+  switch (decoder.ftrace_clock()) {
+    case FtraceClock::FTRACE_CLOCK_UNSPECIFIED:
+      clock_id = BuiltinClock::BUILTIN_CLOCK_BOOTTIME;
+      break;
+    case FtraceClock::FTRACE_CLOCK_MONO_RAW:
+      clock_id = BuiltinClock::BUILTIN_CLOCK_MONOTONIC_RAW;
+      break;
+    case FtraceClock::FTRACE_CLOCK_GLOBAL:
+    case FtraceClock::FTRACE_CLOCK_LOCAL:
+      // Per-cpu tracing clocks that aren't normally available in userspace.
+      // "local" (aka sched_clock in the kernel) does not guarantee ordering for
+      // events happening on different cpus, but is typically coherent enough
+      // for us to render the trace. (Overall skew is ~2ms per hour against
+      // boottime on a modern arm64 phone.)
+      //
+      // Treat this as a sequence-scoped clock, using the timestamp pair from
+      // cpu0 as recorded in the bundle. Note: the timestamps will be in the
+      // future relative to the data covered by the bundle, as the timestamping
+      // is done at ftrace read time.
+      clock_id = ClockTracker::SequenceToGlobalClock(packet_sequence_id,
+                                                     kSequenceScopedClockId);
+      break;
+    default:
+      return base::ErrStatus(
+          "Unable to parse ftrace packets with unknown clock");
+  }
 
-  ClockTracker::ClockId global_id = ClockTracker::SequenceToGlobalClock(
-      packet_sequence_id, kFtraceGlobalClockIdForOldKernels);
-  context_->clock_tracker->AddSnapshot(
-      {ClockTracker::ClockTimestamp(global_id, ftrace_ts),
-       ClockTracker::ClockTimestamp(BuiltinClock::BUILTIN_CLOCK_BOOTTIME,
-                                    boot_ts)});
+  // Add the {boottime, clock_id} timestamp pair as a clock snapshot, skipping
+  // duplicates since multiple sequential ftrace bundles can share a snapshot.
+  if (decoder.has_ftrace_timestamp() && decoder.has_boot_timestamp() &&
+      latest_ftrace_clock_snapshot_ts_ != decoder.ftrace_timestamp()) {
+    PERFETTO_DCHECK(clock_id != BuiltinClock::BUILTIN_CLOCK_BOOTTIME);
+    int64_t ftrace_timestamp = decoder.ftrace_timestamp();
+    context_->clock_tracker->AddSnapshot(
+        {ClockTracker::ClockTimestamp(clock_id, ftrace_timestamp),
+         ClockTracker::ClockTimestamp(BuiltinClock::BUILTIN_CLOCK_BOOTTIME,
+                                      decoder.boot_timestamp())});
+    latest_ftrace_clock_snapshot_ts_ = ftrace_timestamp;
+  }
+  return clock_id;
 }
 
 void FtraceTokenizer::TokenizeFtraceGpuWorkPeriod(
@@ -548,5 +562,4 @@ std::optional<protozero::Field> FtraceTokenizer::GetFtraceEventField(
   return ts_field;
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
@@ -58,10 +58,9 @@ class FtraceTokenizer {
       ClockTracker::ClockId,
       const protos::pbzero::FtraceEventBundle::CompactSched::Decoder& compact,
       const std::vector<StringId>& string_table);
-
-  void HandleFtraceClockSnapshot(int64_t ftrace_ts,
-                                 int64_t boot_ts,
-                                 uint32_t packet_sequence_id);
+  base::StatusOr<ClockTracker::ClockId> HandleFtraceClockSnapshot(
+      protos::pbzero::FtraceEventBundle::Decoder& decoder,
+      uint32_t packet_sequence_id);
   void TokenizeFtraceGpuWorkPeriod(uint32_t cpu,
                                    TraceBlobView event,
                                    RefPtr<PacketSequenceStateGeneration> state);


### PR DESCRIPTION
There are cases (e.g. ftrace_config.preserve_ftrace_buffer) when ftrace might
be timestamped using a non-boot clock, usually the default "local" clock.

Allow such traces in trace_processor, doing a best-effort clock sync to the
primary trace clock while treating the "local" clock as a sequence-scoped
clock. As a simplification, we don't track the clock separately per cpu as the
inter-cpu skew should be minimal for a cross-cpu trace to make sense in the
first place.

This is based on, and supersedes #1825.