### PR TITLE
cts: add aflags to jni target to fix build

### DIFF
--- a/test/cts/producer/jni/Android.bp
+++ b/test/cts/producer/jni/Android.bp
@@ -15,6 +15,7 @@ cc_library_shared {
   header_libs: ["jni_headers"],
   static_libs: [
     "perfetto_cts_jni_deps",
+    "perfetto_flags_c_lib",
     "libperfetto_client_experimental",
   ],
   shared_libs: [


### PR DESCRIPTION
Fixes:
In file included from external/perfetto/test/cts/producer/jni/fake_producer_jni.cc:22:
In file included from external/perfetto/include/perfetto/ext/base/unix_task_runner.h:26:
In file included from external/perfetto/include/perfetto/ext/base/rt_mutex.h:34:
external/perfetto/include/perfetto/ext/base/flags.h:24:10: fatal error: 'perfetto_flags.h' file not found
   24 | #include <perfetto_flags.h>
      |          ^~~~~~~~~~~~~~~~~~