### PR TITLE
Fix headers in lock_free_task_runner.cc

### DIFF
--- a/src/base/lock_free_task_runner.cc
+++ b/src/base/lock_free_task_runner.cc
@@ -18,10 +18,14 @@
 
 #include "perfetto/base/build_config.h"
 
-#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-#include <poll.h>
-#else
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 #include <windows.h>
+
+// Keep the \n before to prevent clang-format reordering.
+#include <synchapi.h>
+#else
+#include <unistd.h>
+#include <poll.h>
 #endif
 
 #include <thread>


### PR DESCRIPTION
Follow up to #2940
Add also synchapi.h, as it is in unix_task_runner.c.
I don't remember why, but i remember there was a reason why I
had to add it to UnixTaskRunner back then (probably MinGW).
Also add the unistd.h required for QNX.
