### PR TITLE
ui: Remove '2GB per tab' text in dialog box

### DIFF
--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -295,7 +295,7 @@ function showOutOfMemoryDialog() {
       m(
         'span',
         'The in-memory representation of the trace is too big ' +
-          'for the browser memory limits (typically 2GB per tab).',
+          'for the browser memory limits.',
       ),
       m('br'),
       m(


### PR DESCRIPTION
This value is wrong. In fact, it's difficult to know how much memory we can use as it depends on a number of factors, but it's probably more than 2GB.