### PR TITLE
gen_merged_protos: fix hang if package specifier is missing

### DIFF
--- a/tools/gen_merged_protos
+++ b/tools/gen_merged_protos
@@ -84,7 +84,9 @@ def merge_protos_content(proto_paths):
       content = f.read()
 
     # Remove header
-    header = re.match(r'\/(\*|\/)(?:.|\s)*?package .*;\n', content)
+    header = re.match(r'\/(\*|\/)(?s:.)*?package .*;\n', content)
+    if header is None:
+      raise Exception('Proto file ' + path + ' does not specify a package')
     header = header.group(0)
     content = content[len(header):]
 


### PR DESCRIPTION
The script looks for the `package` specifier to identify the end of the header section it needs to remove. However, with the current regular expression, if that line is missing, the match won't fail within a reasonable amount of time. Instead, due to [catastrophic backtracking], it will simply hang.

I encountered this when adding a 1.4KiB proto file and importing it from trace.proto. Because I'd forgotten the `package` specifier, when I ran `gen_merged_protos` it never finished, even when I left it running overnight.

The catastrophic backtracking appears to be caused by the use of two different branches when matching the text between the comment opening and the package specifier. Replacing these with a `.` with the `DOTALL` flag enabled is equivalent, and seems to avoid the problem. We can also then add a helpful error message if the specifier is missing.

[catastrophic backtracking]: https://regular-expressions.info/catastrophic.html