### PR TITLE
Remove 'group by' clause for notification blocking calls.

### DIFF
--- a/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinNotificationsBlockingCall.ts
+++ b/ui/src/plugins/com.android.PinAndroidPerfMetrics/handlers/pinNotificationsBlockingCall.ts
@@ -76,7 +76,6 @@ FROM slice s
 WHERE
     thread.is_main_thread AND
     _is_relevant_notifications_blocking_call(s.name, s.dur)
-GROUP BY s.name
   `;
 
     const trackName = notificationName + ' blocking calls';


### PR DESCRIPTION
The current behaviour is incorrect as only one slice is pinned in the trace due to the group by slice.name clause. All notification blocking call slices should be pinned.

Test: manual test with trace
