### PR TITLE
tools: Set VENV_PYTHON as abspath

### DIFF
--- a/tools/release_python.py
+++ b/tools/release_python.py
@@ -30,7 +30,7 @@ NC = '\033[0m'  # No Color
 
 # Constants for paths. Assumes the script is run from the repository root.
 SETUP_PY_PATH = 'python/setup.py'
-VENV_PYTHON = '.venv/bin/python'
+VENV_PYTHON = os.path.abspath('.venv/bin/python')
 
 
 def info(msg: str) -> None:


### PR DESCRIPTION
Fixes:

```
Previous HEAD position was ec431ee001 perfetto(python): Bump version to 0.14.0 (#2558)
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
Traceback (most recent call last):
  File "/usr/local/google/home/sashwinbalaji/Desktop/perfetto/tools/release_python.py", line 233, in <module>
    main()
  File "/usr/local/google/home/sashwinbalaji/Desktop/perfetto/tools/release_python.py", line 227, in main
    publish(args.commit)
  File "/usr/local/google/home/sashwinbalaji/Desktop/perfetto/tools/release_python.py", line 152, in publish
    run_cmd(VENV_PYTHON, '-m', 'build', cwd='python')
  File "/usr/local/google/home/sashwinbalaji/Desktop/perfetto/tools/release_python.py", line 61, in run_cmd
    subprocess.run(args, check=check, cwd=cwd)
  File "/usr/lib/python3.12/subprocess.py", line 550, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/subprocess.py", line 1028, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.12/subprocess.py", line 1963, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '.venv/bin/python'
```

Reason being: script changes its working directory, but the path to the Python executable is relative.

`run_cmd(VENV_PYTHON, '-m', 'build', cwd='python')` changes the current directory to the python/ subdirectory before running the command making effectively VENV_PYTHON=~/Desktop/perfetto/python/.venv/bin/python  which doesn't exist.