### PR TITLE
Fix crash in ProtoLogMessageDecoder on param mismatch

### DIFF
--- a/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
@@ -61,12 +61,24 @@ std::optional<DecodedMessage> ProtoLogMessageDecoder::Decode(
         case '%':
           break;
         case 'd': {
+          if (sint64_params_itr == sint64_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           base::StackString<32> param("%" PRId64, *sint64_params_itr);
           formatted_message.append(param.c_str());
           ++sint64_params_itr;
           break;
         }
         case 'o': {
+          if (sint64_params_itr == sint64_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           base::StackString<32> param(
               "%" PRIo64, static_cast<uint64_t>(*sint64_params_itr));
           formatted_message.append(param.c_str());
@@ -74,6 +86,12 @@ std::optional<DecodedMessage> ProtoLogMessageDecoder::Decode(
           break;
         }
         case 'x': {
+          if (sint64_params_itr == sint64_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           base::StackString<32> param(
               "%" PRIx64, static_cast<uint64_t>(*sint64_params_itr));
           formatted_message.append(param.c_str());
@@ -81,29 +99,59 @@ std::optional<DecodedMessage> ProtoLogMessageDecoder::Decode(
           break;
         }
         case 'f': {
+          if (double_params_itr == double_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           base::StackString<32> param("%f", *double_params_itr);
           formatted_message.append(param.c_str());
           ++double_params_itr;
           break;
         }
         case 'e': {
+          if (double_params_itr == double_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           base::StackString<32> param("%e", *double_params_itr);
           formatted_message.append(param.c_str());
           ++double_params_itr;
           break;
         }
         case 'g': {
+          if (double_params_itr == double_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           base::StackString<32> param("%g", *double_params_itr);
           formatted_message.append(param.c_str());
           ++double_params_itr;
           break;
         }
         case 's': {
+          if (str_params_itr == string_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           formatted_message.append(*str_params_itr);
           ++str_params_itr;
           break;
         }
         case 'b': {
+          if (boolean_params_itr == boolean_params.end()) {
+            context_->storage->IncrementStats(
+                stats::winscope_protolog_param_mismatch);
+            formatted_message.append("[MISSING_PARAM]");
+            break;
+          }
           formatted_message.append(*boolean_params_itr ? "true" : "false");
           ++boolean_params_itr;
           break;
@@ -118,6 +166,13 @@ std::optional<DecodedMessage> ProtoLogMessageDecoder::Decode(
       formatted_message.push_back(message[i]);
       i += 1;
     }
+  }
+
+  if (sint64_params_itr != sint64_params.end() ||
+      double_params_itr != double_params.end() ||
+      boolean_params_itr != boolean_params.end() ||
+      str_params_itr != string_params.end()) {
+    context_->storage->IncrementStats(stats::winscope_protolog_param_mismatch);
   }
 
   return DecodedMessage{tracked_message->level, group->tag, formatted_message,

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -461,6 +461,9 @@ namespace perfetto::trace_processor::stats {
   F(winscope_protolog_view_config_collision,                                   \
                                           kSingle,  kInfo,     kAnalysis,      \
       "Got a viewer config collision!"),                                       \
+  F(winscope_protolog_param_mismatch,                                          \
+                                          kSingle,  kInfo,     kAnalysis,      \
+      "Message had mismatching parameters!"),                                  \
   F(winscope_viewcapture_parse_errors,                                         \
                                           kSingle,  kError,    kAnalysis,      \
       "ViewCapture packet has unknown fields, which results in some "          \


### PR DESCRIPTION
The ProtoLogMessageDecoder would crash with a segmentation fault when processing a message where the number of format specifiers did not match the number of provided parameters. This was caused by reading past the end of the parameter vectors.

This change adds defensive checks to validate that a parameter exists before it is accessed. If a parameter is missing, a placeholder string "[MISSING_PARAM]" is used instead, and a stat is incremented to track the occurrence of these mismatches.

This is a defensive fix, as the writer-side code should ideally prevent these mismatches from being written into the trace.

Bug: 447556988
Test: Manually verified with the trace from the bug.
