### PR TITLE
 Let serialize_python_trace take a list of extension descriptors

### DIFF
--- a/python/generators/diff_tests/trace_generator.py
+++ b/python/generators/diff_tests/trace_generator.py
@@ -55,6 +55,7 @@ class TraceGenerator:
         python_trace_path,
         self.trace_descriptor_path,
     ]
+    python_cmd.extend(self.extension_descriptor_paths)
 
     # Add the test dir to the PYTHONPATH to allow synth_common to be found.
     env = os.environ.copy()

--- a/python/generators/diff_tests/utils.py
+++ b/python/generators/diff_tests/utils.py
@@ -115,11 +115,12 @@ def serialize_textproto_trace(trace_descriptor_path: str,
 
 
 def serialize_python_trace(root_dir: str, trace_descriptor_path: str,
+                           extension_descriptor_paths: List[str],
                            python_trace_path: str, out_stream: IO[bytes]):
   from python.generators.diff_tests.trace_generator import TraceGenerator
   TraceGenerator(trace_descriptor_path,
-                 []).serialize_python_trace(root_dir, python_trace_path,
-                                            out_stream)
+                 extension_descriptor_paths).serialize_python_trace(
+                     root_dir, python_trace_path, out_stream)
 
 
 def get_trace_descriptor_path(out_path: str, trace_descriptor: str):

--- a/test/synth_common.py
+++ b/test/synth_common.py
@@ -844,19 +844,21 @@ def read_descriptor(file_name):
 
 
 def create_pool(args):
-  trace_descriptor = read_descriptor(args.trace_descriptor)
-
   pool = descriptor_pool.DescriptorPool()
-  for file in trace_descriptor.file:
-    pool.Add(file)
-
+  for descriptor_file in args.trace_descriptors:
+    trace_descriptor = read_descriptor(descriptor_file)
+    for file in trace_descriptor.file:
+      pool.Add(file)
   return pool
 
 
 def create_trace():
   parser = argparse.ArgumentParser()
   parser.add_argument(
-      'trace_descriptor', type=str, help='location of trace descriptor')
+      'trace_descriptors',
+      type=str,
+      nargs='+',
+      help='locations of trace descriptors')
   args = parser.parse_args()
 
   pool = create_pool(args)

--- a/test/synth_common.py
+++ b/test/synth_common.py
@@ -883,6 +883,7 @@ def create_trace():
       'ChromeRAILMode',
       'ChromeLatencyInfo',
       'ChromeProcessDescriptor',
+      'ChromeTrackEvent',
       'CounterDescriptor',
       'ThreadDescriptor',
   ])
@@ -905,6 +906,8 @@ def create_trace():
           pool,
           pool.FindMessageTypeByName(
               'perfetto.protos.ChromeProcessDescriptor')),
+      ChromeTrackEvent=get_message_class(
+          pool, pool.FindMessageTypeByName('perfetto.protos.ChromeTrackEvent')),
       CounterDescriptor=get_message_class(
           pool,
           pool.FindMessageTypeByName('perfetto.protos.CounterDescriptor')),

--- a/tools/serialize_test_trace.py
+++ b/tools/serialize_test_trace.py
@@ -70,8 +70,8 @@ def main():
   trace_path = args.trace_path
 
   if trace_path.endswith('.py'):
-    serialize_python_trace(ROOT_DIR, trace_descriptor_path, trace_path,
-                           sys.stdout.buffer)
+    serialize_python_trace(ROOT_DIR, trace_descriptor_path,
+                           extension_descriptors, trace_path, sys.stdout.buffer)
   elif trace_path.endswith('.textproto'):
     serialize_textproto_trace(trace_descriptor_path, extension_descriptors,
                               trace_path, sys.stdout.buffer)


### PR DESCRIPTION
serialize_textproto_trace() accepts a main `trace_descriptor_path` and a list of `extension_descriptor_paths`. serialize_python_trace() only takes a single path. This means extension messages defined in chrome_track_event.descriptor won't be loaded during python difftests.

Close the feature gap by updating serialize_test_trace.py to pass extension descriptors to utils.serialize_python_trace(), synth_common.create_trace() to accept multiple descriptors on the command-line, and all the intermediate functions to pass along the extension descriptors.

To demonstrate that this works, adds ChromeTrackEvent to the descriptor pool (even though no tests use it yet). Without the fix that causes synth_common.create_trace() to fail with: KeyError: "Couldn't find message perfetto.protos.ChromeTrackEvent"