### PR TITLE
tp: fix support for JITted frames in simpleperf profiles

### DIFF
--- a/src/trace_processor/importers/common/symbol_tracker.h
+++ b/src/trace_processor/importers/common/symbol_tracker.h
@@ -34,6 +34,7 @@ class SymbolTracker {
   struct Dso {
     uint64_t load_bias;
     AddressRangeMap<std::string> symbols;
+    bool symbols_are_absolute = false;
   };
 
   explicit SymbolTracker(TraceProcessorContext* context);

--- a/src/trace_processor/importers/perf/perf_tracker.cc
+++ b/src/trace_processor/importers/perf/perf_tracker.cc
@@ -29,6 +29,7 @@
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/importers/common/address_range.h"
 #include "src/trace_processor/importers/common/create_mapping_params.h"
@@ -126,6 +127,11 @@ void PerfTracker::AddSimpleperfFile2(const FileFeature::Decoder& file) {
       return;
   }
 
+  // JIT functions use absolute addresses for their symbols instead of relative
+  // ones.
+  dso.symbols_are_absolute =
+      base::StringView(file.path())
+          .StartsWith("/data/local/tmp/perf.data_jit_app_cache");
   InsertSymbols(file, dso.symbols);
   context_->symbol_tracker->dsos().Insert(
       context_->storage->InternString(file.path()), std::move(dso));

--- a/src/traceconv/trace_to_text.cc
+++ b/src/traceconv/trace_to_text.cc
@@ -200,7 +200,8 @@ bool TraceToText(std::istream* input, std::ostream* output) {
         return false;
     } while (input_reader.Read(buffer.get(), &buffer_len, kMaxMsgSize));
     return input_reader.ok();
-  } else if (type == TraceType::kProtoTraceType) {
+  } else if (type == TraceType::kProtoTraceType ||
+             type == trace_processor::kSymbolsTraceType) {
     do {
       online_trace_to_text.Feed(buffer.get(), buffer_len);
       if (!online_trace_to_text.ok())
@@ -208,7 +209,7 @@ bool TraceToText(std::istream* input, std::ostream* output) {
     } while (input_reader.Read(buffer.get(), &buffer_len, kMaxMsgSize));
     return input_reader.ok();
   } else {
-    PERFETTO_ELOG("Unrecognised file.");
+    PERFETTO_ELOG("Unrecognised file (type: %d).", type);
     return false;
   }
 }


### PR DESCRIPTION
We were not correctly handling the addresses for those: they're
different to symbols for normal simpleperf ELF profiles so add special
case for handling them;
