### PR TITLE
Parse SF corner radii separately.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
@@ -197,8 +197,19 @@ tables::SurfaceFlingerLayerTable::Id SurfaceFlingerLayersParser::InsertLayerRow(
   if (layer_decoder.has_parent()) {
     layer.parent = layer_decoder.parent();
   }
-  if (layer_decoder.has_corner_radius()) {
-    layer.corner_radius = static_cast<double>(layer_decoder.corner_radius());
+  if (layer_decoder.has_corner_radii()) {
+    protos::pbzero::CornerRadiiProto::Decoder corner_radii(
+        layer_decoder.corner_radii());
+    layer.corner_radius_tl = static_cast<double>(corner_radii.tl());
+    layer.corner_radius_tr = static_cast<double>(corner_radii.tr());
+    layer.corner_radius_bl = static_cast<double>(corner_radii.bl());
+    layer.corner_radius_br = static_cast<double>(corner_radii.br());
+  } else if (layer_decoder.has_corner_radius()) {
+    auto radius = static_cast<double>(layer_decoder.corner_radius());
+    layer.corner_radius_tl = radius;
+    layer.corner_radius_tr = radius;
+    layer.corner_radius_bl = radius;
+    layer.corner_radius_br = radius;
   }
   if (layer_decoder.has_hwc_composition_type()) {
     layer.hwc_composition_type = layer_decoder.hwc_composition_type();

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -266,7 +266,10 @@ SURFACE_FLINGER_LAYER_TABLE = Table(
         C('layer_name', CppOptional(CppString())),
         C('is_visible', CppInt64()),
         C('parent', CppOptional(CppInt64())),
-        C('corner_radius', CppOptional(CppDouble())),
+        C('corner_radius_tl', CppOptional(CppDouble())),
+        C('corner_radius_tr', CppOptional(CppDouble())),
+        C('corner_radius_bl', CppOptional(CppDouble())),
+        C('corner_radius_br', CppOptional(CppDouble())),
         C('hwc_composition_type', CppOptional(CppInt64())),
         C('is_hidden_by_policy', CppInt64()),
         C('z_order_relative_of', CppOptional(CppInt64())),
@@ -292,8 +295,14 @@ SURFACE_FLINGER_LAYER_TABLE = Table(
                 'Computed layer visibility',
             'parent':
                 'Parent layer id',
-            'corner_radius':
-                'Layer corner radius',
+            'corner_radius_tl':
+                'Layer corner radius top left',
+            'corner_radius_tr':
+                'Layer corner radius top right',
+            'corner_radius_bl':
+                'Layer corner radius bottom left',
+            'corner_radius_br':
+                'Layer corner radius bottom right',
             'hwc_composition_type':
                 'Hwc composition type',
             'is_hidden_by_policy':

--- a/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
+++ b/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
@@ -98,7 +98,7 @@ packet {
         queued_frames: 0
         is_protected: false
         curr_frame: 0
-        corner_radius: 0.000000
+        corner_radii: { tl: 0.100000 bl: 0.300000 br: 0.400000 }
         source_bounds {
           left: -10800.000000
           top: -24000.000000

--- a/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
@@ -109,7 +109,10 @@ class SurfaceFlingerLayers(TestSuite):
           layer_id,
           layer_name,
           parent,
-          corner_radius,
+          corner_radius_tl,
+          corner_radius_tr,
+          corner_radius_bl,
+          corner_radius_br,
           hwc_composition_type,
           z_order_relative_of,
           is_missing_z_parent,
@@ -121,14 +124,14 @@ class SurfaceFlingerLayers(TestSuite):
         LIMIT 7;
         """,
         out=Csv("""
-        "id","snapshot_id","layer_id","layer_name","parent","corner_radius","hwc_composition_type","z_order_relative_of","is_missing_z_parent","is_visible","layer_rect_id","input_rect_id"
-        0,0,3,"Display 0 name="Built-in Screen"#3","[NULL]",0.000000,"[NULL]",5,1,0,"[NULL]","[NULL]"
-        1,0,4,"WindowedMagnification:0:31#4",3,0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
-        2,1,3,"Display 0 name="Built-in Screen"#3","[NULL]",0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
-        3,1,4,"WindowedMagnification:0:31#4",3,0.000000,"[NULL]","[NULL]",0,0,3,"[NULL]"
-        4,2,"[NULL]","[NULL]",-1,"[NULL]","[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
-        5,2,1,"layer1","[NULL]",1.000000,2,"[NULL]",0,0,9,10
-        6,2,2,"layer2","[NULL]","[NULL]","[NULL]","[NULL]",0,1,11,12
+        "id","snapshot_id","layer_id","layer_name","parent","corner_radius_tl","corner_radius_tr","corner_radius_bl","corner_radius_br","hwc_composition_type","z_order_relative_of","is_missing_z_parent","is_visible","layer_rect_id","input_rect_id"
+        0,0,3,"Display 0 name="Built-in Screen"#3","[NULL]",0.000000,0.000000,0.000000,0.000000,"[NULL]",5,1,0,"[NULL]","[NULL]"
+        1,0,4,"WindowedMagnification:0:31#4",3,0.100000,0.000000,0.300000,0.400000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        2,1,3,"Display 0 name="Built-in Screen"#3","[NULL]",0.000000,0.000000,0.000000,0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        3,1,4,"WindowedMagnification:0:31#4",3,0.000000,0.000000,0.000000,0.000000,"[NULL]","[NULL]",0,0,3,"[NULL]"
+        4,2,"[NULL]","[NULL]",-1,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        5,2,1,"layer1","[NULL]",1.000000,1.000000,1.000000,1.000000,2,"[NULL]",0,0,9,10
+        6,2,2,"layer2","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]",0,1,11,12
         """))
 
   def test_tables_have_raw_protos(self):


### PR DESCRIPTION
Bug: 427244076
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="SurfaceFlingerLayer|PerfettoTable:winscope"
