### PR TITLE
Fix exception in write_cmdlines

### DIFF
--- a/python/generators/diff_tests/runner.py
+++ b/python/generators/diff_tests/runner.py
@@ -62,7 +62,7 @@ class DiffTestsRunner:
 
   def __init__(self, config: Config):
     self.config = config
-    self.test_loader = TestLoader(os.path.abspath(config.test_dir))
+    self.test_loader = TestLoader(os.path.abspath(self.config.test_dir))
 
   def run(self) -> TestResults:
     tests = self.test_loader.discover_and_load_tests(self.config.name_filter)
@@ -178,12 +178,14 @@ class DiffTestsRunner:
         res += 'tools/serialize_test_trace.py '
         assert result.test.trace_path
         res += '--descriptor {} {} {} > {}\n'.format(
-            os.path.relpath(trace_descriptor_path, config.test_dir), " ".join([
-                "--extension-descriptor {}".format(
-                    os.path.relpath(p, config.test_dir))
-                for p in extension_descriptor_paths
-            ]), os.path.relpath(result.test.trace_path, config.test_dir),
-            os.path.relpath(trace_path, config.test_dir),
+            os.path.relpath(trace_descriptor_path,
+                            self.config.test_dir), " ".join([
+                                "--extension-descriptor {}".format(
+                                    os.path.relpath(p, self.config.test_dir))
+                                for p in extension_descriptor_paths
+                            ]),
+            os.path.relpath(result.test.trace_path, self.config.test_dir),
+            os.path.relpath(trace_path, self.config.test_dir),
             extension_descriptor_paths)
       res += f"Command line:\n{' '.join(result.cmd)}\n"
       return res


### PR DESCRIPTION
Fixes an exception thrown from write_cmdlines if a difftest fails:

```
NameError: name 'config' is not defined. Did you mean: 'Config'?
```

The regression was introduced in commit 3e17997fd8523ee042707dd1a53172bd560b1951