### PR TITLE
ui: refactor CSS to support embedding applications

### DIFF
--- a/docs/design-docs/ui-css.md
+++ b/docs/design-docs/ui-css.md
@@ -1,0 +1,70 @@
+# CSS Styling in the UI
+
+This document describes the organization of CSS styling rules for the UI, how those styles are used for theming the UI, and how they are accessed from canvas rendering code.
+
+## Modular CSS
+
+The source for the UI's CSS stylesheet is the [src/assets/perfetto.scss](../../ui/src/assets/perfetto.scss) file.
+As its name indicates, this uses the SCSS ([Sass][sass]) framework for modular CSS definitions.
+The output of the CSS build from this source file and its included modules is [perfetto.css](../../ui/out/dist_version/perfetto.css).
+
+The [assets/](../../ui/src/assets/) directory contains a number of SCSS modules corresponding to major parts of the UI:
+
+- `common.scss` provides core style classes for the main Perfetto UI and imports all of the theming concerns such as fonts, colours, shadows, etc. (more on those [below](#theming))
+- `details.scss` provides styling of the Details panel and related elements
+- other files such as `topbar.scss`, `sidebar.scss`, `viewer_page.scss` cover the various top-level components of the main UI in largely self-evident fashion
+- `base/*/base.scss` are a parallel set of modules one set of which exclusively is included in the Sass build according to the target deployment.
+[More on this, below](#embedder-modules)
+
+The widgets comprising the UI component library for reusable elements such as buttons, menus, tables, tabbed panels, and more have their styles defined in SCSS modules in the [src/assets/widgets/](../../ui/src/assets/widgets/) directory.
+These modules correspond roughly one-for-one to the widget implementations in the [src/widgets/](../../ui/src/widgets/) directory.
+
+[sass]: https://sass-lang.com
+
+## Class Naming
+
+As much as possible, in the interest of ensuring isolation of the UI's CSS styling from any application that embeds it, styling is applied to UI elements by class.
+To mitigate potential clashes with CSS class names in an embedding application, class names should be prefixed with `pf-` whenever there is a possibility that a class will be first member of a selector for any rule.
+In the interest of succinctness and clarity, where class names are only used within the scope of more general selectors, especially in nested SCSS rules, then the `pf-` prefix may be omitted.
+
+There is one special class named `perfetto` that is applied to the `<main>` element that renders the main UI.
+This is intended to allow embedding applications to target CSS rules to the Perfetto UI if necessary to override styles in some fashion that is not accommodated by the [theme variables](#theming).
+It is not intended to be used by the UI's own default styling or themes, except in the very limited case described in the next section.
+
+## Embedder Modules
+
+One of the goals of the style definitions in the UI is to work well in applications that embed the Perfetto UI for whatever purpose.
+In practice, this means that CSS styles must not "leak" from Perfetto UI's stylesheet into the embedding application and also that styles must not leak from that embedding context into Perfetto UI.
+This is largely ensured by rigorous application of CSS classes for styling, with the `pf-` prefix as [discussed above](#class-naming).
+However, there are certain default styles that it is practical to apply on a structural basis to elements more generally.
+To that end, the [base/*](../../ui/src/assets/base/) module directories provide for inclusion of deployment-specific CSS rules.
+In the [build.js](../../ui/build.js) script, exactly one of these `base/*` directories is added to the Sass module path to resolve the `@import 'base'` directive:
+
+- `base/default/`: the `base.scss` module in this directory includes default stylings for the `<html>`, `<button>`, `<h1>`, and other elements specifically for the default stand-alone deployment of the UI app
+- `base/embedded/`: the `base.scss` module in this directory includes alternative rules that attempt to prevent leaking of their styles into the host application, which is assumed to have ownership of default styling of these various HTML elements.
+It is then up to an embedding application to address any deficiencies in these rule definitions, for example where their specificity causes them unintentionally to override other rules in the Perfetto UI CSS that were meant to be more specific and actually are in the default configuration
+
+Adding new style definitions to these base modules should be a last resort.
+Any contributions that would enable the removal style definitions from these base modules will almost certainly be welcome.
+
+## Theming
+
+Also in the `src/widgets/` directory, though not only intended for widgets, are two files implementing theming for the UI:
+
+- [theme_variables.scss](../../ui/src/assets/widgets/theme_variables.scss) provides a `:root` rule definining CSS variables for all of the fonts, colours, shadows, and other style definitions that are potentially configurable by _themes_.
+As such, these need to be standard CSS variables, exposed at run-time in the CSS engine, so that they may be substitutable by selection of different themes in Perfetto UI itself or by an application that embeds the Perfetto UI and so needs to style it to match its own theme
+- [theme.scss](../../ui/src/assets/widgets/theme.scss) defines a number of SCSS build-time variables and macros that are used throughout the style definitions of the widgets and other components, in large part leveraging the CSS variables described in the previous `theme_variables.scss` module
+
+All theme variables defined for the UI are prefixed with `pf-` to allow them to coexist with any potential embedding applications theming scheme.
+Applications that wish to override the UI's default theme must ensure that their redefinitions of these variables are effective on the `<html><body>` element in the DOM, as explained in the next section.
+
+## Canvas Rendering
+
+The TS/JS code that renders canvas content at run-time must naturally fit into the static styling scheme of the UI.
+This means that the various painting routines of components such as track renderers and the timeline overview access at run-time to the DOM's current effective CSS stylesheet.
+This is accomplished by looking up the current values of as many of the CSS variables defined in the `theme_variables.scss` module as are required and storing them in pseudo-constants, in the [css_constants.ts](../../ui/src/frontend/css_constants.ts) TS module.
+The `initCssConstants()` function is invoked at UI start-up to fill the initial values of these pseudo-constants and on receipt of the `'RELOAD-CSS-CONSTANTS'` message.
+Embedding applications must ensure reloading of the CSS pseudo-constants whenever they change the theme.
+
+Crucially, `initCssConstants()` function extracts the values of CSS variables from the effective styling of the `<html><body>` element.
+This obviously catches the UI's default theme as defined in the `:root` rule in `theme_variables.scss` but it requires Perfetto UI or any other application embedding it to override this theme, if at all, by redefining those CSS variables at this level of the DOM.

--- a/ui/build.js
+++ b/ui/build.js
@@ -91,6 +91,7 @@ const cfg = {
   crossOriginIsolation: false,
   testFilter: '',
   noOverrideGnArgs: false,
+  embedded: false,
 
   // The fields below will be changed by main() after cmdline parsing.
   // Directory structure:
@@ -161,6 +162,10 @@ async function main() {
     help: 'filter Jest tests by regex, e.g. \'chrome_render\'',
   });
   parser.add_argument('--no-override-gn-args', {action: 'store_true'});
+  parser.add_argument('--embedded', '-e', {
+    action: 'store_true',
+    help: 'Build for embedding Perfetto UI in other applications (affects especially CSS)'
+  });
 
   const args = parser.parse_args();
   const clean = !args.no_build;
@@ -393,7 +398,8 @@ function copyUiTestArtifactsAssets(src, dst) {
 }
 
 function compileScss() {
-  const src = pjoin(ROOT_DIR, 'ui/src/assets/perfetto.scss');
+  const cssSrc = pjoin(ROOT_DIR, 'ui/src/assets');
+  const src = pjoin(cssSrc, 'perfetto.scss');
   const dst = pjoin(cfg.outDistDir, 'perfetto.css');
   // In watch mode, don't exit(1) if scss fails. It can easily happen by
   // having a typo in the css. It will still print an error.
@@ -401,6 +407,11 @@ function compileScss() {
   const args = [src, dst];
   if (!cfg.verbose) {
     args.unshift('--quiet');
+  }
+  if (cfg.embedded) {
+    args.unshift('-I', pjoin(cssSrc, 'base/embedded'));
+  } else {
+    args.unshift('-I', pjoin(cssSrc, 'base/default'));
   }
   addTask(execModule, ['sass', args, {noErrCheck}]);
   if (cfg.bigtrace) {

--- a/ui/src/assets/base/default/base.scss
+++ b/ui/src/assets/base/default/base.scss
@@ -1,0 +1,78 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@media (pointer: coarse) {
+  // Disable long-press text selection on tablets. That collides with the mouse
+  // emulation we do where long press emulates a mousedown+move+up (to
+  // distinguish it from pans).
+  html {
+    // required for iOS which doesn't support unprefixed user-select.
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+}
+
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html {
+  font-family: Roboto, verdana, sans-serif;
+  height: 100%;
+  width: 100%;
+  touch-action: pan-x pan-y;
+}
+
+html,
+body,
+main.perfetto {
+  height: 100%;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  overscroll-behavior: none;
+  overflow: hidden;
+}
+
+pre,
+code {
+  font-family: var(--pf-monospace-font);
+}
+
+h1,
+h2,
+h3 {
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+button {
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  outline: inherit;
+
+  &.close {
+      font-family: var(--pf-monospace-font);
+  }
+}
+

--- a/ui/src/assets/base/embedded/base.scss
+++ b/ui/src/assets/base/embedded/base.scss
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This mix-in applies its style content to all known possible root DOM
+// selectors of the Perfetto UI. If there should be any other roots for
+// the UI DOM, add them in here.
+@mixin pf-root {
+  body[data-perfetto_version],
+  main.perfetto,
+  .pf-popup-portal {
+    @content
+  }
+}
+
+@include pf-root {
+  * {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  font-family: Roboto, verdana, sans-serif;
+  height: 100%;
+  width: 100%;
+  touch-action: pan-x pan-y;
+}
+
+@include pf-root {
+  pre,
+  code {
+    font-family: var(--pf-monospace-font);
+  }
+
+  h1,
+  h2,
+  h3 {
+    padding: 0;
+    margin: 0;
+  }
+
+  button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+
+    &.close {
+        font-family: var(--pf-monospace-font);
+    }
+  }
+}

--- a/ui/src/assets/base/embedded/base.scss
+++ b/ui/src/assets/base/embedded/base.scss
@@ -29,7 +29,7 @@
     -webkit-tap-highlight-color: transparent;
   }
 
-  font-family: Roboto, verdana, sans-serif;
+  font-family: var(--pf-heading-font);
   height: 100%;
   width: 100%;
   touch-action: pan-x pan-y;

--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -12,23 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@import "widgets/theme_variables";
 @import "widgets/theme";
 @import "typefaces";
 @import "fonts";
 @import "base";
-
-:root {
-  --pf-sidebar-width: 230px;
-  --pf-topbar-height: 44px;
-  --pf-monospace-font: "Roboto Mono", monospace;
-  --pf-track-shell-width: 250px;
-  --pf-track-border-color: #00000025;
-  --pf-anim-easing: cubic-bezier(0.4, 0, 0.2, 1);
-  --pf-selection-stroke-color: #00344596;
-  --pf-selection-fill-color: #8398e64d;
-  --pf-overview-timeline-non-visible-color: #c8c8c8cc;
-  --pf-details-content-height: 308px;
-}
 
 @mixin transition($time: 0.1s) {
   transition:
@@ -67,7 +55,7 @@ main.perfetto {
     "statusbar statusbar";
   grid-template-rows: auto auto 1fr auto;
   grid-template-columns: auto 1fr;
-  color: #121212;
+  color: var(--pf-main-color);
   overflow: hidden;
 }
 
@@ -79,12 +67,12 @@ body.pf-filedrag::after {
   left: 0;
   right: 0;
   bottom: 0;
-  border: 10px dashed #404854;
+  border: 10px dashed var(--pf-filedrag-border-color);
   text-align: center;
   font-size: 3rem;
   line-height: 100vh;
-  color: #333;
-  background: rgba(255, 255, 255, 0.5);
+  color: var(--pf-filedrag-color);
+  background: var(--pf-filedrag-background);
 }
 
 .pf-page {
@@ -96,9 +84,8 @@ body.pf-filedrag::after {
   line-height: 18px;
 }
 
-$table-hover-color: hsl(214, 22%, 90%);
-
-$table-border-color: rgba(60, 76, 92, 0.4);
+$table-hover-color: var(--pf-table-hover-color);
+$table-border-color: var(--pf-table-border-color);
 
 $bottom-tab-padding: 10px;
 
@@ -137,7 +124,7 @@ $bottom-tab-padding: 10px;
     }
 
     &.has-left-border {
-      border-left: 1px solid rgba(60, 76, 92, 0.4);
+      border-left: 1px solid var(--pf-has-left-border);
     }
   }
 }
@@ -182,8 +169,8 @@ $bottom-tab-padding: 10px;
 
 .pf-query-error {
   padding: 20px 10px;
-  color: hsl(-10, 50%, 50%);
-  font-family: "Roboto Mono", sans-serif;
+  color: var(--pf-query-error-color);
+  font-family: var(--pf-monospace-font);
   font-size: 12px;
   font-weight: 300;
   white-space: pre;
@@ -195,21 +182,21 @@ header.pf-overview {
   left: 0;
   display: flex;
   align-content: baseline;
-  background-color: hsl(213, 22%, 82%);
-  color: hsl(213, 22%, 20%);
-  font-family: "Roboto Condensed", sans-serif;
+  background-color: var(--pf-overview-header-background);
+  color: var(--pf-overview-header-color);
+  font-family: var(--pf-font);
   font-size: 15px;
   font-weight: 400;
   padding: 4px 10px;
   vertical-align: middle;
-  border-color: hsl(213, 22%, 75%);
+  border-color: var(--pf-overview-header-border);
   border-style: solid;
   border-width: 1px 0;
   .code {
     font-family: var(--pf-monospace-font);
     font-size: 12px;
     margin-left: 10px;
-    color: hsl(213, 22%, 40%);
+    color: var(--pf-overview-header-code);
   }
   span {
     white-space: nowrap;
@@ -225,7 +212,7 @@ header.pf-overview {
 }
 
 .pf-perf-stats {
-  --stroke-color: hsl(217, 39%, 94%);
+  --stroke-color: var(--pf-perf-stats-stroke);
   position: fixed;
   bottom: 0;
   left: 0;
@@ -234,14 +221,14 @@ header.pf-overview {
   font-family: var(--pf-monospace-font);
   padding: 10px 24px;
   z-index: 100;
-  background-color: rgba(27, 28, 29, 0.9);
+  background-color: var(--pf-perf-stats-background);
 
   button {
     text-decoration: underline;
-    color: hsl(45, 100%, 48%);
+    color: var(--pf-perf-stats-button);
 
     &:hover {
-      color: hsl(6, 70%, 53%);
+      color: var(--pf-perf-stats-button-hover);
     }
   }
   .close-button {
@@ -279,9 +266,9 @@ header.pf-overview {
   left: 10px;
   bottom: 10px;
   width: 550px;
-  background-color: #19212b;
+  background-color: var(--pf-cookie-background);
   font-size: 14px;
-  color: rgb(180, 183, 186);
+  color: var(--pf-cookie-color);
   border-radius: 5px;
   padding: 20px;
 
@@ -295,15 +282,15 @@ header.pf-overview {
   button {
     padding: 10px;
     border-radius: 3px;
-    color: #fff;
+    color: var(--pf-cookie-button-color);
     margin-left: 5px;
     a {
       text-decoration: none;
-      color: #fff;
+      color: var(--pf-cookie-button-color);
     }
   }
   button:hover {
-    background-color: #373f4b;
+    background-color: var(--pf-cookie-button-hover-background);
     cursor: pointer;
   }
 }
@@ -317,7 +304,7 @@ header.pf-overview {
     border-radius: 10px;
     padding: 7px;
     margin: 5px;
-    background-color: #c7d0db;
+    background-color: var(--pf-pivot-mode-button-background);
   }
 
   &.pf-query-error {
@@ -366,7 +353,7 @@ header.pf-overview {
 }
 
 .pf-history-item {
-  border-bottom: 1px solid hsl(213, 22%, 75%);
+  border-bottom: 1px solid var(--pf-history-border);
   padding: 0.25em 0.5em;
   max-height: 150px;
   overflow-y: auto;
@@ -384,7 +371,7 @@ header.pf-overview {
     &:hover::after {
       content: "Doubleclick to re-run";
       font-size: 12px;
-      color: rgba(0, 0, 0, 20%);
+      color: var(--pf-history-hover-color);
       position: absolute;
       top: 0;
       margin: auto;
@@ -393,7 +380,7 @@ header.pf-overview {
   }
 
   &:hover {
-    background-color: hsl(213, 22%, 94%);
+    background-color: var(--pf-history-hover-background);
     .history-item-buttons {
       visibility: visible;
     }

--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -130,7 +130,7 @@ $bottom-tab-padding: 10px;
     padding: 3px 5px;
     white-space: nowrap;
 
-    i.material-icons {
+    i.pf-material-icons {
       // Shrink the icons inside the table cells to increase the information
       // density a little bit.
       font-size: 16px;
@@ -409,8 +409,8 @@ header.pf-overview {
   button {
     margin: 0 0.5rem;
 
-    i.material-icons,
-    i.material-icons-filled {
+    i.pf-material-icons,
+    i.pf-material-icons-filled {
       font-size: 18px;
     }
   }

--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -15,18 +15,19 @@
 @import "widgets/theme";
 @import "typefaces";
 @import "fonts";
+@import "base";
 
 :root {
-  --sidebar-width: 230px;
-  --topbar-height: 44px;
-  --monospace-font: "Roboto Mono", monospace;
-  --track-shell-width: 250px;
-  --track-border-color: #00000025;
-  --anim-easing: cubic-bezier(0.4, 0, 0.2, 1);
-  --selection-stroke-color: #00344596;
-  --selection-fill-color: #8398e64d;
-  --overview-timeline-non-visible-color: #c8c8c8cc;
-  --details-content-height: 308px;
+  --pf-sidebar-width: 230px;
+  --pf-topbar-height: 44px;
+  --pf-monospace-font: "Roboto Mono", monospace;
+  --pf-track-shell-width: 250px;
+  --pf-track-border-color: #00000025;
+  --pf-anim-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --pf-selection-stroke-color: #00344596;
+  --pf-selection-fill-color: #8398e64d;
+  --pf-overview-timeline-non-visible-color: #c8c8c8cc;
+  --pf-details-content-height: 308px;
 }
 
 @mixin transition($time: 0.1s) {
@@ -50,68 +51,14 @@
   content: $content;
 }
 
-* {
-  box-sizing: border-box;
-  -webkit-tap-highlight-color: transparent;
-}
-
-html {
-  font-family: Roboto, verdana, sans-serif;
-  height: 100%;
-  width: 100%;
-  touch-action: pan-x pan-y;
-}
-
-@media (pointer: coarse) {
-  // Disable long-press text selection on tablets. That collides with the mouse
-  // emulation we do where long press emulates a mousedown+move+up (to
-  // distinguish it from pans).
-  html {
-    // required for iOS which doesn't support unprefixed user-select.
-    -webkit-user-select: none;
-    user-select: none;
-    -webkit-touch-callout: none;
-  }
-}
-
-html,
-body,
-body > main {
-  height: 100%;
-  width: 100%;
-  padding: 0;
-  margin: 0;
-  overscroll-behavior: none;
-  overflow: hidden;
-}
-
-pre,
-code {
-  font-family: var(--monospace-font);
-}
-
 // This is to minimize Mac vs Linux Chrome Headless rendering differences
-// when running UI intergrationtests via puppeteer.
+// when running UI integration tests via puppeteer.
 body.testing {
   -webkit-font-smoothing: antialiased !important;
   font-kerning: none !important;
 }
 
-h1,
-h2,
-h3 {
-  font-family: inherit;
-  font-size: inherit;
-  font-weight: inherit;
-  padding: 0;
-  margin: 0;
-}
-table {
-  -webkit-user-select: text;
-  user-select: text;
-}
-
-body > main {
+main.perfetto {
   display: grid;
   grid-template-areas:
     "sidebar topbar"
@@ -124,7 +71,7 @@ body > main {
   overflow: hidden;
 }
 
-body.filedrag::after {
+body.pf-filedrag::after {
   content: "Drop the trace file to open it";
   position: fixed;
   z-index: 99;
@@ -140,32 +87,7 @@ body.filedrag::after {
   background: rgba(255, 255, 255, 0.5);
 }
 
-button {
-  background: none;
-  color: inherit;
-  border: none;
-  padding: 0;
-  font: inherit;
-  cursor: pointer;
-  outline: inherit;
-}
-
-button.close {
-  font-family: var(--monospace-font);
-}
-
-.full-page-loading-screen {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: row;
-  background: #3e4a5a url("assets/logo-3d.png") no-repeat fixed center;
-}
-
-.page {
+.pf-page {
   grid-area: page;
 }
 
@@ -224,7 +146,7 @@ $bottom-tab-padding: 10px;
   @include table-component;
 }
 
-.pivot-table {
+.pf-pivot-table {
   @include table-component;
 
   thead,
@@ -258,7 +180,7 @@ $bottom-tab-padding: 10px;
   }
 }
 
-.query-error {
+.pf-query-error {
   padding: 20px 10px;
   color: hsl(-10, 50%, 50%);
   font-family: "Roboto Mono", sans-serif;
@@ -267,61 +189,7 @@ $bottom-tab-padding: 10px;
   white-space: pre;
 }
 
-.dropdown {
-  display: inline-block;
-  position: relative;
-}
-
-.dropdown-button {
-  cursor: pointer;
-}
-
-.popup-menu {
-  position: absolute;
-  background-color: white;
-  right: 0;
-  box-shadow: 0 0 4px 0 #999;
-  /* TODO(hjd): Reduce and make z-index use sensible. */
-  z-index: 1000;
-
-  &.closed {
-    display: none;
-  }
-
-  &.opened {
-    display: block;
-  }
-
-  button.open-menu {
-    border-radius: 0;
-    margin: 0;
-    height: auto;
-    background: transparent;
-    color: #111;
-    font-size: 12px;
-    padding: 0.4em 1em;
-    white-space: nowrap;
-    width: 100%;
-    text-align: right;
-    line-height: 1;
-    display: block; // Required in order for inherited white-space property not
-    // to screw up vertical rendering of the popup menu items.
-
-    &:hover {
-      background: #c7d0db;
-    }
-  }
-
-  .nested-menu {
-    padding-right: 1em;
-  }
-}
-
-.x-scrollable {
-  overflow-x: auto;
-}
-
-header.overview {
+header.pf-overview {
   position: sticky;
   top: 0;
   left: 0;
@@ -338,7 +206,7 @@ header.overview {
   border-style: solid;
   border-width: 1px 0;
   .code {
-    font-family: var(--monospace-font);
+    font-family: var(--pf-monospace-font);
     font-size: 12px;
     margin-left: 10px;
     color: hsl(213, 22%, 40%);
@@ -356,36 +224,22 @@ header.overview {
   }
 }
 
-.text-select {
-  user-select: text;
-  -webkit-user-select: text;
-}
-
-button.query-ctrl {
-  background: #262f3c;
-  color: white;
-  border-radius: 10px;
-  font-size: 10px;
-  height: 18px;
-  line-height: 18px;
-  min-width: 7em;
-  margin: auto 0 auto 1rem;
-}
-
-.perf-stats {
+.pf-perf-stats {
   --stroke-color: hsl(217, 39%, 94%);
   position: fixed;
   bottom: 0;
   left: 0;
   width: 600px;
   color: var(--stroke-color);
-  font-family: var(--monospace-font);
+  font-family: var(--pf-monospace-font);
   padding: 10px 24px;
   z-index: 100;
   background-color: rgba(27, 28, 29, 0.9);
+
   button {
     text-decoration: underline;
     color: hsl(45, 100%, 48%);
+
     &:hover {
       color: hsl(6, 70%, 53%);
     }
@@ -398,7 +252,8 @@ button.query-ctrl {
     height: 20px;
     color: var(--stroke-color);
   }
-  & > section {
+
+  &>section {
     padding: 5px;
     border-bottom: 1px solid var(--stroke-color);
   }
@@ -418,7 +273,7 @@ button.query-ctrl {
   }
 }
 
-.cookie-consent {
+.pf-cookie-consent {
   position: absolute;
   z-index: 10;
   left: 10px;
@@ -453,11 +308,7 @@ button.query-ctrl {
   }
 }
 
-.disallow-selection {
-  user-select: none;
-}
-
-.pivot-table {
+.pf-pivot-table {
   user-select: text;
   -webkit-user-select: text;
   padding: $bottom-tab-padding;
@@ -469,7 +320,7 @@ button.query-ctrl {
     background-color: #c7d0db;
   }
 
-  &.query-error {
+  &.pf-query-error {
     color: red;
   }
 
@@ -500,21 +351,7 @@ button.query-ctrl {
   }
 }
 
-.name-completion {
-  input {
-    width: 90%;
-  }
-  min-height: 20vh;
-  min-width: 30vw;
-
-  .arguments-popup-sizer {
-    color: transparent;
-    user-select: none;
-    height: 0;
-  }
-}
-
-.reorderable-cell {
+.pf-reorderable-cell {
   &.dragged {
     color: gray;
   }
@@ -528,7 +365,7 @@ button.query-ctrl {
   }
 }
 
-.history-item {
+.pf-history-item {
   border-bottom: 1px solid hsl(213, 22%, 75%);
   padding: 0.25em 0.5em;
   max-height: 150px;
@@ -563,7 +400,7 @@ button.query-ctrl {
   }
 }
 
-.history-item-buttons {
+.pf-history-item-buttons {
   position: sticky;
   float: right;
   top: 0;
@@ -576,13 +413,5 @@ button.query-ctrl {
     i.material-icons-filled {
       font-size: 18px;
     }
-  }
-}
-
-.context-wrapper {
-  white-space: nowrap;
-
-  i.material-icons {
-    margin-left: 0;
   }
 }

--- a/ui/src/assets/components/data_grid.scss
+++ b/ui/src/assets/components/data_grid.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-$border: 1px solid rgb(225, 225, 225);
+$border: 1px solid var(--pf-datagrid-border-color);
 
 .pf-data-grid {
   display: flex;
@@ -41,14 +41,14 @@ $border: 1px solid rgb(225, 225, 225);
   // Highlight rows on hover.
   tr {
     &:hover {
-      background-color: rgb(239, 241, 244);
+      background-color: var(--pf-datagrid-hover-background);
     }
   }
 
   thead {
     position: sticky;
     top: 0;
-    background-color: white;
+    background-color: var(--pf-datagrid-head-background);
 
     tr {
       &:hover {
@@ -121,7 +121,7 @@ $border: 1px solid rgb(225, 225, 225);
   }
 
   &__button-hint {
-    color: gray;
+    color: var(--pf-datagrid-button-hint-color);
   }
 
   &__cell--number {
@@ -130,7 +130,7 @@ $border: 1px solid rgb(225, 225, 225);
 
   &__cell--null {
     text-align: center;
-    color: gray;
+    color: var(--pf-datagrid-cell-null-color);
     font-style: italic;
   }
 

--- a/ui/src/assets/details.scss
+++ b/ui/src/assets/details.scss
@@ -29,9 +29,9 @@
     &.grey {
       border-radius: 3px;
       border: 1px solid transparent;
-      background-color: #e8e8e8;
+      background-color: var(--pf-details-gray-icon);
       &:hover {
-        border: #475566 solid 1px;
+        border: var(--pf-details-gray-icon-hover-border) solid 1px;
       }
     }
   }
@@ -47,7 +47,7 @@
     z-index: 1;
 
     display: flex;
-    background: white;
+    background: var(--pf-details-header);
     h2 {
       font-size: 16px;
       font-weight: 400;
@@ -73,7 +73,7 @@
         background-color: $table-hover-color;
 
         &.no-highlight {
-          background-color: white;
+          background-color: var(--pf-details-header-no-highlight);
         }
       }
     }
@@ -137,13 +137,13 @@
 
 .pf-details-panel {
   .flow-info i.pf-material-icons {
-    color: rgb(60, 86, 136);
+    color: var(--pf-details-flow-link);
   }
 
   .warning {
     position: relative;
     font-size: 13px;
-    color: hsl(45, 100%, 48%);
+    color: var(--pf-details-warning-color);
   }
 
   .warning i.pf-material-icons {
@@ -153,9 +153,9 @@
   .warning .tooltip {
     visibility: hidden;
 
-    background-color: white;
-    color: #3f4040;
-    box-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
+    background-color: var(--pf-details-tooltip-background);
+    color: var(--pf-details-tooltip-color);
+    box-shadow: var(--pf-details-tooltip-shadow);
 
     padding: 4px;
     border-radius: 4px;
@@ -174,7 +174,7 @@
   }
 
   .flow-button {
-    color: rgb(60, 86, 136);
+    color: var(--pf-details-flow-link);
   }
 }
 
@@ -183,9 +183,9 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  font-family: "Roboto Condensed", sans-serif;
+  font-family: var(--pf-font);
   font-weight: 300;
-  color: #3c4b5d;
+  color: var(--pf-notes-panel-color);
 
   .notes-editor-panel-heading-bar {
     display: flex;
@@ -202,12 +202,12 @@
   input[type="text"] {
     flex-grow: 1;
     border-radius: 4px;
-    border: 1px solid #dcdcdc;
+    border: 1px solid var(--pf-notes-panel-input-border);
     padding: 3px;
     margin: 0 10px;
     &:focus {
       outline: none;
-      box-shadow: 1px 1px 1px rgba(23, 32, 44, 0.3);
+      box-shadow: var(--pf-notes-panel-input-shadow);
     }
   }
 }
@@ -244,25 +244,25 @@
   font-family: var(--pf-monospace-font);
 
   .D {
-    color: hsl(122, 20%, 40%);
+    color: var(--pf-android-log-d);
   }
   .V {
-    color: hsl(122, 20%, 30%);
+    color: var(--pf-android-log-v);
   }
   .I {
-    color: hsl(0, 0%, 20%);
+    color: var(--pf-android-log-i);
   }
   .W {
-    color: hsl(45, 60%, 45%);
+    color: var(--pf-android-log-w);
   }
   .E {
-    color: hsl(4, 90%, 58%);
+    color: var(--pf-android-log-e);
   }
   .F {
-    color: hsl(291, 64%, 42%);
+    color: var(--pf-android-log-f);
   }
   .pf-highlighted {
-    background: #d2efe0;
+    background: var(--pf-android-log-highlighted);
   }
 }
 

--- a/ui/src/assets/details.scss
+++ b/ui/src/assets/details.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.details-panel {
+.pf-details-panel {
   @include bottom-panel-font;
 
   // This is required to position locally-scoped (i.e. non-full-screen) modal
@@ -129,64 +129,56 @@
   }
 }
 
-.details-table-multicolumn {
-  display: flex;
-  user-select: "text";
-}
 
 .flow-link:hover {
   cursor: pointer;
   text-decoration: underline;
 }
 
-.flow-info i.material-icons {
-  color: rgb(60, 86, 136);
+.pf-details-panel {
+  .flow-info i.material-icons {
+    color: rgb(60, 86, 136);
+  }
+
+  .warning {
+    position: relative;
+    font-size: 13px;
+    color: hsl(45, 100%, 48%);
+  }
+
+  .warning i.material-icons {
+    font-size: 13px;
+  }
+
+  .warning .tooltip {
+    visibility: hidden;
+
+    background-color: white;
+    color: #3f4040;
+    box-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
+
+    padding: 4px;
+    border-radius: 4px;
+
+    text-align: center;
+    white-space: nowrap;
+
+    position: absolute;
+    z-index: 1;
+    top: -5px;
+    left: 105%;
+  }
+
+  .warning:hover .tooltip {
+    visibility: visible;
+  }
+
+  .flow-button {
+    color: rgb(60, 86, 136);
+  }
 }
 
-.warning {
-  position: relative;
-  font-size: 13px;
-  color: hsl(45, 100%, 48%);
-}
-
-.warning i.material-icons {
-  font-size: 13px;
-}
-
-.warning .tooltip {
-  visibility: hidden;
-
-  background-color: white;
-  color: #3f4040;
-  box-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
-
-  padding: 4px;
-  border-radius: 4px;
-
-  text-align: center;
-  white-space: nowrap;
-
-  position: absolute;
-  z-index: 1;
-  top: -5px;
-  left: 105%;
-}
-
-.warning:hover .tooltip {
-  visibility: visible;
-}
-
-.flow-button {
-  color: rgb(60, 86, 136);
-}
-
-.half-width-panel {
-  max-width: 50%;
-  flex-grow: 1;
-  height: fit-content;
-}
-
-.notes-editor-panel {
+.pf-notes-editor-panel {
   padding: 10px;
   display: flex;
   flex-direction: column;
@@ -220,7 +212,7 @@
   }
 }
 
-.sum {
+.pf-details-panel .flow-events-table .sum {
   font-weight: bolder;
   font-size: 12px;
   .sum-data {
@@ -228,113 +220,10 @@
   }
 }
 
-.log-panel {
-  display: contents;
-
-  header {
-    position: sticky;
-    top: 0;
-    left: 0;
-    z-index: 1;
-    background-color: white;
-    color: #3c4b5d;
-    padding: 5px;
-    display: grid;
-    grid-template-columns: auto auto;
-    justify-content: space-between;
-  }
-
-  .log-rows-label {
-    display: flex;
-    align-items: center;
-  }
-
-  .log-filters {
-    display: flex;
-    margin-right: 5px;
-    align-items: center;
-
-    .log-label {
-      padding-right: 0.35rem;
-    }
-
-    .tag-container {
-      height: auto;
-      min-height: 34px;
-      padding: 2px;
-      margin: 2px;
-      cursor: text;
-      border-radius: 3px;
-      display: flex;
-      align-items: center;
-
-      .chips .chip {
-        display: inline-block;
-        width: auto;
-        float: left;
-
-        background-color: #0878b2;
-        color: #fff;
-        border-radius: 3px;
-        margin: 2px;
-        overflow: hidden;
-
-        .chip-button {
-          padding: 4px;
-          cursor: pointer;
-          background-color: #054570;
-          display: inline-block;
-        }
-
-        .chip-text {
-          padding: 4px;
-          display: inline-block;
-          pointer-events: none;
-        }
-      }
-
-      .chip-input {
-        margin-left: 5px;
-      }
-    }
-
-    .filter-widget {
-      user-select: none;
-      cursor: pointer;
-      position: relative;
-      display: inline-block;
-    }
-
-    .filter-widget .tooltip {
-      visibility: hidden;
-      width: 120px;
-      background-color: black;
-      color: #fff;
-      text-align: center;
-      border-radius: 6px;
-      padding: 5px 0;
-
-      /* Position the tooltip */
-      position: absolute;
-      z-index: 1;
-      top: 130%;
-      right: 50%;
-    }
-
-    .filter-widget:hover .tooltip {
-      visibility: visible;
-    }
-  }
-
-  header.stale {
-    color: grey;
-  }
-}
-
 .pf-ftrace-explorer {
   height: 100%;
   font-size: 11px;
-  font-family: var(--monospace-font);
+  font-family: var(--pf-monospace-font);
 
   .pf-ftrace-namebox {
     display: flex;
@@ -352,7 +241,7 @@
 .pf-android-logs-table {
   height: 100%;
   font-size: 11px;
-  font-family: var(--monospace-font);
+  font-family: var(--pf-monospace-font);
 
   .D {
     color: hsl(122, 20%, 40%);
@@ -381,7 +270,7 @@
   margin: 10px;
 }
 
-.screenshot-panel {
+.pf-screenshot-panel {
   height: 100%;
   img {
     max-height: 100%;
@@ -392,7 +281,7 @@
   height: 100%;
 }
 
-.flamegraph-profile {
+.pf-flamegraph-profile {
   height: 100%;
   // This is required to position locally-scoped (i.e. non-full-screen) modal
   // dialogs within the panel, as they use position: absolute.

--- a/ui/src/assets/details.scss
+++ b/ui/src/assets/details.scss
@@ -19,7 +19,7 @@
   // dialogs within the panel, as they use position: absolute.
   position: relative;
 
-  .material-icons {
+  .pf-material-icons {
     @include transition(0.3s);
     font-size: 16px;
     margin-left: 5px;
@@ -136,7 +136,7 @@
 }
 
 .pf-details-panel {
-  .flow-info i.material-icons {
+  .flow-info i.pf-material-icons {
     color: rgb(60, 86, 136);
   }
 
@@ -146,7 +146,7 @@
     color: hsl(45, 100%, 48%);
   }
 
-  .warning i.material-icons {
+  .warning i.pf-material-icons {
     font-size: 13px;
   }
 

--- a/ui/src/assets/flags_page.scss
+++ b/ui/src/assets/flags_page.scss
@@ -14,75 +14,74 @@
 
 @import "widgets/theme";
 
-.flags-page {
+.pf-flags-page {
   overflow-y: scroll;
+  .flags-content {
+    max-width: 100ch;
+    width: 60%;
+    margin: 0 auto;
+    padding: 3rem;
+    display: grid;
+
+    h1 {
+      font-size: larger;
+      margin: 1rem 1rem;
+    }
+
+    button {
+      background: none;
+      border: 1px solid rgb(218, 220, 224);
+      border-radius: $pf-border-radius;
+      color: rgb(25, 103, 210);
+      font-size: 0.8125rem;
+      padding: 8px 12px;
+      cursor: pointer;
+      font-weight: 500;
+      margin: 3px 0.5rem;
+    }
+  }
+
+  .flag-widget {
+    display: grid;
+    grid-template:
+      "title control" auto
+      "description control" auto / 1fr auto;
+    row-gap: 0.3rem;
+    padding: 1rem 1rem;
+    align-items: center;
+
+    &:nth-child(2n + 1) {
+      background-color: #f6f6f6;
+    }
+
+    &.focused {
+      background-color: #f8f0ac;
+    }
+
+    select {
+      grid-area: control;
+      background: white;
+      border: 1px solid rgb(25, 103, 210);
+      color: rgb(25, 103, 210);
+      font-size: 0.8125rem;
+      height: 1.625rem;
+      letter-spacing: 0.01em;
+      max-width: 150px;
+      text-align-last: center;
+      width: 100%;
+    }
+
+    label {
+      font-weight: bold;
+    }
+
+    .description {
+      font-size: smaller;
+    }
+  }
 }
 
-.flags-content {
-  max-width: 100ch;
-  width: 60%;
-  margin: 0 auto;
-  padding: 3rem;
-  display: grid;
-
-  h1 {
-    font-size: larger;
-    margin: 1rem 1rem;
-  }
-
-  button {
-    background: none;
-    border: 1px solid rgb(218, 220, 224);
-    border-radius: $pf-border-radius;
-    color: rgb(25, 103, 210);
-    font-size: 0.8125rem;
-    padding: 8px 12px;
-    cursor: pointer;
-    font-weight: 500;
-    margin: 3px 0.5rem;
-  }
-}
-
-.flag-widget {
-  display: grid;
-  grid-template:
-    "title control" auto
-    "description control" auto / 1fr auto;
-  row-gap: 0.3rem;
-  padding: 1rem 1rem;
-  align-items: center;
-
-  &:nth-child(2n + 1) {
-    background-color: #f6f6f6;
-  }
-
-  &.focused {
-    background-color: #f8f0ac;
-  }
-
-  select {
-    grid-area: control;
-    background: white;
-    border: 1px solid rgb(25, 103, 210);
-    color: rgb(25, 103, 210);
-    font-size: 0.8125rem;
-    height: 1.625rem;
-    letter-spacing: 0.01em;
-    max-width: 150px;
-    text-align-last: center;
-    width: 100%;
-  }
-
-  label {
-    font-weight: bold;
-  }
-
-  .description {
-    font-size: smaller;
-  }
-}
-
-.flags-page__footer {
+.pf-flags-page__footer {
   margin-top: 12px;
   display: flex;
   justify-content: center;

--- a/ui/src/assets/fonts.scss
+++ b/ui/src/assets/fonts.scss
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 @mixin bottom-panel-font {
-  font-family: "Roboto Condensed", sans-serif;
+  font-family: var(--pf-font);
   font-weight: 300;
-  color: #3c4b5d;
+  color: var(--pf-main-color);
 }

--- a/ui/src/assets/hiring_banner.scss
+++ b/ui/src/assets/hiring_banner.scss
@@ -1,4 +1,4 @@
-.hiring-banner {
+.pf-hiring-banner {
   font-family: "Roboto", sans-serif;
   font-size: 12px;
   background: #db4634;

--- a/ui/src/assets/home_page.scss
+++ b/ui/src/assets/home_page.scss
@@ -14,7 +14,7 @@
 
 @import "widgets/theme";
 
-.home-page {
+.pf-home-page {
   display: grid;
   align-items: stretch;
   justify-items: center;
@@ -169,4 +169,4 @@
     font-family: $pf-font;
     color: #333;
   }
-} // .home-page
+} // .pf-home-page

--- a/ui/src/assets/metrics_page.scss
+++ b/ui/src/assets/metrics_page.scss
@@ -22,7 +22,7 @@
   margin-right: 1rem;
 }
 
-.metrics-page {
+.pf-metrics-page {
   padding: 30px;
   font-family: "Roboto", sans-serif;
   overflow-y: scroll;

--- a/ui/src/assets/modal.scss
+++ b/ui/src/assets/modal.scss
@@ -14,13 +14,13 @@
 
 @import "widgets/theme";
 
-// The opacity changes are only transitional. Once the `modalFadeOut` animation
+// The opacity changes are only transitional. Once the `pf-modalFadeOut` animation
 // reaches the end, the Mithril component that renders .modal-backdrop
 // (and .modal-dialog) is fully destroyed and removed from the DOM.
 // We use keyframes+animation, rather than transition, because the former allow
 // hooking the onanimationend events to synchronize the Mithril removal with
 // the end of the CSS animation.
-@keyframes modalFadeOut {
+@keyframes pf-modalFadeOut {
   from {
     opacity: 1;
   }
@@ -29,7 +29,7 @@
   }
 }
 
-@keyframes modalFadeIn {
+@keyframes pf-modalFadeIn {
   from {
     opacity: 0;
   }
@@ -38,7 +38,7 @@
   }
 }
 
-.modal-backdrop {
+.pf-modal-backdrop {
   position: absolute;
   z-index: 99;
   background-color: rgba(0, 0, 0, 0.6);
@@ -47,16 +47,16 @@
   right: 0;
   bottom: 0;
   backdrop-filter: blur(2px);
-  animation: modalFadeIn 0.25s var(--anim-easing);
+  animation: pf-modalFadeIn 0.25s var(--pf-anim-easing);
   animation-fill-mode: both;
 
   &.modal-fadeout {
-    animation: modalFadeOut 0.25s var(--anim-easing);
+    animation: pf-modalFadeOut 0.25s var(--pf-anim-easing);
     animation-fill-mode: both;
   }
 }
 
-.modal-dialog {
+.pf-modal-dialog {
   position: absolute;
   z-index: 100;
   background-color: #fff;
@@ -118,16 +118,16 @@
     margin-top: 2rem;
     gap: 4px;
   } // footer
-}
+} // pf-modal-dialog
 
-.help {
+.pf-help {
   table {
     margin-bottom: 15px;
     td {
       min-width: 250px;
     }
     td:first-child {
-      font-family: var(--monospace-font);
+      font-family: var(--pf-monospace-font);
     }
   }
   h2 {
@@ -136,39 +136,41 @@
   }
 }
 
-.modal-pre {
-  white-space: pre-line;
-  font-size: 13px;
-}
+.pf-modal-dialog {
+  .modal-pre {
+    white-space: pre-line;
+    font-size: 13px;
+  }
 
-.modal-logs,
-.modal-bash {
-  white-space: pre-wrap;
-  border: 1px solid #999;
-  background: #eee;
-  font-size: 10px;
-  font-family: var(--monospace-font);
-  margin-top: 10px;
-  margin-bottom: 10px;
-  min-height: 50px;
-  max-height: 40vh;
-  overflow: auto;
-}
+  .modal-logs,
+  .modal-bash {
+    white-space: pre-wrap;
+    border: 1px solid #999;
+    background: #eee;
+    font-size: 10px;
+    font-family: var(--pf-monospace-font);
+    margin-top: 10px;
+    margin-bottom: 10px;
+    min-height: 50px;
+    max-height: 40vh;
+    overflow: auto;
+  }
 
-.modal-bash {
-  margin: 0;
-  padding: 5px 0;
-  overflow: auto;
-  min-height: 0;
-}
+  .modal-bash {
+    margin: 0;
+    padding: 5px 0;
+    overflow: auto;
+    min-height: 0;
+  }
 
-.modal-textarea {
-  display: block;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  width: 100%;
-}
+  .modal-textarea {
+    display: block;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    width: 100%;
+  }
 
-.modal-small {
-  font-size: 0.75rem;
+  .modal-small {
+    font-size: 0.75rem;
+  }
 }

--- a/ui/src/assets/modal.scss
+++ b/ui/src/assets/modal.scss
@@ -41,7 +41,7 @@
 .pf-modal-backdrop {
   position: absolute;
   z-index: 99;
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: var(--pf-model-backdrop-background);
   top: 0;
   left: 0;
   right: 0;
@@ -59,7 +59,7 @@
 .pf-modal-dialog {
   position: absolute;
   z-index: 100;
-  background-color: #fff;
+  background-color: var(--pf-modal-background);
   margin: auto;
   min-width: 25vw;
   min-height: 10vh;
@@ -87,11 +87,11 @@
     h2 {
       margin-top: 0;
       margin-bottom: 0;
-      font-family: "Roboto", sans-serif;
+      font-family: var(--pf-heading-font);
       font-weight: 600;
       font-size: 1.25rem;
       line-height: 1.25;
-      color: #262f3c;
+      color: var(--pf-modal-title-color);
       box-sizing: border-box;
     }
 
@@ -105,7 +105,7 @@
     font-size: 1rem;
     margin-top: 2rem;
     line-height: 1.5;
-    color: rgba(0, 0, 0, 0.8);
+    color: var(--pf-modal-text-color);
 
     .small-font {
       font-size: 0.9rem;
@@ -145,8 +145,8 @@
   .modal-logs,
   .modal-bash {
     white-space: pre-wrap;
-    border: 1px solid #999;
-    background: #eee;
+    border: 1px solid var(--pf-modal-logs-border);
+    background: var(--pf-modal-logs-background);
     font-size: 10px;
     font-family: var(--pf-monospace-font);
     margin-top: 10px;

--- a/ui/src/assets/query_page.scss
+++ b/ui/src/assets/query_page.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.query-page {
+.pf-query-page {
   overflow-y: auto;
   overflow-x: hidden;
   .pf-editor {

--- a/ui/src/assets/record.scss
+++ b/ui/src/assets/record.scss
@@ -1005,7 +1005,7 @@
     background-color: #fafafa;
   }
 
-  > i.material-icons {
+  > i.pf-material-icons {
     color: rgb(60, 60, 60);
     font-size: 14px;
   }

--- a/ui/src/assets/record.scss
+++ b/ui/src/assets/record.scss
@@ -15,325 +15,54 @@
 @import "widgets/theme";
 
 :root {
-  --record-text-color: #333;
+  --pf-record-text-color: #333;
 }
 
 // The whole record page.
-.record-page {
+.pf-record-page {
   position: relative;
   overflow-y: scroll;
   background-color: #fefefe;
   padding: 40px 20px;
-}
-
-// The always-visible centered box that has menu and sections on the right.
-.record-container {
-  position: relative;
-  max-width: 900px;
-  min-height: 500px;
-  margin: auto;
-  border-radius: $pf-border-radius;
-  box-shadow:
-    0 1px 2px 0 #aaa,
-    0 1px 3px 1px #eee;
-  background-color: #fff;
-  display: grid;
-  grid-template-rows: auto 1fr;
-  grid-template-areas:
-    "header"
-    "content";
-  overflow: hidden;
-  z-index: 6;
-
-  // The body of the record container.
-  .record-container-content {
-    display: grid;
-    grid-template-columns: 2fr 5fr;
-    grid-template-areas: "sidebar section";
-  }
-
-  .full-centered {
-    width: 100%;
-    height: 100%;
-    text-align: center;
-    padding: 180px 30px;
-    font-family: "Roboto", sans-serif;
-    font-size: 25px;
-  }
-}
-
-.record-modal {
-  display: flex;
-  flex-direction: column;
-
-  .line {
-    padding: 10px 10px 10px 10px;
-    border-bottom: 1px solid #808080;
-  }
-
-  .record-modal-section {
-    display: flex;
-    flex-direction: row;
-
-    .logo-wrapping {
-      width: 150px;
-      height: 150px;
-      display: inline-block;
-      margin: 50px 30px 0px 0px;
-      align-self: center;
-
-      i.material-icons {
-        color: #16161d;
-        font-size: 150px;
-      }
-    }
-
-    select {
-      min-width: 300px;
-      min-height: 80px;
-    }
-
-    .record-modal-description {
-      display: flex;
-      flex-direction: column;
-      align-items: left;
-
-      .record-modal-command {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        padding: 10px 0px 10px 0px;
-        color: #fff;
-
-        .code-snippet {
-          width: 100%;
-        }
-      }
-
-      h3 {
-        padding-top: 15px;
-        align-self: start;
-        font-size: 1.2rem;
-        color: #0000ff;
-      }
-
-      h4 {
-        align-self: start;
-        font-size: 1.1rem;
-      }
-
-      text {
-        padding: 10px 0px 10px 0px;
-        color: #000000;
-      }
-
-      input[type="text"] {
-        flex-grow: 1;
-        border-radius: $pf-border-radius;
-        border: 1px solid #dcdcdc;
-        padding: 3px;
-        margin: 0 10px;
-        min-width: 170px;
-
-        &:focus {
-          outline: none;
-          box-shadow: 1px 1px 1px rgba(23, 32, 44, 0.3);
-        }
-      }
-    }
-  }
-
-  .record-modal-button,
-  .record-modal-button-high,
-  .record-modal-logo-button {
-    font-size: 0.875rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    background-color: #0000ff;
-    color: #fff;
-    cursor: pointer;
-    -webkit-appearance: button;
-    text-transform: none;
-    overflow: visible;
-    line-height: 1.15;
-    margin: 5px;
-    will-change: transform;
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-backface-visibility: hidden;
-    backface-visibility: hidden;
-    transform: translateZ(0);
-    transition: transform 0.25s ease-out;
-    align-self: end;
-    text-align: center;
-  }
-
-  .record-modal-button,
-  .record-modal-button-high {
+  // The always-visible centered box that has menu and sections on the right.
+  .record-container {
+    position: relative;
+    max-width: 900px;
+    min-height: 500px;
+    margin: auto;
     border-radius: $pf-border-radius;
-    border-style: none;
-    border-width: 0;
-  }
+    box-shadow:
+      0 1px 2px 0 #aaa,
+      0 1px 3px 1px #eee;
+    background-color: #fff;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-template-areas:
+      "header"
+      "content";
+    overflow: hidden;
+    z-index: 6;
 
-  .record-modal-button-high:disabled {
-    background-color: #808080;
-  }
-
-  .record-modal-button-high {
-    height: 100%;
-    align-self: center;
-    display: flex;
-    align-items: center;
-  }
-
-  .record-modal-logo-button {
-    border-radius: 50%;
-    width: 35px;
-    height: 35px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
-.hider {
-  @include transition(0.2s);
-  position: fixed;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  background: #000;
-  opacity: 0.2;
-  z-index: 5;
-}
-
-.record-header {
-  grid-area: header;
-  padding: 10px;
-  display: flex;
-  flex-direction: column;
-  border-bottom: 1px solid #eee;
-
-  .top-part {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    // Connect/start/stop tracing buttons.
-    .button {
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-      width: auto;
-      height: 50px;
-      margin: 0;
-      > * {
-        @include transition(0.2s);
-        cursor: pointer;
-        border-radius: 10px;
-        margin: 10px;
-        text-align: center;
-        background-color: #eee;
-        font-family: "Roboto", sans-serif;
-        font-size: 17px;
-        @media (max-width: 1280px) {
-          font-size: 1.6vw;
-        }
-        padding: 7px;
-
-        &:hover {
-          background-color: hsl(88, 50%, 84%);
-          box-shadow: 0 0 4px 0 #999;
-        }
-
-        &.selected {
-          background-color: hsl(88, 50%, 67%);
-          box-shadow: 0 0 4px 0 #999;
-        }
-
-        &.disabled {
-          background-color: hsl(0, 0%, 97%);
-        }
-      }
+    // The body of the record container.
+    .record-container-content {
+      display: grid;
+      grid-template-columns: 2fr 5fr;
+      grid-template-areas: "sidebar section";
     }
 
-    .target-and-status {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-evenly;
-
-      .target {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-      }
-
-      label,
-      select,
-      button {
-        font-weight: 300;
-        margin: 3px;
-        color: #333;
-        font-size: 17px;
-        font-family: "Roboto", sans-serif;
-        align-items: center;
-
-        &.error-label {
-          max-width: 500px;
-          color: rgb(255, 0, 0);
-          font-size: 15px;
-        }
-      }
-      .chip {
-        @include transition();
-        display: flex;
-        align-items: center;
-        border: 1px solid #eee;
-        outline: none;
-        margin: 4px;
-        border-radius: 20px;
-        padding: 4px;
-        height: 30px;
-        &:hover,
-        &:active {
-          box-shadow: 0 0 4px 0 #ccc;
-          background-color: #fafafa;
-        }
-        i {
-          margin: 3px;
-          align-items: center;
-        }
-      }
-    }
-  }
-
-  .note {
-    border-radius: 3px;
-    margin-bottom: 5px;
-    background: #f9eeba;
-    padding: 10px;
-    font-family: "Roboto", sans-serif;
-    font-size: 14px;
-    line-height: 20px;
-  }
-
-  select {
-    @include transition();
-    margin-left: 10px;
-    border-radius: 0;
-    border: 1px solid #eee;
-    outline: none;
-    &:hover,
-    &:active {
-      box-shadow: 0 0 6px #ccc;
+    .full-centered {
+      width: 100%;
+      height: 100%;
+      text-align: center;
+      padding: 180px 30px;
+      font-family: "Roboto", sans-serif;
+      font-size: 25px;
     }
   }
 }
 
 // The left-hand-side menu with 'Cpu', 'Memory' etc.
-.record-menu {
+.pf-record-menu {
   grid-area: sidebar;
   .rec {
     color: #ee3326;
@@ -474,7 +203,7 @@
   }
 } // record-menu
 
-.record-section {
+.pf-record-page .record-section {
   grid-area: section;
   background: #fff;
   transition: opacity 0.25s ease;
@@ -510,7 +239,7 @@
 
   .title-config {
     display: inline-block;
-    margin: var(--record-section-padding);
+    margin: var(--pf-record-section-padding);
     flex-grow: 1;
     word-break: break-all;
   }
@@ -597,11 +326,11 @@
   }
 
   // By default space all section elements by the same amount.
-  --record-section-padding: 20px;
+  --pf-record-section-padding: 20px;
 
   > * {
-    padding-left: var(--record-section-padding);
-    padding-right: var(--record-section-padding);
+    padding-left: var(--pf-record-section-padding);
+    padding-right: var(--pf-record-section-padding);
     &:first-child {
       padding-top: 20px;
     }
@@ -630,8 +359,8 @@
     grid-template-columns: 220px 1fr;
     grid-template-areas: "label label" "img descr";
     transition: color 0.2s ease;
-    padding-top: var(--record-section-padding);
-    padding-bottom: var(--record-section-padding);
+    padding-top: var(--pf-record-section-padding);
+    padding-bottom: var(--pf-record-section-padding);
 
     &.compact {
       padding-top: 10px;
@@ -726,7 +455,7 @@
       font-size: 14px;
       font-weight: 200;
       min-height: 50px;
-      color: var(--record-text-color);
+      color: var(--pf-record-text-color);
       line-height: 20px;
     }
 
@@ -769,12 +498,12 @@
   } // probe
 
   .textarea-holder {
-    padding-top: var(--record-section-padding);
+    padding-top: var(--pf-record-section-padding);
   }
 
   .toggle {
     transition: color 0.2s ease;
-    padding-top: var(--record-section-padding);
+    padding-top: var(--pf-record-section-padding);
 
     &:hover {
       > img {
@@ -791,7 +520,7 @@
     > label {
       cursor: pointer;
       font-size: 14px;
-      color: var(--record-text-color);
+      color: var(--pf-record-text-color);
 
       // The per-probe on-off switch.
       input[type="checkbox"] {
@@ -904,7 +633,7 @@
     grid-template-areas:
       "hdr hdr hdr hdr" "descr descr descr descr"
       "icon slider label unit";
-    margin-top: var(--record-section-padding);
+    margin-top: var(--pf-record-section-padding);
 
     &.thin {
       grid-template-columns: 1fr 1fr 100px 0;
@@ -931,7 +660,7 @@
 
     &.thin > header {
       opacity: 1;
-      color: var(--record-text-color);
+      color: var(--pf-record-text-color);
       font-size: 14px;
     }
 
@@ -1044,7 +773,7 @@
     .unit {
       grid-area: unit;
       font-size: 12px;
-      color: var(--record-text-color);
+      color: var(--pf-record-text-color);
       position: relative;
       line-height: 37px;
       overflow: hidden;
@@ -1073,7 +802,7 @@
       @include transition();
       min-height: 25px;
       font-size: 12px;
-      color: var(--record-text-color);
+      color: var(--pf-record-text-color);
       cursor: pointer;
       padding: 5px 0;
     }
@@ -1091,7 +820,7 @@
     }
 
     &.singlecolumn {
-      margin: var(--record-section-padding) 0;
+      margin: var(--pf-record-section-padding) 0;
       padding: 0;
       max-width: 100%;
       width: 100%;
@@ -1127,7 +856,7 @@
 
       &.two-columns {
         height: 400px;
-        margin: var(--record-section-padding);
+        margin: var(--pf-record-section-padding);
         optgroup {
           display: grid;
           padding: 0;
@@ -1158,7 +887,7 @@
     border: 1px solid #eee;
     resize: none;
     outline: none;
-    font-family: var(--monospace-font);
+    font-family: var(--pf-monospace-font);
 
     &::placeholder {
       color: #aaa;
@@ -1182,7 +911,7 @@
     .note {
       border: 1px dashed #ddd;
       background: #f9eeba;
-      margin: var(--record-section-padding);
+      margin: var(--pf-record-section-padding);
       padding: 10px;
       font-family: "Roboto", sans-serif;
       font-size: 14px;
@@ -1236,7 +965,7 @@
     }
 
     .permalinkconfig {
-      margin: var(--record-section-padding);
+      margin: var(--pf-record-section-padding);
       height: 40px;
       max-width: 200px;
       border-radius: 10px;
@@ -1256,7 +985,7 @@
       appearance: none;
       width: 600px;
       height: 30px;
-      margin: var(--record-section-padding);
+      margin: var(--pf-record-section-padding);
       border-radius: 5px;
     }
     ::-webkit-progress-value {
@@ -1268,7 +997,7 @@
   }
 } // record-section
 
-.inline-chip {
+.pf-inline-chip {
   @include transition();
   &:hover,
   &:active {
@@ -1289,18 +1018,18 @@
   border-radius: 9px;
 }
 
-a.inline-chip,
-a.inline-chip:link,
-a.inline-chip:visited {
+a.pf-inline-chip,
+a.pf-inline-chip:link,
+a.pf-inline-chip:visited {
   text-decoration: none;
-  color: var(--record-text-color);
+  color: var(--pf-record-text-color);
 }
 
-.code-snippet {
+.pf-code-snippet {
   display: grid;
   position: relative;
   padding: 0;
-  margin: 0 var(--record-section-padding);
+  margin: 0 var(--pf-record-section-padding);
   background-color: #111;
   border-radius: 4px;
   box-shadow: 0 0 12px #999;
@@ -1341,7 +1070,7 @@ a.inline-chip:visited {
     display: block;
     margin: 10px 5px 20px 20px;
     color: #ccc;
-    font-family: var(--monospace-font);
+    font-family: var(--pf-monospace-font);
     font-size: 12px;
     line-height: 20px;
     overflow-y: auto;
@@ -1383,11 +1112,11 @@ a.inline-chip:visited {
   > button:active:hover {
     transform: scale(0.9);
   }
-} // code-snippet
+} // pf-code-snippet
 
 // For RecordingV2
 
-.record-section[id="target"] {
+.pf-record-page .record-section[id="target"] {
   header {
     font-size: 1rem;
     font-weight: 600;
@@ -1484,7 +1213,7 @@ a.inline-chip:visited {
   }
 
   .preflight-checks-table {
-    font-family: var(--monospace-font);
+    font-family: var(--pf-monospace-font);
     font-size: 0.8rem;
     display: block;
     border-collapse: collapse;

--- a/ui/src/assets/sidebar.scss
+++ b/ui/src/assets/sidebar.scss
@@ -221,7 +221,7 @@
               text-decoration: line-through;
             }
           }
-          .material-icons {
+          .pf-material-icons {
             margin-right: 10px;
             font-size: 20px;
           }

--- a/ui/src/assets/sidebar.scss
+++ b/ui/src/assets/sidebar.scss
@@ -15,11 +15,9 @@
 @import "widgets/theme";
 
 .pf-sidebar {
-  --pf-sidebar-padding-bottom: 40px;
-  --pf-sidebar-timing: 0.15s;
   grid-area: sidebar;
   z-index: 4;
-  background-color: #262f3c;
+  background-color: var(--pf-sidebar-background);
   overflow: hidden;
   width: var(--pf-sidebar-width);
   display: flex;
@@ -29,20 +27,20 @@
     margin-left var(--pf-anim-easing) var(--pf-sidebar-timing),
     visibility linear var(--pf-sidebar-timing);
   > * {
-    border-bottom: 1px solid #404854;
+    border-bottom: 1px solid var(--pf-sidebar-border-bottom);
   }
   input[type="file"] {
     display: none;
   }
   > header {
-    font-family: "Roboto Condensed", sans-serif;
+    font-family: var(--pf-font);
     font-weight: 700;
     font-size: 24px;
     height: var(--pf-topbar-height);
     line-height: var(--pf-topbar-height);
     vertical-align: middle;
     padding: 0 12px;
-    color: #fff;
+    color: var(--pf-sidebar-header-color);
     overflow: visible;
     .brand {
       height: 36px;
@@ -57,23 +55,23 @@
       position: absolute;
       font-size: 10px;
       line-height: 5px;
-      font-family: "Roboto", sans-serif;
+      font-family: var(--pf-heading-font);
       top: 7px;
       right: 48px;
     }
     &.canary::before {
       content: "CANARY";
-      color: #ffd700;
+      color: var(--pf-sidebar-canary-color);
     }
     &.autopush::before {
       content: "AUTOPUSH";
-      color: #aed581;
+      color: var(--pf-sidebar-autopush-color);
     }
   }
   .sidebar-button {
     position: fixed;
     z-index: 5;
-    background-color: #262f3c;
+    background-color: var(--pf-sidebar-background);
     height: var(--pf-topbar-height);
     left: calc(var(--pf-sidebar-width) - 50px);
     border-radius: 0 5px 5px 0;
@@ -94,7 +92,7 @@
       background-color: transparent;
       border-radius: unset;
       border-bottom: none;
-      color: #aaaaaa;
+      color: var(--pf-sidebar-hide-sidebar-color);
     }
   }
   .sidebar-scroll {
@@ -104,11 +102,11 @@
       width: 0.5em;
     }
     &::-webkit-scrollbar-track {
-      background-color: #19212b;
+      background-color: var(--pf-sidebar-scrollbar-background);
       border-radius: 2px;
     }
     &::-webkit-scrollbar-thumb {
-      background: #b4b7ba6e;
+      background: var(--pf-sidebar-scrollbar-thumb-background);
       border-radius: 2px;
     }
     > .sidebar-scroll-container {
@@ -131,12 +129,12 @@
             margin: 0 12px;
           }
           > h1 {
-            color: #fff;
+            color: var(--pf-sidebar-section-header-h1-color);
             font-size: 15px;
           }
           > h2 {
             @include transition();
-            color: rgba(255, 255, 255, 0.5);
+            color: var(--pf-sidebar-section-header-h2-color);
             font-size: 12px;
             margin-top: 8px;
             font-weight: 400;
@@ -144,16 +142,16 @@
           &:before {
             @include material-icon("expand_more");
             float: right;
-            color: rgba(255, 255, 255, 0.3);
+            color: var(--pf-sidebar-section-header-before-color);
             margin-right: 12px;
             margin-top: -4px;
           }
         }
         &:hover {
-          background-color: #373f4b;
+          background-color: var(--pf-sidebar-section-hover-background);
         }
         &.expanded {
-          background-color: #19212b;
+          background-color: var(--pf-sidebar-section-expanded-background);
           max-height: unset;
           .section-header {
             h2 {
@@ -176,9 +174,9 @@
         pointer-events: none;
         @include transition();
         opacity: 0;
-        color: #b4b7ba;
+        color: var(--pf-sidebar-section-content-color);
         a {
-          color: #b4b7ba;
+          color: var(--pf-sidebar-section-content-a-color);
         }
         ul {
           list-style-type: none;
@@ -194,7 +192,7 @@
             text-decoration: none;
             display: block;
             &.pending {
-              color: rgba(255, 255, 255, 0.3);
+              color: var(--pf-sidebar-pending-color);
               &::after {
                 content: " ";
                 display: inline-block;
@@ -204,8 +202,8 @@
                 height: 18px;
                 margin-left: 10px;
                 border-radius: 50%;
-                border: 2px solid #b4b7ba;
-                border-color: #b4b7ba transparent;
+                border: 2px solid var(--pf-sidebar-pending-spinner-border);
+                border-color: var(--pf-sidebar-pending-spinner-border) transparent;
                 animation: pending-spinner 1.25s linear infinite;
               }
               @keyframes pending-spinner {
@@ -226,16 +224,16 @@
             font-size: 20px;
           }
           &:hover {
-            background-color: #373f4b;
+            background-color: var(--pf-sidebar-li-hover-background);
           }
           .trace-file-name {
             white-space: break-spaces;
-            font-family: "Roboto Condensed", sans-serif;
+            font-family: var(--pf-font);
             word-break: break-all;
             font-weight: 300;
             letter-spacing: 0;
             margin-top: -10px;
-            color: #fff;
+            color: var(--pf-sidebar-trace-file-name-color);
           }
         }
       }
@@ -253,18 +251,18 @@
     grid-gap: 10px;
 
     > button {
-      color: hsl(217, 39%, 94%);
+      color: var(--pf-sidebar-footer-button-color);
       i {
         font-size: 24px;
       }
 
       &:hover {
-        color: hsl(45, 100%, 48%);
+        color: var(--pf-sidebar-footer-button-hover-color);
       }
     }
 
     > .dbg-info-square {
-      font-family: "Roboto Condensed", sans-serif;
+      font-family: var(--pf-font);
       width: 24px;
       height: 24px;
       line-height: 24px;
@@ -274,22 +272,22 @@
       align-items: center;
 
       margin: 1px 0;
-      background: #12161b;
-      color: #4e71b3;
+      background: var(--pf-sidebar-footer-dbg-info-background);
+      color: var(--pf-sidebar-footer-dbg-info-color);
       border-radius: $pf-border-radius;
       font-size: 12px;
       text-align: center;
       &.green {
-        background: #7aca75;
-        color: #12161b;
+        background: var(--pf-sidebar-footer-dbg-info-green-background);
+        color: var(--pf-sidebar-footer-dbg-info-green-color);
       }
       &.amber {
-        background: #ffc107;
-        color: #333;
+        background: var(--pf-sidebar-footer-dbg-info-amber-background);
+        color: var(--pf-sidebar-footer-dbg-info-amber-color);
       }
       &.red {
-        background: #d32f2f;
-        color: #fff;
+        background: var(--pf-sidebar-footer-dbg-info-red-background);
+        color: var(--pf-sidebar-footer-dbg-info-red-color);
       }
       > div {
         font-size: 10px;
@@ -302,9 +300,9 @@
       right: 8px;
       bottom: 3px;
       font-size: 12px;
-      font-family: "Roboto Condensed", sans-serif;
+      font-family: var(--pf-font);
       a {
-        color: rgba(255, 255, 255, 0.5);
+        color: var(--pf-sidebar-footer-version-link-color);
         text-decoration: none;
       }
       margin-top: 11px;
@@ -319,12 +317,12 @@ body.testing .sidebar-footer {
 }
 
 .pf-help .keycap {
-  background-color: #fafbfc;
-  border: 1px solid #d1d5da;
-  border-bottom-color: #c6cbd1;
+  background-color: var(--pf-help-keycap-background);
+  border: 1px solid var(--pf-help-keycap-border);
+  border-bottom-color: var(--pf-help-keycap-border-bottom);
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #c6cbd1;
-  color: #444d56;
+  box-shadow: var(--pf-help-keycap-shadow);
+  color: var(--pf-help-keycap-color);
   display: inline-block;
   font-family: var(--pf-monospace-font);
   vertical-align: middle;

--- a/ui/src/assets/sidebar.scss
+++ b/ui/src/assets/sidebar.scss
@@ -14,20 +14,20 @@
 
 @import "widgets/theme";
 
-.sidebar {
-  --sidebar-padding-bottom: 40px;
-  --sidebar-timing: 0.15s;
+.pf-sidebar {
+  --pf-sidebar-padding-bottom: 40px;
+  --pf-sidebar-timing: 0.15s;
   grid-area: sidebar;
   z-index: 4;
   background-color: #262f3c;
   overflow: hidden;
-  width: var(--sidebar-width);
+  width: var(--pf-sidebar-width);
   display: flex;
   position: relative;
   flex-direction: column;
   transition:
-    margin-left var(--anim-easing) var(--sidebar-timing),
-    visibility linear var(--sidebar-timing);
+    margin-left var(--pf-anim-easing) var(--pf-sidebar-timing),
+    visibility linear var(--pf-sidebar-timing);
   > * {
     border-bottom: 1px solid #404854;
   }
@@ -38,8 +38,8 @@
     font-family: "Roboto Condensed", sans-serif;
     font-weight: 700;
     font-size: 24px;
-    height: var(--topbar-height);
-    line-height: var(--topbar-height);
+    height: var(--pf-topbar-height);
+    line-height: var(--pf-topbar-height);
     vertical-align: middle;
     padding: 0 12px;
     color: #fff;
@@ -74,12 +74,12 @@
     position: fixed;
     z-index: 5;
     background-color: #262f3c;
-    height: var(--topbar-height);
-    left: calc(var(--sidebar-width) - 50px);
+    height: var(--pf-topbar-height);
+    left: calc(var(--pf-sidebar-width) - 50px);
     border-radius: 0 5px 5px 0;
     border-bottom: inherit;
     visibility: visible; // So stays visible when the sidebar is hidden.
-    transition: left var(--anim-easing) var(--sidebar-timing);
+    transition: left var(--pf-anim-easing) var(--pf-sidebar-timing);
     width: 48px;
     overflow: hidden;
     > button {
@@ -88,7 +88,7 @@
   }
   &.hide-sidebar {
     visibility: hidden;
-    margin-left: calc(var(--sidebar-width) * -1);
+    margin-left: calc(var(--pf-sidebar-width) * -1);
     .sidebar-button {
       left: 0;
       background-color: transparent;
@@ -114,7 +114,7 @@
     > .sidebar-scroll-container {
       position: relative;
       min-height: 100%;
-      padding-bottom: var(--sidebar-padding-bottom);
+      padding-bottom: var(--pf-sidebar-padding-bottom);
 
       > section {
         @include transition();
@@ -248,7 +248,7 @@
     width: 100%;
     padding: 2px 10px;
     display: grid;
-    height: -var(--sidebar-padding-bottom);
+    height: -var(--pf-sidebar-padding-bottom);
     grid-template-columns: repeat(4, min-content);
     grid-gap: 10px;
 
@@ -318,7 +318,7 @@ body.testing .sidebar-footer {
   visibility: hidden;
 }
 
-.keycap {
+.pf-help .keycap {
   background-color: #fafbfc;
   border: 1px solid #d1d5da;
   border-bottom-color: #c6cbd1;
@@ -326,7 +326,7 @@ body.testing .sidebar-footer {
   box-shadow: inset 0 -1px 0 #c6cbd1;
   color: #444d56;
   display: inline-block;
-  font-family: var(--monospace-font);
+  font-family: var(--pf-monospace-font);
   vertical-align: middle;
 
   line-height: 20px;

--- a/ui/src/assets/topbar.scss
+++ b/ui/src/assets/topbar.scss
@@ -127,7 +127,7 @@
       .current {
         padding-right: 10px;
       }
-      .material-icons.left {
+      .pf-material-icons.left {
         border-right: rgb(218, 217, 217) solid 1px;
       }
     }

--- a/ui/src/assets/topbar.scss
+++ b/ui/src/assets/topbar.scss
@@ -24,8 +24,8 @@
   position: relative;
   z-index: 3;
   overflow: visible;
-  background-color: hsl(215, 1%, 95%);
-  box-shadow: 0px 1px 2px 1px #00000026;
+  background-color: var(--pf-topbar-background);
+  box-shadow: var(--pf-topbar-shadow);
   min-height: var(--pf-topbar-height);
   display: flex;
   justify-content: center;
@@ -37,17 +37,17 @@
     grid-template-areas: "icon input stepthrough";
     grid-template-columns: 34px auto max-content;
     border-radius: $pf-border-radius;
-    background-color: white;
+    background-color: var(--pf-omnibox-background);
     border: solid 1px transparent;
     &:focus-within {
       border-color: $pf-colour-thin-border;
-      box-shadow: 1px 1px 8px rgba(0, 0, 0, 0.2);
+      box-shadow: var(--pf-omnibox-focus-shadow);
     }
     line-height: 34px;
     &:before {
       @include material-icon("search");
       margin: 5px;
-      color: #aaa;
+      color: var(--pf-omnibox-search-icon);
       grid-area: icon;
     }
     input {
@@ -55,35 +55,35 @@
       border: 0;
       padding: 0 10px;
       font-size: 18px;
-      font-family: "Roboto Condensed", sans-serif;
+      font-family: $pf-font;
       font-weight: 300;
-      color: #666;
+      color: var(--pf-omnibox-input-color);
       background-color: transparent;
       &:focus {
         outline: none;
       }
       &::placeholder {
-        color: #b4b7ba;
-        font-family: "Roboto Condensed", sans-serif;
+        color: var(--pf-omnibox-input-placeholder);
+        font-family: $pf-font;
         font-weight: 400;
       }
     }
     &.query-mode {
-      background-color: #111;
+      background-color: var(--pf-omnibox-query-background);
       border-radius: 0;
       width: 100%;
       max-width: 100%;
       margin-top: 0;
-      border-left: 1px solid #404854;
+      border-left: 1px solid var(--pf-omnibox-query-border);
       height: var(--pf-topbar-height);
       input {
-        color: #9ddc67;
+        color: var(--pf-omnibox-query-input);
         font-family: var(--pf-monospace-font);
         padding-left: 0;
       }
       &:before {
         content: "attach_money";
-        color: #9ddc67;
+        color: var(--pf-omnibox-query-input);
         font-size: 26px;
         padding-top: 5px;
       }
@@ -92,7 +92,7 @@
       &:before {
         @include material-icon("chevron_right");
         margin: 5px;
-        color: #aaa;
+        color: var(--pf-omnibox-search-icon);
         grid-area: icon;
       }
     }
@@ -100,17 +100,17 @@
       &:before {
         @include material-icon("question_mark");
         margin: 5px;
-        color: #aaa;
+        color: var(--pf-omnibox-search-icon);
         grid-area: icon;
       }
     }
     &.message-mode {
-      background-color: hsl(0, 0%, 89%);
+      background-color: var(--pf-omnibox-message-background);
       border-radius: $pf-border-radius;
       input::placeholder {
         font-weight: 400;
         font-family: var(--pf-monospace-font);
-        color: hsl(213, 40%, 50%);
+        color: var(--pf-omnibox-message-placeholder);
       }
       &:before {
         content: "info";
@@ -121,14 +121,14 @@
       display: flex;
       font: inherit;
       font-size: 14px;
-      font-family: "Roboto Condensed", sans-serif;
+      font-family: $pf-font;
       font-weight: 300;
-      color: #aaa;
+      color: var(--pf-stepthrough-color);
       .current {
         padding-right: 10px;
       }
       .pf-material-icons.left {
-        border-right: rgb(218, 217, 217) solid 1px;
+        border-right: var(--pf-stepthrough-left-border) solid 1px;
       }
     }
   }
@@ -142,7 +142,7 @@
     &:before {
       content: "";
       position: absolute;
-      background-color: hsl(219, 50%, 50%);
+      background-color: var(--pf-progress-background);
       top: 0;
       left: 0;
       bottom: 0;
@@ -153,7 +153,7 @@
     &:after {
       content: "";
       position: absolute;
-      background-color: hsl(219, 50%, 50%);
+      background-color: var(--pf-progress-background);
       top: 0;
       left: 0;
       bottom: 0;
@@ -198,16 +198,16 @@
     padding: 8px 10px;
     margin: 0 10px;
     border-radius: 2px;
-    background: hsl(210, 10%, 73%);
+    background: var(--pf-notification-background);
     &:hover {
-      background: hsl(210, 10%, 83%);
+      background: var(--pf-notification-background-hover);
     }
 
     &.preferred {
-      background: hsl(210, 98%, 53%);
-      color: #fff;
+      background: var(--pf-notification-preferred-background);
+      color: var(--pf-notification-preferred-color);
       &:hover {
-        background: hsl(210, 98%, 63%);
+        background: var(--pf-notification-preferred-background-hover);
       }
     }
   }
@@ -219,7 +219,7 @@
   display: flex;
   align-items: center;
   .error {
-    color: #ef6c00;
+    color: var(--pf-topbar-error-color);
     &:hover {
       cursor: pointer;
     }
@@ -233,7 +233,7 @@
 .pf-error-popup {
   width: 100px;
   font-size: 14px;
-  font-family: "Roboto Condensed", sans-serif;
+  font-family: $pf-font;
 }
 
 .pf-topbar.hide-sidebar {

--- a/ui/src/assets/topbar.scss
+++ b/ui/src/assets/topbar.scss
@@ -19,14 +19,14 @@
   max-width: 600px;
 }
 
-.topbar {
+.pf-topbar {
   grid-area: topbar;
   position: relative;
   z-index: 3;
   overflow: visible;
   background-color: hsl(215, 1%, 95%);
   box-shadow: 0px 1px 2px 1px #00000026;
-  min-height: var(--topbar-height);
+  min-height: var(--pf-topbar-height);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -75,10 +75,10 @@
       max-width: 100%;
       margin-top: 0;
       border-left: 1px solid #404854;
-      height: var(--topbar-height);
+      height: var(--pf-topbar-height);
       input {
         color: #9ddc67;
-        font-family: var(--monospace-font);
+        font-family: var(--pf-monospace-font);
         padding-left: 0;
       }
       &:before {
@@ -109,7 +109,7 @@
       border-radius: $pf-border-radius;
       input::placeholder {
         font-weight: 400;
-        font-family: var(--monospace-font);
+        font-family: var(--pf-monospace-font);
         color: hsl(213, 40%, 50%);
       }
       &:before {
@@ -213,7 +213,7 @@
   }
 }
 
-.error-box {
+.pf-error-box {
   position: absolute;
   right: 10px;
   display: flex;
@@ -230,25 +230,13 @@
   }
 }
 
-.error-popup {
+.pf-error-popup {
   width: 100px;
   font-size: 14px;
   font-family: "Roboto Condensed", sans-serif;
 }
 
-.hint-text {
-  padding-bottom: 5px;
-}
-
-.hint-dismiss-button {
-  color: #f4fafb;
-  background-color: #19212b;
-  width: fit-content;
-  padding: 3px;
-  border-radius: 3px;
-}
-
-.hide-sidebar {
+.pf-topbar.hide-sidebar {
   .query-mode {
     padding-left: 48px;
   }

--- a/ui/src/assets/trace_info_page.scss
+++ b/ui/src/assets/trace_info_page.scss
@@ -25,7 +25,7 @@
     border-radius: 8px;
 
     &.errors {
-      background-color: #f3e5f5;
+      background-color: var(--pf-traceinfo-errors-background);
     }
 
     .metric-error {
@@ -36,7 +36,7 @@
     }
 
     h2 {
-      font-family: "Roboto", sans-serif;
+      font-family: var(--pf-heading-font);
       font-weight: 400;
       letter-spacing: 0.25px;
       font-size: 2rem;
@@ -48,7 +48,7 @@
       font-weight: 400;
       margin-top: 1.25rem;
       margin-bottom: 1rem;
-      color: #333;
+      color: var(--pf-traceinfo-header-color);
     }
 
     h4 {
@@ -56,13 +56,13 @@
       font-weight: 400;
       line-height: 1.25rem;
       margin: 10px 0;
-      color: #333;
+      color: var(--pf-traceinfo-header-color);
     }
 
     .contextual-help {
       font-size: 18px;
       margin-left: 10px;
-      color: #43a047;
+      color: var(--pf-traceinfo-help-color);
       cursor: default;
     }
 
@@ -72,7 +72,7 @@
       thead td {
         margin-bottom: 5px;
         padding-bottom: 5px;
-        border-bottom: 1px solid #333;
+        border-bottom: 1px solid var(--pf-traceinfo-table-header-border);
         font-weight: 500;
       }
       tr td {
@@ -81,7 +81,7 @@
 
       tbody {
         tr:nth-child(2n + 1) td {
-          background-color: rgba(0, 0, 0, 0.04);
+          background-color: var(--pf-traceinfo-table-odd-background);
         }
 
         td.name {

--- a/ui/src/assets/trace_info_page.scss
+++ b/ui/src/assets/trace_info_page.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.trace-info-page {
+.pf-trace-info-page {
   overflow-y: auto;
   overflow-x: hidden;
   padding: 0 20px;
@@ -29,7 +29,7 @@
     }
 
     .metric-error {
-      font-family: var(--monospace-font);
+      font-family: var(--pf-monospace-font);
       font-size: 12px;
       padding: 5px;
       word-break: break-all;
@@ -89,7 +89,7 @@
         }
 
         td {
-          font-family: var(--monospace-font);
+          font-family: var(--pf-monospace-font);
           font-size: 12px;
           padding: 5px;
           word-break: break-all;

--- a/ui/src/assets/typefaces.scss
+++ b/ui/src/assets/typefaces.scss
@@ -112,11 +112,11 @@
     "opsz" 24;
 }
 
-.material-icons {
+.pf-material-icons {
   @include icon;
 }
 
-.material-icons-filled {
+.pf-material-icons-filled {
   @include icon;
   @include icon-filled;
 }

--- a/ui/src/assets/viewer_page.scss
+++ b/ui/src/assets/viewer_page.scss
@@ -56,7 +56,7 @@
 }
 
 .pf-timeline-toolbar {
-  width: var(--track-shell-width);
+  width: var(--pf-track-shell-width);
   border-right: solid 1px transparent;
   padding-inline: 2px;
 

--- a/ui/src/assets/viewer_page.scss
+++ b/ui/src/assets/viewer_page.scss
@@ -18,7 +18,7 @@
 
   &__overview {
     z-index: 3;
-    background: white;
+    background: var(--pf-viewer-background);
 
     .pf-overview-timeline {
       height: 70px;
@@ -28,9 +28,9 @@
   &__header {
     display: grid;
     grid-template-columns: 1fr auto;
-    box-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
+    box-shadow: var(--pf-viewer-header-shadow);
     z-index: 2;
-    background: white;
+    background: var(--pf-viewer-background);
 
     &:after {
       content: "";
@@ -45,7 +45,7 @@
     flex: 0 0 auto;
     max-height: 40%;
     z-index: 1;
-    box-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
+    box-shadow: var(--pf-viewer-header-shadow);
     scrollbar-gutter: stable;
   }
 

--- a/ui/src/assets/widgets/button.scss
+++ b/ui/src/assets/widgets/button.scss
@@ -55,8 +55,8 @@
     margin-left: 6px; // Make some room between the icon and label
   }
 
-  & > .material-icons,
-  & > .material-icons-filled {
+  & > .pf-material-icons,
+  & > .pf-material-icons-filled {
     font-size: inherit;
     line-height: inherit;
   }

--- a/ui/src/assets/widgets/button.scss
+++ b/ui/src/assets/widgets/button.scss
@@ -19,12 +19,12 @@
   background: $intent-color;
 
   &:hover {
-    background: lighten($intent-color, 5%);
+    background: color-mix(in oklab, $intent-color 95%, white);
   }
 
   &:active,
   &.pf-active {
-    background: darken($intent-color, 5%);
+    background: color-mix(in oklab, $intent-color 95%, black);
   }
 
   &[disabled] {
@@ -33,7 +33,7 @@
     }
 
     &.pf-active {
-      background: darken($intent-color, 5%);
+      background: color-mix(in oklab, $intent-color 95%, black);
     }
   }
 }
@@ -119,19 +119,19 @@
     }
 
     &.pf-intent-primary {
-      @include filled-color-scheme($color-primary, white);
+      @include filled-color-scheme($pf-color-primary, white);
     }
 
     &.pf-intent-success {
-      @include filled-color-scheme($color-success, white);
+      @include filled-color-scheme($pf-color-success, white);
     }
 
     &.pf-intent-danger {
-      @include filled-color-scheme($color-danger, white);
+      @include filled-color-scheme($pf-color-danger, white);
     }
 
     &.pf-intent-warning {
-      @include filled-color-scheme($color-warning, black);
+      @include filled-color-scheme($pf-color-warning, black);
     }
   }
 
@@ -155,15 +155,15 @@
     }
 
     &.pf-intent-success {
-      color: $color-success;
+      color: $pf-color-success;
     }
 
     &.pf-intent-danger {
-      color: $color-danger;
+      color: $pf-color-danger;
     }
 
     &.pf-intent-warning {
-      color: $color-warning;
+      color: $pf-color-warning;
     }
 
     &[disabled] {

--- a/ui/src/assets/widgets/chip.scss
+++ b/ui/src/assets/widgets/chip.scss
@@ -36,8 +36,8 @@
     margin-left: 6px; // Make some room between the icon and label
   }
 
-  & > .material-icons,
-  & > .material-icons-filled {
+  & > .pf-material-icons,
+  & > .pf-material-icons-filled {
     font-size: inherit;
     line-height: inherit;
   }

--- a/ui/src/assets/widgets/details_shell.scss
+++ b/ui/src/assets/widgets/details_shell.scss
@@ -26,10 +26,10 @@
     flex-direction: row;
     align-items: baseline;
     gap: 6px;
-    background-color: white;
-    color: black;
+    background-color: var(--pf-details-background);
+    color: var(--pf-details-color);
     padding: 8px 8px 5px 8px;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid var(--pf-details-border);
 
     .pf-header-title {
       font-size: 18px;

--- a/ui/src/assets/widgets/editor.scss
+++ b/ui/src/assets/widgets/editor.scss
@@ -21,7 +21,7 @@
     height: 100%;
 
     .cm-scroller {
-      font-family: var(--monospace-font);
+      font-family: var(--pf-monospace-font);
       font-size: 13px;
     }
   }

--- a/ui/src/assets/widgets/flamegraph.scss
+++ b/ui/src/assets/widgets/flamegraph.scss
@@ -63,12 +63,12 @@
 .pf-flamegraph-filter-bar-popup-content {
   white-space: pre-line;
   width: max-content;
-  font-family: "Roboto Condensed", sans-serif;
+  font-family: var(--pf-font);
 }
 
 .pf-flamegraph-tooltip-popup {
   width: max-content;
-  font-family: "Roboto Condensed", sans-serif;
+  font-family: var(--pf-font);
   font-size: 15px;
   display: flex;
   flex-direction: column;

--- a/ui/src/assets/widgets/hotkey.scss
+++ b/ui/src/assets/widgets/hotkey.scss
@@ -17,12 +17,12 @@
 .pf-keycap {
   user-select: none;
   line-height: 1;
-  background-color: #fafbfc;
-  border: 1px solid #d1d5da;
-  border-bottom-color: #c6cbd1;
+  background-color: var(--pf-keycap-background);
+  border: 1px solid var(--pf-keycap-border);
+  border-bottom-color: var(--pf-keycap-border-bottom);
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 #c6cbd1;
-  color: #444d56;
+  box-shadow: inset 0 -1px 0 var(--pf-keycap-border-bottom);
+  color: var(--pf-keycap-color);
   display: inline-block;
   font-family: $pf-font;
   vertical-align: baseline;

--- a/ui/src/assets/widgets/menu.scss
+++ b/ui/src/assets/widgets/menu.scss
@@ -48,7 +48,7 @@
       grid-area: label;
     }
 
-    & > .material-icons {
+    & > .pf-material-icons {
       font-size: inherit;
       line-height: inherit;
     }

--- a/ui/src/assets/widgets/popup.scss
+++ b/ui/src/assets/widgets/popup.scss
@@ -31,10 +31,13 @@
 }
 
 .pf-popup {
-  background: white;
+  --pf-popup-background: white;
+  --pf-popup-shadow: 2px 2px 16px rgba(0, 0, 0, 0.2);
+
+  background: var(--pf-popup-background);
   border: solid 1px $pf-colour-thin-border;
   border-radius: $pf-border-radius;
-  box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--pf-popup-shadow);
   max-width: 350px; // Sensible default width for most popups
 
   .pf-popup-content {

--- a/ui/src/assets/widgets/select.scss
+++ b/ui/src/assets/widgets/select.scss
@@ -35,7 +35,7 @@
   // ... any smaller and it stops looking like a select input!
   min-width: 80px;
 
-  & > .material-icons {
+  & > .pf-material-icons {
     font-size: inherit;
     line-height: inherit;
     float: left;

--- a/ui/src/assets/widgets/split_panel.scss
+++ b/ui/src/assets/widgets/split_panel.scss
@@ -28,8 +28,8 @@
   }
 
   &__handle {
-    background-color: hsl(215, 1%, 95%);
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    background-color: var(--pf-split-panel-handle-background);
+    border: 1px solid var(--pf-split-panel-handle-border);
     border-bottom: none;
     cursor: row-resize;
     // Disable user selection since this handle is draggable to resize the
@@ -49,6 +49,6 @@
   &__drawer {
     flex-shrink: 0;
     overflow: auto;
-    box-shadow: #0000003b 0px 0px 3px 1px;
+    box-shadow: var(--pf-split-panel-drawer-shadow);
   }
 }

--- a/ui/src/assets/widgets/tabbed_split_panel.scss
+++ b/ui/src/assets/widgets/tabbed_split_panel.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.pf-tab-handle {
+.pf-tab-handle {  
   display: flex;
   align-items: baseline;
 
@@ -23,31 +23,31 @@
   }
 
   &__tab {
-    font-family: "Roboto Condensed", sans-serif;
-    color: #3c4b5d;
+    font-family: var(--pf-font);
+    color: var(--pf-tab-color);
     padding: 4px;
     margin-top: 3px;
     align-items: center;
     cursor: pointer;
     font-size: 13px;
     border-radius: 3px 3px 0 0;
-    background-color: #0000000f;
-    border-right: solid 1px hsla(0, 0%, 75%, 1);
+    background-color: var(--pf-tab-background);
+    border-right: var(--pf-tab-border);
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
     z-index: 5;
-    box-shadow: #0000003b 0px 0px 3px 1px;
+    box-shadow: var(--pf-tab-shadow);
     display: flex;
     align-items: baseline;
     gap: 2px;
 
     &:hover {
-      background-color: hsla(0, 0%, 85%, 1);
+      background-color: var(--pf-tab-hover-background);
     }
 
     &[active] {
-      background-color: white;
+      background-color: var(--pf-tab-active-background);
       cursor: default;
     }
 

--- a/ui/src/assets/widgets/theme.scss
+++ b/ui/src/assets/widgets/theme.scss
@@ -14,9 +14,9 @@
 
 // Standard theme settings for widgets
 
-$pf-font: "Roboto Condensed", sans-serif;
-$pf-border-radius: 2px;
-$pf-anim-timing: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+$pf-font: var(--pf-font);
+$pf-border-radius: var(--pf-border-radius);
+$pf-anim-timing: var(--pf-anim-timing);
 
 // Here we describe two colour schemes: primary and minimal
 // It is assumed widgets exist on a light background
@@ -26,29 +26,29 @@ $pf-anim-timing: 150ms cubic-bezier(0.4, 0, 0.2, 1);
 // Other controls might use the primary scheme by default, but have a minimal
 // configuration which makes them use the minimal colour scheme.
 
-$pf-primary-foreground: #fff;
-$pf-primary-foreground-disabled: #aaa;
-$pf-primary-border: #31466f;
-$pf-primary-background: #3d5688;
-$pf-primary-background-hover: #4966a2;
-$pf-primary-background-active: #243e71;
-$pf-primary-background-disabled: #666;
+$pf-primary-foreground: var(--pf-primary-foreground);
+$pf-primary-foreground-disabled: var(--pf-primary-foreground-disabled);
+$pf-primary-border: var(--pf-primary-border);
+$pf-primary-background: var(--pf-primary-background);
+$pf-primary-background-hover: var(--pf-primary-background-hover);
+$pf-primary-background-active: var(--pf-primary-background-active);
+$pf-primary-background-disabled: var(--pf-primary-background-disabled);
 
-$pf-minimal-foreground: #19212b;
-$pf-minimal-foreground-disabled: #aaa;
-$pf-minimal-border: #aaa;
-$pf-minimal-background: none;
-$pf-minimal-background-hover: #0001;
-$pf-minimal-background-active: #0002;
-$pf-minimal-background-disabled: none;
+$pf-minimal-foreground: var(--pf-minimal-foreground);
+$pf-minimal-foreground-disabled: var(--pf-minimal-foreground-disabled);
+$pf-minimal-border: var(--pf-minimal-border);
+$pf-minimal-background: var(--pf-minimal-background);
+$pf-minimal-background-hover: var(--pf-minimal-background-hover);
+$pf-minimal-background-active: var(--pf-minimal-background-active);
+$pf-minimal-background-disabled: var(--pf-minimal-background-disabled);
 
-$color-primary: #3d5688;
-$color-danger: #912929;
-$color-success: #3c832b;
-$color-warning: #dca612;
+$pf-color-primary: var(--pf-color-primary);
+$pf-color-danger: var(--pf-color-danger);
+$pf-color-success: var(--pf-color-success);
+$pf-color-warning: var(--pf-color-warning);
 
-$pf-colour-thin-border: #aaa;
+$pf-colour-thin-border: var(--pf-colour-thin-border);
 
 @mixin focus {
-  outline: 2px auto #64b5f6;
+  outline: 2px auto var(--pf-focus-border);
 }

--- a/ui/src/assets/widgets/theme_variables.scss
+++ b/ui/src/assets/widgets/theme_variables.scss
@@ -1,0 +1,252 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Standard theme settings for widgets as overridable variables
+
+:root {
+  /* For the theme.scss Sass variables. */
+  --pf-font: "Roboto Condensed", sans-serif;
+  --pf-heading-font: "Roboto", sans-serif;
+  --pf-monospace-font: "Roboto Mono", monospace;
+  --pf-border-radius: 2px;
+  --pf-anim-timing: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+
+  --pf-primary-foreground: #fff;
+  --pf-primary-foreground-disabled: #aaa;
+  --pf-primary-border: #31466f;
+  --pf-primary-background: #3d5688;
+  --pf-primary-background-hover: #4966a2;
+  --pf-primary-background-active: #243e71;
+  --pf-primary-background-disabled: #666;
+
+  --pf-minimal-foreground: #19212b;
+  --pf-minimal-foreground-disabled: #aaa;
+  --pf-minimal-border: #aaa;
+  --pf-minimal-background: none;
+  --pf-minimal-background-hover: #0001;
+  --pf-minimal-background-active: #0002;
+  --pf-minimal-background-disabled: none;
+
+  --pf-color-primary: #3d5688;
+  --pf-color-danger: #912929;
+  --pf-color-success: #3c832b;
+  --pf-color-warning: #dca612;
+  --pf-colour-thin-border: #aaa;
+  --pf-focus-border: #64b5f6;
+
+  --pf-table-hover-color: hsl(214, 22%, 90%);
+  --pf-table-border-color: rgba(60, 76, 92, 0.4);
+
+  /* Common */
+  --pf-sidebar-width: 230px;
+  --pf-topbar-height: 44px;
+  --pf-track-shell-width: 250px;
+  --pf-track-border-color: #00000025;
+  --pf-anim-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  --pf-selection-stroke-color: #00344596;
+  --pf-selection-fill-color: #8398e64d;
+  --pf-overview-timeline-non-visible-color: #c8c8c8cc;
+  --pf-details-content-height: 308px;
+
+  --pf-main-color: #121212;
+  --pf-filedrag-border-color: #404854;
+  --pf-filedrag-color: #333;
+  --pf-filedrag-background: rgba(255, 255, 255, 0.5);
+  --pf-query-error-color: hsl(-10, 50%, 50%);
+  --pf-overview-header-background: hsl(213, 22%, 82%);
+  --pf-overview-header-color: hsl(213, 22%, 20%);
+  --pf-overview-header-border: hsl(213, 22%, 75%);
+  --pf-overview-header-code: hsl(213, 22%, 40%);
+  --pf-perf-stats-stroke: hsl(217, 39%, 94%);
+  --pf-perf-stats-background: rgba(27, 28, 29, 0.9);
+  --pf-perf-stats-button: hsl(45, 100%, 48%);
+  --pf-perf-stats-button-hover: hsl(6, 70%, 53%);
+  --pf-cookie-background: #19212b;
+  --pf-cookie-color: rgb(180, 183, 186);
+  --pf-cookie-button-color: #fff;
+  --pf-cookie-button-hover-background: #373f4b;
+  --pf-pivot-mode-button-background: #c7d0db;
+  --pf-has-left-border: rgba(60, 76, 92, 0.4);
+  --pf-history-border: hsl(213, 22%, 75%);
+  --pf-history-hover-background: hsl(213, 22%, 94%);
+  --pf-history-hover-color: rgba(0, 0, 0, 0.2);
+
+  /* Top Bar */
+  --pf-topbar-background: hsl(215, 1%, 95%);
+  --pf-topbar-shadow: 0px 1px 2px 1px #00000026;
+  --pf-topbar-error-color: #ef6c00;
+  --pf-stepthrough-color: #aaa;
+  --pf-stepthrough-left-border: rgb(218, 217, 217);
+  --pf-progress-background: hsl(219, 50%, 50%);
+  --pf-notification-background: hsl(210, 10%, 73%);
+  --pf-notification-background-hover: hsl(210, 10%, 83%);
+  --pf-notification-preferred-background: hsl(210, 98%, 53%);
+  --pf-notification-preferred-background-hover: hsl(210, 98%, 63%);
+  --pf-notification-preferred-color: #fff;
+
+  /* Omnibox */
+  --pf-omnibox-background: white;
+  --pf-omnibox-search-icon: #aaa;
+  --pf-omnibox-input-color: #666;
+  --pf-omnibox-input-placeholder: #b4b7ba;
+  --pf-omnibox-query-background: #111;
+  --pf-omnibox-query-border: #404854;
+  --pf-omnibox-query-input: #9ddc67;
+  --pf-omnibox-message-background: hsl(0, 0%, 89%);
+  --pf-omnibox-message-placeholder: hsl(213, 40%, 50%);
+  --pf-omnibox-focus-shadow: 1px 1px 8px rgba(0, 0, 0, 0.2);
+
+  /* Data Grids */
+  --pf-datagrid-border-color: rgb(225, 225, 225);
+  --pf-datagrid-hover-background: rgb(239, 241, 244);
+  --pf-datagrid-head-background: white;
+  --pf-datagrid-button-hint-color: gray;
+  --pf-datagrid-cell-null-color: gray;
+
+  /* Details Panel */
+  --pf-details-background: white;
+  --pf-details-color: black;
+  --pf-details-border: rgba(0, 0, 0, 0.2);
+  --pf-details-gray-icon: #e8e8e8;
+  --pf-details-gray-icon-hover-border: #475566;
+  --pf-details-header: white;
+  --pf-details-header-no-highlight: white;
+  --pf-details-flow-link: rgb(60, 86, 136);
+  --pf-details-warning-color: hsl(45, 100%, 48%);
+  --pf-details-tooltip-background: white;
+  --pf-details-tooltip-color: #3f4040;
+  --pf-details-tooltip-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
+
+  /* Notes Panel */
+  --pf-notes-panel-color: #3c4b5d;
+  --pf-notes-panel-input-border: #dcdcdc;
+  --pf-notes-panel-input-shadow: 1px 1px 1px rgba(23, 32, 44, 0.3);
+
+  /* Android Logs Panel */
+  --pf-android-log-d: hsl(122, 20%, 40%);
+  --pf-android-log-v: hsl(122, 20%, 30%);
+  --pf-android-log-i: hsl(0, 0%, 20%);
+  --pf-android-log-w: hsl(45, 60%, 45%);
+  --pf-android-log-e: hsl(4, 90%, 58%);
+  --pf-android-log-f: hsl(291, 64%, 42%);
+  --pf-android-log-highlighted: #d2efe0;
+
+  /* Keycaps (such as for Hotkeys) */
+  --pf-keycap-color: #444d56;
+  --pf-keycap-background: #fafbfc;
+  --pf-keycap-border: #d1d5da;
+  --pf-keycap-border-bottom: #c6cbd1;
+
+  /* Modal Dialogs */
+  --pf-model-backdrop-background: rgba(0, 0, 0, 0.6);
+  --pf-modal-background: #fff;
+  --pf-modal-title-color: #262f3c;
+  --pf-modal-text-color: rgba(0, 0, 0, 0.8);
+  --pf-modal-logs-background: #eee;
+  --pf-modal-logs-border: #999;
+
+  /* Help Dialog */
+  --pf-help-keycap-background: #fafbfc;
+  --pf-help-keycap-border: #d1d5da;
+  --pf-help-keycap-border-bottom: #c6cbd1;
+  --pf-help-keycap-shadow: inset 0 -1px 0 #c6cbd1;
+  --pf-help-keycap-color: #444d56;
+
+  /* Split Panels */
+  --pf-split-panel-handle-background: hsl(215, 1%, 95%);
+  --pf-split-panel-handle-border: rgba(0, 0, 0, 0.1);
+  --pf-split-panel-drawer-shadow: #0000003b 0px 0px 3px 1px;
+
+  /* Tabs */
+  --pf-tab-color: #3c4b5d;
+  --pf-tab-background: #0000000f;
+  --pf-tab-border: 1px solid hsla(0, 0%, 75%, 1);
+  --pf-tab-shadow: #0000003b 0px 0px 3px 1px;
+  --pf-tab-hover-background: hsla(0, 0%, 85%, 1);
+  --pf-tab-active-background: white;
+
+  /* Trees */
+  --pf-tree-spinner-color: lightgray;
+  --pf-tree-children-border: rgba(0, 0, 0, 0.2);
+
+  /* Tracks */
+  --pf-track-text-color-dark: hsl(213, 22%, 30%);
+  --pf-track-text-color-light: white;
+  --pf-track-highlight-background: #ffe263;
+  --pf-track-drag-highlight-color: rgb(29, 85, 189);
+  --pf-track-default-background: white;
+  --pf-track-collapsed-background: hsla(190, 49%, 97%, 1);
+  --pf-track-expanded-background: hsl(215, 22%, 19%);
+  --pf-track-indent-size: 8px;
+  --pf-track-indent-background: lightgray;
+  --pf-track-background-pattern-dark: #ddd;
+  --pf-track-background-pattern-light: #fff;
+  --pf-track-title-popup-shadow: 1px 1px 2px 2px var(--pf-track-border-color);
+  --pf-track-title-popup-background: #fff;
+  --pf-track-title-popup-color: hsl(213, 22%, 30%);
+  
+  /* Tool-tips */
+  --pf-tooltip-background: white;
+  --pf-tooltip-shadow: 2px 2px 16px rgba(0, 0, 0, 0.2);
+
+  /* Virtual Tables */
+  --pf-vtable-background: white;
+  --pf-vtable-background-header-shadow: 0px 0px 8px #0001;
+  --pf-vtable-background-pattern: #ddd;
+  --pf-vtable-background-row-odd: hsl(214, 22%, 95%);
+  --pf-vtable-background-row-even: white;
+
+  /* Viewer Page */
+  --pf-viewer-background: white;
+  --pf-viewer-header-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
+  
+  /* Trace Info Page */
+  --pf-traceinfo-errors-background: #f3e5f5;
+  --pf-traceinfo-header-color: #333;
+  --pf-traceinfo-help-color: #43a047;
+  --pf-traceinfo-table-header-border: #333;
+  --pf-traceinfo-table-odd-background: rgba(0, 0, 0, 0.04);
+
+  /* Sidebar */
+  --pf-sidebar-background: #262f3c;
+  --pf-sidebar-border-bottom: #404854;
+  --pf-sidebar-header-color: #fff;
+  --pf-sidebar-canary-color: #ffd700;
+  --pf-sidebar-autopush-color: #aed581;
+  --pf-sidebar-hide-sidebar-color: #aaaaaa;
+  --pf-sidebar-scrollbar-background: #19212b;
+  --pf-sidebar-scrollbar-thumb-background: #b4b7ba6e;
+  --pf-sidebar-section-header-h1-color: #fff;
+  --pf-sidebar-section-header-h2-color: rgba(255, 255, 255, 0.5);
+  --pf-sidebar-section-header-before-color: rgba(255, 255, 255, 0.3);
+  --pf-sidebar-section-hover-background: #373f4b;
+  --pf-sidebar-section-expanded-background: #19212b;
+  --pf-sidebar-section-content-color: #b4b7ba;
+  --pf-sidebar-section-content-a-color: #b4b7ba;
+  --pf-sidebar-pending-color: rgba(255, 255, 255, 0.3);
+  --pf-sidebar-pending-spinner-border: #b4b7ba;
+  --pf-sidebar-li-hover-background: #373f4b;
+  --pf-sidebar-trace-file-name-color: #fff;
+  --pf-sidebar-footer-button-color: hsl(217, 39%, 94%);
+  --pf-sidebar-footer-button-hover-color: hsl(45, 100%, 48%);
+  --pf-sidebar-footer-dbg-info-background: #12161b;
+  --pf-sidebar-footer-dbg-info-color: #4e71b3;
+  --pf-sidebar-footer-dbg-info-green-background: #7aca75;
+  --pf-sidebar-footer-dbg-info-green-color: #12161b;
+  --pf-sidebar-footer-dbg-info-amber-background: #ffc107;
+  --pf-sidebar-footer-dbg-info-amber-color: #333;
+  --pf-sidebar-footer-dbg-info-red-background: #d32f2f;
+  --pf-sidebar-footer-dbg-info-red-color: #fff;
+  --pf-sidebar-footer-version-link-color: rgba(255, 255, 255, 0.5);
+}

--- a/ui/src/assets/widgets/theme_variables.scss
+++ b/ui/src/assets/widgets/theme_variables.scss
@@ -132,6 +132,7 @@
   --pf-notes-panel-color: #3c4b5d;
   --pf-notes-panel-input-border: #dcdcdc;
   --pf-notes-panel-input-shadow: 1px 1px 1px rgba(23, 32, 44, 0.3);
+  --pf-notes-panel-note-text-background: rgba(255, 255, 255, 0.8);
 
   /* Android Logs Panel */
   --pf-android-log-d: hsl(122, 20%, 40%);
@@ -195,6 +196,12 @@
   --pf-track-title-popup-shadow: 1px 1px 2px 2px var(--pf-track-border-color);
   --pf-track-title-popup-background: #fff;
   --pf-track-title-popup-color: hsl(213, 22%, 30%);
+  --pf-track-loading-background: #eee;
+  --pf-track-loading-color: #666;
+  --pf-track-legend-background: rgba(255, 255, 255, 0.6);
+  --pf-track-legend-color: #666;
+  --pf-track-histogram-neutral-color: rgba(240, 240, 240, 1);
+  --pf-track-hatch-pattern-color: rgba(255, 255, 255, 0.3);
   
   /* Tool-tips */
   --pf-tooltip-background: white;
@@ -210,7 +217,9 @@
   /* Viewer Page */
   --pf-viewer-background: white;
   --pf-viewer-header-shadow: 1px 3px 15px rgba(23, 32, 44, 0.3);
-  
+  --pf-viewer-secondary-color: #666;
+  --pf-viewer-dividing-line-color: #999;
+
   /* Trace Info Page */
   --pf-traceinfo-errors-background: #f3e5f5;
   --pf-traceinfo-header-color: #333;

--- a/ui/src/assets/widgets/tooltip.scss
+++ b/ui/src/assets/widgets/tooltip.scss
@@ -16,13 +16,13 @@
 
 .pf-cursor-tooltip {
   position: absolute;
-  background: white;
+  background: var(--pf-tooltip-background);
 
   font-family: $pf-font;
   z-index: 10;
   padding: 2px 6px;
   border-radius: $pf-border-radius;
   border: solid 1px $pf-minimal-border;
-  box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: var(--pf-tooltip-shadow);
   pointer-events: none;
 }

--- a/ui/src/assets/widgets/track_shell.scss
+++ b/ui/src/assets/widgets/track_shell.scss
@@ -16,32 +16,25 @@
 @import "theme";
 
 .pf-track {
-  --text-color-dark: hsl(213, 22%, 30%);
-  --text-color-light: white;
-  --drag-highlight-color: rgb(29, 85, 189);
-  --default-background: white;
-  --collapsed-background: hsla(190, 49%, 97%, 1);
-  --expanded-background: hsl(215, 22%, 19%);
-  --indent-size: 8px;
-
   // Default values - should be overridden from JS
-  --sticky-top: 0;
-  --depth: 0;
+  --pf-track-sticky-top: 0;
+  --pf-track-depth: 0;
+  // --pf-track-height has no default and is set in JS
 
-  font-family: "Roboto Condensed", sans-serif;
+  font-family: var(--pf-font);
   font-weight: 300;
   font-size: 14px;
-  color: var(--text-color-dark);
-  background-color: var(--default-background);
+  color: var(--pf-track-text-color-dark);
+  background-color: var(--pf-track-default-background);
   user-select: none;
-  scroll-margin-top: calc(var(--sticky-top) * 1px);
+  scroll-margin-top: calc(var(--pf-track-sticky-top) * 1px);
 
   &__header {
-    height: calc(var(--height) * 1px);
+    height: calc(var(--pf-track-height) * 1px);
     display: grid;
     grid-template-columns:
-      calc(var(--depth) * var(--indent-size)) calc(
-        var(--pf-track-shell-width) - (var(--depth) * var(--indent-size))
+      calc(var(--pf-track-depth) * var(--pf-track-indent-size)) calc(
+        var(--pf-track-shell-width) - (var(--pf-track-depth) * var(--pf-track-indent-size))
       )
       1fr;
     grid-template-areas: "indent shell canvas";
@@ -49,19 +42,19 @@
     &::before {
       content: "";
       grid-area: indent;
-      background: lightgray;
+      background: var(--pf-track-indent-background);
     }
 
     &--summary {
-      background-color: var(--collapsed-background);
+      background-color: var(--pf-track-collapsed-background);
     }
 
     &--expanded--summary {
       position: sticky;
-      top: calc(var(--sticky-top) * 1px);
-      z-index: calc(16 - var(--depth));
-      background-color: var(--expanded-background);
-      color: var(--text-color-light);
+      top: calc(var(--pf-track-sticky-top) * 1px);
+      z-index: calc(16 - var(--pf-track-depth));
+      background-color: var(--pf-track-expanded-background);
+      color: var(--pf-track-text-color-light);
     }
   }
 
@@ -72,20 +65,20 @@
     border-color: var(--pf-track-border-color);
 
     &--highlight {
-      background-color: #ffe263;
-      color: var(--text-color-dark);
+      background-color: var(--pf-track-highlight-background);
+      color: var(--pf-track-text-color-dark);
     }
 
     &--drag-after {
-      box-shadow: inset 0 -6px 3px -3px var(--drag-highlight-color);
+      box-shadow: inset 0 -6px 3px -3px var(--pf-track-drag-highlight-color);
     }
 
     &--drag-inside {
-      box-shadow: inset -6px 0 3px -3px var(--drag-highlight-color);
+      box-shadow: inset -6px 0 3px -3px var(--pf-track-drag-highlight-color);
     }
 
     &--drag-before {
-      box-shadow: inset 0 6px 3px -3px var(--drag-highlight-color);
+      box-shadow: inset 0 6px 3px -3px var(--pf-track-drag-highlight-color);
     }
 
     &--clickable {
@@ -121,13 +114,13 @@
     &--error {
       // Necessary trig because we have 45deg stripes
       $pattern-density: 1px * math.sqrt(2);
-      $pattern-col: #ddd;
+      $pattern-col: var(--pf-track-background-pattern-dark);
 
       background: repeating-linear-gradient(-45deg,
-          $pattern-col,
-          $pattern-col $pattern-density,
-          white $pattern-density,
-          white $pattern-density * 4);
+          var(--pf-track-background-pattern-dark),
+          var(--pf-track-background-pattern-dark) $pattern-density,
+          var(--pf-track-background-pattern-light) $pattern-density,
+          var(--pf-track-background-pattern-light) $pattern-density * 4);
     }
   }
 
@@ -140,7 +133,7 @@
       "none subtitle subtitle subtitle";
     padding: 1px;
     position: sticky;
-    top: calc(var(--sticky-top) * 1px);
+    top: calc(var(--pf-track-sticky-top) * 1px);
   }
 
   &__title-spacer {
@@ -170,9 +163,9 @@
     }
 
     &:hover &-popup--visible {
-      box-shadow: 1px 1px 2px 2px var(--pf-track-border-color);
-      background: white;
-      color: hsl(213, 22%, 30%);
+      box-shadow: var(--pf-track-title-popup-shadow);
+      background: var(--pf-track-title-popup-background);
+      color: var(--pf-track-title-popup-color);
     }
   }
 

--- a/ui/src/assets/widgets/track_shell.scss
+++ b/ui/src/assets/widgets/track_shell.scss
@@ -41,7 +41,7 @@
     display: grid;
     grid-template-columns:
       calc(var(--depth) * var(--indent-size)) calc(
-        var(--track-shell-width) - (var(--depth) * var(--indent-size))
+        var(--pf-track-shell-width) - (var(--depth) * var(--indent-size))
       )
       1fr;
     grid-template-areas: "indent shell canvas";
@@ -69,7 +69,7 @@
     grid-area: shell;
     border-width: 0 1px 1px 0; // Borders on bottom and right
     border-style: solid;
-    border-color: var(--track-border-color);
+    border-color: var(--pf-track-border-color);
 
     &--highlight {
       background-color: #ffe263;
@@ -116,20 +116,18 @@
   &__canvas {
     grid-area: canvas;
     overflow: hidden; // Keeps subtitle width contained
-    border-bottom: solid 1px var(--track-border-color);
+    border-bottom: solid 1px var(--pf-track-border-color);
 
     &--error {
       // Necessary trig because we have 45deg stripes
       $pattern-density: 1px * math.sqrt(2);
       $pattern-col: #ddd;
 
-      background: repeating-linear-gradient(
-        -45deg,
-        $pattern-col,
-        $pattern-col $pattern-density,
-        white $pattern-density,
-        white $pattern-density * 4
-      );
+      background: repeating-linear-gradient(-45deg,
+          $pattern-col,
+          $pattern-col $pattern-density,
+          white $pattern-density,
+          white $pattern-density * 4);
     }
   }
 
@@ -167,11 +165,12 @@
       white-space: nowrap;
       user-select: none;
       width: max-content;
-      z-index: 10; /* Ensures it appears above other elements */
+      z-index: 10;
+      /* Ensures it appears above other elements */
     }
 
     &:hover &-popup--visible {
-      box-shadow: 1px 1px 2px 2px var(--track-border-color);
+      box-shadow: 1px 1px 2px 2px var(--pf-track-border-color);
       background: white;
       color: hsl(213, 22%, 30%);
     }

--- a/ui/src/assets/widgets/tree.scss
+++ b/ui/src/assets/widgets/tree.scss
@@ -1,6 +1,6 @@
 @import "theme";
 
-$chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='8' width='8'%3E%3Cline x1='2' y1='0' x2='6' y2='4' stroke='black'/%3E%3Cline x1='6' y1='4' x2='2' y2='8' stroke='black'/%3E%3C/svg%3E");
+$chevron-svg: var(--pf-chevron-svg);
 
 .pf-tree {
   font-family: $pf-font;
@@ -39,27 +39,29 @@ $chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' 
       width: 16px;
       justify-content: center;
       align-items: center;
+      @include icon;
     }
 
     &.pf-collapsed > .pf-tree-left > .pf-tree-gutter {
       cursor: pointer;
-
+      translate: -3px 0;
       &::after {
-        content: $chevron-svg;
+        content: "chevron_right";
       }
     }
     &.pf-expanded > .pf-tree-left > .pf-tree-gutter {
       cursor: pointer;
+      rotate: 90deg;
+      translate: 0 -5px;
       &::after {
-        content: $chevron-svg;
-        rotate: 90deg;
+        content: "chevron_right";
       }
     }
 
     &.pf-loading > .pf-tree-left > .pf-tree-gutter {
       &::after {
         content: "";
-        border: solid 1px lightgray;
+        border: solid 1px var(--pf-tree-spinner-lightgray);
         border-top: solid 1px $pf-primary-background;
         animation: pf-spinner-rotation 1s infinite linear;
         width: 8px;
@@ -82,7 +84,7 @@ $chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' 
     grid-column: 1 / span 2;
     grid-template-columns: subgrid;
     row-gap: 5px;
-    border-left: solid rgba(0, 0, 0, 0.2) 1px;
+    border-left: solid var(--pf-tree-children-border) 1px;
     margin-left: 6px;
     padding-left: 6px;
   }

--- a/ui/src/assets/widgets/treetable.scss
+++ b/ui/src/assets/widgets/treetable.scss
@@ -14,7 +14,6 @@
 
 @import "theme";
 
-$chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='8' width='8'%3E%3Cline x1='2' y1='0' x2='6' y2='4' stroke='black'/%3E%3Cline x1='6' y1='4' x2='2' y2='8' stroke='black'/%3E%3C/svg%3E");
 
 .pf-treetable {
   font-family: $pf-font;
@@ -45,19 +44,20 @@ $chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' 
   }
   td.pf-treetable-node {
     .pf-treetable-gutter {
+      @include icon;
+      rotate: 90deg;
+      translate: 0 -5px;
       &::before {
-        content: $chevron-svg;
+        content: "chevron_right";
         display: inline-block;
         cursor: pointer;
         width: 12px;
-        rotate: 90deg;
       }
     }
     &.pf-collapsed {
       .pf-treetable-gutter {
-        &::before {
-          rotate: 0deg;
-        }
+        rotate: 0deg;
+        translate: -3px 0;
       }
     }
   }

--- a/ui/src/assets/widgets/virtual_table.scss
+++ b/ui/src/assets/widgets/virtual_table.scss
@@ -21,7 +21,7 @@
     overflow: auto;
     font-family: $pf-font;
     position: relative;
-    background: white; // Performance tweak - see b/335451611
+    background: var(--pf-vtable-background); // Performance tweak - see b/335451611
 
     .pf-vtable-content {
       display: inline-flex;
@@ -33,12 +33,12 @@
         position: sticky;
         top: 0;
         z-index: 1;
-        background: white;
+        background: var(--pf-vtable-background);
         white-space: nowrap;
         padding-inline: 4px;
 
         // A shadow improves distinction between header and content
-        box-shadow: #0001 0px 0px 8px;
+        box-shadow: var(--pf-vtable-background-header-shadow);
       }
 
       .pf-vtable-data {
@@ -54,15 +54,15 @@
 
         // Necessary trig because we have a 45deg stripes
         $pattern-density: 1px * math.sqrt(2);
-        $pattern-col: #ddd;
+        $pattern-col: var(--pf-vtable-background-pattern);
         overflow: hidden;
 
         background: repeating-linear-gradient(
           -45deg,
-          $pattern-col,
-          $pattern-col $pattern-density,
-          white $pattern-density,
-          white $pattern-density * 2
+          var(--pf-vtable-background-pattern),
+          var(--pf-vtable-background-pattern) $pattern-density,
+          var(--pf-vtable-background) $pattern-density,
+          var(--pf-vtable-background) $pattern-density * 2
         );
 
         .pf-vtable-puck {
@@ -73,11 +73,11 @@
             padding-inline: 4px;
 
             &:nth-child(odd) {
-              background-color: hsl(214, 22%, 95%);
+              background-color: var(--pf-vtable-background-row-odd);
             }
 
             &:nth-child(even) {
-              background-color: white;
+              background-color: var(--pf-vtable-background-row-even);
             }
 
             &:hover {

--- a/ui/src/components/checkerboard.ts
+++ b/ui/src/components/checkerboard.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {FONT_NAME, TRACK_LOADING_BACKGROUND, TRACK_LOADING_FOREGROUND} from "../frontend/css_constants";
+
 const LOADING_TEXT = 'Loading...';
 let LOADING_TEXT_WIDTH = 0;
 
@@ -23,10 +25,10 @@ export function checkerboard(
   rightPx: number,
 ): void {
   const widthPx = rightPx - leftPx;
-  ctx.font = '12px Roboto Condensed';
-  ctx.fillStyle = '#eee';
+  ctx.font = `12px ${FONT_NAME}`;
+  ctx.fillStyle = TRACK_LOADING_BACKGROUND;
   ctx.fillRect(leftPx, 0, widthPx, heightPx);
-  ctx.fillStyle = '#666';
+  ctx.fillStyle = TRACK_LOADING_FOREGROUND;
   const oldBaseline = ctx.textBaseline;
   ctx.textBaseline = 'middle';
   if (LOADING_TEXT_WIDTH === 0) {

--- a/ui/src/components/query_table/query_table.ts
+++ b/ui/src/components/query_table/query_table.ts
@@ -190,7 +190,7 @@ export class QueryTable implements m.ClassComponent<QueryTableAttrs> {
 
   private renderContent(resp: QueryResponse, dataSource: DataGridDataSource) {
     if (resp.error) {
-      return m('.query-error', `SQL error: ${resp.error}`);
+      return m('.pf-query-error', `SQL error: ${resp.error}`);
     }
 
     const onViewerPage =

--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -30,6 +30,7 @@ import {LONG, NUM} from '../../trace_processor/query_result';
 import {checkerboardExcept} from '../checkerboard';
 import {AsyncDisposableStack} from '../../base/disposable_stack';
 import {Trace} from '../../public/trace';
+import {FONT_NAME, TRACK_LEGEND_BACKGROUND, TRACK_LEGEND_FOREGROUND} from '../../frontend/css_constants';
 
 function roundAway(n: number): number {
   const exp = Math.ceil(Math.log10(Math.max(Math.abs(n), 1)));
@@ -580,7 +581,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
       ctx.stroke();
       ctx.setLineDash([]);
     }
-    ctx.font = '10px Roboto Condensed';
+    ctx.font = `10px ${FONT_NAME}`;
 
     const hover = this.hover;
     if (hover !== undefined) {
@@ -624,9 +625,9 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     }
 
     // Write the Y scale on the top left corner.
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+    ctx.fillStyle = TRACK_LEGEND_BACKGROUND;
     ctx.fillRect(0, 0, 42, 13);
-    ctx.fillStyle = '#666';
+    ctx.fillStyle = TRACK_LEGEND_FOREGROUND;
     ctx.textAlign = 'left';
     ctx.textBaseline = 'alphabetic';
     ctx.fillText(`${yLabel}`, 5, 11);

--- a/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
+++ b/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
@@ -113,7 +113,7 @@ export class PivotTable implements m.ClassComponent<PivotTableAttrs> {
 
     return [
       m(CustomTable<PivotTreeNode>, {
-        className: 'pivot-table',
+        className: 'pf-pivot-table',
         data: nodes,
         columns: [
           {

--- a/ui/src/components/widgets/sql/table/table.ts
+++ b/ui/src/components/widgets/sql/table/table.ts
@@ -332,7 +332,7 @@ export class SqlTable implements m.ClassComponent<SqlTableConfig> {
         },
         this.state.isLoading() && m(Spinner),
         this.state.getQueryError() !== undefined &&
-          m('.query-error', this.state.getQueryError()),
+          m('.pf-query-error', this.state.getQueryError()),
       ),
     ];
   }

--- a/ui/src/core/cookie_consent.ts
+++ b/ui/src/core/cookie_consent.ts
@@ -33,7 +33,7 @@ export class CookieConsent implements m.ClassComponent {
   view() {
     if (!this.showCookieConsent) return;
     return m(
-      '.cookie-consent',
+      '.pf-cookie-consent',
       m(
         '.cookie-text',
         `This site uses cookies from Google to deliver its services and to

--- a/ui/src/core/perf_manager.ts
+++ b/ui/src/core/perf_manager.ts
@@ -49,7 +49,7 @@ export class PerfManager {
     // return here just a container and handle its rendering ourselves.
     const perfMgr = this;
     let removed = false;
-    return m('.perf-stats', {
+    return m('.pf-perf-stats', {
       oncreate(vnode: m.VnodeDOM) {
         const animationFrame = (dom: Element) => {
           if (removed) return;
@@ -74,7 +74,7 @@ interface PerfStatsUiAttrs {
 class PerfStatsUi implements m.ClassComponent<PerfStatsUiAttrs> {
   view({attrs}: m.Vnode<PerfStatsUiAttrs>) {
     return m(
-      '.perf-stats',
+      '.pf-perf-stats',
       {},
       m('section', this.renderRafSchedulerStats()),
       m(

--- a/ui/src/core/perf_manager.ts
+++ b/ui/src/core/perf_manager.ts
@@ -85,7 +85,7 @@ class PerfStatsUi implements m.ClassComponent<PerfStatsUiAttrs> {
             raf.scheduleFullRedraw();
           },
         },
-        m('i.material-icons', 'close'),
+        m('i.pf-material-icons', 'close'),
       ),
       attrs.perfMgr.containers.map((c, i) =>
         m('section', m('div', `Container #${i + 1}`), c.renderPerfStats()),

--- a/ui/src/core_plugins/flags_page/flags_page.ts
+++ b/ui/src/core_plugins/flags_page/flags_page.ts
@@ -106,7 +106,7 @@ export class FlagsPage implements m.ClassComponent<FlagsPageAttrs> {
   view() {
     const needsReload = channelChanged();
     return m(
-      '.flags-page',
+      '.pf-flags-page',
       m(
         '.flags-content',
         m('h1', 'Feature flags'),
@@ -151,7 +151,7 @@ export class FlagsPage implements m.ClassComponent<FlagsPageAttrs> {
           .map((flag) => m(FlagWidget, {flag})),
 
         m(
-          '.flags-page__footer',
+          '.pf-flags-page__footer',
           m(
             'span',
             'Are you looking for plugins? These have moved to the ',

--- a/ui/src/core_plugins/flow_events/flow_events_panel.ts
+++ b/ui/src/core_plugins/flow_events/flow_events_panel.ts
@@ -38,7 +38,7 @@ export class FlowEventsAreaSelectedPanel
         'Show',
         m(
           'a.warning',
-          m('i.material-icons', 'warning'),
+          m('i.pf-material-icons', 'warning'),
           m(
             '.tooltip',
             'Showing a large number of flows may impact performance.',
@@ -70,7 +70,7 @@ export class FlowEventsAreaSelectedPanel
         m(
           'td.sum-data',
           m(
-            'i.material-icons',
+            'i.pf-material-icons',
             {
               onclick: () => {
                 if (allWasChecked) {
@@ -101,7 +101,7 @@ export class FlowEventsAreaSelectedPanel
         m(
           'td.flow-info',
           m(
-            'i.material-icons',
+            'i.pf-material-icons',
             {
               onclick: () => {
                 if (wasChecked) {

--- a/ui/src/core_plugins/flow_events/flow_events_panel.ts
+++ b/ui/src/core_plugins/flow_events/flow_events_panel.ts
@@ -117,7 +117,7 @@ export class FlowEventsAreaSelectedPanel
       rows.push(m('tr', data));
     });
 
-    return m('.details-panel', [
+    return m('.pf-details-panel', [
       m('.details-panel-heading', m('h2', `Selected flow events`)),
       m('.flow-events-table', m('table', rows)),
     ]);

--- a/ui/src/frontend/css_constants.ts
+++ b/ui/src/frontend/css_constants.ts
@@ -45,9 +45,9 @@ export function initCssConstants() {
   BACKGROUND_COLOR = getCssStr('--main-background-color') ?? BACKGROUND_COLOR;
   FOREGROUND_COLOR = getCssStr('--main-foreground-color') ?? FOREGROUND_COLOR;
   COLLAPSED_BACKGROUND =
-    getCssStr('--collapsed-background') ?? COLLAPSED_BACKGROUND;
+    getCssStr('--pf-track-collapsed-background') ?? COLLAPSED_BACKGROUND;
   EXPANDED_BACKGROUND =
-    getCssStr('--expanded-background') ?? EXPANDED_BACKGROUND;
+    getCssStr('--pf-track-expanded-background') ?? EXPANDED_BACKGROUND;
 }
 
 function getCssStr(prop: string): string | undefined {

--- a/ui/src/frontend/css_constants.ts
+++ b/ui/src/frontend/css_constants.ts
@@ -29,19 +29,19 @@ export let COLLAPSED_BACKGROUND = '#ffffff';
 export let EXPANDED_BACKGROUND = '#ffffff';
 
 export function initCssConstants() {
-  TRACK_SHELL_WIDTH = getCssNum('--track-shell-width') ?? TRACK_SHELL_WIDTH;
-  SIDEBAR_WIDTH = getCssNum('--sidebar-width') ?? SIDEBAR_WIDTH;
-  TRACK_BORDER_COLOR = getCssStr('--track-border-color') ?? TRACK_BORDER_COLOR;
-  TOPBAR_HEIGHT = getCssNum('--topbar-height') ?? TOPBAR_HEIGHT;
+  TRACK_SHELL_WIDTH = getCssNum('--pf-track-shell-width') ?? TRACK_SHELL_WIDTH;
+  SIDEBAR_WIDTH = getCssNum('--pf-sidebar-width') ?? SIDEBAR_WIDTH;
+  TRACK_BORDER_COLOR = getCssStr('--pf-track-border-color') ?? TRACK_BORDER_COLOR;
+  TOPBAR_HEIGHT = getCssNum('--pf-topbar-height') ?? TOPBAR_HEIGHT;
   SELECTION_STROKE_COLOR =
-    getCssStr('--selection-stroke-color') ?? SELECTION_STROKE_COLOR;
+    getCssStr('--pf-selection-stroke-color') ?? SELECTION_STROKE_COLOR;
   SELECTION_FILL_COLOR =
-    getCssStr('--selection-fill-color') ?? SELECTION_FILL_COLOR;
+    getCssStr('--pf-selection-fill-color') ?? SELECTION_FILL_COLOR;
   OVERVIEW_TIMELINE_NON_VISIBLE_COLOR =
-    getCssStr('--overview-timeline-non-visible-color') ??
+    getCssStr('--pf-overview-timeline-non-visible-color') ??
     OVERVIEW_TIMELINE_NON_VISIBLE_COLOR;
   DEFAULT_DETAILS_CONTENT_HEIGHT =
-    getCssNum('--details-content-height') ?? DEFAULT_DETAILS_CONTENT_HEIGHT;
+    getCssNum('--pf-details-content-height') ?? DEFAULT_DETAILS_CONTENT_HEIGHT;
   BACKGROUND_COLOR = getCssStr('--main-background-color') ?? BACKGROUND_COLOR;
   FOREGROUND_COLOR = getCssStr('--main-foreground-color') ?? FOREGROUND_COLOR;
   COLLAPSED_BACKGROUND =

--- a/ui/src/frontend/css_constants.ts
+++ b/ui/src/frontend/css_constants.ts
@@ -24,9 +24,19 @@ export let SELECTION_FILL_COLOR = '#8398e64d';
 export let OVERVIEW_TIMELINE_NON_VISIBLE_COLOR = '#c8c8c8cc';
 export let DEFAULT_DETAILS_CONTENT_HEIGHT = 308;
 export let BACKGROUND_COLOR = '#ffffff';
-export let FOREGROUND_COLOR = '#222';
-export let COLLAPSED_BACKGROUND = '#ffffff';
-export let EXPANDED_BACKGROUND = '#ffffff';
+export let FOREGROUND_COLOR = '#121212';
+export let DIVIDER_COLOR = '#999';
+export let TRACK_COLLAPSED_BACKGROUND = '#ffffff';
+export let TRACK_EXPANDED_BACKGROUND = '#ffffff';
+export let FONT_NAME = 'Roboto Condensed';
+export let TRACK_LOADING_BACKGROUND = '#eee';
+export let TRACK_LOADING_FOREGROUND = '#666';
+export let TRACK_LEGEND_BACKGROUND = 'rgba(255, 255, 255, 0.6)';
+export let TRACK_LEGEND_FOREGROUND = '#666';
+export let TRACK_HISTOGRAM_NEUTRAL_FILL_COLOR = 'rgba(240, 240, 240, 1)';
+export let TRACK_HATCH_PATTERN_COLOR = 'rgba(255, 255, 255, 0.3)';
+export let NOTES_PANEL_TEXT_COLOR = '#3c4b5d';
+export let NOTES_PANEL_NOTE_TEXT_BACKGROUND = 'rgba(255, 255, 255, 0.8)';
 
 export function initCssConstants() {
   TRACK_SHELL_WIDTH = getCssNum('--pf-track-shell-width') ?? TRACK_SHELL_WIDTH;
@@ -42,12 +52,22 @@ export function initCssConstants() {
     OVERVIEW_TIMELINE_NON_VISIBLE_COLOR;
   DEFAULT_DETAILS_CONTENT_HEIGHT =
     getCssNum('--pf-details-content-height') ?? DEFAULT_DETAILS_CONTENT_HEIGHT;
-  BACKGROUND_COLOR = getCssStr('--main-background-color') ?? BACKGROUND_COLOR;
-  FOREGROUND_COLOR = getCssStr('--main-foreground-color') ?? FOREGROUND_COLOR;
-  COLLAPSED_BACKGROUND =
-    getCssStr('--pf-track-collapsed-background') ?? COLLAPSED_BACKGROUND;
-  EXPANDED_BACKGROUND =
-    getCssStr('--pf-track-expanded-background') ?? EXPANDED_BACKGROUND;
+  BACKGROUND_COLOR = getCssStr('--pf-viewer-background') ?? BACKGROUND_COLOR;
+  FOREGROUND_COLOR = getCssStr('--pf-main-color') ?? FOREGROUND_COLOR;
+  DIVIDER_COLOR = getCssStr('--pf-viewer-dividing-line-color') ?? DIVIDER_COLOR;
+  TRACK_COLLAPSED_BACKGROUND =
+    getCssStr('--pf-track-collapsed-background') ?? TRACK_COLLAPSED_BACKGROUND;
+  TRACK_EXPANDED_BACKGROUND =
+    getCssStr('--pf-track-expanded-background') ?? TRACK_EXPANDED_BACKGROUND;
+  FONT_NAME = getCssStr('--pf-font') ?? FONT_NAME;
+  TRACK_LOADING_BACKGROUND = getCssStr('--pf-track-loading-background') ?? TRACK_LOADING_BACKGROUND;
+  TRACK_LOADING_FOREGROUND = getCssStr('--pf-track-loading-color') ?? TRACK_LOADING_FOREGROUND;
+  TRACK_LEGEND_BACKGROUND = getCssStr('--pf-track-legend-background') ?? TRACK_LEGEND_BACKGROUND;
+  TRACK_LEGEND_FOREGROUND = getCssStr('--pf-track-legend-color') ?? TRACK_LEGEND_FOREGROUND;
+  TRACK_HISTOGRAM_NEUTRAL_FILL_COLOR = getCssStr('--pf-track-histogram-neutral-color') ?? TRACK_HISTOGRAM_NEUTRAL_FILL_COLOR;
+  TRACK_HATCH_PATTERN_COLOR = getCssStr('--pf-track-hatch-pattern-color') ?? TRACK_HATCH_PATTERN_COLOR;
+  NOTES_PANEL_TEXT_COLOR = getCssStr('--pf-notes-panel-color') ?? NOTES_PANEL_TEXT_COLOR;
+  NOTES_PANEL_NOTE_TEXT_BACKGROUND = getCssStr('--pf-notes-panel-note-text-background') ?? NOTES_PANEL_NOTE_TEXT_BACKGROUND;
 }
 
 function getCssStr(prop: string): string | undefined {

--- a/ui/src/frontend/file_drop_handler.ts
+++ b/ui/src/frontend/file_drop_handler.ts
@@ -22,7 +22,7 @@ export function installFileDropHandler() {
     evt.stopPropagation();
     lastDragTarget = evt.target;
     if (dragEventHasFiles(evt)) {
-      document.body.classList.add('filedrag');
+      document.body.classList.add('pf-filedrag');
     }
   };
 
@@ -30,14 +30,14 @@ export function installFileDropHandler() {
     evt.preventDefault();
     evt.stopPropagation();
     if (evt.target === lastDragTarget) {
-      document.body.classList.remove('filedrag');
+      document.body.classList.remove('pf-filedrag');
     }
   };
 
   window.ondrop = (evt: DragEvent) => {
     evt.preventDefault();
     evt.stopPropagation();
-    document.body.classList.remove('filedrag');
+    document.body.classList.remove('pf-filedrag');
     if (evt.dataTransfer && dragEventHasFiles(evt)) {
       const file = evt.dataTransfer.files[0];
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -80,7 +80,7 @@ class KeyMappingsHelp implements m.ClassComponent {
 
   view(): m.Children {
     return m(
-      '.help',
+      '.pf-help',
       m('h2', 'Navigation'),
       m(
         'table',

--- a/ui/src/frontend/home_page.ts
+++ b/ui/src/frontend/home_page.ts
@@ -68,7 +68,7 @@ export class Hints implements m.ClassComponent {
 export class HomePage implements m.ClassComponent {
   view() {
     return m(
-      '.page.home-page',
+      '.pf-page.pf-home-page',
       m(
         '.home-page-center',
         m(

--- a/ui/src/frontend/note_editor.ts
+++ b/ui/src/frontend/note_editor.ts
@@ -48,7 +48,7 @@ export class NoteEditor implements m.ClassComponent<NodeDetailsPanelAttrs> {
     }
     const startTime = getStartTimestamp(note);
     return m(
-      '.notes-editor-panel',
+      '.pf-notes-editor-panel',
       {
         key: id, // Every note shoul get its own brand new DOM.
       },

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -375,7 +375,7 @@ export class Sidebar implements m.ClassComponent<OptionalTraceImplAttrs> {
             onclick: () => sidebar.toggleVisibility(),
           },
           m(
-            'i.material-icons',
+            'i.pf-material-icons',
             {
               title: sidebar.visible ? 'Hide menu' : 'Show menu',
             },
@@ -484,7 +484,7 @@ export class Sidebar implements m.ClassComponent<OptionalTraceImplAttrs> {
           disabled,
           title: tooltip,
         },
-        exists(item.icon) && m('i.material-icons', valueOrCallback(item.icon)),
+        exists(item.icon) && m('i.pf-material-icons', valueOrCallback(item.icon)),
         text,
       ),
     );

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -325,7 +325,7 @@ class SidebarFooter implements m.ClassComponent<OptionalTraceImplAttrs> {
 class HiringBanner implements m.ClassComponent {
   view() {
     return m(
-      '.hiring-banner',
+      '.pf-hiring-banner',
       m(
         'a',
         {
@@ -351,10 +351,10 @@ export class Sidebar implements m.ClassComponent<OptionalTraceImplAttrs> {
     const sidebar = AppImpl.instance.sidebar;
     if (!sidebar.enabled) return null;
     return m(
-      'nav.sidebar',
+      'nav.pf-sidebar',
       {
         class: sidebar.visible ? 'show-sidebar' : 'hide-sidebar',
-        // 150 here matches --sidebar-timing in the css.
+        // 150 here matches --pf-sidebar-timing in the css.
         // TODO(hjd): Should link to the CSS variable.
         ontransitionstart: (e: TransitionEvent) => {
           if (e.target !== e.currentTarget) return;

--- a/ui/src/frontend/topbar.ts
+++ b/ui/src/frontend/topbar.ts
@@ -49,7 +49,7 @@ class TraceErrorIcon implements m.ClassComponent<TraceImplAttrs> {
       ? `${totErrors} import or data loss errors detected.`
       : `Metric error detected.`;
     return m(
-      '.error-box',
+      '.pf-error-box',
       m(
         Popup,
         {
@@ -61,7 +61,7 @@ class TraceErrorIcon implements m.ClassComponent<TraceImplAttrs> {
             this.tracePopupErrorDismissed = true;
           },
         },
-        m('.error-popup', 'Data-loss/import error. Click for more info.'),
+        m('.pf-error-popup', 'Data-loss/import error. Click for more info.'),
       ),
       m(
         'a.error',
@@ -87,7 +87,7 @@ export class Topbar implements m.ClassComponent<TopbarAttrs> {
   view({attrs}: m.Vnode<TopbarAttrs>) {
     const {omnibox} = attrs;
     return m(
-      '.topbar',
+      '.pf-topbar',
       {
         class: AppImpl.instance.sidebar.visible ? '' : 'hide-sidebar',
       },

--- a/ui/src/frontend/topbar.ts
+++ b/ui/src/frontend/topbar.ts
@@ -67,7 +67,7 @@ class TraceErrorIcon implements m.ClassComponent<TraceImplAttrs> {
         'a.error',
         {href: '#!/info'},
         m(
-          'i.material-icons',
+          'i.pf-material-icons',
           {
             title: message + ` Click for more info.`,
           },

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -754,7 +754,7 @@ export class UiMainPerTrace implements m.ClassComponent {
       HotkeyContext,
       {hotkeys},
       m(
-        'main',
+        'main.perfetto',
         m(Sidebar, {trace: this.trace}),
         m(Topbar, {
           omnibox: this.renderOmnibox(),

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -719,14 +719,14 @@ export class UiMainPerTrace implements m.ClassComponent {
           {
             onclick: () => searchMgr.stepBackwards(),
           },
-          m('i.material-icons.left', 'keyboard_arrow_left'),
+          m('i.pf-material-icons.left', 'keyboard_arrow_left'),
         ),
         m(
           'button',
           {
             onclick: () => searchMgr.stepForward(),
           },
-          m('i.material-icons.right', 'keyboard_arrow_right'),
+          m('i.pf-material-icons.right', 'keyboard_arrow_right'),
         ),
       );
     }

--- a/ui/src/frontend/value.ts
+++ b/ui/src/frontend/value.ts
@@ -166,7 +166,7 @@ function renderValue(name: string, value: Value): m.Children {
         return null;
       }
       return m(
-        'i.material-icons.grey',
+        'i.pf-material-icons.grey',
         {
           onclick: button.action,
           title: button.hoverText,

--- a/ui/src/frontend/viewer_page/notes_panel.ts
+++ b/ui/src/frontend/viewer_page/notes_panel.ts
@@ -26,7 +26,7 @@ import {Note, SpanNote} from '../../public/note';
 import {Button, ButtonBar} from '../../widgets/button';
 import {MenuDivider, MenuItem, PopupMenu} from '../../widgets/menu';
 import {Select} from '../../widgets/select';
-import {TRACK_SHELL_WIDTH} from '../css_constants';
+import {DIVIDER_COLOR, NOTES_PANEL_NOTE_TEXT_BACKGROUND, NOTES_PANEL_TEXT_COLOR, TRACK_SHELL_WIDTH} from '../css_constants';
 import {generateTicks, getMaxMajorTicks, TickType} from './gridline_helper';
 import {TextInput} from '../../widgets/text_input';
 import {Popup} from '../../widgets/popup';
@@ -418,7 +418,7 @@ export class NotesPanel {
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D, size: Size2D) {
-    ctx.fillStyle = '#999';
+    ctx.fillStyle = DIVIDER_COLOR;
     ctx.fillRect(TRACK_SHELL_WIDTH - 1, 0, 1, size.height);
 
     const trackSize = {...size, width: size.width - TRACK_SHELL_WIDTH};
@@ -495,14 +495,14 @@ export class NotesPanel {
         const summary = toSummary(note.text);
         const measured = ctx.measureText(summary);
         // Add a white semi-transparent background for the text.
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.8)';
+        ctx.fillStyle = NOTES_PANEL_NOTE_TEXT_BACKGROUND;
         ctx.fillRect(
           left + FLAG_WIDTH + 2,
           size.height + 2,
           measured.width + 2,
           -12,
         );
-        ctx.fillStyle = '#3c4b5d';
+        ctx.fillStyle = NOTES_PANEL_TEXT_COLOR;
         ctx.fillText(summary, left + FLAG_WIDTH + 3, size.height + 1);
       }
     }

--- a/ui/src/frontend/viewer_page/tickmark_panel.ts
+++ b/ui/src/frontend/viewer_page/tickmark_panel.ts
@@ -18,7 +18,7 @@ import {Size2D} from '../../base/geom';
 import {TimeScale} from '../../base/time_scale';
 import {getOrCreate} from '../../base/utils';
 import {TraceImpl} from '../../core/trace_impl';
-import {TRACK_SHELL_WIDTH} from '../css_constants';
+import {DIVIDER_COLOR, TRACK_SHELL_WIDTH} from '../css_constants';
 import {generateTicks, getMaxMajorTicks, TickType} from './gridline_helper';
 import {SearchOverviewTrack} from './search_overview_track';
 
@@ -46,7 +46,7 @@ export class TickmarkPanel {
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D, size: Size2D): void {
-    ctx.fillStyle = '#999';
+    ctx.fillStyle = DIVIDER_COLOR;
     ctx.fillRect(TRACK_SHELL_WIDTH - 1, 0, 1, size.height);
 
     const trackSize = {...size, width: size.width - TRACK_SHELL_WIDTH};

--- a/ui/src/frontend/viewer_page/time_axis_panel.ts
+++ b/ui/src/frontend/viewer_page/time_axis_panel.ts
@@ -20,7 +20,7 @@ import {Time, time, formatDate} from '../../base/time';
 import {TimeScale} from '../../base/time_scale';
 import {TimestampFormat} from '../../public/timeline';
 import {Trace} from '../../public/trace';
-import {TRACK_SHELL_WIDTH} from '../css_constants';
+import {DIVIDER_COLOR, FONT_NAME, TRACK_SHELL_WIDTH} from '../css_constants';
 import {
   generateTicks,
   getMaxMajorTicks,
@@ -39,9 +39,9 @@ export class TimeAxisPanel {
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D, size: Size2D) {
-    ctx.fillStyle = '#999';
+    ctx.fillStyle = DIVIDER_COLOR;
     ctx.textAlign = 'left';
-    ctx.font = '11px Roboto Condensed';
+    ctx.font = `11px ${FONT_NAME}`;
 
     this.renderOffsetTimestamp(ctx);
 
@@ -205,7 +205,7 @@ function renderRawTimestamp(
   y: number,
   minWidth: number,
 ) {
-  ctx.font = '11px Roboto Condensed';
+  ctx.font = `11px ${FONT_NAME}`;
   ctx.fillText(time, x, y, minWidth);
   return ctx.measureText(time).width;
 }
@@ -222,7 +222,7 @@ function renderTimecode(
   minWidth: number,
 ): number {
   const timecode = Time.toTimecode(time);
-  ctx.font = '11px Roboto Condensed';
+  ctx.font = `11px ${FONT_NAME}`;
 
   const {dhhmmss} = timecode;
   const thinSpace = '\u2009';
@@ -230,7 +230,7 @@ function renderTimecode(
   ctx.fillText(dhhmmss, x, y, minWidth);
   const {width: firstRowWidth} = ctx.measureText(subsec);
 
-  ctx.font = '10.5px Roboto Condensed';
+  ctx.font = `10.5px ${FONT_NAME}`;
   ctx.fillText(subsec, x, y + 10, minWidth);
   const {width: secondRowWidth} = ctx.measureText(subsec);
 

--- a/ui/src/frontend/viewer_page/time_selection_panel.ts
+++ b/ui/src/frontend/viewer_page/time_selection_panel.ts
@@ -23,6 +23,8 @@ import {TraceImpl} from '../../core/trace_impl';
 import {TimestampFormat} from '../../public/timeline';
 import {
   BACKGROUND_COLOR,
+  DIVIDER_COLOR,
+  FONT_NAME,
   FOREGROUND_COLOR,
   TRACK_SHELL_WIDTH,
 } from '../css_constants';
@@ -94,7 +96,7 @@ function drawHBar(
 
   ctx.textBaseline = 'middle';
   ctx.fillStyle = FOREGROUND_COLOR;
-  ctx.font = '10px Roboto Condensed';
+  ctx.font = `10px ${FONT_NAME}`;
   ctx.fillText(label, labelXLeft, yMid);
 }
 
@@ -127,7 +129,7 @@ function drawIBar(
 
   ctx.textBaseline = 'middle';
   ctx.fillStyle = FOREGROUND_COLOR;
-  ctx.font = '10px Roboto Condensed';
+  ctx.font = `10px ${FONT_NAME}`;
   ctx.fillText(label, xPosLabel, yMid);
 }
 
@@ -141,7 +143,7 @@ export class TimeSelectionPanel {
   }
 
   renderCanvas(ctx: CanvasRenderingContext2D, size: Size2D) {
-    ctx.fillStyle = '#999';
+    ctx.fillStyle = DIVIDER_COLOR;
     ctx.fillRect(TRACK_SHELL_WIDTH - 1, 0, 1, size.height);
 
     const trackSize = {...size, width: size.width - TRACK_SHELL_WIDTH};

--- a/ui/src/frontend/viewer_page/viewer_page.ts
+++ b/ui/src/frontend/viewer_page/viewer_page.ts
@@ -56,7 +56,7 @@ class ViewerPage implements m.ClassComponent<ViewerPageAttrs> {
   view({attrs}: m.CVnode<ViewerPageAttrs>) {
     const {trace} = attrs;
     return m(
-      '.pf-viewer-page.page',
+      '.pf-viewer-page.pf-page',
       m(
         TabPanel,
         {trace},

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -32,6 +32,12 @@ import {
 } from '../../trace_processor/sql_utils';
 import {AsyncDisposableStack} from '../../base/disposable_stack';
 import {Trace} from '../../public/trace';
+import {
+  FONT_NAME,
+  TRACK_HISTOGRAM_NEUTRAL_FILL_COLOR,
+  TRACK_LEGEND_BACKGROUND,
+  TRACK_LEGEND_FOREGROUND,
+} from '../../frontend/css_constants';
 
 export interface Data extends TrackData {
   timestamps: BigInt64Array;
@@ -341,7 +347,7 @@ export class CpuFreqTrack implements TrackRenderer {
     }
 
     // Draw CPU idle rectangles that overlay the CPU freq graph.
-    ctx.fillStyle = `rgba(240, 240, 240, 1)`;
+    ctx.fillStyle = TRACK_HISTOGRAM_NEUTRAL_FILL_COLOR;
     {
       for (let i = startIdx; i < endIdx; i++) {
         if (data.lastIdleValues[i] < 0) {
@@ -366,7 +372,7 @@ export class CpuFreqTrack implements TrackRenderer {
       }
     }
 
-    ctx.font = '10px Roboto Condensed';
+    ctx.font = `10px ${FONT_NAME}`;
 
     if (this.hoveredValue !== undefined && this.hoveredTs !== undefined) {
       ctx.fillStyle = color.setHSL({s: 45, l: 75}).cssString;
@@ -402,9 +408,9 @@ export class CpuFreqTrack implements TrackRenderer {
 
     // Write the Y scale on the top left corner.
     ctx.textBaseline = 'alphabetic';
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+    ctx.fillStyle = TRACK_LEGEND_BACKGROUND;
     ctx.fillRect(0, 0, 42, 18);
-    ctx.fillStyle = '#666';
+    ctx.fillStyle = TRACK_LEGEND_FOREGROUND;
     ctx.textAlign = 'left';
     ctx.fillText(`${yLabel}`, 4, 14);
 

--- a/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_details_panel.ts
@@ -91,7 +91,7 @@ export class CpuProfileSampleFlamegraphDetailsPanel
 
   render() {
     return m(
-      '.flamegraph-profile',
+      '.pf-flamegraph-profile',
       m(
         DetailsShell,
         {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -111,9 +111,9 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     }
 
     return m(
-      '.page.explore-page',
+      '.pf-page.pf-explore-page',
       m(
-        '.explore-page__header',
+        '.pf-explore-page__header',
         m('h1', `${ExplorePageModeToLabel[state.mode]}`),
         m('span', {style: {flexGrow: 1}}),
         state.mode === ExplorePageModes.QUERY_BUILDER

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/operation_component.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/operation_component.ts
@@ -32,7 +32,7 @@ export interface OperatorAttrs {
 export class Operator implements m.ClassComponent<OperatorAttrs> {
   view({attrs}: m.CVnode<OperatorAttrs>): m.Children {
     return m(
-      '.explore-page__rowish',
+      '.pf-explore-page__rowish',
       m(Section, {title: 'Filters'}, m(FilterOperation, attrs.filter)),
       m(Section, {title: 'Aggregation'}, m(GroupByOperation, attrs.groupby)),
     );

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/query_node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/query_node_explorer.ts
@@ -161,7 +161,7 @@ export class QueryNodeExplorer
           attrs.node.coreModify(),
           this.selectedView === SelectedView.kSql &&
             m(
-              '.code-snippet',
+              '.pf-code-snippet',
               m(Button, {
                 title: 'Copy to clipboard',
                 onclick: () => copyToClipboard(sql),
@@ -172,7 +172,7 @@ export class QueryNodeExplorer
           this.selectedView === SelectedView.kModify && operators(),
           this.selectedView === SelectedView.kProto &&
             m(
-              '.code-snippet',
+              '.pf-code-snippet',
               m(Button, {
                 title: 'Copy to clipboard',
                 onclick: () => copyToClipboard(textproto),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.explore-page {
+.pf-explore-page {
   position: relative;
   overflow: auto;
   padding: 0.25rem;

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -103,7 +103,7 @@ export class HeapProfileFlamegraphDetailsPanel
   render() {
     const {type, ts} = this.props;
     return m(
-      '.flamegraph-profile',
+      '.pf-flamegraph-profile',
       this.maybeShowModal(this.trace, type, this.heapGraphIncomplete),
       m(
         DetailsShell,

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
@@ -207,7 +207,7 @@ export function createThreadInstrumentsSamplesProfileTrack(
 
 function renderDetailsPanel(flamegraph: QueryFlamegraph, ts: time) {
   return m(
-    '.flamegraph-profile',
+    '.pf-flamegraph-profile',
     m(
       DetailsShell,
       {

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
@@ -207,7 +207,7 @@ export function createThreadPerfSamplesProfileTrack(
 
 function renderDetailsPanel(flamegraph: QueryFlamegraph, ts: time) {
   return m(
-    '.flamegraph-profile',
+    '.pf-flamegraph-profile',
     m(
       DetailsShell,
       {

--- a/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
@@ -347,7 +347,7 @@ export class MetricsPage implements m.ClassComponent<MetricsPageAttrs> {
     const v1Controller = assertExists(this.v1Controller);
     const json = v1Controller.resultAsJson;
     return m(
-      '.metrics-page',
+      '.pf-metrics-page',
       m(
         '',
         m(SegmentedButtons, {

--- a/ui/src/plugins/dev.perfetto.QueryLog/styles.scss
+++ b/ui/src/plugins/dev.perfetto.QueryLog/styles.scss
@@ -15,7 +15,11 @@
 .pf-query-log-table {
   tr:nth-child(even) {
     border-collapse: collapse;
-    background-color: #f0f0f0;
+    background-color: var(--pf-vtable-background-row-even);
+  }
+
+  tr:nth-child(odd) {
+    background-color: var(--pf-vtable-background-row-odd);
   }
 
   td:first-child {

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_history.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_history.ts
@@ -43,7 +43,7 @@ export class QueryHistoryComponent
     return m(
       '.query-history',
       m(
-        'header.overview',
+        'header.pf-overview',
         `Query history (${queryHistoryStorage.data.length} queries)`,
       ),
       starred.map((attrs) => m(HistoryItemComponent, attrs)),
@@ -66,9 +66,9 @@ export class HistoryItemComponent
   view(vnode: m.Vnode<HistoryItemComponentAttrs>): m.Child {
     const query = vnode.attrs.entry.query;
     return m(
-      '.history-item',
+      '.pf-history-item',
       m(
-        '.history-item-buttons',
+        '.pf-history-item-buttons',
         m(
           'button',
           {

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -112,7 +112,7 @@ export interface QueryPageAttrs {
 export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
   view({attrs}: m.CVnode<QueryPageAttrs>) {
     return m(
-      '.query-page',
+      '.pf-query-page',
       m(Callout, 'Enter query and press Cmd/Ctrl + Enter'),
       state.enteredText.includes('"') &&
         m(

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/instructions_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/instructions_page.ts
@@ -93,7 +93,7 @@ class InstructionsPage implements m.ClassComponent<RecMgrAttrs> {
             title: 'Copy to clipboard',
             onclick: () => copyToClipboard(this.configTxt),
           },
-          m('i.material-icons', 'assignment'),
+          m('i.pf-material-icons', 'assignment'),
         ),
         m('code', this.configTxt),
       ),

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/instructions_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/instructions_page.ts
@@ -83,10 +83,10 @@ class InstructionsPage implements m.ClassComponent<RecMgrAttrs> {
             this.docsLink.replace('https://', ''),
           ),
         ),
-      this.cmdline && m('.code-snippet', m('code', this.cmdline)),
+      this.cmdline && m('.pf-code-snippet', m('code', this.cmdline)),
       m('p', 'Save the file below as: config.pbtx'),
       m(
-        '.code-snippet',
+        '.pf-code-snippet',
         m(
           'button',
           {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/record_page.ts
@@ -68,7 +68,7 @@ export class RecordPageV2 implements m.ClassComponent<RecordPageAttrs> {
         ? attrs.subpage.substring(1)
         : DEFAULT_SUBPAGE;
     return m(
-      '.record-page',
+      '.pf-record-page',
       m(
         '.record-container',
         m(
@@ -117,7 +117,7 @@ export class RecordPageV2 implements m.ClassComponent<RecordPageAttrs> {
   private renderMenu() {
     const pages = Array.from(this.recMgr.pages.values());
     return m(
-      '.record-menu',
+      '.pf-record-menu',
       m(RecordingCtl, {recMgr: this.recMgr}),
       m(
         'header',

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/saved_configs.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/saved_configs.ts
@@ -86,7 +86,7 @@ class SavedConfigsPage implements m.ClassComponent<RecMgrAttrs> {
               this.newConfigName = '';
             },
           },
-          m('i.material-icons', 'save'),
+          m('i.pf-material-icons', 'save'),
         ),
       ]),
       this.savedConfigs.map((s) => this.renderSavedSessions(s)),
@@ -106,7 +106,7 @@ class SavedConfigsPage implements m.ClassComponent<RecMgrAttrs> {
             this.recMgr.loadSession(item.config);
           },
         },
-        m('i.material-icons', 'file_upload'),
+        m('i.pf-material-icons', 'file_upload'),
       ),
       m(
         'button',
@@ -122,7 +122,7 @@ class SavedConfigsPage implements m.ClassComponent<RecMgrAttrs> {
             savedCfg.config = this.recMgr.serializeSession();
           },
         },
-        m('i.material-icons', 'save'),
+        m('i.pf-material-icons', 'save'),
       ),
       m(
         'button',
@@ -131,7 +131,7 @@ class SavedConfigsPage implements m.ClassComponent<RecMgrAttrs> {
           title: 'Generate a shareable URL for the saved config',
           onclick: () => shareRecordConfig(item.config),
         },
-        m('i.material-icons', 'share'),
+        m('i.pf-material-icons', 'share'),
       ),
       m(
         'button',
@@ -146,7 +146,7 @@ class SavedConfigsPage implements m.ClassComponent<RecMgrAttrs> {
             self.savedConfigs.splice(idx, 1);
           },
         },
-        m('i.material-icons', 'delete'),
+        m('i.pf-material-icons', 'delete'),
       ),
     ]);
   }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/docs_chip.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/docs_chip.ts
@@ -23,7 +23,7 @@ export class DocsChip implements m.ClassComponent<DocsChipAttrs> {
     return m(
       'a.pf-inline-chip',
       {href: attrs.href, title: 'Open docs in new tab', target: '_blank'},
-      m('i.material-icons', 'info'),
+      m('i.pf-material-icons', 'info'),
       ' Docs',
     );
   }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/docs_chip.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/docs_chip.ts
@@ -21,7 +21,7 @@ interface DocsChipAttrs {
 export class DocsChip implements m.ClassComponent<DocsChipAttrs> {
   view({attrs}: m.CVnode<DocsChipAttrs>) {
     return m(
-      'a.inline-chip',
+      'a.pf-inline-chip',
       {href: attrs.href, title: 'Open docs in new tab', target: '_blank'},
       m('i.material-icons', 'info'),
       ' Docs',

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
@@ -121,7 +121,7 @@ export class Slider implements ProbeSetting {
       '.slider' + (attrs.cssClass ?? ''),
       m('header', attrs.title),
       description ? m('header.descr', attrs.description) : '',
-      attrs.icon !== undefined ? m('i.material-icons', attrs.icon) : [],
+      attrs.icon !== undefined ? m('i.pf-material-icons', attrs.icon) : [],
       m(`input[id="${id}"][type=range][min=0][max=${maxIdx}][value=${idx}]`, {
         disabled,
         oninput: (e: InputEvent) => {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/traced_over_websocket/target_connection_management_dialog.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/traced_over_websocket/target_connection_management_dialog.ts
@@ -52,7 +52,7 @@ class TracedConnectioManagementDialog implements m.ClassComponent<DialogAttrs> {
   view({attrs}: m.CVnode<DialogAttrs>) {
     const provider = attrs.provider;
     return m(
-      '.record-page',
+      '.pf-record-page',
       m(
         'div',
         'Forward port 8037 with ssh from the local host to the ' +

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
@@ -36,6 +36,7 @@ import {exists} from '../../base/utils';
 import {ThreadMap} from '../dev.perfetto.Thread/threads';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {Cpu} from '../../base/multi_machine_trace';
+import {FONT_NAME, TRACK_HATCH_PATTERN_COLOR} from '../../frontend/css_constants';
 
 export interface Data extends TrackData {
   // Slices are stored in a columnar fashion. All fields have the same length.
@@ -255,7 +256,7 @@ export class CpuSliceTrack implements TrackRenderer {
     const visWindowEndPx = size.width;
 
     ctx.textAlign = 'center';
-    ctx.font = '12px Roboto Condensed';
+    ctx.font = `12px ${FONT_NAME}`;
     const charWidth = ctx.measureText('dbpqaouk').width / 8;
 
     const timespan = visibleWindow.toTimeSpan();
@@ -363,10 +364,10 @@ export class CpuSliceTrack implements TrackRenderer {
       subTitle = cropText(subTitle, charWidth, visibleWidth);
       const rectXCenter = left + visibleWidth / 2;
       ctx.fillStyle = textColor.cssString;
-      ctx.font = '12px Roboto Condensed';
+      ctx.font = `12px${FONT_NAME}`;
       ctx.fillText(title, rectXCenter, MARGIN_TOP + RECT_HEIGHT / 2 - 1);
       ctx.fillStyle = textColor.setAlpha(0.6).cssString;
-      ctx.font = '10px Roboto Condensed';
+      ctx.font = `10px ${FONT_NAME}`;
       ctx.fillText(subTitle, rectXCenter, MARGIN_TOP + RECT_HEIGHT / 2 + 9);
     }
 
@@ -503,7 +504,7 @@ function getHatchedPattern(mainCtx: CanvasRenderingContext2D): CanvasPattern {
   const SIZE = 8;
   canvas.width = canvas.height = SIZE;
   const ctx = assertExists(canvas.getContext('2d'));
-  ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+  ctx.strokeStyle = TRACK_HATCH_PATTERN_COLOR;
   ctx.beginPath();
   ctx.lineWidth = 1;
   ctx.moveTo(0, SIZE);

--- a/ui/src/plugins/dev.perfetto.Screenshots/screenshot_panel.ts
+++ b/ui/src/plugins/dev.perfetto.Screenshots/screenshot_panel.ts
@@ -43,7 +43,7 @@ export class ScreenshotDetailsPanel implements TrackEventDetailsPanel {
     }
     assertTrue(this.sliceDetails.args[0].key == 'screenshot.jpg_image');
     return m(
-      '.screenshot-panel',
+      '.pf-screenshot-panel',
       m('img', {
         src: 'data:image/png;base64, ' + this.sliceDetails.args[0].displayValue,
       }),

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
@@ -112,7 +112,7 @@ class StatsSection implements m.ClassComponent<StatsSectionAttrs> {
     const tableRows = data.map((row) => {
       const help = [];
       if (Boolean(row.description)) {
-        help.push(m('i.material-icons.contextual-help', 'help_outline'));
+        help.push(m('i.pf-material-icons.contextual-help', 'help_outline'));
       }
       const idx = row.idx !== '' ? `[${row.idx}]` : '';
       return m(

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/trace_info_page.ts
@@ -513,7 +513,7 @@ export class TraceInfoPage implements m.ClassComponent<TraceInfoPageAttrs> {
   view({attrs}: m.CVnode<TraceInfoPageAttrs>) {
     const engine = assertExists(this.engine);
     return m(
-      '.trace-info-page',
+      '.pf-trace-info-page',
       m(LoadingErrors, {trace: attrs.trace}),
       m(StatsSection, {
         engine,

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.widgets-page {
+.pf-widgets-page {
   padding: 20px;
   font-size: 16px;
   overflow: auto;

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -720,7 +720,7 @@ function RadioButtonGroupDemo() {
 export class WidgetsPage implements m.ClassComponent<{app: App}> {
   view({attrs}: m.Vnode<{app: App}>) {
     return m(
-      '.widgets-page',
+      '.pf-widgets-page',
       m('h1', 'Widgets'),
       m(WidgetShowcase, {
         label: 'Button',

--- a/ui/src/test/perfetto_ui_test_helper.ts
+++ b/ui/src/test/perfetto_ui_test_helper.ts
@@ -30,12 +30,12 @@ export class PerfettoTestHelper {
   constructor(readonly page: Page) {}
 
   resetFocus(): Promise<void> {
-    return this.page.click('.sidebar img.brand');
+    return this.page.click('.pf-sidebar img.brand');
   }
 
   async sidebarSize(): Promise<Size2D> {
     if (this.cachedSidebarSize === undefined) {
-      const size = await this.page.locator('main > .sidebar').boundingBox();
+      const size = await this.page.locator('main > .pf-sidebar').boundingBox();
       this.cachedSidebarSize = assertExists(size);
     }
     return this.cachedSidebarSize;

--- a/ui/src/widgets/custom_table.ts
+++ b/ui/src/widgets/custom_table.ts
@@ -136,7 +136,7 @@ class ReorderableCellGroup
   view(vnode: m.Vnode<ReorderableCellGroupAttrs>): m.Children {
     return vnode.attrs.cells.map((cell, index) =>
       m(
-        `td.reorderable-cell${cell.extraClasses}`,
+        `td.pf-reorderable-cell${cell.extraClasses}`,
         {
           draggable: 'draggable',
           class: this.getClassForIndex(index),

--- a/ui/src/widgets/empty_state.ts
+++ b/ui/src/widgets/empty_state.ts
@@ -40,7 +40,7 @@ export class EmptyState implements m.ClassComponent<EmptyStateAttrs> {
     return m(
       '.pf-empty-state',
       {className},
-      m('i.material-icons', icon),
+      m('i.pf-material-icons', icon),
       title && m('.pf-empty-state-title', title),
       m('.pf-empty-state-content', children),
     );

--- a/ui/src/widgets/modal.ts
+++ b/ui/src/widgets/modal.ts
@@ -141,9 +141,9 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
     }
 
     const aria = '[aria-labelledby=mm-title][aria-model][role=dialog]';
-    const align = attrs.vAlign === 'TOP' ? '.modal-dialog-valign-top' : '';
+    const align = attrs.vAlign === 'TOP' ? '.pf-modal-dialog-valign-top' : '';
     return m(
-      '.modal-backdrop',
+      '.pf-modal-backdrop',
       {
         onclick: this.onBackdropClick.bind(this, attrs),
         onkeyup: this.onBackdropKeyupdown.bind(this, attrs),
@@ -151,7 +151,7 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
         tabIndex: 0,
       },
       m(
-        `.modal-dialog${align}${aria}`,
+        `.pf-modal-dialog${align}${aria}`,
         m(
           'header',
           m('h2', {id: 'mm-title'}, attrs.title),
@@ -172,7 +172,7 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
     // Only react when clicking on the backdrop. Don't close if the user clicks
     // on the dialog itself.
     const t = e.target;
-    if (t instanceof Element && t.classList.contains('modal-backdrop')) {
+    if (t instanceof Element && t.classList.contains('pf-modal-backdrop')) {
       closeModal(attrs.key);
     }
   }

--- a/ui/src/widgets/track_shell.ts
+++ b/ui/src/widgets/track_shell.ts
@@ -148,9 +148,9 @@ export class TrackShell implements m.ClassComponent<TrackShellAttrs> {
       {
         id,
         style: {
-          '--height': trackHeight,
-          '--depth': clamp(depth, 0, 16),
-          '--sticky-top': Math.max(0, stickyTop),
+          '--pf-track-height': trackHeight,
+          '--pf-track-depth': clamp(depth, 0, 16),
+          '--pf-track-sticky-top': Math.max(0, stickyTop),
         },
         ref,
       },


### PR DESCRIPTION
As described in #2166, these changes are sufficient for my embedding application to isolate its CSS styling from Perfetto UI and to apply its light and dark themes, covering these three subjects:

- broadening the application of the `pf-` class name prefix that seems recently to be the norm to longer extant style classes
- extracting font, color, shadow, and other similar definitions into real (not Sass) CSS variables that can be overridden by an embedding application for consistency with its them
- pull more fonts and colors from the effective CSS styles in the DOM in canvas rendering code, to match the theming supported by the previous item

I have attempted to organize the changes thematically (no pun intended) into separate commits for clarity. Please let me know if you prefer them all squashed or factored out into separate PR. Although, in the latter case, they would constitute a chain of dependencies as each commit builds on the previous.

And, of course, what further changes you would request in this PR or in follow-ups. For example, my application does not use the minimap timeline overview, so that is not changed in this PR.

Fixes #2166