### PR TITLE
ui: Add multi-trace open modal feature

### DIFF
--- a/ui/src/core/default_plugins.ts
+++ b/ui/src/core/default_plugins.ts
@@ -50,6 +50,7 @@ export const defaultPlugins = [
   'dev.perfetto.LargeScreensPerf',
   'dev.perfetto.LinuxPerf',
   'dev.perfetto.MetricsPage',
+  'dev.perfetto.MultiTraceOpen',
   'dev.perfetto.PinAndroidPerfMetrics',
   'dev.perfetto.PinSysUITracks',
   'dev.perfetto.PowerRails',

--- a/ui/src/core_plugins/multi_trace_open/index.ts
+++ b/ui/src/core_plugins/multi_trace_open/index.ts
@@ -1,0 +1,52 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PerfettoPlugin} from '../../public/plugin';
+import {App} from '../../public/app';
+import {showMultiTraceModal} from './multi_trace_modal';
+
+const MULTI_TRACE_COMMAND_ID = 'dev.perfetto.MultiTraceOpen#openMultipleTraces';
+
+function openFilePickerAndShowModal() {
+  const input = document.createElement('input');
+  input.setAttribute('type', 'file');
+  input.setAttribute('multiple', 'multiple');
+  input.style.display = 'none';
+  input.addEventListener('change', async () => {
+    if (!input.files) return;
+    const files = [...input.files];
+    if (files.length > 0) {
+      showMultiTraceModal(files);
+    }
+  });
+  input.click();
+}
+
+export default class implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.MultiTraceOpen';
+
+  static onActivate(app: App): void {
+    app.commands.registerCommand({
+      id: MULTI_TRACE_COMMAND_ID,
+      name: 'Open multiple trace files',
+      callback: () => openFilePickerAndShowModal(),
+    });
+    app.sidebar.addMenuItem({
+      commandId: MULTI_TRACE_COMMAND_ID,
+      section: 'navigation',
+      icon: 'library_books',
+    });
+  }
+  async onTraceLoad(): Promise<void> {}
+}

--- a/ui/src/core_plugins/multi_trace_open/multi_trace_controller.ts
+++ b/ui/src/core_plugins/multi_trace_open/multi_trace_controller.ts
@@ -1,0 +1,412 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  SyncConfig,
+  TraceFile,
+  TraceFileAnalyzed,
+  AnchorLink,
+} from './multi_trace_types';
+import {uuidv4} from '../../base/uuid';
+import {assertExists} from '../../base/logging';
+import {TraceAnalyzer} from './trace_analyzer';
+
+function getErrorMessage(e: unknown): string {
+  const err = e instanceof Error ? e.message : `${e}`;
+  if (err.includes('(ERR:fmt)')) {
+    return `The file opened doesn't look like a Perfetto trace or any other supported trace format.`;
+  }
+  return err;
+}
+
+// A prioritized list of clock names to be used when selecting a reference
+// clock automatically.
+const PREFERRED_REFERENCE_CLOCKS = [
+  'BOOTTIME',
+  'MONOTONIC',
+  'MONOTONIC_RAW',
+  'MONOTONIC_COARSE',
+  'TSC',
+  'REALTIME',
+  'REALTIME_COARSE',
+  'PERF',
+];
+
+// A wrapper to associate a TraceFile with its internal state.
+interface TraceFileWrapper {
+  trace: TraceFile;
+}
+
+// The possible error states for the modal, used to show a helpful message
+// to the user and disable the "Open Traces" button.
+export type LoadingError =
+  | 'NO_TRACES'
+  | 'ANALYZING'
+  | 'SYNC_ERROR'
+  | 'TRACE_ERROR'
+  | 'INCOMPLETE_CONFIG';
+
+/**
+ * The controller for the multi-trace modal.
+ * This class manages the state of the traces, their analysis, and their
+ * synchronization configuration.
+ */
+export class MultiTraceController {
+  private wrappers: TraceFileWrapper[] = [];
+  private selectedUuid?: string;
+  private traceAnalyzer: TraceAnalyzer;
+  private onStateChanged: () => void;
+  syncError?: string;
+
+  constructor(traceAnalyzer: TraceAnalyzer, onStateChanged: () => void) {
+    this.traceAnalyzer = traceAnalyzer;
+    this.onStateChanged = onStateChanged;
+  }
+
+  // ===========================================================================
+  // Public Getters
+  // ===========================================================================
+
+  get traces(): ReadonlyArray<TraceFile> {
+    return this.wrappers.map((x) => x.trace);
+  }
+
+  get selectedTrace(): Readonly<TraceFile> | undefined {
+    return this.wrappers.find((w) => w.trace.uuid === this.selectedUuid)?.trace;
+  }
+
+  get isOpeningAllowed(): boolean {
+    return this.getLoadingError() === undefined;
+  }
+
+  getLoadingError(): LoadingError | undefined {
+    if (this.traces.length === 0) {
+      return 'NO_TRACES';
+    }
+    if (this.isAnalyzing() || this.isSyncing()) {
+      return 'ANALYZING';
+    }
+    if (this.syncError) {
+      return 'SYNC_ERROR';
+    }
+    if (this.hasTraceError()) {
+      return 'TRACE_ERROR';
+    }
+    if (!this.isSyncConfigComplete()) {
+      return 'INCOMPLETE_CONFIG';
+    }
+    return undefined;
+  }
+
+  // ===========================================================================
+  // Public Actions
+  // ===========================================================================
+
+  async addFiles(files: ReadonlyArray<File>) {
+    const newTraces: TraceFileWrapper[] = Array.from(files).map((file) => ({
+      trace: {
+        file,
+        uuid: uuidv4(),
+        status: 'not-analyzed',
+      },
+    }));
+    for (const {trace} of this.wrappers) {
+      if (trace.status === 'analyzed' && trace.syncMode === 'AUTOMATIC') {
+        trace.syncConfig = {
+          syncMode: 'CALCULATING',
+        };
+      }
+    }
+    this.wrappers.push(...newTraces);
+    await Promise.all(newTraces.map((trace) => this.analyzeTrace(trace)));
+  }
+
+  selectTrace(uuid: string) {
+    this.selectedUuid = uuid;
+  }
+
+  removeTrace(uuid: string) {
+    const index = this.wrappers.findIndex((w) => w.trace.uuid === uuid);
+    if (index > -1) {
+      this.wrappers.splice(index, 1);
+    }
+    if (this.selectedUuid === uuid) {
+      this.selectedUuid = undefined;
+    }
+    this.recomputeSync();
+    this.onStateChanged();
+  }
+
+  setTraceOffset(anchorLink: AnchorLink, rawOffset: string) {
+    const offset = parseInt(rawOffset, 10);
+    if (Number.isNaN(offset) || !Number.isInteger(Number(rawOffset))) {
+      anchorLink.offset = {
+        kind: 'invalid',
+        raw: rawOffset,
+        error: 'Offset must be a valid integer.',
+      };
+    } else {
+      anchorLink.offset = {
+        kind: 'valid',
+        raw: rawOffset,
+        value: offset,
+      };
+    }
+    this.onStateChanged();
+  }
+
+  // ===========================================================================
+  // Core Synchronization Logic
+  // ===========================================================================
+
+  findBestClock(trace: TraceFileAnalyzed): string | undefined {
+    const availableClocks = new Set(trace.clocks.map((c) => c.name));
+    const bestClock = PREFERRED_REFERENCE_CLOCKS.find((c) =>
+      availableClocks.has(c),
+    );
+    return bestClock ?? trace.clocks[0]?.name;
+  }
+
+  recomputeSync() {
+    this.syncError = undefined;
+
+    if (this.traces.some((trace) => trace.status === 'analyzing')) {
+      return;
+    }
+    const analyzedTraces = this.wrappers
+      .map(({trace}) => trace)
+      .filter((trace): trace is TraceFileAnalyzed => {
+        return trace.status === 'analyzed';
+      });
+
+    const manualTraces = analyzedTraces.filter(
+      (trace) => trace.syncMode === 'MANUAL',
+    );
+    const automaticTraces = analyzedTraces.filter(
+      (trace) => trace.syncMode === 'AUTOMATIC',
+    );
+
+    const manualReferences = manualTraces.filter(
+      (trace) => trace.syncConfig.syncMode === 'REFERENCE',
+    );
+
+    if (manualReferences.length > 1) {
+      this.syncError = 'Only one reference clock can be chosen.';
+      this.onStateChanged();
+      return;
+    }
+
+    const adj = new Map<string, string[]>();
+    const clocksByUuid = new Map<string, Set<string>>();
+    for (const trace of analyzedTraces) {
+      adj.set(trace.uuid, []);
+      clocksByUuid.set(trace.uuid, new Set(trace.clocks.map((c) => c.name)));
+    }
+
+    for (let i = 0; i < analyzedTraces.length; i++) {
+      for (let j = i + 1; j < analyzedTraces.length; j++) {
+        const traceA = analyzedTraces[i];
+        const traceB = analyzedTraces[j];
+        const clocksA = assertExists(clocksByUuid.get(traceA.uuid));
+        const clocksB = assertExists(clocksByUuid.get(traceB.uuid));
+        if ([...clocksA].some((clock) => clocksB.has(clock))) {
+          adj.get(traceA.uuid)!.push(traceB.uuid);
+          adj.get(traceB.uuid)!.push(traceA.uuid);
+        }
+      }
+    }
+
+    let referenceUuid: string | undefined =
+      manualReferences.length === 1 ? manualReferences[0].uuid : undefined;
+
+    if (!referenceUuid && automaticTraces.length > 0) {
+      for (const clock of PREFERRED_REFERENCE_CLOCKS) {
+        const traceWithClock = automaticTraces.find((t) =>
+          clocksByUuid.get(t.uuid)!.has(clock),
+        );
+        if (traceWithClock) {
+          referenceUuid = traceWithClock.uuid;
+          break;
+        }
+      }
+      if (!referenceUuid && automaticTraces.length > 0) {
+        referenceUuid = automaticTraces.reduce((a, b) =>
+          adj.get(a.uuid)!.length > adj.get(b.uuid)!.length ? a : b,
+        ).uuid;
+      }
+    }
+
+    const newConfigs = new Map<string, SyncConfig>();
+    if (referenceUuid) {
+      const queue: string[] = [referenceUuid];
+      const visited = new Set<string>([referenceUuid]);
+      const referenceTrace = analyzedTraces.find(
+        (t) => t.uuid === referenceUuid,
+      )!;
+      if (referenceTrace.syncMode === 'AUTOMATIC') {
+        const referenceTraceClocks = clocksByUuid.get(referenceUuid)!;
+        const bestClock = PREFERRED_REFERENCE_CLOCKS.find((c) =>
+          referenceTraceClocks.has(c),
+        );
+        newConfigs.set(referenceUuid, {
+          syncMode: 'REFERENCE',
+          referenceClock: bestClock ?? referenceTrace.clocks[0]?.name,
+        });
+      }
+
+      while (queue.length > 0) {
+        const parentUuid = queue.shift()!;
+        for (const childUuid of adj.get(parentUuid)!) {
+          if (visited.has(childUuid)) continue;
+          visited.add(childUuid);
+          const childTrace = analyzedTraces.find((t) => t.uuid === childUuid)!;
+          if (childTrace.syncMode === 'MANUAL') continue;
+
+          const parentClocks = clocksByUuid.get(parentUuid)!;
+          const childClocks = clocksByUuid.get(childUuid)!;
+          const bestCommonClock = PREFERRED_REFERENCE_CLOCKS.find(
+            (c) => parentClocks.has(c) && childClocks.has(c),
+          );
+
+          if (bestCommonClock) {
+            newConfigs.set(childUuid, {
+              syncMode: 'SYNC_TO_OTHER',
+              syncClock: {
+                thisTraceClock: bestCommonClock,
+                anchorTraceUuid: parentUuid,
+                anchorClock: bestCommonClock,
+                offset: {kind: 'valid', raw: '0', value: 0},
+              },
+            });
+            queue.push(childUuid);
+          }
+        }
+      }
+    }
+
+    for (const trace of automaticTraces) {
+      const newConfig = newConfigs.get(trace.uuid);
+      if (newConfig) {
+        trace.syncConfig = newConfig;
+      } else {
+        trace.syncConfig = {
+          syncMode: 'REFERENCE',
+          referenceClock: trace.clocks[0]?.name,
+        };
+      }
+    }
+    this.onStateChanged();
+  }
+
+  // ===========================================================================
+  // Trace Analysis
+  // ===========================================================================
+
+  private async analyzeTrace(wrapper: TraceFileWrapper) {
+    if (wrapper.trace.status !== 'not-analyzed') {
+      return;
+    }
+    wrapper.trace = {
+      ...wrapper.trace,
+      status: 'analyzing',
+      progress: 0,
+    };
+    this.onStateChanged();
+    try {
+      const result = await this.traceAnalyzer.analyze(
+        wrapper.trace.file,
+        (progress) => {
+          if (wrapper.trace.status === 'analyzing') {
+            wrapper.trace.progress = progress;
+            this.onStateChanged();
+          }
+        },
+      );
+
+      wrapper.trace = {
+        ...wrapper.trace,
+        status: 'analyzed',
+        format: result.format,
+        clocks: result.clocks,
+        syncMode: 'AUTOMATIC',
+        syncConfig: {
+          syncMode: 'CALCULATING',
+        },
+      };
+    } catch (e) {
+      wrapper.trace = {
+        ...wrapper.trace,
+        status: 'error',
+        error: getErrorMessage(e),
+      };
+    } finally {
+      this.recomputeSync();
+      this.onStateChanged();
+    }
+  }
+
+  // ===========================================================================
+  // Internal State Helpers
+  // ===========================================================================
+
+  isAnalyzing(): boolean {
+    return this.traces.some((trace) => trace.status === 'analyzing');
+  }
+
+  private hasTraceError(): boolean {
+    return this.traces.some((trace) => trace.status === 'error');
+  }
+
+  private isSyncing(): boolean {
+    return this.traces.some((trace) => {
+      return (
+        trace.status === 'analyzed' &&
+        trace.syncConfig.syncMode === 'CALCULATING'
+      );
+    });
+  }
+
+  private isSyncConfigComplete(): boolean {
+    for (const trace of this.traces) {
+      if (trace.status !== 'analyzed') {
+        continue;
+      }
+      const config = trace.syncConfig;
+      if (config.syncMode === 'REFERENCE') {
+        if (config.referenceClock === undefined) {
+          return false;
+        }
+      } else if (config.syncMode === 'SYNC_TO_OTHER') {
+        if (
+          config.syncClock.thisTraceClock === undefined ||
+          config.syncClock.anchorClock === undefined ||
+          config.syncClock.anchorTraceUuid === undefined ||
+          config.syncClock.offset.kind === 'invalid'
+        ) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  // ===========================================================================
+  // Testing Helpers
+  // ===========================================================================
+
+  // visible for testing
+  setTracesForTesting(traces: TraceFile[]) {
+    this.wrappers = traces.map((trace) => ({trace}));
+  }
+}

--- a/ui/src/core_plugins/multi_trace_open/multi_trace_controller_unittest.ts
+++ b/ui/src/core_plugins/multi_trace_open/multi_trace_controller_unittest.ts
@@ -1,0 +1,477 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {MultiTraceController} from './multi_trace_controller';
+import {TraceFileAnalyzed} from './multi_trace_types';
+import {TraceAnalysisResult, TraceAnalyzer} from './trace_analyzer';
+
+// Helper to create a mock TraceFileAnalyzed object for manual mode tests
+function createMockTrace(
+  uuid: string,
+  clocks: string[],
+  syncMode: 'AUTOMATIC' | 'MANUAL' = 'AUTOMATIC',
+): TraceFileAnalyzed {
+  return {
+    uuid,
+    file: new File([], `${uuid}.pftrace`),
+    status: 'analyzed',
+    format: 'Perfetto',
+    clocks: clocks.map((name) => ({name, count: 100})),
+    syncMode,
+    syncConfig: {syncMode: 'REFERENCE', referenceClock: ''}, // Default config
+  };
+}
+
+// A fake TraceAnalyzer for testing purposes.
+class FakeTraceAnalyzer implements TraceAnalyzer {
+  private results = new Map<string, TraceAnalysisResult>();
+  private errors = new Map<string, Error>();
+
+  setResult(fileName: string, result: TraceAnalysisResult) {
+    this.results.set(fileName, result);
+  }
+
+  setError(fileName: string, error: Error) {
+    this.errors.set(fileName, error);
+  }
+
+  async analyze(
+    file: File,
+    _onProgress: (progress: number) => void,
+  ): Promise<TraceAnalysisResult> {
+    if (this.errors.has(file.name)) {
+      throw this.errors.get(file.name)!;
+    }
+    const result = this.results.get(file.name);
+    if (result) {
+      return result;
+    }
+    throw new Error(`No mock result set for ${file.name}`);
+  }
+}
+
+// Helper to create a File object for tests
+function createMockFile(name: string): File {
+  return new File([], name);
+}
+
+describe('MultiTraceController', () => {
+  let controller: MultiTraceController;
+  let fakeAnalyzer: FakeTraceAnalyzer;
+  let onStateChanged: jest.Mock;
+
+  beforeEach(() => {
+    fakeAnalyzer = new FakeTraceAnalyzer();
+    onStateChanged = jest.fn();
+    controller = new MultiTraceController(fakeAnalyzer, onStateChanged);
+  });
+
+  it('should initialize with no traces or errors', () => {
+    expect(controller.traces).toHaveLength(0);
+    expect(controller.syncError).toBeUndefined();
+  });
+
+  it('should set a single trace as a root', async () => {
+    const file = createMockFile('trace1.pftrace');
+    fakeAnalyzer.setResult(file.name, {
+      format: 'Perfetto',
+      clocks: [{name: 'BOOTTIME', count: 1}],
+    });
+
+    await controller.addFiles([file]);
+
+    const trace = controller.traces[0] as TraceFileAnalyzed;
+    expect(trace.syncConfig.syncMode).toEqual('REFERENCE');
+  });
+
+  it('should sync two traces based on preferred clock order', async () => {
+    const file1 = createMockFile('trace1.pftrace');
+    const file2 = createMockFile('trace2.pftrace');
+    // trace1 has a lower priority clock
+    fakeAnalyzer.setResult(file1.name, {
+      format: 'Perfetto',
+      clocks: [{name: 'MONOTONIC', count: 1}],
+    });
+    // trace2 has a higher priority clock
+    fakeAnalyzer.setResult(file2.name, {
+      format: 'Perfetto',
+      clocks: [{name: 'BOOTTIME', count: 1}],
+    });
+
+    await controller.addFiles([file1, file2]);
+
+    const trace1 = controller.traces.find(
+      (t) => t.file.name === file1.name,
+    ) as TraceFileAnalyzed;
+    const trace2 = controller.traces.find(
+      (t) => t.file.name === file2.name,
+    ) as TraceFileAnalyzed;
+
+    // Trace 2 should be root as it has the higher priority clock
+    expect(trace2.syncConfig.syncMode).toEqual('REFERENCE');
+    // In this specific test, they can't sync, so trace1 will also be a root.
+    expect(trace1.syncConfig.syncMode).toEqual('REFERENCE');
+  });
+
+  it('should select the highest priority clock for a single root trace', async () => {
+    const file = createMockFile('trace1.pftrace');
+    const clocks = [
+      {name: 'REALTIME_COARSE', count: 1},
+      {name: 'REALTIME', count: 1},
+      {name: 'MONOTONIC_RAW', count: 1},
+      {name: 'MONOTONIC_COARSE', count: 1},
+      {name: 'MONOTONIC', count: 1},
+      {name: 'BOOTTIME', count: 1},
+    ];
+    fakeAnalyzer.setResult(file.name, {format: 'Perfetto', clocks});
+
+    await controller.addFiles([file]);
+
+    const trace = controller.traces[0] as TraceFileAnalyzed;
+    expect(trace.syncConfig.syncMode).toEqual('REFERENCE');
+    if (trace.syncConfig.syncMode === 'REFERENCE') {
+      expect(trace.syncConfig.referenceClock).toEqual('BOOTTIME');
+    }
+  });
+
+  it('should choose the highest priority common clock for sync', async () => {
+    const file1 = createMockFile('trace1.pftrace');
+    const file2 = createMockFile('trace2.pftrace');
+    // Both traces share a high and low priority clock
+    const clocks = [
+      {name: 'REALTIME_COARSE', count: 1},
+      {name: 'BOOTTIME', count: 1},
+    ];
+    fakeAnalyzer.setResult(file1.name, {format: 'Perfetto', clocks});
+    fakeAnalyzer.setResult(file2.name, {format: 'Perfetto', clocks});
+
+    await controller.addFiles([file1, file2]);
+
+    const trace1 = controller.traces[0] as TraceFileAnalyzed;
+    const trace2 = controller.traces[1] as TraceFileAnalyzed;
+
+    // Assuming trace1 becomes the root
+    const syncTrace =
+      trace1.syncConfig.syncMode === 'REFERENCE' ? trace2 : trace1;
+    const rootTrace =
+      trace1.syncConfig.syncMode === 'REFERENCE' ? trace1 : trace2;
+
+    expect(syncTrace.syncConfig.syncMode).toEqual('SYNC_TO_OTHER');
+    if (syncTrace.syncConfig.syncMode === 'SYNC_TO_OTHER') {
+      expect(syncTrace.syncConfig.syncClock?.anchorTraceUuid).toEqual(
+        rootTrace.uuid,
+      );
+      // This is the key check: it must use the best clock.
+      expect(syncTrace.syncConfig.syncClock?.thisTraceClock).toEqual(
+        'BOOTTIME',
+      );
+      expect(syncTrace.syncConfig.syncClock?.anchorClock).toEqual('BOOTTIME');
+    } else {
+      fail('One trace should be syncing to the other');
+    }
+  });
+
+  it('should handle multiple disconnected traces', async () => {
+    const file1 = createMockFile('trace1.pftrace');
+    const file2 = createMockFile('trace2.pftrace');
+    fakeAnalyzer.setResult(file1.name, {
+      format: 'Perfetto',
+      clocks: [{name: 'BOOTTIME', count: 1}],
+    });
+    fakeAnalyzer.setResult(file2.name, {
+      format: 'Perfetto',
+      clocks: [{name: 'MONOTONIC', count: 1}],
+    });
+
+    await controller.addFiles([file1, file2]);
+
+    const trace1 = controller.traces[0] as TraceFileAnalyzed;
+    const trace2 = controller.traces[1] as TraceFileAnalyzed;
+
+    // Both should become roots as they can't be synced
+    expect(trace1.syncConfig.syncMode).toEqual('REFERENCE');
+    expect(trace2.syncConfig.syncMode).toEqual('REFERENCE');
+  });
+
+  it('should respect a manual root', () => {
+    const trace1 = createMockTrace('uuid1', ['BOOTTIME']);
+    const trace2 = createMockTrace('uuid2', ['BOOTTIME'], 'MANUAL');
+    trace2.syncConfig = {syncMode: 'REFERENCE', referenceClock: 'BOOTTIME'};
+    controller.setTracesForTesting([trace1, trace2]);
+
+    controller.recomputeSync();
+
+    // trace2 is the manual root, so trace1 must sync to it
+    expect(trace1.syncConfig.syncMode).toEqual('SYNC_TO_OTHER');
+    if (trace1.syncConfig.syncMode === 'SYNC_TO_OTHER') {
+      expect(trace1.syncConfig.syncClock.anchorTraceUuid).toEqual('uuid2');
+    }
+  });
+
+  it('should detect and report multiple manual roots', () => {
+    const trace1 = createMockTrace('uuid1', ['BOOTTIME'], 'MANUAL');
+    trace1.syncConfig = {syncMode: 'REFERENCE', referenceClock: 'BOOTTIME'};
+    const trace2 = createMockTrace('uuid2', ['MONOTONIC'], 'MANUAL');
+    trace2.syncConfig = {syncMode: 'REFERENCE', referenceClock: 'MONOTONIC'};
+    controller.setTracesForTesting([trace1, trace2]);
+
+    controller.recomputeSync();
+
+    expect(controller.syncError).toEqual(
+      'Only one reference clock can be chosen.',
+    );
+  });
+
+  it('should respect a manual sync configuration', () => {
+    const trace1 = createMockTrace('uuid1', ['BOOTTIME']);
+    const trace2 = createMockTrace('uuid2', ['MONOTONIC'], 'MANUAL');
+    const trace3 = createMockTrace('uuid3', ['MONOTONIC']);
+
+    trace2.syncConfig = {
+      syncMode: 'SYNC_TO_OTHER',
+      syncClock: {
+        thisTraceClock: 'MONOTONIC',
+        anchorTraceUuid: 'uuid1',
+        anchorClock: 'BOOTTIME',
+        offset: {kind: 'valid', raw: '0', value: 0},
+      },
+    };
+    controller.setTracesForTesting([trace1, trace2, trace3]);
+
+    controller.recomputeSync();
+
+    expect(trace1.syncConfig.syncMode).toEqual('REFERENCE');
+    if (trace2.syncConfig.syncMode === 'SYNC_TO_OTHER') {
+      expect(trace2.syncConfig.syncClock.anchorTraceUuid).toEqual('uuid1');
+    }
+    if (trace3.syncConfig.syncMode === 'SYNC_TO_OTHER') {
+      expect(trace3.syncConfig.syncClock.anchorTraceUuid).toEqual('uuid2');
+      expect(trace3.syncConfig.syncClock.thisTraceClock).toEqual('MONOTONIC');
+    }
+  });
+
+  describe('getLoadingError', () => {
+    it('returns NO_TRACES when no traces are loaded', () => {
+      expect(controller.getLoadingError()).toEqual('NO_TRACES');
+    });
+
+    it('returns TRACE_ERROR when a trace has an error', async () => {
+      const file = createMockFile('error_trace.pftrace');
+      fakeAnalyzer.setError(file.name, new Error('Analysis failed'));
+      await controller.addFiles([file]);
+      expect(controller.getLoadingError()).toEqual('TRACE_ERROR');
+    });
+
+    it('returns SYNC_ERROR when multiple manual roots are set', () => {
+      const trace1 = createMockTrace('uuid1', ['BOOTTIME'], 'MANUAL');
+      trace1.syncConfig = {syncMode: 'REFERENCE', referenceClock: 'BOOTTIME'};
+      const trace2 = createMockTrace('uuid2', ['MONOTONIC'], 'MANUAL');
+      trace2.syncConfig = {syncMode: 'REFERENCE', referenceClock: 'MONOTONIC'};
+      controller.setTracesForTesting([trace1, trace2]);
+      controller.recomputeSync();
+      expect(controller.getLoadingError()).toEqual('SYNC_ERROR');
+    });
+
+    it('returns INCOMPLETE_CONFIG when a root clock is not set', () => {
+      const trace = createMockTrace('uuid1', ['BOOTTIME'], 'MANUAL');
+      trace.syncConfig = {syncMode: 'REFERENCE', referenceClock: undefined};
+      controller.setTracesForTesting([trace]);
+      expect(controller.getLoadingError()).toEqual('INCOMPLETE_CONFIG');
+    });
+
+    it('returns INCOMPLETE_CONFIG when a sync target is not fully set', () => {
+      const trace = createMockTrace('uuid1', ['BOOTTIME'], 'MANUAL');
+      trace.syncConfig = {
+        syncMode: 'SYNC_TO_OTHER',
+        syncClock: {
+          thisTraceClock: 'BOOTTIME',
+          anchorClock: undefined,
+          offset: {kind: 'valid', raw: '0', value: 0},
+        },
+      };
+      controller.setTracesForTesting([trace]);
+      expect(controller.getLoadingError()).toEqual('INCOMPLETE_CONFIG');
+    });
+
+    it('returns undefined when configuration is valid', () => {
+      const trace = createMockTrace('uuid1', ['BOOTTIME'], 'MANUAL');
+      trace.syncConfig = {syncMode: 'REFERENCE', referenceClock: 'BOOTTIME'};
+      controller.setTracesForTesting([trace]);
+      expect(controller.getLoadingError()).toBeUndefined();
+    });
+  });
+
+  describe('addFiles', () => {
+    it('should add a file that fails analysis', async () => {
+      const file = createMockFile('error.pftrace');
+      fakeAnalyzer.setError(file.name, new Error('Test analysis error'));
+      await controller.addFiles([file]);
+      expect(controller.traces.length).toBe(1);
+      const trace = controller.traces[0];
+      expect(trace.status).toBe('error');
+      if (trace.status === 'error') {
+        expect(trace.error).toBe('Test analysis error');
+      }
+    });
+
+    it('should add files to a non-empty list', async () => {
+      const file1 = createMockFile('trace1.pftrace');
+      fakeAnalyzer.setResult(file1.name, {
+        format: 'Perfetto',
+        clocks: [{name: 'BOOTTIME', count: 1}],
+      });
+      await controller.addFiles([file1]);
+      expect(controller.traces.length).toBe(1);
+
+      const file2 = createMockFile('trace2.pftrace');
+      fakeAnalyzer.setResult(file2.name, {
+        format: 'Perfetto',
+        clocks: [{name: 'BOOTTIME', count: 1}],
+      });
+      await controller.addFiles([file2]);
+      expect(controller.traces.length).toBe(2);
+    });
+  });
+
+  describe('removeTrace', () => {
+    it('should correctly recompute sync when an anchor trace is removed', () => {
+      const trace1 = createMockTrace('uuid1', ['BOOTTIME']);
+      const trace2 = createMockTrace('uuid2', ['BOOTTIME']);
+      controller.setTracesForTesting([trace1, trace2]);
+      controller.recomputeSync();
+
+      // Ensure trace2 is synced to trace1
+      const syncedTrace = controller.traces.find(
+        (t) => (t as TraceFileAnalyzed).syncConfig.syncMode === 'SYNC_TO_OTHER',
+      ) as TraceFileAnalyzed;
+      const referenceTrace = controller.traces.find(
+        (t) => (t as TraceFileAnalyzed).syncConfig.syncMode === 'REFERENCE',
+      ) as TraceFileAnalyzed;
+      expect(syncedTrace).toBeDefined();
+      expect(referenceTrace).toBeDefined();
+
+      // Remove the reference trace
+      controller.removeTrace(referenceTrace.uuid);
+
+      // The synced trace should now become a reference trace
+      expect(syncedTrace.syncConfig.syncMode).toBe('REFERENCE');
+    });
+  });
+
+  describe('findBestClock', () => {
+    it('should return the first clock if no preferred clock is found', () => {
+      const trace = createMockTrace('uuid1', [
+        'UNCOMMON_CLOCK',
+        'ANOTHER_CLOCK',
+      ]);
+      expect(controller.findBestClock(trace)).toBe('UNCOMMON_CLOCK');
+    });
+
+    it('should return undefined if there are no clocks', () => {
+      const trace = createMockTrace('uuid1', []);
+      expect(controller.findBestClock(trace)).toBeUndefined();
+    });
+  });
+
+  describe('setTraceOffset', () => {
+    let trace: TraceFileAnalyzed;
+
+    beforeEach(() => {
+      trace = createMockTrace('uuid1', [], 'MANUAL');
+    });
+
+    it('should parse valid integer strings', () => {
+      trace.syncConfig = {
+        syncMode: 'SYNC_TO_OTHER',
+        syncClock: {offset: {kind: 'valid', raw: '0', value: 0}},
+      };
+      controller.setTracesForTesting([trace]);
+      if (trace.syncConfig.syncMode === 'SYNC_TO_OTHER') {
+        const anchorLink = trace.syncConfig.syncClock;
+        controller.setTraceOffset(anchorLink, '123');
+        expect(anchorLink.offset).toEqual({
+          kind: 'valid',
+          raw: '123',
+          value: 123,
+        });
+
+        controller.setTraceOffset(anchorLink, '-456');
+        expect(anchorLink.offset).toEqual({
+          kind: 'valid',
+          raw: '-456',
+          value: -456,
+        });
+
+        controller.setTraceOffset(anchorLink, '0');
+        expect(anchorLink.offset).toEqual({kind: 'valid', raw: '0', value: 0});
+      }
+    });
+
+    it('should invalidate non-integer strings', () => {
+      trace.syncConfig = {
+        syncMode: 'SYNC_TO_OTHER',
+        syncClock: {offset: {kind: 'valid', raw: '0', value: 0}},
+      };
+      controller.setTracesForTesting([trace]);
+      if (trace.syncConfig.syncMode === 'SYNC_TO_OTHER') {
+        const anchorLink = trace.syncConfig.syncClock;
+        controller.setTraceOffset(anchorLink, '123.45');
+        expect(anchorLink.offset.kind).toBe('invalid');
+
+        controller.setTraceOffset(anchorLink, 'abc');
+        expect(anchorLink.offset.kind).toBe('invalid');
+
+        controller.setTraceOffset(anchorLink, '');
+        expect(anchorLink.offset.kind).toBe('invalid');
+
+        controller.setTraceOffset(anchorLink, '-');
+        expect(anchorLink.offset.kind).toBe('invalid');
+      }
+    });
+
+    it('should call onStateChanged when offset is modified', () => {
+      trace.syncConfig = {
+        syncMode: 'SYNC_TO_OTHER',
+        syncClock: {offset: {kind: 'valid', raw: '0', value: 0}},
+      };
+      controller.setTracesForTesting([trace]);
+      if (trace.syncConfig.syncMode === 'SYNC_TO_OTHER') {
+        const anchorLink = trace.syncConfig.syncClock;
+        controller.setTraceOffset(anchorLink, '123');
+        expect(onStateChanged).toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('selectTrace', () => {
+    it('should select a trace by UUID', () => {
+      const trace1 = createMockTrace('uuid1', []);
+      const trace2 = createMockTrace('uuid2', []);
+      controller.setTracesForTesting([trace1, trace2]);
+
+      controller.selectTrace('uuid2');
+      expect(controller.selectedTrace?.uuid).toBe('uuid2');
+    });
+
+    it('should deselect when a non-existent UUID is provided', () => {
+      const trace1 = createMockTrace('uuid1', []);
+      controller.setTracesForTesting([trace1]);
+      controller.selectTrace('uuid1');
+      expect(controller.selectedTrace?.uuid).toBe('uuid1');
+
+      controller.selectTrace('non-existent-uuid');
+      expect(controller.selectedTrace).toBeUndefined();
+    });
+  });
+});

--- a/ui/src/core_plugins/multi_trace_open/multi_trace_modal.ts
+++ b/ui/src/core_plugins/multi_trace_open/multi_trace_modal.ts
@@ -1,0 +1,773 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {AppImpl} from '../../core/app_impl';
+import {Button, ButtonVariant} from '../../widgets/button';
+import {CardStack} from '../../widgets/card';
+import {Intent} from '../../widgets/common';
+import {Icon} from '../../widgets/icon';
+import {closeModal, redrawModal, showModal} from '../../widgets/modal';
+import {Select} from '../../widgets/select';
+import {Callout} from '../../widgets/callout';
+import {Spinner} from '../../widgets/spinner';
+import {Stack} from '../../widgets/stack';
+import {Switch} from '../../widgets/switch';
+import {TextInput} from '../../widgets/text_input';
+import {MultiTraceController} from './multi_trace_controller';
+import {
+  AnchorLink,
+  SyncConfig,
+  AnchoredConfig,
+  TraceFile,
+  TraceFileAnalyzed,
+  TraceStatus,
+} from './multi_trace_types';
+import {WasmTraceAnalyzer} from './trace_analyzer';
+
+const MODAL_KEY = 'multi-trace-modal';
+
+// =============================================================================
+// Shell Component
+// =============================================================================
+
+interface MultiTraceModalAttrs {
+  initialFiles: ReadonlyArray<File>;
+}
+
+class MultiTraceModalShell implements m.ClassComponent<MultiTraceModalAttrs> {
+  private controller = new MultiTraceController(new WasmTraceAnalyzer(), () =>
+    redrawModal(),
+  );
+
+  oncreate({attrs}: m.Vnode<MultiTraceModalAttrs>) {
+    this.controller.addFiles(attrs.initialFiles);
+  }
+
+  view() {
+    return m(
+      Stack,
+      {className: 'pf-multi-trace-modal', orientation: 'vertical'},
+      m(
+        Stack,
+        {
+          className: 'pf-multi-trace-modal__main',
+          orientation: 'horizontal',
+        },
+        m(TraceListComponent, {
+          traces: this.controller.traces,
+          controller: this.controller,
+        }),
+        this.controller.selectedTrace && [
+          m('.pf-multi-trace-modal__separator'),
+          m(TraceDetailsPanelComponent, {
+            trace: this.controller.selectedTrace,
+            controller: this.controller,
+          }),
+        ],
+      ),
+      m(
+        Stack,
+        {className: 'pf-multi-trace-modal__footer', orientation: 'horizontal'},
+        this.renderActions(),
+      ),
+    );
+  }
+
+  private renderActions() {
+    const footerMessage = this.getFooterMessage();
+    const isDisabled = !!footerMessage;
+    const openButton = m(Button, {
+      label: 'Open Traces',
+      intent: Intent.Primary,
+      variant: ButtonVariant.Filled,
+      onclick: () => this.openTraces(),
+      disabled: isDisabled,
+    });
+
+    return [
+      footerMessage &&
+        m(
+          Callout,
+          {
+            className: 'pf-multi-trace-modal__footer-error',
+            intent: Intent.Danger,
+            icon: 'error_outline',
+          },
+          footerMessage,
+        ),
+      openButton,
+    ];
+  }
+
+  private getFooterMessage(): string | undefined {
+    const error = this.controller.getLoadingError();
+    if (error === undefined) {
+      return undefined;
+    }
+    switch (error) {
+      case 'NO_TRACES':
+        return 'Add at least one trace to open.';
+      case 'ANALYZING':
+        return 'Wait for all traces to be analyzed and synced.';
+      case 'SYNC_ERROR':
+        return this.controller.syncError;
+      case 'TRACE_ERROR':
+        return 'Remove traces with errors before opening.';
+      case 'INCOMPLETE_CONFIG':
+        return 'All traces must be fully configured before opening.';
+      default:
+        return 'An unknown error occurred.';
+    }
+  }
+
+  private openTraces() {
+    if (this.controller.traces.length === 0) {
+      return;
+    }
+    const files = this.controller.traces.map((t) => t.file);
+    AppImpl.instance.openTraceFromMultipleFiles(files);
+    closeModal(MODAL_KEY);
+  }
+}
+
+// =============================================================================
+// Trace List Component
+// =============================================================================
+
+interface TraceListComponentAttrs {
+  traces: ReadonlyArray<TraceFile>;
+  controller: MultiTraceController;
+}
+
+class TraceListComponent implements m.ClassComponent<TraceListComponentAttrs> {
+  view({attrs}: m.Vnode<TraceListComponentAttrs>) {
+    const {traces, controller} = attrs;
+    return m(
+      Stack,
+      {className: 'pf-multi-trace-modal__list-panel', orientation: 'vertical'},
+      traces.map((trace) => this.renderTraceItem(trace, controller)),
+      m(
+        CardStack,
+        {
+          className: 'pf-multi-trace-modal__add-card',
+          onclick: () => this.addTraces(controller),
+        },
+        m(Icon, {icon: 'add'}),
+        'Add more traces',
+      ),
+    );
+  }
+
+  private renderTraceItem(trace: TraceFile, controller: MultiTraceController) {
+    return m(
+      CardStack,
+      {
+        className: 'pf-multi-trace-modal__card',
+        direction: 'horizontal',
+        key: trace.uuid,
+      },
+      this.renderTraceInfo(trace, controller),
+      this.renderCardActions(trace, controller),
+    );
+  }
+
+  private renderTraceInfo(trace: TraceFile, controller: MultiTraceController) {
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__info',
+        spacing: 'large',
+        orientation: 'vertical',
+      },
+      m('.pf-multi-trace-modal__name', trace.file.name),
+      m(
+        Stack,
+        {orientation: 'horizontal', spacing: 'large'},
+        m(
+          Stack,
+          {
+            className: 'pf-multi-trace-modal__size',
+            orientation: 'horizontal',
+          },
+          m('strong', 'Size:'),
+          m('span', `${(trace.file.size / (1024 * 1024)).toFixed(1)} MB`),
+        ),
+        trace.status === 'analyzed'
+          ? m(
+              Stack,
+              {
+                className: 'pf-multi-trace-modal__format',
+                orientation: 'horizontal',
+              },
+              m('strong', 'Format:'),
+              m('span', trace.format),
+            )
+          : this.renderTraceStatus(trace),
+      ),
+      trace.status === 'analyzed' && this.renderSyncStatus(trace, controller),
+    );
+  }
+
+  private renderSyncStatus(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+  ) {
+    return m(
+      '.pf-multi-trace-modal__sync-status',
+      m(Icon, {icon: 'sync'}),
+      this.renderSyncSummary(trace, controller),
+    );
+  }
+
+  private renderSyncSummary(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+  ): m.Children {
+    const config = trace.syncConfig;
+
+    switch (config.syncMode) {
+      case 'CALCULATING':
+        return m('span', 'Waiting for other traces to be analyzed...');
+      case 'REFERENCE':
+        return m('span', [
+          'Reference clock: ',
+          m('strong', config.referenceClock ?? '[Select a clock]'),
+        ]);
+      case 'SYNC_TO_OTHER': {
+        const anchorTrace = controller.traces.find(
+          (t) => t.uuid === config.syncClock?.anchorTraceUuid,
+        );
+        const anchorName = anchorTrace?.file.name ?? '[Select a trace]';
+        const thisTraceClock =
+          config.syncClock?.thisTraceClock ?? '[Select a clock]';
+        const anchorClock = config.syncClock?.anchorClock ?? '[Select a clock]';
+        const offset =
+          config.syncClock.offset.kind === 'valid' &&
+          config.syncClock.offset.value !== 0
+            ? ` (offset: ${config.syncClock.offset.raw} ns)`
+            : '';
+        return m('span', [
+          'Sync: ',
+          m('strong', thisTraceClock),
+          ' → ',
+          m('strong', anchorClock),
+          ' in ',
+          m('span.pf-multi-trace-modal__sync-target', anchorName),
+          offset,
+        ]);
+      }
+      default:
+        return m('span', 'Unknown sync state');
+    }
+  }
+
+  private renderCardActions(
+    trace: TraceFile,
+    controller: MultiTraceController,
+  ) {
+    return m(
+      '.pf-multi-trace-modal__actions',
+      m(Button, {
+        icon: 'edit',
+        onclick: () => controller.selectTrace(trace.uuid),
+      }),
+      m(Button, {
+        icon: 'delete',
+        onclick: () => controller.removeTrace(trace.uuid),
+        disabled: controller.isAnalyzing(),
+      }),
+    );
+  }
+
+  private renderTraceStatus(trace: TraceFile) {
+    const statusInfo = getStatusInfo(trace.status);
+    const progressText =
+      trace.status === 'analyzing'
+        ? ` (${(trace.progress * 100).toFixed(0)}%)`
+        : '';
+    return m(
+      Stack,
+      {
+        orientation: 'horizontal',
+        className: 'pf-multi-trace-modal__status-wrapper',
+        spacing: 'small',
+      },
+      trace.status === 'analyzing' && m(Spinner),
+      m(
+        '.pf-multi-trace-modal__status' + statusInfo.class,
+        `${statusInfo.text}${progressText}`,
+      ),
+    );
+  }
+
+  private addTraces(controller: MultiTraceController) {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.multiple = true;
+    input.addEventListener('change', () => {
+      if (input.files) {
+        controller.addFiles([...input.files]);
+      }
+    });
+    input.click();
+  }
+}
+
+// =============================================================================
+// Trace Details Panel Component
+// =============================================================================
+
+interface TraceDetailsPanelComponentAttrs {
+  trace: TraceFile;
+  controller: MultiTraceController;
+}
+
+class TraceDetailsPanelComponent
+  implements m.ClassComponent<TraceDetailsPanelComponentAttrs>
+{
+  view({attrs}: m.Vnode<TraceDetailsPanelComponentAttrs>) {
+    const {trace} = attrs;
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__details-panel',
+        orientation: 'vertical',
+      },
+      m('h3.pf-multi-trace-modal__details-header', trace.file.name),
+      this.renderDetailsPanelContent(attrs),
+    );
+  }
+
+  private renderDetailsPanelContent({
+    trace,
+    controller,
+  }: TraceDetailsPanelComponentAttrs): m.Children {
+    switch (trace.status) {
+      case 'analyzed':
+        return this.renderAnalyzedDetails(trace, controller);
+      case 'analyzing':
+        return this.renderAnalyzingDetails(trace);
+      case 'error':
+        return this.renderErrorDetails(trace);
+      case 'not-analyzed':
+        return this.renderNotAnalyzedDetails();
+      default:
+        return m('span', 'Unknown trace status');
+    }
+  }
+
+  private renderAnalyzingDetails(trace: TraceFile): m.Children {
+    const progress = 'progress' in trace ? trace.progress : 0;
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__analyzing-details',
+        orientation: 'vertical',
+      },
+      m(Spinner),
+      m('span', `Analyzing... ${(progress * 100).toFixed(0)}%`),
+    );
+  }
+
+  private renderErrorDetails(trace: TraceFile): m.Children {
+    const error = 'error' in trace ? trace.error : 'Unknown error';
+    return m('span', `Error: ${error}`);
+  }
+
+  private renderNotAnalyzedDetails(): m.Children {
+    return m('span', 'This trace has not been analyzed yet.');
+  }
+
+  private renderAnalyzedDetails(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+  ) {
+    const isManual = trace.syncMode === 'MANUAL';
+    const config = trace.syncConfig;
+
+    if (config.syncMode === 'CALCULATING') {
+      return m(
+        Stack,
+        {
+          className: 'pf-multi-trace-modal__details-content',
+          orientation: 'vertical',
+        },
+        this.renderClockSyncMethodSelector(trace, controller),
+        m('span', 'Waiting for other traces to be analyzed...'),
+      );
+    }
+
+    return m(
+      Stack,
+      {
+        className: 'pf-multi-trace-modal__details-content',
+      },
+      this.renderClockSyncMethodSelector(trace, controller),
+      this.renderDetailRow(
+        'Alignment Method',
+        isManual
+          ? this.renderAlignmentMethodSelector(trace, controller)
+          : m(
+              'span.pf-multi-trace-modal__static-select',
+              config.syncMode === 'REFERENCE'
+                ? 'Reference clock provider'
+                : 'Anchored to another trace',
+            ),
+      ),
+      config.syncMode === 'REFERENCE'
+        ? this.renderReferenceTraceDetails(trace, controller, isManual)
+        : this.renderSyncedTraceDetails(trace, controller, isManual),
+    );
+  }
+
+  private renderReferenceTraceDetails(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+    isManual: boolean,
+  ) {
+    if (trace.syncConfig.syncMode !== 'REFERENCE') return [];
+    const config = trace.syncConfig;
+    return [
+      this.renderDetailRow(
+        'Reference clock',
+        isManual
+          ? this.renderReferenceClockSelector(trace, controller)
+          : m(
+              'span.pf-multi-trace-modal__static-select',
+              config.referenceClock,
+            ),
+      ),
+    ];
+  }
+
+  private renderSyncedTraceDetails(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+    isManual: boolean,
+  ) {
+    if (trace.syncConfig.syncMode !== 'SYNC_TO_OTHER') return [];
+
+    if (isManual) {
+      return this.renderManualSyncDetails(trace, controller, trace.syncConfig);
+    } else {
+      const config = trace.syncConfig;
+      const anchorTraceName =
+        controller.traces.find(
+          (t) => t.uuid === config.syncClock.anchorTraceUuid,
+        )?.file.name ?? 'Not set';
+      return [
+        this.renderDetailRow(
+          "This trace's clock",
+          m(
+            'span.pf-multi-trace-modal__static-select',
+            config.syncClock.thisTraceClock ?? 'Not set',
+          ),
+        ),
+        this.renderDetailRow(
+          'Anchor trace',
+          m('span.pf-multi-trace-modal__static-select', anchorTraceName),
+        ),
+        this.renderDetailRow(
+          'Anchor clock',
+          m(
+            'span.pf-multi-trace-modal__static-select',
+            config.syncClock.anchorClock ?? 'Not set',
+          ),
+        ),
+        this.renderDetailRow(
+          'Offset (ns)',
+          m(
+            'span.pf-multi-trace-modal__static-select',
+            config.syncClock.offset.raw,
+          ),
+        ),
+      ];
+    }
+  }
+
+  private renderManualSyncDetails(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+    config: AnchoredConfig,
+  ) {
+    const anchorLink = config.syncClock;
+    const otherTraces = controller.traces.filter((t) => t.uuid !== trace.uuid);
+
+    const rawAnchorTrace = anchorLink.anchorTraceUuid
+      ? controller.traces.find((t) => t.uuid === anchorLink.anchorTraceUuid)
+      : undefined;
+
+    let anchorTrace: TraceFileAnalyzed | undefined = undefined;
+    if (rawAnchorTrace?.status === 'analyzed') {
+      anchorTrace = rawAnchorTrace;
+    }
+
+    return [
+      this.renderDetailRow(
+        "This trace's clock",
+        this.renderThisTraceClockSelector(trace, controller, anchorLink),
+      ),
+      this.renderDetailRow(
+        'Anchor trace',
+        this.renderAnchorTraceSelector(controller, anchorLink, otherTraces),
+      ),
+      this.renderDetailRow(
+        'Anchor clock',
+        this.renderAnchorClockSelector(controller, anchorLink, anchorTrace),
+      ),
+      this.renderDetailRow(
+        'Offset (ns)',
+        m(TextInput, {
+          className: 'pf-multi-trace-modal__offset-input',
+          type: 'text',
+          value: anchorLink.offset.raw,
+          oninput: (e: Event) => {
+            const target = e.target as HTMLInputElement;
+            controller.setTraceOffset(anchorLink, target.value);
+            redrawModal();
+          },
+        }),
+      ),
+      anchorLink.offset.kind === 'invalid' &&
+        m(
+          Callout,
+          {
+            className: 'pf-multi-trace-modal__offset-error',
+            intent: Intent.Danger,
+            icon: 'error',
+          },
+          anchorLink.offset.error,
+        ),
+    ];
+  }
+
+  private renderDetailRow(label: string, content: m.Children) {
+    return m(
+      Stack,
+      {className: 'pf-multi-trace-modal__form-group'},
+      m('label', label),
+      content,
+    );
+  }
+
+  private renderAlignmentMethodSelector(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+  ) {
+    return m(
+      Select,
+      {
+        className: 'pf-multi-trace-modal__select',
+        value: trace.syncConfig.syncMode,
+        onchange: (e: Event) => {
+          const target = e.target as HTMLSelectElement;
+          const newSyncMode = target.value as SyncConfig['syncMode'];
+          if (newSyncMode === 'REFERENCE') {
+            trace.syncConfig = {
+              syncMode: 'REFERENCE',
+              referenceClock: controller.findBestClock(trace),
+            };
+          } else {
+            trace.syncConfig = {
+              syncMode: 'SYNC_TO_OTHER',
+              syncClock: {
+                thisTraceClock: undefined,
+                anchorTraceUuid: undefined,
+                anchorClock: undefined,
+                offset: {kind: 'valid', raw: '0', value: 0},
+              },
+            };
+          }
+          controller.recomputeSync();
+          redrawModal();
+        },
+      },
+      m('option', {value: 'REFERENCE'}, 'Use as reference'),
+      m('option', {value: 'SYNC_TO_OTHER'}, 'Sync to another trace'),
+    );
+  }
+
+  private renderReferenceClockSelector(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+  ) {
+    if (trace.syncConfig.syncMode !== 'REFERENCE') return;
+    return m(
+      Select,
+      {
+        className: 'pf-multi-trace-modal__select',
+        value: trace.syncConfig.referenceClock ?? '',
+        onchange: (e: Event) => {
+          const target = e.target as HTMLSelectElement;
+          trace.syncConfig = {
+            syncMode: 'REFERENCE',
+            referenceClock: target.value || undefined,
+          };
+          controller.recomputeSync();
+        },
+      },
+      m('option', {value: ''}, 'Select a clock'),
+      trace.clocks.map((clock) => m('option', {value: clock.name}, clock.name)),
+    );
+  }
+
+  private renderThisTraceClockSelector(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+    anchorLink: AnchorLink,
+  ) {
+    return m(
+      Select,
+      {
+        className: 'pf-multi-trace-modal__select',
+        value: anchorLink.thisTraceClock ?? '',
+        onchange: (e: Event) => {
+          const target = e.target as HTMLSelectElement;
+          anchorLink.thisTraceClock = target.value || undefined;
+          controller.recomputeSync();
+        },
+      },
+      m('option', {value: ''}, 'Select a clock'),
+      (trace.clocks ?? []).map((clock) =>
+        m('option', {value: clock.name}, clock.name),
+      ),
+    );
+  }
+
+  private renderAnchorTraceSelector(
+    controller: MultiTraceController,
+    anchorLink: AnchorLink,
+    otherTraces: TraceFile[],
+  ) {
+    const otherAnalyzedTraces = otherTraces.filter(
+      (t): t is TraceFileAnalyzed => t.status === 'analyzed',
+    );
+    return m(
+      Select,
+      {
+        className: 'pf-multi-trace-modal__select',
+        value: anchorLink.anchorTraceUuid ?? '',
+        onchange: (e: Event) => {
+          const target = e.target as HTMLSelectElement;
+          anchorLink.anchorTraceUuid = target.value || undefined;
+          anchorLink.anchorClock = undefined; // Reset target clock when target trace changes
+          controller.recomputeSync();
+          redrawModal();
+        },
+      },
+      m('option', {value: ''}, 'Select a trace'),
+      otherAnalyzedTraces.map((other) =>
+        m('option', {value: other.uuid}, other.file.name),
+      ),
+    );
+  }
+
+  private renderAnchorClockSelector(
+    controller: MultiTraceController,
+    anchorLink: AnchorLink,
+    anchorTrace: TraceFileAnalyzed | undefined,
+  ) {
+    const isAnchorTraceSelected = !!anchorLink.anchorTraceUuid;
+
+    return m(
+      Select,
+      {
+        className: 'pf-multi-trace-modal__select',
+        disabled: !isAnchorTraceSelected,
+        value: anchorLink.anchorClock ?? '',
+        onchange: (e: Event) => {
+          const target = e.target as HTMLSelectElement;
+          anchorLink.anchorClock = target.value || undefined;
+          controller.recomputeSync();
+        },
+      },
+      isAnchorTraceSelected && anchorTrace
+        ? [
+            m('option', {value: ''}, 'Select a clock'),
+            anchorTrace.clocks.map((clock) =>
+              m('option', {value: clock.name}, clock.name),
+            ),
+          ]
+        : m(
+            'option',
+            {value: '', disabled: true, selected: true},
+            'Select an anchor trace first',
+          ),
+    );
+  }
+
+  private renderClockSyncMethodSelector(
+    trace: TraceFileAnalyzed,
+    controller: MultiTraceController,
+  ) {
+    return this.renderDetailRow(
+      'Clock Sync Method',
+      m(Switch, {
+        label: 'Automatic',
+        labelLeft: 'Manual',
+        checked: trace.syncMode === 'AUTOMATIC',
+        onchange: (e: Event) => {
+          const target = e.target as HTMLInputElement;
+          trace.syncMode = target.checked ? 'AUTOMATIC' : 'MANUAL';
+          controller.recomputeSync();
+        },
+      }),
+    );
+  }
+}
+
+// =============================================================================
+// Public API & Helpers
+// =============================================================================
+
+export function showMultiTraceModal(initialFiles: ReadonlyArray<File>) {
+  showModal({
+    title: 'Open Multiple Traces',
+    icon: 'library_books',
+    key: MODAL_KEY,
+    className: 'pf-multi-trace-modal-override',
+    content: () => m(MultiTraceModalShell, {initialFiles}),
+  });
+}
+
+function getStatusInfo(status: TraceStatus) {
+  switch (status) {
+    case 'analyzed':
+      return {
+        class: '.pf-multi-trace-modal__status--analyzed',
+        text: 'Analyzed',
+      };
+    case 'analyzing':
+      return {
+        class: '.pf-multi-trace-modal__status--analyzing',
+        text: 'Analyzing...',
+      };
+    case 'not-analyzed':
+      return {
+        class: '',
+        text: 'Not analyzed',
+      };
+    case 'error':
+      return {
+        class: '.pf-multi-trace-modal__status--error',
+        text: 'Error',
+      };
+    default:
+      return {
+        class: '',
+        text: 'Unknown',
+      };
+  }
+}

--- a/ui/src/core_plugins/multi_trace_open/multi_trace_types.ts
+++ b/ui/src/core_plugins/multi_trace_open/multi_trace_types.ts
@@ -1,0 +1,137 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the type definitions for the multi-trace opening feature.
+
+// =============================================================================
+// Trace File States
+// A trace file can be in one of several states, from not-yet-analyzed to fully
+// analyzed or errored.
+// =============================================================================
+
+// The base properties for any trace file shown in the UI.
+export interface TraceFileBase {
+  uuid: string;
+  file: File;
+}
+
+// A trace file that has been added but the analyzer has not yet started.
+export interface TraceFileNotAnalyzed extends TraceFileBase {
+  status: 'not-analyzed';
+}
+
+// A trace file that is currently being analyzed.
+export interface TraceFileAnalyzing extends TraceFileBase {
+  status: 'analyzing';
+  progress: number; // A value between 0 and 1.
+}
+
+// A trace file that has been successfully analyzed.
+export interface TraceFileAnalyzed extends TraceFileBase {
+  status: 'analyzed';
+  format: string;
+  clocks: ClockInfo[];
+  syncMode: 'AUTOMATIC' | 'MANUAL';
+  syncConfig: SyncConfig;
+}
+
+// A trace file that failed to be analyzed.
+export interface TraceFileError extends TraceFileBase {
+  status: 'error';
+  error: string;
+}
+
+// A union type representing any possible state of a trace file.
+export type TraceFile =
+  | TraceFileNotAnalyzed
+  | TraceFileAnalyzing
+  | TraceFileAnalyzed
+  | TraceFileError;
+
+// A union of all possible status strings.
+export type TraceStatus = TraceFile['status'];
+
+// =============================================================================
+// Synchronization Configuration
+// These types define how a trace should be synchronized with others.
+// =============================================================================
+
+// The configuration for a trace that acts as the absolute point of reference
+// for all other traces.
+export interface ReferenceConfig {
+  syncMode: 'REFERENCE';
+  referenceClock?: string;
+}
+
+// The configuration for a trace that is synchronized by aligning it to another
+// trace (the "anchor").
+export interface AnchoredConfig {
+  syncMode: 'SYNC_TO_OTHER';
+  syncClock: AnchorLink;
+}
+
+// A temporary state for a trace while its automatic configuration is being
+// computed.
+export interface CalculatingConfig {
+  syncMode: 'CALCULATING';
+}
+
+// A union type representing any possible synchronization configuration.
+export type SyncConfig = ReferenceConfig | AnchoredConfig | CalculatingConfig;
+
+// =============================================================================
+// Synchronization Primitives
+// These are the low-level building blocks for the synchronization configuration.
+// =============================================================================
+
+// Defines the link between a clock in the current trace and a clock in an
+// "anchor" trace.
+export interface AnchorLink {
+  thisTraceClock?: string;
+  anchorTraceUuid?: string;
+  anchorClock?: string;
+  offset: Offset;
+}
+
+// A discriminated union to handle the validation of the time offset input.
+// This allows the UI to store the raw string from the input while also storing
+// the parsed numeric value and any validation errors.
+
+// Represents a valid, parsed offset.
+export interface ValidOffset {
+  kind: 'valid';
+  raw: string;
+  value: number;
+}
+
+// Represents an invalid offset, storing the original string and an error message.
+export interface InvalidOffset {
+  kind: 'invalid';
+  raw: string;
+  error: string;
+}
+
+// A union type for the offset, which can be either valid or invalid.
+export type Offset = ValidOffset | InvalidOffset;
+
+// =============================================================================
+// Trace Metadata
+// Miscellaneous types describing the contents of a trace.
+// =============================================================================
+
+// Information about a clock domain found within a trace.
+export interface ClockInfo {
+  name: string;
+  count: number; // The number of clock snapshots.
+}

--- a/ui/src/core_plugins/multi_trace_open/styles.scss
+++ b/ui/src/core_plugins/multi_trace_open/styles.scss
@@ -1,0 +1,220 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import "../../assets/widgets/theme.scss";
+
+.pf-multi-trace-modal {
+  $border-color-light: #eee;
+  $border-color-medium: #ccc;
+  $text-color-primary: #333;
+  $text-color-secondary: rgba(0, 0, 0, 0.6);
+  $text-color-tertiary: #666;
+  $text-color-hint: #999;
+  $status-color-analyzed: #4caf50;
+  $status-color-error: #d9534f;
+  $status-color-neutral: $border-color-medium;
+  $bg-color-add-card: #fafafa;
+  $bg-color-add-card-hover: #f0f0f0;
+  $primary-color: var(--primary-color, #3e8ad3);
+  $primary-color-border: rgba(62, 138, 211, 0.3);
+
+  &__main {
+    align-items: stretch;
+    min-height: 500px;
+  }
+
+  &__list-panel {
+    border: none;
+    overflow-y: auto;
+    width: 550px;
+    max-height: 700px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+
+  &__card {
+    padding: 16px;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__name {
+    color: $text-color-primary;
+    font-size: 0.95em;
+    font-weight: 600;
+  }
+
+  &__size,
+  &__status,
+  &__format,
+  &__sync-status {
+    color: $text-color-secondary;
+    font-size: 0.9em;
+  }
+
+  &__size strong,
+  &__format strong {
+    font-weight: 600;
+  }
+
+  &__sync-status {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+
+    .material-symbols-outlined {
+      font-size: 1.2em;
+    }
+  }
+
+  &__actions {
+    min-width: 50px;
+  }
+
+  &__status {
+    &::before {
+      content: "";
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      margin-right: 6px;
+      border-radius: 50%;
+      background-color: $status-color-neutral;
+    }
+
+    &--analyzed::before {
+      background-color: $status-color-analyzed;
+    }
+
+    &--analyzing::before {
+      display: none;
+    }
+
+    &--error::before {
+      background-color: $status-color-error;
+    }
+  }
+
+  &__status-wrapper {
+    align-items: center;
+  }
+
+  &__add-card {
+    border: 1px dashed $border-color-medium;
+    background-color: $bg-color-add-card;
+    cursor: pointer;
+    padding: 8px;
+    color: $text-color-tertiary;
+    font-family: "Roboto", sans-serif;
+    font-size: 0.9em;
+    font-weight: bold;
+    align-items: center;
+
+    &:hover {
+      background: $bg-color-add-card-hover;
+    }
+  }
+
+  &__footer {
+    border-top: 1px solid $border-color-light;
+    padding-top: 8px;
+    margin-top: 0px;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__footer-error {
+    margin-right: auto;
+    font-family: $pf-font;
+  }
+
+  &__separator {
+    width: 1px;
+    background-color: $border-color-medium;
+    margin-left: 8px;
+    margin-right: 8px;
+  }
+
+  &__details-panel {
+    width: 300px;
+  }
+
+  &__details-header {
+    margin-bottom: 16px;
+    font-size: 1.1em;
+    font-weight: 600;
+  }
+
+  &__form-group {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+
+    label {
+      font-weight: 600;
+      font-size: 0.9em;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    > *:last-child {
+      min-width: 0;
+    }
+  }
+
+  &__select,
+  &__offset-input {
+    width: 100%;
+  }
+
+  &__offset-error {
+    font-family: $pf-font;
+    margin-top: 4px;
+  }
+
+  &__analyzing-details {
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    gap: 16px;
+    font-size: 1.2em;
+    color: $text-color-secondary;
+  }
+
+  .pf-hint {
+    color: $text-color-hint;
+    font-size: 1.2em;
+  }
+
+  &__static-select {
+    font-family: $pf-font;
+    font-size: inherit;
+    font-weight: 500;
+    border-radius: $pf-border-radius $pf-border-radius 0 0;
+    padding: 1px 2px;
+    color: $pf-minimal-foreground;
+  }
+}
+
+.pf-multi-trace-modal-override {
+  main {
+    margin-top: 16px;
+  }
+  padding: 16px;
+  overflow-y: hidden;
+  max-width: none;
+  max-height: none;
+}

--- a/ui/src/core_plugins/multi_trace_open/trace_analyzer.ts
+++ b/ui/src/core_plugins/multi_trace_open/trace_analyzer.ts
@@ -1,0 +1,107 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {WasmEngineProxy} from '../../trace_processor/wasm_engine_proxy';
+import {uuidv4} from '../../base/uuid';
+import {TraceFileStream} from '../../core/trace_stream';
+import {NUM, STR} from '../../trace_processor/query_result';
+import {ClockInfo} from './multi_trace_types';
+
+export interface TraceAnalysisResult {
+  format: string;
+  clocks: ClockInfo[];
+}
+
+export interface TraceAnalyzer {
+  analyze(
+    file: File,
+    onProgress: (progress: number) => void,
+  ): Promise<TraceAnalysisResult>;
+}
+
+function mapTraceType(rawType: string): string {
+  switch (rawType) {
+    case 'proto':
+      return 'Perfetto';
+    default:
+      return rawType;
+  }
+}
+
+export class WasmTraceAnalyzer implements TraceAnalyzer {
+  async analyze(
+    file: File,
+    onProgress: (progress: number) => void,
+  ): Promise<TraceAnalysisResult> {
+    using engine = new WasmEngineProxy(uuidv4());
+    engine.resetTraceProcessor({
+      tokenizeOnly: true,
+      cropTrackEvents: false,
+      ingestFtraceInRawTable: false,
+      analyzeTraceProtoContent: false,
+      ftraceDropUntilAllCpusValid: false,
+    });
+    const stream = new TraceFileStream(file);
+    for (;;) {
+      const res = await stream.readChunk();
+      onProgress(res.bytesRead / file.size);
+      await engine.parse(res.data);
+      if (res.eof) {
+        await engine.notifyEof();
+        break;
+      }
+    }
+    const result = await engine.query(`
+        SELECT
+          parent.trace_type
+        FROM __intrinsic_trace_file parent
+        LEFT JOIN __intrinsic_trace_file child ON parent.id = child.parent_id
+        WHERE child.id IS NULL
+      `);
+    const it = result.iter({trace_type: STR});
+    const leafNodes = [];
+    for (; it.valid(); it.next()) {
+      leafNodes.push(it.trace_type);
+    }
+    if (leafNodes.length > 1) {
+      throw new Error(
+        'This trace contains multiple sub-traces, which is not supported ' +
+          'because recursive synchronization is tricky. Please open each ' +
+          'sub-trace individually.',
+      );
+    }
+    if (leafNodes.length === 0) {
+      throw new Error('Could not determine trace type');
+    }
+
+    // Also query for the clocks in this trace
+    const clocksResult = await engine.query(`
+        SELECT clock_name, COUNT(*) as count
+        FROM clock_snapshot
+        WHERE clock_name IS NOT NULL
+        GROUP BY clock_name
+        ORDER BY count DESC
+      `);
+    const clocks: ClockInfo[] = [];
+    const clockIt = clocksResult.iter({clock_name: STR, count: NUM});
+    for (; clockIt.valid(); clockIt.next()) {
+      clocks.push({name: clockIt.clock_name, count: clockIt.count});
+    }
+
+    return {
+      format: mapTraceType(leafNodes[0]),
+      clocks,
+    };
+  }
+}


### PR DESCRIPTION
This commit introduces the new multi-trace open modal, a feature that allows users to open and synchronize multiple traces simultaneously.

Key features include:
- A new plugin (`dev.perfetto.MultiTraceOpen`) that adds a "Open multiple trace files" menu item.
- A comprehensive modal UI for managing and configuring multiple traces.
- Automatic trace analysis to determine format and available clock domains.
- An automatic clock synchronization algorithm that attempts to find the best reference clock and align other traces accordingly.
- A manual override system for fine-grained control over clock synchronization, including setting reference clocks, anchoring traces to one another, and specifying time offsets.
- Detailed UI feedback on trace status, analysis progress, and synchronization configuration.

The feature is structured into several components for maintainability:
- `MultiTraceModalShell`: The main container and state owner.
- `TraceListComponent`: Renders the list of traces.
- `TraceDetailsPanelComponent`: Renders the details for the selected trace.
- `MultiTraceController`: Manages the state and business logic, decoupled from the view.
- `WasmTraceAnalyzer`: A dedicated trace analyzer that runs in a separate worker.

Test: ui/run-unittests --out out/ui-unittest
