### PR TITLE
Always use constexpr category registry with Find

### DIFF
--- a/include/perfetto/tracing/track_event_legacy.h
+++ b/include/perfetto/tracing/track_event_legacy.h
@@ -1004,19 +1004,19 @@ ConvertThreadId(const PerfettoLegacyCurrentThreadId&);
 // non-zero indicates at least one tracing session for this category is active.
 // Note that callers should not make any assumptions at what each bit represents
 // in the status byte. Does not support dynamic categories.
-#define TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category)              \
-  reinterpret_cast<const uint8_t*>(                                       \
-      [&] {                                                               \
-        static_assert(                                                    \
-            !std::is_same<::perfetto::DynamicCategory,                    \
-                          decltype(category)>::value,                     \
-            "Enabled flag pointers are not supported for dynamic trace "  \
-            "categories.");                                               \
-      },                                                                  \
-      PERFETTO_TRACK_EVENT_NAMESPACE::internal::kCategoryRegistry         \
-          .GetCategoryState(                                              \
-              PERFETTO_TRACK_EVENT_NAMESPACE::internal::kCategoryRegistry \
-                  .Find(category, /*is_dynamic=*/false)))
+#define TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category)             \
+  reinterpret_cast<const uint8_t*>(                                      \
+      [&] {                                                              \
+        static_assert(                                                   \
+            !std::is_same<::perfetto::DynamicCategory,                   \
+                          decltype(category)>::value,                    \
+            "Enabled flag pointers are not supported for dynamic trace " \
+            "categories.");                                              \
+      },                                                                 \
+      PERFETTO_TRACK_EVENT_NAMESPACE::internal::kCategoryRegistry        \
+          .GetCategoryState(PERFETTO_TRACK_EVENT_NAMESPACE::internal::   \
+                                kConstExprCategoryRegistry.Find(         \
+                                    category, /*is_dynamic=*/false)))
 
 // Given a pointer returned by TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED,
 // yields a pointer to the name of the corresponding category group.


### PR DESCRIPTION
Profiling of Chrome shows that about 5% of the cycles used by Perfetto tracing is in the TrackEventCategoryRegistry::StringEq method, which is constexpr and documented to be intended for compile-time category lookups. Since it's showing up in runtime traces, it's not always being executed at compile time.

The root cause is that there are two global TrackEventCategoryRegistry objects, `kConstExprCategoryRegistry` for compile-time lookups and `kCategoryRegistry` for runtime lookups. In theory a single constexpr object could be used for both purposes but due to https://bugs.llvm.org/show_bug.cgi?id=51558 the object that includes a pointer to runtime state data can't be constexpr. (See comments in track_event_macros.h.)

StringEq() is only called from the Find() method, which is only called in constexpr context. However one reference to it in track_event_legacy.h uses the non-constexpr `kCategoryRegistry` variable name, causing the compiler to execute the lookup at runtime.

