### PR TITLE
stdlib: Add suspend-aware CPU utilization metrics

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/process.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/process.sql
@@ -132,6 +132,8 @@ RETURNS TABLE (
   megacycles LONG,
   -- Total runtime duration
   runtime LONG,
+  -- Total runtime duration, while 'awake' (CPUs not suspended).
+  awake_runtime LONG,
   -- Minimum CPU frequency in kHz
   min_freq LONG,
   -- Maximum CPU frequency in kHz
@@ -156,6 +158,7 @@ SELECT
   cast_int!(SUM(ii.dur * freq / 1000)) AS millicycles,
   cast_int!(SUM(ii.dur * freq / 1000) / 1e9) AS megacycles,
   sum(ii.dur) AS runtime,
+  sum(to_monotonic(ii.ts + ii.dur) - to_monotonic(ii.ts)) AS awake_runtime,
   min(freq) AS min_freq,
   max(freq) AS max_freq,
   cast_int!(SUM((ii.dur * freq / 1000)) / SUM(ii.dur / 1000)) AS avg_freq
@@ -164,3 +167,49 @@ JOIN threads_counters
   USING (id)
 GROUP BY
   upid;
+
+-- Returns a table with process utilization over a given interval.
+--
+-- Utilization is computed as runtime over the duration of the interval, aggregated by process name.
+-- Utilization can be normalized (divide by number of cpus) or unnormalized.
+CREATE PERFETTO FUNCTION cpu_process_utilization_in_interval(
+    -- Start of the interval.
+    ts TIMESTAMP,
+    -- Duration of the interval.
+    dur LONG
+)
+RETURNS TABLE (
+  -- The name of the process
+  process_name STRING,
+  -- Total runtime of all processes with this name, while 'awake' (CPUs not suspended).
+  awake_dur LONG,
+  -- Percentage of 'awake_dur' over the 'awake' duration of the interval, normalized by the number of CPUs.
+  -- Values in [0.0, 100.0]
+  awake_utilization DOUBLE,
+  -- Percentage of 'awake_dur' over the 'awake' duration of the interval, unnormalized.
+  -- Values in [0.0, 100.0 * <number_of_cpus>]
+  awake_unnormalized_utilization DOUBLE
+) AS
+SELECT
+  process.name AS process_name,
+  sum(awake_runtime) AS awake_dur,
+  round(
+    sum(awake_runtime) * 100.0 / (
+      to_monotonic($ts + $dur) - to_monotonic($ts)
+    ) / (
+      SELECT
+        max(cpu) + 1
+      FROM cpu
+    ),
+    2
+  ) AS awake_utilization,
+  round(sum(awake_runtime) * 100.0 / (
+    to_monotonic($ts + $dur) - to_monotonic($ts)
+  ), 2) AS awake_unnormalized_utilization
+FROM cpu_cycles_per_process_in_interval($ts, $dur)
+JOIN process
+  USING (upid)
+WHERE
+  process.name IS NOT NULL
+GROUP BY
+  process.name;

--- a/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/process.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/process.sql
@@ -117,6 +117,9 @@ GROUP BY
   upid;
 
 -- Aggregated CPU statistics for each process in a provided interval.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_cycles_per_process_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,
@@ -172,6 +175,9 @@ GROUP BY
 --
 -- Utilization is computed as runtime over the duration of the interval, aggregated by process name.
 -- Utilization can be normalized (divide by number of cpus) or unnormalized.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_process_utilization_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,

--- a/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/slice.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/slice.sql
@@ -74,6 +74,9 @@ LEFT JOIN intersected
   ON slice_id = ts.id AND ts.dur = intersected.dur;
 
 -- CPU cycles per each slice in interval.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_cycles_per_thread_slice_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,

--- a/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/system.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/system.sql
@@ -100,6 +100,9 @@ SELECT
 FROM _cpu_freq_per_thread;
 
 -- Aggregated CPU statistics in a provided interval. Results in one row.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_cycles_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,
@@ -138,6 +141,9 @@ JOIN _cpu_freq_per_thread
 --
 -- Utilization  is computed as runtime over the duration of the interval.
 -- Utilization can be normalized (divide by number of cores) or unnormalized.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_utilization_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,
@@ -204,6 +210,9 @@ GROUP BY
   ucpu;
 
 -- Aggregated CPU statistics for each CPU in a provided interval.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_cycles_per_cpu_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,

--- a/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/thread.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/thread.sql
@@ -109,6 +109,9 @@ GROUP BY
   utid;
 
 -- Aggregated CPU statistics for each thread in a provided interval.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_cycles_per_thread_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,
@@ -152,6 +155,9 @@ GROUP BY
 --
 -- Utilization is computed as runtime over the duration of the interval, aggregated by thread name.
 -- Utilization can be normalized (divide by number of CPUs) or unnormalized.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION cpu_thread_utilization_in_interval(
     -- Start of the interval.
     ts TIMESTAMP,

--- a/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/thread.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/linux/cpu/utilization/thread.sql
@@ -124,6 +124,8 @@ RETURNS TABLE (
   megacycles LONG,
   -- Total runtime duration
   runtime LONG,
+  -- Total runtime duration, while 'awake' (CPUs not suspended).
+  awake_runtime LONG,
   -- Minimum CPU frequency in kHz
   min_freq LONG,
   -- Maximum CPU frequency in kHz
@@ -136,6 +138,7 @@ SELECT
   cast_int!(SUM(ii.dur * freq / 1000)) AS millicycles,
   cast_int!(SUM(ii.dur * freq / 1000 )/ 1e9) AS megacycles,
   sum(ii.dur) AS runtime,
+  sum(to_monotonic(ii.ts + ii.dur) - to_monotonic(ii.ts)) AS awake_runtime,
   min(freq) AS min_freq,
   max(freq) AS max_freq,
   cast_int!(SUM((ii.dur * freq / 1000)) / SUM(ii.dur / 1000)) AS avg_freq
@@ -144,3 +147,47 @@ JOIN _cpu_freq_per_thread AS c
   USING (id)
 GROUP BY
   utid;
+
+-- Returns a table of thread utilization over a given interval.
+--
+-- Utilization is computed as runtime over the duration of the interval, aggregated by thread name.
+-- Utilization can be normalized (divide by number of CPUs) or unnormalized.
+CREATE PERFETTO FUNCTION cpu_thread_utilization_in_interval(
+    -- Start of the interval.
+    ts TIMESTAMP,
+    -- Duration of the interval.
+    dur LONG
+)
+RETURNS TABLE (
+  -- The name of the thread
+  thread_name STRING,
+  -- Total runtime of all threads with this name, while 'awake' (CPUs not suspended).
+  awake_dur LONG,
+  -- Percentage of 'awake_dur' over the 'awake' duration of the interval, normalized by the number of CPUs.
+  -- Values in [0.0, 100.0]
+  awake_utilization DOUBLE,
+  -- Percentage of 'awake_dur' over the 'awake' duration of the interval, unnormalized.
+  -- Values in [0.0, 100.0 * <number_of_cpus>]
+  awake_unnormalized_utilization DOUBLE
+) AS
+SELECT
+  thread.name AS thread_name,
+  sum(awake_runtime) AS awake_dur,
+  round(
+    sum(awake_runtime) * 100.0 / (
+      to_monotonic($ts + $dur) - to_monotonic($ts)
+    ) / (
+      SELECT
+        max(cpu) + 1
+      FROM cpu
+    ),
+    2
+  ) AS awake_utilization,
+  round(sum(awake_runtime) * 100.0 / (
+    to_monotonic($ts + $dur) - to_monotonic($ts)
+  ), 2) AS awake_unnormalized_utilization
+FROM cpu_cycles_per_thread_in_interval($ts, $dur)
+JOIN thread
+  USING (utid)
+GROUP BY
+  thread.name;

--- a/src/trace_processor/perfetto_sql/stdlib/sched/time_in_state.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/sched/time_in_state.sql
@@ -171,6 +171,9 @@ ORDER BY
   4 DESC;
 
 -- Time the thread spent each state and cpu in a given interval.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION sched_time_in_state_and_cpu_for_thread_in_interval(
     -- The start of the interval.
     ts TIMESTAMP,
@@ -219,6 +222,9 @@ ORDER BY
   5 DESC;
 
 -- Time spent by CPU in each scheduling state in a provided interval.
+--
+-- This function is only designed to run over a small number of intervals
+-- (10-100 at most). It will be *very slow* for large sets of intervals.
 CREATE PERFETTO FUNCTION sched_time_in_state_for_cpu_in_interval(
     -- CPU id.
     cpu LONG,


### PR DESCRIPTION
This change introduces functions to calculate CPU utilization, accounting for potential suspend periods by using the monotonic clock for computation of durations.

Added 'awake_runtime' column to the result of the functions:
	- 'cpu_cycles_in_interval'
	- 'cpu_cycles_per_thread_in_interval'
	- 'cpu_cycles_per_process_in_interval' This new column measures runtime using 'sum(to_monotonic(ii.ts + ii.dur)- to_monotonic(ii.ts))', ensuring that time elapsed during system suspend is not included in the duration.

Introduced new utilization functions:
1. 'cpu_utilization_in_interval': all CPUs utilization over given interval;
2. 'cpu_thread_utilization_in_interval': per thread_name utilization over given interval;
3. 'cpu_process_utilization_in_interval': per process_name utilization over given interval;

These new functions consume the 'awake_runtime' from the modified functions from above. The output is:
	- ['thread_name'|'process_name']: for the thread/process functions
	- 'awake_dur': Total runtime while 'awake' (CPUs not suspended)
	- 'awake_utilization': Percentage of 'awake_dur' over the 'awake' duration of the given interval, normalized by the number of CPUs. Values in [0.0, 100.0]
	- 'awake_unnormalized_utilization': unnormalized percentage. Values in [0.0, 100.0 * <number_of_cpus>]

Added new test cases to
`test/trace_processor/diff_tests/stdlib/linux/cpu.py` for each new functions.
Updated existing test cases for the modified functions to validate the new 'awake_runtime' column.

Test:
tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter='.*_utilization_in_interval.*'
