### PR TITLE
tp: Handle ChromeThreadDescriptor is_sandboxed_tid in trace processor

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -193,6 +193,14 @@ class ProcessTracker {
   // > 0 for remote machines.
   UniqueTid swapper_utid() const { return swapper_utid_; }
 
+  // Returns a unique synthetic tid based on the provided |tid| and |pid|.
+  // This is useful in systems where the pid is unique but the tid is not.
+  // The returned synthetic tid has the following format:
+  // [PID(high 32-bits)][TID(low 32-bits)]
+  static int64_t CreateSyntheticTid(int64_t tid, int64_t pid) {
+    return (pid << 32) | tid;
+  }
+
  private:
   // Returns the utid of a thread having |tid| and |pid| as the parent process.
   // pid == std::nullopt matches all processes.

--- a/src/trace_processor/importers/proto/track_event_module.cc
+++ b/src/trace_processor/importers/proto/track_event_module.cc
@@ -95,7 +95,8 @@ void TrackEventModule::ParseTracePacketData(const TracePacket::Decoder& decoder,
       break;
     case TracePacket::kThreadDescriptorFieldNumber:
       // TODO(eseckler): Remove once Chrome has switched to TrackDescriptors.
-      parser_.ParseThreadDescriptor(decoder.thread_descriptor());
+      parser_.ParseThreadDescriptor(decoder.thread_descriptor(),
+                                    /*is_sandboxed=*/false);
       break;
     case TracePacket::kTrackEventFieldNumber:
       PERFETTO_DFATAL("Wrong TracePacket number");

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -56,7 +56,7 @@ class TrackEventParser {
                             uint32_t packet_sequence_id);
   UniquePid ParseProcessDescriptor(int64_t packet_timestamp,
                                    protozero::ConstBytes);
-  UniqueTid ParseThreadDescriptor(protozero::ConstBytes);
+  UniqueTid ParseThreadDescriptor(protozero::ConstBytes, bool);
 
   void ParseTrackEvent(int64_t ts,
                        const TrackEventData* event_data,

--- a/src/trace_processor/importers/proto/track_event_tracker.h
+++ b/src/trace_processor/importers/proto/track_event_tracker.h
@@ -68,8 +68,8 @@ class TrackEventTracker {
     };
 
     uint64_t parent_uuid = 0;
-    std::optional<uint32_t> pid;
-    std::optional<uint32_t> tid;
+    std::optional<int64_t> pid;
+    std::optional<int64_t> tid;
     int64_t min_timestamp = 0;
     StringId name = kNullStringId;
     StringId description = kNullStringId;


### PR DESCRIPTION
TraceProcessor will soon require tids to have unique, non-overlapping lifetimes. Using the is_sandboxed_tid field, TP can now create a unique synthetic tid for track descriptors. This is needed because there is no feasible way to provide the mapping of namespaced tids and the "real" root-level tid from the Chrome browser.
