### PR TITLE
tp: prepend to path when generating tp table headers

### DIFF
--- a/tools/gen_tp_table_headers.py
+++ b/tools/gen_tp_table_headers.py
@@ -24,7 +24,7 @@ from typing import Set
 
 # Allow importing of root-relative modules.
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-sys.path.append(os.path.join(ROOT_DIR))
+sys.path.insert(0, os.path.join(ROOT_DIR))
 
 #pylint: disable=wrong-import-position
 from python.generators.trace_processor_table.serialize import serialize_header


### PR DESCRIPTION
Ensures that our own code is always found first instead of some pip
package on users systems called "src" or "python".

Fixes: https://github.com/google/perfetto/issues/2579
