### PR TITLE
exp: Remove the option to visualize node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -122,11 +122,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     this.deselectNode(state);
   }
 
-  handleVisualizeNode(state: ExplorePageState, node: QueryNode) {
-    this.selectNode(state, node);
-    state.mode = ExplorePageModes.DATA_VISUALISER;
-  }
-
   handleDuplicateNode(state: ExplorePageState, node: QueryNode) {
     const attrsCopy = node.getStateCopy();
     switch (node.type) {
@@ -218,7 +213,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
           onAddSlicesSource: () => this.handleAddSlicesSource(state),
           onAddSqlSource: () => this.handleAddSqlSource(attrs),
           onClearAllNodes: () => this.handleClearAllNodes(state),
-          onVisualizeNode: (node) => this.handleVisualizeNode(state, node),
           onDuplicateNode: (node) => this.handleDuplicateNode(state, node),
           onDeleteNode: (node) => this.handleDeleteNode(state, node),
         }),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -41,7 +41,6 @@ export interface QueryBuilderAttrs {
   readonly onAddSlicesSource: () => void;
   readonly onAddSqlSource: () => void;
   readonly onClearAllNodes: () => void;
-  readonly onVisualizeNode: (node: QueryNode) => void;
   readonly onDuplicateNode: (node: QueryNode) => void;
   readonly onDeleteNode: (node: QueryNode) => void;
 }
@@ -135,7 +134,6 @@ export class QueryBuilder implements m.ClassComponent<QueryBuilderAttrs> {
           onAddSlicesSource,
           onAddSqlSource,
           onClearAllNodes,
-          onVisualizeNode: attrs.onVisualizeNode,
           onDuplicateNode: attrs.onDuplicateNode,
           onDeleteNode: attrs.onDeleteNode,
         }),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
@@ -38,7 +38,6 @@ export interface NodeBoxAttrs {
   readonly isDragging: boolean;
   readonly onNodeSelected: (node: QueryNode) => void;
   readonly onNodeDragStart: (node: QueryNode, event: DragEvent) => void;
-  readonly onVisualizeNode: (node: QueryNode) => void;
   readonly onDuplicateNode: (node: QueryNode) => void;
   readonly onDeleteNode: (node: QueryNode) => void;
   readonly onNodeRendered: (node: QueryNode, element: HTMLElement) => void;
@@ -55,7 +54,7 @@ function renderWarningIcon(node: QueryNode): m.Child {
 }
 
 function renderContextMenu(attrs: NodeBoxAttrs): m.Child {
-  const {node, onVisualizeNode, onDuplicateNode, onDeleteNode} = attrs;
+  const {node, onDuplicateNode, onDeleteNode} = attrs;
   return m(
     PopupMenu,
     {
@@ -64,11 +63,6 @@ function renderContextMenu(attrs: NodeBoxAttrs): m.Child {
         icon: Icons.ContextMenuAlt,
       }),
     },
-    m(MenuItem, {
-      label: 'Visualise Data',
-      icon: Icons.Chart,
-      onclick: () => onVisualizeNode(node),
-    }),
     m(MenuItem, {
       label: 'Duplicate',
       onclick: () => onDuplicateNode(node),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_graph.ts
@@ -56,7 +56,6 @@ export interface NodeGraphAttrs {
   readonly onAddSlicesSource: () => void;
   readonly onAddSqlSource: () => void;
   readonly onClearAllNodes: () => void;
-  readonly onVisualizeNode: (node: QueryNode) => void;
   readonly onDuplicateNode: (node: QueryNode) => void;
   readonly onDeleteNode: (node: QueryNode) => void;
 }
@@ -253,7 +252,6 @@ export class NodeGraph implements m.ClassComponent<NodeGraphAttrs> {
             layout,
             onNodeSelected,
             onNodeDragStart: this.onNodeDragStart,
-            onVisualizeNode: attrs.onVisualizeNode,
             onDuplicateNode: attrs.onDuplicateNode,
             onDeleteNode: attrs.onDeleteNode,
             onNodeRendered: this.onNodeRendered,


### PR DESCRIPTION
We stopped visalising node correctly some time ago, so remove it until we implement it for the new version of Explore Page