### PR TITLE
tp: Make stack_profile_tracker per machine

### DIFF
--- a/src/trace_processor/trace_processor_context.cc
+++ b/src/trace_processor/trace_processor_context.cc
@@ -67,7 +67,6 @@ void InitPerTraceAndMachineState(TraceProcessorContext* context) {
       Ptr<ProcessTrackTranslationTable>::MakeRoot(context->storage.get());
   context->event_tracker = Ptr<EventTracker>::MakeRoot(context);
   context->sched_event_tracker = Ptr<SchedEventTracker>::MakeRoot(context);
-  context->stack_profile_tracker = Ptr<StackProfileTracker>::MakeRoot(context);
   context->args_translation_table =
       Ptr<ArgsTranslationTable>::MakeRoot(context->storage.get());
 
@@ -84,6 +83,7 @@ void InitPerMachineState(TraceProcessorContext* context, uint32_t machine_id) {
   context->clock_tracker = Ptr<ClockTracker>::MakeRoot(context);
   context->mapping_tracker = Ptr<MappingTracker>::MakeRoot(context);
   context->cpu_tracker = Ptr<CpuTracker>::MakeRoot(context);
+  context->stack_profile_tracker = Ptr<StackProfileTracker>::MakeRoot(context);
 }
 
 void CopyPerMachineState(const TraceProcessorContext* source,
@@ -94,6 +94,7 @@ void CopyPerMachineState(const TraceProcessorContext* source,
   dest->clock_tracker = source->clock_tracker.Fork();
   dest->mapping_tracker = source->mapping_tracker.Fork();
   dest->cpu_tracker = source->cpu_tracker.Fork();
+  dest->stack_profile_tracker = source->stack_profile_tracker.Fork();
 }
 
 void InitPerTraceState(TraceProcessorContext* context, uint32_t raw_trace_id) {

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -182,6 +182,7 @@ class TraceProcessorContext {
   PerMachinePtr<MappingTracker> mapping_tracker;
   PerMachinePtr<MachineTracker> machine_tracker;
   PerMachinePtr<CpuTracker> cpu_tracker;
+  PerMachinePtr<StackProfileTracker> stack_profile_tracker;
 
   // Per-Machine, Per-Trace State
   // ==========================
@@ -198,7 +199,6 @@ class TraceProcessorContext {
   PerTraceAndMachinePtr<FlowTracker> flow_tracker;
   PerTraceAndMachinePtr<EventTracker> event_tracker;
   PerTraceAndMachinePtr<SchedEventTracker> sched_event_tracker;
-  PerTraceAndMachinePtr<StackProfileTracker> stack_profile_tracker;
 
   // These fields are stored as pointers to Destructible objects rather than
   // their actual type (a subclass of Destructible), as the concrete subclass


### PR DESCRIPTION
This is to fix a problem where for gzip traces

In that case `StackProfileTracker::OnFrameCreated()` and `StackProfileTracker::HasFramesWithoutKnownPackage()` are called with different `StackProfileTracker`s, which breaks.

Testing this and refactoring trace_processor to prevent problems like this is a job for another day.

Bug: https://buganizer.corp.google.com/issues/440567101