### PR TITLE
Fix path handling in discover_and_load_tests.

### DIFF
--- a/python/generators/diff_tests/runner.py
+++ b/python/generators/diff_tests/runner.py
@@ -31,15 +31,11 @@ from python.generators.diff_tests.test_executor import (QueryTestExecutor,
                                                         MetricV2TestExecutor)
 from python.generators.diff_tests.test_loader import TestLoader
 
-ROOT_DIR = os.path.dirname(
-    os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-
 
 @dataclass
 class TestResults:
   """Results of running the test suite.
-  
+
   Mostly used for printing aggregated results.
   """
   test_failures: List[str]
@@ -66,12 +62,10 @@ class DiffTestsRunner:
 
   def __init__(self, config: Config):
     self.config = config
-    self.test_loader = TestLoader(
-        os.path.abspath(os.path.join(__file__, '../../../../test/data')))
+    self.test_loader = TestLoader(os.path.abspath(config.test_dir))
 
   def run(self) -> TestResults:
-    tests = self.test_loader.discover_and_load_tests(ROOT_DIR,
-                                                     self.config.name_filter)
+    tests = self.test_loader.discover_and_load_tests(self.config.name_filter)
 
     trace_descriptor_path = get_trace_descriptor_path(
         os.path.dirname(self.config.trace_processor_path),
@@ -184,12 +178,13 @@ class DiffTestsRunner:
         res += 'tools/serialize_test_trace.py '
         assert result.test.trace_path
         res += '--descriptor {} {} {} > {}\n'.format(
-            os.path.relpath(trace_descriptor_path, ROOT_DIR), " ".join([
+            os.path.relpath(trace_descriptor_path, config.test_dir), " ".join([
                 "--extension-descriptor {}".format(
-                    os.path.relpath(p, ROOT_DIR))
+                    os.path.relpath(p, config.test_dir))
                 for p in extension_descriptor_paths
-            ]), os.path.relpath(result.test.trace_path, ROOT_DIR),
-            os.path.relpath(trace_path, ROOT_DIR), extension_descriptor_paths)
+            ]), os.path.relpath(result.test.trace_path, config.test_dir),
+            os.path.relpath(trace_path, config.test_dir),
+            extension_descriptor_paths)
       res += f"Command line:\n{' '.join(result.cmd)}\n"
       return res
 

--- a/python/generators/diff_tests/test_loader.py
+++ b/python/generators/diff_tests/test_loader.py
@@ -30,13 +30,12 @@ if TYPE_CHECKING:
 class TestLoader:
   """Discovers and loads all tests."""
 
-  def __init__(self, test_data_dir: str):
-    self.test_data_dir = test_data_dir
+  def __init__(self, root_dir: os.PathLike):
+    self.root_dir = root_dir
 
-  def discover_and_load_tests(self, root_dir: str,
-                              name_filter: str) -> List[TestCase]:
+  def discover_and_load_tests(self, name_filter: str) -> List[TestCase]:
     # Import the index file to discover all the tests.
-    include_path = os.path.join(root_dir, 'test', 'trace_processor',
+    include_path = os.path.join(self.root_dir, 'test', 'trace_processor',
                                 'diff_tests')
     sys.path.append(include_path)
     from include_index import fetch_all_diff_tests

--- a/python/generators/diff_tests/utils.py
+++ b/python/generators/diff_tests/utils.py
@@ -136,12 +136,11 @@ def get_trace_descriptor_path(out_path: str, trace_descriptor: str):
   return trace_descriptor_path
 
 
-def read_all_tests(name_filter: str, root_dir: str,
-                   test_data_dir: str) -> List[models.TestCase]:
+def read_all_tests(name_filter: str,
+                   root_dir: os.PathLike) -> List[models.TestCase]:
   """Reads all diff tests from the given directory."""
   from python.generators.diff_tests.test_loader import TestLoader
-  return TestLoader(test_data_dir).discover_and_load_tests(
-      root_dir, name_filter)
+  return TestLoader(root_dir).discover_and_load_tests(name_filter)
 
 
 def write_diff(expected: str, actual: str) -> str:

--- a/tools/diff_test_trace_processor.py
+++ b/tools/diff_test_trace_processor.py
@@ -98,8 +98,7 @@ def main():
       keep_input=args.keep_input,
       print_slowest_tests=args.print_slowest_tests)
   test_runner = DiffTestsRunner(config)
-  tests = test_runner.test_loader.discover_and_load_tests(
-      ROOT_DIR, config.name_filter)
+  tests = test_runner.test_loader.discover_and_load_tests(config.name_filter)
   sys.stderr.write(f"[==========] Running {len(tests)} tests.\n")
   results = test_runner.run()
   sys.stderr.write(results.str(args.no_colors, len(tests)))


### PR DESCRIPTION
Chrome's run_perfetto_diff_tests script passes --test-dir to use a custom set of tests in an include_index.py file from the chromium repo. However after the refactor in commit
c73249ac86b183522a7aed9fbde127d8e3f65848, --test-dir is ignored and the script runs the complete set of diff tests from
test/trace_processor/diff_tests/include_index.py, most of which aren't supported from Chrome.

This fixes the problem by making sure --test-dir is passed through to TestLoader:

* TestLoader's test_data_dir param is never used (all its methods actually use blueprint.test_data_dir). Remove it.
* discover_and_load_tests from the same TestLoader should always look in the same dir, so move its root_dir param to the constructor, replacing test_data_dir.
* Fix DiffTestsRunner to pass config.test_dir, which is the --test-dir command-line override that defaults to ROOT_DIR, instead of ROOT_DIR.
