### PR TITLE
ui: improve markers for selected events.

### DIFF
--- a/ui/src/frontend/viewer_page/time_selection_panel.ts
+++ b/ui/src/frontend/viewer_page/time_selection_panel.ts
@@ -69,8 +69,11 @@ function drawHBar(
   const labelWidth = ctx.measureText(label).width;
 
   // Find a good position for the label:
-  // By default put the label in the middle of the H:
-  let labelXLeft = Math.floor(xWidth / 2 - labelWidth / 2 + xLeft);
+  // By default put the label in the middle of the visible portion of the H.
+  const visibleLeft = Math.max(xLeft, bounds.x);
+  const visibleRight = Math.min(xRight, bounds.x + bounds.width);
+  const visibleCenter = Math.floor((visibleLeft + visibleRight) / 2);
+  let labelXLeft = Math.floor(visibleCenter - labelWidth / 2);
 
   if (
     labelWidth > target.width ||
@@ -129,6 +132,30 @@ function drawIBar(
   ctx.fillStyle = FOREGROUND_COLOR;
   ctx.font = '10px Roboto Condensed';
   ctx.fillText(label, xPosLabel, yMid);
+}
+
+// Draws a marker: triangle pointing down.
+function drawMarker(ctx: CanvasRenderingContext2D, target: BBox, bounds: BBox) {
+  const xPos = Math.floor(target.x);
+  if (xPos < bounds.x || xPos > bounds.x + bounds.width) return;
+
+  ctx.fillStyle = FOREGROUND_COLOR;
+  const yMid = Math.floor(target.height / 2 + target.y);
+  const size = 4;
+
+  // Don't draw in the track shell.
+  ctx.beginPath();
+  ctx.rect(bounds.x, bounds.y, bounds.width, bounds.height);
+  ctx.clip();
+
+  // Draw triangle pointing down. Offset it down a bit to balance triange being top-heavy.
+  const yCenter = yMid + 1;
+  ctx.beginPath();
+  ctx.moveTo(xPos - size, yCenter - size);
+  ctx.lineTo(xPos + size, yCenter - size);
+  ctx.lineTo(xPos, yCenter + size);
+  ctx.closePath();
+  ctx.fill();
 }
 
 export class TimeSelectionPanel {
@@ -190,7 +217,9 @@ export class TimeSelectionPanel {
       ) {
         const start = selection.ts;
         const end = Time.add(selection.ts, selection.dur);
-        if (end > start) {
+        if (selection.dur === 0n) {
+          this.renderInstantEvent(ctx, timescale, size, selection.ts);
+        } else if (end > start) {
           this.renderSpan(ctx, timescale, size, start, end);
         }
       }
@@ -248,6 +277,25 @@ export class TimeSelectionPanel {
       },
       this.getBBoxFromSize(trackSize),
       label,
+    );
+  }
+
+  renderInstantEvent(
+    ctx: CanvasRenderingContext2D,
+    timescale: TimeScale,
+    trackSize: Size2D,
+    ts: time,
+  ) {
+    const xPos = timescale.timeToPx(ts);
+    drawMarker(
+      ctx,
+      {
+        x: xPos,
+        y: 0,
+        width: 0,
+        height: trackSize.height,
+      },
+      this.getBBoxFromSize(trackSize),
     );
   }
 


### PR DESCRIPTION
- Draw a marker (small triangle) pointing down for instant events. We currently draw a range for non-instant selected events, draw a marker for selected instant events as well to make it easier to spot them.
- Draw the label in the middle for the intersection of (visible range, event span) for non-instant selections: currently it's always rendered in the middle of the event span, even when it's outside of the viewport.

Instant event marker (after this patch):
<img width="319" height="394" alt="Screenshot 2025-08-04 at 17 08 37" src="https://github.com/user-attachments/assets/bc5d65db-c07d-4056-9387-ee45165663bc" />

Non-instant selected event label when zoomed in (before):
<img width="1244" height="395" alt="Screenshot 2025-08-04 at 17 10 17" src="https://github.com/user-attachments/assets/f1e83d3e-6f0a-4435-917a-31e561d1690c" />

Non-instant selected event label when zoomed in (after this patch):
<img width="1235" height="369" alt="Screenshot 2025-08-04 at 17 10 42" src="https://github.com/user-attachments/assets/383df446-4ed1-4ab3-ae7e-f5dad2b5b4d0" />
