### PR TITLE
ui: fix the wasm oom error RPC command.

### DIFF
--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -286,7 +286,7 @@ function showOutOfMemoryDialog() {
   const tpCmd =
     'curl -LO https://get.perfetto.dev/trace_processor\n' +
     'chmod +x ./trace_processor\n' +
-    'trace_processor --httpd /path/to/trace.pftrace\n' +
+    './trace_processor --httpd /path/to/trace.pftrace\n' +
     '# Reload the UI, it will prompt to use the HTTP+RPC interface';
   showModal({
     title: 'Oops! Your WASM trace processor ran out of memory',


### PR DESCRIPTION
to execute the downloaded trace_processor it should be prefixed with './'

This prefix is not appropriate Windows platforms, but it is clear this does not intend to target Windows due to presence of curl and chmod, so this *nix platform specific fix should not cause issues.