### PR TITLE
Refactor UpdateThreadNameAndMaybeProcessName to use UniqueTid

### DIFF
--- a/src/trace_processor/importers/art_method/art_method_parser.cc
+++ b/src/trace_processor/importers/art_method/art_method_parser.cc
@@ -41,7 +41,7 @@ void ArtMethodParser::Parse(int64_t ts, ArtMethodEvent e) {
   UniqueTid utid = context_->process_tracker->GetOrCreateThread(e.tid);
   if (e.comm) {
     context_->process_tracker->UpdateThreadNameAndMaybeProcessName(
-        e.tid, *e.comm, ThreadNamePriority::kOther);
+        utid, *e.comm, ThreadNamePriority::kOther);
   }
   TrackId track_id = context_->track_tracker->InternThreadTrack(utid);
   switch (e.action) {

--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -397,13 +397,12 @@ void ProcessTracker::SetStartTsIfUnset(UniquePid upid,
 }
 
 void ProcessTracker::UpdateThreadNameAndMaybeProcessName(
-    int64_t tid,
+    UniqueTid utid,
     StringId thread_name,
     ThreadNamePriority priority) {
   auto& tt = *context_->storage->mutable_thread_table();
   auto& pt = *context_->storage->mutable_process_table();
 
-  auto utid = GetOrCreateThread(tid);
   UpdateThreadName(utid, thread_name, priority);
   auto trr = tt[utid];
   std::optional<UniquePid> opt_upid = trr.upid();
@@ -411,7 +410,7 @@ void ProcessTracker::UpdateThreadNameAndMaybeProcessName(
     return;
   }
   auto prr = pt[*opt_upid];
-  if (prr.pid() == tid) {
+  if (prr.pid() == trr.tid()) {
     PERFETTO_DCHECK(trr.is_main_thread());
     prr.set_name(thread_name);
   }

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -139,7 +139,7 @@ class ProcessTracker {
 
   // Called on a task rename event to set the thread name and possibly process
   // name (if the tid provided is the main thread of the process).
-  void UpdateThreadNameAndMaybeProcessName(int64_t tid,
+  void UpdateThreadNameAndMaybeProcessName(UniqueTid utid,
                                            StringId thread_name,
                                            ThreadNamePriority priority);
 

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -2507,8 +2507,9 @@ void FtraceParser::ParseTaskRename(ConstBytes blob) {
   protos::pbzero::TaskRenameFtraceEvent::Decoder evt(blob);
   uint32_t tid = static_cast<uint32_t>(evt.pid());
   StringId comm = context_->storage->InternString(evt.newcomm());
+  auto utid = context_->process_tracker->GetOrCreateThread(tid);
   context_->process_tracker->UpdateThreadNameAndMaybeProcessName(
-      tid, comm, ThreadNamePriority::kFtrace);
+      utid, comm, ThreadNamePriority::kFtrace);
 }
 
 void FtraceParser::ParseBinderTransaction(int64_t timestamp,

--- a/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
+++ b/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
@@ -272,8 +272,10 @@ void GenericKernelParser::ParseGenericTaskRenameEvent(
     protozero::ConstBytes data) {
   protos::pbzero::GenericKernelTaskRenameEvent::Decoder task_rename_event(data);
   StringId comm = context_->storage->InternString(task_rename_event.comm());
+  auto utid =
+      context_->process_tracker->GetOrCreateThread(task_rename_event.tid());
   context_->process_tracker->UpdateThreadNameAndMaybeProcessName(
-      task_rename_event.tid(), comm, ThreadNamePriority::kGenericKernelTask);
+      utid, comm, ThreadNamePriority::kGenericKernelTask);
 }
 
 void GenericKernelParser::ParseGenericCpuFrequencyEvent(

--- a/src/trace_processor/importers/perf_text/perf_text_trace_parser.cc
+++ b/src/trace_processor/importers/perf_text/perf_text_trace_parser.cc
@@ -42,7 +42,7 @@ void PerfTextTraceParser::Parse(int64_t ts, PerfTextEvent evt) {
                  : context_->process_tracker->GetOrCreateThread(evt.tid);
   if (evt.comm) {
     context_->process_tracker->UpdateThreadNameAndMaybeProcessName(
-        evt.tid, *evt.comm, ThreadNamePriority::kOther);
+        row.utid, *evt.comm, ThreadNamePriority::kOther);
   }
   ss->Insert(row);
 }


### PR DESCRIPTION
ProcessTracker should rely more on UniqueTids given they disambiguate the thread in question since Perfetto allows concurrent tids.

Bug: 425694654
