### PR TITLE
Add missing include to subprocess.h

### DIFF
--- a/src/profiling/symbolizer/subprocess.h
+++ b/src/profiling/symbolizer/subprocess.h
@@ -18,6 +18,7 @@
 #ifndef SRC_PROFILING_SYMBOLIZER_SUBPROCESS_H_
 #define SRC_PROFILING_SYMBOLIZER_SUBPROCESS_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
It is missing cstdint, required for int64_t. This is breaking clang module builds on chromium.
