### PR TITLE
ui: Remove buttons entirely from track shell when not hovered

### DIFF
--- a/ui/src/assets/widgets/middle_ellipsis.scss
+++ b/ui/src/assets/widgets/middle_ellipsis.scss
@@ -16,6 +16,7 @@
   display: flex;
   flex-direction: row;
   overflow: hidden;
+  max-width: fit-content;
 
   .pf-middle-ellipsis-left {
     overflow: hidden;

--- a/ui/src/assets/widgets/track_shell.scss
+++ b/ui/src/assets/widgets/track_shell.scss
@@ -104,16 +104,16 @@
     }
 
     .pf-visible-on-hover {
-      visibility: hidden;
+      display: none;
 
       &.pf-active {
-        visibility: unset;
+        display: unset;
       }
     }
 
     &:hover {
       .pf-visible-on-hover {
-        visibility: unset;
+        display: unset;
       }
     }
   }
@@ -122,6 +122,13 @@
     // Make the track buttons a little larger so they're easier to see & click
     font-size: var(--pf-font-size-l);
     margin-left: 2px;
+
+    // If any buttons are active, show all the visible-on-hover buttons
+    &:has(.pf-active) {
+      .pf-visible-on-hover {
+        display: unset;
+      }
+    }
   }
 
   &__canvas {
@@ -147,7 +154,7 @@
 
   &__menubar {
     display: grid;
-    grid-template-columns: auto 1fr auto auto;
+    grid-template-columns: auto 1fr auto;
     grid-template-rows: auto auto;
     grid-template-areas:
       "icon title chips buttons"
@@ -167,9 +174,16 @@
     grid-area: icon;
   }
 
-  &__title {
+  &__title-container {
     grid-area: title;
 
+    display: flex;
+    flex-direction: row;
+
+    min-width: 0;
+  }
+
+  &__title {
     &-popup {
       position: absolute;
       border-radius: 2px;
@@ -198,10 +212,6 @@
   &__subtitle {
     grid-area: subtitle;
     font-size: 11px;
-  }
-
-  &__buttons {
-    grid-area: buttons;
   }
 
   &__crash-popup {

--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -701,7 +701,11 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     return m(
       PopupMenu,
       {
-        trigger: m(Button, {icon: 'show_chart', compact: true}),
+        trigger: m(Button, {
+          className: 'pf-visible-on-hover',
+          icon: 'show_chart',
+          compact: true,
+        }),
       },
       this.getCounterContextMenuItems(),
     );

--- a/ui/src/frontend/timeline_page/track_view.ts
+++ b/ui/src/frontend/timeline_page/track_view.ts
@@ -136,6 +136,7 @@ export class TrackView {
     const buttons = attrs.lite
       ? []
       : [
+          this.renderTrackMenuButton(),
           renderer?.track.getTrackShellButtons?.(),
           description !== undefined &&
             this.renderHelpButton(
@@ -144,10 +145,9 @@ export class TrackView {
                 : linkify(description),
             ),
           (removable || node.removable) && this.renderCloseButton(),
-          // We don't want summary tracks to be pinned as they rarely have
-          // useful information.
+
+          // These two can be permanently visible so they must go at the end.
           !node.isSummary && this.renderPinButton(),
-          this.renderTrackMenuButton(),
           this.renderAreaSelectionCheckbox(),
         ];
 
@@ -355,6 +355,7 @@ export class TrackView {
       icon: Icons.Close,
       title: 'Remove track',
       compact: true,
+      className: 'pf-visible-on-hover',
     });
   }
 

--- a/ui/src/widgets/track_shell.ts
+++ b/ui/src/widgets/track_shell.ts
@@ -327,19 +327,8 @@ export class TrackShell implements m.ClassComponent<TrackShellAttrs> {
                   icon: collapsed ? Icons.ExpandDown : Icons.ExpandUp,
                 })
               : m('.pf-track__title-spacer'),
-            m(TrackTitle, {title: attrs.title}),
-            chips &&
-              m(
-                Stack,
-                {
-                  className: 'pf-track__chips',
-                  spacing: 'small',
-                  orientation: 'horizontal',
-                },
-                chips.map((chip) =>
-                  m(Chip, {label: chip, compact: true, rounded: true}),
-                ),
-              ),
+            m(TrackTitle, {title: attrs.title, chips}),
+
             m(
               ButtonBar,
               {
@@ -462,20 +451,37 @@ function renderCrashButton(error: Error, pluginId: string | undefined) {
 
 interface TrackTitleAttrs {
   readonly title: string;
+  readonly chips?: ReadonlyArray<string>;
 }
 
 class TrackTitle implements m.ClassComponent<TrackTitleAttrs> {
   private readonly trash = new DisposableStack();
 
   view({attrs}: m.Vnode<TrackTitleAttrs>) {
-    return m(
-      MiddleEllipsis,
-      {
-        className: 'pf-track__title',
-        text: attrs.title,
-      },
-      m('.pf-track__title-popup', attrs.title),
-    );
+    const {chips} = attrs;
+
+    return m('.pf-track__title-container', [
+      m(
+        MiddleEllipsis,
+        {
+          className: 'pf-track__title',
+          text: attrs.title,
+        },
+        m('.pf-track__title-popup', attrs.title),
+      ),
+      chips &&
+        m(
+          Stack,
+          {
+            className: 'pf-track__chips',
+            spacing: 'small',
+            orientation: 'horizontal',
+          },
+          chips.map((chip) =>
+            m(Chip, {label: chip, compact: true, rounded: true}),
+          ),
+        ),
+    ]);
   }
 
   oncreate({dom}: m.VnodeDOM<TrackTitleAttrs>) {


### PR DESCRIPTION
Currently, some track shell buttons appear only on hover - which avoids cluttering the UI visually. However the invisible buttons still take up space in the shell which is could be otherwise used for the title.

When titles are very long it would be nice if we could use that space for the title instead of the buttons, especially if the track has a chip on it too (e.g. main thread), which takes up even more space.

This patch makes it so that the buttons are actually removed (display: none) when the track shell is not hovered, so the space may be used for the title.

The one bit of UX that I think is essential is that the permanent track buttons (those that remain even when the track is not being hovered) remain in the same place, so that they don't move when you go to click them, which would be maddening. In order to preserve this feature while also removing the hover-only buttons, I've had to change the order of the track shell buttons so that the permanent ones are always on the right. This could be a little jarring, but I don't see any other way to do it.


# Screenshots

## More room for long track names:

Before:
<img width="273" height="187" alt="image" src="https://github.com/user-attachments/assets/94d2c1a8-77e5-46f4-a072-395772ee9dba" />

After:
<img width="264" height="223" alt="image" src="https://github.com/user-attachments/assets/14390925-7304-45c8-ad28-10fbca78f0f8" />

## Note: Reordered buttons:

Before:
<img width="288" height="105" alt="image" src="https://github.com/user-attachments/assets/7d1a4d84-2eec-4120-8db3-488c40a2d42d" />

After:
<img width="288" height="124" alt="image" src="https://github.com/user-attachments/assets/8afefe98-a45b-4340-9de4-8c87becfcad1" />