### PR TITLE
tp: fix: fix regex.h build on windows

### DIFF
--- a/src/trace_processor/util/regex.h
+++ b/src/trace_processor/util/regex.h
@@ -116,6 +116,7 @@ class Regex {
       }
     }
 #else
+    base::ignore_result(out);
     if (s)
       PERFETTO_FATAL("Windows regex is not supported.");
 #endif


### PR DESCRIPTION
MSVC does not see that out is used in the non-Windows branch.
