### PR TITLE
stdlib: Add table for power rail metadata

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -79,3 +79,23 @@ SELECT
 FROM counter_leading_intervals!(counter_table) AS c
 JOIN counter_track AS t
   ON c.track_id = t.id;
+
+-- High level metadata about each of the power rails.
+CREATE PERFETTO TABLE android_power_rails_metadata (
+  -- Power rail name. Alias of `counter_track.name`.
+  power_rail_name STRING,
+  -- Raw power rail name from the hardware.
+  raw_power_rail_name STRING,
+  -- Power rail track id. Alias of `counter_track.id`.
+  track_id JOINID(track.id),
+  -- Subsystem name that this power rail belongs to.
+  subsystem_name STRING
+) AS
+SELECT
+  t.name AS power_rail_name,
+  extract_arg(t.source_arg_set_id, 'raw_name') AS raw_power_rail_name,
+  t.id AS track_id,
+  extract_arg(t.source_arg_set_id, 'subsystem_name') AS subsystem_name
+FROM counter_track AS t
+WHERE
+  t.type = 'power_rails';

--- a/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
+++ b/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
@@ -150,3 +150,42 @@ class PowerPowerRails(TestSuite):
         "power.rails.cpu.mid",333.000000,3
         "power.rails.gpu",999.000000,1
         """))
+
+  def test_android_power_rails_metadata(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          power_rails {
+            rail_descriptor {
+              index: 4
+              rail_name: "S3M_VDD_CPUCL1"
+              subsys_name: "cpu"
+              sampling_rate: 1023
+            }
+          }
+        }
+        packet {
+          power_rails {
+            rail_descriptor {
+              index: 3
+              rail_name: "S2S_VDD_G3D"
+              subsys_name: "gpu"
+              sampling_rate: 1022
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE android.power_rails;
+        SELECT
+          power_rail_name,
+          raw_power_rail_name,
+          subsystem_name
+        FROM android_power_rails_metadata
+        ORDER BY power_rail_name;
+        """,
+        out=Csv("""
+        "power_rail_name","raw_power_rail_name","subsystem_name"
+        "power.rails.cpu.mid","S3M_VDD_CPUCL1","cpu"
+        "power.rails.gpu","S2S_VDD_G3D","gpu"
+        """))


### PR DESCRIPTION
The current table contains one row per sample making it non-ideal for looking information about power rail tracks. In addition it does not have any info about the rail subsystem or other metadata.

Add a new table to make it easy to query this info.
