### PR TITLE
ui: Make the isInternalUser flag available to regular plugins

### DIFF
--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -543,6 +543,10 @@ export class TraceImpl implements Trace {
   get settings(): SettingsManager {
     return this.settingsProxy;
   }
+
+  get isInternalUser(): boolean {
+    return this.appImpl.isInternalUser;
+  }
 }
 
 // A convenience interface to inject the App in Mithril components.

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -65,6 +65,11 @@ export interface App {
    */
   readonly raf: Raf;
 
+  // True if the current user is an 'internal' user. E.g. a Googler on
+  // ui.perfetto.dev. Plugins might use this to determine whether to show
+  // certain internal links or expose certain experimental features by default.
+  readonly isInternalUser: boolean;
+
   /**
    * Navigate to a new page.
    */


### PR DESCRIPTION
This allows normal plugins (not core plugins) to be able to access the isInternalUser flag on the App and Trace objects.
