### PR TITLE
Fix bug in PerfettoApiTest#NoFlushFlag/System

### DIFF
--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -5296,6 +5296,8 @@ TEST_P(PerfettoApiTest, NoFlushFlag) {
   dsd_flush.set_track_event_descriptor_raw("DESC_");
   UpdateDataSource<FlushDataSource>(dsd_flush);
 
+  perfetto::test::SyncProducers();
+
   result = tracing_session->QueryServiceStateBlocking();
   ASSERT_TRUE(result.success);
   ASSERT_TRUE(state.ParseFromArray(result.service_state_data.data(),


### PR DESCRIPTION
Fix a test. This test has always been buggy as it was missing
a sync fence. It was passing by accident just because the
old task runner was slower.
The new task runner makes the bug visible because runs tasks
faster.
This can be repro locally by setting
enable_perfetto_lockfree_taskrunner=true

Bug: 447118803