### PR TITLE
ui: Remove global scrollTo() function

### DIFF
--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -17,7 +17,7 @@ import {createStore, Migrate, Store} from '../base/store';
 import {TimelineImpl} from './timeline';
 import {Command} from '../public/command';
 import {Trace} from '../public/trace';
-import {ScrollToArgs, setScrollToFunction} from '../public/scroll_helper';
+import {ScrollToArgs} from '../public/scroll_helper';
 import {Track} from '../public/track';
 import {EngineBase, EngineProxy} from '../trace_processor/engine';
 import {CommandManagerImpl} from './command_manager';
@@ -271,9 +271,6 @@ export class TraceImpl implements Trace {
         return settingInstance;
       },
     });
-
-    // TODO(primiano): remove this injection once we plumb Trace everywhere.
-    setScrollToFunction((x: ScrollToArgs) => ctx.scrollHelper.scrollTo(x));
   }
 
   scrollTo(where: ScrollToArgs): void {

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -18,7 +18,6 @@ import {PostedTrace} from '../core/trace_source';
 import {showModal} from '../widgets/modal';
 import {initCssConstants} from './css_constants';
 import {toggleHelp} from './help_modal';
-import {scrollTo} from '../public/scroll_helper';
 import {AppImpl} from '../core/app_impl';
 
 const TRUSTED_ORIGINS_KEY = 'trustedOrigins';
@@ -272,8 +271,15 @@ async function scrollToTimeRange(
   postedScrollToRange: PostedScrollToRange,
   maxAttempts?: number,
 ) {
-  const ready = AppImpl.instance.trace && !AppImpl.instance.isLoadingTrace;
-  if (!ready) {
+  const app = AppImpl.instance;
+  const trace = app.trace;
+  if (trace && !app.isLoadingTrace) {
+    const start = Time.fromSeconds(postedScrollToRange.timeStart);
+    const end = Time.fromSeconds(postedScrollToRange.timeEnd);
+    trace.scrollTo({
+      time: {start, end, viewPercentage: postedScrollToRange.viewPercentage},
+    });
+  } else {
     if (maxAttempts === undefined) {
       maxAttempts = 0;
     }
@@ -282,12 +288,6 @@ async function scrollToTimeRange(
       return;
     }
     setTimeout(scrollToTimeRange, 200, postedScrollToRange, maxAttempts + 1);
-  } else {
-    const start = Time.fromSeconds(postedScrollToRange.timeStart);
-    const end = Time.fromSeconds(postedScrollToRange.timeEnd);
-    scrollTo({
-      time: {start, end, viewPercentage: postedScrollToRange.viewPercentage},
-    });
   }
 }
 

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_jank_cause_link_utils.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_jank_cause_link_utils.ts
@@ -25,7 +25,6 @@ import {
   CauseThread,
   ScrollJankCauseMap,
 } from './scroll_jank_cause_map';
-import {scrollTo} from '../../public/scroll_helper';
 import {Trace} from '../../public/trace';
 
 const UNKNOWN_NAME = 'Unknown';
@@ -200,11 +199,11 @@ export function getCauseLink(
       {
         icon: Icons.UpdateSelection,
         onclick: () => {
-          scrollTo({
+          trace.scrollTo({
             track: {uri: trackUris[0], expandGroup: true},
           });
           if (exists(ts) && exists(dur)) {
-            scrollTo({
+            trace.scrollTo({
               time: {
                 start: ts,
                 end: Time.fromRaw(ts + dur),

--- a/ui/src/public/scroll_helper.ts
+++ b/ui/src/public/scroll_helper.ts
@@ -50,20 +50,3 @@ export interface ScrollToArgs {
     expandGroup?: boolean;
   };
 }
-
-// TODO(primiano): remove this injection once we plumb Trace into all the
-// components. Right now too many places need this. This is a temporary solution
-// to avoid too many invasive refactorings at once.
-
-type ScrollToFunction = (a: ScrollToArgs) => void;
-let _scrollToFunction: ScrollToFunction | undefined = undefined;
-
-// If a Trace object is avilable, prefer Trace.scrollTo(). It points to the
-// same function.
-export function scrollTo(args: ScrollToArgs) {
-  _scrollToFunction?.(args);
-}
-
-export function setScrollToFunction(f: ScrollToFunction | undefined) {
-  _scrollToFunction = f;
-}


### PR DESCRIPTION
All usages have been replaced with trace.scrollTo()