### PR TITLE
ui: Add ButtonGroup widget

### DIFF
--- a/ui/src/assets/widgets/button.scss
+++ b/ui/src/assets/widgets/button.scss
@@ -184,3 +184,20 @@
   gap: 2px;
   align-items: baseline;
 }
+
+.pf-button-group {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+
+  .pf-button:not(:last-child) {
+    border-top-right-radius: unset;
+    border-bottom-right-radius: unset;
+    border-right: unset;
+  }
+
+  .pf-button:not(:first-child) {
+    border-top-left-radius: unset;
+    border-bottom-left-radius: unset;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -18,7 +18,13 @@ import {Hotkey, Platform} from '../../base/hotkeys';
 import {isString} from '../../base/object_utils';
 import {Icons} from '../../base/semantic_icons';
 import {Anchor} from '../../widgets/anchor';
-import {Button, ButtonBar, ButtonVariant} from '../../widgets/button';
+import {
+  Button,
+  ButtonAttrs,
+  ButtonBar,
+  ButtonGroup,
+  ButtonVariant,
+} from '../../widgets/button';
 import {Callout} from '../../widgets/callout';
 import {Checkbox} from '../../widgets/checkbox';
 import {Editor} from '../../widgets/editor';
@@ -676,6 +682,41 @@ function SegmentedButtonsDemo({attrs}: {attrs: {}}) {
   };
 }
 
+function RadioButtonGroupDemo() {
+  let setting: 'yes' | 'maybe' | 'no' = 'no';
+  console.log(setting);
+  return {
+    view: ({attrs}: m.Vnode<ButtonAttrs>) => {
+      return m(ButtonGroup, [
+        m(Button, {
+          ...attrs,
+          label: 'Yes',
+          active: setting === 'yes',
+          onclick: () => {
+            setting = 'yes';
+          },
+        }),
+        m(Button, {
+          ...attrs,
+          label: 'Maybe',
+          active: setting === 'maybe',
+          onclick: () => {
+            setting = 'maybe';
+          },
+        }),
+        m(Button, {
+          ...attrs,
+          label: 'No',
+          active: setting === 'no',
+          onclick: () => {
+            setting = 'no';
+          },
+        }),
+      ]);
+    },
+  };
+}
+
 export class WidgetsPage implements m.ClassComponent<{app: App}> {
   view({attrs}: m.Vnode<{app: App}>) {
     return m(
@@ -752,6 +793,31 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
         renderWidget: (opts) => m(SegmentedButtonsDemo, opts),
         initialOpts: {
           disabled: false,
+        },
+      }),
+      m(WidgetShowcase, {
+        label: 'ButtonGroup',
+        renderWidget: (opts) =>
+          m(Stack, [
+            m(ButtonGroup, [
+              m(Button, {
+                label: 'Commit',
+                ...opts,
+              }),
+              m(Button, {
+                icon: Icons.ContextMenu,
+                ...opts,
+              }),
+            ]),
+            m(RadioButtonGroupDemo, opts),
+          ]),
+        initialOpts: {
+          variant: new EnumOption(
+            ButtonVariant.Filled,
+            Object.values(ButtonVariant),
+          ),
+          disabled: false,
+          intent: new EnumOption(Intent.None, Object.values(Intent)),
         },
       }),
       m(WidgetShowcase, {

--- a/ui/src/widgets/button.ts
+++ b/ui/src/widgets/button.ts
@@ -86,7 +86,7 @@ export class Button implements m.ClassComponent<ButtonAttrs> {
       dismissPopup,
       iconFilled,
       intent = Intent.None,
-      variant = ButtonVariant.Minimal,
+      variant = ButtonVariant.Filled,
       ...htmlAttrs
     } = attrs;
 
@@ -152,5 +152,21 @@ function classForVariant(variant: ButtonVariant) {
 export class ButtonBar implements m.ClassComponent<HTMLAttrs> {
   view({attrs, children}: m.CVnode<HTMLAttrs>): m.Children {
     return m('.pf-button-bar', attrs, children);
+  }
+}
+
+/**
+ * A set of buttons that are visually grouped together into one super-widget.
+ * The inside borders are de-duplicated, and the inside rounded corners removed.
+ *
+ * This is useful for when you have a set of radio buttons, or a button with an
+ * additional dropdown button to allow for additional actions to be selected.
+ *
+ * Very similar to the SegmentedButtons widget, but offers more control over the
+ * individual buttons.
+ */
+export class ButtonGroup implements m.ClassComponent<HTMLAttrs> {
+  view({attrs, children}: m.CVnode<HTMLAttrs>): m.Children {
+    return m('.pf-button-group', attrs, children);
   }
 }


### PR DESCRIPTION
The ButtonGroup widget is a container widget housing a set of buttons that are visually grouped together into one super-widget. The inside borders are de-duplicated, and the inside rounded corners removed.

This is useful for when you have a set of radio buttons, or for adding a drop down menu to an existing button. 

Very similar to the SegmentedButtons widget, but offers more control over the individual buttons.