### PR TITLE
tp: Set unknown protolog level as UNKNOWN.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/protolog_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.cc
@@ -24,6 +24,7 @@
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
@@ -188,7 +189,7 @@ void ProtoLogParser::PopulateReservedRowWithMessage(
   auto* protolog_table = storage->mutable_protolog_table();
   auto row = protolog_table->FindById(table_row_id).value();
 
-  StringPool::Id level = kNullStringId;
+  StringPool::Id level = log_level_unknown_string_id_;
   switch (log_level) {
     case ProtoLogLevel::DEBUG:
       level = log_level_debug_string_id_;


### PR DESCRIPTION
Bug: 433513794
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="ProtoLog"