### PR TITLE
ui: show cam alloc/finish information

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_parser.h
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.h
@@ -47,6 +47,7 @@
 #include "src/trace_processor/importers/ftrace/virtio_gpu_tracker.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/version_number.h"
 
 namespace perfetto::trace_processor {
 
@@ -183,6 +184,11 @@ class FtraceParser {
                          protozero::ConstBytes);
   void ParseScmCallEnd(int64_t timestamp, uint32_t pid, protozero::ConstBytes);
   void ParseCmaAllocStart(int64_t timestamp, uint32_t pid);
+  void ParseCmaAllocFinish(int64_t timestamp,
+                           uint32_t pid,
+                           protozero::ConstBytes);
+  Variadic FindMigrationInfo(UniqueTid utid, const char* key);
+  void ParseMmAllocContigMigrateRangeInfo(uint32_t pid, protozero::ConstBytes);
   void ParseCmaAllocInfo(int64_t timestamp,
                          uint32_t pid,
                          protozero::ConstBytes);
@@ -462,6 +468,10 @@ class FtraceParser {
   // Record number of transmitted bytes to the network interface card.
   std::unordered_map<std::string, uint64_t> nic_transmitted_bytes_;
 
+  // Record tid to migrate info.
+  std::unordered_map<UniqueTid, std::unordered_map<std::string, Variadic>>
+      tid_to_migration_info_;
+
   // Record number of kfree_skb with ip protocol.
   uint64_t num_of_kfree_skb_ip_prot = 0;
 
@@ -523,6 +533,8 @@ class FtraceParser {
 
   base::FlatHashMap<std::pair<uint64_t, int64_t>, uint32_t, PairHash>
       inode_offset_thread_map_;
+
+  std::optional<VersionNumber> kernel_version_;
 };
 
 }  // namespace perfetto::trace_processor

--- a/test/trace_processor/diff_tests/parser/memory/tests.py
+++ b/test/trace_processor/diff_tests/parser/memory/tests.py
@@ -111,3 +111,60 @@ class MemoryParser(TestSuite):
         "name","ts","dur","name"
         "mem.dma_buffer",100,100,"1 kB"
         """))
+
+  def test_cma_alloc_finish(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          system_info {
+            utsname {
+              sysname: "Linux"
+              release: "6.1.0"
+            }
+          }
+        }
+        packet {
+          ftrace_events {
+            cpu: 2
+            event {
+              timestamp: 80000000000000
+              pid: 123
+              cma_alloc_start {
+                align: 8
+                count: 1024
+                name: "test_cma"
+              }
+            }
+            event {
+              timestamp: 80000000000050
+              pid: 123
+              mm_alloc_contig_migrate_range_info {
+                start: 1234
+                end: 2258
+                migratetype: 64
+                nr_migrated: 10
+                nr_reclaimed: 1000
+                nr_mapped: 99
+              }
+            }
+            event {
+              timestamp: 80000000000100
+              pid: 123
+              cma_alloc_finish {
+                align: 8
+                count: 1024
+                name: "test_cma"
+                page: 2000
+                pfn: 2048
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        SELECT ts, dur, name FROM slice WHERE name = 'mm_cma_alloc';
+        """,
+        out=Csv("""
+        "ts","dur","name"
+        80000000000000,100,"mm_cma_alloc"
+        """))


### PR DESCRIPTION
The Linux kernel, starting from v6.1, introduced a new ftrace event sequence for tracking Contiguous Memory Allocator (CMA) allocations. This change updates the ftrace parser to correctly handle both the legacy (pre-6.1) and modern event sequences.

The new implementation introduces parsing for the following flow on kernels 6.1+:
CmaAllocStart -> MmAllocContigMigrateRangeInfo -> CmaAllocFinish

Bug: 329188870

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
