### PR TITLE
docs: fix devloper tools stacked branch creation command

### DIFF
--- a/docs/contributing/developer-tools.md
+++ b/docs/contributing/developer-tools.md
@@ -102,7 +102,7 @@ git new-branch my-feature
 git commit -a -m 'My feature'
 
 # Create a new branch for adding something on top of the feature.
-git new-branch my-feature-2
+git new-branch my-feature-2 --current-parent
 
 # ... hack away, make changes
 


### PR DESCRIPTION
by default git new-branch creates the branch from main, instead of
the current branch. based on the comments in the docs, that does not
appear to be the intent on the example.

update the docs to create the 2nd branch using --current-parent so
that my-feature-2 is stacked on top of my-feature instead of main,
which appears to be the intent in the example.
