### PR TITLE
Give 'Alloc young' gc_type alloc instead of young.

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/garbage_collection.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/garbage_collection.sql
@@ -149,12 +149,12 @@ SELECT
   last_value,
   value,
   CASE
-    WHEN gc_name GLOB '*young*'
-    THEN 'young'
     WHEN gc_name GLOB '*NativeAlloc*'
     THEN 'native_alloc'
     WHEN gc_name GLOB '*Alloc*'
     THEN 'alloc'
+    WHEN gc_name GLOB '*young*'
+    THEN 'young'
     WHEN gc_name GLOB '*CollectorTransition*'
     THEN 'collector_transition'
     WHEN gc_name GLOB '*Explicit*'


### PR DESCRIPTION
Bug: 429198070

android_garbage_collection_events labels 'Alloc young concurrent mark compact GC' GCs as 'young' GCs. These should be labeled as 'alloc' GCs instead, because the impacts on the app are much more like alloc GCs than young GCs.