### PR TITLE
Add proto for JobScheduler job events

### DIFF
--- a/include/perfetto/public/protos/trace/android/android_track_event.pzc.h
+++ b/include/perfetto/public/protos/trace/android/android_track_event.pzc.h
@@ -44,6 +44,108 @@ PERFETTO_PB_FIELD(perfetto_protos_AndroidBitmap,
                   7);
 PERFETTO_PB_FIELD(perfetto_protos_AndroidBitmap, VARINT, int64_t, id, 8);
 
+PERFETTO_PB_MSG(perfetto_protos_AndroidJobSchedulerJob);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  job_id,
+                  1);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  source_uid,
+                  2);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  proxy_uid,
+                  3);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  state,
+                  4);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  standby_bucket,
+                  5);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  requested_priority,
+                  6);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  effective_priority,
+                  7);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  num_previous_attempts,
+                  8);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int64_t,
+                  deadline_ms,
+                  9);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int64_t,
+                  delay_ms,
+                  10);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int64_t,
+                  job_start_latency_ms,
+                  11);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  num_uncompleted_work_items,
+                  12);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  proc_state,
+                  13);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int64_t,
+                  periodic_job_interval_ms,
+                  14);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int64_t,
+                  periodic_job_flex_interval_ms,
+                  15);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  num_reschedules_due_to_abandonment,
+                  16);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  back_off_policy_type,
+                  17);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  internal_stop_reason,
+                  18);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int32_t,
+                  public_stop_reason,
+                  19);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
+                  VARINT,
+                  int64_t,
+                  job_state_flags,
+                  20);
+
 PERFETTO_PB_MSG(perfetto_protos_AndroidMessageQueue);
 PERFETTO_PB_FIELD(perfetto_protos_AndroidMessageQueue,
                   STRING,
@@ -96,4 +198,10 @@ PERFETTO_PB_EXTENSION_FIELD(perfetto_protos_AndroidTrackEvent,
                             perfetto_protos_AndroidBitmap,
                             bitmap,
                             2005);
+PERFETTO_PB_EXTENSION_FIELD(perfetto_protos_AndroidTrackEvent,
+                            perfetto_protos_TrackEvent,
+                            MSG,
+                            perfetto_protos_AndroidJobSchedulerJob,
+                            job_scheduler_job,
+                            2006);
 #endif  // INCLUDE_PERFETTO_PUBLIC_PROTOS_TRACE_ANDROID_ANDROID_TRACK_EVENT_PZC_H_

--- a/protos/perfetto/trace/android/android_track_event.proto
+++ b/protos/perfetto/trace/android/android_track_event.proto
@@ -33,6 +33,90 @@ message AndroidMessageQueue {
   optional uint64 message_delay_ms = 4;
 }
 
+message AndroidJobSchedulerJob {
+  // Job id.
+  optional int32 job_id = 1;
+  // Job user id.
+  optional int32 source_uid = 2;
+  // Job user id.
+  optional int32 proxy_uid = 3;
+  // FINISHED = 0;
+  // STARTED = 1;
+  // SCHEDULED = 2;
+  // CANCELLED = 3;
+  optional int32 state = 4;
+  // The standby bucket of the app that scheduled the job. These match the
+  // framework constants defined in JobSchedulerService.java with the addition
+  // of UNKNOWN using -1, as ACTIVE is already assigned 0.
+  // UNKNOWN = -1;
+  // ACTIVE = 0;
+  // WORKING_SET = 1;
+  // FREQUENT = 2;
+  // RARE = 3;
+  // NEVER = 4;
+  // RESTRICTED = 5;
+  // EXEMPTED = 6;
+  optional int32 standby_bucket = 5;
+  // The priority set by the app (via JobInfo.Builder.setPriority()).
+  optional int32 requested_priority = 6;
+  // The priority JobScheduler ran the job at. Only valid for STARTED and
+  // FINISHED states.
+  optional int32 effective_priority = 7;
+  // Number of times JobScheduler has tried to run this particular job. This
+  // value is incremented when a job is stopped and rescheduled for various
+  // reasons (lost network, constraints no longer satisfied, etc). For periodic
+  // be newly scheduled and therefore this value reflects the time since the
+  // most recent (re)schedule. This is only valid for the STARTED and FINISHED
+  // states.
+  optional int32 num_previous_attempts = 8;
+  // The deadline that the Job has requested.
+  // This is only valid if has_deadline_constraint is true.
+  optional int64 deadline_ms = 9;
+  // The delay that the Job has requested.
+  // This is only valid if has_timing_delay_constraint is true.
+  optional int64 delay_ms = 10;
+  // The amount of time that elapsed between the job being scheduled (state =
+  // SCHEDULED) and it being started (state = STARTED). Persisted jobs loaded at
+  // boot are considered to be scheduled at boot, so all values are within the
+  // current boot cycle. Periodic and other rescheduled jobs are considered to
+  // be newly scheduled and therefore this value reflects the time since the
+  // most recent (re)schedule. This is only valid for the STARTED and FINISHED
+  // states.
+  optional int64 job_start_latency_ms = 11;
+  // The number of JobWorkItems the app has attached to this job but not
+  // completed (by calling JobParameters.completeWork()).
+  optional int32 num_uncompleted_work_items = 12;
+  // Proc state of the UID of the logged event
+  // See android.app.ProcessStateEnum
+  optional int32 proc_state = 13;
+  // Interval for the job to recur when it is set as periodic.
+  optional int64 periodic_job_interval_ms = 14;
+  // Flex interval for the periodic job. This value is set via the second
+  // parameter of JobInfo.Builder.setPeriodic(long, long). The job can
+  // execute at any time in a window flex length at the end of the period.
+  // Trace tag set via JobInfo.Builder.setTraceTag(). Basic PII filtering has
+  // been applied,
+  // but further filtering should be done by clients.
+  optional int64 periodic_job_flex_interval_ms = 15;
+  // Number of reschedules due to job being abandoned.
+  optional int32 num_reschedules_due_to_abandonment = 16;
+  // Back off policy applied to the job that gets rescheduled.
+  // The internal reason a job has stopped.
+  // UNKNOWN_POLICY = 0;
+  // LINEAR = 1;
+  // EXPONENTIAL = 2;
+  optional int32 back_off_policy_type = 17;
+  // The publicly returned reason onStopJob() was called.
+  // This is only applicable when the state is FINISHED.
+  // The default value is INTERNAL_STOP_REASON_UNKNOWN.
+  optional int32 internal_stop_reason = 18;
+  // This is only applicable when the state is FINISHED, but may be undefined if
+  // JobService.onStopJob() was never called for the job.
+  optional int32 public_stop_reason = 19;
+  // Bitfield of boolean states of the job.
+  optional int64 job_state_flags = 20;
+}
+
 // Information about an android.graphics.Bitmap.
 message AndroidBitmap {
   // Allocation size, in bytes.
@@ -69,5 +153,7 @@ message AndroidTrackEvent {
     optional AndroidMessageQueue message_queue = 2004;
     // Bitmaps
     optional AndroidBitmap bitmap = 2005;
+    // JobScheduler jobs.
+    optional AndroidJobSchedulerJob job_scheduler_job = 2006;
   }
 }


### PR DESCRIPTION
This change introduces a new proto message, AndroidJobSchedulerJob, for Perfetto tracing of JobScheduler events. This message is added as an extension to AndroidTrackEvent.

The AndroidJobSchedulerJob proto includes fields to capture a comprehensive view of a job's state and lifecycle.

These additions will provide detailed insights into the job lifecycle and enable more effective debugging and analysis of JobScheduler behavior.

Bug: 441360426