### PR TITLE
Use os.replace instead of os.rename

### DIFF
--- a/infra/ci/worker/sandbox_runner.py
+++ b/infra/ci/worker/sandbox_runner.py
@@ -60,7 +60,7 @@ def create_sandbox_token(token_path):
   ]).decode().strip()
   with open(token_path + '.tmp', 'w') as f:
     f.write(sandbox_svc_token)
-  os.rename(token_path + '.tmp', token_path)
+  os.replace(token_path + '.tmp', token_path)
 
 
 def main():

--- a/infra/ci/worker/sandbox_runner.py
+++ b/infra/ci/worker/sandbox_runner.py
@@ -60,7 +60,7 @@ def create_sandbox_token(token_path):
   ]).decode().strip()
   with open(token_path + '.tmp', 'w') as f:
     f.write(sandbox_svc_token)
-  os.replace(token_path + '.tmp', token_path)
+  os.rename(token_path + '.tmp', token_path)
 
 
 def main():

--- a/tools/extract_linux_syscall_tables
+++ b/tools/extract_linux_syscall_tables
@@ -109,7 +109,7 @@ def Main():
   with open(tmp_file, 'w') as f:
     with contextlib.redirect_stdout(f):
       print_tables()
-  os.rename(tmp_file, dst_file)
+  os.replace(tmp_file, dst_file)
 
   print('Running clang-format (might fail if depot_tools isn\'t in the PATH)')
   os.system('clang-format -i ' + dst_file)

--- a/tools/gen_amalgamated_python_tools
+++ b/tools/gen_amalgamated_python_tools
@@ -103,7 +103,7 @@ def amalgamate(src, dst, check_only=False):
   with open(dst + '.tmp', 'w', encoding='utf-8') as f:
     f.write(new_content)
   os.chmod(dst + '.tmp', 0o755)
-  os.rename(dst + '.tmp', dst)
+  os.replace(dst + '.tmp', dst)
   return True
 
 

--- a/tools/roll-prebuilts
+++ b/tools/roll-prebuilts
@@ -131,7 +131,7 @@ def update_manifest(git_revision, tool_name, archs):
 
   with open(out_file + '.tmp', 'w') as f:
     f.write(content)
-  os.rename(out_file + '.tmp', out_file)
+  os.replace(out_file + '.tmp', out_file)
   os.chmod(out_file, 0o755)
 
 


### PR DESCRIPTION
Perfetto's scripts use `os.rename` to replace files with new versions. However, `os.rename` fails on Windows when the destination file exists.

`os.replace` is equivalent to `os.rename` on POSIX, and on Windows allows replacing an existing file (see [docs](https://docs.python.org/3/library/os.html#os.rename)). This change replaces uses of `os.rename` with `os.replace`, because the scripts don't seem like they intend to fail if the file already exists.

This fixes the following error on Windows:
```
PS C:\src\perfetto> python3 tools/gen_all out/default
Running python3 tools\check_include_violations
Running python3 tools\check_proto_comments
Running python3 tools\fix_include_guards
0 files changed
Running python3 tools\gen_merged_protos
Running python3 tools\gen_amalgamated_python_tools
INFO    : Amalgamating python/tools/record_android_trace.py -> tools/record_android_trace
Traceback (most recent call last):
  File "C:\src\perfetto\tools\gen_amalgamated_python_tools", line 123, in <module>
    sys.exit(main())
             ^^^^^^
  File "C:\src\perfetto\tools\gen_amalgamated_python_tools", line 118, in main
    success = success and amalgamate(src, dst, check_only)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\src\perfetto\tools\gen_amalgamated_python_tools", line 106, in amalgamate
    os.rename(dst + '.tmp', dst)
FileExistsError: [WinError 183] Cannot create a file when that file already exists: 'tools/record_android_trace.tmp' -> 'tools/record_android_trace'
Error: Command: python3 tools\gen_amalgamated_python_tools failed
```