### PR TITLE
infra: Run presubmit diff against the merge-base of HEAD and origin/main

### DIFF
--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -96,8 +96,14 @@ def get_changed_files(merge_base: Optional[str]) -> List[str]:
           if not line.startswith(' D')
       ]
 
+      # Find the merge-base between merge_base and HEAD to avoid picking up
+      # other changes if merge_base has moved on.
+      merge_base_result = run_command(['git', 'merge-base', merge_base, 'HEAD'])
+      merge_base_commit = merge_base_result.stdout.strip()
+
       diff_result = run_command([
-          'git', 'diff', '--name-only', '--diff-filter=crd', merge_base, 'HEAD'
+          'git', 'diff', '--name-only', '--diff-filter=crd', merge_base_commit,
+          'HEAD'
       ])
       diff_files = diff_result.stdout.splitlines()
 


### PR DESCRIPTION
When running presubmit checks, we currently check changed files between HEAD and (by default) origin/main. However, if you're working on an older branch and origin/main has moved on, this diff can include changes that are not part of your branch.

This patch changes the presubmit checks to diff against the merge-base (i.e. the closest common ancestor between origin/main and HEAD, so that it includes only the files you've changed in your branch.
