### PR TITLE
tp: stdlib: adds symbolize and etm diff tests

### DIFF
--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -152,6 +152,7 @@ from diff_tests.stdlib.span_join.tests_left_join import SpanJoinLeftJoin
 from diff_tests.stdlib.span_join.tests_outer_join import SpanJoinOuterJoin
 from diff_tests.stdlib.span_join.tests_regression import SpanJoinRegression
 from diff_tests.stdlib.span_join.tests_smoke import SpanJoinSmoke
+from diff_tests.stdlib.symbolize.tests import Symbolize
 from diff_tests.stdlib.tests import StdlibSmoke
 from diff_tests.stdlib.timestamps.tests import Timestamps
 from diff_tests.stdlib.traced.stats import TracedStats
@@ -214,6 +215,7 @@ def fetch_all_diff_tests(index_path: str) -> List['testing.TestCase']:
       SmokeComputeMetrics,
       SmokeJson,
       SmokeSchedEvents,
+      Symbolize,
       InputMethodClients,
       InputMethodManagerService,
       InputMethodService,

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -21,7 +21,7 @@ from python.generators.diff_tests.testing import TestSuite
 
 class Symbolize(TestSuite):
 
-  def test_llvm_symbolize_table(self):
+  def test_callstack_frame_symbolize_table(self):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
@@ -35,7 +35,7 @@ class Symbolize(TestSuite):
           line_number,
           mapping_id,
           address
-        FROM _symbolize!(
+        FROM _callstack_frame_symbolize!(
             _linux_perf_etm_metadata(0)
             WHERE mapping_id = 1
         );
@@ -61,7 +61,7 @@ class Symbolize(TestSuite):
         "<invalid>","<invalid>",0,1,434500225580
         """))
 
-  def test_llvm_symbolize_subquery(self):
+  def test_callstack_frame_symbolize_subquery(self):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
@@ -74,7 +74,7 @@ class Symbolize(TestSuite):
           line_number,
           mapping_id,
           address
-        FROM _symbolize!((
+        FROM _callstack_frame_symbolize!((
             SELECT
             __intrinsic_file.name AS file_name,
             __intrinsic_etm_iterate_instruction_range.address - stack_profile_mapping.start + stack_profile_mapping.exact_offset + __intrinsic_elf_file.load_bias AS rel_pc,

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Path, DataPath, Metric
+from python.generators.diff_tests.testing import Csv, Json, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class Symbolize(TestSuite):
+
+  def test_llvm_symbolize_table(self):
+    return DiffTestBlueprint(
+        register_files_dir=DataPath('simpleperf/bin'),
+        trace=DataPath('simpleperf/cs_etm_u.perf'),
+        query="""
+        INCLUDE PERFETTO MODULE callstacks.symbolize;
+        INCLUDE PERFETTO MODULE linux.perf.etm;
+
+        SELECT
+          function_name,
+          replace(file_name, rtrim(file_name, replace(file_name, '/', '')), '') AS short_file_nam,
+          line_number,
+          mapping_id,
+          address
+        FROM _symbolize!(
+            _linux_perf_etm_metadata(0)
+            WHERE mapping_id = 1
+        );
+        """,
+        out=Csv("""
+        "function_name","short_file_nam","line_number","mapping_id","address"
+        "main","etm.cc",62,1,434500225096
+        "main","etm.cc",0,1,434500225100
+        "main","etm.cc",62,1,434500225104
+        "main","etm.cc",60,1,434500225084
+        "A()","etm.cc",44,1,434500225128
+        "A()","etm.cc",44,1,434500225132
+        "A()","etm.cc",44,1,434500225136
+        "A()","etm.cc",46,1,434500225140
+        "A()","etm.cc",46,1,434500225144
+        "A()","etm.cc",47,1,434500225148
+        "A()","etm.cc",47,1,434500225152
+        "A()","etm.cc",47,1,434500225156
+        "A()","etm.cc",47,1,434500225160
+        "<invalid>","<invalid>",0,1,434500225568
+        "<invalid>","<invalid>",0,1,434500225572
+        "<invalid>","<invalid>",0,1,434500225576
+        "<invalid>","<invalid>",0,1,434500225580
+        """))
+
+  def test_llvm_symbolize_subquery(self):
+    return DiffTestBlueprint(
+        register_files_dir=DataPath('simpleperf/bin'),
+        trace=DataPath('simpleperf/cs_etm_u.perf'),
+        query="""
+        INCLUDE PERFETTO MODULE callstacks.symbolize;
+
+        SELECT
+          function_name,
+          replace(file_name, rtrim(file_name, replace(file_name, '/', '')), '') AS short_file_nam,
+          line_number,
+          mapping_id,
+          address
+        FROM _symbolize!((
+            SELECT
+            __intrinsic_file.name AS file_name,
+            __intrinsic_etm_iterate_instruction_range.address - stack_profile_mapping.start + stack_profile_mapping.exact_offset + __intrinsic_elf_file.load_bias AS rel_pc,
+            __intrinsic_etm_decode_trace.mapping_id AS mapping_id,
+            __intrinsic_etm_iterate_instruction_range.address AS address
+            FROM __intrinsic_etm_decode_trace(0)
+            JOIN __intrinsic_etm_iterate_instruction_range
+              ON __intrinsic_etm_decode_trace.instruction_range = __intrinsic_etm_iterate_instruction_range.instruction_range
+            JOIN stack_profile_mapping
+              ON __intrinsic_etm_decode_trace.mapping_id = stack_profile_mapping.id
+            JOIN __intrinsic_elf_file
+              ON stack_profile_mapping.build_id = __intrinsic_elf_file.build_id
+            JOIN __intrinsic_file
+              ON __intrinsic_elf_file.file_id = __intrinsic_file.id
+            WHERE mapping_id = 1
+        ));
+        """,
+        out=Csv("""
+        "function_name","short_file_nam","line_number","mapping_id","address"
+        "main","etm.cc",62,1,434500225096
+        "main","etm.cc",0,1,434500225100
+        "main","etm.cc",62,1,434500225104
+        "main","etm.cc",60,1,434500225084
+        "A()","etm.cc",44,1,434500225128
+        "A()","etm.cc",44,1,434500225132
+        "A()","etm.cc",44,1,434500225136
+        "A()","etm.cc",46,1,434500225140
+        "A()","etm.cc",46,1,434500225144
+        "A()","etm.cc",47,1,434500225148
+        "A()","etm.cc",47,1,434500225152
+        "A()","etm.cc",47,1,434500225156
+        "A()","etm.cc",47,1,434500225160
+        "<invalid>","<invalid>",0,1,434500225568
+        "<invalid>","<invalid>",0,1,434500225572
+        "<invalid>","<invalid>",0,1,434500225576
+        "<invalid>","<invalid>",0,1,434500225580
+        """))


### PR DESCRIPTION
This PR adds diff tests for SQL symbolize.

This can only be merged when there is support for optional diff tests based on configuration. #2381

https://github.com/google/perfetto/pull/2375#issuecomment-3145328234
