### PR TITLE
infra: Remove luci.recipes.use_python3 experiment

### DIFF
--- a/infra/luci/generated/cr-buildbucket.cfg
+++ b/infra/luci/generated/cr-buildbucket.cfg
@@ -34,10 +34,6 @@ buckets {
         '  "recipe": "perfetto"'
         '}'
       service_account: "perfetto-luci-official-builder@chops-service-accounts.iam.gserviceaccount.com"
-      experiments {
-        key: "luci.recipes.use_python3"
-        value: 100
-      }
     }
     builders {
       name: "perfetto-official-builder-linux"
@@ -55,10 +51,6 @@ buckets {
         '  "recipe": "perfetto"'
         '}'
       service_account: "perfetto-luci-official-builder@chops-service-accounts.iam.gserviceaccount.com"
-      experiments {
-        key: "luci.recipes.use_python3"
-        value: 100
-      }
     }
     builders {
       name: "perfetto-official-builder-mac"
@@ -80,10 +72,6 @@ buckets {
         path: "macos_sdk"
       }
       service_account: "perfetto-luci-official-builder@chops-service-accounts.iam.gserviceaccount.com"
-      experiments {
-        key: "luci.recipes.use_python3"
-        value: 100
-      }
     }
     builders {
       name: "perfetto-official-builder-windows"
@@ -105,10 +93,6 @@ buckets {
         path: "windows_sdk"
       }
       service_account: "perfetto-luci-official-builder@chops-service-accounts.iam.gserviceaccount.com"
-      experiments {
-        key: "luci.recipes.use_python3"
-        value: 100
-      }
     }
   }
 }

--- a/infra/luci/generated/project.cfg
+++ b/infra/luci/generated/project.cfg
@@ -7,7 +7,7 @@
 name: "perfetto"
 access: "group:all"
 lucicfg {
-  version: "1.43.14"
+  version: "1.45.8"
   package_dir: ".."
   config_dir: "generated"
   entry_point: "main.star"

--- a/infra/luci/main.star
+++ b/infra/luci/main.star
@@ -82,7 +82,6 @@ def official_builder(name, os, caches=[]):
             name = "perfetto",
             cipd_package = "infra/recipe_bundles/chromium.googlesource.com/external/github.com/google/perfetto",
             cipd_version = "refs/heads/upstream/main",
-            use_python3 = True,
         ),
         dimensions = {
             "pool": "luci.perfetto.official",


### PR DESCRIPTION
Python3 is used by default in recipes now and this config is not
necessary anymore.

Bug: [440235171](https://issues.chromium.org/issues/440235171)