### PR TITLE
tp: Add zlib dep to summary_integrationtest

### DIFF
--- a/src/trace_processor/trace_summary/BUILD.gn
+++ b/src/trace_processor/trace_summary/BUILD.gn
@@ -60,4 +60,8 @@ source_set("integrationtests") {
     "../../base:test_support",
     "../util:descriptors",
   ]
+
+  if (enable_perfetto_zlib) {
+    deps += [ "../../../gn:zlib" ]
+  }
 }


### PR DESCRIPTION
This is a speculative fix for a build failure observed during the Chromium roll.