### PR TITLE
[SDK] Make slow tag explicit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,7 +27,9 @@ Unreleased:
     * Improved the performance of merging large number of track_event tracks
       both during loading and during panning/zooming operations.
   SDK:
-    *
+    * "slow" tag is no longer implicitly added to trace categories with
+      "disabled-by-default-" prefix. Instead, clients should explicitly specify
+      the tag.
 
 v51.2 - 2025-07-03:
   Trace Processor:

--- a/src/tracing/internal/track_event_internal.cc
+++ b/src/tracing/internal/track_event_internal.cc
@@ -195,20 +195,11 @@ bool TrackEventInternal::Initialize(
       cat->set_name(category->name);
       if (category->description)
         cat->set_description(category->description);
-      bool has_slow_tag = false;
       for (const auto& tag : category->tags) {
         if (tag) {
           cat->add_tags(tag);
-          if (!strcmp(tag, kSlowTag)) {
-            has_slow_tag = true;
-          }
         }
       }
-      // Disabled-by-default categories get a "slow" tag.
-      if (!strncmp(category->name, kLegacySlowPrefix,
-                   strlen(kLegacySlowPrefix)) &&
-          !has_slow_tag)
-        cat->add_tags(kSlowTag);
     }
   }
   dsd.set_track_event_descriptor_raw(ted.SerializeAsString());
@@ -363,11 +354,6 @@ bool TrackEventInternal::IsCategoryEnabled(
         break;
       if (matcher(tag))
         return true;
-    }
-    // Legacy "disabled-by-default" categories automatically get the "slow" tag.
-    if (!strncmp(category.name, kLegacySlowPrefix, strlen(kLegacySlowPrefix)) &&
-        matcher(kSlowTag)) {
-      return true;
     }
     return false;
   };


### PR DESCRIPTION
"slow" tag is no longer implicitly added to trace categories with
"disabled-by-default-" prefix. 
Instead, clients should explicitly specify the tag.
I recently updated Chrome, v8 and webrtc to add explcit slow tags to those categories.
Reason: this gains in clarity since the category list is used as the source of truth
for category documentation.