### PR TITLE
Parse the cpu_frequency_limits ftrace event from systrace

### DIFF
--- a/src/trace_processor/importers/common/tracks_common.h
+++ b/src/trace_processor/importers/common/tracks_common.h
@@ -133,6 +133,22 @@ inline constexpr auto kCpuFrequencyBlueprint = tracks::CounterBlueprint(
     tracks::DimensionBlueprints(kCpuDimensionBlueprint),
     tracks::StaticNameBlueprint("cpufreq"));
 
+inline constexpr auto kCpuMaxFrequencyLimitBlueprint = tracks::CounterBlueprint(
+    "cpu_max_frequency_limit",
+    tracks::UnknownUnitBlueprint(),
+    tracks::DimensionBlueprints(kCpuDimensionBlueprint),
+    tracks::FnNameBlueprint([](uint32_t cpu) {
+      return base::StackString<255>("Cpu %u Max Freq Limit", cpu);
+    }));
+
+inline constexpr auto kCpuMinFrequencyLimitBlueprint = tracks::CounterBlueprint(
+    "cpu_min_frequency_limit",
+    tracks::UnknownUnitBlueprint(),
+    tracks::DimensionBlueprints(kCpuDimensionBlueprint),
+    tracks::FnNameBlueprint([](uint32_t cpu) {
+      return base::StackString<255>("Cpu %u Min Freq Limit", cpu);
+    }));
+
 inline constexpr auto kGpuFrequencyBlueprint = tracks::CounterBlueprint(
     "gpu_frequency",
     tracks::StaticUnitBlueprint("MHz"),

--- a/src/trace_processor/importers/ftrace/ftrace_parser.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.cc
@@ -3274,27 +3274,13 @@ void FtraceParser::ParseCpuFrequencyLimits(int64_t timestamp,
                                            protozero::ConstBytes blob) {
   protos::pbzero::CpuFrequencyLimitsFtraceEvent::Decoder evt(blob);
 
-  static constexpr auto kMaxBlueprint = tracks::CounterBlueprint(
-      "cpu_max_frequency_limit", tracks::UnknownUnitBlueprint(),
-      tracks::DimensionBlueprints(tracks::kCpuDimensionBlueprint),
-      tracks::FnNameBlueprint([](uint32_t cpu) {
-        return base::StackString<255>("Cpu %u Max Freq Limit", cpu);
-      }));
-
   TrackId max_track = context_->track_tracker->InternTrack(
-      kMaxBlueprint, tracks::Dimensions(evt.cpu_id()));
+      tracks::kCpuMaxFrequencyLimitBlueprint, tracks::Dimensions(evt.cpu_id()));
   context_->event_tracker->PushCounter(
       timestamp, static_cast<double>(evt.max_freq()), max_track);
 
-  static constexpr auto kMinBlueprint = tracks::CounterBlueprint(
-      "cpu_min_frequency_limit", tracks::UnknownUnitBlueprint(),
-      tracks::DimensionBlueprints(tracks::kCpuDimensionBlueprint),
-      tracks::FnNameBlueprint([](uint32_t cpu) {
-        return base::StackString<255>("Cpu %u Min Freq Limit", cpu);
-      }));
-
   TrackId min_track = context_->track_tracker->InternTrack(
-      kMinBlueprint, tracks::Dimensions(evt.cpu_id()));
+      tracks::kCpuMinFrequencyLimitBlueprint, tracks::Dimensions(evt.cpu_id()));
   context_->event_tracker->PushCounter(
       timestamp, static_cast<double>(evt.min_freq()), min_track);
 }

--- a/src/trace_processor/importers/systrace/systrace_line_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_line_parser.cc
@@ -149,6 +149,34 @@ base::Status SystraceLineParser::ParseLine(const SystraceLine& line) {
     TrackId track = context_->track_tracker->InternTrack(
         tracks::kCpuFrequencyBlueprint, tracks::Dimensions(event_cpu.value()));
     context_->event_tracker->PushCounter(line.ts, new_state.value(), track);
+  } else if (line.event_name == "cpu_frequency_limits") {
+    std::optional<uint32_t> event_cpu = base::StringToUInt32(args["cpu_id"]);
+    if (!event_cpu.has_value()) {
+      return base::Status("Could not convert event cpu");
+    }
+    std::optional<double> max_freq =
+        args.Find("max") != nullptr ? base::StringToDouble(args["max"])
+                                    : base::StringToDouble(args["max_freq"]);
+    std::optional<double> min_freq =
+        args.Find("min") != nullptr ? base::StringToDouble(args["min"])
+                                    : base::StringToDouble(args["min_freq"]);
+    if (max_freq.has_value()) {
+      TrackId max_track = context_->track_tracker->InternTrack(
+          tracks::kCpuMaxFrequencyLimitBlueprint,
+          tracks::Dimensions(event_cpu.value()));
+      context_->event_tracker->PushCounter(
+          line.ts, static_cast<double>(max_freq.value()), max_track);
+    }
+    if (min_freq.has_value()) {
+      TrackId min_track = context_->track_tracker->InternTrack(
+          tracks::kCpuMinFrequencyLimitBlueprint,
+          tracks::Dimensions(event_cpu.value()));
+      context_->event_tracker->PushCounter(
+          line.ts, static_cast<double>(min_freq.value()), min_track);
+    }
+    if (!max_freq.has_value() && !min_freq.has_value()) {
+      return base::Status("Could not convert both max_freq and min_freq");
+    }
   } else if (line.event_name == "cpu_idle") {
     std::optional<uint32_t> event_cpu = base::StringToUInt32(args["cpu_id"]);
     std::optional<double> new_state = base::StringToDouble(args["state"]);

--- a/test/trace_processor/diff_tests/parser/sched/cpu_frequency_limits.systrace
+++ b/test/trace_processor/diff_tests/parser/sched/cpu_frequency_limits.systrace
@@ -1,0 +1,12 @@
+       <unknown>-200   (-----) [000] .... 0.090000: cpu_frequency_limits: min=500000 max=2800000 cpu_id=6
+       <unknown>-500   (-----) [000] .... 0.100000: cpu_frequency_limits: min=500000 max=1700000 cpu_id=6
+       <unknown>-80    (-----) [000] .... 0.110000: cpu_frequency_limits: min=1400000 max=2800000 cpu_id=6
+       <unknown>-300   (-----) [000] .... 0.120000: cpu_frequency_limits: min=500000 max=1500000 cpu_id=6
+       <unknown>-300   (-----) [004] .... 0.120000: cpu_frequency_limits: min=600000 max=1400000 cpu_id=4
+       <unknown>-600   (-----) [004] .... 0.130000: cpu_frequency_limits: min=800000 max=2200000 cpu_id=4
+       <unknown>-200   (-----) [000] .... 1.090000: cpu_frequency_limits: min_freq=500000 max_freq=2800000 cpu_id=6
+       <unknown>-500   (-----) [000] .... 1.100000: cpu_frequency_limits: min_freq=500000 max_freq=1700000 cpu_id=6
+       <unknown>-80    (-----) [000] .... 1.110000: cpu_frequency_limits: min_freq=1400000 max_freq=2800000 cpu_id=6
+       <unknown>-300   (-----) [000] .... 1.120000: cpu_frequency_limits: min_freq=500000 max_freq=1500000 cpu_id=6
+       <unknown>-300   (-----) [004] .... 1.120000: cpu_frequency_limits: min_freq=600000 max_freq=1400000 cpu_id=4
+       <unknown>-600   (-----) [004] .... 1.130000: cpu_frequency_limits: min_freq=800000 max_freq=2200000 cpu_id=4

--- a/test/trace_processor/diff_tests/parser/sched/cpu_frequency_limits_test.sql
+++ b/test/trace_processor/diff_tests/parser/sched/cpu_frequency_limits_test.sql
@@ -1,0 +1,12 @@
+SELECT
+    ts,
+    value,
+    REPLACE(name, " Freq Limit", "") AS cpu
+FROM
+    counter AS c
+LEFT JOIN
+    counter_track AS t
+    ON c.track_id = t.id
+WHERE
+    name GLOB "* Freq Limit"
+ORDER BY ts;

--- a/test/trace_processor/diff_tests/parser/sched/tests.py
+++ b/test/trace_processor/diff_tests/parser/sched/tests.py
@@ -24,20 +24,7 @@ class SchedParser(TestSuite):
   def test_cpu_frequency_limits(self):
     return DiffTestBlueprint(
         trace=Path('cpu_frequency_limits.textproto'),
-        query="""
-        SELECT
-          ts,
-          value,
-          REPLACE(name, " Freq Limit", "") AS cpu
-        FROM
-          counter AS c
-        LEFT JOIN
-          counter_track AS t
-          ON c.track_id = t.id
-        WHERE
-          name GLOB "* Freq Limit"
-        ORDER BY ts;
-        """,
+        query=Path('cpu_frequency_limits_test.sql'),
         out=Csv("""
         "ts","value","cpu"
         90000000,2800000.000000,"Cpu 6 Max"
@@ -52,6 +39,38 @@ class SchedParser(TestSuite):
         120000000,600000.000000,"Cpu 4 Min"
         130000000,2200000.000000,"Cpu 4 Max"
         130000000,800000.000000,"Cpu 4 Min"
+        """))
+
+  def test_cpu_frequency_limits_from_systrace(self):
+    return DiffTestBlueprint(
+        trace=Path('cpu_frequency_limits.systrace'),
+        query=Path('cpu_frequency_limits_test.sql'),
+        out=Csv("""
+        "ts","value","cpu"
+        90000000,2800000.000000,"Cpu 6 Max"
+        90000000,500000.000000,"Cpu 6 Min"
+        100000000,1700000.000000,"Cpu 6 Max"
+        100000000,500000.000000,"Cpu 6 Min"
+        110000000,2800000.000000,"Cpu 6 Max"
+        110000000,1400000.000000,"Cpu 6 Min"
+        120000000,1500000.000000,"Cpu 6 Max"
+        120000000,500000.000000,"Cpu 6 Min"
+        120000000,1400000.000000,"Cpu 4 Max"
+        120000000,600000.000000,"Cpu 4 Min"
+        130000000,2200000.000000,"Cpu 4 Max"
+        130000000,800000.000000,"Cpu 4 Min"
+        1090000000,2800000.000000,"Cpu 6 Max"
+        1090000000,500000.000000,"Cpu 6 Min"
+        1100000000,1700000.000000,"Cpu 6 Max"
+        1100000000,500000.000000,"Cpu 6 Min"
+        1110000000,2800000.000000,"Cpu 6 Max"
+        1110000000,1400000.000000,"Cpu 6 Min"
+        1120000000,1500000.000000,"Cpu 6 Max"
+        1120000000,500000.000000,"Cpu 6 Min"
+        1120000000,1400000.000000,"Cpu 4 Max"
+        1120000000,600000.000000,"Cpu 4 Min"
+        1130000000,2200000.000000,"Cpu 4 Max"
+        1130000000,800000.000000,"Cpu 4 Min"
         """))
 
   def test_sched_cpu_util_cfs(self):


### PR DESCRIPTION
Parse the cpu_frequency_limits ftrace event from systrace, and show it on the Perfetto UI in the same way as from proto.

Test: tools/diff_test_trace_processor.py <trace_processor_shell> --name-filter='SchedParser:cpu_frequency_limits_from_systrace'

Background: When loading Android Systrace using PerfettoUI, the cpu_frequency_limits event is not parsed and displayed in PerfettoUI, whereas it is parsed when loading Perfetto. This commit adds parsing for the cpu_frequency_limits event in Android Systrace. The effect after the commit is shown below: 
<img width="1666" height="398" alt="image" src="https://github.com/user-attachments/assets/0160259e-9dd6-42ce-8942-da21dbd2ac3d" />
