### PR TITLE
stdlib: Add shared counter scale option to SVG counter macros

### DIFF
--- a/test/trace_processor/diff_tests/stdlib/export/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/export/tests.py
@@ -232,7 +232,8 @@ a:hover { text-decoration: none !important; }
               upid,
               tord,
               2000,
-              50);
+              50,
+              1);
           """,
         out=Csv("""
 "svg_group_key","svg"


### PR DESCRIPTION
Test: tools/diff_test_trace_processor.py out/android/trace_processor_shell --name-filter '.*svg.*'
