### PR TITLE
tp: add missing index on parent id for perf samples

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/linux/perf/samples.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/perf/samples.sql
@@ -25,6 +25,8 @@ FROM _callstacks_for_callsites!((
 ORDER BY
   c.id;
 
+CREATE PERFETTO INDEX _linux_perf_raw_callstacks_parent_id_idx ON _linux_perf_raw_callstacks(parent_id);
+
 -- Table summarising the callstacks captured during all
 -- perf samples in the trace.
 --


### PR DESCRIPTION
Required as just below we join on parent_id. If the join happens the
wrong way around, we need this to be fast.
