### PR TITLE
tp: fix parsing of gpu counter descriptors

### DIFF
--- a/src/trace_processor/importers/proto/gpu_event_parser.h
+++ b/src/trace_processor/importers/proto/gpu_event_parser.h
@@ -62,6 +62,7 @@ class GpuEventParser {
       protos::pbzero::VulkanMemoryEvent::Operation;
   explicit GpuEventParser(TraceProcessorContext*);
 
+  void TokenizeGpuCounterEvent(ConstBytes);
   void ParseGpuCounterEvent(int64_t ts, ConstBytes);
   void ParseGpuRenderStageEvent(int64_t ts,
                                 PacketSequenceStateGeneration*,

--- a/src/trace_processor/importers/proto/graphics_event_module.h
+++ b/src/trace_processor/importers/proto/graphics_event_module.h
@@ -19,10 +19,12 @@
 
 #include <cstdint>
 
+#include "perfetto/trace_processor/ref_counted.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/proto/frame_timeline_event_parser.h"
 #include "src/trace_processor/importers/proto/gpu_event_parser.h"
 #include "src/trace_processor/importers/proto/graphics_frame_event_parser.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
@@ -35,6 +37,13 @@ class GraphicsEventModule : public ProtoImporterModule {
                                TraceProcessorContext* context);
 
   ~GraphicsEventModule() override;
+
+  ModuleResult TokenizePacket(
+      const protos::pbzero::TracePacket_Decoder&,
+      TraceBlobView* packet,
+      int64_t packet_timestamp,
+      RefPtr<PacketSequenceStateGeneration> sequence_state,
+      uint32_t field_id) override;
 
   void ParseTracePacketData(const protos::pbzero::TracePacket::Decoder&,
                             int64_t ts,


### PR DESCRIPTION
Turns out some GPU vendors set timestamps on descriptor packets which are broken and are ending up less than zero (because of different clock + clock sync).

Fix this by handling gpu descriptors at tokenization time instead. This ensures they are always handled first.

Fixes: https://github.com/google/perfetto/issues/3055
