### PR TITLE
 CI: setup ccache after the cache directory is restored.

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -33,12 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup ccache
-        shell: bash
-        run: |
-          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
-          ccache --zero-stats
-
       - uses: ./.github/actions/install-build-deps
         with:
           install-flags: --android
@@ -48,6 +42,12 @@ jobs:
         with:
           directory: ${{ env.PERFETTO_CACHE_DIR }}
           cache_key: ${{ env.PERFETTO_CI_BUILD_CACHE_KEY }}
+
+      - name: Setup ccache
+        shell: bash
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - name: Start emulator in the background
         shell: bash

--- a/.github/workflows/fuzzer-tests.yml
+++ b/.github/workflows/fuzzer-tests.yml
@@ -34,17 +34,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup ccache
-        shell: bash
-        run: |
-          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
-          ccache --zero-stats
-
       - name: Restore cache
         uses: ./.github/actions/cache-on-google-cloud-storage/restore
         with:
           directory: ${{ env.PERFETTO_CACHE_DIR }}
           cache_key: ${{ env.PERFETTO_CI_BUILD_CACHE_KEY }}
+
+      - name: Setup ccache
+        shell: bash
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - uses: ./.github/actions/install-build-deps
 

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -55,12 +55,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup ccache
-        shell: bash
-        run: |
-          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
-          ccache --zero-stats
-
       - name: Setup artifacts
         shell: bash
         run: |
@@ -73,6 +67,12 @@ jobs:
         with:
           directory: ${{ env.PERFETTO_CACHE_DIR }}
           cache_key: ${{ env.PERFETTO_CI_BUILD_CACHE_KEY }}
+
+      - name: Setup ccache
+        shell: bash
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - uses: ./.github/actions/install-build-deps
         with:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -52,17 +52,17 @@ jobs:
         with:
           install-flags: --ui
 
-      - name: Setup ccache
-        shell: bash
-        run: |
-          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
-          ccache --zero-stats
-
       - name: Restore cache
         uses: ./.github/actions/cache-on-google-cloud-storage/restore
         with:
           directory: ${{ env.PERFETTO_CACHE_DIR }}
           cache_key: ${{ env.PERFETTO_CI_BUILD_CACHE_KEY }}
+
+      - name: Setup ccache
+        shell: bash
+        run: |
+          bash .github/workflows/ccache_env.sh | tee -a $GITHUB_ENV
+          ccache --zero-stats
 
       - name: Build Perfetto UI
         shell: bash

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -586,6 +586,7 @@ bool TracingServiceImpl::AttachConsumer(ConsumerEndpointImpl* consumer,
 base::Status TracingServiceImpl::EnableTracing(ConsumerEndpointImpl* consumer,
                                                const TraceConfig& cfg,
                                                base::ScopedFile fd) {
+  // Trigger CI build.
   PERFETTO_DCHECK_THREAD(thread_checker_);
 
   // If the producer is specifying a UUID, respect that (at least for the first


### PR DESCRIPTION
Otherwise, the previously zeroed ccache stats are overwritten
with the aggregated stats for all the previously cached builds.