### PR TITLE
tp: Introduce view capture extractor.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14464,6 +14464,7 @@ filegroup {
         "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc",
         "src/trace_processor/importers/proto/winscope/winscope_geometry.cc",
         "src/trace_processor/importers/proto/winscope/winscope_module.cc",
         "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc",
@@ -14492,6 +14493,7 @@ filegroup {
     srcs: [
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor_unittest.cc",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation_unittest.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor_unittest.cc",
         "src/trace_processor/importers/proto/winscope/winscope_geometry_unittest.cc",
     ],
 }

--- a/BUILD
+++ b/BUILD
@@ -2197,6 +2197,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.h",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.h",
+        "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.h",
         "src/trace_processor/importers/proto/winscope/winscope_context.h",
         "src/trace_processor/importers/proto/winscope/winscope_geometry.cc",
         "src/trace_processor/importers/proto/winscope/winscope_geometry.h",

--- a/src/trace_processor/importers/proto/winscope/BUILD.gn
+++ b/src/trace_processor/importers/proto/winscope/BUILD.gn
@@ -45,6 +45,8 @@ source_set("full") {
     "viewcapture_args_parser.h",
     "viewcapture_parser.cc",
     "viewcapture_parser.h",
+    "viewcapture_views_extractor.cc",
+    "viewcapture_views_extractor.h",
     "winscope_context.h",
     "winscope_geometry.cc",
     "winscope_geometry.h",
@@ -102,6 +104,7 @@ perfetto_unittest_source_set("unittests") {
     "surfaceflinger_layers_test_utils.h",
     "surfaceflinger_layers_visibility_computation_unittest.cc",
     "viewcapture_test_utils.h",
+    "viewcapture_views_extractor_unittest.cc",
     "winscope_geometry_test_utils.h",
     "winscope_geometry_unittest.cc",
   ]

--- a/src/trace_processor/importers/proto/winscope/viewcapture_test_utils.h
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_test_utils.h
@@ -21,6 +21,7 @@
 #include <optional>
 #include <vector>
 
+#include "perfetto/protozero/scattered_heap_buffer.h"
 #include "protos/perfetto/trace/android/viewcapture.pbzero.h"
 
 namespace perfetto::trace_processor::winscope::viewcapture::test {
@@ -65,7 +66,7 @@ class SnapshotProtoBuilder {
 
     int32_t i = 0;
     for (const auto& view : views_) {
-      auto* view_proto = snapshot_proto.add_views();
+      auto* view_proto = snapshot_proto->add_views();
 
       view_proto->set_id(view.id_.has_value() ? view.id_.value() : i);
       i++;

--- a/src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.h"
+
+#include <unordered_map>
+#include <utility>
+
+namespace perfetto::trace_processor::winscope::viewcapture {
+
+namespace {
+const auto ROOT_PARENT_ID = -1;
+
+void ExtractNodeIdsDfs(
+    int32_t current_id,
+    const std::unordered_map<int32_t, std::vector<int32_t>>&
+        child_ids_by_parent,
+    const std::unordered_map<int32_t, ViewDecoder>& views_by_id,
+    std::vector<int32_t>& node_ids_dfs) {
+  auto view_pos = views_by_id.find(current_id);
+  if (view_pos == views_by_id.end()) {
+    return;
+  }
+  node_ids_dfs.push_back(view_pos->second.id());
+
+  auto child_it = child_ids_by_parent.find(current_id);
+  if (child_it != child_ids_by_parent.end()) {
+    const std::vector<int32_t>& child_ids = child_it->second;
+    for (int32_t child_id : child_ids) {
+      ExtractNodeIdsDfs(child_id, child_ids_by_parent, views_by_id,
+                        node_ids_dfs);
+    }
+  }
+}
+}  // namespace
+
+// Returns a vector of views in top-to-bottom drawing order (z order), so
+// we can determine visibility based on parents.
+
+std::vector<ViewDecoder> ExtractViewsTopToBottom(
+    const SnapshotDecoder& snapshot_decoder) {
+  int32_t root_node_id = 0;
+  std::unordered_map<int32_t, std::vector<int32_t>> child_ids_by_parent;
+  std::unordered_map<int32_t, ViewDecoder> views_by_id;
+
+  for (auto it = snapshot_decoder.views(); it; ++it) {
+    ViewDecoder view(*it);
+    auto node_id = view.id();
+
+    if (view.parent_id() == ROOT_PARENT_ID) {
+      root_node_id = node_id;
+    } else {
+      const auto parent = view.parent_id();
+      child_ids_by_parent[parent].emplace_back(node_id);
+    }
+
+    views_by_id.emplace(node_id, std::move(view));
+  }
+
+  std::vector<int32_t> node_ids_dfs;
+  ExtractNodeIdsDfs(root_node_id, child_ids_by_parent, views_by_id,
+                    node_ids_dfs);
+
+  std::vector<ViewDecoder> views_dfs;
+  views_dfs.reserve(node_ids_dfs.size());
+  for (int32_t id : node_ids_dfs) {
+    views_dfs.emplace_back(std::move(views_by_id.at(id)));
+  }
+  return views_dfs;
+}
+
+}  // namespace perfetto::trace_processor::winscope::viewcapture

--- a/src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.h
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_VIEWCAPTURE_VIEWS_EXTRACTOR_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_VIEWCAPTURE_VIEWS_EXTRACTOR_H_
+
+#include <vector>
+#include "protos/perfetto/trace/android/viewcapture.pbzero.h"
+
+namespace perfetto::trace_processor::winscope::viewcapture {
+
+namespace {
+using SnapshotDecoder = protos::pbzero::ViewCapture::Decoder;
+using ViewDecoder = protos::pbzero::ViewCapture::View::Decoder;
+}  // namespace
+
+std::vector<ViewDecoder> ExtractViewsTopToBottom(
+    const SnapshotDecoder& snapshot_decoder);
+
+}  // namespace perfetto::trace_processor::winscope::viewcapture
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_VIEWCAPTURE_VIEWS_EXTRACTOR_H_

--- a/src/trace_processor/importers/proto/winscope/viewcapture_views_extractor_unittest.cc
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_views_extractor_unittest.cc
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.h"
+
+#include <vector>
+
+#include "src/trace_processor/importers/proto/winscope/viewcapture_test_utils.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::winscope::viewcapture::test {
+
+namespace {
+
+void CheckExtractionTopToBottom(const std::string& snapshot,
+                                const std::vector<int32_t> expected) {
+  protos::pbzero::ViewCapture::Decoder snapshot_decoder(snapshot);
+  const auto& result = ExtractViewsTopToBottom(snapshot_decoder);
+
+  std::vector<int32_t> layer_ids;
+  for (const auto& layer : result) {
+    layer_ids.push_back(layer.id());
+  }
+  ASSERT_EQ(layer_ids, expected);
+}
+
+}  // namespace
+
+TEST(ViewCaptureExtractLayersTopToBottom, IdentifiesRootByParentId) {
+  const auto snapshot = SnapshotProtoBuilder()
+                            .AddView(View().SetId(1).SetParentId(0))
+                            .AddView(View().SetId(3).SetParentId(1))
+                            .AddView(View().SetId(2).SetParentId(0))
+                            .AddView(View().SetId(0).SetParentId(-1))
+                            .Build();
+  CheckExtractionTopToBottom(snapshot, {0, 1, 3, 2});
+}
+
+TEST(ViewCaptureExtractLayersTopToBottom, RetrievesDfs) {
+  const auto snapshot = SnapshotProtoBuilder()
+                            .AddView(View().SetParentId(-1))
+                            .AddView(View().SetParentId(0))
+                            .AddView(View().SetParentId(0))
+                            .AddView(View().SetParentId(1))
+                            .AddView(View().SetParentId(2))
+                            .AddView(View().SetParentId(2))
+                            .AddView(View().SetParentId(5))
+                            .Build();
+  CheckExtractionTopToBottom(snapshot, {0, 1, 3, 2, 4, 5, 6});
+}
+}  // namespace perfetto::trace_processor::winscope::viewcapture::test


### PR DESCRIPTION
To process views in DFS order for visibility computation.

Bug: 438683146
Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=ViewCapture*
