### PR TITLE
tp: Add test for empty table in II and add better error message for sorted ts

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc
@@ -34,6 +34,7 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/small_vector.h"
 #include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/public/compiler.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/interval_intersector.h"
@@ -328,8 +329,13 @@ struct IntervalTreeIntervalsAgg
             ctx, "Interval intersect only accepts positive `ts` values.");
         return;
       }
-      sqlite::result::Error(
-          ctx, "Interval intersect requires intervals to be sorted by ts.");
+      base::StackString<1024> err_msg(
+          "Interval intersect requires intervals to be sorted by ts. "
+          "Current interval(id %d) start %ld is less than the last interval "
+          "start %ld.",
+          interval.id, sqlite::value::Int64(argv[1]),
+          agg_ctx.last_interval_start);
+      sqlite::result::Error(ctx, err_msg.c_str());
       return;
     }
     int64_t dur = sqlite::value::Int64(argv[2]);

--- a/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
@@ -1028,3 +1028,27 @@ class IntervalsIntersect(TestSuite):
         6,1,1,12
         8,0,2,12
         """))
+
+  def test_one_table_empty(self):
+    return DiffTestBlueprint(
+        trace=TextProto(""),
+        query="""
+        INCLUDE PERFETTO MODULE intervals.intersect;
+
+        CREATE PERFETTO TABLE A AS
+          WITH data(id, ts, dur) AS (
+            VALUES
+            (0, 1, 6)
+          )
+          SELECT * FROM data;
+
+        CREATE PERFETTO TABLE B AS
+        SELECT * FROM A LIMIT 0;
+
+        SELECT ts, dur, id_0, id_1
+        FROM _interval_intersect!((A, B), ())
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "ts","dur","id_0","id_1"
+        """))


### PR DESCRIPTION
We didn't test for empty interval intersect source.

The error message for ts not sorted usually required print debugging, so making it more verbose will make dubigging easier.