### PR TITLE
perf proto: Exclusive counting for raw events

### DIFF
--- a/protos/perfetto/common/perf_events.proto
+++ b/protos/perfetto/common/perf_events.proto
@@ -158,6 +158,9 @@ message PerfEvents {
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
+    optional bool exclude_user = 5;
+    optional bool exclude_kernel = 6;
+    optional bool exclude_hv = 7;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -2033,6 +2033,9 @@ message PerfEvents {
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
+    optional bool exclude_user = 5;
+    optional bool exclude_kernel = 6;
+    optional bool exclude_hv = 7;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -2033,6 +2033,9 @@ message PerfEvents {
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
+    optional bool exclude_user = 5;
+    optional bool exclude_kernel = 6;
+    optional bool exclude_hv = 7;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/src/profiling/perf/event_config.cc
+++ b/src/profiling/perf/event_config.cc
@@ -267,7 +267,8 @@ std::optional<PerfCounter> MakePerfCounter(
   } else if (event_desc.has_raw_event()) {
     const auto& raw = event_desc.raw_event();
     return PerfCounter::RawEvent(name, raw.type(), raw.config(), raw.config1(),
-                                 raw.config2());
+                                 raw.config2(), raw.exclude_user(),
+                                 raw.exclude_kernel(), raw.exclude_hv());
   } else {
     return PerfCounter::BuiltinCounter(
         name, protos::gen::PerfEvents::PerfEvents::SW_CPU_CLOCK,
@@ -329,7 +330,10 @@ PerfCounter PerfCounter::RawEvent(std::string name,
                                   uint32_t type,
                                   uint64_t config,
                                   uint64_t config1,
-                                  uint64_t config2) {
+                                  uint64_t config2,
+                                  bool exclude_user,
+                                  bool exclude_kernel,
+                                  bool exclude_hv) {
   PerfCounter ret;
   ret.type = PerfCounter::Type::kRawEvent;
   ret.name = std::move(name);
@@ -338,6 +342,9 @@ PerfCounter PerfCounter::RawEvent(std::string name,
   ret.attr_config = config;
   ret.attr_config1 = config1;
   ret.attr_config2 = config2;
+  ret.attr_exclude_user = exclude_user;
+  ret.attr_exclude_kernel = exclude_kernel;
+  ret.attr_exclude_hv = exclude_hv;
   return ret;
 }
 
@@ -398,6 +405,9 @@ std::optional<EventConfig> EventConfig::CreatePolling(
   pe.config = timebase_event.attr_config;
   pe.config1 = timebase_event.attr_config1;
   pe.config2 = timebase_event.attr_config2;
+  pe.exclude_user = timebase_event.attr_exclude_user;
+  pe.exclude_kernel = timebase_event.attr_exclude_kernel;
+  pe.exclude_hv = timebase_event.attr_exclude_hv;
 
   // Include all counters in the group when reading the timebase. Always set
   // this option as it changes the layout of the data returned by the read
@@ -417,6 +427,9 @@ std::optional<EventConfig> EventConfig::CreatePolling(
     pe_follower.config = e.attr_config;
     pe_follower.config1 = e.attr_config1;
     pe_follower.config2 = e.attr_config2;
+    pe_follower.exclude_user = e.attr_exclude_user;
+    pe_follower.exclude_kernel = e.attr_exclude_kernel;
+    pe_follower.exclude_hv = e.attr_exclude_hv;
     pe_follower.sample_type = pe.sample_type;
 
     pe_followers.push_back(pe_follower);
@@ -556,6 +569,9 @@ std::optional<EventConfig> EventConfig::CreateSampling(
   pe.config = timebase_event.attr_config;
   pe.config1 = timebase_event.attr_config1;
   pe.config2 = timebase_event.attr_config2;
+  pe.exclude_user = timebase_event.attr_exclude_user;
+  pe.exclude_kernel = timebase_event.attr_exclude_kernel;
+  pe.exclude_hv = timebase_event.attr_exclude_hv;
   if (sampling_frequency) {
     pe.freq = true;
     pe.sample_freq = sampling_frequency;
@@ -602,6 +618,9 @@ std::optional<EventConfig> EventConfig::CreateSampling(
     pe_follower.config = e.attr_config;
     pe_follower.config1 = e.attr_config1;
     pe_follower.config2 = e.attr_config2;
+    pe_follower.exclude_user = e.attr_exclude_user;
+    pe_follower.exclude_kernel = e.attr_exclude_kernel;
+    pe_follower.exclude_hv = e.attr_exclude_hv;
     // Some arguments must match the timebase:
     pe_follower.sample_type = pe.sample_type;
     pe_follower.clockid = pe.clockid;

--- a/src/profiling/perf/event_config.h
+++ b/src/profiling/perf/event_config.h
@@ -83,8 +83,14 @@ struct PerfCounter {
   // sycall-level description of the event (perf_event_attr):
   uint32_t attr_type = 0;
   uint64_t attr_config = 0;
-  uint64_t attr_config1 = 0;  // optional extension
-  uint64_t attr_config2 = 0;  // optional extension
+  uint64_t attr_config1 = 0;   // optional extension
+  uint64_t attr_config2 = 0;   // optional extension
+  bool attr_exclude_user = 0;  // If this bit is set, the count excludes events
+                               // that happen in user space.
+  bool attr_exclude_kernel = 0;  // If this bit is set, the count excludes
+                                 // events that happen in kernel space.
+  bool attr_exclude_hv = 0;  // If this bit is set, the count excludes events
+                             // that happen in the hypervisor.
 
   Type event_type() const { return type; }
 
@@ -102,7 +108,10 @@ struct PerfCounter {
                               uint32_t type,
                               uint64_t config,
                               uint64_t config1,
-                              uint64_t config2);
+                              uint64_t config2,
+                              bool exclude_user,
+                              bool exclude_kernel,
+                              bool exclude_hv);
 };
 
 // Describes a single profiling configuration. Bridges the gap between the data

--- a/src/profiling/perf/perf_producer.cc
+++ b/src/profiling/perf/perf_producer.cc
@@ -203,6 +203,9 @@ void WritePerfEventDefaultsPacket(const EventConfig& event_config,
       raw_pb->set_config(timebase.attr_config);
       raw_pb->set_config1(timebase.attr_config1);
       raw_pb->set_config2(timebase.attr_config2);
+      raw_pb->set_exclude_user(timebase.attr_exclude_user);
+      raw_pb->set_exclude_kernel(timebase.attr_exclude_kernel);
+      raw_pb->set_exclude_hv(timebase.attr_exclude_hv);
       break;
     }
   }
@@ -235,6 +238,9 @@ void WritePerfEventDefaultsPacket(const EventConfig& event_config,
         raw_pb->set_config(e.attr_config);
         raw_pb->set_config1(e.attr_config1);
         raw_pb->set_config2(e.attr_config2);
+        raw_pb->set_exclude_user(e.attr_exclude_user);
+        raw_pb->set_exclude_kernel(e.attr_exclude_kernel);
+        raw_pb->set_exclude_hv(e.attr_exclude_hv);
         break;
       }
     }

--- a/src/trace_processor/importers/proto/perf_sample_tracker.cc
+++ b/src/trace_processor/importers/proto/perf_sample_tracker.cc
@@ -119,8 +119,10 @@ StringId InternCounterName(
     // This doesn't follow any pre-existing naming scheme, but aims to be a
     // short-enough default that is distinguishable.
     base::StackString<128> name(
-        "raw.0x%" PRIx32 ".0x%" PRIx64 ".0x%" PRIx64 ".0x%" PRIx64, raw.type(),
-        raw.config(), raw.config1(), raw.config2());
+        "raw.0x%" PRIx32 ".0x%" PRIx64 ".0x%" PRIx64 ".0x%" PRIx64 "%s%s%s",
+        raw.type(), raw.config(), raw.config1(), raw.config2(),
+        raw.exclude_user() ? ":!u" : "", raw.exclude_kernel() ? ":!k" : "",
+        raw.exclude_hv() ? ":!h" : "");
     return context->storage->InternString(name.string_view());
   }
 


### PR DESCRIPTION
Using RawEvents allow trace to separate if events are caused by kernel or application.