### PR TITLE
tp: perform trace time conversion, assuming MONOTONIC for perf text

### DIFF
--- a/src/trace_processor/importers/perf_text/BUILD.gn
+++ b/src/trace_processor/importers/perf_text/BUILD.gn
@@ -25,6 +25,7 @@ source_set("perf_text") {
     ":perf_text_event",
     ":perf_text_sample_line_parser",
     "../../../../gn:default_deps",
+    "../../../../protos/perfetto/trace:minimal_zero",
     "../../sorter",
     "../../storage",
     "../../tables",

--- a/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
+++ b/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
@@ -15,11 +15,11 @@
  */
 
 #include "src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.h"
-#include "src/trace_processor/importers/perf_text/perf_text_trace_parser.h"
 
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -28,19 +28,24 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
+#include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/mapping_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"
 #include "src/trace_processor/importers/common/virtual_memory_mapping.h"
 #include "src/trace_processor/importers/perf_text/perf_text_event.h"
 #include "src/trace_processor/importers/perf_text/perf_text_sample_line_parser.h"
+#include "src/trace_processor/importers/perf_text/perf_text_trace_parser.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
 #include "src/trace_processor/storage/stats.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/trace_blob_view_reader.h"
+
+#include "protos/perfetto/trace/clock_snapshot.pbzero.h"
 
 namespace perfetto::trace_processor::perf_text_importer {
 
@@ -63,6 +68,9 @@ PerfTextTraceTokenizer::PerfTextTraceTokenizer(TraceProcessorContext* ctx)
 PerfTextTraceTokenizer::~PerfTextTraceTokenizer() = default;
 
 base::Status PerfTextTraceTokenizer::Parse(TraceBlobView blob) {
+  context_->clock_tracker->SetTraceTimeClock(
+      protos::pbzero::ClockSnapshot::Clock::MONOTONIC);
+
   reader_.PushBack(std::move(blob));
   std::vector<FrameId> frames;
   // Loop over each sample.
@@ -157,7 +165,11 @@ base::Status PerfTextTraceTokenizer::Parse(TraceBlobView blob) {
     evt.pid = sample->pid;
     evt.callsite_id = *parent_callsite;
 
-    stream_->Push(sample->ts, evt);
+    ASSIGN_OR_RETURN(
+        int64_t trace_ts,
+        context_->clock_tracker->ToTraceTime(
+            protos::pbzero::ClockSnapshot::Clock::MONOTONIC, sample->ts));
+    stream_->Push(trace_ts, evt);
     reader_.PopFrontUntil(it.file_offset());
   }
 }


### PR DESCRIPTION
Required when merging multiple traces together.
