### PR TITLE
tp: don't pass 'e' flag into fopen on Windows in test.

### DIFF
--- a/src/trace_processor/trace_database_integrationtest.cc
+++ b/src/trace_processor/trace_database_integrationtest.cc
@@ -26,6 +26,7 @@
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/scoped_file.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/trace_processor/basic_types.h"
@@ -111,9 +112,13 @@ class TraceProcessorIntegrationTest : public ::testing::Test {
                          size_t min_chunk_size = 512,
                          size_t max_chunk_size = kMaxChunkSize) {
     EXPECT_LE(min_chunk_size, max_chunk_size);
+    std::string flags = base::kFopenReadFlag;
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+    flags += "b";  // Open in binary (untranslated) mode.
+#endif
     base::ScopedFstream f(
         fopen(base::GetTestDataPath(std::string("test/data/") + name).c_str(),
-              "rbe"));
+              flags.c_str()));
     std::minstd_rand0 rnd_engine(0);
     std::uniform_int_distribution<size_t> dist(min_chunk_size, max_chunk_size);
     while (!feof(*f)) {


### PR DESCRIPTION
Otherwise `TraceProcessorIntegrationTest#LoadTrace` silently crashes on Windows.

After this patch  all integration tests on windows passes.

This is a follow-up to 5db14d5cfd6104a513c83d0d2c2fef190f85b937

Tested:
```
$ python .\tools\gn gen .\out\win_all\ --arg='enable_perfetto_integration_tests=true enable_perfetto_trace_processor=true'
$ python .\tools\ninja -C .\out\win_all\
$ .\out\win_all\perfetto_integrationtests.exe

...
[==========] 428 tests from 32 test suites ran. (166220 ms total)
[  PASSED  ] 422 tests.
[  SKIPPED ] 6 tests, listed below:
...
```
