### PR TITLE
tp: Fix segfault in tree partition

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/structural_tree_partition.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/structural_tree_partition.cc
@@ -96,6 +96,9 @@ void StructuralTreePartition::StructuralTreePartition::Step(
           "NULL parent_id) expected.");
     }
     agg_ctx.root = Row{id, kNullParentId, group};
+    if (id >= agg_ctx.child_count_by_id.size()) {
+      agg_ctx.child_count_by_id.resize(id + 1);
+    }
     return;
   }
 


### PR DESCRIPTION
During the Step phase, the code builds a child_count_by_id vector to store the number of children for each node. It correctly resized this vector whenever it saw a non-root node with an ID larger than the vector's current size. However, it missed doing this check for the root node (the one with a NULL parent).

If the root node happened to have the largest ID in the entire tree, the child_count_by_id vector was never made large enough to include its ID. This led to a crash in the Final phase, which would try to read from an out-of-bounds index in that vector when processing the root node's children, causing the segmentation fault.

The fix was to add the missing size check for the root node in the Step function so that when the root node is found, the child_count_by_id vector is resized to be large enough to include the root's ID.

This guarantees that the vector is always correctly sized for all nodes in the tree, preventing the out-of-bounds read and fixing the crash.