### PR TITLE
Only include etm.sql in the stdlib with enable_perfetto_etm_importer

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15147,7 +15147,6 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/linux/memory/general.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/memory/high_watermark.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/memory/process.sql",
-        "src/trace_processor/perfetto_sql/stdlib/linux/perf/etm.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/perf/samples.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/perf/spe.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/threads.sql",

--- a/BUILD
+++ b/BUILD
@@ -3218,7 +3218,6 @@ perfetto_filegroup(
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_linux_perf_perf",
     srcs = [
-        "src/trace_processor/perfetto_sql/stdlib/linux/perf/etm.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/perf/samples.sql",
         "src/trace_processor/perfetto_sql/stdlib/linux/perf/spe.sql",
     ],

--- a/src/trace_processor/perfetto_sql/stdlib/linux/perf/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/perf/BUILD.gn
@@ -16,8 +16,11 @@ import("../../../../../../gn/perfetto_sql.gni")
 
 perfetto_sql_source_set("perf") {
   sources = [
-    "etm.sql",
     "samples.sql",
     "spe.sql",
   ]
+
+  if (enable_perfetto_etm_importer) {
+    sources += [ "etm.sql" ]
+  }
 }


### PR DESCRIPTION
This fixes smoke tests that do "INCLUDE PERFETTO MODULE *" when ETM is disabled. In particular Chrome runs a subset of the tests that includes `StdlibSmoke:empty_file` but not any `Etm` tests, so it's test suite needs this.

`Etm:etm_metadata`, which uses etm.sql, is still run unconditionally in the standalone Perfetto build (https://github.com/google/perfetto/issues/2381). However it (and all the other Etm tests) already failed when run with ETM disabled. This just changes the failure from:

> no such table: __intrinsic_etm_decode_trace

to

> INCLUDE: unknown module 'linux.perf.etm'