### PR TITLE
exp: Show details on nodes

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -21,6 +21,7 @@
 @import "./operations/operation_component.scss";
 @import "./nodes/sources/slices_source.scss";
 @import "./nodes/sources/table_source.scss";
+@import "./nodes/aggregation_node.scss";
 
 .pf-query-builder-layout {
   display: grid;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
@@ -118,19 +118,15 @@ function renderFilters(attrs: NodeBoxAttrs): m.Child {
   return m(
     '.pf-node-box__filters',
     node.state.filters.map((filter) => {
-      if ('value' in filter) {
-        return m(Chip, {
-          label: `${filter.column} ${filter.op} ${filter.value}`,
-          removable: true,
-          onRemove: () => onRemoveFilter(node, filter),
-        });
-      } else {
-        return m(Chip, {
-          label: `${filter.column} ${filter.op}`,
-          removable: true,
-          onRemove: () => onRemoveFilter(node, filter),
-        });
-      }
+      const label =
+        'value' in filter
+          ? `${filter.column} ${filter.op} ${filter.value}`
+          : `${filter.column} ${filter.op}`;
+      return m(Chip, {
+        label,
+        removable: true,
+        onRemove: () => onRemoveFilter(node, filter),
+      });
     }),
   );
 }
@@ -177,6 +173,7 @@ export const NodeBox: m.Component<NodeBoxAttrs> = {
       m(
         '.pf-node-box__content',
         m('span.pf-node-box__title', node.getTitle()),
+        m('.pf-node-box__details', node.nodeDetails?.()),
         renderFilters(attrs),
       ),
       renderContextMenu(attrs),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.scss
@@ -12,27 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import "../../../../../assets/theme";
+@import "../../../../assets/theme";
 
-.pf-slice-source-label {
-  display: flex;
-  align-items: center;
-  font-family: var(--pf-font-compact);
-
-  span {
-    display: inline-block;
-    margin-right: 0.625rem;
-    min-width: 6.25rem;
-  }
-}
-
-.pf-slice-source-box {
-  padding: 0.625rem;
-  margin-bottom: 0.625rem;
-  border: 1px solid var(--pf-color-border);
-}
-
-.pf-slice-source-details {
+.pf-aggregation-node-details {
   padding-top: 5px;
   font-size: 0.8em;
   color: var(--pf-color-text-lighter);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
@@ -160,6 +160,32 @@ export class AggregationNode implements QueryNode {
     return this.state.customTitle ?? 'Aggregation';
   }
 
+  nodeDetails?(): m.Child | undefined {
+    const details: m.Child[] = [];
+    const groupByCols = this.state.groupByColumns
+      .filter((c) => c.checked)
+      .map((c) => c.name);
+    if (groupByCols.length > 0) {
+      details.push(m('div', `Group by: ${groupByCols.join(', ')}`));
+    }
+
+    const aggs = this.state.aggregations
+      .filter((agg) => agg.isValid)
+      .map(
+        (agg) =>
+          `${agg.aggregationOp}(${agg.column?.name}) AS ${agg.newColumnName ?? placeholderNewColumnName(agg)}`,
+      );
+
+    if (aggs.length > 0) {
+      details.push(m('div', `${aggs.join(', ')}`));
+    }
+
+    if (details.length === 0) {
+      return;
+    }
+    return m('.pf-aggregation-node-details', details);
+  }
+
   nodeSpecificModify(): m.Child {
     return m(
       '.node-specific-modify',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -120,6 +120,27 @@ export class SlicesSourceNode extends SourceNode {
     return sq;
   }
 
+  nodeDetails?(): m.Child | undefined {
+    const details: m.Child[] = [];
+    if (this.state.slice_name) {
+      details.push(m('div', `slice_name: ${this.state.slice_name}`));
+    }
+    if (this.state.thread_name) {
+      details.push(m('div', `thread_name: ${this.state.thread_name}`));
+    }
+    if (this.state.process_name) {
+      details.push(m('div', `process_name: ${this.state.process_name}`));
+    }
+    if (this.state.track_name) {
+      details.push(m('div', `track_name: ${this.state.track_name}`));
+    }
+
+    if (details.length === 0) {
+      return;
+    }
+    return m('.pf-slice-source-details', details);
+  }
+
   nodeSpecificModify(): m.Child {
     return m(
       '',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -73,6 +73,7 @@ export interface QueryNode {
   validate(): boolean;
   getTitle(): string;
   nodeSpecificModify(onExecute?: () => void): m.Child;
+  nodeDetails?(): m.Child | undefined;
   clone(): QueryNode;
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined;
   isMaterialised(): boolean;


### PR DESCRIPTION
The commit introduces a feature that displays configuration details directly on the nodes. Specifically, it adds a summary of the settings for "Aggregation" and "Slices Source" nodes. For example, an Aggregation node will now show which columns it's grouping by and what aggregate functions are being used.