### PR TITLE
tp: etm: rename trace to chunk

### DIFF
--- a/src/trace_processor/importers/etm/element_cursor.cc
+++ b/src/trace_processor/importers/etm/element_cursor.cc
@@ -42,22 +42,22 @@ ElementCursor::ElementCursor(TraceStorage* storage)
 ElementCursor::~ElementCursor() = default;
 
 base::Status ElementCursor::Filter(
-    std::optional<tables::EtmV4TraceTable::Id> trace_id,
+    std::optional<tables::EtmV4ChunkTable::Id> chunk_id,
     ElementTypeMask type_mask) {
-  trace_id_ = trace_id;
+  chunk_id_ = chunk_id;
   type_mask_ = type_mask;
-  if (!trace_id.has_value() || type_mask_.empty()) {
+  if (!chunk_id.has_value() || type_mask_.empty()) {
     SetAtEof();
     return base::OkStatus();
   }
   auto session = *storage_->etm_v4_session_table().FindById(
-      storage_->etm_v4_trace_table().FindById(*trace_id)->session_id());
+      storage_->etm_v4_chunk_table().FindById(*chunk_id)->session_id());
   RETURN_IF_ERROR(ResetDecoder(session.configuration_id()));
 
   reader_->SetTs(session.start_ts().value_or(0));
   // We expect this to overflow to 0 in the Next() below
   element_index_ = std::numeric_limits<uint32_t>::max();
-  const auto& data = StorageHandle(storage_).GetTrace(*trace_id);
+  const auto& data = StorageHandle(storage_).GetChunk(*chunk_id);
   data_start_ = data.data();
   data_ = data_start_;
   data_end_ = data.data() + data.size();

--- a/src/trace_processor/importers/etm/element_cursor.h
+++ b/src/trace_processor/importers/etm/element_cursor.h
@@ -72,20 +72,21 @@ class ElementTypeMask {
 
 // Helper class to feed data to an `EtmV4Decoder` that offers a Sqlite friendly
 // API.
-// Given a trace this class will allow you to iterate the ETM elements contained
+// Given a chunk this class will allow you to iterate the ETM elements contained
 // in it. It also give you the ability to filter out some elements.
+// Be aware the in the OSCD namespace an ETM chunk is an ETM trace.
 class ElementCursor : public EtmV4Decoder::Delegate {
  public:
   explicit ElementCursor(TraceStorage* storage);
   ~ElementCursor() override;
 
-  base::Status Filter(std::optional<tables::EtmV4TraceTable::Id> trace_id,
+  base::Status Filter(std::optional<tables::EtmV4ChunkTable::Id> chunk_id,
                       ElementTypeMask type_mask);
 
   base::Status Next();
   bool Eof() { return !needs_flush_ && data_ == data_end_; }
 
-  tables::EtmV4TraceTable::Id trace_id() const { return *trace_id_; }
+  tables::EtmV4ChunkTable::Id chunk_id() const { return *chunk_id_; }
   ocsd_trc_index_t index() const {
     return static_cast<uintptr_t>(data_ - data_start_);
   }
@@ -117,7 +118,7 @@ class ElementCursor : public EtmV4Decoder::Delegate {
   std::unique_ptr<EtmV4Decoder> decoder_;
   // Configuration used to create the above decoder
   std::optional<tables::EtmV4ConfigurationTable::Id> config_id_;
-  std::optional<tables::EtmV4TraceTable::Id> trace_id_;
+  std::optional<tables::EtmV4ChunkTable::Id> chunk_id_;
 
   const uint8_t* data_start_;
   const uint8_t* data_;

--- a/src/trace_processor/importers/etm/etm_tracker.cc
+++ b/src/trace_processor/importers/etm/etm_tracker.cc
@@ -38,15 +38,15 @@ EtmTracker::EtmTracker(TraceProcessorContext* context) : context_(context) {}
 EtmTracker::~EtmTracker() = default;
 
 void EtmTracker::AddSessionData(tables::EtmV4SessionTable::Id session_id,
-                                std::vector<TraceBlobView> traces) {
-  uint32_t trace_set_id = context_->storage->etm_v4_trace_table().row_count();
+                                std::vector<TraceBlobView> chunks) {
+  uint32_t chunk_set_id = context_->storage->etm_v4_chunk_table().row_count();
 
-  for (auto& trace : traces) {
-    auto trace_id = context_->storage->mutable_etm_v4_trace_table()
-                        ->Insert({session_id, trace_set_id,
-                                  static_cast<int64_t>(trace.size())})
+  for (auto& chunk : chunks) {
+    auto chunk_id = context_->storage->mutable_etm_v4_chunk_table()
+                        ->Insert({session_id, chunk_set_id,
+                                  static_cast<int64_t>(chunk.size())})
                         .id;
-    StorageHandle(context_).StoreTrace(trace_id, std::move(trace));
+    StorageHandle(context_).StoreChunk(chunk_id, std::move(chunk));
   }
 }
 
@@ -62,7 +62,7 @@ EtmTracker::InsertEtmV4Config(PerCpuConfiguration per_cpu_configs) {
     row.set_id = set_id;
 
     row.cpu = cpu;
-    row.cs_trace_id = etm_v4_config.getTraceID();
+    row.cs_trace_stream_id = etm_v4_config.getTraceID();
     row.core_profile =
         context_->storage->InternString(ToString(etm_v4_config.coreProfile()));
     row.arch_version =

--- a/src/trace_processor/importers/etm/etm_tracker.h
+++ b/src/trace_processor/importers/etm/etm_tracker.h
@@ -46,7 +46,7 @@ class EtmTracker : public Destructible {
   base::Status Finalize();
 
   void AddSessionData(tables::EtmV4SessionTable::Id session_id,
-                      std::vector<TraceBlobView> traces);
+                      std::vector<TraceBlobView> chunks);
 
   base::FlatSet<tables::EtmV4ConfigurationTable::Id> InsertEtmV4Config(
       PerCpuConfiguration per_cpu_configs);

--- a/src/trace_processor/importers/etm/etm_v4_decoder.cc
+++ b/src/trace_processor/importers/etm/etm_v4_decoder.cc
@@ -27,6 +27,7 @@
 #include "src/trace_processor/importers/etm/opencsd.h"
 #include "src/trace_processor/importers/etm/target_memory_reader.h"
 
+// Be aware the in the OSCD namespace an ETM chunk is an ETM trace.
 namespace perfetto::trace_processor::etm {
 namespace {
 uint32_t ClampToUint32(size_t size) {

--- a/src/trace_processor/importers/etm/etm_v4_decoder.h
+++ b/src/trace_processor/importers/etm/etm_v4_decoder.h
@@ -31,8 +31,9 @@ namespace perfetto::trace_processor::etm {
 class MappingVersion;
 class TargetMemoryReader;
 
-// Wrapper around the open_csd packet processor. This class will take ETM traces
+// Wrapper around the open_csd packet processor. This class will take ETM chunks
 // as input and output a stream of ETM elements.
+// Be aware the in the OSCD namespace an ETM chunk is an ETM trace.
 class EtmV4Decoder : private ITrcGenElemIn {
  public:
   class Delegate {

--- a/src/trace_processor/importers/etm/etm_v4_stream.h
+++ b/src/trace_processor/importers/etm/etm_v4_stream.h
@@ -59,7 +59,7 @@ class EtmV4Stream : public perf_importer::AuxDataStream, public ITrcDataIn {
     explicit SessionState(tables::EtmV4SessionTable::Id in_session_id)
         : session_id(in_session_id) {}
     tables::EtmV4SessionTable::Id session_id;
-    std::vector<TraceBlobView> traces_;
+    std::vector<TraceBlobView> chunks_;
   };
 
   base::Status ParseFramedData(uint64_t offset, TraceBlobView data);
@@ -69,7 +69,7 @@ class EtmV4Stream : public perf_importer::AuxDataStream, public ITrcDataIn {
   void EndChunkedTrace();
 
   void StartSession(std::optional<int64_t> start_ts);
-  void AddTrace(TraceBlobView trace);
+  void AddChunk(TraceBlobView trace);
   void EndSession();
 
   TraceProcessorContext* const context_;

--- a/src/trace_processor/importers/etm/etm_v4_stream_demultiplexer.cc
+++ b/src/trace_processor/importers/etm/etm_v4_stream_demultiplexer.cc
@@ -39,6 +39,7 @@
 #include "src/trace_processor/importers/perf/util.h"
 #include "src/trace_processor/tables/etm_tables_py.h"
 
+// Be aware the in the OSCD namespace an ETM chunk is an ETM trace.
 namespace perfetto::trace_processor::etm {
 namespace {
 
@@ -286,8 +287,8 @@ class EtmV4StreamDemultiplexer : public perf_importer::AuxDataTokenizer {
 
     auto stream = std::make_unique<EtmV4Stream>(context_, &decoder_, config_id);
 
-    RETURN_IF_ERROR(decoder_.Attach(static_cast<uint8_t>(config.cs_trace_id()),
-                                    stream.get()));
+    RETURN_IF_ERROR(decoder_.Attach(
+        static_cast<uint8_t>(config.cs_trace_stream_id()), stream.get()));
     PERFETTO_CHECK(streams_.Insert(config.cpu(), std::move(stream)).second);
     return base::OkStatus();
   }

--- a/src/trace_processor/importers/etm/frame_decoder.cc
+++ b/src/trace_processor/importers/etm/frame_decoder.cc
@@ -41,9 +41,10 @@ base::StatusOr<bool> FrameDecoder::TraceDataIn(const ocsd_datapath_op_t op,
   return error_logger_.ToErrorOrKeepGoing(resp);
 }
 
-base::Status FrameDecoder::Attach(uint8_t cs_trace_id, ITrcDataIn* data_in) {
+base::Status FrameDecoder::Attach(uint8_t cs_trace_stream_id,
+                                  ITrcDataIn* data_in) {
   return error_logger_.ToStatus(
-      frame_decoder_.getIDStreamAttachPt(cs_trace_id)->attach(data_in));
+      frame_decoder_.getIDStreamAttachPt(cs_trace_stream_id)->attach(data_in));
 }
 
 }  // namespace perfetto::trace_processor::etm

--- a/src/trace_processor/importers/etm/frame_decoder.h
+++ b/src/trace_processor/importers/etm/frame_decoder.h
@@ -36,7 +36,7 @@ class FrameDecoder {
                                    const uint8_t* data_block,
                                    uint32_t* num_bytes_processed);
 
-  base::Status Attach(uint8_t cs_trace_id, ITrcDataIn* data_in);
+  base::Status Attach(uint8_t cs_trace_stream_id, ITrcDataIn* data_in);
 
  private:
   ocsd_demux_stats_t demux_stats_;

--- a/src/trace_processor/importers/etm/opencsd.h
+++ b/src/trace_processor/importers/etm/opencsd.h
@@ -17,6 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_ETM_OPENCSD_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_ETM_OPENCSD_H_
 
+// Be aware the in the OSCD namespace an ETM chunk is an ETM trace.
 // This file should be used instead of the librarys <opencsd.h>. This limits the
 // number of includes and in particular avoids <opencsd/ptm/ptm_decoder.h> that
 // has some inline functions that throw exceptions. This messes up the build

--- a/src/trace_processor/importers/etm/storage_handle.cc
+++ b/src/trace_processor/importers/etm/storage_handle.cc
@@ -37,16 +37,16 @@ const Configuration& StorageHandle::GetEtmV4Config(
       storage_->etm_v4_configuration_data()[id.value].get());
 }
 
-void StorageHandle::StoreTrace(tables::EtmV4TraceTable::Id id,
-                               TraceBlobView trace) {
-  PERFETTO_CHECK(id.value == storage_->etm_v4_trace_data().size());
-  storage_->mutable_etm_v4_trace_data()->push_back(std::move(trace));
+void StorageHandle::StoreChunk(tables::EtmV4ChunkTable::Id id,
+                               TraceBlobView chunk) {
+  PERFETTO_CHECK(id.value == storage_->etm_v4_chunk_data().size());
+  storage_->mutable_etm_v4_chunk_data()->push_back(std::move(chunk));
 }
 
-const TraceBlobView& StorageHandle::GetTrace(
-    tables::EtmV4TraceTable::Id id) const {
-  PERFETTO_CHECK(id.value < storage_->etm_v4_trace_data().size());
-  return storage_->etm_v4_trace_data()[id.value];
+const TraceBlobView& StorageHandle::GetChunk(
+    tables::EtmV4ChunkTable::Id id) const {
+  PERFETTO_CHECK(id.value < storage_->etm_v4_chunk_data().size());
+  return storage_->etm_v4_chunk_data()[id.value];
 }
 
 }  // namespace perfetto::trace_processor::etm

--- a/src/trace_processor/importers/etm/storage_handle.h
+++ b/src/trace_processor/importers/etm/storage_handle.h
@@ -45,8 +45,8 @@ class StorageHandle {
   const Configuration& GetEtmV4Config(
       tables::EtmV4ConfigurationTable::Id) const;
 
-  void StoreTrace(tables::EtmV4TraceTable::Id id, TraceBlobView trace);
-  const TraceBlobView& GetTrace(tables::EtmV4TraceTable::Id id) const;
+  void StoreChunk(tables::EtmV4ChunkTable::Id id, TraceBlobView chunk);
+  const TraceBlobView& GetChunk(tables::EtmV4ChunkTable::Id id) const;
 
  private:
   TraceStorage* storage_;

--- a/src/trace_processor/importers/etm/target_memory_reader.h
+++ b/src/trace_processor/importers/etm/target_memory_reader.h
@@ -35,11 +35,11 @@ class TargetMemoryReader : public ITargetMemAccess {
   explicit TargetMemoryReader(const TargetMemory* memory) : memory_(memory) {}
 
   ocsd_err_t ReadTargetMemory(const ocsd_vaddr_t address,
-                              const uint8_t cs_trace_id,
+                              const uint8_t cs_trace_stream_id,
                               const ocsd_mem_space_acc_t mem_space,
                               uint32_t* num_bytes,
                               uint8_t* p_buffer) override;
-  void InvalidateMemAccCache(const uint8_t cs_trace_id) override;
+  void InvalidateMemAccCache(const uint8_t cs_trace_stream_id) override;
 
   void SetTs(int64_t ts);
   void SetPeContext(const ocsd_pe_context&);

--- a/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.cc
@@ -53,27 +53,27 @@ base::StatusOr<ocsd_gen_trc_elem_t> ToElementType(sqlite3_value* value) {
   return *type;
 }
 
-base::StatusOr<tables::EtmV4TraceTable::Id> GetEtmV4TraceId(
+base::StatusOr<tables::EtmV4ChunkTable::Id> GetEtmV4ChunkId(
     const TraceStorage* storage,
     sqlite3_value* argv) {
   SqlValue in_id = sqlite::utils::SqliteValueToSqlValue(argv);
   if (in_id.type != SqlValue::kLong) {
-    return base::ErrStatus("trace_id must be LONG");
+    return base::ErrStatus("chunk_id must be LONG");
   }
 
   if (in_id.AsLong() < 0 ||
-      in_id.AsLong() >= storage->etm_v4_trace_table().row_count()) {
-    return base::ErrStatus("Invalid trace_id value: %" PRIu32,
-                           storage->etm_v4_trace_table().row_count());
+      in_id.AsLong() >= storage->etm_v4_chunk_table().row_count()) {
+    return base::ErrStatus("Invalid chunk_id value: %" PRIu32,
+                           storage->etm_v4_chunk_table().row_count());
   }
 
-  return tables::EtmV4TraceTable::Id(static_cast<uint32_t>(in_id.AsLong()));
+  return tables::EtmV4ChunkTable::Id(static_cast<uint32_t>(in_id.AsLong()));
 }
 
 static constexpr char kSchema[] = R"(
     CREATE TABLE x(
-      trace_id INTEGER HIDDEN,
-      trace_index INTEGER,
+      chunk_id INTEGER HIDDEN,
+      chunk_index INTEGER,
       element_index INTEGER,
       element_type TEXT,
       timestamp INTEGER,
@@ -89,8 +89,8 @@ static constexpr char kSchema[] = R"(
   )";
 
 enum class ColumnIndex {
-  kTraceId,
-  kTraceIndex,
+  kChunkId,
+  kChunkIndex,
   kElementIndex,
   kElementType,
   kTimestamp,
@@ -104,14 +104,14 @@ enum class ColumnIndex {
   kInstructionRange
 };
 
-constexpr char kTraceIdEqArg = 't';
+constexpr char kChunkIdEqArg = 't';
 constexpr char kElementTypeEqArg = 'e';
 constexpr char kElementTypeInArg = 'E';
 
 }  // namespace
 
-class EtmDecodeTraceVtable::Cursor
-    : public sqlite::Module<EtmDecodeTraceVtable>::Cursor {
+class EtmDecodeChunkVtable::Cursor
+    : public sqlite::Module<EtmDecodeChunkVtable>::Cursor {
  public:
   explicit Cursor(Vtab* vtab) : cursor_(vtab->storage) {}
 
@@ -129,7 +129,7 @@ class EtmDecodeTraceVtable::Cursor
   ElementCursor cursor_;
 };
 
-base::StatusOr<ElementTypeMask> EtmDecodeTraceVtable::Cursor::GetTypeMask(
+base::StatusOr<ElementTypeMask> EtmDecodeChunkVtable::Cursor::GetTypeMask(
     sqlite3_value* argv,
     bool is_inlist) {
   ElementTypeMask mask;
@@ -151,11 +151,11 @@ base::StatusOr<ElementTypeMask> EtmDecodeTraceVtable::Cursor::GetTypeMask(
   return mask;
 }
 
-base::Status EtmDecodeTraceVtable::Cursor::Filter(int,
+base::Status EtmDecodeChunkVtable::Cursor::Filter(int,
                                                   const char* idxStr,
                                                   int argc,
                                                   sqlite3_value** argv) {
-  std::optional<tables::EtmV4TraceTable::Id> id;
+  std::optional<tables::EtmV4ChunkTable::Id> id;
   ElementTypeMask type_mask;
   type_mask.set_all();
   if (argc != static_cast<int>(strlen(idxStr))) {
@@ -163,8 +163,8 @@ base::Status EtmDecodeTraceVtable::Cursor::Filter(int,
   }
   for (; *idxStr != 0; ++idxStr, ++argv) {
     switch (*idxStr) {
-      case kTraceIdEqArg: {
-        ASSIGN_OR_RETURN(id, GetEtmV4TraceId(cursor_.storage(), *argv));
+      case kChunkIdEqArg: {
+        ASSIGN_OR_RETURN(id, GetEtmV4ChunkId(cursor_.storage(), *argv));
         break;
       }
       case kElementTypeEqArg: {
@@ -188,12 +188,12 @@ base::Status EtmDecodeTraceVtable::Cursor::Filter(int,
   return cursor_.Filter(id, type_mask);
 }
 
-int EtmDecodeTraceVtable::Cursor::Column(sqlite3_context* ctx, int raw_n) {
+int EtmDecodeChunkVtable::Cursor::Column(sqlite3_context* ctx, int raw_n) {
   switch (static_cast<ColumnIndex>(raw_n)) {
-    case ColumnIndex::kTraceId:
-      sqlite::result::Long(ctx, cursor_.trace_id().value);
+    case ColumnIndex::kChunkId:
+      sqlite::result::Long(ctx, cursor_.chunk_id().value);
       break;
-    case ColumnIndex::kTraceIndex:
+    case ColumnIndex::kChunkIndex:
       sqlite::result::Long(ctx, static_cast<int64_t>(cursor_.index()));
       break;
     case ColumnIndex::kElementIndex:
@@ -251,7 +251,7 @@ int EtmDecodeTraceVtable::Cursor::Column(sqlite3_context* ctx, int raw_n) {
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::Connect(sqlite3* db,
+int EtmDecodeChunkVtable::Connect(sqlite3* db,
                                   void* ctx,
                                   int,
                                   const char* const*,
@@ -265,12 +265,12 @@ int EtmDecodeTraceVtable::Connect(sqlite3* db,
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::Disconnect(sqlite3_vtab* vtab) {
+int EtmDecodeChunkVtable::Disconnect(sqlite3_vtab* vtab) {
   delete GetVtab(vtab);
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::BestIndex(sqlite3_vtab* tab,
+int EtmDecodeChunkVtable::BestIndex(sqlite3_vtab* tab,
                                     sqlite3_index_info* info) {
   bool seen_id_eq = false;
   int argv_index = 1;
@@ -279,17 +279,17 @@ int EtmDecodeTraceVtable::BestIndex(sqlite3_vtab* tab,
     auto& in = info->aConstraint[i];
     auto& out = info->aConstraintUsage[i];
 
-    if (in.iColumn == static_cast<int>(ColumnIndex::kTraceId)) {
+    if (in.iColumn == static_cast<int>(ColumnIndex::kChunkId)) {
       if (!in.usable) {
         return SQLITE_CONSTRAINT;
       }
       if (in.op != SQLITE_INDEX_CONSTRAINT_EQ) {
         return sqlite::utils::SetError(
-            tab, "trace_id only supports equality constraints");
+            tab, "chunk_id only supports equality constraints");
       }
       seen_id_eq = true;
 
-      idx_str += kTraceIdEqArg;
+      idx_str += kChunkIdEqArg;
       out.argvIndex = argv_index++;
       out.omit = true;
       continue;
@@ -312,7 +312,7 @@ int EtmDecodeTraceVtable::BestIndex(sqlite3_vtab* tab,
     }
   }
   if (!seen_id_eq) {
-    return sqlite::utils::SetError(tab, "Constraint required on trace_id");
+    return sqlite::utils::SetError(tab, "Constraint required on chunk_id");
   }
 
   info->idxStr = sqlite3_mprintf("%s", idx_str.c_str());
@@ -321,18 +321,18 @@ int EtmDecodeTraceVtable::BestIndex(sqlite3_vtab* tab,
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::Open(sqlite3_vtab* sql_vtab,
+int EtmDecodeChunkVtable::Open(sqlite3_vtab* sql_vtab,
                                sqlite3_vtab_cursor** cursor) {
   *cursor = new Cursor(GetVtab(sql_vtab));
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::Close(sqlite3_vtab_cursor* cursor) {
+int EtmDecodeChunkVtable::Close(sqlite3_vtab_cursor* cursor) {
   delete GetCursor(cursor);
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::Filter(sqlite3_vtab_cursor* cur,
+int EtmDecodeChunkVtable::Filter(sqlite3_vtab_cursor* cur,
                                  int idxNum,
                                  const char* idxStr,
                                  int argc,
@@ -344,7 +344,7 @@ int EtmDecodeTraceVtable::Filter(sqlite3_vtab_cursor* cur,
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::Next(sqlite3_vtab_cursor* cur) {
+int EtmDecodeChunkVtable::Next(sqlite3_vtab_cursor* cur) {
   auto status = GetCursor(cur)->Next();
   if (!status.ok()) {
     return sqlite::utils::SetError(cur->pVtab, status);
@@ -352,17 +352,17 @@ int EtmDecodeTraceVtable::Next(sqlite3_vtab_cursor* cur) {
   return SQLITE_OK;
 }
 
-int EtmDecodeTraceVtable::Eof(sqlite3_vtab_cursor* cur) {
+int EtmDecodeChunkVtable::Eof(sqlite3_vtab_cursor* cur) {
   return GetCursor(cur)->Eof();
 }
 
-int EtmDecodeTraceVtable::Column(sqlite3_vtab_cursor* cur,
+int EtmDecodeChunkVtable::Column(sqlite3_vtab_cursor* cur,
                                  sqlite3_context* ctx,
                                  int raw_n) {
   return GetCursor(cur)->Column(ctx, raw_n);
 }
 
-int EtmDecodeTraceVtable::Rowid(sqlite3_vtab_cursor*, sqlite_int64*) {
+int EtmDecodeChunkVtable::Rowid(sqlite3_vtab_cursor*, sqlite_int64*) {
   return SQLITE_ERROR;
 }
 

--- a/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.h
@@ -25,9 +25,9 @@ namespace perfetto::trace_processor {
 class TraceStorage;
 namespace etm {
 
-struct EtmDecodeTraceVtable : sqlite::Module<EtmDecodeTraceVtable> {
+struct EtmDecodeChunkVtable : sqlite::Module<EtmDecodeChunkVtable> {
   using Context = TraceStorage;
-  struct Vtab : sqlite::Module<EtmDecodeTraceVtable>::Vtab {
+  struct Vtab : sqlite::Module<EtmDecodeChunkVtable>::Vtab {
     explicit Vtab(TraceStorage* in_storage) : storage(in_storage) {}
     TraceStorage* storage;
   };

--- a/src/trace_processor/perfetto_sql/stdlib/linux/perf/etm.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/perf/etm.sql
@@ -13,15 +13,15 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- TODO(fouly): elaborate on how to select trace_id after trace_id aggregates are created
--- TODO(fouly): explain where trace_id comes from after __intrinsic_etm_v4_trace is no longer intrinsic
+-- TODO(fouly): elaborate on how to select chunk_id after chunk_id aggregates are created
+-- TODO(fouly): explain where chunk_id comes from after __intrinsic_etm_v4_chunk is no longer intrinsic
 
--- This is a table that extracts the file_path for the binary and the relative address for each ETM instruction in a specific ETM trace.
+-- This is a table that extracts the file_path for the binary and the relative address for each ETM instruction in a specific ETM chunk.
 -- The most common use case will be to use this data to help symbolize the addresses in order to map instructions back to the code that caused them.
 -- To get ETM data you need to have enabled enable_perfetto_etm_importer in your gn args.
 CREATE PERFETTO FUNCTION _linux_perf_etm_metadata(
-    -- ID of the trace.
-    trace_id LONG
+    -- ID of the chunk.
+    chunk_id LONG
 )
 RETURNS TABLE (
   -- Name of the file containing the instruction.
@@ -36,13 +36,13 @@ RETURNS TABLE (
 SELECT
   __intrinsic_file.name AS file_name,
   __intrinsic_etm_iterate_instruction_range.address - stack_profile_mapping.start + stack_profile_mapping.exact_offset + __intrinsic_elf_file.load_bias AS rel_pc,
-  __intrinsic_etm_decode_trace.mapping_id AS mapping_id,
+  __intrinsic_etm_decode_chunk.mapping_id AS mapping_id,
   __intrinsic_etm_iterate_instruction_range.address AS address
-FROM __intrinsic_etm_decode_trace($trace_id)
+FROM __intrinsic_etm_decode_chunk($chunk_id)
 JOIN __intrinsic_etm_iterate_instruction_range
-  ON __intrinsic_etm_decode_trace.instruction_range = __intrinsic_etm_iterate_instruction_range.instruction_range
+  ON __intrinsic_etm_decode_chunk.instruction_range = __intrinsic_etm_iterate_instruction_range.instruction_range
 JOIN stack_profile_mapping
-  ON __intrinsic_etm_decode_trace.mapping_id = stack_profile_mapping.id
+  ON __intrinsic_etm_decode_chunk.mapping_id = stack_profile_mapping.id
 JOIN __intrinsic_elf_file
   ON stack_profile_mapping.build_id = __intrinsic_elf_file.build_id
 JOIN __intrinsic_file

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -711,17 +711,17 @@ class TraceStorage {
   tables::EtmV4SessionTable* mutable_etm_v4_session_table() {
     return &etm_v4_session_table_;
   }
-  const tables::EtmV4TraceTable& etm_v4_trace_table() const {
-    return etm_v4_trace_table_;
+  const tables::EtmV4ChunkTable& etm_v4_chunk_table() const {
+    return etm_v4_chunk_table_;
   }
-  tables::EtmV4TraceTable* mutable_etm_v4_trace_table() {
-    return &etm_v4_trace_table_;
+  tables::EtmV4ChunkTable* mutable_etm_v4_chunk_table() {
+    return &etm_v4_chunk_table_;
   }
-  const std::vector<TraceBlobView>& etm_v4_trace_data() const {
-    return etm_v4_trace_data_;
+  const std::vector<TraceBlobView>& etm_v4_chunk_data() const {
+    return etm_v4_chunk_data_;
   }
-  std::vector<TraceBlobView>* mutable_etm_v4_trace_data() {
-    return &etm_v4_trace_data_;
+  std::vector<TraceBlobView>* mutable_etm_v4_chunk_data() {
+    return &etm_v4_chunk_data_;
   }
   const tables::FileTable& file_table() const { return file_table_; }
   tables::FileTable* mutable_file_table() { return &file_table_; }
@@ -1169,9 +1169,9 @@ class TraceStorage {
   // Indexed by tables::EtmV4ConfigurationTable::Id
   std::vector<std::unique_ptr<Destructible>> etm_v4_configuration_data_;
   tables::EtmV4SessionTable etm_v4_session_table_{&string_pool_};
-  tables::EtmV4TraceTable etm_v4_trace_table_{&string_pool_};
+  tables::EtmV4ChunkTable etm_v4_chunk_table_{&string_pool_};
   // Indexed by tables::EtmV4TraceTable::Id
-  std::vector<TraceBlobView> etm_v4_trace_data_;
+  std::vector<TraceBlobView> etm_v4_chunk_data_;
   std::unique_ptr<Destructible> etm_target_memory_;
   tables::FileTable file_table_{&string_pool_};
   tables::ElfFileTable elf_file_table_{&string_pool_};

--- a/src/trace_processor/tables/etm_tables.py
+++ b/src/trace_processor/tables/etm_tables.py
@@ -35,7 +35,7 @@ ETM_V4_CONFIGURATION = Table(
     columns=[
         C('set_id', CppUint32(), flags=ColumnFlag.SORTED | ColumnFlag.SET_ID),
         C('cpu', CppUint32(), cpp_access=CppAccess.READ),
-        C('cs_trace_id', CppUint32(), cpp_access=CppAccess.READ),
+        C('cs_trace_stream_id', CppUint32(), cpp_access=CppAccess.READ),
         C('core_profile', CppString()),
         C('arch_version', CppString()),
         C('major_version', CppUint32()),
@@ -52,12 +52,12 @@ ETM_V4_CONFIGURATION = Table(
         columns={
             'set_id':
                 '''
-                  Groups all configuration ros that belong to the same trace.
+                  Groups all configuration ros that belong to the same ETM trace.
                   There is one row per each CPU where ETM was configured.
                 ''',
             'cpu':
                 'CPU this configuration applies to.',
-            'cs_trace_id':
+            'cs_trace_stream_id':
                 'Trace Stream ID register',
             'core_profile':
                 'Core Profile (e.g. Cortex-A or Cortex-M)',
@@ -104,27 +104,27 @@ ETM_V4_SESSION = Table(
                     'ETM configuration',
                     joinable='__intrinsic_etm_v4_configuration.id'),
             'start_ts':
-                'time the trace ETM trace collection started.',
+                'COCK_MONOTONIC timestamp for when the ETM session collection started.',
         },
     ))
 
-ETM_V4_TRACE = Table(
+ETM_V4_CHUNK = Table(
     python_module=__file__,
-    class_name='EtmV4TraceTable',
-    sql_name='__intrinsic_etm_v4_trace',
+    class_name='EtmV4ChunkTable',
+    sql_name='__intrinsic_etm_v4_chunk',
     columns=[
         C('session_id',
           CppTableId(ETM_V4_SESSION),
           cpp_access=CppAccess.READ,
           cpp_access_duration=CppAccessDuration.POST_FINALIZATION),
-        C('trace_set_id',
+        C('chunk_set_id',
           CppUint32(),
           flags=ColumnFlag.SORTED | ColumnFlag.SET_ID),
         C('size', CppInt64()),
     ],
     tabledoc=TableDoc(
         doc='''
-          Represents a contiguous chunk of ETM trace data for a core. The data
+          Represents a contiguous chunk of ETM chunk data for a core. The data
           collected during a session might be split into different chunks in the
           case of data loss.
         ''',
@@ -133,9 +133,9 @@ ETM_V4_TRACE = Table(
             'session_id':
                 ColumnDoc(
                     'Session this data belongs to',
-                    joinable='__intrinsic_etm_v4_trace.id'),
-            'trace_set_id':
-                'Groups all the traces belonging to the same session.',
+                    joinable='__intrinsic_etm_v4_chunk.id'),
+            'chunk_set_id':
+                'Groups all the chunks belonging to the same session.',
             'size':
                 'Size in bytes',
         },
@@ -214,6 +214,6 @@ ELF_FILE_TABLE = Table(
         }))
 
 ALL_TABLES = [
-    ETM_V4_CONFIGURATION, ETM_V4_TRACE, ETM_V4_SESSION, FILE_TABLE,
+    ETM_V4_CONFIGURATION, ETM_V4_CHUNK, ETM_V4_SESSION, FILE_TABLE,
     ELF_FILE_TABLE
 ]

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -980,7 +980,7 @@ TraceProcessorImpl::GetUnfinalizedStaticTables(TraceStorage* storage) {
   AddUnfinalizedStaticTable(tables,
                             storage->mutable_etm_v4_configuration_table());
   AddUnfinalizedStaticTable(tables, storage->mutable_etm_v4_session_table());
-  AddUnfinalizedStaticTable(tables, storage->mutable_etm_v4_trace_table());
+  AddUnfinalizedStaticTable(tables, storage->mutable_etm_v4_chunk_table());
   AddUnfinalizedStaticTable(
       tables, storage->mutable_experimental_missing_chrome_processes_table());
   AddUnfinalizedStaticTable(
@@ -1315,8 +1315,8 @@ std::unique_ptr<PerfettoSqlEngine> TraceProcessorImpl::InitPerfettoSqlEngine(
       "__intrinsic_slice_mipmap",
       std::make_unique<SliceMipmapOperator::Context>(engine.get()));
 #if PERFETTO_BUILDFLAG(PERFETTO_ENABLE_ETM_IMPORTER)
-  engine->RegisterVirtualTableModule<etm::EtmDecodeTraceVtable>(
-      "__intrinsic_etm_decode_trace", storage);
+  engine->RegisterVirtualTableModule<etm::EtmDecodeChunkVtable>(
+      "__intrinsic_etm_decode_chunk", storage);
   engine->RegisterVirtualTableModule<etm::EtmIterateRangeVtable>(
       "__intrinsic_etm_iterate_instruction_range", storage);
 #endif

--- a/test/trace_processor/diff_tests/parser/etm/decode_chunk.out
+++ b/test/trace_processor/diff_tests/parser/etm/decode_chunk.out
@@ -1,4 +1,4 @@
-"trace_index","element_index","element_type","timestamp","cycle_count","exception_level","context_id","isa","start_address","end_address","mapping_id"
+"chunk_index","element_index","element_type","timestamp","cycle_count","exception_level","context_id","isa","start_address","end_address","mapping_id"
 12,0,"NO_SYNC","[NULL]","[NULL]","[NULL]","[NULL]","UNKNOWN",-1,-1,"[NULL]"
 40,1,"TRACE_ON","[NULL]","[NULL]","[NULL]","[NULL]","UNKNOWN",-1,-1,"[NULL]"
 40,2,"PE_CONTEXT","[NULL]","[NULL]",0,315,"AARCH64",-1,-1,"[NULL]"

--- a/test/trace_processor/diff_tests/parser/etm/tests.py
+++ b/test/trace_processor/diff_tests/parser/etm/tests.py
@@ -30,7 +30,7 @@ class Etm(TestSuite):
             __intrinsic_etm_v4_configuration AS C,
              __intrinsic_etm_v4_session AS s
              ON c.id = s.configuration_id,
-             __intrinsic_etm_v4_trace AS t
+             __intrinsic_etm_v4_chunk AS t
              ON s.id = t.session_id
           WHERE start_ts < 21077000721310
           ORDER BY start_ts ASC
@@ -59,26 +59,26 @@ class Etm(TestSuite):
         query='''
           SELECT count(*)
           FROM
-            __intrinsic_etm_v4_trace t,
-            __intrinsic_etm_decode_trace d
-            ON t.id = d.trace_id
+            __intrinsic_etm_v4_chunk t,
+            __intrinsic_etm_decode_chunk d
+            ON t.id = d.chunk_id
         ''',
         out=Csv('''
           "count(*)"
           5871
         '''))
 
-  def test_decode_trace(self):
+  def test_decode_chunk(self):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
         query='''
           SELECT *
           FROM
-            __intrinsic_etm_decode_trace
-          WHERE trace_id = 0
+            __intrinsic_etm_decode_chunk
+          WHERE chunk_id = 0
         ''',
-        out=Path('decode_trace.out'))
+        out=Path('decode_chunk.out'))
 
   def test_iterate_instructions(self):
     return DiffTestBlueprint(
@@ -87,10 +87,10 @@ class Etm(TestSuite):
         query='''
           SELECT d.element_index, i.*
           FROM
-            __intrinsic_etm_decode_trace d,
+            __intrinsic_etm_decode_chunk d,
             __intrinsic_etm_iterate_instruction_range i
             USING(instruction_range)
-          WHERE trace_id = 0 AND mapping_id = 1
+          WHERE chunk_id = 0 AND mapping_id = 1
         ''',
         out=Path('iterate_instructions.out'))
 


### PR DESCRIPTION
In order to avoid using the overloaded trace term, an ETM trace is now an ETM chunk.

However it is important to note in the OSCD (Decoder for ETM) namespace an ETM chunk is an ETM trace.
