### PR TITLE
Update dependency on android_jank_cuj in jank CUJ pin plugin.

### DIFF
--- a/src/trace_processor/metrics/sql/android/jank/android_jank_cuj_init.sql
+++ b/src/trace_processor/metrics/sql/android/jank/android_jank_cuj_init.sql
@@ -64,3 +64,9 @@ SELECT RUN_METRIC('android/jank/slices.sql');
 -- jank cause analysis of traces.
 SELECT RUN_METRIC('android/jank/internal/query_base.sql');
 SELECT RUN_METRIC('android/jank/query_functions.sql');
+
+-- Creates a table that matches CUJ counters with the correct CUJs.
+-- After the CUJ ends FrameTracker emits counters with the number of total
+-- frames, missed frames, longest frame duration, etc.
+-- The same numbers are also reported by FrameTracker to statsd.
+SELECT RUN_METRIC('android/jank/internal/counters.sql');

--- a/ui/src/plugins/com.android.AndroidCujs/index.ts
+++ b/ui/src/plugins/com.android.AndroidCujs/index.ts
@@ -42,7 +42,7 @@ export async function addJankCUJDebugTrack(
 }
 
 const JANK_CUJ_QUERY_PRECONDITIONS = `
-  SELECT RUN_METRIC('android/android_jank_cuj.sql');
+  SELECT RUN_METRIC('android/jank/android_jank_cuj_init.sql');
   INCLUDE PERFETTO MODULE android.critical_blocking_calls;
 `;
 


### PR DESCRIPTION
The tables generated for the android_jank_cuj.sql have been moved to a different SQL to remove dependency on the actual metric.
