### PR TITLE
github: fix a typo in the 'Save build-deps' action key.

### DIFF
--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -59,4 +59,4 @@ runs:
       with:
         path: buildtools
         # TODO(lalitm): see the comment above about the cache key.
-        key: buildtool-${{ hashFiles('buildtools/BUILD.gn') }}-${{ steps.cachekey.outputs.suffix }}-${{ hashFiles('tools/install-build-deps') }}
+        key: buildtools-${{ hashFiles('buildtools/BUILD.gn') }}-${{ steps.cachekey.outputs.suffix }}-${{ hashFiles('tools/install-build-deps') }}

--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -53,8 +53,7 @@ runs:
       run: tools/install-build-deps ${{ inputs.install-flags }}
       shell: bash
 
-    - name: Save build-deps cache (only on main)
-      if: github.ref == 'refs/heads/main'
+    - name: Save build-deps cache (on each brunch, for testing)
       uses: actions/cache/save@v4
       with:
         path: buildtools

--- a/.github/actions/install-build-deps/action.yml
+++ b/.github/actions/install-build-deps/action.yml
@@ -53,7 +53,8 @@ runs:
       run: tools/install-build-deps ${{ inputs.install-flags }}
       shell: bash
 
-    - name: Save build-deps cache (on each brunch, for testing)
+    - name: Save build-deps cache (only on main)
+      if: github.ref == 'refs/heads/main'
       uses: actions/cache/save@v4
       with:
         path: buildtools

--- a/src/base/scoped_sched_boost_unittest.cc
+++ b/src/base/scoped_sched_boost_unittest.cc
@@ -182,8 +182,6 @@ TEST_F(ScopedSchedBoostTest, MoveOperation) {
 }
 
 TEST_F(ScopedSchedBoostTest, IgnoreWrongConfig) {
-  // trigger the CI build change.
-
   ON_CALL(sched_hooks_, SetSchedConfig(_))
       .WillByDefault(Invoke([&](const SchedOsHooks::SchedOsConfig& arg) {
         if (arg.policy == SCHED_FIFO && arg.rt_prio < 1) {

--- a/src/base/scoped_sched_boost_unittest.cc
+++ b/src/base/scoped_sched_boost_unittest.cc
@@ -182,6 +182,8 @@ TEST_F(ScopedSchedBoostTest, MoveOperation) {
 }
 
 TEST_F(ScopedSchedBoostTest, IgnoreWrongConfig) {
+  // trigger the CI build change.
+
   ON_CALL(sched_hooks_, SetSchedConfig(_))
       .WillByDefault(Invoke([&](const SchedOsHooks::SchedOsConfig& arg) {
         if (arg.policy == SCHED_FIFO && arg.rt_prio < 1) {


### PR DESCRIPTION
Otherwise the cache is never restored when running the `actions/cache/restore@v4`
inside the `./.github/actions/install-build-deps` action.