### PR TITLE
ui: Rename DatasetSliceTrack to SliceTrack

### DIFF
--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -14,7 +14,7 @@
 
 import {sqliteString} from '../../base/string_utils';
 import {uuidv4} from '../../base/uuid';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from './slice_track';
 import {
   createQueryCounterTrack,
   SqlTableCounterTrack,
@@ -388,7 +388,7 @@ export class BreakdownTracks {
       title,
       newFilters,
       (uri: string, filtersClause: string) => {
-        return DatasetSliceTrack.createMaterialized({
+        return SliceTrack.createMaterialized({
           trace: this.props.trace,
           uri,
           dataset: new SourceDataset({
@@ -453,7 +453,7 @@ export class BreakdownTracks {
       filtersClause: string,
     ) => Promise<
       | SqlTableCounterTrack
-      | DatasetSliceTrack<{
+      | SliceTrack<{
           ts: bigint;
           dur: bigint;
           name: string;

--- a/ui/src/components/tracks/debug_tracks.ts
+++ b/ui/src/components/tracks/debug_tracks.ts
@@ -22,7 +22,7 @@ import {
   sqlValueToReadableString,
   sqlValueToSqliteString,
 } from '../../trace_processor/sql_utils';
-import {DatasetSliceTrack} from './dataset_slice_track';
+import {SliceTrack} from './slice_track';
 import {
   RAW_PREFIX,
   DebugSliceTrackDetailsPanel,
@@ -196,7 +196,7 @@ async function addPivotedSliceTracks(
 
     trace.tracks.registerTrack({
       uri,
-      renderer: DatasetSliceTrack.create({
+      renderer: SliceTrack.create({
         trace,
         uri,
         dataset: new SourceDataset({
@@ -232,7 +232,7 @@ function addSingleSliceTrack(
 ) {
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -35,7 +35,7 @@ import {
 import {Point2D, Size2D} from '../../base/geom';
 import {exists} from '../../base/utils';
 import {removeFalsyValues} from '../../base/array_utils';
-import {DatasetSliceTrackDetailsPanel} from './dataset_slice_track_details_panel';
+import {SliceTrackDetailsPanel} from './slice_track_details_panel';
 
 export interface InstantStyle {
   /**
@@ -54,7 +54,7 @@ export interface InstantStyle {
   render(ctx: CanvasRenderingContext2D, rect: Size2D & Point2D): void;
 }
 
-export interface DatasetSliceTrackAttrs<T extends DatasetSchema> {
+export interface SliceTrackAttrs<T extends DatasetSchema> {
   /**
    * The trace object used by the track for accessing the query engine and other
    * trace-related resources.
@@ -201,34 +201,34 @@ export type RowSchema = {
 type SliceWithRow<T> = Slice & {row: T};
 
 function getDataset<T extends DatasetSchema>(
-  attrs: DatasetSliceTrackAttrs<T>,
+  attrs: SliceTrackAttrs<T>,
 ): SourceDataset<T> {
   const dataset = attrs.dataset;
   return typeof dataset === 'function' ? dataset() : dataset;
 }
 
-export class DatasetSliceTrack<T extends RowSchema> extends BaseSliceTrack<
+export class SliceTrack<T extends RowSchema> extends BaseSliceTrack<
   SliceWithRow<T>,
   BaseRow & T
 > {
   readonly rootTableName?: string;
 
   /**
-   * Factory function to create a DatasetSliceTrack. This is purely an alias for new
-   * DatasetSliceTrack() but exists for symmetry with createMaterialized()
+   * Factory function to create a SliceTrack. This is purely an alias for new
+   * SliceTrack() but exists for symmetry with createMaterialized()
    * below.
    *
    * @param attrs The track attributes
-   * @returns A fully initialized DatasetSliceTrack
+   * @returns A fully initialized SliceTrack
    */
   static create<T extends RowSchema>(
-    attrs: DatasetSliceTrackAttrs<T>,
-  ): DatasetSliceTrack<T> {
-    return new DatasetSliceTrack(attrs);
+    attrs: SliceTrackAttrs<T>,
+  ): SliceTrack<T> {
+    return new SliceTrack(attrs);
   }
 
   /**
-   * Async factory function to create a DatasetSliceTrack, first materializing
+   * Async factory function to create a SliceTrack, first materializing
    * the dataset into a perfetto table. This can be more efficient if for
    * example the dataset is a complex query with multiple joins or window
    * functions, so materializing it up front can improve rendering performance,
@@ -244,11 +244,11 @@ export class DatasetSliceTrack<T extends RowSchema> extends BaseSliceTrack<
    *   operations such as aggregations or search.
    *
    * @param attrs The track attributes
-   * @returns A fully initialized DatasetSliceTrack
+   * @returns A fully initialized SliceTrack
    */
   static async createMaterialized<T extends RowSchema>(
-    attrs: DatasetSliceTrackAttrs<T>,
-  ): Promise<DatasetSliceTrack<T>> {
+    attrs: SliceTrackAttrs<T>,
+  ): Promise<SliceTrack<T>> {
     const originalDataset = getDataset(attrs);
     // Create materialized table from the render query - we might as well
     // materialize the calculated columns that are missing from the source
@@ -274,13 +274,13 @@ export class DatasetSliceTrack<T extends RowSchema> extends BaseSliceTrack<
       },
     });
 
-    return new DatasetSliceTrack({
+    return new SliceTrack({
       ...attrs,
       dataset: materializedDataset,
     });
   }
 
-  private constructor(private readonly attrs: DatasetSliceTrackAttrs<T>) {
+  private constructor(private readonly attrs: SliceTrackAttrs<T>) {
     const dataset = getDataset(attrs);
     super(
       attrs.trace,
@@ -351,7 +351,7 @@ export class DatasetSliceTrack<T extends RowSchema> extends BaseSliceTrack<
     } else {
       // Provide a default details panel that shows all dataset fields
       const dataset = getDataset(this.attrs);
-      return new DatasetSliceTrackDetailsPanel(
+      return new SliceTrackDetailsPanel(
         this.trace,
         dataset,
         sel as unknown as T,

--- a/ui/src/components/tracks/slice_track_details_panel.ts
+++ b/ui/src/components/tracks/slice_track_details_panel.ts
@@ -23,12 +23,12 @@ import {Section} from '../../widgets/section';
 import {Tree, TreeNode} from '../../widgets/tree';
 import {DurationWidget} from '../widgets/duration';
 import {Timestamp} from '../widgets/timestamp';
-import {RowSchema} from './dataset_slice_track';
+import {RowSchema} from './slice_track';
 import {exists} from '../../base/utils';
 import {Time} from '../../base/time';
 
 /**
- * Default details panel for DatasetSliceTrack that displays all fields from
+ * Default details panel for SliceTrack that displays all fields from
  * the dataset query.
  *
  * This panel provides a "better than nothing" experience when no custom
@@ -36,7 +36,7 @@ import {Time} from '../../base/time';
  * - Common slice fields (name, ts, dur) with appropriate formatting
  * - All other dataset columns as readable strings
  */
-export class DatasetSliceTrackDetailsPanel<T extends RowSchema>
+export class SliceTrackDetailsPanel<T extends RowSchema>
   implements TrackEventDetailsPanel
 {
   constructor(

--- a/ui/src/components/tracks/visualized_args_track.ts
+++ b/ui/src/components/tracks/visualized_args_track.ts
@@ -18,7 +18,7 @@ import {Icons} from '../../base/semantic_icons';
 import {uuidv4Sql} from '../../base/uuid';
 import {createView} from '../../trace_processor/sql_utils';
 import {Trace} from '../../public/trace';
-import {DatasetSliceTrack} from './dataset_slice_track';
+import {SliceTrack} from './slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, LONG_NULL, NUM, STR} from '../../trace_processor/query_result';
 import {ThreadSliceDetailsPanel} from '../details/thread_slice_details_tab';
@@ -74,7 +74,7 @@ export async function createVisualizedArgsTrack({
     `,
   });
 
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.AndroidDesktopMode/index.ts
+++ b/ui/src/plugins/com.android.AndroidDesktopMode/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
@@ -30,7 +30,7 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri: TRACK_URI,
-      renderer: await DatasetSliceTrack.createMaterialized({
+      renderer: await SliceTrack.createMaterialized({
         trace: ctx,
         uri: TRACK_URI,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.AndroidLog/logs_track.ts
+++ b/ui/src/plugins/com.android.AndroidLog/logs_track.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {LONG, NUM, STR, STR_NULL} from '../../trace_processor/query_result';
 import {Trace} from '../../public/trace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {makeColorScheme} from '../../components/colorizer';
 import {HSLColor} from '../../base/color';
@@ -38,7 +38,7 @@ const DEPTH_TO_COLOR = [
 const EVT_PX = 6; // Width of an event tick in pixels.
 
 export function createAndroidLogTrack(trace: Trace, uri: string) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     rootTableName: 'android_logs',
@@ -62,7 +62,7 @@ export function createAndroidLogTrack(trace: Trace, uri: string) {
         from android_logs
         order by ts
         -- android_logs aren't guaranteed to be ordered by ts, but this is a
-        -- requirements for DatasetSliceTrack's mipmap operator to work 
+        -- requirements for SliceTrack's mipmap operator to work 
         -- correctly, so we must explicitly sort them above.
       `,
       schema: {

--- a/ui/src/plugins/com.android.AndroidLongBatterySupport/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatterySupport/index.ts
@@ -16,10 +16,7 @@ import {Trace} from '../../public/trace';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Engine} from '../../trace_processor/engine';
-import {
-  DatasetSliceTrack,
-  RowSchema,
-} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack, RowSchema} from '../../components/tracks/slice_track';
 import {CounterOptions} from '../../components/tracks/base_counter_track';
 import {createQueryCounterTrack} from '../../components/tracks/query_counter_track';
 import {TrackNode} from '../../public/workspace';
@@ -74,7 +71,7 @@ export default class implements PerfettoPlugin {
     groupCollapsed = true,
   ) {
     const uri = `/long_battery_tracing_${name}`;
-    const track = await DatasetSliceTrack.createMaterialized({
+    const track = await SliceTrack.createMaterialized({
       trace: ctx,
       uri,
       dataset,

--- a/ui/src/plugins/com.android.AndroidStartup/index.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/index.ts
@@ -15,7 +15,7 @@
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {TrackNode} from '../../public/workspace';
 import {optimizationsTrack} from './optimizations';
@@ -41,7 +41,7 @@ export default class implements PerfettoPlugin {
     const startupTrackUri = `/android_startups`;
     ctx.tracks.registerTrack({
       uri: startupTrackUri,
-      renderer: await DatasetSliceTrack.createMaterialized({
+      renderer: await SliceTrack.createMaterialized({
         trace: ctx,
         uri: startupTrackUri,
         dataset: new SourceDataset({
@@ -74,7 +74,7 @@ export default class implements PerfettoPlugin {
     const breakdownTrackUri = '/android_startups_breakdown';
     ctx.tracks.registerTrack({
       uri: breakdownTrackUri,
-      renderer: await DatasetSliceTrack.createMaterialized({
+      renderer: await SliceTrack.createMaterialized({
         trace: ctx,
         uri: breakdownTrackUri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.AndroidStartup/optimizations.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/optimizations.ts
@@ -15,7 +15,7 @@
 import {Trace} from '../../public/trace';
 import {STR, LONG, NUM} from '../../trace_processor/query_result';
 import {TrackNode} from '../../public/workspace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {DebugSliceTrackDetailsPanel} from '../../components/tracks/debug_slice_track_details_panel';
 
@@ -110,7 +110,7 @@ export async function optimizationsTrack(
   const tableName = `_startup_optimization_slices`;
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -142,7 +142,7 @@ function classLoadingTrack(
   const uri = `/android_startups/${startup.id}/classloading`;
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.AvfVmCpuTimeline/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
@@ -76,7 +76,7 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      renderer: DatasetSliceTrack.create({
+      renderer: SliceTrack.create({
         trace: ctx,
         uri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
+++ b/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
@@ -17,7 +17,7 @@ import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
 import {SLICE_TRACK_KIND} from '../../public/track_kinds';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 
 export default class implements PerfettoPlugin {
@@ -57,7 +57,7 @@ export default class implements PerfettoPlugin {
     for (; it.valid(); it.next()) {
       const {trackId, gpuId, uid, packageName} = it;
       const uri = `/gpu_work_period_${gpuId}_${uid}`;
-      const track = await DatasetSliceTrack.createMaterialized({
+      const track = await SliceTrack.createMaterialized({
         trace: ctx,
         uri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.InputEvents/index.ts
+++ b/ui/src/plugins/com.android.InputEvents/index.ts
@@ -15,7 +15,7 @@
 import {LONG, STR} from '../../trace_processor/query_result';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {TrackNode} from '../../public/workspace';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
@@ -37,7 +37,7 @@ export default class implements PerfettoPlugin {
 
     await ctx.engine.query('INCLUDE PERFETTO MODULE android.input;');
     const uri = 'com.android.InputEvents#InputEventsTrack';
-    const track = await DatasetSliceTrack.createMaterialized({
+    const track = await SliceTrack.createMaterialized({
       trace: ctx,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
+++ b/ui/src/plugins/com.android.TrustyTeeCpuTimeline/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
@@ -43,7 +43,7 @@ export default class implements PerfettoPlugin {
 
     ctx.tracks.registerTrack({
       uri,
-      renderer: DatasetSliceTrack.create({
+      renderer: SliceTrack.create({
         trace: ctx,
         uri,
         dataset: new SourceDataset({

--- a/ui/src/plugins/com.example.Tracks/index.ts
+++ b/ui/src/plugins/com.example.Tracks/index.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {TrackNode} from '../../public/workspace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {getColorForSlice, makeColorScheme} from '../../components/colorizer';
@@ -72,7 +72,7 @@ async function addBasicSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -100,7 +100,7 @@ async function addFilteredSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -134,7 +134,7 @@ async function addSliceTrackWithCustomColorizer(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -165,7 +165,7 @@ async function addInstantTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -191,7 +191,7 @@ async function addFlatSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -219,7 +219,7 @@ async function addFixedColorSliceTrack(trace: Trace): Promise<void> {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({
@@ -314,7 +314,7 @@ function addTracksWithHelpText(trace: Trace) {
 
   trace.tracks.registerTrack({
     uri,
-    renderer: DatasetSliceTrack.create({
+    renderer: SliceTrack.create({
       trace: trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_track.ts
@@ -15,13 +15,13 @@
 import {LONG, NUM} from '../../trace_processor/query_result';
 import {CpuProfileSampleFlamegraphDetailsPanel} from './cpu_profile_details_panel';
 import {Trace} from '../../public/trace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {Time} from '../../base/time';
 import {getColorForSample} from '../../components/colorizer';
 
 export function createCpuProfileTrack(trace: Trace, uri: string, utid: number) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/actual_frames_track.ts
@@ -18,7 +18,7 @@ import {ColorScheme} from '../../base/color_scheme';
 import {LONG, NUM, STR, STR_NULL} from '../../trace_processor/query_result';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 
 // color named and defined based on Material Design color palettes
@@ -43,7 +43,7 @@ export function createActualFramesTrack(
   maxDepth: number,
   trackIds: ReadonlyArray<number>,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Frames/expected_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/expected_frames_track.ts
@@ -17,7 +17,7 @@ import {makeColorScheme} from '../../components/colorizer';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 
 const GREEN = makeColorScheme(new HSLColor('#4CAF50')); // Green 500
@@ -28,7 +28,7 @@ export function createExpectedFramesTrack(
   maxDepth: number,
   trackIds: ReadonlyArray<number>,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     initialMaxDepth: maxDepth,

--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_track.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_track.ts
@@ -14,7 +14,7 @@
 
 import {Store} from '../../base/store';
 import {materialColorScheme} from '../../components/colorizer';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
@@ -29,7 +29,7 @@ export function createFtraceTrack(
   ucpu: number,
   store: Store<FtraceFilter>,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: () => {

--- a/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
+++ b/ui/src/plugins/dev.perfetto.GpuByProcess/index.ts
@@ -22,7 +22,7 @@ import {
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {TrackNode} from '../../public/workspace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 
@@ -60,7 +60,7 @@ export default class implements PerfettoPlugin {
       const uri = `dev.perfetto.GpuByProcess#${upid}`;
       ctx.tracks.registerTrack({
         uri,
-        renderer: DatasetSliceTrack.create({
+        renderer: SliceTrack.create({
           trace: ctx,
           uri,
           dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Time} from '../../base/time';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
@@ -29,7 +29,7 @@ export function createHeapProfileTrack(
   upid: number,
   heapProfileIsIncomplete: boolean,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
@@ -24,7 +24,7 @@ import {Timestamp} from '../../components/widgets/timestamp';
 import {Time, time} from '../../base/time';
 import {Flamegraph, FLAMEGRAPH_STATE_SCHEMA} from '../../widgets/flamegraph';
 import {Trace} from '../../public/trace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {Stack} from '../../widgets/stack';
 
@@ -35,7 +35,7 @@ export function createProcessInstrumentsSamplesProfileTrack(
   uri: string,
   upid: number,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({
@@ -119,7 +119,7 @@ export function createThreadInstrumentsSamplesProfileTrack(
   uri: string,
   utid: number,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
@@ -24,7 +24,7 @@ import {Timestamp} from '../../components/widgets/timestamp';
 import {Time, time} from '../../base/time';
 import {Flamegraph, FLAMEGRAPH_STATE_SCHEMA} from '../../widgets/flamegraph';
 import {Trace} from '../../public/trace';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {Stack} from '../../widgets/stack';
 
@@ -35,7 +35,7 @@ export function createProcessPerfSamplesProfileTrack(
   uri: string,
   upid: number,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({
@@ -119,7 +119,7 @@ export function createThreadPerfSamplesProfileTrack(
   uri: string,
   utid: number,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
@@ -14,7 +14,7 @@
 
 import {HSLColor} from '../../base/color';
 import {ColorScheme} from '../../base/color_scheme';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
@@ -36,7 +36,7 @@ export function createThreadStateTrack(
   uri: string,
   utid: number,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.Screenshots/screenshots_track.ts
+++ b/ui/src/plugins/dev.perfetto.Screenshots/screenshots_track.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {ScreenshotDetailsPanel} from './screenshot_panel';
 
 export function createScreenshotsTrack(trace: Trace, uri: string) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceMetadata/index.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {Time} from '../../base/time';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Timestamp} from '../../components/widgets/timestamp';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
@@ -46,7 +46,7 @@ export default class implements PerfettoPlugin {
       return;
     }
     const uri = `/clock_snapshots`;
-    const track = DatasetSliceTrack.create({
+    const track = SliceTrack.create({
       trace,
       uri,
       dataset: new SourceDataset({

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
@@ -18,10 +18,7 @@ import {clamp} from '../../base/math_utils';
 import {exists} from '../../base/utils';
 import {getColorForSlice} from '../../components/colorizer';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
-import {
-  DatasetSliceTrack,
-  renderTooltip,
-} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack, renderTooltip} from '../../components/tracks/slice_track';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -63,7 +60,7 @@ export async function createTraceProcessorSliceTrack({
   trackIds,
   detailsPanel,
 }: TraceProcessorSliceTrackAttrs) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: await getDataset(trace.engine, trackIds),

--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/critical_user_interaction_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/critical_user_interaction_track.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {PageLoadDetailsPanel} from './page_load_details_panel';
 import {StartupDetailsPanel} from './startup_details_panel';
 import {WebContentInteractionPanel} from './web_content_interaction_details_panel';
@@ -22,7 +22,7 @@ import {SourceDataset} from '../../trace_processor/dataset';
 import {Trace} from '../../public/trace';
 
 export function createCriticalUserInteractionTrack(trace: Trace, uri: string) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_track.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {JANK_COLOR} from './jank_colors';
 import {EventLatencySliceDetailsPanel} from './event_latency_details_panel';
 import {Trace} from '../../public/trace';
@@ -27,7 +27,7 @@ export function createEventLatencyTrack(
   uri: string,
   baseTable: string,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/flat_colored_duration_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/flat_colored_duration_track.ts
@@ -23,7 +23,7 @@ import {DurationWidget} from '../../components/widgets/duration';
 import {Timestamp} from '../../components/widgets/timestamp';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Time} from '../../base/time';
 
 /*
@@ -36,7 +36,7 @@ export function createFlatColoredDurationTrack(
   uri: string,
   sqlSrc: string,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
@@ -30,7 +30,7 @@ import {createTopLevelScrollTrack} from './scroll_track';
 import {createScrollTimelineTrack} from './scroll_timeline_track';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {escapeQuery} from '../../trace_processor/query_utils';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 
@@ -242,7 +242,7 @@ export default class implements PerfettoPlugin {
     {
       // Add a track for the VSync slices.
       const uri = 'org.chromium.ChromeScrollJank#ChromeVsync';
-      const track = await DatasetSliceTrack.createMaterialized({
+      const track = await SliceTrack.createMaterialized({
         trace: ctx,
         uri,
         dataset: new SourceDataset({
@@ -315,7 +315,7 @@ export default class implements PerfettoPlugin {
 
       for (const step of steps) {
         const uri = `org.chromium.ChromeScrollJank#chrome_scroll_update_info.${step.column}`;
-        const track = await DatasetSliceTrack.createMaterialized({
+        const track = await SliceTrack.createMaterialized({
           trace: ctx,
           uri,
           dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_jank_v3_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_jank_v3_track.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {JANK_COLOR} from './jank_colors';
 import {getColorForSlice} from '../../components/colorizer';
 import {ScrollJankV3DetailsPanel} from './scroll_jank_v3_details_panel';
@@ -24,7 +24,7 @@ const UNKNOWN_SLICE_NAME = 'Unknown';
 const JANK_SLICE_NAME = ' Jank';
 
 export function createScrollJankV3Track(trace: Trace, uri: string) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_track.ts
@@ -23,7 +23,7 @@ import {
   ScrollTimelineModel,
   ScrollUpdateClassification,
 } from './scroll_timeline_model';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 
 const INDIGO = makeColorScheme(new HSLColor([231, 48, 48]));
@@ -54,7 +54,7 @@ export function createScrollTimelineTrack(
   trace: Trace,
   model: ScrollTimelineModel,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri: model.trackUri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_track.ts
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {ScrollDetailsPanel} from './scroll_details_panel';
 
 export function createTopLevelScrollTrack(trace: Trace, uri: string) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.chromium.ChromeTasks/track.ts
+++ b/ui/src/plugins/org.chromium.ChromeTasks/track.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Utid} from '../../components/sql_utils/core_types';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
 import {ChromeTasksDetailsPanel} from './details';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
@@ -24,7 +24,7 @@ export function createChromeTasksThreadTrack(
   uri: string,
   utid: Utid,
 ) {
-  return DatasetSliceTrack.create({
+  return SliceTrack.create({
     trace,
     uri,
     dataset: new SourceDataset({

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -19,7 +19,7 @@ import {
   BaseCounterTrack,
   CounterOptions,
 } from '../../components/tracks/base_counter_track';
-import {DatasetSliceTrack} from '../../components/tracks/dataset_slice_track';
+import {SliceTrack} from '../../components/tracks/slice_track';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {SLICE_TRACK_KIND} from '../../public/track_kinds';
@@ -195,7 +195,7 @@ async function hasWattsonGpuSupport(engine: Engine): Promise<boolean> {
 
 async function addWattsonMarkersElements(ctx: Trace, group: TrackNode) {
   const uri = `/wattson/markers_window`;
-  const track = await DatasetSliceTrack.createMaterialized({
+  const track = await SliceTrack.createMaterialized({
     trace: ctx,
     uri,
     dataset: new SourceDataset({


### PR DESCRIPTION
Seeing as DatasetSliceTrack is now the de-facto way to create slice tracks, it makes sense to rename it.
