### PR TITLE
base: Improve TaskRunner tests

### DIFF
--- a/src/base/task_runner_unittest.cc
+++ b/src/base/task_runner_unittest.cc
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-#include "perfetto/base/build_config.h"
-
-#include "perfetto/ext/base/unix_task_runner.h"
-
 #include <random>
 #include <thread>
 
+#include "perfetto/base/build_config.h"
 #include "perfetto/ext/base/event_fd.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/pipe.h"


### PR DESCRIPTION
- Turn the test into a typed test. In the next CLs
  this will test two implementations, the existing and
  the new LockFreeTaskRunner.
- Add some more tests about some edge cases I worked out
  while developing LockFreeTaskRunner.

Bug: b/394504259