### PR TITLE
Add 2nd track to display client view on BinderViz plugin

### DIFF
--- a/ui/src/plugins/com.android.AndroidBinderViz/index.ts
+++ b/ui/src/plugins/com.android.AndroidBinderViz/index.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023 The Android Open Source Project
+// Copyright (C) 2025 The Android Open Source Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,31 +20,37 @@ import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 
 export default class implements PerfettoPlugin {
-  static readonly id = 'com.android.AndroidBinderVizPlugin';
+  static readonly id = 'com.android.AndroidBinderViz';
 
   async onTraceLoad(ctx: Trace): Promise<void> {
+    await this.createBinderTransactionTrack(ctx, 'server', 'client');
+    await this.createBinderTransactionTrack(ctx, 'client', 'server');
+  }
+
+  async createBinderTransactionTrack(ctx: Trace, perspective: string, opposite_perspective: string) {
+
     const binderCounterBreakdowns = new BreakdownTracks({
       trace: ctx,
-      trackTitle: 'Binder Transaction Counts',
+      trackTitle: `Binder ${perspective} Transaction Counts`,
       modules: ['android.binder', 'android.binder_breakdown'],
       aggregationType: BreakdownTrackAggType.COUNT,
       aggregation: {
         columns: [
-          'server_process',
-          '(IFNULL(interface, "unknown"))',
-          '(IFNULL(method_name, "unknown"))',
-          '(client_process || ":" || client_upid)',
-          '(client_thread || ":" ||  client_utid)',
+          `${perspective}_process`,
+          `(IFNULL(interface, "unknown interface"))`,
+          `(IFNULL(method_name, "unknown method"))`,
+          `(${opposite_perspective}_process || ":" || ${opposite_perspective}_upid)`,
+          `(${opposite_perspective}_thread || ":" ||  ${opposite_perspective}_utid)`,
         ],
-        tsCol: 'client_ts',
-        durCol: 'client_dur',
+        tsCol: `${opposite_perspective}_ts`,
+        durCol: `${opposite_perspective}_dur`,
         tableName: 'android_binder_txns',
       },
       slice: {
         columns: ['aidl_name'],
         tableName: 'android_binder_txns',
-        tsCol: 'client_ts',
-        durCol: 'client_dur',
+        tsCol: `${opposite_perspective}_ts`,
+        durCol: `${opposite_perspective}_dur`,
       },
       pivots: {
         columns: ['reason_type', 'reason'],


### PR DESCRIPTION
The existing track is "server" centric. This makes it difficult for app developers to visualize the bindings that their processes are making as clients.

Extend the plugin the display a second, "client" track

Bug: 438713106
Test: load traces and check the plugin result.