### PR TITLE
tp: diff_tests: adds optional diff tests based on config

### DIFF
--- a/python/generators/diff_tests/models.py
+++ b/python/generators/diff_tests/models.py
@@ -25,7 +25,7 @@ TestName = str
 
 
 @dataclass
-class DiscoveredDb:
+class DiscoveredTests:
   """In-memory database of all discovered tests."""
   # All tests which match the given name filter and module constraints.
   runnable: List['TestCase']
@@ -33,11 +33,8 @@ class DiscoveredDb:
   # All tests which are skipped because they don't match the name filter.
   skipped_name_filter: List[str]
 
-  # All tests which are skipped for other reasons (module constraints).
-  skipped_other: List[Tuple[str, str]]
-
-  # All tests which are warnings.
-  warnings: List[Tuple[str, str]]
+  # All tests which are skipped due to a missing module.
+  skipped_module_missing: List[Tuple[str, str]]
 
 
 @dataclass

--- a/python/generators/diff_tests/models.py
+++ b/python/generators/diff_tests/models.py
@@ -17,11 +17,27 @@ import os
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from .testing import DiffTestBlueprint
 
 TestName = str
+
+
+@dataclass
+class DiscoveredDb:
+  """In-memory database of all discovered tests."""
+  # All tests which match the given name filter and module constraints.
+  runnable: List['TestCase']
+
+  # All tests which are skipped because they don't match the name filter.
+  skipped_name_filter: List[str]
+
+  # All tests which are skipped for other reasons (module constraints).
+  skipped_other: List[Tuple[str, str]]
+
+  # All tests which are warnings.
+  warnings: List[Tuple[str, str]]
 
 
 @dataclass

--- a/python/generators/diff_tests/runner.py
+++ b/python/generators/diff_tests/runner.py
@@ -88,18 +88,18 @@ class DiffTestsRunner:
   def __init__(self, config: Config):
     self.config = config
     self.test_loader = TestLoader(os.path.abspath(self.config.test_dir))
-    self.modules = self._get_build_config()
+    self.current_modules = self._get_build_config()
 
   def run(self) -> TestResults:
     # Discover all tests first to get the total count.
-    all_tests = self.test_loader.discover_and_load_tests('.*', self.modules)
+    all_tests = self.test_loader.discover_and_load_tests('.*', self.current_modules)
     total_tests_to_run_no_filter = len(all_tests)
     skipped_no_filter = len(self.test_loader.skipped_tests)
     warning_no_filter = len(self.test_loader.warning_tests)
 
     # Now filter the tests to get the ones that will actually run.
     tests = self.test_loader.discover_and_load_tests(self.config.name_filter,
-                                                     self.modules)
+                                                     self.current_modules)
     total_tests_to_run_filter = len(tests)
 
     sys.stderr.write(

--- a/python/generators/diff_tests/test_loader.py
+++ b/python/generators/diff_tests/test_loader.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 from python.generators.diff_tests.testing import (BinaryProto, Csv, DataPath,
                                                   DiffTestBlueprint, Json, Path,
                                                   Systrace, TextProto)
-from python.generators.diff_tests.models import TestCase, TestType
+from python.generators.diff_tests.models import DiscoveredDb, TestCase, TestType
 
 if TYPE_CHECKING:
   from python.generators.diff_tests.testing import TestSuite
@@ -36,9 +36,7 @@ class TestLoader:
     self.warning_tests: List[Tuple[str, str]] = []
 
   def discover_and_load_tests(self, name_filter: str,
-                              current_modules: Set[str]) -> List[TestCase]:
-    self.skipped_tests = []
-    self.warning_tests = []
+                              current_modules: Set[str]) -> DiscoveredDb:
     # Import the index file to discover all the tests.
     include_path = os.path.join(self.root_dir, 'test', 'trace_processor',
                                 'diff_tests')
@@ -48,16 +46,25 @@ class TestLoader:
 
     all_tests_data = fetch_all_diff_tests(include_path)
 
-    tests = []
+    runnable: List[TestCase] = []
+    skipped_name_filter: List[str] = []
+    skipped_other: List[Tuple[str, str]] = []
+    warnings: List[Tuple[str, str]] = []
+
+    query_metric_pattern = re.compile(name_filter)
     for name, blueprint in all_tests_data:
+      if not query_metric_pattern.match(os.path.basename(name)):
+        skipped_name_filter.append(name)
+        continue
+
       should_run, reason, is_warning = self._validate_test(
-          name, name_filter, blueprint, current_modules)
+          name, blueprint, current_modules)
       if not should_run:
         if reason:
           if is_warning:
-            self.warning_tests.append((name, reason))
+            warnings.append((name, reason))
           else:
-            self.skipped_tests.append((name, reason))
+            skipped_other.append((name, reason))
         continue
 
       query_path = self._get_query_path(name, blueprint)
@@ -67,23 +74,18 @@ class TestLoader:
       register_files_dir = self._get_register_files_dir(name, blueprint)
       test_type = self._get_test_type(blueprint)
 
-      tests.append(
+      runnable.append(
           TestCase(name, blueprint, query_path, trace_path, expected_path,
                    expected_str, register_files_dir, test_type))
-    return tests
+    return DiscoveredDb(runnable, skipped_name_filter, skipped_other, warnings)
 
-  def _validate_test(self, name: str, name_filter: str,
-                     blueprint: DiffTestBlueprint,
-                     current_modules: Set[str]) -> Tuple[bool, Optional[str], bool]:
-    query_metric_pattern = re.compile(name_filter)
-    if not query_metric_pattern.match(os.path.basename(name)):
-      return False, None, False
-
+  def _validate_test(
+      self, name: str, blueprint: DiffTestBlueprint,
+      current_modules: Set[str]) -> Tuple[bool, Optional[str], bool]:
     if blueprint.module_dependencies:
       for module in blueprint.module_dependencies:
         if module not in current_modules:
           return False, f"module '{module}' not found", False
-
     return True, None, False
 
   def _get_test_type(self, blueprint: DiffTestBlueprint) -> TestType:

--- a/python/generators/diff_tests/test_loader.py
+++ b/python/generators/diff_tests/test_loader.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 from python.generators.diff_tests.testing import (BinaryProto, Csv, DataPath,
                                                   DiffTestBlueprint, Json, Path,
                                                   Systrace, TextProto)
-from python.generators.diff_tests.models import DiscoveredDb, TestCase, TestType
+from python.generators.diff_tests.models import DiscoveredTests, TestCase, TestType
 
 if TYPE_CHECKING:
   from python.generators.diff_tests.testing import TestSuite
@@ -32,11 +32,9 @@ class TestLoader:
 
   def __init__(self, root_dir: os.PathLike):
     self.root_dir = root_dir
-    self.skipped_tests: List[Tuple[str, str]] = []
-    self.warning_tests: List[Tuple[str, str]] = []
 
   def discover_and_load_tests(self, name_filter: str,
-                              current_modules: Set[str]) -> DiscoveredDb:
+                              enabled_modules: Set[str]) -> DiscoveredTests:
     # Import the index file to discover all the tests.
     include_path = os.path.join(self.root_dir, 'test', 'trace_processor',
                                 'diff_tests')
@@ -48,8 +46,7 @@ class TestLoader:
 
     runnable: List[TestCase] = []
     skipped_name_filter: List[str] = []
-    skipped_other: List[Tuple[str, str]] = []
-    warnings: List[Tuple[str, str]] = []
+    skipped_module_missing: List[Tuple[str, str]] = []
 
     query_metric_pattern = re.compile(name_filter)
     for name, blueprint in all_tests_data:
@@ -57,14 +54,10 @@ class TestLoader:
         skipped_name_filter.append(name)
         continue
 
-      should_run, reason, is_warning = self._validate_test(
-          name, blueprint, current_modules)
+      should_run, reason = self._validate_test(blueprint, enabled_modules)
       if not should_run:
         if reason:
-          if is_warning:
-            warnings.append((name, reason))
-          else:
-            skipped_other.append((name, reason))
+          skipped_module_missing.append((name, reason))
         continue
 
       query_path = self._get_query_path(name, blueprint)
@@ -77,16 +70,18 @@ class TestLoader:
       runnable.append(
           TestCase(name, blueprint, query_path, trace_path, expected_path,
                    expected_str, register_files_dir, test_type))
-    return DiscoveredDb(runnable, skipped_name_filter, skipped_other, warnings)
+    return DiscoveredTests(runnable, skipped_name_filter,
+                           skipped_module_missing)
 
-  def _validate_test(
-      self, name: str, blueprint: DiffTestBlueprint,
-      current_modules: Set[str]) -> Tuple[bool, Optional[str], bool]:
+  # Returns a bool that is true if and only if the test should run, and a string
+  # describing the reason the test did not run
+  def _validate_test(self, blueprint: DiffTestBlueprint,
+                     enabled_modules: Set[str]) -> Tuple[bool, Optional[str]]:
     if blueprint.module_dependencies:
       for module in blueprint.module_dependencies:
-        if module not in current_modules:
-          return False, f"module '{module}' not found", False
-    return True, None, False
+        if module not in enabled_modules:
+          return False, f"module '{module}' not found"
+    return True, None
 
   def _get_test_type(self, blueprint: DiffTestBlueprint) -> TestType:
     if blueprint.is_metric():

--- a/python/generators/diff_tests/test_loader.py
+++ b/python/generators/diff_tests/test_loader.py
@@ -36,7 +36,7 @@ class TestLoader:
     self.warning_tests: List[Tuple[str, str]] = []
 
   def discover_and_load_tests(self, name_filter: str,
-                              modules: Set[str]) -> List[TestCase]:
+                              current_modules: Set[str]) -> List[TestCase]:
     self.skipped_tests = []
     self.warning_tests = []
     # Import the index file to discover all the tests.
@@ -51,7 +51,7 @@ class TestLoader:
     tests = []
     for name, blueprint in all_tests_data:
       should_run, reason, is_warning = self._validate_test(
-          name, name_filter, blueprint, modules)
+          name, name_filter, blueprint, current_modules)
       if not should_run:
         if reason:
           if is_warning:
@@ -74,14 +74,14 @@ class TestLoader:
 
   def _validate_test(self, name: str, name_filter: str,
                      blueprint: DiffTestBlueprint,
-                     modules: Set[str]) -> Tuple[bool, Optional[str], bool]:
+                     current_modules: Set[str]) -> Tuple[bool, Optional[str], bool]:
     query_metric_pattern = re.compile(name_filter)
     if not query_metric_pattern.match(os.path.basename(name)):
       return False, None, False
 
-    if blueprint.modules:
-      for module in blueprint.modules:
-        if module not in modules:
+    if blueprint.module_dependencies:
+      for module in blueprint.module_dependencies:
+        if module not in current_modules:
           return False, f"module '{module}' not found", False
 
     return True, None, False

--- a/python/generators/diff_tests/testing.py
+++ b/python/generators/diff_tests/testing.py
@@ -139,8 +139,8 @@ class DiffTestBlueprint:
   out: Union[Path, DataPath, Json, Csv, TextProto, BinaryProto]
   trace_modifier: Union[TraceInjector, None] = None
   register_files_dir: Optional[DataPath] = None
-  # If set, this test will only be run if all of these modules are enabled.
-  modules: Optional[List[str]] = None
+  # If set, this test will only be run if all of these module_dependencies are enabled.
+  module_dependencies: Optional[List[str]] = None
   index_dir: str = ''
   test_data_dir: str = ''
 

--- a/python/generators/diff_tests/testing.py
+++ b/python/generators/diff_tests/testing.py
@@ -128,7 +128,7 @@ class TraceInjector:
 @dataclass
 class DiffTestBlueprint:
   """Blueprint for running the diff test.
-  
+
   'query' is being run over data from the 'trace 'and result will be compared
   to the 'out. Each test (function in class inheriting from TestSuite) returns
   a DiffTestBlueprint.
@@ -139,6 +139,8 @@ class DiffTestBlueprint:
   out: Union[Path, DataPath, Json, Csv, TextProto, BinaryProto]
   trace_modifier: Union[TraceInjector, None] = None
   register_files_dir: Optional[DataPath] = None
+  # If set, this test will only be run if all of these modules are enabled.
+  modules: Optional[List[str]] = None
   index_dir: str = ''
   test_data_dir: str = ''
 
@@ -192,7 +194,7 @@ def removeprefix(s: str, prefix: str):
 
 class TestSuite:
   """Virtual class responsible for fetching diff tests.
-  
+
   All functions with name starting with `test_` have to return
   DiffTestBlueprint and function name is a test name. All DiffTestModules have
   to be included in `test/diff_tests/trace_processor/include_index.py`. `fetch`

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -69,6 +69,7 @@ from diff_tests.parser.chrome.tests import ChromeParser
 from diff_tests.parser.chrome.tests_memory_snapshots import ChromeMemorySnapshots
 from diff_tests.parser.chrome.tests_v8 import ChromeV8Parser
 from diff_tests.parser.cros.tests import Cros
+from diff_tests.parser.etm.tests import Etm
 from diff_tests.parser.fs.tests import Fs
 from diff_tests.parser.ftrace.block_io_tests import BlockIo
 from diff_tests.parser.ftrace.ftrace_crop_tests import FtraceCrop
@@ -190,6 +191,7 @@ def fetch_all_diff_tests(
       ChromeV8Parser,
       Cros,
       Deobfuscation,
+      Etm,
       Fs,
       Fuchsia,
       GenericFtrace,

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -155,6 +155,7 @@ from diff_tests.stdlib.span_join.tests_left_join import SpanJoinLeftJoin
 from diff_tests.stdlib.span_join.tests_outer_join import SpanJoinOuterJoin
 from diff_tests.stdlib.span_join.tests_regression import SpanJoinRegression
 from diff_tests.stdlib.span_join.tests_smoke import SpanJoinSmoke
+from diff_tests.stdlib.symbolize.tests import Symbolize
 from diff_tests.stdlib.tests import StdlibSmoke
 from diff_tests.stdlib.timestamps.tests import Timestamps
 from diff_tests.stdlib.traced.stats import TracedStats
@@ -221,6 +222,7 @@ def fetch_all_diff_tests(
       SmokeComputeMetrics,
       SmokeJson,
       SmokeSchedEvents,
+      Symbolize,
       InputMethodClients,
       InputMethodManagerService,
       InputMethodService,

--- a/test/trace_processor/diff_tests/parser/etm/tests.py
+++ b/test/trace_processor/diff_tests/parser/etm/tests.py
@@ -23,7 +23,7 @@ class Etm(TestSuite):
   def test_sessions(self):
     return DiffTestBlueprint(
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        modules=['etm'],
+        module_dependencies=['etm'],
         query='''
           SELECT start_ts, cpu, size
           FROM
@@ -56,7 +56,7 @@ class Etm(TestSuite):
   def test_decode_all(self):
     return DiffTestBlueprint(
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        modules=['etm'],
+        module_dependencies=['etm'],
         query='''
           SELECT count(*)
           FROM
@@ -73,7 +73,7 @@ class Etm(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        modules=['etm'],
+        module_dependencies=['etm'],
         query='''
           SELECT *
           FROM
@@ -86,7 +86,7 @@ class Etm(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        modules=['etm'],
+        module_dependencies=['etm'],
         query='''
           SELECT d.element_index, i.*
           FROM
@@ -101,7 +101,7 @@ class Etm(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        modules=['etm'],
+        module_dependencies=['etm'],
         query='''
           INCLUDE PERFETTO MODULE linux.perf.etm;
           SELECT

--- a/test/trace_processor/diff_tests/parser/etm/tests.py
+++ b/test/trace_processor/diff_tests/parser/etm/tests.py
@@ -18,12 +18,12 @@ from python.generators.diff_tests.testing import DiffTestBlueprint
 from python.generators.diff_tests.testing import TestSuite
 
 
-# TODO(fouly): add ETM to include_index when conditional difftests are added
 class Etm(TestSuite):
 
   def test_sessions(self):
     return DiffTestBlueprint(
         trace=DataPath('simpleperf/cs_etm_u.perf'),
+        modules=['etm'],
         query='''
           SELECT start_ts, cpu, size
           FROM
@@ -56,6 +56,7 @@ class Etm(TestSuite):
   def test_decode_all(self):
     return DiffTestBlueprint(
         trace=DataPath('simpleperf/cs_etm_u.perf'),
+        modules=['etm'],
         query='''
           SELECT count(*)
           FROM
@@ -72,6 +73,7 @@ class Etm(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
+        modules=['etm'],
         query='''
           SELECT *
           FROM
@@ -84,6 +86,7 @@ class Etm(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
+        modules=['etm'],
         query='''
           SELECT d.element_index, i.*
           FROM
@@ -98,6 +101,7 @@ class Etm(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
+        modules=['etm'],
         query='''
           INCLUDE PERFETTO MODULE linux.perf.etm;
           SELECT

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -21,7 +21,7 @@ from python.generators.diff_tests.testing import TestSuite
 
 class Symbolize(TestSuite):
 
-  def test_llvm_symbolize_table(self):
+  def test_callstack_frame_symbolize_table(self):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
@@ -35,7 +35,7 @@ class Symbolize(TestSuite):
           line_number,
           mapping_id,
           address
-        FROM _symbolize!(
+        FROM _callstack_frame_symbolize!(
             _linux_perf_etm_metadata(0)
             WHERE mapping_id = 1
         );
@@ -61,7 +61,7 @@ class Symbolize(TestSuite):
         "<invalid>","<invalid>",0,1,434500225580
         """))
 
-  def test_llvm_symbolize_subquery(self):
+  def test_callstack_frame_symbolize_subquery(self):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
@@ -74,7 +74,7 @@ class Symbolize(TestSuite):
           line_number,
           mapping_id,
           address
-        FROM _symbolize!((
+        FROM _callstack_frame_symbolize!((
             SELECT
             __intrinsic_file.name AS file_name,
             __intrinsic_etm_iterate_instruction_range.address - stack_profile_mapping.start + stack_profile_mapping.exact_offset + __intrinsic_elf_file.load_bias AS rel_pc,

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -25,7 +25,7 @@ class Symbolize(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        modules=['llvm_symbolizer'],
+        module_dependencies=['llvm_symbolizer'],
         query="""
         INCLUDE PERFETTO MODULE callstacks.symbolize;
         INCLUDE PERFETTO MODULE linux.perf.etm;
@@ -66,7 +66,7 @@ class Symbolize(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        modules=['llvm_symbolizer'],
+        module_dependencies=['llvm_symbolizer'],
         query="""
         INCLUDE PERFETTO MODULE callstacks.symbolize;
 

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Path, DataPath, Metric
+from python.generators.diff_tests.testing import Csv, Json, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class Symbolize(TestSuite):
+
+  def test_llvm_symbolize_table(self):
+    return DiffTestBlueprint(
+        register_files_dir=DataPath('simpleperf/bin'),
+        trace=DataPath('simpleperf/cs_etm_u.perf'),
+        query="""
+        INCLUDE PERFETTO MODULE callstacks.symbolize;
+        INCLUDE PERFETTO MODULE linux.perf.etm;
+
+        SELECT
+          function_name,
+          replace(file_name, rtrim(file_name, replace(file_name, '/', '')), '') AS short_file_nam,
+          line_number,
+          mapping_id,
+          address
+        FROM _symbolize!(
+            _linux_perf_etm_metadata(0)
+            WHERE mapping_id = 1
+        );
+        """,
+        out=Csv("""
+        "function_name","short_file_nam","line_number","mapping_id","address"
+        "main","etm.cc",62,1,434500225096
+        "main","etm.cc",0,1,434500225100
+        "main","etm.cc",62,1,434500225104
+        "main","etm.cc",60,1,434500225084
+        "A()","etm.cc",44,1,434500225128
+        "A()","etm.cc",44,1,434500225132
+        "A()","etm.cc",44,1,434500225136
+        "A()","etm.cc",46,1,434500225140
+        "A()","etm.cc",46,1,434500225144
+        "A()","etm.cc",47,1,434500225148
+        "A()","etm.cc",47,1,434500225152
+        "A()","etm.cc",47,1,434500225156
+        "A()","etm.cc",47,1,434500225160
+        "<invalid>","<invalid>",0,1,434500225568
+        "<invalid>","<invalid>",0,1,434500225572
+        "<invalid>","<invalid>",0,1,434500225576
+        "<invalid>","<invalid>",0,1,434500225580
+        """))
+
+  def test_llvm_symbolize_subquery(self):
+    return DiffTestBlueprint(
+        register_files_dir=DataPath('simpleperf/bin'),
+        trace=DataPath('simpleperf/cs_etm_u.perf'),
+        query="""
+        INCLUDE PERFETTO MODULE callstacks.symbolize;
+
+        SELECT
+          function_name,
+          replace(file_name, rtrim(file_name, replace(file_name, '/', '')), '') AS short_file_nam,
+          line_number,
+          mapping_id,
+          address
+        FROM _symbolize!((
+            SELECT
+            __intrinsic_file.name AS file_name,
+            __intrinsic_etm_iterate_instruction_range.address - stack_profile_mapping.start + stack_profile_mapping.exact_offset + __intrinsic_elf_file.load_bias AS rel_pc,
+            __intrinsic_etm_decode_trace.mapping_id AS mapping_id,
+            __intrinsic_etm_iterate_instruction_range.address AS address
+            FROM __intrinsic_etm_decode_trace(0)
+            JOIN __intrinsic_etm_iterate_instruction_range
+              ON __intrinsic_etm_decode_trace.instruction_range = __intrinsic_etm_iterate_instruction_range.instruction_range
+            JOIN stack_profile_mapping
+              ON __intrinsic_etm_decode_trace.mapping_id = stack_profile_mapping.id
+            JOIN __intrinsic_elf_file
+              ON stack_profile_mapping.build_id = __intrinsic_elf_file.build_id
+            JOIN __intrinsic_file
+              ON __intrinsic_elf_file.file_id = __intrinsic_file.id
+            WHERE mapping_id = 1
+        ));
+        """,
+        out=Csv("""
+        "function_name","short_file_nam","line_number","mapping_id","address"
+        "main","etm.cc",62,1,434500225096
+        "main","etm.cc",0,1,434500225100
+        "main","etm.cc",62,1,434500225104
+        "main","etm.cc",60,1,434500225084
+        "A()","etm.cc",44,1,434500225128
+        "A()","etm.cc",44,1,434500225132
+        "A()","etm.cc",44,1,434500225136
+        "A()","etm.cc",46,1,434500225140
+        "A()","etm.cc",46,1,434500225144
+        "A()","etm.cc",47,1,434500225148
+        "A()","etm.cc",47,1,434500225152
+        "A()","etm.cc",47,1,434500225156
+        "A()","etm.cc",47,1,434500225160
+        "<invalid>","<invalid>",0,1,434500225568
+        "<invalid>","<invalid>",0,1,434500225572
+        "<invalid>","<invalid>",0,1,434500225576
+        "<invalid>","<invalid>",0,1,434500225580
+        """))

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -25,7 +25,7 @@ class Symbolize(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        module_dependencies=['llvm_symbolizer'],
+        module_dependencies=['llvm_symbolizer', 'etm'],
         query="""
         INCLUDE PERFETTO MODULE callstacks.symbolize;
         INCLUDE PERFETTO MODULE linux.perf.etm;
@@ -66,7 +66,7 @@ class Symbolize(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
-        module_dependencies=['llvm_symbolizer'],
+        module_dependencies=['llvm_symbolizer', 'etm'],
         query="""
         INCLUDE PERFETTO MODULE callstacks.symbolize;
 

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -25,6 +25,7 @@ class Symbolize(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
+        modules=['llvm_symbolizer'],
         query="""
         INCLUDE PERFETTO MODULE callstacks.symbolize;
         INCLUDE PERFETTO MODULE linux.perf.etm;
@@ -65,6 +66,7 @@ class Symbolize(TestSuite):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
+        modules=['llvm_symbolizer'],
         query="""
         INCLUDE PERFETTO MODULE callstacks.symbolize;
 
@@ -78,13 +80,13 @@ class Symbolize(TestSuite):
             SELECT
             __intrinsic_file.name AS file_name,
             __intrinsic_etm_iterate_instruction_range.address - stack_profile_mapping.start + stack_profile_mapping.exact_offset + __intrinsic_elf_file.load_bias AS rel_pc,
-            __intrinsic_etm_decode_trace.mapping_id AS mapping_id,
+            __intrinsic_etm_decode_chunk.mapping_id AS mapping_id,
             __intrinsic_etm_iterate_instruction_range.address AS address
-            FROM __intrinsic_etm_decode_trace(0)
+            FROM __intrinsic_etm_decode_chunk(0)
             JOIN __intrinsic_etm_iterate_instruction_range
-              ON __intrinsic_etm_decode_trace.instruction_range = __intrinsic_etm_iterate_instruction_range.instruction_range
+              ON __intrinsic_etm_decode_chunk.instruction_range = __intrinsic_etm_iterate_instruction_range.instruction_range
             JOIN stack_profile_mapping
-              ON __intrinsic_etm_decode_trace.mapping_id = stack_profile_mapping.id
+              ON __intrinsic_etm_decode_chunk.mapping_id = stack_profile_mapping.id
             JOIN __intrinsic_elf_file
               ON stack_profile_mapping.build_id = __intrinsic_elf_file.build_id
             JOIN __intrinsic_file

--- a/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/symbolize/tests.py
@@ -21,7 +21,7 @@ from python.generators.diff_tests.testing import TestSuite
 
 class Symbolize(TestSuite):
 
-  def test_callstack_frame_symbolize_table(self):
+  def test_callstack_frame_symbolize_etm_tables(self):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
@@ -62,7 +62,7 @@ class Symbolize(TestSuite):
         "<invalid>","<invalid>",0,1,434500225580
         """))
 
-  def test_callstack_frame_symbolize_subquery(self):
+  def test_callstack_frame_symbolize_etm_subquery(self):
     return DiffTestBlueprint(
         register_files_dir=DataPath('simpleperf/bin'),
         trace=DataPath('simpleperf/cs_etm_u.perf'),
@@ -96,6 +96,84 @@ class Symbolize(TestSuite):
         """,
         out=Csv("""
         "function_name","short_file_nam","line_number","mapping_id","address"
+        "main","etm.cc",62,1,434500225096
+        "main","etm.cc",0,1,434500225100
+        "main","etm.cc",62,1,434500225104
+        "main","etm.cc",60,1,434500225084
+        "A()","etm.cc",44,1,434500225128
+        "A()","etm.cc",44,1,434500225132
+        "A()","etm.cc",44,1,434500225136
+        "A()","etm.cc",46,1,434500225140
+        "A()","etm.cc",46,1,434500225144
+        "A()","etm.cc",47,1,434500225148
+        "A()","etm.cc",47,1,434500225152
+        "A()","etm.cc",47,1,434500225156
+        "A()","etm.cc",47,1,434500225160
+        "<invalid>","<invalid>",0,1,434500225568
+        "<invalid>","<invalid>",0,1,434500225572
+        "<invalid>","<invalid>",0,1,434500225576
+        "<invalid>","<invalid>",0,1,434500225580
+        """))
+
+  def test_callstack_frame_symbolize(self):
+    return DiffTestBlueprint(
+        register_files_dir=DataPath('simpleperf/bin'),
+        trace=DataPath('simpleperf/cs_etm_u.perf'),
+        module_dependencies=['llvm_symbolizer'],
+        query="""
+        INCLUDE PERFETTO MODULE callstacks.symbolize;
+
+        SELECT
+          function_name,
+          replace(file_name, rtrim(file_name, replace(file_name, '/', '')), '') AS short_file_name,
+          line_number,
+          mapping_id,
+          address
+        FROM _callstack_frame_symbolize!((
+            SELECT
+              dynamic_file.name AS file_name,
+              static_data.rel_pc,
+              static_data.mapping_id,
+              static_data.address
+            FROM
+              (
+                SELECT name
+                FROM __intrinsic_file
+                WHERE name GLOB '*/bin/etm'
+                LIMIT 1
+              ) AS dynamic_file
+            CROSS JOIN
+              -- This section has been modified to be compatible
+              (
+                SELECT
+                  column1 AS rel_pc,
+                  column2 AS mapping_id,
+                  column3 AS address
+                FROM (
+                  VALUES
+                    (18504,1,434500225096),
+                    (18508,1,434500225100),
+                    (18512,1,434500225104),
+                    (18492,1,434500225084),
+                    (18536,1,434500225128),
+                    (18540,1,434500225132),
+                    (18544,1,434500225136),
+                    (18548,1,434500225140),
+                    (18552,1,434500225144),
+                    (18556,1,434500225148),
+                    (18560,1,434500225152),
+                    (18564,1,434500225156),
+                    (18568,1,434500225160),
+                    (18976,1,434500225568),
+                    (18980,1,434500225572),
+                    (18984,1,434500225576),
+                    (18988,1,434500225580)
+                )
+              ) AS static_data
+        ));
+        """,
+        out=Csv("""
+        "function_name","short_file_name","line_number","mapping_id","address"
         "main","etm.cc",62,1,434500225096
         "main","etm.cc",0,1,434500225100
         "main","etm.cc",62,1,434500225104

--- a/tools/diff_test_trace_processor.py
+++ b/tools/diff_test_trace_processor.py
@@ -98,10 +98,8 @@ def main():
       keep_input=args.keep_input,
       print_slowest_tests=args.print_slowest_tests)
   test_runner = DiffTestsRunner(config)
-  tests = test_runner.test_loader.discover_and_load_tests(config.name_filter)
-  sys.stderr.write(f"[==========] Running {len(tests)} tests.\n")
   results = test_runner.run()
-  sys.stderr.write(results.str(args.no_colors, len(tests)))
+  sys.stderr.write(results.str(args.no_colors))
 
   if args.print_slowest_tests:
     sys.stderr.write('\n--- Slowest tests ---\n')


### PR DESCRIPTION
Adds conditional diff tests based on the modules in the current build.
DiffTestBlueprint now has a new field named modules where a list of module names can be provided for each diff test.

This PR is designed to resolve #2381 and should allow for #2382 while preventing situations like #2478.