### PR TITLE
tp: support YYYY-MM-DD logcat date format

### DIFF
--- a/src/trace_processor/importers/android_bugreport/android_log_event.cc
+++ b/src/trace_processor/importers/android_bugreport/android_log_event.cc
@@ -51,7 +51,12 @@ std::optional<AndroidLogEvent::Format> AndroidLogEvent::DetectFormat(
   if (p.size() < 5)
     return std::nullopt;
 
-  if (p[0].size() != 5 || p[0][2] != '-')
+  // Check for MM-DD format (5 chars, dash at position 2)
+  // or YYYY-MM-DD format (10 chars, dash at position 4)
+  bool is_mm_dd = (p[0].size() == 5 && p[0][2] == '-');
+  bool is_yyyy_mm_dd = (p[0].size() == 10 && p[0][4] == '-' && p[0][7] == '-');
+
+  if (!is_mm_dd && !is_yyyy_mm_dd)
     return std::nullopt;
 
   if (p[1].size() < 10 || p[1][2] != ':' || p[1][5] != ':' || p[1][8] != '.')

--- a/src/trace_processor/importers/android_bugreport/android_log_reader.h
+++ b/src/trace_processor/importers/android_bugreport/android_log_reader.h
@@ -100,7 +100,7 @@ class AndroidLogReader : public ChunkedLineReader {
 
  private:
   std::optional<AndroidLogEvent::Format> format_;
-  int32_t year_;
+  int32_t default_year_;
   bool wait_for_tz_;
   std::vector<TimestampedAndroidLogEvent> non_tz_adjusted_events_;
 };


### PR DESCRIPTION
Currently Perfetto can only parse dates of the format MM-DD, however
this requires Perfetto to guess the year, however this is error prone
and can fail in a number of ways:
- for dates like 01-01 it is unclear if it is Jan 1st of the current
 year or Jan 1st 1970 which sometimes shows up in logcat when incorrect
 clock is used or system clock is not set at boot.
- for traces that span the new year boundary guessing a single year
 for all log events is not sufficient.

Allow users to provide the year via commands like `adb logcat -v year`
in order to bypass Perfetto's year guessing logic so they don't get
tripped up by corner cases. Year guessing will still remain in place when
the year is not provided in the logs.
