### PR TITLE
Remove py3_only from recipes.cfg

### DIFF
--- a/infra/config/recipes.cfg
+++ b/infra/config/recipes.cfg
@@ -13,7 +13,6 @@
     }
   },
   "project_id": "perfetto",
-  "py3_only": true,
   "recipes_path": "infra/luci",
   "repo_name": "perfetto"
 }


### PR DESCRIPTION
Python3 is used by default in recipes now and this config is not
necessary anymore.

Bug: [440235171](https://issues.chromium.org/issues/440235171)