### PR TITLE
fix(python): Ensure trace_processor_shell is terminated on Windows

### DIFF
--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
+import signal
 import dataclasses as dc
 from urllib.parse import urlparse
 from typing import List, Optional, Union
@@ -302,9 +305,16 @@ class TraceProcessor:
     return False
 
   def close(self):
-    if hasattr(self, 'subprocess'):
-      self.subprocess.kill()
+    if hasattr(self, 'subprocess') and self.subprocess:
+      # On Windows, we need to kill the whole process group.
+      # On other platforms, killing the parent is enough.
+      if sys.platform == 'win32':
+        os.kill(self.subprocess.pid, signal.CTRL_BREAK_EVENT)
+      else:
+        self.subprocess.kill()
       self.subprocess.wait()
+      # Set to None so __del__ doesn't call this again.
+      self.subprocess = None
 
     if hasattr(self, 'http'):
       self.http.conn.close()

--- a/python/perfetto/trace_processor/shell.py
+++ b/python/perfetto/trace_processor/shell.py
@@ -73,11 +73,17 @@ def load_shell(
 
   temp_stdout = tempfile.TemporaryFile()
   temp_stderr = tempfile.TemporaryFile()
+
+  creationflags = 0
+  if sys.platform == 'win32':
+    creationflags = subprocess.CREATE_NEW_PROCESS_GROUP
+
   p = subprocess.Popen(
       tp_exec + args,
       stdin=subprocess.DEVNULL,
       stdout=temp_stdout,
-      stderr=None if verbose else temp_stderr)
+      stderr=None if verbose else temp_stderr,
+      creationflags=creationflags)
 
   success = False
   for _ in range(load_timeout + 1):


### PR DESCRIPTION
Related issue is: https://github.com/google/perfetto/issues/2140

On Windows, the `trace_processor_shell.exe` subprocess launched by the Python API was not terminated when the `TraceProcessor` object was closed. This resulted in an orphan process that continued to run indefinitely, consuming resources until manually killed.

This was caused by two issues specific to the Windows platform:

1. The `trace_processor_shell` daemonizes itself, creating a new worker process and detaching from the parent. The original PID held by the Python script belonged to the short-lived launcher, not the actual worker.
2. Unlike on POSIX systems, terminating a parent process on Windows does not automatically terminate its children.

This change ensures that the lifecycle of `trace_processor_shell` is correctly managed on all supported platforms.
