### PR TITLE
Revert "tp: fix compile on windows by adding noreturn conditionally (…

### DIFF
--- a/src/trace_processor/util/regex.h
+++ b/src/trace_processor/util/regex.h
@@ -24,19 +24,12 @@
 #include <vector>
 
 #include "perfetto/base/build_config.h"
-#include "perfetto/base/compiler.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_or.h"
 
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <regex.h>
-#endif
-
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#define PERFETTO_WIN_NORETURN PERFETTO_NORETURN
-#else
-#define PERFETTO_WIN_NORETURN
 #endif
 
 namespace perfetto::trace_processor::regex {
@@ -101,8 +94,7 @@ class Regex {
   // The first element is the full match. Subsequent elements are parenthesized
   // subexpressions.
   // Returns nullopt if there is no match.
-  void Submatch(const char* s,
-                std::vector<std::string_view>& out) PERFETTO_WIN_NORETURN {
+  void Submatch(const char* s, std::vector<std::string_view>& out) {
 #if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
     PERFETTO_CHECK(regex_);
     const auto& rgx = regex_.value();
@@ -124,9 +116,8 @@ class Regex {
       }
     }
 #else
-    base::ignore_result(s);
-    base::ignore_result(out);
-    PERFETTO_FATAL("Windows regex is not supported.");
+    if (s)
+      PERFETTO_FATAL("Windows regex is not supported.");
 #endif
   }
 


### PR DESCRIPTION
…#2914)"

This reverts commit db14c6a444db148a1d4d132d5fb0a815b3f9857c.

Also adds a conditional PERFETTO_FATAL as suggested in https://github.com/google/perfetto/pull/2914#discussion_r2343825644

The original commit causes perfetto->chromium autoroller failures, e.g. https://chromium-review.googlesource.com/c/chromium/src/+/6950397
