### PR TITLE
diff_tests: Include extra descriptors in serialize_test_trace command

### DIFF
--- a/python/generators/diff_tests/runner.py
+++ b/python/generators/diff_tests/runner.py
@@ -452,10 +452,13 @@ class TestCaseRunner:
                                    or self.test.trace_path.endswith('.py')):
         res += 'Command to generate trace:\n'
         res += 'tools/serialize_test_trace.py '
-        res += '--descriptor {} {} > {}\n'.format(
-            os.path.relpath(self.trace_descriptor_path, ROOT_DIR),
-            os.path.relpath(self.test.trace_path, ROOT_DIR),
-            os.path.relpath(trace_path, ROOT_DIR))
+        res += '--descriptor {} {} {} > {}\n'.format(
+            os.path.relpath(self.trace_descriptor_path, ROOT_DIR), " ".join([
+                "--extension-descriptor {}".format(
+                    os.path.relpath(p, ROOT_DIR))
+                for p in extension_descriptor_paths
+            ]), os.path.relpath(self.test.trace_path, ROOT_DIR),
+            os.path.relpath(trace_path, ROOT_DIR), extension_descriptor_paths)
       res += f"Command line:\n{' '.join(result.cmd)}\n"
       return res
 

--- a/tools/serialize_test_trace.py
+++ b/tools/serialize_test_trace.py
@@ -33,6 +33,11 @@ def main():
       '--out', type=str, help='out directory to search for trace descriptor')
   parser.add_argument(
       '--descriptor', type=str, help='path to the trace descriptor')
+  parser.add_argument(
+      '--extension-descriptor',
+      action='append',
+      type=str,
+      help='paths to additional descriptors')
   parser.add_argument('trace_path', type=str, help='path of trace to serialize')
   args = parser.parse_args()
 
@@ -58,6 +63,9 @@ def main():
   else:
     raise RuntimeError(
         'Exactly one of --out and --descriptor should be provided')
+
+  if args.extension_descriptor:
+    extension_descriptors.extend(args.extension_descriptor)
 
   trace_path = args.trace_path
 


### PR DESCRIPTION
When a test fails, the framework tells you how to serialize the trace. The command given by the framework is broken if the trace uses extensions. For example, when the diff_test
`WindowManager:has_expected_rows` fails, the suggested command fails to generate the trace.

This commit fixes the problem.
