### PR TITLE
ui: Add code snippet widget

### DIFF
--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -38,6 +38,7 @@
 @import "widgets/charts";
 @import "widgets/checkbox";
 @import "widgets/chip";
+@import "widgets/code_snippet";
 @import "widgets/details_shell";
 @import "widgets/editor";
 @import "widgets/empty_state";

--- a/ui/src/assets/widgets/code_snippet.scss
+++ b/ui/src/assets/widgets/code_snippet.scss
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-code-snippet {
+  background-color: var(--pf-color-background-secondary);
+  border: 1px solid var(--pf-color-border);
+  border-radius: 4px;
+  overflow: hidden;
+
+  .pf-code-snippet-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 4px;
+    padding-left: 12px;
+    border-bottom: 1px solid var(--pf-color-border);
+  }
+
+  .pf-code-snippet-language {
+    font-size: 0.8em;
+    color: var(--pf-color-text-secondary);
+  }
+
+  pre {
+    margin: 0;
+    padding: 12px;
+    overflow-x: auto;
+    font-size: 0.8em;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -79,6 +79,7 @@ import {Card, CardStack} from '../../widgets/card';
 import {Stack} from '../../widgets/stack';
 import {Tooltip} from '../../widgets/tooltip';
 import {TabStrip} from '../../widgets/tabs';
+import {CodeSnippet} from '../../widgets/code_snippet';
 
 const DATA_ENGLISH_LETTER_FREQUENCY = {
   table: [
@@ -1881,6 +1882,20 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
           });
         },
         initialOpts: {},
+      }),
+
+      m(WidgetShowcase, {
+        label: 'CodeSnippet',
+        renderWidget: ({wide}) =>
+          m(CodeSnippet, {
+            language: 'SQL',
+            text: Boolean(wide)
+              ? 'SELECT a_very_long_column_name, another_super_long_column_name, yet_another_ridiculously_long_column_name FROM a_table_with_an_unnecessarily_long_name WHERE some_condition_is_true AND another_condition_is_also_true;'
+              : 'SELECT * FROM slice LIMIT 10;',
+          }),
+        initialOpts: {
+          wide: false,
+        },
       }),
     );
   }

--- a/ui/src/widgets/code_snippet.ts
+++ b/ui/src/widgets/code_snippet.ts
@@ -1,0 +1,51 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {copyToClipboard} from '../base/clipboard';
+import {classNames} from '../base/classnames';
+import {Button, ButtonVariant} from './button';
+
+interface CodeSnippetAttrs {
+  // The text to be displayed in the code snippet.
+  readonly text: string;
+  // The language of the code snippet.
+  readonly language?: string;
+  // Any additional classes to apply to the container.
+  readonly class?: string;
+}
+
+export class CodeSnippet implements m.ClassComponent<CodeSnippetAttrs> {
+  view({attrs}: m.Vnode<CodeSnippetAttrs>) {
+    const {text, language, class: className} = attrs;
+
+    return m(
+      '.pf-code-snippet',
+      {
+        className: classNames(className),
+      },
+      m(
+        '.pf-code-snippet-header',
+        m('span.pf-code-snippet-language', language),
+        m(Button, {
+          onclick: () => copyToClipboard(text),
+          icon: 'content_copy',
+          variant: ButtonVariant.Minimal,
+          title: 'Copy to clipboard',
+        }),
+      ),
+      m('pre', m('code', text)),
+    );
+  }
+}


### PR DESCRIPTION
Adds a code snippet widget with builtin scrolling and a copy button.

<img width="284" height="135" alt="image" src="https://github.com/user-attachments/assets/af44b0b2-089d-4313-9325-9f8b5fa83211" />
