### PR TITLE
feat: allow multiple tabs to use the HTTP RPC accelerator + file sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ GRTAGS
 GTAGS
 perf.data*
 TAGS
+/storage*

--- a/README_SHARED_PERFETTO.md
+++ b/README_SHARED_PERFETTO.md
@@ -1,0 +1,44 @@
+## Shared Perfetto Web UI
+### Build
+- Update dependencies
+```
+tools/install-build-deps
+tools/install-build-deps --ui
+```
+- build ui
+```
+ui/build
+ui/run-dev-server
+```
+
+- build processor
+```
+tools/gn args out/ubuntu
+tools/ninja -C out/ubuntu trace_processor_shell
+```
+
+Build args
+```
+> vim out/ubuntu/args.gn
+target_os = "linux"
+target_cpu = "x64"
+```
+
+### Example
+Run trace_processor
+```
+./out/ubuntu/trace_processor_shell --httpd
+```
+
+Open: http://0.0.0.0:10000/
+
+To open a stored file that has been uploaded to the server:
+http://0.0.0.0:10000/#!/viewer?storage=fileName
+
+Or open the "Uploaded Files" page in the sidebar.
+
+To build a docker image: 
+docker build -f Docker/Dockerfile .
+
+### Design Document
+- https://docs.google.com/document/d/16ylk61fJBYUsW6SEbCLTnGeYAqpFhptJmmyQ0eEElcw/edit?usp=sharing

--- a/include/perfetto/ext/base/http/http_server.h
+++ b/include/perfetto/ext/base/http/http_server.h
@@ -159,7 +159,7 @@ class HttpServer : public UnixSocket::EventListener {
  public:
   HttpServer(TaskRunner*, HttpRequestHandler*);
   ~HttpServer() override;
-  void Start(int port);
+  void Start(const std::string& host, int port);
   void AddAllowedOrigin(const std::string&);
 
  private:

--- a/protos/perfetto/trace_processor/trace_processor.proto
+++ b/protos/perfetto/trace_processor/trace_processor.proto
@@ -101,6 +101,7 @@ message TraceProcessorRpc {
     TPM_DISABLE_AND_READ_METATRACE = 9;
     TPM_GET_STATUS = 10;
     TPM_RESET_TRACE_PROCESSOR = 11;
+    TPM_PARSE_FROM_STORED_FILE = 12;
   }
 
   oneof type {
@@ -122,6 +123,7 @@ message TraceProcessorRpc {
   oneof args {
     // TraceProcessorMethod request args.
 
+    string file_name = 100;
     // For TPM_APPEND_TRACE_DATA.
     bytes append_trace_data = 101;
     // For TPM_QUERY_STREAMING.
@@ -146,6 +148,8 @@ message TraceProcessorRpc {
     DisableAndReadMetatraceResult metatrace = 209;
     // For TPM_GET_STATUS.
     StatusResult status = 210;
+    //For TPM_PARSE_FROM_STORED_FILE
+    ParseFromStoredFileArgs parse_from_stored_file_args = 211;
   }
 
   // Previously: RawQueryArgs for TPM_QUERY_RAW_DEPRECATED
@@ -327,4 +331,8 @@ message ResetTraceProcessorArgs {
   optional bool ingest_ftrace_in_raw_table = 2;
   optional bool analyze_trace_proto_content = 3;
   optional bool ftrace_drop_until_all_cpus_valid = 4;
+}
+
+message ParseFromStoredFileArgs{
+  optional string file_name = 1;
 }

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.cc
@@ -244,7 +244,7 @@ void PerfettoSqlEngine::RegisterStaticTable(Table* table,
 
   base::StackString<1024> sql(
       R"(
-        CREATE VIRTUAL TABLE %s USING static_table;
+        CREATE VIRTUAL TABLE IF NOT EXISTS %s USING static_table;
         INSERT INTO perfetto_tables(name) VALUES('%s');
       )",
       table_name.c_str(), table_name.c_str());
@@ -268,7 +268,7 @@ void PerfettoSqlEngine::RegisterStaticTableFunction(
       std::make_unique<DbSqliteModule::State>(std::move(fn));
 
   base::StackString<1024> sql(
-      "CREATE VIRTUAL TABLE %s USING static_table_function;", name.c_str());
+      "CREATE VIRTUAL TABLE IF NOT EXISTS %s USING static_table_function;", name.c_str());
   auto status =
       Execute(SqlSource::FromTraceProcessorImplementation(sql.ToStdString()));
   if (!status.ok()) {
@@ -600,7 +600,7 @@ base::Status PerfettoSqlEngine::ExecuteCreateTable(
     RETURN_IF_ERROR(drop_res.status());
   }
 
-  base::StackString<1024> create("CREATE VIRTUAL TABLE %s USING runtime_table",
+  base::StackString<1024> create("CREATE VIRTUAL TABLE IF NOT EXISTS %s USING runtime_table",
                                  create_table.name.c_str());
 
   // Make sure we didn't accidentally leak a state from a previous function
@@ -896,7 +896,7 @@ base::Status PerfettoSqlEngine::ExecuteCreateFunction(
   }
 
   base::StackString<1024> create(
-      "CREATE VIRTUAL TABLE %s USING runtime_table_function",
+      "CREATE VIRTUAL TABLE IF NOT EXISTS %s USING runtime_table_function",
       state->prototype.function_name.c_str());
 
   // Make sure we didn't accidentally leak a state from a previous function

--- a/src/trace_processor/rpc/httpd.h
+++ b/src/trace_processor/rpc/httpd.h
@@ -29,7 +29,7 @@ class TraceProcessor;
 // The unique_ptr argument is optional. If non-null, the HTTP server will adopt
 // an existing instance with a pre-loaded trace. If null, it will create a new
 // instance when pushing data into the /parse endpoint.
-void RunHttpRPCServer(std::unique_ptr<TraceProcessor>, const std::string&);
+void RunHttpRPCServer(std::unique_ptr<TraceProcessor>, const std::string&, const std::string&, int timeout_seconds = 600);
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -438,6 +438,7 @@ base::Status TraceProcessorImpl::NotifyEndOfFile() {
 }
 
 size_t TraceProcessorImpl::RestoreInitialTables() {
+  /**
   // We should always have at least as many objects now as we did in the
   // constructor.
   uint64_t registered_count_before = engine_->SqliteRegisteredObjectCount();
@@ -450,7 +451,8 @@ size_t TraceProcessorImpl::RestoreInitialTables() {
   uint64_t registered_count_after = engine_->SqliteRegisteredObjectCount();
   PERFETTO_CHECK(registered_count_after ==
                  sqlite_objects_post_constructor_initialization_);
-  return static_cast<size_t>(registered_count_before - registered_count_after);
+  */
+  return 0;
 }
 
 Iterator TraceProcessorImpl::ExecuteQuery(const std::string& sql) {

--- a/src/websocket_bridge/websocket_bridge.cc
+++ b/src/websocket_bridge/websocket_bridge.cc
@@ -96,9 +96,10 @@ void WSBridge::Main(int, char**) {
   srv.AddAllowedOrigin("http://localhost:10000");
   srv.AddAllowedOrigin("http://127.0.0.1:10000");
   srv.AddAllowedOrigin("https://ui.perfetto.dev");
+  srv.AddAllowedOrigin("http://0.0.0.0:10000");
 
   srv.Start(kWebsocketPort);
-  PERFETTO_LOG("[WSBridge] Listening on 127.0.0.1:%d", kWebsocketPort);
+  PERFETTO_LOG("[WSBridge] Listening on 0.0.0.0:%d", kWebsocketPort);
   task_runner_.Run();
 }
 

--- a/ui/build.js
+++ b/ui/build.js
@@ -84,7 +84,7 @@ const cfg = {
   debug: false,
   bigtrace: false,
   startHttpServer: false,
-  httpServerListenHost: '127.0.0.1',
+  httpServerListenHost: '0.0.0.0',
   httpServerListenPort: 10000,
   wasmModules: ['trace_processor', 'traceconv'],
   crossOriginIsolation: false,
@@ -857,7 +857,12 @@ function mklink(src, dst) {
     if (fs.lstatSync(dst).isSymbolicLink() && fs.readlinkSync(dst) === src) {
       return;
     } else {
-      fs.unlinkSync(dst);
+      const stat = fs.lstatSync(dst);
+      if (stat.isDirectory()) {
+        fs.rmdirSync(dst, { recursive: true });
+      } else {
+        fs.unlinkSync(dst);
+      }
     }
   }
   fs.symlinkSync(src, dst);

--- a/ui/package.json
+++ b/ui/package.json
@@ -79,6 +79,7 @@
   "scripts": {
     "build": "node build.js",
     "test": "node build.js --run-unittests",
-    "lint": "npx eslint . --ext .js,.ts"
+    "lint": "npx eslint . --ext .js,.ts",
+    "run-dev-server": "node build.js --serve --watch"
   }
 }

--- a/ui/run-dev-server
+++ b/ui/run-dev-server
@@ -14,4 +14,4 @@
 # limitations under the License.
 
 UI_DIR="$(cd -P ${BASH_SOURCE[0]%/*}; pwd)"
-$UI_DIR/node $UI_DIR/build.js --serve --watch "$@"
+$UI_DIR/node $UI_DIR/build.js --serve --cross-origin-isolation --watch "$@"

--- a/ui/src/common/actions.ts
+++ b/ui/src/common/actions.ts
@@ -36,7 +36,7 @@ import {
   DropDirection,
   performReordering,
 } from './dragndrop_logic';
-import {createEmptyState} from './empty_state';
+//import {createEmptyState} from './empty_state';
 import {
   MetatraceTrackId,
   traceEventBegin,
@@ -100,6 +100,7 @@ export interface PostedScrollToRange {
   viewPercentage?: number;
 }
 
+/**
 function clearTraceState(state: StateDraft) {
   const nextId = state.nextId;
   const recordConfig = state.recordConfig;
@@ -120,6 +121,7 @@ function clearTraceState(state: StateDraft) {
   state.chromeCategories = chromeCategories;
   state.newEngineMode = newEngineMode;
 }
+*/
 
 function generateNextId(draft: StateDraft): string {
   const nextId = String(Number(draft.nextId) + 1);
@@ -157,7 +159,7 @@ let statusTraceEvent: TraceEventScope | undefined;
 
 export const StateActions = {
   openTraceFromFile(state: StateDraft, args: {file: File}): void {
-    clearTraceState(state);
+    // clearTraceState(state);
     const id = generateNextId(state);
     state.engine = {
       id,
@@ -167,7 +169,7 @@ export const StateActions = {
   },
 
   openTraceFromBuffer(state: StateDraft, args: PostedTrace): void {
-    clearTraceState(state);
+    // clearTraceState(state);
     const id = generateNextId(state);
     state.engine = {
       id,
@@ -177,7 +179,7 @@ export const StateActions = {
   },
 
   openTraceFromUrl(state: StateDraft, args: {url: string}): void {
-    clearTraceState(state);
+    // clearTraceState(state);
     const id = generateNextId(state);
     state.engine = {
       id,
@@ -186,8 +188,18 @@ export const StateActions = {
     };
   },
 
+  openTraceFromStoredFile(state: StateDraft, _args: {fileName: string}): void {
+    // clearTraceState(state);
+    const id = generateNextId(state);
+    state.engine = {
+      id,
+      ready: false,
+      source: {type: 'STORED_FILE', fileName: _args.fileName},
+    };
+  },
+
   openTraceFromHttpRpc(state: StateDraft, _args: {}): void {
-    clearTraceState(state);
+    // clearTraceState(state);
     const id = generateNextId(state);
     state.engine = {
       id,
@@ -874,6 +886,14 @@ export const StateActions = {
       const trackKey = pinnedTracks[index];
       this.toggleTrackPinned(state, {trackKey});
     }
+  },
+
+   clearAllTracks(state: StateDraft, _: {}) {
+    // Clear all tracks from the state
+    state.tracks = {};
+    state.trackGroups = {};
+    state.pinnedTracks = [];
+    state.scrollingTracks = [];
   },
 
   togglePivotTable(

--- a/ui/src/common/state.ts
+++ b/ui/src/common/state.ts
@@ -239,11 +239,17 @@ export interface TraceHttpRpcSource {
   type: 'HTTP_RPC';
 }
 
+export interface ServerStoredFileSource{
+  type: 'STORED_FILE';
+  fileName: string;
+}
+
 export type TraceSource =
   | TraceFileSource
   | TraceArrayBufferSource
   | TraceUrlSource
-  | TraceHttpRpcSource;
+  | TraceHttpRpcSource
+  | ServerStoredFileSource;
 
 export interface TrackState {
   uri: string;

--- a/ui/src/frontend/files_page.ts
+++ b/ui/src/frontend/files_page.ts
@@ -1,0 +1,289 @@
+import m from 'mithril';
+import {createPage} from './pages';
+
+interface FilesPageState {
+  files: string[];
+  loading: boolean;
+  error: string | null;
+}
+
+const state: FilesPageState = {
+  files: [],
+  loading: false,
+  error: null,
+};
+
+async function fetchFileList() {
+  state.loading = true;
+  state.error = null;
+  
+  const URL = `http://${window.location.hostname}:9001/getFileList`;
+  try {
+    const response = await fetch(URL, {method: 'GET'});
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const text = await response.text();
+    state.files = text.split('\n').filter(f => f.trim() !== '');
+  } catch (error) {
+    state.error = error instanceof Error ? error.message : 'Unknown error';
+    state.files = [];
+  } finally {
+    state.loading = false;
+  }
+}
+
+class FilesPageContents implements m.ClassComponent {
+  oncreate() {
+    fetchFileList();
+  }
+
+  view() {
+    return m('.files-page',
+      m('.header-section',
+        m('h1.page-title', 
+          m('span.icon.material-icons', 'folder'),
+          'Trace Files'
+        ),
+        m('p.page-subtitle', 'Browse and open available trace files'),
+      ),
+      
+      state.loading && 
+        m('.loading-container',
+          m('.spinner'),
+          m('p', 'Loading files...')
+        ),
+      
+      state.error && 
+        m('.error-container',
+          m('.error-icon.material-icons', 'error_outline'),
+          m('h3', 'Failed to load files'),
+          m('p', state.error),
+          m('button.retry-btn', {onclick: fetchFileList}, 
+            m('span.icon.material-icons', 'refresh'),
+            'Try Again'
+          )
+        ),
+      
+      !state.loading && !state.error && state.files.length === 0 &&
+        m('.empty-container',
+          m('.empty-icon.material-icons', 'folder_open'),
+          m('h3', 'No files found'),
+          m('p', 'There are no trace files available in the system. Try refreshing the page.')
+        ),
+      
+      !state.loading && !state.error && state.files.length > 0 &&
+        m('.files-grid',
+          m('.files-header',
+            m('.header-item', 'File Name'),
+            m('.header-item', 'Size'),
+            m('.header-item', 'Actions')
+          ),
+          m('.files-list',
+            state.files.map((filename, index) => 
+              m('.file-item', {
+                key: filename,
+                class: index % 2 === 0 ? 'even' : 'odd'
+              },
+                m('.file-info',
+                  m('.file-icon.material-icons', 'description'),
+                  m('.file-name', filename)
+                ),
+                m('.file-size', '--'),
+                m('.file-actions',
+                  m('button.open-btn', {
+                    onclick: () => {
+                      window.location.href = `#!/viewer?storage=${encodeURIComponent(filename)}`;
+                    }
+                  },
+                    m('span.icon.material-icons', 'open_in_new'),
+                    'Open'
+                  )
+                )
+              )
+            )
+          )
+        )
+    );
+  }
+}
+
+export const FilesPage = createPage({
+  view() {
+    return m('.files-page-container', 
+      m('style', `
+        .files-page-container {
+          padding: 24px;
+          max-width: 1200px;
+          margin: 0 auto;
+          font-family: 'Roboto', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+        }
+
+        .header-section {
+          margin-bottom: 32px;
+        }
+
+        .page-title {
+          font-size: 28px;
+          font-weight: 300;
+          color: #202124;
+          margin: 0 0 8px 0;
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+
+        .page-title .icon {
+          font-size: 32px;
+          color: #1a73e8;
+        }
+
+        .page-subtitle {
+          font-size: 16px;
+          color: #5f6368;
+          margin: 0 0 16px 0;
+        }
+
+        .refresh-btn, .retry-btn, .open-btn {
+          background: #1a73e8;
+          color: white;
+          border: none;
+          padding: 8px 16px;
+          border-radius: 4px;
+          cursor: pointer;
+          font-size: 14px;
+          display: inline-flex;
+          align-items: center;
+          gap: 8px;
+          transition: background-color 0.2s;
+        }
+
+        .refresh-btn:hover, .retry-btn:hover, .open-btn:hover {
+          background: #1557b0;
+        }
+
+        .refresh-btn:disabled {
+          background: #bdc1c6;
+          cursor: not-allowed;
+        }
+
+        .loading-container, .error-container, .empty-container {
+          text-align: center;
+          padding: 48px 24px;
+          background: white;
+          border-radius: 8px;
+          box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+        }
+
+        .spinner {
+          border: 3px solid #f3f3f3;
+          border-top: 3px solid #1a73e8;
+          border-radius: 50%;
+          width: 40px;
+          height: 40px;
+          animation: spin 1s linear infinite;
+          margin: 0 auto 16px;
+        }
+
+        @keyframes spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+
+        .error-icon, .empty-icon {
+          font-size: 48px;
+          color: #dadce0;
+          margin-bottom: 16px;
+        }
+
+        .error-icon {
+          color: #d93025;
+        }
+
+        .files-grid {
+          background: white;
+          border-radius: 8px;
+          box-shadow: 0 1px 3px rgba(0,0,0,0.12);
+          overflow: hidden;
+        }
+
+        .files-header {
+          display: grid;
+          grid-template-columns: 1fr 100px 120px;
+          background: #f8f9fa;
+          padding: 12px 16px;
+          font-weight: 500;
+          color: #5f6368;
+          font-size: 14px;
+        }
+
+        .files-list {
+          max-height: 600px;
+          overflow-y: auto;
+        }
+
+        .file-item {
+          display: grid;
+          grid-template-columns: 1fr 100px 120px;
+          align-items: center;
+          padding: 12px 16px;
+          border-bottom: 1px solid #f0f0f0;
+          transition: background-color 0.2s;
+        }
+
+        .file-item:hover {
+          background-color: #f8f9fa;
+        }
+
+        .file-item.even {
+          background-color: #fafafa;
+        }
+
+        .file-info {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+
+        .file-icon {
+          color: #1a73e8;
+          font-size: 20px;
+        }
+
+        .file-name {
+          font-size: 14px;
+          color: #202124;
+          font-weight: 500;
+        }
+
+        .file-size {
+          font-size: 14px;
+          color: #5f6368;
+        }
+
+        .file-actions {
+          display: flex;
+          justify-content: flex-end;
+        }
+
+        .open-btn {
+          background: transparent;
+          color: #1a73e8;
+          border: 1px solid #dadce0;
+          padding: 6px 12px;
+          font-size: 13px;
+        }
+
+        .open-btn:hover {
+          background: #f8f9fa;
+          border-color: #1a73e8;
+        }
+
+        .open-btn .icon {
+          font-size: 16px;
+        }
+      `),
+      m(FilesPageContents)
+    );
+  },
+});

--- a/ui/src/frontend/globals.ts
+++ b/ui/src/frontend/globals.ts
@@ -238,6 +238,7 @@ class Globals implements AppContext {
   showTraceErrorPopup = true;
 
   traceContext = defaultTraceContext;
+  currentTraceName = '';
 
   readonly sidebarMenuItems = new Registry<SidebarMenuItem>((m) => m.commandId);
 

--- a/ui/src/frontend/metrics_page.ts
+++ b/ui/src/frontend/metrics_page.ts
@@ -60,7 +60,7 @@ async function getMetric(
   metric: string,
   format: Format,
 ): Promise<string> {
-  const result = await engine.computeMetric([metric], format);
+  const result = await engine.computeMetric(globals.currentTraceName, [metric], format);
   if (result instanceof Uint8Array) {
     return `Uint8Array<len=${result.length}>`;
   } else {

--- a/ui/src/frontend/router.ts
+++ b/ui/src/frontend/router.ts
@@ -54,6 +54,9 @@ const ROUTE_SCHEMA = z
     // For permalink hash.
     s: z.string().optional().catch(undefined),
 
+    //For opening a file stored in the backend.
+    storage: z.string().optional().catch(undefined),
+
     // DEPRECATED: for #!/record?p=cpu subpages (b/191255021).
     p: z.string().optional().catch(undefined),
 
@@ -65,7 +68,7 @@ const ROUTE_SCHEMA = z
     // non-standard port. This requires the CSP_WS_PERMISSIVE_PORT flag to relax
     // the Content Security Policy.
     rpc_port: z.string().regex(/\d+/).optional().catch(undefined),
-
+    rpc_host_port: z.string().optional().catch(undefined),
     // Override the referrer. Useful for scripts such as
     // record_android_trace to record where the trace is coming from.
     referrer: z.string().optional().catch(undefined),

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -167,6 +167,7 @@ function getSections(): Section[] {
           i: 'extension',
           isVisible: () => PLUGINS_PAGE_IN_NAV_FLAG.get(),
         },
+        {t: 'Uploaded Files', a: navigateFiles, i: 'folder'},
       ],
     },
 
@@ -418,6 +419,12 @@ function navigateMetrics(e: Event) {
 function navigateInfo(e: Event) {
   e.preventDefault();
   Router.navigate('#!/info');
+}
+
+function navigateFiles(e: Event) {
+  e.preventDefault();
+  Router.navigate('#!/files');
+  window.location.reload();
 }
 
 function navigateViewer(e: Event) {

--- a/ui/src/frontend/trace_url_handler.ts
+++ b/ui/src/frontend/trace_url_handler.ts
@@ -39,6 +39,10 @@ export function maybeOpenTraceFromRoute(route: Route) {
     return;
   }
 
+  if(route.args.storage){
+    maybeLoadTraceFromStoredFile(route.args.storage);
+  }
+
   const url = route.args.url;
   if (url && url !== getCurrentTraceUrl()) {
     // /?url=https://commondatastorage.googleapis.com/bucket/trace
@@ -213,6 +217,14 @@ async function maybeOpenCachedTrace(traceUuid: string) {
     // action so this has effect even if the user clicks Esc or clicks outside
     // of the modal dialog and dismisses it.
     navigateToOldTraceUuid();
+  }
+}
+
+function maybeLoadTraceFromStoredFile(fileName: string){
+  // Only load the trace if no trace is currently active
+  if (globals.state.traceUuid === undefined) {
+    globals.currentTraceName = fileName;
+    globals.dispatch(Actions.openTraceFromStoredFile({fileName}));
   }
 }
 

--- a/ui/src/frontend/track_panel.ts
+++ b/ui/src/frontend/track_panel.ts
@@ -121,7 +121,7 @@ export class CrashButton implements m.ClassComponent<CrashButtonAttrs> {
   private renderErrorMessage(error: Error): m.Children {
     return m(
       '',
-      'This track has crashed',
+      'This track has crashed (possibly due to a long period of inactivity), consider reloading the page',
       m(Button, {
         label: 'Re-raise exception',
         intent: Intent.Primary,

--- a/ui/src/protos/index.ts
+++ b/ui/src/protos/index.ts
@@ -61,6 +61,7 @@ import MeminfoCounters = protos.perfetto.protos.MeminfoCounters;
 import MetatraceCategories = protos.perfetto.protos.MetatraceCategories;
 import NativeContinuousDumpConfig = protos.perfetto.protos.HeapprofdConfig.ContinuousDumpConfig;
 import NetworkPacketTraceConfig = protos.perfetto.protos.NetworkPacketTraceConfig;
+import ParseFromStoredFileArgs = protos.perfetto.protos.ParseFromStoredFileArgs;
 import PerfEventConfig = protos.perfetto.protos.PerfEventConfig;
 import PerfEvents = protos.perfetto.protos.PerfEvents;
 import PerfettoMetatrace = protos.perfetto.protos.PerfettoMetatrace;
@@ -128,6 +129,7 @@ export {
   MetatraceCategories,
   NativeContinuousDumpConfig,
   NetworkPacketTraceConfig,
+  ParseFromStoredFileArgs,
   PerfettoMetatrace,
   PerfEventConfig,
   PerfEvents,

--- a/ui/src/trace_processor/http_rpc_engine.ts
+++ b/ui/src/trace_processor/http_rpc_engine.ts
@@ -33,13 +33,17 @@ export class HttpRpcEngine extends EngineBase {
   private connected = false;
 
   // Can be changed by frontend/index.ts when passing ?rpc_port=1234 .
-  static rpcPort = '9001';
+  static rpcHostPort = window.location.hostname + ":9001";
 
   constructor(id: string, loadingTracker?: LoadingTracker) {
     super(loadingTracker);
     this.id = id;
   }
 
+  rpcSendFileName(fileName: string): void {
+    this.rpcSendRequestBytes(new TextEncoder().encode(fileName));
+  }
+  
   rpcSendRequestBytes(data: Uint8Array): void {
     if (this.websocket === undefined) {
       const wsUrl = `ws://${HttpRpcEngine.hostAndPort}/websocket`;
@@ -118,6 +122,6 @@ export class HttpRpcEngine extends EngineBase {
   }
 
   static get hostAndPort() {
-    return `127.0.0.1:${HttpRpcEngine.rpcPort}`;
+    return `${HttpRpcEngine.rpcHostPort}`;
   }
 }

--- a/ui/src/trace_processor/sql_utils.ts
+++ b/ui/src/trace_processor/sql_utils.ts
@@ -229,7 +229,7 @@ export async function createVirtualTable(
   tableName: string,
   using: string,
 ): Promise<AsyncDisposable> {
-  await engine.query(`CREATE VIRTUAL TABLE ${tableName} USING ${using}`);
+  await engine.query(`CREATE VIRTUAL TABLE IF NOT EXISTS ${tableName} USING ${using}`);
   return {
     [Symbol.asyncDispose]: async () => {
       await engine.tryQuery(`DROP TABLE IF EXISTS ${tableName}`);


### PR DESCRIPTION
Added a feature that solves the issue that at most one tab can be using the http + rpc accelerator. Also added file sharing feature that allows multiple different traces to be opened across multiple tabs and devices.
Design document of this change can be found here: 

https://docs.google.com/document/d/16ylk61fJBYUsW6SEbCLTnGeYAqpFhptJmmyQ0eEElcw/edit?usp=sharing