### PR TITLE
luci: fix regenerating scheduler file

### DIFF
--- a/infra/luci/generated/luci-scheduler.cfg
+++ b/infra/luci/generated/luci-scheduler.cfg
@@ -57,6 +57,20 @@ trigger {
     refs: "regexp:refs/tags/upstream/v.+"
   }
 }
+trigger {
+  id: "perfetto-nightly-trigger"
+  realm: "official"
+  schedule: "0 5 * * *"
+  acl_sets: "official"
+  triggers: "perfetto-official-builder-android"
+  triggers: "perfetto-official-builder-linux"
+  triggers: "perfetto-official-builder-mac"
+  triggers: "perfetto-official-builder-windows"
+  gitiles {
+    repo: "https://chromium.googlesource.com/external/github.com/google/perfetto"
+    refs: "regexp:refs/heads/main"
+  }
+}
 acl_sets {
   name: "official"
   acls {


### PR DESCRIPTION
Forgot to do this in
https://github.com/google/perfetto/commit/4e396dcd6dc9147157d46bde4ef04124edd7e617,
wasn't picked up correctly.
