### PR TITLE
Fix adding slow tag to dynamic categories

### DIFF
--- a/src/tracing/track_event_category_registry.cc
+++ b/src/tracing/track_event_category_registry.cc
@@ -22,7 +22,7 @@ namespace {
 static constexpr const char kLegacySlowPrefix[] = "disabled-by-default-";
 static constexpr const char kSlowTag[] = "slow";
 
-}
+}  // namespace
 
 // static
 Category Category::FromDynamicCategory(const char* name) {
@@ -34,8 +34,7 @@ Category Category::FromDynamicCategory(const char* name) {
   Category category(name);
   PERFETTO_DCHECK(category.name);
   // Disabled-by-default categories get a "slow" tag.
-  if (!strncmp(name, kLegacySlowPrefix,
-                strlen(kLegacySlowPrefix))) {
+  if (!strncmp(name, kLegacySlowPrefix, strlen(kLegacySlowPrefix))) {
     return category.SetTags(kSlowTag);
   }
   return category;

--- a/src/tracing/track_event_category_registry.cc
+++ b/src/tracing/track_event_category_registry.cc
@@ -17,6 +17,12 @@
 #include "perfetto/tracing/track_event_category_registry.h"
 
 namespace perfetto {
+namespace {
+
+static constexpr const char kLegacySlowPrefix[] = "disabled-by-default-";
+static constexpr const char kSlowTag[] = "slow";
+
+}
 
 // static
 Category Category::FromDynamicCategory(const char* name) {
@@ -27,6 +33,11 @@ Category Category::FromDynamicCategory(const char* name) {
   }
   Category category(name);
   PERFETTO_DCHECK(category.name);
+  // Disabled-by-default categories get a "slow" tag.
+  if (!strncmp(name, kLegacySlowPrefix,
+                strlen(kLegacySlowPrefix))) {
+    return category.SetTags(kSlowTag);
+  }
   return category;
 }
 


### PR DESCRIPTION
Previous PR broke chrome autoroll
https://github.com/google/perfetto/pull/2159#pullrequestreview-3033403436

Because dynamic categories don't have a slow tag anymore. 
This PR fixes the tests by adding slow tag once again, only on dynamic categories with "disabled-by-default-"
prefix.

Bug: b/433191228