### PR TITLE
traced_perf: Detect always-on CPUs correctly.

### DIFF
--- a/src/profiling/perf/perf_producer.cc
+++ b/src/profiling/perf/perf_producer.cc
@@ -87,6 +87,11 @@ uint32_t NumberOfCpus() {
 bool IsCpuOnline(uint32_t cpu) {
   base::StackString<128> path("/sys/devices/system/cpu/cpu%" PRIu32 "/online",
                               cpu);
+  // Always-on CPUs do not have an "online" attribute so treat an absent |path|
+  // as online.
+  if (!base::FileExists(path.c_str())) {
+    return true;
+  }
   std::string res;
   if (!base::ReadFile(path.c_str(), &res)) {
     return false;


### PR DESCRIPTION
On many x86 devices, CPU 0 cannot be offlined. As such, /sys/devices/system/cpu/cpu0/online does not exist. IsCpuOnline() treats a missing or otherwise-unreadable online file as the CPU being offline. Until commit 99524a6e0e22 ("traced_perf: Allow CPU 0 to be excluded when offline (#2219)"), this was fine, since CPU 0 was always assumed to be online, and so IsCpuOnline() was never called for CPU 0. Now, on x86, the core that cannot be offlined is always treated as offline.

Avoid this by treating absent /sys/devices/system/cpu/cpu*/online files as the CPU core being online.

Bug: 435585417