### PR TITLE
stdlib: add default anr durations to android_anrs table

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/anrs.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/anrs.sql
@@ -57,6 +57,71 @@ SELECT
     ELSE 'UNKNOWN_ANR_TYPE'
   END;
 
+CREATE PERFETTO FUNCTION _get_broadcast_flag(
+    subject STRING
+)
+RETURNS LONG AS
+SELECT
+  CASE
+    WHEN $subject IS NULL OR NOT $subject GLOB 'Broadcast of Intent *flg=*'
+    THEN NULL
+    ELSE unhex(str_split(substr($subject, instr($subject, ' flg=') + 5), ' ', 0))
+  END AS flag;
+
+-- Function to get the default ANR duration in milliseconds based on ANR type.
+-- Note: These are common defaults. Actual timeouts can vary by OEM, Android version, and FG/BG status.
+CREATE PERFETTO FUNCTION _default_anr_dur(
+    anr_type STRING,
+    subject STRING
+)
+RETURNS LONG AS
+SELECT
+  CASE
+    WHEN $anr_type IS NULL
+    THEN NULL
+    WHEN $anr_type = 'BROADCAST_OF_INTENT'
+    AND (
+      _get_broadcast_flag($subject) & x'10000000'
+    ) = 0
+    THEN 60000
+    WHEN $anr_type = 'BROADCAST_OF_INTENT'
+    AND (
+      _get_broadcast_flag($subject) IS NULL OR (
+        _get_broadcast_flag($subject) & x'10000000'
+      ) != 0
+    )
+    THEN 10000
+    WHEN $anr_type = 'INPUT_DISPATCHING_TIMEOUT'
+    THEN 5000
+    WHEN $anr_type = 'INPUT_DISPATCHING_TIMEOUT_NO_FOCUSED_WINDOW'
+    THEN 5000
+    WHEN $anr_type = 'START_FOREGROUND_SERVICE'
+    THEN 30000
+    WHEN $anr_type = 'EXECUTING_SERVICE'
+    THEN 20000
+    WHEN $anr_type = 'JOB_SERVICE_START'
+    THEN 8000
+    WHEN $anr_type = 'JOB_SERVICE_STOP'
+    THEN 8000
+    WHEN $anr_type = 'JOB_SERVICE_BIND'
+    THEN 8000
+    WHEN $anr_type = 'JOB_SERVICE_NOTIFICATION_NOT_PROVIDED'
+    THEN 8000
+    WHEN $anr_type = 'BIND_APPLICATION'
+    THEN 15000
+    WHEN $anr_type = 'CONTENT_PROVIDER_NOT_RESPONDING'
+    THEN NULL
+    WHEN $anr_type = 'GPU_HANG'
+    THEN NULL
+    WHEN $anr_type = 'APP_TRIGGERED'
+    THEN NULL
+    WHEN $anr_type = 'FOREGROUND_SHORT_SERVICE_TIMEOUT'
+    THEN 180000
+    WHEN $anr_type = 'FOREGROUND_SERVICE_TIMEOUT'
+    THEN 30000
+    ELSE NULL
+  END;
+
 -- Some of the anr timer events don't use the standard anr types and we have to convert them (temporal solution).
 -- For 'JobScheduler' there's not a 1:1 mapping to a standard type.
 CREATE PERFETTO FUNCTION _platform_to_standard_anr_type(
@@ -195,7 +260,7 @@ SELECT
     anr.ts - abt.timer_ts
   ) AS timer_delay,
   coalesce(_platform_to_standard_anr_type(abt.anr_type), _extract_anr_type(s.subject)) AS anr_type,
-  abt.anr_dur_ms
+  coalesce(abt.anr_dur_ms, _default_anr_dur(_extract_anr_type(s.subject), s.subject)) AS anr_dur_ms
 FROM anr
 LEFT JOIN subject AS s
   USING (error_id)

--- a/test/trace_processor/diff_tests/stdlib/android/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/tests.py
@@ -117,29 +117,29 @@ class AndroidStdlib(TestSuite):
         trace=Path('../../metrics/android/android_anr_metric.py'),
         query="""
         INCLUDE PERFETTO MODULE android.anrs;
-        SELECT process_name, pid, upid, error_id, ts, subject, anr_type
+        SELECT process_name, pid, upid, error_id, ts, subject, anr_type, anr_dur_ms
         FROM android_anrs;
       """,
         out=Csv("""
-        "process_name","pid","upid","error_id","ts","subject","anr_type"
-        "com.google.android.app1",11167,"[NULL]","da24554c-452a-4ae1-b74a-fb898f6e0982",1000,"Test ANR subject 1","UNKNOWN_ANR_TYPE"
-        "com.google.android.app2","[NULL]","[NULL]","8612fece-c2f1-4aeb-9d45-8e6d9d0201cf",2000,"Test ANR subject 2","UNKNOWN_ANR_TYPE"
-        "com.google.android.app3","[NULL]","[NULL]","c25916a0-a8f0-41f3-87df-319e06471a0f",3000,"[NULL]","[NULL]"
-        "com.disney.disneyplus",23215,"[NULL]","1eb3813d-45d3-4a9a-ab80-0ebeb88ea25a",4000,"Broadcast of Intent { act=android.os.action.DEVICE_IDLE_MODE_CHANGED flg=0x50000010 cmp=com.disney.disneyplus/Di.a }","BROADCAST_OF_INTENT"
-        "com.disney.disneyplus",27195,"[NULL]","50756b89-eadc-40c9-aef2-8886adb7d936",5000,"Broadcast of Intent { act=android.intent.action.DATE_CHANGED flg=0x20200010 cmp=com.disney.disneyplus/Di.a }","BROADCAST_OF_INTENT"
-        "com.android.chrome",17874,"[NULL]","60b9d4b6-6487-4800-bd12-3f9d547482e3",6000,"Input dispatching timed out (88f6a9 com.android.chrome/org.chromium.chrome.browser.customtabs.CustomTabActivity is not responding. Waited 5000ms for FocusEvent(hasFocus=false)).","INPUT_DISPATCHING_TIMEOUT"
-        "com.microsoft.teams",10645,"[NULL]","2d1dff06-54a3-450b-8123-0d21e67715c4",7000,"Input dispatching timed out (Application does not have a focused window).","INPUT_DISPATCHING_TIMEOUT_NO_FOCUSED_WINDOW"
-        "com.google.android.apps.internal.betterbug",26587,"[NULL]","1c733cef-dee3-42a1-bff5-6ac2bb3167ae",8000,"Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{76a32df u10 com.google.android.apps.internal.betterbug/.ramdumpuploader.RamdumpUploadService c:com.google.android.apps.internal.betterbug}","START_FOREGROUND_SERVICE"
-        "com.android.systemui",2342,"[NULL]","f2eb9ced-2327-402c-bf7c-dc498fafa5cd",9000,"executing service com.android.systemui/.doze.DozeService, waited 156441ms","EXECUTING_SERVICE"
-        "com.android.settings",15028,"[NULL]","9361cad8-c888-4f03-bff9-9ed8c69d583b",11000,"ContentProvider not responding","CONTENT_PROVIDER_NOT_RESPONDING"
-        "com.google.android.youtube.tv",16563,"[NULL]","600c4866-02c0-4d46-a69c-21d9ac377ad0",12000,"App requested: Buffer processing hung up due to stuck fence. Indicates GPU hang","GPU_HANG"
-        "com.android.chrome",18090,"[NULL]","fd96eb0a-ccba-474b-8044-b7cd27e812c2",13000,"No response to onStartJob","JOB_SERVICE_START"
-        "com.android.chrome",13534,"[NULL]","4e1f9f12-d9bf-4d6b-9e2b-1dfeaf774859",14000,"No response to onStopJob","JOB_SERVICE_STOP"
-        "com.android.vending",18264,"[NULL]","8a83c04e-fd35-4945-9fcc-7736f4242cae",15000,"Timed out while trying to bind","JOB_SERVICE_BIND"
-        "com.android.phone",3538,"[NULL]","df199866-4a6a-4388-b79f-2c76b6d5bb00",16000,"Process ProcessRecord{1a270e8 3538:com.android.phone/1001} failed to complete startup","BIND_APPLICATION"
-        "com.google.netops.pager",28509,"[NULL]","62abad99-bd09-44ef-bbbb-40db5c4d5539",17000,"A foreground service of FOREGROUND_SERVICE_TYPE_SHORT_SERVICE did not stop within a timeout: ComponentInfo{com.google.netops.pager/com.google.netops.pager.NotifierService}","FOREGROUND_SHORT_SERVICE_TIMEOUT"
-        "com.whatsapp",11456,"[NULL]","975b36a1-8b4a-4d69-875e-2c33e140bd1c",18000,"A foreground service of type dataSync did not stop within a timeout: ComponentInfo{com.whatsapp/com.whatsapp.service.GcmFGService}","FOREGROUND_SERVICE_TIMEOUT"
-        "com.android.chrome",22768,"[NULL]","05122f25-2f5b-4650-aeeb-cf59a9d6295a",19000,"required notification not provided","JOB_SERVICE_NOTIFICATION_NOT_PROVIDED"
+        "process_name","pid","upid","error_id","ts","subject","anr_type","anr_dur_ms"
+        "com.google.android.app1",11167,"[NULL]","da24554c-452a-4ae1-b74a-fb898f6e0982",1000,"Test ANR subject 1","UNKNOWN_ANR_TYPE","[NULL]"
+        "com.google.android.app2","[NULL]","[NULL]","8612fece-c2f1-4aeb-9d45-8e6d9d0201cf",2000,"Test ANR subject 2","UNKNOWN_ANR_TYPE","[NULL]"
+        "com.google.android.app3","[NULL]","[NULL]","c25916a0-a8f0-41f3-87df-319e06471a0f",3000,"[NULL]","[NULL]","[NULL]"
+        "com.disney.disneyplus",23215,"[NULL]","1eb3813d-45d3-4a9a-ab80-0ebeb88ea25a",4000,"Broadcast of Intent { act=android.os.action.DEVICE_IDLE_MODE_CHANGED flg=0x50000010 cmp=com.disney.disneyplus/Di.a }","BROADCAST_OF_INTENT",10000
+        "com.disney.disneyplus",27195,"[NULL]","50756b89-eadc-40c9-aef2-8886adb7d936",5000,"Broadcast of Intent { act=android.intent.action.DATE_CHANGED flg=0x20200010 cmp=com.disney.disneyplus/Di.a }","BROADCAST_OF_INTENT",60000
+        "com.android.chrome",17874,"[NULL]","60b9d4b6-6487-4800-bd12-3f9d547482e3",6000,"Input dispatching timed out (88f6a9 com.android.chrome/org.chromium.chrome.browser.customtabs.CustomTabActivity is not responding. Waited 5000ms for FocusEvent(hasFocus=false)).","INPUT_DISPATCHING_TIMEOUT",5000
+        "com.microsoft.teams",10645,"[NULL]","2d1dff06-54a3-450b-8123-0d21e67715c4",7000,"Input dispatching timed out (Application does not have a focused window).","INPUT_DISPATCHING_TIMEOUT_NO_FOCUSED_WINDOW",5000
+        "com.google.android.apps.internal.betterbug",26587,"[NULL]","1c733cef-dee3-42a1-bff5-6ac2bb3167ae",8000,"Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{76a32df u10 com.google.android.apps.internal.betterbug/.ramdumpuploader.RamdumpUploadService c:com.google.android.apps.internal.betterbug}","START_FOREGROUND_SERVICE",30000
+        "com.android.systemui",2342,"[NULL]","f2eb9ced-2327-402c-bf7c-dc498fafa5cd",9000,"executing service com.android.systemui/.doze.DozeService, waited 156441ms","EXECUTING_SERVICE",20000
+        "com.android.settings",15028,"[NULL]","9361cad8-c888-4f03-bff9-9ed8c69d583b",11000,"ContentProvider not responding","CONTENT_PROVIDER_NOT_RESPONDING","[NULL]"
+        "com.google.android.youtube.tv",16563,"[NULL]","600c4866-02c0-4d46-a69c-21d9ac377ad0",12000,"App requested: Buffer processing hung up due to stuck fence. Indicates GPU hang","GPU_HANG","[NULL]"
+        "com.android.chrome",18090,"[NULL]","fd96eb0a-ccba-474b-8044-b7cd27e812c2",13000,"No response to onStartJob","JOB_SERVICE_START",8000
+        "com.android.chrome",13534,"[NULL]","4e1f9f12-d9bf-4d6b-9e2b-1dfeaf774859",14000,"No response to onStopJob","JOB_SERVICE_STOP",8000
+        "com.android.vending",18264,"[NULL]","8a83c04e-fd35-4945-9fcc-7736f4242cae",15000,"Timed out while trying to bind","JOB_SERVICE_BIND",8000
+        "com.android.phone",3538,"[NULL]","df199866-4a6a-4388-b79f-2c76b6d5bb00",16000,"Process ProcessRecord{1a270e8 3538:com.android.phone/1001} failed to complete startup","BIND_APPLICATION",15000
+        "com.google.netops.pager",28509,"[NULL]","62abad99-bd09-44ef-bbbb-40db5c4d5539",17000,"A foreground service of FOREGROUND_SERVICE_TYPE_SHORT_SERVICE did not stop within a timeout: ComponentInfo{com.google.netops.pager/com.google.netops.pager.NotifierService}","FOREGROUND_SHORT_SERVICE_TIMEOUT",180000
+        "com.whatsapp",11456,"[NULL]","975b36a1-8b4a-4d69-875e-2c33e140bd1c",18000,"A foreground service of type dataSync did not stop within a timeout: ComponentInfo{com.whatsapp/com.whatsapp.service.GcmFGService}","FOREGROUND_SERVICE_TIMEOUT",30000
+        "com.android.chrome",22768,"[NULL]","05122f25-2f5b-4650-aeeb-cf59a9d6295a",19000,"required notification not provided","JOB_SERVICE_NOTIFICATION_NOT_PROVIDED",8000
       """))
 
   def test_anr_with_timer(self):
@@ -152,7 +152,7 @@ class AndroidStdlib(TestSuite):
       """,
         out=Csv("""
         "process_name","pid","upid","error_id","ts","subject","timer_delay","anr_type","anr_dur_ms"
-        "com.google.android.videos",4464,1765,"d55b1536-9c53-422a-af00-33daaf992b0d",184660962756627,"Process ProcessRecord{c098c64 4464:com.google.android.videos/u0a224} failed to complete startup","[NULL]","BIND_APPLICATION","[NULL]"
+        "com.google.android.videos",4464,1765,"d55b1536-9c53-422a-af00-33daaf992b0d",184660962756627,"Process ProcessRecord{c098c64 4464:com.google.android.videos/u0a224} failed to complete startup","[NULL]","BIND_APPLICATION",15000
         "com.google.android.gms.persistent",30647,112,"45210ec5-1525-49c3-816c-75afb1973d0b",184707199069963,"Broadcast of Intent { act=com.google.android.gms.tron.ALARM flg=0x10 xflg=0x4 pkg=com.google.android.gms cmp=com.google.android.gms/.tron.AlarmReceiver (has extras) }",22247029,"BROADCAST_OF_INTENT",60006
       """))
 


### PR DESCRIPTION
Add default anr durations to android_anrs table

When the anr_dur can't be computed from the timer expiration event, we fallback to the default anr durations for common ANR types (default means in AOSP/Pixel). Actual values can vary by OEM or Android version.

Test:tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter '.*anr.*'
