### PR TITLE
ui: Add CopyToClipboardButton widget

### DIFF
--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*
-TODO(stevegolton):
-- Add debug track button....
-*/
-
 import m from 'mithril';
 import {findRef, toHTMLElement} from '../../base/dom_utils';
 import {download} from '../../base/download_utils';
@@ -43,32 +38,10 @@ import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {ResizeHandle} from '../../widgets/resize_handle';
 import {Stack, StackAuto} from '../../widgets/stack';
 import {Icon} from '../../widgets/icon';
-
-class CopyHelper {
-  private _copied = false;
-  private timeoutId: ReturnType<typeof setTimeout> | undefined;
-  private readonly timeout: number;
-
-  constructor(timeout = 2000) {
-    this.timeout = timeout;
-  }
-
-  get copied(): boolean {
-    return this._copied;
-  }
-
-  async copy(text: string) {
-    await navigator.clipboard.writeText(text);
-    this._copied = true;
-    m.redraw();
-
-    clearTimeout(this.timeoutId);
-    this.timeoutId = setTimeout(() => {
-      this._copied = false;
-      m.redraw();
-    }, this.timeout);
-  }
-}
+import {
+  CopyHelper,
+  CopyToClipboardButton,
+} from '../../widgets/copy_to_clipboard_button';
 
 export interface QueryPageAttrs {
   readonly trace: Trace;
@@ -302,29 +275,4 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
       ],
     );
   }
-}
-
-interface CopyToClipboardButtonAttrs {
-  readonly textToCopy: string;
-  readonly title?: string;
-  readonly label?: string;
-}
-
-function CopyToClipboardButton() {
-  const helper = new CopyHelper();
-
-  return {
-    view({attrs}: m.Vnode<CopyToClipboardButtonAttrs>): m.Children {
-      const label = helper.copied ? 'Copied' : attrs.label;
-      return m(Button, {
-        title: attrs.title ?? 'Copy to clipboard',
-        icon: helper.copied ? Icons.Check : Icons.Copy,
-        intent: helper.copied ? Intent.Success : Intent.None,
-        label,
-        onclick: async () => {
-          await helper.copy(attrs.textToCopy);
-        },
-      });
-    },
-  };
 }

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -61,6 +61,7 @@ import {MiddleEllipsis} from '../../widgets/middle_ellipsis';
 import {Chip} from '../../widgets/chip';
 import {TrackShell} from '../../widgets/track_shell';
 import {CopyableLink} from '../../widgets/copyable_link';
+import {CopyToClipboardButton} from '../../widgets/copy_to_clipboard_button';
 import {VirtualOverlayCanvas} from '../../widgets/virtual_overlay_canvas';
 import {SplitPanel, Tab} from '../../widgets/split_panel';
 import {parseAndPrintTree} from '../../base/perfetto_sql_lang/language';
@@ -969,6 +970,21 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
           }),
         initialOpts: {
           noicon: false,
+        },
+      }),
+      m(WidgetShowcase, {
+        label: 'CopyToClipboardButton',
+        renderWidget: (opts) =>
+          m(CopyToClipboardButton, {
+            textToCopy: 'Text to copy',
+            ...opts,
+          }),
+        initialOpts: {
+          label: 'Copy',
+          variant: new EnumOption(
+            ButtonVariant.Outlined,
+            Object.values(ButtonVariant),
+          ),
         },
       }),
       m(WidgetShowcase, {

--- a/ui/src/widgets/copy_to_clipboard_button.ts
+++ b/ui/src/widgets/copy_to_clipboard_button.ts
@@ -1,0 +1,76 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Icons} from '../base/semantic_icons';
+import {Button, ButtonVariant} from './button';
+import {Intent} from './common';
+
+export class CopyHelper {
+  private _copied = false;
+  private timeoutId: ReturnType<typeof setTimeout> | undefined;
+  private readonly timeout: number;
+
+  constructor(timeout = 2000) {
+    this.timeout = timeout;
+  }
+
+  get copied(): boolean {
+    return this._copied;
+  }
+
+  async copy(text: string) {
+    await navigator.clipboard.writeText(text);
+    this._copied = true;
+    m.redraw();
+
+    clearTimeout(this.timeoutId);
+    this.timeoutId = setTimeout(() => {
+      this._copied = false;
+      m.redraw();
+    }, this.timeout);
+  }
+}
+
+export interface CopyToClipboardButtonAttrs {
+  readonly textToCopy: string;
+  readonly title?: string;
+  readonly label?: string;
+  readonly variant?: ButtonVariant;
+}
+
+export function CopyToClipboardButton(): m.Component<CopyToClipboardButtonAttrs> {
+  const helper = new CopyHelper();
+
+  return {
+    view({attrs}: m.Vnode<CopyToClipboardButtonAttrs>): m.Children {
+      const hasLabel = Boolean(attrs.label);
+      const label = (function () {
+        if (!hasLabel) return '';
+        if (helper.copied) return 'Copied';
+        return attrs.label;
+      })();
+      return m(Button, {
+        variant: attrs.variant,
+        title: attrs.title ?? 'Copy to clipboard',
+        icon: helper.copied ? Icons.Check : Icons.Copy,
+        intent: helper.copied ? Intent.Success : Intent.None,
+        label,
+        onclick: async () => {
+          await helper.copy(attrs.textToCopy);
+        },
+      });
+    },
+  };
+}


### PR DESCRIPTION
A button that copies text to the clipboard when clicked and also provides some visual feedback.

![copy-to-clipboard-button](https://github.com/user-attachments/assets/a648a5f4-bf77-4d06-95c3-aa2145181bf1)

