### PR TITLE
ui: Fix alpha levels on counter track labels

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -631,7 +631,9 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     // Write the Y scale on the top left corner.
     ctx.textBaseline = 'alphabetic';
     ctx.fillStyle = theme.COLOR_BACKGROUND;
+    ctx.globalAlpha = 0.6;
     ctx.fillRect(0, 0, 42, 18);
+    ctx.globalAlpha = 1;
     ctx.fillStyle = theme.COLOR_TEXT;
     ctx.textAlign = 'left';
     ctx.fillText(`${yLabel}`, 4, 14);

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -411,7 +411,7 @@ export class CpuFreqTrack implements TrackRenderer {
     // Write the Y scale on the top left corner.
     ctx.textBaseline = 'alphabetic';
     ctx.fillStyle = theme.COLOR_BACKGROUND;
-    ctx.globalAlpha = 0.8;
+    ctx.globalAlpha = 0.6;
     ctx.fillRect(0, 0, 42, 18);
     ctx.globalAlpha = 1;
     ctx.fillStyle = theme.COLOR_TEXT;


### PR DESCRIPTION
Fixes a mistake in #2541 where the counter track labels were being drawn in with no alpha, whereas before they had an alpha value of 0.6. The PR sets the alpha values for both counter tracks to 0.6.
