### PR TITLE
stdlib: Fix Wattson markers slice bug

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
@@ -17,18 +17,24 @@
 -- provide the proper Wattson markers slice if user inserts only one pair of
 -- Wattson markers, which is the pre-defined agreement.
 CREATE PERFETTO TABLE _wattson_markers_window AS
+WITH
+  markers AS (
+    SELECT
+      min(ts) FILTER(WHERE
+        name = 'wattson_start') AS start,
+      max(ts) FILTER(WHERE
+        name = 'wattson_stop') AS stop
+    FROM slice
+    WHERE
+      name IN ('wattson_start', 'wattson_stop')
+  )
 SELECT
-  min(ts) FILTER(WHERE
-    name = 'wattson_start') AS ts,
-  max(ts) FILTER(WHERE
-    name = 'wattson_stop') - min(ts) FILTER(WHERE
-    name = 'wattson_start') AS dur,
+  start AS ts,
+  stop - start AS dur,
   'Markers window' AS name
-FROM slice
+FROM markers
 WHERE
-  name IN ('wattson_start', 'wattson_stop')
-HAVING
-  ts IS NOT NULL;
+  start IS NOT NULL;
 
 -- Helper macro for using Perfetto table with interval intersect
 CREATE PERFETTO MACRO _ii_subquery(


### PR DESCRIPTION
Update the Wattson markers table to display only if the start marker is defined. Consistent with how other slices are displayed in Perfetto, if the end of slice is missing, display only the start with end trailing off; if the end slice is missing, do not display the slice at all.

Test: tools/diff_test_trace_processor.py out/linux/trace_processor_shell --name-filter '.wattson.'
Bug: 432505126
