### PR TITLE
ui: split RunQuery command into two commands

### DIFF
--- a/docs/visualization/commands-automation-reference.md
+++ b/docs/visualization/commands-automation-reference.md
@@ -304,7 +304,7 @@ groups for context.
 
 #### `dev.perfetto.RunQuery`
 
-Executes a PerfettoSQL query and displays results in the query tab.
+Executes a PerfettoSQL query without displaying results.
 
 **Arguments:**
 
@@ -315,6 +315,23 @@ Executes a PerfettoSQL query and displays results in the query tab.
 ```json
 {
   "id": "dev.perfetto.RunQuery",
+  "args": ["CREATE PERFETTO FUNCTION my_func(x INT) RETURNS INT AS SELECT $x * 2"]
+}
+```
+
+#### `dev.perfetto.RunQueryAndShowTab`
+
+Executes a PerfettoSQL query and displays results in a new query tab.
+
+**Arguments:**
+
+- `query` (string, required): PerfettoSQL query to execute
+
+**Example:**
+
+```json
+{
+  "id": "dev.perfetto.RunQueryAndShowTab",
   "args": ["SELECT ts, dur, name FROM slice LIMIT 50"]
 }
 ```

--- a/docs/visualization/ui-automation.md
+++ b/docs/visualization/ui-automation.md
@@ -209,7 +209,7 @@ This macro helps identify performance bottlenecks:
       "args": [".*CPU.*"]
     },
     {
-      "id": "dev.perfetto.RunQuery",
+      "id": "dev.perfetto.RunQueryAndShowTab",
       "args": [
         "SELECT thread.name, COUNT(*) as blocks, SUM(dur)/1000000 as total_ms FROM thread_state JOIN thread USING(utid) WHERE state = 'D' GROUP BY thread.name ORDER BY total_ms DESC LIMIT 10"
       ]

--- a/ui/src/core/startup_command_allowlist.ts
+++ b/ui/src/core/startup_command_allowlist.ts
@@ -37,6 +37,7 @@ export const STARTUP_COMMAND_ALLOWLIST: string[] = [
 
   // Query commands
   'dev.perfetto.RunQuery',
+  'dev.perfetto.RunQueryAndShowTab',
 
   // Commands will be added here based on user suggestions
 ];

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -210,6 +210,20 @@ export class UiMainPerTrace implements m.ClassComponent {
       },
       {
         id: 'dev.perfetto.RunQuery',
+        name: 'Runs an SQL query',
+        callback: async (rawSql: unknown) => {
+          const query =
+            typeof rawSql === 'string'
+              ? rawSql
+              : await trace.omnibox.prompt('Enter SQL...');
+          if (!query) {
+            return;
+          }
+          await trace.engine.query(query);
+        },
+      },
+      {
+        id: 'dev.perfetto.RunQueryAndShowTab',
         name: 'Runs an SQL query and opens results in a tab',
         callback: async (rawSql: unknown) => {
           const query =

--- a/ui/src/test/startup_commands_allowlist.test.ts
+++ b/ui/src/test/startup_commands_allowlist.test.ts
@@ -15,6 +15,7 @@
 import {test, expect} from '@playwright/test';
 import {PerfettoTestHelper} from './perfetto_ui_test_helper';
 import {STARTUP_COMMAND_ALLOWLIST} from '../core/startup_command_allowlist';
+import {NUM} from '../trace_processor/query_result';
 
 interface CommandTestCase {
   id: string;
@@ -151,6 +152,30 @@ const COMMAND_TEST_CASES: CommandTestCase[] = [
   // Query commands
   {
     id: 'dev.perfetto.RunQuery',
+    args: ['CREATE TABLE test_command_execution AS SELECT 42 as test_value'],
+    traceFile: 'chrome_rendering_desktop.pftrace', // Chrome trace for creating test table
+    maskQueryDetails: true,
+    after: async () => {
+      const trace = self.app.trace;
+      if (!trace) throw new Error('No trace loaded');
+
+      // Verify the table was created by querying it
+      const result = await trace.engine.query(
+        'SELECT test_value FROM test_command_execution',
+      );
+      if (result.error() !== undefined) {
+        throw new Error(`Failed to query test table: ${result.error()}`);
+      }
+
+      // Verify we got the expected constant value
+      const row = result.firstRow({test_value: NUM});
+      if (row.test_value !== 42) {
+        throw new Error(`Expected test_value=42, got: ${row.test_value}`);
+      }
+    },
+  },
+  {
+    id: 'dev.perfetto.RunQueryAndShowTab',
     args: ['select ts, dur, name from slice limit 50'],
     traceFile: 'chrome_rendering_desktop.pftrace', // Chrome trace with rich slice data for queries
     maskQueryDetails: true,


### PR DESCRIPTION
RunQuery was really also creating a tab: we might sometimes want a way
to just run some SQL without doing that (e.g. including some modules
which we'll use to create some debug tracks).

Split the command into two -> RunQuery and RunQueryAndShowTab which each
do what they say. Add the necessary documentation and tests for both.
