### PR TITLE
ui: Add warning messages for missing trace events for each CPU track in Wattson

### DIFF
--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
+
 import {createAggregationTab} from '../../components/aggregation_adapter';
 import {
   BaseCounterTrack,
@@ -232,24 +233,11 @@ async function addWattsonCpuElements(
     const eventItems = missingEvents.map((event) => m('li', event));
     warningMsg.push(
       m(
-        'div',
-        {style: 'color: red'},
+        '.wattson-warning',
         'Perfetto trace configuration is missing below trace_events for Wattson to work:',
-        m(
-          'ul',
-          {style: 'margin-top: 4px; margin-bottom: 4px; padding-left: 20px;'},
-          eventItems,
-        ),
+        m('.wattson-warning-list', eventItems),
       ),
     );
-  } else {
-    warningMsg.push(
-      m(
-        'span',
-        'Perfetto trace configuration has satisified minimum requirements for Wattson to work',
-      ),
-    );
-    warningMsg.push(m('br'));
   }
   const warningDesc = m('', warningMsg);
 

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -105,29 +105,7 @@ async function hasWattsonSufficientCPUConfigs(
 
   const dsuDependencyQuery = await engine.query(
     `
-    INCLUDE PERFETTO MODULE wattson.device_infos;
-    INCLUDE PERFETTO MODULE wattson.curves.device_cpu_2d;
-    CREATE OR REPLACE PERFETTO TABLE _filtered_curves_2d_raw AS
-    SELECT
-      dc.policy,
-      dc.freq_khz,
-      dc.dep_policy,
-      dc.dep_freq,
-      dc.active,
-      dc.idle0,
-      dc.idle1,
-      dc.static
-    FROM _device_curves_2d AS dc
-    JOIN _wattson_device AS device
-      ON dc.device = device.name;
-    CREATE OR REPLACE PERFETTO TABLE _cpu_w_dsu_dependency AS
-    SELECT DISTINCT
-      cpu
-    FROM _filtered_curves_2d_raw
-    JOIN _dev_cpu_policy_map
-      USING (policy)
-    WHERE
-      dep_policy = 255;
+    INCLUDE PERFETTO MODULE wattson.curves.utils;
     SELECT count(*) AS count FROM _cpu_w_dsu_dependency;
     `,
   );

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -110,7 +110,6 @@ async function hasWattsonSufficientCPUConfigs(
     `,
   );
 
-  // required for Pixel 9/10/...
   if (dsuDependencyQuery.firstRow({count: NUM}).count > 0) {
     requiredFtraceEvents.push('devfreq/devfreq_frequency');
   }

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -228,18 +228,17 @@ async function addWattsonCpuElements(
     ucpus.add(it.ucpu);
   }
 
-  const warningMsg: m.Children[] = [];
-  if (missingEvents.length > 0) {
-    const eventItems = missingEvents.map((event) => m('li', event));
-    warningMsg.push(
+  const warningDesc =
+    missingEvents.length > 0 ?
       m(
-        '.wattson-warning',
+        '.pf-wattson-warning',
         'Perfetto trace configuration is missing below trace_events for Wattson to work:',
-        m('.wattson-warning-list', eventItems),
-      ),
-    );
-  }
-  const warningDesc = m('', warningMsg);
+        m(
+          '.pf-wattson-warning__list',
+          missingEvents.map((event) => m('li', event)),
+        ),
+      ) :
+      undefined;
 
   // CPUs estimate as part of CPU subsystem
   const cpus = ctx.traceInfo.cpus.filter((cpu) => ucpus.has(cpu.ucpu));

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {createAggregationTab} from '../../components/aggregation_adapter';
 import {
   BaseCounterTrack,
@@ -23,7 +24,7 @@ import {Trace} from '../../public/trace';
 import {SLICE_TRACK_KIND} from '../../public/track_kinds';
 import {TrackNode} from '../../public/workspace';
 import {Engine} from '../../trace_processor/engine';
-import {NUM} from '../../trace_processor/query_result';
+import {NUM, STR_NULL} from '../../trace_processor/query_result';
 import {WattsonEstimateSelectionAggregator} from './estimate_aggregator';
 import {WattsonPackageSelectionAggregator} from './package_aggregator';
 import {WattsonProcessSelectionAggregator} from './process_aggregator';
@@ -40,6 +41,7 @@ export default class implements PerfettoPlugin {
     const markersSupported = await hasWattsonMarkersSupport(ctx.engine);
     const cpuSupported = await hasWattsonCpuSupport(ctx.engine);
     const gpuSupported = await hasWattsonGpuSupport(ctx.engine);
+    const missingCpuConfigs = await hasWattsonSufficientCPUConfigs(ctx.engine);
 
     // Short circuit if Wattson is not supported for this Perfetto trace
     if (!(markersSupported || cpuSupported || gpuSupported)) return;
@@ -51,7 +53,7 @@ export default class implements PerfettoPlugin {
       await addWattsonMarkersElements(ctx, group);
     }
     if (cpuSupported) {
-      await addWattsonCpuElements(ctx, group);
+      await addWattsonCpuElements(ctx, group, missingCpuConfigs);
     }
     if (gpuSupported) {
       await addWattsonGpuElements(ctx, group);
@@ -88,6 +90,72 @@ class WattsonSubsystemEstimateTrack extends BaseCounterTrack {
       FROM _system_state_${this.queryKey}
     `;
   }
+}
+
+// Walk through user's Perfetto Trace Configs and check
+// against bare minimum configs that makes Wattson work.
+// Add the missing ones to missingEvents, display in UI.
+async function hasWattsonSufficientCPUConfigs(
+  engine: Engine,
+): Promise<string[]> {
+  const requiredFtraceEvents: string[] = [
+    'power/cpu_frequency',
+    'power/cpu_idle',
+  ];
+
+  const dsuDependencyQuery = await engine.query(
+    `
+    INCLUDE PERFETTO MODULE wattson.device_infos;
+    INCLUDE PERFETTO MODULE wattson.curves.device_cpu_2d;
+    CREATE OR REPLACE PERFETTO TABLE _filtered_curves_2d_raw AS
+    SELECT
+      dc.policy,
+      dc.freq_khz,
+      dc.dep_policy,
+      dc.dep_freq,
+      dc.active,
+      dc.idle0,
+      dc.idle1,
+      dc.static
+    FROM _device_curves_2d AS dc
+    JOIN _wattson_device AS device
+      ON dc.device = device.name;
+    CREATE OR REPLACE PERFETTO TABLE _cpu_w_dsu_dependency AS
+    SELECT DISTINCT
+      cpu
+    FROM _filtered_curves_2d_raw
+    JOIN _dev_cpu_policy_map
+      USING (policy)
+    WHERE
+      dep_policy = 255;
+    SELECT count(*) AS count FROM _cpu_w_dsu_dependency;
+    `,
+  );
+
+  // required for Pixel 9/10/...
+  if (dsuDependencyQuery.firstRow({count: NUM}).count > 0) {
+    requiredFtraceEvents.push('devfreq/devfreq_frequency');
+  }
+
+  const missingEvents: string[] = [];
+  const query = `
+    SELECT str_value
+    FROM metadata
+    WHERE name = 'trace_config_pbtxt';
+    `;
+
+  const result = await engine.query(query);
+  const row = result.maybeFirstRow({str_value: STR_NULL});
+  const traceConfig = row?.str_value || '';
+
+  for (const event of requiredFtraceEvents) {
+    const eventPattern = new RegExp(`ftrace_events:\\s*"${event}"`);
+    if (!eventPattern.test(traceConfig)) {
+      missingEvents.push(event);
+    }
+  }
+
+  return missingEvents;
 }
 
 async function hasWattsonMarkersSupport(engine: Engine): Promise<boolean> {
@@ -163,7 +231,11 @@ async function addWattsonMarkersElements(ctx: Trace, group: TrackNode) {
   group.addChildInOrder(new TrackNode({uri, name: 'Wattson markers window'}));
 }
 
-async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
+async function addWattsonCpuElements(
+  ctx: Trace,
+  group: TrackNode,
+  missingEvents: string[],
+) {
   // ctx.traceInfo.cpus contains all cpus seen from all events. Filter the set
   // if it's seen in sched slices.
   const queryRes = await ctx.engine.query(
@@ -178,6 +250,32 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
     ucpus.add(it.ucpu);
   }
 
+  const warningMsg: m.Children[] = [];
+  if (missingEvents.length > 0) {
+    const eventItems = missingEvents.map((event) => m('li', event));
+    warningMsg.push(
+      m(
+        'div',
+        {style: 'color: red'},
+        'Perfetto trace configuration is missing below trace_events for Wattson to work:',
+        m(
+          'ul',
+          {style: 'margin-top: 4px; margin-bottom: 4px; padding-left: 20px;'},
+          eventItems,
+        ),
+      ),
+    );
+  } else {
+    warningMsg.push(
+      m(
+        'span',
+        'Perfetto trace configuration has satisified minimum requirements for Wattson to work',
+      ),
+    );
+    warningMsg.push(m('br'));
+  }
+  const warningDesc = m('', warningMsg);
+
   // CPUs estimate as part of CPU subsystem
   const cpus = ctx.traceInfo.cpus.filter((cpu) => ucpus.has(cpu.ucpu));
   for (const cpu of cpus) {
@@ -185,6 +283,7 @@ async function addWattsonCpuElements(ctx: Trace, group: TrackNode) {
     const uri = `/wattson/cpu_subsystem_estimate_cpu${cpu.ucpu}`;
     ctx.tracks.registerTrack({
       uri,
+      description: () => warningDesc,
       renderer: new WattsonSubsystemEstimateTrack(
         ctx,
         uri,

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -229,16 +229,16 @@ async function addWattsonCpuElements(
   }
 
   const warningDesc =
-    missingEvents.length > 0 ?
-      m(
-        '.pf-wattson-warning',
-        'Perfetto trace configuration is missing below trace_events for Wattson to work:',
-        m(
-          '.pf-wattson-warning__list',
-          missingEvents.map((event) => m('li', event)),
-        ),
-      ) :
-      undefined;
+    missingEvents.length > 0
+      ? m(
+          '.pf-wattson-warning',
+          'Perfetto trace configuration is missing below trace_events for Wattson to work:',
+          m(
+            '.pf-wattson-warning__list',
+            missingEvents.map((event) => m('li', event)),
+          ),
+        )
+      : undefined;
 
   // CPUs estimate as part of CPU subsystem
   const cpus = ctx.traceInfo.cpus.filter((cpu) => ucpus.has(cpu.ucpu));

--- a/ui/src/plugins/org.kernel.Wattson/styles.scss
+++ b/ui/src/plugins/org.kernel.Wattson/styles.scss
@@ -1,0 +1,23 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.wattson-warning {
+  color: red;
+}
+
+.wattson-warning-list {
+  margin-top: 4px;
+  margin-bottom: 4px;
+  padding-left: 20px;
+}

--- a/ui/src/plugins/org.kernel.Wattson/styles.scss
+++ b/ui/src/plugins/org.kernel.Wattson/styles.scss
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.wattson-warning {
-  color: red;
-}
+@import '../../assets/theme';
 
-.wattson-warning-list {
-  margin-top: 4px;
-  margin-bottom: 4px;
-  padding-left: 20px;
+.pf-wattson-warning {
+  color: var(--pf-color-danger);
+
+  &__list {
+    padding-left: 20px;
+  }
 }

--- a/ui/src/plugins/org.kernel.Wattson/styles.scss
+++ b/ui/src/plugins/org.kernel.Wattson/styles.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import '../../assets/theme';
+@import "../../assets/theme";
 
 .pf-wattson-warning {
   color: var(--pf-color-danger);


### PR DESCRIPTION
In case users missed some necessary ftrace_events for Wattson, Perfetto UI will show nothing which confuses the users. There needs to be warning messages telling user which bare minimum ftrace_events he forgot adding in Perfetto Trace Config. It's per track and not for the whole Wattson group because the missing traces might be different per track.

For short-term, this patchset is reusing the "help" icon to display the warning messages. The missing events will be generated by comparing between bare minimum trace events and user's configured events. Once generated, missing events will be passed to each CPU Estimate Track and display in red color: "Perfetto trace configuration is missing below events for Wattson to work :<missing_event_list>"  Limitation is that user needs to hover over the track and click on the "help" icon to display the message. In long term, there should be a dedicated icon to be implemented.

Test: Local Perfetto UI Test
Bug: 444535474
