### PR TITLE
BUILD.gn: Fix `tools/gen_all` with cross compilation

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -206,6 +206,9 @@ if (perfetto_build_standalone) {
   if (is_linux || is_android || is_mac) {
     all_targets += [ "src/tracebox" ]
   }
+
+  # This is needed by `tools/gen_c_protos`.
+  all_targets += [ "src/protozero/protoc_plugin:protozero_c_plugin" ]
 }
 
 if (enable_perfetto_merged_protos_check) {


### PR DESCRIPTION
Running `tools/gen_all` when doing a cross compilation (for example, for android) fails, because protozero_c_plugin is missing.

This commit fixes the problem.

Suggested-by: cairno@google.com