### PR TITLE
tp: make sure expected/actual frame timeline is sorted by id

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tables_views.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/tables_views.sql
@@ -981,7 +981,8 @@ FROM slice AS s
 JOIN process_track AS t
   ON s.track_id = t.id
 WHERE
-  t.type = 'android_expected_frame_timeline';
+  t.type = 'android_expected_frame_timeline'
+ORDER BY s.id;
 
 -- This table contains information on the actual timeline and additional
 -- analysis related to the performance of either a display frame or a surface
@@ -1054,7 +1055,8 @@ FROM slice AS s
 JOIN process_track AS t
   ON s.track_id = t.id
 WHERE
-  t.type = 'android_actual_frame_timeline';
+  t.type = 'android_actual_frame_timeline'
+ORDER BY s.id;
 
 -- Stores class information within ART heap graphs. It represents Java/Kotlin
 -- classes that exist in the heap, including their names, inheritance


### PR DESCRIPTION
Prevents include perfetto module android.surfaceflinger from taking forever on some traces
