### PR TITLE
ui: Add ability to scale counter track height beyond 4x

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -105,7 +105,7 @@ class RangeSharer {
 
     const tag = `${options.yRangeSharingKey}-${options.yMode}-${
       options.yDisplay
-    }-${!!options.enlarge}`;
+    }-${options.chartHeightSize}`;
     const cachedRange = this.tagToRange.get(tag);
     if (cachedRange === undefined) {
       this.tagToRange.set(tag, [min, max]);
@@ -163,6 +163,9 @@ export interface CounterOptions {
   // readable value.
   yRangeRounding: 'strict' | 'human_readable';
 
+  // Scales the height of the chart.
+  chartHeightSize: 1 | 4 | 8 | 16 | 32;
+
   // Allows *extending* the range of the y-axis counter increasing
   // the maximum (via yOverrideMaximum) or decreasing the minimum
   // (via yOverrideMinimum). This is useful for percentage counters
@@ -173,9 +176,6 @@ export interface CounterOptions {
 
   // If set all counters with the same key share a range.
   yRangeSharingKey?: string;
-
-  // Show the chart as 4x the height.
-  enlarge?: boolean;
 
   // unit for the counter. This is displayed in the tooltip and
   // legend.
@@ -268,6 +268,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
       yRangeRounding: 'human_readable',
       yMode: 'value',
       yDisplay: 'zero',
+      chartHeightSize: 1,
     };
   }
 
@@ -281,7 +282,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
 
   getHeight() {
     const height = 40;
-    return this.getCounterOptions().enlarge ? height * 4 : height;
+    return height * this.getCounterOptions().chartHeightSize;
   }
 
   // A method to render menu items for switching the defualt
@@ -334,6 +335,68 @@ export abstract class BaseCounterTrack implements TrackRenderer {
         }),
       ),
 
+      m(
+        MenuItem,
+        {
+          label: `Enlarge (currently: ${options.chartHeightSize}x)`,
+        },
+        m(MenuItem, {
+          label: `Small (1x)`,
+          icon:
+            options.chartHeightSize === 1
+              ? 'radio_button_checked'
+              : 'radio_button_unchecked',
+          onclick: () => {
+            options.chartHeightSize = 1;
+            this.invalidate();
+          },
+        }),
+        m(MenuItem, {
+          label: `Medium (4x)`,
+          icon:
+            options.chartHeightSize === 4
+              ? 'radio_button_checked'
+              : 'radio_button_unchecked',
+          onclick: () => {
+            options.chartHeightSize = 4;
+            this.invalidate();
+          },
+        }),
+        m(MenuItem, {
+          label: `Large (8x)`,
+          icon:
+            options.chartHeightSize === 8
+              ? 'radio_button_checked'
+              : 'radio_button_unchecked',
+          onclick: () => {
+            options.chartHeightSize = 8;
+            this.invalidate();
+          },
+        }),
+        m(MenuItem, {
+          label: `XLarge (16x)`,
+          icon:
+            options.chartHeightSize === 16
+              ? 'radio_button_checked'
+              : 'radio_button_unchecked',
+          onclick: () => {
+            options.chartHeightSize = 16;
+            this.invalidate();
+          },
+        }),
+        m(MenuItem, {
+          label: `XXLarge (32x)`,
+          icon:
+            options.chartHeightSize === 32
+              ? 'radio_button_checked'
+              : 'radio_button_unchecked',
+          onclick: () => {
+            options.chartHeightSize = 32;
+            this.invalidate();
+          },
+        }),
+      ),
+
       m(MenuItem, {
         label: 'Zoom on scroll',
         icon:
@@ -342,15 +405,6 @@ export abstract class BaseCounterTrack implements TrackRenderer {
             : 'check_box_outline_blank',
         onclick: () => {
           options.yRange = options.yRange === 'viewport' ? 'all' : 'viewport';
-          this.invalidate();
-        },
-      }),
-
-      m(MenuItem, {
-        label: `Enlarge`,
-        icon: options.enlarge ? 'check_box' : 'check_box_outline_blank',
-        onclick: () => {
-          options.enlarge = !options.enlarge;
           this.invalidate();
         },
       }),


### PR DESCRIPTION
This commit adds the ability for the user to enlarge the counter track heights beyond 4x.
- Added 1x, 4x, 8x, 16x, 32x magnification
- Moved option to above "Zoom on Scroll"

Feature Request #2380 

```
./tools/format-sources
```

<img width="1015" height="591" alt="image" src="https://github.com/user-attachments/assets/8b8315ab-3e73-4f66-8d6e-317f737b61f8" />
