### PR TITLE
tp: Winscope geometry fixes surfaced from WM flicker tests.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
@@ -215,26 +215,13 @@ tables::SurfaceFlingerLayerTable::Id SurfaceFlingerLayersParser::InsertLayerRow(
     layer.parent = layer_decoder.parent();
   }
 
-  auto has_corner_radii = false;
-  if (layer_decoder.has_corner_radii()) {
-    protos::pbzero::CornerRadiiProto::Decoder corner_radii(
-        layer_decoder.corner_radii());
-    if (corner_radii.tl() > 0 || corner_radii.tr() > 0 ||
-        corner_radii.bl() > 0 || corner_radii.br() > 0) {
-      has_corner_radii = true;
-      layer.corner_radius_tl = static_cast<double>(corner_radii.tl());
-      layer.corner_radius_tr = static_cast<double>(corner_radii.tr());
-      layer.corner_radius_bl = static_cast<double>(corner_radii.bl());
-      layer.corner_radius_br = static_cast<double>(corner_radii.br());
-    }
-  }
-  if (!has_corner_radii && layer_decoder.has_corner_radius()) {
-    auto radius = static_cast<double>(layer_decoder.corner_radius());
-    layer.corner_radius_tl = radius;
-    layer.corner_radius_tr = radius;
-    layer.corner_radius_bl = radius;
-    layer.corner_radius_br = radius;
-  }
+  auto corner_radii =
+      surfaceflinger_layers::layer::GetCornerRadii(layer_decoder);
+  layer.corner_radius_tl = corner_radii.tl;
+  layer.corner_radius_tr = corner_radii.tr;
+  layer.corner_radius_bl = corner_radii.bl;
+  layer.corner_radius_br = corner_radii.br;
+
   if (layer_decoder.has_hwc_composition_type()) {
     layer.hwc_composition_type = layer_decoder.hwc_composition_type();
   }

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
@@ -179,6 +179,34 @@ inline TransformMatrix GetTransformMatrix(const LayerDecoder& layer_decoder) {
   }
   return matrix;
 }
+
+// Constructs corner radii from available proto data.
+inline geometry::CornerRadii GetCornerRadii(const LayerDecoder& layer) {
+  geometry::CornerRadii corner_radii;
+
+  bool has_corner_radii = false;
+  if (layer.has_corner_radii()) {
+    protos::pbzero::CornerRadiiProto::Decoder radii_decoder(
+        layer.corner_radii());
+    if (radii_decoder.tl() > 0 || radii_decoder.tr() > 0 ||
+        radii_decoder.bl() > 0 || radii_decoder.br() > 0) {
+      has_corner_radii = true;
+      corner_radii.tl = static_cast<double>(radii_decoder.tl());
+      corner_radii.tr = static_cast<double>(radii_decoder.tr());
+      corner_radii.bl = static_cast<double>(radii_decoder.bl());
+      corner_radii.br = static_cast<double>(radii_decoder.br());
+    }
+  }
+  if (!has_corner_radii && layer.has_corner_radius()) {
+    auto radius = static_cast<double>(layer.corner_radius());
+    corner_radii.tl = radius;
+    corner_radii.tr = radius;
+    corner_radii.bl = radius;
+    corner_radii.br = radius;
+  }
+
+  return corner_radii;
+}
 }  // namespace layer
 
 namespace display {

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
@@ -22,12 +22,28 @@
 
 namespace perfetto::trace_processor::winscope::geometry {
 namespace {
-static bool IsFloatEqual(double a, double b) {
-  return std::abs(a - b) < 0.000001;
+const double CLOSE_THRESHOLD = 0.01;
+const double EQUAL_THRESHOLD = 0.000001;
+
+bool IsEqual(double a, double b) {
+  return std::abs(a - b) < EQUAL_THRESHOLD;
 }
 
-static bool IsFloatClose(double a, double b) {
-  return std::abs(a - b) < 0.01;
+bool IsClose(double a, double b) {
+  return std::abs(a - b) < CLOSE_THRESHOLD;
+}
+
+bool IsApproxLe(double a, double b) {
+  return a <= b || IsClose(a, b);
+}
+
+// Checks if (x, y) is within circle centered at (cx, cy) with radius r.
+// Used to determine if a rect is completely contained within another
+// when accounting for corner radii.
+bool IsPointInCircle(Point point, Point center, double r) {
+  double dx = point.x - center.x;
+  double dy = point.y - center.y;
+  return dx * dx + dy * dy <= r * r + CLOSE_THRESHOLD;
 }
 }  // namespace
 
@@ -70,15 +86,57 @@ Rect Rect::CropRect(const Rect& other) const {
   return Rect(max_left, max_top, min_right, min_bottom);
 }
 
-bool Rect::ContainsRect(const Rect& other) const {
+// Checks if rect contains another rect, accounting for individual corner radii
+// of each rect.
+bool Rect::ContainsRect(const Rect& inner) const {
+  if (IsEmpty()) {
+    return false;
+  }
+
   auto right = x + w;
-  auto other_right = other.x + other.w;
+  auto inner_right = inner.x + inner.w;
   auto bottom = y + h;
-  auto other_bottom = other.y + other.h;
-  return !IsEmpty() && (x <= other.x || IsFloatClose(x, other.x)) &&
-         (y <= other.y || IsFloatClose(y, other.y)) &&
-         ((right >= other_right) || IsFloatClose(right, other_right)) &&
-         ((bottom >= other_bottom) || IsFloatClose(bottom, other_bottom));
+  auto inner_bottom = inner.y + inner.h;
+
+  auto bounding_box_contained =
+      IsApproxLe(x, inner.x) && IsApproxLe(y, inner.y) &&
+      IsApproxLe(inner_right, right) && IsApproxLe(inner_bottom, bottom);
+  if (!bounding_box_contained) {
+    return false;
+  }
+
+  // For each corner we check that the center of the inner rect corner's circle
+  // is contained within the outer rect corner's circle.
+
+  Point c_o{x + radii.tl, y + radii.tl};
+  Point c_i{inner.x + inner.radii.tl, inner.y + inner.radii.tl};
+  if (radii.tl > inner.radii.tl && !(c_o.y < c_i.y) && !(c_o.x < c_i.x) &&
+      !IsPointInCircle(c_i, c_o, radii.tl)) {
+    return false;
+  }
+
+  c_o = Point{right - radii.tr, y + radii.tr};
+  c_i = Point{inner_right - inner.radii.tr, inner.y + inner.radii.tr};
+  if (radii.tr > inner.radii.tr && !(c_o.y < c_i.y) && !(c_o.x >= c_i.x) &&
+      !IsPointInCircle(c_i, c_o, radii.tr)) {
+    return false;
+  }
+
+  c_o = Point{x + radii.bl, bottom - radii.bl};
+  c_i = Point{inner.x + inner.radii.bl, inner_bottom - inner.radii.bl};
+  if (radii.bl > inner.radii.bl && !(c_o.y >= c_i.y) && !(c_o.x < c_i.x) &&
+      !IsPointInCircle(c_i, c_o, radii.bl)) {
+    return false;
+  }
+
+  c_o = Point{right - radii.br, bottom - radii.br};
+  c_i = Point{inner_right - inner.radii.br, inner_bottom - inner.radii.br};
+  if (radii.br > inner.radii.br && !(c_o.y >= c_i.y) && !(c_o.x >= c_i.x) &&
+      !IsPointInCircle(c_i, c_o, radii.br)) {
+    return false;
+  }
+
+  return true;
 }
 
 bool Rect::IntersectsRect(const Rect& other) const {
@@ -107,19 +165,19 @@ bool Rect::IntersectsRect(const Rect& other) const {
 }
 
 bool Rect::operator==(const Rect& other) const {
-  return IsFloatEqual(x, other.x) && IsFloatEqual(y, other.y) &&
-         IsFloatEqual(w, other.w) && IsFloatEqual(h, other.h);
+  return IsEqual(x, other.x) && IsEqual(y, other.y) && IsEqual(w, other.w) &&
+         IsEqual(h, other.h);
 }
 
 bool Rect::IsAlmostEqual(const Rect& other) const {
-  return (IsFloatClose(x, other.x) && IsFloatClose(y, other.y) &&
-          IsFloatClose(w, other.w) && IsFloatClose(h, other.h));
+  return (IsClose(x, other.x) && IsClose(y, other.y) && IsClose(w, other.w) &&
+          IsClose(h, other.h));
 }
 
 bool TransformMatrix::operator==(const TransformMatrix& other) const {
-  return IsFloatEqual(dsdx, other.dsdx) && IsFloatEqual(dsdy, other.dsdy) &&
-         IsFloatEqual(dtdx, other.dtdx) && IsFloatEqual(dtdy, other.dtdy) &&
-         IsFloatEqual(tx, other.tx) && IsFloatEqual(ty, other.ty);
+  return IsEqual(dsdx, other.dsdx) && IsEqual(dsdy, other.dsdy) &&
+         IsEqual(dtdx, other.dtdx) && IsEqual(dtdy, other.dtdy) &&
+         IsEqual(tx, other.tx) && IsEqual(ty, other.ty);
 }
 
 Point TransformMatrix::TransformPoint(Point point) const {
@@ -161,7 +219,7 @@ TransformMatrix TransformMatrix::Inverse() const {
 }
 
 bool TransformMatrix::IsValid() const {
-  return !IsFloatEqual(dsdx * dsdy, dtdx * dtdy);
+  return !IsEqual(dsdx * dsdy, dtdx * dtdy);
 }
 
 double TransformMatrix::Det() const {

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.h
@@ -34,6 +34,14 @@ struct Size {
   double h;
 };
 
+// Represents a 2D rect's corner radii (specified in SurfaceFlinger).
+struct CornerRadii {
+  double tl = 0;
+  double tr = 0;
+  double bl = 0;
+  double br = 0;
+};
+
 // Used to represent and manipulate Winscope rect data to perform various
 // computations during Winscope data parsing, such as computing SurfaceFlinger
 // visibilities. These rects are added to the __intrinsic_winscope_rect table.
@@ -56,6 +64,7 @@ class Rect {
   double y = 0;
   double w = 0;
   double h = 0;
+  CornerRadii radii;
 };
 
 // Represents a region e.g. visible region, touchable region in SurfaceFlinger.

--- a/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
@@ -129,10 +129,10 @@ class SurfaceFlingerLayers(TestSuite):
         1,0,4,"WindowedMagnification:0:31#4",3,0.100000,0.000000,0.300000,0.400000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
         2,1,3,"Display 0 name="Built-in Screen"#3","[NULL]",0.000000,0.000000,0.000000,0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
         3,1,4,"WindowedMagnification:0:31#4",3,0.000000,0.000000,0.000000,0.000000,"[NULL]","[NULL]",0,0,3,"[NULL]"
-        4,2,"[NULL]","[NULL]",-1,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
-        5,2,-2,"[NULL]",-2,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        4,2,"[NULL]","[NULL]",-1,0.000000,0.000000,0.000000,0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
+        5,2,-2,"[NULL]",-2,0.000000,0.000000,0.000000,0.000000,"[NULL]","[NULL]",0,0,"[NULL]","[NULL]"
         6,2,1,"layer1","[NULL]",1.000000,1.000000,1.000000,1.000000,2,"[NULL]",0,0,9,10
-        7,2,2,"layer2","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]",0,1,11,12
+        7,2,2,"layer2","[NULL]",0.000000,0.000000,0.000000,0.000000,"[NULL]","[NULL]",0,1,11,12
         """))
 
   def test_tables_have_raw_protos(self):


### PR DESCRIPTION
Properly account for corner radius in occlusion calculation.

Bug: 312910010
Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=WinscopeGeometryRect*
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="SurfaceFlingerLayer|PerfettoTable:winscope"
