### PR TITLE
tp: fix clashing of track group ids across traces

### DIFF
--- a/src/trace_processor/export_json_unittest.cc
+++ b/src/trace_processor/export_json_unittest.cc
@@ -99,6 +99,8 @@ class ExportJsonTest : public ::testing::Test {
     context_.process_track_translation_table.reset(
         new ProcessTrackTranslationTable(context_.storage.get()));
     context_.track_compressor.reset(new TrackCompressor(&context_));
+    context_.track_group_idx_state =
+        std::make_unique<TrackCompressorGroupIdxState>();
   }
 
   std::string ToJson(ArgumentFilterPredicate argument_filter = nullptr,

--- a/src/trace_processor/importers/common/track_compressor.cc
+++ b/src/trace_processor/importers/common/track_compressor.cc
@@ -19,11 +19,18 @@
 #include <algorithm>
 #include <cstdint>
 #include <iterator>
+#include <utility>
 #include <vector>
 
 #include "perfetto/base/logging.h"
+#include "perfetto/ext/base/fnv_hash.h"
+#include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/common/process_track_translation_table.h"
+#include "src/trace_processor/importers/common/tracks.h"
+#include "src/trace_processor/importers/common/tracks_common.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/variadic.h"
 
 namespace perfetto::trace_processor {
 

--- a/src/trace_processor/importers/common/track_compressor.h
+++ b/src/trace_processor/importers/common/track_compressor.h
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/hash.h"
 #include "perfetto/public/compiler.h"
@@ -65,6 +66,12 @@ using uncompressed_dimensions_t = decltype(UncompressedDimensions(
             : std::tuple_size_v<typename BlueprintT::dimensions_t> - 1>()));
 
 }  // namespace internal
+
+// Keeps track of the track group count across multiple traces/machines to
+// avoid clashes.
+struct TrackCompressorGroupIdxState {
+  uint32_t track_groups = 0;
+};
 
 // "Compresses" and interns trace processor tracks for a given track type.
 //
@@ -377,7 +384,7 @@ class TrackCompressor {
   PERFETTO_ALWAYS_INLINE TrackSet& GetOrCreateTrackSet(uint64_t hash) {
     auto [it, inserted] = sets_.Insert(hash, {});
     if (inserted) {
-      it->set_id = static_cast<uint32_t>(sets_.size() - 1);
+      it->set_id = context_->track_group_idx_state->track_groups++;
     }
     return *it;
   }

--- a/src/trace_processor/importers/common/track_compressor_unittest.cc
+++ b/src/trace_processor/importers/common/track_compressor_unittest.cc
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-#include <memory>
-
 #include "src/trace_processor/importers/common/track_compressor.h"
 
-#include "src/trace_processor/importers/common/args_tracker.h"
+#include <memory>
+
 #include "src/trace_processor/importers/common/global_args_tracker.h"
 #include "src/trace_processor/importers/common/process_track_translation_table.h"
 #include "src/trace_processor/importers/common/track_tracker.h"
@@ -51,6 +50,8 @@ class TrackCompressorUnittest : public testing::Test {
     context_.track_compressor = std::make_unique<TrackCompressor>(&context_);
     context_.process_track_translation_table =
         std::make_unique<ProcessTrackTranslationTable>(context_.storage.get());
+    context_.track_group_idx_state =
+        std::make_unique<TrackCompressorGroupIdxState>();
 
     storage_ = context_.storage.get();
     tracker_ = context_.track_compressor.get();

--- a/src/trace_processor/importers/proto/network_trace_module_unittest.cc
+++ b/src/trace_processor/importers/proto/network_trace_module_unittest.cc
@@ -77,6 +77,8 @@ class NetworkTraceModuleTest : public testing::Test {
     context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kFullSort);
     context_.descriptor_pool_ = std::make_unique<DescriptorPool>();
+    context_.track_group_idx_state =
+        std::make_unique<TrackCompressorGroupIdxState>();
   }
 
   base::Status TokenizeAndParse() {

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -269,6 +269,8 @@ class ProtoTraceParserTest : public ::testing::Test {
     context_.heap_graph_tracker = std::make_unique<HeapGraphTracker>(storage_);
 
     context_.track_compressor.reset(new TrackCompressor(&context_));
+    context_.track_group_idx_state =
+        std::make_unique<TrackCompressorGroupIdxState>();
 
     reader_ = std::make_unique<ProtoTraceReader>(&context_);
   }

--- a/src/trace_processor/trace_processor_context.cc
+++ b/src/trace_processor/trace_processor_context.cc
@@ -145,6 +145,8 @@ void InitGlobalState(TraceProcessorContext* context, const Config& config) {
   context->forked_context_state =
       Ptr<TraceProcessorContext::ForkedContextState>::MakeRoot();
   context->clock_converter = Ptr<ClockConverter>::MakeRoot(context);
+  context->track_group_idx_state =
+      Ptr<TrackCompressorGroupIdxState>::MakeRoot();
   context->register_additional_proto_modules = nullptr;
 
   // Per-Trace State (Miscategorized).
@@ -168,6 +170,7 @@ void CopyGlobalState(const TraceProcessorContext* source,
   dest->descriptor_pool_ = source->descriptor_pool_.Fork();
   dest->forked_context_state = source->forked_context_state.Fork();
   dest->clock_converter = source->clock_converter.Fork();
+  dest->track_group_idx_state = source->track_group_idx_state.Fork();
   dest->register_additional_proto_modules =
       source->register_additional_proto_modules;
 

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -53,12 +53,12 @@ class StackProfileTracker;
 class SymbolTracker;
 class TraceFileTracker;
 class TraceReaderRegistry;
-struct TrackCompressorGroupIdxState;
 class TraceSorter;
 class TraceStorage;
 class TrackCompressor;
 class TrackTracker;
 struct ProtoImporterModuleContext;
+struct TrackCompressorGroupIdxState;
 
 using MachineId = tables::MachineTable::Id;
 

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -20,7 +20,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <tuple>
 #include <utility>
 
 #include "perfetto/ext/base/flat_hash_map.h"
@@ -54,6 +53,7 @@ class StackProfileTracker;
 class SymbolTracker;
 class TraceFileTracker;
 class TraceReaderRegistry;
+struct TrackCompressorGroupIdxState;
 class TraceSorter;
 class TraceStorage;
 class TrackCompressor;
@@ -137,6 +137,7 @@ class TraceProcessorContext {
   GlobalPtr<DescriptorPool> descriptor_pool_;
   GlobalPtr<ForkedContextState> forked_context_state;
   GlobalPtr<ClockConverter> clock_converter;
+  GlobalPtr<TrackCompressorGroupIdxState> track_group_idx_state;
 
   // The registration function for additional proto modules.
   // This is populated by TraceProcessorImpl to allow for late registration of


### PR DESCRIPTION
We should ensure they are put in differnt sets to ensure we don't end up
with multiple traes both assigning group 0
