### PR TITLE
enable_perfetto_rtmutex: fix chromium build

### DIFF
--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -271,11 +271,12 @@ declare_args() {
   # Note that on Android platform (non-standalone) builds this flag is ignored
   # and the Android flag "use_rt_mutex" is used instead (perfetto_flags.aconfig)
   # When building in chromium, we mirror the logic in chromium's base/BUILD.gn
-  # which says enable_mutex_priority_inheritance  = is_android && (x64 || arm64)
+  # which says enable_mutex_priority_inheritance = is_android && (x64 || arm64)
   # On chromium the BPF syscall sandbox allows PI mutexes only on 64bit Android.
   enable_perfetto_rt_mutex =
-      (!is_wasm && ((build_with_chromium || perfetto_build_standalone) &&
-                    (current_cpu == "x64" || current_cpu == "arm64"))) ||
+      (!is_wasm &&
+       (((build_with_chromium && is_android) || perfetto_build_standalone) &&
+        (current_cpu == "x64" || current_cpu == "arm64"))) ||
       is_perfetto_build_generator
 }
 


### PR DESCRIPTION
In the previous CL i missed a is_android.
The comment explains it well, but the code didn't do what the
comment said.
This should unblock the autoroller.