### PR TITLE
Fix macro condition for pre-macOS-10.12 GetThreadCPUTimeNs

### DIFF
--- a/include/perfetto/base/time.h
+++ b/include/perfetto/base/time.h
@@ -119,7 +119,8 @@ inline TimeNanos GetBootTimeNs() {
 }
 
 // Before MacOS 10.12 clock_gettime() was not implemented.
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+#if (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && \
+     __MAC_OS_X_VERSION_MIN_REQUIRED < 101200)
 inline TimeNanos GetThreadCPUTimeNs() {
   mach_port_t this_thread = mach_thread_self();
   mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;


### PR DESCRIPTION
The check uses `__MAC_OS_X_VERSION_MIN_REQUIRED` without checking if its defined. In an iOS build, the macro won't be defined so it'll evaluate to 0, and so the check will always evaluate to true. That version of GetThreadCPUTimeNs will trip up the sandbox for Chromium iOS blink.