### PR TITLE
Emit 0 instead of null for sched duration

### DIFF
--- a/src/trace_processor/metrics/sql/trace_metadata.sql
+++ b/src/trace_processor/metrics/sql/trace_metadata.sql
@@ -52,7 +52,7 @@ SELECT TraceMetadata(
     WHERE name = 'trace_config_pbtxt'
   ),
   'sched_duration_ns', (
-    SELECT MAX(TO_MONOTONIC(ts)) - MIN(TO_MONOTONIC(ts)) FROM sched
+    SELECT IFNULL(MAX(TO_MONOTONIC(ts)) - MIN(TO_MONOTONIC(ts)), 0) FROM sched
   ),
   'tracing_started_ns', (
     SELECT int_value FROM metadata


### PR DESCRIPTION
Emit 0 instead of null for sched duration

Handles a case where 24hrs traces in wear emits null sched duration as the sched table is empty 