### PR TITLE
tp: remove ArgsTracker from the context

### DIFF
--- a/src/trace_processor/importers/common/event_tracker.cc
+++ b/src/trace_processor/importers/common/event_tracker.cc
@@ -63,7 +63,8 @@ std::optional<CounterId> EventTracker::PushCounter(
     const SetArgsCallback& args_callback) {
   auto maybe_counter_id = PushCounter(timestamp, value, track_id);
   if (maybe_counter_id) {
-    auto inserter = context_->args_tracker->AddArgsTo(*maybe_counter_id);
+    ArgsTracker args_tracker(context_);
+    auto inserter = args_tracker.AddArgsTo(*maybe_counter_id);
     args_callback(&inserter);
   }
   return maybe_counter_id;

--- a/src/trace_processor/importers/common/event_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/event_tracker_unittest.cc
@@ -43,7 +43,6 @@ class EventTrackerTest : public ::testing::Test {
     context.storage = std::make_unique<TraceStorage>();
     context.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context.storage.get());
-    context.args_tracker = std::make_unique<ArgsTracker>(&context);
     context.process_tracker = std::make_unique<ProcessTracker>(&context);
     context.event_tracker = std::make_unique<EventTracker>(&context);
     context.track_tracker = std::make_unique<TrackTracker>(&context);

--- a/src/trace_processor/importers/common/flow_tracker.cc
+++ b/src/trace_processor/importers/common/flow_tracker.cc
@@ -148,10 +148,10 @@ void FlowTracker::InsertFlow(FlowId flow_id,
   auto* it = flow_id_to_v1_flow_id_map_.Find(flow_id);
   if (it) {
     // TODO(b/168007725): Add any args from v1 flow events and also export them.
-    auto inserter = context_->args_tracker->AddArgsTo(id);
+    ArgsTracker args_tracker(context_);
+    auto inserter = args_tracker.AddArgsTo(id);
     inserter.AddArg(name_key_id_, Variadic::String(it->name));
     inserter.AddArg(cat_key_id_, Variadic::String(it->cat));
-    context_->args_tracker->Flush();
   }
 }
 

--- a/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc
+++ b/src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc
@@ -52,7 +52,6 @@ void LegacyV8CpuProfileTracker::Parse(int64_t ts,
     context_->storage->IncrementStats(
         stats::legacy_v8_cpu_profile_invalid_sample);
   }
-  context_->args_tracker->Flush();
 }
 
 void LegacyV8CpuProfileTracker::SetStartTsForSessionAndPid(uint64_t session_id,

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -39,7 +39,6 @@ class ProcessTrackerTest : public ::testing::Test {
     context.storage = std::make_unique<TraceStorage>();
     context.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context.storage.get());
-    context.args_tracker = std::make_unique<ArgsTracker>(&context);
     context.process_tracker = std::make_unique<ProcessTracker>(&context);
     context.event_tracker = std::make_unique<EventTracker>(&context);
   }

--- a/src/trace_processor/importers/common/slice_tracker.cc
+++ b/src/trace_processor/importers/common/slice_tracker.cc
@@ -330,8 +330,8 @@ void SliceTracker::FlushPendingSlices() {
 
   // Translate and flush all pending args.
   for (const auto& translatable_arg : translatable_args_) {
-    auto bound_inserter =
-        context_->args_tracker->AddArgsTo(translatable_arg.slice_id);
+    ArgsTracker args_tracker(context_);
+    auto bound_inserter = args_tracker.AddArgsTo(translatable_arg.slice_id);
     context_->args_translation_table->TranslateArgs(
         translatable_arg.compact_arg_set, bound_inserter);
   }

--- a/src/trace_processor/importers/common/thread_state_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/thread_state_tracker_unittest.cc
@@ -53,7 +53,6 @@ class ThreadStateTrackerUnittest : public testing::Test {
         new GlobalArgsTracker(context_.storage.get()));
     context_.machine_tracker.reset(new MachineTracker(&context_, 0));
     context_.cpu_tracker.reset(new CpuTracker(&context_));
-    context_.args_tracker.reset(new ArgsTracker(&context_));
     tracker_.reset(new ThreadStateTracker(&context_));
   }
 

--- a/src/trace_processor/importers/common/track_compressor_unittest.cc
+++ b/src/trace_processor/importers/common/track_compressor_unittest.cc
@@ -47,7 +47,6 @@ class TrackCompressorUnittest : public testing::Test {
     context_.storage = std::make_unique<TraceStorage>();
     context_.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context_.storage.get());
-    context_.args_tracker = std::make_unique<ArgsTracker>(&context_);
     context_.track_tracker = std::make_unique<TrackTracker>(&context_);
     context_.track_compressor = std::make_unique<TrackCompressor>(&context_);
     context_.process_track_translation_table =

--- a/src/trace_processor/importers/ftrace/binder_tracker_unittest.cc
+++ b/src/trace_processor/importers/ftrace/binder_tracker_unittest.cc
@@ -41,7 +41,6 @@ class BinderTrackerTest : public ::testing::Test {
     context.storage.reset(new TraceStorage());
     context.global_args_tracker.reset(
         new GlobalArgsTracker(context.storage.get()));
-    context.args_tracker.reset(new ArgsTracker(&context));
     context.args_translation_table.reset(
         new ArgsTranslationTable(context.storage.get()));
     context.slice_tracker.reset(new SliceTracker(&context));

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -1594,7 +1594,8 @@ void FtraceParser::ParseLegacyGenericFtrace(int64_t ts,
       context_->storage->mutable_ftrace_event_table()
           ->Insert({ts, event_id, utid, {}, {}, ucpu})
           .id;
-  auto inserter = context_->args_tracker->AddArgsTo(id);
+  ArgsTracker args_tracker(context_);
+  auto inserter = args_tracker.AddArgsTo(id);
 
   for (auto it = evt.field(); it; ++it) {
     protos::pbzero::GenericFtraceEvent::Field::Decoder fld(*it);
@@ -1645,7 +1646,8 @@ void FtraceParser::ParseGenericFtrace(uint32_t event_proto_id,
       context_->storage->mutable_ftrace_event_table()
           ->Insert({ts, descriptor->name, utid, {}, {}, ucpu})
           .id;
-  auto inserter = context_->args_tracker->AddArgsTo(id);
+  ArgsTracker args_tracker(context_);
+  auto inserter = args_tracker.AddArgsTo(id);
 
   // Insert fields into |args|.
   for (auto fld = decoder.ReadField(); fld.valid(); fld = decoder.ReadField()) {
@@ -1691,7 +1693,8 @@ void FtraceParser::ParseTypedFtraceToRaw(
           ->Insert(
               {timestamp, message_strings.message_name_id, utid, {}, {}, ucpu})
           .id;
-  auto inserter = context_->args_tracker->AddArgsTo(id);
+  ArgsTracker args_tracker(context_);
+  auto inserter = args_tracker.AddArgsTo(id);
 
   for (auto fld = decoder.ReadField(); fld.valid(); fld = decoder.ReadField()) {
     uint32_t field_id = fld.id();

--- a/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker.cc
@@ -242,7 +242,8 @@ void FtraceSchedEventTracker::PushSchedWakingCompact(uint32_t cpu,
         context_->storage->mutable_ftrace_event_table()->Insert(row).id;
 
     using SW = protos::pbzero::SchedWakingFtraceEvent;
-    auto inserter = context_->args_tracker->AddArgsTo(id);
+    ArgsTracker args_tracker(context_);
+    auto inserter = args_tracker.AddArgsTo(id);
     auto add_raw_arg = [this, &inserter](int field_num, Variadic var) {
       StringId key = sched_waking_field_ids_[static_cast<size_t>(field_num)];
       inserter.AddArg(key, var);
@@ -286,7 +287,8 @@ void FtraceSchedEventTracker::AddRawSchedSwitchEvent(uint32_t cpu,
     // to index these events using the field ids.
     using SS = protos::pbzero::SchedSwitchFtraceEvent;
 
-    auto inserter = context_->args_tracker->AddArgsTo(id);
+    ArgsTracker args_tracker(context_);
+    auto inserter = args_tracker.AddArgsTo(id);
     auto add_raw_arg = [this, &inserter](int field_num, Variadic var) {
       StringId key = sched_switch_field_ids_[static_cast<size_t>(field_num)];
       inserter.AddArg(key, var);

--- a/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker_unittest.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker_unittest.cc
@@ -44,7 +44,6 @@ class SchedEventTrackerTest : public ::testing::Test {
     context.storage = std::make_unique<TraceStorage>();
     context.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context.storage.get());
-    context.args_tracker = std::make_unique<ArgsTracker>(&context);
     context.event_tracker = std::make_unique<EventTracker>(&context);
     context.process_tracker = std::make_unique<ProcessTracker>(&context);
     context.machine_tracker = std::make_unique<MachineTracker>(&context, 0);

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -183,7 +183,6 @@ class FuchsiaTraceParserTest : public ::testing::Test {
     context_.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context_.storage.get());
     context_.stack_profile_tracker.reset(new StackProfileTracker(&context_));
-    context_.args_tracker = std::make_unique<ArgsTracker>(&context_);
     context_.args_translation_table.reset(new ArgsTranslationTable(storage_));
     context_.metadata_tracker =
         std::make_unique<MetadataTracker>(context_.storage.get());

--- a/src/trace_processor/importers/proto/content_analyzer.cc
+++ b/src/trace_processor/importers/proto/content_analyzer.cc
@@ -107,7 +107,8 @@ void ProtoContentAnalyzer::NotifyEndOfFile() {
                 .id;
         if (!previous_path_id.has_value()) {
           // Add annotations to the current row as an args set.
-          auto inserter = context_->args_tracker->AddArgsTo(path_id);
+          ArgsTracker args_tracker(context_);
+          auto inserter = args_tracker.AddArgsTo(path_id);
           for (auto& annotation : annotated_map.key()) {
             inserter.AddArg(annotation.first,
                             Variadic::String(annotation.second));

--- a/src/trace_processor/importers/proto/gpu_event_parser.cc
+++ b/src/trace_processor/importers/proto/gpu_event_parser.cc
@@ -317,7 +317,8 @@ void GpuEventParser::InsertTrackForUninternedRenderStage(
   rr.set_name(name);
 
   PERFETTO_DCHECK(!rr.source_arg_set_id());
-  auto inserter = context_->args_tracker->AddArgsTo(track_id);
+  ArgsTracker args_tracker(context_);
+  auto inserter = args_tracker.AddArgsTo(track_id);
   inserter.AddArg(description_id_, Variadic::String(description));
 }
 
@@ -735,7 +736,8 @@ void GpuEventParser::ParseVulkanMemoryEvent(
   VulkanAllocId id = allocs->Insert(vulkan_memory_event_row).id;
 
   if (vulkan_memory_event.has_annotations()) {
-    auto inserter = context_->args_tracker->AddArgsTo(id);
+    ArgsTracker args_tracker(context_);
+    auto inserter = args_tracker.AddArgsTo(id);
 
     for (auto it = vulkan_memory_event.annotations(); it; ++it) {
       protos::pbzero::VulkanMemoryEventAnnotation::Decoder annotation(*it);

--- a/src/trace_processor/importers/proto/memory_tracker_snapshot_parser.cc
+++ b/src/trace_processor/importers/proto/memory_tracker_snapshot_parser.cc
@@ -301,8 +301,8 @@ MemoryTrackerSnapshotParser::EmitNode(
 
   auto* node_table = context_->storage->mutable_memory_snapshot_node_table();
   auto rr = *node_table->FindById(node_row_id);
-  ArgsTracker::BoundInserter args =
-      context_->args_tracker->AddArgsTo(node_row_id);
+  ArgsTracker args_tracker(context_);
+  ArgsTracker::BoundInserter args = args_tracker.AddArgsTo(node_row_id);
 
   for (const auto& entry : node.const_entries()) {
     switch (entry.second.type) {

--- a/src/trace_processor/importers/proto/network_trace_module_unittest.cc
+++ b/src/trace_processor/importers/proto/network_trace_module_unittest.cc
@@ -65,7 +65,6 @@ class NetworkTraceModuleTest : public testing::Test {
     storage_ = context_.storage.get();
     context_.track_tracker = std::make_unique<TrackTracker>(&context_);
     context_.slice_tracker = std::make_unique<SliceTracker>(&context_);
-    context_.args_tracker = std::make_unique<ArgsTracker>(&context_);
     context_.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(storage_);
     context_.slice_translation_table =
@@ -90,7 +89,6 @@ class NetworkTraceModuleTest : public testing::Test {
         reader->Parse(TraceBlobView(TraceBlob::CopyFrom(v.data(), v.size())));
     context_.sorter->ExtractEventsForced();
     context_.slice_tracker->FlushPendingSlices();
-    context_.args_tracker->Flush();
     return status;
   }
 

--- a/src/trace_processor/importers/proto/perf_sample_tracker_unittest.cc
+++ b/src/trace_processor/importers/proto/perf_sample_tracker_unittest.cc
@@ -52,7 +52,6 @@ class PerfSampleTrackerTest : public ::testing::Test {
     context.cpu_tracker = std::make_unique<CpuTracker>(&context);
     context.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context.storage.get());
-    context.args_tracker = std::make_unique<ArgsTracker>(&context);
     context.track_tracker = std::make_unique<TrackTracker>(&context);
     perf_sample_tracker = std::make_unique<PerfSampleTracker>(&context);
   }

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
@@ -109,7 +109,6 @@ void ProtoTraceParserImpl::ParseTrackEvent(int64_t ts, TrackEventData data) {
   const TraceBlobView& blob = data.trace_packet_data.packet;
   protos::pbzero::TracePacket::Decoder packet(blob.data(), blob.length());
   module_context_->track_module->ParseTrackEventData(packet, ts, data);
-  context_->args_tracker->Flush();
 }
 
 void ProtoTraceParserImpl::ParseEtwEvent(uint32_t cpu,
@@ -117,11 +116,6 @@ void ProtoTraceParserImpl::ParseEtwEvent(uint32_t cpu,
                                          TracePacketData data) {
   PERFETTO_DCHECK(module_context_->etw_module);
   module_context_->etw_module->ParseEtwEventData(cpu, ts, data);
-
-  // TODO(lalitm): maybe move this to the flush method in the trace processor
-  // once we have it. This may reduce performance in the ArgsTracker though so
-  // needs to be handled carefully.
-  context_->args_tracker->Flush();
 }
 
 void ProtoTraceParserImpl::ParseFtraceEvent(uint32_t cpu,
@@ -129,11 +123,6 @@ void ProtoTraceParserImpl::ParseFtraceEvent(uint32_t cpu,
                                             TracePacketData data) {
   PERFETTO_DCHECK(module_context_->ftrace_module);
   module_context_->ftrace_module->ParseFtraceEventData(cpu, ts, data);
-
-  // TODO(lalitm): maybe move this to the flush method in the trace processor
-  // once we have it. This may reduce performance in the ArgsTracker though so
-  // needs to be handled carefully.
-  context_->args_tracker->Flush();
 }
 
 void ProtoTraceParserImpl::ParseInlineSchedSwitch(uint32_t cpu,
@@ -141,11 +130,6 @@ void ProtoTraceParserImpl::ParseInlineSchedSwitch(uint32_t cpu,
                                                   InlineSchedSwitch data) {
   PERFETTO_DCHECK(module_context_->ftrace_module);
   module_context_->ftrace_module->ParseInlineSchedSwitch(cpu, ts, data);
-
-  // TODO(lalitm): maybe move this to the flush method in the trace processor
-  // once we have it. This may reduce performance in the ArgsTracker though so
-  // needs to be handled carefully.
-  context_->args_tracker->Flush();
 }
 
 void ProtoTraceParserImpl::ParseInlineSchedWaking(uint32_t cpu,
@@ -153,11 +137,6 @@ void ProtoTraceParserImpl::ParseInlineSchedWaking(uint32_t cpu,
                                                   InlineSchedWaking data) {
   PERFETTO_DCHECK(module_context_->ftrace_module);
   module_context_->ftrace_module->ParseInlineSchedWaking(cpu, ts, data);
-
-  // TODO(lalitm): maybe move this to the flush method in the trace processor
-  // once we have it. This may reduce performance in the ArgsTracker though so
-  // needs to be handled carefully.
-  context_->args_tracker->Flush();
 }
 
 void ProtoTraceParserImpl::ParseChromeEvents(int64_t ts, ConstBytes blob) {
@@ -371,7 +350,8 @@ void ProtoTraceParserImpl::ParseMetatraceEvent(int64_t ts, ConstBytes blob) {
     auto opt_id =
         context_->event_tracker->PushCounter(ts, event.counter_value(), track);
     if (opt_id) {
-      auto inserter = context_->args_tracker->AddArgsTo(*opt_id);
+      ArgsTracker args_tracker(context_);
+      auto inserter = args_tracker.AddArgsTo(*opt_id);
       args_fn(&inserter);
     }
   }

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -239,7 +239,6 @@ class ProtoTraceParserTest : public ::testing::Test {
     context_.mapping_tracker.reset(new MappingTracker(&context_));
     context_.stack_profile_tracker =
         std::make_unique<StackProfileTracker>(&context_);
-    context_.args_tracker = std::make_unique<ArgsTracker>(&context_);
     context_.args_translation_table.reset(new ArgsTranslationTable(storage_));
     context_.metadata_tracker.reset(
         new MetadataTracker(context_.storage.get()));

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -1072,7 +1072,8 @@ void SystemProbesParser::ParseCpuInfo(ConstBytes blob) {
     }
 
     if (auto* id = std::get_if<ArmCpuIdentifier>(&cpu_info.identifier)) {
-      context_->args_tracker->AddArgsTo(ucpu)
+      ArgsTracker args_tracker(context_);
+      args_tracker.AddArgsTo(ucpu)
           .AddArg(arm_cpu_implementer,
                   Variadic::UnsignedInteger(id->implementer))
           .AddArg(arm_cpu_architecture,

--- a/src/trace_processor/importers/proto/track_event_event_importer.h
+++ b/src/trace_processor/importers/proto/track_event_event_importer.h
@@ -1139,7 +1139,8 @@ class TrackEventEventImporter {
             ->Insert({ts_, parser_->raw_legacy_event_id_, *utid_, 0})
             .id;
 
-    auto inserter = context_->args_tracker->AddArgsTo(id);
+    ArgsTracker args_tracker(context_);
+    auto inserter = args_tracker.AddArgsTo(id);
     inserter
         .AddArg(parser_->legacy_event_category_key_id_,
                 Variadic::String(category_id_))

--- a/src/trace_processor/importers/proto/winscope/android_input_event_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/android_input_event_parser.cc
@@ -91,7 +91,8 @@ void AndroidInputEventParser::ParseMotionEvent(
   auto event_row_id = context_.storage->mutable_android_motion_events_table()
                           ->Insert(event_row)
                           .id;
-  auto inserter = context_.args_tracker->AddArgsTo(event_row_id);
+  ArgsTracker args_tracker(&context_);
+  auto inserter = args_tracker.AddArgsTo(event_row_id);
   ArgsParser writer{packet_ts, inserter, *context_.storage};
 
   base::Status status =
@@ -124,7 +125,8 @@ void AndroidInputEventParser::ParseKeyEvent(
   auto event_row_id = context_.storage->mutable_android_key_events_table()
                           ->Insert(event_row)
                           .id;
-  auto inserter = context_.args_tracker->AddArgsTo(event_row_id);
+  ArgsTracker args_tracker(&context_);
+  auto inserter = args_tracker.AddArgsTo(event_row_id);
   ArgsParser writer{packet_ts, inserter, *context_.storage};
 
   base::Status status =
@@ -155,7 +157,8 @@ void AndroidInputEventParser::ParseWindowDispatchEvent(
           ->Insert(event_row)
           .id;
 
-  auto inserter = context_.args_tracker->AddArgsTo(event_row_id);
+  ArgsTracker args_tracker(&context_);
+  auto inserter = args_tracker.AddArgsTo(event_row_id);
   ArgsParser writer{packet_ts, inserter, *context_.storage};
 
   base::Status status = args_parser_.ParseMessage(

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
@@ -128,8 +128,8 @@ const SnapshotId SurfaceFlingerLayersParser::ParseSnapshot(
           ->Insert(snapshot)
           .id;
 
-  auto inserter =
-      context_->trace_processor_context_->args_tracker->AddArgsTo(snapshot_id);
+  ArgsTracker args_tracker(context_->trace_processor_context_);
+  auto inserter = args_tracker.AddArgsTo(snapshot_id);
   ArgsParser writer(timestamp, inserter, *storage);
   const auto table_name = tables::SurfaceFlingerLayersSnapshotTable::Name();
   auto allowed_fields =

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc
@@ -51,7 +51,8 @@ void SurfaceFlingerTransactionsParser::Parse(int64_t timestamp,
           ->Insert(row)
           .id;
 
-  auto inserter = context_->args_tracker->AddArgsTo(snapshot_id);
+  ArgsTracker args_tracker(context_);
+  auto inserter = args_tracker.AddArgsTo(snapshot_id);
   ArgsParser writer(timestamp, inserter, *context_->storage);
   base::Status status = args_parser_.ParseMessage(
       blob,

--- a/src/trace_processor/importers/proto/winscope/viewcapture_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_parser.cc
@@ -42,7 +42,8 @@ void ViewCaptureParser::Parse(int64_t timestamp,
   auto snapshot_id =
       context_->storage->mutable_viewcapture_table()->Insert(row).id;
 
-  auto inserter = context_->args_tracker->AddArgsTo(snapshot_id);
+  ArgsTracker args_tracker(context_);
+  auto inserter = args_tracker.AddArgsTo(snapshot_id);
   ViewCaptureArgsParser writer(timestamp, inserter, *context_->storage,
                                seq_state);
   const auto table_name = tables::ViewCaptureTable::Name();

--- a/src/trace_processor/trace_processor_context.cc
+++ b/src/trace_processor/trace_processor_context.cc
@@ -57,7 +57,6 @@ using Ptr = TraceProcessorContextPtr<T>;
 
 void InitPerTraceAndMachineState(TraceProcessorContext* context) {
   // Per-machine state (legacy).
-  context->args_tracker = Ptr<ArgsTracker>::MakeRoot(context);
   context->track_tracker = Ptr<TrackTracker>::MakeRoot(context);
   context->track_compressor = Ptr<TrackCompressor>::MakeRoot(context);
   context->slice_tracker = Ptr<SliceTracker>::MakeRoot(context);

--- a/src/trace_processor/trace_processor_storage_impl.cc
+++ b/src/trace_processor/trace_processor_storage_impl.cc
@@ -102,10 +102,6 @@ void TraceProcessorStorageImpl::Flush() {
   if (context()->sorter) {
     context()->sorter->ExtractEventsForced();
   }
-  auto& all = context()->forked_context_state->trace_and_machine_to_context;
-  for (auto it = all.GetIterator(); it; ++it) {
-    it.value()->args_tracker->Flush();
-  }
 }
 
 base::Status TraceProcessorStorageImpl::NotifyEndOfFile() {
@@ -131,7 +127,6 @@ base::Status TraceProcessorStorageImpl::NotifyEndOfFile() {
   for (auto it = all.GetIterator(); it; ++it) {
     it.value()->event_tracker->FlushPendingEvents();
     it.value()->slice_tracker->FlushPendingSlices();
-    it.value()->args_tracker->Flush();
     it.value()->process_tracker->NotifyEndOfFile();
   }
   return base::OkStatus();

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -32,7 +32,6 @@
 
 namespace perfetto::trace_processor {
 
-class ArgsTracker;
 class ArgsTranslationTable;
 class ClockConverter;
 class ClockTracker;
@@ -192,7 +191,6 @@ class TraceProcessorContext {
   PerTraceAndMachinePtr<ProcessTrackTranslationTable>
       process_track_translation_table;
   PerTraceAndMachinePtr<SliceTranslationTable> slice_translation_table;
-  PerTraceAndMachinePtr<ArgsTracker> args_tracker;
   PerTraceAndMachinePtr<TrackTracker> track_tracker;
   PerTraceAndMachinePtr<TrackCompressor> track_compressor;
   PerTraceAndMachinePtr<SliceTracker> slice_tracker;

--- a/test/trace_processor/diff_tests/metrics/chrome/tests_args.py
+++ b/test/trace_processor/diff_tests/metrics/chrome/tests_args.py
@@ -28,16 +28,16 @@ class ChromeArgs(TestSuite):
         out=TextProto(r"""
         [perfetto.protos.chrome_unsymbolized_args]: {
           args {
+            module: "/libmonochrome_64.so"
+            build_id: "7f0715c286f8b16c10e4ad349cda3b9b56c7a773"
+            address: 234
+            google_lookup_id: "c215077ff8866cb110e4ad349cda3b9b0"
+          }
+          args {
              module: "/liblib.so"
              build_id: "6275696c642d6964"
              address: 123
              google_lookup_id: "6275696c642d6964"
-           }
-           args {
-             module: "/libmonochrome_64.so"
-             build_id: "7f0715c286f8b16c10e4ad349cda3b9b56c7a773"
-             address: 234
-             google_lookup_id: "c215077ff8866cb110e4ad349cda3b9b0"
            }
         }
         """))

--- a/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_transactions.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_transactions.py
@@ -113,7 +113,6 @@ class SurfaceFlingerTransactions(TestSuite):
         INCLUDE PERFETTO MODULE android.winscope.surfaceflinger;
         SELECT
           snapshot_id,
-          arg_set_id,
           transaction_id,
           pid,
           uid,
@@ -125,9 +124,9 @@ class SurfaceFlingerTransactions(TestSuite):
         WHERE transaction_type = 'LAYER_CHANGED';
         """,
         out=Csv("""
-        "snapshot_id","arg_set_id","transaction_id","pid","uid","layer_id","display_id","flags_id"
-        0,0,10518374908656,0,10238,100,"[NULL]",0
-        1,21,10518374908658,0,10238,100,"[NULL]",0
+        "snapshot_id","transaction_id","pid","uid","layer_id","display_id","flags_id"
+        0,10518374908656,0,10238,100,"[NULL]",0
+        1,10518374908658,0,10238,100,"[NULL]",0
         """))
 
   def test_surfaceflinger_transaction_layer_change_args(self):


### PR DESCRIPTION
Create it on demand instead. Reduces the std::sort penalty when sorting
across many events
