### PR TITLE
Make perfetto_trace_protos vendor_available

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16713,6 +16713,7 @@ cc_library_static {
         "libprotobuf-cpp-lite",
     ],
     host_supported: true,
+    vendor_available: true,
     generated_headers: [
         "perfetto_protos_perfetto_common_lite_gen_headers",
         "perfetto_protos_perfetto_config_android_lite_gen_headers",

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -123,6 +123,7 @@ target_host_supported = [
 target_vendor_available = [
     '//:libperfetto_client_experimental',
     '//src/shared_lib:libperfetto_c',
+    '//protos/perfetto/trace:perfetto_trace_protos',
 ]
 
 # Library targets that should be exported as "cc_library" instead of


### PR DESCRIPTION
Port of internal commit.

**Original commit message:**
Subject: Make perfetto_trace_protos vendor_available

Due to b/424439549, Soong wasn't enforcing that vendor modules could only link against
other vendor modules.  Add vendor_available to perfetto_trace_protos
since it is used by a vendor module to allow re-enabling the error in
Soong.

Bug: 424439549
Flag: EXEMPT build only fix
Test: builds
Change-Id: Ibe0de069bf11aeacf8963c343270c8cfbac9f55d

---
Original internal commit hash: 0a676964732d71ecf9a34aa98d3cc2d5701212b5
Cherry-picked with `-x`.
This PR is part of a stack. Base branch: main
