### PR TITLE
tp: ui: implement tp/ui support for track event merge control

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,9 +5,17 @@ Unreleased:
     * Added `android.bitmaps` module with timeseries information about bitmap
       usage in Android.
   Trace Processor:
-    *
+    * Added support for `sibling_merge_behavior` and `sibling_merge_key` in
+      `TrackDescriptor` for TrackEvent, allowing for finer-grained control over
+      how tracks are merged. See UI section for more details.
   UI:
-    *
+    * Added support for controlling TrackEvent track merging through the
+      `TrackDescriptor` proto. This is especially useful for users converting
+      external traces into Perfetto format or using the SDK. Tracks can now
+      specify a `sibling_merge_behavior` and a `sibling_merge_key` to override
+      the default name-based merging. This allows for forcing tracks with the
+      same name to be displayed separately, or forcing tracks with different
+      names to be merged into a single UI track.
   SDK:
     *
 

--- a/docs/getting-started/converting.md
+++ b/docs/getting-started/converting.md
@@ -372,8 +372,10 @@ operation tracks the **same `name`** (e.g., "Network Connections" or "File
 I/O"). The slices themselves on these tracks can have distinct names (e.g., "GET
 /api/data", "Read /config.txt").
 
-The Perfetto UI will typically group or visually merge tracks that have the same
-name.
+The Perfetto UI will group or visually merge tracks that have the same name.
+This is a convention and can be controlled by the user. For more details, see
+the section on controlling merging in the
+[synthetic track event reference docs](/docs/reference/synthetic-track-event.md#controlling-track-merging).
 
 ### Python Example
 
@@ -860,6 +862,7 @@ you can:
 - **Visualize your trace:** Open your generated `.pftrace` file in the
   [Perfetto UI](https://ui.perfetto.dev) to explore your data on an interactive
   timeline.
-- **Analyze with SQL:** Use the [Trace Processor](/docs/analysis/getting-started.md) to
-  query your custom trace data. Your custom tracks and events will populate
-  standard tables like `slice`, `track`, `counter`, etc.
+- **Analyze with SQL:** Use the
+  [Trace Processor](/docs/analysis/getting-started.md) to query your custom
+  trace data. Your custom tracks and events will populate standard tables like
+  `slice`, `track`, `counter`, etc.

--- a/docs/reference/synthetic-track-event.md
+++ b/docs/reference/synthetic-track-event.md
@@ -519,3 +519,130 @@ your `trace_converter_template.py` script.
 </details>
 
 ![Interning Data for Trace Size Optimization](/docs/images/synthetic-track-event-interning.png)
+
+## {#controlling-track-merging} Controlling Track Merging
+
+By default, the Perfetto UI merges tracks that share the same name. This is
+often the desired behavior for grouping related asynchronous events. However,
+there are scenarios where you need more explicit control. You can override this
+default merging logic using the `sibling_merge_behavior` and `sibling_merge_key`
+fields in the `TrackDescriptor`.
+
+This allows you to:
+
+- **Prevent merging**: Force tracks, even with the same name, to always be
+  displayed separately.
+- **Merge by key**: Force tracks to merge based on a custom key, regardless of
+  their names.
+
+The `sibling_merge_behavior` field can be set to one of the following values:
+
+- `SIBLING_MERGE_BEHAVIOR_BY_TRACK_NAME` (the default): Merges sibling tracks
+  that have the same `name`.
+- `SIBLING_MERGE_BEHAVIOR_NONE`: Prevents the track from being merged with any
+  of its siblings.
+- `SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY`: Merges sibling tracks that have
+  the same `sibling_merge_key` string.
+
+### Python Example: Preventing Merging
+
+In this example, we create two tracks with the same name. By setting their
+`sibling_merge_behavior` to `SIBLING_MERGE_BEHAVIOR_NONE`, we ensure they are
+always displayed as distinct tracks in the UI.
+
+<details>
+<summary><a style="cursor: pointer;"><b>Click to expand/collapse Python code</b></a></summary>
+
+```python
+    TRUSTED_PACKET_SEQUENCE_ID = 9003
+
+    # --- Define Track UUIDs ---
+    track1_uuid = 1
+    track2_uuid = 2
+
+    # Helper to define a TrackDescriptor
+    def define_custom_track(track_uuid, name):
+        packet = builder.add_packet()
+        desc = packet.track_descriptor
+        desc.uuid = track_uuid
+        desc.name = name
+        desc.sibling_merge_behavior = TrackDescriptor.SIBLING_MERGE_BEHAVIOR_NONE
+
+    # 1. Define the tracks
+    define_custom_track(track1_uuid, "My Separate Track")
+    define_custom_track(track2_uuid, "My Separate Track")
+
+    # Helper to add a slice event
+    def add_slice_event(ts, event_type, event_track_uuid, name=None):
+        packet = builder.add_packet()
+        packet.timestamp = ts
+        packet.track_event.type = event_type
+        packet.track_event.track_uuid = event_track_uuid
+        if name:
+            packet.track_event.name = name
+        packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+
+    # 2. Add events to the tracks
+    add_slice_event(ts=1000, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track1_uuid, name="Slice 1")
+    add_slice_event(ts=1100, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track1_uuid)
+
+    add_slice_event(ts=1200, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track2_uuid, name="Slice 2")
+    add_slice_event(ts=1300, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track2_uuid)
+```
+
+</details>
+
+![Preventing Merging](/docs/images/synthetic-track-event-no-merge.png)
+
+### Python Example: Merging by Key
+
+In this example, we create two tracks with different names but the same
+`sibling_merge_key`. By setting their `sibling_merge_behavior` to
+`SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY`, we instruct the UI to merge them
+into a single visual track. The name of the merged group will be taken from one
+of the tracks (usually the one with the lower UUID).
+
+<details>
+<summary><a style="cursor: pointer;"><b>Click to expand/collapse Python code</b></a></summary>
+
+```python
+    TRUSTED_PACKET_SEQUENCE_ID = 9004
+
+    # --- Define Track UUIDs ---
+    track1_uuid = 1
+    track2_uuid = 2
+
+    # Helper to define a TrackDescriptor
+    def define_custom_track(track_uuid, name, merge_key):
+        packet = builder.add_packet()
+        desc = packet.track_descriptor
+        desc.uuid = track_uuid
+        desc.name = name
+        desc.sibling_merge_behavior = TrackDescriptor.SIBLING_MERGE_BEHAVIOR_BY_SIBLING_MERGE_KEY
+        desc.sibling_merge_key = merge_key
+
+    # 1. Define the tracks with the same merge key
+    define_custom_track(track1_uuid, "HTTP GET", "conn-123")
+    define_custom_track(track2_uuid, "HTTP POST", "conn-123")
+
+    # Helper to add a slice event
+    def add_slice_event(ts, event_type, event_track_uuid, name=None):
+        packet = builder.add_packet()
+        packet.timestamp = ts
+        packet.track_event.type = event_type
+        packet.track_event.track_uuid = event_track_uuid
+        if name:
+            packet.track_event.name = name
+        packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+
+    # 2. Add events to the tracks
+    add_slice_event(ts=1000, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track1_uuid, name="GET /data")
+    add_slice_event(ts=1100, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track1_uuid)
+
+    add_slice_event(ts=1200, event_type=TrackEvent.TYPE_SLICE_BEGIN, event_track_uuid=track2_uuid, name="POST /submit")
+    add_slice_event(ts=1300, event_type=TrackEvent.TYPE_SLICE_END, event_track_uuid=track2_uuid)
+```
+
+</details>
+
+![Merging by Key](/docs/images/synthetic-track-event-merge-by-key.png)

--- a/src/trace_processor/containers/string_pool.h
+++ b/src/trace_processor/containers/string_pool.h
@@ -70,6 +70,8 @@ class StringPool {
 
  public:
   struct Id {
+    static constexpr bool kHashable = true;
+
     Id() = default;
 
     constexpr bool operator==(const Id& other) const { return other.id == id; }
@@ -119,6 +121,10 @@ class StringPool {
     }
 
     PERFETTO_ALWAYS_INLINE static constexpr Id Null() { return Id(0u); }
+
+    // For hashing.
+    const char* data() const { return reinterpret_cast<const char*>(&id); }
+    size_t size() const { return sizeof(id); }
 
    private:
     constexpr explicit Id(uint32_t i) : id(i) {}

--- a/src/trace_processor/export_json_unittest.cc
+++ b/src/trace_processor/export_json_unittest.cc
@@ -794,7 +794,7 @@ TEST_F(ExportJsonTest, InstantEvent) {
 
   // Global track.
   TrackEventTracker track_event_tracker(&context_);
-  TrackId track2 = *track_event_tracker.InternDescriptorTrack(
+  TrackId track2 = *track_event_tracker.InternDescriptorTrackInstant(
       TrackEventTracker::kDefaultDescriptorTrackUuid, kNullStringId,
       std::nullopt);
   context_.storage->mutable_slice_table()->Insert(
@@ -804,7 +804,7 @@ TEST_F(ExportJsonTest, InstantEvent) {
   TrackEventTracker::DescriptorTrackReservation reservation;
   reservation.parent_uuid = 0;
   track_event_tracker.ReserveDescriptorTrack(1234, reservation);
-  TrackId track3 = *track_event_tracker.InternDescriptorTrack(
+  TrackId track3 = *track_event_tracker.InternDescriptorTrackInstant(
       1234, kNullStringId, std::nullopt);
   context_.storage->mutable_slice_table()->Insert(
       {kTimestamp3, 0, track3, cat_id, name_id, 0, 0, 0});

--- a/src/trace_processor/importers/common/track_compressor.cc
+++ b/src/trace_processor/importers/common/track_compressor.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
+#include <optional>
 #include <vector>
 
 #include "perfetto/base/logging.h"

--- a/src/trace_processor/importers/common/track_tracker.h
+++ b/src/trace_processor/importers/common/track_tracker.h
@@ -30,6 +30,7 @@
 #include "perfetto/ext/base/hash.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/public/compiler.h"
+#include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/common/global_args_tracker.h"
 #include "src/trace_processor/importers/common/tracks.h"
@@ -215,6 +216,8 @@ class TrackTracker {
         a[i].value = Variadic::Integer(std::get<i>(dimensions));
       } else if constexpr (std::is_integral_v<elem_t>) {
         a[i].value = Variadic::Integer(std::get<i>(dimensions));
+      } else if constexpr (std::is_same_v<elem_t, StringPool::Id>) {
+        a[i].value = Variadic::String(std::get<i>(dimensions));
       } else {
         static_assert(std::is_same_v<elem_t, base::StringView>,
                       "Unknown type for dimension");

--- a/src/trace_processor/importers/common/tracks.h
+++ b/src/trace_processor/importers/common/tracks.h
@@ -98,6 +98,11 @@ constexpr auto StringDimensionBlueprint(const char name[]) {
   return DimensionBlueprintT<base::StringView>{{name}};
 }
 
+// Adds a string dimension with the given name.
+constexpr auto StringIdDimensionBlueprint(const char name[]) {
+  return DimensionBlueprintT<StringPool::Id>{{name}};
+}
+
 // Adds a int64_t dimension with the given name.
 constexpr auto LongDimensionBlueprint(const char name[]) {
   return DimensionBlueprintT<int64_t>{{name}};

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -48,6 +48,7 @@
 #include "src/trace_processor/importers/common/slice_tracker.h"
 #include "src/trace_processor/importers/common/slice_translation_table.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
+#include "src/trace_processor/importers/common/track_compressor.h"
 #include "src/trace_processor/importers/common/track_tracker.h"
 #include "src/trace_processor/importers/ftrace/ftrace_sched_event_tracker.h"
 #include "src/trace_processor/importers/proto/additional_modules.h"
@@ -264,6 +265,7 @@ class ProtoTraceParserTest : public ::testing::Test {
         kTraceDescriptor.data(), kTraceDescriptor.size());
 
     context_.perf_sample_tracker.reset(new PerfSampleTracker(&context_));
+    context_.track_compressor.reset(new TrackCompressor(&context_));
 
     RegisterDefaultModules(&context_);
     RegisterAdditionalModules(&context_);

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -28,6 +28,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/ext/base/string_writer.h"
@@ -164,7 +165,7 @@ class TrackEventEventImporter {
           event_data_->trace_packet_data.packet, annotation);
     }
 
-    RETURN_IF_ERROR(ParseTrackAssociation());
+    RETURN_IF_ERROR(ParseInitialTrackAssociation());
 
     // If we have legacy thread time / instruction count fields, also parse them
     // into the counters tables.
@@ -297,8 +298,7 @@ class TrackEventEventImporter {
     return kNullStringId;
   }
 
-  base::Status ParseTrackAssociation() {
-    TrackTracker* track_tracker = context_->track_tracker.get();
+  base::Status ParseInitialTrackAssociation() {
     ProcessTracker* procs = context_->process_tracker.get();
 
     // Consider track_uuid from the packet and TrackEventDefaults, fall back to
@@ -317,14 +317,6 @@ class TrackEventEventImporter {
     //      TrackEvent types), or
     //   b) a default track.
     if (track_uuid_) {
-      auto interned = track_event_tracker_->InternDescriptorTrack(
-          track_uuid_, name_id_, packet_sequence_id_);
-      if (!interned) {
-        return base::ErrStatus(
-            "track_event_parser: unable to find track matching UUID %" PRIu64,
-            track_uuid_);
-      }
-      track_id_ = *interned;
       auto resolved = track_event_tracker_->ResolveDescriptorTrack(track_uuid_);
       PERFETTO_DCHECK(resolved);
       switch (resolved->scope()) {
@@ -359,18 +351,18 @@ class TrackEventEventImporter {
       // set explicitly to 0 (e.g. to override a default track_uuid) and we have
       // a legacy phase. Events with real phases should use |track_uuid| to
       // specify a different track (or use the pid/tid_override fields).
-      bool fallback_to_legacy_pid_tid_tracks =
+      fallback_to_legacy_pid_tid_tracks_ =
           (!event_.has_track_uuid() || !event_.has_type()) &&
           pid_tid_state_valid;
 
       // Always allow fallback if we have a process override.
-      fallback_to_legacy_pid_tid_tracks |= legacy_event_.has_pid_override();
+      fallback_to_legacy_pid_tid_tracks_ |= legacy_event_.has_pid_override();
 
       // A thread override requires a valid pid.
-      fallback_to_legacy_pid_tid_tracks |=
+      fallback_to_legacy_pid_tid_tracks_ |=
           legacy_event_.has_tid_override() && pid_tid_state_valid;
 
-      if (fallback_to_legacy_pid_tid_tracks) {
+      if (fallback_to_legacy_pid_tid_tracks_) {
         auto pid = static_cast<uint32_t>(sequence_state_->pid());
         auto tid = static_cast<uint32_t>(sequence_state_->tid());
         if (legacy_event_.has_pid_override()) {
@@ -387,17 +379,117 @@ class TrackEventEventImporter {
 
         utid_ = procs->UpdateThread(tid, pid);
         upid_ = storage_->thread_table()[*utid_].upid();
-        track_id_ = track_tracker->InternThreadTrack(*utid_);
-      } else {
-        auto opt_track = track_event_tracker_->InternDescriptorTrack(
-            TrackEventTracker::kDefaultDescriptorTrackUuid, kNullStringId,
-            std::nullopt);
-        track_id_ = *opt_track;
       }
     }
 
     if (!legacy_event_.has_phase())
       return base::OkStatus();
+
+    // Legacy phases may imply a different track than the one specified by
+    // the fallback (or default track uuid) above.
+    switch (legacy_event_.phase()) {
+      case 'b':
+      case 'e':
+      case 'n':
+      case 'S':
+      case 'T':
+      case 'p':
+      case 'F': {
+        legacy_passthrough_utid_ = utid_;
+        break;
+      }
+      case 'i':
+      case 'I': {
+        // Intern tracks for global or process-scoped legacy instant events.
+        switch (legacy_event_.instant_event_scope()) {
+          case LegacyEvent::SCOPE_UNSPECIFIED:
+          case LegacyEvent::SCOPE_THREAD:
+            // Thread-scoped legacy instant events already have the right
+            // track based on the tid/pid of the sequence.
+            if (!utid_) {
+              return base::ErrStatus(
+                  "Thread-scoped instant event without thread association");
+            }
+            break;
+          case LegacyEvent::SCOPE_GLOBAL:
+            legacy_passthrough_utid_ = utid_;
+            utid_ = std::nullopt;
+            break;
+          case LegacyEvent::SCOPE_PROCESS:
+            if (!upid_) {
+              return base::ErrStatus(
+                  "Process-scoped instant event without process association");
+            }
+            legacy_passthrough_utid_ = utid_;
+            utid_ = std::nullopt;
+            break;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    return base::OkStatus();
+  }
+
+  base::StatusOr<TrackId> ParseTrackAssociationBegin() {
+    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
+      return ParseTrackAssociationInternal(std::nullopt);
+    }
+    return ParseTrackAssociationInternal(
+        track_event_tracker_->InternDescriptorTrackBegin(
+            track_uuid_, name_id_,
+            track_uuid_ ? std::make_optional(packet_sequence_id_)
+                        : std::nullopt));
+  }
+
+  base::StatusOr<TrackId> ParseTrackAssociationEnd() {
+    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
+      return ParseTrackAssociationInternal(std::nullopt);
+    }
+    return ParseTrackAssociationInternal(
+        track_event_tracker_->InternDescriptorTrackEnd(
+            track_uuid_, name_id_,
+            track_uuid_ ? std::make_optional(packet_sequence_id_)
+                        : std::nullopt));
+  }
+
+  base::StatusOr<TrackId> ParseTrackAssociationInstant() {
+    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
+      return ParseTrackAssociationInternal(std::nullopt);
+    }
+    return ParseTrackAssociationInternal(
+        track_event_tracker_->InternDescriptorTrackInstant(
+            track_uuid_, name_id_,
+            track_uuid_ ? std::make_optional(packet_sequence_id_)
+                        : std::nullopt));
+  }
+
+  base::StatusOr<TrackId> ParseTrackAssociationCounter() {
+    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
+      return ParseTrackAssociationInternal(std::nullopt);
+    }
+    return ParseTrackAssociationInternal(
+        track_event_tracker_->InternDescriptorTrackCounter(
+            track_uuid_, name_id_,
+            track_uuid_ ? std::make_optional(packet_sequence_id_)
+                        : std::nullopt));
+  }
+
+  base::StatusOr<TrackId> ParseTrackAssociationForLegacy() {
+    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
+      return ParseTrackAssociationInternal(std::nullopt);
+    }
+    return ParseTrackAssociationInternal(
+        track_event_tracker_->InternDescriptorTrackLegacy(
+            track_uuid_, name_id_,
+            track_uuid_ ? std::make_optional(packet_sequence_id_)
+                        : std::nullopt));
+  }
+
+  base::StatusOr<TrackId> ParseTrackAssociationInternal(
+      std::optional<TrackId> opt_id) {
+    TrackTracker* track_tracker = context_->track_tracker.get();
 
     // Legacy phases may imply a different track than the one specified by
     // the fallback (or default track uuid) above.
@@ -441,12 +533,9 @@ class TrackEventEventImporter {
                                ":" + legacy_event_.id_scope().ToStdString();
           id_scope = storage_->InternString(base::StringView(concat));
         }
-
-        track_id_ = context_->track_tracker->InternLegacyAsyncTrack(
+        return context_->track_tracker->InternLegacyAsyncTrack(
             name_id_, upid_.value_or(0), source_id, source_id_is_process_scoped,
             id_scope);
-        legacy_passthrough_utid_ = utid_;
-        break;
       }
       case 'i':
       case 'I': {
@@ -456,13 +545,9 @@ class TrackEventEventImporter {
           case LegacyEvent::SCOPE_THREAD:
             // Thread-scoped legacy instant events already have the right
             // track based on the tid/pid of the sequence.
-            if (!utid_) {
-              return base::ErrStatus(
-                  "Thread-scoped instant event without thread association");
-            }
             break;
           case LegacyEvent::SCOPE_GLOBAL:
-            track_id_ = context_->track_tracker->InternTrack(
+            return context_->track_tracker->InternTrack(
                 tracks::kLegacyGlobalInstantsBlueprint, tracks::Dimensions(),
                 tracks::BlueprintName(),
                 [this](ArgsTracker::BoundInserter& inserter) {
@@ -471,16 +556,8 @@ class TrackEventEventImporter {
                       Variadic::String(
                           context_->storage->InternString("chrome")));
                 });
-            legacy_passthrough_utid_ = utid_;
-            utid_ = std::nullopt;
-            break;
           case LegacyEvent::SCOPE_PROCESS:
-            if (!upid_) {
-              return base::ErrStatus(
-                  "Process-scoped instant event without process association");
-            }
-
-            track_id_ = context_->track_tracker->InternTrack(
+            return context_->track_tracker->InternTrack(
                 tracks::kChromeProcessInstantBlueprint,
                 tracks::Dimensions(*upid_), tracks::BlueprintName(),
                 [this](ArgsTracker::BoundInserter& inserter) {
@@ -489,9 +566,6 @@ class TrackEventEventImporter {
                       Variadic::String(
                           context_->storage->InternString("chrome")));
                 });
-            legacy_passthrough_utid_ = utid_;
-            utid_ = std::nullopt;
-            break;
         }
         break;
       }
@@ -499,7 +573,28 @@ class TrackEventEventImporter {
         break;
     }
 
-    return base::OkStatus();
+    if (!track_uuid_ && fallback_to_legacy_pid_tid_tracks_) {
+      auto pid = static_cast<uint32_t>(sequence_state_->pid());
+      auto tid = static_cast<uint32_t>(sequence_state_->tid());
+      if (legacy_event_.has_pid_override()) {
+        pid = static_cast<uint32_t>(legacy_event_.pid_override());
+        tid = static_cast<uint32_t>(-1);
+      }
+      if (legacy_event_.has_tid_override())
+        tid = static_cast<uint32_t>(legacy_event_.tid_override());
+
+      if (!pid || !tid) {
+        return base::ErrStatus(
+            "track_event_parser: pid/tid 0 is reserved for swapper thread");
+      }
+      return track_tracker->InternThreadTrack(*utid_);
+    }
+    if (!opt_id) {
+      return base::ErrStatus(
+          "track_event_parser: unable to find track matching UUID %" PRIu64,
+          track_uuid_);
+    }
+    return *opt_id;
   }
 
   int32_t ParsePhaseOrType() {
@@ -522,12 +617,13 @@ class TrackEventEventImporter {
   base::Status ParseCounterEvent() {
     // Tokenizer ensures that TYPE_COUNTER events are associated with counter
     // tracks and have values.
-    PERFETTO_DCHECK(storage_->track_table().FindById(track_id_));
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationCounter());
+    PERFETTO_DCHECK(storage_->track_table().FindById(track_id));
     PERFETTO_DCHECK(event_.has_counter_value() ||
                     event_.has_double_counter_value());
 
     context_->event_tracker->PushCounter(
-        ts_, static_cast<double>(event_data_->counter_value), track_id_,
+        ts_, static_cast<double>(event_data_->counter_value), track_id,
         [this](BoundInserter* inserter) { ParseTrackEventArgs(inserter); });
     return base::OkStatus();
   }
@@ -607,8 +703,9 @@ class TrackEventEventImporter {
     PERFETTO_DCHECK(track_uuid_it);
     PERFETTO_DCHECK(index < TrackEventData::kMaxNumExtraCounters);
 
-    auto opt_resolved = track_event_tracker_->InternDescriptorTrack(
+    auto opt_resolved = track_event_tracker_->InternDescriptorTrackCounter(
         *track_uuid_it, kNullStringId, packet_sequence_id_);
+    PERFETTO_CHECK(opt_resolved);
     TrackId track_id = *opt_resolved;
 
     double value = event_data_->extra_counter_values[index];
@@ -632,8 +729,9 @@ class TrackEventEventImporter {
           "TrackEvent with phase B without thread association");
     }
 
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationBegin());
     auto opt_slice_id = context_->slice_tracker->Begin(
-        ts_, track_id_, category_id_, name_id_,
+        ts_, track_id, category_id_, name_id_,
         [this](BoundInserter* inserter) { ParseTrackEventArgs(inserter); });
     if (opt_slice_id.has_value()) {
       auto rr =
@@ -654,8 +752,9 @@ class TrackEventEventImporter {
       return base::ErrStatus(
           "TrackEvent with phase E without thread association");
     }
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationEnd());
     auto opt_slice_id = context_->slice_tracker->End(
-        ts_, track_id_, category_id_, name_id_,
+        ts_, track_id, category_id_, name_id_,
         [this](BoundInserter* inserter) { ParseTrackEventArgs(inserter); });
     if (!opt_slice_id)
       return base::OkStatus();
@@ -696,8 +795,9 @@ class TrackEventEventImporter {
     if (duration_ns < 0)
       return base::ErrStatus("TrackEvent with phase X with negative duration");
 
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationForLegacy());
     auto opt_slice_id = context_->slice_tracker->Scoped(
-        ts_, track_id_, category_id_, name_id_, duration_ns,
+        ts_, track_id, category_id_, name_id_, duration_ns,
         [this](BoundInserter* inserter) { ParseTrackEventArgs(inserter); });
     if (opt_slice_id.has_value()) {
       auto rr =
@@ -736,15 +836,16 @@ class TrackEventEventImporter {
     }
     FlowId flow_id = context_->flow_tracker->GetFlowIdForV1Event(
         opt_source_id.value(), category_id_, name_id_);
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationForLegacy());
     switch (phase) {
       case 's':
-        context_->flow_tracker->Begin(track_id_, flow_id);
+        context_->flow_tracker->Begin(track_id, flow_id);
         break;
       case 't':
-        context_->flow_tracker->Step(track_id_, flow_id);
+        context_->flow_tracker->Step(track_id, flow_id);
         break;
       case 'f':
-        context_->flow_tracker->End(track_id_, flow_id,
+        context_->flow_tracker->End(track_id, flow_id,
                                     legacy_event_.bind_to_enclosing(),
                                     /* close_flow = */ false);
         break;
@@ -830,8 +931,9 @@ class TrackEventEventImporter {
                          Variadic::String(phase_id));
       }
     };
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationInstant());
     opt_slice_id =
-        context_->slice_tracker->Scoped(ts_, track_id_, category_id_, name_id_,
+        context_->slice_tracker->Scoped(ts_, track_id, category_id_, name_id_,
                                         duration_ns, std::move(args_inserter));
     if (!opt_slice_id) {
       return base::OkStatus();
@@ -865,8 +967,9 @@ class TrackEventEventImporter {
       inserter->AddArg(parser_->legacy_event_phase_key_id_,
                        Variadic::String(phase_id));
     };
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationBegin());
     auto opt_slice_id = context_->slice_tracker->Begin(
-        ts_, track_id_, category_id_, name_id_, args_inserter);
+        ts_, track_id, category_id_, name_id_, args_inserter);
     if (!opt_slice_id.has_value()) {
       return base::OkStatus();
     }
@@ -887,8 +990,9 @@ class TrackEventEventImporter {
   }
 
   base::Status ParseAsyncEndEvent() {
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationEnd());
     auto opt_slice_id = context_->slice_tracker->End(
-        ts_, track_id_, category_id_, name_id_,
+        ts_, track_id, category_id_, name_id_,
         [this](BoundInserter* inserter) { ParseTrackEventArgs(inserter); });
     if (!opt_slice_id)
       return base::OkStatus();
@@ -907,9 +1011,10 @@ class TrackEventEventImporter {
     // Parse step events as instant events. Reconstructing the begin/end times
     // of the child slice would be too complicated, see b/178540838. For JSON
     // export, we still record the original step's phase in an arg.
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationInstant());
     int64_t duration_ns = 0;
     context_->slice_tracker->Scoped(
-        ts_, track_id_, category_id_, name_id_, duration_ns,
+        ts_, track_id, category_id_, name_id_, duration_ns,
         [this, phase](BoundInserter* inserter) {
           ParseTrackEventArgs(inserter);
 
@@ -927,10 +1032,11 @@ class TrackEventEventImporter {
   base::Status ParseAsyncInstantEvent() {
     // Handle instant events as slices with zero duration, so that they end
     // up nested underneath their parent slices.
+    ASSIGN_OR_RETURN(auto track_id, ParseTrackAssociationInstant());
     int64_t duration_ns = 0;
     int64_t tidelta = 0;
     auto opt_slice_id = context_->slice_tracker->Scoped(
-        ts_, track_id_, category_id_, name_id_, duration_ns,
+        ts_, track_id, category_id_, name_id_, duration_ns,
         [this](BoundInserter* inserter) { ParseTrackEventArgs(inserter); });
     if (!opt_slice_id.has_value()) {
       return base::OkStatus();
@@ -1320,11 +1426,11 @@ class TrackEventEventImporter {
   StringId category_id_;
   StringId name_id_;
   uint64_t track_uuid_;
-  TrackId track_id_;
   std::optional<UniqueTid> utid_;
   std::optional<UniqueTid> upid_;
   std::optional<int64_t> thread_timestamp_;
   std::optional<int64_t> thread_instruction_count_;
+  bool fallback_to_legacy_pid_tid_tracks_ = false;
 
   // All events in legacy JSON require a thread ID, but for some types of
   // events (e.g. async events or process/global-scoped instants), we don't

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tables_views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tables_views.sql
@@ -72,7 +72,16 @@ CREATE PERFETTO VIEW track (
   -- expand the args.
   source_arg_set_id ARGSETID,
   -- Machine identifier, non-null for tracks on a remote machine.
-  machine_id LONG
+  machine_id LONG,
+  -- An opaque key indicating that this track belongs to a group of tracks which
+  -- are "conceptually" the same track.
+  --
+  -- Tracks in trace processor don't allow overlapping events to allow for easy
+  -- analysis (i.e. SQL window functions, SPAN JOIN and other similar
+  -- operators). However, in visualization settings (e.g. the UI), the
+  -- distinction doesn't matter and all tracks with the same `track_group_id`
+  -- should be merged together into a single logical "UI track".
+  track_group_id LONG
 ) AS
 SELECT
   id,
@@ -81,7 +90,8 @@ SELECT
   dimension_arg_set_id,
   parent_id,
   source_arg_set_id,
-  machine_id
+  machine_id,
+  track_group_id
 FROM __intrinsic_track;
 
 -- Contains information about the CPUs on the device this trace was taken on.

--- a/src/trace_processor/perfetto_sql/stdlib/viz/summary/track_event.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/summary/track_event.sql
@@ -133,12 +133,7 @@ LEFT JOIN _track_event_has_children AS c
 LEFT JOIN _min_ts_per_track AS m
   USING (id)
 GROUP BY
-  -- Merge by parent id if it exists or, if not, then by upid/utid scope.
-  coalesce('Tp' || track.parent_id, 'Pr' || upid, 'Th' || utid),
-  is_counter,
-  track.name,
-  -- Don't merge tracks by name which have children or are counters.
-  iif(NOT c.id IS NULL OR is_counter, track.id, NULL)
+  coalesce(track.track_group_id, track.id)
 ORDER BY
   track.parent_id,
   unioned.order_id;

--- a/src/trace_processor/tables/track_tables.py
+++ b/src/trace_processor/tables/track_tables.py
@@ -67,6 +67,12 @@ TRACK_TABLE = Table(
             cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
             cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
         ),
+        C(
+            "track_group_id",
+            CppOptional(CppUint32()),
+            sql_access=SqlAccess.HIGH_PERF,
+            cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
+        ),
         C("event_type", CppString()),
         C("counter_unit", CppOptional(CppString())),
         C(

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -308,7 +308,6 @@ class TrackEvent(TestSuite):
         "thread=t2",1
         "thread=t3",1
         "thread=t4","[NULL]"
-        "tid=1","[NULL]"
         """))
 
   def test_track_event_descriptions(self):
@@ -352,7 +351,6 @@ class TrackEvent(TestSuite):
         "thread=t2","Thread t2"
         "thread=t3","[NULL]"
         "thread=t4","[NULL]"
-        "tid=1","[NULL]"
         """))
 
   # Instant events
@@ -584,8 +582,6 @@ class TrackEvent(TestSuite):
           "trace_id","trace_id",1234,"[NULL]"
           "trace_id_is_process_scoped","trace_id_is_process_scoped",0,"[NULL]"
           "upid","upid",1,"[NULL]"
-          "utid","utid",1,"[NULL]"
-          "utid","utid",2,"[NULL]"
         '''))
 
   # Counters
@@ -791,9 +787,12 @@ class TrackEvent(TestSuite):
           "event.category","event.category","[NULL]","disabled-by-default-histogram_samples"
           "event.name","event.name","[NULL]","[NULL]"
           "is_root_in_scope","is_root_in_scope",1,"[NULL]"
+          "merge_key_type","merge_key_type",0,"[NULL]"
+          "merge_key_value","merge_key_value","[NULL]","Default Track"
+          "parent_track_uuid","parent_track_uuid",0,"[NULL]"
           "source","source","[NULL]","descriptor"
           "trace_id","trace_id",0,"[NULL]"
-          "track_uuid","track_uuid",0,"[NULL]"
+          "track_compressor_idx","track_compressor_idx",0,"[NULL]"
         '''))
 
   # Flow events importing from proto
@@ -973,7 +972,6 @@ class TrackEvent(TestSuite):
         "thread=t2",1
         "thread=t3",1
         "thread=t4","[NULL]"
-        "tid=1","[NULL]"
         """))
 
   # Tests thread_counter_track.machine_id is not null.

--- a/test/trace_processor/diff_tests/parser/translated_args/tests.py
+++ b/test/trace_processor/diff_tests/parser/translated_args/tests.py
@@ -36,9 +36,12 @@ class TranslatedArgs(TestSuite):
           "event.category","event.category","[NULL]","cat1"
           "event.name","event.name","[NULL]","name1"
           "is_root_in_scope","is_root_in_scope",1,"[NULL]"
+          "merge_key_type","merge_key_type",0,"[NULL]"
+          "merge_key_value","merge_key_value","[NULL]","Default Track"
+          "parent_track_uuid","parent_track_uuid",0,"[NULL]"
           "source","source","[NULL]","descriptor"
           "trace_id","trace_id",0,"[NULL]"
-          "track_uuid","track_uuid",0,"[NULL]"
+          "track_compressor_idx","track_compressor_idx",0,"[NULL]"
         '''))
 
   def test_chrome_histogram(self):

--- a/test/trace_processor/diff_tests/stdlib/viz/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/viz/tests.py
@@ -443,7 +443,6 @@ class Viz(TestSuite):
           "chrono1","chronological_parent","[NULL]","[NULL]"
           "chrono2","chronological_parent","[NULL]","[NULL]"
           "explicit_child:-5 z-index","explicit_parent","[NULL]",-5
-          "explicit_child:-5 z-index","explicit_parent","[NULL]",-5
           "explicit_child:5 z-index","explicit_parent","[NULL]",5
           "explicit_child:no z-index","explicit_parent","[NULL]","[NULL]"
           "a","lexicographic_parent","[NULL]","[NULL]"
@@ -473,8 +472,8 @@ class Viz(TestSuite):
         "chronological_parent",1
         "event_for_unnamed_child",4
         "explicit_child:-5 z-index",1
-        "explicit_child:5 z-index",4
-        "explicit_child:no z-index",3
+        "explicit_child:5 z-index",3
+        "explicit_child:no z-index",2
         "explicit_parent",2
         "lexicographic_parent",3
         """))


### PR DESCRIPTION
Implements the actual work necessary to correctly parse the protos and
use them to control merge behaviour.

As a bonus, we implement support for minimzing the number of tracks in
the trace processor meaning large traces should be much better
supported.

CHROME_STDLIB_MANUAL_ROLL=trace processor maintainer change
