### PR TITLE
Add support to give extra cors origins to trace processor shell.

### DIFF
--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -41,10 +41,10 @@ namespace {
 
 constexpr int kBindPort = 9001;
 
-// Sets the Access-Control-Allow-Origin: $origin on the following origins.
-// This affects only browser clients that use CORS. Other HTTP clients (e.g. the
-// python API) don't look at CORS headers.
-const char* kAllowedCORSOrigins[] = {
+// Sets by default the Access-Control-Allow-Origin: $origin on the following
+// origins. This affects only browser clients that use CORS. Other HTTP clients
+// (e.g. the python API) don't look at CORS headers.
+const char* kDefaultAllowedCORSOrigins[] = {
     "https://ui.perfetto.dev",
     "http://localhost:10000",
     "http://127.0.0.1:10000",
@@ -54,7 +54,9 @@ class Httpd : public base::HttpRequestHandler {
  public:
   explicit Httpd(std::unique_ptr<TraceProcessor>, bool is_preloaded_eof);
   ~Httpd() override;
-  void Run(const std::string& listen_ip, int port);
+  void Run(const std::string& listen_ip,
+           int port,
+           const std::vector<std::string>& additional_cors_origins);
 
  private:
   // HttpRequestHandler implementation.
@@ -100,9 +102,14 @@ Httpd::Httpd(std::unique_ptr<TraceProcessor> preloaded_instance,
       http_srv_(&task_runner_, this) {}
 Httpd::~Httpd() = default;
 
-void Httpd::Run(const std::string& listen_ip, int port) {
-  for (const auto& kAllowedCORSOrigin : kAllowedCORSOrigins) {
-    http_srv_.AddAllowedOrigin(kAllowedCORSOrigin);
+void Httpd::Run(const std::string& listen_ip,
+                int port,
+                const std::vector<std::string>& additional_cors_origins) {
+  for (const auto& kDefaultAllowedCORSOrigin : kDefaultAllowedCORSOrigins) {
+    http_srv_.AddAllowedOrigin(kDefaultAllowedCORSOrigin);
+  }
+  for (const auto& additional_cors_origin : additional_cors_origins) {
+    http_srv_.AddAllowedOrigin(additional_cors_origin);
   }
   http_srv_.Start(listen_ip, port);
   PERFETTO_ILOG(
@@ -149,7 +156,7 @@ void Httpd::OnHttpRequest(const base::HttpRequest& req) {
 
   if (req.uri == "/websocket" && req.is_websocket_handshake) {
     // Will trigger OnWebsocketMessage() when is received.
-    // It returns a 403 if the origin is not in kAllowedCORSOrigins.
+    // It returns a 403 if the origin is not one of CORS allowed origins.
     return conn.UpgradeToWebsocket(req);
   }
 
@@ -268,13 +275,12 @@ void Httpd::OnWebsocketMessage(const base::WebsocketMessage& msg) {
 
 void RunHttpRPCServer(std::unique_ptr<TraceProcessor> preloaded_instance,
                       bool is_preloaded_eof,
-                      const std::string& listen_ip,
-                      const std::string& port_number) {
+                      const HttpRPCServerOptions& options) {
   Httpd srv(std::move(preloaded_instance), is_preloaded_eof);
-  std::optional<int> port_opt = base::StringToInt32(port_number);
-  std::string ip = listen_ip.empty() ? "localhost" : listen_ip;
+  std::optional<int> port_opt = base::StringToInt32(options.port_number);
+  std::string ip = options.listen_ip.empty() ? "localhost" : options.listen_ip;
   int port = port_opt.has_value() ? *port_opt : kBindPort;
-  srv.Run(ip, port);
+  srv.Run(ip, port, options.additional_cors_origins);
 }
 
 void Httpd::ServeHelpPage(const base::HttpRequest& req) {

--- a/src/trace_processor/rpc/httpd.h
+++ b/src/trace_processor/rpc/httpd.h
@@ -19,23 +19,30 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace perfetto::trace_processor {
 
 class TraceProcessor;
+
+struct HttpRPCServerOptions {
+  // listen_ip is the ip address which http server will listen on, it can be an
+  // ipv4 or an ipv6 or a domain.
+  std::string listen_ip;
+  // port_number is the port which http server will listen on.
+  std::string port_number;
+  // Additional origins to allow for CORS requests.
+  std::vector<std::string> additional_cors_origins;
+};
 
 // Starts a RPC server that handles requests using protobuf-over-HTTP.
 // It takes control of the calling thread and does not return.
 // preloaded_instance is optional. If non-null, the HTTP server will adopt
 // an existing instance with a pre-loaded trace. If null, it will create a new
 // instance when pushing data into the /parse endpoint.
-// listen_ip is the ip address which http server will listen on,
-// it can be an ipv4 or an ipv6 or a domain.
-// port_number is the port which http server will listen on.
 void RunHttpRPCServer(std::unique_ptr<TraceProcessor> preloaded_instance,
                       bool is_preloaded_eof,
-                      const std::string& listen_ip,
-                      const std::string& port_number);
+                      const HttpRPCServerOptions& options);
 
 }  // namespace perfetto::trace_processor
 


### PR DESCRIPTION
Fixes #1271 

Option added: --http-additional-cors-origins

e.g. ./trace_processor_shell --httpd --http-additional-cors-origins=http://localhost:8080,http://192.168.1.1:3000  my_trace

Without change:

```
[074.129]      http_server.cc:312 [HTTP] The origin "http://localhost:10005" is not allowed, Access-Control-Allow-Origin won't be emitted. If this request comes from a browser it will fail.
```
<img width="1129" height="359" alt="cors_error" src="https://github.com/user-attachments/assets/760d7337-ecaf-4767-801b-2c7db5f6a659" />

With Change

```
[479.015]      http_server.cc:120 [HTTP] New connection
[479.015]      http_server.cc:271 [HTTP] POST /status [body=0B, origin="http://localhost:10005"]
[502.175]      http_server.cc:271 [HTTP] POST /status [body=0B, origin="http://localhost:10005"]
[504.299]      http_server.cc:271 [HTTP] POST /status [body=0B, origin="http://localhost:10005"]
[504.304]      http_server.cc:120 [HTTP] New connection
[504.304]      http_server.cc:271 [HTTP] GET /websocket [body=0B, origin="http://localhost:10005"]
```
<img width="1148" height="529" alt="no_error" src="https://github.com/user-attachments/assets/6f1c5906-4a40-46e1-96a3-b131dc421423" />

