### PR TITLE
tp: StructuredQuery SQL doesn't require cols anymore

### DIFF
--- a/protos/perfetto/perfetto_sql/structured_query.proto
+++ b/protos/perfetto/perfetto_sql/structured_query.proto
@@ -113,7 +113,7 @@ message PerfettoSqlStructuredQuery {
     // results with at least one column.
     optional string sql = 1;
 
-    // The name of columns which will be returned by the SQL. Required.
+    // The name of columns which will be returned by the SQL. Optional.
     repeated string column_names = 2;
 
     // A list of dependencies for this SQL query. Optional.

--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator.cc
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator.cc
@@ -338,17 +338,18 @@ base::StatusOr<std::string> GeneratorImpl::SqlSource(
     }
   }
 
+  std::string cols_str = "";
   if (sql.column_names()->size() == 0) {
-    return base::ErrStatus("Sql must specify columns");
+    cols_str = "*";
+  } else {
+    std::vector<std::string> cols;
+    for (auto it = sql.column_names(); it; ++it) {
+      cols.push_back(it->as_std_string());
+    }
+    cols_str = base::Join(cols, ", ");
   }
 
-  std::vector<std::string> cols;
-  for (auto it = sql.column_names(); it; ++it) {
-    cols.push_back(it->as_std_string());
-  }
-  std::string join_str = base::Join(cols, ", ");
-
-  std::string generated_sql = "(SELECT " + join_str + " FROM (" +
+  std::string generated_sql = "(SELECT " + cols_str + " FROM (" +
                               std::move(rewriter).Build().sql() + "))";
   return generated_sql;
 }

--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
@@ -538,6 +538,27 @@ TEST(StructuredQueryGeneratorTest, SqlSourceWithNoDependencies) {
     )"));
 }
 
+TEST(StructuredQueryGeneratorTest, SqlSourceWithNoColumns) {
+  StructuredQueryGenerator gen;
+  auto proto = ToProto(R"(
+    sql: {
+      sql: "SELECT s.id, s.ts, s.dur FROM slice s"
+    }
+  )");
+  auto ret = gen.Generate(proto.data(), proto.size());
+  ASSERT_OK_AND_ASSIGN(std::string res, ret);
+  ASSERT_THAT(res, EqualsIgnoringWhitespace(R"(
+    WITH
+    sq_0 AS (
+      SELECT * FROM (
+        SELECT *
+        FROM (SELECT s.id, s.ts, s.dur FROM slice s)
+      )
+    )
+    SELECT * FROM sq_0
+    )"));
+}
+
 TEST(StructuredQueryGeneratorTest, SqlSourceWithUnusedDependencies) {
   StructuredQueryGenerator gen;
   auto proto = ToProto(R"(


### PR DESCRIPTION
The fact that StructuredQuery required columns was making it very difficult to create Sql structured queries from Explore Page - we didn't know programatically what are the columns that user provided.

Not providing columns will just make you select all columns (`*`).