### PR TITLE
Clean up single-arg `testing::Invoke()`s in `src/base/` (1/n)

### DIFF
--- a/src/base/metatrace_unittest.cc
+++ b/src/base/metatrace_unittest.cc
@@ -29,7 +29,6 @@ namespace perfetto {
 namespace {
 
 namespace m = ::perfetto::metatrace;
-using ::testing::Invoke;
 
 class MetatraceTest : public ::testing::Test {
  public:
@@ -150,7 +149,7 @@ TEST_F(MetatraceTest, HandleOverruns) {
     Enable(m::TAG_ANY);
     std::string checkpoint_name = "ReadTask " + std::to_string(iteration);
     auto checkpoint = task_runner_.CreateCheckpoint(checkpoint_name);
-    EXPECT_CALL(*this, ReadCallback()).WillOnce(Invoke(checkpoint));
+    EXPECT_CALL(*this, ReadCallback()).WillOnce(checkpoint);
 
     for (size_t i = 0; i < m::RingBuffer::kCapacity; i++)
       m::TraceCounter(/*tag=*/1, /*id=*/42, /*value=*/cnt++);
@@ -200,7 +199,7 @@ TEST_F(MetatraceTest, InterleavedReadWrites) {
     last_value_read = last;
   };
 
-  EXPECT_CALL(*this, ReadCallback()).WillRepeatedly(Invoke(read_task));
+  EXPECT_CALL(*this, ReadCallback()).WillRepeatedly(read_task);
 
   // The writer will write continuously counters from 0 to kMaxValue.
   auto writer_done = task_runner_.CreateCheckpoint("writer_done");
@@ -239,7 +238,7 @@ TEST_F(MetatraceTest, ThreadRaces) {
 
     std::string checkpoint_name = "ReadTask " + std::to_string(iteration);
     auto checkpoint = task_runner_.CreateCheckpoint(checkpoint_name);
-    EXPECT_CALL(*this, ReadCallback()).WillOnce(Invoke(checkpoint));
+    EXPECT_CALL(*this, ReadCallback()).WillOnce(checkpoint);
 
     auto thread_main = [](uint16_t thd_idx) {
       for (size_t i = 0; i < m::RingBuffer::kCapacity + 500; i++)

--- a/src/base/scoped_sched_boost_unittest.cc
+++ b/src/base/scoped_sched_boost_unittest.cc
@@ -31,7 +31,6 @@
 using testing::_;
 using testing::ElementsAre;
 using testing::Eq;
-using testing::Invoke;
 using testing::NiceMock;
 using testing::Return;
 
@@ -67,14 +66,13 @@ class MockSchedOsHooks : public SchedOsHooks {
  public:
   explicit MockSchedOsHooks(SchedOsConfig init_config)
       : current_config(init_config) {
-    ON_CALL(*this, GetCurrentSchedConfig()).WillByDefault(Invoke([&] {
+    ON_CALL(*this, GetCurrentSchedConfig()).WillByDefault([&] {
       return current_config;
-    }));
-    ON_CALL(*this, SetSchedConfig)
-        .WillByDefault(Invoke([&](const SchedOsConfig& arg) {
-          current_config = arg;
-          return OkStatus();
-        }));
+    });
+    ON_CALL(*this, SetSchedConfig).WillByDefault([&](const SchedOsConfig& arg) {
+      current_config = arg;
+      return OkStatus();
+    });
   }
   MOCK_METHOD(base::Status, SetSchedConfig, (const SchedOsConfig&), (override));
   MOCK_METHOD(base::StatusOr<base::SchedOsHooks::SchedOsConfig>,
@@ -183,13 +181,13 @@ TEST_F(ScopedSchedBoostTest, MoveOperation) {
 
 TEST_F(ScopedSchedBoostTest, IgnoreWrongConfig) {
   ON_CALL(sched_hooks_, SetSchedConfig(_))
-      .WillByDefault(Invoke([&](const SchedOsHooks::SchedOsConfig& arg) {
+      .WillByDefault([&](const SchedOsHooks::SchedOsConfig& arg) {
         if (arg.policy == SCHED_FIFO && arg.rt_prio < 1) {
           return ErrStatus("Priority for SCHED_FIFO policy must be >= 1");
         }
         sched_hooks_.current_config = arg;
         return OkStatus();
-      }));
+      });
 
   auto ok_other_boost = ScopedSchedBoost::Boost(
       SchedPolicyAndPrio{SchedPolicyAndPrio::Policy::kSchedOther, 5});


### PR DESCRIPTION
[Not needed and deprecated][0]. This PR will help unblock rolling GoogleTest in Chromium: https://crbug.com/439838457

`gemini-cli` assisted with the generation of this PR.

[0]: https://github.com/google/googletest/blob/a05c0915074bcd1b82f232e081da9bb6c205c28d/googlemock/include/gmock/gmock-actions.h#L2045