### PR TITLE
CI: show more precise ccache statistics.

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Setup ccache
         shell: bash
-        run: bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - uses: ./.github/actions/install-build-deps
         with:
@@ -61,7 +63,7 @@ jobs:
 
       - name: Print ccache stats
         shell: bash
-        run: ccache --show-stats
+        run: ccache --show-stats --verbose
 
       - name: perfetto_unittests
         shell: bash

--- a/.github/workflows/fuzzer-tests.yml
+++ b/.github/workflows/fuzzer-tests.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Setup ccache
         shell: bash
-        run: bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - name: Restore cache
         uses: ./.github/actions/cache-on-google-cloud-storage/restore
@@ -53,6 +55,10 @@ jobs:
       - name: Build
         shell: bash
         run: tools/ninja -C out/dist fuzzers
+
+      - name: Print ccache stats
+        shell: bash
+        run: ccache --show-stats --verbose
 
       - name: Run single fuzzer iteration
         shell: bash

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -57,7 +57,9 @@ jobs:
 
       - name: Setup ccache
         shell: bash
-        run: bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - name: Setup artifacts
         shell: bash
@@ -89,7 +91,7 @@ jobs:
 
       - name: Print ccache stats
         shell: bash
-        run: ccache --show-stats
+        run: ccache --show-stats --verbose
 
       - name: setup symbolizer paths
         shell: bash

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -54,7 +54,9 @@ jobs:
 
       - name: Setup ccache
         shell: bash
-        run: bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - name: Restore cache
         uses: ./.github/actions/cache-on-google-cloud-storage/restore
@@ -70,7 +72,7 @@ jobs:
 
       - name: Print ccache stats
         shell: bash
-        run: ccache --show-stats
+        run: ccache --show-stats --verbose
 
 
       - name: UI unittests


### PR DESCRIPTION
We need stats only for the current build, not the aggregated stats for all the previously cached builds.
When setting up the ccache, we zero stats for the cache, so when the build is finished,
the `ccache --show-stats` prints statistics for the current build only.

Also add '--verbose' to show cache failures.
