### PR TITLE
docs: point code links to GitHub repo instead of source.chromium.org

### DIFF
--- a/infra/perfetto.dev/src/markdown_render.js
+++ b/infra/perfetto.dev/src/markdown_render.js
@@ -19,8 +19,7 @@ const fs = require("fs-extra");
 const path = require("path");
 const hljs = require("highlight.js");
 
-const CS_BASE_URL =
-  "https://source.chromium.org/chromium/chromium/src/+/main:third_party/perfetto/";
+const CS_BASE_URL = "https://github.com/google/perfetto/tree/main";
 
 const ROOT_DIR = path.dirname(path.dirname(path.dirname(__dirname)));
 


### PR DESCRIPTION
For example, the [`[/src/trace_processor](/src/trace_processor)` link](https://github.com/google/perfetto/blob/36e2b7c69f94d8e9961a2510968dd18cb0344c98/docs/analysis/trace-processor.md#L4) at the top of https://perfetto.dev/docs/analysis/trace-processor points to https://source.chromium.org/chromium/chromium/src/+/main:third_party/perfetto//src/trace_processor. Since the code is now officially hosted here on GitHub, I believe that should point to https://github.com/google/perfetto/tree/main/src/trace_processor.

Links to specific lines do get properly formatted for GitHub, but it still links to source.chromium.org: https://github.com/google/perfetto/blob/36e2b7c69f94d8e9961a2510968dd18cb0344c98/infra/perfetto.dev/src/markdown_render.js#L106-L107

I quickly checked the generated source code links (directories and files with/without specific line) and it all looks good.

----

Note that links to specific lines seem to be pretty out of date, since they just point to `main` and not a specific commit. Mostly these ones from https://perfetto.dev/docs/design-docs/life-of-a-tracing-session:

* `/protos/perfetto/config/trace_config.proto#50`
* `/protos/perfetto/ipc/consumer_port.proto#117`
* `/protos/perfetto/ipc/consumer_port.proto#38`
* `/protos/perfetto/ipc/consumer_port.proto#41`
* `/protos/perfetto/ipc/consumer_port.proto#52`
* `/protos/perfetto/ipc/consumer_port.proto#65`
* `/protos/perfetto/ipc/producer_port.proto#105`
* `/protos/perfetto/ipc/producer_port.proto#110`
* `/protos/perfetto/ipc/producer_port.proto#112`
* `/protos/perfetto/ipc/producer_port.proto#132`
* `/protos/perfetto/ipc/producer_port.proto#34`
* `/protos/perfetto/ipc/producer_port.proto#41`