### PR TITLE
ui: fix terrible performance of nested subquery

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/dmabuf.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/dmabuf.sql
@@ -16,13 +16,7 @@
 -- Raw ftrace events
 CREATE PERFETTO TABLE _raw_dmabuf_events AS
 SELECT
-  (
-    SELECT
-      int_value
-    FROM args
-    WHERE
-      arg_set_id = c.arg_set_id AND key = 'inode'
-  ) AS inode,
+  extract_arg(arg_set_id, 'inode') AS inode,
   tt.utid,
   c.ts,
   cast_int!(c.value) AS buf_size


### PR DESCRIPTION
	SQLite really struggles, use extract_arg which will always be faster
