### PR TITLE
gn: don't enforce case-sensitivity on Windows

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -51,6 +51,7 @@ config("extra_warnings") {
         "-Wno-float-equal",
         "-Wno-unused-macros",
         "-Wno-old-style-cast",
+        "-Wno-nonportable-system-include-path",
       ]
     }
   } else {


### PR DESCRIPTION
We're getting an error [1] when compiling on Windows.

But the usage of windows.h was intentional for MingW usecase where
the Windows.h header has some issues.

Given that Windows filesystems are not case sensitive, stop the compiler
warning which verifies this.

```
[1] FAILED: obj/src/base/base.string_utils.obj
../../buildtools/win/clang/bin\clang-cl.exe /nologo /showIncludes /FC -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_DEPRECATE -DNOMINMAX -D_HAS_EXCEPTIONS=0 -DNDEBUG -DWIN32_LEAN_AND_MEAN -DPERFETTO_IMPLEMENTATION -I../.. -I../../src/profiling/memory/include -I../../include -Igen/build_config -Igen -fstrict-aliasing -Wformat -Wno-deprecated /bigobj /Gy /FS /utf-8 /Zc:__cplusplus /WX -fcolor-diagnostics /Zi /W2 /wd4244 /wd4267 -Wno-float-equal -Wno-unused-macros -Wno-old-style-cast -Weverything -Wno-c++98-compat-pedantic -Wno-c++98-compat -Wno-disabled-macro-expansion -Wno-documentation-unknown-command -Wno-gnu-include-next -Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-padded -Wno-poison-system-directories -Wno-pre-c11-compat -Wno-reserved-id-macro -Wno-reserved-identifier -Wno-shadow-uncaptured-local -Wno-unknown-sanitizers -Wno-unknown-warning-option -Wno-unsafe-buffer-usage -Wno-switch-default /O2 /Zc:inline /GR- /std:c++17   /c ../../src/base/string_utils.cc /Foobj/src/base/base.string_utils.obj /Fd"obj/src/base/base_c.pdb" /guard:cf /ZH:SHA_256
../../src/base/string_utils.cc(28,10): error: non-portable path to file '<Windows.h>'; specified path differs in case from file name on disk [-Werror,-Wnonportable-system-include-path]
   28 | #include <windows.h>
      |          ^~~~~~~~~~~
      |          <Windows.h>
1 error generated.
```