### PR TITLE
Clean up single-arg `testing::Invoke()`s in rest of `src/` (5/5)

### DIFF
--- a/src/protozero/proto_decoder_unittest.cc
+++ b/src/protozero/proto_decoder_unittest.cc
@@ -38,7 +38,6 @@ namespace {
 using ::testing::_;
 using ::testing::ElementsAre;
 using ::testing::InSequence;
-using ::testing::Invoke;
 using namespace proto_utils;
 
 TEST(ProtoDecoderTest, ReadString) {

--- a/src/trace_processor/importers/common/event_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/event_tracker_unittest.cc
@@ -35,7 +35,6 @@ namespace {
 
 using ::testing::_;
 using ::testing::InSequence;
-using ::testing::Invoke;
 
 class EventTrackerTest : public ::testing::Test {
  public:

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -31,7 +31,6 @@ namespace {
 
 using ::testing::_;
 using ::testing::InSequence;
-using ::testing::Invoke;
 
 class ProcessTrackerTest : public ::testing::Test {
  public:

--- a/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker_unittest.cc
+++ b/src/trace_processor/importers/ftrace/ftrace_sched_event_tracker_unittest.cc
@@ -36,7 +36,6 @@ namespace {
 
 using ::testing::_;
 using ::testing::InSequence;
-using ::testing::Invoke;
 
 class SchedEventTrackerTest : public ::testing::Test {
  public:

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -76,7 +76,6 @@ using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::IgnoreResult;
 using ::testing::InSequence;
-using ::testing::Invoke;
 using ::testing::InvokeArgument;
 using ::testing::NiceMock;
 using ::testing::Pointwise;

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -117,7 +117,6 @@ using ::testing::Eq;
 using ::testing::HasSubstr;
 using ::testing::IgnoreResult;
 using ::testing::InSequence;
-using ::testing::Invoke;
 using ::testing::InvokeArgument;
 using ::testing::NiceMock;
 using ::testing::Pointwise;

--- a/src/trace_processor/importers/proto/proto_trace_tokenizer_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_tokenizer_unittest.cc
@@ -22,7 +22,6 @@
 namespace perfetto::trace_processor {
 namespace {
 
-using testing::Invoke;
 using testing::MockFunction;
 
 std::string_view ToStringView(const TraceBlobView& tbv) {
@@ -41,14 +40,14 @@ TEST(ProtoTraceTokenizerTest, TwoPacketsSingleBlob) {
   ProtoTraceTokenizer tokenizer;
 
   EXPECT_CALL(cb, Call)
-      .WillOnce(Invoke([](TraceBlobView out) {
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload1");
         return base::OkStatus();
-      }))
-      .WillOnce(Invoke([](TraceBlobView out) {
+      })
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload2");
         return base::OkStatus();
-      }));
+      });
 
   auto bv = TraceBlobView(TraceBlob::CopyFrom(data.data(), data.size()));
   EXPECT_TRUE(tokenizer.Tokenize(std::move(bv), cb.AsStdFunction()).ok());
@@ -64,14 +63,14 @@ TEST(ProtoTraceTokenizerTest, TwoPacketsByteByByte) {
 
   MockFunction<base::Status(TraceBlobView)> cb;
   EXPECT_CALL(cb, Call)
-      .WillOnce(Invoke([](TraceBlobView out) {
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload1");
         return base::OkStatus();
-      }))
-      .WillOnce(Invoke([](TraceBlobView out) {
+      })
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload2");
         return base::OkStatus();
-      }));
+      });
 
   for (uint8_t c : data) {
     auto bv = TraceBlobView(TraceBlob::CopyFrom(&c, sizeof(c)));
@@ -94,18 +93,18 @@ TEST(ProtoTraceTokenizerTest, SkipFieldsSingleBlob) {
 
   MockFunction<base::Status(TraceBlobView)> cb;
   EXPECT_CALL(cb, Call)
-      .WillOnce(Invoke([](TraceBlobView out) {
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload1");
         return base::OkStatus();
-      }))
-      .WillOnce(Invoke([](TraceBlobView out) {
+      })
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload2");
         return base::OkStatus();
-      }))
-      .WillOnce(Invoke([](TraceBlobView out) {
+      })
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload3");
         return base::OkStatus();
-      }));
+      });
 
   auto bv = TraceBlobView(TraceBlob::CopyFrom(data.data(), data.size()));
   EXPECT_TRUE(tokenizer.Tokenize(std::move(bv), cb.AsStdFunction()).ok());
@@ -126,18 +125,18 @@ TEST(ProtoTraceTokenizerTest, SkipFieldsSingleByteByByte) {
 
   MockFunction<base::Status(TraceBlobView)> cb;
   EXPECT_CALL(cb, Call)
-      .WillOnce(Invoke([](TraceBlobView out) {
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload1");
         return base::OkStatus();
-      }))
-      .WillOnce(Invoke([](TraceBlobView out) {
+      })
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload2");
         return base::OkStatus();
-      }))
-      .WillOnce(Invoke([](TraceBlobView out) {
+      })
+      .WillOnce([](TraceBlobView out) {
         EXPECT_EQ(ToStringView(out), "payload3");
         return base::OkStatus();
-      }));
+      });
 
   for (uint8_t c : data) {
     auto bv = TraceBlobView(TraceBlob::CopyFrom(&c, sizeof(c)));

--- a/src/trace_processor/sorter/trace_sorter_unittest.cc
+++ b/src/trace_processor/sorter/trace_sorter_unittest.cc
@@ -41,7 +41,6 @@ namespace {
 
 using ::testing::_;
 using ::testing::InSequence;
-using ::testing::Invoke;
 using ::testing::MockFunction;
 using ::testing::NiceMock;
 
@@ -275,7 +274,7 @@ TEST_F(TraceSorterTest, MultiQueueSorting) {
 
     EXPECT_CALL(*sink_ptr, MockParse(_, _))
         .WillRepeatedly(
-            Invoke([&expectations](int64_t timestamp, FtraceEventData ftrace) {
+            [&expectations](int64_t timestamp, FtraceEventData ftrace) {
               EXPECT_EQ(expectations.begin()->first, timestamp);
               auto& cpus = expectations.begin()->second;
               bool cpu_found = false;
@@ -289,7 +288,7 @@ TEST_F(TraceSorterTest, MultiQueueSorting) {
               if (cpus.empty())
                 expectations.erase(expectations.begin());
               EXPECT_TRUE(cpu_found);
-            }));
+            });
   }
 
   // Allocate a 1000 byte trace blob and push one byte chunks to be sorted with

--- a/src/traced_relay/relay_service_unittest.cc
+++ b/src/traced_relay/relay_service_unittest.cc
@@ -33,7 +33,6 @@ namespace perfetto {
 namespace {
 
 using ::testing::_;
-using ::testing::Invoke;
 
 class TestEventListener : public base::UnixSocket::EventListener {
  public:
@@ -84,11 +83,11 @@ TEST(RelayServiceTest, SetPeerIdentity) {
       base::SockType::kStream);
   auto producer_connected = task_runner.CreateCheckpoint("producer_connected");
   EXPECT_CALL(producer_listener, OnConnect(_, _))
-      .WillOnce(Invoke([&](base::UnixSocket* s, bool conn) {
+      .WillOnce([&](base::UnixSocket* s, bool conn) {
         EXPECT_TRUE(conn);
         EXPECT_EQ(s, producer.get());
         producer_connected();
-      }));
+      });
   task_runner.RunUntilCheckpoint("producer_connected");
 
   // Add some producer data.
@@ -101,17 +100,17 @@ TEST(RelayServiceTest, SetPeerIdentity) {
   auto tcp_client_connected =
       task_runner.CreateCheckpoint("tcp_client_connected");
   EXPECT_CALL(tcp_listener, OnNewIncomingConnection(_))
-      .WillOnce(Invoke([&](base::UnixSocket* client) {
+      .WillOnce([&](base::UnixSocket* client) {
         tcp_client_connection = client;
         tcp_client_connected();
-      }));
+      });
   task_runner.RunUntilCheckpoint("tcp_client_connected");
 
   // Asserts that we can receive the SetPeerIdentity message.
   auto peer_identity_recv = task_runner.CreateCheckpoint("peer_identity_recv");
   ipc::BufferedFrameDeserializer deserializer;
   EXPECT_CALL(tcp_listener, OnDataAvailable(_))
-      .WillRepeatedly(Invoke([&](base::UnixSocket* tcp_conn) {
+      .WillRepeatedly([&](base::UnixSocket* tcp_conn) {
         auto buf = deserializer.BeginReceive();
         auto rsize = tcp_conn->Receive(buf.data, buf.size);
         EXPECT_TRUE(deserializer.EndReceive(rsize));
@@ -129,7 +128,7 @@ TEST(RelayServiceTest, SetPeerIdentity) {
         EXPECT_EQ(std::string("test_data"), frame->data_for_testing()[0]);
 
         peer_identity_recv();
-      }));
+      });
   task_runner.RunUntilCheckpoint("peer_identity_recv");
 }
 
@@ -187,17 +186,17 @@ TEST(RelayClientTest, OnErrorCallback) {
   auto tcp_client_connected =
       task_runner.CreateCheckpoint("tcp_client_connected");
   EXPECT_CALL(tcp_listener, OnNewIncomingConnection(_))
-      .WillOnce(Invoke([&](base::UnixSocket* client) {
+      .WillOnce([&](base::UnixSocket* client) {
         tcp_client_connection = client;
         tcp_client_connected();
-      }));
+      });
   task_runner.RunUntilCheckpoint("tcp_client_connected");
 
   // Just drain the data passed over the socket.
   EXPECT_CALL(tcp_listener, OnDataAvailable(_))
-      .WillRepeatedly(Invoke([&](base::UnixSocket* tcp_conn) {
+      .WillRepeatedly([&](base::UnixSocket* tcp_conn) {
         ::testing::IgnoreResult(tcp_conn->ReceiveString());
-      }));
+      });
 
   EXPECT_FALSE(relay_client->clock_synced_with_service_for_testing());
   // Shutdown the connected connection. The RelayClient should notice this
@@ -235,17 +234,17 @@ TEST(RelayClientTest, SetPeerIdentity) {
   auto tcp_client_connected =
       task_runner.CreateCheckpoint("tcp_client_connected");
   EXPECT_CALL(tcp_listener, OnNewIncomingConnection(_))
-      .WillOnce(Invoke([&](base::UnixSocket* client) {
+      .WillOnce([&](base::UnixSocket* client) {
         tcp_client_connection = client;
         tcp_client_connected();
-      }));
+      });
   task_runner.RunUntilCheckpoint("tcp_client_connected");
 
   // Asserts that we can receive the SetPeerIdentity message.
   auto peer_identity_recv = task_runner.CreateCheckpoint("peer_identity_recv");
   ipc::BufferedFrameDeserializer deserializer;
   EXPECT_CALL(tcp_listener, OnDataAvailable(_))
-      .WillRepeatedly(Invoke([&](base::UnixSocket* tcp_conn) {
+      .WillRepeatedly([&](base::UnixSocket* tcp_conn) {
         auto buf = deserializer.BeginReceive();
         auto rsize = tcp_conn->Receive(buf.data, buf.size);
         EXPECT_TRUE(deserializer.EndReceive(rsize));
@@ -259,7 +258,7 @@ TEST(RelayClientTest, SetPeerIdentity) {
         EXPECT_EQ(set_peer_identity.machine_id_hint(), "fake_machine_id_hint");
 
         peer_identity_recv();
-      }));
+      });
   task_runner.RunUntilCheckpoint("peer_identity_recv");
 }
 

--- a/test/priority_boost_integrationtest.cc
+++ b/test/priority_boost_integrationtest.cc
@@ -64,7 +64,6 @@ inline std::string ToString(const SchedOsHooks::SchedOsConfig& cfg) {
 
 namespace {
 using ::testing::Eq;
-using ::testing::Invoke;
 using ::testing::NiceMock;
 using ::testing::Return;
 
@@ -116,15 +115,15 @@ class PerfettoPriorityBoostIntegrationTest : public ::testing::Test {
   class MockSchedOsHooks : public base::SchedOsHooks {
    public:
     MockSchedOsHooks() : current_config(kInitConfig) {
-      ON_CALL(*this, GetCurrentSchedConfig()).WillByDefault(Invoke([&] {
+      ON_CALL(*this, GetCurrentSchedConfig()).WillByDefault([&] {
         return current_config;
-      }));
+      });
       ON_CALL(*this, SetSchedConfig)
-          .WillByDefault(Invoke([&](const SchedOsConfig& arg) {
+          .WillByDefault([&](const SchedOsConfig& arg) {
             PERFETTO_DCHECK(base::GetThreadId() == expected_boosted_thread);
             current_config = arg;
             return base::OkStatus();
-          }));
+          });
     }
     MOCK_METHOD(base::Status,
                 SetSchedConfig,


### PR DESCRIPTION
[Not needed and deprecated][0]. This PR will help unblock rolling GoogleTest in Chromium: https://crbug.com/439838457

`gemini-cli` assisted with the generation of this PR.

[0]: https://github.com/google/googletest/blob/a05c0915074bcd1b82f232e081da9bb6c205c28d/googlemock/include/gmock/gmock-actions.h#L2045