### PR TITLE
docs: fix git update-stack command in developer tool docs

### DIFF
--- a/docs/contributing/developer-tools.md
+++ b/docs/contributing/developer-tools.md
@@ -129,7 +129,7 @@ git sync-all
 # ... my-feature is approved and merged on GitHub.
 
 # Do a merge again to make everything up-to-date.
-git-update-stack
+git update-stack
 
 # Prune my-feature now it's no longer necessary
 git prune-all


### PR DESCRIPTION
this should be "git update-stack" not "git-update-stack" assuming
this is supposed to depend on the aliases set earlier in the doc.
