### PR TITLE
tp: create special pointer class to handle context forking

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3637,6 +3637,7 @@ perfetto_filegroup(
         "src/trace_processor/types/task_state.h",
         "src/trace_processor/types/tcp_state.h",
         "src/trace_processor/types/trace_processor_context.h",
+        "src/trace_processor/types/trace_processor_context_ptr.h",
         "src/trace_processor/types/variadic.h",
         "src/trace_processor/types/version_number.h",
     ],

--- a/src/trace_processor/forwarding_trace_parser.cc
+++ b/src/trace_processor/forwarding_trace_parser.cc
@@ -148,7 +148,7 @@ void ForwardingTraceParser::UpdateSorterForTraceType(TraceType trace_type) {
         event_handling = TraceSorter::EventHandling::kSortAndDrop;
       }
     }
-    context_->sorter = std::make_shared<TraceSorter>(
+    context_->sorter = std::make_unique<TraceSorter>(
         context_, *minimum_sorting_mode, event_handling);
   }
 

--- a/src/trace_processor/importers/android_bugreport/android_log_unittest.cc
+++ b/src/trace_processor/importers/android_bugreport/android_log_unittest.cc
@@ -62,7 +62,7 @@ class EventParserMock
 class AndroidLogReaderTest : public ::testing::Test {
  public:
   AndroidLogReaderTest() {
-    context_.storage = std::make_shared<TraceStorage>();
+    context_.storage = std::make_unique<TraceStorage>();
     context_.clock_tracker = std::make_unique<ClockTracker>(&context_);
     context_.metadata_tracker =
         std::make_unique<MetadataTracker>(context_.storage.get());

--- a/src/trace_processor/importers/common/event_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/event_tracker_unittest.cc
@@ -40,7 +40,7 @@ using ::testing::Invoke;
 class EventTrackerTest : public ::testing::Test {
  public:
   EventTrackerTest() {
-    context.storage = std::make_shared<TraceStorage>();
+    context.storage = std::make_unique<TraceStorage>();
     context.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context.storage.get());
     context.args_tracker = std::make_unique<ArgsTracker>(&context);

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -36,7 +36,7 @@ using ::testing::Invoke;
 class ProcessTrackerTest : public ::testing::Test {
  public:
   ProcessTrackerTest() {
-    context.storage = std::make_shared<TraceStorage>();
+    context.storage = std::make_unique<TraceStorage>();
     context.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context.storage.get());
     context.args_tracker = std::make_unique<ArgsTracker>(&context);

--- a/src/trace_processor/importers/common/track_compressor_unittest.cc
+++ b/src/trace_processor/importers/common/track_compressor_unittest.cc
@@ -44,9 +44,9 @@ constexpr auto kUnnestable = TrackCompressor::SliceBlueprint(
 class TrackCompressorUnittest : public testing::Test {
  public:
   TrackCompressorUnittest() {
-    context_.storage = std::make_shared<TraceStorage>();
+    context_.storage = std::make_unique<TraceStorage>();
     context_.global_args_tracker =
-        std::make_shared<GlobalArgsTracker>(context_.storage.get());
+        std::make_unique<GlobalArgsTracker>(context_.storage.get());
     context_.args_tracker = std::make_unique<ArgsTracker>(&context_);
     context_.track_tracker = std::make_unique<TrackTracker>(&context_);
     context_.track_compressor = std::make_unique<TrackCompressor>(&context_);

--- a/src/trace_processor/importers/etm/virtual_address_space_unittest.cc
+++ b/src/trace_processor/importers/etm/virtual_address_space_unittest.cc
@@ -56,7 +56,7 @@ tables::MmapRecordTable::ConstRowReference AddMapping(
 
 TEST(VirtualAddressSpaceTest, Empty) {
   TraceProcessorContext context;
-  context.storage = std::make_shared<TraceStorage>();
+  context.storage = std::make_unique<TraceStorage>();
   VirtualAddressSpace vs = VirtualAddressSpace::Builder(&context).Build();
 
   EXPECT_THAT(vs.FindMapping(0, 5), IsNull());
@@ -64,7 +64,7 @@ TEST(VirtualAddressSpaceTest, Empty) {
 
 TEST(VirtualAddressSpaceTest, DisjointRanges) {
   TraceProcessorContext context;
-  context.storage = std::make_shared<TraceStorage>();
+  context.storage = std::make_unique<TraceStorage>();
   auto builder = VirtualAddressSpace::Builder(&context);
   const UniquePid upid = 123;
 
@@ -87,7 +87,7 @@ TEST(VirtualAddressSpaceTest, DisjointRanges) {
 
 TEST(VirtualAddressSpaceTest, ComplexLayout) {
   TraceProcessorContext context;
-  context.storage = std::make_shared<TraceStorage>();
+  context.storage = std::make_unique<TraceStorage>();
   auto builder = VirtualAddressSpace::Builder(&context);
   const UniquePid upid = 123;
 

--- a/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker_unittest.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker_unittest.cc
@@ -41,7 +41,7 @@ using ::testing::Invoke;
 class SchedEventTrackerTest : public ::testing::Test {
  public:
   SchedEventTrackerTest() {
-    context.storage = std::make_shared<TraceStorage>();
+    context.storage = std::make_unique<TraceStorage>();
     context.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context.storage.get());
     context.args_tracker = std::make_unique<ArgsTracker>(&context);

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -177,11 +177,11 @@ class MockEventTracker : public EventTracker {
 class FuchsiaTraceParserTest : public ::testing::Test {
  public:
   FuchsiaTraceParserTest() {
-    context_.storage = std::make_shared<TraceStorage>();
+    context_.storage = std::make_unique<TraceStorage>();
     storage_ = context_.storage.get();
     context_.track_tracker = std::make_unique<TrackTracker>(&context_);
     context_.global_args_tracker =
-        std::make_shared<GlobalArgsTracker>(context_.storage.get());
+        std::make_unique<GlobalArgsTracker>(context_.storage.get());
     context_.stack_profile_tracker.reset(new StackProfileTracker(&context_));
     context_.args_tracker = std::make_unique<ArgsTracker>(&context_);
     context_.args_translation_table.reset(new ArgsTranslationTable(storage_));
@@ -203,7 +203,7 @@ class FuchsiaTraceParserTest : public ::testing::Test {
     context_.clock_tracker = std::make_unique<ClockTracker>(&context_);
     clock_ = context_.clock_tracker.get();
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
-    context_.sorter = std::make_shared<TraceSorter>(
+    context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kFullSort);
     context_.descriptor_pool_ = std::make_unique<DescriptorPool>();
     context_.register_additional_proto_modules = &RegisterAdditionalModules;

--- a/src/trace_processor/importers/perf/aux_stream_manager_unittest.cc
+++ b/src/trace_processor/importers/perf/aux_stream_manager_unittest.cc
@@ -33,7 +33,7 @@ namespace {
 
 std::unique_ptr<TraceProcessorContext> CreateTraceProcessorContext() {
   auto ctx = std::make_unique<TraceProcessorContext>();
-  ctx->storage = std::make_shared<TraceStorage>();
+  ctx->storage = std::make_unique<TraceStorage>();
   return ctx;
 }
 

--- a/src/trace_processor/importers/proto/heap_graph_tracker_unittest.cc
+++ b/src/trace_processor/importers/proto/heap_graph_tracker_unittest.cc
@@ -71,7 +71,7 @@ TEST(HeapGraphTrackerTest, PopulateNativeSize) {
   constexpr int64_t kTimestamp = 1;
 
   TraceProcessorContext context;
-  context.storage = std::make_shared<TraceStorage>();
+  context.storage = std::make_unique<TraceStorage>();
   context.process_tracker = std::make_unique<ProcessTracker>(&context);
   context.process_tracker->GetOrCreateProcess(kPid);
 

--- a/src/trace_processor/importers/proto/network_trace_module_unittest.cc
+++ b/src/trace_processor/importers/proto/network_trace_module_unittest.cc
@@ -60,7 +60,7 @@ class NetworkTraceModuleTest : public testing::Test {
  public:
   NetworkTraceModuleTest() {
     context_.register_additional_proto_modules = &RegisterAdditionalModules;
-    context_.storage = std::make_shared<TraceStorage>();
+    context_.storage = std::make_unique<TraceStorage>();
     storage_ = context_.storage.get();
     storage_ = context_.storage.get();
     context_.track_tracker = std::make_unique<TrackTracker>(&context_);
@@ -75,7 +75,7 @@ class NetworkTraceModuleTest : public testing::Test {
     context_.args_translation_table =
         std::make_unique<ArgsTranslationTable>(storage_);
     context_.track_compressor = std::make_unique<TrackCompressor>(&context_);
-    context_.sorter = std::make_shared<TraceSorter>(
+    context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kFullSort);
     context_.descriptor_pool_ = std::make_unique<DescriptorPool>();
   }

--- a/src/trace_processor/importers/proto/perf_sample_tracker_unittest.cc
+++ b/src/trace_processor/importers/proto/perf_sample_tracker_unittest.cc
@@ -47,7 +47,7 @@ namespace {
 class PerfSampleTrackerTest : public ::testing::Test {
  public:
   PerfSampleTrackerTest() {
-    context.storage = std::make_shared<TraceStorage>();
+    context.storage = std::make_unique<TraceStorage>();
     context.machine_tracker = std::make_unique<MachineTracker>(&context, 0);
     context.cpu_tracker = std::make_unique<CpuTracker>(&context);
     context.global_args_tracker =

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -257,7 +257,7 @@ class ProtoTraceParserTest : public ::testing::Test {
     clock_ = new ClockTracker(&context_);
     context_.clock_tracker.reset(clock_);
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
-    context_.sorter = std::make_shared<TraceSorter>(
+    context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kFullSort);
     context_.descriptor_pool_ = std::make_unique<DescriptorPool>();
 

--- a/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
@@ -52,7 +52,7 @@ class ProtoTraceReaderTest : public ::testing::Test {
     context_.machine_tracker =
         std::make_unique<MachineTracker>(&context_, 0x1001);
     context_.clock_tracker = std::make_unique<ClockTracker>(&context_);
-    context_.sorter = std::make_shared<TraceSorter>(
+    context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kDefault);
     context_.descriptor_pool_ = std::make_unique<DescriptorPool>();
     context_.register_additional_proto_modules = &RegisterAdditionalModules;

--- a/src/trace_processor/importers/proto/winscope/protolog_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.cc
@@ -16,16 +16,12 @@
 
 #include "src/trace_processor/importers/proto/winscope/protolog_parser.h"
 
-#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/protozero/field.h"
 #include "protos/perfetto/trace/android/protolog.pbzero.h"
@@ -35,6 +31,7 @@
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/winscope/protolog_message_decoder.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_context.h"
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/winscope_tables_py.h"
@@ -86,7 +83,7 @@ void ProtoLogParser::ParseProtoLogMessage(
     boolean_params.emplace_back(*it);
   }
 
-  auto storage = context_->trace_processor_context_->storage;
+  auto* storage = context_->trace_processor_context_->storage.get();
 
   std::vector<std::string> string_params;
   if (protolog_message.has_str_param_iids()) {
@@ -184,7 +181,7 @@ void ProtoLogParser::PopulateReservedRowWithMessage(
     std::string& message,
     std::optional<StringId> stacktrace,
     std::optional<std::string>& location) {
-  auto storage = context_->trace_processor_context_->storage;
+  auto* storage = context_->trace_processor_context_->storage.get();
   auto* protolog_table = storage->mutable_protolog_table();
   auto row = protolog_table->FindById(table_row_id).value();
 

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
@@ -15,15 +15,30 @@
  */
 
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.h"
+
 #include <cstdint>
 #include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
+#include "perfetto/base/status.h"
 #include "perfetto/ext/base/base64.h"
+#include "perfetto/ext/base/string_view.h"
 #include "perfetto/protozero/field.h"
+#include "protos/perfetto/trace/android/surfaceflinger_layers.pbzero.h"
 #include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/proto/args_parser.h"
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor.h"
+#include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_rect_computation.h"
 #include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h"
+#include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_context.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry.h"
+#include "src/trace_processor/storage/stats.h"
+#include "src/trace_processor/tables/winscope_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/util/proto_to_args_parser.h"
 #include "src/trace_processor/util/winscope_proto_mapping.h"
 
 namespace perfetto::trace_processor::winscope {
@@ -98,7 +113,7 @@ const SnapshotId SurfaceFlingerLayersParser::ParseSnapshot(
     int64_t timestamp,
     protozero::ConstBytes blob,
     std::optional<uint32_t> sequence_id) {
-  auto storage = context_->trace_processor_context_->storage;
+  auto* storage = context_->trace_processor_context_->storage.get();
   tables::SurfaceFlingerLayersSnapshotTable::Row snapshot;
   snapshot.ts = timestamp;
   snapshot.base64_proto_id = storage->mutable_string_pool()
@@ -136,7 +151,7 @@ void SurfaceFlingerLayersParser::ParseLayer(
         visibility,
     const std::unordered_map<int32_t, LayerDecoder>& layers_by_id,
     const surfaceflinger_layers::SurfaceFlingerRects& rects) {
-  auto storage = context_->trace_processor_context_->storage;
+  auto* storage = context_->trace_processor_context_->storage.get();
   ArgsTracker tracker(context_->trace_processor_context_);
   auto row_id =
       InsertLayerRow(blob, snapshot_id, visibility, layers_by_id, rects);

--- a/src/trace_processor/sorter/trace_sorter.cc
+++ b/src/trace_processor/sorter/trace_sorter.cc
@@ -36,7 +36,7 @@ TraceSorter::TraceSorter(TraceProcessorContext* context,
                          SortingMode sorting_mode,
                          EventHandling event_handling)
     : sorting_mode_(sorting_mode),
-      storage_(context->storage),
+      storage_(context->storage.get()),
       event_handling_(event_handling) {}
 
 TraceSorter::~TraceSorter() {

--- a/src/trace_processor/sorter/trace_sorter.h
+++ b/src/trace_processor/sorter/trace_sorter.h
@@ -289,7 +289,7 @@ class TraceSorter {
   // forced extractionn at the end of the trace.
   SortingMode sorting_mode_ = SortingMode::kDefault;
 
-  std::shared_ptr<TraceStorage> storage_;
+  TraceStorage* storage_;
 
   // Buffer for storing tokenized objects while the corresponding events are
   // being sorted.

--- a/src/trace_processor/types/BUILD.gn
+++ b/src/trace_processor/types/BUILD.gn
@@ -23,6 +23,7 @@ source_set("types") {
     "task_state.h",
     "tcp_state.h",
     "trace_processor_context.h",
+    "trace_processor_context_ptr.h",
     "variadic.h",
     "version_number.h",
   ]

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -25,6 +25,7 @@
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/tables/metadata_tables_py.h"
 #include "src/trace_processor/types/destructible.h"
+#include "src/trace_processor/types/trace_processor_context_ptr.h"
 
 namespace perfetto::trace_processor {
 
@@ -60,13 +61,13 @@ using MachineId = tables::MachineTable::Id;
 class TraceProcessorContext {
  public:
   template <typename T>
-  using GlobalPtr = std::shared_ptr<T>;
+  using GlobalPtr = TraceProcessorContextPtr<T>;
 
   template <typename T>
-  using RootPtr = std::unique_ptr<T>;
+  using RootPtr = TraceProcessorContextPtr<T>;
 
   template <typename T>
-  using PerMachinePtr = std::unique_ptr<T>;
+  using PerMachinePtr = TraceProcessorContextPtr<T>;
 
   class MultiMachineContext;
 
@@ -124,6 +125,7 @@ class TraceProcessorContext {
 
   GlobalPtr<MetadataTracker> metadata_tracker;
   GlobalPtr<Destructible> content_analyzer;
+  GlobalPtr<Destructible> heap_graph_tracker;  // HeapGraphTracker
 
   // Marks whether the uuid was read from the trace.
   // If the uuid was NOT read, the uuid will be made from the hash of the first
@@ -168,7 +170,6 @@ class TraceProcessorContext {
   // the GetOrCreate() method on their subclass type, e.g.
   // SyscallTracker::GetOrCreate(context)
   PerMachinePtr<Destructible> binder_tracker;        // BinderTracker
-  PerMachinePtr<Destructible> heap_graph_tracker;    // HeapGraphTracker
   PerMachinePtr<Destructible> syscall_tracker;       // SyscallTracker
   PerMachinePtr<Destructible> system_info_tracker;   // SystemInfoTracker
   PerMachinePtr<Destructible> systrace_parser;       // SystraceParser

--- a/src/trace_processor/types/trace_processor_context_ptr.h
+++ b/src/trace_processor/types/trace_processor_context_ptr.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_TYPES_TRACE_PROCESSOR_CONTEXT_PTR_H_
+#define SRC_TRACE_PROCESSOR_TYPES_TRACE_PROCESSOR_CONTEXT_PTR_H_
+
+#include <cstddef>
+#include <memory>
+
+namespace perfetto::trace_processor {
+
+// Small shim class to handle owning pointers in TraceProcessorContext objects
+// both at the root level and recursively.
+template <typename T>
+struct TraceProcessorContextPtr {
+ public:
+  TraceProcessorContextPtr() = default;
+  explicit TraceProcessorContextPtr(std::unique_ptr<T> owned)
+      : owned_(std::move(owned)), ptr_(owned_.get()) {}
+  explicit TraceProcessorContextPtr(T* _ptr) : ptr_(_ptr) {}
+
+  // Makes the
+  template <class... Args>
+  static TraceProcessorContextPtr<T> MakeRoot(Args&&... args) {
+    return TraceProcessorContextPtr<T>(
+        std::make_unique<T>(std::forward<Args>(args)...));
+  }
+
+  TraceProcessorContextPtr& operator=(std::unique_ptr<T> owned) {
+    owned_ = std::move(owned);
+    ptr_ = owned_.get();
+    return *this;
+  }
+
+  TraceProcessorContextPtr<T> Fork() const {
+    return TraceProcessorContextPtr<T>(ptr_);
+  }
+  void reset(T* ptr) {
+    owned_.reset(ptr);
+    ptr_ = ptr;
+  }
+
+  T* get() const { return ptr_; }
+  T& operator*() const { return *ptr_; }
+  T* operator->() const { return ptr_; }
+  explicit operator bool() const { return ptr_ != nullptr; }
+
+ private:
+  std::unique_ptr<T> owned_;
+  T* ptr_ = nullptr;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_TYPES_TRACE_PROCESSOR_CONTEXT_PTR_H_


### PR DESCRIPTION
Instead of using shared_ptr/unique_ptr, use a new smart pointer which
correctly handles both being generated as the root pointer and being
"forked" into a sub-context.
