### PR TITLE
perfetto: fix flags target to be vendor and product avaialble

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -19993,4 +19993,6 @@ aconfig_declarations {
 cc_aconfig_library {
     name: "perfetto_flags_c_lib",
     aconfig_declarations: "perfetto_flags-aconfig",
+    vendor_available: true,
+    product_available: true,
 }

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -308,4 +308,6 @@ aconfig_declarations {
 cc_aconfig_library {
     name: "perfetto_flags_c_lib",
     aconfig_declarations: "perfetto_flags-aconfig",
+    vendor_available: true,
+    product_available: true,
 }


### PR DESCRIPTION
The dependent targets have this so make it so here as well.
