### PR TITLE
traced_perf: Allow CPU 0 to be excluded when offline

### DIFF
--- a/src/profiling/perf/perf_producer.cc
+++ b/src/profiling/perf/perf_producer.cc
@@ -110,8 +110,8 @@ std::vector<uint32_t> CreateCpuMask(const protos::gen::PerfEventConfig& cfg) {
     // check explicit mask from cfg, or allow all by default
     if (!target_cpus.empty() && target_cpus.count(cpu) == 0)
       continue;
-    // consider cpu0 to always be online
-    if (cpu > 0 && !IsCpuOnline(cpu))
+
+    if (!IsCpuOnline(cpu))
       continue;
     ret.push_back(cpu);
   }


### PR DESCRIPTION
Hello Perfetto Maintainers,

I'm work at Samsung to CPU analysis, both hardware and software aspects. 
I have been actively using Perfetto and Tracebox and find them very helpful.

Recently in our team, we collect PMU (Performance Monitoring Unit) data per CPU under various scenarios.
During data collection, we observed that if CPU 0 is offline, the PMU data does not get properly collected.

We often analyze only one type of core while some of the CPUs among multiple cores are offline.
e.g.) online - only middle tier core, offline - others core(big, little, etc...)

This has caused difficulties for us, which led to creating a patch resolve this issue.

I would appreciate it if you could review the patch and consider merge it. 
Please feel free to share any other ideas or suggestions.

Thank you.