### PR TITLE
tp: fix brittle tests and warnings

### DIFF
--- a/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
+++ b/src/trace_processor/metrics/sql/chrome/chrome_reliable_range.sql
@@ -150,7 +150,7 @@ FROM
     SELECT upid, NULL AS reliable_from
     FROM chrome_processes_with_missing_main
   )
-ORDER BY start DESC
+ORDER BY start DESC, upid
 LIMIT 1;
 
 DROP VIEW IF EXISTS chrome_reliable_range;

--- a/test/trace_processor/diff_tests/metrics/chrome/tests.py
+++ b/test/trace_processor/diff_tests/metrics/chrome/tests.py
@@ -196,7 +196,7 @@ class ChromeMetrics(TestSuite):
         query=Path('chrome_reliable_range_test.sql'),
         out=Csv("""
         "start","reason","debug_limiting_upid","debug_limiting_utid"
-        1011,"Missing process data for upid=2",2,1
+        1011,"Missing process data for upid=1",1,1
         """))
 
   def test_chrome_reliable_range_missing_browser_main(self):

--- a/test/trace_processor/diff_tests/metrics/startup/android_startup.py
+++ b/test/trace_processor/diff_tests/metrics/startup/android_startup.py
@@ -82,7 +82,7 @@ trace.add_atrace_begin(
     ts=300,
     tid=3,
     pid=3,
-    buf='reportFullyDrawn() for \{com.google.android.calendar\}')
+    buf='reportFullyDrawn() for {{com.google.android.calendar}}')
 trace.add_atrace_end(ts=305, tid=2, pid=2)
 
 # Start intent for calendar, we failed to launch the activity.

--- a/test/trace_processor/diff_tests/metrics/startup/android_startup_slow.py
+++ b/test/trace_processor/diff_tests/metrics/startup/android_startup_slow.py
@@ -96,7 +96,7 @@ trace.add_atrace_begin(
     ts=to_s(300),
     tid=3,
     pid=3,
-    buf='reportFullyDrawn() for \{com.google.android.calendar\}')
+    buf='reportFullyDrawn() for {{com.google.android.calendar}}')
 trace.add_atrace_end(ts=to_s(305), tid=2, pid=2)
 
 # Start intent for calendar, we failed to launch the activity.


### PR DESCRIPTION
* reliable range was doing limit 1 without properly breaking ties if two
  processes had the same timestamp. This lead to inconsistent results if
  the order of FlatHashMap changed
* startups have a warning where \{ is not a valid escape sequence
* ART hprof tests were too brittle, they were relying on ids where the
  insertion order depended on flathashmap order. Improve the tests.
