### PR TITLE
Fix tests that can't be gtest-repeat-ed

### DIFF
--- a/src/base/metatrace_unittest.cc
+++ b/src/base/metatrace_unittest.cc
@@ -246,7 +246,7 @@ TEST_F(MetatraceTest, ThreadRaces) {
         m::TraceCounter(/*tag=*/1, thd_idx, static_cast<int>(i));
     };
 
-    constexpr size_t kNumThreads = 8;
+    constexpr size_t kNumThreads = 2;
     std::array<std::thread, kNumThreads> threads;
     for (size_t thd_idx = 0; thd_idx < kNumThreads; thd_idx++)
       threads[thd_idx] = std::thread(thread_main, thd_idx);

--- a/src/base/no_destructor_unittest.cc
+++ b/src/base/no_destructor_unittest.cc
@@ -57,8 +57,8 @@ class NonTrivial {
 };
 
 TEST(NoDestructorTest, ContainedObjectUsable) {
-  static NoDestructor<NonTrivial> x(std::vector<int>{1, 2, 3},
-                                    std::unique_ptr<int>(new int(42)));
+  NoDestructor<NonTrivial> x(std::vector<int>{1, 2, 3},
+                             std::unique_ptr<int>(new int(42)));
 
   ASSERT_THAT(x.ref().vec_, ::testing::ElementsAre(1, 2, 3));
   ASSERT_EQ(*x.ref().ptr_, 42);

--- a/src/base/paged_memory_unittest.cc
+++ b/src/base/paged_memory_unittest.cc
@@ -171,6 +171,9 @@ TEST(PagedMemoryTest, AccessUncommittedMemoryTriggersASAN) {
 }
 #endif  // ADDRESS_SANITIZER
 
+#if !defined(ADDRESS_SANITIZER) && !defined(LEAK_SANITIZER) && \
+    !defined(THREAD_SANITIZER) && !defined(MEMORY_SANITIZER)
+// This test seems to hang on some sanitizers.
 TEST(PagedMemoryTest, GuardRegions) {
   const size_t kSize = GetSysPageSize();
   PagedMemory mem = PagedMemory::Allocate(kSize);
@@ -179,6 +182,7 @@ TEST(PagedMemoryTest, GuardRegions) {
   EXPECT_DEATH_IF_SUPPORTED({ raw[-1] = 'x'; }, ".*");
   EXPECT_DEATH_IF_SUPPORTED({ raw[kSize] = 'x'; }, ".*");
 }
+#endif
 
 // Disable this on:
 // MacOS: because it doesn't seem to have an equivalent rlimit to bound mmap().

--- a/src/trace_processor/export_json.cc
+++ b/src/trace_processor/export_json.cc
@@ -1293,17 +1293,16 @@ class JsonExporter {
 
       auto new_entry = current_events_.emplace(
           std::piecewise_construct, std::forward_as_tuple(utid),
-          std::forward_as_tuple(writer_, callsite_id, ts, event));
+          std::forward_as_tuple(writer_, callsite_id, ts, event, this));
       return new_entry.first->second.event_id();
     }
 
-    static uint64_t GenerateNewEventId() {
+    uint64_t GenerateNewEventId() {
       // "n"-phase events are nestable async events which get tied together
       // with their id, so we need to give each one a unique ID as we only
       // want the samples to show up on their own track in the trace-viewer
       // but not nested together (unless they're nested under a merged event).
-      static size_t g_id_counter = 0;
-      return ++g_id_counter;
+      return ++id_counter_;
     }
 
    private:
@@ -1312,13 +1311,14 @@ class JsonExporter {
       Sample(TraceFormatWriter& writer,
              CallsiteId callsite_id,
              int64_t ts,
-             Json::Value event)
+             Json::Value event,
+             MergedProfileSamplesEmitter* emitter)
           : writer_(writer),
             callsite_id_(callsite_id),
             begin_ts_(ts),
             end_ts_(ts),
             event_(std::move(event)),
-            event_id_(MergedProfileSamplesEmitter::GenerateNewEventId()),
+            event_id_(emitter->GenerateNewEventId()),
             sample_count_(1) {}
 
       Sample(const Sample&) = delete;
@@ -1380,6 +1380,7 @@ class JsonExporter {
 
     std::unordered_map<UniqueTid, Sample> current_events_;
     TraceFormatWriter& writer_;
+    uint64_t id_counter_ = 0;
   };
 
   base::Status ExportCpuProfileSamples() {
@@ -1470,8 +1471,8 @@ class JsonExporter {
             utid, it.ts(), *opt_current_callsite_id, event);
         event["id"] = base::Uint64ToHexString(parent_event_id);
       } else {
-        event["id"] = base::Uint64ToHexString(
-            MergedProfileSamplesEmitter::GenerateNewEventId());
+        event["id"] =
+            base::Uint64ToHexString(merged_sample_emitter.GenerateNewEventId());
       }
 
       writer_.WriteCommonEvent(event);

--- a/src/trace_processor/util/proto_to_args_parser_unittest.cc
+++ b/src/trace_processor/util/proto_to_args_parser_unittest.cc
@@ -337,12 +337,12 @@ TEST_F(ProtoToArgsParserTest, NestedProtoParsingOverrideSkipped) {
   ASSERT_TRUE(status.ok()) << "Failed to parse kTestMessagesDescriptor: "
                            << status.message();
 
+  int nested_val = 0;
   parser.AddParsingOverrideForField(
-      "super_nested.value_c",
-      [](const protozero::Field& field, ProtoToArgsParser::Delegate&) {
-        static int val = 0;
-        ++val;
-        EXPECT_EQ(1, val);
+      "super_nested.value_c", [&nested_val](const protozero::Field& field,
+                                            ProtoToArgsParser::Delegate&) {
+        ++nested_val;
+        EXPECT_EQ(1, nested_val);
         EXPECT_EQ(field.type(), protozero::proto_utils::ProtoWireType::kVarInt);
         return std::nullopt;
       });


### PR DESCRIPTION
Some tests rely on local statics and fail when using
--gtest_repeat. Fix them.
Also fix some other tests that don't run well on sanitizers.

Test: O=out/linux_tsan/; ninja -C $O perfetto_unittests && $O/perfetto_unittests --gtest_repeat=3 --gtest_break_on_failure