### PR TITLE
ui: make use of newly added track_group_id column

### DIFF
--- a/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidDmabuf/index.ts
@@ -132,10 +132,10 @@ async function addGlobalCounter(ctx: Trace, parent: () => TrackNode) {
 
 async function addGlobalAllocs(ctx: Trace, parent: () => TrackNode) {
   const track = await ctx.engine.query(`
-    select name, group_concat(id) as trackIds
+    select min(name) as name, group_concat(id) as trackIds
     from track
     where type = 'android_dma_allocations'
-    group by name
+    group by track_group_id
   `);
   const it = track.maybeFirstRow({trackIds: STR, name: STR});
   if (!it) {

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -194,14 +194,15 @@ export default class implements PerfettoPlugin {
       with grouped as materialized (
         select
           t.type,
-          t.name,
+          min(t.name) as name,
+          lower(min(t.name)) as lower_name,
           extract_arg(t.dimension_arg_set_id, 'utid') as utid,
           extract_arg(t.dimension_arg_set_id, 'upid') as upid,
           group_concat(t.id) as trackIds,
           count() as trackCount
         from _slice_track_summary s
         join track t using (id)
-        group by type, upid, utid, name
+        group by type, upid, utid, t.track_group_id
       )
       select
         s.type,
@@ -221,7 +222,7 @@ export default class implements PerfettoPlugin {
       left join thread using (utid)
       left join _threads_with_kernel_flag k using (utid)
       left join process tp on thread.upid = tp.upid
-      order by lower(s.name)
+      order by lower_name
     `);
 
     const schemas = new Map(SLICE_TRACK_SCHEMAS.map((x) => [x.type, x]));

--- a/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
+++ b/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
@@ -36,7 +36,7 @@ export default class implements PerfettoPlugin {
           group_concat(distinct t.id) as trackIds,
           count() as trackCount
         from track t
-        where t.name = "Suspend/Resume Latency"
+        where t.type = 'suspend_resume'
       )
       select
         t.trackIds as trackIds,


### PR DESCRIPTION
It's the correct thing to group by instead of grouping by name.
