### PR TITLE
Revert "flags: set use_rt_mutex=True on non-Android-platform builds"

### DIFF
--- a/include/perfetto/ext/base/flags.h
+++ b/include/perfetto/ext/base/flags.h
@@ -36,7 +36,7 @@ namespace perfetto::base::flags {
   X(test_read_only_flag, NonAndroidPlatformDefault_FALSE)              \
   X(use_murmur_hash_for_flat_hash_map, NonAndroidPlatformDefault_TRUE) \
   X(ftrace_clear_offline_cpus_only, NonAndroidPlatformDefault_TRUE)    \
-  X(use_rt_mutex, NonAndroidPlatformDefault_TRUE)
+  X(use_rt_mutex, NonAndroidPlatformDefault_FALSE)
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //


### PR DESCRIPTION
This reverts PR #2621 (c2a5280d94317b5c47408c385618ab2965c56271)
Reason:
Fails in chromium:
https://chromium-review.googlesource.com/c/chromium/src/+/6873392?tab=checks

The futex facility returned an unexpected error code.
Received signal 6
#0 0x627afcfbe292 The futex facility returned an unexpected error code.
Received signal 6
#0 0x574ad0cdc292 The futex facility returned an unexpected error code.
Received signal 6

