### PR TITLE
ui: make extra macros an array

### DIFF
--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -96,7 +96,7 @@ export class AppContext {
 
   // This is normally empty and is injected with extra google-internal macros
   // via is_internal_user.js
-  extraMacros: Record<string, CommandInvocation[]> = {};
+  extraMacros: Record<string, CommandInvocation[]>[] = [];
 
   // The currently open trace.
   currentTrace?: TraceContext;
@@ -405,7 +405,7 @@ export class AppImpl implements App {
     return this.appCtx.extraSqlPackages;
   }
 
-  get extraMacros(): Record<string, CommandInvocation[]> {
+  get extraMacros(): Record<string, CommandInvocation[]>[] {
     return this.appCtx.extraMacros;
   }
 

--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -162,7 +162,10 @@ export default class CoreCommands implements PerfettoPlugin {
     });
 
     // Register both user-defined macros from settings and extra macros from google3
-    const allMacros = {...setting.get(), ...ctx.extraMacros} as MacroConfig;
+    const allMacros = {
+      ...setting.get(),
+      ...ctx.extraMacros.reduce((acc, macro) => ({...acc, ...macro}), {}),
+    } as MacroConfig;
     for (const [macroName, commands] of Object.entries(allMacros)) {
       ctx.commands.registerCommand({
         id: `dev.perfetto.UserMacro.${macroName}`,

--- a/ui/src/frontend/is_internal_user_script_loader.ts
+++ b/ui/src/frontend/is_internal_user_script_loader.ts
@@ -44,7 +44,7 @@ interface Globals {
   // The script adds to this list, hence why it's readonly.
   // WARNING: do not change/rename/move without considering impact on the
   // internal_user script.
-  readonly extraMacros: Record<string, CommandInvocation[]>;
+  readonly extraMacros: Record<string, CommandInvocation[]>[];
 
   // TODO(stevegolton): Check if we actually need to use these.
   // Used when switching to the legacy TraceViewer UI.
@@ -71,7 +71,7 @@ function setupGlobalsProxy(app: AppImpl) {
     get extraSqlPackages(): SqlPackage[] {
       return app.extraSqlPackages;
     },
-    get extraMacros(): Record<string, CommandInvocation[]> {
+    get extraMacros(): Record<string, CommandInvocation[]>[] {
       return app.extraMacros;
     },
     shutdown() {


### PR DESCRIPTION
Allows for hypothetical multiple sets of macros to be injected. We have
one today but this aligns better with the future intention of this API.
