### PR TITLE
stdlib: use track type instead of name to identify power rails

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -58,7 +58,7 @@ WITH
     JOIN counter_track AS t
       ON c.track_id = t.id
     WHERE
-      name GLOB 'power.*'
+      type = 'power_rails'
   )
 SELECT
   c.id,


### PR DESCRIPTION
Use the track type instead of track name to identify power rails since it should be more robust and prevent false positive matches.

