### PR TITLE
CI: install gcloud in sandbox Docker image.

### DIFF
--- a/infra/ci/sandbox/Dockerfile
+++ b/infra/ci/sandbox/Dockerfile
@@ -138,6 +138,17 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*; \
     rm -rf /root/.cache/ /usr/share/man/* /usr/share/doc/*;
 
+# Install gcloud
+RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list; \
+    apt-get update && apt-get install -y google-cloud-cli;
+
+# Create folder for gcloud config
+RUN mkdir -p /tmp/gcloud-config && chmod -R 775 /tmp/gcloud-config;
+ENV CLOUDSDK_CONFIG=/tmp/gcloud-config
+
 WORKDIR /opt/ci
 
 COPY sandbox_entrypoint.sh ./


### PR DESCRIPTION
We later will use the gcloud CLI to access Google Cloud Storage.
