### PR TITLE
tp: move tracking of trace_id for legacy Chrome events to slice

### DIFF
--- a/src/trace_processor/export_json.cc
+++ b/src/trace_processor/export_json.cc
@@ -551,6 +551,11 @@ class JsonExporter {
       return set_id ? *args_sets_.Find(*set_id) : empty_value_;
     }
 
+    std::optional<int64_t> GetLegacyTraceSourceId(ArgSetId set_id) const {
+      auto* ptr = legacy_trace_ids_.Find(set_id);
+      return ptr ? std::make_optional(*ptr) : std::nullopt;
+    }
+
    private:
     Json::Value VariadicToJson(Variadic variadic) {
       switch (variadic.type) {
@@ -643,6 +648,15 @@ class JsonExporter {
           }
         }
 
+        if (args.isMember("legacy_trace_source_id")) {
+          const Json::Value& legacy_trace_source_id =
+              args["legacy_trace_source_id"];
+          if (legacy_trace_source_id.isInt64()) {
+            legacy_trace_ids_[it.key()] = legacy_trace_source_id.asInt64();
+            args.removeMember("legacy_trace_source_id");
+          }
+        }
+
         // Rename source fields.
         if (args.isMember("task")) {
           if (args["task"].isMember("posted_from")) {
@@ -671,6 +685,7 @@ class JsonExporter {
 
     const TraceStorage* storage_;
     base::FlatHashMap<ArgSetId, Json::Value> args_sets_;
+    base::FlatHashMap<ArgSetId, int64_t> legacy_trace_ids_;
     const Json::Value empty_value_;
     const Json::Value nan_value_;
     const Json::Value inf_value_;
@@ -820,6 +835,12 @@ class JsonExporter {
         event["args"].removeMember(kLegacyEventArgsKey);
       }
 
+      std::optional<int64_t> legacy_trace_source_id;
+      if (it.arg_set_id()) {
+        legacy_trace_source_id =
+            args_builder_.GetLegacyTraceSourceId(*it.arg_set_id());
+      }
+
       // To prevent duplicate export of slices, only export slices on descriptor
       // or chrome tracks (i.e. TrackEvent slices). Slices on other tracks may
       // also be present as raw events and handled by trace_to_text. Only add
@@ -916,7 +937,7 @@ class JsonExporter {
         }
         writer_.WriteCommonEvent(event);
       } else if (is_child_track ||
-                 (legacy_chrome_track && track_args->isMember("trace_id"))) {
+                 (legacy_chrome_track && legacy_trace_source_id)) {
         // Async event slice.
         if (legacy_chrome_track) {
           // Legacy async tracks are always process-associated and have args.
@@ -930,11 +951,10 @@ class JsonExporter {
 
           // Preserve original event IDs for legacy tracks. This is so that e.g.
           // memory dump IDs show up correctly in the JSON trace.
-          PERFETTO_DCHECK(track_args->isMember("trace_id"));
+          PERFETTO_DCHECK(legacy_trace_source_id);
           PERFETTO_DCHECK(track_args->isMember("trace_id_is_process_scoped"));
           PERFETTO_DCHECK(track_args->isMember("source_scope"));
-          auto trace_id =
-              static_cast<uint64_t>((*track_args)["trace_id"].asInt64());
+          auto trace_id = static_cast<uint64_t>(*legacy_trace_source_id);
           std::string source_scope = (*track_args)["source_scope"].asString();
           if (!source_scope.empty())
             event["scope"] = source_scope;

--- a/src/trace_processor/export_json_unittest.cc
+++ b/src/trace_processor/export_json_unittest.cc
@@ -1019,17 +1019,31 @@ TEST_F(ExportJsonTest, AsyncEvents) {
   arg.flat_key = arg_key_id;
   arg.key = arg_key_id;
   arg.value = Variadic::Integer(kArgValue);
-  ArgSetId args = context_.global_args_tracker->AddArgSet({arg}, 0, 1);
+  StringId legacy_source_id_key =
+      context_.storage->InternString("legacy_trace_source_id");
+  GlobalArgsTracker::Arg source_id_arg;
+  source_id_arg.flat_key = legacy_source_id_key;
+  source_id_arg.key = legacy_source_id_key;
+  source_id_arg.value = Variadic::Integer(kSourceId);
+  ArgSetId args =
+      context_.global_args_tracker->AddArgSet({arg, source_id_arg}, 0, 2);
   auto& slice = *context_.storage->mutable_slice_table();
   slice[0].set_arg_set_id(args);
 
   // Child event with same timestamps as first one.
   context_.storage->mutable_slice_table()->Insert(
       {kTimestamp, kDuration, track, cat_id, name2_id, 0, 0, 0});
+  ArgSetId args2 =
+      context_.global_args_tracker->AddArgSet({source_id_arg}, 0, 1);
+  slice[1].set_arg_set_id(args2);
 
   // Another overlapping async event on a different track.
   context_.storage->mutable_slice_table()->Insert(
       {kTimestamp3, kDuration3, track2, cat_id, name3_id, 0, 0, 0});
+  source_id_arg.value = Variadic::Integer(kSourceId2);
+  ArgSetId args3 =
+      context_.global_args_tracker->AddArgSet({source_id_arg}, 0, 1);
+  slice[2].set_arg_set_id(args3);
 
   base::TempFile temp_file = base::TempFile::Create();
   FILE* output = fopen(temp_file.path().c_str(), "w+e");
@@ -1163,7 +1177,14 @@ TEST_F(ExportJsonTest, LegacyAsyncEvents) {
   std::vector<Arg> args1;
   arg_inserter("arg1", "value1", args1);
   arg_inserter("legacy_event.phase", "S", args1);
-  ArgSetId arg_id1 = context_.global_args_tracker->AddArgSet(args1, 0, 2);
+  StringId legacy_source_id_key =
+      context_.storage->InternString("legacy_trace_source_id");
+  GlobalArgsTracker::Arg source_id_arg;
+  source_id_arg.flat_key = legacy_source_id_key;
+  source_id_arg.key = legacy_source_id_key;
+  source_id_arg.value = Variadic::Integer(kSourceId);
+  args1.push_back(source_id_arg);
+  ArgSetId arg_id1 = context_.global_args_tracker->AddArgSet(args1, 0, 3);
   auto& slice = *context_.storage->mutable_slice_table();
   slice[0].set_arg_set_id(arg_id1);
 
@@ -1174,7 +1195,8 @@ TEST_F(ExportJsonTest, LegacyAsyncEvents) {
   arg_inserter("arg2", "value2", step_args);
   arg_inserter("legacy_event.phase", "T", step_args);
   arg_inserter("debug.step", "Step1", step_args);
-  ArgSetId arg_id2 = context_.global_args_tracker->AddArgSet(step_args, 0, 3);
+  step_args.push_back(source_id_arg);
+  ArgSetId arg_id2 = context_.global_args_tracker->AddArgSet(step_args, 0, 4);
   slice[1].set_arg_set_id(arg_id2);
 
   // Another overlapping async event on a different track.
@@ -1182,7 +1204,9 @@ TEST_F(ExportJsonTest, LegacyAsyncEvents) {
       {kTimestamp3, kDuration3, track2, cat_id, name3_id, 0, 0, 0});
   std::vector<Arg> args3;
   arg_inserter("legacy_event.phase", "S", args3);
-  ArgSetId arg_id3 = context_.global_args_tracker->AddArgSet(args3, 0, 1);
+  source_id_arg.value = Variadic::Integer(kSourceId2);
+  args3.push_back(source_id_arg);
+  ArgSetId arg_id3 = context_.global_args_tracker->AddArgSet(args3, 0, 2);
   slice[2].set_arg_set_id(arg_id3);
 
   base::TempFile temp_file = base::TempFile::Create();
@@ -1280,6 +1304,15 @@ TEST_F(ExportJsonTest, AsyncEventWithThreadTimestamp) {
   auto* slices = context_.storage->mutable_slice_table();
   auto id_and_row =
       slices->Insert({kTimestamp, kDuration, track, cat_id, name_id, 0, 0, 0});
+  StringId legacy_source_id_key =
+      context_.storage->InternString("legacy_trace_source_id");
+  GlobalArgsTracker::Arg source_id_arg;
+  source_id_arg.flat_key = legacy_source_id_key;
+  source_id_arg.key = legacy_source_id_key;
+  source_id_arg.value = Variadic::Integer(kSourceId);
+  ArgSetId args =
+      context_.global_args_tracker->AddArgSet({source_id_arg}, 0, 1);
+  id_and_row.row_reference.set_arg_set_id(args);
   context_.storage->mutable_virtual_track_slices()->AddVirtualTrackSlice(
       id_and_row.id, kThreadTimestamp, kThreadDuration, 0, 0);
 
@@ -1333,12 +1366,19 @@ TEST_F(ExportJsonTest, UnfinishedAsyncEvent) {
       /*source_scope=*/kNullStringId, TrackCompressor::AsyncSliceType::kBegin);
   context_.args_tracker->Flush();  // Flush track args.
 
-  auto slice_id =
-      context_.storage->mutable_slice_table()
-          ->Insert({kTimestamp, kDuration, track, cat_id, name_id, 0, 0, 0})
-          .id;
+  auto slice_id_and_row = context_.storage->mutable_slice_table()->Insert(
+      {kTimestamp, kDuration, track, cat_id, name_id, 0, 0, 0});
+  StringId legacy_source_id_key =
+      context_.storage->InternString("legacy_trace_source_id");
+  GlobalArgsTracker::Arg source_id_arg;
+  source_id_arg.flat_key = legacy_source_id_key;
+  source_id_arg.key = legacy_source_id_key;
+  source_id_arg.value = Variadic::Integer(kSourceId);
+  ArgSetId args =
+      context_.global_args_tracker->AddArgSet({source_id_arg}, 0, 1);
+  slice_id_and_row.row_reference.set_arg_set_id(args);
   context_.storage->mutable_virtual_track_slices()->AddVirtualTrackSlice(
-      slice_id, kThreadTimestamp, kThreadDuration, 0, 0);
+      slice_id_and_row.id, kThreadTimestamp, kThreadDuration, 0, 0);
 
   base::TempFile temp_file = base::TempFile::Create();
   FILE* output = fopen(temp_file.path().c_str(), "w+e");
@@ -1387,7 +1427,14 @@ TEST_F(ExportJsonTest, AsyncInstantEvent) {
   arg.flat_key = arg_key_id;
   arg.key = arg_key_id;
   arg.value = Variadic::Integer(kArgValue);
-  ArgSetId args = context_.global_args_tracker->AddArgSet({arg}, 0, 1);
+  StringId legacy_source_id_key =
+      context_.storage->InternString("legacy_trace_source_id");
+  GlobalArgsTracker::Arg source_id_arg;
+  source_id_arg.flat_key = legacy_source_id_key;
+  source_id_arg.key = legacy_source_id_key;
+  source_id_arg.value = Variadic::Integer(kSourceId);
+  ArgSetId args =
+      context_.global_args_tracker->AddArgSet({arg, source_id_arg}, 0, 2);
   auto& slice = *context_.storage->mutable_slice_table();
   slice[0].set_arg_set_id(args);
 

--- a/src/trace_processor/importers/common/track_compressor.cc
+++ b/src/trace_processor/importers/common/track_compressor.cc
@@ -31,7 +31,6 @@ namespace perfetto::trace_processor {
 TrackCompressor::TrackCompressor(TraceProcessorContext* context)
     : context_(context),
       source_key_(context->storage->InternString("source")),
-      trace_id_key_(context->storage->InternString("trace_id")),
       trace_id_is_process_scoped_key_(
           context->storage->InternString("trace_id_is_process_scoped")),
       upid_(context->storage->InternString("upid")),
@@ -137,7 +136,6 @@ TrackId TrackCompressor::InternLegacyAsyncTrack(StringId raw_name,
                                                 AsyncSliceType slice_type) {
   auto args_fn = [&](ArgsTracker::BoundInserter& inserter) {
     inserter.AddArg(source_key_, Variadic::String(chrome_source_))
-        .AddArg(trace_id_key_, Variadic::Integer(trace_id))
         .AddArg(trace_id_is_process_scoped_key_,
                 Variadic::Boolean(trace_id_is_process_scoped))
         .AddArg(upid_, Variadic::UnsignedInteger(upid))

--- a/src/trace_processor/importers/common/track_compressor.h
+++ b/src/trace_processor/importers/common/track_compressor.h
@@ -389,7 +389,6 @@ class TrackCompressor {
   TraceProcessorContext* const context_;
 
   const StringId source_key_;
-  const StringId trace_id_key_;
   const StringId trace_id_is_process_scoped_key_;
   const StringId upid_;
   const StringId source_scope_key_;

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -534,12 +534,12 @@ class TrackEventEventImporter {
             return base::ErrStatus(
                 "TrackEvent with local_id without process association");
           }
-
           source_id = static_cast<int64_t>(legacy_event_.local_id());
           source_id_is_process_scoped = true;
         } else {
           return base::ErrStatus("Async LegacyEvent without ID");
         }
+        legacy_trace_source_id_ = source_id;
 
         // Catapult treats nestable async events of different categories with
         // the same ID as separate tracks. We replicate the same behavior
@@ -1261,6 +1261,10 @@ class TrackEventEventImporter {
                            reinterpret_cast<const char*>(decoder->str().data),
                            decoder->str().size))));
     }
+    if (legacy_trace_source_id_) {
+      inserter->AddArg(parser_->legacy_trace_source_id_key_id_,
+                       Variadic::Integer(*legacy_trace_source_id_));
+    }
 
     ArgsParser args_writer(ts_, *inserter, *storage_, sequence_state_,
                            /*support_json=*/true);
@@ -1452,6 +1456,7 @@ class TrackEventEventImporter {
   std::optional<int64_t> thread_timestamp_;
   std::optional<int64_t> thread_instruction_count_;
   bool fallback_to_legacy_pid_tid_tracks_ = false;
+  std::optional<int64_t> legacy_trace_source_id_;
 
   // All events in legacy JSON require a thread ID, but for some types of
   // events (e.g. async events or process/global-scoped instants), we don't

--- a/src/trace_processor/importers/proto/track_event_parser.cc
+++ b/src/trace_processor/importers/proto/track_event_parser.cc
@@ -205,6 +205,8 @@ TrackEventParser::TrackEventParser(TraceProcessorContext* context,
       event_category_key_id_(context_->storage->InternString("event.category")),
       event_name_key_id_(context_->storage->InternString("event.name")),
       correlation_id_key_id_(context->storage->InternString("correlation_id")),
+      legacy_trace_source_id_key_id_(
+          context_->storage->InternString("legacy_trace_source_id")),
       chrome_string_lookup_(context->storage.get()),
       active_chrome_processes_tracker_(context) {
   args_parser_.AddParsingOverrideForField(

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -123,6 +123,7 @@ class TrackEventParser {
   const StringId event_category_key_id_;
   const StringId event_name_key_id_;
   const StringId correlation_id_key_id_;
+  const StringId legacy_trace_source_id_key_id_;
 
   ChromeStringLookup chrome_string_lookup_;
   std::vector<uint32_t> reflect_fields_;

--- a/test/trace_processor/diff_tests/parser/fuchsia/tests.py
+++ b/test/trace_processor/diff_tests/parser/fuchsia/tests.py
@@ -280,7 +280,6 @@ class Fuchsia(TestSuite):
         "somepointer",3285933758964,"[NULL]","[NULL]","pointer","0x2fd10ea19f4"
         "source","[NULL]","chrome","[NULL]","string","chrome"
         "source_scope","[NULL]","[NULL]","[NULL]","string","[NULL]"
-        "trace_id",658,"[NULL]","[NULL]","int","658"
         "trace_id_is_process_scoped",0,"[NULL]","[NULL]","bool","false"
         "track_compressor_idx",0,"[NULL]","[NULL]","int","0"
         "upid",1,"[NULL]","[NULL]","int","1"

--- a/test/trace_processor/diff_tests/parser/track_event/tests.py
+++ b/test/trace_processor/diff_tests/parser/track_event/tests.py
@@ -462,16 +462,20 @@ class TrackEvent(TestSuite):
         """,
         out=Csv("""
         "track","process","thread","thread_process","ts","dur","category","name","key","string_value","int_value"
+        "name1","[NULL]","[NULL]","[NULL]",1000,7000,"cat","name1","legacy_trace_source_id","[NULL]",1234
         "name1","[NULL]","[NULL]","[NULL]",1000,7000,"cat","name1","debug.arg1","value1","[NULL]"
         "name1","[NULL]","[NULL]","[NULL]",1000,7000,"cat","name1","legacy_event.passthrough_utid","[NULL]",1
         "name1","[NULL]","[NULL]","[NULL]",1000,7000,"cat","name1","legacy_event.phase","S","[NULL]"
         "name1","[NULL]","[NULL]","[NULL]",1000,7000,"cat","name1","debug.arg2","value2","[NULL]"
+        "name1","[NULL]","[NULL]","[NULL]",2000,1000,"cat","name1","legacy_trace_source_id","[NULL]",1234
         "name1","[NULL]","[NULL]","[NULL]",2000,1000,"cat","name1","legacy_event.passthrough_utid","[NULL]",2
         "name1","[NULL]","[NULL]","[NULL]",2000,1000,"cat","name1","legacy_event.phase","S","[NULL]"
+        "name1","[NULL]","[NULL]","[NULL]",3000,0,"cat","name1","legacy_trace_source_id","[NULL]",1234
         "name1","[NULL]","[NULL]","[NULL]",3000,0,"cat","name1","debug.arg3","value3","[NULL]"
         "name1","[NULL]","[NULL]","[NULL]",3000,0,"cat","name1","debug.step","Step1","[NULL]"
         "name1","[NULL]","[NULL]","[NULL]",3000,0,"cat","name1","legacy_event.passthrough_utid","[NULL]",1
         "name1","[NULL]","[NULL]","[NULL]",3000,0,"cat","name1","legacy_event.phase","T","[NULL]"
+        "name1","[NULL]","[NULL]","[NULL]",5000,0,"cat","name1","legacy_trace_source_id","[NULL]",1234
         "name1","[NULL]","[NULL]","[NULL]",5000,0,"cat","name1","debug.arg4","value4","[NULL]"
         "name1","[NULL]","[NULL]","[NULL]",5000,0,"cat","name1","debug.step","Step2","[NULL]"
         "name1","[NULL]","[NULL]","[NULL]",5000,0,"cat","name1","legacy_event.passthrough_utid","[NULL]",1
@@ -575,11 +579,11 @@ class TrackEvent(TestSuite):
           "event.name","event.name","[NULL]","[NULL]"
           "event.name","event.name","[NULL]","name1"
           "legacy_event.passthrough_utid","legacy_event.passthrough_utid",1,"[NULL]"
+          "legacy_trace_source_id","legacy_trace_source_id",1234,"[NULL]"
           "name","name","[NULL]","name1"
           "scope","scope","[NULL]","cat"
           "source","source","[NULL]","chrome"
           "source_scope","source_scope","[NULL]","cat"
-          "trace_id","trace_id",1234,"[NULL]"
           "trace_id_is_process_scoped","trace_id_is_process_scoped",0,"[NULL]"
           "track_compressor_idx","track_compressor_idx",0,"[NULL]"
           "upid","upid",1,"[NULL]"


### PR DESCRIPTION
Since now we multiplex slices in trace processor tracks, more than one
source_id can be associated with each track. This makes it not possible
to store this arg on the track. Instead store it on the slice.

Also intercept this at json export to strip it out and convert it to the
ID correctly.
