### PR TITLE
Fix max_duration_per_frame 'aggregation' constant.

### DIFF
--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
@@ -64,7 +64,7 @@ class BlockingCallMetricHandler implements MetricHandler {
     const config = this.blockingCallTrackConfig(metricData);
     addDebugSliceTrack({trace: ctx, ...config});
     // Only trigger adding track for frame when the aggregation is for max duration per frame.
-    if (metricData.aggregation === 'max_dur_per_frame_ns') {
+    if (metricData.aggregation === 'max_dur_per_frame_ns-mean') {
       const frameConfigArgs = await this.frameWithMaxDurBlockingCallTrackConfig(
         ctx,
         metricData,

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/pinBlockingCall.ts
@@ -64,7 +64,8 @@ class BlockingCallMetricHandler implements MetricHandler {
     const config = this.blockingCallTrackConfig(metricData);
     addDebugSliceTrack({trace: ctx, ...config});
     // Only trigger adding track for frame when the aggregation is for max duration per frame.
-    if (metricData.aggregation === 'max_dur_per_frame_ns-mean') {
+    const MAX_DUR_PER_FRAME_NS_MEAN = 'max_dur_per_frame_ns-mean';
+    if (metricData.aggregation === MAX_DUR_PER_FRAME_NS_MEAN) {
       const frameConfigArgs = await this.frameWithMaxDurBlockingCallTrackConfig(
         ctx,
         metricData,


### PR DESCRIPTION
The metric raises alerts on the mean value of the metric. Fixed the constant string with the '-mean' suffix.

Bug: 394866952
Test: manual plugin test for a sample trace
