### PR TITLE
Android Java SDK: Allow user-specified IDs for named tracks

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
@@ -386,7 +386,7 @@ public final class PerfettoTrackEventBuilder {
   }
 
   /** Adds the events to a named track instead of the thread track where the event occurred. */
-  public PerfettoTrackEventBuilder usingNamedTrack(long parentUuid, String name) {
+  public PerfettoTrackEventBuilder usingNamedTrack(long id, String name, long parentUuid) {
     if (!mIsCategoryEnabled) {
       return this;
     }
@@ -396,7 +396,7 @@ public final class PerfettoTrackEventBuilder {
 
     NamedTrack track = mObjectsCache.mNamedTrackCache.get(name.hashCode());
     if (track == null || !track.getName().equals(name)) {
-      track = new NamedTrack(name, parentUuid, mNativeMemoryCleaner);
+      track = new NamedTrack(id, name, parentUuid, mNativeMemoryCleaner);
       mObjectsCache.mNamedTrackCache.put(name.hashCode(), track);
     }
     addPerfettoPointerToExtra(track);
@@ -407,22 +407,22 @@ public final class PerfettoTrackEventBuilder {
    * Adds the events to a process scoped named track instead of the thread track where the event
    * occurred.
    */
-  public PerfettoTrackEventBuilder usingProcessNamedTrack(String name) {
+  public PerfettoTrackEventBuilder usingProcessNamedTrack(long id, String name) {
     if (!mIsCategoryEnabled) {
       return this;
     }
-    return usingNamedTrack(PerfettoTrace.getProcessTrackUuid(), name);
+    return usingNamedTrack(id, name, PerfettoTrace.getProcessTrackUuid());
   }
 
   /**
    * Adds the events to a thread scoped named track instead of the thread track where the event
    * occurred.
    */
-  public PerfettoTrackEventBuilder usingThreadNamedTrack(long tid, String name) {
+  public PerfettoTrackEventBuilder usingThreadNamedTrack(long id, String name, long tid) {
     if (!mIsCategoryEnabled) {
       return this;
     }
-    return usingNamedTrack(PerfettoTrace.getThreadTrackUuid(tid), name);
+    return usingNamedTrack(id, name, PerfettoTrace.getThreadTrackUuid(tid));
   }
 
   /** Adds the events to a counter track instead. This is required for setting counter values. */

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
@@ -26,8 +26,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * @hide
  */
 final class PerfettoTrackEventExtra {
-  private static final AtomicLong sNamedTrackId = new AtomicLong();
-
   private final long mPtr;
 
   PerfettoTrackEventExtra(PerfettoNativeMemoryCleaner memoryCleaner) {
@@ -120,11 +118,13 @@ final class PerfettoTrackEventExtra {
     private final long mPtr;
     private final long mExtraPtr;
     private final String mName;
+    private final long mId;
 
-    NamedTrack(String name, long parentUuid, PerfettoNativeMemoryCleaner memoryCleaner) {
-      mPtr = native_init(sNamedTrackId.incrementAndGet(), name, parentUuid);
+    NamedTrack(long id, String name, long parentUuid, PerfettoNativeMemoryCleaner memoryCleaner) {
+      mPtr = native_init(id, name, parentUuid);
       mExtraPtr = native_get_extra_ptr(mPtr);
       mName = name;
+      mId = id;
       memoryCleaner.registerNativeAllocation(this, mPtr, native_delete());
     }
 

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -211,11 +211,11 @@ public class PerfettoTraceTest {
     PerfettoTrace.Session session = new PerfettoTrace.Session(true, traceConfig.toByteArray());
 
     PerfettoTrace.begin(FOO_CATEGORY, "event")
-        .usingNamedTrack(PerfettoTrace.getProcessTrackUuid(), FOO)
+        .usingNamedTrack(123, FOO, PerfettoTrace.getProcessTrackUuid())
         .emit();
 
     PerfettoTrace.end(FOO_CATEGORY)
-        .usingNamedTrack(PerfettoTrace.getThreadTrackUuid(Process.myTid()), "bar")
+        .usingNamedTrack(456, "bar", PerfettoTrace.getThreadTrackUuid(Process.myTid()))
         .emit();
 
     Trace trace = Trace.parseFrom(session.close());
@@ -254,9 +254,9 @@ public class PerfettoTraceTest {
 
     PerfettoTrace.Session session = new PerfettoTrace.Session(true, traceConfig.toByteArray());
 
-    PerfettoTrace.begin(FOO_CATEGORY, "event").usingProcessNamedTrack(FOO).emit();
+    PerfettoTrace.begin(FOO_CATEGORY, "event").usingProcessNamedTrack(123, FOO).emit();
 
-    PerfettoTrace.end(FOO_CATEGORY).usingThreadNamedTrack(Process.myTid(), "bar").emit();
+    PerfettoTrace.end(FOO_CATEGORY).usingThreadNamedTrack(456, "bar", Process.myTid()).emit();
 
     Trace trace = Trace.parseFrom(session.close());
 


### PR DESCRIPTION
This change modifies the Perfetto Java SDK to enable users to provide their own identifiers when using/creating named tracks.

Previously, named track IDs were generated internally using a static auto-incrementing counter, offering no control to the API user.

The following changes are included:

- Removed the static AtomicLong sNamedTrackId from PerfettoTrackEventExtra.
- Modified the NamedTrack constructor in PerfettoTrackEventExtra to accept a user-provided long id.
- Updated PerfettoTrackEventBuilder methods (usingNamedTrack, usingProcessNamedTrack, usingThreadNamedTrack) to accept a long id parameter and propagate it to the NamedTrack constructor.

This allows for more flexible track management.

Test: bazelisk test //:src_android_sdk_java_test_perfetto_trace_instrumentation_test

