### PR TITLE
tp: refactor proto modules to live in a separate struct

### DIFF
--- a/src/trace_processor/importers/etw/etw_module.cc
+++ b/src/trace_processor/importers/etw/etw_module.cc
@@ -16,14 +16,18 @@
 
 #include "src/trace_processor/importers/etw/etw_module.h"
 
-#include "src/trace_processor/importers/common/parser_types.h"
+#include <cstdint>
 
-namespace perfetto {
-namespace trace_processor {
+#include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+
+namespace perfetto::trace_processor {
+
+EtwModule::EtwModule(ProtoImporterModuleContext* module_context)
+    : ProtoImporterModule(module_context) {}
 
 void EtwModule::ParseEtwEventData(uint32_t /*cpu*/,
                                   int64_t /*ts*/,
                                   const TracePacketData&) {}
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/etw/etw_module.h
+++ b/src/trace_processor/importers/etw/etw_module.h
@@ -17,20 +17,22 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_MODULE_H_
 
+#include <cstdint>
+
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class EtwModule : public ProtoImporterModule {
  public:
+  explicit EtwModule(ProtoImporterModuleContext* module_context);
+
   virtual void ParseEtwEventData(uint32_t cpu,
                                  int64_t ts,
                                  const TracePacketData& data);
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_MODULE_H_

--- a/src/trace_processor/importers/etw/etw_module_impl.cc
+++ b/src/trace_processor/importers/etw/etw_module_impl.cc
@@ -16,20 +16,27 @@
 
 #include "src/trace_processor/importers/etw/etw_module_impl.h"
 
+#include <cstdint>
+#include <utility>
+
+#include "perfetto/trace_processor/ref_counted.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/etw/etw_tokenizer.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
-#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-EtwModuleImpl::EtwModuleImpl(TraceProcessorContext* context)
-    : tokenizer_(context), parser_(context) {
-  RegisterForField(TracePacket::kEtwEventsFieldNumber, context);
+EtwModuleImpl::EtwModuleImpl(ProtoImporterModuleContext* module_context,
+                             TraceProcessorContext* context)
+    : EtwModule(module_context),
+      tokenizer_(module_context, context),
+      parser_(context) {
+  RegisterForField(TracePacket::kEtwEventsFieldNumber);
 }
 
 ModuleResult EtwModuleImpl::TokenizePacket(
@@ -49,5 +56,4 @@ ModuleResult EtwModuleImpl::TokenizePacket(
   return ModuleResult::Ignored();
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/etw/etw_module_impl.h
+++ b/src/trace_processor/importers/etw/etw_module_impl.h
@@ -17,6 +17,11 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_MODULE_IMPL_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_MODULE_IMPL_H_
 
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/etw/etw_module.h"
 #include "src/trace_processor/importers/etw/etw_parser.h"
@@ -26,14 +31,14 @@
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class TraceBlobView;
 
 class EtwModuleImpl : public EtwModule {
  public:
-  explicit EtwModuleImpl(TraceProcessorContext* context);
+  explicit EtwModuleImpl(ProtoImporterModuleContext* module_context,
+                         TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(
       const protos::pbzero::TracePacket::Decoder& decoder,
@@ -56,7 +61,6 @@ class EtwModuleImpl : public EtwModule {
   EtwParser parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_MODULE_IMPL_H_

--- a/src/trace_processor/importers/etw/etw_tokenizer.cc
+++ b/src/trace_processor/importers/etw/etw_tokenizer.cc
@@ -14,24 +14,28 @@
  * limitations under the License.
  */
 
+#include <cstddef>
+#include <cstdint>
 #include <optional>
-
-#include "src/trace_processor/importers/etw/etw_tokenizer.h"
+#include <utility>
 
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/protozero/proto_decoder.h"
 #include "perfetto/protozero/proto_utils.h"
+#include "perfetto/public/compiler.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
+#include "src/trace_processor/importers/etw/etw_tokenizer.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
-#include "src/trace_processor/storage/trace_storage.h"
 
 #include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/trace/etw/etw_event.pbzero.h"
 #include "protos/perfetto/trace/etw/etw_event_bundle.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using protozero::ProtoDecoder;
 using protozero::proto_utils::MakeTagVarInt;
@@ -110,5 +114,4 @@ base::Status EtwTokenizer::TokenizeEtwEvent(
   return base::OkStatus();
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/etw/etw_tokenizer.h
+++ b/src/trace_processor/importers/etw/etw_tokenizer.h
@@ -17,22 +17,25 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_TOKENIZER_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_TOKENIZER_H_
 
+#include <cstdint>
 #include <optional>
 
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/status.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
-#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
-#include "protos/perfetto/trace/etw/etw_event_bundle.pbzero.h"
-
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class EtwTokenizer {
  public:
-  explicit EtwTokenizer(TraceProcessorContext* context) : context_(context) {}
+  explicit EtwTokenizer(ProtoImporterModuleContext* module_context,
+                        TraceProcessorContext* context)
+      : module_context_(module_context), context_(context) {
+    base::ignore_result(module_context_);
+  }
 
   base::Status TokenizeEtwBundle(TraceBlobView bundle,
                                  RefPtr<PacketSequenceStateGeneration> state);
@@ -42,10 +45,10 @@ class EtwTokenizer {
                                 TraceBlobView event,
                                 RefPtr<PacketSequenceStateGeneration> state);
 
+  ProtoImporterModuleContext* module_context_;
   TraceProcessorContext* context_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_ETW_ETW_TOKENIZER_H_

--- a/src/trace_processor/importers/ftrace/ftrace_module.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_module.cc
@@ -15,11 +15,16 @@
  */
 
 #include "src/trace_processor/importers/ftrace/ftrace_module.h"
-#include <cstdint>
-#include "src/trace_processor/importers/common/parser_types.h"
 
-namespace perfetto {
-namespace trace_processor {
+#include <cstdint>
+
+#include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+
+namespace perfetto::trace_processor {
+
+FtraceModule::FtraceModule(ProtoImporterModuleContext* module_context)
+    : ProtoImporterModule(module_context) {}
 
 void FtraceModule::ParseFtraceEventData(uint32_t /*cpu*/,
                                         int64_t /*ts*/,
@@ -33,5 +38,4 @@ void FtraceModule::ParseInlineSchedWaking(uint32_t /*cpu*/,
                                           int64_t /*ts*/,
                                           const InlineSchedWaking&) {}
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/ftrace/ftrace_module.h
+++ b/src/trace_processor/importers/ftrace/ftrace_module.h
@@ -17,15 +17,17 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_MODULE_H_
 
+#include <cstdint>
+
 #include "src/trace_processor/importers/common/parser_types.h"
-#include "src/trace_processor/importers/common/trace_parser.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class FtraceModule : public ProtoImporterModule {
  public:
+  explicit FtraceModule(ProtoImporterModuleContext* module_context);
+
   virtual void ParseFtraceEventData(uint32_t cpu,
                                     int64_t ts,
                                     const TracePacketData& data);
@@ -39,7 +41,6 @@ class FtraceModule : public ProtoImporterModule {
                                       const InlineSchedWaking& data);
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_MODULE_H_

--- a/src/trace_processor/importers/ftrace/ftrace_module_impl.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_module_impl.cc
@@ -16,25 +16,31 @@
 
 #include "src/trace_processor/importers/ftrace/ftrace_module_impl.h"
 
+#include <cstdint>
+#include <utility>
+
+#include "perfetto/trace_processor/ref_counted.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/ftrace/ftrace_parser.h"
 #include "src/trace_processor/importers/ftrace/ftrace_tokenizer.h"
 #include "src/trace_processor/importers/ftrace/generic_ftrace_tracker.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-FtraceModuleImpl::FtraceModuleImpl(TraceProcessorContext* context)
-    : generic_tracker_(context),
-      tokenizer_(context, &generic_tracker_),
+FtraceModuleImpl::FtraceModuleImpl(ProtoImporterModuleContext* module_context,
+                                   TraceProcessorContext* context)
+    : FtraceModule(module_context),
+      generic_tracker_(context),
+      tokenizer_(context, module_context, &generic_tracker_),
       parser_(context, &generic_tracker_) {
-  RegisterForField(TracePacket::kFtraceEventsFieldNumber, context);
-  RegisterForField(TracePacket::kFtraceStatsFieldNumber, context);
+  RegisterForField(TracePacket::kFtraceEventsFieldNumber);
+  RegisterForField(TracePacket::kFtraceStatsFieldNumber);
 }
 
 ModuleResult FtraceModuleImpl::TokenizePacket(
@@ -59,5 +65,4 @@ ModuleResult FtraceModuleImpl::TokenizePacket(
   }
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/ftrace/ftrace_module_impl.h
+++ b/src/trace_processor/importers/ftrace/ftrace_module_impl.h
@@ -17,7 +17,11 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_MODULE_IMPL_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_MODULE_IMPL_H_
 
-#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include <cstdint>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/ftrace/ftrace_module.h"
 #include "src/trace_processor/importers/ftrace/ftrace_parser.h"
@@ -26,14 +30,16 @@
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
-namespace perfetto {
-namespace trace_processor {
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+
+namespace perfetto::trace_processor {
 
 class TraceBlobView;
 
 class FtraceModuleImpl : public FtraceModule {
  public:
-  explicit FtraceModuleImpl(TraceProcessorContext* context);
+  explicit FtraceModuleImpl(ProtoImporterModuleContext* module_context,
+                            TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(
       const protos::pbzero::TracePacket::Decoder& decoder,
@@ -75,7 +81,6 @@ class FtraceModuleImpl : public FtraceModule {
   FtraceParser parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_MODULE_IMPL_H_

--- a/src/trace_processor/importers/ftrace/ftrace_parser.h
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.h
@@ -28,11 +28,10 @@
 
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/ext/base/string_view.h"
+#include "perfetto/ext/base/fnv_hash.h"
 #include "perfetto/protozero/field.h"
 #include "src/trace_processor/importers/common/event_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
-#include "src/trace_processor/importers/common/trace_parser.h"
 #include "src/trace_processor/importers/ftrace/drm_tracker.h"
 #include "src/trace_processor/importers/ftrace/ftrace_descriptors.h"
 #include "src/trace_processor/importers/ftrace/generic_ftrace_tracker.h"
@@ -44,6 +43,7 @@
 #include "src/trace_processor/importers/ftrace/rss_stat_tracker.h"
 #include "src/trace_processor/importers/ftrace/thermal_tracker.h"
 #include "src/trace_processor/importers/ftrace/virtio_gpu_tracker.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 

--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
@@ -17,9 +17,17 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_TOKENIZER_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_TOKENIZER_H_
 
+#include <atomic>
+#include <cstdint>
 #include <optional>
 #include <vector>
 
+#include "perfetto/base/compiler.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/ftrace/generic_ftrace_tracker.h"
@@ -29,14 +37,18 @@
 
 #include "protos/perfetto/trace/ftrace/ftrace_event_bundle.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class FtraceTokenizer {
  public:
   explicit FtraceTokenizer(TraceProcessorContext* context,
+                           ProtoImporterModuleContext* module_context,
                            GenericFtraceTracker* generic_tracker)
-      : context_(context), generic_tracker_(generic_tracker) {}
+      : context_(context),
+        module_context_(module_context),
+        generic_tracker_(generic_tracker) {
+    base::ignore_result(module_context_);
+  }
 
   base::Status TokenizeFtraceBundle(TraceBlobView bundle,
                                     RefPtr<PacketSequenceStateGeneration>,
@@ -78,20 +90,20 @@ class FtraceTokenizer {
       uint32_t event_id,
       const TraceBlobView& event);
 
-  void DlogWithLimit(const base::Status& status) {
+  static void DlogWithLimit(const base::Status& status) {
     static std::atomic<uint32_t> dlog_count(0);
     if (dlog_count++ < 10)
       PERFETTO_DLOG("%s", status.c_message());
   }
 
   TraceProcessorContext* context_;
+  ProtoImporterModuleContext* module_context_;
   GenericFtraceTracker* generic_tracker_;
 
   int64_t latest_ftrace_clock_snapshot_ts_ = 0;
   std::vector<bool> per_cpu_seen_first_bundle_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_FTRACE_FTRACE_TOKENIZER_H_

--- a/src/trace_processor/importers/generic_kernel/generic_kernel_module.cc
+++ b/src/trace_processor/importers/generic_kernel/generic_kernel_module.cc
@@ -16,18 +16,24 @@
 
 #include "src/trace_processor/importers/generic_kernel/generic_kernel_module.h"
 
-namespace perfetto {
-namespace trace_processor {
+#include <cstdint>
+
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/generic_kernel/generic_kernel_parser.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-GenericKernelModule::GenericKernelModule(TraceProcessorContext* context)
-    : parser_(context) {
-  RegisterForField(TracePacket::kGenericKernelTaskStateEventFieldNumber,
-                   context);
-  RegisterForField(TracePacket::kGenericKernelTaskRenameEventFieldNumber,
-                   context);
-  RegisterForField(TracePacket::kGenericKernelCpuFreqEventFieldNumber, context);
+GenericKernelModule::GenericKernelModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), parser_(context) {
+  RegisterForField(TracePacket::kGenericKernelTaskStateEventFieldNumber);
+  RegisterForField(TracePacket::kGenericKernelTaskRenameEventFieldNumber);
+  RegisterForField(TracePacket::kGenericKernelCpuFreqEventFieldNumber);
 }
 
 void GenericKernelModule::ParseTracePacketData(
@@ -51,5 +57,4 @@ void GenericKernelModule::ParseTracePacketData(
   }
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/generic_kernel/generic_kernel_module.h
+++ b/src/trace_processor/importers/generic_kernel/generic_kernel_module.h
@@ -17,17 +17,20 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_GENERIC_KERNEL_GENERIC_KERNEL_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_GENERIC_KERNEL_GENERIC_KERNEL_MODULE_H_
 
+#include <cstdint>
+
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/generic_kernel/generic_kernel_parser.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class GenericKernelModule : public ProtoImporterModule {
  public:
-  explicit GenericKernelModule(TraceProcessorContext* context);
+  explicit GenericKernelModule(ProtoImporterModuleContext* module_context,
+                               TraceProcessorContext* context);
 
   void ParseTracePacketData(const protos::pbzero::TracePacket_Decoder& decoder,
                             int64_t ts,
@@ -38,7 +41,6 @@ class GenericKernelModule : public ProtoImporterModule {
   GenericKernelParser parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_GENERIC_KERNEL_GENERIC_KERNEL_MODULE_H_

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -214,7 +214,9 @@ source_set("full") {
     "../common",
     "../common:parser_types",
     "../etw:full",
+    "../etw:minimal",
     "../ftrace:full",
+    "../ftrace:minimal",
     "../generic_kernel:full",
     "../syscalls:full",
   ]
@@ -236,6 +238,7 @@ source_set("proto_importer_module") {
     "../../../../include/perfetto/trace_processor:trace_processor",
     "../../../base",
     "../../types",
+    "../common:parser_types",
     "../common:trace_parser_hdr",
   ]
 }

--- a/src/trace_processor/importers/proto/additional_modules.cc
+++ b/src/trace_processor/importers/proto/additional_modules.cc
@@ -19,7 +19,9 @@
 #include <memory>
 
 #include "perfetto/base/build_config.h"
+#include "src/trace_processor/importers/etw/etw_module.h"
 #include "src/trace_processor/importers/etw/etw_module_impl.h"
+#include "src/trace_processor/importers/ftrace/ftrace_module.h"
 #include "src/trace_processor/importers/ftrace/ftrace_module_impl.h"
 #include "src/trace_processor/importers/generic_kernel/generic_kernel_module.h"
 #include "src/trace_processor/importers/proto/android_camera_event_module.h"
@@ -47,44 +49,59 @@
 
 namespace perfetto::trace_processor {
 
-void RegisterAdditionalModules(TraceProcessorContext* context) {
+void RegisterAdditionalModules(ProtoImporterModuleContext* module_context,
+                               TraceProcessorContext* context) {
   // Content analyzer and metadata module both depend on this.
   context->descriptor_pool_->AddFromFileDescriptorSet(kTraceDescriptor.data(),
                                                       kTraceDescriptor.size());
 
-  context->modules.emplace_back(new AndroidKernelWakelocksModule(context));
-  context->modules.emplace_back(new AndroidProbesModule(context));
-  context->modules.emplace_back(new NetworkTraceModule(context));
-  context->modules.emplace_back(new GraphicsEventModule(context));
-  context->modules.emplace_back(new HeapGraphModule(context));
-  context->modules.emplace_back(new DeobfuscationModule(context));
-  context->modules.emplace_back(new SystemProbesModule(context));
-  context->modules.emplace_back(new TranslationTableModule(context));
-  context->modules.emplace_back(new StatsdModule(context));
-  context->modules.emplace_back(new AndroidCameraEventModule(context));
-  context->modules.emplace_back(new MetadataModule(context));
-  context->modules.emplace_back(new V8Module(context));
-  context->modules.emplace_back(new PixelModemModule(context));
-  context->modules.emplace_back(new ProfileModule(context));
-  context->modules.emplace_back(new AppWakelockModule(context));
-  context->modules.emplace_back(new GenericKernelModule(context));
+  module_context->modules.emplace_back(
+      new AndroidKernelWakelocksModule(module_context, context));
+  module_context->modules.emplace_back(
+      new AndroidProbesModule(module_context, context));
+  module_context->modules.emplace_back(
+      new NetworkTraceModule(module_context, context));
+  module_context->modules.emplace_back(
+      new GraphicsEventModule(module_context, context));
+  module_context->modules.emplace_back(
+      new HeapGraphModule(module_context, context));
+  module_context->modules.emplace_back(
+      new DeobfuscationModule(module_context, context));
+  module_context->modules.emplace_back(
+      new SystemProbesModule(module_context, context));
+  module_context->modules.emplace_back(
+      new TranslationTableModule(module_context, context));
+  module_context->modules.emplace_back(
+      new StatsdModule(module_context, context));
+  module_context->modules.emplace_back(
+      new AndroidCameraEventModule(module_context, context));
+  module_context->modules.emplace_back(
+      new MetadataModule(module_context, context));
+  module_context->modules.emplace_back(new V8Module(module_context, context));
+  module_context->modules.emplace_back(
+      new PixelModemModule(module_context, context));
+  module_context->modules.emplace_back(
+      new ProfileModule(module_context, context));
+  module_context->modules.emplace_back(
+      new AppWakelockModule(module_context, context));
+  module_context->modules.emplace_back(
+      new GenericKernelModule(module_context, context));
 
 #if PERFETTO_BUILDFLAG(PERFETTO_ENABLE_WINSCOPE)
-  context->modules.emplace_back(new WinscopeModule(context));
+  module_context->modules.emplace_back(
+      new WinscopeModule(module_context, context));
 #endif
 
   // Ftrace/Etw modules are special, because it has one extra method for parsing
   // ftrace/etw packets. So we need to store a pointer to it separately.
-  context->modules.emplace_back(new FtraceModuleImpl(context));
-  context->ftrace_module =
-      static_cast<FtraceModule*>(context->modules.back().get());
-  context->modules.emplace_back(new EtwModuleImpl(context));
-  context->etw_module = static_cast<EtwModule*>(context->modules.back().get());
-
-  if (context->multi_machine_trace_manager) {
-    context->multi_machine_trace_manager->EnableAdditionalModules(
-        RegisterAdditionalModules);
-  }
+  module_context->modules.emplace_back(
+      new FtraceModuleImpl(module_context, context));
+  module_context->ftrace_module =
+      static_cast<FtraceModule*>(module_context->modules.back().get());
+  module_context->modules.emplace_back(
+      new EtwModuleImpl(module_context, context));
+  module_context->etw_module =
+      static_cast<EtwModule*>(module_context->modules.back().get());
 
   if (context->config.analyze_trace_proto_content) {
     context->content_analyzer = std::make_unique<ProtoContentAnalyzer>(context);

--- a/src/trace_processor/importers/proto/additional_modules.h
+++ b/src/trace_processor/importers/proto/additional_modules.h
@@ -19,12 +19,13 @@
 
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
-void RegisterAdditionalModules(TraceProcessorContext*);
+struct ProtoImporterModuleContext;
 
-}  // namespace trace_processor
-}  // namespace perfetto
+void RegisterAdditionalModules(ProtoImporterModuleContext*,
+                               TraceProcessorContext*);
+
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_ADDITIONAL_MODULES_H_

--- a/src/trace_processor/importers/proto/android_camera_event_module.cc
+++ b/src/trace_processor/importers/proto/android_camera_event_module.cc
@@ -40,9 +40,10 @@ namespace perfetto::trace_processor {
 using perfetto::protos::pbzero::TracePacket;
 
 AndroidCameraEventModule::AndroidCameraEventModule(
+    ProtoImporterModuleContext* module_context,
     TraceProcessorContext* context)
-    : context_(context) {
-  RegisterForField(TracePacket::kAndroidCameraFrameEventFieldNumber, context);
+    : ProtoImporterModule(module_context), context_(context) {
+  RegisterForField(TracePacket::kAndroidCameraFrameEventFieldNumber);
 }
 
 AndroidCameraEventModule::~AndroidCameraEventModule() = default;

--- a/src/trace_processor/importers/proto/android_camera_event_module.h
+++ b/src/trace_processor/importers/proto/android_camera_event_module.h
@@ -18,24 +18,21 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_ANDROID_CAMERA_EVENT_MODULE_H_
 
 #include <cstdint>
-#include <optional>
-#include <unordered_map>
 
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
-#include "src/trace_processor/tables/sched_tables_py.h"
-#include "src/trace_processor/tables/slice_tables_py.h"
-#include "src/trace_processor/tables/track_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class AndroidCameraEventModule : public ProtoImporterModule {
  public:
-  explicit AndroidCameraEventModule(TraceProcessorContext* context);
+  explicit AndroidCameraEventModule(ProtoImporterModuleContext* module_context,
+                                    TraceProcessorContext* context);
 
   ~AndroidCameraEventModule() override;
 
@@ -57,7 +54,6 @@ class AndroidCameraEventModule : public ProtoImporterModule {
   TraceProcessorContext* context_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_ANDROID_CAMERA_EVENT_MODULE_H_

--- a/src/trace_processor/importers/proto/android_kernel_wakelocks_module.cc
+++ b/src/trace_processor/importers/proto/android_kernel_wakelocks_module.cc
@@ -42,12 +42,14 @@ namespace perfetto::trace_processor {
 using perfetto::protos::pbzero::TracePacket;
 
 AndroidKernelWakelocksModule::AndroidKernelWakelocksModule(
+    ProtoImporterModuleContext* module_context,
     TraceProcessorContext* context)
-    : context_(context),
+    : ProtoImporterModule(module_context),
+      context_(context),
       kernel_name_id_(context->storage->InternString("kernel")),
       native_name_id_(context->storage->InternString("native")),
       unknown_name_id_(context->storage->InternString("unknown")) {
-  RegisterForField(TracePacket::kKernelWakelockDataFieldNumber, context);
+  RegisterForField(TracePacket::kKernelWakelockDataFieldNumber);
 }
 
 AndroidKernelWakelocksModule::~AndroidKernelWakelocksModule() = default;

--- a/src/trace_processor/importers/proto/android_kernel_wakelocks_module.h
+++ b/src/trace_processor/importers/proto/android_kernel_wakelocks_module.h
@@ -34,7 +34,9 @@ struct KernelWakelockLastValue;
 
 class AndroidKernelWakelocksModule : public ProtoImporterModule {
  public:
-  explicit AndroidKernelWakelocksModule(TraceProcessorContext* context);
+  explicit AndroidKernelWakelocksModule(
+      ProtoImporterModuleContext* module_context,
+      TraceProcessorContext* context);
 
   ~AndroidKernelWakelocksModule() override;
 

--- a/src/trace_processor/importers/proto/android_probes_module.cc
+++ b/src/trace_processor/importers/proto/android_probes_module.cc
@@ -20,7 +20,6 @@
 #include <cstdint>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/string_utils.h"
@@ -46,7 +45,6 @@
 
 #include "protos/perfetto/common/android_energy_consumer_descriptor.pbzero.h"
 #include "protos/perfetto/config/trace_config.pbzero.h"
-#include "protos/perfetto/trace/android/bluetooth_trace.pbzero.h"
 #include "protos/perfetto/trace/android/packages_list.pbzero.h"
 #include "protos/perfetto/trace/power/android_energy_estimation_breakdown.pbzero.h"
 #include "protos/perfetto/trace/power/android_entity_state_residency.pbzero.h"
@@ -124,24 +122,25 @@ const char* MapToFriendlyPowerRailName(base::StringView raw) {
 
 using perfetto::protos::pbzero::TracePacket;
 
-AndroidProbesModule::AndroidProbesModule(TraceProcessorContext* context)
-    : parser_(context),
+AndroidProbesModule::AndroidProbesModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context),
+      parser_(context),
       context_(context),
       power_rail_raw_name_id_(context->storage->InternString("raw_name")),
       power_rail_subsys_name_arg_id_(
           context->storage->InternString("subsystem_name")) {
-  RegisterForField(TracePacket::kBatteryFieldNumber, context);
-  RegisterForField(TracePacket::kPowerRailsFieldNumber, context);
-  RegisterForField(TracePacket::kAndroidEnergyEstimationBreakdownFieldNumber,
-                   context);
-  RegisterForField(TracePacket::kEntityStateResidencyFieldNumber, context);
-  RegisterForField(TracePacket::kAndroidLogFieldNumber, context);
-  RegisterForField(TracePacket::kPackagesListFieldNumber, context);
-  RegisterForField(TracePacket::kAndroidGameInterventionListFieldNumber,
-                   context);
-  RegisterForField(TracePacket::kInitialDisplayStateFieldNumber, context);
-  RegisterForField(TracePacket::kAndroidSystemPropertyFieldNumber, context);
-  RegisterForField(TracePacket::kBluetoothTraceEventFieldNumber, context);
+  RegisterForField(TracePacket::kBatteryFieldNumber);
+  RegisterForField(TracePacket::kPowerRailsFieldNumber);
+  RegisterForField(TracePacket::kAndroidEnergyEstimationBreakdownFieldNumber);
+  RegisterForField(TracePacket::kEntityStateResidencyFieldNumber);
+  RegisterForField(TracePacket::kAndroidLogFieldNumber);
+  RegisterForField(TracePacket::kPackagesListFieldNumber);
+  RegisterForField(TracePacket::kAndroidGameInterventionListFieldNumber);
+  RegisterForField(TracePacket::kInitialDisplayStateFieldNumber);
+  RegisterForField(TracePacket::kAndroidSystemPropertyFieldNumber);
+  RegisterForField(TracePacket::kBluetoothTraceEventFieldNumber);
 }
 
 ModuleResult AndroidProbesModule::TokenizePacket(
@@ -246,10 +245,9 @@ ModuleResult AndroidProbesModule::TokenizePacket(
     energy->set_index(data.index());
     energy->set_timestamp_ms(static_cast<uint64_t>(actual_ts / 1000000));
 
-    std::vector<uint8_t> vec = data_packet.SerializeAsArray();
-    TraceBlob blob = TraceBlob::CopyFrom(vec.data(), vec.size());
-    context_->sorter->PushTracePacket(actual_ts, state,
-                                      TraceBlobView(std::move(blob)),
+    auto [vec, size] = data_packet.SerializeAsUniquePtr();
+    TraceBlobView tbv(TraceBlob::TakeOwnership(std::move(vec), size));
+    context_->sorter->PushTracePacket(actual_ts, state, std::move(tbv),
                                       context_->machine_id());
   }
   return ModuleResult::Handled();
@@ -343,8 +341,7 @@ ModuleResult AndroidProbesModule::ParseAndroidPackagesList(
     context_->storage->mutable_package_list_table()->Insert(
         {context_->storage->InternString(pkg.name()),
          static_cast<int64_t>(pkg.uid()), pkg.debuggable(),
-         pkg.profileable_from_shell(),
-         static_cast<int64_t>(pkg.version_code())});
+         pkg.profileable_from_shell(), pkg.version_code()});
     tracker->InsertedPackage(std::move(pkg_name));
   }
   return ModuleResult::Handled();

--- a/src/trace_processor/importers/proto/android_probes_module.h
+++ b/src/trace_processor/importers/proto/android_probes_module.h
@@ -17,20 +17,25 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_ANDROID_PROBES_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_ANDROID_PROBES_MODULE_H_
 
-#include "perfetto/base/build_config.h"
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/android_probes_parser.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/config/trace_config.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/storage/trace_storage.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class AndroidProbesModule : public ProtoImporterModule {
  public:
-  explicit AndroidProbesModule(TraceProcessorContext* context);
+  explicit AndroidProbesModule(ProtoImporterModuleContext* module_context,
+                               TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(const protos::pbzero::TracePacket_Decoder&,
                               TraceBlobView* packet,
@@ -57,7 +62,6 @@ class AndroidProbesModule : public ProtoImporterModule {
   const StringId power_rail_subsys_name_arg_id_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_ANDROID_PROBES_MODULE_H_

--- a/src/trace_processor/importers/proto/app_wakelock_module.cc
+++ b/src/trace_processor/importers/proto/app_wakelock_module.cc
@@ -16,13 +16,21 @@
 
 #include "src/trace_processor/importers/proto/app_wakelock_module.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "perfetto/ext/base/fnv_hash.h"
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "protos/perfetto/trace/android/app_wakelock_data.pbzero.h"
 #include "protos/perfetto/trace/interned_data/interned_data.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/slice_tracker.h"
 #include "src/trace_processor/importers/common/track_compressor.h"
-#include "src/trace_processor/importers/common/track_tracker.h"
 #include "src/trace_processor/importers/common/tracks.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
@@ -38,13 +46,15 @@ using ::perfetto::protos::pbzero::AppWakelockInfo;
 using ::perfetto::protos::pbzero::TracePacket;
 using ::protozero::ConstBytes;
 
-AppWakelockModule::AppWakelockModule(TraceProcessorContext* context)
-    : context_(context),
+AppWakelockModule::AppWakelockModule(ProtoImporterModuleContext* module_context,
+                                     TraceProcessorContext* context)
+    : ProtoImporterModule(module_context),
+      context_(context),
       arg_flags_(context->storage->InternString("flags")),
       arg_owner_pid_(context->storage->InternString("owner_pid")),
       arg_owner_uid_(context->storage->InternString("owner_uid")),
       arg_work_uid_(context->storage->InternString("work_uid")) {
-  RegisterForField(TracePacket::kAppWakelockBundleFieldNumber, context);
+  RegisterForField(TracePacket::kAppWakelockBundleFieldNumber);
 }
 
 ModuleResult AppWakelockModule::TokenizePacket(
@@ -149,11 +159,10 @@ void AppWakelockModule::ParseWakelockBundle(int64_t ts, ConstBytes blob) {
 void AppWakelockModule::PushPacketBufferForSort(
     int64_t timestamp,
     RefPtr<PacketSequenceStateGeneration> state) {
-  std::pair<std::unique_ptr<uint8_t[]>, size_t> v =
-      packet_buffer_.SerializeAsUniquePtr();
-  context_->sorter->PushTracePacket(
-      timestamp, std::move(state),
-      TraceBlobView(TraceBlob::TakeOwnership(std::move(v.first), v.second)));
+  auto [vec, size] = packet_buffer_.SerializeAsUniquePtr();
+  TraceBlobView tbv(TraceBlob::TakeOwnership(std::move(vec), size));
+  context_->sorter->PushTracePacket(timestamp, std::move(state),
+                                    std::move(tbv));
   packet_buffer_.Reset();
 }
 

--- a/src/trace_processor/importers/proto/app_wakelock_module.h
+++ b/src/trace_processor/importers/proto/app_wakelock_module.h
@@ -17,7 +17,11 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_APP_WAKELOCK_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_APP_WAKELOCK_MODULE_H_
 
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
@@ -29,7 +33,8 @@ namespace perfetto::trace_processor {
 
 class AppWakelockModule : public ProtoImporterModule {
  public:
-  explicit AppWakelockModule(TraceProcessorContext* context);
+  explicit AppWakelockModule(ProtoImporterModuleContext* module_context,
+                             TraceProcessorContext* context);
   ~AppWakelockModule() override = default;
 
   // Tokenize and de-intern WakelockBundles so that bundles of multiple

--- a/src/trace_processor/importers/proto/chrome_system_probes_module.cc
+++ b/src/trace_processor/importers/proto/chrome_system_probes_module.cc
@@ -15,20 +15,23 @@
  */
 
 #include "src/trace_processor/importers/proto/chrome_system_probes_module.h"
-#include "perfetto/base/build_config.h"
+#include <cstdint>
+
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/chrome_system_probes_parser.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
 ChromeSystemProbesModule::ChromeSystemProbesModule(
+    ProtoImporterModuleContext* module_context,
     TraceProcessorContext* context)
-    : parser_(context) {
-  RegisterForField(TracePacket::kProcessStatsFieldNumber, context);
+    : ProtoImporterModule(module_context), parser_(context) {
+  RegisterForField(TracePacket::kProcessStatsFieldNumber);
 }
 
 void ChromeSystemProbesModule::ParseTracePacketData(
@@ -43,5 +46,4 @@ void ChromeSystemProbesModule::ParseTracePacketData(
   }
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/chrome_system_probes_module.h
+++ b/src/trace_processor/importers/proto/chrome_system_probes_module.h
@@ -17,20 +17,22 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_CHROME_SYSTEM_PROBES_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_CHROME_SYSTEM_PROBES_MODULE_H_
 
-#include "perfetto/base/build_config.h"
+#include <cstdint>
+
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/chrome_system_probes_parser.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 // Parses only the Chrome recorded system stats fields. This is separated from
 // SystemProbesModule due to the binary size impact of the system probes parser.
 class ChromeSystemProbesModule : public ProtoImporterModule {
  public:
-  explicit ChromeSystemProbesModule(TraceProcessorContext* context);
+  explicit ChromeSystemProbesModule(ProtoImporterModuleContext* module_context,
+                                    TraceProcessorContext* context);
 
   void ParseTracePacketData(const protos::pbzero::TracePacket_Decoder& decoder,
                             int64_t ts,
@@ -41,7 +43,6 @@ class ChromeSystemProbesModule : public ProtoImporterModule {
   ChromeSystemProbesParser parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_CHROME_SYSTEM_PROBES_MODULE_H_

--- a/src/trace_processor/importers/proto/default_modules.cc
+++ b/src/trace_processor/importers/proto/default_modules.cc
@@ -15,6 +15,7 @@
  */
 
 #include "src/trace_processor/importers/proto/default_modules.h"
+
 #include "src/trace_processor/importers/etw/etw_module.h"
 #include "src/trace_processor/importers/ftrace/ftrace_module.h"
 #include "src/trace_processor/importers/proto/chrome_system_probes_module.h"
@@ -23,27 +24,31 @@
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/track_event_module.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
-void RegisterDefaultModules(TraceProcessorContext* context) {
+void RegisterDefaultModules(ProtoImporterModuleContext* module_context,
+                            TraceProcessorContext* context) {
   // Ftrace and Etw modules are special, because they have an extra method for
   // parsing the ftrace/etw packets. So we need to store a pointer to it
   // separately.
-  context->modules.emplace_back(new FtraceModule());
-  context->ftrace_module =
-      static_cast<FtraceModule*>(context->modules.back().get());
-  context->modules.emplace_back(new EtwModule());
-  context->etw_module = static_cast<EtwModule*>(context->modules.back().get());
+  module_context->modules.emplace_back(new FtraceModule(module_context));
+  module_context->ftrace_module =
+      static_cast<FtraceModule*>(module_context->modules.back().get());
+  module_context->modules.emplace_back(new EtwModule(module_context));
+  module_context->etw_module =
+      static_cast<EtwModule*>(module_context->modules.back().get());
 
-  context->modules.emplace_back(new TrackEventModule(context));
-  context->track_module =
-      static_cast<TrackEventModule*>(context->modules.back().get());
+  module_context->modules.emplace_back(
+      new TrackEventModule(module_context, context));
+  module_context->track_module =
+      static_cast<TrackEventModule*>(module_context->modules.back().get());
 
-  context->modules.emplace_back(new MemoryTrackerSnapshotModule(context));
-  context->modules.emplace_back(new ChromeSystemProbesModule(context));
-  context->modules.emplace_back(new MetadataMinimalModule(context));
+  module_context->modules.emplace_back(
+      new MemoryTrackerSnapshotModule(module_context, context));
+  module_context->modules.emplace_back(
+      new ChromeSystemProbesModule(module_context, context));
+  module_context->modules.emplace_back(
+      new MetadataMinimalModule(module_context, context));
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/default_modules.h
+++ b/src/trace_processor/importers/proto/default_modules.h
@@ -19,12 +19,13 @@
 
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
-void RegisterDefaultModules(TraceProcessorContext*);
+struct ProtoImporterModuleContext;
 
-}  // namespace trace_processor
-}  // namespace perfetto
+void RegisterDefaultModules(ProtoImporterModuleContext*,
+                            TraceProcessorContext*);
+
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEFAULT_MODULES_H_

--- a/src/trace_processor/importers/proto/deobfuscation_module.cc
+++ b/src/trace_processor/importers/proto/deobfuscation_module.cc
@@ -16,13 +16,27 @@
 
 #include "src/trace_processor/importers/proto/deobfuscation_module.h"
 
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/string_view.h"
 #include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/trace_blob.h"
 #include "protos/perfetto/trace/profiling/deobfuscation.pbzero.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/args_translation_table.h"
 #include "src/trace_processor/importers/common/deobfuscation_mapping_table.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/importers/proto/heap_graph_tracker.h"
 #include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/metadata_tables_py.h"
+#include "src/trace_processor/tables/profiler_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/profiler_util.h"
 
@@ -31,9 +45,11 @@ namespace perfetto::trace_processor {
 using ::perfetto::protos::pbzero::TracePacket;
 using ::protozero::ConstBytes;
 
-DeobfuscationModule::DeobfuscationModule(TraceProcessorContext* context)
-    : context_(context) {
-  RegisterForField(TracePacket::kDeobfuscationMappingFieldNumber, context);
+DeobfuscationModule::DeobfuscationModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), context_(context) {
+  RegisterForField(TracePacket::kDeobfuscationMappingFieldNumber);
 }
 
 DeobfuscationModule::~DeobfuscationModule() = default;

--- a/src/trace_processor/importers/proto/deobfuscation_module.h
+++ b/src/trace_processor/importers/proto/deobfuscation_module.h
@@ -17,22 +17,29 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEOBFUSCATION_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEOBFUSCATION_MODULE_H_
 
+#include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/trace_blob.h"
 #include "protos/perfetto/trace/profiling/deobfuscation.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/heap_graph_tracker.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/tables/metadata_tables_py.h"
+#include "src/trace_processor/tables/profiler_tables_py.h"
 
 namespace perfetto::trace_processor {
 
 // Importer module for deobfuscation data.
 class DeobfuscationModule : public ProtoImporterModule {
  public:
-  explicit DeobfuscationModule(TraceProcessorContext* context);
+  explicit DeobfuscationModule(ProtoImporterModuleContext* module_context,
+                               TraceProcessorContext* context);
   ~DeobfuscationModule() override;
 
   // TODO (ddiproietto): Is it better to use TokenizePacket instead?

--- a/src/trace_processor/importers/proto/graphics_event_module.cc
+++ b/src/trace_processor/importers/proto/graphics_event_module.cc
@@ -15,25 +15,34 @@
  */
 
 #include "src/trace_processor/importers/proto/graphics_event_module.h"
-#include "src/trace_processor/importers/common/trace_parser.h"
+
+#include <cstdint>
+
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/types/trace_processor_context.h"
 
 namespace perfetto {
 namespace trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-GraphicsEventModule::GraphicsEventModule(TraceProcessorContext* context)
-    : parser_(context),
+GraphicsEventModule::GraphicsEventModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context),
+      parser_(context),
       frame_parser_(context),
       frame_timeline_parser_(context) {
-  RegisterForField(TracePacket::kFrameTimelineEventFieldNumber, context);
-  RegisterForField(TracePacket::kGpuCounterEventFieldNumber, context);
-  RegisterForField(TracePacket::kGpuRenderStageEventFieldNumber, context);
-  RegisterForField(TracePacket::kGpuLogFieldNumber, context);
-  RegisterForField(TracePacket::kGpuMemTotalEventFieldNumber, context);
-  RegisterForField(TracePacket::kGraphicsFrameEventFieldNumber, context);
-  RegisterForField(TracePacket::kVulkanMemoryEventFieldNumber, context);
-  RegisterForField(TracePacket::kVulkanApiEventFieldNumber, context);
+  RegisterForField(TracePacket::kFrameTimelineEventFieldNumber);
+  RegisterForField(TracePacket::kGpuCounterEventFieldNumber);
+  RegisterForField(TracePacket::kGpuRenderStageEventFieldNumber);
+  RegisterForField(TracePacket::kGpuLogFieldNumber);
+  RegisterForField(TracePacket::kGpuMemTotalEventFieldNumber);
+  RegisterForField(TracePacket::kGraphicsFrameEventFieldNumber);
+  RegisterForField(TracePacket::kVulkanMemoryEventFieldNumber);
+  RegisterForField(TracePacket::kVulkanApiEventFieldNumber);
 }
 
 GraphicsEventModule::~GraphicsEventModule() = default;

--- a/src/trace_processor/importers/proto/graphics_event_module.h
+++ b/src/trace_processor/importers/proto/graphics_event_module.h
@@ -18,7 +18,7 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_GRAPHICS_EVENT_MODULE_H_
 
 #include <cstdint>
-#include "perfetto/base/build_config.h"
+
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/frame_timeline_event_parser.h"
 #include "src/trace_processor/importers/proto/gpu_event_parser.h"
@@ -27,12 +27,12 @@
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class GraphicsEventModule : public ProtoImporterModule {
  public:
-  explicit GraphicsEventModule(TraceProcessorContext* context);
+  explicit GraphicsEventModule(ProtoImporterModuleContext* module_context,
+                               TraceProcessorContext* context);
 
   ~GraphicsEventModule() override;
 
@@ -47,7 +47,6 @@ class GraphicsEventModule : public ProtoImporterModule {
   FrameTimelineEventParser frame_timeline_parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_GRAPHICS_EVENT_MODULE_H_

--- a/src/trace_processor/importers/proto/heap_graph_module.cc
+++ b/src/trace_processor/importers/proto/heap_graph_module.cc
@@ -15,20 +15,27 @@
  */
 
 #include "src/trace_processor/importers/proto/heap_graph_module.h"
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <vector>
 
+#include "perfetto/protozero/field.h"
+#include "perfetto/protozero/proto_utils.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/proto/heap_graph_tracker.h"
+#include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/profiler_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
 #include "perfetto/ext/base/string_view.h"
-#include "protos/perfetto/trace/profiling/deobfuscation.pbzero.h"
 #include "protos/perfetto/trace/profiling/heap_graph.pbzero.h"
 #include "protos/perfetto/trace/profiling/profile_common.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 namespace {
 
@@ -62,9 +69,10 @@ bool ForEachVarInt(const T& decoder, F fn) {
 
 using perfetto::protos::pbzero::TracePacket;
 
-HeapGraphModule::HeapGraphModule(TraceProcessorContext* context)
-    : context_(context) {
-  RegisterForField(TracePacket::kHeapGraphFieldNumber, context);
+HeapGraphModule::HeapGraphModule(ProtoImporterModuleContext* module_context,
+                                 TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), context_(context) {
+  RegisterForField(TracePacket::kHeapGraphFieldNumber);
 }
 
 void HeapGraphModule::ParseTracePacketData(
@@ -246,5 +254,4 @@ void HeapGraphModule::NotifyEndOfFile() {
   heap_graph_tracker->FinalizeAllProfiles();
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/heap_graph_module.h
+++ b/src/trace_processor/importers/proto/heap_graph_module.h
@@ -17,18 +17,21 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_HEAP_GRAPH_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_HEAP_GRAPH_MODULE_H_
 
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/heap_graph_tracker.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class HeapGraphModule : public ProtoImporterModule {
  public:
-  explicit HeapGraphModule(TraceProcessorContext* context);
+  explicit HeapGraphModule(ProtoImporterModuleContext* module_context,
+                           TraceProcessorContext* context);
 
   void ParseTracePacketData(const protos::pbzero::TracePacket_Decoder& decoder,
                             int64_t ts,
@@ -43,7 +46,6 @@ class HeapGraphModule : public ProtoImporterModule {
   TraceProcessorContext* context_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_HEAP_GRAPH_MODULE_H_

--- a/src/trace_processor/importers/proto/memory_tracker_snapshot_module.cc
+++ b/src/trace_processor/importers/proto/memory_tracker_snapshot_module.cc
@@ -15,17 +15,23 @@
  */
 
 #include "src/trace_processor/importers/proto/memory_tracker_snapshot_module.h"
-#include "src/trace_processor/importers/common/parser_types.h"
 
-namespace perfetto {
-namespace trace_processor {
+#include <cstdint>
+
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+#include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
 MemoryTrackerSnapshotModule::MemoryTrackerSnapshotModule(
+    ProtoImporterModuleContext* module_context,
     TraceProcessorContext* context)
-    : parser_(context) {
-  RegisterForField(TracePacket::kMemoryTrackerSnapshotFieldNumber, context);
+    : ProtoImporterModule(module_context), parser_(context) {
+  RegisterForField(TracePacket::kMemoryTrackerSnapshotFieldNumber);
 }
 
 MemoryTrackerSnapshotModule::~MemoryTrackerSnapshotModule() = default;
@@ -46,5 +52,4 @@ void MemoryTrackerSnapshotModule::NotifyEndOfFile() {
   parser_.NotifyEndOfFile();
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/memory_tracker_snapshot_module.h
+++ b/src/trace_processor/importers/proto/memory_tracker_snapshot_module.h
@@ -17,17 +17,21 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_MEMORY_TRACKER_SNAPSHOT_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_MEMORY_TRACKER_SNAPSHOT_MODULE_H_
 
+#include <cstdint>
+
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/memory_tracker_snapshot_parser.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class MemoryTrackerSnapshotModule : public ProtoImporterModule {
  public:
-  explicit MemoryTrackerSnapshotModule(TraceProcessorContext* context);
+  explicit MemoryTrackerSnapshotModule(
+      ProtoImporterModuleContext* module_context,
+      TraceProcessorContext* context);
 
   ~MemoryTrackerSnapshotModule() override;
 
@@ -42,7 +46,6 @@ class MemoryTrackerSnapshotModule : public ProtoImporterModule {
   MemoryTrackerSnapshotParser parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_MEMORY_TRACKER_SNAPSHOT_MODULE_H_

--- a/src/trace_processor/importers/proto/metadata_minimal_module.cc
+++ b/src/trace_processor/importers/proto/metadata_minimal_module.cc
@@ -16,24 +16,36 @@
 
 #include "src/trace_processor/importers/proto/metadata_minimal_module.h"
 
+#include <cstdint>
+#include <string>
+
 #include "perfetto/ext/base/base64.h"
 #include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/base/string_view.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
+#include "src/trace_processor/storage/metadata.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/variadic.h"
 
 #include "protos/perfetto/trace/chrome/chrome_benchmark_metadata.pbzero.h"
 #include "protos/perfetto/trace/chrome/chrome_metadata.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-MetadataMinimalModule::MetadataMinimalModule(TraceProcessorContext* context)
-    : context_(context) {
-  RegisterForField(TracePacket::kChromeMetadataFieldNumber, context);
-  RegisterForField(TracePacket::kChromeBenchmarkMetadataFieldNumber, context);
+MetadataMinimalModule::MetadataMinimalModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), context_(context) {
+  RegisterForField(TracePacket::kChromeMetadataFieldNumber);
+  RegisterForField(TracePacket::kChromeBenchmarkMetadataFieldNumber);
 }
 
 ModuleResult MetadataMinimalModule::TokenizePacket(
@@ -193,5 +205,4 @@ void MetadataMinimalModule::ParseChromeMetadataPacket(ConstBytes blob) {
   }
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/metadata_minimal_module.h
+++ b/src/trace_processor/importers/proto/metadata_minimal_module.h
@@ -17,21 +17,22 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_METADATA_MINIMAL_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_METADATA_MINIMAL_MODULE_H_
 
-#include "src/trace_processor/importers/common/trace_parser.h"
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
-#include "src/trace_processor/storage/trace_storage.h"
-
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class MetadataMinimalModule : public ProtoImporterModule {
  public:
   using ConstBytes = protozero::ConstBytes;
-  explicit MetadataMinimalModule(TraceProcessorContext* context);
+  explicit MetadataMinimalModule(ProtoImporterModuleContext* module_context,
+                                 TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(
       const protos::pbzero::TracePacket::Decoder& decoder,
@@ -49,7 +50,6 @@ class MetadataMinimalModule : public ProtoImporterModule {
   uint32_t chrome_metadata_count_ = 0;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_METADATA_MINIMAL_MODULE_H_

--- a/src/trace_processor/importers/proto/metadata_module.cc
+++ b/src/trace_processor/importers/proto/metadata_module.cc
@@ -56,8 +56,10 @@ constexpr auto kTriggerTrackBlueprint =
 
 }  // namespace
 
-MetadataModule::MetadataModule(TraceProcessorContext* context)
-    : context_(context),
+MetadataModule::MetadataModule(ProtoImporterModuleContext* module_context,
+                               TraceProcessorContext* context)
+    : ProtoImporterModule(module_context),
+      context_(context),
       producer_name_key_id_(context_->storage->InternString("producer_name")),
       trusted_producer_uid_key_id_(
           context_->storage->InternString("trusted_producer_uid")),
@@ -65,11 +67,11 @@ MetadataModule::MetadataModule(TraceProcessorContext* context)
           context_->storage->InternString("chrome_trigger.name")),
       chrome_trigger_hash_id_(
           context_->storage->InternString("chrome_trigger.name_hash")) {
-  RegisterForField(TracePacket::kUiStateFieldNumber, context);
-  RegisterForField(TracePacket::kTriggerFieldNumber, context);
-  RegisterForField(TracePacket::kChromeTriggerFieldNumber, context);
-  RegisterForField(TracePacket::kCloneSnapshotTriggerFieldNumber, context);
-  RegisterForField(TracePacket::kTraceUuidFieldNumber, context);
+  RegisterForField(TracePacket::kUiStateFieldNumber);
+  RegisterForField(TracePacket::kTriggerFieldNumber);
+  RegisterForField(TracePacket::kChromeTriggerFieldNumber);
+  RegisterForField(TracePacket::kCloneSnapshotTriggerFieldNumber);
+  RegisterForField(TracePacket::kTraceUuidFieldNumber);
 }
 
 ModuleResult MetadataModule::TokenizePacket(

--- a/src/trace_processor/importers/proto/metadata_module.h
+++ b/src/trace_processor/importers/proto/metadata_module.h
@@ -17,20 +17,24 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_METADATA_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_METADATA_MODULE_H_
 
-#include "src/trace_processor/importers/common/trace_parser.h"
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
-
-#include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/storage/trace_storage.h"
 
-namespace perfetto {
-namespace trace_processor {
+#include "protos/perfetto/trace/trace_packet.pbzero.h"
+
+namespace perfetto::trace_processor {
 
 class MetadataModule : public ProtoImporterModule {
  public:
   using ConstBytes = protozero::ConstBytes;
-  explicit MetadataModule(TraceProcessorContext* context);
+  explicit MetadataModule(ProtoImporterModuleContext* module_context,
+                          TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(
       const protos::pbzero::TracePacket::Decoder& decoder,
@@ -67,7 +71,6 @@ class MetadataModule : public ProtoImporterModule {
   const StringId chrome_trigger_hash_id_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_METADATA_MODULE_H_

--- a/src/trace_processor/importers/proto/multi_machine_trace_manager.h
+++ b/src/trace_processor/importers/proto/multi_machine_trace_manager.h
@@ -17,15 +17,13 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_MULTI_MACHINE_TRACE_MANAGER_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_MULTI_MACHINE_TRACE_MANAGER_H_
 
+#include <cstdint>
 #include <memory>
-#include <vector>
 
 #include "perfetto/ext/base/flat_hash_map.h"
-#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class TraceProcessorContext;
 class ProtoTraceReader;
@@ -83,11 +81,8 @@ class MultiMachineTraceManager {
   // Owns contexts for remote machines.
   base::FlatHashMap<RawMachineId, RemoteMachineContext>
       remote_machine_contexts_;
-
-  ProtoImporterModuleFactory additional_modules_factory_ = nullptr;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_MULTI_MACHINE_TRACE_MANAGER_H_

--- a/src/trace_processor/importers/proto/network_trace_module.h
+++ b/src/trace_processor/importers/proto/network_trace_module.h
@@ -20,8 +20,9 @@
 #include <cstdint>
 
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/protozero/field.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
-#include "src/trace_processor/importers/common/args_tracker.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
@@ -31,12 +32,12 @@
 #include "protos/perfetto/trace/android/network_trace.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class NetworkTraceModule : public ProtoImporterModule {
  public:
-  explicit NetworkTraceModule(TraceProcessorContext* context);
+  explicit NetworkTraceModule(ProtoImporterModuleContext* module_context,
+                              TraceProcessorContext* context);
   ~NetworkTraceModule() override = default;
 
   // Tokenize and de-intern NetworkPacketBundles so that bundles of multiple
@@ -95,7 +96,6 @@ class NetworkTraceModule : public ProtoImporterModule {
   const StringId packet_count_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_NETWORK_TRACE_MODULE_H_

--- a/src/trace_processor/importers/proto/pixel_modem_module.cc
+++ b/src/trace_processor/importers/proto/pixel_modem_module.cc
@@ -16,29 +16,34 @@
 
 #include "src/trace_processor/importers/proto/pixel_modem_module.h"
 
-#include "perfetto/base/build_config.h"
-#include "perfetto/ext/base/string_writer.h"
-#include "perfetto/protozero/scattered_heap_buffer.h"
-#include "src/trace_processor/importers/common/machine_tracker.h"
-#include "src/trace_processor/importers/common/track_tracker.h"
+#include <cstdint>
+#include <utility>
 
+#include "perfetto/base/status.h"
+#include "perfetto/protozero/field.h"
+#include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "perfetto/trace_processor/trace_blob.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/pixel_modem_parser.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
+#include "src/trace_processor/storage/stats.h"
 
-#include "protos/perfetto/common/android_energy_consumer_descriptor.pbzero.h"
 #include "protos/perfetto/trace/android/pixel_modem_events.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-PixelModemModule::PixelModemModule(TraceProcessorContext* context)
-    : context_(context), parser_(context) {
-  RegisterForField(TracePacket::kPixelModemEventsFieldNumber, context);
-  RegisterForField(TracePacket::kPixelModemTokenDatabaseFieldNumber, context);
+PixelModemModule::PixelModemModule(ProtoImporterModuleContext* module_context,
+                                   TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), context_(context), parser_(context) {
+  RegisterForField(TracePacket::kPixelModemEventsFieldNumber);
+  RegisterForField(TracePacket::kPixelModemTokenDatabaseFieldNumber);
 }
 
 ModuleResult PixelModemModule::TokenizePacket(
@@ -56,9 +61,8 @@ ModuleResult PixelModemModule::TokenizePacket(
     base::Status status = parser_.SetDatabase(database.database());
     if (status.ok()) {
       return ModuleResult::Handled();
-    } else {
-      return ModuleResult::Error(status.message());
     }
+    return ModuleResult::Error(status.message());
   }
 
   if (field_id != TracePacket::kPixelModemEventsFieldNumber) {
@@ -93,9 +97,9 @@ ModuleResult PixelModemModule::TokenizePacket(
     // not read this.
     data_packet->set_timestamp(static_cast<uint64_t>(packet_timestamp));
     data_packet->set_pixel_modem_events()->add_events(event_bytes);
-    std::vector<uint8_t> vec = data_packet.SerializeAsArray();
-    TraceBlob blob = TraceBlob::CopyFrom(vec.data(), vec.size());
-    context_->sorter->PushTracePacket(ts, state, TraceBlobView(std::move(blob)),
+    auto [vec, size] = data_packet.SerializeAsUniquePtr();
+    TraceBlobView tbv(TraceBlob::TakeOwnership(std::move(vec), size));
+    context_->sorter->PushTracePacket(ts, state, std::move(tbv),
                                       context_->machine_id());
   }
 
@@ -118,5 +122,4 @@ void PixelModemModule::ParseTracePacketData(const TracePacket::Decoder& decoder,
   parser_.ParseEvent(ts, decoder.timestamp(), *it);
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/pixel_modem_module.h
+++ b/src/trace_processor/importers/proto/pixel_modem_module.h
@@ -17,19 +17,22 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_PIXEL_MODEM_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_PIXEL_MODEM_MODULE_H_
 
+#include <cstdint>
+
+#include "perfetto/trace_processor/ref_counted.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/pixel_modem_parser.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
-#include "protos/perfetto/config/trace_config.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class PixelModemModule : public ProtoImporterModule {
  public:
-  explicit PixelModemModule(TraceProcessorContext* context);
+  explicit PixelModemModule(ProtoImporterModuleContext* module_context,
+                            TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(const protos::pbzero::TracePacket_Decoder&,
                               TraceBlobView* packet,
@@ -47,7 +50,6 @@ class PixelModemModule : public ProtoImporterModule {
   PixelModemParser parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_PIXEL_MODEM_MODULE_H_

--- a/src/trace_processor/importers/proto/profile_module.h
+++ b/src/trace_processor/importers/proto/profile_module.h
@@ -17,20 +17,23 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_PROFILE_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_PROFILE_MODULE_H_
 
+#include <cstdint>
 #include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 // Importer module for heap and CPU sampling profile data.
 // TODO(eseckler): consider moving heap profiles here as well.
 class ProfileModule : public ProtoImporterModule {
  public:
-  explicit ProfileModule(TraceProcessorContext* context);
+  explicit ProfileModule(ProtoImporterModuleContext* module_context,
+                         TraceProcessorContext* context);
   ~ProfileModule() override;
 
   ModuleResult TokenizePacket(
@@ -73,7 +76,6 @@ class ProfileModule : public ProtoImporterModule {
   TraceProcessorContext* context_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_PROFILE_MODULE_H_

--- a/src/trace_processor/importers/proto/proto_importer_module.cc
+++ b/src/trace_processor/importers/proto/proto_importer_module.cc
@@ -16,14 +16,21 @@
 
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+#include "perfetto/public/compiler.h"
 #include "perfetto/trace_processor/ref_counted.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
-ProtoImporterModule::ProtoImporterModule() {}
+ProtoImporterModule::ProtoImporterModule(
+    ProtoImporterModuleContext* module_context)
+    : module_context_(module_context) {}
 
 ProtoImporterModule::~ProtoImporterModule() {}
 
@@ -45,17 +52,11 @@ void ProtoImporterModule::ParseTracePacketData(
 void ProtoImporterModule::ParseTraceConfig(
     const protos::pbzero::TraceConfig_Decoder&) {}
 
-void ProtoImporterModule::RegisterForField(uint32_t field_id,
-                                           TraceProcessorContext* context) {
-  if (context->modules_by_field.size() <= field_id) {
-    context->modules_by_field.resize(field_id + 1);
+void ProtoImporterModule::RegisterForField(uint32_t field_id) {
+  if (module_context_->modules_by_field.size() <= field_id) {
+    module_context_->modules_by_field.resize(field_id + 1);
   }
-  context->modules_by_field[field_id].push_back(this);
+  module_context_->modules_by_field[field_id].push_back(this);
 }
 
-void ProtoImporterModule::RegisterForAllFields(TraceProcessorContext* context) {
-  context->modules_for_all_fields.push_back(this);
-}
-
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/proto_importer_module.h
+++ b/src/trace_processor/importers/proto/proto_importer_module.h
@@ -153,6 +153,9 @@ class ProtoImporterModule {
   ProtoImporterModuleContext* module_context_;
 };
 
+// Contains the common state for all proto modules and the proto parser.
+//
+// Used to store per-trace state in a place where everyone can access it.
 struct ProtoImporterModuleContext {
   // The module at the index N is registered to handle field id N in
   // TracePacket.

--- a/src/trace_processor/importers/proto/proto_importer_module.h
+++ b/src/trace_processor/importers/proto/proto_importer_module.h
@@ -18,8 +18,10 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_PROTO_IMPORTER_MODULE_H_
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
@@ -36,6 +38,9 @@ class TracePacket_Decoder;
 
 namespace trace_processor {
 
+class EtwModule;
+class FtraceModule;
+class TrackEventModule;
 class TraceBlobView;
 class TraceProcessorContext;
 
@@ -94,10 +99,12 @@ class ModuleResult {
   std::optional<std::string> error_;
 };
 
+struct ProtoImporterModuleContext;
+
 // Base class for modules.
 class ProtoImporterModule {
  public:
-  ProtoImporterModule();
+  explicit ProtoImporterModule(ProtoImporterModuleContext* module_context);
 
   virtual ~ProtoImporterModule();
 
@@ -141,11 +148,19 @@ class ProtoImporterModule {
   virtual void NotifyEndOfFile() {}
 
  protected:
-  void RegisterForField(uint32_t field_id, TraceProcessorContext*);
-  // Primarily intended for special modules that need to get all TracePacket's,
-  // for example for trace proto content analysis. Most modules need to register
-  // for specific fields using the method above.
-  void RegisterForAllFields(TraceProcessorContext*);
+  void RegisterForField(uint32_t field_id);
+
+  ProtoImporterModuleContext* module_context_;
+};
+
+struct ProtoImporterModuleContext {
+  // The module at the index N is registered to handle field id N in
+  // TracePacket.
+  std::vector<std::vector<ProtoImporterModule*>> modules_by_field;
+  std::vector<std::unique_ptr<ProtoImporterModule>> modules;
+  FtraceModule* ftrace_module = nullptr;
+  EtwModule* etw_module = nullptr;
+  TrackEventModule* track_module = nullptr;
 };
 
 }  // namespace trace_processor

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.h
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.h
@@ -23,6 +23,7 @@
 #include "perfetto/protozero/field.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/trace_parser.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/storage/trace_storage.h"
 
 namespace perfetto {
@@ -39,7 +40,7 @@ class TraceProcessorContext;
 class ProtoTraceParserImpl : public ProtoTraceParser {
  public:
   using ConstBytes = protozero::ConstBytes;
-  explicit ProtoTraceParserImpl(TraceProcessorContext*);
+  ProtoTraceParserImpl(TraceProcessorContext*, ProtoImporterModuleContext*);
   ~ProtoTraceParserImpl() override;
 
   void ParseTrackEvent(int64_t ts, TrackEventData data) override;
@@ -68,6 +69,7 @@ class ProtoTraceParserImpl : public ProtoTraceParser {
   void ParseMetatraceEvent(int64_t ts, ConstBytes);
 
   TraceProcessorContext* context_;
+  ProtoImporterModuleContext* module_context_ = nullptr;
 
   const StringId metatrace_id_;
   const StringId data_name_id_;

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -28,6 +29,7 @@
 #include "src/trace_processor/importers/common/chunked_trace_reader.h"
 #include "src/trace_processor/importers/proto/multi_machine_trace_manager.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_builder.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/proto_trace_tokenizer.h"
 #include "src/trace_processor/storage/trace_storage.h"
 
@@ -45,6 +47,7 @@ class TraceConfig_Decoder;
 namespace trace_processor {
 
 class PacketSequenceState;
+class ProtoTraceParserImpl;
 class TraceProcessorContext;
 class TraceSorter;
 class TraceStorage;
@@ -114,7 +117,6 @@ class ProtoTraceReader : public ChunkedTraceReader {
   base::Status ParseExtensionDescriptor(ConstBytes descriptor);
 
   TraceProcessorContext* context_;
-
   ProtoTraceTokenizer tokenizer_;
 
   // Temporary. Currently trace packets do not have a timestamp, so the

--- a/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
@@ -15,14 +15,23 @@
  */
 
 #include "src/trace_processor/importers/proto/proto_trace_reader.h"
-#include <memory>
 
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/status.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
+#include "perfetto/trace_processor/trace_blob.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
 #include "protos/perfetto/common/builtin_clock.pbzero.h"
+#include "protos/perfetto/trace/trace.pbzero.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
+#include "src/trace_processor/importers/proto/additional_modules.h"
 #include "src/trace_processor/storage/trace_storage.h"
-
 #include "test/gtest_and_gmock.h"
 
 #include "protos/perfetto/trace/clock_snapshot.pbzero.h"
@@ -41,6 +50,7 @@ class ProtoTraceReaderTest : public ::testing::Test {
     context_.machine_tracker =
         std::make_unique<MachineTracker>(&context_, 0x1001);
     context_.clock_tracker = std::make_unique<ClockTracker>(&context_);
+    context_.register_additional_proto_modules = &RegisterAdditionalModules;
     proto_trace_reader_ = std::make_unique<ProtoTraceReader>(&context_);
   }
 

--- a/src/trace_processor/importers/proto/statsd_module.h
+++ b/src/trace_processor/importers/proto/statsd_module.h
@@ -25,7 +25,6 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/trace_processor/ref_counted.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
-#include "src/trace_processor/importers/common/trace_parser.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/storage/trace_storage.h"
@@ -37,7 +36,8 @@ namespace perfetto::trace_processor {
 
 class StatsdModule : public ProtoImporterModule {
  public:
-  explicit StatsdModule(TraceProcessorContext* context);
+  explicit StatsdModule(ProtoImporterModuleContext* module_context,
+                        TraceProcessorContext* context);
 
   ~StatsdModule() override;
 

--- a/src/trace_processor/importers/proto/system_probes_module.cc
+++ b/src/trace_processor/importers/proto/system_probes_module.cc
@@ -15,24 +15,31 @@
  */
 
 #include "src/trace_processor/importers/proto/system_probes_module.h"
-#include "perfetto/base/build_config.h"
+
+#include <cstdint>
+
+#include "perfetto/trace_processor/ref_counted.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/system_probes_parser.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-SystemProbesModule::SystemProbesModule(TraceProcessorContext* context)
-    : parser_(context) {
-  RegisterForField(TracePacket::kProcessTreeFieldNumber, context);
-  RegisterForField(TracePacket::kProcessStatsFieldNumber, context);
-  RegisterForField(TracePacket::kSysStatsFieldNumber, context);
-  RegisterForField(TracePacket::kSystemInfoFieldNumber, context);
-  RegisterForField(TracePacket::kCpuInfoFieldNumber, context);
+SystemProbesModule::SystemProbesModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), parser_(context) {
+  RegisterForField(TracePacket::kProcessTreeFieldNumber);
+  RegisterForField(TracePacket::kProcessStatsFieldNumber);
+  RegisterForField(TracePacket::kSysStatsFieldNumber);
+  RegisterForField(TracePacket::kSystemInfoFieldNumber);
+  RegisterForField(TracePacket::kCpuInfoFieldNumber);
 }
 
 ModuleResult SystemProbesModule::TokenizePacket(
@@ -70,5 +77,4 @@ void SystemProbesModule::ParseTracePacketData(
   }
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/system_probes_module.h
+++ b/src/trace_processor/importers/proto/system_probes_module.h
@@ -17,20 +17,22 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_SYSTEM_PROBES_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_SYSTEM_PROBES_MODULE_H_
 
-#include "perfetto/base/build_config.h"
-#include "src/trace_processor/importers/common/trace_parser.h"
+#include <cstdint>
+
+#include "perfetto/trace_processor/ref_counted.h"
+#include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/system_probes_parser.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class SystemProbesModule : public ProtoImporterModule {
  public:
-  explicit SystemProbesModule(TraceProcessorContext* context);
+  explicit SystemProbesModule(ProtoImporterModuleContext* module_context,
+                              TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(const protos::pbzero::TracePacket::Decoder&,
                               TraceBlobView* packet,
@@ -47,7 +49,6 @@ class SystemProbesModule : public ProtoImporterModule {
   SystemProbesParser parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_SYSTEM_PROBES_MODULE_H_

--- a/src/trace_processor/importers/proto/track_event_module.cc
+++ b/src/trace_processor/importers/proto/track_event_module.cc
@@ -36,15 +36,17 @@ namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-TrackEventModule::TrackEventModule(TraceProcessorContext* context)
-    : track_event_tracker_(new TrackEventTracker(context)),
-      tokenizer_(context, track_event_tracker_.get()),
+TrackEventModule::TrackEventModule(ProtoImporterModuleContext* module_context,
+                                   TraceProcessorContext* context)
+    : ProtoImporterModule(module_context),
+      track_event_tracker_(new TrackEventTracker(context)),
+      tokenizer_(module_context, context, track_event_tracker_.get()),
       parser_(context, track_event_tracker_.get()) {
-  RegisterForField(TracePacket::kTrackEventRangeOfInterestFieldNumber, context);
-  RegisterForField(TracePacket::kTrackEventFieldNumber, context);
-  RegisterForField(TracePacket::kTrackDescriptorFieldNumber, context);
-  RegisterForField(TracePacket::kThreadDescriptorFieldNumber, context);
-  RegisterForField(TracePacket::kProcessDescriptorFieldNumber, context);
+  RegisterForField(TracePacket::kTrackEventRangeOfInterestFieldNumber);
+  RegisterForField(TracePacket::kTrackEventFieldNumber);
+  RegisterForField(TracePacket::kTrackDescriptorFieldNumber);
+  RegisterForField(TracePacket::kThreadDescriptorFieldNumber);
+  RegisterForField(TracePacket::kProcessDescriptorFieldNumber);
 
   context->descriptor_pool_->AddFromFileDescriptorSet(
       kTrackEventDescriptor.data(), kTrackEventDescriptor.size());

--- a/src/trace_processor/importers/proto/track_event_module.h
+++ b/src/trace_processor/importers/proto/track_event_module.h
@@ -33,7 +33,8 @@ namespace perfetto::trace_processor {
 
 class TrackEventModule : public ProtoImporterModule {
  public:
-  explicit TrackEventModule(TraceProcessorContext* context);
+  explicit TrackEventModule(ProtoImporterModuleContext* module_context,
+                            TraceProcessorContext* context);
 
   ~TrackEventModule() override;
 

--- a/src/trace_processor/importers/proto/track_event_parser.h
+++ b/src/trace_processor/importers/proto/track_event_parser.h
@@ -23,7 +23,6 @@
 #include "perfetto/protozero/field.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/slice_tracker.h"
-#include "src/trace_processor/importers/common/trace_parser.h"
 #include "src/trace_processor/importers/proto/active_chrome_processes_tracker.h"
 #include "src/trace_processor/importers/proto/chrome_string_lookup.h"
 #include "src/trace_processor/storage/trace_storage.h"

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "perfetto/base/build_config.h"
+#include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_or.h"
@@ -62,22 +63,26 @@
 #include "src/trace_processor/types/variadic.h"
 
 namespace perfetto::trace_processor {
-
 namespace {
 using protos::pbzero::CounterDescriptor;
 }
 
-TrackEventTokenizer::TrackEventTokenizer(TraceProcessorContext* context,
-                                         TrackEventTracker* track_event_tracker)
+TrackEventTokenizer::TrackEventTokenizer(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context,
+    TrackEventTracker* track_event_tracker)
     : context_(context),
       track_event_tracker_(track_event_tracker),
+      module_context_(module_context),
       counter_name_thread_time_id_(
           context_->storage->InternString("thread_time")),
       counter_name_thread_instruction_count_id_(
           context_->storage->InternString("thread_instruction_count")),
       counter_unit_ids_{{kNullStringId, context_->storage->InternString("ns"),
                          context_->storage->InternString("count"),
-                         context_->storage->InternString("bytes")}} {}
+                         context_->storage->InternString("bytes")}} {
+  base::ignore_result(module_context_);
+}
 
 ModuleResult TrackEventTokenizer::TokenizeRangeOfInterestPacket(
     RefPtr<PacketSequenceStateGeneration> /*state*/,

--- a/src/trace_processor/importers/proto/track_event_tokenizer.h
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.h
@@ -48,7 +48,9 @@ struct TrackEventData;
 
 class TrackEventTokenizer {
  public:
-  explicit TrackEventTokenizer(TraceProcessorContext*, TrackEventTracker*);
+  explicit TrackEventTokenizer(ProtoImporterModuleContext*,
+                               TraceProcessorContext*,
+                               TrackEventTracker*);
 
   ModuleResult TokenizeRangeOfInterestPacket(
       RefPtr<PacketSequenceStateGeneration> state,
@@ -86,6 +88,7 @@ class TrackEventTokenizer {
 
   TraceProcessorContext* const context_;
   TrackEventTracker* const track_event_tracker_;
+  ProtoImporterModuleContext* const module_context_;
 
   const StringId counter_name_thread_time_id_;
   const StringId counter_name_thread_instruction_count_id_;

--- a/src/trace_processor/importers/proto/translation_table_module.cc
+++ b/src/trace_processor/importers/proto/translation_table_module.cc
@@ -15,22 +15,29 @@
  */
 #include "src/trace_processor/importers/proto/translation_table_module.h"
 
+#include <cstdint>
+
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/importers/common/args_translation_table.h"
 #include "src/trace_processor/importers/common/process_track_translation_table.h"
 #include "src/trace_processor/importers/common/slice_translation_table.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "protos/perfetto/trace/translation/translation_table.pbzero.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 using perfetto::protos::pbzero::TracePacket;
 
-TranslationTableModule::TranslationTableModule(TraceProcessorContext* context)
-    : context_(context) {
-  RegisterForField(TracePacket::kTranslationTableFieldNumber, context);
+TranslationTableModule::TranslationTableModule(
+    ProtoImporterModuleContext* module_context,
+    TraceProcessorContext* context)
+    : ProtoImporterModule(module_context), context_(context) {
+  RegisterForField(TracePacket::kTranslationTableFieldNumber);
 }
 
 TranslationTableModule::~TranslationTableModule() = default;
@@ -142,5 +149,4 @@ void TranslationTableModule::ParseChromeStudyRules(
   }
 }
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/translation_table_module.h
+++ b/src/trace_processor/importers/proto/translation_table_module.h
@@ -18,19 +18,20 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRANSLATION_TABLE_MODULE_H_
 
 #include <cstdint>
-#include <optional>
 
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class TranslationTableModule : public ProtoImporterModule {
  public:
-  explicit TranslationTableModule(TraceProcessorContext* context);
+  explicit TranslationTableModule(ProtoImporterModuleContext* module_context,
+                                  TraceProcessorContext* context);
 
   ~TranslationTableModule() override;
 
@@ -52,7 +53,6 @@ class TranslationTableModule : public ProtoImporterModule {
   TraceProcessorContext* context_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_TRANSLATION_TABLE_MODULE_H_

--- a/src/trace_processor/importers/proto/v8_module.cc
+++ b/src/trace_processor/importers/proto/v8_module.cc
@@ -19,12 +19,15 @@
 #include <cstdint>
 #include <optional>
 
-#include "perfetto/base/logging.h"
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
+#include "perfetto/trace_processor/trace_blob_view.h"
 #include "protos/perfetto/trace/chrome/v8.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+#include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/v8_sequence_state.h"
 #include "src/trace_processor/importers/proto/v8_tracker.h"
 #include "src/trace_processor/storage/stats.h"
@@ -46,13 +49,16 @@ using ::perfetto::protos::pbzero::V8WasmCode;
 
 }  // namespace
 
-V8Module::V8Module(TraceProcessorContext* context)
-    : context_(context), v8_tracker_(V8Tracker::GetOrCreate(context_)) {
-  RegisterForField(TracePacket::kV8JsCodeFieldNumber, context_);
-  RegisterForField(TracePacket::kV8InternalCodeFieldNumber, context_);
-  RegisterForField(TracePacket::kV8WasmCodeFieldNumber, context_);
-  RegisterForField(TracePacket::kV8RegExpCodeFieldNumber, context_);
-  RegisterForField(TracePacket::kV8CodeMoveFieldNumber, context_);
+V8Module::V8Module(ProtoImporterModuleContext* module_context,
+                   TraceProcessorContext* context)
+    : ProtoImporterModule(module_context),
+      context_(context),
+      v8_tracker_(V8Tracker::GetOrCreate(context)) {
+  RegisterForField(TracePacket::kV8JsCodeFieldNumber);
+  RegisterForField(TracePacket::kV8InternalCodeFieldNumber);
+  RegisterForField(TracePacket::kV8WasmCodeFieldNumber);
+  RegisterForField(TracePacket::kV8RegExpCodeFieldNumber);
+  RegisterForField(TracePacket::kV8CodeMoveFieldNumber);
 }
 
 V8Module::~V8Module() = default;

--- a/src/trace_processor/importers/proto/v8_module.h
+++ b/src/trace_processor/importers/proto/v8_module.h
@@ -22,18 +22,17 @@
 
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/v8_tables_py.h"
 
-namespace perfetto {
-namespace protos {
-namespace pbzero {
+namespace perfetto::protos::pbzero {
 class TracePacket_Decoder;
 }
-}  // namespace protos
-namespace trace_processor {
+
+namespace perfetto::trace_processor {
 
 class PacketSequenceState;
 struct TracePacketData;
@@ -46,7 +45,8 @@ class V8Tracker;
 // associated debug information has been loaded in each of the isolates.
 class V8Module : public ProtoImporterModule {
  public:
-  explicit V8Module(TraceProcessorContext* context);
+  explicit V8Module(ProtoImporterModuleContext* module_context,
+                    TraceProcessorContext* context);
 
   ~V8Module() override;
 
@@ -95,7 +95,6 @@ class V8Module : public ProtoImporterModule {
   base::FlatHashMap<tables::V8IsolateTable::Id, uint32_t> isolate_to_pid_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_V8_MODULE_H_

--- a/src/trace_processor/importers/proto/winscope/winscope_module.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_module.h
@@ -18,8 +18,11 @@
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_MODULE_H_
 
 #include <cstdint>
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/ref_counted.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/winscope/android_input_event_parser.h"
 #include "src/trace_processor/importers/proto/winscope/protolog_parser.h"
@@ -28,13 +31,14 @@
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.h"
 #include "src/trace_processor/importers/proto/winscope/viewcapture_parser.h"
 #include "src/trace_processor/importers/proto/winscope/winscope_context.h"
+#include "src/trace_processor/util/proto_to_args_parser.h"
 
-namespace perfetto {
-namespace trace_processor {
+namespace perfetto::trace_processor {
 
 class WinscopeModule : public ProtoImporterModule {
  public:
-  explicit WinscopeModule(TraceProcessorContext* context);
+  explicit WinscopeModule(ProtoImporterModuleContext* module_context,
+                          TraceProcessorContext* context);
 
   ModuleResult TokenizePacket(
       const protos::pbzero::TracePacket::Decoder& decoder,
@@ -73,7 +77,6 @@ class WinscopeModule : public ProtoImporterModule {
   ViewCaptureParser viewcapture_parser_;
 };
 
-}  // namespace trace_processor
-}  // namespace perfetto
+}  // namespace perfetto::trace_processor
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_MODULE_H_

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -68,7 +68,6 @@
 #include "src/trace_processor/importers/json/json_utils.h"
 #include "src/trace_processor/importers/ninja/ninja_log_parser.h"
 #include "src/trace_processor/importers/perf/perf_data_tokenizer.h"
-#include "src/trace_processor/importers/perf/perf_event.h"
 #include "src/trace_processor/importers/perf/perf_tracker.h"
 #include "src/trace_processor/importers/perf/record_parser.h"
 #include "src/trace_processor/importers/perf/spe_record_parser.h"
@@ -457,6 +456,12 @@ std::pair<int64_t, int64_t> GetTraceTimestampBoundsNs(
 
 TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
     : TraceProcessorStorageImpl(cfg), config_(cfg) {
+  context_.register_additional_proto_modules = &RegisterAdditionalModules;
+  if (context_.register_additional_proto_modules) {
+    context_.register_additional_proto_modules(
+        context_.proto_importer_module_context.get(), &context_);
+  }
+
   context_.reader_registry->RegisterTraceReader<AndroidDumpstateReader>(
       kAndroidDumpstateTraceType);
   context_.android_dumpstate_event_parser =
@@ -559,7 +564,6 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
         kTraceSummaryDescriptor.data(), kTraceSummaryDescriptor.size());
     PERFETTO_CHECK(status.ok());
   }
-  RegisterAdditionalModules(&context_);
 
   // Register stdlib packages.
   auto packages = GetStdlibPackages();

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -64,7 +64,7 @@ class PerfSampleTracker;
 class PerfTextTraceParser;
 class ProcessTracker;
 class ProcessTrackTranslationTable;
-class ProtoImporterModule;
+struct ProtoImporterModuleContext;
 class ProtoTraceParser;
 class SchedEventTracker;
 class SliceTracker;
@@ -171,6 +171,7 @@ class TraceProcessorContext {
   // clang-format on
 
   std::unique_ptr<ProtoTraceParser> proto_trace_parser;
+  std::unique_ptr<ProtoImporterModuleContext> proto_importer_module_context;
 
   // These fields are trace parsers which will be called by |forwarding_parser|
   // once the format of the trace is discovered. They are placed here as they
@@ -190,17 +191,6 @@ class TraceProcessorContext {
   // reflection-based parsers.
   std::unique_ptr<DescriptorPool> descriptor_pool_;
 
-  // The module at the index N is registered to handle field id N in
-  // TracePacket.
-  std::vector<std::vector<ProtoImporterModule*>> modules_by_field;
-  std::vector<std::unique_ptr<ProtoImporterModule>> modules;
-  // Pointers to modules from the modules vector that need to be called for
-  // all fields.
-  std::vector<ProtoImporterModule*> modules_for_all_fields;
-  FtraceModule* ftrace_module = nullptr;
-  EtwModule* etw_module = nullptr;
-  TrackEventModule* track_module = nullptr;
-
   // Marks whether the uuid was read from the trace.
   // If the uuid was NOT read, the uuid will be made from the hash of the first
   // 4KB of the trace.
@@ -210,6 +200,13 @@ class TraceProcessorContext {
 
   // Manages the contexts for reading trace data emitted from remote machines.
   std::unique_ptr<MultiMachineTraceManager> multi_machine_trace_manager;
+
+  // The registration function for additional proto modules.
+  // This is populated by TraceProcessorImpl to allow for late registration of
+  // modules.
+  using RegisterAdditionalProtoModulesFn = void(ProtoImporterModuleContext*,
+                                                TraceProcessorContext*);
+  RegisterAdditionalProtoModulesFn* register_additional_proto_modules = nullptr;
 };
 
 }  // namespace perfetto::trace_processor


### PR DESCRIPTION
This CL does a major refactoring across all of the proto parser and module
to depend on a separate module context instead of the trace processor
context. This is the first step to stopping parser-local state from
using the context entirely for non-processor wide state.

For now, the struct is also stored inside the context but this will
change down the line to live in ProtoTraceReader.

While this change touches a lot of files, in practice, it's just quite
a mechanical change and there should be no behavioural change as a
result of this CL.
