### PR TITLE
Add collect clocks primitive to trace redactor

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15742,6 +15742,7 @@ filegroup {
     srcs: [
         "src/trace_redaction/add_synth_threads_to_process_trees.cc",
         "src/trace_redaction/broadphase_packet_filter.cc",
+        "src/trace_redaction/collect_clocks.cc",
         "src/trace_redaction/collect_frame_cookies.cc",
         "src/trace_redaction/collect_system_info.cc",
         "src/trace_redaction/collect_timeline_events.cc",
@@ -15757,6 +15758,7 @@ filegroup {
         "src/trace_redaction/redact_ftrace_events.cc",
         "src/trace_redaction/redact_process_events.cc",
         "src/trace_redaction/redact_sched_events.cc",
+        "src/trace_redaction/redactor_clock_converter.cc",
         "src/trace_redaction/reduce_threads_in_process_trees.cc",
         "src/trace_redaction/scrub_process_stats.cc",
         "src/trace_redaction/trace_redaction_framework.cc",
@@ -15770,6 +15772,7 @@ filegroup {
     name: "perfetto_src_trace_redaction_unittests",
     srcs: [
         "src/trace_redaction/broadphase_packet_filter_unittest.cc",
+        "src/trace_redaction/collect_clocks_unittest.cc",
         "src/trace_redaction/collect_frame_cookies_unittest.cc",
         "src/trace_redaction/collect_system_info_unittest.cc",
         "src/trace_redaction/collect_timeline_events_unittest.cc",

--- a/src/trace_redaction/BUILD.gn
+++ b/src/trace_redaction/BUILD.gn
@@ -32,6 +32,8 @@ source_set("trace_redaction") {
     "add_synth_threads_to_process_trees.h",
     "broadphase_packet_filter.cc",
     "broadphase_packet_filter.h",
+    "collect_clocks.cc",
+    "collect_clocks.h",
     "collect_frame_cookies.cc",
     "collect_frame_cookies.h",
     "collect_system_info.cc",
@@ -63,6 +65,8 @@ source_set("trace_redaction") {
     "redact_process_events.h",
     "redact_sched_events.cc",
     "redact_sched_events.h",
+    "redactor_clock_converter.cc",
+    "redactor_clock_converter.h",
     "reduce_threads_in_process_trees.cc",
     "reduce_threads_in_process_trees.h",
     "scrub_process_stats.cc",
@@ -125,6 +129,7 @@ perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
     "broadphase_packet_filter_unittest.cc",
+    "collect_clocks_unittest.cc",
     "collect_frame_cookies_unittest.cc",
     "collect_system_info_unittest.cc",
     "collect_timeline_events_unittest.cc",

--- a/src/trace_redaction/collect_clocks.cc
+++ b/src/trace_redaction/collect_clocks.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_redaction/collect_clocks.h"
+
+#include "perfetto/protozero/field.h"
+
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "src/trace_redaction/trace_redaction_framework.h"
+
+#include "protos/perfetto/trace/clock_snapshot.pbzero.h"
+#include "protos/perfetto/trace/trace_packet_defaults.pbzero.h"
+
+using namespace perfetto::trace_processor;
+
+namespace perfetto::trace_redaction {
+
+base::Status CollectClocks::Collect(
+    const protos::pbzero::TracePacket::Decoder& packet,
+    Context* context) const {
+  context->clock_snapshot.clear();
+  if (packet.has_clock_snapshot()) {
+    protos::pbzero::ClockSnapshot_Decoder snapshot_decoder(
+        packet.clock_snapshot());
+
+    if (snapshot_decoder.has_primary_trace_clock()) {
+      int32_t trace_clock = snapshot_decoder.primary_trace_clock();
+      context->clock_converter.SetPrimaryTraceClock(
+          static_cast<int64_t>(trace_clock));
+    }
+    for (auto clock_it = snapshot_decoder.clocks(); clock_it; clock_it++) {
+      RedactorClockSynchronizer::ClockTimestamp clock_ts(0, 0);
+
+      protos::pbzero::ClockSnapshot_Clock_Decoder clock_decoder(
+          clock_it->as_bytes());
+
+      if (clock_decoder.has_clock_id()) {
+        RedactorClockSynchronizer::Clock clock =
+            RedactorClockSynchronizer::Clock(
+                static_cast<int64_t>(clock_decoder.clock_id()));
+        clock_ts.clock = clock;
+      }
+
+      if (clock_decoder.has_timestamp()) {
+        clock_ts.timestamp = static_cast<int64_t>(clock_decoder.timestamp());
+      }
+      context->clock_snapshot.push_back(clock_ts);
+    }
+
+    RETURN_IF_ERROR(
+        context->clock_converter.AddClockSnapshot(context->clock_snapshot));
+  } else if (packet.has_trace_packet_defaults()) {
+    RETURN_IF_ERROR(
+        OnTracePacketDefaults(packet.trace_packet_defaults(), context));
+  }
+
+  return base::OkStatus();
+}
+
+base::Status CollectClocks::OnTracePacketDefaults(
+    protozero::ConstBytes trace_packet_defaults_bytes,
+    Context* context) const {
+  protos::pbzero::TracePacketDefaults_Decoder trace_packet_defaults_decoder(
+      trace_packet_defaults_bytes);
+  if (trace_packet_defaults_decoder.has_timestamp_clock_id()) {
+    uint32_t perf_clock_id = trace_packet_defaults_decoder.timestamp_clock_id();
+    context->clock_converter.SetPerfTraceClock(perf_clock_id);
+    return base::OkStatus();
+  }
+
+  return base::OkStatus();
+}
+
+}  // namespace perfetto::trace_redaction

--- a/src/trace_redaction/collect_clocks.h
+++ b/src/trace_redaction/collect_clocks.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_REDACTION_COLLECT_CLOCKS_H_
+#define SRC_TRACE_REDACTION_COLLECT_CLOCKS_H_
+
+#include "src/trace_redaction/trace_redaction_framework.h"
+
+namespace perfetto::trace_redaction {
+
+class CollectClocks : public CollectPrimitive {
+ private:
+  base::Status OnTracePacketDefaults(
+      protozero::ConstBytes trace_packet_defaults_bytes,
+      Context* context) const;
+
+ public:
+  base::Status Collect(const protos::pbzero::TracePacket::Decoder&,
+                       Context*) const override;
+};
+
+}  // namespace perfetto::trace_redaction
+
+#endif  // SRC_TRACE_REDACTION_COLLECT_CLOCKS_H_

--- a/src/trace_redaction/collect_clocks_unittest.cc
+++ b/src/trace_redaction/collect_clocks_unittest.cc
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_redaction/collect_clocks.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "src/base/test/status_matchers.h"
+#include "test/gtest_and_gmock.h"
+
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
+#include "protos/perfetto/trace/clock_snapshot.gen.h"
+#include "protos/perfetto/trace/trace_packet.gen.h"
+#include "protos/perfetto/trace/trace_packet_defaults.gen.h"
+
+namespace perfetto::trace_redaction {
+
+class CollectClocksTest : public testing::Test {
+ protected:
+  base::Status Collect() {
+    std::string trace_buffer;
+    for (auto&& packet : packets_) {
+      protos::pbzero::TracePacket::Decoder decoder(packet.SerializeAsString());
+      RETURN_IF_ERROR(collect_.Begin(&context_));
+      RETURN_IF_ERROR(collect_.Collect(decoder, &context_));
+      RETURN_IF_ERROR(collect_.End(&context_));
+    }
+
+    return base::OkStatus();
+  }
+
+  std::vector<protos::gen::TracePacket> packets_;
+  Context context_;
+  CollectClocks collect_;
+};
+
+TEST_F(CollectClocksTest, CollectsClocksAndConvertsPerfToTraceTs) {
+  protos::gen::TracePacket trace_defaults_packet;
+  auto* packet_defaults = trace_defaults_packet.mutable_trace_packet_defaults();
+
+  // This is the perf samples clock
+  packet_defaults->set_timestamp_clock_id(1);
+  packets_.push_back(trace_defaults_packet);
+
+  protos::gen::TracePacket clock_snapshot_packet;
+
+  auto* clock_snapshot = clock_snapshot_packet.mutable_clock_snapshot();
+  clock_snapshot->set_primary_trace_clock(
+      static_cast<protos::gen::BuiltinClock>(4));
+  auto* clocks = clock_snapshot->mutable_clocks();
+
+  // Add a few clocks
+  protos::gen::ClockSnapshot_Clock clock1;
+  clock1.set_clock_id(4);
+  clock1.set_timestamp(100);
+  clocks->push_back(clock1);
+
+  protos::gen::ClockSnapshot_Clock clock2;
+  clock2.set_clock_id(1);
+  clock2.set_timestamp(500);
+  clocks->push_back(clock2);
+
+  packets_.push_back(clock_snapshot_packet);
+
+  ASSERT_OK(Collect());
+  ASSERT_EQ(context_.clock_converter.GetPrimaryTraceClock(), 4);
+  ASSERT_EQ(context_.clock_converter.GetPerfTraceClock(), 1);
+
+  uint64_t trace_ts;
+  context_.clock_converter.ConvertPerfToTrace(700, &trace_ts);
+  ASSERT_EQ(trace_ts, 300u);  // 700 - 500 + 100 = 300
+
+  context_.clock_converter.ConvertPerfToTrace(1000, &trace_ts);
+  ASSERT_EQ(trace_ts, 600u);  // 1000 - 500 + 100
+}
+
+}  // namespace perfetto::trace_redaction

--- a/src/trace_redaction/redactor_clock_converter.cc
+++ b/src/trace_redaction/redactor_clock_converter.cc
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_redaction/redactor_clock_converter.h"
+
+namespace perfetto::trace_redaction {
+
+using ClockId = RedactorClockSynchronizer::ClockId;
+
+RedactorClockSynchronizerListenerImpl::RedactorClockSynchronizerListenerImpl()
+    : trace_time_updates_(0) {}
+
+base::Status RedactorClockSynchronizerListenerImpl::OnClockSyncCacheMiss() {
+  return base::OkStatus();
+}
+
+base::Status RedactorClockSynchronizerListenerImpl::OnInvalidClockSnapshot() {
+  PERFETTO_ELOG("Invalid clocks snapshot found during redaction");
+  return base::ErrStatus("Invalid clocks snapshot found during redaction");
+}
+
+base::Status RedactorClockSynchronizerListenerImpl::OnTraceTimeClockIdChanged(
+    ClockId trace_time_clock_id [[maybe_unused]]) {
+  ++trace_time_updates_;
+  if (PERFETTO_UNLIKELY(trace_time_updates_ > 1)) {
+    // We expect the trace time to remain constant for a trace.
+    PERFETTO_ELOG(
+        "Redactor clock conversion trace time unexpectedly changed %d times",
+        trace_time_updates_);
+    return base::ErrStatus(
+        "Redactor clock conversion trace time unexpectedly changed %d times",
+        trace_time_updates_);
+  }
+  return base::OkStatus();
+}
+
+base::Status RedactorClockSynchronizerListenerImpl::OnSetTraceTimeClock(
+    ClockId trace_time_clock_id [[maybe_unused]]) {
+  return base::OkStatus();
+}
+
+bool RedactorClockSynchronizerListenerImpl::IsLocalHost() {
+  // Redactor does not support multi-machine clock conversion
+  return true;
+}
+
+ClockId RedactorClockConverter::GetPrimaryTraceClock() {
+  return primary_trace_clock;
+}
+
+base::Status RedactorClockConverter::SetPrimaryTraceClock(ClockId clock_id) {
+  primary_trace_clock = clock_id;
+  RETURN_IF_ERROR(clock_synchronizer.get()->SetTraceTimeClock(clock_id));
+  return base::OkStatus();
+}
+
+void RedactorClockConverter::SetPerfTraceClock(ClockId clock_id) {
+  perf_clock = clock_id;
+}
+
+ClockId RedactorClockConverter::GetPerfTraceClock() {
+  return perf_clock;
+}
+
+base::Status RedactorClockConverter::AddClockSnapshot(
+    std::vector<RedactorClockSynchronizer::ClockTimestamp>& clock_snapshot) {
+  base::StatusOr<uint32_t> snapshot_id =
+      clock_synchronizer.get()->AddSnapshot(clock_snapshot);
+  RETURN_IF_ERROR(snapshot_id.status());
+  return base::OkStatus();
+}
+
+base::Status RedactorClockConverter::ConvertPerfToTrace(
+    uint64_t perf_ts,
+    uint64_t* out_ts) const {
+  ASSIGN_OR_RETURN(int64_t trace_ts, clock_synchronizer.get()->ToTraceTime(
+                                         static_cast<int64_t>(perf_clock),
+                                         static_cast<int64_t>(perf_ts)));
+  *out_ts = static_cast<uint64_t>(trace_ts);
+  return base::OkStatus();
+}
+
+}  // namespace perfetto::trace_redaction

--- a/src/trace_redaction/redactor_clock_converter.h
+++ b/src/trace_redaction/redactor_clock_converter.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_REDACTION_REDACTOR_CLOCK_CONVERTER_H_
+#define SRC_TRACE_REDACTION_REDACTOR_CLOCK_CONVERTER_H_
+
+#include "perfetto/ext/base/status_macros.h"
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
+#include "src/trace_processor/util/clock_synchronizer.h"
+
+namespace perfetto::trace_redaction {
+
+class RedactorClockSynchronizerListenerImpl {
+ private:
+  // Number of time that trace time has been updated.
+  uint32_t trace_time_updates_;
+
+ public:
+  RedactorClockSynchronizerListenerImpl();
+
+  base::Status OnClockSyncCacheMiss();
+
+  base::Status OnInvalidClockSnapshot();
+
+  base::Status OnTraceTimeClockIdChanged(
+      perfetto::trace_processor::ClockSynchronizer<
+          RedactorClockSynchronizerListenerImpl>::ClockId trace_time_clock_id);
+
+  base::Status OnSetTraceTimeClock(
+      perfetto::trace_processor::ClockSynchronizer<
+          RedactorClockSynchronizerListenerImpl>::ClockId trace_time_clock_id);
+
+  // Always returns true as redactor only supports local host clock conversion.
+  bool IsLocalHost();
+};
+
+using RedactorClockSynchronizer = perfetto::trace_processor::ClockSynchronizer<
+    RedactorClockSynchronizerListenerImpl>;
+
+/**
+ * This class handles conversions between different clocks for trace redactor.
+ *
+ * This class is a wrapper for trace_processor::ClockSynchronizer with the
+ * addition that it caches clocks required for conversion for different data
+ * sources and it is designed to be used by the trace redactor.
+ *
+ * Any trace packet intends to use the redactor ProcessThreadTimeline and whose
+ * clock won't be the default trace time should use this class to convert
+ * it to the default trace time which is used by ProcessThreadTimeline.
+ */
+class RedactorClockConverter {
+ private:
+  std::unique_ptr<RedactorClockSynchronizer> clock_synchronizer;
+  RedactorClockSynchronizer::ClockId primary_trace_clock;
+  RedactorClockSynchronizer::ClockId perf_clock;
+
+ public:
+  RedactorClockConverter() {
+    // Set the default clocks for the trace
+    primary_trace_clock = protos::pbzero::BuiltinClock::BUILTIN_CLOCK_BOOTTIME;
+    perf_clock = protos::pbzero::BuiltinClock::BUILTIN_CLOCK_MONOTONIC_RAW;
+
+    std::unique_ptr<RedactorClockSynchronizerListenerImpl> clock_listener =
+        std::make_unique<RedactorClockSynchronizerListenerImpl>();
+    clock_synchronizer =
+        std::make_unique<RedactorClockSynchronizer>(std::move(clock_listener));
+  }
+
+  RedactorClockSynchronizer::ClockId GetPrimaryTraceClock();
+
+  base::Status SetPrimaryTraceClock(
+      RedactorClockSynchronizer::ClockId clock_id);
+
+  void SetPerfTraceClock(RedactorClockSynchronizer::ClockId clock_id);
+
+  RedactorClockSynchronizer::ClockId GetPerfTraceClock();
+
+  base::Status AddClockSnapshot(
+      std::vector<RedactorClockSynchronizer::ClockTimestamp>& clock_snapshot);
+
+  base::Status ConvertPerfToTrace(uint64_t perf_ts, uint64_t* out_ts) const;
+};
+
+}  // namespace perfetto::trace_redaction
+
+#endif  // SRC_TRACE_REDACTION_REDACTOR_CLOCK_CONVERTER_H_

--- a/src/trace_redaction/trace_redaction_framework.h
+++ b/src/trace_redaction/trace_redaction_framework.h
@@ -29,6 +29,7 @@
 #include "perfetto/base/status.h"
 #include "src/trace_redaction/frame_cookie.h"
 #include "src/trace_redaction/process_thread_timeline.h"
+#include "src/trace_redaction/redactor_clock_converter.h"
 
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 
@@ -356,6 +357,9 @@ class Context {
   std::optional<SystemInfo> system_info;
 
   std::unique_ptr<SyntheticProcess> synthetic_process;
+
+  std::vector<RedactorClockSynchronizer::ClockTimestamp> clock_snapshot;
+  RedactorClockConverter clock_converter;
 };
 
 // Extracts low-level data from the trace and writes it into the context. The

--- a/src/trace_redaction/trace_redactor.cc
+++ b/src/trace_redaction/trace_redactor.cc
@@ -30,6 +30,7 @@
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_redaction/add_synth_threads_to_process_trees.h"
 #include "src/trace_redaction/broadphase_packet_filter.h"
+#include "src/trace_redaction/collect_clocks.h"
 #include "src/trace_redaction/collect_frame_cookies.h"
 #include "src/trace_redaction/collect_system_info.h"
 #include "src/trace_redaction/collect_timeline_events.h"
@@ -168,6 +169,7 @@ std::unique_ptr<TraceRedactor> TraceRedactor::CreateInstance(
   redactor->emplace_collect<CollectTimelineEvents>();
   redactor->emplace_collect<CollectFrameCookies>();
   redactor->emplace_collect<CollectSystemInfo>();
+  redactor->emplace_collect<CollectClocks>();
 
   // Add all builders.
   redactor->emplace_build<ReduceFrameCookies>();


### PR DESCRIPTION
Collect clocks primitive is used to collect clock information from the trace. This is intended to be used in future commits to perform redactor Timeline conversions between different clocks in redacted traces.
