### PR TITLE
tools: make git_set_parent error on invalid input branch

### DIFF
--- a/tools/git_set_parent.py
+++ b/tools/git_set_parent.py
@@ -8,7 +8,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(ROOT_DIR))
 
 #pylint: disable=wrong-import-position
-from python.tools.git_utils import run_git_command, get_current_branch
+from python.tools.git_utils import run_git_command, get_current_branch, get_all_branches
 #pylint: enable=wrong-import-position
 
 
@@ -30,6 +30,12 @@ def main():
     sys.exit(1)
 
   parent_branch = args.parent_branch
+
+  all_branches = get_all_branches()
+  if parent_branch not in all_branches:
+    print(f"Error: Branch '{parent_branch}' does not exist.", file=sys.stderr)
+    sys.exit(1)
+
   run_git_command(['config', f'branch.{target_branch}.parent', parent_branch])
   print(f"Set parent of '{target_branch}' to '{parent_branch}'.")
 


### PR DESCRIPTION
Setting the parent to a branch that does not exist can cause all
of the stack related tools to fail when updating or syncing if one
of the parents don't exist.

To help mitigate the impact of user errors, prevent the user from
setting an invalid branch vs erroring later.
