### PR TITLE
tp: build: mutual exclusion of llvm_symbolizer and libcxx flags

### DIFF
--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -465,3 +465,10 @@ assert(!enable_perfetto_traced_probes || enable_perfetto_platform_services)
 # |perfetto_use_system_protobuf| must be set.
 assert(!perfetto_use_pkgconfig || perfetto_use_system_protobuf,
        "perfetto_use_pkgconfig requires perfetto_use_system_protobuf")
+
+# enable_perfetto_llvm_symbolizer is not compatible with use_custom_libcxx
+# because the former dynamically links to system llvm which is compiled using
+# libstdc++ which makes it incompatible with building using libcxx.
+assert(
+    !enable_perfetto_llvm_symbolizer || !use_custom_libcxx,
+    "enable_perfetto_llvm_symbolizer and use_custom_libcxx are mutually exclusive. If you are seeing this error then you have set enable_perfetto_llvm_symbolizer=true and must set use_custom_libcxx=false to use llvm_symbolizer.")


### PR DESCRIPTION
Adds mutual exclusion between the flags enable_perfetto_llvm_symbolizer and use_custom_libcxx.

enable_perfetto_llvm_symbolizer is not compatible with use_custom_libcxx because the former dynamically links to system llvm which is compiled using libstdc++ which makes it incompatible with building using libcxx.

