### PR TITLE
Normalize path separators in fix_include_guards

### DIFF
--- a/tools/fix_include_guards
+++ b/tools/fix_include_guards
@@ -78,7 +78,7 @@ def main():
       for name in files:
         if not name.endswith('.h'):
           continue
-        fpath = os.path.join(root, name)
+        fpath = os.path.join(root, name).replace(os.path.sep, '/')
         if fpath in EXCLUDED_FILES:
           continue
         num_files_changed += fix_guards(fpath, checkonly)


### PR DESCRIPTION
This change ensures that file paths in fix_include_guards use `/` path separators.

On Windows, `os.path.join` results in a path separated by backslashes, which causes the script to fail its asserts on files intended to be excluded (because the paths don't match those in the `EXCLUDED_FILES` list, which uses forward slashes).

Without this change, on Windows:
```
PS C:\src\perfetto> python3 tools/fix_include_guards
Traceback (most recent call last):
  File "C:\src\perfetto\tools\fix_include_guards", line 92, in <module>
    sys.exit(main())
             ^^^^^^
  File "C:\src\perfetto\tools\fix_include_guards", line 84, in main
    num_files_changed += fix_guards(fpath, checkonly)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\src\perfetto\tools\fix_include_guards", line 47, in fix_guards
    assert endif_line_idx > 0, fpath
           ^^^^^^^^^^^^^^^^^^
AssertionError: src\trace_processor\perfetto_sql\grammar\perfettosql_grammar.h
```

With this change:
```
PS C:\src\perfetto> python3 tools/fix_include_guards                                                                                                                                                               
0 files changed
```