### PR TITLE
exp: Propagate table filters to NodeExplorer filters

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -22,6 +22,7 @@ import {QueryNodeExplorer} from './query_node_explorer';
 import {NodeGraph} from './node_graph';
 import {Trace} from 'src/public/trace';
 import {NodeDataViewer} from './node_data_viewer';
+import {FilterDefinition} from '../../../components/widgets/data_grid/common';
 import {columnInfoFromSqlColumn, newColumnInfoList} from './column_info';
 import {StdlibTableNode} from './sources/stdlib_table';
 import {SqlSourceNode} from './sources/sql_source';
@@ -147,6 +148,19 @@ export class QueryBuilder implements m.ClassComponent<QueryBuilderAttrs> {
             trace,
             query: this.query,
             executeQuery: !this.queryExecuted,
+            filters:
+              // TODO(mayzner): This is a temporary fix for handling the filtering of SQL node.
+              selectedNode.type === NodeType.kSqlSource
+                ? []
+                : selectedNode.state.filters,
+            onFiltersChanged:
+              selectedNode.type === NodeType.kSqlSource
+                ? undefined
+                : (filters: ReadonlyArray<FilterDefinition>) => {
+                    selectedNode.state.filters = filters as FilterDefinition[];
+                    this.queryExecuted = false;
+                    m.redraw();
+                  },
             onQueryExecuted: ({
               columns,
               queryError,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.ts
@@ -41,14 +41,16 @@ export interface UIFilter {
  */
 export interface FilterAttrs {
   sourceCols: ColumnInfo[];
-  filters: FilterDefinition[];
-  onFiltersChanged?: (filters: FilterDefinition[]) => void;
+  filters: ReadonlyArray<FilterDefinition>;
+  onFiltersChanged?: (filters: ReadonlyArray<FilterDefinition>) => void;
 }
 
 export class FilterOperation implements m.ClassComponent<FilterAttrs> {
   private error?: string;
   private uiFilters: UIFilter[] = [];
-  private parentOnFiltersChanged?: (filters: FilterDefinition[]) => void;
+  private parentOnFiltersChanged?: (
+    filters: ReadonlyArray<FilterDefinition>,
+  ) => void;
 
   oninit({attrs}: m.Vnode<FilterAttrs>) {
     this.uiFilters = attrs.filters.map(filterDefinitionToUiFilter);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/query_node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/query_node_explorer.ts
@@ -106,8 +106,10 @@ export class QueryNodeExplorer
             filter: {
               sourceCols: node.state.sourceCols,
               filters: node.state.filters,
-              onFiltersChanged: (newFilters: FilterDefinition[]) => {
-                node.state.filters = newFilters;
+              onFiltersChanged: (
+                newFilters: ReadonlyArray<FilterDefinition>,
+              ) => {
+                node.state.filters = newFilters as FilterDefinition[];
               },
             },
             groupby: {


### PR DESCRIPTION
Filtering node can be applied both from table and from QueryNodeExplorer