### PR TITLE
ui: implement URL parameter commands for trace-specific startup commands

### DIFF
--- a/ui/src/core/command_manager.ts
+++ b/ui/src/core/command_manager.ts
@@ -62,6 +62,27 @@ export function validateCommandInvocations(
   return invalidCommands;
 }
 
+/**
+ * Parses URL commands parameter from route args.
+ * @param commandsParam URL commands parameter (JSON-encoded string)
+ * @returns Parsed commands array or undefined if parsing fails
+ */
+export function parseUrlCommands(
+  commandsParam: string | undefined,
+): CommandInvocation[] | undefined {
+  if (!commandsParam) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(commandsParam);
+    const result = commandInvocationArraySchema.safeParse(parsed);
+    return result.success ? result.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export interface CommandWithMatchInfo extends Command {
   segments: FuzzySegment[];
 }

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -20,7 +20,7 @@ import {Trace} from '../public/trace';
 import {ScrollToArgs} from '../public/scroll_helper';
 import {Track} from '../public/track';
 import {EngineBase, EngineProxy} from '../trace_processor/engine';
-import {CommandManagerImpl} from './command_manager';
+import {CommandManagerImpl, parseUrlCommands} from './command_manager';
 import {NoteManagerImpl} from './note_manager';
 import {OmniboxManagerImpl} from './omnibox_manager';
 import {SearchManagerImpl} from './search_manager';
@@ -231,6 +231,14 @@ export class TraceImpl implements Trace {
       },
     });
 
+    // Very important: the commands from the URL *should* be executed before
+    // the commands from settings as the user settings should take priority
+    // over the trace settings.
+    const urlCommands =
+      parseUrlCommands(ctx.appCtx.initialRouteArgs.startupCommands) ?? [];
+    const settingsCommands = ctx.appCtx.startupCommandsSetting.get();
+    const allStartupCommands = [...urlCommands, ...settingsCommands];
+
     // CommandManager is global. Here we intercept the registerCommand() because
     // we want any commands registered via the Trace interface to be
     // unregistered when the trace unloads (before a new trace is loaded) to
@@ -243,7 +251,7 @@ export class TraceImpl implements Trace {
       },
 
       hasStartupCommands(): boolean {
-        return ctx.appCtx.startupCommandsSetting.get().length > 0;
+        return allStartupCommands.length > 0;
       },
 
       async runStartupCommands(): Promise<void> {
@@ -254,8 +262,7 @@ export class TraceImpl implements Trace {
         // - Trace data is fully accessible
         // - UI state has been restored from any saved workspace
         // - Commands can safely query trace data and modify UI state
-        const commands = ctx.appCtx.startupCommandsSetting.get();
-        for (const command of commands) {
+        for (const command of allStartupCommands) {
           try {
             // Execute through proxy to access both global and trace-specific
             // commands.

--- a/ui/src/public/route_schema.ts
+++ b/ui/src/public/route_schema.ts
@@ -66,6 +66,9 @@ export const ROUTE_SCHEMA = z
     query: z.string().optional().catch(undefined),
     visStart: z.string().optional().catch(undefined),
     visEnd: z.string().optional().catch(undefined),
+
+    // Startup commands to execute on trace load (JSON-encoded array)
+    startupCommands: z.string().optional().catch(undefined),
   })
 
   // Allow arbitrary values to pass through, these may be forwarded to plugins.


### PR DESCRIPTION
- Add 'startupCommands' URL parameter to route schema for JSON-encoded command arrays
- Add parseUrlCommands() utility function to parse and validate URL commands
- Modify trace startup command system to execute URL commands before settings commands
- URL commands have higher priority and are trace-specific vs global settings commands
- Commands are parsed once during trace construction for efficiency

Example URL: #!/viewer?startupCommands=[{"id":"perfetto.CoreCommands#RunQuery","args":[]}]

Bug: https://github.com/google/perfetto/issues/1342
