### PR TITLE
ui: implement startup commands feature

### DIFF
--- a/ui/src/assets/components/json_settings_editor.scss
+++ b/ui/src/assets/components/json_settings_editor.scss
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import "../../assets/theme";
+@import "../theme";
 
-.pf-macro-settings {
-  width: 500px;
+.pf-json-settings-editor {
+  width: 400px;
 
   &__editor-section {
     margin-bottom: 10px;

--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -29,6 +29,7 @@
 // Widgets/components - keep these sorted alphabetically
 @import "components/aggregation_adapter";
 @import "components/data_grid";
+@import "components/json_settings_editor";
 @import "components/query_history";
 @import "components/query_table";
 @import "widgets/anchor";

--- a/ui/src/components/json_settings_editor.ts
+++ b/ui/src/components/json_settings_editor.ts
@@ -1,0 +1,135 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {z} from 'zod';
+import m from 'mithril';
+import {Editor} from '../widgets/editor';
+import {Callout} from '../widgets/callout';
+import {Intent} from '../widgets/common';
+import {Button} from '../widgets/button';
+import {Setting} from '../public/settings';
+
+export interface JsonSettingsEditorOptions<T> {
+  // Zod schema for validation
+  schema: z.ZodSchema<T>;
+  // Optional validator function for additional business logic validation
+  validator?: (data: T) => string | undefined;
+}
+
+export class JsonSettingsEditor<T> {
+  private textareaValue: string | undefined;
+  private originalValue: string | undefined;
+  private jsonError: string | undefined = undefined;
+  private currentSetting: Setting<T> | undefined;
+
+  constructor(private options: JsonSettingsEditorOptions<T>) {}
+
+  render(setting: Setting<T>): m.Children {
+    this.currentSetting = setting;
+    this.initializeTextValue();
+
+    return m('div', {className: 'pf-json-settings-editor'}, [
+      m('div', {className: 'pf-json-settings-editor__editor-section'}, [
+        m(Editor, {
+          text: this.textareaValue,
+          className: 'pf-json-settings-editor__editor',
+          onUpdate: (text: string) => this.handleUpdate(text),
+          onSave: () => this.handleSave(),
+        }),
+        this.jsonError !== undefined &&
+          m(
+            Callout,
+            {
+              intent: Intent.Danger,
+              className: 'pf-json-settings-editor__error',
+            },
+            `JSON Error: ${this.jsonError}`,
+          ),
+        m('div', {className: 'pf-json-settings-editor__actions'}, [
+          m(Button, {
+            label: 'Save',
+            disabled: this.isSaveDisabled(),
+            onclick: () => this.handleSave(),
+          }),
+        ]),
+      ]),
+    ]);
+  }
+
+  private initializeTextValue(): void {
+    if (this.textareaValue === undefined && this.currentSetting) {
+      const data = this.currentSetting.get();
+      this.originalValue = this.stringifyData(data);
+      this.textareaValue = this.originalValue;
+    }
+  }
+
+  private stringifyData(data: T): string {
+    return JSON.stringify(data, null, 2);
+  }
+
+  private handleUpdate(text: string): void {
+    this.textareaValue = text;
+    this.validateAndSetError(text);
+  }
+
+  private handleSave(): void {
+    if (this.textareaValue === undefined || !this.currentSetting) return;
+    const validatedData = this.validateAndSetError(this.textareaValue);
+    if (validatedData !== undefined) {
+      this.currentSetting.set(validatedData);
+      this.originalValue = this.textareaValue;
+    }
+  }
+
+  private hasUnsavedChanges(): boolean {
+    return this.textareaValue !== this.originalValue;
+  }
+
+  private isSaveDisabled(): boolean {
+    return this.jsonError !== undefined || !this.hasUnsavedChanges();
+  }
+
+  private validateAndSetError(text: string): T | undefined {
+    try {
+      const parsed = JSON.parse(text);
+      const result = this.options.schema.safeParse(parsed);
+      if (!result.success) {
+        this.jsonError = result.error.issues
+          .map((issue) => {
+            const path =
+              issue.path.length > 0 ? `at ${issue.path.join('.')}` : '';
+            return `${issue.message} ${path}`.trim();
+          })
+          .join(', ');
+        return undefined;
+      }
+
+      // Run additional validation if provided
+      if (this.options.validator) {
+        const validationError = this.options.validator(result.data);
+        if (validationError !== undefined) {
+          this.jsonError = validationError;
+          return undefined;
+        }
+      }
+
+      this.jsonError = undefined;
+      return result.data;
+    } catch (err) {
+      this.jsonError = err instanceof Error ? err.message : 'Invalid JSON';
+      return undefined;
+    }
+  }
+}

--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -26,7 +26,7 @@ import {Setting, SettingsManager} from '../public/settings';
 import {DurationPrecision, TimestampFormat} from '../public/timeline';
 import {NewEngineMode} from '../trace_processor/engine';
 import {AnalyticsInternal, initAnalytics} from './analytics_impl';
-import {CommandManagerImpl} from './command_manager';
+import {CommandInvocation, CommandManagerImpl} from './command_manager';
 import {featureFlags} from './feature_flags';
 import {loadTrace} from './load_trace';
 import {OmniboxManagerImpl} from './omnibox_manager';
@@ -55,6 +55,7 @@ export interface AppInitArgs {
   readonly durationPrecisionSetting: Setting<DurationPrecision>;
   readonly timezoneOverrideSetting: Setting<string>;
   readonly analyticsSetting: Setting<boolean>;
+  readonly startupCommandsSetting: Setting<CommandInvocation[]>;
 }
 
 /**
@@ -109,6 +110,7 @@ export class AppContext {
   readonly timestampFormat: Setting<TimestampFormat>;
   readonly durationPrecision: Setting<DurationPrecision>;
   readonly timezoneOverride: Setting<string>;
+  readonly startupCommandsSetting: Setting<CommandInvocation[]>;
 
   // This constructor is invoked only once, when frontend/index.ts invokes
   // AppMainImpl.initialize().
@@ -116,6 +118,7 @@ export class AppContext {
     this.timestampFormat = initArgs.timestampFormatSetting;
     this.durationPrecision = initArgs.durationPrecisionSetting;
     this.timezoneOverride = initArgs.timezoneOverrideSetting;
+    this.startupCommandsSetting = initArgs.startupCommandsSetting;
     this.settingsManager = initArgs.settingsManager;
     this.initArgs = initArgs;
     this.initialRouteArgs = initArgs.initialRouteArgs;

--- a/ui/src/core/command_manager.ts
+++ b/ui/src/core/command_manager.ts
@@ -12,10 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {z} from 'zod';
 import {FuzzyFinder, FuzzySegment} from '../base/fuzzy';
 import {Registry} from '../base/registry';
 import {Command, CommandManager} from '../public/command';
 import {raf} from './raf_scheduler';
+
+/**
+ * Zod schema for a single command invocation.
+ * Used for programmatic command execution like startup commands.
+ */
+export const commandInvocationSchema = z.object({
+  /** The command ID to execute (e.g., 'perfetto.CoreCommands#RunQueryAllProcesses'). */
+  id: z.string(),
+  /** Arguments to pass to the command. */
+  args: z.array(z.string()),
+});
+
+/**
+ * Specification for invoking a command with arguments.
+ * Inferred from the Zod schema to keep types in sync.
+ */
+export type CommandInvocation = z.infer<typeof commandInvocationSchema>;
+
+/**
+ * Zod schema for validating CommandInvocation arrays.
+ * Used by settings that store lists of commands to execute.
+ */
+export const commandInvocationArraySchema = z.array(commandInvocationSchema);
+
+/**
+ * Validates that all command invocations reference existing commands.
+ * @param commands Array of command invocations to validate
+ * @param commandManager Command manager to check command existence
+ * @returns Array of invalid command IDs, empty if all commands are valid
+ */
+export function validateCommandInvocations(
+  commands: CommandInvocation[],
+  commandManager: CommandManager,
+): string[] {
+  const invalidCommands: string[] = [];
+
+  for (const command of commands) {
+    if (!commandManager.hasCommand(command.id)) {
+      invalidCommands.push(command.id);
+    }
+  }
+
+  return invalidCommands;
+}
 
 export interface CommandWithMatchInfo extends Command {
   segments: FuzzySegment[];
@@ -55,5 +100,21 @@ export class CommandManagerImpl implements CommandManager {
     return finder.find(searchTerm).map((result) => {
       return {segments: result.segments, ...result.item};
     });
+  }
+
+  hasStartupCommands(): boolean {
+    // This should never be called on the global CommandManager.
+    // Startup commands should only be checked in trace context.
+    throw new Error(
+      'hasStartupCommands() should only be called on trace command manager',
+    );
+  }
+
+  async runStartupCommands(): Promise<void> {
+    // This should never be called on the global CommandManager.
+    // Startup commands should only be executed in trace context.
+    throw new Error(
+      'runStartupCommands() should only be called on trace command manager',
+    );
   }
 }

--- a/ui/src/core/fake_trace_impl.ts
+++ b/ui/src/core/fake_trace_impl.ts
@@ -21,6 +21,7 @@ import {SettingsManagerImpl} from './settings_manager';
 import {TraceImpl} from './trace_impl';
 import {TraceInfoImpl} from './trace_info_impl';
 import {DurationPrecision, TimestampFormat} from '../public/timeline';
+import {commandInvocationArraySchema} from './command_manager';
 
 export interface FakeTraceImplArgs {
   // If true suppresses exceptions when trying to issue a query. This is to
@@ -66,6 +67,13 @@ export function initializeAppImplForTesting(): AppImpl {
         description: '',
         schema: z.boolean(),
         defaultValue: true,
+      }),
+      startupCommandsSetting: settingsManager.register({
+        id: 'startupCommands',
+        name: 'Startup Commands',
+        description: '',
+        schema: commandInvocationArraySchema,
+        defaultValue: [],
       }),
     });
   }

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -270,6 +270,20 @@ async function loadTraceIntoEngine(
     deserializeAppStatePhase2(serializedAppState, trace);
   }
 
+  // Execute startup commands as the final step - simulates user actions
+  // after the trace is fully loaded and any saved state has been restored.
+  // This ensures startup commands see the complete, final state of the trace.
+  if (trace.commands.hasStartupCommands()) {
+    updateStatus(app, 'Running startup commands');
+    // Disable prompts during startup commands to prevent blocking
+    app.omnibox.disablePrompts();
+    try {
+      await trace.commands.runStartupCommands();
+    } finally {
+      app.omnibox.enablePrompts();
+    }
+  }
+
   return trace;
 }
 

--- a/ui/src/core/omnibox_manager.ts
+++ b/ui/src/core/omnibox_manager.ts
@@ -39,6 +39,7 @@ export class OmniboxManagerImpl implements OmniboxManager {
   private _forceShortTextSearch = false;
   private _text = '';
   private _statusMessageContainer: {msg?: string} = {};
+  private _promptsDisabled = false;
 
   get mode(): OmniboxMode {
     return this._mode;
@@ -122,6 +123,10 @@ export class OmniboxManagerImpl implements OmniboxManager {
     text: string,
     choicesOrDefaultValue?: ReadonlyArray<string> | PromptChoices<T> | string,
   ): Promise<string | T | undefined> {
+    if (this._promptsDisabled) {
+      return Promise.resolve(undefined);
+    }
+
     this._mode = OmniboxMode.Prompt;
     this._omniboxSelectionIndex = 0;
     this.rejectPendingPrompt();
@@ -201,6 +206,15 @@ export class OmniboxManagerImpl implements OmniboxManager {
     this.setMode(defaultMode, focus);
     this._omniboxSelectionIndex = 0;
     this._statusMessageContainer = {};
+  }
+
+  disablePrompts(): void {
+    this._promptsDisabled = true;
+    this.rejectPendingPrompt();
+  }
+
+  enablePrompts(): void {
+    this._promptsDisabled = false;
   }
 
   private rejectPendingPrompt() {

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -59,6 +59,11 @@ import {DurationPrecision, TimestampFormat} from '../public/timeline';
 import {timezoneOffsetMap} from '../base/time';
 import {ThemeProvider} from './theme_provider';
 import {OverlayContainer} from '../widgets/overlay_container';
+import {JsonSettingsEditor} from '../components/json_settings_editor';
+import {
+  CommandInvocation,
+  commandInvocationArraySchema,
+} from '../core/command_manager';
 
 const CSP_WS_PERMISSIVE_PORT = featureFlags.register({
   id: 'cspAllowAnyWebsocketPort',
@@ -206,6 +211,25 @@ function main() {
     requiresReload: true,
   });
 
+  const startupCommandsEditor = new JsonSettingsEditor<CommandInvocation[]>({
+    schema: commandInvocationArraySchema,
+  });
+
+  const startupCommandsSetting = settingsManager.register({
+    id: 'startupCommands',
+    name: 'Startup Commands',
+    description: `
+      Commands to run automatically after a trace loads and any saved state is
+      restored. These commands execute as if a user manually invoked them after
+      the trace is fully ready, making them ideal for automating common
+      post-load actions like running queries, expanding tracks, or setting up
+      custom views.
+    `,
+    schema: commandInvocationArraySchema,
+    defaultValue: [],
+    render: (setting) => startupCommandsEditor.render(setting),
+  });
+
   AppImpl.initialize({
     initialRouteArgs: Router.parseUrl(window.location.href).args,
     settingsManager,
@@ -213,6 +237,7 @@ function main() {
     durationPrecisionSetting,
     timezoneOverrideSetting,
     analyticsSetting,
+    startupCommandsSetting,
   });
 
   // Load the css. The load is asynchronous and the CSS is not ready by the time


### PR DESCRIPTION
- Add startup commands feature that executes commands after trace load
- Create reusable JsonSettingsEditor widget for JSON-based settings
- Refactor macro settings to use the new widget and shared schemas
- Add command validation with improved error reporting grouped by macro
- Use z.infer to keep TypeScript types in sync with Zod schemas
- Consolidate command invocation schemas in command_manager.ts
- Add proper JSDoc documentation for all new interfaces and functions
- Update macro execution to use command IDs instead of names for consistency

Bug: https://github.com/google/perfetto/issues/1342
Bug: https://github.com/google/perfetto/issues/2551
