### PR TITLE
tp: add hex_to_dec function

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/utils.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/utils.h
@@ -473,68 +473,53 @@ struct RegexpExtract : public sqlite::Function<RegexpExtract> {
   }
 };
 
-struct HexToDec : public sqlite::Function<HexToDec> {
-  static constexpr char kName[] = "HEX_TO_DEC";
+struct UnHex : public sqlite::Function<UnHex> {
+  static constexpr char kName[] = "UNHEX";
   static constexpr int kArgCount = 1;
 
-  static void Step(sqlite3_context* ctx, int argc, sqlite3_value** argv);
+  static void Step(sqlite3_context* ctx, int, sqlite3_value** argv) {
+    sqlite::Type type = sqlite::value::Type(argv[0]);
+
+    if (type == sqlite::Type::kNull) {
+      return sqlite::result::Null(ctx);
+    }
+    if (type != sqlite::Type::kText) {
+      return sqlite::result::Error(ctx, "UNHEX: argument must be text");
+    }
+
+    std::string_view hex_str(sqlite::value::Text(argv[0]));
+
+    // Trim leading and trailing whitespace
+    size_t first = hex_str.find_first_not_of(" \t\n\r\f\v");
+    if (first == std::string_view::npos) {
+      return sqlite::result::Error(ctx,
+                                   "UNHEX: input is empty or only whitespace");
+    }
+    size_t last = hex_str.find_last_not_of(" \t\n\r\f\v");
+    hex_str = hex_str.substr(first, (last - first + 1));
+
+    // Handle optional "0x" or "0X" prefix
+    if (hex_str.length() >= 2 && hex_str[0] == '0' &&
+        (hex_str[1] == 'x' || hex_str[1] == 'X')) {
+      hex_str.remove_prefix(2);
+    }
+
+    if (hex_str.empty()) {
+      return sqlite::result::Error(ctx,
+                                   "UNHEX: hex string is empty after prefix");
+    }
+
+    std::optional<int64_t> result =
+        perfetto::base::StringViewToInt64(hex_str, 16);
+
+    if (!result.has_value()) {
+      return sqlite::result::Error(ctx,
+                                   "UNHEX: invalid or out of range hex string");
+    }
+
+    return sqlite::result::Long(ctx, *result);
+  }
 };
-
-void HexToDec::Step(sqlite3_context* ctx, int, sqlite3_value** argv) {
-  sqlite::Type type = sqlite::value::Type(argv[0]);
-
-  if (type == sqlite::Type::kNull) {
-    return sqlite::result::Null(ctx);
-  }
-  if (type != sqlite::Type::kText) {
-    return sqlite::result::Error(ctx, "HEX_TO_DEC: argument must be text");
-  }
-
-  std::string hex_str(sqlite::value::Text(argv[0]));
-
-  // Trim leading and trailing whitespace
-  size_t first = hex_str.find_first_not_of(" \t\n\r\f\v");
-  if (first == std::string::npos) {
-    return sqlite::result::Error(
-        ctx, "HEX_TO_DEC: input is empty or only whitespace");
-  }
-  size_t last = hex_str.find_last_not_of(" \t\n\r\f\v");
-  hex_str = hex_str.substr(first, (last - first + 1));
-
-  // Handle optional "0x" or "0X" prefix
-  size_t start_pos = 0;
-  if (hex_str.length() >= 2 && hex_str[0] == '0' &&
-      (hex_str[1] == 'x' || hex_str[1] == 'X')) {
-    start_pos = 2;
-  }
-
-  const char* num_start = hex_str.data() + start_pos;
-  const char* num_end = hex_str.data() + hex_str.length();
-
-  if (num_start == num_end) {
-    return sqlite::result::Error(
-        ctx, "HEX_TO_DEC: hex string is empty after prefix");
-  }
-
-  // Convert using std::from_chars, as it does not throw exceptions.
-  int64_t val = 0;
-  auto [ptr, ec] = std::from_chars(num_start, num_end, val, 16);
-
-  if (ec == std::errc::invalid_argument) {
-    return sqlite::result::Error(ctx, "HEX_TO_DEC: invalid hex string format");
-  }
-  if (ec == std::errc::result_out_of_range) {
-    return sqlite::result::Error(ctx,
-                                 "HEX_TO_DEC: value out of range for int64");
-  }
-  if (ptr != num_end) {
-    // Not all characters were consumed, indicating invalid characters.
-    return sqlite::result::Error(
-        ctx, "HEX_TO_DEC: hex string contains non-hex characters");
-  }
-
-  return sqlite::result::Long(ctx, val);
-}
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -1283,7 +1283,7 @@ std::unique_ptr<PerfettoSqlEngine> TraceProcessorImpl::InitPerfettoSqlEngine(
     RegisterSqliteFunction<RegexpExtract>(engine.get());
   }
 
-  RegisterSqliteFunction<HexToDec>(engine.get());
+  RegisterSqliteFunction<UnHex>(engine.get());
 
   // Old style function registration.
   // TODO(lalitm): migrate this over to using RegisterFunction once aggregate

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -123,7 +123,7 @@ from diff_tests.stdlib.android.frames_tests import Frames
 from diff_tests.stdlib.android.gpu import AndroidGpu
 from diff_tests.stdlib.android.heap_graph_tests import HeapGraph
 from diff_tests.stdlib.android.heap_profile_tests import HeapProfile
-from diff_tests.stdlib.prelude.hex_to_dec import HexToDec
+from diff_tests.stdlib.prelude.unhex import UnHex
 from diff_tests.stdlib.android.memory import AndroidMemory
 from diff_tests.stdlib.android.network_packets import AndroidNetworkPackets
 from diff_tests.stdlib.android.startups_tests import Startups
@@ -302,7 +302,7 @@ def fetch_all_diff_tests(
       Memory,
       PreludeMathFunctions,
       HeapGraph,
-      HexToDec,
+      UnHex,
       PreludePprofFunctions,
       PreludeWindowFunctions,
       RegexpExtract,

--- a/test/trace_processor/diff_tests/stdlib/prelude/unhex.py
+++ b/test/trace_processor/diff_tests/stdlib/prelude/unhex.py
@@ -15,24 +15,24 @@
 # limitations under the License.
 
 from python.generators.diff_tests.testing import Path, DataPath, Metric
-from python.generators.diff_tests.testing import Csv, Json, TextProto
+from python.generators.diff_tests.testing import Csv, Json, TextProto, RawText
 from python.generators.diff_tests.testing import DiffTestBlueprint
 from python.generators.diff_tests.testing import TestSuite
 
 
-class HexToDec(TestSuite):
+class UnHex(TestSuite):
 
-  def test_hex_to_dec(self):
+  def test_unhex(self):
     return DiffTestBlueprint(
         trace=TextProto(''),
         query="""
         SELECT
-          hex_to_dec('0xF') AS with_prefix,
-          hex_to_dec('F') AS without_prefix,
-          hex_to_dec('\t  0Xf    \n\r\f\v') AS with_space,
-          hex_to_dec('0') AS zero,
-          hex_to_dec(NULL) AS null_param,
-          hex_to_dec('0x58646cfa') AS big
+          unhex('0xF') AS with_prefix,
+          unhex('F') AS without_prefix,
+          unhex('\t  0Xf    \n\r\f\v') AS with_space,
+          unhex('0') AS zero,
+          unhex(NULL) AS null_param,
+          unhex('0x58646cfa') AS big
         """,
         out=Csv("""
         "with_prefix","without_prefix","with_space","zero","null_param","big"


### PR DESCRIPTION
Adds a new SQLite function 'HEX_TO_DEC' to Trace Processor, to convert hexadecimal strings
to signed 64-bit integers.

The function handles:
- Leading/trailing whitespaces
- Optional '0x' or '0X' prefixes
- Returns SQL errors for invalid formats, empty inputs or out-of-range
  numbers.

Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter '.\*hex_to_dec.\*'
