### PR TITLE
stdlib: expose userfriendly power rail names.

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -86,6 +86,8 @@ CREATE PERFETTO TABLE android_power_rails_metadata (
   power_rail_name STRING,
   -- Raw power rail name from the hardware.
   raw_power_rail_name STRING,
+  -- User-friendly name for the power rail.
+  friendly_name STRING,
   -- Power rail track id. Alias of `counter_track.id`.
   track_id JOINID(track.id),
   -- Subsystem name that this power rail belongs to.
@@ -96,6 +98,7 @@ CREATE PERFETTO TABLE android_power_rails_metadata (
 SELECT
   t.name AS power_rail_name,
   extract_arg(t.source_arg_set_id, 'raw_name') AS raw_power_rail_name,
+  CASE WHEN t.name GLOB 'power.rails.*' THEN substr(t.name, 13) ELSE NULL END AS friendly_name,
   t.id AS track_id,
   extract_arg(t.source_arg_set_id, 'subsystem_name') AS subsystem_name,
   t.machine_id AS machine_id

--- a/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
+++ b/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
@@ -174,18 +174,30 @@ class PowerPowerRails(TestSuite):
             }
           }
         }
+        packet {
+          power_rails {
+            rail_descriptor {
+              index: 5
+              rail_name: "L14S_ALIVE"
+              subsys_name: "system"
+              sampling_rate: 1024
+            }
+          }
+        }
         """),
         query="""
         INCLUDE PERFETTO MODULE android.power_rails;
         SELECT
           power_rail_name,
           raw_power_rail_name,
+          friendly_name,
           subsystem_name
         FROM android_power_rails_metadata
         ORDER BY power_rail_name;
         """,
         out=Csv("""
-        "power_rail_name","raw_power_rail_name","subsystem_name"
-        "power.rails.cpu.mid","S3M_VDD_CPUCL1","cpu"
-        "power.rails.gpu","S2S_VDD_G3D","gpu"
+        "power_rail_name","raw_power_rail_name","friendly_name","subsystem_name"
+        "power.L14S_ALIVE_uws","L14S_ALIVE","[NULL]","system"
+        "power.rails.cpu.mid","S3M_VDD_CPUCL1","cpu.mid","cpu"
+        "power.rails.gpu","S2S_VDD_G3D","gpu","gpu"
         """))


### PR DESCRIPTION
There exists a map of raw to userfriendly name in
https://github.com/google/perfetto/blob/0c893ed6bf6b42e3fee58daf3380d301c72550ed/src/trace_processor/importers/proto/android_probes_module.cc#L59-L120

We would like to expose these names to users of the stdlib without the
"power.rails." prefix which is part of the track name itself.

It is possible these user friendly name mappings should be moved into
the stdlib instead of mapping in trace processor, but it is possible
consumers of the power rails are referencing the track names in SQL
already so that will be left to a future change.

This PR mainly aims to create an API to get the userfrienly name that
can be depended upon by the ui regardless of if this mapping logic is
in trace processor or in the stdlib.

#Bug: 2249
