### PR TITLE
bazel: Export //protos/third_party/chromium:zero

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -5145,6 +5145,20 @@ perfetto_cc_library(
     ],
 )
 
+perfetto_cc_library(
+    name = "chromium_zero",
+    hdrs = [
+        ":protos_perfetto_trace_track_event_zero_h",
+        ":protos_third_party_chromium_zero_h",
+    ],
+    visibility = PERFETTO_CONFIG.public_visibility,
+    deps = [
+        ":protos_perfetto_trace_track_event_zero",
+        ":protos_third_party_chromium_zero",
+        ":protozero",
+    ],
+)
+
 # GN target: //protos/perfetto/common:cpp
 perfetto_cc_protocpp_library(
     name = "protos_perfetto_common_cpp",
@@ -7016,6 +7030,15 @@ perfetto_proto_library(
     ],
     exports = [
         ":protos_perfetto_trace_track_event_protos",
+    ],
+)
+
+# GN target: //protos/third_party/chromium:zero
+perfetto_cc_protozero_library(
+    name = "protos_third_party_chromium_zero",
+    deps = [
+        ":protos_perfetto_trace_track_event_zero",
+        ":protos_third_party_chromium_protos",
     ],
 )
 

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -164,6 +164,21 @@ proto_groups = {
     }
 }
 
+protozero_groups = {
+    'trace_zero': {
+        'sources': [
+            '//protos/perfetto/trace:minimal_zero',
+            '//protos/perfetto/trace:non_minimal_zero',
+        ],
+        'visibility': ALLOWLIST_PUBLIC_VISIBILITY,
+    },
+    # Required for building Chromium's `//base` with Bazel.
+    'chromium_zero': {
+        'sources': ['//protos/third_party/chromium:zero'],
+        'visibility': ALLOWLIST_PUBLIC_VISIBILITY,
+    }
+}
+
 # Path for the protobuf sources in the standalone build.
 buildtools_protobuf_src = '//buildtools/protobuf/src'
 
@@ -922,14 +937,11 @@ def gen_target_helper(gn_target: GnParser.Target,
   return [label]
 
 
-def gen_protozero_group_target(gn: GnParser):
-  label = BazelLabel('trace_zero', 'perfetto_cc_library')
+def gen_protozero_group_target(gn: GnParser, name: str, desc: Dict[str, Any]):
+  label = BazelLabel(name, 'perfetto_cc_library')
 
   deps = set()
-  for ss in [
-      '//protos/perfetto/trace:minimal_zero',
-      '//protos/perfetto/trace:non_minimal_zero',
-  ]:
+  for ss in desc['sources']:
     deps.add(ss)
     deps.update(t.name for t in gn.get_target(ss).transitive_proto_deps())
 
@@ -940,7 +952,7 @@ def gen_protozero_group_target(gn: GnParser):
 
   label.deps = sorted(label.deps)
   label.hdrs = sorted(label.hdrs)
-  label.visibility = ALLOWLIST_PUBLIC_VISIBILITY
+  label.visibility = desc['visibility']
 
   return [label]
 
@@ -1080,8 +1092,10 @@ exports_files(["NOTICE"])
   for l_name, t_desc in proto_groups.items():
     res += ''.join(str(x) for x in gen_proto_group_target(gn, l_name, t_desc))
 
-  # Generate targets for protozero group.
-  res += ''.join(str(x) for x in gen_protozero_group_target(gn))
+  # Generate targets for protozero groups.
+  for l_name, t_desc in protozero_groups.items():
+    res += ''.join(
+        str(x) for x in gen_protozero_group_target(gn, l_name, t_desc))
 
   # For any non-source set and non-descriptor targets, ensure the source set
   # associated to that target is discovered.


### PR DESCRIPTION
Internally within Google, we build [libchrome], a subset of Chromium's `//base` library, with Bazel. This requires building the protos in Chromium's `//base/tracing/protos`, automatically rolled into Perfetto, as protozero headers, as OSS libchrome [generates the headers](https://crrev.com/c/4852792) after building Perfetto's protozero plugin.

Due to the [one version rule] and other restrictions, we cannot import these protos twice into the internal monorepo. The source of truth would therefore be Perfetto, and so we would need protozero headers for these Chromium protos inside the Perfetto build rules.

Expose `//protos/third_party/chromium:zero` in Bazel to allow building Chromium's `//base/tracing/protos` with Bazel.

Googlers: See b/433847644 for more details.

[libchrome]: https://www.chromium.org/chromium-os/developer-library/guides/infrastructure/libchrome/
[one version rule]: https://opensource.google/documentation/reference/thirdparty/oneversion