### PR TITLE
Move .clang-format-ignore from chromium into third_party

### DIFF
--- a/protos/third_party/.clang-format-ignore
+++ b/protos/third_party/.clang-format-ignore
@@ -1,3 +1,3 @@
 # Don't reformat auto imported proto files
-**/*.proto
+chromium/**/*.proto
 


### PR DESCRIPTION
This change moves .clang-format-ignore from chromium into the parent directory to prevent it from being overwritten by rolls from chromium. Also updates the path to point inside chromium.