### PR TITLE
Add url params option for the record android trace script

### DIFF
--- a/python/tools/record_android_trace.py
+++ b/python/tools/record_android_trace.py
@@ -110,6 +110,9 @@ def setup_arguments():
   help = 'The web address used to open trace files'
   parser.add_argument('--origin', default='https://ui.perfetto.dev', help=help)
 
+  help = 'The URL Params to open the trace file'
+  parser.add_argument('--url-params', default=None, help=help)
+
   help = 'Force the use of the sideloaded binaries rather than system daemons'
   parser.add_argument('--sideload', action='store_true', help=help)
 
@@ -420,7 +423,7 @@ def start_trace(args, print_log=True):
       prt('\n')
       prt('Opening the trace (%s) in the browser' % host_file)
     open_browser = not args.no_open_browser
-    open_trace_in_browser(host_file, open_browser, args.origin)
+    open_trace_in_browser(host_file, open_browser, args.origin, args.url_params)
 
   return host_file
 
@@ -455,7 +458,7 @@ def find_adb():
     sys.exit(1)
 
 
-def open_trace_in_browser(path, open_browser, origin):
+def open_trace_in_browser(path, open_browser, origin, url_params):
   # We reuse the HTTP+RPC port because it's the only one allowed by the CSP.
   PORT = 9001
   path = os.path.abspath(path)
@@ -464,6 +467,8 @@ def open_trace_in_browser(path, open_browser, origin):
   socketserver.TCPServer.allow_reuse_address = True
   with socketserver.TCPServer(('127.0.0.1', PORT), HttpHandler) as httpd:
     address = f'{origin}/#!/?url=http://127.0.0.1:{PORT}/{fname}&referrer=record_android_trace'
+    if url_params:
+      address += '&' + url_params      
     if open_browser:
       webbrowser.open_new_tab(address)
     else:

--- a/python/tools/record_android_trace.py
+++ b/python/tools/record_android_trace.py
@@ -110,8 +110,8 @@ def setup_arguments():
   help = 'The web address used to open trace files'
   parser.add_argument('--origin', default='https://ui.perfetto.dev', help=help)
 
-  help = 'The URL Params to open the trace file'
-  parser.add_argument('--url-params', default=None, help=help)
+  help = 'The URL Params to pass to browser when open the trace file'
+  parser.add_argument('--url-params', nargs='+', default=None, help=help)
 
   help = 'Force the use of the sideloaded binaries rather than system daemons'
   parser.add_argument('--sideload', action='store_true', help=help)
@@ -468,7 +468,7 @@ def open_trace_in_browser(path, open_browser, origin, url_params):
   with socketserver.TCPServer(('127.0.0.1', PORT), HttpHandler) as httpd:
     address = f'{origin}/#!/?url=http://127.0.0.1:{PORT}/{fname}&referrer=record_android_trace'
     if url_params:
-      address += '&' + url_params      
+      address += '&' + '&'.join(url_params)
     if open_browser:
       webbrowser.open_new_tab(address)
     else:

--- a/tools/record_android_trace
+++ b/tools/record_android_trace
@@ -401,6 +401,9 @@ def setup_arguments():
   help = 'The web address used to open trace files'
   parser.add_argument('--origin', default='https://ui.perfetto.dev', help=help)
 
+  help = 'The URL Params to open the trace file'
+  parser.add_argument('--url-params', default=None, help=help)
+
   help = 'Force the use of the sideloaded binaries rather than system daemons'
   parser.add_argument('--sideload', action='store_true', help=help)
 
@@ -711,7 +714,7 @@ def start_trace(args, print_log=True):
       prt('\n')
       prt('Opening the trace (%s) in the browser' % host_file)
     open_browser = not args.no_open_browser
-    open_trace_in_browser(host_file, open_browser, args.origin)
+    open_trace_in_browser(host_file, open_browser, args.origin, args.url_params)
 
   return host_file
 
@@ -746,7 +749,7 @@ def find_adb():
     sys.exit(1)
 
 
-def open_trace_in_browser(path, open_browser, origin):
+def open_trace_in_browser(path, open_browser, origin, url_params):
   # We reuse the HTTP+RPC port because it's the only one allowed by the CSP.
   PORT = 9001
   path = os.path.abspath(path)
@@ -755,6 +758,8 @@ def open_trace_in_browser(path, open_browser, origin):
   socketserver.TCPServer.allow_reuse_address = True
   with socketserver.TCPServer(('127.0.0.1', PORT), HttpHandler) as httpd:
     address = f'{origin}/#!/?url=http://127.0.0.1:{PORT}/{fname}&referrer=record_android_trace'
+    if url_params:
+      address += '&' + url_params
     if open_browser:
       webbrowser.open_new_tab(address)
     else:

--- a/tools/record_android_trace
+++ b/tools/record_android_trace
@@ -401,8 +401,8 @@ def setup_arguments():
   help = 'The web address used to open trace files'
   parser.add_argument('--origin', default='https://ui.perfetto.dev', help=help)
 
-  help = 'The URL Params to open the trace file'
-  parser.add_argument('--url-params', default=None, help=help)
+  help = 'The URL Params to pass to browser when open the trace file'
+  parser.add_argument('--url-params', nargs='+', default=None, help=help)
 
   help = 'Force the use of the sideloaded binaries rather than system daemons'
   parser.add_argument('--sideload', action='store_true', help=help)
@@ -759,7 +759,7 @@ def open_trace_in_browser(path, open_browser, origin, url_params):
   with socketserver.TCPServer(('127.0.0.1', PORT), HttpHandler) as httpd:
     address = f'{origin}/#!/?url=http://127.0.0.1:{PORT}/{fname}&referrer=record_android_trace'
     if url_params:
-      address += '&' + url_params
+      address += '&' + '&'.join(url_params)
     if open_browser:
       webbrowser.open_new_tab(address)
     else:


### PR DESCRIPTION
when we use the tools/record_android_trace, it will be good we can pass the url params when open the trace in the browser. This is part of change for this feature rquest ([2400](https://github.com/google/perfetto/issues/2400)) . 

The default value are the same as before, so there is no logic changes.

**Test:**
run the script: ./gen_amalgamated_python_tools to generate the record_android_trace and tested with an Android device trace, all works as expected.

When pass the url-params with cmd: `tools/record_android_trace -c perfetto.config --url-params test1 test2 test3`, the url-params is append to the url correctly in the browser. 
