### PR TITLE
tp: fix empty line reading in ChunkedLineReader

### DIFF
--- a/src/trace_processor/importers/android_bugreport/chunked_line_reader.cc
+++ b/src/trace_processor/importers/android_bugreport/chunked_line_reader.cc
@@ -44,19 +44,22 @@ TraceBlobView Append(const TraceBlobView& head, const TraceBlobView& tail) {
 }
 
 struct SpliceResult {
-  // Full line including '\n'. Empty if no full line was found.
+  // Full line including '\n'.
   TraceBlobView line;
   // Any leftovers
   TraceBlobView leftovers;
+  // True if a complete line was found (even if it's empty)
+  bool found_line;
 };
 
 SpliceResult SpliceAtNewLine(TraceBlobView data) {
   for (size_t i = 0; i < data.size(); ++i) {
     if (data.data()[i] == '\n') {
-      return {data.slice_off(0, i), data.slice_off(i + 1, data.size() - i - 1)};
+      return {data.slice_off(0, i), data.slice_off(i + 1, data.size() - i - 1),
+              true};
     }
   }
-  return {TraceBlobView(), std::move(data)};
+  return {TraceBlobView(), std::move(data), false};
 }
 }  // namespace
 
@@ -69,7 +72,7 @@ base::StatusOr<TraceBlobView> ChunkedLineReader::SpliceLoop(
     TraceBlobView data) {
   while (true) {
     SpliceResult res = SpliceAtNewLine(std::move(data));
-    if (res.line.size() == 0) {
+    if (!res.found_line) {
       return std::move(res.leftovers);
     }
     RETURN_IF_ERROR(OnLine(res.line));
@@ -88,7 +91,7 @@ base::Status ChunkedLineReader::Parse(TraceBlobView data) {
   }
 
   SpliceResult res = SpliceAtNewLine(std::move(data));
-  if (res.line.size() == 0) {
+  if (!res.found_line) {
     buffer_ = Append(buffer_, res.leftovers);
     return base::OkStatus();
   }

--- a/test/trace_processor/diff_tests/parser/android/tests_dumpstate.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_dumpstate.py
@@ -45,7 +45,11 @@ class AndroidDumpstate(TestSuite):
         trace=RawText(
             "========================================================\n"
             "== dumpstate: 2021-08-24 23:35:40\n"
-            "========================================================\n"),
+            "========================================================\n"
+            "\n"
+            "Build: crosshatch-userdebug 12 SPB5.210812.002 7671067 dev-keys\n"
+            "Build fingerprint: 'google/crosshatch/crosshatch:12/SPB5.210812.002/7671067:userdebug/dev-keys'\n"
+        ),
         query="""
         SELECT
           section, service, line
@@ -57,6 +61,9 @@ class AndroidDumpstate(TestSuite):
         "[NULL]","[NULL]","========================================================"
         "[NULL]","[NULL]","== dumpstate: 2021-08-24 23:35:40"
         "[NULL]","[NULL]","========================================================"
+        "[NULL]","[NULL]",""
+        "[NULL]","[NULL]","Build: crosshatch-userdebug 12 SPB5.210812.002 7671067 dev-keys"
+        "[NULL]","[NULL]","Build fingerprint: 'google/crosshatch/crosshatch:12/SPB5.210812.002/7671067:userdebug/dev-keys'"
         """))
 
   def test_android_dumpstate_standalone_battery_stats_checkin(self):


### PR DESCRIPTION
ChunkedLineReader currently will stop abruptly upon the first empty
line that is encountered. This change fixes that by removing the
assumption that a zero size line indicates a failure. Instead we
create a separate boolean in SpliceResult to indicate success/failure
independent of the result line size, which allows us to produce zero
size strings AND report success at the same time.

ChuckedLineReader is currently only used by standalone Logcat,
Battery Stats checkins, and standalone dumpstate.

Out of these, Dumpsate is the only one that will normally contain
blank lines, and thus is the only one impacted by this. For this
reason we update the diff test to include the first 6 lines of the
example dumpstate file instead of 3 so that it will include a blank
line. Prior to this change standalone dumpstate would bail out after
parsing the first 3 lines since the 4th line is typically blank.
