### PR TITLE
ui: support for hosting Perfetto in other applications

### DIFF
--- a/docs/concepts/ui-embedder-context-api.md
+++ b/docs/concepts/ui-embedder-context-api.md
@@ -1,0 +1,60 @@
+# EmbedderContext API
+
+This document provides an overview of the `EmbedderContext` API in Perfetto UI, as defined in [`ui/src/core/embedder.ts`](../../ui/src/core/embedder.ts).
+This API allows host (embedding) applications to customize various aspects of Perfetto UI's behavior, especially for advanced integration scenarios.
+
+## Overview
+
+The `EmbedderContext` interface provides a collection of optional hooks, flags, and handlers that a host application can implement to control or override specific Perfetto UI behaviors.
+The primary intended use case is in applications that take care of such concerns as acquiring and managing Perfetto traces but wish to reuse/embed the Perfetto UI for presentation of those traces to the user.
+
+The context object must be set *before* loading the main Perfetto UI module to ensure proper integration.
+
+Host applications can configure the `EmbedderContext` to customize the following aspects of the Perfetto UI app:
+
+- **Custom Error Handling**: Suppress Perfetto UI's internal error handling, deferring to whatever the host application does in that regard.
+- **UI Rendering Control**: Prevent the start-up of the Perfetto UI app from rendering its main interface, allowing the host application can selectively instantiate components.
+- **Content Security Policy Strategy**: Customization of how the CSP is installed in the application, with optional filtering of the rules.
+- **Storage Customization**: Prefix cache storage keys for coexistence with other applications' caches and for certain application frameworks' restrictions.
+- **Routing Hooks**: Intercept or override URL navigation and route handling.
+- **Custom PostMessage Handling**: Process unrecognized messages posted to the window.
+- **Preloaded Trace Handling**: Indicate how Perfetto should deal with traces pre-loaded in the trace processor backend.
+- **App State Restoration**: Delegate Perfetto app state persistence to the host application.
+
+## Setting the Embedder Context
+
+The host application _must_ set its embedder context via the `setEmbedderContext()` function _before_ the Perfetto UI app is initialized.
+This function may be called only once.
+Attempting to replace an established embedder context throws an error.
+
+Since Perfetto UI's main entry point (e.g., `frontend/index.ts`) references the embedder context as it initializes, the safest approach is:
+
+- define your embedder context and call `setEmbedderContext()` in a dedicated module.
+Ideally it will not need to import any other Perfetto UI modules than `embedder.ts` and a few minimal dependencies for types and APIs such as `Router` and `RafScheduler`
+- ensure that this module is imported by your application before any Perfetto source modules
+
+### Example
+
+Suppose you have an application integrating Perfetto:
+
+```typescript
+// perfetto-setup.ts
+import {setEmbedderContext} from 'perfetto/ui/dist/core/embedder';
+
+setEmbedderContext({
+  suppressErrorHandling: true,
+  suppressMainUi: true,
+  cachePrefix: 'https:/',
+  // ...other overrides
+});
+```
+
+Then, in your application entrypoint:
+
+```typescript
+// index.ts
+import './perfetto-setup';        // <-- Import this first!
+import 'perfetto/ui/dist/frontend/index'; // Now load Perfetto UI
+```
+
+This ensures the embedder context is established before Perfetto's frontend initialization.

--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -48,6 +48,7 @@ const char* kDefaultAllowedCORSOrigins[] = {
     "https://ui.perfetto.dev",
     "http://localhost:10000",
     "http://127.0.0.1:10000",
+    "file://",
 };
 
 class Httpd : public base::HttpRequestHandler {

--- a/ui/src/base/http_utils.ts
+++ b/ui/src/base/http_utils.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {embedderContext} from '../core/embedder';
 import {assertTrue} from './logging';
 
 export function fetchWithTimeout(
@@ -79,8 +80,8 @@ export function getServingRoot() {
   const script = document.currentScript as HTMLScriptElement;
 
   if (script === null) {
-    // Can be null in tests.
-    assertTrue(typeof jest !== 'undefined');
+    // Can be null in tests or an embedding application.
+    assertTrue(typeof jest !== 'undefined' || embedderContext !== undefined);
     return '';
   }
 

--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -28,6 +28,7 @@ import {DurationPrecision, TimestampFormat} from '../public/timeline';
 import {NewEngineMode} from '../trace_processor/engine';
 import {AnalyticsInternal, initAnalytics} from './analytics_impl';
 import {CommandInvocation, CommandManagerImpl} from './command_manager';
+import {embedderContext} from './embedder';
 import {featureFlags} from './feature_flags';
 import {loadTrace} from './load_trace';
 import {OmniboxManagerImpl} from './omnibox_manager';
@@ -138,9 +139,14 @@ export class AppContext {
       initArgs.enforceStartupCommandAllowlistSetting;
     this.settingsManager = initArgs.settingsManager;
     this.initArgs = initArgs;
-    this.initialRouteArgs = initArgs.initialRouteArgs;
+    this.initialRouteArgs = {
+      ...initArgs.initialRouteArgs,
+      ...(embedderContext?.initialRouteArgs ?? {}),
+    };
     this.serviceWorkerController = new ServiceWorkerController();
-    this.embeddedMode = this.initialRouteArgs.mode === 'embedded';
+    this.embeddedMode =
+      this.initialRouteArgs.mode === 'embedded' ||
+      embedderContext !== undefined;
     this.testingMode =
       self.location !== undefined &&
       self.location.search.indexOf('testing=1') >= 0;

--- a/ui/src/core/cache_manager.ts
+++ b/ui/src/core/cache_manager.ts
@@ -18,6 +18,7 @@
  * containing it is discarded by Chrome (e.g. because the tab was not used for
  * a long time) or when the user accidentally hits reload.
  */
+import {embedderContext} from './embedder';
 import {TraceArrayBufferSource, TraceSource} from './trace_source';
 
 const TRACE_CACHE_NAME = 'cached_traces';
@@ -129,7 +130,8 @@ export async function cacheTrace(
     ],
   ]);
   await deleteStaleEntries();
-  const key = `/_${TRACE_CACHE_NAME}/${traceUuid}`;
+  const cachePrefix = embedderContext?.cachePrefix ?? '';
+  const key = `${cachePrefix}/_${TRACE_CACHE_NAME}/${traceUuid}`;
   await cachePut(key, new Response(trace, {headers}));
 
   // Verify the file was actually cached, large files can silently fail.
@@ -151,7 +153,10 @@ export async function tryGetTrace(
   traceUuid: string,
 ): Promise<TraceArrayBufferSource | undefined> {
   await deleteStaleEntries();
-  const response = await cacheMatch(`/_${TRACE_CACHE_NAME}/${traceUuid}`);
+  const cachePrefix = embedderContext?.cachePrefix ?? '';
+  const response = await cacheMatch(
+    `${cachePrefix}/_${TRACE_CACHE_NAME}/${traceUuid}`,
+  );
 
   if (!response) return undefined;
   return {

--- a/ui/src/core/embedder.ts
+++ b/ui/src/core/embedder.ts
@@ -1,0 +1,155 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {RouteArgs} from '../public/route_schema';
+import {Route} from './router';
+import {SerializedAppState} from './state_serialization_schema';
+
+/**
+ * An optional intercept of various routing APIs to customize how Perfetto UI
+ * responds to and initiates URL navigation to present different parts of the app.
+ */
+export interface RoutingHooks {
+  /** Optional override of window URL hash change handling in the `Router`. */
+  onHashChange?(oldRoute: Route, newRoute: Route): Route;
+  /** Optional override of navigating to a new window URL in the `Router`. */
+  navigate?(uri: string): void;
+  /** Optional override of opening a trace on URL navigation. */
+  openTraceFromRoute?(route: Route): boolean;
+  /** Optional override of state tracking what is the current route to which the UI has navigated. */
+  readonly currentRoute?: Route;
+}
+
+/**
+ * An optional strategy for installation of Perfetto UI's content security
+ * policy by whatever means is appropriate for the host application. It is
+ * likely that the embedder already has a `<meta>` tag defining the policy,
+ * so this is an opportunity to update that tag, create it if it does not
+ * already exist, or apply the policy in some other application-specific manner.
+ * Additionally, the embedder is free to select from and augment the given
+ * `policy` rules.
+ *
+ * @param policy a content security policy to install
+ */
+export interface ContentSecurityPolicyInstaller {
+  (policy: Readonly<Record<string, string[]>>): void;
+}
+
+/**
+ * An optional handler for post messages not recognized by Perfetto UI.
+ */
+export interface PostMessageHandler {
+  /**
+   * Attempt to handle the given data received in a post message.
+   * @returns `true` if successfully handled;
+   *    `false` to indicate that the message is unrecognized or unsupported
+   */
+  (messageData: MessageEvent['data']): boolean;
+}
+
+/**
+ * Enumeration of responses to the query of what to do with a trace found pre-loaded
+ * into the trace processor when starting Perfetto UI.
+ */
+export type PreloadedTraceOption = 'use_trace' | 'reset_rpc' | 'use_wasm';
+/**
+ * Signature of a function querying what to do with a trace found pre-loaded
+ * into the trace processor when starting Perfetto UI.
+ *
+ * @param loadedTraceName a user-presentable label for the trace that was loaded
+ */
+export interface PreloadedTraceQuery {
+  (loadedTraceName: string): Promise<PreloadedTraceOption>;
+}
+
+/**
+ * Optional overrides/intercepts of basic Perfetto UI behaviours
+ * for integration with host (embedding) applications. If the context
+ * does not exist, then there is no host application.
+ */
+export interface EmbedderContext {
+  /**
+   * Optional flag to suppress the built-in error handling.
+   * If `true`, the host application avers that it will handle uncaught
+   * exceptions and promise rejections.
+   */
+  readonly suppressErrorHandling?: boolean;
+
+  /**
+   * Optional flag to suppress rendering of the main UI.
+   * If `true`, then the host application is responsible for instantiating
+   * some portion of the Perfetto UI when and as required.
+   */
+  readonly suppressMainUi?: boolean;
+
+  /**
+   * Optional prefix to prepend on the URLs used as keys for cache storage
+   * in the `CacheManager`.
+   */
+  readonly cachePrefix?: string;
+
+  /**
+   * Optional hooks to intercept/override routing functions, as described
+   * in the `RoutingHooks` interface.
+   */
+  readonly routingHooks?: RoutingHooks;
+
+  /**
+   * Optional initial route arguments to inject as defaults before route args
+   * parsed from the window URL are overlaid.
+   */
+  readonly initialRouteArgs?: RouteArgs;
+
+  /**
+   * Optional content-security policy installation strategy.
+   */
+  readonly setContentSecurityPolicy?: ContentSecurityPolicyInstaller;
+
+  /**
+   * Optional handler for post messages not recognized by Perfetto UI.
+   */
+  readonly postMessageHandler?: PostMessageHandler;
+
+  /**
+   * Optional strategy for how to deal with a trace that is found pre-loaded into the
+   * trace processor at start-up.
+   */
+  readonly shouldUsePreloadedTrace?: PreloadedTraceQuery;
+
+  /**
+   * Optional serialized application state to seed the loading of a trace. Useful for
+   * applications that save UI and plug-in state to restore when reloading a trace
+   * that had been loaded in an earlier session.
+   */
+  readonly appState?: SerializedAppState;
+}
+
+export declare const embedderContext: Readonly<EmbedderContext> | undefined;
+
+let _embedderContext: typeof embedderContext;
+Object.defineProperty(exports, 'embedderContext', {
+  get: () => _embedderContext,
+  enumerable: true,
+});
+
+/**
+ * Set the embedder context for customization of the UI application behaviour
+ * within the embedding application. This may only be set once.
+ */
+export function setEmbedderContext(embedderContext: EmbedderContext): void {
+  if (_embedderContext) {
+    throw new Error('embedder context is already set');
+  }
+  _embedderContext = embedderContext;
+}

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -48,6 +48,7 @@ import {TraceSource} from './trace_source';
 import {Router} from '../core/router';
 import {TraceInfoImpl} from './trace_info_impl';
 import {base64Decode} from '../base/string_utils';
+import {embedderContext} from './embedder';
 
 const ENABLE_CHROME_RELIABLE_RANGE_ZOOM_FLAG = featureFlags.register({
   id: 'enableChromeReliableRangeZoom',
@@ -178,7 +179,7 @@ async function loadTraceIntoEngine(
   engine: EngineBase,
 ): Promise<TraceImpl> {
   let traceStream: TraceStream | undefined;
-  const serializedAppState = traceSource.serializedAppState;
+  let serializedAppState = traceSource.serializedAppState;
   if (traceSource.type === 'FILE') {
     traceStream = new TraceFileStream(traceSource.file);
   } else if (traceSource.type === 'ARRAY_BUFFER') {
@@ -192,6 +193,9 @@ async function loadTraceIntoEngine(
   } else {
     throw new Error(`Unknown source: ${JSON.stringify(traceSource)}`);
   }
+
+  // Maybe serialized app state was injected from the host application
+  serializedAppState ??= embedderContext?.appState;
 
   // |traceStream| can be undefined in the case when we are using the external
   // HTTP+RPC endpoint and the trace processor instance has already loaded

--- a/ui/src/core/page_manager.ts
+++ b/ui/src/core/page_manager.ts
@@ -18,6 +18,7 @@ import {Registry} from '../base/registry';
 import {PageHandler} from '../public/page';
 import {Router} from './router';
 import {Gate} from '../base/mithril_utils';
+import {embedderContext} from './embedder';
 
 export class PageManagerImpl {
   private readonly registry = new Registry<PageHandler>((x) => x.route);
@@ -36,7 +37,9 @@ export class PageManagerImpl {
 
   // Called by index.ts upon the main frame redraw callback.
   renderPageForCurrentRoute(): m.Children {
-    const route = Router.parseFragment(location.hash);
+    const route =
+      embedderContext?.routingHooks?.currentRoute ??
+      Router.parseFragment(location.hash);
     this.previousPages.set(route.page, {
       page: route.page,
       subpage: route.subpage,
@@ -63,7 +66,7 @@ export class PageManagerImpl {
 
   // Will return undefined if either: (1) the route does not exist; (2) the
   // route exists, it requires a trace, but there is no trace loaded.
-  private renderPageForRoute(page: string, subpage: string) {
+  renderPageForRoute(page: string, subpage: string): m.Children {
     const handler = this.registry.tryGet(page);
     if (handler === undefined) {
       return undefined;

--- a/ui/src/core/router.ts
+++ b/ui/src/core/router.ts
@@ -15,6 +15,7 @@
 import m from 'mithril';
 import {assertTrue} from '../base/logging';
 import {RouteArgs, ROUTE_SCHEMA} from '../public/route_schema';
+import {embedderContext} from './embedder';
 
 export const ROUTE_PREFIX = '#!';
 
@@ -88,6 +89,15 @@ export class Router {
     const oldRoute = Router.parseUrl(e.oldURL);
     const newRoute = Router.parseUrl(e.newURL);
 
+    const fromEmbedder = embedderContext?.routingHooks?.onHashChange?.(
+      oldRoute,
+      newRoute,
+    );
+    if (fromEmbedder) {
+      this.onRouteChanged(fromEmbedder);
+      return;
+    }
+
     if (
       newRoute.args.local_cache_key === undefined &&
       oldRoute.args.local_cache_key
@@ -126,7 +136,11 @@ export class Router {
 
   static navigate(newHash: string) {
     assertTrue(newHash.startsWith(ROUTE_PREFIX));
-    window.location.hash = newHash;
+    if (embedderContext?.routingHooks?.navigate) {
+      embedderContext.routingHooks.navigate(newHash);
+    } else {
+      window.location.hash = newHash;
+    }
   }
 
   // Breaks down a fragment into a Route object.

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -21,6 +21,7 @@ import {AppImpl} from '../core/app_impl';
 import {SerializedAppState} from '../core/state_serialization_schema';
 import {parseAppState} from '../core/state_serialization';
 import {BUCKET_NAME} from '../base/gcs_uploader';
+import {embedderContext} from '../core/embedder';
 
 const TRUSTED_ORIGINS_KEY = 'trustedOrigins';
 
@@ -208,6 +209,8 @@ export function postMessageHandler(messageEvent: MessageEvent) {
     }
   } else if (messageEvent.data instanceof ArrayBuffer) {
     postedTrace = {title: 'External trace', buffer: messageEvent.data};
+  } else if (embedderContext?.postMessageHandler?.(messageEvent) === true) {
+    return;
   } else {
     console.warn(
       'Unknown postMessage() event received. If you are trying to open a ' +

--- a/ui/src/frontend/trace_url_handler.ts
+++ b/ui/src/frontend/trace_url_handler.ts
@@ -20,6 +20,7 @@ import {loadAndroidBugToolInfo} from './android_bug_tool';
 import {Route, Router} from '../core/router';
 import {taskTracker} from './task_tracker';
 import {AppImpl} from '../core/app_impl';
+import {embedderContext} from '../core/embedder';
 
 function getCurrentTraceUrl(): undefined | string {
   const source = AppImpl.instance.trace?.traceInfo.source;
@@ -30,6 +31,10 @@ function getCurrentTraceUrl(): undefined | string {
 }
 
 export function maybeOpenTraceFromRoute(route: Route) {
+  if (embedderContext?.routingHooks?.openTraceFromRoute?.(route)) {
+    return; // Handled by the embedding application
+  }
+
   if (route.args.s) {
     // /?s=xxxx for permalinks.
     loadPermalink(route.args.s);

--- a/ui/src/frontend/viewer_page/wasd_navigation_handler.ts
+++ b/ui/src/frontend/viewer_page/wasd_navigation_handler.ts
@@ -113,6 +113,11 @@ export class KeyboardNavigationHandler implements Disposable {
     this.onZoomed = onZoomed;
     this.trash = new DisposableStack();
 
+    if (!element.getAttribute('tabindex')) {
+      // Make it focusable and also tabbable for keyboard accessibility
+      element.setAttribute('tabindex', '0');
+    }
+
     document.body.addEventListener('keydown', this.boundOnKeyDown);
     document.body.addEventListener('keyup', this.boundOnKeyUp);
     this.element.addEventListener('mousemove', this.boundOnMouseMove);

--- a/ui/src/public/raf.ts
+++ b/ui/src/public/raf.ts
@@ -26,6 +26,15 @@ export interface Raf {
   scheduleCanvasRedraw(): void;
 
   /**
+   * Add a callback for DOM redraws. `cb` will be called whenever a DOM
+   * redraw is scheduled using {@link scheduleFullRedraw()}.
+   *
+   * @param cb - The callback to called when DOM is redrawn.
+   * @returns - A disposable object that removes the callback when disposed.
+   */
+  addDomRedrawCallback(cb: RedrawCallback): Disposable;
+
+  /**
    * Add a callback for canvas redraws. `cb` will be called whenever a canvas
    * redraw is scheduled canvas redraw using {@link scheduleCanvasRedraw()}.
    *


### PR DESCRIPTION
Define a new embedderContext variable exported from a new embedder.ts module that an embedding application can assign once to inject customization of the Perfetto UI behavior. This includes flags to suppress default capabilities and call-back hooks to override default capabilities, such as:

- adjust routing to work with applications that use hashes already for their own incompatible routing requirements
- customization of the installation of the content security policy
- allow to control cache keys for browser restrictions on caching
- allow file CORS origins for desktop-style applications
- scope key handling to the viewer page so that it doesn't get key events from other UI elements in the host application
- current script is null also in some embedder apps, not just in tests
- suppressing the dialog that prompts to open a trace already loaded in the trace_processor_shell, for apps that manage this a priori
- suppressing registration of error handlers. An embedding application often has its own error handling

Additionally, in support of incorporating the build output into another application's packaging:

- enable generating .d.ts files. Some types had to be exported that previously weren't in order for TypeScript to be able to correctly resolve its generated type definitions
- support loading the trace database from a stream provided by the host application (such as from a remote backend)
- make @types/mithril a dev dependency
- remove unused dependencies from package.json
- explicitly define which location TS `@types` should be read from. Otherwise the tsc compiler possibly finds the types in an embedder application's `node_modules/@types` directory, which can cause clashes esp. between Mithril and React's types for HTML elements
- return showHelp's showModal promise. This allows a host application to track whether the help dialog is (still) showing

Fixes #2266
