### PR TITLE
ui: Minor tweaks in DataGrid

### DIFF
--- a/ui/src/assets/components/data_grid.scss
+++ b/ui/src/assets/components/data_grid.scss
@@ -17,7 +17,6 @@ $border: 1px solid rgb(225, 225, 225);
 .pf-data-grid {
   display: flex;
   flex-direction: column;
-  font-weight: 300;
   white-space: nowrap;
   overflow: hidden;
 
@@ -36,6 +35,7 @@ $border: 1px solid rgb(225, 225, 225);
   table {
     min-width: 100%;
     border-spacing: 0;
+    font-weight: 300;
   }
 
   // Highlight rows on hover.
@@ -138,29 +138,7 @@ $border: 1px solid rgb(225, 225, 225);
     visibility: hidden;
   }
 
-  &__toolbar {
-    display: flex;
-    padding: 2px;
-    align-items: baseline;
-    gap: 2px;
-  }
-
-  &__toolbar-filters {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 4px;
-    padding: 2px;
-    flex-grow: 1;
-  }
-
   &__filter-chip {
     cursor: pointer;
-  }
-
-  &__toolbar-pagination {
-    display: flex;
-    gap: 4px;
-    align-items: baseline;
   }
 }

--- a/ui/src/assets/widgets/box.scss
+++ b/ui/src/assets/widgets/box.scss
@@ -19,4 +19,20 @@
     height: 100%;
     overflow-y: hidden;
   }
+
+  &.pf-spacing-none {
+    padding: 0px;
+  }
+
+  &.pf-spacing-small {
+    padding: 2px;
+  }
+
+  &.pf-spacing-medium {
+    padding: 4px;
+  }
+
+  &.pf-spacing-large {
+    padding: 6px;
+  }
 }

--- a/ui/src/assets/widgets/stack.scss
+++ b/ui/src/assets/widgets/stack.scss
@@ -27,8 +27,24 @@
     overflow-y: hidden;
   }
 
-  &--gap-none {
+  &.pf-spacing-none {
     gap: 0px;
+  }
+
+  &.pf-spacing-small {
+    gap: 2px;
+  }
+
+  &.pf-spacing-medium {
+    gap: 4px;
+  }
+
+  &.pf-spacing-large {
+    gap: 6px;
+  }
+
+  &--wrap {
+    flex-wrap: wrap;
   }
 }
 

--- a/ui/src/base/semantic_icons.ts
+++ b/ui/src/base/semantic_icons.ts
@@ -46,6 +46,7 @@ export class Icons {
   static readonly ContextMenuAlt = 'more_vert';
   static readonly Warning = 'warning';
   static readonly Help = 'help';
+  static readonly Download = 'download';
 
   // Page control
   static readonly NextPage = 'chevron_right';

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -34,7 +34,7 @@ export class AggregationPanel
   view({attrs}: m.CVnode<AggregationPanelAttrs>) {
     const {dataSource, sorting, columns, barChartData} = attrs;
 
-    return m(Stack, {fillHeight: true, gap: 'none'}, [
+    return m(Stack, {fillHeight: true, spacing: 'none'}, [
       barChartData && m(StackFixed, m(Box, this.renderBarChart(barChartData))),
       m(StackAuto, this.renderTable(dataSource, sorting, columns)),
     ]);

--- a/ui/src/plugins/org.kernel.Wattson/aggregation_panel.ts
+++ b/ui/src/plugins/org.kernel.Wattson/aggregation_panel.ts
@@ -51,7 +51,7 @@ export class WattsonAggregationPanel
   ) {
     const columnsById = new Map(columns.map((c) => [c.columnId, c]));
     return m(DataGrid, {
-      toolbarItems: m(
+      toolbarItemsLeft: m(
         Box,
         m(SegmentedButtons, {
           options: [{label: 'µW'}, {label: 'mW'}],

--- a/ui/src/widgets/box.ts
+++ b/ui/src/widgets/box.ts
@@ -14,18 +14,25 @@
 
 import m from 'mithril';
 import {classNames} from '../base/classnames';
+import {classForSpacing, HTMLAttrs, Spacing} from './common';
 
-export interface BoxAttrs {
+export interface BoxAttrs extends HTMLAttrs {
   readonly fillHeight?: boolean;
+  readonly spacing?: Spacing;
 }
 
 export class Box implements m.ClassComponent<BoxAttrs> {
   view({attrs, children}: m.CVnode<BoxAttrs>) {
-    const {fillHeight = false} = attrs;
+    const {fillHeight = false, className, spacing = 'medium', ...rest} = attrs;
     return m(
       '.pf-box',
       {
-        className: classNames(fillHeight && 'pf-box--fill-height'),
+        ...rest,
+        className: classNames(
+          className,
+          fillHeight && 'pf-box--fill-height',
+          classForSpacing(spacing),
+        ),
       },
       children,
     );

--- a/ui/src/widgets/common.ts
+++ b/ui/src/widgets/common.ts
@@ -94,3 +94,20 @@ export function classForIntent(intent: Intent): string | undefined {
       return assertUnreachable(intent);
   }
 }
+
+export type Spacing = 'none' | 'small' | 'medium' | 'large';
+
+export function classForSpacing(spacing: Spacing): string {
+  switch (spacing) {
+    case 'none':
+      return 'pf-spacing-none';
+    case 'small':
+      return 'pf-spacing-small';
+    case 'medium':
+      return 'pf-spacing-medium';
+    case 'large':
+      return 'pf-spacing-large';
+    default:
+      assertUnreachable(spacing);
+  }
+}

--- a/ui/src/widgets/stack.ts
+++ b/ui/src/widgets/stack.ts
@@ -14,12 +14,13 @@
 
 import m from 'mithril';
 import {classNames} from '../base/classnames';
-import {HTMLAttrs} from './common';
+import {classForSpacing, HTMLAttrs, Spacing} from './common';
 
 interface StackAttrs extends HTMLAttrs {
   readonly orientation?: 'horizontal' | 'vertical';
   readonly fillHeight?: boolean;
-  readonly gap?: 'none' | 'normal';
+  readonly spacing?: Spacing;
+  readonly wrap?: boolean;
 }
 
 export class Stack implements m.ClassComponent<StackAttrs> {
@@ -27,8 +28,9 @@ export class Stack implements m.ClassComponent<StackAttrs> {
     const {
       orientation = 'vertical',
       fillHeight = false,
-      gap = 'normal',
+      spacing = 'medium',
       className,
+      wrap,
       ...htmlAttrs
     } = attrs;
     return m(
@@ -37,7 +39,8 @@ export class Stack implements m.ClassComponent<StackAttrs> {
         className: classNames(
           orientation === 'horizontal' && 'pf-stack--horiz',
           fillHeight && 'pf-stack--fill-height',
-          gap === 'none' && 'pf-stack--gap-none',
+          classForSpacing(spacing),
+          wrap && 'pf-stack--wrap',
           className,
         ),
         ...htmlAttrs,
@@ -47,14 +50,25 @@ export class Stack implements m.ClassComponent<StackAttrs> {
   }
 }
 
-export class StackAuto implements m.ClassComponent {
-  view({children}: m.CVnode) {
-    return m('.pf-stack-auto', children);
+/**
+ * StackAuto is a container element designed to live inside a Stack. It will
+ * automatically grow and shrink to fill the available space in the Stack.
+ * This is useful for elements that should take up as much space as possible
+ * without exceeding the bounds of the Stack.
+ */
+export class StackAuto implements m.ClassComponent<HTMLAttrs> {
+  view({attrs, children}: m.CVnode<HTMLAttrs>) {
+    return m('.pf-stack-auto', attrs, children);
   }
 }
 
-export class StackFixed implements m.ClassComponent {
-  view({children}: m.CVnode) {
-    return m('.pf-stack-fixed', children);
+/**
+ * StackFixed is a container element designed to live inside a Stack.
+ * It will not grow or shrink, and will maintain its size based on its content.
+ * This is useful for fixed-size elements that should not be resized.
+ */
+export class StackFixed implements m.ClassComponent<HTMLAttrs> {
+  view({attrs, children}: m.CVnode<HTMLAttrs>) {
+    return m('.pf-stack-fixed', attrs, children);
   }
 }


### PR DESCRIPTION
- Reuse Stack and Box widgets instead of inventing our own.
- Add spacing attr to Box and Stack to adjust padding and gap size.
- Allow left and right toolbar items to be placed.
- Download icon on blob download button.
