### PR TITLE
ui: Improve the hotkey context widget

### DIFF
--- a/ui/src/assets/perfetto.scss
+++ b/ui/src/assets/perfetto.scss
@@ -51,6 +51,7 @@
 @import "widgets/form";
 @import "widgets/grid_layout";
 @import "widgets/grid";
+@import "widgets/hotkey_context";
 @import "widgets/hotkey";
 @import "widgets/icon";
 @import "widgets/linear_progress";

--- a/ui/src/assets/widgets/hotkey_context.scss
+++ b/ui/src/assets/widgets/hotkey_context.scss
@@ -1,0 +1,41 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-hotkey-context {
+  position: relative;
+
+  &--show-focus-ring {
+    // Show a little ring around the context element when it has focus.
+    &:focus-within {
+      &::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        pointer-events: none;
+        box-shadow: inset 0 0 0 2px var(--pf-color-accent);
+
+        // This shouldn't be necessary - we should avoid using z-index in other
+        // places such as the sidebar then we can remove this.
+        z-index: 10;
+      }
+    }
+  }
+
+  &--fill-height {
+    height: 100%;
+  }
+}

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -64,6 +64,7 @@ import {
   CommandInvocation,
   commandInvocationArraySchema,
 } from '../core/command_manager';
+import {HotkeyConfig, HotkeyContext} from '../widgets/hotkey_context';
 
 const CSP_WS_PERMISSIVE_PORT = featureFlags.register({
   id: 'cspAllowAnyWebsocketPort',
@@ -347,12 +348,33 @@ function onCssLoaded() {
 
   // Mount the main mithril component. This also forces a sync render pass.
   raf.mount(document.body, {
-    view: () =>
-      m(ThemeProvider, {theme: themeSetting.get() as 'dark' | 'light'}, [
-        m(OverlayContainer, {fillParent: true}, [
-          m(UiMain, {key: themeSetting.get()}),
-        ]),
-      ]),
+    view: () => {
+      const app = AppImpl.instance;
+      const commands = app.commands;
+      const hotkeys: HotkeyConfig[] = [];
+      for (const {id, defaultHotkey} of commands.commands) {
+        if (defaultHotkey) {
+          hotkeys.push({
+            callback: () => commands.runCommand(id),
+            hotkey: defaultHotkey,
+          });
+        }
+      }
+
+      return m(
+        ThemeProvider,
+        {theme: themeSetting.get() as 'dark' | 'light'},
+        m(
+          HotkeyContext,
+          {hotkeys, fillHeight: true, autoFocus: true},
+          m(
+            OverlayContainer,
+            {fillParent: true},
+            m(UiMain, {key: themeSetting.get()}),
+          ),
+        ),
+      );
+    },
   });
 
   if (

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -28,7 +28,6 @@ import {TraceImpl} from '../core/trace_impl';
 import {Command} from '../public/command';
 import {Anchor} from '../widgets/anchor';
 import {Button} from '../widgets/button';
-import {HotkeyConfig, HotkeyContext} from '../widgets/hotkey_context';
 import {HotkeyGlyphs} from '../widgets/hotkey_glyphs';
 import {LinearProgress} from '../widgets/linear_progress';
 import {maybeRenderFullscreenModalDialog, showModal} from '../widgets/modal';
@@ -358,41 +357,27 @@ export class UiMainPerTrace implements m.ClassComponent {
 
   view(): m.Children {
     const app = AppImpl.instance;
-    const hotkeys: HotkeyConfig[] = [];
-    for (const {id, defaultHotkey} of app.commands.commands) {
-      if (defaultHotkey) {
-        hotkeys.push({
-          callback: () => app.commands.runCommand(id),
-          hotkey: defaultHotkey,
-        });
-      }
-    }
-
     const isSomethingLoading =
       AppImpl.instance.isLoadingTrace ||
       (this.trace?.engine.numRequestsPending ?? 0) > 0 ||
       taskTracker.hasPendingTasks();
 
     return m(
-      HotkeyContext,
-      {hotkeys},
-      m(
-        'main.pf-ui-main',
-        m(Sidebar, {trace: this.trace}),
-        m(Topbar, {
-          omnibox: this.renderOmnibox(),
-          trace: this.trace,
-        }),
-        m(LinearProgress, {
-          className: 'pf-ui-main__loading',
-          state: isSomethingLoading ? 'indeterminate' : 'none',
-        }),
-        m('.pf-ui-main__page-container', app.pages.renderPageForCurrentRoute()),
-        m(CookieConsent),
-        maybeRenderFullscreenModalDialog(),
-        showStatusBarFlag.get() && renderStatusBar(app.trace),
-        app.perfDebugging.renderPerfStats(),
-      ),
+      'main.pf-ui-main',
+      m(Sidebar, {trace: this.trace}),
+      m(Topbar, {
+        omnibox: this.renderOmnibox(),
+        trace: this.trace,
+      }),
+      m(LinearProgress, {
+        className: 'pf-ui-main__loading',
+        state: isSomethingLoading ? 'indeterminate' : 'none',
+      }),
+      m('.pf-ui-main__page-container', app.pages.renderPageForCurrentRoute()),
+      m(CookieConsent),
+      maybeRenderFullscreenModalDialog(),
+      showStatusBarFlag.get() && renderStatusBar(app.trace),
+      app.perfDebugging.renderPerfStats(),
     );
   }
 

--- a/ui/src/widgets/hotkey_context.ts
+++ b/ui/src/widgets/hotkey_context.ts
@@ -14,34 +14,68 @@
 
 import m from 'mithril';
 import {checkHotkey, Hotkey} from '../base/hotkeys';
+import {toHTMLElement} from '../base/dom_utils';
+import {classNames} from '../base/classnames';
 
 export interface HotkeyConfig {
-  hotkey: Hotkey;
-  callback: () => void;
+  readonly hotkey: Hotkey;
+  readonly callback: () => void;
 }
 
 export interface HotkeyContextAttrs {
-  hotkeys: HotkeyConfig[];
+  // An array of hotkeys to listen for.
+  readonly hotkeys: HotkeyConfig[];
+
+  // If true, the context will fill the height of its parent container.
+  // This is useful for contexts that are used as a full-screen overlay.
+  readonly fillHeight?: boolean;
+
+  // If true, the context will be focused on creation to capture key events.
+  // Defaults to false.
+  readonly autoFocus?: boolean;
+
+  // If true, a focus ring will be shown when the context is focused.
+  // Defaults to false.
+  readonly showFocusRing?: boolean;
 }
 
 export class HotkeyContext implements m.ClassComponent<HotkeyContextAttrs> {
   private hotkeys?: HotkeyConfig[];
 
   view(vnode: m.Vnode<HotkeyContextAttrs>): m.Children {
-    return vnode.children;
+    return m(
+      '.pf-hotkey-context',
+      {
+        // The tabindex is necessary to make the context focusable.
+        // This is needed to capture key events.
+        // The -1 value means it won't be focusable by tabbing, but can be
+        // focused programmatically.
+        tabindex: -1,
+        className: classNames(
+          vnode.attrs.fillHeight && 'pf-hotkey-context--fill-height',
+          vnode.attrs.showFocusRing && 'pf-hotkey-context--show-focus-ring',
+        ),
+      },
+      vnode.children,
+    );
   }
 
   oncreate(vnode: m.VnodeDOM<HotkeyContextAttrs>) {
-    document.addEventListener('keydown', this.onKeyDown);
+    vnode.dom.addEventListener('keydown', this.onKeyDown);
     this.hotkeys = vnode.attrs.hotkeys;
+    if (vnode.attrs.autoFocus) {
+      // Focus the context to ensure it captures key events.
+      // This is useful when the context is created dynamically.
+      toHTMLElement(vnode.dom).focus();
+    }
   }
 
   onupdate(vnode: m.VnodeDOM<HotkeyContextAttrs>) {
     this.hotkeys = vnode.attrs.hotkeys;
   }
 
-  onremove(_vnode: m.VnodeDOM<HotkeyContextAttrs>) {
-    document.removeEventListener('keydown', this.onKeyDown);
+  onremove(vnode: m.VnodeDOM<HotkeyContextAttrs>) {
+    vnode.dom.removeEventListener('keydown', this.onKeyDown);
     this.hotkeys = undefined;
   }
 


### PR DESCRIPTION
Turn it into a proper div in the DOM, and attach key events to this instead of to the document. This means that the hotkeys are only triggered when the the context element is focuesed. This makes the UI more friendly to embedded contexts.

In order to maintain behavior in the normal build of the UI, this context is automatically focused on creation, which means hotkeys work without having to focus anything first on ui.perfetto.dev.
