### PR TITLE
ui: Add pf- prefix to all widgets / component classes

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -14,7 +14,6 @@
 
 @import "theme";
 @import "typefaces";
-@import "fonts";
 
 :root {
   --sidebar-width: 230px;

--- a/ui/src/assets/components/pivot_table.scss
+++ b/ui/src/assets/components/pivot_table.scss
@@ -1,0 +1,79 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import "../theme";
+
+.pf-pivot-table {
+  user-select: text;
+  -webkit-user-select: text;
+  padding: 10px;
+
+  button.mode-button {
+    border-radius: 10px;
+    padding: 7px;
+    margin: 5px;
+    background-color: #c7d0db;
+  }
+
+  &.query-error {
+    color: red;
+  }
+
+  .total-values {
+    text-align: right;
+    padding-right: 10px;
+    font-weight: bolder;
+  }
+
+  .empty-result {
+    padding: 10px;
+  }
+
+  td.menu {
+    text-align: left;
+  }
+
+  td.action-button {
+    min-width: fit-content;
+    width: 1px;
+  }
+
+  td {
+    // In context menu icon to go on a separate line.
+    // In regular pivot table cells, avoids wrapping the icon spacer to go on
+    // a separate line.
+    white-space: pre;
+  }
+
+  thead,
+  i {
+    cursor: pointer;
+  }
+  td.first {
+    border-left: 1px solid $table-border-color;
+    padding-left: 6px;
+  }
+  .disabled {
+    cursor: default;
+  }
+  .indent {
+    display: inline-block;
+    // 16px is the width of expand_more/expand_less icon to pad out cells
+    // without the button
+    width: 16px;
+  }
+  strong {
+    font-weight: 400;
+  }
+}

--- a/ui/src/assets/components/query_history.scss
+++ b/ui/src/assets/components/query_history.scss
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 .pf-query-history {
-  header.overview {
+  &__header {
     position: sticky;
     top: 0;
     display: flex;
@@ -29,73 +29,47 @@
     border-style: solid;
     border-width: 1px 0;
     z-index: 1;
-    .code {
-      font-family: var(--monospace-font);
-      font-size: 12px;
-      margin-left: 10px;
-      color: hsl(213, 22%, 40%);
-    }
-    span {
-      white-space: nowrap;
-    }
-    span.code {
-      text-overflow: ellipsis;
-      max-width: 50vw;
-      overflow: hidden;
-    }
-    span.spacer {
-      flex-grow: 1;
-    }
   }
-}
 
-.pf-history-item {
-  border-bottom: 1px solid hsl(213, 22%, 75%);
-  padding: 0.25em 0.5em;
-  max-height: 150px;
-  overflow-y: auto;
-  position: relative;
-
-  pre {
-    font-size: 10pt;
-    margin: 0;
-    overflow-x: auto;
-    overflow-y: hidden;
-    white-space: pre-wrap;
+  &__item {
+    border-bottom: 1px solid hsl(213, 22%, 75%);
+    padding: 0.25em 0.5em;
+    max-height: 150px;
+    overflow-y: auto;
     position: relative;
-    cursor: pointer;
 
-    &:hover::after {
-      content: "Doubleclick to re-run";
-      font-size: 12px;
-      color: rgba(0, 0, 0, 20%);
-      position: absolute;
-      top: 0;
-      margin: auto;
-      right: 0;
+    pre {
+      font-size: 10pt;
+      margin: 0;
+      overflow-x: auto;
+      overflow-y: hidden;
+      white-space: pre-wrap;
+      position: relative;
+      cursor: pointer;
+
+      &:hover::after {
+        content: "Doubleclick to re-run";
+        font-size: 12px;
+        color: rgba(0, 0, 0, 20%);
+        position: absolute;
+        top: 0;
+        margin: auto;
+        right: 0;
+      }
+    }
+
+    &:hover {
+      background-color: hsl(213, 22%, 94%);
+      .pf-query-history__item-buttons {
+        visibility: visible;
+      }
     }
   }
 
-  &:hover {
-    background-color: hsl(213, 22%, 94%);
-    .pf-history-item-buttons {
-      visibility: visible;
-    }
-  }
-}
-
-.pf-history-item-buttons {
-  position: sticky;
-  float: right;
-  top: 0;
-  visibility: hidden;
-
-  button {
-    margin: 0 0.5rem;
-
-    i.material-icons,
-    i.material-icons-filled {
-      font-size: 18px;
-    }
+  &__item-buttons {
+    position: sticky;
+    top: 0;
+    float: right;
+    visibility: hidden;
   }
 }

--- a/ui/src/assets/components/query_table.scss
+++ b/ui/src/assets/components/query_table.scss
@@ -15,13 +15,7 @@
 .pf-query-panel {
   display: contents;
 
-  .pf-query-warning {
-    padding: 4px;
-    position: sticky;
-    left: 0;
-  }
-
-  .query-error {
+  &__query-error {
     padding: 20px 10px;
     color: hsl(-10, 50%, 50%);
     font-family: "Roboto Mono", sans-serif;

--- a/ui/src/assets/help_modal.scss
+++ b/ui/src/assets/help_modal.scss
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 The Android Open Source Project
+// Copyright (C) 2025 The Android Open Source Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@mixin bottom-panel-font {
-  font-family: "Roboto Condensed", sans-serif;
-  font-weight: 300;
-  color: #3c4b5d;
+.pf-help-modal {
+  table {
+    margin-bottom: 15px;
+    td {
+      min-width: 250px;
+    }
+    td:first-child {
+      font-family: var(--monospace-font);
+    }
+  }
+  h2 {
+    font: inherit;
+    font-weight: bold;
+  }
 }

--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -25,6 +25,7 @@
 @import "statusbar";
 @import "cookie_consent";
 @import "perf_monitor";
+@import "help_modal";
 
 // Widgets/components - keep these sorted alphabetically
 @import "components/aggregation_adapter";

--- a/ui/src/assets/theme.scss
+++ b/ui/src/assets/theme.scss
@@ -49,6 +49,7 @@ $color-warning: #dca612;
 
 $pf-colour-thin-border: #aaa;
 $table-hover-color: hsl(214, 22%, 90%);
+$table-border-color: rgba(60, 76, 92, 0.4);
 
 @mixin focus {
   outline: 2px auto #64b5f6;

--- a/ui/src/assets/widgets/checkbox.scss
+++ b/ui/src/assets/widgets/checkbox.scss
@@ -44,7 +44,7 @@
 
   display: inline-block;
   position: relative; // Turns this container into a positioned element
-  font-family: $pf-font;
+  font-family: inherit;
   font-size: inherit;
   color: $pf-minimal-foreground;
   user-select: none;

--- a/ui/src/assets/widgets/modal.scss
+++ b/ui/src/assets/widgets/modal.scss
@@ -15,8 +15,8 @@
 @import "../theme";
 
 // The opacity changes are only transitional. Once the `modalFadeOut` animation
-// reaches the end, the Mithril component that renders .modal-backdrop
-// (and .modal-dialog) is fully destroyed and removed from the DOM.
+// reaches the end, the Mithril component that renders .pf-modal-backdrop
+// (and .pf-modal-dialog) is fully destroyed and removed from the DOM.
 // We use keyframes+animation, rather than transition, because the former allow
 // hooking the onanimationend events to synchronize the Mithril removal with
 // the end of the CSS animation.
@@ -38,7 +38,7 @@
   }
 }
 
-.modal-backdrop {
+.pf-modal-backdrop {
   position: absolute;
   z-index: 99;
   background-color: rgba(0, 0, 0, 0.6);
@@ -56,7 +56,7 @@
   }
 }
 
-.modal-dialog {
+.pf-modal-dialog {
   position: absolute;
   z-index: 100;
   background-color: #fff;
@@ -74,7 +74,7 @@
   font-family: Roboto, sans-serif;
   font-weight: 300;
 
-  &.modal-dialog-valign-top {
+  &.pf-modal-dialog-valign-top {
     top: 1rem;
     transform: translate(-50%, 0);
   }
@@ -126,29 +126,13 @@
   } // footer
 }
 
-.help {
-  table {
-    margin-bottom: 15px;
-    td {
-      min-width: 250px;
-    }
-    td:first-child {
-      font-family: var(--monospace-font);
-    }
-  }
-  h2 {
-    font: inherit;
-    font-weight: bold;
-  }
-}
-
-.modal-pre {
+.pf-modal-pre {
   white-space: pre-line;
   font-size: 13px;
 }
 
-.modal-logs,
-.modal-bash {
+.pf-modal-logs,
+.pf-modal-bash {
   white-space: pre-wrap;
   border: 1px solid #999;
   background: #eee;
@@ -161,20 +145,20 @@
   overflow: auto;
 }
 
-.modal-bash {
+.pf-modal-bash {
   margin: 0;
   padding: 5px 0;
   overflow: auto;
   min-height: 0;
 }
 
-.modal-textarea {
+.pf-modal-textarea {
   display: block;
   margin-top: 10px;
   margin-bottom: 10px;
   width: 100%;
 }
 
-.modal-small {
+.pf-modal-small {
   font-size: 0.75rem;
 }

--- a/ui/src/assets/widgets/table.scss
+++ b/ui/src/assets/widgets/table.scss
@@ -14,10 +14,10 @@
 
 @import "../theme";
 
-$table-border-color: rgba(60, 76, 92, 0.4);
-
-@mixin table-component {
-  @include bottom-panel-font;
+.pf-generic-table {
+  font-family: "Roboto Condensed", sans-serif;
+  font-weight: 300;
+  color: #3c4b5d;
   font-size: 14px;
   line-height: 18px;
   width: 100%;
@@ -28,6 +28,26 @@ $table-border-color: rgba(60, 76, 92, 0.4);
 
     td.reorderable-cell {
       cursor: grab;
+
+      &.dragged {
+        color: gray;
+      }
+
+      &.highlight-left {
+        background: linear-gradient(
+          90deg,
+          $table-border-color,
+          transparent 20%
+        );
+      }
+
+      &.highlight-right {
+        background: linear-gradient(
+          270deg,
+          $table-border-color,
+          transparent 20%
+        );
+      }
     }
   }
 
@@ -53,91 +73,5 @@ $table-border-color: rgba(60, 76, 92, 0.4);
     &.has-left-border {
       border-left: 1px solid rgba(60, 76, 92, 0.4);
     }
-  }
-}
-
-.generic-table {
-  @include table-component;
-}
-
-.pivot-table {
-  @include table-component;
-
-  thead,
-  i {
-    cursor: pointer;
-  }
-  td.first {
-    border-left: 1px solid $table-border-color;
-    padding-left: 6px;
-  }
-  .disabled {
-    cursor: default;
-  }
-  .indent {
-    display: inline-block;
-    // 16px is the width of expand_more/expand_less icon to pad out cells
-    // without the button
-    width: 16px;
-  }
-  strong {
-    font-weight: 400;
-  }
-}
-
-.reorderable-cell {
-  &.dragged {
-    color: gray;
-  }
-
-  &.highlight-left {
-    background: linear-gradient(90deg, $table-border-color, transparent 20%);
-  }
-
-  &.highlight-right {
-    background: linear-gradient(270deg, $table-border-color, transparent 20%);
-  }
-}
-
-.pivot-table {
-  user-select: text;
-  -webkit-user-select: text;
-  padding: 10px;
-
-  button.mode-button {
-    border-radius: 10px;
-    padding: 7px;
-    margin: 5px;
-    background-color: #c7d0db;
-  }
-
-  &.query-error {
-    color: red;
-  }
-
-  .total-values {
-    text-align: right;
-    padding-right: 10px;
-    font-weight: bolder;
-  }
-
-  .empty-result {
-    padding: 10px;
-  }
-
-  td.menu {
-    text-align: left;
-  }
-
-  td.action-button {
-    min-width: fit-content;
-    width: 1px;
-  }
-
-  td {
-    // In context menu icon to go on a separate line.
-    // In regular pivot table cells, avoids wrapping the icon spacer to go on
-    // a separate line.
-    white-space: pre;
   }
 }

--- a/ui/src/base/semantic_icons.ts
+++ b/ui/src/base/semantic_icons.ts
@@ -60,4 +60,7 @@ export class Icons {
   static readonly SortDesc = 'arrow_downward';
   static readonly ResetState = 'restart_alt';
   static readonly Remove = 'clear';
+
+  static readonly Play = 'play_arrow';
+  static readonly Edit = 'edit';
 }

--- a/ui/src/components/query_table/query_table.ts
+++ b/ui/src/components/query_table/query_table.ts
@@ -32,6 +32,7 @@ import {DataGrid, renderCell} from '../widgets/data_grid/data_grid';
 import {DataGridDataSource} from '../widgets/data_grid/common';
 import {InMemoryDataSource} from '../widgets/data_grid/in_memory_data_source';
 import {Anchor} from '../../widgets/anchor';
+import {Box} from '../../widgets/box';
 
 type Numeric = bigint | number;
 
@@ -184,23 +185,20 @@ export class QueryTable implements m.ClassComponent<QueryTableAttrs> {
     return m(
       '.pf-query-panel',
       resp.statementWithOutputCount > 1 &&
-        m(
-          '.pf-query-warning',
-          m(
-            Callout,
-            {icon: 'warning'},
+        m(Box, [
+          m(Callout, {icon: 'warning'}, [
             `${resp.statementWithOutputCount} out of ${resp.statementCount} `,
             'statements returned a result. ',
             'Only the results for the last statement are displayed.',
-          ),
-        ),
+          ]),
+        ]),
       this.renderContent(resp, dataSource),
     );
   }
 
   private renderContent(resp: QueryResponse, dataSource: DataGridDataSource) {
     if (resp.error) {
-      return m('.query-error', `SQL error: ${resp.error}`);
+      return m('.pf-query-panel__query-error', `SQL error: ${resp.error}`);
     }
 
     const onViewerPage =

--- a/ui/src/components/tracks/add_debug_track_menu.ts
+++ b/ui/src/components/tracks/add_debug_track_menu.ts
@@ -114,7 +114,7 @@ export class AddDebugTrackMenu
             // Allow Esc to close popup.
             if (e.key === 'Escape') return;
           },
-          oninput: (e: KeyboardEvent) => {
+          oninput: (e: InputEvent) => {
             if (!e.target) return;
             this.trackName = (e.target as HTMLInputElement).value;
           },

--- a/ui/src/components/widgets/query_history.ts
+++ b/ui/src/components/widgets/query_history.ts
@@ -15,9 +15,10 @@
 import m from 'mithril';
 import {Icons} from '../../base/semantic_icons';
 import {assertTrue} from '../../base/logging';
-import {Icon} from '../../widgets/icon';
 import {z} from 'zod';
 import {Trace} from '../../public/trace';
+import {Button} from '../../widgets/button';
+import {Stack} from '../../widgets/stack';
 
 const QUERY_HISTORY_KEY = 'queryHistory';
 
@@ -46,7 +47,7 @@ export class QueryHistoryComponent
         ...rest,
       },
       m(
-        'header.overview',
+        '.pf-query-history__header',
         `Query history (${queryHistoryStorage.data.length} queries)`,
       ),
       starred.map((attrs) => m(HistoryItemComponent, attrs)),
@@ -69,44 +70,39 @@ export class HistoryItemComponent
   view(vnode: m.Vnode<HistoryItemComponentAttrs>): m.Child {
     const query = vnode.attrs.entry.query;
     return m(
-      '.pf-history-item',
+      '.pf-query-history__item',
       m(
-        '.pf-history-item-buttons',
-        m(
-          'button',
-          {
+        Stack,
+        {
+          className: 'pf-query-history__item-buttons',
+          orientation: 'horizontal',
+        },
+        [
+          m(Button, {
             onclick: () => {
               queryHistoryStorage.setStarred(
                 vnode.attrs.index,
                 !vnode.attrs.entry.starred,
               );
             },
-          },
-          m(Icon, {icon: Icons.Star, filled: vnode.attrs.entry.starred}),
-        ),
-        m(
-          'button',
-          {
+            icon: Icons.Star,
+            iconFilled: vnode.attrs.entry.starred,
+          }),
+          m(Button, {
             onclick: () => vnode.attrs.setQuery(query),
-          },
-          m(Icon, {icon: 'edit'}),
-        ),
-        m(
-          'button',
-          {
+            icon: Icons.Edit,
+          }),
+          m(Button, {
             onclick: () => vnode.attrs.runQuery(query),
-          },
-          m(Icon, {icon: 'play_arrow'}),
-        ),
-        m(
-          'button',
-          {
+            icon: Icons.Play,
+          }),
+          m(Button, {
             onclick: () => {
               queryHistoryStorage.remove(vnode.attrs.index);
             },
-          },
-          m(Icon, {icon: 'delete'}),
-        ),
+            icon: Icons.Delete,
+          }),
+        ],
       ),
       m(
         'pre',

--- a/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
+++ b/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
@@ -113,7 +113,7 @@ export class PivotTable implements m.ClassComponent<PivotTableAttrs> {
 
     return [
       m(CustomTable<PivotTreeNode>, {
-        className: 'pivot-table',
+        className: 'pf-pivot-table',
         data: nodes,
         columns: [
           {

--- a/ui/src/components/widgets/sql/table/table.ts
+++ b/ui/src/components/widgets/sql/table/table.ts
@@ -185,7 +185,7 @@ class ColumnFilter implements m.ClassComponent<ColumnFilterAttrs> {
             id: 'column_filter_value',
             ref: 'COLUMN_FILTER_VALUE',
             autofocus: true,
-            oninput: (e: KeyboardEvent) => {
+            oninput: (e: InputEvent) => {
               if (!e.target) return;
 
               this.inputValue = (e.target as HTMLInputElement).value;

--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -23,6 +23,7 @@ import {AppImpl} from '../core/app_impl';
 import {Router} from '../core/router';
 import {Button, ButtonVariant} from '../widgets/button';
 import {Intent} from '../widgets/common';
+import {Checkbox} from '../widgets/checkbox';
 
 const MODAL_KEY = 'crash_modal';
 
@@ -179,21 +180,19 @@ class ErrorDialogComponent implements m.ClassComponent<ErrorDetails> {
     if (this.traceState !== 'NOT_AVAILABLE') {
       shareTraceSection = m(
         'div',
+        m(Checkbox, {
+          checked: this.attachTrace,
+          oninput: (ev: InputEvent) => {
+            const checked = (ev.target as HTMLInputElement).checked;
+            this.onUploadCheckboxChange(checked);
+          },
+          label:
+            this.traceState === 'UPLOADING'
+              ? `Uploading trace... ${this.uploadStatus}`
+              : 'Tick to share the current trace and help debugging',
+        }),
         m(
-          'label',
-          m(`input[type=checkbox]`, {
-            checked: this.attachTrace,
-            oninput: (ev: InputEvent) => {
-              const checked = (ev.target as HTMLInputElement).checked;
-              this.onUploadCheckboxChange(checked);
-            },
-          }),
-          this.traceState === 'UPLOADING'
-            ? `Uploading trace... ${this.uploadStatus}`
-            : 'Tick to share the current trace and help debugging',
-        ), // m('label')
-        m(
-          'div.modal-small',
+          'div.pf-modal-small',
           `This will upload the trace and attach a link to the bug.
           You may leave it unchecked and attach the trace manually to the bug
           if preferred.`,
@@ -204,13 +203,13 @@ class ErrorDialogComponent implements m.ClassComponent<ErrorDetails> {
     return [
       m(
         'div',
-        m('.modal-logs', msg),
+        m('.pf-modal-logs', msg),
         m(
           'span',
           `Please provide any additional details describing
         how the crash occurred:`,
         ),
-        m('textarea.modal-textarea', {
+        m('textarea.pf-modal-textarea', {
           rows: 3,
           maxlength: 1000,
           oninput: (ev: InputEvent) => {
@@ -305,7 +304,7 @@ function showOutOfMemoryDialog() {
       ),
       m('br'),
       m('br'),
-      m('.modal-bash', tpCmd),
+      m('.pf-modal-bash', tpCmd),
       m('br'),
       m('span', 'For details see '),
       m('a', {href: url, target: '_blank'}, url),
@@ -347,7 +346,7 @@ function showWebUSBError() {
       try again.`,
       ),
       m('br'),
-      m('.modal-bash', '> adb kill-server'),
+      m('.pf-modal-bash', '> adb kill-server'),
       m('br'),
       m('span', 'For details see '),
       m('a', {href: 'http://b/159048331', target: '_blank'}, 'b/159048331'),

--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -80,7 +80,7 @@ class KeyMappingsHelp implements m.ClassComponent {
 
   view(): m.Children {
     return m(
-      '.help',
+      '.pf-help-modal',
       m('h2', 'Navigation'),
       m(
         'table',

--- a/ui/src/frontend/permalink.ts
+++ b/ui/src/frontend/permalink.ts
@@ -182,7 +182,7 @@ export async function loadPermalink(gcsFileName: string): Promise<void> {
             "state wont't be recovered",
         ),
         m('p', 'Error details:'),
-        m('.modal-logs', error),
+        m('.pf-modal-logs', error),
       ),
       buttons: [
         {

--- a/ui/src/frontend/rpc_http_dialog.ts
+++ b/ui/src/frontend/rpc_http_dialog.ts
@@ -239,7 +239,7 @@ async function showDialogVersionMismatch(
   let result = MismatchedVersionDialog.Dismissed;
   await showModal({
     title: 'Version mismatch',
-    content: m('.modal-pre', getVersionMismatchMessage(tpStatus)),
+    content: m('.pf-modal-pre', getVersionMismatchMessage(tpStatus)),
     buttons: [
       {
         primary: true,
@@ -277,7 +277,7 @@ async function showDialogIncompatibleRPC(
   let result = IncompatibleRpcDialogResult.Dismissed;
   await showModal({
     title: 'Incompatible RPC version',
-    content: m('.modal-pre', getIncompatibleRpcMessage(tpStatus)),
+    content: m('.pf-modal-pre', getIncompatibleRpcMessage(tpStatus)),
     buttons: [
       {
         text: 'Use builtin Wasm',
@@ -310,7 +310,7 @@ async function showDialogToUsePreloadedTrace(
   let result = PreloadedDialogResult.Dismissed;
   await showModal({
     title: 'Use trace processor native acceleration?',
-    content: m('.modal-pre', getPromptMessage(tpStatus)),
+    content: m('.pf-modal-pre', getPromptMessage(tpStatus)),
     buttons: [
       {
         text: 'YES, use loaded trace',

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -147,7 +147,7 @@ Alternatively, connect to a trace_processor_shell --httpd instance.
 `;
     showModal({
       title: `Trace processor doesn't have high-precision timers`,
-      content: m('.modal-pre', PROMPT),
+      content: m('.pf-modal-pre', PROMPT),
       buttons: [
         {
           text: 'YES, record metatrace',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -227,7 +227,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
               }),
             m(TextInput, {
               placeholder: node.getTitle(),
-              oninput: (e: KeyboardEvent) => {
+              oninput: (e: InputEvent) => {
                 if (!e.target) return;
                 node.state.customTitle = (
                   e.target as HTMLInputElement

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -188,19 +188,13 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
     } else {
       return [
         queryResult.statementWithOutputCount > 1 &&
-          m(
-            '.pf-query-warning',
-            m(
-              Box,
-              m(
-                Callout,
-                {icon: 'warning', intent: Intent.None},
-                `${queryResult.statementWithOutputCount} out of ${queryResult.statementCount} `,
-                'statements returned a result. ',
-                'Only the results for the last statement are displayed.',
-              ),
-            ),
-          ),
+          m(Box, [
+            m(Callout, {icon: 'warning', intent: Intent.None}, [
+              `${queryResult.statementWithOutputCount} out of ${queryResult.statementCount} `,
+              'statements returned a result. ',
+              'Only the results for the last statement are displayed.',
+            ]),
+          ]),
         m(DataGrid, {
           className: 'pf-query-page__results',
           data: dataSource,

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -1950,7 +1950,10 @@ class ModalShowcase implements m.ClassComponent {
 
     let content;
     if (staticContent) {
-      content = m('.modal-pre', 'Content of the modal dialog.\nEnd of content');
+      content = m(
+        '.pf-modal-pre',
+        'Content of the modal dialog.\nEnd of content',
+      );
     } else {
       // The humble counter is basically the VDOM 'Hello world'!
       function CounterComponent() {

--- a/ui/src/test/queries.test.ts
+++ b/ui/src/test/queries.test.ts
@@ -72,13 +72,13 @@ test('query page', async () => {
   }
 
   // Now test the query history.
-  page.locator('.pf-query-history .pf-history-item').nth(0).click();
+  page.locator('.pf-query-history .pf-query-history__item').nth(0).click();
   await pth.waitForPerfettoIdle();
   expect(await textbox.textContent()).toEqual(
     'select id, ts, dur, name from slices limit 3',
   );
 
-  page.locator('.pf-query-history .pf-history-item').nth(2).click();
+  page.locator('.pf-query-history .pf-query-history__item').nth(2).click();
   await pth.waitForPerfettoIdle();
   expect(await textbox.textContent()).toEqual(
     'select id, ts, dur, name from slices limit 1',
@@ -86,7 +86,7 @@ test('query page', async () => {
 
   // Double click on the 2nd one and expect the query is re-ran.
   page
-    .locator('.pf-query-page .pf-query-history .pf-history-item')
+    .locator('.pf-query-page .pf-query-history .pf-query-history__item')
     .nth(1)
     .dblclick();
   await pth.waitForPerfettoIdle();

--- a/ui/src/test/table_viewer.test.ts
+++ b/ui/src/test/table_viewer.test.ts
@@ -28,7 +28,7 @@ async function clickTableHeader(headerName: string | RegExp) {
 
 function getTableCells(text?: string | RegExp): Locator {
   return page.locator(
-    '.pf-details-shell .generic-table tr:not(.header) a.pf-anchor',
+    '.pf-details-shell .pf-generic-table tr:not(.header) a.pf-anchor',
     {
       hasText: text,
     },

--- a/ui/src/widgets/common.ts
+++ b/ui/src/widgets/common.ts
@@ -47,7 +47,7 @@ export interface HTMLInputAttrs extends HTMLFocusableAttrs {
   readonly disabled?: boolean;
   readonly type?: string;
   readonly onchange?: (e: InputEvent) => void;
-  readonly oninput?: (e: KeyboardEvent) => void;
+  readonly oninput?: (e: InputEvent) => void;
   readonly onkeydown?: (e: KeyboardEvent) => void;
   readonly onkeyup?: (e: KeyboardEvent) => void;
   readonly value?: string | number;

--- a/ui/src/widgets/custom_table.ts
+++ b/ui/src/widgets/custom_table.ts
@@ -70,11 +70,11 @@ export class CustomTable<T> implements m.ClassComponent<CustomTableAttrs<T>> {
     }
 
     return m(
-      `table.generic-table`,
+      `table.pf-generic-table`,
       {
         className: attrs.className,
         // TODO(altimin, stevegolton): this should be the default for
-        // generic-table, but currently it is overriden by
+        // pf-generic-table, but currently it is overriden by
         // .pf-details-shell .pf-content table, so specify this here for now.
         style: {
           'table-layout': 'auto',

--- a/ui/src/widgets/modal.ts
+++ b/ui/src/widgets/modal.ts
@@ -145,17 +145,17 @@ export class Modal implements m.ClassComponent<ModalAttrs> {
     }
 
     const aria = '[aria-labelledby=mm-title][aria-model][role=dialog]';
-    const align = attrs.vAlign === 'TOP' ? '.modal-dialog-valign-top' : '';
+    const align = attrs.vAlign === 'TOP' ? '.pf-modal-dialog-valign-top' : '';
     const customClass = attrs.className ? '.' + attrs.className : '';
     return m(
-      '.modal-backdrop',
+      '.pf-modal-backdrop',
       {
         onclick: this.onBackdropClick.bind(this, attrs),
         onkeydown: this.onBackdropKeydown.bind(this, attrs),
         tabIndex: 0,
       },
       m(
-        `.modal-dialog${align}${customClass}${aria}`,
+        `.pf-modal-dialog${align}${customClass}${aria}`,
         m(
           'header',
           m(

--- a/ui/src/widgets/popup.ts
+++ b/ui/src/widgets/popup.ts
@@ -181,7 +181,7 @@ export class Popup implements m.ClassComponent<PopupAttrs> {
         if (closestPopup) {
           return {container: closestPopup};
         }
-        const closestModal = dom.closest('.modal-dialog');
+        const closestModal = dom.closest('.pf-modal-dialog');
         if (closestModal) {
           return {container: closestModal};
         }

--- a/ui/src/widgets/table.ts
+++ b/ui/src/widgets/table.ts
@@ -276,7 +276,7 @@ export class Table implements m.ClassComponent<TableAttrs<any>> {
     const attrs = vnode.attrs;
 
     return m(
-      'table.generic-table',
+      'table.pf-generic-table',
       m(
         'thead',
         m(

--- a/ui/src/widgets/tooltip.ts
+++ b/ui/src/widgets/tooltip.ts
@@ -115,7 +115,7 @@ export class Tooltip implements m.ClassComponent<TooltipAttrs> {
         if (closestPopup) {
           return {container: closestPopup};
         }
-        const closestModal = dom.closest('.modal-dialog');
+        const closestModal = dom.closest('.pf-modal-dialog');
         if (closestModal) {
           return {container: closestModal};
         }


### PR DESCRIPTION
This PR adds the prefix `pf-` to all widget and component CSS classes where practical. Some classes that are scoped by selectors to be inside a class with the prefix are omitted for practicality's sake. This is to enable embedding Perfetto in other web apps while avoiding collisions.