### PR TITLE
RTFutex flag: disable in chromium

### DIFF
--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -270,14 +270,11 @@ declare_args() {
   # Enables the use of priority-inheritance mutexes via PTHREAD_PRIO_INHERIT.
   # Note that on Android platform (non-standalone) builds this flag is ignored
   # and the Android flag "use_rt_mutex" is used instead (perfetto_flags.aconfig)
-  # When building in chromium, we mirror the logic in chromium's base/BUILD.gn
-  # which says enable_mutex_priority_inheritance = is_android && (x64 || arm64)
-  # On chromium the BPF syscall sandbox allows PI mutexes only on 64bit Android.
+  # This is disabled in chromium, because the BPF-sandbox allows PI-futex only
+  # when a field-trial is enabled, which is incompatible with a build time flag.
   enable_perfetto_rt_mutex =
-      (!is_wasm &&
-       (((build_with_chromium && is_android) || perfetto_build_standalone) &&
-        (current_cpu == "x64" || current_cpu == "arm64"))) ||
-      is_perfetto_build_generator
+      !is_wasm && (perfetto_build_standalone || is_perfetto_build_generator) &&
+      !build_with_chromium
 }
 
 declare_args() {


### PR DESCRIPTION
Give up trying to enable RTFutex in chromium.
Turns out the bpf-sandbox allows it only when a field trial is enabled,
but that is incompatible with a build-time flag.

Bug: https://g-issues.chromium.org/issues/441377060
