### PR TITLE
ui: Remove dictToTreeNodes() and friends, use TreeNode directly

### DIFF
--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/generic_slice_details_tab.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/generic_slice_details_tab.ts
@@ -20,7 +20,7 @@ import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
 import {SqlRef} from '../../widgets/sql_ref';
-import {dictToTree, Tree, TreeNode} from '../../widgets/tree';
+import {Tree, TreeNode} from '../../widgets/tree';
 import {Trace} from '../../public/trace';
 
 export interface ColumnConfig {
@@ -58,22 +58,24 @@ export class GenericSliceDetailsTab implements TrackEventDetailsPanel {
       return m('h2', 'Loading');
     }
 
-    const args: {[key: string]: m.Child} = {};
-    if (this.columns !== undefined) {
-      for (const key of Object.keys(this.columns)) {
-        let argKey = key;
-        if (this.columns[key].displayName !== undefined) {
-          argKey = this.columns[key].displayName!;
-        }
-        args[argKey] = sqlValueToReadableString(this.data[key]);
-      }
-    } else {
-      for (const key of Object.keys(this.data)) {
-        args[key] = sqlValueToReadableString(this.data[key]);
-      }
-    }
+    const columns = this.columns;
+    const data = this.data;
 
-    const details = dictToTree(args);
+    const detailNodes =
+      columns !== undefined
+        ? Object.keys(columns).map((key) => {
+            const argKey = columns[key].displayName ?? key;
+            return m(TreeNode, {
+              left: argKey,
+              right: sqlValueToReadableString(data[key]),
+            });
+          })
+        : Object.keys(this.data).map((key) => {
+            return m(TreeNode, {
+              left: key,
+              right: sqlValueToReadableString(data[key]),
+            });
+          });
 
     return m(
       DetailsShell,
@@ -82,7 +84,7 @@ export class GenericSliceDetailsTab implements TrackEventDetailsPanel {
       },
       m(
         GridLayout,
-        m(Section, {title: 'Details'}, m(Tree, details)),
+        m(Section, {title: 'Details'}, m(Tree, detailNodes)),
         m(
           Section,
           {title: 'Metadata'},

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/startup_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/startup_details_panel.ts
@@ -21,7 +21,7 @@ import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
 import {SqlRef} from '../../widgets/sql_ref';
-import {dictToTreeNodes, Tree} from '../../widgets/tree';
+import {Tree, TreeNode} from '../../widgets/tree';
 import {asUpid, Upid} from '../../components/sql_utils/core_types';
 import {Trace} from '../../public/trace';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
@@ -81,30 +81,6 @@ export class StartupDetailsPanel implements TrackEventDetailsPanel {
     }
   }
 
-  private getDetailsDictionary() {
-    const details: {[key: string]: m.Child} = {};
-    if (this.data === undefined) return details;
-    details['Activity ID'] = this.data.startupId;
-    details['Browser Upid'] = this.data.upid;
-    details['Startup Event'] = this.data.eventName;
-    details['Startup Timestamp'] = m(Timestamp, {
-      trace: this.trace,
-      ts: this.data.startupBeginTs,
-    });
-    details['Duration to First Visible Content'] = m(DurationWidget, {
-      trace: this.trace,
-      dur: this.data.durToFirstVisibleContent,
-    });
-    if (this.data.launchCause) {
-      details['Launch Cause'] = this.data.launchCause;
-    }
-    details['SQL ID'] = m(SqlRef, {
-      table: 'chrome_startups',
-      id: this.id,
-    });
-    return details;
-  }
-
   render() {
     if (!this.data) {
       return m('h2', 'Loading');
@@ -122,7 +98,37 @@ export class StartupDetailsPanel implements TrackEventDetailsPanel {
           m(
             Section,
             {title: 'Details'},
-            m(Tree, dictToTreeNodes(this.getDetailsDictionary())),
+            m(Tree, [
+              m(TreeNode, {left: 'Activity ID', right: this.data.startupId}),
+              m(TreeNode, {left: 'Browser Upid', right: this.data.upid}),
+              m(TreeNode, {left: 'Startup Event', right: this.data.eventName}),
+              m(TreeNode, {
+                left: 'Startup Timestamp',
+                right: m(Timestamp, {
+                  trace: this.trace,
+                  ts: this.data.startupBeginTs,
+                }),
+              }),
+              m(TreeNode, {
+                left: 'Duration to First Visible Content',
+                right: m(DurationWidget, {
+                  trace: this.trace,
+                  dur: this.data.durToFirstVisibleContent,
+                }),
+              }),
+              this.data.launchCause &&
+                m(TreeNode, {
+                  left: 'Launch Cause',
+                  right: this.data.launchCause,
+                }),
+              m(TreeNode, {
+                left: 'SQL ID',
+                right: m(SqlRef, {
+                  table: 'chrome_startups',
+                  id: this.id,
+                }),
+              }),
+            ]),
           ),
         ),
       ),

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/web_content_interaction_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/web_content_interaction_details_panel.ts
@@ -36,7 +36,7 @@ import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
 import {SqlRef} from '../../widgets/sql_ref';
-import {dictToTreeNodes, Tree} from '../../widgets/tree';
+import {Tree, TreeNode} from '../../widgets/tree';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
 
@@ -85,27 +85,6 @@ export class WebContentInteractionPanel implements TrackEventDetailsPanel {
     };
   }
 
-  private getDetailsDictionary() {
-    const details: {[key: string]: m.Child} = {};
-    if (this.data === undefined) return details;
-    details['Interaction'] = this.data.interactionType;
-    details['Timestamp'] = m(Timestamp, {trace: this.trace, ts: this.data.ts});
-    details['Duration'] = m(DurationWidget, {
-      trace: this.trace,
-      dur: this.data.dur,
-    });
-    details['Renderer Upid'] = this.data.upid;
-    details['Total duration of all events'] = m(DurationWidget, {
-      trace: this.trace,
-      dur: this.data.totalDurationMs,
-    });
-    details['SQL ID'] = m(SqlRef, {
-      table: 'chrome_web_content_interactions',
-      id: this.id,
-    });
-    return details;
-  }
-
   render() {
     if (!this.data) {
       return m('h2', 'Loading');
@@ -123,7 +102,38 @@ export class WebContentInteractionPanel implements TrackEventDetailsPanel {
           m(
             Section,
             {title: 'Details'},
-            m(Tree, dictToTreeNodes(this.getDetailsDictionary())),
+            m(Tree, [
+              m(TreeNode, {
+                left: 'Interaction',
+                right: this.data.interactionType,
+              }),
+              m(TreeNode, {
+                left: 'Timestamp',
+                right: m(Timestamp, {trace: this.trace, ts: this.data.ts}),
+              }),
+              m(TreeNode, {
+                left: 'Duration',
+                right: m(DurationWidget, {
+                  trace: this.trace,
+                  dur: this.data.dur,
+                }),
+              }),
+              m(TreeNode, {left: 'Renderer Upid', right: this.data.upid}),
+              m(TreeNode, {
+                left: 'Total duration of all events',
+                right: m(DurationWidget, {
+                  trace: this.trace,
+                  dur: this.data.totalDurationMs,
+                }),
+              }),
+              m(TreeNode, {
+                left: 'SQL ID',
+                right: m(SqlRef, {
+                  table: 'chrome_web_content_interactions',
+                  id: this.id,
+                }),
+              }),
+            ]),
           ),
         ),
       ),

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_details_panel.ts
@@ -37,7 +37,7 @@ import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {Section} from '../../widgets/section';
 import {SqlRef} from '../../widgets/sql_ref';
 import {MultiParagraphText, TextParagraph} from '../../widgets/text_paragraph';
-import {dictToTreeNodes, Tree} from '../../widgets/tree';
+import {Tree, TreeNode} from '../../widgets/tree';
 import {
   buildScrollOffsetsGraph,
   getInputScrollDeltas,
@@ -262,44 +262,60 @@ export class ScrollDetailsPanel implements TrackEventDetailsPanel {
     }
   }
 
-  private renderMetricsDictionary(): m.Child[] {
-    const metrics: {[key: string]: m.Child} = {};
-    metrics['Total Finger Input Event Count'] = this.metrics.inputEventCount;
-    metrics['Total Vsyncs within Scrolling period'] = this.metrics.frameCount;
-    metrics['Total Chrome Presented Frames'] = this.metrics.presentedFrameCount;
-    metrics['Total Janky Frames'] = this.metrics.jankyFrameCount;
-    metrics['Number of Vsyncs Janky Frames were Delayed by'] =
-      this.metrics.missedVsyncs;
+  private renderMetricsDictionary(): m.Children {
+    return [
+      m(TreeNode, {
+        left: 'Total Finger Input Event Count',
+        right: this.metrics.inputEventCount,
+      }),
+      m(TreeNode, {
+        left: 'Total Vsyncs within Scrolling period',
+        right: this.metrics.frameCount,
+      }),
+      m(TreeNode, {
+        left: 'Total Chrome Presented Frames',
+        right: this.metrics.presentedFrameCount,
+      }),
+      m(TreeNode, {
+        left: 'Total Janky Frames',
+        right: this.metrics.jankyFrameCount,
+      }),
+      m(TreeNode, {
+        left: 'Number of Vsyncs Janky Frames were Delayed by',
+        right: this.metrics.missedVsyncs,
+      }),
 
-    if (this.metrics.jankyFramePercent !== undefined) {
-      metrics[
-        'Janky Frame Percentage (Total Janky Frames / Total Chrome Presented Frames)'
-      ] = `${this.metrics.jankyFramePercent}%`;
-    }
+      this.metrics.jankyFramePercent !== undefined &&
+        m(TreeNode, {
+          left: 'Janky Frame Percentage (Total Janky Frames / Total Chrome Presented Frames)',
+          right: `${this.metrics.jankyFramePercent}%`,
+        }),
 
-    if (this.metrics.startOffset != undefined) {
-      metrics['Starting Offset'] = this.metrics.startOffset;
-    }
+      this.metrics.startOffset !== undefined &&
+        m(TreeNode, {
+          left: 'Starting Offset',
+          right: this.metrics.startOffset,
+        }),
 
-    if (this.metrics.endOffset != undefined) {
-      metrics['Ending Offset'] = this.metrics.endOffset;
-    }
+      this.metrics.endOffset !== undefined &&
+        m(TreeNode, {
+          left: 'Ending Offset',
+          right: this.metrics.endOffset,
+        }),
 
-    if (
-      this.metrics.startOffset != undefined &&
-      this.metrics.endOffset != undefined
-    ) {
-      metrics['Net Pixels Scrolled'] = Math.abs(
-        this.metrics.endOffset - this.metrics.startOffset,
-      );
-    }
+      this.metrics.startOffset !== undefined &&
+        this.metrics.endOffset !== undefined &&
+        m(TreeNode, {
+          left: 'Net Pixels Scrolled',
+          right: Math.abs(this.metrics.endOffset - this.metrics.startOffset),
+        }),
 
-    if (this.metrics.totalPixelsScrolled != undefined) {
-      metrics['Total Pixels Scrolled (all directions)'] =
-        this.metrics.totalPixelsScrolled;
-    }
-
-    return dictToTreeNodes(metrics);
+      this.metrics.totalPixelsScrolled !== undefined &&
+        m(TreeNode, {
+          left: 'Total Pixels Scrolled (all directions)',
+          right: this.metrics.totalPixelsScrolled,
+        }),
+    ];
   }
 
   private getDelayTable(): m.Child {
@@ -392,16 +408,9 @@ export class ScrollDetailsPanel implements TrackEventDetailsPanel {
   }
 
   render() {
-    if (this.data == undefined) {
+    if (this.data === undefined) {
       return m('h2', 'Loading');
     }
-
-    const details = dictToTreeNodes({
-      'Scroll ID': `${this.data.id}`,
-      'Start time': m(Timestamp, {trace: this.trace, ts: this.data.ts}),
-      'Duration': m(DurationWidget, {trace: this.trace, dur: this.data.dur}),
-      'SQL ID': m(SqlRef, {table: 'chrome_scrolls', id: this.id}),
-    });
 
     return m(
       DetailsShell,
@@ -412,7 +421,28 @@ export class ScrollDetailsPanel implements TrackEventDetailsPanel {
         GridLayout,
         m(
           GridLayoutColumn,
-          m(Section, {title: 'Details'}, m(Tree, details)),
+          m(
+            Section,
+            {title: 'Details'},
+            m(Tree, [
+              m(TreeNode, {left: 'Scroll ID', right: `${this.data.id}`}),
+              m(TreeNode, {
+                left: 'Start time',
+                right: m(Timestamp, {trace: this.trace, ts: this.data.ts}),
+              }),
+              m(TreeNode, {
+                left: 'Duration',
+                right: m(DurationWidget, {
+                  trace: this.trace,
+                  dur: this.data.dur,
+                }),
+              }),
+              m(TreeNode, {
+                left: 'SQL ID',
+                right: m(SqlRef, {table: 'chrome_scrolls', id: this.id}),
+              }),
+            ]),
+          ),
           m(
             Section,
             {title: 'Slice Metrics'},

--- a/ui/src/widgets/tree.ts
+++ b/ui/src/widgets/tree.ts
@@ -135,26 +135,6 @@ export class TreeNode implements m.ClassComponent<TreeNodeAttrs> {
   }
 }
 
-export function dictToTreeNodes(dict: {[key: string]: m.Child}): m.Child[] {
-  const children: m.Child[] = [];
-  for (const key of Object.keys(dict)) {
-    if (dict[key] == undefined) {
-      continue;
-    }
-    children.push(
-      m(TreeNode, {
-        left: key,
-        right: dict[key],
-      }),
-    );
-  }
-  return children;
-}
-
-// Create a flat tree from a POJO
-export function dictToTree(dict: {[key: string]: m.Child}): m.Children {
-  return m(Tree, dictToTreeNodes(dict));
-}
 interface LazyTreeNodeAttrs {
   // Same as TreeNode (see above).
   left?: m.Children;


### PR DESCRIPTION
This patch is a small code tidy up. It should contain zero functional changes.

Currently we use two utility functions `dictToTreeNodes()` and `dictToTree()` to  generate `m(Tree, ...)` and `m(TreeNode, ...)` widgets from dicts. While on paper these seem reasonable, they actually add a layer of indirection to the code which makes it confusing to write, read, and modify. Using `m(TreeNode, ...)` directly really isn't that much of a hardship, and permits usage of familiar mithril niceties such as conditional rendering. I.e. `conditional && m(TreeNode, {...})`
