### PR TITLE
ui: Move QueryHistoryComponent to components

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -321,41 +321,6 @@ $bottom-tab-padding: 10px;
   overflow-x: auto;
 }
 
-header.overview {
-  position: sticky;
-  top: 0;
-  left: 0;
-  display: flex;
-  align-content: baseline;
-  background-color: hsl(213, 22%, 82%);
-  color: hsl(213, 22%, 20%);
-  font-family: "Roboto Condensed", sans-serif;
-  font-size: 15px;
-  font-weight: 400;
-  padding: 4px 10px;
-  vertical-align: middle;
-  border-color: hsl(213, 22%, 75%);
-  border-style: solid;
-  border-width: 1px 0;
-  .code {
-    font-family: var(--monospace-font);
-    font-size: 12px;
-    margin-left: 10px;
-    color: hsl(213, 22%, 40%);
-  }
-  span {
-    white-space: nowrap;
-  }
-  span.code {
-    text-overflow: ellipsis;
-    max-width: 50vw;
-    overflow: hidden;
-  }
-  span.spacer {
-    flex-grow: 1;
-  }
-}
-
 .text-select {
   user-select: text;
   -webkit-user-select: text;
@@ -525,57 +490,6 @@ button.query-ctrl {
 
   &.highlight-right {
     background: linear-gradient(270deg, $table-border-color, transparent 20%);
-  }
-}
-
-.history-item {
-  border-bottom: 1px solid hsl(213, 22%, 75%);
-  padding: 0.25em 0.5em;
-  max-height: 150px;
-  overflow-y: auto;
-  position: relative;
-
-  pre {
-    font-size: 10pt;
-    margin: 0;
-    overflow-x: auto;
-    overflow-y: hidden;
-    white-space: pre-wrap;
-    position: relative;
-    cursor: pointer;
-
-    &:hover::after {
-      content: "Doubleclick to re-run";
-      font-size: 12px;
-      color: rgba(0, 0, 0, 20%);
-      position: absolute;
-      top: 0;
-      margin: auto;
-      right: 0;
-    }
-  }
-
-  &:hover {
-    background-color: hsl(213, 22%, 94%);
-    .history-item-buttons {
-      visibility: visible;
-    }
-  }
-}
-
-.history-item-buttons {
-  position: sticky;
-  float: right;
-  top: 0;
-  visibility: hidden;
-
-  button {
-    margin: 0 0.5rem;
-
-    i.material-icons,
-    i.material-icons-filled {
-      font-size: 18px;
-    }
   }
 }
 

--- a/ui/src/assets/components/query_history.scss
+++ b/ui/src/assets/components/query_history.scss
@@ -1,0 +1,101 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-query-history {
+  header.overview {
+    position: sticky;
+    top: 0;
+    display: flex;
+    align-content: baseline;
+    background-color: hsl(213, 22%, 82%);
+    color: hsl(213, 22%, 20%);
+    font-family: "Roboto Condensed", sans-serif;
+    font-size: 15px;
+    font-weight: 400;
+    padding: 4px 10px;
+    vertical-align: middle;
+    border-color: hsl(213, 22%, 75%);
+    border-style: solid;
+    border-width: 1px 0;
+    z-index: 1;
+    .code {
+      font-family: var(--monospace-font);
+      font-size: 12px;
+      margin-left: 10px;
+      color: hsl(213, 22%, 40%);
+    }
+    span {
+      white-space: nowrap;
+    }
+    span.code {
+      text-overflow: ellipsis;
+      max-width: 50vw;
+      overflow: hidden;
+    }
+    span.spacer {
+      flex-grow: 1;
+    }
+  }
+}
+
+.pf-history-item {
+  border-bottom: 1px solid hsl(213, 22%, 75%);
+  padding: 0.25em 0.5em;
+  max-height: 150px;
+  overflow-y: auto;
+  position: relative;
+
+  pre {
+    font-size: 10pt;
+    margin: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    white-space: pre-wrap;
+    position: relative;
+    cursor: pointer;
+
+    &:hover::after {
+      content: "Doubleclick to re-run";
+      font-size: 12px;
+      color: rgba(0, 0, 0, 20%);
+      position: absolute;
+      top: 0;
+      margin: auto;
+      right: 0;
+    }
+  }
+
+  &:hover {
+    background-color: hsl(213, 22%, 94%);
+    .pf-history-item-buttons {
+      visibility: visible;
+    }
+  }
+}
+
+.pf-history-item-buttons {
+  position: sticky;
+  float: right;
+  top: 0;
+  visibility: hidden;
+
+  button {
+    margin: 0 0.5rem;
+
+    i.material-icons,
+    i.material-icons-filled {
+      font-size: 18px;
+    }
+  }
+}

--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -31,6 +31,7 @@
 // Widgets/components - keep these sorted alphabetically
 @import "components/aggregation_adapter";
 @import "components/data_grid";
+@import "components/query_history";
 @import "widgets/anchor";
 @import "widgets/box";
 @import "widgets/button";

--- a/ui/src/components/widgets/query_history.ts
+++ b/ui/src/components/widgets/query_history.ts
@@ -22,6 +22,7 @@ import {Trace} from '../../public/trace';
 const QUERY_HISTORY_KEY = 'queryHistory';
 
 export interface QueryHistoryComponentAttrs {
+  readonly className?: string;
   trace: Trace;
   runQuery: (query: string) => void;
   setQuery: (query: string) => void;
@@ -30,18 +31,20 @@ export interface QueryHistoryComponentAttrs {
 export class QueryHistoryComponent
   implements m.ClassComponent<QueryHistoryComponentAttrs>
 {
-  view({attrs}: m.CVnode<QueryHistoryComponentAttrs>): m.Child {
-    const runQuery = attrs.runQuery;
-    const setQuery = attrs.setQuery;
+  view({attrs}: m.CVnode<QueryHistoryComponentAttrs>) {
+    const {trace, runQuery, setQuery, ...rest} = attrs;
     const unstarred: HistoryItemComponentAttrs[] = [];
     const starred: HistoryItemComponentAttrs[] = [];
     for (let i = queryHistoryStorage.data.length - 1; i >= 0; i--) {
       const entry = queryHistoryStorage.data[i];
       const arr = entry.starred ? starred : unstarred;
-      arr.push({trace: attrs.trace, index: i, entry, runQuery, setQuery});
+      arr.push({trace, index: i, entry, runQuery, setQuery});
     }
     return m(
-      '.query-history',
+      '.pf-query-history',
+      {
+        ...rest,
+      },
       m(
         'header.overview',
         `Query history (${queryHistoryStorage.data.length} queries)`,
@@ -66,9 +69,9 @@ export class HistoryItemComponent
   view(vnode: m.Vnode<HistoryItemComponentAttrs>): m.Child {
     const query = vnode.attrs.entry.query;
     return m(
-      '.history-item',
+      '.pf-history-item',
       m(
-        '.history-item-buttons',
+        '.pf-history-item-buttons',
         m(
           'button',
           {

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -21,10 +21,13 @@ import {
 } from '../../components/query_table/queries';
 import {Callout} from '../../widgets/callout';
 import {Editor} from '../../widgets/editor';
-import {QueryHistoryComponent, queryHistoryStorage} from './query_history';
 import {Trace, TraceAttrs} from '../../public/trace';
 import {addQueryResultsTab} from '../../components/query_table/query_result_tab';
 import {QueryTable} from '../../components/query_table/query_table';
+import {
+  QueryHistoryComponent,
+  queryHistoryStorage,
+} from '../../components/widgets/query_history';
 
 interface QueryPageState {
   enteredText: string;

--- a/ui/src/test/queries.test.ts
+++ b/ui/src/test/queries.test.ts
@@ -72,20 +72,23 @@ test('query page', async () => {
   }
 
   // Now test the query history.
-  page.locator('.query-history .history-item').nth(0).click();
+  page.locator('.pf-query-history .pf-history-item').nth(0).click();
   await pth.waitForPerfettoIdle();
   expect(await textbox.textContent()).toEqual(
     'select id, ts, dur, name from slices limit 3',
   );
 
-  page.locator('.query-history .history-item').nth(2).click();
+  page.locator('.pf-query-history .pf-history-item').nth(2).click();
   await pth.waitForPerfettoIdle();
   expect(await textbox.textContent()).toEqual(
     'select id, ts, dur, name from slices limit 1',
   );
 
   // Double click on the 2nd one and expect the query is re-ran.
-  page.locator('.query-page .query-history .history-item').nth(1).dblclick();
+  page
+    .locator('.query-page .pf-query-history .pf-history-item')
+    .nth(1)
+    .dblclick();
   await pth.waitForPerfettoIdle();
   expect(
     await page.locator('.query-page .pf-data-grid tbody tr').count(),


### PR DESCRIPTION
- Move query_history.ts to components/
- Update imports
- Extract css from common.scss
- Use 'pf-' prefixes
- Allow className to be passed to the component