### PR TITLE
ui: Tidy up borders a little in TabbedSplitPanel

### DIFF
--- a/ui/src/assets/widgets/split_panel.scss
+++ b/ui/src/assets/widgets/split_panel.scss
@@ -29,8 +29,7 @@
 
   &__handle {
     background-color: var(--pf-color-background-secondary);
-    border: 1px solid var(--pf-color-border);
-    border-bottom: none;
+    border-top: 1px solid var(--pf-color-border);
     cursor: row-resize;
     // Disable user selection since this handle is draggable to resize the
     // bottom panels.

--- a/ui/src/assets/widgets/tabbed_split_panel.scss
+++ b/ui/src/assets/widgets/tabbed_split_panel.scss
@@ -32,7 +32,6 @@
     cursor: pointer;
     font-size: 13px;
     border-radius: 3px 3px 0 0;
-    border-right: solid 1px var(--pf-color-border);
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;


### PR DESCRIPTION
Remove the side borders on the tab handle and the border-right on each tab.