### PR TITLE
stdlib: make android_anrs a perfetto table

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/anrs.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/anrs.sql
@@ -144,7 +144,7 @@ SELECT
   END;
 
 -- List of all ANRs that occurred in the trace (one row per ANR).
-CREATE PERFETTO VIEW android_anrs (
+CREATE PERFETTO TABLE android_anrs (
   -- Name of the process that triggered the ANR.
   process_name STRING,
   -- PID of the process that triggered the ANR.
@@ -158,7 +158,7 @@ CREATE PERFETTO VIEW android_anrs (
   -- Subject line of the ANR.
   subject STRING,
   -- The duration between the timer expiration event and the anr counter event
-  timer_delay DOUBLE,
+  timer_delay LONG,
   -- The standard type of ANR.
   anr_type STRING,
   -- Duration of the ANR, computed from the timer expiration event.


### PR DESCRIPTION
This PR changes the type of android_anrs from a perfetto view to a perfetto table.

Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter '.*anr.*'
