### PR TITLE
Also keep last zero delta in counter_leading_intervals().

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/types/counter.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/types/counter.h
@@ -29,6 +29,10 @@ struct CounterTrackPartition {
   std::vector<int64_t> id;
   std::vector<int64_t> ts;
   std::vector<double> val;
+
+  int64_t last_equal_id;
+  int64_t last_equal_ts;
+  double last_equal_val;
 };
 
 struct PartitionedCounter {

--- a/src/trace_processor/perfetto_sql/stdlib/counters/intervals.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/counters/intervals.sql
@@ -17,8 +17,8 @@
 -- For a given counter timeline (e.g. a single counter track), returns
 -- intervals of time where the counter has the same value. For every run
 -- of identical values, this macro will return a row for the first one,
--- and a row merging all subsequent ones. This to to facilitate construction
--- of counters from delta_values.
+-- the last one, and a row merging all other ones. This to to facilitate
+-- construction of counters from delta_values.
 --
 -- Intervals are computed in a "forward-looking" way. That is, if a counter
 -- changes value at some timestamp, it's assumed it *just* reached that

--- a/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
+++ b/test/trace_processor/diff_tests/parser/power/tests_power_rails.py
@@ -34,7 +34,7 @@ class PowerPowerRails(TestSuite):
       """,
         out=Csv("""
         "power_rail_name","AVG(value)","COUNT(*)"
-        "power.PPVAR_VPH_PWR_ABH_uws",7384987.339286,56
+        "power.PPVAR_VPH_PWR_ABH_uws",7388261.216667,60
         "power.PPVAR_VPH_PWR_OLED_uws",202362991.655738,61
         """))
 

--- a/test/trace_processor/diff_tests/stdlib/counters/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/counters/tests.py
@@ -45,3 +45,29 @@ class StdlibCounterIntervals(TestSuite):
         1,0,10,2,10.000000,20.000000,"[NULL]"
         3,10,19990,2,20.000000,"[NULL]",10.000000
         """))
+
+  def test_intervals_counter_leading_zero_deltas(self):
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+        INCLUDE PERFETTO MODULE counters.intervals;
+
+          WITH data(id, ts, value, track_id) AS (
+            VALUES
+            (1, 10, 10, 1),
+            (2, 20, 11, 1),
+            (3, 30, 11, 1),
+            (4, 40, 11, 1),
+            (5, 50, 11, 1),
+            (6, 60, 12, 1)
+          )
+          SELECT * FROM counter_leading_intervals!(data);
+        """,
+        out=Csv("""
+        "id","ts","dur","track_id","value","next_value","delta_value"
+        1,10,10,1,10.000000,11.000000,"[NULL]"
+        2,20,10,1,11.000000,11.000000,1.000000
+        3,30,20,1,11.000000,11.000000,0.000000
+        5,50,10,1,11.000000,12.000000,0.000000
+        6,60,19940,1,12.000000,"[NULL]",1.000000
+        """))

--- a/test/trace_processor/diff_tests/stdlib/linux/memory.py
+++ b/test/trace_processor/diff_tests/stdlib/linux/memory.py
@@ -58,11 +58,11 @@ class Memory(TestSuite):
         37592474220,12993896,1,1982,"com.android.systemui",125865984
         37605468116,1628,1,1982,"com.android.systemui",126050304
         37605469744,1302,1,1982,"com.android.systemui",129040384
-        37605471046,333772827,1,1982,"com.android.systemui",129040384
+        37605471046,212934245,1,1982,"com.android.systemui",129040384
+        37818405291,120838582,1,1982,"com.android.systemui",129040384
         37939243873,120479574,1,1982,"com.android.systemui",372977664
         38059723447,936,1,1982,"com.android.systemui",373043200
         38059724383,6749186,1,1982,"com.android.systemui",373174272
         38066473569,7869426,1,1982,"com.android.systemui",373309440
         38074342995,11596761,1,1982,"com.android.systemui",373444608
-        38085939756,4877848,1,1982,"com.android.systemui",373579776
               """))


### PR DESCRIPTION
This means we also correctly handle transitions from zero in counters, as well as to zero. This should have been in PR 2925.

Bug: http://b/422976190
