### PR TITLE
tp: Extend WM tables with container type.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.cc
+++ b/src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.cc
@@ -29,7 +29,16 @@
 namespace perfetto::trace_processor::winscope {
 
 WindowManagerHierarchyWalker::WindowManagerHierarchyWalker(StringPool* pool)
-    : pool_(pool) {}
+    : pool_(pool),
+      k_root_window_container_id_(pool_->InternString("RootWindowContainer")),
+      k_display_content_id_(pool_->InternString("DisplayContent")),
+      k_display_area_id_(pool_->InternString("DisplayArea")),
+      k_task_id_(pool_->InternString("Task")),
+      k_task_fragment_id_(pool_->InternString("TaskFragment")),
+      k_activity_id_(pool_->InternString("Activity")),
+      k_window_token_id_(pool_->InternString("WindowToken")),
+      k_window_state_id_(pool_->InternString("WindowState")),
+      k_window_container_id_(pool_->InternString("WindowContainer")) {}
 
 base::StatusOr<
     std::vector<WindowManagerHierarchyWalker::ExtractedWindowContainer>>
@@ -68,7 +77,8 @@ base::Status WindowManagerHierarchyWalker::ParseRootWindowContainer(
 
   result->push_back(ExtractedWindowContainer{
       tokenAndTitle->title, tokenAndTitle->token, std::nullopt, std::nullopt,
-      window_container.visible(), std::nullopt, std::move(pruned_proto)});
+      window_container.visible(), std::nullopt, std::move(pruned_proto),
+      k_root_window_container_id_});
 
   return ParseWindowContainerChildren(window_container, tokenAndTitle->token,
                                       result);
@@ -138,7 +148,8 @@ base::Status WindowManagerHierarchyWalker::ParseWindowContainerProto(
 
   result->push_back(ExtractedWindowContainer{
       tokenAndTitle->title, tokenAndTitle->token, parent_token, child_index,
-      window_container.visible(), std::nullopt, std::move(pruned_proto)});
+      window_container.visible(), std::nullopt, std::move(pruned_proto),
+      k_window_container_id_});
 
   return ParseWindowContainerChildren(window_container, tokenAndTitle->token,
                                       result);
@@ -183,7 +194,7 @@ base::Status WindowManagerHierarchyWalker::ParseDisplayContentProto(
 
   result->push_back(ExtractedWindowContainer{
       title, token, parent_token, child_index, window_container.visible(),
-      display, std::move(pruned_proto)});
+      display, std::move(pruned_proto), k_display_content_id_});
 
   current_display_id_ = display_content.id();
   current_rect_depth_ = 1;
@@ -218,7 +229,7 @@ base::Status WindowManagerHierarchyWalker::ParseDisplayAreaProto(
 
   result->push_back(ExtractedWindowContainer{
       title, token, parent_token, child_index, window_container.visible(),
-      std::nullopt, std::move(pruned_proto)});
+      std::nullopt, std::move(pruned_proto), k_display_area_id_});
 
   return ParseWindowContainerChildren(window_container, token, result);
 }
@@ -244,7 +255,8 @@ base::Status WindowManagerHierarchyWalker::ParseTaskProto(
 
   result->push_back(ExtractedWindowContainer{
       tokenAndTitle->title, tokenAndTitle->token, parent_token, child_index,
-      window_container.visible(), std::nullopt, std::move(pruned_proto)});
+      window_container.visible(), std::nullopt, std::move(pruned_proto),
+      k_task_id_});
 
   return ParseWindowContainerChildren(window_container, tokenAndTitle->token,
                                       result);
@@ -276,7 +288,7 @@ base::Status WindowManagerHierarchyWalker::ParseActivityRecordProto(
 
   result->push_back(ExtractedWindowContainer{
       title, token, parent_token, child_index, activity.visible(), std::nullopt,
-      std::move(pruned_proto)});
+      std::move(pruned_proto), k_activity_id_});
 
   return ParseWindowContainerChildren(window_container, token, result);
 }
@@ -303,7 +315,7 @@ base::Status WindowManagerHierarchyWalker::ParseWindowTokenProto(
 
   result->push_back(ExtractedWindowContainer{
       title, token, parent_token, child_index, window_container.visible(),
-      std::nullopt, std::move(pruned_proto)});
+      std::nullopt, std::move(pruned_proto), k_window_token_id_});
 
   return ParseWindowContainerChildren(window_container, token, result);
 }
@@ -340,7 +352,8 @@ base::Status WindowManagerHierarchyWalker::ParseWindowStateProto(
 
   result->push_back(ExtractedWindowContainer{
       tokenAndTitle->title, tokenAndTitle->token, parent_token, child_index,
-      window_state.is_visible(), rect, std::move(pruned_proto)});
+      window_state.is_visible(), rect, std::move(pruned_proto),
+      k_window_state_id_});
 
   return ParseWindowContainerChildren(window_container, tokenAndTitle->token,
                                       result);
@@ -366,7 +379,8 @@ base::Status WindowManagerHierarchyWalker::ParseTaskFragmentProto(
 
   result->push_back(ExtractedWindowContainer{
       tokenAndTitle->title, tokenAndTitle->token, parent_token, child_index,
-      window_container.visible(), std::nullopt, std::move(pruned_proto)});
+      window_container.visible(), std::nullopt, std::move(pruned_proto),
+      k_task_fragment_id_});
 
   return ParseWindowContainerChildren(window_container, tokenAndTitle->token,
                                       result);

--- a/src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.h
+++ b/src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.h
@@ -48,7 +48,9 @@ class WindowManagerHierarchyWalker {
     std::optional<uint32_t> child_index;
     bool is_visible;
     std::optional<ExtractedRect> rect;
-    std::vector<uint8_t> pruned_proto;  // proto without children submessages
+    std::vector<uint8_t> pruned_proto;    // proto without children submessages
+    const StringPool::Id container_type;  // container proto type e.g.
+                                          // DisplayContent, ActivityRecord
   };
 
   static constexpr const char* kErrorMessageMissingField =
@@ -134,6 +136,15 @@ class WindowManagerHierarchyWalker {
   StringPool* pool_{nullptr};
   int32_t current_display_id_{-1};
   uint32_t current_rect_depth_{0};
+  const StringPool::Id k_root_window_container_id_;
+  const StringPool::Id k_display_content_id_;
+  const StringPool::Id k_display_area_id_;
+  const StringPool::Id k_task_id_;
+  const StringPool::Id k_task_fragment_id_;
+  const StringPool::Id k_activity_id_;
+  const StringPool::Id k_window_token_id_;
+  const StringPool::Id k_window_state_id_;
+  const StringPool::Id k_window_container_id_;
 };
 
 }  // namespace perfetto::trace_processor::winscope

--- a/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
@@ -91,6 +91,7 @@ void WindowManagerParser::InsertWindowContainerRows(
     row.parent_token = window_container.parent_token;
     row.child_index = window_container.child_index;
     row.is_visible = window_container.is_visible;
+    row.container_type = window_container.container_type;
 
     if (window_container.rect) {
       row.window_rect_id = InsertRectRows(*window_container.rect);

--- a/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
@@ -52,7 +52,9 @@ CREATE PERFETTO VIEW android_windowmanager_windowcontainer (
   -- The window container visibility
   is_visible BOOL,
   -- The rect corresponding to this window container
-  window_rect_id LONG
+  window_rect_id LONG,
+  -- The window container type e.g. DisplayContent, TaskFragment
+  container_type STRING
 ) AS
 SELECT
   id,
@@ -64,5 +66,6 @@ SELECT
   parent_token,
   child_index,
   is_visible,
-  window_rect_id
+  window_rect_id,
+  container_type
 FROM __intrinsic_windowmanager_windowcontainer;

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -802,6 +802,10 @@ WINDOW_MANAGER_WINDOW_CONTAINER_TABLE = Table(
             CppOptional(CppTableId(WINSCOPE_TRACE_RECT_TABLE)),
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
         ),
+        C(
+            'container_type',
+            CppString(),
+        ),
     ],
     wrapping_sql_view=WrappingSqlView('windowmanager_windowcontainer'),
     tabledoc=TableDoc(
@@ -826,6 +830,8 @@ WINDOW_MANAGER_WINDOW_CONTAINER_TABLE = Table(
                 "The window container visibility",
             'window_rect_id':
                 "The rect corresponding to this window container",
+            'container_type':
+                "The window container type e.g. DisplayContent, TaskFragment",
         }))
 
 PROTOLOG_TABLE = Table(


### PR DESCRIPTION
Required to build hierarchy.

Bug: 438681230

Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=WindowManager*

Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell --name-filter="PerfettoTable:winscope|WindowManager"
