### PR TITLE
ui: Add standard padding around the 'Critical Path Lite' button

### DIFF
--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_details_panel.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {Anchor} from '../../widgets/anchor';
-import {Button, ButtonVariant} from '../../widgets/button';
+import {Button, ButtonBar, ButtonVariant} from '../../widgets/button';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
@@ -40,6 +40,7 @@ import {goToSchedSlice} from '../../components/widgets/sched';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
 import {formatDuration} from '../../components/time_utils';
+import {Stack} from '../../widgets/stack';
 
 interface RelatedThreadStates {
   prev?: ThreadState;
@@ -296,9 +297,8 @@ export class ThreadStateDetailsPanel implements TrackEventDetailsPanel {
       );
     };
 
-    return [
-      m(
-        Tree,
+    return m(Stack, [
+      m(Tree, [
         this.relatedStates.prev &&
           m(TreeNode, {
             left: 'Previous state',
@@ -317,20 +317,22 @@ export class ThreadStateDetailsPanel implements TrackEventDetailsPanel {
           }),
         renderWaker(this.relatedStates),
         renderWakees(this.relatedStates),
-      ),
+      ]),
       this.trace.commands.hasCommand(CRITICAL_PATH_LITE_CMD) &&
-        m(Button, {
-          label: 'Critical path lite',
-          intent: Intent.Primary,
-          variant: ButtonVariant.Filled,
-          onclick: () => {
-            this.trace.commands.runCommand(
-              CRITICAL_PATH_LITE_CMD,
-              this.threadState?.thread?.utid,
-            );
-          },
-        }),
-    ];
+        m(ButtonBar, [
+          m(Button, {
+            label: 'Critical path lite',
+            intent: Intent.Primary,
+            variant: ButtonVariant.Filled,
+            onclick: () => {
+              this.trace.commands.runCommand(
+                CRITICAL_PATH_LITE_CMD,
+                this.threadState?.thread?.utid,
+              );
+            },
+          }),
+        ]),
+    ]);
   }
 
   isLoading() {


### PR DESCRIPTION
Uses standard padding and spacing container widgets to provide some padding around the button.
