### PR TITLE
Moving 'Device State' track to StandardGroups

### DIFF
--- a/ui/src/plugins/dev.perfetto.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/dev.perfetto.AndroidLongBatteryTracing/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {Trace} from '../../public/trace';
+import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Engine} from '../../trace_processor/engine';
 import {createQuerySliceTrack} from '../../components/tracks/query_slice_track';
@@ -834,6 +835,8 @@ const BT_ACTIVITY = `
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.AndroidLongBatteryTracing';
+  static readonly dependencies = [StandardGroupsPlugin];
+
   private readonly groups = new Map<string, TrackNode>();
 
   private addTrack(
@@ -960,6 +963,10 @@ export default class implements PerfettoPlugin {
     }
 
     const groupName = 'Device State';
+    const deviceStateGroup = ctx.plugins
+      .getPlugin(StandardGroupsPlugin)
+      .getOrCreateStandardGroup(ctx.workspace, 'DEVICE_STATE');
+    this.groups.set(groupName, deviceStateGroup);
 
     const query = (name: string, track: string) =>
       this.addBatteryStatsEvent(ctx, name, track, groupName, features);

--- a/ui/src/plugins/dev.perfetto.StandardGroups/index.ts
+++ b/ui/src/plugins/dev.perfetto.StandardGroups/index.ts
@@ -26,6 +26,7 @@ export type StandardGroup =
   | 'CPU'
   | 'GPU'
   | 'NETWORK'
+  | 'DEVICE_STATE'
   | 'SYSTEM';
 
 export default class implements PerfettoPlugin {
@@ -42,6 +43,7 @@ export default class implements PerfettoPlugin {
     IO: makeGroupNode('IO'),
     MEMORY: makeGroupNode('Memory'),
     NETWORK: makeGroupNode('Network'),
+    DEVICE_STATE: makeGroupNode('Device State'),
     SYSTEM: makeGroupNode('System'),
   };
 


### PR DESCRIPTION
This is so that 'Device State' can be used by other plugins and not depend on AndroidLongBatteryTracing
