### PR TITLE
ui: Fix bug where child track titles stick to the wrong place inside non-summary track groups

### DIFF
--- a/ui/src/frontend/viewer_page/track_tree_view.ts
+++ b/ui/src/frontend/viewer_page/track_tree_view.ts
@@ -175,8 +175,10 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
       // Advance the global top position.
       top += trackView.height;
 
-      // Advance the sticky top position for our children.
-      const childStickyTop = stickyTop + trackView.height;
+      // Advance the sticky top position for our children, if we are sticky.
+      const childStickyTop = node.isSummary
+        ? stickyTop + trackView.height
+        : stickyTop;
 
       const children =
         (node.expanded || filtersApplied) &&


### PR DESCRIPTION
Before:
![before](https://github.com/user-attachments/assets/ee5e31d1-e8d1-48b4-9fbf-15acf3d9aa6d)

After:
![after](https://github.com/user-attachments/assets/74999818-20ae-4341-9774-4353e8259ddd)

