### PR TITLE
tools: fix cpu_profile temp file handling on Windows

### DIFF
--- a/python/tools/cpu_profile.py
+++ b/python/tools/cpu_profile.py
@@ -342,10 +342,12 @@ def record_trace(config, profile_target):
     sys.exit("This tool requires Android T+ to run.")
 
   # Push configuration to the device.
+  # On Windows, temp files cannot be accessed by external processes while open
+  # due to file locking, so we must close before adb push and manually cleanup.
   tf = tempfile.NamedTemporaryFile(delete=False)
   try:
-    tf.file.write(config.encode('utf-8'))
-    tf.file.flush()
+    tf.write(config.encode('utf-8'))
+    tf.flush()
     tf.close()
     profile_config_path = '/data/misc/perfetto-configs/config-' + UUID
     adb_check_output(['adb', 'push', tf.name, profile_config_path])

--- a/tools/cpu_profile
+++ b/tools/cpu_profile
@@ -608,10 +608,12 @@ def record_trace(config, profile_target):
     sys.exit("This tool requires Android T+ to run.")
 
   # Push configuration to the device.
+  # On Windows, temp files cannot be accessed by external processes while open
+  # due to file locking, so we must close before adb push and manually cleanup.
   tf = tempfile.NamedTemporaryFile(delete=False)
   try:
-    tf.file.write(config.encode('utf-8'))
-    tf.file.flush()
+    tf.write(config.encode('utf-8'))
+    tf.flush()
     tf.close()
     profile_config_path = '/data/misc/perfetto-configs/config-' + UUID
     adb_check_output(['adb', 'push', tf.name, profile_config_path])


### PR DESCRIPTION
On Windows, temp files cannot be accessed by external processes while
still open due to file locking. This caused adb push to fail when
trying to push the config file to the device.

Fix by closing the temp file before adb push and using try/finally
to ensure proper cleanup even if errors occur.

Fixes: https://github.com/google/perfetto/issues/734
