### PR TITLE
stdlib: Make static_freq generic across CPUs

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
@@ -50,6 +50,8 @@ CREATE PERFETTO VIEW _curves_w_dependencies (
   l3_miss_count LONG,
   no_static LONG,
   all_cpu_deep_idle LONG,
+  freq_1d_static LONG,
+  freq_2d_static LONG,
   dependency LONG
 ) AS
 -- Table that is dependent on differet CPU's frequency
@@ -103,18 +105,18 @@ LEFT JOIN _filtered_curves_2d AS lut3
   AND lut3.dependency = base.dependency
   AND lut3.idle = base.idle_3
 LEFT JOIN _filtered_curves_1d AS static_1d
-  ON static_1d.policy = 0 AND static_1d.freq_khz = base.freq_0 AND static_1d.idle = 255
+  ON static_1d.freq_khz = base.freq_1d_static AND static_1d.idle = 255
 LEFT JOIN _filtered_curves_2d AS static_2d
-  ON static_2d.freq_khz = base.freq_0
+  ON static_2d.freq_khz = base.freq_2d_static
   AND static_2d.dependency = base.dependency
   AND static_2d.idle = 255
 -- LUT joins for L3 cache
 LEFT JOIN _filtered_curves_l3 AS l3_hit_lut
-  ON l3_hit_lut.freq_khz = base.freq_0
+  ON l3_hit_lut.freq_khz = base.freq_2d_static
   AND l3_hit_lut.dependency = base.dependency
   AND l3_hit_lut.action = 'hit'
 LEFT JOIN _filtered_curves_l3 AS l3_miss_lut
-  ON l3_miss_lut.freq_khz = base.freq_0
+  ON l3_miss_lut.freq_khz = base.freq_2d_static
   AND l3_miss_lut.dependency = base.dependency
   AND l3_miss_lut.action = 'miss';
 

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
@@ -83,7 +83,11 @@ SELECT
   coalesce(base.cpu5_curve, 0.0) AS cpu5_curve,
   coalesce(base.cpu6_curve, 0.0) AS cpu6_curve,
   coalesce(base.cpu7_curve, 0.0) AS cpu7_curve,
-  iif(no_static = 1, 0.0, coalesce(static_1d.curve_value, static_2d.curve_value)) AS static_curve,
+  iif(
+    no_static = 1,
+    0.0,
+    coalesce(static_1d.curve_value, 0.0) + coalesce(static_2d.curve_value, 0.0)
+  ) AS static_curve,
   iif(all_cpu_deep_idle = 1, 0, base.l3_hit_count * l3_hit_lut.curve_value) AS l3_hit_value,
   iif(all_cpu_deep_idle = 1, 0, base.l3_miss_count * l3_miss_lut.curve_value) AS l3_miss_value
 FROM _curves_w_dependencies AS base

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/w_cpu_dependence.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/w_cpu_dependence.sql
@@ -56,6 +56,8 @@ SELECT
   d.l3_miss_count,
   d.no_static,
   d.all_cpu_deep_idle,
+  d.freq_1d_static,
+  d.freq_2d_static,
   -- If dependency_max is 0, dependent CPUs are not active, so use the minimum
   -- freq/voltage vote
   iif(d.dependency_max = 0, m.min_dependency, d.dependency_max) AS dependency

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/w_dsu_dependence.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/w_dsu_dependence.sql
@@ -44,7 +44,9 @@ SELECT
   l3_hit_count,
   l3_miss_count,
   no_static,
-  all_cpu_deep_idle
+  all_cpu_deep_idle,
+  freq_1d_static,
+  freq_2d_static
 FROM _w_independent_cpus_calc AS base, _use_devfreq_for_calc;
 
 -- Get nominal devfreq_dsu counter, OR use a dummy one for Pixel 9 VM traces
@@ -104,6 +106,8 @@ SELECT
   c.l3_miss_count,
   c.no_static,
   c.all_cpu_deep_idle,
+  c.freq_1d_static,
+  c.freq_2d_static,
   d.dsu_freq AS dependency
 FROM _interval_intersect!(
   (

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/curves/utils.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/curves/utils.sql
@@ -215,3 +215,21 @@ WHERE
       1
     FROM base
   );
+
+-- Find the exemplar CPU for the policy with no freq/voltage dependency. The CPU
+-- managing the policy is the first CPU that comes online for a given policy.
+-- This is usually the min(CPU #) since Linux initializes CPUs in ascending
+-- order (e.g. CPU4 for policy4).
+CREATE PERFETTO TABLE _cpu_for_1d_static AS
+SELECT
+  min(cpu) AS cpu
+FROM _cpus_with_no_dependency;
+
+-- Find the exemplar CPU for the policy with a freq/voltage dependency. The CPU
+-- managing the policy is the first CPU that comes online for a given policy.
+-- This is usually the min(CPU #) since Linux initializes CPUs in ascending
+-- order (e.g. CPU0 for policy0).
+CREATE PERFETTO TABLE _cpu_for_2d_static AS
+SELECT
+  min(cpu) AS cpu
+FROM _cpus_with_dependency;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
@@ -133,7 +133,6 @@ WITH
       ("Tensor G4", 5, 4),
       ("Tensor G4", 6, 4),
       ("Tensor G4", 7, 7),
-      ("Tensor G4", 255, 255),
       ("neo", 0, 0),
       ("neo", 1, 0),
       ("neo", 2, 0),


### PR DESCRIPTION
Get the frequency that corresponds to the static vote (for both 1D and
2D dependent policies) generically instead of assuming it will be on
CPU0.

Additionally, handle the cases where there are multiple static values
coming from both the 1D and 2D policies.

Bug: 434979529
Signed-off-by: Samuel Wu <wusamuel@google.com>