### PR TITLE
[track] Fix Unreachable error in MergedKey

### DIFF
--- a/src/trace_processor/importers/proto/track_event_tracker.cc
+++ b/src/trace_processor/importers/proto/track_event_tracker.cc
@@ -515,6 +515,7 @@ TrackEventTracker::InternDescriptorTrackImpl(
           if (!parent_resolved_track->is_root()) {
             set_parent_id(id);
           }
+          return id;
         }
         auto [type, key] = GetMergeKey(*reservation, translated_name);
         return context_->track_compressor->CreateTrackFactory(


### PR DESCRIPTION
This PR fixes Unreachable error by adding a missing early return when trakc merging is disabled.

https://buganizer.corp.google.com/issues/440315270