### PR TITLE
ui: support larger time units in selection duration.

### DIFF
--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -295,6 +295,8 @@ export class Duration {
     let result = '';
     if (duration < 1) return '0s';
     const unitAndValue: [string, bigint][] = [
+      ['y', 31_536_000_000_000_000n],
+      ['d', 86_400_000_000_000n],
       ['h', 3_600_000_000_000n],
       ['m', 60_000_000_000n],
       ['s', 1_000_000_000n],

--- a/ui/src/base/time_unittest.ts
+++ b/ui/src/base/time_unittest.ts
@@ -38,10 +38,10 @@ test('Duration.format', () => {
   expect(Duration.format(200_000_000_030n)).toEqual('3m 20s 30ns');
   expect(Duration.format(3_600_000_000_000n)).toEqual('1h');
   expect(Duration.format(3_600_000_000_001n)).toEqual('1h 1ns');
-  expect(Duration.format(86_400_000_000_000n)).toEqual('24h');
-  expect(Duration.format(86_400_000_000_001n)).toEqual('24h 1ns');
-  expect(Duration.format(31_536_000_000_000_000n)).toEqual('8,760h');
-  expect(Duration.format(31_536_000_000_000_001n)).toEqual('8,760h 1ns');
+  expect(Duration.format(86_400_000_000_000n)).toEqual('1d');
+  expect(Duration.format(86_400_000_000_001n)).toEqual('1d 1ns');
+  expect(Duration.format(31_536_000_000_000_000n)).toEqual('1y');
+  expect(Duration.format(31_536_000_000_000_001n)).toEqual('1y 1ns');
 });
 
 test('Duration.humanise', () => {


### PR DESCRIPTION
To better support longer durations, add support for printing years
and days if the selected time period is large enough.

<img width="244" height="89" alt="image" src="https://github.com/user-attachments/assets/00da00c3-5dd0-4505-84bb-e92c44c5279f" />

