### PR TITLE
tp: fix parsing of integer id2 values and large timestamps

### DIFF
--- a/src/trace_processor/importers/json/BUILD.gn
+++ b/src/trace_processor/importers/json/BUILD.gn
@@ -62,6 +62,7 @@ if (enable_perfetto_trace_processor_json) {
   perfetto_unittest_source_set("unittests") {
     testonly = true
     sources = [
+      "json_parser_unittest.cc",
       "json_trace_tokenizer_unittest.cc",
       "json_utils_unittest.cc",
     ]
@@ -70,6 +71,7 @@ if (enable_perfetto_trace_processor_json) {
       ":minimal",
       "../../../../gn:default_deps",
       "../../../../gn:gtest_and_gmock",
+      "../../../base",
       "../../types",
     ]
   }

--- a/src/trace_processor/importers/json/json_parser_unittest.cc
+++ b/src/trace_processor/importers/json/json_parser_unittest.cc
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/json/json_parser.h"
+
+#include <string>
+#include <string_view>
+
+#include "perfetto/base/status.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::json {
+namespace {
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+
+class JsonParserTest : public ::testing::Test {
+ protected:
+  void Parse(std::string_view str,
+             JsonValue& value,
+             std::string& unescaped_str,
+             bool expect_ok = true) {
+    const char* begin = str.data();
+    const char* end = begin + str.size();
+    const char* cur = begin;
+    base::Status status;
+    if (!internal::SkipWhitespace(cur, end)) {
+      return;
+    }
+    auto res = ParseValue(cur, end, value, unescaped_str, status);
+    if (expect_ok) {
+      EXPECT_EQ(res, ReturnCode::kOk);
+      EXPECT_TRUE(status.ok()) << status.message();
+    } else {
+      EXPECT_NE(res, ReturnCode::kOk);
+      EXPECT_FALSE(status.ok());
+    }
+  }
+};
+
+TEST_F(JsonParserTest, ParseNull) {
+  constexpr std::string_view kJson = "null";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  EXPECT_TRUE(std::holds_alternative<Null>(value));
+}
+
+TEST_F(JsonParserTest, ParseTrue) {
+  constexpr std::string_view kJson = "true";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<bool>(value));
+  EXPECT_TRUE(std::get<bool>(value));
+}
+
+TEST_F(JsonParserTest, ParseFalse) {
+  constexpr std::string_view kJson = "false";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<bool>(value));
+  EXPECT_FALSE(std::get<bool>(value));
+}
+
+TEST_F(JsonParserTest, ParseInteger) {
+  constexpr std::string_view kJson = "12345,";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<int64_t>(value));
+  EXPECT_EQ(std::get<int64_t>(value), 12345);
+}
+
+TEST_F(JsonParserTest, ParseNegativeInteger) {
+  constexpr std::string_view kJson = "-12345,";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<int64_t>(value));
+  EXPECT_EQ(std::get<int64_t>(value), -12345);
+}
+
+TEST_F(JsonParserTest, ParseDouble) {
+  constexpr std::string_view kJson = "123.45,";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<double>(value));
+  EXPECT_DOUBLE_EQ(std::get<double>(value), 123.45);
+}
+
+TEST_F(JsonParserTest, ParseLargeDouble) {
+  constexpr std::string_view kJson = "1750244461563845.0,";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<double>(value));
+  EXPECT_DOUBLE_EQ(std::get<double>(value), 1750244461563845.0);
+}
+
+TEST_F(JsonParserTest, ParseString) {
+  constexpr std::string_view kJson = "\"hello world\"";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(value));
+  EXPECT_EQ(std::get<std::string_view>(value), "hello world");
+}
+
+TEST_F(JsonParserTest, ParseStringWithEscapes) {
+  constexpr std::string_view kJson = "\"hello \\\"world\\\"\"";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(value));
+  EXPECT_EQ(std::get<std::string_view>(value), "hello \"world\"");
+}
+
+TEST_F(JsonParserTest, ParseObject) {
+  constexpr std::string_view kJson = "{\"key\": \"value\"}";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<Object>(value));
+  EXPECT_EQ(std::get<Object>(value).contents, "{\"key\": \"value\"}");
+}
+
+TEST_F(JsonParserTest, ParseArray) {
+  constexpr std::string_view kJson = "[1, 2, 3]";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<Array>(value));
+  EXPECT_EQ(std::get<Array>(value).contents, "[1, 2, 3]");
+}
+
+TEST_F(JsonParserTest, InvalidToken) {
+  constexpr std::string_view kJson = "invalid";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str, false);
+}
+
+TEST(JsonParserIteratorTest, EmptyObject) {
+  constexpr std::string_view kJson = "{}";
+  Iterator it;
+  it.Reset(kJson.data(), kJson.data() + kJson.size());
+  ASSERT_TRUE(it.ParseStart());
+  ASSERT_EQ(it.ParseObjectFieldWithoutRecursing(), ReturnCode::kEndOfScope);
+  ASSERT_TRUE(it.eof());
+}
+
+TEST(JsonParserIteratorTest, SimpleObject) {
+  constexpr std::string_view kJson = R"({"key": "value", "key2": 123})";
+  Iterator it;
+  it.Reset(kJson.data(), kJson.data() + kJson.size());
+  ASSERT_TRUE(it.ParseStart());
+
+  ASSERT_EQ(it.ParseObjectFieldWithoutRecursing(), ReturnCode::kOk);
+  EXPECT_EQ(it.key(), "key");
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(it.value()));
+  EXPECT_EQ(std::get<std::string_view>(it.value()), "value");
+
+  ASSERT_EQ(it.ParseObjectFieldWithoutRecursing(), ReturnCode::kOk);
+  EXPECT_EQ(it.key(), "key2");
+  ASSERT_TRUE(std::holds_alternative<int64_t>(it.value()));
+  EXPECT_EQ(std::get<int64_t>(it.value()), 123);
+
+  ASSERT_EQ(it.ParseObjectFieldWithoutRecursing(), ReturnCode::kEndOfScope);
+  ASSERT_TRUE(it.eof());
+}
+
+TEST(JsonParserIteratorTest, NestedObject) {
+  constexpr std::string_view kJson =
+      R"({"key": {"nested_key": "nested_value"}})";
+  Iterator it;
+  it.Reset(kJson.data(), kJson.data() + kJson.size());
+  ASSERT_TRUE(it.ParseStart());
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kOk);
+  EXPECT_EQ(it.key(), "key");
+  ASSERT_TRUE(std::holds_alternative<Object>(it.value()));
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kOk);
+  EXPECT_EQ(it.key(), "nested_key");
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(it.value()));
+  EXPECT_EQ(std::get<std::string_view>(it.value()), "nested_value");
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kEndOfScope);
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kEndOfScope);
+  ASSERT_TRUE(it.eof());
+}
+
+TEST(JsonParserIteratorTest, SimpleArray) {
+  constexpr std::string_view kJson = R"(["value", 123, true, null])";
+  Iterator it;
+  it.Reset(kJson.data(), kJson.data() + kJson.size());
+  ASSERT_TRUE(it.ParseStart());
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kOk);
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(it.value()));
+  EXPECT_EQ(std::get<std::string_view>(it.value()), "value");
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kOk);
+  ASSERT_TRUE(std::holds_alternative<int64_t>(it.value()));
+  EXPECT_EQ(std::get<int64_t>(it.value()), 123);
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kOk);
+  ASSERT_TRUE(std::holds_alternative<bool>(it.value()));
+  EXPECT_TRUE(std::get<bool>(it.value()));
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kOk);
+  ASSERT_TRUE(std::holds_alternative<Null>(it.value()));
+
+  ASSERT_EQ(it.ParseAndRecurse(), ReturnCode::kEndOfScope);
+  ASSERT_TRUE(it.eof());
+}
+
+TEST(JsonParserUnescapeTest, Unescape) {
+  std::string res;
+  base::Status status;
+  constexpr std::string_view kEscaped = R"(\"\\\/\b\f\n\r\t\u1234)";
+  auto ret = internal::UnescapeString(
+      kEscaped.data(), kEscaped.data() + kEscaped.size(), res, status);
+  ASSERT_EQ(ret, internal::ReturnCode::kOk);
+  ASSERT_TRUE(status.ok());
+  EXPECT_EQ(res, "\"\\/\b\f\n\r\t\xe1\x88\xb4");
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::json

--- a/src/trace_processor/importers/json/json_trace_tokenizer.h
+++ b/src/trace_processor/importers/json/json_trace_tokenizer.h
@@ -110,8 +110,6 @@ class JsonTraceTokenizer : public ChunkedTraceReader {
 
   bool ParseTraceEventContents();
 
-  void ParseId2(std::string_view, std::string_view&, std::string_view&);
-
   base::Status ParseV8SampleEvent(const JsonEvent& event);
 
   base::Status HandleTraceEvent(const char* start,

--- a/test/trace_processor/diff_tests/parser/json/tests.py
+++ b/test/trace_processor/diff_tests/parser/json/tests.py
@@ -1028,3 +1028,143 @@ class JsonParser(TestSuite):
         out=Csv("""
           "name","ts","dur"
         """))
+
+  def test_json_id2_global_int_id(self):
+    return DiffTestBlueprint(
+        trace=Json('''
+          {
+              "traceEvents": [
+                  {
+                      "name": "process_name",
+                      "ph": "M",
+                      "pid": 2,
+                      "args": {
+                          "name": "device2"
+                      }
+                  },
+                  {
+                      "name": "thread_name",
+                      "ph": "M",
+                      "pid": 2,
+                      "tid": 2,
+                      "args": {
+                          "name": "send2"
+                      }
+                  },
+                  {
+                      "name": "write",
+                      "ph": "b",
+                      "pid": 2,
+                      "tid": 2,
+                      "ts": 1850244461563845.0,
+                      "id2": {
+                          "global": 1
+                      },
+                      "args": {
+                          "dev_name": "86",
+                          "wr": "129010217631161",
+                          "op_type": "3",
+                          "src_num": "1",
+                          "dst_num": "3",
+                          "ah_num": "1",
+                          "length": "1048577"
+                      }
+                  },
+                  {
+                      "name": "write",
+                      "ph": "e",
+                      "pid": 2,
+                      "tid": 2,
+                      "ts": 1850244461564012.0,
+                      "id2": {
+                          "global": 1
+                      }
+                  }
+              ]
+          }
+        '''),
+        query='''
+          SELECT
+            slice.name,
+            slice.ts,
+            slice.dur,
+            track.name as track_name,
+            track.type as track_type
+          FROM slice
+          JOIN track on slice.track_id = track.id
+          WHERE slice.name = "write"
+        ''',
+        out=Csv("""
+          "name","ts","dur","track_name","track_type"
+          "write",1850244461563845000,167000,"write","legacy_async_global_slice"
+        """))
+
+  def test_json_id2_local_int_id(self):
+    return DiffTestBlueprint(
+        trace=Json('''
+          {
+              "traceEvents": [
+                  {
+                      "name": "process_name",
+                      "ph": "M",
+                      "pid": 1,
+                      "args": {
+                          "name": "device"
+                      }
+                  },
+                  {
+                      "name": "thread_name",
+                      "ph": "M",
+                      "pid": 1,
+                      "tid": 1,
+                      "args": {
+                          "name": "send"
+                      }
+                  },
+                  {
+                      "name": "write",
+                      "ph": "b",
+                      "pid": 1,
+                      "tid": 1,
+                      "ts": 1750244461563845.0,
+                      "id2": {
+                          "local": 0
+                      },
+                      "args": {
+                          "dev_name": "85",
+                          "wr": "129010217631160",
+                          "op_type": "2",
+                          "src_num": "0",
+                          "dst_num": "2",
+                          "ah_num": "0",
+                          "length": "1048576"
+                      }
+                  },
+                  {
+                      "name": "write",
+                      "ph": "e",
+                      "pid": 1,
+                      "tid": 1,
+                      "ts": 1750244461564012.0,
+                      "id2": {
+                          "local": 0
+                      }
+                  }
+              ]
+          }
+        '''),
+        query='''
+          SELECT
+            slice.name,
+            slice.ts,
+            slice.dur,
+            track.name as track_name,
+            track.type as track_type
+          FROM slice
+          JOIN track on slice.track_id = track.id
+          WHERE slice.name = "write"
+        ''',
+        out=Csv("""
+          "name","ts","dur","track_name","track_type"
+          "write",1750244461563845000,167000,"write","legacy_async_process_slice"
+        """))


### PR DESCRIPTION
We were missing this in the JSON parser rewrite.

Also add unittests for the parser and fix a small bug in timestamp
conversion for largish timestamps

Fixes: https://github.com/google/perfetto/issues/2092
