### PR TITLE
TraceProcessor: Fix "all missed frames" track count to match metric

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/frames/jank_type.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frames/jank_type.sql
@@ -38,3 +38,16 @@ CREATE PERFETTO FUNCTION android_is_app_jank_type(
 RETURNS BOOL AS
 SELECT
   $jank_type GLOB '*App Deadline Missed*';
+
+-- Categorizes whether the jank was caused by the sf, app or "Dropped Frame"
+CREATE PERFETTO FUNCTION android_is_missed_frame_type(
+    -- the jank type
+    -- from args.display_value with key = "Jank type"
+    jank_type STRING
+)
+-- True if jank_type represents missed frame jank
+RETURNS BOOL AS
+SELECT
+  android_is_sf_jank_type($jank_type)
+  OR android_is_app_jank_type($jank_type)
+  OR $jank_type GLOB '*Dropped Frame*';

--- a/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/fullTraceJankMetricHandler.ts
+++ b/ui/src/plugins/dev.perfetto.PinAndroidPerfMetrics/handlers/fullTraceJankMetricHandler.ts
@@ -69,7 +69,7 @@ class FullTraceJankMetricHandler implements MetricHandler {
       jankTypeFilter = ' android_is_sf_jank_type(display_value)';
       jankTypeDisplayName = 'sf';
     } else {
-      jankTypeFilter = " display_value != 'None'";
+      jankTypeFilter = ' android_is_missed_frame_type(display_value)';
       jankTypeDisplayName = 'all';
     }
     const processName = metricData.process;


### PR DESCRIPTION
- This commit fixes a discrepancy where the "all missed frames" track in the UI plugin showed more frames than the official `missed_frames` metric, causing confusion during analysis.
- The track previously used a broad `display_value != 'None'` filter, which included non-severe jank types (e.g., Delayed Frames) that the metric intentionally excludes.
- A new standard SQL function, `android_is_missed_frame_type`, is introduced to encapsulate the metric's precise definition of a missed frame.
- The UI plugin is updated to use this new function, ensuring the visual track and the metric count are now consistent.

Bug: 435429713
Test: Manual - Rebuild Perfetto and open a trace with jank and pin perfetto_ft_systemui-missed_frames. Verify the number of distinct slices on the track now matches the count in the metric report.
Change-Id: I10cfdf840c90de58d64b0eb1084439dda5a7f209
