### PR TITLE
tp: fix assumption of track being resolvable

### DIFF
--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -318,7 +318,12 @@ class TrackEventEventImporter {
     //   b) a default track.
     if (track_uuid_) {
       auto resolved = track_event_tracker_->ResolveDescriptorTrack(track_uuid_);
-      PERFETTO_DCHECK(resolved);
+      if (!resolved) {
+        return base::ErrStatus(
+            "track_event_parser: unable to resolve track matching UUID "
+            "%" PRIu64,
+            track_uuid_);
+      }
       switch (resolved->scope()) {
         case TrackEventTracker::ResolvedDescriptorTrack::Scope::kThread:
           utid_ = resolved->utid();


### PR DESCRIPTION
DCHECK was leftover from some pre-refactoring, is no longer valid.

Fixes: b/431818646
