### PR TITLE
Support more gralloc allocator process names

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/dmabuf.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/dmabuf.sql
@@ -43,6 +43,7 @@ WITH
       USING (upid)
     WHERE
       process.name GLOB '/vendor/bin/hw/android.hardware.graphics.allocator*'
+      OR process.name GLOB '/vendor/bin/hw/*gralloc.allocator*'
   )
 SELECT
   flow.slice_out AS client_slice_id,


### PR DESCRIPTION
This change adds an additional GLOB pattern to
match other variations of the process name.

Bug: b/430805731

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
