### PR TITLE
Categorize etw_meminfo counter tracks as MEMORY to be displayed in the UI

### DIFF
--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_tracks.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_tracks.ts
@@ -142,6 +142,11 @@ export const COUNTER_TRACK_SCHEMAS: ReadonlyArray<CounterTrackTypeSchema> = [
     group: 'Diskstat',
   },
   {
+    type: 'etw_meminfo',
+    topLevelGroup: 'MEMORY',
+    group: 'ETW Memory Counters',
+  },
+  {
     type: 'f2fs_iostat_latency',
     topLevelGroup: 'IO',
     group: 'F2FS IOStat Latency',


### PR DESCRIPTION
Verified locally.