### PR TITLE
tracebox: add elog if traced_perf is compiled out

### DIFF
--- a/src/tracebox/tracebox.cc
+++ b/src/tracebox/tracebox.cc
@@ -236,9 +236,14 @@ int TraceboxMain(int argc, char** argv) {
 
   std::string traced_perf_notify_msg;
   base::ReadPlatformHandle(*traced_perf_sync_pipe.rd, &traced_perf_notify_msg);
-  if (traced_perf_notify_msg != "1")
+  if (traced_perf_notify_msg != "1") {
     PERFETTO_FATAL(
         "The traced_perf service failed unexpectedly. Check the logs");
+  }
+#else
+  PERFETTO_ELOG(
+      "Unsupported: linux.perf data source support (traced_perf) "
+      "compiled-out.");
 #endif
 
   perfetto_cmd.ConnectToServiceRunAndMaybeNotify();


### PR DESCRIPTION
Minimal change to help users notice cases like
https://github.com/google/perfetto/issues/2481.

This is in the forking path, so it won't spam the "usage" invocations.
Doing something more complex like showing errors in UI is not worth it.
I'd rather spend time figuring out how to refactor traced_perf to not 
require libunwindstack outside of Android.