### PR TITLE
Update ActivityRecord proto with safe region bounds

### DIFF
--- a/protos/perfetto/trace/android/server/windowmanagerservice.proto
+++ b/protos/perfetto/trace/android/server/windowmanagerservice.proto
@@ -400,6 +400,7 @@ message ActivityRecordProto {
   optional int64 request_open_in_browser_education_timestamp = 47;
   optional bool should_allow_simulate_requested_orientation_for_camera_compat =
       48;
+  optional RectProto safe_region_bounds = 49;
 }
 
 // represents WindowToken


### PR DESCRIPTION
Add `SAFE_REGION_BOUNDS` in the ActivityRecord proto as an optional Rect field.

Bug: 408212762