### PR TITLE
shared_lib: Don't call back if category was not enabled

### DIFF
--- a/src/shared_lib/track_event.cc
+++ b/src/shared_lib/track_event.cc
@@ -173,8 +173,11 @@ static void DisableRegisteredCategory(PerfettoTeCategoryImpl* cat,
                                       uint32_t instance_index) {
   PERFETTO_DCHECK(instance_index < perfetto::internal::kMaxDataSourceInstances);
   // Matches the acquire_load in DataSource::Trace().
-  cat->instances.fetch_and(static_cast<uint8_t>(~(1u << instance_index)),
-                           std::memory_order_release);
+  uint8_t old = cat->instances.fetch_and(
+      static_cast<uint8_t>(~(1u << instance_index)), std::memory_order_release);
+  if (!(old & static_cast<uint8_t>(1u << instance_index))) {
+    return;
+  }
   bool global_state_changed = false;
   if (!cat->instances.load(std::memory_order_relaxed)) {
     cat->flag.store(false, std::memory_order_relaxed);


### PR DESCRIPTION
When a track_event data source instance is started, we call the category callback only if the category is enabled for that config.

When a track event data source instance is stopped, we used to call the category callback even if the category was disabled.

Let's only call it if the category was enabled for that config.
