### PR TITLE
android: update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,20 +5,18 @@
 # Perfetto tracing internals and API/ABI boundaries.
 primiano@google.com
 
-# UI, Ftrace interop, traced_probes, protozero, Android internals.
-
 # Trace Processor, metrics, infra.
 lalitm@google.com
 mayzner@google.com
 
+# Ftrace interop, traced_probes, protozero, Android internals.
 # Callstack / memory profilers, traced_probes & Linux internals.
 ddiproietto@google.com
 rsavitski@google.com
 
-# Chromium-related things and tracing SDK.
-eseckler@google.com
-nuskos@google.com
-oysteine@google.com
+# Horizontal work
+sashwinbalaji@google.com
+ktimofeev@google.com
 
 # UI
 stevegolton@google.com
@@ -26,13 +24,9 @@ stevegolton@google.com
 # Most Android-related metrics.
 ilkos@google.com
 
-# fmayer@ left the team. Please try first rsavitski@, ddiproietto@ or primiano@
-# and leave fmayer@ as an emergency-only escalation on profilers.
-fmayer@google.com
+# Chromium-related things and tracing SDK.
+eseckler@google.com
+nuskos@google.com
+oysteine@google.com
 
-# chromium.org aliases for adding DEPS entries from chromium subprojects to
-# third_party/perfetto.
-eseckler@chromium.org
-nuskos@chromium.org
-skyostil@chromium.org
 include platform/system/core:main:/janitors/OWNERS #{LAST_RESORT_SUGGESTION}


### PR DESCRIPTION
Grant Ashwin and Kirill android owners. Mainly to approve github->android-internal merges at this point.

I've also removed the chromium accounts because the related workflows now work against github (our new source of truth). Keeping the chrometto @google account for now, but can remove those as well.
