### PR TITLE
atrace: Create Wattson atrace category

### DIFF
--- a/src/traced/probes/ftrace/predefined_tracepoints.cc
+++ b/src/traced/probes/ftrace/predefined_tracepoints.cc
@@ -379,6 +379,21 @@ base::FlatSet<GroupAndName> GenerateCameraTracePoints(
   return events;
 }
 
+base::FlatSet<GroupAndName> GenerateWattsonTracePoints(
+    const ProtoTranslationTable* table) {
+  base::FlatSet<GroupAndName> events;
+  InsertEvent("cpuhp", "cpuhp_enter", &events);
+  InsertEvent("cpuhp", "cpuhp_exit", &events);
+  InsertEvent("cpuhp", "cpuhp_multi_enter", &events);
+  InsertEvent("devfreq", "devfreq_frequency", &events);
+  InsertEvent("ftrace", "print", &events);
+  InsertEvent("power", "cpu_frequency", &events);
+  InsertEvent("power", "cpu_idle", &events);
+  InsertEvent("power", "suspend_resume", &events);
+  InsertEvent("sched", "sched_switch", &events);
+  return events;
+}
+
 std::map<std::string, base::FlatSet<GroupAndName>>
 GeneratePredefinedTracePoints(const ProtoTranslationTable* table,
                               Tracefs* ftrace) {
@@ -412,6 +427,7 @@ GeneratePredefinedTracePoints(const ProtoTranslationTable* table,
   tracepoints["memory"] = GenerateMemoryTracePoints(ftrace);
   tracepoints["thermal"] = GenerateThermalTracePoints();
   tracepoints["camera"] = GenerateCameraTracePoints(table);
+  tracepoints["wattson"] = GenerateWattsonTracePoints(table);
   return tracepoints;
 }
 }  // namespace


### PR DESCRIPTION
Create a Wattson atrace category that encapsulates the necessary ftrace events needed for Wattson to run. This simplifies the Perfetto configuration that Wattson users need to specify before starting tracing.
This code change is in sync with code change at ag/35021822 for platform/frameworks/native/cmds/atrace/atrace.cpp.

Bug: 437968566

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
