### PR TITLE
tp: etm: binary info error fix

### DIFF
--- a/include/perfetto/trace_processor/trace_blob_view.h
+++ b/include/perfetto/trace_processor/trace_blob_view.h
@@ -53,6 +53,7 @@ class alignas(8) TraceBlobView {
                          size_t offset = 0,
                          size_t length = kWholeBlob) {
     PERFETTO_DCHECK(offset <= std::numeric_limits<uint32_t>::max());
+    PERFETTO_CHECK(blob.size() <= std::numeric_limits<uint32_t>::max());
     data_ = blob.data() + offset;
     if (length == kWholeBlob) {
       length_ = static_cast<uint32_t>(blob.size() - offset);

--- a/include/perfetto/trace_processor/trace_processor.h
+++ b/include/perfetto/trace_processor/trace_processor.h
@@ -146,7 +146,7 @@ class PERFETTO_EXPORT_COMPONENT TraceProcessor : public TraceProcessorStorage {
   // if you pass binaries these are used to decode ETM traces.
   // Registering the same file twice will return an error.
   virtual base::Status RegisterFileContent(const std::string& path,
-                                           TraceBlobView content) = 0;
+                                           TraceBlob content) = 0;
 
   // Interrupts the current query. Typically used by Ctrl-C handler.
   virtual void InterruptQuery() = 0;

--- a/src/trace_processor/importers/common/registered_file_tracker.cc
+++ b/src/trace_processor/importers/common/registered_file_tracker.cc
@@ -23,17 +23,17 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-#include "perfetto/trace_processor/trace_blob_view.h"
-#include "src/trace_processor/util/elf/binary_info.h"
+#include "perfetto/trace_processor/trace_blob.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/etm_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/build_id.h"
+#include "src/trace_processor/util/elf/binary_info.h"
 
 namespace perfetto::trace_processor {
 
 base::Status RegisteredFileTracker::AddFile(const std::string& name,
-                                            TraceBlobView data) {
+                                            TraceBlob data) {
   StringId name_id = context_->storage->InternString(name);
   auto* it = files_by_path_.Find(name_id);
   if (it) {
@@ -71,6 +71,11 @@ base::Status RegisteredFileTracker::AddFile(const std::string& name,
     files_by_build_id_.Insert(*build_id, id);
   }
   return base::OkStatus();
+}
+TraceBlob RegisteredFileTracker::GetContent(tables::FileTable::Id id) const {
+  PERFETTO_DCHECK(id.value < file_content_.size());
+  const auto& blob = file_content_[id.value];
+  return TraceBlob::CopyFrom(blob.data(), blob.size());
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/common/registered_file_tracker.cc
+++ b/src/trace_processor/importers/common/registered_file_tracker.cc
@@ -72,10 +72,9 @@ base::Status RegisteredFileTracker::AddFile(const std::string& name,
   }
   return base::OkStatus();
 }
-TraceBlob RegisteredFileTracker::GetContent(tables::FileTable::Id id) const {
+TraceBlob& RegisteredFileTracker::GetContent(tables::FileTable::Id id) const {
   PERFETTO_DCHECK(id.value < file_content_.size());
-  const auto& blob = file_content_[id.value];
-  return TraceBlob::CopyFrom(blob.data(), blob.size());
+  return file_content_[id.value];
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/common/registered_file_tracker.cc
+++ b/src/trace_processor/importers/common/registered_file_tracker.cc
@@ -72,7 +72,7 @@ base::Status RegisteredFileTracker::AddFile(const std::string& name,
   }
   return base::OkStatus();
 }
-TraceBlob& RegisteredFileTracker::GetContent(tables::FileTable::Id id) const {
+TraceBlob& RegisteredFileTracker::GetContent(tables::FileTable::Id id) {
   PERFETTO_DCHECK(id.value < file_content_.size());
   return file_content_[id.value];
 }

--- a/src/trace_processor/importers/common/registered_file_tracker.h
+++ b/src/trace_processor/importers/common/registered_file_tracker.h
@@ -38,7 +38,7 @@ class RegisteredFileTracker {
       : context_(context) {}
 
   base::Status AddFile(const std::string& name, TraceBlob data);
-  TraceBlob& GetContent(tables::FileTable::Id id) const;
+  TraceBlob& GetContent(tables::FileTable::Id id);
 
   std::optional<tables::ElfFileTable::Id> FindBuildId(
       const BuildId& build_id) const {

--- a/src/trace_processor/importers/common/registered_file_tracker.h
+++ b/src/trace_processor/importers/common/registered_file_tracker.h
@@ -38,7 +38,7 @@ class RegisteredFileTracker {
       : context_(context) {}
 
   base::Status AddFile(const std::string& name, TraceBlob data);
-  TraceBlob GetContent(tables::FileTable::Id id) const;
+  TraceBlob& GetContent(tables::FileTable::Id id) const;
 
   std::optional<tables::ElfFileTable::Id> FindBuildId(
       const BuildId& build_id) const {

--- a/src/trace_processor/importers/common/registered_file_tracker.h
+++ b/src/trace_processor/importers/common/registered_file_tracker.h
@@ -24,7 +24,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/trace_processor/trace_blob_view.h"
+#include "perfetto/trace_processor/trace_blob.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/etm_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
@@ -37,11 +37,8 @@ class RegisteredFileTracker {
   explicit RegisteredFileTracker(TraceProcessorContext* context)
       : context_(context) {}
 
-  base::Status AddFile(const std::string& name, TraceBlobView data);
-  TraceBlobView GetContent(tables::FileTable::Id id) const {
-    PERFETTO_DCHECK(id.value < file_content_.size());
-    return file_content_[id.value].copy();
-  }
+  base::Status AddFile(const std::string& name, TraceBlob data);
+  TraceBlob GetContent(tables::FileTable::Id id) const;
 
   std::optional<tables::ElfFileTable::Id> FindBuildId(
       const BuildId& build_id) const {
@@ -50,14 +47,13 @@ class RegisteredFileTracker {
   }
 
  private:
-  void IndexFileType(tables::FileTable::Id file_id,
-                     const TraceBlobView& content);
+  void IndexFileType(tables::FileTable::Id file_id, const TraceBlob& content);
 
   TraceProcessorContext* context_;
   base::FlatHashMap<BuildId, tables::ElfFileTable::Id> files_by_build_id_;
 
   // Indexed by `tables::FileTable::Id`
-  std::vector<TraceBlobView> file_content_;
+  std::vector<TraceBlob> file_content_;
 
   base::FlatHashMap<StringId, tables::FileTable::Id> files_by_path_;
 };

--- a/src/trace_processor/importers/etm/mapping_version.h
+++ b/src/trace_processor/importers/etm/mapping_version.h
@@ -20,7 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "perfetto/trace_processor/trace_blob_view.h"
+#include "perfetto/trace_processor/trace_blob.h"
 #include "src/trace_processor/importers/common/address_range.h"
 #include "src/trace_processor/storage/trace_storage.h"
 
@@ -31,7 +31,7 @@ class MappingVersion {
   MappingVersion(MappingId id,
                  int64_t create_ts,
                  AddressRange range,
-                 std::optional<TraceBlobView> content);
+                 std::optional<TraceBlob> content);
 
   bool Contains(uint64_t address) const { return range_.Contains(address); }
   bool Contains(const AddressRange& range) const {
@@ -44,9 +44,7 @@ class MappingVersion {
   MappingId id() const { return id_; }
   // Returns a valid pointer if data is available or nullptr otherwise
   const uint8_t* data() const {
-    // We make sure in the constructor that if content_ length is 0 the pointer
-    // will be null.
-    return content_.data();
+    return content_.size() == 0 ? nullptr : content_.data();
   }
 
   MappingVersion SplitFront(uint64_t mid);
@@ -57,7 +55,7 @@ class MappingVersion {
   AddressRange range_;
   // Content is either empty and points to nullptr, or has the same length as
   // `range_`. This is CHECKED in the constructor.
-  TraceBlobView content_;
+  TraceBlob content_;
 };
 
 }  // namespace perfetto::trace_processor::etm

--- a/src/trace_processor/importers/etm/virtual_address_space.cc
+++ b/src/trace_processor/importers/etm/virtual_address_space.cc
@@ -58,7 +58,8 @@ void VirtualAddressSpace::Builder::AddMapping(
         static_cast<uint64_t>(mapping.exact_offset()), range.size());
 
     PERFETTO_CHECK(file_range.Contains(required_file_range));
-
+    // TODO(rasikanavarange): The following copy is not efficient and will need
+    // clean up later
     content = TraceBlob::CopyFrom(blob.data() + required_file_range.start(),
                                   required_file_range.length());
   }

--- a/src/trace_processor/importers/etm/virtual_address_space.cc
+++ b/src/trace_processor/importers/etm/virtual_address_space.cc
@@ -51,7 +51,7 @@ void VirtualAddressSpace::Builder::AddMapping(
 
   std::optional<TraceBlob> content;
   if (mmap.file_id()) {
-    TraceBlob blob =
+    TraceBlob& blob =
         context_->registered_file_tracker->GetContent(*mmap.file_id());
     auto file_range = AddressRange::FromStartAndSize(0, blob.size());
     auto required_file_range = AddressRange::FromStartAndSize(

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -839,7 +839,7 @@ void TraceProcessorImpl::SetCurrentTraceName(const std::string& name) {
 }
 
 base::Status TraceProcessorImpl::RegisterFileContent(const std::string& path,
-                                                     TraceBlobView content) {
+                                                     TraceBlob content) {
   return context_.registered_file_tracker->AddFile(path, std::move(content));
 }
 

--- a/src/trace_processor/trace_processor_impl.h
+++ b/src/trace_processor/trace_processor_impl.h
@@ -104,7 +104,7 @@ class TraceProcessorImpl : public TraceProcessor,
   void SetCurrentTraceName(const std::string&) override;
 
   base::Status RegisterFileContent(const std::string& path,
-                                   TraceBlobView content) override;
+                                   TraceBlob content) override;
 
   void InterruptQuery() override;
 

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -1804,7 +1804,7 @@ base::Status RegisterAllFilesInFolder(const std::string& path,
       return base::ErrStatus("Failed to mmap file: %s", file_full_path.c_str());
     }
     RETURN_IF_ERROR(tp.RegisterFileContent(
-        file_full_path, TraceBlobView(TraceBlob::FromMmap(std::move(mmap)))));
+        file_full_path, TraceBlob::FromMmap(std::move(mmap))));
   }
   return base::OkStatus();
 }

--- a/src/trace_processor/util/elf/binary_info.cc
+++ b/src/trace_processor/util/elf/binary_info.cc
@@ -38,7 +38,10 @@ bool InRange(const void* base,
   return ptr >= base && static_cast<const char*>(ptr) + size <=
                             static_cast<const char*>(base) + total_size;
 }
-
+// TODO(rasikanavarange): ETM registers files with large sizes causing size in
+// TraceBlobView to become truncated. This means we can not trust any of the
+// below checks for large files. So a solution is needed that is not too
+// expensive memory wise. b/438916722
 template <typename E>
 std::optional<uint64_t> GetElfLoadBias(const void* mem, size_t size) {
   const typename E::Ehdr* ehdr = static_cast<const typename E::Ehdr*>(mem);


### PR DESCRIPTION
As a temporary fix for b/438916722.
ETM registers files with large sizes causing TraceBlobView size to become truncated. This means we can not trust any of the below checks for large files. So a solution is needed that is not too expensive memory wise.

This PR converts these from errors to warnings and adds a TODO to find a memory efficient fix later.