### PR TITLE
tp: switch args hashing and string pool hashing to MurmurHash

### DIFF
--- a/include/perfetto/ext/base/flags.h
+++ b/include/perfetto/ext/base/flags.h
@@ -34,7 +34,7 @@ namespace perfetto::base::flags {
 // contexts.
 #define PERFETTO_READ_ONLY_FLAGS(X)                       \
   X(test_read_only_flag, NonAndroidPlatformDefault_FALSE) \
-  X(use_murmur_hash_for_flat_hash_map, NonAndroidPlatformDefault_FALSE)
+  X(use_murmur_hash_for_flat_hash_map, NonAndroidPlatformDefault_TRUE)
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //

--- a/include/perfetto/ext/base/flat_hash_map.h
+++ b/include/perfetto/ext/base/flat_hash_map.h
@@ -20,6 +20,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flags.h"
 #include "perfetto/ext/base/fnv_hash.h"
+#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/utils.h"
 
 #include <algorithm>
@@ -83,9 +84,7 @@ template <typename Key,
           typename Value,
           typename Hasher =
               std::conditional_t<base::flags::use_murmur_hash_for_flat_hash_map,
-                                 // TODO(lalitm): switch this to actually point
-                                 // to MurmurHash.
-                                 base::FnvHash<Key>,
+                                 base::MurmurHash<Key>,
                                  base::FnvHash<Key>>,
           typename Probe = QuadraticProbe,
           bool AppendOnly = false>

--- a/include/perfetto/ext/base/murmur_hash.h
+++ b/include/perfetto/ext/base/murmur_hash.h
@@ -23,37 +23,27 @@
 #include <cstring>
 #include <limits>
 #include <string>
+#include <type_traits>
 
 #include "perfetto/public/compiler.h"
 
-// This file implements a 64-bit variant of the MurmurHash algorithm.
+// This file provides an implementation of the 64-bit MurmurHash2 algorithm,
+// also known as MurmurHash64A. This algorithm, created by Austin Appleby, is a
+// fast, non-cryptographic hash function with excellent distribution properties,
+// making it ideal for use in hash tables.
 //
-// The algorithm is a custom hybrid that combines elements from both MurmurHash2
-// and MurmurHash3 to achieve excellent performance for non-cryptographic use
-// cases. It is heavily inspired by the high-performance hash implementation
-// found in DuckDB.
-//
-// --- Algorithm Comparison ---
-//
-// This implementation differs from the standard MurmurHash algorithms:
-//
-// - vs. MurmurHash2: It uses the same primary multiplication constant
-//   (0xc6a4a7935bd1e995) as MurmurHash2 but features a simpler body loop
-//   (a single XOR and multiply) and the stronger `fmix64` finalizer from
-//   MurmurHash3.
-//
-// - vs. MurmurHash3: It uses the exact same `fmix64` finalization function but
-//   substitutes MurmurHash3's complex, rotation-heavy body loop with a much
-//   simpler and faster one.
-//
-// In summary, it makes a performance-oriented trade-off: a simpler main loop
-// combined with a high-quality final mixing stage.
+// The file also includes related hashing utilities:
+// - A standalone `fmix64` finalizer from MurmurHash3, used for hashing
+//   individual numeric types.
+// - A hash combiner for creating a single hash from a sequence of values.
 //
 // NOTE: This implementation is NOT cryptographically secure. It must not be
 // used for security-sensitive applications like password storage or digital
 // signatures, as it is not designed to be resistant to malicious attacks.
 
 namespace perfetto::base {
+
+namespace murmur_internal {
 
 // Finalizes an intermediate hash value using the `fmix64` routine from
 // MurmurHash3.
@@ -67,7 +57,7 @@ namespace perfetto::base {
 //
 // Returns:
 //   The final, well-mixed 64-bit hash value.
-inline uint64_t MurmurHash(uint64_t h) {
+inline uint64_t MurmurHashMix(uint64_t h) {
   h ^= h >> 33;
   h *= 0xff51afd7ed558ccdULL;
   h ^= h >> 33;
@@ -75,94 +65,184 @@ inline uint64_t MurmurHash(uint64_t h) {
   h ^= h >> 33;
   return h;
 }
-inline uint64_t MurmurHash(uint32_t h) {
-  return MurmurHash(static_cast<uint64_t>(h));
-}
-inline uint64_t MurmurHash(int64_t h) {
-  return MurmurHash(static_cast<uint64_t>(h));
-}
-inline uint64_t MurmurHash(int32_t h) {
-  return MurmurHash(static_cast<uint64_t>(h));
-}
-inline uint64_t MurmurHash(double h) {
-  static_assert(sizeof(double) == sizeof(uint64_t));
 
-  // Normalize floating point representations which can vary.
-  if (PERFETTO_UNLIKELY(h == 0.0)) {
-    // Turn negative zero into positive zero
-    h = 0.0;
-  } else if (PERFETTO_UNLIKELY(std::isnan(h))) {
-    // Turn arbtirary NaN representations to a consistent NaN repr.
-    h = std::numeric_limits<double>::quiet_NaN();
-  }
-
-  uint64_t res;
-  memcpy(&res, &h, sizeof(double));
-  return MurmurHash(res);
-}
-
-// Computes a 64-bit hash for a block of memory.
+// Computes a 64-bit hash for a block of memory using the MurmurHash64A
+// algorithm.
 //
-// This function implements the main body of the custom Murmur-style hash. As
-// described in the file-level comment, it uses a simplified processing loop for
-// performance and applies the strong `fmix64` finalizer from MurmurHash3.
-//
-// The process involves four steps:
-// 1. Initialization: Seeding the hash with the input length.
-// 2. Main Loop: Processing 8-byte chunks with a `XOR` and `MULTIPLY` sequence.
-// 3. Tail Processing: Handling the final 1-7 bytes.
-// 4. Finalization: Applying the `fmix64` mix via the other MurmurHash overload.
+// The process involves four main steps:
+// 1. Initialization: The hash state is seeded with a value derived from the
+//    input length.
+// 2. Main Loop: Data is processed in 8-byte chunks, with each chunk being
+//    mixed into the hash state.
+// 3. Tail Processing: The final 1-7 bytes of data are handled.
+// 4. Finalization: The hash state is passed through a final mixing sequence to
+//    ensure good bit distribution.
 //
 // Args:
 //   input: A pointer to the data to be hashed.
 //   len:   The length of the data in bytes.
 //
 // Returns:
-//   The 64-bit hash of the input data.
-inline uint64_t MurmurHash(const void* input, size_t len) {
-  // Uses constants inspired by the high-performance hash implementation found
-  // at:
-  // https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/common/types/hash.hpp
-  constexpr uint64_t kMultiplicationConstant1 = 0xc6a4a7935bd1e995ULL;
-  constexpr uint64_t kMultiplicationConstant2 = 0xd6e8feb86659fd93ULL;
+//   The 64-bit MurmurHash64A hash of the input data.
+inline uint64_t MurmurHashBytes(const void* input, size_t len) {
+  // This implementation follows the canonical MurmurHash64A algorithm.
+  // The constants `kMulConstant` (m) and the shift value `47` (r) are from
+  // the original specification.
+  // The seed is inspired by the one used in DuckDB.
   constexpr uint64_t kSeed = 0xe17a1465U;
+  static constexpr uint64_t kMulConstant = 0xc6a4a7935bd1e995;
+  static constexpr int kShift = 47;
 
-  // Initialize the hash value with the seed and a transformation of the input
-  // length. This helps ensure that inputs of different lengths are unlikely to
-  // collide.
-  uint64_t hash_value = kSeed ^ (len * kMultiplicationConstant1);
+  uint64_t h = kSeed ^ (len * kMulConstant);
+  const uint64_t* data = reinterpret_cast<const uint64_t*>(input);
+  const uint64_t* end = data + (len / 8);
+  while (data != end) {
+    uint64_t k = *data++;
 
-  // Set up pointers for iterating through the data.
-  const auto* byte_ptr = static_cast<const uint8_t*>(input);
-  const size_t remainder = len % 8;
-  const uint8_t* end = byte_ptr + len - remainder;
+    k *= kMulConstant;
+    k ^= k >> kShift;
+    k *= kMulConstant;
 
-  // The main loop processes data in 8-byte blocks for performance. Each block
-  // is XORed and multiplied into the hash state.
-  for (; byte_ptr != end; byte_ptr += 8) {
-    uint64_t chunk;
-    memcpy(&chunk, byte_ptr, sizeof(chunk));
-    hash_value ^= chunk;
-    hash_value *= kMultiplicationConstant2;
+    h ^= k;
+    h *= kMulConstant;
   }
 
-  // Handle the final 1-7 bytes if the data length is not a multiple of 8.
-  // This ensures that all input bytes contribute to the final hash.
-  if (remainder != 0) {
-    uint64_t last_chunk = 0;
-    memcpy(&last_chunk, byte_ptr, remainder);
-    hash_value ^= last_chunk;
-    hash_value *= kMultiplicationConstant2;
+  const uint8_t* data2 = reinterpret_cast<const uint8_t*>(data);
+  switch (len & 7) {
+    case 7:
+      h ^= uint64_t(data2[6]) << 48;
+      [[fallthrough]];
+    case 6:
+      h ^= uint64_t(data2[5]) << 40;
+      [[fallthrough]];
+    case 5:
+      h ^= uint64_t(data2[4]) << 32;
+      [[fallthrough]];
+    case 4:
+      h ^= uint64_t(data2[3]) << 24;
+      [[fallthrough]];
+    case 3:
+      h ^= uint64_t(data2[2]) << 16;
+      [[fallthrough]];
+    case 2:
+      h ^= uint64_t(data2[1]) << 8;
+      [[fallthrough]];
+    case 1:
+      h ^= uint64_t(data2[0]);
+      h *= kMulConstant;
   }
 
-  // Finalize the hash by calling the integer-based MurmurHash function to
-  // perform the final mixing.
-  return MurmurHash(hash_value);
-}
-inline uint64_t MurmurHash(const std::string& res) {
-  return MurmurHash(res.data(), res.size());
+  h ^= h >> kShift;
+  h *= kMulConstant;
+  h ^= h >> kShift;
+
+  return h;
 }
 
-}  // namespace perfetto::trace_processor::util
+template <typename Float, typename Int>
+Int NormalizeFloatToInt(Float value) {
+  static_assert(std::is_floating_point_v<Float>);
+  static_assert(std::is_integral_v<Int>);
+
+  // Normalize floating point representations which can vary.
+  if (PERFETTO_UNLIKELY(value == 0.0)) {
+    // Turn negative zero into positive zero
+    value = 0.0;
+  } else if (PERFETTO_UNLIKELY(std::isnan(value))) {
+    // Turn arbtirary NaN representations to a consistent NaN repr.
+    value = std::numeric_limits<Float>::quiet_NaN();
+  }
+  Int res;
+  static_assert(sizeof(Float) == sizeof(Int));
+  memcpy(&res, &value, sizeof(Float));
+  return res;
+}
+
+}  // namespace murmur_internal
+
+// std::hash<T> drop-in class which uses the core MurmurHash functions above to
+// produce a hash.
+//
+// Uses:
+//  1) MurmurHashMix for fixed size numeric types (integers, floats, doubles).
+//  2) MurmurHashBytes for string types (string, string_view) etc.
+//  3) Falls back to std::hash<T> for all other types.
+//     TODO(lalitm): create a absl-like API for allowing aribtrary types
+//     to be hashed without needing to override std::hash<T>.
+template <typename T>
+struct MurmurHash {
+  uint64_t operator()(const T& value) const {
+    if constexpr (std::is_integral_v<T>) {
+      return murmur_internal::MurmurHashMix(static_cast<uint64_t>(value));
+    } else if constexpr (std::is_same_v<T, double>) {
+      return murmur_internal::MurmurHashMix(
+          murmur_internal::NormalizeFloatToInt<double, uint64_t>(value));
+    } else if constexpr (std::is_same_v<T, float>) {
+      return murmur_internal::MurmurHashMix(
+          murmur_internal::NormalizeFloatToInt<float, uint32_t>(value));
+    } else if constexpr (std::is_same_v<T, std::string> ||
+                         std::is_same_v<T, std::string_view>) {
+      return murmur_internal::MurmurHashBytes(value.data(), value.size());
+    } else {
+      return std::hash<T>{}(value);
+    }
+  }
+};
+
+// Simple wrapper function around MurmurHash to improve clarity in callsites
+// to not have to instantiate the class and then call operator().
+template <typename T>
+uint64_t MurmurHashValue(const T& value) {
+  return MurmurHash<T>{}(value);
+}
+
+// A helper class to create a 64-bit MurmurHash from a series of
+// structured fields.
+//
+// IMPORTANT: This is NOT a true streaming hash. It is an order-dependent
+// combiner. It does not guarantee that hashing two concatenated chunks of data
+// will produce the same result as hashing them separately in sequence. It is
+// designed exclusively for creating a hash from a fixed set of fields.
+class MurmurHashCombiner {
+ public:
+  MurmurHashCombiner() : hash_(kSeed) {}
+
+  // Combines the hash of one or more arguments into the combiner's state.
+  //
+  // This function uses a C++17 fold expression to hash each argument with
+  // `MurmurHashValue` and then mixes it into the current state via the private
+  // `Update` method. The combination is order-dependent.
+  template <typename... Args>
+  void Combine(const Args&... args) {
+    // A C++17 fold expression that calls our private Update for each hashed
+    // arg.
+    (Update(MurmurHashValue(args)), ...);
+  }
+
+  // Returns the digest (i.e. current state of the combiner).
+  inline uint64_t digest() const { return hash_; }
+
+ private:
+  // Low-level update with a pre-computed hash value. This uses a fast,
+  // order-dependent combination step inspired by the `hash_combine` function
+  // in the Boost C++ libraries.
+  inline void Update(uint64_t piece_hash) {
+    hash_ ^= piece_hash + 0x9e3779b9 + (hash_ << 6) + (hash_ >> 2);
+  }
+
+  static constexpr uint64_t kSeed = 0xe17a1465U;
+  uint64_t hash_;
+};
+
+// Simple wrapper function around MurmurHashCombiner to improve clarity in
+// callsites to not have to instantiate the class, call Combine() then digest().
+template <typename... Args>
+uint64_t MurmurHashCombine(const Args&... value) {
+  MurmurHashCombiner combiner;
+  combiner.Combine(value...);
+  return combiner.digest();
+}
+
+}  // namespace perfetto::base
 
 #endif  // INCLUDE_PERFETTO_EXT_BASE_MURMUR_HASH_H_

--- a/src/base/murmur_hash_unittest.cc
+++ b/src/base/murmur_hash_unittest.cc
@@ -25,7 +25,8 @@ namespace {
 TEST(MurmurHashTest, StringView) {
   base::StringView a = "abc";
   base::StringView b = "def";
-  EXPECT_NE(MurmurHash(a.data(), a.size()), MurmurHash(b.data(), b.size()));
+  EXPECT_NE(murmur_internal::MurmurHashBytes(a.data(), a.size()),
+            murmur_internal::MurmurHashBytes(b.data(), b.size()));
 }
 
 }  // namespace

--- a/src/trace_processor/containers/string_pool.h
+++ b/src/trace_processor/containers/string_pool.h
@@ -32,6 +32,7 @@
 #include "perfetto/base/thread_annotations.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/hash.h"
+#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/containers/null_term_string_view.h"
@@ -201,7 +202,7 @@ class StringPool {
     if (str.data() == nullptr) {
       return Id::Null();
     }
-    auto hash = str.Hash();
+    auto hash = base::MurmurHashValue(std::string_view(str.data(), str.size()));
 
     // Perform a hashtable insertion with a null ID just to check if the string
     // is already inserted. If it's not, overwrite 0 with the actual Id.
@@ -221,7 +222,7 @@ class StringPool {
     if (str.data() == nullptr) {
       return Id::Null();
     }
-    auto hash = str.Hash();
+    auto hash = base::MurmurHashValue(std::string_view(str.data(), str.size()));
 
     MaybeLockGuard guard{mutex_, should_acquire_mutex_};
     Id* id = string_index_.Find(hash);

--- a/src/trace_processor/importers/common/global_args_tracker.h
+++ b/src/trace_processor/importers/common/global_args_tracker.h
@@ -24,6 +24,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/hash.h"
+#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/small_vector.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/metadata_tables_py.h"
@@ -63,41 +64,6 @@ class GlobalArgsTracker {
   };
   static_assert(std::is_trivially_destructible<Arg>::value,
                 "Args must be trivially destructible");
-
-  struct ArgHasher {
-    uint64_t operator()(const CompactArg& arg) const noexcept {
-      base::FnvHasher hash;
-      hash.Update(arg.key.raw_id());
-      // We don't hash arg.flat_key because it's a subsequence of arg.key.
-      switch (arg.value.type) {
-        case Variadic::Type::kInt:
-          hash.Update(arg.value.int_value);
-          break;
-        case Variadic::Type::kUint:
-          hash.Update(arg.value.uint_value);
-          break;
-        case Variadic::Type::kString:
-          hash.Update(arg.value.string_value.raw_id());
-          break;
-        case Variadic::Type::kReal:
-          hash.Update(arg.value.real_value);
-          break;
-        case Variadic::Type::kPointer:
-          hash.Update(arg.value.pointer_value);
-          break;
-        case Variadic::Type::kBool:
-          hash.Update(arg.value.bool_value);
-          break;
-        case Variadic::Type::kJson:
-          hash.Update(arg.value.json_value.raw_id());
-          break;
-        case Variadic::Type::kNull:
-          hash.Update(0);
-          break;
-      }
-      return hash.digest();
-    }
-  };
 
   explicit GlobalArgsTracker(TraceStorage* storage);
 
@@ -139,15 +105,44 @@ class GlobalArgsTracker {
       valid.emplace_back(&arg);
     }
 
-    base::FnvHasher hash;
+    base::MurmurHashCombiner combiner;
     for (const auto* it : valid) {
-      hash.Update(ArgHasher()(*it));
+      const auto& arg = *it;
+      combiner.Combine(arg.key.raw_id());
+      combiner.Combine(arg.value.type);
+      // We don't hash arg.flat_key because it's a subsequence of arg.key.
+      switch (arg.value.type) {
+        case Variadic::Type::kInt:
+          combiner.Combine(arg.value.int_value);
+          break;
+        case Variadic::Type::kUint:
+          combiner.Combine(arg.value.uint_value);
+          break;
+        case Variadic::Type::kString:
+          combiner.Combine(arg.value.string_value.raw_id());
+          break;
+        case Variadic::Type::kReal:
+          combiner.Combine(arg.value.real_value);
+          break;
+        case Variadic::Type::kPointer:
+          combiner.Combine(arg.value.pointer_value);
+          break;
+        case Variadic::Type::kBool:
+          combiner.Combine(arg.value.bool_value);
+          break;
+        case Variadic::Type::kJson:
+          combiner.Combine(arg.value.json_value.raw_id());
+          break;
+        case Variadic::Type::kNull:
+          combiner.Combine(0);
+          break;
+      }
     }
 
     auto& arg_table = *storage_->mutable_arg_table();
 
     uint32_t arg_set_id = arg_table.row_count();
-    ArgSetHash digest = hash.digest();
+    ArgSetHash digest = combiner.digest();
     auto [it, inserted] = arg_row_for_hash_.Insert(digest, arg_set_id);
     if (!inserted) {
       // Already inserted.


### PR DESCRIPTION
These are some of the most CPU hot places in trace processor, switching to MurmurHash improves load performance on a large CPU/arg heavy trace by ~7% (47s -> 44s).