### PR TITLE
tools: clarify LIKE is also banned in stdlib

### DIFF
--- a/python/generators/sql_processing/utils.py
+++ b/python/generators/sql_processing/utils.py
@@ -186,8 +186,8 @@ def check_banned_words(sql: str) -> List[str]:
       continue
 
     if 'like' in line.casefold():
-      errors.append(
-          'LIKE is banned in trace processor metrics. Prefer GLOB instead.\n')
+      errors.append('LIKE is banned in trace processor metrics and stdlib. '
+                    'Prefer GLOB instead.\n')
       continue
 
     if 'create_function' in line.casefold():


### PR DESCRIPTION
Clarify the error message that is printed when like is used in stdlib
to reflect that is is banned in both metric and the stdlib.
