### PR TITLE
changelog: tp: highlight identical ts sorting edge case from ffb178a1a3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,8 @@ Unreleased:
       arguments as multiple track_event tracks could have contributed to a
       single trace processor track. If you want the previous behaviour, specify
       `sibling_merge_behaviour: SIBLING_MERGE_BEHAVIOR_NONE`.
+    * Internal changes to packet sorting that might change the parsing order of
+      data with identical timestamps, relative to previous releases.
   UI:
     * Added support for controlling TrackEvent track merging through the
       `TrackDescriptor` proto. This is especially useful for users converting


### PR DESCRIPTION
Before: all ftrace data (inline sched waking, inline sched switch, ftrace events) was placed onto a shared set of per-cpu queues in the sorter. Also track event and track packet shared a sorter queue.

After: each type of data is is given its own queue: in the case of ftrace, it's given independent per-cpu queues (i.e. waking, switch and normal ftrace events each get their own set of per-CPU queues).
