### PR TITLE
tp: perf_text: document clock assumptions

### DIFF
--- a/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
+++ b/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
@@ -68,6 +68,12 @@ PerfTextTraceTokenizer::PerfTextTraceTokenizer(TraceProcessorContext* ctx)
 PerfTextTraceTokenizer::~PerfTextTraceTokenizer() = default;
 
 base::Status PerfTextTraceTokenizer::Parse(TraceBlobView blob) {
+  // Guess the clock used for timestamps, which would normally be described in
+  // `perf script --header`, which we don't expect to be included.
+  // Further, if the recording was using the default perf_clock (typically
+  // equivalent to sched_clock), the latter doesn't have a representation in
+  // perfetto at the time of writing.
+  // Therefore, approximate all clocks as MONOTONIC.
   context_->clock_tracker->SetTraceTimeClock(
       protos::pbzero::ClockSnapshot::Clock::MONOTONIC);
 


### PR DESCRIPTION
I'd like us to be pedantic when guessing/assuming clocks going forward.
Here's my interpretation for "3abf62f957 tp: perform trace time
conversion, assuming MONOTONIC for perf text (#2759)"