### PR TITLE
Winscope geometry fixes.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14491,6 +14491,7 @@ filegroup {
     srcs: [
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor_unittest.cc",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation_unittest.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_geometry_unittest.cc",
     ],
 }
 

--- a/src/trace_processor/importers/proto/winscope/BUILD.gn
+++ b/src/trace_processor/importers/proto/winscope/BUILD.gn
@@ -99,5 +99,7 @@ perfetto_unittest_source_set("unittests") {
     "surfaceflinger_layers_extractor_unittest.cc",
     "surfaceflinger_layers_test_utils.h",
     "surfaceflinger_layers_visibility_computation_unittest.cc",
+    "winscope_geometry_test_utils.h",
+    "winscope_geometry_unittest.cc",
   ]
 }

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_test_utils.h
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_test_utils.h
@@ -17,16 +17,12 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_SURFACEFLINGER_LAYERS_TEST_UTILS_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_SURFACEFLINGER_LAYERS_TEST_UTILS_H_
 
-#include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation.h"
-
 #include <optional>
-#include <unordered_map>
 #include <vector>
 
-#include "protos/perfetto/trace/android/graphics/rect.gen.h"
 #include "protos/perfetto/trace/android/surfaceflinger_common.gen.h"
 #include "protos/perfetto/trace/android/surfaceflinger_layers.gen.h"
-#include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h"
 
 namespace perfetto::trace_processor::winscope::surfaceflinger_layers::test {
 
@@ -46,9 +42,6 @@ struct ActiveBuffer {
 
 namespace {
 using LayerProto = protos::gen::LayerProto;
-using FloatRectProto = protos::gen::FloatRectProto;
-using RectProto = protos::gen::RectProto;
-
 void UpdateColor(protos::gen::LayerProto* layer, Color color) {
   auto* color_proto = layer->mutable_color();
   color_proto->set_r(color.r);
@@ -63,20 +56,6 @@ void UpdateActiveBuffer(protos::gen::LayerProto* layer, ActiveBuffer buffer) {
   buffer_proto->set_height(buffer.height);
   buffer_proto->set_stride(buffer.stride);
   buffer_proto->set_format(buffer.format);
-}
-
-void UpdateRect(protos::gen::FloatRectProto* rect_proto, geometry::Rect rect) {
-  rect_proto->set_left(static_cast<float>(rect.x));
-  rect_proto->set_top(static_cast<float>(rect.y));
-  rect_proto->set_right(static_cast<float>(rect.x + rect.w));
-  rect_proto->set_bottom(static_cast<float>(rect.y + rect.h));
-}
-
-void UpdateRect(protos::gen::RectProto* rect_proto, geometry::Rect rect) {
-  rect_proto->set_left(static_cast<int32_t>(rect.x));
-  rect_proto->set_top(static_cast<int32_t>(rect.y));
-  rect_proto->set_right(static_cast<int32_t>(rect.x + rect.w));
-  rect_proto->set_bottom(static_cast<int32_t>(rect.y + rect.h));
 }
 }  // namespace
 
@@ -214,15 +193,16 @@ class SnapshotProtoBuilder {
         UpdateActiveBuffer(layer_proto, layer.active_buffer_.value());
       }
       if (layer.source_bounds_.has_value()) {
-        UpdateRect(layer_proto->mutable_source_bounds(),
-                   layer.source_bounds_.value());
+        geometry::test::UpdateRect(layer_proto->mutable_source_bounds(),
+                                   layer.source_bounds_.value());
       }
       if (layer.screen_bounds_.has_value()) {
-        UpdateRect(layer_proto->mutable_screen_bounds(),
-                   layer.screen_bounds_.value());
+        geometry::test::UpdateRect(layer_proto->mutable_screen_bounds(),
+                                   layer.screen_bounds_.value());
       }
       if (layer.bounds_.has_value()) {
-        UpdateRect(layer_proto->mutable_bounds(), layer.bounds_.value());
+        geometry::test::UpdateRect(layer_proto->mutable_bounds(),
+                                   layer.bounds_.value());
       }
       if (layer.flags_.has_value()) {
         layer_proto->set_flags(layer.flags_.value());
@@ -237,7 +217,7 @@ class SnapshotProtoBuilder {
       if (layer.visible_region_rects_.has_value()) {
         auto* visible_region_proto = layer_proto->mutable_visible_region();
         for (auto& rect : layer.visible_region_rects_.value()) {
-          UpdateRect(visible_region_proto->add_rect(), rect);
+          geometry::test::UpdateRect(visible_region_proto->add_rect(), rect);
         }
       }
       if (layer.is_opaque_.has_value()) {

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
@@ -59,11 +59,7 @@ Rect::Rect(double left, double top, double right, double bottom) {
 }
 
 bool Rect::IsEmpty() const {
-  const bool null_value_present = IsFloatEqual(x, -1) || IsFloatEqual(y, -1) ||
-                                  IsFloatEqual(x + w, -1) ||
-                                  IsFloatEqual(y + h, -1);
-  const bool null_h_or_w = w <= 0 || h <= 0;
-  return null_value_present || null_h_or_w;
+  return w <= 0 || h <= 0;
 }
 
 Rect Rect::CropRect(const Rect& other) const {
@@ -75,8 +71,14 @@ Rect Rect::CropRect(const Rect& other) const {
 }
 
 bool Rect::ContainsRect(const Rect& other) const {
-  return (w > 0 && h > 0 && x <= other.x && y <= other.y &&
-          (x + w >= other.x + other.w) && (y + h >= other.y + other.h));
+  auto right = x + w;
+  auto other_right = other.x + other.w;
+  auto bottom = y + h;
+  auto other_bottom = other.y + other.h;
+  return !IsEmpty() && (x <= other.x || IsFloatClose(x, other.x)) &&
+         (y <= other.y || IsFloatClose(y, other.y)) &&
+         ((right >= other_right) || IsFloatClose(right, other_right)) &&
+         ((bottom >= other_bottom) || IsFloatClose(bottom, other_bottom));
 }
 
 bool Rect::IntersectsRect(const Rect& other) const {

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_GEOMETRY_TEST_UTILS_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_GEOMETRY_TEST_UTILS_H_
+
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry.h"
+
+#include "protos/perfetto/trace/android/graphics/rect.gen.h"
+#include "protos/perfetto/trace/android/surfaceflinger_common.gen.h"
+#include "protos/perfetto/trace/android/surfaceflinger_layers.gen.h"
+
+namespace perfetto::trace_processor::winscope::geometry::test {
+
+using FloatRectProto = protos::gen::FloatRectProto;
+using RectProto = protos::gen::RectProto;
+
+inline void UpdateRect(protos::gen::FloatRectProto* rect_proto,
+                       geometry::Rect rect) {
+  rect_proto->set_left(static_cast<float>(rect.x));
+  rect_proto->set_top(static_cast<float>(rect.y));
+  rect_proto->set_right(static_cast<float>(rect.x + rect.w));
+  rect_proto->set_bottom(static_cast<float>(rect.y + rect.h));
+}
+
+inline void UpdateRect(protos::gen::RectProto* rect_proto,
+                       geometry::Rect rect) {
+  rect_proto->set_left(static_cast<int32_t>(rect.x));
+  rect_proto->set_top(static_cast<int32_t>(rect.y));
+  rect_proto->set_right(static_cast<int32_t>(rect.x + rect.w));
+  rect_proto->set_bottom(static_cast<int32_t>(rect.y + rect.h));
+}
+}  // namespace perfetto::trace_processor::winscope::geometry::test
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_GEOMETRY_TEST_UTILS_H_

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry_unittest.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry_unittest.cc
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry.h"
+
+#include "protos/perfetto/trace/android/graphics/rect.gen.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::winscope::geometry::test {
+
+namespace {
+const Rect test_rect(1, 2, 10, 15);
+
+void CheckRectEquality(Rect rect, Rect other) {
+  ASSERT_EQ(rect.x, other.x);
+  ASSERT_EQ(rect.y, other.y);
+  ASSERT_EQ(rect.w, other.w);
+  ASSERT_EQ(rect.h, other.h);
+}
+}  // namespace
+
+TEST(WinscopeGeometryRect, BuildsFromLTRB) {
+  ASSERT_EQ(test_rect.x, 1);
+  ASSERT_EQ(test_rect.y, 2);
+  ASSERT_EQ(test_rect.w, 9);
+  ASSERT_EQ(test_rect.h, 13);
+}
+
+TEST(WinscopeGeometryRect, BuildsFromRectProto) {
+  protos::gen::RectProto rect_proto;
+  UpdateRect(&rect_proto, test_rect);
+  auto blob = rect_proto.SerializeAsString();
+  protos::pbzero::RectProto::Decoder rect_decoder(blob);
+  auto rect_from_proto = Rect(rect_decoder);
+  CheckRectEquality(rect_from_proto, test_rect);
+}
+
+TEST(WinscopeGeometryRect, BuildsFromFloatRectProto) {
+  protos::gen::FloatRectProto rect_proto;
+  UpdateRect(&rect_proto, test_rect);
+  auto blob = rect_proto.SerializeAsString();
+  protos::pbzero::FloatRectProto::Decoder rect_decoder(blob);
+  auto rect_from_proto = Rect(rect_decoder);
+  CheckRectEquality(rect_from_proto, test_rect);
+}
+
+TEST(WinscopeGeometryRectIsEmpty, ZeroRect) {
+  auto rect = Rect(0, 0, 0, 0);
+  ASSERT_TRUE(rect.IsEmpty());
+}
+
+TEST(WinscopeGeometryRectIsEmpty, NegativeHW) {
+  auto rect = Rect(0, 0, -10, -10);
+  ASSERT_TRUE(rect.IsEmpty());
+}
+
+TEST(WinscopeGeometryRectIsEmpty, ValidRect) {
+  ASSERT_FALSE(test_rect.IsEmpty());
+}
+
+TEST(WinscopeGeometryRectIsEmpty, NegativeLT) {
+  auto rect = Rect(-1, -1, 0, 0);
+  ASSERT_FALSE(rect.IsEmpty());
+}
+
+TEST(WinscopeGeometryRectCropRect, ReducesHeight) {
+  auto rect = Rect(0, 0, 2, 10);
+  auto crop = Rect(0, 0, 10, 5);
+  auto cropped_rect = rect.CropRect(crop);
+  auto expected_rect = Rect(0, 0, 2, 5);
+  CheckRectEquality(expected_rect, cropped_rect);
+}
+
+TEST(WinscopeGeometryRectCropRect, ReducesWidth) {
+  auto rect = Rect(0, 0, 10, 2);
+  auto crop = Rect(0, 0, 5, 10);
+  auto cropped_rect = rect.CropRect(crop);
+  auto expected_rect = Rect(0, 0, 5, 2);
+  CheckRectEquality(expected_rect, cropped_rect);
+}
+
+TEST(WinscopeGeometryRectCropRect, NoChangeForLargerCrop) {
+  auto rect = Rect(0, 0, 5, 5);
+  auto crop = Rect(0, 0, 10, 10);
+  auto cropped_rect = rect.CropRect(crop);
+  CheckRectEquality(cropped_rect, rect);
+}
+
+TEST(WinscopeGeometryRectContainsRect, ExactMatch) {
+  ASSERT_TRUE(test_rect.ContainsRect(test_rect));
+}
+
+TEST(WinscopeGeometryRectContainsRect, MatchWithinThreshold) {
+  auto other = Rect(0.99994, 1.99994, 5, 5);
+  ASSERT_TRUE(test_rect.ContainsRect(other));
+}
+
+TEST(WinscopeGeometryRectContainsRect, SmallerRect) {
+  auto other = Rect(1.5, 2.5, 9.5, 14.5);
+  ASSERT_TRUE(test_rect.ContainsRect(other));
+}
+
+TEST(WinscopeGeometryRectContainsRect, LargerRect) {
+  auto rect = Rect(1.5, 2.5, 9.5, 14.5);
+  ASSERT_FALSE(rect.ContainsRect(test_rect));
+}
+
+TEST(WinscopeGeometryRectIntersectsRect, ExactMatch) {
+  ASSERT_TRUE(test_rect.IntersectsRect(test_rect));
+}
+
+TEST(WinscopeGeometryRectIntersectsRect, Overlap) {
+  auto rect = Rect(0, 0, 5, 5);
+  auto other = Rect(2, 2, 7, 7);
+  ASSERT_TRUE(rect.IntersectsRect(other));
+}
+
+TEST(WinscopeGeometryRectIntersectsRect, NoOverlap) {
+  auto rect = Rect(0, 0, 5, 5);
+  auto other = Rect(5, 5, 10, 10);
+  ASSERT_FALSE(rect.IntersectsRect(other));
+}
+
+TEST(WinscopeGeometryRectIsAlmostEqual, SameRects) {
+  auto other = Rect(1, 2, 10, 15);
+  ASSERT_TRUE(test_rect.IsAlmostEqual(other));
+}
+
+TEST(WinscopeGeometryRectIsAlmostEqual, WithinThreshold) {
+  auto other = Rect(1, 2, 10, 15.005);
+  ASSERT_TRUE(test_rect.IsAlmostEqual(other));
+}
+
+TEST(WinscopeGeometryRectIsAlmostEqual, OutsideThreshold) {
+  auto other = Rect(1, 2, 10, 15.011);
+  ASSERT_FALSE(test_rect.IsAlmostEqual(other));
+}
+
+TEST(WinscopeGeometryRectIsAlmostEqual, DifferentRects) {
+  auto other = Rect(1, 2, 10, 16);
+  ASSERT_FALSE(test_rect.IsAlmostEqual(other));
+}
+}  // namespace perfetto::trace_processor::winscope::geometry::test


### PR DESCRIPTION
Surfaced during Flicker test cleanup.

Bug: 312910010
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="SurfaceFlingerLayer|PerfettoTable:winscope"
Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=WinscopeGeometry*
