### PR TITLE
luci: include winscope in luci build.

### DIFF
--- a/infra/luci/recipes/perfetto.py
+++ b/infra/luci/recipes/perfetto.py
@@ -74,7 +74,7 @@ def GnArgs(platform):
   (os, cpu) = platform.split('-')
   base_args = " ".join([
       'is_clang=true', 'monolithic_binaries=true', 'is_debug=false',
-      'enable_perfetto_winscope=false', 'enable_perfetto_etm_importer=false'
+      'enable_perfetto_etm_importer=false'
   ])
   if os not in ('android', 'linux', 'mac'):
     return base_args  # No cross-compiling on Windows.


### PR DESCRIPTION
Required as we need an official build available to update the Flicker TP binaries.

Bug: 312910010