### PR TITLE
ui: Fix datagrid layout

### DIFF
--- a/ui/src/assets/components/data_grid.scss
+++ b/ui/src/assets/components/data_grid.scss
@@ -19,16 +19,18 @@ $border: 1px solid rgb(225, 225, 225);
   flex-direction: column;
   font-weight: 300;
   white-space: nowrap;
+  overflow: hidden;
 
   // If fill height is set, the grid should fill the height of its parent, and
   // the table content should scroll, otherwise it takes the height of the table
   // content.
   &--fill-height {
     height: 100%;
+  }
 
-    .pf-data-grid__table {
-      overflow: auto;
-    }
+  &__table {
+    overflow: auto;
+    flex: 1; // Allow the table to grow and fill the available space.
   }
 
   table {
@@ -140,6 +142,7 @@ $border: 1px solid rgb(225, 225, 225);
     display: flex;
     padding: 2px;
     align-items: baseline;
+    gap: 2px;
   }
 
   &__toolbar-filters {

--- a/ui/src/assets/widgets/stack.scss
+++ b/ui/src/assets/widgets/stack.scss
@@ -19,11 +19,16 @@
 
   &--horiz {
     flex-direction: row;
+    align-items: baseline;
   }
 
   &--fill-height {
     height: 100%;
     overflow-y: hidden;
+  }
+
+  &--gap-none {
+    gap: 0px;
   }
 }
 

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -34,7 +34,7 @@ export class AggregationPanel
   view({attrs}: m.CVnode<AggregationPanelAttrs>) {
     const {dataSource, sorting, columns, barChartData} = attrs;
 
-    return m(Stack, {fillHeight: true}, [
+    return m(Stack, {fillHeight: true, gap: 'none'}, [
       barChartData && m(StackFixed, m(Box, this.renderBarChart(barChartData))),
       m(StackAuto, this.renderTable(dataSource, sorting, columns)),
     ]);

--- a/ui/src/components/query_table/query_table.ts
+++ b/ui/src/components/query_table/query_table.ts
@@ -199,6 +199,7 @@ export class QueryTable implements m.ClassComponent<QueryTableAttrs> {
     return m(DataGrid, {
       // If filters are defined by no onFilterChanged handler, the grid operates
       // in filter read only mode.
+      fillHeight: true,
       filters: [],
       columns: resp.columns.map((c) => ({name: c})),
       data: dataSource,

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
@@ -57,6 +57,11 @@
 
   .widget-container {
     display: flex;
+
+    // Put the widget in the center of the container
+    align-items: center;
+    justify-content: center;
+
     min-width: 300px;
     max-width: 600px;
     min-height: 250px;
@@ -66,11 +71,7 @@
     border: dashed 1px gray;
     margin: 10px 0 10px 0;
     padding: 16px;
-
-    & > * {
-      margin: auto;
-      vertical-align: middle;
-    }
+    overflow: hidden;
   }
 
   .widget-container-wide {

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -1707,7 +1707,9 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
                   dur,
                   state,
                   thread.name as thread_name,
-                  dur
+                  dur,
+                  io_wait,
+                  ucpu
                 FROM thread_state ts
                 JOIN thread USING(utid)
               `,
@@ -1726,6 +1728,8 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
                 },
                 {name: 'state', title: 'State'},
                 {name: 'thread_name', title: 'Thread'},
+                {name: 'ucpu', title: 'CPU'},
+                {name: 'io_wait', title: 'IO Wait'},
               ],
               maxRowsPerPage: 10,
             });

--- a/ui/src/widgets/stack.ts
+++ b/ui/src/widgets/stack.ts
@@ -18,17 +18,23 @@ import {classNames} from '../base/classnames';
 interface StackAttrs {
   readonly orientation?: 'horizontal' | 'vertical';
   readonly fillHeight?: boolean;
+  readonly gap?: 'none' | 'normal';
 }
 
 export class Stack implements m.ClassComponent<StackAttrs> {
   view({attrs, children}: m.CVnode<StackAttrs>) {
-    const {orientation = 'vertical', fillHeight = false} = attrs;
+    const {
+      orientation = 'vertical',
+      fillHeight = false,
+      gap = 'normal',
+    } = attrs;
     return m(
       '.pf-stack',
       {
         className: classNames(
           orientation === 'horizontal' && 'pf-stack--horiz',
           fillHeight && 'pf-stack--fill-height',
+          gap === 'none' && 'pf-stack--gap-none',
         ),
       },
       children,


### PR DESCRIPTION
Fixed the datagrid's css so that the table scrolls, not the toolbar when space is limited, which means the toolbar / paging controls stay put and the table header stays pinned to the top when scrolling large pages.

Also fixed the widget layout to hide the overflow, limiting the size of widgets so that they get a chance to overflow and demonstrate scrolling.

Tested in the following places:
- Aggregation panels
- Query page
- Queries in the tab drawer
- Widgets page
- Explore page

Demo - notice the paging controls stay put while scrolling the table, and the table header sticks to the top when scrolling vertically, but says aligned with the columns when scrolling horizontally.

[e4c3f120-663d-4f3c-80f2-b79a45a1928f.webm](https://github.com/user-attachments/assets/30e445fe-4677-46a4-ab7e-c471d41e080e)
