### PR TITLE
stdlib: Prioritize deobfuscated names in heap graph macros

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/class_tree.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/class_tree.sql
@@ -73,7 +73,7 @@ RETURNS TableOrSubquery AS
     )
   SELECT
     path_hash,
-    c.name AS class_name,
+    coalesce(c.deobfuscated_name, c.name) AS class_name,
     count(r.owned_id) AS outgoing_reference_count,
     o.*
   FROM _path_hashes AS h
@@ -105,8 +105,8 @@ RETURNS TableOrSubquery AS
     )
   SELECT
     path_hash,
-    c.name AS class_name,
-    r.field_name,
+    coalesce(c.deobfuscated_name, c.name) AS class_name,
+    coalesce(r.deobfuscated_field_name, r.field_name) AS field_name,
     r.field_type_name,
     src.*
   FROM _path_hashes AS h
@@ -138,8 +138,8 @@ RETURNS TableOrSubquery AS
     )
   SELECT
     path_hash,
-    c.name AS class_name,
-    r.field_name,
+    coalesce(c.deobfuscated_name, c.name) AS class_name,
+    coalesce(r.deobfuscated_field_name, r.field_name) AS field_name,
     r.field_type_name,
     dst.*
   FROM _path_hashes AS h
@@ -162,7 +162,7 @@ CREATE PERFETTO MACRO _heap_graph_retained_object_count_agg(
 RETURNS TableOrSubquery AS
 (
   SELECT
-    c.name AS class_name,
+    coalesce(c.deobfuscated_name, c.name) AS class_name,
     o.heap_type,
     o.root_type,
     o.reachable,
@@ -206,7 +206,7 @@ CREATE PERFETTO MACRO _heap_graph_retaining_object_count_agg(
 RETURNS TableOrSubquery AS
 (
   SELECT
-    c.name AS class_name,
+    coalesce(c.deobfuscated_name, c.name) AS class_name,
     o.heap_type,
     o.root_type,
     o.reachable,
@@ -253,7 +253,7 @@ RETURNS TableOrSubquery AS
     count() AS object_count,
     sum(o.self_size) AS total_size,
     sum(o.native_size) AS total_native_size,
-    c.name AS class_name
+    coalesce(c.deobfuscated_name, c.name) AS class_name
   FROM $path_hashes AS h
   JOIN heap_graph_object AS o
     ON h.id = o.id


### PR DESCRIPTION
Bug: b/440568443

The optional actions in the Java Heap Graph details panel (e.g., Objects, Direct References, Indirect References) were displaying obfuscated class and field names, even when deobfuscated versions were available.

This was because the underlying SQL macros in class_tree.sql directly selected `c.name` or `r.field_name` instead of checking for the `deobfuscated_*` columns.

This commit updates the following macros to use COALESCE to display the deobfuscated name/field if available:
- _heap_graph_object_references_agg
- _heap_graph_incoming_references_agg
- _heap_graph_outgoing_references_agg
- _heap_graph_retained_object_count_agg
- _heap_graph_retaining_object_count_agg
- _heap_graph_duplicate_objects_agg

The changes made:
- 'c.name' change to 'coalesce(c.deobfuscated_name, c.name)'
- 'r.field_name' change to 'coalesce(r.deobfuscated_field_name, r.field_name)'
