### PR TITLE
stdlib: Fix to_svg sql

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/export/to_svg.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/export/to_svg.sql
@@ -522,7 +522,7 @@ RETURNS Expr AS
   SELECT
     tp.svg_group_key,
     tp.track_group_key,
-    '<text x="5" y="15" font-size="11" fill="#333">' || _escape_xml(CAST(label_text AS STRING)) || '</text>' || '<g transform="translate(0,20)">' || coalesce(
+    '<text x="5" y="15" font-size="11" fill="#333">' || _escape_xml(cast_string!(label_text)) || '</text>' || '<g transform="translate(0,20)">' || coalesce(
       (
         SELECT
           GROUP_CONCAT(


### PR DESCRIPTION
For some reason, the macros are unhappy with cast( AS STRING).

Switching to cast_string!() fixes

Test: tools/diff_test_trace_processor.py out/android/trace_processor_shell --name-filter '.*svg.*'
Change-Id: I9c08123dbbb7d5ce19940375e2bb62989e4922db

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
