### PR TITLE
exp: Use DataGrid directly in NodeDataExplorer

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_data_viewer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_data_viewer.ts
@@ -14,15 +14,25 @@
 
 import m from 'mithril';
 
-import {TextParagraph} from '../../../widgets/text_paragraph';
-import {QueryTable} from '../../../components/query_table/query_table';
-import {runQueryForQueryTable} from '../../../components/query_table/queries';
 import {AsyncLimiter} from '../../../base/async_limiter';
-import {QueryResponse} from '../../../components/query_table/queries';
-import {Trace} from '../../../public/trace';
-import {MenuItem, PopupMenu} from '../../../widgets/menu';
-import {Button} from '../../../widgets/button';
 import {Icons} from '../../../base/semantic_icons';
+import {
+  QueryResponse,
+  runQueryForQueryTable,
+} from '../../../components/query_table/queries';
+import {DataGridDataSource} from '../../../components/widgets/data_grid/common';
+import {
+  DataGrid,
+  renderCell,
+} from '../../../components/widgets/data_grid/data_grid';
+import {InMemoryDataSource} from '../../../components/widgets/data_grid/in_memory_data_source';
+import {Trace} from '../../../public/trace';
+import {SqlValue} from '../../../trace_processor/query_result';
+import {Button} from '../../../widgets/button';
+import {Callout} from '../../../widgets/callout';
+import {DetailsShell} from '../../../widgets/details_shell';
+import {MenuItem, PopupMenu} from '../../../widgets/menu';
+import {TextParagraph} from '../../../widgets/text_paragraph';
 import {Query, queryToRun} from '../query_node';
 
 export interface NodeDataViewerAttrs {
@@ -40,166 +50,181 @@ export interface NodeDataViewerAttrs {
 
 export class NodeDataViewer implements m.ClassComponent<NodeDataViewerAttrs> {
   private readonly asyncLimiter = new AsyncLimiter();
-  private resp?: QueryResponse;
+  private response?: QueryResponse;
+  private dataSource?: DataGridDataSource;
+
+  oncreate({attrs}: m.CVnode<NodeDataViewerAttrs>) {
+    this.runQuery(attrs);
+  }
+
+  onupdate({attrs}: m.CVnode<NodeDataViewerAttrs>) {
+    this.runQuery(attrs);
+  }
+
+  private runQuery(attrs: NodeDataViewerAttrs) {
+    this.asyncLimiter.schedule(async () => {
+      if (
+        attrs.query === undefined ||
+        attrs.query instanceof Error ||
+        !attrs.executeQuery
+      ) {
+        return;
+      }
+
+      this.response = await runQueryForQueryTable(
+        queryToRun(attrs.query),
+        attrs.trace.engine,
+      );
+
+      this.dataSource = new InMemoryDataSource(this.response.rows);
+
+      const queryError = getQueryError(attrs.query, this.response);
+      const responseError = getResponseError(this.response);
+      const dataError =
+        this.response?.totalRowCount === 0
+          ? new Error('Query returned no rows')
+          : undefined;
+
+      attrs.onQueryExecuted({
+        columns: this.response.columns,
+        queryError,
+        responseError,
+        dataError,
+      });
+
+      m.redraw();
+    });
+  }
 
   view({attrs}: m.CVnode<NodeDataViewerAttrs>) {
-    const isQueryInvalid = (): Error | undefined => {
-      if (attrs.query instanceof Error) {
-        return attrs.query;
-      }
-      if (!this.resp) {
-        return undefined;
-      }
-
-      if (this.resp.error) {
-        return new Error(this.resp.error);
-      }
-      return undefined;
-    };
-
-    const isResponseInvalid = (): Error | undefined => {
-      // Those are the checks that should be handled by isQueryInvalid().
-      if (!this.resp || this.resp.error) {
-        return undefined;
-      }
-
-      if (
-        this.resp.statementCount > 0 &&
-        this.resp.statementWithOutputCount === 0 &&
-        this.resp.columns.length === 0
-      ) {
-        return new Error('The last statement must produce an output.');
-      }
-
-      if (this.resp.statementWithOutputCount > 1) {
-        return new Error('Only the last statement can produce an output.');
-      }
-
-      if (this.resp.statementCount > 1) {
-        // Statements are broken by semicolon. We trim and remove empty statements
-        // that can result from the query ending with a semicolon.
-        // TODO(mayzner): This logic has to be implemented in Trace Processor.
-        const statements = this.resp.query
-          .split(';')
-          .map((x) => x.trim())
-          .filter((x) => x.length > 0);
-        const allButLast = statements.slice(0, statements.length - 1);
-        const moduleIncludeRegex =
-          /^\s*INCLUDE\s+PERFETTO\s+MODULE\s+[\w._]+\s*$/i;
-        for (const stmt of allButLast) {
-          if (!moduleIncludeRegex.test(stmt)) {
-            return new Error(
-              `Only 'INCLUDE PERFETTO MODULE ...;' statements are ` +
-                `allowed before the final statement. Error on: "${stmt}"`,
-            );
-          }
-        }
-      }
-
-      return undefined;
-    };
-
-    const runQuery = () => {
-      this.asyncLimiter.schedule(async () => {
-        if (
-          attrs.query === undefined ||
-          attrs.query instanceof Error ||
-          !attrs.executeQuery
-        ) {
-          return;
-        }
-
-        this.resp = await runQueryForQueryTable(
-          queryToRun(attrs.query),
-          attrs.trace.engine,
-        );
-
-        let dataError: Error | undefined = undefined;
-        if (this.resp.totalRowCount === 0) {
-          dataError = new Error('Query returned no rows');
-        }
-
-        attrs.onQueryExecuted({
-          columns: this.resp.columns,
-          queryError: isQueryInvalid(),
-          responseError: isResponseInvalid(),
-          dataError,
-        });
-      });
-    };
-
-    runQuery();
-    const queryError = isQueryInvalid();
-    const responseError = isResponseInvalid();
+    const queryError = getQueryError(attrs.query, this.response);
+    const responseError = getResponseError(this.response);
     const error = queryError ?? responseError;
 
-    let statusText: string | undefined = undefined;
-    if (attrs.query === undefined) {
-      statusText = 'No data to display';
-    } else if (this.resp === undefined) {
-      statusText = 'Typing...';
-    }
-
+    const statusText = this.getStatusText(attrs.query);
     const message = error ? `Error: ${error.message}` : statusText;
 
-    return [
-      m(
-        '.pf-node-data-viewer',
-        m(
-          '.pf-node-data-viewer__title-row',
-          m('.title', 'Query data'),
-          m('span.spacer'), // Push menu to the right
-          m(
-            PopupMenu,
-            {
-              trigger: m(Button, {
-                icon: Icons.ContextMenuAlt,
-              }),
-            },
-            [
-              m(MenuItem, {
-                label: 'Left',
-                onclick: () => {
-                  attrs.onPositionChange('left');
-                },
-              }),
-              m(MenuItem, {
-                label: 'Right',
-                onclick: () => {
-                  attrs.onPositionChange('right');
-                },
-              }),
-              m(MenuItem, {
-                label: 'Bottom',
-                onclick: () => {
-                  attrs.onPositionChange('bottom');
-                },
-              }),
-            ],
-          ),
-        ),
-        message && !responseError
-          ? m(TextParagraph, {text: message})
-          : m(
-              'article',
-              {
-                style: {
-                  display: 'flex',
-                  flexDirection: 'column',
-                  flexGrow: 1,
-                },
-              },
-              [
-                m(QueryTable, {
-                  trace: attrs.trace,
-                  query:
-                    attrs.query instanceof Error ? '' : queryToRun(attrs.query),
-                  resp: this.resp,
-                  fillParent: true,
-                }),
-              ],
-            ),
-      ),
-    ];
+    return m(
+      DetailsShell,
+      {
+        title: 'Query data',
+        fillParent: true,
+        buttons: this.renderMenu(attrs),
+      },
+      this.renderContent(message),
+    );
   }
+
+  private getStatusText(query?: Query | Error): string | undefined {
+    if (query === undefined) {
+      return 'No data to display';
+    } else if (this.response === undefined) {
+      return 'Typing...';
+    }
+    return undefined;
+  }
+
+  private renderMenu(attrs: NodeDataViewerAttrs): m.Children {
+    return m(
+      PopupMenu,
+      {
+        trigger: m(Button, {
+          icon: Icons.ContextMenuAlt,
+        }),
+      },
+      [
+        m(MenuItem, {
+          label: 'Left',
+          onclick: () => attrs.onPositionChange('left'),
+        }),
+        m(MenuItem, {
+          label: 'Right',
+          onclick: () => attrs.onPositionChange('right'),
+        }),
+        m(MenuItem, {
+          label: 'Bottom',
+          onclick: () => attrs.onPositionChange('bottom'),
+        }),
+      ],
+    );
+  }
+
+  private renderContent(message?: string): m.Children {
+    if (message) {
+      return m(TextParagraph, {text: message});
+    }
+
+    if (this.response && this.dataSource) {
+      const warning =
+        this.response.statementWithOutputCount > 1
+          ? m(
+              Callout,
+              {icon: 'warning'},
+              `${this.response.statementWithOutputCount} out of ${this.response.statementCount} `,
+              'statements returned a result. ',
+              'Only the results for the last statement are displayed.',
+            )
+          : null;
+
+      return [
+        warning,
+        m(DataGrid, {
+          fillHeight: true,
+          columns: this.response.columns.map((c) => ({name: c})),
+          data: this.dataSource,
+          showFiltersInToolbar: false,
+          cellRenderer: (value: SqlValue, name: string) => {
+            return renderCell(value, name);
+          },
+        }),
+      ];
+    }
+    return null;
+  }
+}
+
+function getQueryError(
+  query?: Query | Error,
+  response?: QueryResponse,
+): Error | undefined {
+  if (query instanceof Error) {
+    return query;
+  }
+  if (response?.error) {
+    return new Error(response.error);
+  }
+  return undefined;
+}
+
+function getResponseError(response?: QueryResponse): Error | undefined {
+  if (!response || response.error) {
+    return undefined;
+  }
+
+  if (
+    response.statementCount > 0 &&
+    response.statementWithOutputCount === 0 &&
+    response.columns.length === 0
+  ) {
+    return new Error('The last statement must produce an output.');
+  }
+
+  if (response.statementCount > 1) {
+    const statements = response.query
+      .split(';')
+      .map((x) => x.trim())
+      .filter((x) => x.length > 0);
+    const allButLast = statements.slice(0, statements.length - 1);
+    const moduleIncludeRegex = /^\s*INCLUDE\s+PERFETTO\s+MODULE\s+[\w._]+\s*$/i;
+    for (const stmt of allButLast) {
+      if (!moduleIncludeRegex.test(stmt)) {
+        return new Error(
+          `Only 'INCLUDE PERFETTO MODULE ...;' statements are ` +
+            `allowed before the final statement. Error on: "${stmt}"`,
+        );
+      }
+    }
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
QueryTable was a wrapper around DataGrid, there was no need to use it. This is the first step of the refactor of node_data_explorer, that didn't require changing DataGrid