### PR TITLE
Add gn/run_binary.py script

### DIFF
--- a/gn/run_binary.py
+++ b/gn/run_binary.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 The Android Open Source Project
+# Copyright (C) 2025 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Script to wrap protoc execution.
+"""Runs a binary.
 
-This script exists to work-around the bad depfile generation by protoc when
-generating descriptors."""
+This script exists because GN action only works with python scripts."""
 
 import sys
 import subprocess

--- a/gn/standalone/proto_library.gni
+++ b/gn/standalone/proto_library.gni
@@ -162,7 +162,7 @@ template("proto_library") {
                     _host_executable_suffix
       protoc_rebased_path = "./" + rebase_path(protoc_path, root_build_dir)
     }
-    script = "//gn/standalone/protoc.py"
+    script = "//gn/run_binary.py"
     args = [
       # Path should be rebased because |root_build_dir| for current toolchain
       # may be different from |root_out_dir| of protoc built on host toolchain.

--- a/tools/install-build-deps
+++ b/tools/install-build-deps
@@ -186,11 +186,6 @@ BUILD_DEPS_HOST = [
     # Keep in sync with Chromium's //third_party/protobuf.
     Dependency(
         'buildtools/protobuf',
-        # If you revert the below version back to an earlier version of
-        # protobuf, make sure to revert the changes to
-        # //gn/standalone/protoc.py as well.
-        #
-        # This comment can be removed with protobuf is next upreved.
         'https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf.git',
         'f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c',  # refs/tags/v21.12
         'all',


### PR DESCRIPTION
It will be used by a future commit.

We can also use it as a wrapper for protoc
(https://r.android.com/3097027 removed most of the logic from the protoc wrapper).