### PR TITLE
tp: significantly speed up compile time of tp

### DIFF
--- a/src/trace_processor/dataframe/dataframe.cc
+++ b/src/trace_processor/dataframe/dataframe.cc
@@ -28,6 +28,7 @@
 #include "perfetto/ext/base/status_or.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/dataframe/cursor_impl.h"  // IWYU pragma: keep
+#include "src/trace_processor/dataframe/impl/bytecode_instructions.h"
 #include "src/trace_processor/dataframe/impl/query_plan.h"
 #include "src/trace_processor/dataframe/impl/types.h"
 #include "src/trace_processor/dataframe/specs.h"
@@ -283,6 +284,14 @@ std::vector<std::shared_ptr<impl::Column>> Dataframe::CreateColumnVector(
     }));
   }
   return columns;
+}
+
+std::vector<std::string> Dataframe::QueryPlan::BytecodeToString() const {
+  std::vector<std::string> result;
+  for (const auto& instr : plan_.bytecode) {
+    result.push_back(impl::bytecode::ToString(instr));
+  }
+  return result;
 }
 
 }  // namespace perfetto::trace_processor::dataframe

--- a/src/trace_processor/dataframe/dataframe.h
+++ b/src/trace_processor/dataframe/dataframe.h
@@ -30,12 +30,10 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/status_or.h"
-#include "perfetto/ext/base/variant.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/dataframe/cursor.h"
 #include "src/trace_processor/dataframe/impl/bit_vector.h"
-#include "src/trace_processor/dataframe/impl/bytecode_instructions.h"
 #include "src/trace_processor/dataframe/impl/query_plan.h"
 #include "src/trace_processor/dataframe/impl/types.h"
 #include "src/trace_processor/dataframe/specs.h"
@@ -83,13 +81,7 @@ class Dataframe {
 
     // Returns the bytecode instructions of the query plan as a vector of
     // strings, where each string represents a single bytecode instruction.
-    std::vector<std::string> BytecodeToString() const {
-      std::vector<std::string> result;
-      for (const auto& instr : plan_.bytecode) {
-        result.push_back(impl::bytecode::ToString(instr));
-      }
-      return result;
-    }
+    std::vector<std::string> BytecodeToString() const;
 
     // An estimate for the cost of executing the query plan.
     double estimated_cost() const { return plan_.params.estimated_cost; }

--- a/src/trace_processor/dataframe/impl/query_plan.cc
+++ b/src/trace_processor/dataframe/impl/query_plan.cc
@@ -1234,4 +1234,9 @@ void QueryPlanBuilder::AddLinearFilterEqBytecode(
   indices_reg_ = span_reg;
 }
 
+template <typename T>
+T& QueryPlanBuilder::AddOpcode(RowCountModifier rc) {
+  return AddOpcode<T>(bytecode::Index<T>(), rc, T::kCost);
+}
+
 }  // namespace perfetto::trace_processor::dataframe::impl

--- a/src/trace_processor/dataframe/impl/query_plan.h
+++ b/src/trace_processor/dataframe/impl/query_plan.h
@@ -38,7 +38,6 @@
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/dataframe/impl/bytecode_core.h"
-#include "src/trace_processor/dataframe/impl/bytecode_instructions.h"
 #include "src/trace_processor/dataframe/impl/bytecode_registers.h"
 #include "src/trace_processor/dataframe/impl/slab.h"
 #include "src/trace_processor/dataframe/impl/types.h"
@@ -315,9 +314,7 @@ class QueryPlanBuilder {
 
   // Adds a new bytecode instruction of type T to the plan.
   template <typename T>
-  T& AddOpcode(RowCountModifier rc) {
-    return AddOpcode<T>(bytecode::Index<T>(), rc, T::kCost);
-  }
+  T& AddOpcode(RowCountModifier rc);
 
   // Adds a new bytecode instruction of type T with the given option value.
   template <typename T>


### PR DESCRIPTION
Lots of places include dataframe.h and query_plan.h which also
indirectly caused including the whole bytecode. But this was only used
for string conversion which barely *any* code needs to care about.
Out-line those to speed up TP builds signifcantly.
