### PR TITLE
Copybara import from Chromium: proto and stdlib changes

### DIFF
--- a/protos/third_party/chromium/chrome_track_event_import_wrapper.proto
+++ b/protos/third_party/chromium/chrome_track_event_import_wrapper.proto
@@ -5,4 +5,4 @@
 syntax = "proto2";
 
 // Import all .proto files that should be included in the proto descriptor.
-import public "chrome_track_event.proto";
+import public "protos/third_party/chromium/chrome_track_event.proto";

--- a/protos/third_party/chromium/optimization_guide/.clang-format-ignore
+++ b/protos/third_party/chromium/optimization_guide/.clang-format-ignore
@@ -1,3 +1,0 @@
-# Don't reformat auto imported proto files
-*.proto
-


### PR DESCRIPTION
Copybara import from Chromium: proto and stdlib changes

COPYBARA_IMPORT=Project import generated by Copybara.

GitOrigin-RevId: be68446e180370c868646c13119523a3d9741a44