### PR TITLE
ui: Add intent coloring to Icon widgets

### DIFF
--- a/ui/src/assets/widgets/icon.scss
+++ b/ui/src/assets/widgets/icon.scss
@@ -13,13 +13,32 @@
 // limitations under the License.
 
 @import "../typefaces";
+@import "theme";
 
 .pf-icon {
   @include icon;
   &.pf-filled {
     @include icon-filled;
   }
+
   line-height: inherit;
   font-size: inherit;
   vertical-align: bottom;
+  user-select: none; // We usually don't expect icons to be selectable.
+
+  &.pf-intent-primary {
+    color: $color-primary;
+  }
+
+  &.pf-intent-danger {
+    color: $color-danger;
+  }
+
+  &.pf-intent-success {
+    color: $color-success;
+  }
+
+  &.pf-intent-warning {
+    color: $color-warning;
+  }
 }

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -1010,7 +1010,10 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
       m(WidgetShowcase, {
         label: 'Icon',
         renderWidget: (opts) => m(Icon, {icon: 'star', ...opts}),
-        initialOpts: {filled: false},
+        initialOpts: {
+          filled: false,
+          intent: new EnumOption(Intent.None, Object.values(Intent)),
+        },
       }),
       m(WidgetShowcase, {
         label: 'MultiSelect panel',

--- a/ui/src/widgets/icon.ts
+++ b/ui/src/widgets/icon.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {HTMLAttrs} from './common';
 import {classNames} from '../base/classnames';
+import {classForIntent, HTMLAttrs, Intent} from './common';
 
 export interface IconAttrs extends HTMLAttrs {
   // The material icon name.
@@ -22,16 +22,22 @@ export interface IconAttrs extends HTMLAttrs {
   // Whether to show the filled version of the icon.
   // Defaults to false.
   filled?: boolean;
+  // Color the icon by specifying an intent.
+  intent?: Intent;
 }
 
 export class Icon implements m.ClassComponent<IconAttrs> {
   view({attrs}: m.Vnode<IconAttrs>): m.Child {
-    const {icon, filled, className, ...htmlAttrs} = attrs;
+    const {icon, filled, className, intent = Intent.None, ...htmlAttrs} = attrs;
     return m(
       'i.pf-icon',
       {
         ...htmlAttrs,
-        className: classNames(className, filled && 'pf-filled'),
+        className: classNames(
+          className,
+          filled && 'pf-filled',
+          classForIntent(intent),
+        ),
       },
       icon,
     );


### PR DESCRIPTION
This allows icons to be colored using the usual intent colors (primary, success, danger, warning).

Also make icons non-selectable, as folks usually don't want to select icons.
