### PR TITLE
Revert "Migrate android_jank_cuj metric to use stdlib tables and local composition. (#2182)"

### DIFF
--- a/src/trace_processor/metrics/sql/android/android_jank_cuj.sql
+++ b/src/trace_processor/metrics/sql/android/android_jank_cuj.sql
@@ -13,207 +13,63 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- Create the base table (`android_jank_cuj`) containing all completed CUJs
+-- found in the trace.
+SELECT RUN_METRIC('android/jank/cujs.sql');
+
+-- Create tables to store each CUJs main, render, HWC release,
+-- and GPU completion threads.
+-- Also stores the (not CUJ-specific) threads of SF: main, render engine,
+-- and GPU completion threads.
+SELECT RUN_METRIC('android/jank/relevant_threads.sql');
+
+-- Create tables to store the main slices on each of the relevant threads
+-- * `Choreographer#doFrame` on the main thread
+-- * `DrawFrames on the render` thread
+-- * `waiting for HWC release` on the HWC release thread
+-- * `Waiting for GPU completion` on the GPU completion thread
+-- * `commit` and `composite` on SF main thread.
+-- * `REThreaded::drawLayers` on SF RenderEngine thread.
+-- Also extracts vsync ids and GPU completion fence ids that allow us to match
+-- slices to concrete vsync IDs.
+-- Slices and vsyncs are matched between the app and SF processes by looking
+-- at the actual frame timeline data.
+-- We only store the slices that were produced for the vsyncs within the
+-- CUJ markers.
+SELECT RUN_METRIC('android/jank/relevant_slices.sql');
+
+-- Computes the boundaries of specific frames and overall CUJ boundaries
+-- on specific important threads since each thread will work on a frame at a
+-- slightly different time.
+-- We also compute the corrected CUJ ts boundaries. This is necessary because
+-- the instrumentation logs begin/end CUJ markers *during* the first frame and
+-- typically *right at the start* of the last CUJ frame. The ts boundaries in
+-- `android_jank_cuj` table are based on these markers so do not actually
+-- contain the whole CUJ, but instead overlap with all Choreographer#doFrame
+-- slices that belong to a CUJ.
+SELECT RUN_METRIC('android/jank/cujs_boundaries.sql');
+
+-- With relevant slices and corrected boundaries we can now estimate the ts
+-- boundaries of each frame within the CUJ.
+-- We also match with the data from the actual timeline to check which frames
+-- missed the deadline and whether this was due to the app or SF.
+SELECT RUN_METRIC('android/jank/frames.sql');
+
+-- Creates tables with slices from various relevant threads that are within
+-- the CUJ boundaries. Used as data sources for further processing and
+-- jank cause analysis of traces.
+SELECT RUN_METRIC('android/jank/slices.sql');
+
+-- Creates tables and functions to be used for manual investigations and
+-- jank cause analysis of traces.
+SELECT RUN_METRIC('android/jank/internal/query_base.sql');
+SELECT RUN_METRIC('android/jank/query_functions.sql');
+
 -- Creates a table that matches CUJ counters with the correct CUJs.
 -- After the CUJ ends FrameTracker emits counters with the number of total
 -- frames, missed frames, longest frame duration, etc.
 -- The same numbers are also reported by FrameTracker to statsd.
-
-SELECT RUN_METRIC('android/process_metadata.sql');
-INCLUDE PERFETTO MODULE android.surfaceflinger;
-INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
-INCLUDE PERFETTO MODULE android.cujs.sysui_cuj_counters;
-INCLUDE PERFETTO MODULE android.frames.jank_type;
-INCLUDE PERFETTO MODULE android.frames.timeline;
-
--- Table captures additional data related to each frame in a CUJ. This information includes
--- data like missed type of jank, missed app/sf frame, missed sf/hwui callbacks etc.
-DROP TABLE IF EXISTS _android_jank_cuj_frames_data;
-CREATE PERFETTO TABLE _android_jank_cuj_frames_data AS
-WITH actual_timeline_with_vsync AS (
-  SELECT
-    *,
-    CAST(name AS INTEGER) AS vsync
-  FROM actual_frame_timeline_slice
-  WHERE dur > 0
-),
-expected_timeline_with_vsync AS (
-  SELECT *, CAST(name AS INTEGER) AS vsync
-  FROM expected_frame_timeline_slice
-  WHERE dur > 0
-),
-frames_in_cuj AS (
-  SELECT
-    frame.upid,
-    frame.layer_name AS frame_layer_name,
-    frame.frame_id,
-    actual_frame.display_frame_token,
-    cuj_id,
-    frame_ts,
-    (
-      frame_ts + frame.dur
-    ) AS ts_end,
-    jank_type,
-    on_time_finish,
-    sf_callback_missed,
-    hwui_callback_missed
-  FROM _android_frames_in_cuj frame
-  JOIN actual_timeline_with_vsync AS actual_frame
-    ON frame.frame_id = actual_frame.vsync
-  LEFT JOIN _vsync_missed_callback AS missed_callback USING(vsync)
-  WHERE
-    frame.cuj_layer_id IS NULL
-    OR (
-      actual_frame.layer_name GLOB '*#*'
-      AND frame.cuj_layer_id
-        = android_get_layer_id_from_name(actual_frame.layer_name)
-      AND frame.layer_id
-        = android_get_layer_id_from_name(actual_frame.layer_name))
-)
-SELECT
-  ROW_NUMBER() OVER (PARTITION BY cuj_id ORDER BY frame_id ASC) AS frame_number,
-  cuj_id,
-  -- We use MAX to check if at least one of the layers jank_type matches the pattern
-  MAX(android_is_app_jank_type(jank_type)) AS app_missed,
-  -- We use MAX to check if at least one of the layers jank_type matches the pattern
-  MAX(android_is_sf_jank_type(jank_type)) AS sf_missed,
-  IFNULL(MAX(sf_callback_missed), 0) AS sf_callback_missed,
-  IFNULL(MAX(hwui_callback_missed), 0) AS hwui_callback_missed,
-  -- We use MIN to check if ALL layers finished on time
-  MIN(on_time_finish) AS on_time_finish,
-  frame_id,
-  frame_layer_name,
-  vsync_boundary.display_frame_token,
-  e.ts AS ts_expected,
-  -- In cases where we are drawing multiple layers, there will be  one
-  -- expected frame timeline slice, but multiple actual frame timeline slices.
-  -- As a simplification we just take here the min(ts) and max(ts_end) of
-  -- the actual frame timeline slices.
-  MIN(frame_ts) AS ts_actual_min,
-  MAX(ts_end) AS ts_end_actual_max,
-  -- In case expected timeline is missing, as a fallback we use the typical frame deadline
-  -- for 60Hz.
-  COALESCE(MAX(e.dur), 16600000) AS dur_expected
-FROM frames_in_cuj vsync_boundary
-JOIN expected_timeline_with_vsync e
-  ON e.upid = vsync_boundary.upid  AND e.vsync = vsync_boundary.frame_id
-GROUP BY cuj_id, e.vsync, e.ts;
-
--- Combine trace frame data with Choreographer#doFrame
-DROP TABLE IF EXISTS android_jank_cuj_frame_trace_data;
-CREATE PERFETTO TABLE android_jank_cuj_frame_trace_data AS
-WITH do_frame_ordered AS (
-  SELECT
-    *,
-    -- ts_end of the previous do_frame, or -1 if no previous do_frame found
-    COALESCE(LAG(ts_end) OVER (PARTITION BY cuj_id ORDER BY vsync ASC), -1) AS ts_prev_do_frame_end
-  FROM _android_jank_cuj_do_frames
-),
-trace_metrics_frame AS (
-  select timeline.*,
-   do_frame.ts AS ts_do_frame_start,
-   CASE
-       WHEN ts_expected IS NULL
-         THEN do_frame.ts
-       ELSE MAX(do_frame.ts_prev_do_frame_end, timeline.ts_expected)
-   END AS ts
-   FROM do_frame_ordered do_frame
-   LEFT JOIN _android_jank_cuj_frames_data timeline
-    ON do_frame.cuj_id = timeline.cuj_id AND do_frame.vsync = timeline.frame_id
-)
-SELECT
-  cuj_id,
-  frame_number,
-  frame_id,
-  ts,
-  ts_expected,
-  ts_do_frame_start,
-  app_missed,
-  sf_missed,
-  sf_callback_missed,
-  hwui_callback_missed,
-  on_time_finish,
-  ts_end_actual_max - ts AS dur,
-  ts_end_actual_max - ts_do_frame_start AS dur_unadjusted,
-  dur_expected,
-  ts_end_actual_max AS ts_end,
-  frame_layer_name
-FROM trace_metrics_frame;
-
--- Table captures CUJ scoped frame data for the SF process.
-DROP TABLE IF EXISTS android_jank_cuj_sf_frame_trace_data;
-CREATE PERFETTO TABLE android_jank_cuj_sf_frame_trace_data AS
-WITH android_jank_cuj_sf_frame_base AS (
-  SELECT DISTINCT
-    boundary.cuj_id,
-    boundary.vsync,
-    boundary.ts,
-    boundary.ts_main_thread_start,
-    boundary.ts_end,
-    boundary.dur,
-    actual_timeline.jank_tag = 'Self Jank' AS sf_missed,
-    NULL AS app_missed, -- for simplicity align schema with android_jank_cuj_frame
-    jank_tag,
-    jank_type,
-    prediction_type,
-    present_type,
-    gpu_composition,
-    -- In case expected timeline is missing, as a fallback we use the typical frame deadline
-    -- for 60Hz.
-    COALESCE(expected_timeline.dur, 16600000) AS dur_expected
-  FROM _android_jank_cuj_sf_main_thread_frame_boundary boundary
-  JOIN _android_sf_process sf_process
-  JOIN actual_frame_timeline_slice actual_timeline
-    ON actual_timeline.upid = sf_process.upid
-      AND boundary.vsync = CAST(actual_timeline.name AS INTEGER)
-  JOIN _android_jank_cuj_frames_data ft
-    ON CAST(actual_timeline.name AS INTEGER) = ft.display_frame_token
-      AND boundary.cuj_id = ft.cuj_id
-  LEFT JOIN expected_frame_timeline_slice expected_timeline
-    ON expected_timeline.upid = actual_timeline.upid
-      AND expected_timeline.name = actual_timeline.name
-)
-SELECT
- *,
- ROW_NUMBER() OVER (PARTITION BY cuj_id ORDER BY vsync ASC) AS frame_number
-FROM android_jank_cuj_sf_frame_base;
-
--- Table captures various missed frames and callbacks counters from counter tracks in a process.
-DROP TABLE IF EXISTS android_jank_cuj_counter_metrics;
-CREATE PERFETTO TABLE android_jank_cuj_counter_metrics AS
--- Order CUJs to get the ts of the next CUJ with the same name.
--- This is to avoid selecting counters logged for the next CUJ in case multiple
--- CUJs happened in a short succession.
-WITH cujs_ordered AS (
-  SELECT
-    cuj_id,
-    cuj_name,
-    cuj_slice_name,
-    upid,
-    state,
-    ts_end,
-    CASE
-      WHEN process_name GLOB 'com.android.*' THEN ts_end
-      WHEN process_name = 'com.google.android.apps.nexuslauncher' THEN ts_end
-      -- Some processes publish (a subset of) counters right before ending the
-      -- CUJ marker slice. Updating the SQL query to consider counters up to 4ms
-      -- before the CUJ ends in that case.
-      ELSE MAX(ts, ts_end - 4000000)
-    END AS ts_earliest_allowed_counter,
-    LEAD(ts_end) OVER (PARTITION BY cuj_name ORDER BY ts_end ASC) AS ts_end_next_cuj
-  FROM android_sysui_jank_cujs
-)
-SELECT
-  cuj_id,
-  _android_jank_cuj_counter_value(cuj_name, 'totalFrames', ts_earliest_allowed_counter, ts_end_next_cuj) AS total_frames,
-  _android_jank_cuj_counter_value(cuj_name, 'missedFrames', ts_earliest_allowed_counter, ts_end_next_cuj) AS missed_frames,
-  _android_jank_cuj_counter_value(cuj_name, 'missedAppFrames', ts_earliest_allowed_counter, ts_end_next_cuj) AS missed_app_frames,
-  _android_jank_cuj_counter_value(cuj_name, 'missedSfFrames', ts_earliest_allowed_counter, ts_end_next_cuj) AS missed_sf_frames,
-  _android_jank_cuj_counter_value(cuj_name, 'maxSuccessiveMissedFrames', ts_earliest_allowed_counter, ts_end_next_cuj) AS missed_frames_max_successive,
-  -- convert ms to nanos to align with the unit for `dur` in the other tables
-  _android_jank_cuj_counter_value(cuj_name, 'maxFrameTimeMillis', ts_earliest_allowed_counter, ts_end_next_cuj) * 1000000 AS frame_dur_max,
-  _android_cuj_missed_vsyncs_for_callback(cuj_slice_name, ts_earliest_allowed_counter, ts_end_next_cuj, '*SF*') AS sf_callback_missed_frames,
-  _android_cuj_missed_vsyncs_for_callback(cuj_slice_name, ts_earliest_allowed_counter, ts_end_next_cuj, '*HWUI*') AS hwui_callback_missed_frames
-FROM cujs_ordered cuj;
+SELECT RUN_METRIC('android/jank/internal/counters.sql');
 
 DROP VIEW IF EXISTS android_jank_cuj_output;
 CREATE PERFETTO VIEW android_jank_cuj_output AS
@@ -224,10 +80,10 @@ SELECT
         AndroidJankCujMetric_Cuj(
           'id', cuj_id,
           'name', cuj_name,
-          'process', process_metadata_proto(cuj.upid),
+          'process', process_metadata,
           'layer_name', layer_name,
-          'ts', cuj.ts,
-          'dur', cuj.dur,
+          'ts', COALESCE(boundary.ts, cuj.ts),
+          'dur', COALESCE(boundary.dur, cuj.dur),
           'counter_metrics', (
             SELECT AndroidJankCujMetric_Metrics(
               'total_frames', total_frames,
@@ -258,7 +114,7 @@ SELECT
               'frame_dur_ms_p90', PERCENTILE(f.dur / 1e6, 90),
               'frame_dur_ms_p95', PERCENTILE(f.dur / 1e6, 95),
               'frame_dur_ms_p99', PERCENTILE(f.dur / 1e6, 99))
-            FROM android_jank_cuj_frame_trace_data f
+            FROM android_jank_cuj_frame f
             WHERE f.cuj_id = cuj.cuj_id),
           'timeline_metrics', (
             SELECT AndroidJankCujMetric_Metrics(
@@ -278,13 +134,13 @@ SELECT
               'frame_dur_ms_p90', PERCENTILE(f.dur / 1e6, 90),
               'frame_dur_ms_p95', PERCENTILE(f.dur / 1e6, 95),
               'frame_dur_ms_p99', PERCENTILE(f.dur / 1e6, 99))
-            FROM android_jank_cuj_frame_trace_data f
+            FROM android_jank_cuj_frame_timeline f
             WHERE f.cuj_id = cuj.cuj_id),
           'frame', (
             SELECT RepeatedField(
               AndroidJankCujMetric_Frame(
                 'frame_number', f.frame_number,
-                'vsync', f.frame_id,
+                'vsync', f.vsync,
                 'ts', f.ts,
                 'dur', f.dur,
                 'dur_expected', f.dur_expected,
@@ -292,7 +148,7 @@ SELECT
                 'sf_missed', f.sf_missed,
                 'sf_callback_missed', f.sf_callback_missed,
                 'hwui_callback_missed', f.hwui_callback_missed))
-            FROM android_jank_cuj_frame_trace_data f
+            FROM android_jank_cuj_frame f
             WHERE f.cuj_id = cuj.cuj_id
             ORDER BY frame_number ASC),
           'sf_frame', (
@@ -304,9 +160,11 @@ SELECT
                 'dur', f.dur,
                 'dur_expected', f.dur_expected,
                 'sf_missed', f.sf_missed))
-            FROM android_jank_cuj_sf_frame_trace_data f
+            FROM android_jank_cuj_sf_frame f
             WHERE f.cuj_id = cuj.cuj_id
             ORDER BY frame_number ASC)
         ))
-      FROM android_sysui_jank_cujs cuj
+      FROM android_jank_cuj cuj
+      LEFT JOIN android_jank_cuj_boundary boundary USING (cuj_id)
+      LEFT JOIN android_jank_cuj_layer_name cuj_layer USING (cuj_id)
       ORDER BY cuj.cuj_id ASC));

--- a/src/trace_processor/metrics/sql/android/jank/internal/counters.sql
+++ b/src/trace_processor/metrics/sql/android/jank/internal/counters.sql
@@ -12,7 +12,6 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
-
 INCLUDE PERFETTO MODULE android.cujs.sysui_cuj_counters;
 INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
 
@@ -32,9 +31,7 @@ WITH cujs_ordered AS (
     CASE
       WHEN process_name GLOB 'com.android.*' THEN ts_end
       WHEN process_name = 'com.google.android.apps.nexuslauncher' THEN ts_end
-      -- Some processes publish (a subset of) counters right before ending the
-      -- CUJ marker slice. Updating the SQL query to consider counters up to 4ms
-      -- before the CUJ ends in that case.
+      -- Some processes publish counters just before logging the CUJ end
       ELSE MAX(ts, ts_end - 4000000)
     END AS ts_earliest_allowed_counter,
     LEAD(ts_end) OVER (PARTITION BY cuj_name ORDER BY ts_end ASC) AS ts_end_next_cuj

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql
@@ -138,49 +138,77 @@ SELECT
 
 -- Track all distinct frames that overlap with the CUJ slice.
 CREATE PERFETTO VIEW _android_frames_in_cuj AS
-SELECT
-  row_number() OVER (PARTITION BY cuj.cuj_id ORDER BY frame.ts) AS frame_idx,
-  count(*) OVER (PARTITION BY cuj.cuj_id) AS frame_cnt,
-  _extract_cuj_name_from_slice(cuj.cuj_slice_name) AS cuj_name,
-  cuj.upid,
-  cuj.process_name,
-  cie.layer_id AS cuj_layer_id,
-  frame.layer_id,
-  frame.layer_name,
-  frame.frame_id,
-  frame.do_frame_id,
-  frame.expected_frame_timeline_id,
-  cuj.cuj_id,
-  frame.ts AS frame_ts,
-  frame.dur AS dur,
-  (
-    frame.ts + frame.dur
-  ) AS ts_end,
-  ui_thread_utid
-FROM android_frames_layers AS frame
-JOIN _sysui_cuj_instant_events AS cie
-  ON frame.ui_thread_utid = cie.ui_thread AND frame.layer_id IS NOT NULL
-JOIN _sysui_cujs_slices AS cuj
-  ON cie.cuj_id = cuj.cuj_id
--- Check whether the frame_id falls within the begin and end vsync of the cuj.
--- Also check if the frame start or end timestamp falls within the cuj boundary.
-WHERE
-  frame_id >= begin_vsync
-  AND frame_id <= end_vsync
-  AND (
-    -- frame start within cuj
-    (
-      frame.ts >= cuj.ts AND frame.ts <= cuj.ts_end
-    )
-    -- frame end within cuj
-    OR (
+-- Captures all frames in the CUJ boundary. In cases where there are multiple actual frames, there
+-- can be multiple rows with the same frame_id.
+WITH
+  all_frames_in_cuj AS (
+    SELECT
+      _extract_cuj_name_from_slice(cuj.cuj_slice_name) AS cuj_name,
+      cuj.upid,
+      cuj.process_name,
+      frame.layer_id,
+      frame.frame_id,
+      frame.do_frame_id,
+      frame.expected_frame_timeline_id,
+      cuj.cuj_id,
+      frame.ts AS frame_ts,
+      frame.dur AS dur,
       (
         frame.ts + frame.dur
-      ) >= cuj.ts AND (
-        frame.ts + frame.dur
-      ) <= cuj.ts_end
-    )
-  );
+      ) AS ts_end,
+      ui_thread_utid
+    FROM android_frames_layers AS frame
+    JOIN _sysui_cuj_instant_events AS cie
+      ON frame.ui_thread_utid = cie.ui_thread AND frame.layer_id IS NOT NULL
+    JOIN _sysui_cujs_slices AS cuj
+      ON cie.cuj_id = cuj.cuj_id
+    -- Check whether the frame_id falls within the begin and end vsync of the cuj.
+    -- Also check if the frame start or end timestamp falls within the cuj boundary.
+    WHERE
+      frame_id >= begin_vsync
+      AND frame_id <= end_vsync
+      AND (
+        -- frame start within cuj
+        (
+          frame.ts >= cuj.ts AND frame.ts <= cuj.ts_end
+        )
+        -- frame end within cuj
+        OR (
+          (
+            frame.ts + frame.dur
+          ) >= cuj.ts AND (
+            frame.ts + frame.dur
+          ) <= cuj.ts_end
+        )
+      )
+  )
+SELECT
+  row_number() OVER (PARTITION BY cuj_id ORDER BY min(frame_ts)) AS frame_idx,
+  count(*) OVER (PARTITION BY cuj_id) AS frame_cnt,
+  -- Column values with no aggregation function will stay identical across rows. For eg.
+  -- a cuj_name, upid will be the same for a given cuj_id. do_frame_id or expected_frame_timeline_id
+  -- will be the same for a given frame_id. Hence it is ok to not have aggregation functions for
+  -- all selected columns.
+  cuj_name,
+  upid,
+  layer_id,
+  process_name,
+  frame_id,
+  do_frame_id,
+  expected_frame_timeline_id,
+  cuj_id,
+  ui_thread_utid,
+  -- In case of multiple frames for a frame_id, consider the min start timestamp.
+  min(frame_ts) AS frame_ts,
+  -- In case of multiple frames for a frame_id, consider the max end timestamp.
+  max(ts_end) AS ts_end,
+  (
+    max(ts_end) - min(frame_ts)
+  ) AS dur
+FROM all_frames_in_cuj
+GROUP BY
+  frame_id,
+  cuj_id;
 
 -- Table tracking all jank CUJs information.
 CREATE PERFETTO TABLE android_sysui_jank_cujs (
@@ -214,8 +242,6 @@ CREATE PERFETTO TABLE android_sysui_jank_cujs (
   ui_thread JOINID(thread.id),
   -- layer id associated with the actual frame.
   layer_id LONG,
-  -- layer name associated with the actual frame.
-  layer_name STRING,
   -- vysnc id of the first frame that falls within the CUJ boundary.
   begin_vsync LONG,
   -- vysnc id of the last frame that falls within the CUJ boundary.
@@ -284,7 +310,6 @@ SELECT
   END AS state,
   cuj_events.ui_thread,
   cuj_events.layer_id,
-  boundary.layer_name,
   cuj_events.begin_vsync,
   cuj_events.end_vsync
 FROM _sysui_cujs_slices AS cuj
@@ -418,8 +443,6 @@ CREATE PERFETTO TABLE android_jank_latency_cujs (
   ui_thread JOINID(thread.id),
   -- layer id associated with the actual frame.
   layer_id LONG,
-  -- layer name associated with the actual frame.
-  layer_name STRING,
   -- vysnc id of the first frame that falls within the CUJ boundary.
   begin_vsync LONG,
   -- vysnc id of the last frame that falls within the CUJ boundary.
@@ -438,7 +461,6 @@ SELECT
   -- upid is used as the ui_thread as it's the tid of the main thread.
   upid AS ui_thread,
   NULL AS layer_id,
-  NULL AS layer_name,
   NULL AS begin_vsync,
   NULL AS end_vsync,
   "latency" AS cuj_type,

--- a/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
@@ -105,21 +105,11 @@ SELECT
   upid
 FROM _get_frame_table_with_id('DrawFrame*');
 
---Extract layer_id from a given layer_name.
-CREATE PERFETTO FUNCTION android_get_layer_id_from_name(
-    -- Layer name for a given frame.
-    layer_name STRING
-)
--- int_value for the layer_id.
-RETURNS LONG AS
-SELECT
-  CAST(str_split($layer_name, '#', 1) AS INTEGER);
-
 -- Fetch distinct actual frames per layer per process.
 CREATE PERFETTO TABLE _distinct_layer_actual_timeline_slice_per_process AS
 SELECT
   cast_int!(name) AS frame_id,
-  android_get_layer_id_from_name(layer_name) AS layer_id,
+  CAST(str_split(layer_name, '#', 1) AS INTEGER) AS layer_id,
   layer_name,
   id AS slice_id,
   ts,

--- a/test/trace_processor/diff_tests/metrics/graphics/android_jank_cuj.out
+++ b/test/trace_processor/diff_tests/metrics/graphics/android_jank_cuj.out
@@ -16,7 +16,7 @@ android_jank_cuj {
       is_kernel_task: false
     }
     ts: 0
-    dur: 115000000
+    dur: 123000000
     frame {
       frame_number: 1
       vsync: 10
@@ -194,7 +194,7 @@ android_jank_cuj {
       is_kernel_task: false
     }
     ts: 0
-    dur: 702000000
+    dur: 901000010
     frame {
       frame_number: 1
       vsync: 10
@@ -410,13 +410,13 @@ android_jank_cuj {
       missed_app_frames: 7
       missed_sf_frames: 2
       frame_dur_max: 61000000
-      frame_dur_avg: 31738461
-      frame_dur_p50: 25000000
-      frame_dur_p90: 60000000
+      frame_dur_avg: 27192307
+      frame_dur_p50: 22000000
+      frame_dur_p90: 56800000
       frame_dur_p95: 61000000
       frame_dur_p99: 61000000
-      frame_dur_ms_p50: 25.0
-      frame_dur_ms_p90: 60.0
+      frame_dur_ms_p50: 22.000000
+      frame_dur_ms_p90: 56.80000000000001
       frame_dur_ms_p95: 61.000000
       frame_dur_ms_p99: 61.000000
       sf_callback_missed_frames: 1

--- a/test/trace_processor/diff_tests/metrics/graphics/android_jank_cuj_query_test.sql
+++ b/test/trace_processor/diff_tests/metrics/graphics/android_jank_cuj_query_test.sql
@@ -13,53 +13,8 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- Create the base table (`android_jank_cuj`) containing all completed CUJs
--- found in the trace.
-SELECT RUN_METRIC('android/jank/cujs.sql');
--- Create tables to store each CUJs main, render, HWC release,
--- and GPU completion threads.
--- Also stores the (not CUJ-specific) threads of SF: main, render engine,
--- and GPU completion threads.
-SELECT RUN_METRIC('android/jank/relevant_threads.sql');
+SELECT RUN_METRIC('android/android_jank_cuj.sql');
 
--- Create tables to store the main slices on each of the relevant threads
--- * `Choreographer#doFrame` on the main thread
--- * `DrawFrames on the render` thread
--- * `waiting for HWC release` on the HWC release thread
--- * `Waiting for GPU completion` on the GPU completion thread
--- * `commit` and `composite` on SF main thread.
--- * `REThreaded::drawLayers` on SF RenderEngine thread.
--- Also extracts vsync ids and GPU completion fence ids that allow us to match
--- slices to concrete vsync IDs.
--- Slices and vsyncs are matched between the app and SF processes by looking
--- at the actual frame timeline data.
--- We only store the slices that were produced for the vsyncs within the
--- CUJ markers.
-SELECT RUN_METRIC('android/jank/relevant_slices.sql');
-
--- Computes the boundaries of specific frames and overall CUJ boundaries
--- on specific important threads since each thread will work on a frame at a
--- slightly different time.
--- We also compute the corrected CUJ ts boundaries. This is necessary because
--- the instrumentation logs begin/end CUJ markers *during* the first frame and
--- typically *right at the start* of the last CUJ frame. The ts boundaries in
--- `android_jank_cuj` table are based on these markers so do not actually
--- contain the whole CUJ, but instead overlap with all Choreographer#doFrame
--- slices that belong to a CUJ.
-SELECT RUN_METRIC('android/jank/cujs_boundaries.sql');
--- With relevant slices and corrected boundaries we can now estimate the ts
--- boundaries of each frame within the CUJ.
--- We also match with the data from the actual timeline to check which frames
--- missed the deadline and whether this was due to the app or SF.
-SELECT RUN_METRIC('android/jank/frames.sql');
--- Creates tables with slices from various relevant threads that are within
--- the CUJ boundaries. Used as data sources for further processing and
--- jank cause analysis of traces.
-SELECT RUN_METRIC('android/jank/slices.sql');
--- Creates tables and functions to be used for manual investigations and
--- jank cause analysis of traces.
-SELECT RUN_METRIC('android/jank/internal/query_base.sql');
-SELECT RUN_METRIC('android/jank/query_functions.sql');
 
 -- First query to look at `binder transaction` on the Main Thread
 

--- a/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
+++ b/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
@@ -32,10 +32,10 @@ class SystemUICujs(TestSuite):
         FROM android_sysui_jank_cujs;
         """,
         out=Csv("""
-        "cuj_id","upid","process_name","cuj_slice_name","cuj_name","slice_id","ts","ts_end","dur","state","ui_thread","layer_id","layer_name","begin_vsync","end_vsync"
-        1,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",4,27000000,65000000,38000000,"completed",3,0,"TX - first_layer#0",20,30
-        2,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",25,85000000,89000000,4000000,"completed",3,2,"TX - third_layer#2",60,70
-        3,2,"com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",39,121000000,143000000,22000000,"completed",5,1,"TX - second_layer#1",80,90
+        "cuj_id","upid","process_name","cuj_slice_name","cuj_name","slice_id","ts","ts_end","dur","state","ui_thread","layer_id","begin_vsync","end_vsync"
+        1,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",4,27000000,65000000,38000000,"completed",3,0,20,30
+        2,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",25,85000000,89000000,4000000,"completed",3,2,60,70
+        3,2,"com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",39,121000000,143000000,22000000,"completed",5,1,80,90
         """))
 
   def test_android_sysui_latency_cujs(self):


### PR DESCRIPTION
This reverts commit 4c804d94ed6dd737ba0ef3d190811fa79bebf5a2.

Failing roll into Google3: http://fusion2/presubmit/807538954/OCL:807538954:BASE:807642419:1758022636326:b51f8c80/targets/invocations/bcead98a-2fd7-43df-b1f3-63ab0bad8da1/targets/%2F%2Fjavatests%2Fcom%2Fgoogle%2Fwireless%2Fandroid%2Ftelemetry%2Fpipelines%2Ftraceextractor%2Fpower:MediumTests/tests