### PR TITLE
Clean up single-arg `testing::Invoke()`s in `src/traced/` (4/n)

### DIFF
--- a/src/traced/probes/android_log/android_log_data_source_unittest.cc
+++ b/src/traced/probes/android_log/android_log_data_source_unittest.cc
@@ -27,7 +27,6 @@
 
 using ::perfetto::protos::gen::AndroidLogConfig;
 using ::perfetto::protos::gen::AndroidLogId;
-using ::testing::Invoke;
 using ::testing::Return;
 
 namespace perfetto {
@@ -68,8 +67,9 @@ class AndroidLogDataSourceTest : public ::testing::Test {
     ASSERT_TRUE(send_sock);
     ASSERT_TRUE(recv_sock);
 
-    EXPECT_CALL(*data_source_, ConnectLogdrSocket())
-        .WillOnce(Invoke([&recv_sock] { return std::move(recv_sock); }));
+    EXPECT_CALL(*data_source_, ConnectLogdrSocket()).WillOnce([&recv_sock] {
+      return std::move(recv_sock);
+    });
 
     data_source_->Start();
 

--- a/src/traced/probes/ftrace/ftrace_config_muxer_unittest.cc
+++ b/src/traced/probes/ftrace/ftrace_config_muxer_unittest.cc
@@ -34,7 +34,6 @@ using testing::Contains;
 using testing::ElementsAre;
 using testing::ElementsAreArray;
 using testing::Eq;
-using testing::Invoke;
 using testing::IsEmpty;
 using testing::NiceMock;
 using testing::Not;
@@ -944,12 +943,12 @@ TEST_F(FtraceConfigMuxerFakeTableTest, AtraceErrorsPropagated) {
       RunAtrace(ElementsAreArray({"atrace", "--async_start", "--only_userspace",
                                   "cat_1", "cat_2"}),
                 _))
-      .WillOnce(Invoke([](const std::vector<std::string>&, std::string* err) {
+      .WillOnce([](const std::vector<std::string>&, std::string* err) {
         EXPECT_NE(err, nullptr);
         if (err)
           err->append("foo\nbar\n");
         return true;
-      }));
+      });
 
   FtraceSetupErrors errors{};
   FtraceConfigId id_a = 23;

--- a/src/traced/probes/ps/process_stats_data_source_unittest.cc
+++ b/src/traced/probes/ps/process_stats_data_source_unittest.cc
@@ -38,7 +38,6 @@ using ::testing::_;
 using ::testing::Contains;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
-using ::testing::Invoke;
 using ::testing::Mock;
 using ::testing::Return;
 using ::testing::Truly;
@@ -186,12 +185,12 @@ TEST_F(ProcessStatsDataSourceTest, DontRescanCachedPIDsAndTIDs) {
   auto data_source = GetProcessStatsDataSource(ds_config);
   for (int p : {10, 11, 12, 20, 21, 22, 30, 31, 32}) {
     EXPECT_CALL(*data_source, ReadProcPidFile(p, "status"))
-        .WillOnce(Invoke([](int32_t pid, const std::string&) {
+        .WillOnce([](int32_t pid, const std::string&) {
           int32_t tgid = (pid / 10) * 10;
           return "Name: \tthread_" + std::to_string(pid) +
                  "\nTgid:  " + std::to_string(tgid) +
                  "\nPid:   " + std::to_string(pid) + "\nPPid:  1\n";
-        }));
+        });
     if (p % 10 == 0) {
       std::string proc_name = "proc_" + std::to_string(p);
       proc_name.resize(proc_name.size() + 1);  // Add a trailing \0.
@@ -315,11 +314,11 @@ TEST_F(ProcessStatsDataSourceTest, RenamePids) {
   auto data_source = GetProcessStatsDataSource(config);
   for (int p : {10, 20}) {
     EXPECT_CALL(*data_source, ReadProcPidFile(p, "status"))
-        .WillRepeatedly(Invoke([](int32_t pid, const std::string&) {
+        .WillRepeatedly([](int32_t pid, const std::string&) {
           return "Name: \tthread_" + std::to_string(pid) +
                  "\nTgid:  " + std::to_string(pid) +
                  "\nPid:   " + std::to_string(pid) + "\nPPid:  1\n";
-        }));
+        });
 
     std::string old_proc_name = "proc_" + std::to_string(p);
     old_proc_name.resize(old_proc_name.size() + 1);  // Add a trailing \0.
@@ -401,43 +400,41 @@ TEST_F(ProcessStatsDataSourceTest, ProcessStats) {
   auto checkpoint = task_runner_.CreateCheckpoint("all_done");
 
   const std::string& fake_proc_path = fake_proc.path();
-  EXPECT_CALL(*data_source, OpenProcDir())
-      .WillRepeatedly(Invoke([&fake_proc_path] {
-        return base::ScopedDir(opendir(fake_proc_path.c_str()));
-      }));
+  EXPECT_CALL(*data_source, OpenProcDir()).WillRepeatedly([&fake_proc_path] {
+    return base::ScopedDir(opendir(fake_proc_path.c_str()));
+  });
   EXPECT_CALL(*data_source, GetProcMountpoint())
-      .WillRepeatedly(
-          Invoke([&fake_proc_path] { return fake_proc_path.c_str(); }));
+      .WillRepeatedly([&fake_proc_path] { return fake_proc_path.c_str(); });
 
   const int kNumIters = 4;
   int iter = 0;
   for (int pid : kPids) {
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "status"))
-        .WillRepeatedly(Invoke([&iter](int32_t p, const std::string&) {
+        .WillRepeatedly([&iter](int32_t p, const std::string&) {
           return base::StackString<1024>{
               "Name:	pid_10\nVmSize:	 %d kB\nVmRSS:\t%d  kB\n",
               p * 100 + iter * 10 + 1, p * 100 + iter * 10 + 2}
               .ToStdString();
-        }));
+        });
 
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "dmabuf_rss"))
-        .WillRepeatedly(Invoke([](int32_t, const std::string&) {
+        .WillRepeatedly([](int32_t, const std::string&) {
           return base::StackString<1024>{"%d\n", getpagesize()}.ToStdString();
-        }));
+        });
 
     // By default scan_smaps_rollup is off and /proc/<pid>/smaps_rollup
     // shouldn't be read.
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "smaps_rollup")).Times(0);
 
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "stat"))
-        .WillRepeatedly(Invoke([&iter](int32_t p, const std::string&) {
+        .WillRepeatedly([&iter](int32_t p, const std::string&) {
           return ToProcStatString(static_cast<uint64_t>(p * 100 + iter * 10),
                                   static_cast<uint64_t>(p * 200 + iter * 20),
                                   /*starttime_ticks=*/0);
-        }));
+        });
 
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "oom_score_adj"))
-        .WillRepeatedly(Invoke(
+        .WillRepeatedly(
             [checkpoint, kPids, &iter](int32_t inner_pid, const std::string&) {
               auto oom_score = inner_pid * 100 + iter * 10 + 3;
               if (inner_pid == kPids[base::ArraySize(kPids) - 1]) {
@@ -445,7 +442,7 @@ TEST_F(ProcessStatsDataSourceTest, ProcessStats) {
                   checkpoint();
               }
               return std::to_string(oom_score);
-            }));
+            });
   }
 
   data_source->Start();
@@ -510,32 +507,32 @@ TEST_F(ProcessStatsDataSourceTest, CacheProcessStats) {
 
   auto checkpoint = task_runner_.CreateCheckpoint("all_done");
 
-  EXPECT_CALL(*data_source, OpenProcDir()).WillRepeatedly(Invoke([&fake_proc] {
+  EXPECT_CALL(*data_source, OpenProcDir()).WillRepeatedly([&fake_proc] {
     return base::ScopedDir(opendir(fake_proc.path().c_str()));
-  }));
+  });
 
   const int kNumIters = 4;
   int iter = 0;
   EXPECT_CALL(*data_source, ReadProcPidFile(kPid, "status"))
-      .WillRepeatedly(Invoke([checkpoint](int32_t p, const std::string&) {
+      .WillRepeatedly([checkpoint](int32_t p, const std::string&) {
         base::StackString<1024> ret(
             "Name:	pid_10\nVmSize:	 %d kB\nVmRSS:\t%d  kB\n", p * 100 + 1,
             p * 100 + 2);
         return ret.ToStdString();
-      }));
+      });
 
   EXPECT_CALL(*data_source, ReadProcPidFile(kPid, "dmabuf_rss"))
-      .WillRepeatedly(Invoke([checkpoint](int32_t, const std::string&) {
+      .WillRepeatedly([checkpoint](int32_t, const std::string&) {
         return base::StackString<1024>{"%d\n", getpagesize()}.ToStdString();
-      }));
+      });
 
   EXPECT_CALL(*data_source, ReadProcPidFile(kPid, "oom_score_adj"))
       .WillRepeatedly(
-          Invoke([checkpoint, &iter](int32_t inner_pid, const std::string&) {
+          [checkpoint, &iter](int32_t inner_pid, const std::string&) {
             if (++iter == kNumIters)
               checkpoint();
             return std::to_string(inner_pid * 100);
-          }));
+          });
 
   data_source->Start();
   task_runner_.RunUntilCheckpoint("all_done");
@@ -623,40 +620,36 @@ TEST_F(ProcessStatsDataSourceTest, ScanSmapsRollupIsOn) {
 
   auto checkpoint = task_runner_.CreateCheckpoint("all_done");
   const auto fake_proc_path = fake_proc.path();
-  EXPECT_CALL(*data_source, OpenProcDir())
-      .WillRepeatedly(Invoke([&fake_proc_path] {
-        return base::ScopedDir(opendir(fake_proc_path.c_str()));
-      }));
+  EXPECT_CALL(*data_source, OpenProcDir()).WillRepeatedly([&fake_proc_path] {
+    return base::ScopedDir(opendir(fake_proc_path.c_str()));
+  });
   EXPECT_CALL(*data_source, GetProcMountpoint())
-      .WillRepeatedly(
-          Invoke([&fake_proc_path] { return fake_proc_path.c_str(); }));
+      .WillRepeatedly([&fake_proc_path] { return fake_proc_path.c_str(); });
 
   const int kNumIters = 4;
   int iter = 0;
   for (int pid : kPids) {
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "status"))
-        .WillRepeatedly(
-            Invoke([checkpoint, &iter](int32_t p, const std::string&) {
-              base::StackString<1024> ret(
-                  "Name:	pid_10\nVmSize:	 %d kB\nVmRSS:\t%d  kB\n",
-                  p * 100 + iter * 10 + 1, p * 100 + iter * 10 + 2);
-              return ret.ToStdString();
-            }));
+        .WillRepeatedly([checkpoint, &iter](int32_t p, const std::string&) {
+          base::StackString<1024> ret(
+              "Name:	pid_10\nVmSize:	 %d kB\nVmRSS:\t%d  kB\n",
+              p * 100 + iter * 10 + 1, p * 100 + iter * 10 + 2);
+          return ret.ToStdString();
+        });
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "dmabuf_rss"))
-        .WillRepeatedly(Invoke([](int32_t, const std::string&) {
+        .WillRepeatedly([](int32_t, const std::string&) {
           return base::StackString<1024>{"%d\n", getpagesize()}.ToStdString();
-        }));
+        });
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "smaps_rollup"))
-        .WillRepeatedly(
-            Invoke([checkpoint, &iter](int32_t p, const std::string&) {
-              base::StackString<1024> ret(
-                  "Name:	pid_10\nRss:	 %d kB\nPss:\t%d  kB\n",
-                  p * 100 + iter * 10 + 4, p * 100 + iter * 10 + 5);
-              return ret.ToStdString();
-            }));
+        .WillRepeatedly([checkpoint, &iter](int32_t p, const std::string&) {
+          base::StackString<1024> ret(
+              "Name:	pid_10\nRss:	 %d kB\nPss:\t%d  kB\n",
+              p * 100 + iter * 10 + 4, p * 100 + iter * 10 + 5);
+          return ret.ToStdString();
+        });
 
     EXPECT_CALL(*data_source, ReadProcPidFile(pid, "oom_score_adj"))
-        .WillRepeatedly(Invoke(
+        .WillRepeatedly(
             [checkpoint, kPids, &iter](int32_t inner_pid, const std::string&) {
               auto oom_score = inner_pid * 100 + iter * 10 + 3;
               if (inner_pid == kPids[base::ArraySize(kPids) - 1]) {
@@ -664,7 +657,7 @@ TEST_F(ProcessStatsDataSourceTest, ScanSmapsRollupIsOn) {
                   checkpoint();
               }
               return std::to_string(oom_score);
-            }));
+            });
   }
 
   data_source->Start();

--- a/src/traced/probes/sys_stats/sys_stats_data_source_unittest.cc
+++ b/src/traced/probes/sys_stats/sys_stats_data_source_unittest.cc
@@ -32,7 +32,6 @@
 #include "protos/perfetto/trace/sys_stats/sys_stats.gen.h"
 
 using ::testing::_;
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::UnorderedElementsAre;
 
@@ -494,9 +493,9 @@ TEST_F(SysStatsDataSourceTest, ThermalZones) {
   EXPECT_CALL(*data_source, OpenDirAndLogOnErrorOnce(
                                 "/sys/class/thermal/",
                                 data_source->GetThermalErrorLoggedAddress()))
-      .WillRepeatedly(Invoke([&fake_thermal_symdir] {
+      .WillRepeatedly([&fake_thermal_symdir] {
         return base::ScopedDir(opendir(fake_thermal_symdir.path().c_str()));
-      }));
+      });
 
   EXPECT_CALL(*data_source,
               ReadFileToUInt64("/sys/class/thermal/thermal_zone0/temp"))
@@ -547,17 +546,17 @@ TEST_F(SysStatsDataSourceTest, CpuIdleStates) {
   EXPECT_CALL(*data_source, OpenDirAndLogOnErrorOnce(
                                 "/sys/devices/system/cpu/",
                                 data_source->GetCpuIdleErrorLoggedAddress()))
-      .WillOnce(Invoke([&fake_cpuidle] {
+      .WillOnce([&fake_cpuidle] {
         return base::ScopedDir(opendir(fake_cpuidle.path().c_str()));
-      }));
+      });
 
   EXPECT_CALL(*data_source, OpenDirAndLogOnErrorOnce(
                                 "/sys/devices/system/cpu/cpu0/cpuidle/",
                                 data_source->GetCpuIdleErrorLoggedAddress()))
-      .WillRepeatedly(Invoke([&fake_cpuidle] {
+      .WillRepeatedly([&fake_cpuidle] {
         std::string path = fake_cpuidle.path() + "/cpu0/cpuidle";
         return base::ScopedDir(opendir(path.c_str()));
-      }));
+      });
 
   EXPECT_CALL(
       *data_source,
@@ -664,9 +663,9 @@ TEST_F(SysStatsDataSourceTest, DevfreqAll) {
   EXPECT_CALL(*data_source, OpenDirAndLogOnErrorOnce(
                                 "/sys/class/devfreq/",
                                 data_source->GetDevfreqErrorLoggedAddress()))
-      .WillRepeatedly(Invoke([&fake_devfreq_symdir] {
+      .WillRepeatedly([&fake_devfreq_symdir] {
         return base::ScopedDir(opendir(fake_devfreq_symdir.path().c_str()));
-      }));
+      });
   EXPECT_CALL(*data_source, ReadDevfreqCurFreq("10010.devfreq_device_a"))
       .WillRepeatedly(Return(kDevfreq1));
   EXPECT_CALL(*data_source, ReadDevfreqCurFreq("10020.devfreq_device_b"))


### PR DESCRIPTION
[Not needed and deprecated][0]. This PR will help unblock rolling GoogleTest in Chromium: https://crbug.com/439838457

`gemini-cli` assisted with the generation of this PR.

[0]: https://github.com/google/googletest/blob/a05c0915074bcd1b82f232e081da9bb6c205c28d/googlemock/include/gmock/gmock-actions.h#L2045