### PR TITLE
Parse MEMINFO ETW events in TraceProcessor

### DIFF
--- a/src/trace_processor/importers/etw/etw_parser.cc
+++ b/src/trace_processor/importers/etw/etw_parser.cc
@@ -53,16 +53,17 @@ static constexpr auto kFreePageCountBlueprint =
                              tracks::StaticUnitBlueprint("pages"),
                              tracks::DimensionBlueprints(),
                              tracks::StaticNameBlueprint("Free Page Count"));
-static constexpr auto kModifiedPageCountBlueprint =
-    tracks::CounterBlueprint("modified_page_count",
-                             tracks::StaticUnitBlueprint("pages"),
-                             tracks::DimensionBlueprints(),
-                             tracks::StaticNameBlueprint("Modified Page Count"));
+static constexpr auto kModifiedPageCountBlueprint = tracks::CounterBlueprint(
+    "modified_page_count",
+    tracks::StaticUnitBlueprint("pages"),
+    tracks::DimensionBlueprints(),
+    tracks::StaticNameBlueprint("Modified Page Count"));
 static constexpr auto kModifiedNoWritePageCountBlueprint =
-    tracks::CounterBlueprint("modified_no_write_page_count",
-                             tracks::StaticUnitBlueprint("pages"),
-                             tracks::DimensionBlueprints(),
-                             tracks::StaticNameBlueprint("Modified No Write Page Count"));
+    tracks::CounterBlueprint(
+        "modified_no_write_page_count",
+        tracks::StaticUnitBlueprint("pages"),
+        tracks::DimensionBlueprints(),
+        tracks::StaticNameBlueprint("Modified No Write Page Count"));
 static constexpr auto kBadPageCountBlueprint =
     tracks::CounterBlueprint("bad_page_count",
                              tracks::StaticUnitBlueprint("pages"),
@@ -72,22 +73,24 @@ static constexpr auto kModifiedPageCountPageFileBlueprint =
     tracks::CounterBlueprint("modified_page_count_page_file",
                              tracks::StaticUnitBlueprint("pages"),
                              tracks::DimensionBlueprints(),
-                             tracks::StaticNameBlueprint("Modified Page Count Page Pile Page Count"));
-static constexpr auto kPagedPoolPageCountBlueprint =
-    tracks::CounterBlueprint("paged_pool_page_count",
-                             tracks::StaticUnitBlueprint("pages"),
-                             tracks::DimensionBlueprints(),
-                             tracks::StaticNameBlueprint("Paged Pool Page Count"));
+                             tracks::StaticNameBlueprint(
+                                 "Modified Page Count Page Pile Page Count"));
+static constexpr auto kPagedPoolPageCountBlueprint = tracks::CounterBlueprint(
+    "paged_pool_page_count",
+    tracks::StaticUnitBlueprint("pages"),
+    tracks::DimensionBlueprints(),
+    tracks::StaticNameBlueprint("Paged Pool Page Count"));
 static constexpr auto kNonPagedPoolPageCountBlueprint =
-    tracks::CounterBlueprint("non_paged_pool_page_count",
-                             tracks::StaticUnitBlueprint("pages"),
-                             tracks::DimensionBlueprints(),
-                             tracks::StaticNameBlueprint("Non Paged Pool Page Count"));
-static constexpr auto kMdlPageCountBlueprint =
-    tracks::CounterBlueprint("mdl_page_count",
-                             tracks::StaticUnitBlueprint("pages"),
-                             tracks::DimensionBlueprints(),
-                             tracks::StaticNameBlueprint("Memory Descriptor List Page Count"));
+    tracks::CounterBlueprint(
+        "non_paged_pool_page_count",
+        tracks::StaticUnitBlueprint("pages"),
+        tracks::DimensionBlueprints(),
+        tracks::StaticNameBlueprint("Non Paged Pool Page Count"));
+static constexpr auto kMdlPageCountBlueprint = tracks::CounterBlueprint(
+    "mdl_page_count",
+    tracks::StaticUnitBlueprint("pages"),
+    tracks::DimensionBlueprints(),
+    tracks::StaticNameBlueprint("Memory Descriptor List Page Count"));
 static constexpr auto kCommitPageCountBlueprint =
     tracks::CounterBlueprint("commit_page_count",
                              tracks::StaticUnitBlueprint("pages"),
@@ -99,10 +102,10 @@ static constexpr auto kStandbyPageCountBlueprint = tracks::CounterBlueprint(
     tracks::StaticUnitBlueprint("pages"),
     tracks::DimensionBlueprints(
         tracks::UintDimensionBlueprint("priority_level")),
-tracks::FnNameBlueprint([](uint32_t priority_level) {
-  return base::StackString<255>("Standby Page Count Pri-%ud",
-                                priority_level);
-}));
+    tracks::FnNameBlueprint([](uint32_t priority_level) {
+      return base::StackString<255>("Standby Page Count Pri-%ud",
+                                    priority_level);
+    }));
 
 static constexpr auto kRepurposedPageCountBlueprint = tracks::CounterBlueprint(
     "repurposed_page_count",
@@ -112,8 +115,7 @@ static constexpr auto kRepurposedPageCountBlueprint = tracks::CounterBlueprint(
     tracks::FnNameBlueprint([](uint32_t priority_level) {
       return base::StackString<255>("Repurposed Page Count Pri-%ud",
                                     priority_level);
-    }
-    ));
+    }));
 
 }  // namespace
 
@@ -170,42 +172,40 @@ void EtwParser::ParseReadyThread(int64_t timestamp,
 
 void EtwParser::ParseMemInfo(int64_t timestamp, ConstBytes blob) {
   protos::pbzero::MemInfoEtwEvent::Decoder meminfo(blob);
-  TrackId zero_page_count_track_id = context_->track_tracker->InternTrack(
-      kZeroPageCountBlueprint );
+  TrackId zero_page_count_track_id =
+      context_->track_tracker->InternTrack(kZeroPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.zero_page_count(),
                                        zero_page_count_track_id);
 
-  TrackId free_page_count_track_id = context_->track_tracker->InternTrack(
-      kFreePageCountBlueprint);
+  TrackId free_page_count_track_id =
+      context_->track_tracker->InternTrack(kFreePageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.free_page_count(),
                                        free_page_count_track_id);
 
-  TrackId modified_page_count_track_id = context_->track_tracker->InternTrack(
-      kModifiedPageCountBlueprint);
+  TrackId modified_page_count_track_id =
+      context_->track_tracker->InternTrack(kModifiedPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.modified_page_count(),
                                        modified_page_count_track_id);
 
   TrackId modified_no_write_page_count_track_id =
-      context_->track_tracker->InternTrack(
-          kModifiedNoWritePageCountBlueprint);
+      context_->track_tracker->InternTrack(kModifiedNoWritePageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp,
                                        meminfo.modified_no_write_page_count(),
                                        modified_no_write_page_count_track_id);
 
-  TrackId bad_page_count_track_id = context_->track_tracker->InternTrack(
-      kBadPageCountBlueprint);
+  TrackId bad_page_count_track_id =
+      context_->track_tracker->InternTrack(kBadPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.bad_page_count(),
                                        bad_page_count_track_id);
 
   TrackId modified_page_count_page_file_track_id =
-      context_->track_tracker->InternTrack(
-          kModifiedPageCountPageFileBlueprint);
-  context_->event_tracker->PushCounter(
-      timestamp, meminfo.modified_page_count_page_file(),
-      modified_page_count_page_file_track_id);
+      context_->track_tracker->InternTrack(kModifiedPageCountPageFileBlueprint);
+  context_->event_tracker->PushCounter(timestamp,
+                                       meminfo.modified_page_count_page_file(),
+                                       modified_page_count_page_file_track_id);
 
-  TrackId paged_pool_page_count_track_id = context_->track_tracker->InternTrack(
-      kPagedPoolPageCountBlueprint);
+  TrackId paged_pool_page_count_track_id =
+      context_->track_tracker->InternTrack(kPagedPoolPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp,
                                        meminfo.paged_pool_page_count(),
                                        paged_pool_page_count_track_id);
@@ -216,30 +216,33 @@ void EtwParser::ParseMemInfo(int64_t timestamp, ConstBytes blob) {
                                        meminfo.non_paged_pool_page_count(),
                                        non_paged_pool_page_count_track_id);
 
-  TrackId mdl_page_count_track_id = context_->track_tracker->InternTrack(
-      kMdlPageCountBlueprint);
+  TrackId mdl_page_count_track_id =
+      context_->track_tracker->InternTrack(kMdlPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.mdl_page_count(),
                                        mdl_page_count_track_id);
 
-  TrackId commit_page_count_track_id = context_->track_tracker->InternTrack(
-      kCommitPageCountBlueprint);
+  TrackId commit_page_count_track_id =
+      context_->track_tracker->InternTrack(kCommitPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.commit_page_count(),
                                        commit_page_count_track_id);
 
   auto standby_page_count_iterator = meminfo.standby_page_counts();
-  for (int i = 0; standby_page_count_iterator; ++i, ++standby_page_count_iterator) {
+  for (int i = 0; standby_page_count_iterator;
+       ++i, ++standby_page_count_iterator) {
     TrackId standby_page_count_track_id = context_->track_tracker->InternTrack(
         kStandbyPageCountBlueprint, tracks::Dimensions(i));
-    context_->event_tracker->PushCounter(timestamp, *standby_page_count_iterator,
-                                         standby_page_count_track_id);
+    context_->event_tracker->PushCounter(
+        timestamp, *standby_page_count_iterator, standby_page_count_track_id);
   }
 
   auto repurposed_page_count_iterator = meminfo.repurposed_page_counts();
-  for (int i = 0; repurposed_page_count_iterator; ++i, ++repurposed_page_count_iterator) {
+  for (int i = 0; repurposed_page_count_iterator;
+       ++i, ++repurposed_page_count_iterator) {
     TrackId repurposed_page_count_track_id =
         context_->track_tracker->InternTrack(kRepurposedPageCountBlueprint,
                                              tracks::Dimensions(i));
-    context_->event_tracker->PushCounter(timestamp, *repurposed_page_count_iterator,
+    context_->event_tracker->PushCounter(timestamp,
+                                         *repurposed_page_count_iterator,
                                          repurposed_page_count_track_id);
     ++i;
   }

--- a/src/trace_processor/importers/etw/etw_parser.cc
+++ b/src/trace_processor/importers/etw/etw_parser.cc
@@ -41,49 +41,79 @@ namespace perfetto {
 namespace trace_processor {
 
 namespace {
+using protozero::ConstBytes;
 
 static constexpr auto kZeroPageCountBlueprint =
     tracks::CounterBlueprint("zero_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Zero Page Count"));
 static constexpr auto kFreePageCountBlueprint =
     tracks::CounterBlueprint("free_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Free Page Count"));
 static constexpr auto kModifiedPageCountBlueprint =
     tracks::CounterBlueprint("modified_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Modified Page Count"));
 static constexpr auto kModifiedNoWritePageCountBlueprint =
     tracks::CounterBlueprint("modified_no_write_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Modified No Write Page Count"));
 static constexpr auto kBadPageCountBlueprint =
     tracks::CounterBlueprint("bad_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Bad Page Count"));
 static constexpr auto kModifiedPageCountPageFileBlueprint =
     tracks::CounterBlueprint("modified_page_count_page_file",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Modified Page Count Page Pile Page Count"));
 static constexpr auto kPagedPoolPageCountBlueprint =
     tracks::CounterBlueprint("paged_pool_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Paged Pool Page Count"));
 static constexpr auto kNonPagedPoolPageCountBlueprint =
     tracks::CounterBlueprint("non_paged_pool_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Non Paged Pool Page Count"));
 static constexpr auto kMdlPageCountBlueprint =
     tracks::CounterBlueprint("mdl_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Memory Descriptor List Page Count"));
 static constexpr auto kCommitPageCountBlueprint =
     tracks::CounterBlueprint("commit_page_count",
-                             tracks::StaticUnitBlueprint("pages"));
+                             tracks::StaticUnitBlueprint("pages"),
+                             tracks::DimensionBlueprints(),
+                             tracks::StaticNameBlueprint("Commit Page Count"));
 
 static constexpr auto kStandbyPageCountBlueprint = tracks::CounterBlueprint(
     "standby_page_count",
     tracks::StaticUnitBlueprint("pages"),
     tracks::DimensionBlueprints(
-        tracks::UintDimensionBlueprint("priority_level")));
+        tracks::UintDimensionBlueprint("priority_level")),
+tracks::FnNameBlueprint([](uint32_t priority_level) {
+  return base::StackString<255>("Standby Page Count Pri-%ud",
+                                priority_level);
+}));
 
 static constexpr auto kRepurposedPageCountBlueprint = tracks::CounterBlueprint(
     "repurposed_page_count",
     tracks::StaticUnitBlueprint("pages"),
     tracks::DimensionBlueprints(
-        tracks::UintDimensionBlueprint("priority_level")));
+        tracks::UintDimensionBlueprint("priority_level")),
+    tracks::FnNameBlueprint([](uint32_t priority_level) {
+      return base::StackString<255>("Repurposed Page Count Pri-%ud",
+                                    priority_level);
+    }
+    ));
 
 }  // namespace
 
@@ -141,81 +171,78 @@ void EtwParser::ParseReadyThread(int64_t timestamp,
 void EtwParser::ParseMemInfo(int64_t timestamp, ConstBytes blob) {
   protos::pbzero::MemInfoEtwEvent::Decoder meminfo(blob);
   TrackId zero_page_count_track_id = context_->track_tracker->InternTrack(
-      kZeroPageCountBlueprint, name = "Zero Page Count");
+      kZeroPageCountBlueprint );
   context_->event_tracker->PushCounter(timestamp, meminfo.zero_page_count(),
                                        zero_page_count_track_id);
 
   TrackId free_page_count_track_id = context_->track_tracker->InternTrack(
-      kFreePageCountBlueprint, name = "Free Page Count");
+      kFreePageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.free_page_count(),
                                        free_page_count_track_id);
 
   TrackId modified_page_count_track_id = context_->track_tracker->InternTrack(
-      kModifiedPageCountBlueprint, name = "Modified Page Count");
+      kModifiedPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.modified_page_count(),
                                        modified_page_count_track_id);
 
   TrackId modified_no_write_page_count_track_id =
       context_->track_tracker->InternTrack(
-          kModifiedNoWritePageCountBlueprint,
-          name = "Modified No Write Page Count");
+          kModifiedNoWritePageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp,
                                        meminfo.modified_no_write_page_count(),
                                        modified_no_write_page_count_track_id);
 
   TrackId bad_page_count_track_id = context_->track_tracker->InternTrack(
-      kBadPageCountBlueprint, name = "Bad Page Count");
+      kBadPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.bad_page_count(),
                                        bad_page_count_track_id);
 
-  TrackId modified_page_count_page_file_page_count_track_id =
+  TrackId modified_page_count_page_file_track_id =
       context_->track_tracker->InternTrack(
-          kModifiedPageCountPageFilePageCountBlueprint,
-          name = "ModifiedPageCountPageFile Page Count");
+          kModifiedPageCountPageFileBlueprint);
   context_->event_tracker->PushCounter(
-      timestamp, meminfo.modified_page_count_page_file_page_count(),
-      modified_page_count_page_file_page_count_track_id);
+      timestamp, meminfo.modified_page_count_page_file(),
+      modified_page_count_page_file_track_id);
 
   TrackId paged_pool_page_count_track_id = context_->track_tracker->InternTrack(
-      kPagedPoolPageCountBlueprint, name = "Paged Pool Page Count");
+      kPagedPoolPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp,
                                        meminfo.paged_pool_page_count(),
                                        paged_pool_page_count_track_id);
 
   TrackId non_paged_pool_page_count_track_id =
-      context_->track_tracker->InternTrack(kNonPagedPoolPageCountBlueprint,
-                                           name = "Non Paged Pool Page Count");
+      context_->track_tracker->InternTrack(kNonPagedPoolPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp,
                                        meminfo.non_paged_pool_page_count(),
                                        non_paged_pool_page_count_track_id);
 
   TrackId mdl_page_count_track_id = context_->track_tracker->InternTrack(
-      kMdlPageCountBlueprint, name = "Memory Descriptor List Page Count");
+      kMdlPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.mdl_page_count(),
                                        mdl_page_count_track_id);
 
   TrackId commit_page_count_track_id = context_->track_tracker->InternTrack(
-      kCommitPageCountBlueprint, name = "Commit Page Count");
+      kCommitPageCountBlueprint);
   context_->event_tracker->PushCounter(timestamp, meminfo.commit_page_count(),
                                        commit_page_count_track_id);
 
-  for (int i = 0; i < meminfo.standby_page_counts_size(); ++i) {
+  auto standby_page_count_iterator = meminfo.standby_page_counts();
+  for (int i = 0; standby_page_count_iterator; ++i, ++standby_page_count_iterator) {
     TrackId standby_page_count_track_id = context_->track_tracker->InternTrack(
-        kStandbyPageCountBlueprint, tracks::Dimensions(i),
-        tracks::DynamicString("Standby Page Count PRI(" + std::string(i) +
-                              ")"));
-    context_->event_tracker->PushCounter(
-        timestamp, meminfo.standby_page_counts(i), commit_page_count_track_id);
-  }    
+        kStandbyPageCountBlueprint, tracks::Dimensions(i));
+    context_->event_tracker->PushCounter(timestamp, *standby_page_count_iterator,
+                                         standby_page_count_track_id);
+  }
 
-  for (int i = 0; i < meminfo.repurposed_page_counts_size(); ++i) {
-    TrackId repurposed_page_count_track_id = context_->track_tracker->InternTrack(
-        kRepurposedPageCountBlueprint, tracks::Dimensions(i),
-        tracks::DynamicString("Repurposed Page Count PRI(" + std::string(i) +
-                              ")"));
-    context_->event_tracker->PushCounter(
-        timestamp, meminfo.repurposed_page_counts(i), commit_page_count_track_id);
-  }    
+  auto repurposed_page_count_iterator = meminfo.repurposed_page_counts();
+  for (int i = 0; repurposed_page_count_iterator; ++i, ++repurposed_page_count_iterator) {
+    TrackId repurposed_page_count_track_id =
+        context_->track_tracker->InternTrack(kRepurposedPageCountBlueprint,
+                                             tracks::Dimensions(i));
+    context_->event_tracker->PushCounter(timestamp, *repurposed_page_count_iterator,
+                                         repurposed_page_count_track_id);
+    ++i;
+  }
 }
 
 void EtwParser::PushSchedSwitch(uint32_t cpu,

--- a/src/trace_processor/importers/etw/etw_parser.h
+++ b/src/trace_processor/importers/etw/etw_parser.h
@@ -39,6 +39,7 @@ class EtwParser {
   void ParseReadyThread(int64_t timestamp,
                         uint32_t waker_tid,
                         protozero::ConstBytes);
+  void ParseMemInfo(int64_t timestamp, protozero::ConstBytes);
   void PushSchedSwitch(uint32_t cpu,
                        int64_t timestamp,
                        uint32_t prev_pid,


### PR DESCRIPTION
This change parses MemInfo ETW events in TraceProcessor.

This was verified using `trace_processor_shell`.
