### PR TITLE
fix mingw builds

### DIFF
--- a/include/perfetto/base/platform_handle.h
+++ b/include/perfetto/base/platform_handle.h
@@ -29,7 +29,7 @@ namespace base {
 // Windows has two types of "handles", which, in UNIX-land, both map to int:
 // 1. File handles returned by the posix-compatibility API like _open().
 //    These are just int(s) and should stay such, because all the posix-like API
-//    in Windows.h take an int, not a HANDLE.
+//    in windows.h take an int, not a HANDLE.
 // 2. Handles returned by old-school WINAPI like CreateFile, CreateEvent etc.
 //    These are proper HANDLE(s). PlatformHandle should be used here.
 //
@@ -39,8 +39,8 @@ namespace base {
 // WaitForMultipleObjects, hence in base::TaskRunner.AddFileDescriptorWatch().
 // On POSIX OSes, a SocketHandle is really just an int (a file descriptor).
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-// Windows.h typedefs HANDLE to void*, and SOCKET to uintptr_t. We use their
-// types to avoid leaking Windows.h through our headers.
+// windows.h typedefs HANDLE to void*, and SOCKET to uintptr_t. We use their
+// types to avoid leaking windows.h through our headers.
 using PlatformHandle = void*;
 using SocketHandle = uintptr_t;
 
@@ -61,7 +61,7 @@ struct PlatformHandleChecker {
 // The definition of this lives in base/file_utils.cc (to avoid creating an
 // extra build edge for a one liner). This is really an alias for close() (UNIX)
 // CloseHandle() (Windows). THe indirection layer is just to avoid leaking
-// system headers like Windows.h through perfetto headers.
+// system headers like windows.h through perfetto headers.
 // Thre return value is always UNIX-style: 0 on success, -1 on failure.
 int ClosePlatformHandle(PlatformHandle);
 

--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -68,7 +68,7 @@ ScopedFile OpenFile(const std::string& path,
                     FileOpenMode = kFileModeInvalid);
 ScopedFstream OpenFstream(const char* path, const char* mode);
 
-// This is an alias for close(). It's to avoid leaking Windows.h in headers.
+// This is an alias for close(). It's to avoid leaking windows.h in headers.
 // Exported because ScopedFile is used in the /include/ext API by Chromium
 // component builds.
 int PERFETTO_EXPORT_COMPONENT CloseFile(int fd);

--- a/src/base/ctrl_c_handler.cc
+++ b/src/base/ctrl_c_handler.cc
@@ -21,8 +21,8 @@
 #include "perfetto/base/logging.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <io.h>
+#include <windows.h>
 #else
 #include <signal.h>
 #include <unistd.h>

--- a/src/base/ctrl_c_handler.cc
+++ b/src/base/ctrl_c_handler.cc
@@ -21,7 +21,7 @@
 #include "perfetto/base/logging.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <io.h>
 #else
 #include <signal.h>

--- a/src/base/event_fd.cc
+++ b/src/base/event_fd.cc
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <synchapi.h>
 #elif PERFETTO_BUILDFLAG(PERFETTO_OS_QNX)
 #include <unistd.h>

--- a/src/base/event_fd.cc
+++ b/src/base/event_fd.cc
@@ -20,8 +20,8 @@
 #include <stdint.h>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <synchapi.h>
+#include <windows.h>
 #elif PERFETTO_BUILDFLAG(PERFETTO_OS_QNX)
 #include <unistd.h>
 #elif PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) || \

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -36,7 +36,7 @@
 #include "perfetto/ext/base/utils.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <direct.h>
 #include <io.h>
 #include <stringapiset.h>

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -36,10 +36,10 @@
 #include "perfetto/ext/base/utils.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <direct.h>
 #include <io.h>
 #include <stringapiset.h>
+#include <windows.h>
 #else
 #include <dirent.h>
 #include <unistd.h>

--- a/src/base/paged_memory.cc
+++ b/src/base/paged_memory.cc
@@ -21,7 +21,7 @@
 #include <cstddef>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #else  // PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <sys/mman.h>
 #endif  // PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)

--- a/src/base/pipe.cc
+++ b/src/base/pipe.cc
@@ -21,7 +21,7 @@
 #include <fcntl.h>  // For O_BINARY (Windows) and F_SETxx (UNIX)
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <namedpipeapi.h>
 #else
 #include <sys/types.h>

--- a/src/base/pipe.cc
+++ b/src/base/pipe.cc
@@ -21,8 +21,8 @@
 #include <fcntl.h>  // For O_BINARY (Windows) and F_SETxx (UNIX)
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <namedpipeapi.h>
+#include <windows.h>
 #else
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/base/scoped_mmap.cc
+++ b/src/base/scoped_mmap.cc
@@ -27,7 +27,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #elif PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace perfetto::base {

--- a/src/base/string_utils.cc
+++ b/src/base/string_utils.cc
@@ -25,7 +25,7 @@
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_APPLE)
 #include <xlocale.h>
 #elif PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include <cinttypes>

--- a/src/base/subprocess_unittest.cc
+++ b/src/base/subprocess_unittest.cc
@@ -19,7 +19,7 @@
 #include <thread>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <signal.h>
 #include <sys/stat.h>

--- a/src/base/subprocess_windows.cc
+++ b/src/base/subprocess_windows.cc
@@ -26,7 +26,7 @@
 #include <mutex>
 #include <tuple>
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/time.h"

--- a/src/base/temp_file.cc
+++ b/src/base/temp_file.cc
@@ -23,10 +23,10 @@
 #include <string.h>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <direct.h>
 #include <fileapi.h>
 #include <io.h>
+#include <windows.h>
 #else
 #include <unistd.h>
 #endif

--- a/src/base/temp_file.cc
+++ b/src/base/temp_file.cc
@@ -23,7 +23,7 @@
 #include <string.h>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <direct.h>
 #include <fileapi.h>
 #include <io.h>

--- a/src/base/test/vm_test_utils.cc
+++ b/src/base/test/vm_test_utils.cc
@@ -28,7 +28,7 @@
 #include <vector>
 
 // clang-format off
-#include <Windows.h>
+#include <windows.h>
 #include <Psapi.h>
 // clang-format on
 #else  // PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)

--- a/src/base/thread_checker.cc
+++ b/src/base/thread_checker.cc
@@ -17,7 +17,7 @@
 #include "perfetto/ext/base/thread_checker.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace perfetto {

--- a/src/base/thread_utils.cc
+++ b/src/base/thread_utils.cc
@@ -24,7 +24,7 @@
 #include <zircon/syscalls.h>
 #include <zircon/types.h>
 #elif PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace perfetto {

--- a/src/base/threading/channel_unittest.cc
+++ b/src/base/threading/channel_unittest.cc
@@ -26,8 +26,8 @@
 #include "test/gtest_and_gmock.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <synchapi.h>
+#include <windows.h>
 #else
 #include <poll.h>
 #endif

--- a/src/base/threading/channel_unittest.cc
+++ b/src/base/threading/channel_unittest.cc
@@ -26,7 +26,7 @@
 #include "test/gtest_and_gmock.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <synchapi.h>
 #else
 #include <poll.h>

--- a/src/base/time.cc
+++ b/src/base/time.cc
@@ -23,7 +23,7 @@
 #include "perfetto/ext/base/string_utils.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <unistd.h>
 #endif

--- a/src/base/unix_socket.cc
+++ b/src/base/unix_socket.cc
@@ -30,8 +30,8 @@
 // The include order matters on these three Windows header groups.
 #include <windows.h>
 
-#include <ws2tcpip.h>
 #include <winsock2.h>
+#include <ws2tcpip.h>
 
 #include <afunix.h>
 #else

--- a/src/base/unix_socket.cc
+++ b/src/base/unix_socket.cc
@@ -28,10 +28,10 @@
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 // The include order matters on these three Windows header groups.
-#include <Windows.h>
+#include <windows.h>
 
-#include <WS2tcpip.h>
-#include <WinSock2.h>
+#include <ws2tcpip.h>
+#include <winsock2.h>
 
 #include <afunix.h>
 #else

--- a/src/base/unix_task_runner.cc
+++ b/src/base/unix_task_runner.cc
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <synchapi.h>
 #else
 #include <unistd.h>

--- a/src/base/unix_task_runner.cc
+++ b/src/base/unix_task_runner.cc
@@ -23,8 +23,8 @@
 #include <stdlib.h>
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <synchapi.h>
+#include <windows.h>
 #else
 #include <unistd.h>
 #endif

--- a/src/base/utils.cc
+++ b/src/base/utils.cc
@@ -57,9 +57,9 @@
 #endif  // OS_LINUX | OS_ANDROID
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <windows.h>
 #include <io.h>
 #include <malloc.h>  // For _aligned_malloc().
+#include <windows.h>
 #endif
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)

--- a/src/base/utils.cc
+++ b/src/base/utils.cc
@@ -57,7 +57,7 @@
 #endif  // OS_LINUX | OS_ANDROID
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #include <io.h>
 #include <malloc.h>  // For _aligned_malloc().
 #endif

--- a/src/base/utils_unittest.cc
+++ b/src/base/utils_unittest.cc
@@ -19,7 +19,7 @@
 #include "perfetto/base/build_config.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <fcntl.h>
 #include <signal.h>

--- a/src/profiling/symbolizer/filesystem_windows.cc
+++ b/src/profiling/symbolizer/filesystem_windows.cc
@@ -18,7 +18,7 @@
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 
-#include <Windows.h>
+#include <windows.h>
 
 namespace perfetto {
 namespace profiling {

--- a/src/profiling/symbolizer/subprocess_windows.cc
+++ b/src/profiling/symbolizer/subprocess_windows.cc
@@ -22,7 +22,7 @@
 #include <sstream>
 #include <string>
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "perfetto/base/logging.h"
 

--- a/src/tracing/ipc/shared_memory_windows.cc
+++ b/src/tracing/ipc/shared_memory_windows.cc
@@ -21,7 +21,7 @@
 #include <memory>
 #include <random>
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/string_utils.h"

--- a/src/tracing/platform_windows.cc
+++ b/src/tracing/platform_windows.cc
@@ -18,7 +18,7 @@
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 
-#include <Windows.h>
+#include <windows.h>
 
 #include "perfetto/ext/base/thread_task_runner.h"
 #include "perfetto/tracing/internal/tracing_tls.h"

--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -36,7 +36,7 @@
 #include "test/integrationtest_initializer.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>  // For CreateFile().
+#include <windows.h>  // For CreateFile().
 #else
 #include <sys/socket.h>
 #include <sys/types.h>

--- a/src/tracing/test/api_test_support.cc
+++ b/src/tracing/test/api_test_support.cc
@@ -31,7 +31,7 @@
 #endif
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace perfetto {

--- a/test/stress_test/stress_test.cc
+++ b/test/stress_test/stress_test.cc
@@ -45,7 +45,7 @@
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <Windows.h>
+#include <windows.h>
 #else
 #include <signal.h>
 #endif


### PR DESCRIPTION
Upstreaming patches from JuliaPackaging/Yggdrasil#11770. One remaining
issue is that `NetworkPacketEvent_Decoder` in the sdk header defines a
member function with the name `interface`, which conflicts with a mingw
macro, but I wasn't able to figure out from where that definition was
generated
