### PR TITLE
ui: Fix content overflow in current selection panel's GridLayoutColumn

### DIFF
--- a/ui/src/assets/widgets/grid_layout.scss
+++ b/ui/src/assets/widgets/grid_layout.scss
@@ -29,6 +29,11 @@ $pf-responsive-gutter: 8px;
     flex-direction: column;
     gap: $pf-responsive-gutter;
   }
+
+  .pf-grid-layout-column > * {
+    word-break: break-word;
+  }
+
   td {
     word-break: break-all;
   }


### PR DESCRIPTION
When rendering the args tree with renderArguments, long value texts overflow outside the GridLayoutColumn component. This update adds CSS styling to enable automatic word-level wrapping, ensuring the content stays within the column boundaries.

Before: 
<img width="3376" height="598" alt="before-gridlayoutcolumn" src="https://github.com/user-attachments/assets/95a953ae-732f-4f83-a2a1-20ae3c0a8c0c" />

After:
<img width="3378" height="864" alt="after-gridlayoutcolumn" src="https://github.com/user-attachments/assets/3aa4e253-6c04-4d4f-b8ee-b2a933a0fdd4" />
