### PR TITLE
ui: Fix multiselect checkbox alignment

### DIFF
--- a/ui/src/assets/widgets/multiselect.scss
+++ b/ui/src/assets/widgets/multiselect.scss
@@ -34,7 +34,7 @@
     }
   }
   .pf-multiselect-item {
-    display: block; // Put each item on a new line
+    display: flex; // Put each item on a new line
     margin-top: 5px;
   }
   .pf-multiselect-header {


### PR DESCRIPTION
Currently checkboxes in multiselect input are being overridden with display: block, which nullifies the gap between the checkbox and the label, and also pulls the label vertically out of line with the checkbox.

<img width="322" height="329" alt="image" src="https://github.com/user-attachments/assets/d4d9ea37-e95d-48aa-966c-941e63cce1f0" />

This PR changes the `block` modifier to `flex` so the items still fill the container horizontally but also retain their internal flex layout.

<img width="321" height="321" alt="image" src="https://github.com/user-attachments/assets/c89eb982-e48b-45dd-babd-a437ff7a95e1" />
