### PR TITLE
docs: ftrace: actually fix __assign_str macro comment

### DIFF
--- a/docs/getting-started/ftrace.md
+++ b/docs/getting-started/ftrace.md
@@ -504,6 +504,9 @@ and do not need to be specified.
 
 Tracepoint declaration example, named `trk_example/tid_track_example`:
 
+_Note: on kernels older than v6.10, \_\_assign_str requires two arguments, see
+[this patch](https://lore.kernel.org/linux-trace-kernel/20240516133454.681ba6a0@rorschach.local.home/)._
+
 ```h
 // trace/events/trk_example.h
 #undef TRACE_SYSTEM
@@ -526,7 +529,7 @@ TRACE_EVENT(tid_track_example,
     ),
     TP_fast_assign(
         __entry->track_event_type = track_event_type;
-        /* on kernels before v6.10: __assign_str(slice_name, slice_name) */
+        /* kernels before v6.10: __assign_str(slice_name, slice_name) */
         __assign_str(slice_name);
     ),
     TP_printk(


### PR DESCRIPTION


Fixes: f8afd4d7c0 docs: clarify syntax for __string usage in ftrace kernel documentation (#2993)
Fixes: ce4a52ec16 docs: fix typo in ftrace.md (#2988)