### PR TITLE
exp: Show filters on nodes

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -320,6 +320,13 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         },
         onImport: () => this.handleImport(attrs),
         onExport: () => this.handleExport(state, trace),
+        onRemoveFilter: (node, filter) => {
+          const filterIndex = node.state.filters.indexOf(filter);
+          if (filterIndex > -1) {
+            node.state.filters.splice(filterIndex, 1);
+          }
+          attrs.onStateUpdate({...state});
+        },
       }),
     );
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -25,6 +25,7 @@ import {DataExplorer} from './data_explorer';
 import {
   DataGridDataSource,
   DataGridModel,
+  FilterDefinition,
 } from '../../../components/widgets/data_grid/common';
 import {InMemoryDataSource} from '../../../components/widgets/data_grid/in_memory_data_source';
 import {QueryResponse} from '../../../components/query_table/queries';
@@ -62,6 +63,7 @@ export interface BuilderAttrs {
   readonly onDeleteNode: (node: QueryNode) => void;
   readonly onImport: () => void;
   readonly onExport: () => void;
+  readonly onRemoveFilter: (node: QueryNode, filter: FilterDefinition) => void;
 }
 
 export class Builder implements m.ClassComponent<BuilderAttrs> {
@@ -181,6 +183,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
           },
           onImport: attrs.onImport,
           onExport: attrs.onExport,
+          onRemoveFilter: attrs.onRemoveFilter,
         }),
       ),
       m('.pf-qb-explorer', explorer),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph.ts
@@ -19,6 +19,7 @@ import {Button, ButtonVariant} from '../../../widgets/button';
 import {Intent} from '../../../widgets/common';
 import {MenuItem, PopupMenu} from '../../../widgets/menu';
 import {QueryNode} from '../query_node';
+import {FilterDefinition} from '../../../components/widgets/data_grid/common';
 
 import {
   NodeBox,
@@ -100,6 +101,7 @@ export interface GraphAttrs {
   readonly onDeleteNode: (node: QueryNode) => void;
   readonly onImport: () => void;
   readonly onExport: () => void;
+  readonly onRemoveFilter: (node: QueryNode, filter: FilterDefinition) => void;
 }
 
 export class Graph implements m.ClassComponent<GraphAttrs> {
@@ -434,6 +436,7 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
             onAddAggregation: attrs.onAddAggregation,
             onAddIntervalIntersect: attrs.onAddIntervalIntersect,
             onNodeRendered,
+            onRemoveFilter: attrs.onRemoveFilter,
           }),
         );
       }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.scss
@@ -82,6 +82,15 @@
   }
 }
 
+.pf-node-box__content {
+  display: flex;
+  flex-direction: column;
+}
+
+.pf-node-box__filters {
+  margin-top: 0.5rem;
+}
+
 .pf-node-box {
   position: absolute;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
@@ -19,6 +19,8 @@ import {Icons} from '../../../base/semantic_icons';
 import {Button} from '../../../widgets/button';
 import {MenuItem, PopupMenu} from '../../../widgets/menu';
 import {QueryNode} from '../query_node';
+import {FilterDefinition} from '../../../components/widgets/data_grid/common';
+import {Chip} from '../../../widgets/chip';
 import {Icon} from '../../../widgets/icon';
 
 export const PADDING = 20;
@@ -48,6 +50,7 @@ export interface NodeBoxAttrs {
   readonly onAddAggregation: (node: QueryNode) => void;
   readonly onAddIntervalIntersect: (node: QueryNode) => void;
   readonly onNodeRendered: (node: QueryNode, element: HTMLElement) => void;
+  readonly onRemoveFilter: (node: QueryNode, filter: FilterDefinition) => void;
 }
 
 function renderWarningIcon(node: QueryNode): m.Child {
@@ -80,7 +83,7 @@ function renderContextMenu(attrs: NodeBoxAttrs): m.Child {
     {
       trigger: m(Button, {
         iconFilled: true,
-        icon: Icons.ContextMenuAlt,
+        icon: Icons.ContextMenu,
       }),
     },
     ...menuItems,
@@ -104,6 +107,30 @@ function renderAddButton(attrs: NodeBoxAttrs): m.Child {
     m(MenuItem, {
       label: 'Interval Intersect',
       onclick: () => onAddIntervalIntersect(node),
+    }),
+  );
+}
+
+function renderFilters(attrs: NodeBoxAttrs): m.Child {
+  const {node, onRemoveFilter} = attrs;
+  if (node.state.filters.length === 0) return null;
+
+  return m(
+    '.pf-node-box__filters',
+    node.state.filters.map((filter) => {
+      if ('value' in filter) {
+        return m(Chip, {
+          label: `${filter.column} ${filter.op} ${filter.value}`,
+          removable: true,
+          onRemove: () => onRemoveFilter(node, filter),
+        });
+      } else {
+        return m(Chip, {
+          label: `${filter.column} ${filter.op}`,
+          removable: true,
+          onRemove: () => onRemoveFilter(node, filter),
+        });
+      }
     }),
   );
 }
@@ -147,7 +174,11 @@ export const NodeBox: m.Component<NodeBoxAttrs> = {
         });
       }),
       renderWarningIcon(node),
-      m('span.pf-node-box__title', node.getTitle()),
+      m(
+        '.pf-node-box__content',
+        m('span.pf-node-box__title', node.getTitle()),
+        renderFilters(attrs),
+      ),
       renderContextMenu(attrs),
       node.nextNodes.map((_, i) => {
         const portCount = node.nextNodes.length;


### PR DESCRIPTION
This commit adds a UI feature to the Explore Page that displays active filters as Chips directly on the query nodes. It also allows users to remove a filter by clicking on it.