### PR TITLE
Re-add surfaceflinger tables related to jank metrics outside stdlib.

### DIFF
--- a/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
+++ b/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
@@ -57,6 +57,14 @@ DROP TABLE IF EXISTS android_jank_cuj_sf_process;
 CREATE PERFETTO TABLE android_jank_cuj_sf_process AS
 SELECT * FROM _android_sf_process;
 
+DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread;
+CREATE PERFETTO TABLE android_jank_cuj_sf_main_thread AS
+SELECT * FROM _android_sf_main_thread;
+
+CREATE OR REPLACE PERFETTO FUNCTION android_jank_cuj_sf_thread(thread_name STRING)
+RETURNS TABLE(upid INT, utid INT, name STRING, track_id INT) AS
+SELECT * FROM _android_sf_thread($thread_name);
+
 DROP TABLE IF EXISTS android_jank_cuj_sf_gpu_completion_thread;
 CREATE PERFETTO TABLE android_jank_cuj_sf_gpu_completion_thread AS
 SELECT * FROM _ANDROID_SF_THREAD('GPU completion');

--- a/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
+++ b/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
@@ -57,10 +57,12 @@ DROP TABLE IF EXISTS android_jank_cuj_sf_process;
 CREATE PERFETTO TABLE android_jank_cuj_sf_process AS
 SELECT * FROM _android_sf_process;
 
+-- TODO(devianb): Remove table once we migrate google3 pipelines away from using them.
 DROP TABLE IF EXISTS android_jank_cuj_sf_main_thread;
 CREATE PERFETTO TABLE android_jank_cuj_sf_main_thread AS
 SELECT * FROM _android_sf_main_thread;
 
+-- TODO(devianb): Removed function once we migrate google3 pipelines away from using them.
 CREATE OR REPLACE PERFETTO FUNCTION android_jank_cuj_sf_thread(thread_name STRING)
 RETURNS TABLE(upid INT, utid INT, name STRING, track_id INT) AS
 SELECT * FROM _android_sf_thread($thread_name);


### PR DESCRIPTION
These tables are being used in telemtry scripts, and removing them causes breakages.