### PR TITLE
WIP support clone operation for 'write_into_file' sessions.

### DIFF
--- a/include/perfetto/ext/tracing/core/null_consumer_endpoint_for_testing.h
+++ b/include/perfetto/ext/tracing/core/null_consumer_endpoint_for_testing.h
@@ -34,7 +34,7 @@ class NullConsumerEndpointForTesting : public ConsumerEndpoint {
   void ChangeTraceConfig(const perfetto::TraceConfig&) override {}
   void StartTracing() override {}
   void DisableTracing() override {}
-  void CloneSession(CloneSessionArgs) override {}
+  void CloneSession(CloneSessionArgs, base::ScopedFile) override {}
   void Flush(uint32_t, FlushCallback, FlushFlags) override {}
   void ReadBuffers() override {}
   void FreeBuffers() override {}

--- a/include/perfetto/ext/tracing/core/tracing_service.h
+++ b/include/perfetto/ext/tracing/core/tracing_service.h
@@ -227,7 +227,8 @@ class PERFETTO_EXPORT_COMPONENT ConsumerEndpoint {
     // milliseconds) of the trigger that caused the clone.
     uint64_t clone_trigger_delay_ms = 0;
   };
-  virtual void CloneSession(CloneSessionArgs) = 0;
+  virtual void CloneSession(CloneSessionArgs,
+                            base::ScopedFile = base::ScopedFile()) = 0;
 
   // Requests all data sources to flush their data immediately and invokes the
   // passed callback once all of them have acked the flush (in which case

--- a/src/tracing/internal/tracing_backend_fake.cc
+++ b/src/tracing/internal/tracing_backend_fake.cc
@@ -134,7 +134,7 @@ class UnsupportedConsumerEndpoint : public ConsumerEndpoint {
   void QueryCapabilities(QueryCapabilitiesCallback) override {}
 
   void SaveTraceForBugreport(SaveTraceForBugreportCallback) override {}
-  void CloneSession(CloneSessionArgs) override {}
+  void CloneSession(CloneSessionArgs, base::ScopedFile) override {}
 
  private:
   Consumer* const consumer_;

--- a/src/tracing/ipc/consumer/consumer_ipc_client_impl.h
+++ b/src/tracing/ipc/consumer/consumer_ipc_client_impl.h
@@ -75,7 +75,7 @@ class ConsumerIPCClientImpl : public TracingService::ConsumerEndpoint,
                          QueryServiceStateCallback) override;
   void QueryCapabilities(QueryCapabilitiesCallback) override;
   void SaveTraceForBugreport(SaveTraceForBugreportCallback) override;
-  void CloneSession(CloneSessionArgs) override;
+  void CloneSession(CloneSessionArgs, base::ScopedFile) override;
 
   // ipc::ServiceProxy::EventListener implementation.
   // These methods are invoked by the IPC layer, which knows nothing about

--- a/src/tracing/ipc/service/consumer_ipc_service.cc
+++ b/src/tracing/ipc/service/consumer_ipc_service.cc
@@ -355,7 +355,9 @@ void ConsumerIPCService::CloneSession(
   if (req.has_clone_trigger_delay_ms()) {
     args.clone_trigger_delay_ms = req.clone_trigger_delay_ms();
   }
-  remote_consumer->service_endpoint->CloneSession(std::move(args));
+  base::ScopedFile fd = ipc::Service::TakeReceivedFD();
+  remote_consumer->service_endpoint->CloneSession(std::move(args),
+                                                  std::move(fd));
 }
 
 // Called by the service in response to

--- a/test/cmdline_integrationtest.cc
+++ b/test/cmdline_integrationtest.cc
@@ -247,6 +247,8 @@ class PerfettoCmdlineTest : public ::testing::Test {
     task_runner_.RunUntilCheckpoint("data_written");
 
     ASSERT_EQ(0, perfetto_br_proc.Run(&stderr_)) << "stderr: " << stderr_;
+    PERFETTO_LOG("perfetto_br_proc, stderr:\n%s\n==========================",
+                 stderr_.c_str());
     perfetto_proc.SendSigterm();
     background_trace.join();
 
@@ -1042,7 +1044,39 @@ TEST_F(PerfettoCmdlineTest, SaveForBugreport) {
   RunBugreportTest(std::move(trace_config));
 }
 
-TEST_F(PerfettoCmdlineTest, SaveForBugreport_WriteIntoFile) {
+// TEST_F(PerfettoCmdlineTest, SaveForBugreport_WriteIntoFileFast) {
+//   TraceConfig trace_config = CreateTraceConfigForBugreportTest();
+//   trace_config.set_file_write_period_ms(1);
+//   trace_config.set_write_into_file(true);
+//   RunBugreportTest(std::move(trace_config));
+// }
+
+// TEST_F(PerfettoCmdlineTest, SaveForBugreport_WriteIntoFile) {
+//   TraceConfig trace_config = CreateTraceConfigForBugreportTest();
+//   trace_config.set_file_write_period_ms(
+//       1);  // Now the file should be written and copied.
+//   trace_config.set_write_into_file(true);
+//   const std::string write_into_file_path = RandomTraceFileName();
+//   ScopedFileRemove remove_on_test_exit(write_into_file_path);
+//   trace_config.set_output_path(write_into_file_path);
+//   RunBugreportTest(std::move(trace_config));
+//   {
+//     uint32_t expected_packets = 0;
+//     for (auto& ds : trace_config.data_sources()) {
+//       if (ds.config().has_for_testing())
+//         expected_packets = ds.config().for_testing().message_count();
+//     }
+//
+//     protos::gen::Trace trace;
+//     ASSERT_TRUE(ParseNotEmptyTraceFromFile(write_into_file_path, trace));
+//     uint32_t test_packets = 0;
+//     for (const auto& p : trace.packet())
+//       test_packets += p.has_for_testing() ? 1 : 0;
+//     ASSERT_EQ(test_packets, expected_packets) << write_into_file_path;
+//   }
+// }
+
+TEST_F(PerfettoCmdlineTest, SaveForBugreport_WriteIntoFileOld) {
   TraceConfig trace_config = CreateTraceConfigForBugreportTest();
   trace_config.set_file_write_period_ms(60000);  // Will never hit this.
   trace_config.set_write_into_file(true);
@@ -1218,6 +1252,9 @@ TEST_F(PerfettoCmdlineTest, SaveAllForBugreport_FourTraces) {
   traces.emplace_back(CreateTraceConfigForBugreportTest(/*score=*/4, add_filt));
   traces.back().cfg.set_unique_session_name(session_prefix + "_4");
 
+  const std::string write_into_file_path = RandomTraceFileName();
+  PERFETTO_LOG("normal output file: %s", write_into_file_path.c_str());
+
   for (auto& trace : traces) {
     std::string cfg = trace.cfg.SerializeAsString();
     trace.proc = ExecPerfetto({"-o", base::kDevNull, "-c", "-"}, cfg);
@@ -1349,5 +1386,15 @@ TEST_F(PerfettoCmdlineTest, SaveAllForBugreport_LargeTrace) {
   ExpectTraceContainsTestMessages(trace, kMsgCount);
   ExpectTraceContainsTestMessagesWithSize(trace, kMsgSize);
 }
+
+// TEST_F(PerfettoCmdlineTest, WriteIntoFileSaveForBugreport) {
+//   const std::string write_into_file_path = RandomTraceFileName();
+//   ScopedFileRemove remove_on_test_exit(write_into_file_path);
+//   TraceConfig cfg = CreateTraceConfigForBugreportTest();
+//   cfg.set_write_into_file(true);
+//   cfg.set_write_into_file(write_into_file_path);
+//   Exec trace_proc = ExecPerfetto({"-o", base::kDevNull, "-c", "-"},
+//                                   cfg.SerializeAsString());
+// }
 
 }  // namespace perfetto


### PR DESCRIPTION
We pass a FD from the `perfetto_cmd` into the `traced` when doing `CloneSession` RPC call.
In `traced` we:
1. Copy the data already written to `write_into_file` fd to the `clone_session` fd.
2. Flush data for the `write_into_file` session
3. When the data is flushed and cloned, instead of asking customer to read it back we write it in `traced`.

Unit tests:
`WriteIntoFileCloneSession` is a simple test
`CloneSessionPreamblePackets_DEBUG` is an important one (missing asserts though). It should test that our "alternative" clone code flow generates the trace that contains all the expected lifecycle events.
