### PR TITLE
ui: Theme-aware counter track colors

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -484,7 +484,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     await this.maybeRequestData(rawCountersKey);
   }
 
-  render({ctx, size, timescale}: TrackRenderContext): void {
+  render({ctx, size, timescale, theme}: TrackRenderContext): void {
     // In any case, draw whatever we have (which might be stale/incomplete).
     const limits = this.limits;
     const data = this.counters;
@@ -524,8 +524,8 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     const expCapped = Math.min(exp - 3, 9);
     const hue = (180 - Math.floor(expCapped * (180 / 6)) + 360) % 360;
 
-    ctx.fillStyle = `hsl(${hue}, 45%, 75%)`;
-    ctx.strokeStyle = `hsl(${hue}, 45%, 45%)`;
+    ctx.fillStyle = `hsla(${hue}, 45%, 50%, 0.6)`;
+    ctx.strokeStyle = `hsl(${hue}, 45%, 50%)`;
 
     const calculateX = (ts: time) => {
       return Math.floor(timescale.timeToPx(ts));
@@ -629,12 +629,12 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     }
 
     // Write the Y scale on the top left corner.
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
-    ctx.fillRect(0, 0, 42, 13);
-    ctx.fillStyle = '#666';
-    ctx.textAlign = 'left';
     ctx.textBaseline = 'alphabetic';
-    ctx.fillText(`${yLabel}`, 5, 11);
+    ctx.fillStyle = theme.COLOR_BACKGROUND;
+    ctx.fillRect(0, 0, 42, 18);
+    ctx.fillStyle = theme.COLOR_TEXT;
+    ctx.textAlign = 'left';
+    ctx.fillText(`${yLabel}`, 4, 14);
 
     // TODO(hjd): Refactor this into checkerboardExcept
     {

--- a/ui/src/core/track_manager_unittest.ts
+++ b/ui/src/core/track_manager_unittest.ts
@@ -52,6 +52,16 @@ const dummyCtx: TrackRenderContext = {
   visibleWindow,
   resolution: Duration.ZERO,
   timescale: new TimeScale(visibleWindow, {left: 0, right: 0}),
+  theme: {
+    COLOR_BORDER: 'hotpink',
+    COLOR_BORDER_SECONDARY: 'hotpink',
+    COLOR_BACKGROUND_SECONDARY: 'hotpink',
+    COLOR_ACCENT: 'hotpink',
+    COLOR_BACKGROUND: 'hotpink',
+    COLOR_TEXT: 'hotpink',
+    COLOR_TEXT_MUTED: 'hotpink',
+    COLOR_NEUTRAL: 'hotpink',
+  },
 };
 
 beforeEach(() => {

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -40,13 +40,23 @@ import {Button} from '../../widgets/button';
 import {MenuDivider, MenuItem, PopupMenu} from '../../widgets/menu';
 import {TrackShell} from '../../widgets/track_shell';
 import {Tree, TreeNode} from '../../widgets/tree';
-import {COLOR_ACCENT} from '../css_constants';
+import {
+  COLOR_ACCENT,
+  COLOR_BACKGROUND,
+  COLOR_BACKGROUND_SECONDARY,
+  COLOR_BORDER,
+  COLOR_BORDER_SECONDARY,
+  COLOR_NEUTRAL,
+  COLOR_TEXT,
+  COLOR_TEXT_MUTED,
+} from '../css_constants';
 import {calculateResolution} from './resolution';
 import {Trace} from '../../public/trace';
 import {Anchor} from '../../widgets/anchor';
 import {showModal} from '../../widgets/modal';
 import {copyToClipboard} from '../../base/clipboard';
 import {Popup} from '../../widgets/popup';
+import {Theme} from '../../public/theme';
 
 const TRACK_HEIGHT_MIN_PX = 18;
 const TRACK_HEIGHT_DEFAULT_PX = 30;
@@ -290,6 +300,17 @@ export class TrackView {
       return;
     }
 
+    const theme: Theme = {
+      COLOR_BORDER,
+      COLOR_BORDER_SECONDARY,
+      COLOR_BACKGROUND_SECONDARY,
+      COLOR_ACCENT,
+      COLOR_BACKGROUND,
+      COLOR_NEUTRAL,
+      COLOR_TEXT,
+      COLOR_TEXT_MUTED,
+    };
+
     const start = performance.now();
     node.uri &&
       renderer?.render({
@@ -299,6 +320,7 @@ export class TrackView {
         resolution: maybeNewResolution.value,
         ctx,
         timescale,
+        theme,
       });
 
     this.highlightIfTrackInAreaSelection(ctx, timescale, trackRect);

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -254,7 +254,13 @@ export class CpuFreqTrack implements TrackRenderer {
     return text;
   }
 
-  render({ctx, size, timescale, visibleWindow}: TrackRenderContext): void {
+  render({
+    ctx,
+    size,
+    timescale,
+    visibleWindow,
+    theme,
+  }: TrackRenderContext): void {
     // TODO: fonts and colors should come from the CSS and not hardcoded here.
     const data = this.fetcher.data;
 
@@ -288,8 +294,10 @@ export class CpuFreqTrack implements TrackRenderer {
       saturation = 0;
     }
 
-    ctx.fillStyle = color.setHSL({s: saturation, l: 70}).cssString;
-    ctx.strokeStyle = color.setHSL({s: saturation, l: 55}).cssString;
+    ctx.fillStyle = color
+      .setHSL({s: saturation, l: 50})
+      .setAlpha(0.6).cssString;
+    ctx.strokeStyle = color.setHSL({s: saturation, l: 50}).cssString;
 
     const calculateX = (timestamp: time) => {
       return Math.floor(timescale.timeToPx(timestamp));
@@ -402,9 +410,11 @@ export class CpuFreqTrack implements TrackRenderer {
 
     // Write the Y scale on the top left corner.
     ctx.textBaseline = 'alphabetic';
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.6)';
+    ctx.fillStyle = theme.COLOR_BACKGROUND;
+    ctx.globalAlpha = 0.8;
     ctx.fillRect(0, 0, 42, 18);
-    ctx.fillStyle = '#666';
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = theme.COLOR_TEXT;
     ctx.textAlign = 'left';
     ctx.fillText(`${yLabel}`, 4, 14);
 

--- a/ui/src/public/theme.ts
+++ b/ui/src/public/theme.ts
@@ -1,0 +1,24 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface Theme {
+  COLOR_BORDER: string;
+  COLOR_BORDER_SECONDARY: string;
+  COLOR_BACKGROUND_SECONDARY: string;
+  COLOR_ACCENT: string;
+  COLOR_BACKGROUND: string;
+  COLOR_TEXT: string;
+  COLOR_TEXT_MUTED: string;
+  COLOR_NEUTRAL: string;
+}

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -22,6 +22,7 @@ import {TrackEventDetailsPanel} from './details_panel';
 import {TrackEventDetails, TrackEventSelection} from './selection';
 import {SourceDataset} from '../trace_processor/dataset';
 import {TrackNode} from './workspace';
+import {Theme} from './theme';
 
 export interface TrackFilterCriteria {
   readonly name: string;
@@ -107,6 +108,8 @@ export interface TrackRenderContext extends TrackContext {
    * A time scale used for translating between pixels and time.
    */
   readonly timescale: TimeScale;
+
+  readonly theme: Theme;
 }
 
 // A definition of a track, including a renderer implementation and metadata.


### PR DESCRIPTION
Before:
<img width="732" height="351" alt="image" src="https://github.com/user-attachments/assets/e6e8f354-1c78-4a55-b494-c3fc0af7db61" />


After:
<img width="877" height="432" alt="image" src="https://github.com/user-attachments/assets/6c01ba1a-5cc1-4f48-8878-56b25e297d41" />

