### PR TITLE
etw_parser: Improve performance of task state lookup

### DIFF
--- a/src/trace_processor/importers/etw/etw_parser.cc
+++ b/src/trace_processor/importers/etw/etw_parser.cc
@@ -242,7 +242,7 @@ StringId EtwParser::TaskStateToStringId(int64_t task_state_int) {
   const auto state = static_cast<uint8_t>(task_state_int);
 
   // Mapping for the different Etw states with their string description.
-  static const base::StringView etw_states[] = {
+  static constexpr std::string_view etw_states[] = {
       "Initialized",    // 0x00
       "Ready",          // 0x01
       "Running",        // 0x02


### PR DESCRIPTION
The `etw_states_map` in `TaskStateToStringId` was being constructed on every function call, which is inefficient.

This patch replaces the `std::map` with a `static constexpr` array (`std::string_view[]`). This ensures the lookup table is initialized at compile time and provides a more efficient array-index lookup.