### PR TITLE
Move process to parent thread associations to new method

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -113,10 +113,15 @@ class ProcessTracker {
   // Called when a task_newtask without the CLONE_THREAD flag is observed.
   // This force the tracker to start both a new UTID and a new UPID.
   UniquePid StartNewProcess(std::optional<int64_t> timestamp,
-                            std::optional<int64_t> parent_tid,
+                            std::optional<UniquePid> parent_upid,
                             int64_t pid,
                             StringId main_thread_name,
                             ThreadNamePriority priority);
+
+  // Associates a process with its parent thread. Used when the tid that
+  // created the process is known, but not the parent process. Exclusively,
+  // used by Ftrace on new task events where only the parent tid is provided.
+  void AssociateProcessToParentUtid(UniquePid upid, UniqueTid parent_utid);
 
   // Updates a process' parent. If the upid was previously associated with
   // a different parent process, then the upid process is considered reused

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -2483,11 +2483,14 @@ void FtraceParser::ParseTaskNewTask(int64_t timestamp,
   // If the process is a fork, start a new process.
   if ((clone_flags & kCloneThread) == 0) {
     // This is a plain-old fork() or equivalent.
-    proc_tracker->StartNewProcess(timestamp, source_tid, new_tid, new_comm,
-                                  ThreadNamePriority::kFtrace);
+    auto upid =
+        proc_tracker->StartNewProcess(timestamp, std::nullopt, new_tid,
+                                      new_comm, ThreadNamePriority::kFtrace);
 
     auto source_utid = proc_tracker->GetOrCreateThread(source_tid);
     auto new_utid = proc_tracker->GetOrCreateThread(new_tid);
+
+    proc_tracker->AssociateProcessToParentUtid(upid, source_utid);
 
     ThreadStateTracker::GetOrCreate(context_)->PushNewTaskEvent(
         timestamp, new_utid, source_utid);


### PR DESCRIPTION
ProcessTracker::StartNewProcess assumes a Linux-based system, where PIDs and TIDs can be used interchangeably. In order to generalize ProcessTracker's implementation, StartNewProcess now accepts an optional upid for the parent process and the new AssociateProcessToParentUtid method is provided specifically for Ftrace to add any pending associations between the new process and its parent.

Bug: 439687339
