### PR TITLE
wasm: configure stack size

### DIFF
--- a/gn/standalone/wasm.gni
+++ b/gn/standalone/wasm.gni
@@ -53,6 +53,8 @@ template("wasm_lib") {
       "-s",
       "ALLOW_TABLE_GROWTH=1",
       "-s",
+      "STACK_SIZE=2MB",
+      "-s",
       "WASM_ASYNC_COMPILATION=0",
       "-s",
       "EXPORTED_RUNTIME_METHODS=" + _exports,


### PR DESCRIPTION
Increase wasm stack size to 2MB

Traversing the window manager hierarchy in the proto was often causing stack overflows. The traversal (dfs) is done in WindowManagerHierarchyWalker, it involves creating protozero decoders on the stack (>1KB each), which quickly consumes the default stack size.
