### PR TITLE
ui: Fix incorrect target buffer configuration

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/advanced.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/advanced.ts
@@ -147,7 +147,7 @@ function procThreadAssociation(): RecordProbe {
       );
       tc.addBuffer(bufId, bufSizeKb);
 
-      const ds = tc.addDataSource(PROC_STATS_DS_NAME);
+      const ds = tc.addDataSource(PROC_STATS_DS_NAME, bufId);
       const cfg = (ds.processStatsConfig ??= {});
       cfg.scanAllProcessesOnStart = settings.initialScan.enabled || undefined;
     },


### PR DESCRIPTION
The process stats data source was previously being created without a `targetBuffer` specified in the `addDataSource` call. This caused it to incorrectly use the default buffer, even though a dedicated `proc_assoc` buffer was created for it.