### PR TITLE
ui: Make input element fill remaining space in TextInput widget

### DIFF
--- a/ui/src/assets/widgets/text_input.scss
+++ b/ui/src/assets/widgets/text_input.scss
@@ -36,10 +36,13 @@
     padding: 0;
     margin: 0;
     color: inherit;
+    flex: 1; // Allow input to grow and shrink to fill available space
 
-    outline: none; // Disable the default outline
-    border: none; // Disable the default border
+    // Disable default styles
+    outline: none;
+    border: none;
     background: none;
+    min-width: 0; // input elements have a default min-width, set to 0 to allow flexbox to work properly
   }
 
   &__left-icon {


### PR DESCRIPTION
Currently when the TextInput widget is stretched horizontally the input element remains a fixed size. This patch just adds a flex grow property to the input element to allow it it to fill the remaining space.