### PR TITLE
ui: Convert Area.trackUris to a ReadonlyArray

### DIFF
--- a/ui/src/core/state_serialization_schema.ts
+++ b/ui/src/core/state_serialization_schema.ts
@@ -40,7 +40,7 @@ const SELECTION_SCHEMA = z.discriminatedUnion('kind', [
     kind: z.literal('AREA'),
     start: zTime,
     end: zTime,
-    trackUris: z.array(z.string()),
+    trackUris: z.array(z.string()).readonly(),
   }),
 ]);
 

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -291,7 +291,7 @@ export class UiMainPerTrace implements m.ClassComponent {
           // - If nothing is selected, or all selected tracks are entirely
           //   selected, then select the entire trace. This allows double tapping
           //   Ctrl+A to select the entire track, then select the entire trace.
-          let tracksToSelect: string[];
+          let tracksToSelect: ReadonlyArray<string>;
           const selection = trace.selection.selection;
           if (selection.kind === 'area') {
             // Something is already selected, let's see if it covers the entire

--- a/ui/src/public/selection.ts
+++ b/ui/src/public/selection.ts
@@ -170,9 +170,7 @@ export interface TrackEventDetails {
 export interface Area {
   readonly start: time;
   readonly end: time;
-  // TODO(primiano): this should be ReadonlyArray<> after the pivot table state
-  // doesn't use State/Immer anymore.
-  readonly trackUris: string[];
+  readonly trackUris: ReadonlyArray<string>;
 }
 
 export interface AreaSelection extends Area {


### PR DESCRIPTION
Now that the old pivot table implementation has been removed, we are no longer using this object with immer, so we can fix this old TODO.
