### PR TITLE
tp: Fix overlapping gpu_render_stage slices being dropped

### DIFF
--- a/include/perfetto/ext/base/status_macros.h
+++ b/include/perfetto/ext/base/status_macros.h
@@ -21,11 +21,11 @@
 
 // Evaluates |expr|, which should return a base::Status. If the status is an
 // error status, returns the status from the current function.
-#define RETURN_IF_ERROR(expr)                           \
-  do {                                                  \
-    base::Status status_macro_internal_status = (expr); \
-    if (!status_macro_internal_status.ok())             \
-      return status_macro_internal_status;              \
+#define RETURN_IF_ERROR(expr)                                       \
+  do {                                                              \
+    ::perfetto::base::Status status_macro_internal_status = (expr); \
+    if (!status_macro_internal_status.ok())                         \
+      return status_macro_internal_status;                          \
   } while (0)
 
 #define PERFETTO_INTERNAL_CONCAT_IMPL(x, y) x##y

--- a/src/trace_processor/importers/proto/gpu_event_parser.h
+++ b/src/trace_processor/importers/proto/gpu_event_parser.h
@@ -117,9 +117,14 @@ class GpuEventParser {
   base::FlatHashMap<uint32_t, GpuCounterState> gpu_counter_state_;
 
   // For GpuRenderStageEvent
+  struct HwQueueInfo {
+    StringId name;
+    StringId description;
+  };
   const StringId description_id_;
   const StringId correlation_id_;
-  std::vector<std::optional<TrackId>> gpu_hw_queue_ids_;
+  std::vector<std::optional<HwQueueInfo>> gpu_hw_queue_ids_;
+  base::FlatHashMap<uint64_t, bool> gpu_hw_queue_ids_name_to_set_;
 
   // Map of stage ID -> pair(stage name, stage description)
   std::vector<std::pair<StringId, StringId>> gpu_render_stage_ids_;

--- a/test/trace_processor/diff_tests/parser/graphics/gpu_render_stages_overlapping.py
+++ b/test/trace_processor/diff_tests/parser/graphics/gpu_render_stages_overlapping.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import sys, path
+
+import synth_common
+
+trace = synth_common.create_trace()
+
+# hw_queue_id is the index in the list. Add a dummy for id 0.
+trace.add_gpu_render_stages_hw_queue_spec([
+    {
+        'name': 'dummy queue 0'
+    },
+    {
+        'name': 'queue 1',
+        'description': 'queue desc 1'
+    },
+])
+
+# stage_id is the index in the list. Add a dummy for id 0.
+trace.add_gpu_render_stages_stage_spec([
+    {
+        'name': 'dummy stage 0'
+    },
+    {
+        'name': 'stage 1'
+    },
+])
+
+# Add two overlapping render stages on the same queue.
+# hw_queue_id=1 and stage_id=1 should pick up the specs above.
+trace.add_gpu_render_stages(
+    ts=100, event_id=1, duration=10, hw_queue_id=1, stage_id=1, context=42)
+
+trace.add_gpu_render_stages(
+    ts=105, event_id=2, duration=10, hw_queue_id=1, stage_id=1, context=42)
+
+sys.stdout.buffer.write(trace.trace.SerializeToString())

--- a/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
+++ b/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
@@ -124,7 +124,7 @@ class GraphicsGpuTrace(TestSuite):
           "queue 0","queue desc 0",110,5,"stage 0",0,"[NULL]","[NULL]",42,16,"[NULL]",16,"render_pass",16,"command_buffer",0,0,"[NULL]"
           "queue 0","queue desc 0",120,5,"stage 0",0,"[NULL]","[NULL]",42,16,"framebuffer",16,"render_pass",16,"command_buffer",0,0,"[NULL]"
           "queue 0","queue desc 0",130,5,"stage 0",0,"[NULL]","[NULL]",42,16,"renamed_buffer",0,"[NULL]",0,"[NULL]",0,0,"[NULL]"
-          "Unknown GPU Queue ","[NULL]",140,5,"render stage(18446744073709551615)",0,"[NULL]","[NULL]",42,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,1024,"[NULL]"
+          "Unknown GPU Queue 4294967295","[NULL]",140,5,"render stage(18446744073709551615)",0,"[NULL]","[NULL]",42,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,4294967295,"[NULL]"
           "queue 0","queue desc 0",150,5,"stage 0",0,"[NULL]","[NULL]",42,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,0,"0"
           "queue 0","queue desc 0",160,5,"stage 0",0,"[NULL]","[NULL]",42,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,0,"63,64"
           "queue 0","queue desc 0",170,5,"stage 0",0,"[NULL]","[NULL]",42,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,0,"64"
@@ -179,7 +179,7 @@ class GraphicsGpuTrace(TestSuite):
           "track_name","track_desc","ts","dur","slice_name","depth","flat_key","string_value","context_id","render_target","render_target_name","render_pass","render_pass_name","command_buffer","command_buffer_name","submission_id","hw_queue_id","render_subpasses"
           "vertex","vertex queue",100,10,"binning",0,"description","binning graphics",0,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,1,"[NULL]"
           "fragment","fragment queue",200,10,"render",0,"description","render graphics",0,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,2,"[NULL]"
-          "queue2","queue2 description",300,10,"render",0,"description","render graphics",0,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,1,"[NULL]"
+          "vertex","vertex queue",300,10,"render",0,"description","render graphics",0,0,"[NULL]",0,"[NULL]",0,"[NULL]",0,1,"[NULL]"
         '''))
 
   def test_vulkan_api_events(self):
@@ -235,3 +235,23 @@ class GraphicsGpuTrace(TestSuite):
         "gpu_log","GPU Log",5,0,"VERBOSE","message","message5"
         "gpu_log","GPU Log",5,0,"VERBOSE","tag","tag1"
         """))
+
+  def test_gpu_render_stages_overlapping(self):
+    return DiffTestBlueprint(
+        trace=Path('gpu_render_stages_overlapping.py'),
+        query='''
+          SELECT
+            g.name AS track_name,
+            ts,
+            dur,
+            s.name AS slice_name,
+            depth
+          FROM gpu_track g
+          JOIN gpu_slice s ON g.id = s.track_id
+          ORDER BY ts;
+        ''',
+        out=Csv('''
+          "track_name","ts","dur","slice_name","depth"
+          "queue 1",100,10,"stage 1",0
+          "queue 1",105,10,"stage 1",0
+        '''))


### PR DESCRIPTION
The SliceTracker was silently dropping overlapping gpu_render_stage_event
slices that occurred on the same hardware queue.

This change moves the gpu_render_stage event parsing to use the
TrackCompressor API. To prevent overlaps, TrackCompressor creates the
minimal number of tracks necessary for a given hardware queue, placing
conflicting slices on different tracks. These tracks are associated with
the same hw_queue_id, allowing the UI to compress them into a single
visual track with stacked events. This ensures no slice data is lost.

A new diff test is added to verify that two overlapping events on the
same hw_queue_id are both processed and appear correctly in the
gpu_slice table.

Fixes: https://github.com/google/perfetto/issues/2473
