### PR TITLE
ui: Replace unstyled 'a' elements with 'Anchor'

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.ts
@@ -248,7 +248,7 @@ export class FlagsPage implements m.ClassComponent<FlagsPageAttrs> {
           m(
             'span',
             'Are you looking for plugins? These have moved to the ',
-            m('a', {href: '#!/plugins'}, 'plugins'),
+            m(Anchor, {href: '#!/plugins'}, 'plugins'),
             ' page.',
           ),
         ),

--- a/ui/src/frontend/error_dialog.ts
+++ b/ui/src/frontend/error_dialog.ts
@@ -23,6 +23,8 @@ import {Router} from '../core/router';
 import {Button, ButtonVariant} from '../widgets/button';
 import {Intent} from '../widgets/common';
 import {Checkbox} from '../widgets/checkbox';
+import {Anchor} from '../widgets/anchor';
+import {Icons} from '../base/semantic_icons';
 
 const MODAL_KEY = 'crash_modal';
 
@@ -306,7 +308,7 @@ function showOutOfMemoryDialog() {
       m('.pf-modal-bash', tpCmd),
       m('br'),
       m('span', 'For details see '),
-      m('a', {href: url, target: '_blank'}, url),
+      m(Anchor, {href: url, target: '_blank', icon: Icons.ExternalLink}, url),
     ),
   });
 }
@@ -348,7 +350,15 @@ function showWebUSBError() {
       m('.pf-modal-bash', '> adb kill-server'),
       m('br'),
       m('span', 'For details see '),
-      m('a', {href: 'http://b/159048331', target: '_blank'}, 'b/159048331'),
+      m(
+        Anchor,
+        {
+          href: 'http://b/159048331',
+          target: '_blank',
+          icon: Icons.ExternalLink,
+        },
+        'b/159048331',
+      ),
     ),
   });
 }

--- a/ui/src/frontend/legacy_trace_viewer.ts
+++ b/ui/src/frontend/legacy_trace_viewer.ts
@@ -20,6 +20,8 @@ import {showModal} from '../widgets/modal';
 import {utf8Decode} from '../base/string_utils';
 import {convertToJson} from './trace_converter';
 import {assetSrc} from '../base/assets';
+import {Anchor} from '../widgets/anchor';
+import {Icons} from '../base/semantic_icons';
 
 const CTRACE_HEADER = 'TRACE:\n';
 
@@ -198,10 +200,11 @@ export async function openInOldUIWithSizeCheck(trace: Blob): Promise<void> {
         'p',
         'More options can be found at ',
         m(
-          'a',
+          Anchor,
           {
             href: 'https://goto.google.com/opening-large-traces',
             target: '_blank',
+            icon: Icons.ExternalLink,
           },
           'go/opening-large-traces',
         ),

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -52,6 +52,8 @@ import {LinearProgress} from '../widgets/linear_progress';
 import {taskTracker} from './task_tracker';
 import {Button} from '../widgets/button';
 import {initCssConstants} from './css_constants';
+import {Anchor} from '../widgets/anchor';
+import {Icons} from '../base/semantic_icons';
 
 const showStatusBarFlag = featureFlags.register({
   id: 'Enable status bar',
@@ -888,8 +890,11 @@ export class UiMainPerTrace implements m.ClassComponent {
           'Perfetto UI features are limited for JSON traces. ',
           'We recommend recording ',
           m(
-            'a',
-            {href: 'https://perfetto.dev/docs/quickstart/chrome-tracing'},
+            Anchor,
+            {
+              href: 'https://perfetto.dev/docs/quickstart/chrome-tracing',
+              icon: Icons.ExternalLink,
+            },
             'proto-format traces',
           ),
           ' from Chrome.',


### PR DESCRIPTION
The Anchor widget has better theme support than plain 'a' elements.
