### PR TITLE
ui: stabilize macro commands to run on startup

### DIFF
--- a/docs/visualization/commands-automation-reference.md
+++ b/docs/visualization/commands-automation-reference.md
@@ -336,6 +336,40 @@ Executes a PerfettoSQL query and displays results in a new query tab.
 }
 ```
 
+### Macro Commands
+
+Macros are user-defined sequences of commands that execute in order. They provide a way to automate complex, multi-step analysis workflows.
+
+#### User-defined Macros
+
+Macros can be defined through the UI settings and automatically get stable command IDs.
+
+**Command Pattern:**
+
+- `dev.perfetto.UserMacro.{macroName}` - Executes a user-defined macro
+
+**Arguments:**
+
+None (macro commands and arguments are pre-configured)
+
+**Example:**
+
+```json
+{
+  "id": "dev.perfetto.UserMacro.MyAnalysisWorkflow",
+  "args": []
+}
+```
+
+**Notes:**
+
+- Each macro contains a sequence of commands that execute in order
+- When used as startup commands, all commands within the macro must also be allowlisted
+- Macros can include any stable automation command from this reference
+- Failed commands within a macro are logged but don't stop execution of remaining commands
+
+---
+
 ## Using Commands for Automation
 
 These stable automation commands can be used in several contexts:

--- a/ui/src/core/startup_command_allowlist.ts
+++ b/ui/src/core/startup_command_allowlist.ts
@@ -42,7 +42,7 @@ export const STARTUP_COMMAND_ALLOWLIST: string[] = [
   // Commands will be added here based on user suggestions
 ];
 
-// Create a set for faster lookups
+// Create a set for faster lookups of exact matches
 const STARTUP_COMMAND_ALLOWLIST_SET = new Set(STARTUP_COMMAND_ALLOWLIST);
 
 /**
@@ -51,5 +51,15 @@ const STARTUP_COMMAND_ALLOWLIST_SET = new Set(STARTUP_COMMAND_ALLOWLIST);
  * @returns true if the command ID is in the allowlist, false otherwise
  */
 export function isStartupCommandAllowed(commandId: string): boolean {
-  return STARTUP_COMMAND_ALLOWLIST_SET.has(commandId);
+  // First check for exact match (fastest)
+  if (STARTUP_COMMAND_ALLOWLIST_SET.has(commandId)) {
+    return true;
+  }
+
+  // Special case: allow all user-defined macros
+  if (commandId.startsWith('dev.perfetto.UserMacro.')) {
+    return true;
+  }
+
+  return false;
 }

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -242,27 +242,10 @@ export class TraceImpl implements Trace {
       parseUrlCommands(ctx.appCtx.initialRouteArgs.startupCommands) ?? [];
     const settingsCommands = ctx.appCtx.startupCommandsSetting.get();
 
-    // Filter commands through the allowlist if enforcement is enabled
-    const unfilteredCommands = [...urlCommands, ...settingsCommands];
+    // Combine URL and settings commands - runtime allowlist checking will handle filtering
+    const allStartupCommands = [...urlCommands, ...settingsCommands];
     const enforceAllowlist =
       ctx.appCtx.enforceStartupCommandAllowlistSetting.get();
-
-    const allStartupCommands = enforceAllowlist
-      ? unfilteredCommands.filter((cmd) => isStartupCommandAllowed(cmd.id))
-      : unfilteredCommands;
-
-    // Log any filtered commands for debugging when enforcement is enabled
-    if (enforceAllowlist) {
-      const filteredOut = unfilteredCommands.filter(
-        (cmd) => !isStartupCommandAllowed(cmd.id),
-      );
-      if (filteredOut.length > 0) {
-        console.warn(
-          'The following startup commands were filtered out (not in allowlist):',
-          filteredOut.map((cmd) => `${cmd.id}(${cmd.args.join(', ')})`),
-        );
-      }
-    }
 
     // CommandManager is global. Here we intercept the registerCommand() because
     // we want any commands registered via the Trace interface to be
@@ -287,18 +270,32 @@ export class TraceImpl implements Trace {
         // - Trace data is fully accessible
         // - UI state has been restored from any saved workspace
         // - Commands can safely query trace data and modify UI state
-        for (const command of allStartupCommands) {
-          try {
-            // Execute through proxy to access both global and trace-specific
-            // commands.
-            await ctx.appCtx.commandMgr.runCommand(command.id, ...command.args);
-          } catch (error) {
-            // TODO(stevegolton): Add a mechanism to notify users of startup
-            // command errors. This will involve creating a notification UX
-            // similar to VSCode where there are popups on the bottom right
-            // of the UI.
-            console.warn(`Startup command ${command.id} failed:`, error);
+
+        // Set allowlist checking during startup if enforcement enabled
+        if (enforceAllowlist) {
+          ctx.appCtx.commandMgr.setAllowlistCheck(isStartupCommandAllowed);
+        }
+
+        try {
+          for (const command of allStartupCommands) {
+            try {
+              // Execute through proxy to access both global and trace-specific
+              // commands.
+              await ctx.appCtx.commandMgr.runCommand(
+                command.id,
+                ...command.args,
+              );
+            } catch (error) {
+              // TODO(stevegolton): Add a mechanism to notify users of startup
+              // command errors. This will involve creating a notification UX
+              // similar to VSCode where there are popups on the bottom right
+              // of the UI.
+              console.warn(`Startup command ${command.id} failed:`, error);
+            }
           }
+        } finally {
+          // Always restore default (allow all) behavior when done
+          ctx.appCtx.commandMgr.setAllowlistCheck(() => true);
         }
       },
     });

--- a/ui/src/test/startup_commands_allowlist.test.ts
+++ b/ui/src/test/startup_commands_allowlist.test.ts
@@ -14,7 +14,10 @@
 
 import {test, expect} from '@playwright/test';
 import {PerfettoTestHelper} from './perfetto_ui_test_helper';
-import {STARTUP_COMMAND_ALLOWLIST} from '../core/startup_command_allowlist';
+import {
+  STARTUP_COMMAND_ALLOWLIST,
+  isStartupCommandAllowed,
+} from '../core/startup_command_allowlist';
 
 interface CommandTestCase {
   id: string;
@@ -181,6 +184,19 @@ const COMMAND_TEST_CASES: CommandTestCase[] = [
     maskQueryDetails: true,
   },
 ];
+
+test('macro commands are allowed correctly', async () => {
+  // Test isStartupCommandAllowed function with macro commands
+  expect(isStartupCommandAllowed('dev.perfetto.UserMacro.TestMacro')).toBe(
+    true,
+  );
+  expect(isStartupCommandAllowed('dev.perfetto.UserMacro.AnotherMacro')).toBe(
+    true,
+  );
+  expect(isStartupCommandAllowed('dev.perfetto.UserMacro.')).toBe(true); // Edge case: empty name
+  expect(isStartupCommandAllowed('dev.perfetto.UserMacro')).toBe(false); // Missing dot
+  expect(isStartupCommandAllowed('dev.perfetto.NotUserMacro.Test')).toBe(false); // Different prefix
+});
 
 test('all allowlisted commands have corresponding test cases', async () => {
   // Extract command IDs from allowlist and test cases


### PR DESCRIPTION
If the user defines a macro, as long as all the commands used inside are
allowlisted, there should be no problem with also allowlisting the macro
itself.

This allows for people to define a macro and then make a startup command
out of that macro which I think would be a reasonably common usecase.
