### PR TITLE
ui: Fix lingering omnibox text bug

### DIFF
--- a/ui/src/core/omnibox_manager.ts
+++ b/ui/src/core/omnibox_manager.ts
@@ -37,7 +37,7 @@ export class OmniboxManagerImpl implements OmniboxManager {
   private _pendingPrompt?: Prompt;
   private _omniboxSelectionIndex = 0;
   private _forceShortTextSearch = false;
-  private _textForMode = new Map<OmniboxMode, string>();
+  private _text = '';
   private _statusMessageContainer: {msg?: string} = {};
 
   get mode(): OmniboxMode {
@@ -49,7 +49,7 @@ export class OmniboxManagerImpl implements OmniboxManager {
   }
 
   get text(): string {
-    return this._textForMode.get(this._mode) ?? '';
+    return this._text;
   }
 
   get selectionIndex(): number {
@@ -69,7 +69,7 @@ export class OmniboxManagerImpl implements OmniboxManager {
   }
 
   setText(value: string): void {
-    this._textForMode.set(this._mode, value);
+    this._text = value;
   }
 
   setSelectionIndex(index: number): void {
@@ -90,6 +90,7 @@ export class OmniboxManagerImpl implements OmniboxManager {
     this._mode = mode;
     this._focusOmniboxNextRender = focus;
     this._omniboxSelectionIndex = 0;
+    this._text = '';
     this.rejectPendingPrompt();
   }
 


### PR DESCRIPTION
Currently, the omnibox text for a given command likes to stick around even after the command has completed. This makes it confusing when you e.g. run the same prompt twice as the previous filter text will still be present in the omnibox on the second attempt.

This patch switches to using \a single string to hold the omnibox text (as opposed to one per mode) and clears it down whenever the mode changes.
