### PR TITLE
fix remaining copyright header issue in python code.

### DIFF
--- a/python/generators/diff_tests/testing.py
+++ b/python/generators/diff_tests/testing.py
@@ -3,7 +3,6 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-# You may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Fix the last issue with python code copyright headers, which in this
case is a duplicated line.

The aim here is to get the header for testing.py to match the other
python files.
