### PR TITLE
Update suspend.sql

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/suspend.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/suspend.sql
@@ -31,7 +31,8 @@ WITH
   suspend_slice_from_minimal AS (
     SELECT
       ts,
-      dur
+      dur,
+      coalesce(lead(ts) OVER (ORDER BY ts), trace_end()) - ts - dur AS duration_gap
     FROM track AS t
     JOIN slice AS s
       ON s.track_id = t.id
@@ -42,7 +43,7 @@ WITH
     SELECT
       ts,
       dur,
-      lead(ts) OVER (ORDER BY ts) - ts - dur AS duration_gap
+      coalesce(lead(ts) OVER (ORDER BY ts), trace_end()) - ts - dur AS duration_gap
     FROM slice
     JOIN track
       ON slice.track_id = track.id
@@ -61,12 +62,14 @@ WITH
   suspend_slice_pre_filter AS (
     SELECT
       ts,
-      dur
+      dur,
+      duration_gap
     FROM suspend_slice_from_minimal
     UNION ALL
     SELECT
       ts,
-      dur
+      dur,
+      duration_gap
     FROM suspend_slice_latency
   ),
   suspend_slice AS (
@@ -77,7 +80,7 @@ WITH
       dur
     FROM suspend_slice_pre_filter
     WHERE
-      dur > 0
+      duration_gap >= 0
   ),
   awake_slice AS (
     -- If we don't have any rows, use the trace bounds if bounds are defined.


### PR DESCRIPTION
In the previous PR, we introduced duration_gap but never used it. This PR uses that to filter out any overlapping suspends, which tends to happen when there are data loss.

This is identical to https://github.com/google/perfetto/pull/2883 but I messed up the branch so now I'm attempting again

