### PR TITLE
docs: Fix broken links of ui-development in docs

### DIFF
--- a/docs/contributing/build-instructions.md
+++ b/docs/contributing/build-instructions.md
@@ -38,7 +38,7 @@ tools/install-build-deps [--android] [--ui] [--linux-arm]
 to build for `target_os = "android"`.
 
 `--ui` will pull NodeJS and all the NPM modules required to build the
-Web UI. See the [UI Development](#ui-development) section below for more.
+Web UI. See the [UI Development](docs/contributing/ui-getting-started.md) section below for more.
 
 `--linux-arm` will pull the sysroots for cross-compiling for Linux ARM/64.
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -21,7 +21,7 @@ ui/run-dev-server
 
 Then navigate to `http://localhost:10000`.
 
-See also https://perfetto.dev/docs/contributing/build-instructions#ui-development
+See also https://perfetto.dev/docs/contributing/ui-getting-started
 
 ## Unit tests
 


### PR DESCRIPTION
## Summary

I was trying to follow the instructions in [build instructions](https://perfetto.dev/docs/contributing/build-instructions) to build the UI on my machine, but found that the link https://perfetto.dev/docs/contributing/build-instructions#ui-development was broken. I checked other sections and I think `ui-development` has been immigrated to [ui-getting-started ](https://perfetto.dev/docs/contributing/ui-getting-started). The broken changes seem to come from [commit 12d35e0](https://github.com/google/perfetto/commit/12d35e089098a2c0828725c3b17f23971c09ad10#diff-1eb35a14909e4b4c5cc28a13ac2e246e55a3de7e5027aff2fe23f84daa174db5), where `ui-development.md` was deleted. This PR adjusted two links in `build-instructions.md` and `ui/README.md`. 

Please note and check if the changed links work well. I haven't tested since I didn't find instructions to build the docs locally.