### PR TITLE
github: don't append 'github.run_id' to the build cache key.

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -44,9 +44,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
-          restore-keys: |
-            cache-${{ env.PERFETTO_CI_JOB_NAME }}-
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}
 
       - name: Start emulator in the background
         run: tools/run_android_emulator --pid /tmp/emulator.pid -v &
@@ -75,4 +73,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}

--- a/.github/workflows/bazel-tests.yml
+++ b/.github/workflows/bazel-tests.yml
@@ -46,9 +46,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
-          restore-keys: |
-            cache-${{ env.PERFETTO_CI_JOB_NAME }}-
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}
 
       - uses: ./.github/actions/install-build-deps
         with:
@@ -81,4 +79,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}

--- a/.github/workflows/fuzzer-tests.yml
+++ b/.github/workflows/fuzzer-tests.yml
@@ -41,9 +41,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
-          restore-keys: |
-            cache-${{ env.PERFETTO_CI_JOB_NAME }}-
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}
 
       - uses: ./.github/actions/install-build-deps
 
@@ -65,4 +63,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -68,9 +68,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ matrix.config.name }}-${{ github.run_id }}
-          restore-keys: |
-            cache-${{ matrix.config.name }}-
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}
 
       - uses: ./.github/actions/install-build-deps
         with:
@@ -149,4 +147,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ matrix.config.name }}-${{ github.run_id }}
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -57,9 +57,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
-          restore-keys: |
-            cache-${{ env.PERFETTO_CI_JOB_NAME }}-
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}
 
       - name: Build Perfetto UI
         run: |
@@ -113,4 +111,4 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ${{ env.PERFETTO_CACHE_DIR }}
-          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}-${{ github.run_id }}
+          key: cache-${{ env.PERFETTO_CI_JOB_NAME }}


### PR DESCRIPTION
The 'github.run_id' is unique for each run, so when running the next build
for the same job, the cache key is different. Instead of the most recent cache,  
one of the older caches is used (using 'restore-keys:').

We only update caches when building the main branch, so it is OK 
if more than one concurrent build is running, in this case one of the writers
win and in the worst case slightly outdated (e.g. HEAD~1) build cache will be saved.
