### PR TITLE
exp: Modify Columns node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -24,6 +24,7 @@ import {
 import {SlicesSourceNode} from './query_builder/nodes/sources/slices_source';
 import {SqlSourceNode} from './query_builder/nodes/sources/sql_source';
 import {AggregationNode} from './query_builder/nodes/aggregation_node';
+import {ModifyColumnsNode} from './query_builder/nodes/modify_columns_node';
 import {Trace} from '../../public/trace';
 import {IntervalIntersectNode} from './query_builder/nodes/interval_intersect_node';
 import {NodeBoxLayout} from './query_builder/node_box';
@@ -92,6 +93,21 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       prevNodes: [node],
       groupByColumns: [],
       aggregations: [],
+      filters: [],
+    });
+    node.nextNodes.push(newNode);
+    onStateUpdate({
+      ...state,
+      selectedNode: newNode,
+    });
+  }
+
+  handleAddModifyColumns(attrs: ExplorePageAttrs, node: QueryNode) {
+    const {state, onStateUpdate} = attrs;
+    const newNode = new ModifyColumnsNode({
+      prevNodes: [node],
+      newColumns: [],
+      selectedColumns: [],
       filters: [],
     });
     node.nextNodes.push(newNode);
@@ -320,6 +336,11 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         onAddAggregationNode: () => {
           if (state.selectedNode) {
             this.handleAddAggregation(attrs, state.selectedNode);
+          }
+        },
+        onAddModifyColumnsNode: () => {
+          if (state.selectedNode) {
+            this.handleAddModifyColumns(attrs, state.selectedNode);
           }
         },
         onAddIntervalIntersectNode: () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -31,6 +31,10 @@ import {
   AggregationSerializedState,
 } from './query_builder/nodes/aggregation_node';
 import {
+  ModifyColumnsNode,
+  ModifyColumnsSerializedState,
+} from './query_builder/nodes/modify_columns_node';
+import {
   IntervalIntersectNode,
   IntervalIntersectNodeState,
   IntervalIntersectSerializedState,
@@ -44,6 +48,7 @@ type SerializedNodeState =
   | SlicesSourceSerializedState
   | SqlSourceSerializedState
   | AggregationSerializedState
+  | ModifyColumnsSerializedState
   | IntervalIntersectSerializedState;
 
 // Interfaces for the serialized JSON structure
@@ -150,6 +155,11 @@ function createNodeInstance(
       return new AggregationNode(
         AggregationNode.deserializeState(state as AggregationSerializedState),
       );
+    case NodeType.kModifyColumns:
+      return new ModifyColumnsNode({
+        ...(state as ModifyColumnsSerializedState),
+        prevNodes: [],
+      });
     case NodeType.kIntervalIntersect:
       const nodeState: IntervalIntersectNodeState = {
         ...(state as IntervalIntersectSerializedState),
@@ -230,7 +240,6 @@ export function deserializeState(
         nextNode.prevNodes.push(node);
       }
     }
-
     if (serializedNode.type === NodeType.kIntervalIntersect) {
       (node as IntervalIntersectNode).state.intervalNodes =
         IntervalIntersectNode.deserializeState(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -21,6 +21,7 @@
 @import "./operations/operation_component.scss";
 @import "./nodes/sources/slices_source.scss";
 @import "./nodes/sources/table_source.scss";
+@import "./nodes/modify_columns_node.scss";
 
 .pf-query-builder-layout {
   display: grid;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -56,6 +56,7 @@ export interface BuilderAttrs {
 
   // Add derived nodes.
   readonly onAddAggregationNode: (node: QueryNode) => void;
+  readonly onAddModifyColumnsNode: (node: QueryNode) => void;
   readonly onAddIntervalIntersectNode: (node: QueryNode) => void;
 
   readonly onClearAllNodes: () => void;
@@ -175,6 +176,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
           onClearAllNodes,
           onDuplicateNode: attrs.onDuplicateNode,
           onAddAggregation: attrs.onAddAggregationNode,
+          onAddModifyColumns: attrs.onAddModifyColumnsNode,
           onAddIntervalIntersect: attrs.onAddIntervalIntersectNode,
           onDeleteNode: (node: QueryNode) => {
             if (node.isMaterialised()) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph.ts
@@ -95,6 +95,7 @@ export interface GraphAttrs {
   readonly onAddSlicesSource: () => void;
   readonly onAddSqlSource: () => void;
   readonly onAddAggregation: (node: QueryNode) => void;
+  readonly onAddModifyColumns: (node: QueryNode) => void;
   readonly onAddIntervalIntersect: (node: QueryNode) => void;
   readonly onClearAllNodes: () => void;
   readonly onDuplicateNode: (node: QueryNode) => void;
@@ -442,6 +443,7 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
             onDuplicateNode: attrs.onDuplicateNode,
             onDeleteNode: attrs.onDeleteNode,
             onAddAggregation: attrs.onAddAggregation,
+            onModifyColumns: attrs.onAddModifyColumns,
             onAddIntervalIntersect: attrs.onAddIntervalIntersect,
             onNodeRendered,
             onRemoveFilter: attrs.onRemoveFilter,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
@@ -48,6 +48,7 @@ export interface NodeBoxAttrs {
   readonly onDuplicateNode: (node: QueryNode) => void;
   readonly onDeleteNode: (node: QueryNode) => void;
   readonly onAddAggregation: (node: QueryNode) => void;
+  readonly onModifyColumns: (node: QueryNode) => void;
   readonly onAddIntervalIntersect: (node: QueryNode) => void;
   readonly onNodeRendered: (node: QueryNode, element: HTMLElement) => void;
   readonly onRemoveFilter: (node: QueryNode, filter: FilterDefinition) => void;
@@ -91,7 +92,8 @@ function renderContextMenu(attrs: NodeBoxAttrs): m.Child {
 }
 
 function renderAddButton(attrs: NodeBoxAttrs): m.Child {
-  const {node, onAddAggregation, onAddIntervalIntersect} = attrs;
+  const {node, onAddAggregation, onModifyColumns, onAddIntervalIntersect} =
+    attrs;
   return m(
     PopupMenu,
     {
@@ -103,6 +105,10 @@ function renderAddButton(attrs: NodeBoxAttrs): m.Child {
     m(MenuItem, {
       label: 'Aggregate',
       onclick: () => onAddAggregation(node),
+    }),
+    m(MenuItem, {
+      label: 'Modify Columns',
+      onclick: () => onModifyColumns(node),
     }),
     m(MenuItem, {
       label: 'Interval Intersect',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-column-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pf-column {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &[draggable="true"] {
+    cursor: grab;
+  }
+
+  .pf-text-input {
+    width: 100px;
+  }
+}
+
+.pf-add-column-button {
+  margin-top: 8px;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -1,0 +1,339 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {
+  QueryNode,
+  QueryNodeState,
+  nextNodeId,
+  NodeType,
+} from '../../query_node';
+import {Checkbox} from '../../../../widgets/checkbox';
+import {TextInput} from '../../../../widgets/text_input';
+import {
+  ColumnInfo,
+  columnInfoFromName,
+  newColumnInfoList,
+} from '../column_info';
+import protos from '../../../../protos';
+import {FilterDefinition} from '../../../../components/widgets/data_grid/common';
+import {createFiltersProto, FilterOperation} from '../operations/filter';
+
+interface NewColumn {
+  expression: string;
+  name: string;
+  module?: string;
+}
+
+export interface ModifyColumnsSerializedState {
+  prevNodeIds: string[];
+  newColumns: NewColumn[];
+  selectedColumns: ColumnInfo[];
+  filters: FilterDefinition[];
+  customTitle?: string;
+}
+
+export interface ModifyColumnsState extends QueryNodeState {
+  prevNodes: QueryNode[];
+  newColumns: NewColumn[];
+  selectedColumns: ColumnInfo[];
+  filters: FilterDefinition[];
+  customTitle?: string;
+}
+
+export class ModifyColumnsNode implements QueryNode {
+  readonly nodeId: string;
+  readonly type = NodeType.kModifyColumns;
+  prevNodes: QueryNode[] | undefined;
+  nextNodes: QueryNode[];
+  sourceCols: ColumnInfo[];
+  readonly state: ModifyColumnsState;
+
+  constructor(state: ModifyColumnsState) {
+    this.nodeId = nextNodeId();
+    // This node assumes it has only one previous node.
+    this.sourceCols =
+      state.prevNodes.length > 0 ? state.prevNodes[0].finalCols : [];
+    if (state.selectedColumns.length === 0 && this.sourceCols.length > 0) {
+      state.selectedColumns = newColumnInfoList(this.sourceCols);
+    }
+    this.prevNodes = state.prevNodes;
+    this.nextNodes = [];
+    this.state = state;
+  }
+
+  onPrevNodesUpdated() {
+    // This node assumes it has only one previous node.
+    this.sourceCols =
+      this.state.prevNodes.length > 0 ? this.state.prevNodes[0].finalCols : [];
+    if (this.state.selectedColumns.length === 0 && this.sourceCols.length > 0) {
+      this.state.selectedColumns = newColumnInfoList(this.sourceCols);
+    }
+  }
+
+  static deserializeState(
+    nodes: Map<string, QueryNode>,
+    serializedState: ModifyColumnsSerializedState,
+  ): ModifyColumnsState {
+    const prevNodes = serializedState.prevNodeIds.map((id) => nodes.get(id)!);
+    return {
+      ...serializedState,
+      prevNodes,
+    };
+  }
+
+  get finalCols(): ColumnInfo[] {
+    const finalCols = newColumnInfoList(
+      this.state.selectedColumns.filter((col) => col.checked),
+    );
+    this.state.newColumns.forEach((col) => {
+      finalCols.push(columnInfoFromName(col.name, true));
+    });
+    return finalCols;
+  }
+
+  validate(): boolean {
+    const colNames = new Set<string>();
+    for (const col of this.state.selectedColumns) {
+      if (!col.checked) continue;
+      const name = col.alias ? col.alias.trim() : col.column.name;
+      if (col.alias && name === '') return false; // Disallow empty alias
+      if (colNames.has(name)) {
+        return false;
+      }
+      colNames.add(name);
+    }
+
+    for (const col of this.state.newColumns) {
+      const name = col.name.trim();
+      const expression = col.expression.trim();
+
+      // If a column has an expression, it must have a name and be unique.
+      if (expression !== '') {
+        if (name === '') {
+          return false;
+        }
+        if (colNames.has(name)) {
+          return false;
+        }
+        colNames.add(name);
+      }
+    }
+
+    return true;
+  }
+
+  getTitle(): string {
+    return this.state.customTitle ?? 'Modify Columns';
+  }
+
+  nodeSpecificModify(): m.Child {
+    return m(
+      'div',
+      m(
+        'div.pf-column-list',
+        this.state.selectedColumns.map((col, index) =>
+          m(
+            '.pf-column',
+            {
+              draggable: true,
+              ondragstart: (e: DragEvent) => {
+                e.dataTransfer!.setData('text/plain', index.toString());
+              },
+              ondragover: (e: DragEvent) => {
+                e.preventDefault();
+              },
+              ondrop: (e: DragEvent) => {
+                e.preventDefault();
+                const from = parseInt(
+                  e.dataTransfer!.getData('text/plain'),
+                  10,
+                );
+                const to = index;
+                const [removed] = this.state.selectedColumns.splice(from, 1);
+                this.state.selectedColumns.splice(to, 0, removed);
+              },
+            },
+            m(Checkbox, {
+              checked: col.checked,
+              label: col.column.name,
+              onchange: (e) => {
+                col.checked = (e.target as HTMLInputElement).checked;
+              },
+            }),
+            m(TextInput, {
+              oninput: (e: Event) => {
+                col.alias = (e.target as HTMLInputElement).value;
+              },
+              placeholder: 'alias',
+              value: col.alias ? col.alias : '',
+            }),
+          ),
+        ),
+      ),
+      this.state.newColumns.map((col, index) =>
+        m(
+          '.pf-column',
+          {
+            draggable: true,
+            ondragstart: (e: DragEvent) => {
+              e.dataTransfer!.setData(
+                'text/plain',
+                (this.state.selectedColumns.length + index).toString(),
+              );
+            },
+            ondragover: (e: DragEvent) => {
+              e.preventDefault();
+            },
+            ondrop: (e: DragEvent) => {
+              e.preventDefault();
+              const from = parseInt(e.dataTransfer!.getData('text/plain'), 10);
+              const to = this.state.selectedColumns.length + index;
+              if (from < this.state.selectedColumns.length) {
+                const [removed] = this.state.selectedColumns.splice(from, 1);
+                this.state.newColumns.splice(
+                  to - this.state.selectedColumns.length,
+                  0,
+                  {
+                    expression: removed.column.name,
+                    name: removed.alias || '',
+                  },
+                );
+              } else {
+                const [removed] = this.state.newColumns.splice(
+                  from - this.state.selectedColumns.length,
+                  1,
+                );
+                this.state.newColumns.splice(
+                  to - this.state.selectedColumns.length,
+                  0,
+                  removed,
+                );
+              }
+            },
+          },
+          m(TextInput, {
+            oninput: (e: Event) => {
+              col.expression = (e.target as HTMLInputElement).value;
+            },
+            placeholder: 'expression',
+            value: col.expression,
+          }),
+          m(TextInput, {
+            oninput: (e: Event) => {
+              col.name = (e.target as HTMLInputElement).value;
+            },
+            placeholder: 'name',
+            value: col.name,
+          }),
+          m(
+            'button',
+            {
+              onclick: () => {
+                this.state.newColumns.splice(index, 1);
+              },
+            },
+            'Remove',
+          ),
+        ),
+      ),
+      m(
+        'button.pf-add-column-button',
+        {
+          onclick: () => {
+            this.state.newColumns.push({
+              expression: '',
+              name: '',
+            });
+          },
+        },
+        'Add column',
+      ),
+      m(FilterOperation, {
+        filters: this.state.filters,
+        sourceCols: this.finalCols,
+        onFiltersChanged: (newFilters: ReadonlyArray<FilterDefinition>) => {
+          this.state.filters = newFilters as FilterDefinition[];
+          this.state.onchange?.();
+        },
+      }),
+    );
+  }
+
+  clone(): QueryNode {
+    return new ModifyColumnsNode(this.state);
+  }
+
+  getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
+    const selectColumns: protos.PerfettoSqlStructuredQuery.SelectColumn[] = [];
+    const referencedModules: string[] = [];
+
+    for (const col of this.state.selectedColumns) {
+      if (!col.checked) continue;
+
+      const selectColumn = new protos.PerfettoSqlStructuredQuery.SelectColumn();
+      selectColumn.columnNameOrExpression = col.column.name;
+      if (col.alias) {
+        selectColumn.alias = col.alias;
+      }
+      selectColumns.push(selectColumn);
+    }
+
+    for (const col of this.state.newColumns) {
+      const selectColumn = new protos.PerfettoSqlStructuredQuery.SelectColumn();
+      selectColumn.columnNameOrExpression = col.expression;
+      selectColumn.alias = col.name;
+      selectColumns.push(selectColumn);
+      if (col.module) {
+        referencedModules.push(col.module);
+      }
+    }
+
+    if (!this.prevNodes || this.prevNodes.length === 0) return;
+    // This node assumes it has only one previous node.
+    const prevSq = this.prevNodes[0].getStructuredQuery();
+    if (!prevSq) return;
+
+    prevSq.selectColumns = selectColumns;
+    if (referencedModules.length > 0) {
+      prevSq.referencedModules = referencedModules;
+    }
+
+    const filtersProto = createFiltersProto(this.state.filters, this.finalCols);
+
+    if (filtersProto) {
+      const outerSq = new protos.PerfettoSqlStructuredQuery();
+      outerSq.id = this.nodeId;
+      outerSq.innerQuery = prevSq;
+      outerSq.filters = filtersProto;
+      return outerSq;
+    }
+
+    return prevSq;
+  }
+
+  isMaterialised(): boolean {
+    return false;
+  }
+
+  serializeState(): ModifyColumnsSerializedState {
+    return {
+      prevNodeIds: this.prevNodes!.map((node) => node.nodeId),
+      newColumns: this.state.newColumns,
+      selectedColumns: this.state.selectedColumns,
+      filters: this.state.filters,
+      customTitle: this.state.customTitle,
+    };
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -33,6 +33,9 @@ export enum NodeType {
   // Single node operations
   kSubQuery,
   kAggregation,
+  kModifyColumns,
+
+  // Multi node operations
   kIntervalIntersect,
 }
 

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
@@ -160,6 +160,11 @@ export interface SqlType {
   readonly tableAndColumn?: TableAndColumn;
 }
 
+export const unknownType: SqlType = {
+  name: 'unknown',
+  shortName: 'unknown',
+};
+
 export function createTableColumnFromPerfettoSql(
   trace: Trace,
   col: SqlColumn,


### PR DESCRIPTION
This commit introduces a new "Modify Columns" node to the Explore Page query builder.

   * New Functionality: Users can now add a "Modify Columns" node to their query graph. This node allows them to:
       * Select, reorder, and rename columns from the previous node.
       * Add new columns defined by SQL expressions.
       * Filter the results based on the final set of columns.
   * UI Changes: A "Modify Columns" option has been added to the menu when adding a new node in the query builder UI.
   * Serialization: The new node's state (which columns are selected, new column definitions, filters, etc.) can be saved and loaded, so queries using this feature can be shared and restored.
   * Testing: Unit tests have been added to ensure the serialization and deserialization of the new node work correctly.