### PR TITLE
Remove missed ChromeProcessDescriptor::ProcessType reference

### DIFF
--- a/src/trace_processor/importers/proto/chrome_string_lookup.h
+++ b/src/trace_processor/importers/proto/chrome_string_lookup.h
@@ -36,10 +36,8 @@ class ChromeStringLookup {
   StringId GetThreadName(int32_t thread_type) const;
 
  private:
-  std::map<int32_t /* ChromeProcessDescriptor::ProcessType */, StringId>
-      chrome_process_name_ids_;
-  std::map<int32_t /* ChromeThreadDescriptor::ThreadType */, StringId>
-      chrome_thread_name_ids_;
+  std::map<int32_t /* ProcessType */, StringId> chrome_process_name_ids_;
+  std::map<int32_t /* ThreadType */, StringId> chrome_thread_name_ids_;
 };
 
 }  // namespace trace_processor


### PR DESCRIPTION
The ProcessType and ThreadType enums have been moved to chrome_enums.proto. Cleans up some comments using the old names.
