### PR TITLE
test: Fix Android in-tree build wrt perfetto_flags_c_lib

### DIFF
--- a/test/cts/Android.bp
+++ b/test/cts/Android.bp
@@ -28,6 +28,7 @@ cc_test {
         "libprotobuf-cpp-lite",
         "libperfetto_client_experimental",
         "perfetto_cts_deps",
+        "perfetto_flags_c_lib",
         "perfetto_trace_protos",
     ],
     whole_static_libs: [

--- a/test/cts/art_module/Android.bp
+++ b/test/cts/art_module/Android.bp
@@ -22,6 +22,7 @@ cc_test {
     static_libs: [
         "libgmock",
         "perfetto_cts_deps",
+        "perfetto_flags_c_lib",
         "perfetto_trace_protos",
     ],
     whole_static_libs: [

--- a/test/cts/reporter/Android.bp
+++ b/test/cts/reporter/Android.bp
@@ -24,6 +24,7 @@ cc_test {
     "libprotobuf-cpp-lite",
     "libperfetto_client_experimental",
     "perfetto_cts_deps",
+    "perfetto_flags_c_lib",
     "perfetto_trace_protos",
   ],
   whole_static_libs: [

--- a/test/vts/Android.bp
+++ b/test/vts/Android.bp
@@ -15,6 +15,7 @@ cc_test {
   ],
   static_libs: [
     "libgmock",
+    "perfetto_flags_c_lib",
     "perfetto_vts_deps",
   ],
   whole_static_libs: [


### PR DESCRIPTION
It as broken since 8a5825d4a6f8("tp: use MurmurHash for base::FlatHashMap behind a flag (#2290)", with errors like:

```
FAILED: out/soong/.intermediates/external/perfetto/test/cts/reporter/CtsPerfettoReporterTestCases/android_x86_x86_64/obj/external/perfetto/test/cts/reporter/reporter_test_cts.o
...external/perfetto/test/cts/reporter/CtsPerfettoReporterTestCases/android_x86_x86_64/obj/external/perfetto/test/cts/reporter/reporter_test_cts.o external/perfetto/test/cts/reporter/reporter_test_cts.cc
In file included from external/perfetto/test/cts/reporter/reporter_test_cts.cc:26:
In file included from external/perfetto/test/test_helper.h:46:
In file included from external/perfetto/src/traced/probes/probes_producer.h:31:
In file included from external/perfetto/src/traced/probes/ftrace/ftrace_controller.h:33:
In file included from external/perfetto/src/traced/probes/ftrace/cpu_reader.h:27:
In file included from external/perfetto/include/perfetto/ext/base/flat_hash_map.h:21:
external/perfetto/include/perfetto/ext/base/flags.h:24:10: fatal error: 'perfetto_flags.h' file not found
   24 | #include <perfetto_flags.h>
      |          ^~~~~~~~~~~~~~~~~~
1 error generated.
```

A nice cleanup would be to list all these libraries into a single `default_cc` that's used by everyone depending on `perfetto_cts_deps`, but that's's work for another day, I guess.

Tested: `cd external/perfetto; mm`