### PR TITLE
ui: Display user friendly power rail names.

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql
@@ -86,6 +86,8 @@ CREATE PERFETTO TABLE android_power_rails_metadata (
   power_rail_name STRING,
   -- Raw power rail name from the hardware.
   raw_power_rail_name STRING,
+  -- User-friendly name for the power rail.
+  friendly_name STRING,
   -- Power rail track id. Alias of `counter_track.id`.
   track_id JOINID(track.id),
   -- Subsystem name that this power rail belongs to.
@@ -96,6 +98,7 @@ CREATE PERFETTO TABLE android_power_rails_metadata (
 SELECT
   t.name AS power_rail_name,
   extract_arg(t.source_arg_set_id, 'raw_name') AS raw_power_rail_name,
+  CASE WHEN t.name GLOB 'power.rails.*' THEN substr(t.name, 13) ELSE NULL END AS friendly_name,
   t.id AS track_id,
   extract_arg(t.source_arg_set_id, 'subsystem_name') AS subsystem_name,
   t.machine_id AS machine_id

--- a/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
+++ b/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
@@ -174,18 +174,30 @@ class PowerPowerRails(TestSuite):
             }
           }
         }
+        packet {
+          power_rails {
+            rail_descriptor {
+              index: 5
+              rail_name: "L14S_ALIVE"
+              subsys_name: "system"
+              sampling_rate: 1024
+            }
+          }
+        }
         """),
         query="""
         INCLUDE PERFETTO MODULE android.power_rails;
         SELECT
           power_rail_name,
           raw_power_rail_name,
+          friendly_name,
           subsystem_name
         FROM android_power_rails_metadata
         ORDER BY power_rail_name;
         """,
         out=Csv("""
-        "power_rail_name","raw_power_rail_name","subsystem_name"
-        "power.rails.cpu.mid","S3M_VDD_CPUCL1","cpu"
-        "power.rails.gpu","S2S_VDD_G3D","gpu"
+        "power_rail_name","raw_power_rail_name","friendly_name","subsystem_name"
+        "power.L14S_ALIVE_uws","L14S_ALIVE","[NULL]","system"
+        "power.rails.cpu.mid","S3M_VDD_CPUCL1","cpu.mid","cpu"
+        "power.rails.gpu","S2S_VDD_G3D","gpu","gpu"
         """))

--- a/ui/src/plugins/dev.perfetto.PowerRails/index.ts
+++ b/ui/src/plugins/dev.perfetto.PowerRails/index.ts
@@ -44,10 +44,10 @@ export default class implements PerfettoPlugin {
 
       SELECT
         track_id as trackId,
-        raw_power_rail_name as name,
+        COALESCE(friendly_name, raw_power_rail_name) as name,
         machine_id as machine
       FROM android_power_rails_metadata
-      ORDER BY raw_power_rail_name
+      ORDER BY name
     `);
 
     if (result.numRows() === 0) {

--- a/ui/src/plugins/dev.perfetto.PowerRails/power_counter_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.PowerRails/power_counter_selection_aggregator.ts
@@ -62,7 +62,7 @@ export class PowerCounterSelectionAggregator implements Aggregator {
             GROUP BY track_id
           )
           SELECT
-            raw_power_rail_name AS name,
+            COALESCE(friendly_name, raw_power_rail_name) AS name,
             count,
             (last - first) / 1000 AS delta_value,
             ROUND((last - first)/${durationSec} / 1000, 2) AS rate


### PR DESCRIPTION
Pixels have several of their rails mapped to user frienly names in
trace processor which show up in the default track names. when we
moved to a dedicated PowerRails plugin these names disappeared in
favor of the raw name.

Since the goal of this plugin was user friendliness, bring back the
user friendly rail names, however without the "power.rails." prefix this
time, both because it is redundant and because some of the track
names would not fit in the allocated space in the UI and would need
to be partially truncated.

# Before

<img width="1381" height="560" alt="image" src="https://github.com/user-attachments/assets/8e76f4d0-b647-40d2-8ae0-b4668976fd12" />


# After

<img width="1342" height="577" alt="image" src="https://github.com/user-attachments/assets/c7c39158-b9ff-4cae-8d55-dde596027b0b" />

