### PR TITLE
ui: Set `cursor: pointer` on interactive cards

### DIFF
--- a/ui/src/assets/widgets/card.scss
+++ b/ui/src/assets/widgets/card.scss
@@ -25,6 +25,8 @@ $border-radius: $border-radius-large;
 
     &.pf-interactive {
       transition: $anim-timing;
+      cursor: pointer;
+
       &:hover {
         box-shadow: $box-shadow-3;
       }


### PR DESCRIPTION
Card widgets with 'interactive: true' configured are essentially inviting the user to click on them. Set the cursor to pointer as an extra hint that they are clickable.