### PR TITLE
ui: improve how source/line number aggregation works

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/linux/perf/samples.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/perf/samples.sql
@@ -25,6 +25,8 @@ FROM _callstacks_for_callsites!((
 ORDER BY
   c.id;
 
+CREATE PERFETTO INDEX _linux_perf_raw_callstacks_parent_id_idx ON _linux_perf_raw_callstacks(parent_id);
+
 -- Table summarising the callstacks captured during all
 -- perf samples in the trace.
 --

--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -53,9 +53,7 @@ export interface QueryFlamegraphColumn {
 
 export interface AggQueryFlamegraphColumn extends QueryFlamegraphColumn {
   // The aggregation to be run when nodes are merged together in the flamegraph.
-  //
-  // TODO(lalitm): consider adding extra functions here (e.g. a top 5 or similar).
-  readonly mergeAggregation: 'ONE_OR_NULL' | 'SUM' | 'CONCAT_WITH_COMMA';
+  readonly mergeAggregation: 'ONE_OR_SUMMARY' | 'SUM' | 'CONCAT_WITH_COMMA';
 }
 
 export interface QueryFlamegraphMetric {
@@ -518,8 +516,14 @@ function getPivotFilter(
 function computeGroupedAggExprs(agg: ReadonlyArray<AggQueryFlamegraphColumn>) {
   const aggFor = (x: AggQueryFlamegraphColumn) => {
     switch (x.mergeAggregation) {
-      case 'ONE_OR_NULL':
-        return `IIF(COUNT() = 1, ${x.name}, NULL) AS ${x.name}`;
+      case 'ONE_OR_SUMMARY':
+        return `
+          IIF(
+            COUNT(DISTINCT ${x.name}) = 1,
+            ${x.name},
+            MIN(${x.name}) || ' and ' || COUNT(DISTINCT ${x.name}) || ' others'
+          ) AS ${x.name}
+        `;
       case 'SUM':
         return `SUM(${x.name}) AS ${x.name}`;
       case 'CONCAT_WITH_COMMA':

--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -518,10 +518,10 @@ function computeGroupedAggExprs(agg: ReadonlyArray<AggQueryFlamegraphColumn>) {
     switch (x.mergeAggregation) {
       case 'ONE_OR_SUMMARY':
         return `
-          IIF(
-            COUNT(DISTINCT ${x.name}) = 1,
-            ${x.name},
-            MIN(${x.name}) || ' and ' || COUNT(DISTINCT ${x.name}) || ' others'
+          ${x.name} || IIF(
+            COUNT() = 1,
+            '',
+            ' ' || ' and ' || cast_string!(COUNT(DISTINCT ${x.name})) || ' others'
           ) AS ${x.name}
         `;
       case 'SUM':

--- a/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_details_panel.ts
@@ -50,8 +50,7 @@ export class CpuProfileSampleFlamegraphDetailsPanel
             parent_id as parentId,
             name,
             mapping_name,
-            source_file,
-            cast(line_number AS text) as line_number,
+            source_file || ':' || line_number as source_location,
             self_count
           from _callstacks_for_callsites!((
             select p.callsite_id
@@ -71,14 +70,9 @@ export class CpuProfileSampleFlamegraphDetailsPanel
       [{name: 'mapping_name', displayName: 'Mapping'}],
       [
         {
-          name: 'source_file',
-          displayName: 'Source File',
-          mergeAggregation: 'ONE_OR_NULL',
-        },
-        {
-          name: 'line_number',
-          displayName: 'Line Number',
-          mergeAggregation: 'ONE_OR_NULL',
+          name: 'source_location',
+          displayName: 'Source Location',
+          mergeAggregation: 'ONE_OR_SUMMARY',
         },
       ],
     );

--- a/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
@@ -132,8 +132,7 @@ function computeCpuProfileFlamegraph(trace: Trace, selection: AreaSelection) {
           parent_id as parentId,
           name,
           mapping_name,
-          source_file,
-          cast(line_number AS text) as line_number,
+          source_file || ':' || line_number as source_location,
           self_count
         from _callstacks_for_callsites!((
           select p.callsite_id
@@ -155,14 +154,9 @@ function computeCpuProfileFlamegraph(trace: Trace, selection: AreaSelection) {
     [{name: 'mapping_name', displayName: 'Mapping'}],
     [
       {
-        name: 'source_file',
-        displayName: 'Source File',
-        mergeAggregation: 'ONE_OR_NULL',
-      },
-      {
-        name: 'line_number',
-        displayName: 'Line Number',
-        mergeAggregation: 'ONE_OR_NULL',
+        name: 'source_location',
+        displayName: 'Source Location',
+        mergeAggregation: 'ONE_OR_SUMMARY',
       },
     ],
   );

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -425,8 +425,7 @@ function flamegraphMetricsForHeapProfile(
           parent_id as parentId,
           name,
           mapping_name,
-          source_file,
-          cast(line_number AS text) as line_number,
+          source_file || ':' || line_number as source_location,
           self_size,
           self_count,
           self_alloc_size,
@@ -448,14 +447,9 @@ function flamegraphMetricsForHeapProfile(
     [{name: 'mapping_name', displayName: 'Mapping'}],
     [
       {
-        name: 'source_file',
-        displayName: 'Source File',
-        mergeAggregation: 'ONE_OR_NULL',
-      },
-      {
-        name: 'line_number',
-        displayName: 'Line Number',
-        mergeAggregation: 'ONE_OR_NULL',
+        name: 'source_location',
+        displayName: 'Source Location',
+        mergeAggregation: 'ONE_OR_SUMMARY',
       },
     ],
   );

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
@@ -71,8 +71,7 @@ export function createProcessInstrumentsSamplesProfileTrack(
               parent_id as parentId,
               name,
               mapping_name,
-              source_file,
-              cast(line_number AS text) as line_number,
+              source_file || ':' || line_number as source_location,
               self_count
             from _callstacks_for_callsites!((
               select p.callsite_id
@@ -95,14 +94,9 @@ export function createProcessInstrumentsSamplesProfileTrack(
         [{name: 'mapping_name', displayName: 'Mapping'}],
         [
           {
-            name: 'source_file',
-            displayName: 'Source File',
-            mergeAggregation: 'ONE_OR_NULL',
-          },
-          {
-            name: 'line_number',
-            displayName: 'Line Number',
-            mergeAggregation: 'ONE_OR_NULL',
+            name: 'source_location',
+            displayName: 'Source Location',
+            mergeAggregation: 'ONE_OR_SUMMARY',
           },
         ],
       );
@@ -160,8 +154,7 @@ export function createThreadInstrumentsSamplesProfileTrack(
               parent_id as parentId,
               name,
               mapping_name,
-              source_file,
-              cast(line_number AS text) as line_number,
+              source_file || ':' || line_number as source_location,
               self_count
             from _callstacks_for_callsites!((
               select p.callsite_id
@@ -183,14 +176,9 @@ export function createThreadInstrumentsSamplesProfileTrack(
         [{name: 'mapping_name', displayName: 'Mapping'}],
         [
           {
-            name: 'source_file',
-            displayName: 'Source File',
-            mergeAggregation: 'ONE_OR_NULL',
-          },
-          {
-            name: 'line_number',
-            displayName: 'Line Number',
-            mergeAggregation: 'ONE_OR_NULL',
+            name: 'source_location',
+            displayName: 'Source Location',
+            mergeAggregation: 'ONE_OR_SUMMARY',
           },
         ],
       );

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
@@ -303,8 +303,7 @@ function computePerfSampleFlamegraph(
           parent_id as parentId,
           name,
           mapping_name,
-          source_file,
-          cast(line_number AS text) as line_number,
+          source_file || ':' || line_number as source_location,
           self_count
         from _callstacks_for_callsites!((
           select p.callsite_id
@@ -330,14 +329,9 @@ function computePerfSampleFlamegraph(
     [{name: 'mapping_name', displayName: 'Mapping'}],
     [
       {
-        name: 'source_file',
-        displayName: 'Source File',
-        mergeAggregation: 'ONE_OR_NULL',
-      },
-      {
-        name: 'line_number',
-        displayName: 'Line Number',
-        mergeAggregation: 'ONE_OR_NULL',
+        name: 'source_location',
+        displayName: 'Source Location',
+        mergeAggregation: 'ONE_OR_SUMMARY',
       },
     ],
   );

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
@@ -71,8 +71,7 @@ export function createProcessPerfSamplesProfileTrack(
               parent_id as parentId,
               name,
               mapping_name,
-              source_file,
-              cast(line_number AS text) as line_number,
+              source_file || ':' || line_number as source_location,
               self_count
             from _callstacks_for_callsites!((
               select p.callsite_id
@@ -95,14 +94,9 @@ export function createProcessPerfSamplesProfileTrack(
         [{name: 'mapping_name', displayName: 'Mapping'}],
         [
           {
-            name: 'source_file',
-            displayName: 'Source File',
-            mergeAggregation: 'ONE_OR_NULL',
-          },
-          {
-            name: 'line_number',
-            displayName: 'Line Number',
-            mergeAggregation: 'ONE_OR_NULL',
+            name: 'source_location',
+            displayName: 'Source Location',
+            mergeAggregation: 'ONE_OR_SUMMARY',
           },
         ],
       );
@@ -160,8 +154,7 @@ export function createThreadPerfSamplesProfileTrack(
               parent_id as parentId,
               name,
               mapping_name,
-              source_file,
-              cast(line_number AS text) as line_number,
+              source_file || ':' || line_number as source_location,
               self_count
             from _callstacks_for_callsites!((
               select p.callsite_id
@@ -183,14 +176,9 @@ export function createThreadPerfSamplesProfileTrack(
         [{name: 'mapping_name', displayName: 'Mapping'}],
         [
           {
-            name: 'source_file',
-            displayName: 'Source File',
-            mergeAggregation: 'ONE_OR_NULL',
-          },
-          {
-            name: 'line_number',
-            displayName: 'Line Number',
-            mergeAggregation: 'ONE_OR_NULL',
+            name: 'source_location',
+            displayName: 'Source Location',
+            mergeAggregation: 'ONE_OR_SUMMARY',
           },
         ],
       );


### PR DESCRIPTION
* instead of returning null for when there are multiple source files,
  return a summary at least indicating the first line
* use distinct to detect if the same file is repeated many times instead
  of relying on a simple count
* switch line number to use concat_with_comma: line numbers are small
  enough and infrequent enough to just list all of them.
