### PR TITLE
Move .clang-format.ignore into parent directory

### DIFF
--- a/protos/third_party/chromium/.clang-format-ignore
+++ b/protos/third_party/chromium/.clang-format-ignore
@@ -1,3 +1,3 @@
 # Don't reformat auto imported proto files
-*.proto
+**/*.proto
 


### PR DESCRIPTION
copybara was deleting the clang-format-ignore file so move it to the parent to ensure it remains.

