### PR TITLE
tp: fix subtle bug with perf text format

### DIFF
--- a/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
+++ b/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
@@ -151,6 +151,7 @@ base::Status PerfTextTraceTokenizer::Parse(TraceBlobView blob) {
     if (frames.empty()) {
       context_->storage->IncrementStats(
           stats::perf_text_importer_sample_no_frames);
+      reader_.PopFrontUntil(it.file_offset());
       continue;
     }
 


### PR DESCRIPTION
We were not correctly popping the read data on failure meaning it was
possible to get stuck in an infinite loop in the tokenizer.
