### PR TITLE
ui: Allow any key-value pairs to be passed to (most) widgets

### DIFF
--- a/ui/src/widgets/button.ts
+++ b/ui/src/widgets/button.ts
@@ -82,6 +82,10 @@ interface LabelButtonAttrs extends CommonAttrs {
 
 export type ButtonAttrs = LabelButtonAttrs | IconButtonAttrs;
 
+function isLabelButtonAttrs(attrs: ButtonAttrs): attrs is LabelButtonAttrs {
+  return (attrs as LabelButtonAttrs).label !== undefined;
+}
+
 export class Button implements m.ClassComponent<ButtonAttrs> {
   view({attrs}: m.CVnode<ButtonAttrs>) {
     const {
@@ -99,7 +103,7 @@ export class Button implements m.ClassComponent<ButtonAttrs> {
       ...htmlAttrs
     } = attrs;
 
-    const label = 'label' in attrs ? attrs.label : undefined;
+    const label = isLabelButtonAttrs(attrs) ? attrs.label : undefined;
     const iconOnly = Boolean(icon && !label);
 
     const classes = classNames(

--- a/ui/src/widgets/chip.ts
+++ b/ui/src/widgets/chip.ts
@@ -59,6 +59,10 @@ interface LabelChipAttrs extends CommonAttrs {
 
 export type ChipAttrs = LabelChipAttrs | IconChipAttrs;
 
+function isLabelChipAttrs(attrs: ChipAttrs): attrs is LabelChipAttrs {
+  return (attrs as LabelChipAttrs).label !== undefined;
+}
+
 export class Chip implements m.ClassComponent<ChipAttrs> {
   view({attrs}: m.CVnode<ChipAttrs>) {
     const {
@@ -74,7 +78,7 @@ export class Chip implements m.ClassComponent<ChipAttrs> {
       ...htmlAttrs
     } = attrs;
 
-    const label = 'label' in attrs ? attrs.label : undefined;
+    const label = isLabelChipAttrs(attrs) ? attrs.label : undefined;
 
     const classes = classNames(
       compact && 'pf-compact',

--- a/ui/src/widgets/common.ts
+++ b/ui/src/widgets/common.ts
@@ -21,7 +21,14 @@ import {assertUnreachable} from '../base/logging';
 // Feel free to add any missing attributes as they arise.
 export type Style = string | Partial<CSSStyleDeclaration>;
 
-export interface HTMLAttrs {
+// Covers all key/value pairs, so we don't have to keep updating the HTMLAttrs
+// type for every new attribute we want to support. We still maintain HTMLAttrs
+// an friends for well-known attributes and we can keep adding to it as needed
+// and they will restrict what types can be passed for those attributes, but
+// this give us an escape hatch.
+type ArbitraryAttrs = {[key: string]: unknown};
+
+export type HTMLAttrs = ArbitraryAttrs & {
   readonly ref?: string; // This is a common attribute used in Perfetto.
   readonly style?: Style;
   readonly id?: string;
@@ -36,7 +43,7 @@ export interface HTMLAttrs {
   readonly onmouseup?: (e: MouseEvent) => void;
   readonly onmousemove?: (e: MouseEvent) => void;
   readonly onload?: (e: Event) => void;
-}
+};
 
 export interface HTMLFocusableAttrs extends HTMLAttrs {
   readonly onblur?: (e: FocusEvent) => void;


### PR DESCRIPTION
Currently we restrict which attrs may be passed to widgets via their attributes interfaces, most of which extend HTMLAttrs or one of its more specific sub-interfaces. However, the number of possible HTML attributes is large, and we don't want to have to hard code each possible type but we also don't want to restrict users to only being able to use those hard coded types.

This PR expands the HTMLAttrs type to allow arbitrary key value pairs on top of the well known hard coded types. This provides type safety when using the hard coded types, but also provides an escape hatch for when users want to use new types, they just won't be type checked.

E.g.

```ts
// Before
m(Card, {className: 'foo', role: 'option'}) // Error: 'role' is not a member of HTMLAttrs.

// After
m(Card, {className: 'foo', role: 'option'}) // OK - No error, role's type just isn't checked (unknown), but other attributes such as className are.
```
