### PR TITLE
tp: Compute ViewCapture rects

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14464,6 +14464,7 @@ filegroup {
         "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_visibility_computation.cc",
         "src/trace_processor/importers/proto/winscope/winscope_geometry.cc",

--- a/BUILD
+++ b/BUILD
@@ -2197,6 +2197,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.h",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.h",
+        "src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.h",
         "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.h",
         "src/trace_processor/importers/proto/winscope/viewcapture_visibility_computation.cc",

--- a/src/trace_processor/importers/proto/winscope/BUILD.gn
+++ b/src/trace_processor/importers/proto/winscope/BUILD.gn
@@ -45,6 +45,8 @@ source_set("full") {
     "viewcapture_args_parser.h",
     "viewcapture_parser.cc",
     "viewcapture_parser.h",
+    "viewcapture_rect_computation.cc",
+    "viewcapture_rect_computation.h",
     "viewcapture_views_extractor.cc",
     "viewcapture_views_extractor.h",
     "viewcapture_visibility_computation.cc",

--- a/src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.cc
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.cc
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.h"
+
+#include "src/trace_processor/storage/trace_storage.h"
+
+namespace perfetto::trace_processor::winscope::viewcapture {
+
+// Helpers used only by this computation.
+
+namespace {
+
+// View depth is increased 4x to emphasise difference in z-position.
+const auto DEPTH_MAGNIFICATION = 4;
+
+// Depth and scaling information is stored during the computation for use
+// in making child view rects.
+struct ViewCaptureRect {
+  geometry::Rect rect;
+  int32_t depth;
+  double new_scale_x;
+  double new_scale_y;
+  double scroll_x;
+  double scroll_y;
+};
+
+geometry::Rect MakeRect(const ViewDecoder& view,
+                        double left_shift,
+                        double top_shift,
+                        double scale_x,
+                        double scale_y,
+                        double new_scale_x,
+                        double new_scale_y) {
+  double node_left = static_cast<double>(view.left());
+  double node_translation_x = static_cast<double>(view.translation_x());
+  double node_width = static_cast<double>(view.width());
+  double node_top = static_cast<double>(view.top());
+  double node_translation_y = static_cast<double>(view.translation_y());
+  double node_height = static_cast<double>(view.height());
+
+  auto left = left_shift + (node_left + node_translation_x) * scale_x +
+              (node_width * (scale_x - new_scale_x)) / 2;
+  auto top = top_shift + (node_top + node_translation_y) * scale_y +
+             (node_height * (scale_y - new_scale_y)) / 2;
+  auto width = node_width * new_scale_x;
+  auto height = node_height * new_scale_y;
+  return geometry::Rect(left, top, left + width, top + height);
+}
+}  // namespace
+
+RectComputation::RectComputation(
+    const std::vector<ViewDecoder>& views_top_to_bottom,
+    const std::unordered_map<int32_t, bool>& computed_visibility,
+    WinscopeRectTracker& rect_tracker)
+    : views_top_to_bottom_(views_top_to_bottom),
+      computed_visibility_(computed_visibility),
+      rect_tracker_(rect_tracker) {}
+
+const std::unordered_map<int32_t, TraceRectTableId> RectComputation::Compute() {
+  std::unordered_map<int32_t, ViewCaptureRect> rects;
+  std::unordered_map<int32_t, TraceRectTableId> trace_rect_ids;
+
+  for (auto it = views_top_to_bottom_.begin(); it != views_top_to_bottom_.end();
+       it++) {
+    const ViewDecoder& view = *it;
+
+    double scale_x;
+    double scale_y;
+    double left_shift;
+    double top_shift;
+    int32_t depth;
+
+    auto parent_rect_pos = rects.find(view.parent_id());
+    if (parent_rect_pos == rects.end()) {
+      left_shift = 0;
+      top_shift = 0;
+      depth = 0;
+      scale_x = 1;
+      scale_y = 1;
+    } else {
+      const ViewCaptureRect& parent_rect = parent_rect_pos->second;
+      left_shift = parent_rect.rect.x - parent_rect.scroll_x;
+      top_shift = parent_rect.rect.y - parent_rect.scroll_y;
+      depth = parent_rect.depth + 1;
+      scale_x = parent_rect.new_scale_x;
+      scale_y = parent_rect.new_scale_y;
+    }
+
+    double new_scale_x = scale_x * static_cast<double>(view.scale_x());
+    double new_scale_y = scale_y * static_cast<double>(view.scale_y());
+
+    geometry::Rect rect = MakeRect(view, left_shift, top_shift, scale_x,
+                                   scale_y, new_scale_x, new_scale_y);
+    ViewCaptureRect rect_info{rect,
+                              depth,
+                              new_scale_x,
+                              new_scale_y,
+                              static_cast<double>(view.scroll_x()),
+                              static_cast<double>(view.scroll_y())};
+
+    int32_t node_id = view.id();
+    rects[node_id] = rect_info;
+    trace_rect_ids[node_id] = InsertTraceRectRow(view, rect, depth);
+  }
+  return trace_rect_ids;
+}
+
+TraceRectTableId RectComputation::InsertTraceRectRow(const ViewDecoder& view,
+                                                     geometry::Rect& rect,
+                                                     int32_t depth) {
+  tables::WinscopeTraceRectTable::Row row;
+  row.rect_id = rect_tracker_.GetOrInsertRow(rect);
+  row.group_id = 0;
+  row.depth = static_cast<uint32_t>(depth * DEPTH_MAGNIFICATION);
+  row.is_visible = computed_visibility_.find(view.id())->second;
+  row.opacity = view.alpha();
+  return rect_tracker_.context_->storage->mutable_winscope_trace_rect_table()
+      ->Insert(row)
+      .id;
+}
+}  // namespace perfetto::trace_processor::winscope::viewcapture

--- a/src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.h
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_VIEWCAPTURE_RECT_COMPUTATION_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_VIEWCAPTURE_RECT_COMPUTATION_H_
+
+#include <optional>
+#include <unordered_map>
+#include <vector>
+#include "protos/perfetto/trace/android/viewcapture.pbzero.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.h"
+#include "src/trace_processor/tables/winscope_tables_py.h"
+
+namespace perfetto::trace_processor::winscope::viewcapture {
+
+namespace {
+using TraceRectTableId = tables::WinscopeTraceRectTable::Id;
+using SnapshotDecoder = protos::pbzero::ViewCapture::Decoder;
+using ViewDecoder = protos::pbzero::ViewCapture::View::Decoder;
+}  // namespace
+
+struct SurfaceFlingerRects {
+  std::optional<TraceRectTableId> layer_rect = std::nullopt;
+  std::optional<TraceRectTableId> input_rect = std::nullopt;
+};
+
+class RectComputation {
+ public:
+  explicit RectComputation(
+      const std::vector<ViewDecoder>& views_top_to_bottom,
+      const std::unordered_map<int32_t, bool>& computed_visibility,
+      WinscopeRectTracker& rect_tracker);
+
+  const std::unordered_map<int32_t, TraceRectTableId> Compute();
+
+ private:
+  const std::vector<ViewDecoder>& views_top_to_bottom_;
+  const std::unordered_map<int32_t, bool>& computed_visibility_;
+  WinscopeRectTracker& rect_tracker_;
+
+  TraceRectTableId InsertTraceRectRow(const ViewDecoder& view,
+                                      geometry::Rect& rect,
+                                      int32_t depth);
+};
+}  // namespace perfetto::trace_processor::winscope::viewcapture
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_VIEWCAPTURE_RECT_COMPUTATION_H_


### PR DESCRIPTION
Tested at the table level in subsequent PR, as this computation involves adding rows to the winscope geometry tables.

Bug: 438683146
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="ViewCapture|PerfettoTable:winscope"