### PR TITLE
tp: remove cost estimation for static table functions

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/static_table_function_module.cc
+++ b/src/trace_processor/perfetto_sql/engine/static_table_function_module.cc
@@ -154,10 +154,7 @@ int StaticTableFunctionModule::BestIndex(sqlite3_vtab* tab,
     // plan after that, we can throw a proper error message in xFilter.
     return SQLITE_CONSTRAINT;
   }
-  uint32_t estimate = v->function->EstimateRowCount();
   info->needToFreeIdxStr = true;
-  info->estimatedCost = estimate;
-  info->estimatedRows = estimate;
   info->idxNum = v->best_idx_num++;
   PERFETTO_TP_TRACE(metatrace::Category::QUERY_TIMELINE,
                     "STATIC_TABLE_FUNCTION_BEST_INDEX");

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/ancestor.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/ancestor.cc
@@ -217,9 +217,6 @@ std::string Ancestor::TableName() {
 uint32_t Ancestor::GetArgumentCount() const {
   return 1;
 }
-uint32_t Ancestor::EstimateRowCount() {
-  return 1;
-}
 
 // static
 bool Ancestor::GetAncestorSlices(

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/ancestor.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/ancestor.h
@@ -78,7 +78,6 @@ class Ancestor : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
   // Returns a vector of rows numbers which are ancestors of |slice_id|.
   // Returns std::nullopt if an invalid |slice_id| is given. This is used by

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/connected_flow.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/connected_flow.cc
@@ -299,8 +299,4 @@ uint32_t ConnectedFlow::GetArgumentCount() const {
   return 1;
 }
 
-uint32_t ConnectedFlow::EstimateRowCount() {
-  return 1;
-}
-
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/connected_flow.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/connected_flow.h
@@ -74,7 +74,6 @@ class ConnectedFlow : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   Mode mode_;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/dataframe_query_plan_decoder.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/dataframe_query_plan_decoder.cc
@@ -80,8 +80,5 @@ std::string DataframeQueryPlanDecoder::TableName() {
 uint32_t DataframeQueryPlanDecoder::GetArgumentCount() const {
   return 1;
 }
-uint32_t DataframeQueryPlanDecoder::EstimateRowCount() {
-  return 20;
-}
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/dataframe_query_plan_decoder.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/dataframe_query_plan_decoder.h
@@ -51,7 +51,6 @@ class DataframeQueryPlanDecoder : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   StringPool* string_pool_;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/descendant.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/descendant.cc
@@ -160,9 +160,6 @@ std::string Descendant::TableName() {
 uint32_t Descendant::GetArgumentCount() const {
   return 1;
 }
-uint32_t Descendant::EstimateRowCount() {
-  return 1;
-}
 
 tables::SliceTable::ConstCursor Descendant::MakeCursor(
     const tables::SliceTable& slices) {

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/descendant.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/descendant.h
@@ -63,7 +63,6 @@ class Descendant : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
   static tables::SliceTable::ConstCursor MakeCursor(const tables::SliceTable&);
 

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/dfs_weight_bounded.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/dfs_weight_bounded.cc
@@ -304,9 +304,4 @@ uint32_t DfsWeightBounded::GetArgumentCount() const {
   return 6;
 }
 
-uint32_t DfsWeightBounded::EstimateRowCount() {
-  // TODO(lalitm): improve this estimate.
-  return 1024;
-}
-
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/dfs_weight_bounded.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/dfs_weight_bounded.h
@@ -91,7 +91,6 @@ class DfsWeightBounded : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   StringPool* pool_ = nullptr;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_annotated_stack.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_annotated_stack.cc
@@ -301,8 +301,5 @@ std::string ExperimentalAnnotatedStack::TableName() {
 uint32_t ExperimentalAnnotatedStack::GetArgumentCount() const {
   return 1;
 }
-uint32_t ExperimentalAnnotatedStack::EstimateRowCount() {
-  return 1;
-}
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_annotated_stack.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_annotated_stack.h
@@ -56,7 +56,6 @@ class ExperimentalAnnotatedStack : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   TraceProcessorContext* context_ = nullptr;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flamegraph.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flamegraph.cc
@@ -391,9 +391,5 @@ std::string ExperimentalFlamegraph::TableName() {
 uint32_t ExperimentalFlamegraph::GetArgumentCount() const {
   return 6;
 }
-uint32_t ExperimentalFlamegraph::EstimateRowCount() {
-  // TODO(lalitm): return a better estimate here when possible.
-  return 1024;
-}
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flamegraph.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flamegraph.h
@@ -65,7 +65,6 @@ class ExperimentalFlamegraph : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   TraceProcessorContext* context_ = nullptr;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flat_slice.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flat_slice.cc
@@ -283,8 +283,5 @@ std::string ExperimentalFlatSlice::TableName() {
 uint32_t ExperimentalFlatSlice::GetArgumentCount() const {
   return 2;
 }
-uint32_t ExperimentalFlatSlice::EstimateRowCount() {
-  return context_->storage->slice_table().row_count();
-}
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flat_slice.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flat_slice.h
@@ -77,7 +77,6 @@ class ExperimentalFlatSlice : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
   // Visibile for testing.
   static std::unique_ptr<tables::ExperimentalFlatSliceTable>

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_slice_layout.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_slice_layout.cc
@@ -302,8 +302,5 @@ std::string ExperimentalSliceLayout::TableName() {
 uint32_t ExperimentalSliceLayout::GetArgumentCount() const {
   return 1;
 }
-uint32_t ExperimentalSliceLayout::EstimateRowCount() {
-  return slice_table_->row_count();
-}
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_slice_layout.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_slice_layout.h
@@ -75,7 +75,6 @@ class ExperimentalSliceLayout : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   StringPool* string_pool_;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/static_table_function.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/static_table_function.h
@@ -80,9 +80,6 @@ class StaticTableFunction {
 
   // Returns the number of arguments that the table function takes.
   virtual uint32_t GetArgumentCount() const = 0;
-
-  // Returns the estimated number of rows the table would generate.
-  virtual uint32_t EstimateRowCount() = 0;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/table_info.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/table_info.cc
@@ -121,8 +121,5 @@ std::string TableInfo::TableName() {
 uint32_t TableInfo::GetArgumentCount() const {
   return 1;
 }
-uint32_t TableInfo::EstimateRowCount() {
-  return 1;
-}
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/table_info.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/table_info.h
@@ -53,7 +53,6 @@ class TableInfo : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   StringPool* string_pool_ = nullptr;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_proto_to_args_with_defaults.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_proto_to_args_with_defaults.cc
@@ -367,8 +367,5 @@ std::string WinscopeProtoToArgsWithDefaults::TableName() {
 uint32_t WinscopeProtoToArgsWithDefaults::GetArgumentCount() const {
   return 1;
 }
-uint32_t WinscopeProtoToArgsWithDefaults::EstimateRowCount() {
-  // 100 inflated args per 100 elements per 100 entries
-  return 1000000;
-}
+
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_proto_to_args_with_defaults.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_proto_to_args_with_defaults.h
@@ -58,7 +58,6 @@ class WinscopeProtoToArgsWithDefaults : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   StringPool* string_pool_ = nullptr;

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_surfaceflinger_hierarchy_paths.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_surfaceflinger_hierarchy_paths.cc
@@ -159,8 +159,5 @@ std::string WinscopeSurfaceFlingerHierarchyPaths::TableName() {
 uint32_t WinscopeSurfaceFlingerHierarchyPaths::GetArgumentCount() const {
   return 0;
 }
-uint32_t WinscopeSurfaceFlingerHierarchyPaths::EstimateRowCount() {
-  // 1 path per 100 elements per 100 entries
-  return 10000;
-}
+
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_surfaceflinger_hierarchy_paths.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_surfaceflinger_hierarchy_paths.h
@@ -54,7 +54,6 @@ class WinscopeSurfaceFlingerHierarchyPaths : public StaticTableFunction {
   dataframe::DataframeSpec CreateSpec() override;
   std::string TableName() override;
   uint32_t GetArgumentCount() const override;
-  uint32_t EstimateRowCount() override;
 
  private:
   StringPool* string_pool_ = nullptr;


### PR DESCRIPTION
Our cust estimates at the moment suck and bad estimates are worse than
no estimates at all. Not setting the estimate and row count means that
SQLite sets the maximum values and that means it will try and
materialize the data as much as possible. Thankfully that's exactly what
we want.
