### PR TITLE
ui: Intersect flamegraph slices with area selection

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/viz/slices.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/slices.sql
@@ -20,7 +20,8 @@ INCLUDE PERFETTO MODULE graphs.scan;
 INCLUDE PERFETTO MODULE slices.with_context;
 
 CREATE PERFETTO MACRO _viz_slice_ancestor_agg(
-  inits TableOrSubquery
+  inits TableOrSubquery,
+  nodes TableOrSubquery
 )
 RETURNS TableOrSubquery
 AS
@@ -35,7 +36,7 @@ AS
   FROM _graph_aggregating_scan!(
     (
       SELECT id AS source_node_id, parent_id AS dest_node_id
-      FROM slice
+      FROM $nodes
       WHERE parent_id IS NOT NULL
     ),
     (SELECT id, dur, dur AS self_dur, 1 AS self_count FROM $inits),
@@ -48,10 +49,10 @@ AS
       )
       SELECT a.id, s.dur, s.dur - a.child_dur AS self_dur, 0 AS self_count
       FROM agg a
-      JOIN slice s USING (id)
+      JOIN $nodes s USING (id)
     )
   ) g
-  JOIN slice s USING (id)
+  JOIN $nodes s USING (id)
 );
 
 CREATE PERFETTO VIEW _viz_slices_for_ui_table AS


### PR DESCRIPTION
Currently when we calculate the list of slices that should appear in the flamegraph view we simply find the slices that intersect with the area selection. This patch uses interval intersect to generate a new set of slices based on the intersection with the area selection window, which produces a new set of slices whose ts and dur are clamped to the bounds of the area selection.

This brings flamegraph in line with how the other aggregations work.