### PR TITLE
Fix perfetto->chromium autoroller on Win

### DIFF
--- a/src/base/lock_free_task_runner.cc
+++ b/src/base/lock_free_task_runner.cc
@@ -20,6 +20,8 @@
 
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <poll.h>
+#else
+#include <windows.h>
 #endif
 
 #include <thread>


### PR DESCRIPTION
The autoroller is broken on Win, example: https://chromium-review.googlesource.com/c/chromium/src/+/6949097