### PR TITLE
ui: Fix flow arrowhead rendering for vertical arrow separation

### DIFF
--- a/ui/src/base/bezier_arrow.ts
+++ b/ui/src/base/bezier_arrow.ts
@@ -82,8 +82,8 @@ export function drawBezierArrow(
   const cp2 = endVec.add(endOffset);
 
   ctx.beginPath();
-  ctx.moveTo(start.x, start.y);
-  ctx.bezierCurveTo(cp1.x, cp1.y, cp2.x, cp2.y, end.x, end.y);
+  ctx.moveTo(startVec.x, startVec.y);
+  ctx.bezierCurveTo(cp1.x, cp1.y, cp2.x, cp2.y, endVec.x, endVec.y);
   ctx.stroke();
 }
 

--- a/ui/src/frontend/viewer_page/flow_events_renderer.ts
+++ b/ui/src/frontend/viewer_page/flow_events_renderer.ts
@@ -17,6 +17,7 @@ import {
   HorizontalBounds,
   Point2D,
   Size2D,
+  Vector2D,
   VerticalBounds,
 } from '../../base/geom';
 import {TimeScale} from '../../base/time_scale';
@@ -221,8 +222,8 @@ function drawArrow(
   ctx.fillStyle = `hsl(${hue}, 50%, ${intensity}%)`;
   ctx.lineWidth = width;
 
-  // TODO(stevegolton): Consider vertical distance too
-  const roomForArrowHead = Math.abs(start.x - end.x) > 3 * TRIANGLE_SIZE;
+  const dist = new Vector2D(end).sub(new Vector2D(start)).manhattanDistance;
+  const roomForArrowHead = dist > 3 * TRIANGLE_SIZE;
 
   let startStyle: ArrowHeadStyle;
   if (start.kind === 'vertical_edge') {

--- a/ui/src/frontend/viewer_page/flow_events_renderer.ts
+++ b/ui/src/frontend/viewer_page/flow_events_renderer.ts
@@ -222,8 +222,10 @@ function drawArrow(
   ctx.fillStyle = `hsl(${hue}, 50%, ${intensity}%)`;
   ctx.lineWidth = width;
 
-  const dist = new Vector2D(end).sub(new Vector2D(start)).manhattanDistance;
-  const roomForArrowHead = dist > 3 * TRIANGLE_SIZE;
+  const dist = new Vector2D(end).sub(new Vector2D(start));
+  const roomForArrowHead =
+    Math.abs(dist.x) > 3 * TRIANGLE_SIZE ||
+    Math.abs(dist.y) > 2 * TRIANGLE_SIZE;
 
   let startStyle: ArrowHeadStyle;
   if (start.kind === 'vertical_edge') {


### PR DESCRIPTION
Currently, flow arrowheads are omitted when the start and end points are close together, but the proximity check only considers the x-axis distance. This causes arrowheads to be hidden even when flows span different tracks with adequate vertical separation, making it difficult to discern arrow direction.

This patch calculates wether the start and end points are far enough away in _either_ axis, instead of using only the x-axis distance to determine whether to render the arrowhead.

Also fixed a bug in the arrowhead rendering logic where the arrow body emerges from the arrowhead tip instead of the back of the arrowhead.

Before:
<img width="190" height="161" alt="image" src="https://github.com/user-attachments/assets/281c1255-298f-48c0-ac5a-b54b7b2dea28" />

Arrowhead presence logic fised (but with arrowhead rendering bug):
<img width="212" height="141" alt="image" src="https://github.com/user-attachments/assets/5cf57902-cde1-40b2-b6ee-33a80e410306" />

Final:
<img width="214" height="114" alt="image" src="https://github.com/user-attachments/assets/252c1108-da53-4186-a064-9fc1d6c41e4c" />



