### PR TITLE
tracing: Log exclusive session rejection.

### DIFF
--- a/src/android_stats/perfetto_atoms.h
+++ b/src/android_stats/perfetto_atoms.h
@@ -74,8 +74,11 @@ enum class PerfettoStatsdAtom {
   kTracedEnableTracingInvalidTriggerMode = 52,
   kTracedEnableTracingInvalidBrFilename = 54,
   kTracedEnableTracingFailedSessionSemaphoreCheck = 57,
+  kTracedEnablePriorityBoostNoCapability = 60,
   kTracedEnablePriorityBoostInvalidConfig = 61,
   kTracedEnablePriorityBoostOtherError = 62,
+  kTracedEnableTracingExclusiveSessionRejected = 63,
+  kTracedEnableTracingExclusiveSessionNotAllowed = 64,
 
   // Checkpoints inside perfetto_cmd after tracing has finished.
   kOnTracingDisabled = 4,

--- a/src/android_stats/perfetto_atoms.h
+++ b/src/android_stats/perfetto_atoms.h
@@ -74,7 +74,6 @@ enum class PerfettoStatsdAtom {
   kTracedEnableTracingInvalidTriggerMode = 52,
   kTracedEnableTracingInvalidBrFilename = 54,
   kTracedEnableTracingFailedSessionSemaphoreCheck = 57,
-  kTracedEnablePriorityBoostNoCapability = 60,
   kTracedEnablePriorityBoostInvalidConfig = 61,
   kTracedEnablePriorityBoostOtherError = 62,
   kTracedEnableTracingExclusiveSessionRejected = 63,

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -773,6 +773,9 @@ base::Status TracingServiceImpl::EnableTracing(ConsumerEndpointImpl* consumer,
   // higher priority.
   if (current_exclusive_prio > 0 &&
       current_exclusive_prio >= cfg.exclusive_prio()) {
+    MaybeLogUploadEvent(
+        cfg, uuid,
+        PerfettoStatsdAtom::kTracedEnableTracingExclusiveSessionRejected);
     return PERFETTO_SVC_ERR(
         "An exclusive session with priority %u >= requested priority %u is "
         "already active.",
@@ -782,6 +785,9 @@ base::Status TracingServiceImpl::EnableTracing(ConsumerEndpointImpl* consumer,
   if (cfg.exclusive_prio() > 0) {  // Exclusive mode.
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
     if (consumer->uid_ != AID_ROOT && consumer->uid_ != AID_SHELL) {
+      MaybeLogUploadEvent(
+          cfg, uuid,
+          PerfettoStatsdAtom::kTracedEnableTracingExclusiveSessionNotAllowed);
       return PERFETTO_SVC_ERR(
           "On android, exclusive mode can only be requested by root or shell.");
     }


### PR DESCRIPTION
Add atoms:
- kTracedEnableTracingExclusiveSessionRejected
- kTracedEnableTracingExclusiveSessionNotAllowed