### PR TITLE
CPU-per-UID UI enhancements

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/cpu/cpu_per_uid.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cpu/cpu_per_uid.sql
@@ -49,7 +49,7 @@ SELECT
       package_name
     FROM package_list
     WHERE
-      uid = track.uid AND uid >= 10000
+      uid = track.uid % 100000 AND uid >= 10000
     LIMIT 1
   ) AS package_name
 FROM track;

--- a/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
@@ -865,7 +865,7 @@ export default class implements PerfettoPlugin {
     if (!features.has('atom.cpu_cycles_per_uid_cluster')) {
       return;
     }
-    const groupName = 'CPU per UID (major users)';
+    const groupName = 'CPU per UID (major users, from statsd)';
 
     const e = ctx.engine;
 
@@ -877,7 +877,7 @@ export default class implements PerfettoPlugin {
     for (; it.valid(); it.next()) {
       await support.addCounterTrack(
         ctx,
-        `CPU (${it.cluster}): ${it.pkg}`,
+        `${it.pkg} (${it.cluster})`,
         `select ts, value from high_cpu where pkg = "${it.pkg}" and cluster="${it.cluster}"`,
         groupName,
         {yOverrideMaximum: 100, unit: '%'},


### PR DESCRIPTION
* Don't materialize the counter data, we were eating a lot of time creating lots of tiny tables.
* Create a filtered view with "major users" and a summary view of summed app / system CPU use.
* Add meaningful cluster names.
* Label the statsd source and make its tracks have the same format.
* Fix a bug in stdlib where we didn't attach package name for non-base users.

Bug: http://b/445922810
