### PR TITLE
ui: Fix disappearing slices by removing an optimization that assumes sorted slices in BaseSliceTrack

### DIFF
--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -21,7 +21,6 @@ import {assertExists} from '../../base/logging';
 import {clamp, floatEqual} from '../../base/math_utils';
 import {cropText} from '../../base/string_utils';
 import {Time, time} from '../../base/time';
-import {exists} from '../../base/utils';
 import {uuidv4Sql} from '../../base/uuid';
 import {featureFlags} from '../../core/feature_flags';
 import {raf} from '../../core/raf_scheduler';
@@ -109,15 +108,6 @@ function filterVisibleSlices<S extends Slice>(
   // The last visible slice is simpler, since the slices are sorted
   // by timestamp you can binary search for the last slice such
   // that slice.start <= end.
-
-  // One specific edge case that will come up often is when:
-  // For all slice in slices: slice.startNsQ > end (e.g. all slices are
-  // to the right).
-  // Since the slices are sorted by startS we can check this easily:
-  const maybeFirstSlice: S | undefined = slices[0];
-  if (exists(maybeFirstSlice) && maybeFirstSlice.startNs > end) {
-    return [];
-  }
 
   return slices.filter((slice) => slice.startNs <= end && slice.endNs >= start);
 }
@@ -733,7 +723,6 @@ export abstract class BaseSliceTrack<
         ${resolution}
       ) z
       CROSS JOIN (${this.getSqlSource()}) s using (id)
-      ORDER BY tsQ
     `);
 
     const it = queryRes.iter(this.rowSpec);

--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -733,6 +733,7 @@ export abstract class BaseSliceTrack<
         ${resolution}
       ) z
       CROSS JOIN (${this.getSqlSource()}) s using (id)
+      ORDER BY tsQ
     `);
 
     const it = queryRes.iter(this.rowSpec);


### PR DESCRIPTION
Currently we make the assumption in BaseSliceTrack that slices are ordered by `ts`, which allows us to perform a very specific optimization which avoids rendering anything when the first slice is off the right hand side of the viewport.

However, slices from the mipmap function are ordered by depth first then ts, meaning that slices are not necessarily sorted by ts. In practice, slices at lower depths usually do start before those at higher depths anyway, so this is usually not an issue.

This patch removes the optimization entirely as it seems pretty dubious whether it actually helps all that much.

Fixes: https://buganizer.corp.google.com/issues/446503267
