### PR TITLE
ui: Rebuild css when any *.scss files change inside plugins

### DIFF
--- a/ui/build.js
+++ b/ui/build.js
@@ -121,7 +121,7 @@ const RULES = [
   {r: /ui\/src\/assets\/((.*)[.]png)/, f: copyAssets},
   {r: /buildtools\/typefaces\/(.+[.]woff2)/, f: copyAssets},
   {r: /buildtools\/catapult_trace_viewer\/(.+(js|html))/, f: copyAssets},
-  {r: /ui\/src\/assets\/.+[.]scss|ui\/src\/(?:plugins|core_plugins)\/.+\/styles[.]scss/, f: compileScss},
+  {r: /ui\/src\/assets\/.+[.]scss|ui\/src\/(?:plugins|core_plugins)\/.+[.]scss/, f: compileScss},
   {r: /ui\/src\/chrome_extension\/.*/, f: copyExtensionAssets},
   {r: /.*\/dist\/.+\/(?!manifest\.json).*/, f: genServiceWorkerManifestJson},
   {r: /.*\/dist\/.*[.](js|html|css|wasm)$/, f: notifyLiveServer},
@@ -259,8 +259,8 @@ async function main() {
     generateImports('ui/src/core_plugins', 'all_core_plugins');
     generateImports('ui/src/plugins', 'all_plugins');
     scanDir('ui/src/assets');
-    scanDir('ui/src/plugins', /styles[.]scss$/);
-    scanDir('ui/src/core_plugins', /styles[.]scss$/);
+    scanDir('ui/src/plugins', /[.]scss$/);
+    scanDir('ui/src/core_plugins', /[.]scss$/);
     scanDir('ui/src/chrome_extension');
     scanDir('buildtools/typefaces');
     scanDir('buildtools/catapult_trace_viewer');
@@ -393,6 +393,7 @@ function copyUiTestArtifactsAssets(src, dst) {
 }
 
 function compileScss() {
+  console.log('Compiling SCSS to CSS');
   const src = pjoin(ROOT_DIR, 'ui/src/assets/perfetto.scss');
   const dst = pjoin(cfg.outDistDir, 'perfetto.css');
   // In watch mode, don't exit(1) if scss fails. It can easily happen by


### PR DESCRIPTION
Currently, only changes to styles.scss in plugins are automatically picked up by the build system and patched into the UI when running ui/run-dev-server. This is frustrating as it means plugin devs cannot split plugin styles into multiple files.

This change modifies the file watch regex to include all *.scss files in plugin dirs, and rebuilds and reloads the css when they change.
