### PR TITLE
Fix JNI tests compilation (TaskRunner)

### DIFF
--- a/test/cts/producer/jni/fake_producer_jni.cc
+++ b/test/cts/producer/jni/fake_producer_jni.cc
@@ -26,9 +26,9 @@ namespace {
 static std::mutex g_mutex;
 
 // These variables are guarded by the above mutex.
-static perfetto::base::TaskRunner* g_activity_tr = nullptr;
-static perfetto::base::TaskRunner* g_service_tr = nullptr;
-static perfetto::base::TaskRunner* g_isolated_service_tr = nullptr;
+static perfetto::base::MaybeLockFreeTaskRunner* g_activity_tr = nullptr;
+static perfetto::base::MaybeLockFreeTaskRunner* g_service_tr = nullptr;
+static perfetto::base::MaybeLockFreeTaskRunner* g_isolated_service_tr = nullptr;
 
 }  // namespace
 


### PR DESCRIPTION
Follow up to #2700, which caused a build breakage.
The fake_producer_jni.cc needs the TR impl to call Quit()