### PR TITLE
ui: Tidy up initialPluginRouteArgs

### DIFF
--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -21,7 +21,7 @@ import {SqlPackage} from '../public/extra_sql_packages';
 import {FeatureFlagManager, FlagSettings} from '../public/feature_flag';
 import {PageHandler} from '../public/page';
 import {Raf} from '../public/raf';
-import {RouteArgs} from '../public/route_schema';
+import {RouteArg, RouteArgs} from '../public/route_schema';
 import {Setting, SettingsManager} from '../public/settings';
 import {DurationPrecision, TimestampFormat} from '../public/timeline';
 import {NewEngineMode} from '../trace_processor/engine';
@@ -187,9 +187,7 @@ export class AppContext {
 
 export class AppImpl implements App {
   readonly pluginId: string;
-  readonly initialPluginRouteArgs: {
-    [key: string]: number | boolean | string;
-  };
+  readonly initialPluginRouteArgs: RouteArgs;
   private readonly appCtx: AppContext;
   private readonly pageMgrProxy: PageManagerImpl;
 
@@ -210,7 +208,7 @@ export class AppImpl implements App {
     this.appCtx = appCtx;
     this.pluginId = pluginId;
 
-    const args: {[key: string]: string | number | boolean} = {};
+    const args: {[key: string]: RouteArg} = {};
     this.initialPluginRouteArgs = Object.entries(
       appCtx.initialRouteArgs,
     ).reduce((result, [key, value]) => {
@@ -218,8 +216,8 @@ export class AppImpl implements App {
       const regex = new RegExp(`^${pluginId}:(.+)$`);
       const match = key.match(regex);
 
-      // Only include entries that match the regex and have the right value type
-      if (match && ['string', 'number', 'boolean'].includes(typeof value)) {
+      // Only include entries that match the regex
+      if (match) {
         const newKey = match[1];
         // Use the capture group (what comes after the prefix) as the new key
         result[newKey] = value;

--- a/ui/src/plugins/dev.perfetto.AutoPinAndExpandTracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.AutoPinAndExpandTracks/index.ts
@@ -19,6 +19,7 @@ import {PerfettoPlugin} from '../../public/plugin';
 import {Track} from '../../public/track';
 import {z} from 'zod';
 import {assertIsInstance} from '../../base/logging';
+import {RouteArg} from '../../public/route_schema';
 
 const PLUGIN_ID = 'dev.perfetto.AutoPinAndExpandTracks';
 const SAVED_TRACKS_KEY = `${PLUGIN_ID}#savedPerfettoTracks`;
@@ -29,17 +30,12 @@ const URL_PARAM_EXPAND_TRACKS = 'expand_tracks_with_name_on_startup';
 const URL_PARAM_PINNED_TRACKS = 'pin_tracks_with_name_on_startup';
 
 // Parse the plugin parameters values, only one value support for now
-function getParamValues(pluginParams: string): string[] {
-  if (pluginParams == null) {
-    return [];
-  }
+function getParamValues(param: RouteArg | undefined): string[] {
+  if (typeof param === 'boolean') return [];
+  if (param === undefined) return [];
 
-  const trimmed = pluginParams.trim();
-
-  if (trimmed === '') {
-    return [];
-  }
-
+  const trimmed = param.trim();
+  if (trimmed === '') return [];
   return [trimmed];
 }
 
@@ -83,12 +79,12 @@ export default class AutoPinAndExpandTracks implements PerfettoPlugin {
       addOrReplaceNamedPinnedTracks(parsed.data);
     });
     document.body.appendChild(input);
-    const pluginParams = app.initialPluginRouteArgs ?? {};
+    const pluginParams = app.initialPluginRouteArgs;
     AutoPinAndExpandTracks.expandTracks = getParamValues(
-      String(pluginParams[URL_PARAM_EXPAND_TRACKS]),
+      pluginParams[URL_PARAM_EXPAND_TRACKS],
     );
     AutoPinAndExpandTracks.pinTracks = getParamValues(
-      String(pluginParams[URL_PARAM_PINNED_TRACKS]),
+      pluginParams[URL_PARAM_PINNED_TRACKS],
     );
   }
 

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {RouteArgs} from './route_schema';
+import {RouteArg, RouteArgs} from './route_schema';
 import {CommandManager} from './command';
 import {OmniboxManager} from './omnibox';
 import {SidebarManager} from './sidebar';
@@ -52,7 +52,7 @@ export interface App {
   /**
    * Args in the URL bar that start with this plugin's id.
    */
-  readonly initialPluginRouteArgs: {[key: string]: number | boolean | string};
+  readonly initialPluginRouteArgs: {[key: string]: RouteArg | undefined};
 
   /**
    * Returns the current trace object, if any. The instance being returned is

--- a/ui/src/public/route_schema.ts
+++ b/ui/src/public/route_schema.ts
@@ -14,6 +14,11 @@
 
 import {z} from 'zod';
 
+// Args are parsed by the Router into strings or booleans only.
+// E.g. ?hideSidebar=true&url=a?b?c -> {hideSidebar: true, url: 'a?b?c'}
+const argSchema = z.union([z.string(), z.boolean()]);
+export type RouteArg = z.infer<typeof argSchema>;
+
 // We use .catch(undefined) on every field below to make sure that passing an
 // invalid value doesn't invalidate the other keys which might be valid.
 // Zod default behaviour is atomic: either everything validates correctly or
@@ -72,7 +77,8 @@ export const ROUTE_SCHEMA = z
   })
 
   // Allow arbitrary values to pass through, these may be forwarded to plugins.
-  .catchall(z.union([z.number(), z.string(), z.boolean()]))
+  .catchall(argSchema)
+
   // default({}) ensures at compile-time that every entry is either optional or
   // has a default value.
   .default({});


### PR DESCRIPTION
- Omit the number type from initialPluginRouterArgs value type, as our
  URL parser can never generate numbers (only strings and booleans).
- Export RouterArg type for convenience.
- Tidy up usage of these args in dev.perfetto.AutoPinAndExpandTracks.