### PR TITLE
ui: Improve foundational UI widgets

### DIFF
--- a/ui/src/assets/widgets/modal.scss
+++ b/ui/src/assets/widgets/modal.scss
@@ -84,6 +84,12 @@
     justify-content: space-between;
     align-items: center;
 
+    .modal-title {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
     h2 {
       margin-top: 0;
       margin-bottom: 0;

--- a/ui/src/assets/widgets/switch.scss
+++ b/ui/src/assets/widgets/switch.scss
@@ -14,32 +14,16 @@
 
 @import "theme";
 
-// This checkbox element is expected to contain a checkbox type input followed
-// by an empty span element.
-// The input is completely hidden and an entirely new checkbox is drawn inside
-// the span element. This allows us to style it how we like, and also add some
-// fancy transitions.
-// The box of the checkbox is a fixed sized span element. The tick is also a
-// fixed sized rectange rotated 45 degrees with only the bottom and right
-// borders visible.
-// When unchecked, the tick size and border width is 0, so the tick is
-// completely invsible. When we transition to checked, the border size on the
-// bottom and right sides is immmdiately set to full width, and the tick morphs
-// into view first by expanding along the x axis first, then expanding up the
-// y-axis. This has the effect of making the tick look like it's being drawn
-// onto the page with a pen.
-// When transitioning from checked to unchecked, the animation plays in reverse,
-// and the border width is set to 0 right at the end in order to make the tick
-// completely invisible again.
 .pf-switch {
-  display: inline-block;
-  position: relative; // Turns this container into a positioned element
+  display: inline-flex;
+  align-items: center;
+  position: relative;
   font-family: $pf-font;
   font-size: inherit;
   color: $pf-minimal-foreground;
   user-select: none;
   cursor: pointer;
-  padding-left: 32px + 6px;
+  gap: 6px;
 
   // Hide the default checkbox
   input {
@@ -48,14 +32,13 @@
     pointer-events: none;
   }
 
-  // The span forms the "box" of the checkbox
-  span {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    margin-top: auto;
-    margin-bottom: auto;
+  .pf-switch-label-left {
+    order: 1;
+  }
+
+  .pf-switch-visual {
+    order: 2;
+    position: relative;
     height: 16px;
     width: 32px;
     border-radius: 8px;
@@ -63,7 +46,7 @@
     background: grey;
     vertical-align: middle;
 
-    // The :after element forms the "tick" of the checkbox
+    // The :after element forms the "thumb" of the switch
     &:after {
       content: "";
       display: block;
@@ -82,15 +65,19 @@
     }
   }
 
-  input:checked + span {
+  .pf-switch-label {
+    order: 3;
+  }
+
+  input:checked ~ .pf-switch-visual {
     background: $pf-primary-background;
   }
 
-  input:checked + span:after {
+  input:checked ~ .pf-switch-visual:after {
     left: 18px;
   }
 
-  input:focus-visible + span {
+  input:focus-visible ~ .pf-switch-visual {
     @include focus;
   }
 
@@ -98,7 +85,7 @@
     cursor: not-allowed;
     color: $pf-minimal-foreground-disabled;
 
-    span {
+    .pf-switch-visual {
       border-color: $pf-minimal-foreground-disabled;
       background: $pf-minimal-foreground-disabled;
       &:after {
@@ -106,7 +93,7 @@
       }
     }
 
-    input:checked ~ span {
+    input:checked ~ .pf-switch-visual {
       border-color: $pf-primary-background-disabled;
       background: $pf-primary-background-disabled;
     }

--- a/ui/src/widgets/modal.ts
+++ b/ui/src/widgets/modal.ts
@@ -47,6 +47,8 @@ import {Intent} from './common';
 
 export interface ModalAttrs {
   title: string;
+  icon?: string;
+  className?: string;
   buttons?: ModalButton[];
   vAlign?: 'MIDDLE' /* default */ | 'TOP';
 
@@ -70,6 +72,7 @@ export interface ModalButton {
   text: string;
   primary?: boolean;
   id?: string;
+  disabled?: boolean;
   action?: () => void;
 }
 
@@ -136,25 +139,30 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
             if (button.action !== undefined) button.action();
           },
           label: button.text,
+          disabled: button.disabled,
         }),
       );
     }
 
     const aria = '[aria-labelledby=mm-title][aria-model][role=dialog]';
     const align = attrs.vAlign === 'TOP' ? '.modal-dialog-valign-top' : '';
+    const customClass = attrs.className ? '.' + attrs.className : '';
     return m(
       '.modal-backdrop',
       {
         onclick: this.onBackdropClick.bind(this, attrs),
-        onkeyup: this.onBackdropKeyupdown.bind(this, attrs),
-        onkeydown: this.onBackdropKeyupdown.bind(this, attrs),
+        onkeydown: this.onBackdropKeydown.bind(this, attrs),
         tabIndex: 0,
       },
       m(
-        `.modal-dialog${align}${aria}`,
+        `.modal-dialog${align}${customClass}${aria}`,
         m(
           'header',
-          m('h2', {id: 'mm-title'}, attrs.title),
+          m(
+            '.modal-title',
+            attrs.icon && m(Icon, {icon: attrs.icon}),
+            m('h2', {id: 'mm-title'}, attrs.title),
+          ),
           m(
             'button[aria-label=Close Modal]',
             {onclick: () => closeModal(attrs.key)},
@@ -177,9 +185,9 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
     }
   }
 
-  onBackdropKeyupdown(attrs: ModalAttrs, e: KeyboardEvent) {
+  onBackdropKeydown(attrs: ModalAttrs, e: KeyboardEvent) {
     e.stopPropagation();
-    if (e.key === 'Escape' && e.type !== 'keyup') {
+    if (e.key === 'Escape') {
       closeModal(attrs.key);
     }
   }

--- a/ui/src/widgets/popup.ts
+++ b/ui/src/widgets/popup.ts
@@ -172,13 +172,20 @@ export class Popup implements m.ClassComponent<PopupAttrs> {
     const portalAttrs: PortalAttrs = {
       className: 'pf-popup-portal',
       onBeforeContentMount: (dom: Element): MountOptions => {
-        // Check to see if dom is a descendant of a popup
+        // Check to see if dom is a descendant of a popup or modal
         // If so, get the popup's "container" and put it in there instead
         // This handles the case where popups are placed inside the other popups
         // we nest outselves in their containers instead of document body which
         // means we become part of their hitbox for mouse events.
         const closestPopup = dom.closest(`[ref=${Popup.POPUP_REF}]`);
-        return {container: closestPopup ?? undefined};
+        if (closestPopup) {
+          return {container: closestPopup};
+        }
+        const closestModal = dom.closest('.modal-dialog');
+        if (closestModal) {
+          return {container: closestModal};
+        }
+        return {container: undefined};
       },
       onContentMount: (dom: HTMLElement) => {
         const popupElement = toHTMLElement(

--- a/ui/src/widgets/switch.ts
+++ b/ui/src/widgets/switch.ts
@@ -20,11 +20,15 @@ export interface SwitchAttrs extends HTMLCheckboxAttrs {
   // Optional text to show to the right of the switch.
   // If omitted, no text will be shown.
   label?: string;
+  // Optional text to show to the left of the switch.
+  // If omitted, no text will be shown.
+  labelLeft?: string;
 }
 
 export class Switch implements m.ClassComponent<SwitchAttrs> {
   view({attrs}: m.CVnode<SwitchAttrs>) {
-    const {label, checked, disabled, className, ...htmlAttrs} = attrs;
+    const {label, labelLeft, checked, disabled, className, ...htmlAttrs} =
+      attrs;
 
     const classes = classNames(disabled && 'pf-disabled', className);
 
@@ -36,9 +40,10 @@ export class Switch implements m.ClassComponent<SwitchAttrs> {
         ...htmlAttrs,
         className: classes,
       },
+      labelLeft && m('span.pf-switch-label-left', labelLeft),
       m('input[type=checkbox]', {disabled, checked}),
-      m('span'),
-      label,
+      m('span.pf-switch-visual'),
+      label && m('span.pf-switch-label', label),
     );
   }
 }

--- a/ui/src/widgets/tooltip.ts
+++ b/ui/src/widgets/tooltip.ts
@@ -106,8 +106,20 @@ export class Tooltip implements m.ClassComponent<TooltipAttrs> {
     const portalAttrs: PortalAttrs = {
       className: 'pf-tooltip-portal',
       onBeforeContentMount: (dom: Element): MountOptions => {
+        // Check to see if dom is a descendant of a popup or modal
+        // If so, get the popup's "container" and put it in there instead
+        // This handles the case where popups are placed inside the other popups
+        // we nest outselves in their containers instead of document body which
+        // means we become part of their hitbox for mouse events.
         const closestPopup = dom.closest(`[ref=${Tooltip.TOOLTIP_REF}]`);
-        return {container: closestPopup ?? undefined};
+        if (closestPopup) {
+          return {container: closestPopup};
+        }
+        const closestModal = dom.closest('.modal-dialog');
+        if (closestModal) {
+          return {container: closestModal};
+        }
+        return {container: undefined};
       },
       onContentMount: (dom: HTMLElement) => {
         const popupElement = toHTMLElement(


### PR DESCRIPTION
This commit introduces several improvements to the core UI widgets, enhancing their functionality, styling, and consistency across the application.

Modal:
- Add support for an optional `icon` in the modal title.
- Accept a `className` for custom styling.
- Allow buttons to be individually `disabled`.

Switch:
- Refactor the layout to use Flexbox for better alignment.
- Add support for a `labelLeft` property.
- Improve CSS structure using more specific class names (`.pf-switch-visual`, `.pf-switch-label`).

Popup & Tooltip:
- Update `onBeforeContentMount` to correctly handle rendering within modals, ensuring they are contained within the modal's DOM structure rather than the document body. This prevents z-index issues and ensures correct event handling.

Test: ui/run-unittests --out out/ui-unittest
