### PR TITLE
ui: Add track_event data source option in record page

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/config/trace_config_builder.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/config/trace_config_builder.ts
@@ -76,6 +76,20 @@ export class TraceConfigBuilder {
     cfg.ftraceConfig.atraceCategories.push(...cats);
   }
 
+  addTrackEventEnabledCategories(...cats: string[]) {
+    const cfg = this.addDataSource('track_event');
+    cfg.trackEventConfig ??= {};
+    cfg.trackEventConfig.enabledCategories ??= [];
+    cfg.trackEventConfig.enabledCategories.push(...cats);
+  }
+
+  addTrackEventDisabledCategories(...cats: string[]) {
+    const cfg = this.addDataSource('track_event');
+    cfg.trackEventConfig ??= {};
+    cfg.trackEventConfig.disabledCategories ??= [];
+    cfg.trackEventConfig.disabledCategories.push(...cats);
+  }
+
   toTraceConfig(): protos.TraceConfig {
     const traceCfg = new protos.TraceConfig();
     traceCfg.durationMs = this.durationMs;


### PR DESCRIPTION
Bug: b/440609589

This change introduces a new section to the "Record new trace" page under Android, allowing users to easily configure the `track_event` data source.

The new "Perfetto SDK annotations" section includes:
-   A multi-select dropdown for common categories (initially `mq`, `gfx`, `servicemanager`).
-   A textarea to input additional line-separated enabled categories, supporting wildcards (e.g., `cat_*`).

`TraceConfigBuilder` has been updated with new methods `addTrackEventEnabledCategories` and `addTrackEventDisabledCategories` to support these changes.

Note: This currently uses the atrace icon as a placeholder.

