### PR TITLE
Add a banner to the Query page that points to the Perfetto SQL agent for query generation

### DIFF
--- a/python/tools/check_imports.py
+++ b/python/tools/check_imports.py
@@ -94,6 +94,9 @@ DEPS_ALLOWLIST = [
     # The record plugin needs access to the wasm .d.ts for trace_config_utils.
     ('/plugins/dev.perfetto.RecordTraceV2/*', '/gen/trace_config_utils'),
 
+    # The query page plugin needs access to globals.isInternalUser.
+    ('/plugins/dev.perfetto.QueryPage/*', '/frontend/globals'),
+
     # Misc legitimate deps.
     ('/frontend/index', ['/gen/*']),
     ('/traceconv/index', '/gen/traceconv'),

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -43,6 +43,7 @@ import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {ResizeHandle} from '../../widgets/resize_handle';
 import {Stack, StackAuto} from '../../widgets/stack';
 import {Icon} from '../../widgets/icon';
+import {globals} from '../../frontend/globals';
 
 class CopyHelper {
   private _copied = false;
@@ -75,7 +76,9 @@ export interface QueryPageAttrs {
   readonly editorText: string;
   readonly executedQuery?: string;
   readonly queryResult?: QueryResponse;
+
   onEditorContentUpdate?(content: string): void;
+
   onExecute?(query: string): void;
 }
 
@@ -120,7 +123,10 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
           }),
           m(
             Stack,
-            {orientation: 'horizontal', className: 'pf-query-page__hotkeys'},
+            {
+              orientation: 'horizontal',
+              className: 'pf-query-page__hotkeys',
+            },
             'or press',
             m(HotkeyGlyphs, {hotkey: 'Mod+Enter'}),
           ),
@@ -132,6 +138,31 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
           }),
         ]),
       ]),
+      globals.isInternalUser &&
+        m(
+          Box,
+          m(Callout, {icon: 'star', intent: Intent.None}, [
+            'Try out the ',
+            m(
+              'a',
+              {
+                href: 'http://go/perfetto-sql-agent',
+                target: '_blank',
+              },
+              'Perfetto SQL Agent',
+            ),
+            ' to generate SQL queries and ',
+            m(
+              'a',
+              {
+                href: 'http://go/perfetto-llm-user-guide#report-issues',
+                target: '_blank',
+              },
+              'give feedback',
+            ),
+            '!',
+          ]),
+        ),
       attrs.editorText.includes('"') &&
         m(
           Box,


### PR DESCRIPTION
Add a banner to the Query page that points to the Perfetto SQL agent for query generation. This banner is only visible to internal users (i.e. Googlers).

<img width="2327" height="347" alt="C6o9rxYTDv6LZsg" src="https://github.com/user-attachments/assets/357fd74b-d1b6-4ba7-aa3c-c03a37a438ef" />

The hyperlink opens up the agent on a new tab, which includes an example prompt on how to generate queries:

<img width="2594" height="1598" alt="BBFeCCQpvZHbZkC" src="https://github.com/user-attachments/assets/c75dce02-efae-4779-a9a5-a6cf22db4cb9" />
