### PR TITLE
ui: refactor all UI commands to adhere to `com.namespace.CommandName`

### DIFF
--- a/ui/src/core_plugins/commands/index.ts
+++ b/ui/src/core_plugins/commands/index.ts
@@ -121,7 +121,7 @@ export default class implements PerfettoPlugin {
   static onActivate(ctx: App) {
     if (ctx.sidebar.enabled) {
       ctx.commands.registerCommand({
-        id: 'perfetto.CoreCommands#ToggleLeftSidebar',
+        id: 'dev.perfetto.ToggleLeftSidebar',
         name: 'Toggle left sidebar',
         callback: () => {
           ctx.sidebar.toggleVisibility();
@@ -165,7 +165,7 @@ export default class implements PerfettoPlugin {
     const macros = setting.get() as MacroConfig;
     for (const [macroName, commands] of Object.entries(macros)) {
       ctx.commands.registerCommand({
-        id: `perfetto.CoreCommands#UserDefinedMacros#${macroName}`,
+        id: `dev.perfetto.UserMacro.${macroName}`,
         name: macroName,
         callback: () => {
           for (const command of commands) {
@@ -182,7 +182,7 @@ export default class implements PerfettoPlugin {
     input.addEventListener('change', onInputElementFileSelectionChanged);
     document.body.appendChild(input);
 
-    const OPEN_TRACE_COMMAND_ID = 'perfetto.CoreCommands#openTrace';
+    const OPEN_TRACE_COMMAND_ID = 'dev.perfetto.OpenTrace';
     ctx.commands.registerCommand({
       id: OPEN_TRACE_COMMAND_ID,
       name: 'Open trace file',
@@ -198,7 +198,7 @@ export default class implements PerfettoPlugin {
       icon: 'folder_open',
     });
 
-    const OPEN_LEGACY_COMMAND_ID = 'perfetto.CoreCommands#openTraceInLegacyUi';
+    const OPEN_LEGACY_COMMAND_ID = 'dev.perfetto.OpenTraceInLegacyUi';
     ctx.commands.registerCommand({
       id: OPEN_LEGACY_COMMAND_ID,
       name: 'Open with legacy UI',
@@ -216,7 +216,7 @@ export default class implements PerfettoPlugin {
     }
 
     ctx.commands.registerCommand({
-      id: 'perfetto.closeTrace',
+      id: 'dev.perfetto.CloseTrace',
       name: 'Close trace',
       callback: () => {
         ctx.closeCurrentTrace();
@@ -226,7 +226,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#RunQueryAllProcesses',
+      id: 'dev.perfetto.RunQueryAllProcesses',
       name: 'Run query: All processes',
       callback: () => {
         addQueryResultsTab(ctx, {
@@ -237,7 +237,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#RunQueryCpuTimeByProcess',
+      id: 'dev.perfetto.RunQueryCpuTimeByProcess',
       name: 'Run query: CPU time by process',
       callback: () => {
         addQueryResultsTab(ctx, {
@@ -248,7 +248,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#RunQueryCyclesByStateByCpu',
+      id: 'dev.perfetto.RunQueryCyclesByStateByCpu',
       name: 'Run query: cycles by p-state by CPU',
       callback: () => {
         addQueryResultsTab(ctx, {
@@ -259,7 +259,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#RunQueryCyclesByCpuByProcess',
+      id: 'dev.perfetto.RunQueryCyclesByCpuByProcess',
       name: 'Run query: CPU Time by CPU by process',
       callback: () => {
         addQueryResultsTab(ctx, {
@@ -270,7 +270,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#RunQueryHeapGraphBytesPerType',
+      id: 'dev.perfetto.RunQueryHeapGraphBytesPerType',
       name: 'Run query: heap graph bytes per type',
       callback: () => {
         addQueryResultsTab(ctx, {
@@ -281,7 +281,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#DebugSqlPerformance',
+      id: 'dev.perfetto.DebugSqlPerformance',
       name: 'Debug SQL performance',
       callback: () => {
         addQueryResultsTab(ctx, {
@@ -292,7 +292,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#UnpinAllTracks',
+      id: 'dev.perfetto.UnpinAllTracks',
       name: 'Unpin all pinned tracks',
       callback: () => {
         const workspace = ctx.workspace;
@@ -301,7 +301,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#ExpandAllGroups',
+      id: 'dev.perfetto.ExpandAllGroups',
       name: 'Expand all track groups',
       callback: () => {
         ctx.workspace.flatTracks.forEach((track) => track.expand());
@@ -309,7 +309,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#CollapseAllGroups',
+      id: 'dev.perfetto.CollapseAllGroups',
       name: 'Collapse all track groups',
       callback: () => {
         ctx.workspace.flatTracks.forEach((track) => track.collapse());
@@ -317,7 +317,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#PanToTimestamp',
+      id: 'dev.perfetto.PanToTimestamp',
       name: 'Pan to timestamp',
       callback: (tsRaw: unknown) => {
         const ts = getOrPromptForTimestamp(tsRaw);
@@ -328,7 +328,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#MarkTimestamp',
+      id: 'dev.perfetto.MarkTimestamp',
       name: 'Mark timestamp',
       callback: (tsRaw: unknown) => {
         const ts = getOrPromptForTimestamp(tsRaw);
@@ -341,7 +341,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CoreCommands#ShowCurrentSelectionTab',
+      id: 'dev.perfetto.ShowCurrentSelectionTab',
       name: 'Show current selection tab',
       callback: () => {
         ctx.tabs.showTab('current_selection');

--- a/ui/src/core_plugins/example_traces/index.ts
+++ b/ui/src/core_plugins/example_traces/index.ts
@@ -31,7 +31,7 @@ export default class implements PerfettoPlugin {
   static readonly id = 'perfetto.ExampleTraces';
   static onActivate(ctx: App) {
     const OPEN_EXAMPLE_ANDROID_TRACE_COMMAND_ID =
-      'perfetto.CoreCommands#openExampleAndroidTrace';
+      'dev.perfetto.OpenExampleAndroidTrace';
     ctx.commands.registerCommand({
       id: OPEN_EXAMPLE_ANDROID_TRACE_COMMAND_ID,
       name: 'Open Android example',
@@ -46,7 +46,7 @@ export default class implements PerfettoPlugin {
     });
 
     const OPEN_EXAMPLE_CHROME_TRACE_COMMAND_ID =
-      'perfetto.CoreCommands#openExampleChromeTrace';
+      'dev.perfetto.OpenExampleChromeTrace';
     ctx.commands.registerCommand({
       id: OPEN_EXAMPLE_CHROME_TRACE_COMMAND_ID,
       name: 'Open Chrome example',

--- a/ui/src/core_plugins/notes/index.ts
+++ b/ui/src/core_plugins/notes/index.ts
@@ -30,7 +30,7 @@ export default class implements PerfettoPlugin {
     });
 
     trace.commands.registerCommand({
-      id: 'perfetto.SetTemporarySpanNote',
+      id: 'dev.perfetto.SetTemporarySpanNote',
       name: 'Set the temporary span note based on the current selection',
       callback: () => {
         const range = trace.selection.getTimeSpanOfSelection();
@@ -56,7 +56,7 @@ export default class implements PerfettoPlugin {
     });
 
     trace.commands.registerCommand({
-      id: 'perfetto.AddSpanNote',
+      id: 'dev.perfetto.AddSpanNote',
       name: 'Add a new span note based on the current selection',
       callback: () => {
         const range = trace.selection.getTimeSpanOfSelection();
@@ -71,7 +71,7 @@ export default class implements PerfettoPlugin {
     });
 
     trace.commands.registerCommand({
-      id: 'perfetto.RemoveSelectedNote',
+      id: 'dev.perfetto.RemoveSelectedNote',
       name: 'Remove selected note',
       callback: () => {
         const selection = trace.selection.selection;

--- a/ui/src/core_plugins/settings_page/index.ts
+++ b/ui/src/core_plugins/settings_page/index.ts
@@ -36,7 +36,7 @@ export default class implements PerfettoPlugin {
     });
 
     app.commands.registerCommand({
-      id: 'perfetto.SettingsPage#openSettings',
+      id: 'dev.perfetto.OpenSettings',
       name: 'Open Settings',
       callback: () => {
         app.navigate('#!/settings');

--- a/ui/src/core_plugins/track_utils/index.ts
+++ b/ui/src/core_plugins/track_utils/index.ts
@@ -43,7 +43,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
     // Register this command up front to block the print dialog from appearing
     // when pressing the hotkey before the trace is loaded.
     app.commands.registerCommand({
-      id: 'perfetto.FindTrackByName',
+      id: 'dev.perfetto.FindTrackByName',
       name: 'Find track by name',
       callback: async () => {
         const trace = app.trace;
@@ -70,7 +70,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'perfetto.RunQueryInSelectedTimeWindow',
+      id: 'dev.perfetto.RunQueryInSelectedTimeWindow',
       name: `Run query in selected time window`,
       callback: async () => {
         const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
@@ -84,7 +84,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.FindTrackByUri',
+      id: 'dev.perfetto.FindTrackByUri',
       name: 'Find track by URI',
       callback: async () => {
         const tracksWithUris = ctx.workspace.flatTracksOrdered.filter(
@@ -102,7 +102,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.PinTrackByName',
+      id: 'dev.perfetto.PinTrackByName',
       name: 'Pin track by name',
       defaultHotkey: 'Shift+T',
       callback: async () => {
@@ -118,7 +118,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.SelectNextTrackEvent',
+      id: 'dev.perfetto.SelectNextTrackEvent',
       name: 'Select next track event',
       defaultHotkey: '.',
       callback: async () => {
@@ -127,7 +127,7 @@ export default class TrackUtilsPlugin implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.SelectPreviousTrackEvent',
+      id: 'dev.perfetto.SelectPreviousTrackEvent',
       name: 'Select previous track event',
       defaultHotkey: !TrackUtilsPlugin.dvorakSetting.get() ? ',' : undefined,
       callback: async () => {

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -323,7 +323,7 @@ function onCssLoaded() {
 
   // Add command to toggle the theme.
   AppImpl.instance.commands.registerCommand({
-    id: 'toggleTheme',
+    id: 'dev.perfetto.ToggleTheme',
     name: '[Experimental] Toggle UI Theme',
     callback: () => {
       const currentTheme = themeSetting.get();

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -95,14 +95,14 @@ export class UiMainPerTrace implements m.ClassComponent {
     // loaded).
     const globalCmds: Command[] = [
       {
-        id: 'perfetto.OpenCommandPalette',
+        id: 'dev.perfetto.OpenCommandPalette',
         name: 'Open command palette',
         callback: () => app.omnibox.setMode(OmniboxMode.Command),
         defaultHotkey: '!Mod+Shift+P',
       },
 
       {
-        id: 'perfetto.ShowHelp',
+        id: 'dev.perfetto.ShowHelp',
         name: 'Show help',
         callback: () => toggleHelp(),
         defaultHotkey: '?',
@@ -120,7 +120,7 @@ export class UiMainPerTrace implements m.ClassComponent {
 
     const cmds: Command[] = [
       {
-        id: 'perfetto.SetTimestampFormat',
+        id: 'dev.perfetto.SetTimestampFormat',
         name: 'Set timestamp and duration format',
         callback: async () => {
           const TF = TimestampFormat;
@@ -159,7 +159,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.SetDurationPrecision',
+        id: 'dev.perfetto.SetDurationPrecision',
         name: 'Set duration precision',
         callback: async () => {
           const DF = DurationPrecision;
@@ -177,18 +177,18 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.TogglePerformanceMetrics',
+        id: 'dev.perfetto.TogglePerformanceMetrics',
         name: 'Toggle performance metrics',
         callback: () =>
           (app.perfDebugging.enabled = !app.perfDebugging.enabled),
       },
       {
-        id: 'perfetto.ShareTrace',
+        id: 'dev.perfetto.ShareTrace',
         name: 'Share trace',
         callback: () => shareTrace(trace),
       },
       {
-        id: 'perfetto.SearchNext',
+        id: 'dev.perfetto.SearchNext',
         name: 'Go to next search result',
         callback: () => {
           trace.search.stepForward();
@@ -196,7 +196,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         defaultHotkey: 'Enter',
       },
       {
-        id: 'perfetto.SearchPrev',
+        id: 'dev.perfetto.SearchPrev',
         name: 'Go to previous search result',
         callback: () => {
           trace.search.stepBackwards();
@@ -204,18 +204,18 @@ export class UiMainPerTrace implements m.ClassComponent {
         defaultHotkey: 'Shift+Enter',
       },
       {
-        id: 'perfetto.RunQuery',
+        id: 'dev.perfetto.RunQuery',
         name: 'Run query',
         callback: () => trace.omnibox.setMode(OmniboxMode.Query),
       },
       {
-        id: 'perfetto.Search',
+        id: 'dev.perfetto.Search',
         name: 'Search',
         callback: () => trace.omnibox.setMode(OmniboxMode.Search),
         defaultHotkey: '/',
       },
       {
-        id: 'perfetto.CopyTimeWindow',
+        id: 'dev.perfetto.CopyTimeWindow',
         name: `Copy selected time window to clipboard`,
         callback: async () => {
           const window = await getTimeSpanOfSelectionOrVisibleWindow(trace);
@@ -224,18 +224,18 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.FocusSelection',
+        id: 'dev.perfetto.FocusSelection',
         name: 'Focus current selection',
         callback: () => trace.selection.scrollToSelection(),
         defaultHotkey: 'F',
       },
       {
-        id: 'perfetto.ZoomOnSelection',
+        id: 'dev.perfetto.ZoomOnSelection',
         name: 'Zoom in on current selection',
         callback: () => trace.selection.zoomOnSelection(),
       },
       {
-        id: 'perfetto.Deselect',
+        id: 'dev.perfetto.Deselect',
         name: 'Deselect',
         callback: () => {
           trace.selection.clearSelection();
@@ -243,25 +243,25 @@ export class UiMainPerTrace implements m.ClassComponent {
         defaultHotkey: 'Escape',
       },
       {
-        id: 'perfetto.NextFlow',
+        id: 'dev.perfetto.NextFlow',
         name: 'Next flow',
         callback: () => trace.flows.focusOtherFlow('Forward'),
         defaultHotkey: 'Mod+]',
       },
       {
-        id: 'perfetto.PrevFlow',
+        id: 'dev.perfetto.PrevFlow',
         name: 'Prev flow',
         callback: () => trace.flows.focusOtherFlow('Backward'),
         defaultHotkey: 'Mod+[',
       },
       {
-        id: 'perfetto.MoveNextFlow',
+        id: 'dev.perfetto.MoveNextFlow',
         name: 'Move next flow',
         callback: () => trace.flows.moveByFocusedFlow('Forward'),
         defaultHotkey: ']',
       },
       {
-        id: 'perfetto.MovePrevFlow',
+        id: 'dev.perfetto.MovePrevFlow',
         name: 'Move prev flow',
         callback: () => trace.flows.moveByFocusedFlow('Backward'),
         defaultHotkey: '[',
@@ -270,7 +270,7 @@ export class UiMainPerTrace implements m.ClassComponent {
       // Provides a test bed for resolving events using a SQL table name and ID
       // which is used in deep-linking, amongst other places.
       {
-        id: 'perfetto.SelectEventByTableNameAndId',
+        id: 'dev.perfetto.SelectEventByTableNameAndId',
         name: 'Select event by table name and ID',
         callback: async () => {
           const rootTableName = await trace.omnibox.prompt('Enter table name');
@@ -288,7 +288,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.SelectAll',
+        id: 'dev.perfetto.SelectAll',
         name: 'Select all',
         callback: () => {
           // This is a dual state command:
@@ -334,7 +334,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         defaultHotkey: 'Mod+A',
       },
       {
-        id: 'perfetto.ConvertSelectionToArea',
+        id: 'dev.perfetto.ConvertSelectionToArea',
         name: 'Convert selection to area selection',
         callback: () => {
           const selection = trace.selection.selection;
@@ -350,13 +350,13 @@ export class UiMainPerTrace implements m.ClassComponent {
         defaultHotkey: 'R',
       },
       {
-        id: 'perfetto.ToggleDrawer',
+        id: 'dev.perfetto.ToggleDrawer',
         name: 'Toggle drawer',
         defaultHotkey: 'Q',
         callback: () => trace.tabs.toggleTabPanelVisibility(),
       },
       {
-        id: 'perfetto.CopyPinnedToWorkspace',
+        id: 'dev.perfetto.CopyPinnedToWorkspace',
         name: 'Copy pinned tracks to workspace',
         callback: async () => {
           const pinnedTracks = trace.workspace.pinnedTracks;
@@ -376,7 +376,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.CopyFilteredToWorkspace',
+        id: 'dev.perfetto.CopyFilteredToWorkspace',
         name: 'Copy filtered tracks to workspace',
         callback: async () => {
           // Copies all filtered tracks as a flat list to a new workspace. This
@@ -401,7 +401,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.CopySelectedTracksToWorkspace',
+        id: 'dev.perfetto.CopySelectedTracksToWorkspace',
         name: 'Copy selected tracks to workspace',
         callback: async () => {
           const selection = trace.selection.selection;
@@ -424,7 +424,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.Quicksave',
+        id: 'dev.perfetto.Quicksave',
         name: 'Quicksave UI state to localStorage',
         callback: () => {
           const state = serializeAppState(trace);
@@ -433,7 +433,7 @@ export class UiMainPerTrace implements m.ClassComponent {
         },
       },
       {
-        id: 'perfetto.Quickload',
+        id: 'dev.perfetto.Quickload',
         name: 'Quickload UI state from the localStorage',
         callback: () => {
           const json = localStorage.getItem(QUICKSAVE_LOCALSTORAGE_KEY);

--- a/ui/src/frontend/viewer_page/notes_panel.ts
+++ b/ui/src/frontend/viewer_page/notes_panel.ts
@@ -115,13 +115,9 @@ export class NotesPanel {
           onclick: (e: Event) => {
             e.preventDefault();
             if (allCollapsed) {
-              this.trace.commands.runCommand(
-                'perfetto.CoreCommands#ExpandAllGroups',
-              );
+              this.trace.commands.runCommand('dev.perfetto.ExpandAllGroups');
             } else {
-              this.trace.commands.runCommand(
-                'perfetto.CoreCommands#CollapseAllGroups',
-              );
+              this.trace.commands.runCommand('dev.perfetto.CollapseAllGroups');
             }
           },
           title: allCollapsed ? 'Expand all' : 'Collapse all',

--- a/ui/src/plugins/com.android.AndroidClientServer/index.ts
+++ b/ui/src/plugins/com.android.AndroidClientServer/index.ts
@@ -21,7 +21,7 @@ export default class implements PerfettoPlugin {
   static readonly id = 'com.android.AndroidClientServer';
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidClientServer#ThreadRuntimeIPC',
+      id: 'com.android.ShowClientServerDependencies',
       name: 'Show dependencies in client server model',
       callback: async (sliceId) => {
         if (sliceId === undefined) {

--- a/ui/src/plugins/com.android.AndroidCujs/index.ts
+++ b/ui/src/plugins/com.android.AndroidCujs/index.ts
@@ -276,28 +276,38 @@ export default class implements PerfettoPlugin {
     ctx.commands.registerCommand({
       id: 'com.android.PinJankCUJs',
       name: 'Add track: Android jank CUJs',
-      callback: async () => {
-        await this.pinJankCujs(ctx);
+      callback: () => {
+        ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS).then(() => {
+          addJankCUJDebugTrack(ctx, 'Jank CUJs');
+        });
       },
     });
 
     ctx.commands.registerCommand({
       id: 'com.android.ListJankCUJs',
       name: 'Run query: Android jank CUJs',
-      callback: async () => {
-        await ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS);
-        addQueryResultsTab(ctx, {
-          query: JANK_CUJ_QUERY,
-          title: 'Android Jank CUJs',
-        });
+      callback: () => {
+        ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS).then(() =>
+          addQueryResultsTab(ctx, {
+            query: JANK_CUJ_QUERY,
+            title: 'Android Jank CUJs',
+          }),
+        );
       },
     });
 
     ctx.commands.registerCommand({
       id: 'com.android.PinLatencyCUJs',
       name: 'Add track: Android latency CUJs',
-      callback: async () => {
-        await this.pinLatencyCujs(ctx);
+      callback: () => {
+        addDebugSliceTrack({
+          trace: ctx,
+          data: {
+            sqlSource: LATENCY_CUJ_QUERY,
+            columns: LATENCY_COLUMNS,
+          },
+          title: 'Latency CUJs',
+        });
       },
     });
 
@@ -330,19 +340,4 @@ export default class implements PerfettoPlugin {
     });
   }
 
-  async pinJankCujs(ctx: Trace) {
-    await ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS);
-    await addJankCUJDebugTrack(ctx, 'Jank CUJs');
-  }
-
-  async pinLatencyCujs(ctx: Trace) {
-    addDebugSliceTrack({
-      trace: ctx,
-      data: {
-        sqlSource: LATENCY_CUJ_QUERY,
-        columns: LATENCY_COLUMNS,
-      },
-      title: 'Latency CUJs',
-    });
-  }
 }

--- a/ui/src/plugins/com.android.AndroidCujs/index.ts
+++ b/ui/src/plugins/com.android.AndroidCujs/index.ts
@@ -339,5 +339,4 @@ export default class implements PerfettoPlugin {
       },
     });
   }
-
 }

--- a/ui/src/plugins/com.android.AndroidCujs/index.ts
+++ b/ui/src/plugins/com.android.AndroidCujs/index.ts
@@ -274,30 +274,23 @@ export default class implements PerfettoPlugin {
   static readonly id = 'com.android.AndroidCujs';
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidCujs#PinJankCUJs',
+      id: 'com.android.PinJankCUJs',
       name: 'Add track: Android jank CUJs',
-      callback: () => {
-        ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS).then(() => {
-          addJankCUJDebugTrack(ctx, 'Jank CUJs');
-        });
+      callback: async () => {
+        await this.pinJankCujs(ctx);
       },
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidCujs#ListJankCUJs',
+      id: 'com.android.ListJankCUJs',
       name: 'Run query: Android jank CUJs',
-      callback: () => {
-        ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS).then(() =>
-          addQueryResultsTab(ctx, {
-            query: JANK_CUJ_QUERY,
-            title: 'Android Jank CUJs',
-          }),
-        );
+      callback: async () => {
+        await this.listJankCujs(ctx);
       },
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidCujs#PinLatencyCUJs',
+      id: 'com.android.PinLatencyCUJs',
       name: 'Add track: Android latency CUJs',
       callback: () => {
         addDebugSliceTrack({
@@ -312,7 +305,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidCujs#ListLatencyCUJs',
+      id: 'com.android.ListLatencyCUJs',
       name: 'Run query: Android Latency CUJs',
       callback: () =>
         addQueryResultsTab(ctx, {
@@ -322,7 +315,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidCujs#PinBlockingCalls',
+      id: 'com.android.PinBlockingCalls',
       name: 'Add track: Android Blocking calls during CUJs',
       callback: () => {
         ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS).then(() =>
@@ -337,6 +330,19 @@ export default class implements PerfettoPlugin {
           }),
         );
       },
+    });
+  }
+
+  async pinJankCujs(ctx: Trace) {
+    await ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS);
+    await addJankCUJDebugTrack(ctx, 'Jank CUJs');
+  }
+
+  async listJankCujs(ctx: Trace) {
+    await ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS);
+    addQueryResultsTab(ctx, {
+      query: JANK_CUJ_QUERY,
+      title: 'Android Jank CUJs',
     });
   }
 }

--- a/ui/src/plugins/com.android.AndroidCujs/index.ts
+++ b/ui/src/plugins/com.android.AndroidCujs/index.ts
@@ -285,22 +285,19 @@ export default class implements PerfettoPlugin {
       id: 'com.android.ListJankCUJs',
       name: 'Run query: Android jank CUJs',
       callback: async () => {
-        await this.listJankCujs(ctx);
+        await ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS);
+        addQueryResultsTab(ctx, {
+          query: JANK_CUJ_QUERY,
+          title: 'Android Jank CUJs',
+        });
       },
     });
 
     ctx.commands.registerCommand({
       id: 'com.android.PinLatencyCUJs',
       name: 'Add track: Android latency CUJs',
-      callback: () => {
-        addDebugSliceTrack({
-          trace: ctx,
-          data: {
-            sqlSource: LATENCY_CUJ_QUERY,
-            columns: LATENCY_COLUMNS,
-          },
-          title: 'Latency CUJs',
-        });
+      callback: async () => {
+        await this.pinLatencyCujs(ctx);
       },
     });
 
@@ -338,11 +335,14 @@ export default class implements PerfettoPlugin {
     await addJankCUJDebugTrack(ctx, 'Jank CUJs');
   }
 
-  async listJankCujs(ctx: Trace) {
-    await ctx.engine.query(JANK_CUJ_QUERY_PRECONDITIONS);
-    addQueryResultsTab(ctx, {
-      query: JANK_CUJ_QUERY,
-      title: 'Android Jank CUJs',
+  async pinLatencyCujs(ctx: Trace) {
+    addDebugSliceTrack({
+      trace: ctx,
+      data: {
+        sqlSource: LATENCY_CUJ_QUERY,
+        columns: LATENCY_COLUMNS,
+      },
+      title: 'Latency CUJs',
     });
   }
 }

--- a/ui/src/plugins/com.android.AndroidDesktopMode/index.ts
+++ b/ui/src/plugins/com.android.AndroidDesktopMode/index.ts
@@ -40,7 +40,7 @@ export default class implements PerfettoPlugin {
     await ctx.engine.query(INCLUDE_DESKTOP_MODULE_QUERY);
     await this.registerTrack(ctx, QUERY);
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.DesktopMode#AddTrackDesktopWindowss',
+      id: 'com.android.AddDesktopModeTrack',
       name: 'Add Track: ' + TRACK_NAME,
       callback: () => this.addSimpleTrack(ctx),
     });

--- a/ui/src/plugins/com.android.AndroidLog/index.ts
+++ b/ui/src/plugins/com.android.AndroidLog/index.ts
@@ -129,7 +129,7 @@ export default class implements PerfettoPlugin {
     }
 
     ctx.commands.registerCommand({
-      id: 'perfetto.AndroidLog#ShowLogsTab',
+      id: 'com.android.ShowAndroidLogsTab',
       name: 'Show android logs tab',
       callback: () => {
         ctx.tabs.showTab(androidLogsTabUri);

--- a/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
@@ -1901,7 +1901,7 @@ export default class implements PerfettoPlugin {
   ): Promise<void> {
     if (features.has('google3')) {
       ctx.commands.registerCommand({
-        id: 'perfetto.DayExplorerBlamesByCategory',
+        id: 'com.android.DayExplorerBlamesByCategory',
         name: 'Add tracks: Day Explorer',
         callback: async () => {
           const limitStr = await ctx.omnibox.prompt(

--- a/ui/src/plugins/com.android.AndroidNetwork/index.ts
+++ b/ui/src/plugins/com.android.AndroidNetwork/index.ts
@@ -41,7 +41,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidNetwork#batteryEvents',
+      id: 'com.android.AddBatteryEventsTrack',
       name: 'Add track: battery events',
       callback: async (track) => {
         if (track === undefined) {
@@ -62,7 +62,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidNetwork#activityTrack',
+      id: 'com.android.AddNetworkActivityTrack',
       name: 'Add track: network activity',
       callback: async (groupby, filter, trackName) => {
         if (groupby === undefined) {

--- a/ui/src/plugins/com.android.AndroidPerf/index.ts
+++ b/ui/src/plugins/com.android.AndroidPerf/index.ts
@@ -62,7 +62,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#BinderSystemServerIncoming',
+      id: 'com.android.BinderSystemServerIncoming',
       name: 'Run query: system_server incoming binder graph',
       callback: () =>
         addQueryResultsTab(ctx, {
@@ -73,7 +73,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#BinderSystemServerOutgoing',
+      id: 'com.android.BinderSystemServerOutgoing',
       name: 'Run query: system_server outgoing binder graph',
       callback: () =>
         addQueryResultsTab(ctx, {
@@ -84,7 +84,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#MonitorContentionSystemServer',
+      id: 'com.android.MonitorContentionSystemServer',
       name: 'Run query: system_server monitor_contention graph',
       callback: () =>
         addQueryResultsTab(ctx, {
@@ -95,7 +95,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#BinderAll',
+      id: 'com.android.BinderAll',
       name: 'Run query: all process binder graph',
       callback: () =>
         addQueryResultsTab(ctx, {
@@ -106,7 +106,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#ThreadClusterDistribution',
+      id: 'com.android.ThreadClusterDistribution',
       name: 'Run query: runtime cluster distribution for a thread',
       callback: async (tid) => {
         if (tid === undefined) {
@@ -140,7 +140,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#SchedLatency',
+      id: 'com.android.SchedLatency',
       name: 'Run query: top 50 sched latency for a thread',
       callback: async (tid) => {
         if (tid === undefined) {
@@ -164,7 +164,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#SchedLatencyInSelectedWindow',
+      id: 'com.android.SchedLatencyInSelectedWindow',
       name: 'Top 50 sched latency in selected time window',
       callback: async () => {
         const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
@@ -192,7 +192,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#AppProcessStarts',
+      id: 'com.android.AppProcessStarts',
       name: 'Add tracks: app process starts',
       callback: async () => {
         await ctx.engine.query(
@@ -207,7 +207,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#AppIntentStarts',
+      id: 'com.android.AppIntentStarts',
       name: 'Add tracks: app intent starts',
       callback: async () => {
         await ctx.engine.query(
@@ -222,7 +222,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerf#CounterByFtraceEventArgs',
+      id: 'com.android.CounterByFtraceEventArgs',
       name: 'Add tracks: counter by ftrace event arguments',
       callback: async (event, value, filter, filterValue) => {
         if (event === undefined) {

--- a/ui/src/plugins/com.android.AndroidPerfTraceCounters/index.ts
+++ b/ui/src/plugins/com.android.AndroidPerfTraceCounters/index.ts
@@ -32,7 +32,7 @@ export default class implements PerfettoPlugin {
     const resp = await ctx.engine.query(PERF_TRACE_COUNTERS_PRECONDITION);
     if (resp.numRows() === 0) return;
     ctx.commands.registerCommand({
-      id: 'com.android.AndroidPerfTraceCounters#ThreadRuntimeIPC',
+      id: 'com.android.AddThreadRuntimeIPCTrack',
       name: 'Add a track to show a thread runtime ipc',
       callback: async (tid) => {
         if (tid === undefined) {

--- a/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
@@ -36,7 +36,7 @@ export default class implements PerfettoPlugin {
       await this.createTargetVmTrack(ctx, defaultTargetId);
 
       ctx.commands.registerCommand({
-        id: `${ctx.pluginId}#SelectAvfVmUtid`,
+        id: `com.android.SelectAvfVmUtid`,
         name: 'Select Avf VM utid to add track',
         callback: async () => {
           if (this.validTargets.size === 0) {

--- a/ui/src/plugins/com.android.LargeScreensPerf/index.ts
+++ b/ui/src/plugins/com.android.LargeScreensPerf/index.ts
@@ -30,7 +30,7 @@ export default class implements PerfettoPlugin {
     this.addFoldedStateTrackToDeviceState(ctx);
 
     ctx.commands.registerCommand({
-      id: 'com.android.LargeScreensPerf#UnfoldLatencyTracks',
+      id: 'com.android.UnfoldLatencyTracks',
       name: 'Organize unfold latency tracks',
       callback: async () => {
         this.pinCoreTracks(ctx);

--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
@@ -64,7 +64,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace) {
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.PinAndroidPerfMetrics#PinAndroidPerfMetrics',
+      id: 'com.android.PinAndroidPerfMetrics',
       name: 'Add and Pin: Jank Metric Slice',
       callback: async () => {
         const metric = await ctx.omnibox.prompt(
@@ -76,12 +76,9 @@ export default class implements PerfettoPlugin {
       },
     });
     if (metrics.length !== 0) {
-      // Add track: Android jank CUJs
-      ctx.commands.runCommand('com.android.AndroidCujs#PinJankCUJs');
-
-      // Add track: Android latency CUJs
-      ctx.commands.runCommand('com.android.AndroidCujs#PinLatencyCUJs');
-
+      const plugin = ctx.plugins.getPlugin(AndroidCujsPlugin);
+      await plugin.pinJankCujs(ctx);
+      await plugin.listJankCujs(ctx);
       this.callHandlers(metrics, ctx);
     }
   }

--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
@@ -16,6 +16,7 @@ import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {METRIC_HANDLERS} from './handlers/handlerRegistry';
 import {MetricData, MetricHandlerMatch} from './handlers/metricUtils';
+import AndroidCujsPlugin from '../com.android.AndroidCujs';
 
 const JANK_CUJ_QUERY_PRECONDITIONS = `
   SELECT RUN_METRIC('android/android_blocking_calls_cuj_metric.sql');

--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
@@ -16,7 +16,6 @@ import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {METRIC_HANDLERS} from './handlers/handlerRegistry';
 import {MetricData, MetricHandlerMatch} from './handlers/metricUtils';
-import AndroidCujsPlugin from '../com.android.AndroidCujs';
 
 const JANK_CUJ_QUERY_PRECONDITIONS = `
   SELECT RUN_METRIC('android/android_blocking_calls_cuj_metric.sql');
@@ -76,9 +75,12 @@ export default class implements PerfettoPlugin {
       },
     });
     if (metrics.length !== 0) {
-      const plugin = ctx.plugins.getPlugin(AndroidCujsPlugin);
-      await plugin.pinJankCujs(ctx);
-      await plugin.pinLatencyCujs(ctx);
+      // Add track: Android jank CUJs
+      ctx.commands.runCommand('com.android.PinJankCUJs');
+
+      // Add track: Android latency CUJs
+      ctx.commands.runCommand('com.android.PinLatencyCUJs');
+
       this.callHandlers(metrics, ctx);
     }
   }

--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/index.ts
@@ -78,7 +78,7 @@ export default class implements PerfettoPlugin {
     if (metrics.length !== 0) {
       const plugin = ctx.plugins.getPlugin(AndroidCujsPlugin);
       await plugin.pinJankCujs(ctx);
-      await plugin.listJankCujs(ctx);
+      await plugin.pinLatencyCujs(ctx);
       this.callHandlers(metrics, ctx);
     }
   }

--- a/ui/src/plugins/com.android.PinSysUITracks/index.ts
+++ b/ui/src/plugins/com.android.PinSysUITracks/index.ts
@@ -49,7 +49,7 @@ export default class implements PerfettoPlugin {
     }).upid;
 
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.PinSysUITracks#PinSysUITracks',
+      id: 'com.android.PinSysUITracks',
       name: 'Pin: System UI Related Tracks',
       callback: () => {
         ctx.workspace.flatTracks.forEach((track) => {

--- a/ui/src/plugins/com.android.SysUIWorkspace/index.ts
+++ b/ui/src/plugins/com.android.SysUIWorkspace/index.ts
@@ -31,7 +31,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.SysUIWorkspace#CreateSysUIWorkspace',
+      id: 'com.android.CreateSysUIWorkspace',
       name: 'Create System UI workspace',
       callback: () =>
         ProcessWorkspaceFactory.create(
@@ -78,7 +78,7 @@ class ProcessWorkspaceFactory {
    * No workspace is created if it was there already.
    * This is expected to be called from the default workspace.
    *
-   * @param trace
+   * @param trace The trace context.
    * @param packageName Name of the Android package to create the workspace for.
    * @param workspaceName Desired name for the new workspace.
    * @param tracksToCopy - An optional list of track names to be added to

--- a/ui/src/plugins/com.example.Commands/index.ts
+++ b/ui/src/plugins/com.example.Commands/index.ts
@@ -25,14 +25,14 @@ export default class implements PerfettoPlugin {
   static onActivate(app: App): void {
     // Register a command that logs "Hello, world!" to the console.
     app.commands.registerCommand({
-      id: 'com.example.Commands#LogHelloWorld',
+      id: 'com.example.LogHelloWorld',
       name: 'Log "Hello, world!"',
       callback: () => console.log('Hello, world!'),
     });
 
     // Register a command which can be triggered using a hotkey.
     app.commands.registerCommand({
-      id: 'com.example.Commands#CommandWithHotkey',
+      id: 'com.example.CommandWithHotkey',
       name: 'Log "Hello, world!" with hotkey',
       callback: () => console.log('Hello, world!'),
       defaultHotkey: 'Mod+Shift+H',
@@ -44,7 +44,7 @@ export default class implements PerfettoPlugin {
     // is only available when a trace is loaded. It'll automatically be removed
     // when the trace is closed, or a new trace is loaded.
     trace.commands.registerCommand({
-      id: 'com.example.Commands#LogHelloTrace',
+      id: 'com.example.LogHelloTrace',
       name: 'Log "Hello, trace!"',
       callback: () => console.log('Hello, trace!'),
     });

--- a/ui/src/plugins/com.example.Settings/index.ts
+++ b/ui/src/plugins/com.example.Settings/index.ts
@@ -40,7 +40,7 @@ export default class implements PerfettoPlugin {
 
     // Write it like this (e.g. from a command)
     app.commands.registerCommand({
-      id: 'com.example.Settings#toggleBooleanSetting',
+      id: 'com.example.ToggleBooleanSetting',
       name: 'Toggle Boolean Setting',
       callback: () => {
         // Toggle the boolean setting

--- a/ui/src/plugins/com.example.State/index.ts
+++ b/ui/src/plugins/com.example.State/index.ts
@@ -46,7 +46,7 @@ export default class implements PerfettoPlugin {
     ctx.trash.use(this.store);
 
     ctx.commands.registerCommand({
-      id: 'com.example.ExampleState#ShowCounter',
+      id: 'com.example.ShowCounter',
       name: 'Show ExampleState counter',
       callback: () => {
         const counter = this.store.state.counter;

--- a/ui/src/plugins/com.example.Tracks/index.ts
+++ b/ui/src/plugins/com.example.Tracks/index.ts
@@ -287,7 +287,7 @@ async function addNestedTrackGroup(trace: Trace): Promise<void> {
 
   // Example commands demonstrating workspace manipulation with nested tracks
   trace.commands.registerCommand({
-    id: 'com.example.Tracks#CloneNestedGroupToNewWorkspace',
+    id: 'com.example.CloneNestedGroupToNewWorkspace',
     name: 'Clone nested group to new workspace',
     callback: () => {
       const ws = trace.workspaces.createEmptyWorkspace('New workspace');
@@ -298,7 +298,7 @@ async function addNestedTrackGroup(trace: Trace): Promise<void> {
   });
 
   trace.commands.registerCommand({
-    id: 'com.example.Tracks#DeepCloneNestedGroupToNewWorkspace',
+    id: 'com.example.DeepCloneNestedGroupToNewWorkspace',
     name: 'Clone nested group and children to new workspace',
     callback: () => {
       const ws = trace.workspaces.createEmptyWorkspace('Deep workspace');

--- a/ui/src/plugins/com.google.PixelMemory/index.ts
+++ b/ui/src/plugins/com.google.PixelMemory/index.ts
@@ -296,7 +296,7 @@ export default class implements PerfettoPlugin {
   async onTraceLoad(ctx: Trace): Promise<void> {
     this.registerMemoryCommand(
       ctx,
-      'dev.perfetto.PixelMemory#ShowTotalMemory',
+      'com.google.ShowPixelTotalMemory',
       'Add tracks: show process total memory',
       'COALESCE(rss_and_swap, 0) + COALESCE(gpu_memory, 0)',
       '_rss_anon_file_swap_shmem_gpu',
@@ -304,7 +304,7 @@ export default class implements PerfettoPlugin {
 
     this.registerMemoryCommand(
       ctx,
-      'dev.perfetto.PixelMemory#ShowRssAnonShmemSwapGpuMemory',
+      'com.google.ShowPixelRssAnonShmemSwapGpuMemory',
       'Add tracks: show process total memory (excluding file RSS)',
       'COALESCE(anon_rss_and_swap, 0) + COALESCE(shmem_rss, 0) + ' +
         'COALESCE(gpu_memory, 0)',

--- a/ui/src/plugins/com.google.android.GoogleCamera/index.ts
+++ b/ui/src/plugins/com.google.android.GoogleCamera/index.ts
@@ -20,7 +20,7 @@ export default class implements PerfettoPlugin {
   static readonly id = 'com.google.android.GoogleCamera';
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'com.google.android.GoogleCamera#LoadGoogleCameraStartupView',
+      id: 'com.google.android.LoadGoogleCameraStartupView',
       name: 'Load google camera startup view',
       callback: () => {
         this.loadGCAStartupView(ctx);
@@ -28,7 +28,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'com.google.android.GoogleCamera#PinCameraRelatedTracks',
+      id: 'com.google.android.PinCameraRelatedTracks',
       name: 'Pin camera related tracks',
       callback: async () => {
         const promptResult = await ctx.omnibox.prompt(

--- a/ui/src/plugins/dev.perfetto.AutoPinAndExpandTracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.AutoPinAndExpandTracks/index.ts
@@ -96,7 +96,7 @@ export default class AutoPinAndExpandTracks implements PerfettoPlugin {
     this.ctx = ctx;
 
     ctx.commands.registerCommand({
-      id: `${PLUGIN_ID}#save`,
+      id: `dev.perfetto.SavePinnedTracks`,
       name: 'Save: Pinned tracks',
       callback: () => {
         setSavedState({
@@ -119,7 +119,7 @@ export default class AutoPinAndExpandTracks implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: `${PLUGIN_ID}#saveByName`,
+      id: `dev.perfetto.SavePinnedTracksByName`,
       name: 'Save by name: Pinned tracks',
       callback: async () => {
         const name = await this.ctx.omnibox.prompt(
@@ -132,7 +132,7 @@ export default class AutoPinAndExpandTracks implements PerfettoPlugin {
       },
     });
     ctx.commands.registerCommand({
-      id: `${PLUGIN_ID}#restoreByName`,
+      id: `dev.perfetto.RestorePinnedTracksByName`,
       name: 'Restore by name: Pinned tracks',
       callback: async () => {
         const tracksByName = getSavedState()?.tracksByName ?? [];
@@ -154,7 +154,7 @@ export default class AutoPinAndExpandTracks implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: `${PLUGIN_ID}#exportByName`,
+      id: `dev.perfetto.ExportPinnedTracksByName`,
       name: 'Export by name: Pinned tracks',
       callback: async () => {
         const tracksByName = getSavedState()?.tracksByName ?? [];
@@ -182,7 +182,7 @@ export default class AutoPinAndExpandTracks implements PerfettoPlugin {
       },
     });
     ctx.commands.registerCommand({
-      id: `${PLUGIN_ID}#importByName`,
+      id: `dev.perfetto.ImportPinnedTracksByName`,
       name: 'Import by name: Pinned tracks',
       callback: async () => {
         const files = document.querySelector('.pinned_tracks_import_selector');

--- a/ui/src/plugins/dev.perfetto.Chaos/index.ts
+++ b/ui/src/plugins/dev.perfetto.Chaos/index.ts
@@ -22,7 +22,7 @@ export default class implements PerfettoPlugin {
 
   static onActivate(ctx: App): void {
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.Chaos#CrashNow',
+      id: 'dev.perfetto.CrashNow',
       name: 'Chaos: crash now',
       callback: () => {
         throw new Error('Manual crash from dev.perfetto.Chaos#CrashNow');
@@ -32,7 +32,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.Chaos#CrashNowQuery',
+      id: 'dev.perfetto.CrashNowQuery',
       name: 'Chaos: run crashing query',
       callback: () => {
         ctx.engine.query(`this is a
@@ -47,7 +47,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.Chaos#AddCrashingDebugTrack',
+      id: 'dev.perfetto.AddCrashingDebugTrack',
       name: 'Chaos: add crashing debug track',
       callback: () => {
         addDebugSliceTrack({

--- a/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
@@ -237,7 +237,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CriticalPathLite_AreaSelection',
+      id: 'dev.perfetto.CriticalPathLite_AreaSelection',
       name: 'Critical path lite (over area selection)',
       callback: async () => {
         const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
@@ -280,7 +280,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CriticalPath_AreaSelection',
+      id: 'dev.perfetto.CriticalPath_AreaSelection',
       name: 'Critical path  (over area selection)',
       callback: async () => {
         const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
@@ -315,7 +315,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CriticalPathPprof_AreaSelection',
+      id: 'dev.perfetto.CriticalPathPprof_AreaSelection',
       name: 'Critical path pprof (over area selection)',
       callback: async () => {
         const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);

--- a/ui/src/plugins/dev.perfetto.DebugTracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.DebugTracks/index.ts
@@ -24,7 +24,7 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.DebugTracks';
   async onTraceLoad(ctx: Trace): Promise<void> {
     ctx.commands.registerCommand({
-      id: 'perfetto.DebugTracks#addDebugSliceTrack',
+      id: 'dev.perfetto.AddDebugSliceTrack',
       name: 'Add debug slice track',
       callback: async (arg: unknown) => {
         // This command takes a query and creates a debug track out of it The
@@ -44,7 +44,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.DebugTracks#addDebugCounterTrack',
+      id: 'dev.perfetto.AddDebugCounterTrack',
       name: 'Add debug counter track',
       callback: async (arg: unknown) => {
         const query = await getStringFromArgOrPrompt(ctx, arg);

--- a/ui/src/plugins/dev.perfetto.Ftrace/index.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/index.ts
@@ -108,7 +108,7 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'perfetto.FtraceRaw#ShowFtraceTab',
+      id: 'dev.perfetto.ShowFtraceTab',
       name: 'Show ftrace tab',
       callback: () => {
         ctx.tabs.showTab(ftraceTabUri);

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
@@ -96,7 +96,7 @@ export default class implements PerfettoPlugin {
     // Add a command to select all the perf samples in the trace - it selects
     // the entirety of each process scoped perf sample track.
     trace.commands.registerCommand({
-      id: 'dev.perfetto.LinuxPerf#SelectAllPerfSamples',
+      id: 'dev.perfetto.SelectAllPerfSamples',
       name: 'Select all perf samples',
       callback: () => {
         trace.selection.selectArea({

--- a/ui/src/plugins/dev.perfetto.QueryLog/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryLog/index.ts
@@ -26,7 +26,7 @@ export default class implements PerfettoPlugin {
     const tabUri = `${trace.pluginId}#QueryLogTab`;
 
     trace.commands.registerCommand({
-      id: `${trace.pluginId}#ShowQueryLogTab`,
+      id: `dev.perfetto.ShowQueryLogTab`,
       name: 'Show query log tab',
       callback: () => {
         trace.tabs.showTab(tabUri);

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -80,7 +80,7 @@ export default class implements PerfettoPlugin {
     this.addSchedulingSummaryTracks(ctx);
 
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.Sched#SelectAllThreadStateTracks',
+      id: 'dev.perfetto.SelectAllThreadStateTracks',
       name: 'Select all thread state tracks',
       callback: () => {
         const tracks = ctx.tracks

--- a/ui/src/plugins/dev.perfetto.SqlModules/index.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/index.ts
@@ -34,7 +34,7 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(trace: Trace): Promise<void> {
     trace.commands.registerCommand({
-      id: 'perfetto.OpenSqlModulesTable',
+      id: 'dev.perfetto.OpenSqlModulesTable',
       name: 'Open table...',
       callback: async () => {
         if (!globSqlModules) {

--- a/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
+++ b/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
@@ -68,17 +68,17 @@ export default class implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace) {
     ctx.commands.registerCommand({
-      id: `dev.perfetto.SplitScreen#enableTimelineSync`,
+      id: `dev.perfetto.EnableTimelineSync`,
       name: 'Enable timeline sync with other Perfetto UI tabs',
       callback: () => this.showTimelineSyncDialog(),
     });
     ctx.commands.registerCommand({
-      id: `dev.perfetto.SplitScreen#disableTimelineSync`,
+      id: `dev.perfetto.DisableTimelineSync`,
       name: 'Disable timeline sync',
       callback: () => this.disableTimelineSync(this._sessionId),
     });
     ctx.commands.registerCommand({
-      id: `dev.perfetto.SplitScreen#toggleTimelineSync`,
+      id: `dev.perfetto.ToggleTimelineSync`,
       name: 'Toggle timeline sync with other PerfettoUI tabs',
       callback: () => this.toggleTimelineSync(),
       defaultHotkey: 'Mod+Alt+S',

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/index.ts
@@ -25,7 +25,7 @@ export default class implements PerfettoPlugin {
     const uri = `/critical_user_interactions`;
 
     ctx.commands.registerCommand({
-      id: 'perfetto.CriticalUserInteraction.AddInteractionTrack',
+      id: 'org.chromium.CriticalUserInteraction.AddInteractionTrack',
       name: 'Add track: Chrome interactions',
       callback: () => {
         const track = new TrackNode({

--- a/ui/src/plugins/org.chromium.ChromeNavigation/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeNavigation/index.ts
@@ -48,7 +48,7 @@ export default class implements PerfettoPlugin {
     // so they can easily be inspected without scrolling through a lot of
     // vertical space.
     trace.commands.registerCommand({
-      id: 'org.chromium.ChromeNavigation#PinNavigationTracks',
+      id: 'org.chromium.PinNavigationTracks',
       name: 'Chrome Navigation: Pin relevant tracks',
       callback: () => {
         trace.workspace.flatTracks
@@ -65,7 +65,7 @@ export default class implements PerfettoPlugin {
     // their parent tracks, so we can have the collapsable process/thread
     // tracks and keep the UI consistent.
     trace.commands.registerCommand({
-      id: 'org.chromium.ChromeNavigation#CreateWorkspaceWithTracks',
+      id: 'org.chromium.CreateWorkspaceWithTracks',
       name: `Chrome Navigation: Go to "${NAVIGATION_WORKSPACE_NAME}" workspace`,
       defaultHotkey: 'Shift+N',
       callback: () => {

--- a/ui/src/plugins/org.chromium.OpenTableCommands/index.ts
+++ b/ui/src/plugins/org.chromium.OpenTableCommands/index.ts
@@ -31,7 +31,7 @@ export default class implements PerfettoPlugin {
   async onTraceLoad(ctx: Trace) {
     sqlTableRegistry['slice'] = getSliceTable();
     ctx.commands.registerCommand({
-      id: 'perfetto.ShowTable.slice',
+      id: 'org.chromium.ShowTable.slice',
       name: 'Open table: slice',
       callback: () => {
         extensions.addLegacySqlTableTab(ctx, {
@@ -42,7 +42,7 @@ export default class implements PerfettoPlugin {
 
     sqlTableRegistry['thread'] = getThreadTable();
     ctx.commands.registerCommand({
-      id: 'perfetto.ShowTable.thread',
+      id: 'org.chromium.ShowTable.thread',
       name: 'Open table: thread',
       callback: () => {
         extensions.addLegacySqlTableTab(ctx, {
@@ -53,7 +53,7 @@ export default class implements PerfettoPlugin {
 
     sqlTableRegistry['process'] = getThreadTable();
     ctx.commands.registerCommand({
-      id: 'perfetto.ShowTable.process',
+      id: 'org.chromium.ShowTable.process',
       name: 'Open table: process',
       callback: () => {
         extensions.addLegacySqlTableTab(ctx, {
@@ -64,7 +64,7 @@ export default class implements PerfettoPlugin {
 
     sqlTableRegistry['sched'] = getSchedTable();
     ctx.commands.registerCommand({
-      id: 'perfetto.ShowTable.sched',
+      id: 'org.chromium.ShowTable.sched',
       name: 'Open table: sched',
       callback: () => {
         extensions.addLegacySqlTableTab(ctx, {
@@ -75,7 +75,7 @@ export default class implements PerfettoPlugin {
 
     sqlTableRegistry['thread_state'] = getThreadStateTable();
     ctx.commands.registerCommand({
-      id: 'perfetto.ShowTable.thread_state',
+      id: 'org.chromium.ShowTable.thread_state',
       name: 'Open table: thread_state',
       callback: () => {
         extensions.addLegacySqlTableTab(ctx, {
@@ -86,7 +86,7 @@ export default class implements PerfettoPlugin {
 
     sqlTableRegistry['android_logs'] = getAndroidLogsTable();
     ctx.commands.registerCommand({
-      id: 'perfetto.ShowTable.android_logs',
+      id: 'org.chromium.ShowTable.android_logs',
       name: 'Open table: android_logs',
       callback: () => {
         extensions.addLegacySqlTableTab(ctx, {

--- a/ui/src/public/exposed_commands.ts
+++ b/ui/src/public/exposed_commands.ts
@@ -22,5 +22,5 @@
 // These constants exist just to make the dependency evident at code
 // search time, rather than copy-pasting the string in two places.
 
-export const CRITICAL_PATH_CMD = 'perfetto.CriticalPath';
-export const CRITICAL_PATH_LITE_CMD = 'perfetto.CriticalPathLite';
+export const CRITICAL_PATH_CMD = 'dev.perfetto.CriticalPath';
+export const CRITICAL_PATH_LITE_CMD = 'dev.perfetto.CriticalPathLite';

--- a/ui/src/test/table_viewer.test.ts
+++ b/ui/src/test/table_viewer.test.ts
@@ -62,7 +62,7 @@ test('Table interactions', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('perfetto.ShowTable.slice');
+  await pth.runCommand('dev.perfetto.ShowTable.slice');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -126,7 +126,7 @@ test('Go to slice', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('perfetto.ShowTable.slice');
+  await pth.runCommand('dev.perfetto.ShowTable.slice');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -152,7 +152,7 @@ test('Go to thread_state', async () => {
   await pth.openTraceFile('api34_startup_cold.perfetto-trace');
 
   // Show the slice table via command.
-  await pth.runCommand('perfetto.ShowTable.thread_state');
+  await pth.runCommand('dev.perfetto.ShowTable.thread_state');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -184,7 +184,7 @@ test('Go to sched', async () => {
   await pth.openTraceFile('api34_startup_cold.perfetto-trace');
 
   // Show the slice table via command.
-  await pth.runCommand('perfetto.ShowTable.sched');
+  await pth.runCommand('dev.perfetto.ShowTable.sched');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -221,7 +221,7 @@ test('Go to process', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('perfetto.ShowTable.process');
+  await pth.runCommand('dev.perfetto.ShowTable.process');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^upid/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -243,7 +243,7 @@ test('Go to thread', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('perfetto.ShowTable.thread');
+  await pth.runCommand('dev.perfetto.ShowTable.thread');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^utid/);
   await pth.clickMenuItem('Sort: lowest first');

--- a/ui/src/test/table_viewer.test.ts
+++ b/ui/src/test/table_viewer.test.ts
@@ -62,7 +62,7 @@ test('Table interactions', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('dev.perfetto.ShowTable.slice');
+  await pth.runCommand('org.chromium.ShowTable.slice');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -126,7 +126,7 @@ test('Go to slice', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('dev.perfetto.ShowTable.slice');
+  await pth.runCommand('org.chromium.ShowTable.slice');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -152,7 +152,7 @@ test('Go to thread_state', async () => {
   await pth.openTraceFile('api34_startup_cold.perfetto-trace');
 
   // Show the slice table via command.
-  await pth.runCommand('dev.perfetto.ShowTable.thread_state');
+  await pth.runCommand('org.chromium.ShowTable.thread_state');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -184,7 +184,7 @@ test('Go to sched', async () => {
   await pth.openTraceFile('api34_startup_cold.perfetto-trace');
 
   // Show the slice table via command.
-  await pth.runCommand('dev.perfetto.ShowTable.sched');
+  await pth.runCommand('org.chromium.ShowTable.sched');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^id/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -221,7 +221,7 @@ test('Go to process', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('dev.perfetto.ShowTable.process');
+  await pth.runCommand('org.chromium.ShowTable.process');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^upid/);
   await pth.clickMenuItem('Sort: lowest first');
@@ -243,7 +243,7 @@ test('Go to thread', async () => {
   await pth.openTraceFile('chrome_scroll_without_vsync.pftrace');
 
   // Show the slice table via command.
-  await pth.runCommand('dev.perfetto.ShowTable.thread');
+  await pth.runCommand('org.chromium.ShowTable.thread');
   // Sort the table by id for consistent ordering.
   await clickTableHeader(/^utid/);
   await pth.clickMenuItem('Sort: lowest first');


### PR DESCRIPTION
As commands now become an API that we expect people to start depending
on, it's time to have a formal and consistent way for commands to be
named. After discussion, we've settled on com.namespace.CommandName
similar to how plugins themselves are named.

We intentionally avoid putting the plugin name as it makes refactoring
of code in the core/plugins a pain (people become scared to do
refactoring etc.)
