### PR TITLE
SDK: Emit PHASE_MARK legacy events on the global track

### DIFF
--- a/include/perfetto/tracing/track_event_legacy.h
+++ b/include/perfetto/tracing/track_event_legacy.h
@@ -128,6 +128,12 @@ ConvertThreadId(const PerfettoLegacyCurrentThreadId&);
           /* Fallthrough. */                                               \
           break;                                                           \
       }                                                                    \
+    } else if ((phase) == TRACE_EVENT_PHASE_MARK) {                        \
+      /* Similarly, mark events should always go on the global track. */   \
+      PERFETTO_INTERNAL_LEGACY_EVENT_WITH_FLAGS_ON_TRACK(                  \
+          phase, category, name, ::perfetto::Track::Global(0), flags,      \
+          ##__VA_ARGS__);                                                  \
+      return;                                                              \
     }                                                                      \
     /* If an event targets the current thread or another process, write    \
      * it on the current thread's track. The process override case is      \
@@ -172,6 +178,12 @@ ConvertThreadId(const PerfettoLegacyCurrentThreadId&);
           /* Fallthrough. */                                                 \
           break;                                                             \
       }                                                                      \
+    } else if ((phase) == TRACE_EVENT_PHASE_MARK) {                          \
+      /* Similarly, mark events should always go on the global track. */     \
+      PERFETTO_INTERNAL_LEGACY_EVENT_WITH_FLAGS_ON_TRACK(                    \
+          phase, category, name, ::perfetto::Track::Global(0), flags,        \
+          ##__VA_ARGS__);                                                    \
+      return;                                                                \
     }                                                                        \
     /* If an event targets the current thread or another process, write      \
      * it on the current thread's track. The process override case is        \


### PR DESCRIPTION
Mark events are used by chromium for navigation timing events -- often their timestamps are synthetic and occasionally these timestamps are outside the bounds of regular process lifetimes.

I don't recall how these events were displayed in the old trace viewer in times gone past. But these out-of-process-lifetime events scoped to specific threads lead to erroneously duplicated processes in the trace processor model, when Chrome data is combined with OS process creation events (see b/349970126 for context).

I don't believe these events were intended to be thread-associated, and can probably be global-scoped instead -- which would solve above process lifetime related issues.