### PR TITLE
tp: fix assumption that we know all the proto log levels

### DIFF
--- a/src/trace_processor/importers/proto/winscope/protolog_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.cc
@@ -188,7 +188,7 @@ void ProtoLogParser::PopulateReservedRowWithMessage(
   auto* protolog_table = storage->mutable_protolog_table();
   auto row = protolog_table->FindById(table_row_id).value();
 
-  StringPool::Id level;
+  StringPool::Id level = kNullStringId;
   switch (log_level) {
     case ProtoLogLevel::DEBUG:
       level = log_level_debug_string_id_;


### PR DESCRIPTION
Turns out there is a level which is not covered which is causing a crash
because of uninitialized memory. While this is not the root cause of the
crash, it is a good practice to always have variables like this
initialized anyway.
