### PR TITLE
ui: `new DatasetSliceTrack` -> `DatasetSliceTrack.create`

### DIFF
--- a/ui/src/components/tracks/dataset_slice_track.ts
+++ b/ui/src/components/tracks/dataset_slice_track.ts
@@ -280,7 +280,7 @@ export class DatasetSliceTrack<T extends RowSchema> extends BaseSliceTrack<
     });
   }
 
-  constructor(private readonly attrs: DatasetSliceTrackAttrs<T>) {
+  private constructor(private readonly attrs: DatasetSliceTrackAttrs<T>) {
     const dataset = getDataset(attrs);
     super(
       attrs.trace,

--- a/ui/src/components/tracks/debug_tracks.ts
+++ b/ui/src/components/tracks/debug_tracks.ts
@@ -196,7 +196,7 @@ async function addPivotedSliceTracks(
 
     trace.tracks.registerTrack({
       uri,
-      renderer: new DatasetSliceTrack({
+      renderer: DatasetSliceTrack.create({
         trace,
         uri,
         dataset: new SourceDataset({
@@ -232,7 +232,7 @@ function addSingleSliceTrack(
 ) {
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/components/tracks/visualized_args_track.ts
+++ b/ui/src/components/tracks/visualized_args_track.ts
@@ -74,7 +74,7 @@ export async function createVisualizedArgsTrack({
     `,
   });
 
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.AndroidLog/logs_track.ts
+++ b/ui/src/plugins/com.android.AndroidLog/logs_track.ts
@@ -38,7 +38,7 @@ const DEPTH_TO_COLOR = [
 const EVT_PX = 6; // Width of an event tick in pixels.
 
 export function createAndroidLogTrack(trace: Trace, uri: string) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     rootTableName: 'android_logs',

--- a/ui/src/plugins/com.android.AndroidStartup/optimizations.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/optimizations.ts
@@ -110,7 +110,7 @@ export async function optimizationsTrack(
   const tableName = `_startup_optimization_slices`;
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -142,7 +142,7 @@ function classLoadingTrack(
   const uri = `/android_startups/${startup.id}/classloading`;
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
@@ -76,7 +76,7 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      renderer: new DatasetSliceTrack({
+      renderer: DatasetSliceTrack.create({
         trace: ctx,
         uri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
@@ -43,7 +43,7 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      renderer: new DatasetSliceTrack({
+      renderer: DatasetSliceTrack.create({
         trace: ctx,
         uri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.example.Tracks/index.ts
+++ b/ui/src/plugins/com.example.Tracks/index.ts
@@ -72,7 +72,7 @@ async function addBasicSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -100,7 +100,7 @@ async function addFilteredSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -134,7 +134,7 @@ async function addSliceTrackWithCustomColorizer(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -165,7 +165,7 @@ async function addInstantTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -191,7 +191,7 @@ async function addFlatSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -219,7 +219,7 @@ async function addFixedColorSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -314,7 +314,7 @@ function addTracksWithHelpText(trace: Trace) {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: new DatasetSliceTrack({
+    renderer: DatasetSliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_track.ts
@@ -21,7 +21,7 @@ import {Time} from '../../base/time';
 import {getColorForSample} from '../../components/colorizer';
 
 export function createCpuProfileTrack(trace: Trace, uri: string, utid: number) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -43,7 +43,7 @@ export function createActualFramesTrack(
   maxDepth: number,
   trackIds: ReadonlyArray<number>,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Frames/expected_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/expected_frames_track.ts
@@ -28,7 +28,7 @@ export function createExpectedFramesTrack(
   maxDepth: number,
   trackIds: ReadonlyArray<number>,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     initialMaxDepth: maxDepth,

--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_track.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_track.ts
@@ -29,7 +29,7 @@ export function createFtraceTrack(
   ucpu: number,
   store: Store<FtraceFilter>,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: () => {

--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -60,7 +60,7 @@ export default class implements PerfettoPlugin {
       const uri = `dev.perfetto.GpuByProcess#${upid}`;
       ctx.tracks.registerTrack({
         uri,
-        renderer: new DatasetSliceTrack({
+        renderer: DatasetSliceTrack.create({
           trace: ctx,
           uri,
           dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -29,7 +29,7 @@ export function createHeapProfileTrack(
   upid: number,
   heapProfileIsIncomplete: boolean,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
@@ -35,7 +35,7 @@ export function createProcessInstrumentsSamplesProfileTrack(
   uri: string,
   upid: number,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({
@@ -119,7 +119,7 @@ export function createThreadInstrumentsSamplesProfileTrack(
   uri: string,
   utid: number,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
@@ -35,7 +35,7 @@ export function createProcessPerfSamplesProfileTrack(
   uri: string,
   upid: number,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({
@@ -119,7 +119,7 @@ export function createThreadPerfSamplesProfileTrack(
   uri: string,
   utid: number,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
@@ -36,7 +36,7 @@ export function createThreadStateTrack(
   uri: string,
   utid: number,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Screenshots/screenshots_track.ts
+++ b/ui/src/plugins/dev.perfetto.Screenshots/screenshots_track.ts
@@ -19,7 +19,7 @@ import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {ScreenshotDetailsPanel} from './screenshot_panel';
 
 export function createScreenshotsTrack(trace: Trace, uri: string) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
@@ -46,7 +46,7 @@ export default class implements PerfettoPlugin {
       return;
     }
     const uri = `/clock_snapshots`;
-    const track = new DatasetSliceTrack({
+    const track = DatasetSliceTrack.create({
       trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
@@ -63,7 +63,7 @@ export async function createTraceProcessorSliceTrack({
   trackIds,
   detailsPanel,
 }: TraceProcessorSliceTrackAttrs) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: await getDataset(trace.engine, trackIds),

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/critical_user_interaction_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/critical_user_interaction_track.ts
@@ -22,7 +22,7 @@ import {SourceDataset} from '../../trace_processor/dataset';
 import {Trace} from '../../public/trace';
 
 export function createCriticalUserInteractionTrack(trace: Trace, uri: string) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_track.ts
@@ -27,7 +27,7 @@ export function createEventLatencyTrack(
   uri: string,
   baseTable: string,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/flat_colored_duration_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/flat_colored_duration_track.ts
@@ -36,7 +36,7 @@ export function createFlatColoredDurationTrack(
   uri: string,
   sqlSrc: string,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_jank_v3_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_jank_v3_track.ts
@@ -24,7 +24,7 @@ const UNKNOWN_SLICE_NAME = 'Unknown';
 const JANK_SLICE_NAME = ' Jank';
 
 export function createScrollJankV3Track(trace: Trace, uri: string) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_track.ts
@@ -54,7 +54,7 @@ export function createScrollTimelineTrack(
   trace: Trace,
   model: ScrollTimelineModel,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri: model.trackUri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_track.ts
@@ -19,7 +19,7 @@ import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {ScrollDetailsPanel} from './scroll_details_panel';
 
 export function createTopLevelScrollTrack(trace: Trace, uri: string) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeTasks/track.ts
+++ b/ui/src/plugins/org.chromium.ChromeTasks/track.ts
@@ -24,7 +24,7 @@ export function createChromeTasksThreadTrack(
   uri: string,
   utid: Utid,
 ) {
-  return new DatasetSliceTrack({
+  return DatasetSliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({


### PR DESCRIPTION
This patch makes the `DatasetSliceTrack` constructor private and replaces all uses of `new DatasetSliceTrack(...)` with `DatasetSliceTrack.create(...)`.
