### PR TITLE
tp: etm: fix cycle count for joins

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.cc
@@ -194,9 +194,8 @@ base::Status EtmDecodeChunkVtable::Cursor::HandleFlushingBuffer() {
     buffer_idx_++;
     if (buffer_idx_ >= rows_waiting_for_timestamp_.size()) {
       FlushBuffer();
-    }
-    if (rows_waiting_for_timestamp_[buffer_idx_].element.getType() ==
-        OCSD_GEN_TRC_ELEM_CYCLE_COUNT) {
+    } else if (rows_waiting_for_timestamp_[buffer_idx_].element.getType() ==
+               OCSD_GEN_TRC_ELEM_CYCLE_COUNT) {
       state_.last_cc_value +=
           rows_waiting_for_timestamp_[buffer_idx_].element.cycle_count;
       state_.cumulative_cycle_count = state_.last_cc_value;

--- a/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/etm_decode_trace_vtable.cc
@@ -195,6 +195,12 @@ base::Status EtmDecodeChunkVtable::Cursor::HandleFlushingBuffer() {
     if (buffer_idx_ >= rows_waiting_for_timestamp_.size()) {
       FlushBuffer();
     }
+    if (rows_waiting_for_timestamp_[buffer_idx_].element.getType() ==
+        OCSD_GEN_TRC_ELEM_CYCLE_COUNT) {
+      state_.last_cc_value +=
+          rows_waiting_for_timestamp_[buffer_idx_].element.cycle_count;
+      state_.cumulative_cycle_count = state_.last_cc_value;
+    }
   }
   return base::OkStatus();
 }


### PR DESCRIPTION
This PR fixes an issue with how cumulative cycle counts was calculated in EtmDecodeChunkVtable.

The issue was that during a JOIN with other tables the cumulative cycle count column would always be null.