### PR TITLE
ui: add ability to specify rate-specific units in plugins

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -180,6 +180,11 @@ export interface CounterOptions {
   // unit for the counter. This is displayed in the tooltip and
   // legend.
   unit?: string;
+
+  // unit to use when yMode is set to 'rate'. This rateUnit should be
+  // equivalent to unit/s. For example, if the 'unit' is Joules, the 'rateUnit'
+  // may be set to Watts. If not specified, unit/s will be used.
+  rateUnit?: string;
 }
 
 export abstract class BaseCounterTrack implements TrackRenderer {
@@ -239,7 +244,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
       case 'delta':
         return `${value.toLocaleString()} \u0394${unit}`;
       case 'rate':
-        return `${value.toLocaleString()} \u0394${unit}/s`;
+        return `${value.toLocaleString()} ${this.rateUnit}`;
       default:
         assertUnreachable(options.yMode);
     }
@@ -759,7 +764,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
         yLabel += `\u0394${unit}`;
         break;
       case 'rate':
-        yLabel += `\u0394${unit}/s`;
+        yLabel += ` ${this.rateUnit}`;
         break;
       default:
         assertUnreachable(options.yMode);
@@ -910,6 +915,10 @@ export abstract class BaseCounterTrack implements TrackRenderer {
 
   get unit(): string {
     return this.getCounterOptions().unit ?? '';
+  }
+
+  get rateUnit(): string {
+    return this.getCounterOptions().rateUnit ?? `\u0394${this.unit}/s`;
   }
 
   protected get engine() {


### PR DESCRIPTION
For things like power we may want to specify the rate-mode units in watts instead of the autogenerated joules/sec style units in order to present the user with something more meaningful.

if the plugin does not specify anything then unit/sec will continue to be used for counter tracks in rate mode.

BUG: #2249 