### PR TITLE
Improved track organisation in unfold latency plugin

### DIFF
--- a/ui/src/plugins/dev.perfetto.LargeScreensPerf/index.ts
+++ b/ui/src/plugins/dev.perfetto.LargeScreensPerf/index.ts
@@ -13,32 +13,127 @@
 // limitations under the License.
 
 import {Trace} from '../../public/trace';
+import {TrackNode} from '../../public/workspace';
 import {PerfettoPlugin} from '../../public/plugin';
+import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
+import TraceProcessorTrackPlugin from '../dev.perfetto.TraceProcessorTrack';
+import {NUM} from '../../trace_processor/query_result';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.LargeScreensPerf';
+  static readonly dependencies = [
+    StandardGroupsPlugin,
+    TraceProcessorTrackPlugin,
+  ];
+
   async onTraceLoad(ctx: Trace): Promise<void> {
+    this.addFoldedStateTrackToDeviceState(ctx);
+
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.LargeScreensPerf#PinUnfoldLatencyTracks',
-      name: 'Pin: Unfold latency tracks',
-      callback: () => {
-        ctx.workspace.flatTracks.forEach((track) => {
-          if (
-            !!track.name.includes('UnfoldTransition') ||
-            track.name.includes('Screen on blocked') ||
-            track.name.includes('hingeAngle') ||
-            track.name.includes('UnfoldLightRevealOverlayAnimation') ||
-            track.name.startsWith('waitForAllWindowsDrawn') ||
-            track.name.endsWith('UNFOLD_ANIM>') ||
-            track.name.endsWith('UNFOLD>') ||
-            track.name == 'Waiting for KeyguardDrawnCallback#onDrawn' ||
-            track.name == 'FoldedState' ||
-            track.name == 'FoldUpdate'
-          ) {
-            track.pin();
-          }
-        });
+      id: 'dev.perfetto.LargeScreensPerf#UnfoldLatencyTracks',
+      name: 'Organize unfold latency tracks',
+      callback: async () => {
+        this.pinCoreTracks(ctx);
+        this.addUnfoldMiscSection(ctx);
+        await this.addUnfoldDisplaySwitchingSection(ctx);
+        this.addUnfoldAnimationSection(ctx);
       },
     });
+  }
+
+  private addFoldedStateTrackToDeviceState(ctx: Trace) {
+    const foldedStateTrack = ctx.workspace.flatTracks.find(
+      (t) => t.name == 'FoldedState',
+    );
+    if (foldedStateTrack) {
+      const deviceStateGroup = ctx.plugins
+        .getPlugin(StandardGroupsPlugin)
+        .getOrCreateStandardGroup(ctx.workspace, 'DEVICE_STATE');
+      deviceStateGroup.addChildLast(foldedStateTrack);
+    }
+  }
+
+  private pinCoreTracks(ctx: Trace) {
+    ctx.workspace.flatTracks
+      .filter(
+        (track) =>
+          track.name == 'FoldedState' ||
+          track.name.includes('hingeAngle') ||
+          track.name.endsWith('UNFOLD>'),
+      )
+      .forEach((track) => track.pin());
+  }
+
+  private addUnfoldMiscSection(ctx: Trace) {
+    // section for tracks that don't fit neatly in other sections and are not so important to be pinned
+    const group = new TrackNode({name: 'Unfold misc'});
+    ctx.workspace.addChildFirst(group);
+    ctx.workspace.flatTracks
+      .filter(
+        (t) =>
+          t.name.startsWith('waitForAllWindowsDrawn') ||
+          t.name == 'Waiting for KeyguardDrawnCallback#onDrawn',
+      )
+      .map((t) => t.clone())
+      .forEach((track) => group.addChildLast(track));
+  }
+
+  private addUnfoldAnimationSection(ctx: Trace) {
+    const group = new TrackNode({name: 'Unfold animation'});
+    ctx.workspace.addChildFirst(group);
+    ctx.workspace.flatTracks
+      .filter(
+        (t) =>
+          t.name == 'FoldUpdate' ||
+          t.name.includes('UnfoldTransition') ||
+          t.name.includes('UnfoldLightRevealOverlayAnimation') ||
+          t.name.endsWith('UNFOLD_ANIM>'),
+      )
+      .map((t) => t.clone())
+      .forEach((track) => group.addChildLast(track));
+  }
+
+  private async addUnfoldDisplaySwitchingSection(ctx: Trace) {
+    const group = new TrackNode({name: 'Unfold display switching'});
+    ctx.workspace.addChildFirst(group);
+
+    const displayTracks = ctx.workspace.flatTracks.filter(
+      (t) =>
+        t.name.includes('android.display') ||
+        t.name.includes('Screen on blocked'),
+    );
+    const photonicModulatorTrack = await this.findPhotonicModulatorTrack(ctx);
+    if (photonicModulatorTrack != undefined) {
+      displayTracks.push(photonicModulatorTrack);
+    }
+    displayTracks
+      // sorting so that "android.display" tracks are next to each other
+      .sort((t1, t2) => t1.name.localeCompare(t2.name))
+      .map((t) => t.clone())
+      .forEach((t) => group.addChildFirst(t));
+  }
+
+  private async findPhotonicModulatorTrack(
+    ctx: Trace,
+  ): Promise<TrackNode | undefined> {
+    const photonicModulatorTrackWithSetDisplayState = `
+          SELECT
+            DISTINCT thread_track.id
+          FROM slice
+          JOIN thread_track ON slice.track_id = thread_track.id
+          LEFT JOIN thread ON thread_track.utid = thread.utid
+          WHERE slice.name LIKE "setDisplayState%"
+          AND thread.name LIKE "PhotonicMod%"
+        `;
+    const result = await ctx.engine.query(
+      photonicModulatorTrackWithSetDisplayState,
+    );
+    if (result.numRows() === 0) return;
+    const trackId = result.iter({id: NUM}).id;
+    const track = ctx.trace?.tracks.findTrack((t) =>
+      t.tags?.trackIds?.includes(trackId),
+    );
+    if (!track?.uri) return;
+    return ctx.workspace.getTrackByUri(track.uri);
   }
 }


### PR DESCRIPTION
Instead of pinning all tracks relevant to unfold, we pin only most important ones and rest is grouped below.
I wish we could pin groups as well but currently it's not possible.
This change leaves only 4 tracks pinned and rest is grouped into: Unfold animation, Unfold display switching and Unfold misc.

A few small extra changes:
1. Adding tracks for android.display thread
2. Adding track for PhotonicModulator which is doing the actual display switching. This requires querying content to find track with 'setDisplaySwitching' slice
3. Renaming plugin from 'Pin: Unfold latency tracks' to 'Organize unfold latency tracks'
