### PR TITLE
ui: Fix crash caused by unescaped strings in a flamegraph query

### DIFF
--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -39,6 +39,7 @@ import {
   FlamegraphOptionalAction,
 } from '../widgets/flamegraph';
 import {Trace} from '../public/trace';
+import {sqliteString} from '../base/string_utils';
 
 export interface QueryFlamegraphColumn {
   // The name of the column in SQL.
@@ -220,7 +221,8 @@ async function computeFlamegraphTree(
   const matchingColumns = ['name', ...unaggCols];
   const matchExpr = (x: string) =>
     matchingColumns.map(
-      (c) => `(IFNULL(${c}, '') like '${makeSqlFilter(x)}' escape '\\')`,
+      (c) =>
+        `(IFNULL(${c}, '') like ${sqliteString(makeSqlFilter(x))} escape '\\')`,
     );
 
   const showStackFilter =


### PR DESCRIPTION
Filter strings are currently not escaped properly when SQL is generated, so if the user enters a filter string that contains single quotes like `ss:'foo'` this will result in a crash, as seen in https://buganizer.corp.google.com/issues/443744440.

This patch escapes the filter strings while serializing them to SQL.