### PR TITLE
tp: fix crash when encountering unknown child track ordering

### DIFF
--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -155,7 +155,8 @@ ModuleResult TrackEventTokenizer::TokenizeTrackDescriptorPacket(
         reservation.ordering = Reservation::ChildTracksOrdering::kExplicit;
         break;
       default:
-        PERFETTO_FATAL("Unsupported ChildTracksOrdering");
+        context_->storage->IncrementStats(stats::track_event_tokenizer_errors);
+        return ModuleResult::Handled();
     }
   }
 


### PR DESCRIPTION
Crashing was too aggressive: if we introduce a new value here or someone
accidentally sends us this, it was bad to just unconditionally crash.
Just drop the packet instead.
