### PR TITLE
ui: Remove bottom padding from track shell menu bar - fixes overflowing border bug

### DIFF
--- a/ui/src/assets/widgets/track_shell.scss
+++ b/ui/src/assets/widgets/track_shell.scss
@@ -143,7 +143,8 @@
     grid-template-areas:
       "icon title chips buttons"
       "none subtitle subtitle subtitle";
-    padding: 1px;
+    padding-inline: 1px;
+    padding-top: 1px;
     position: sticky;
     top: calc(var(--sticky-top) * 1px);
   }


### PR DESCRIPTION
Before:

<img width="1029" height="185" alt="image" src="https://github.com/user-attachments/assets/76028d7a-83f6-4aac-b119-c7ec5f320990" />

After:
<img width="1032" height="282" alt="image" src="https://github.com/user-attachments/assets/f38990d7-13e8-4e79-affc-fbf0f964263e" />
