### PR TITLE
tp: Remove AssociateThreadToProcess from process_tracker

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -521,16 +521,16 @@ void ProcessTracker::AssociateThreads(UniqueTid utid1,
   if (opt_upid1.has_value() && !opt_upid2.has_value()) {
     auto prr = pt[*opt_upid1];
     bool is_main_thread = associate_main_threads && rr2.tid() == prr.pid();
-    AssociateThreadToProcess(utid2, *opt_upid1, is_main_thread,
-                             associate_main_threads);
+    AssociateThreadToProcessInternal(utid2, *opt_upid1, is_main_thread);
+    ResolvePendingAssociations(utid2, *opt_upid1, associate_main_threads);
     return;
   }
 
   if (opt_upid2.has_value() && !opt_upid1.has_value()) {
     auto prr = pt[*opt_upid2];
     bool is_main_thread = associate_main_threads && rr1.tid() == prr.pid();
-    AssociateThreadToProcess(utid1, *opt_upid2, is_main_thread,
-                             associate_main_threads);
+    AssociateThreadToProcessInternal(utid1, *opt_upid2, is_main_thread);
+    ResolvePendingAssociations(utid1, *opt_upid2, associate_main_threads);
     return;
   }
 
@@ -629,14 +629,6 @@ void ProcessTracker::AssociateThreadToProcessInternal(UniqueTid utid,
   auto trr = thread_table[utid];
   trr.set_upid(upid);
   trr.set_is_main_thread(is_main_thread);
-}
-
-void ProcessTracker::AssociateThreadToProcess(UniqueTid utid,
-                                              UniquePid upid,
-                                              bool is_main_thread,
-                                              bool associate_main_threads) {
-  AssociateThreadToProcessInternal(utid, upid, is_main_thread);
-  ResolvePendingAssociations(utid, upid, associate_main_threads);
 }
 
 void ProcessTracker::SetMainThread(UniqueTid utid, bool is_main_thread) {

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -197,16 +197,6 @@ class ProcessTracker {
     return std::make_pair(deque.begin(), deque.end());
   }
 
-  // Associates the passed pid as the parent process of the passed thread.
-  // The is_main_thread arguments specifies whether the thread is the process'
-  // main thread. The associate_main_threads boolean parameter is used to
-  // determine if a thread should be marked as the main thread if the tid and
-  // pid match, when resolving pending process associations.
-  void AssociateThreadToProcess(UniqueTid utid,
-                                UniquePid upid,
-                                bool is_main_thread,
-                                bool associate_main_threads);
-
   // Marks the two threads as belonging to the same process, even if we don't
   // know which one yet. If one of the two threads is later mapped to a process,
   // the other will be mapped to the same process. The order of the two threads


### PR DESCRIPTION
The method isn't needed in the current implementation. Let's keep the API tidy and clean.

Bug: 425694654
