### PR TITLE
ui: don't require process name for critical path

### DIFF
--- a/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
@@ -189,7 +189,7 @@ export default class implements PerfettoPlugin {
                     trace_bounds.end_ts - trace_bounds.start_ts) cr,
                   trace_bounds
                 JOIN thread USING(utid)
-                JOIN process USING(upid)
+                LEFT JOIN process USING(upid)
               `,
                 columns: sliceLiteColumnNames,
               },
@@ -266,7 +266,7 @@ export default class implements PerfettoPlugin {
                       ${window.start},
                       ${window.end} - ${window.start}) cr
                 JOIN thread USING(utid)
-                JOIN process USING(upid)
+                LEFT JOIN process USING(upid)
                 `,
             columns: criticalPathsliceLiteColumnNames,
           },


### PR DESCRIPTION
LEFT JOIN to allow correct behaviour even when process names are not
collected (e.g. in other trace types)
