### PR TITLE
perfetto: add streaming python proto builder

### DIFF
--- a/docs/getting-started/converting.md
+++ b/docs/getting-started/converting.md
@@ -866,3 +866,6 @@ you can:
   [Trace Processor](/docs/analysis/getting-started.md) to query your custom
   trace data. Your custom tracks and events will populate standard tables like
   `slice`, `track`, `counter`, etc.
+- **Handle large datasets:** If you are generating very large traces and want to
+  avoid high memory usage, learn how to stream data directly to a file in the
+  [Advanced Guide's section on streaming](/docs/reference/synthetic-track-event.md#handling-large-traces-with-streaming).

--- a/docs/reference/synthetic-track-event.md
+++ b/docs/reference/synthetic-track-event.md
@@ -646,3 +646,123 @@ of the tracks (usually the one with the lower UUID).
 </details>
 
 ![Merging by Key](/docs/images/synthetic-track-event-merge-by-key.png)
+
+## {#handling-large-traces-with-streaming} Handling Large Traces with Streaming
+
+All the examples so far have used the `TraceProtoBuilder`, which builds the
+entire trace in memory before writing it to a file. This is simple and effective
+for moderately sized traces, but can lead to high memory consumption if you are
+generating traces with millions of events.
+
+For these scenarios, the `StreamingTraceProtoBuilder` is the recommended
+solution. It writes each `TracePacket` to a file as it's created, keeping
+memory usage minimal regardless of the trace size.
+
+### How it Works
+
+The API for the streaming builder is slightly different:
+
+1.  **Initialization**: You initialize `StreamingTraceProtoBuilder` with a
+    file-like object opened in binary write mode.
+2.  **Packet Creation**: Instead of `builder.add_packet()`, you call
+    `builder.create_packet()` to get a new, empty `TracePacket`.
+3.  **Packet Writing**: After populating the packet, you must explicitly call
+    `builder.write_packet(packet)` to serialize and write it to the file.
+
+### Python Example: Complete Streaming Script
+
+Here is a complete, standalone Python script that demonstrates how to use the
+`StreamingTraceProtoBuilder`. It is based on the "Creating Basic Timeline
+Slices" example from the [Getting Started guide](/docs/getting-started/converting.md).
+
+You can save this code as a new file (e.g., `streaming_converter.py`) and run it.
+
+<details>
+<summary><a style="cursor: pointer;"><b>Click to expand/collapse Python code</b></a></summary>
+
+```python
+#!/usr/bin/env python3
+import uuid
+
+from perfetto.trace_builder.proto_builder import StreamingTraceProtoBuilder
+from perfetto.protos.perfetto.trace.perfetto_trace_pb2 import TrackEvent
+
+def populate_packets(builder: StreamingTraceProtoBuilder):
+    """
+    This function defines and writes TracePackets to the stream.
+
+    Args:
+        builder: An instance of StreamingTraceProtoBuilder.
+    """
+    # Define a unique ID for this sequence of packets
+    TRUSTED_PACKET_SEQUENCE_ID = 1001
+
+    # Define a unique UUID for your custom track
+    CUSTOM_TRACK_UUID = 12345678
+
+    # 1. Define the Custom Track
+    packet = builder.create_packet()
+    packet.track_descriptor.uuid = CUSTOM_TRACK_UUID
+    packet.track_descriptor.name = "My Custom Data Timeline"
+    builder.write_packet(packet)
+
+    # 2. Emit events for this custom track
+    # Example Event 1: "Task A"
+    packet = builder.create_packet()
+    packet.timestamp = 1000
+    packet.track_event.type = TrackEvent.TYPE_SLICE_BEGIN
+    packet.track_event.track_uuid = CUSTOM_TRACK_UUID
+    packet.track_event.name = "Task A"
+    packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+    builder.write_packet(packet)
+
+    packet = builder.create_packet()
+    packet.timestamp = 1500
+    packet.track_event.type = TrackEvent.TYPE_SLICE_END
+    packet.track_event.track_uuid = CUSTOM_TRACK_UUID
+    packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+    builder.write_packet(packet)
+
+    # Example Event 2: "Task B"
+    packet = builder.create_packet()
+    packet.timestamp = 1600
+    packet.track_event.type = TrackEvent.TYPE_SLICE_BEGIN
+    packet.track_event.track_uuid = CUSTOM_TRACK_UUID
+    packet.track_event.name = "Task B"
+    packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+    builder.write_packet(packet)
+
+    packet = builder.create_packet()
+    packet.timestamp = 1800
+    packet.track_event.type = TrackEvent.TYPE_SLICE_END
+    packet.track_event.track_uuid = CUSTOM_TRACK_UUID
+    packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+    builder.write_packet(packet)
+
+    # Example Event 3: An instantaneous event
+    packet = builder.create_packet()
+    packet.timestamp = 1900
+    packet.track_event.type = TrackEvent.TYPE_INSTANT
+    packet.track_event.track_uuid = CUSTOM_TRACK_UUID
+    packet.track_event.name = "Milestone Y"
+    packet.trusted_packet_sequence_id = TRUSTED_PACKET_SEQUENCE_ID
+    builder.write_packet(packet)
+
+def main():
+    """
+    Initializes the StreamingTraceProtoBuilder and calls populate_packets
+    to write the trace to a file.
+    """
+    output_filename = "my_streamed_trace.pftrace"
+    with open(output_filename, 'wb') as f:
+        builder = StreamingTraceProtoBuilder(f)
+        populate_packets(builder)
+
+    print(f"Trace written to {output_filename}")
+    print(f"Open with [https://ui.perfetto.dev](https://ui.perfetto.dev).")
+
+if __name__ == "__main__":
+    main()
+```
+
+</details>

--- a/python/perfetto/trace_builder/proto_builder.py
+++ b/python/perfetto/trace_builder/proto_builder.py
@@ -11,13 +11,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Provides builders for creating Perfetto traces programmatically.
+
+This module contains two primary classes for building Perfetto traces:
+- TraceProtoBuilder: An in-memory builder suitable for smaller traces.
+- StreamingTraceProtoBuilder: A streaming builder for creating large traces
+  without high memory usage.
+
+Example usage for TraceProtoBuilder:
+  builder = TraceProtoBuilder()
+  packet = builder.add_packet()
+  packet.timestamp = 1000
+  # ... populate packet ...
+  trace_bytes = builder.serialize()
+
+Example usage for StreamingTraceProtoBuilder:
+  with open('trace.pftrace', 'wb') as f:
+    builder = StreamingTraceProtoBuilder(f)
+    packet = builder.create_packet()
+    packet.timestamp = 1000
+    # ... populate packet ...
+    builder.write_packet(packet)
+"""
+
+from typing import IO
 
 from perfetto.protos.perfetto.trace.perfetto_trace_pb2 import Trace
 from perfetto.protos.perfetto.trace.perfetto_trace_pb2 import TracePacket
 
 
 class TraceProtoBuilder:
-  """A builder for creating Perfetto traces from Python."""
+  """An in-memory builder for creating Perfetto traces from Python.
+
+  This class constructs an entire Perfetto trace in memory. It is convenient
+  for smaller traces where memory consumption is not a concern. For generating
+  large traces, consider using `StreamingTraceProtoBuilder` to avoid high
+-  memory usage.
+  """
 
   def __init__(self):
     """Initializes the TraceProtoBuilder."""
@@ -28,4 +58,69 @@ class TraceProtoBuilder:
     return self.trace.packet.add()
 
   def serialize(self) -> bytes:
+    """Serializes the entire trace into a byte string."""
     return self.trace.SerializeToString()
+
+
+class StreamingTraceProtoBuilder:
+  """A streaming builder for creating Perfetto traces into a file.
+
+  This class is designed for generating large Perfetto traces without holding
+  the entire trace in memory. It writes each `TracePacket` to a file-like
+  object as it is created, making it memory-efficient.
+
+  The API is slightly different from `TraceProtoBuilder`. Instead of adding a
+  packet to an internal list, you first create a packet, populate it, and then
+  explicitly write it to the stream.
+
+  Example:
+    with open('my_streamed_trace.pftrace', 'wb') as f:
+      builder = StreamingTraceProtoBuilder(f)
+
+      # Create and write the first packet
+      packet1 = builder.create_packet()
+      packet1.timestamp = 1000
+      packet1.track_event.name = "My Event"
+      builder.write_packet(packet1)
+
+      # Create and write the second packet
+      packet2 = builder.create_packet()
+      packet2.timestamp = 2000
+      packet2.track_event.name = "Another Event"
+      builder.write_packet(packet2)
+  """
+
+  def __init__(self, file: IO[bytes]):
+    """Initializes the StreamingTraceProtoBuilder with a file-like object.
+
+    Args:
+      file: A file-like object opened in binary write mode (e.g., the result
+            of `open('trace.pftrace', 'wb')`).
+    """
+    self._file = file
+    self._trace = Trace()
+
+  def create_packet(self) -> TracePacket:
+    """Creates a new, empty TracePacket object.
+
+    This packet is not yet part of the trace. After populating its fields,
+    you must call `write_packet()` to add it to the output stream.
+
+    Returns:
+      A new `TracePacket` instance.
+    """
+    return TracePacket()
+
+  def write_packet(self, packet: TracePacket):
+    """Serializes and writes a TracePacket to the file stream.
+
+    The packet is wrapped inside a Trace proto as is expected by the Perfetto
+    analysis and visualization tooling.
+
+    Args:
+      packet: The `TracePacket` to be written to the file.
+    """
+    # Clear the packet list.
+    del self._trace.packet[:]
+    self._trace.packet.append(packet)
+    self._file.write(self._trace.SerializeToString())


### PR DESCRIPTION
This CL adds a new class which allows streaming building of traces from
Python (i.e. no need to materialize all the full trace in Python before
writing the file).

Separate class because the interface is less intuitive and has more
potential to go wrong.

Also document all of this fully.
