### PR TITLE
stdlib: add machine_id to android_power_rails_metadata

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -89,13 +89,16 @@ CREATE PERFETTO TABLE android_power_rails_metadata (
   -- Power rail track id. Alias of `counter_track.id`.
   track_id JOINID(track.id),
   -- Subsystem name that this power rail belongs to.
-  subsystem_name STRING
+  subsystem_name STRING,
+  -- Machine id of the device the power rail is associated with.
+  machine_id JOINID(machine.id)
 ) AS
 SELECT
   t.name AS power_rail_name,
   extract_arg(t.source_arg_set_id, 'raw_name') AS raw_power_rail_name,
   t.id AS track_id,
-  extract_arg(t.source_arg_set_id, 'subsystem_name') AS subsystem_name
+  extract_arg(t.source_arg_set_id, 'subsystem_name') AS subsystem_name,
+  t.machine_id AS machine_id
 FROM counter_track AS t
 WHERE
   t.type = 'power_rails';

--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -90,7 +90,7 @@ CREATE PERFETTO TABLE android_power_rails_metadata (
   track_id JOINID(track.id),
   -- Subsystem name that this power rail belongs to.
   subsystem_name STRING,
-  -- Machine id of the device the power rail is associated with.
+  -- The device the power rail is associated with.
   machine_id JOINID(machine.id)
 ) AS
 SELECT


### PR DESCRIPTION
Because we want to use the stdlib in the PowerRails UI plugin, and
we want to ensure this plugin is machine id aware, add the machine
id to the power rail metadata.

Bug: #2249 
