### PR TITLE
Prepare to split chrome_track_event.proto into multiple files

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -11936,6 +11936,7 @@ genrule {
         "protos/perfetto/trace/track_event/track_descriptor.proto",
         "protos/perfetto/trace/track_event/track_event.proto",
         "protos/third_party/chromium/chrome_track_event.proto",
+        "protos/third_party/chromium/chrome_track_event_import_wrapper.proto",
     ],
     tools: [
         "aprotoc",

--- a/protos/third_party/chromium/BUILD.gn
+++ b/protos/third_party/chromium/BUILD.gn
@@ -13,10 +13,4 @@ perfetto_proto_library("@TYPE@") {
   # Chrome .proto files have imports relative to the current directory, since
   # the copies in Chrome live at a different file path (//base/tracing/protos).
   import_dirs = [ "./" ]
-
-  # When rolled into Chrome, extension descriptor is going to be linked into
-  # binary, therefore increasing its size. Including imports means that the
-  # full TrackEvent descriptor is going to be included as well, increasing the
-  # binary size unnecessarily. Therefore, exclude_imports is used.
-  exclude_imports = true
 }

--- a/protos/third_party/chromium/BUILD.gn
+++ b/protos/third_party/chromium/BUILD.gn
@@ -8,7 +8,11 @@ perfetto_proto_library("@TYPE@") {
 
   generate_descriptor = "chrome_track_event.descriptor"
   generator_visibility = [ "../../../src/trace_processor/importers/proto:gen_cc_chrome_track_event_descriptor" ]
-  descriptor_root_source = "chrome_track_event.proto"
+  descriptor_root_source = chrome_track_event_descriptor_source
+
+  # Chrome .proto files have imports relative to the current directory, since
+  # the copies in Chrome live at a different file path (//base/tracing/protos).
+  import_dirs = [ "./" ]
 
   # When rolled into Chrome, extension descriptor is going to be linked into
   # binary, therefore increasing its size. Including imports means that the


### PR DESCRIPTION
An upcoming Chrome patch will split chrome_track_event.proto into multiple files. This updates the build file so that patch won't fail when it's synced in:

Generate chrome_track_event.descriptor from a variable in sources.gni.

Add the current directory to import_dirs so that imports in the split files can be found.