### PR TITLE
base: Fix status_macros for non-perfetto namespace

### DIFF
--- a/include/perfetto/ext/base/status_macros.h
+++ b/include/perfetto/ext/base/status_macros.h
@@ -21,11 +21,11 @@
 
 // Evaluates |expr|, which should return a base::Status. If the status is an
 // error status, returns the status from the current function.
-#define RETURN_IF_ERROR(expr)                           \
-  do {                                                  \
-    base::Status status_macro_internal_status = (expr); \
-    if (!status_macro_internal_status.ok())             \
-      return status_macro_internal_status;              \
+#define RETURN_IF_ERROR(expr)                                       \
+  do {                                                              \
+    ::perfetto::base::Status status_macro_internal_status = (expr); \
+    if (!status_macro_internal_status.ok())                         \
+      return status_macro_internal_status;                          \
   } while (0)
 
 #define PERFETTO_INTERNAL_CONCAT_IMPL(x, y) x##y


### PR DESCRIPTION
We can use the macros from other namespaces (i.e. `protozero`).
