### PR TITLE
Split SetProcessMetadata into two ProcessTracker APIs

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -118,13 +118,18 @@ class ProcessTracker {
                             StringId main_thread_name,
                             ThreadNamePriority priority);
 
-  // Called when a process is seen in a process tree. Retrieves the UniquePid
-  // for that pid or assigns a new one.
+  // Updates a process' parent. If the upid was previously associated with
+  // a different parent process, then the upid process is considered reused
+  // and a new upid for a new process is returned. If no new process is
+  // created, the same upid is returned.
   // Virtual for testing.
-  virtual UniquePid SetProcessMetadata(UniquePid upid,
-                                       std::optional<UniquePid> pupid,
-                                       base::StringView name,
-                                       base::StringView cmdline);
+  virtual UniquePid UpdateProcessWithParent(UniquePid upid, UniquePid pupid);
+
+  // Set the process metadata. Called when a process is seen in a process tree.
+  // Virtual for testing.
+  virtual void SetProcessMetadata(UniquePid upid,
+                                  base::StringView name,
+                                  base::StringView cmdline);
 
   // Sets the process user id.
   void SetProcessUid(UniquePid upid, uint32_t uid);

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -108,14 +108,6 @@ class MockProcessTracker : public ProcessTracker {
   explicit MockProcessTracker(TraceProcessorContext* context)
       : ProcessTracker(context) {}
 
-  MOCK_METHOD(UniquePid,
-              SetProcessMetadata,
-              (UniquePid upid,
-               std::optional<UniquePid> pupid,
-               base::StringView process_name,
-               base::StringView cmdline),
-              (override));
-
   MOCK_METHOD(void,
               UpdateThreadName,
               (UniqueTid utid,

--- a/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc
@@ -493,7 +493,7 @@ void FuchsiaTraceTokenizer::ParseRecord(TraceBlobView tbv) {
           // things such as virtual threads.
           UniquePid upid = context_->process_tracker->GetOrCreateProcess(
               static_cast<uint32_t>(obj_id));
-          procs->SetProcessMetadata(upid, std::optional<uint32_t>(),
+          procs->SetProcessMetadata(upid,
                                     base::StringView(storage->GetString(name)),
                                     base::StringView());
           break;

--- a/src/trace_processor/importers/json/json_trace_parser.cc
+++ b/src/trace_processor/importers/json/json_trace_parser.cc
@@ -111,7 +111,7 @@ void JsonTraceParser::ParseJsonPacket(int64_t timestamp, JsonEvent event) {
   if (event.pid_is_string_id) {
     UniquePid upid = procs->GetOrCreateProcess(event.pid);
     procs->SetProcessMetadata(
-        upid, std::nullopt, storage->GetString(StringPool::Id::Raw(event.pid)),
+        upid, storage->GetString(StringPool::Id::Raw(event.pid)),
         base::StringView());
   }
   if (event.tid_is_string_id) {
@@ -427,8 +427,7 @@ void JsonTraceParser::ParseJsonPacket(int64_t timestamp, JsonEvent event) {
         } else if (name == "process_name") {
           UniquePid upid = procs->GetOrCreateProcess(event.pid);
           procs->SetProcessMetadata(
-              upid, std::nullopt,
-              base::StringView(args_name.data(), args_name.size()),
+              upid, base::StringView(args_name.data(), args_name.size()),
               base::StringView());
         }
       }

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -185,9 +185,13 @@ class MockProcessTracker : public ProcessTracker {
       : ProcessTracker(context) {}
 
   MOCK_METHOD(UniquePid,
+              UpdateProcessWithParent,
+              (UniquePid upid, UniquePid pupid),
+              (override));
+
+  MOCK_METHOD(void,
               SetProcessMetadata,
               (UniquePid upid,
-               std::optional<UniquePid> pupid,
                base::StringView process_name,
                base::StringView cmdline),
               (override));
@@ -760,9 +764,10 @@ TEST_F(ProtoTraceParserTest, LoadProcessPacket) {
 
   EXPECT_CALL(*process_, GetOrCreateProcess(3)).WillOnce(testing::Return(2u));
   EXPECT_CALL(*process_, GetOrCreateProcess(1)).WillOnce(testing::Return(4u));
-  EXPECT_CALL(*process_,
-              SetProcessMetadata(4u, Eq(2u), base::StringView(kProcName1),
-                                 base::StringView(kProcName1)));
+  EXPECT_CALL(*process_, UpdateProcessWithParent(4u, 2u))
+      .WillOnce(testing::Return(4u));
+  EXPECT_CALL(*process_, SetProcessMetadata(4u, base::StringView(kProcName1),
+                                            base::StringView(kProcName1)));
   Tokenize();
   context_.sorter->ExtractEventsForced();
 }
@@ -780,9 +785,10 @@ TEST_F(ProtoTraceParserTest, LoadProcessPacket_FirstCmdline) {
 
   EXPECT_CALL(*process_, GetOrCreateProcess(3)).WillOnce(testing::Return(2u));
   EXPECT_CALL(*process_, GetOrCreateProcess(1)).WillOnce(testing::Return(4u));
-  EXPECT_CALL(*process_,
-              SetProcessMetadata(4u, Eq(2u), base::StringView(kProcName1),
-                                 base::StringView("proc1 proc2")));
+  EXPECT_CALL(*process_, UpdateProcessWithParent(4u, 2u))
+      .WillOnce(testing::Return(4u));
+  EXPECT_CALL(*process_, SetProcessMetadata(4u, base::StringView(kProcName1),
+                                            base::StringView("proc1 proc2")));
   Tokenize();
   context_.sorter->ExtractEventsForced();
 }

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -663,8 +663,10 @@ void SystemProbesParser::ParseProcessTree(ConstBytes blob) {
 
     UniquePid pupid = context_->process_tracker->GetOrCreateProcess(ppid);
     UniquePid upid = context_->process_tracker->GetOrCreateProcess(pid);
-    upid = context_->process_tracker->SetProcessMetadata(upid, pupid, argv0,
-                                                         joined_cmdline);
+
+    upid = context_->process_tracker->UpdateProcessWithParent(upid, pupid);
+
+    context_->process_tracker->SetProcessMetadata(upid, argv0, joined_cmdline);
 
     if (proc.has_uid()) {
       context_->process_tracker->SetProcessUid(

--- a/src/trace_processor/importers/systrace/systrace_trace_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_trace_parser.cc
@@ -187,7 +187,8 @@ base::Status SystraceTraceParser::Parse(TraceBlobView blob) {
               ctx_->process_tracker->GetOrCreateProcess(ppid.value());
           UniquePid upid =
               ctx_->process_tracker->GetOrCreateProcess(pid.value());
-          ctx_->process_tracker->SetProcessMetadata(upid, pupid, name,
+          upid = ctx_->process_tracker->UpdateProcessWithParent(upid, pupid);
+          ctx_->process_tracker->SetProcessMetadata(upid, name,
                                                     base::StringView());
         } else if (state_ == ParseState::kProcessDumpShort &&
                    tokens.size() >= 4) {


### PR DESCRIPTION
Split SetProcessMetadata into two APIs, one which associates a upid with its parent process and another which simply sets the process' metadata. This reduces the amount of side effects the original SetProcessMetadata API had, simplifying ProcessTracker's API semantics.

Bug: 425694654
