### PR TITLE
tp: Extend WM tables with name overrides.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/test/windowmanager_sample_protos.h
+++ b/src/trace_processor/importers/proto/winscope/test/windowmanager_sample_protos.h
@@ -17,6 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_TEST_WINDOWMANAGER_SAMPLE_PROTOS_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_TEST_WINDOWMANAGER_SAMPLE_PROTOS_H_
 
+#include <cstdint>
 #include <string>
 
 #include "perfetto/protozero/scattered_heap_buffer.h"
@@ -105,6 +106,25 @@ class WindowManagerSampleProtos {
     return entry.SerializeAsString();
   }
 
+  static std::string HierarchyWithWindowStateNameOverrides() {
+    protozero::HeapBuffered<protos::pbzero::WindowManagerTraceEntry> entry;
+
+    auto* root = AddRoot(&entry);
+
+    std::vector<std::string> prefixes = {"Starting", "Waiting For Debugger:"};
+    for (size_t i = 0; i < prefixes.size(); i++) {
+      auto* window_state = root->add_children()->set_window();
+      auto* window_state_window_container =
+          window_state->set_window_container();
+      auto* window_state_identifier =
+          window_state_window_container->set_identifier();
+      window_state_identifier->set_hash_code(2 + static_cast<int32_t>(i));
+      window_state_identifier->set_title(prefixes[i] + " state - WindowState");
+    }
+
+    return entry.SerializeAsString();
+  }
+
   static std::string HierarchyWithDisplayArea() {
     protozero::HeapBuffered<protos::pbzero::WindowManagerTraceEntry> entry;
 
@@ -133,6 +153,23 @@ class WindowManagerSampleProtos {
     identifier->set_title("child - Task");
 
     AddGrandchild(window_container);
+
+    return entry.SerializeAsString();
+  }
+
+  static std::string HierarchyWithTaskIdAndName() {
+    protozero::HeapBuffered<protos::pbzero::WindowManagerTraceEntry> entry;
+
+    auto* root = AddRoot(&entry);
+
+    auto* task = root->add_children()->set_task();
+    task->set_id(3);
+    task->set_task_name("MockTask");
+    auto* task_fragment = task->set_task_fragment();
+    auto* window_container = task_fragment->set_window_container();
+    auto* identifier = window_container->set_identifier();
+    identifier->set_hash_code(2);
+    identifier->set_title("child - Task");
 
     return entry.SerializeAsString();
   }

--- a/src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.h
+++ b/src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.h
@@ -48,6 +48,7 @@ class WindowManagerHierarchyWalker {
     std::optional<uint32_t> child_index;
     bool is_visible;
     std::optional<ExtractedRect> rect;
+    std::optional<StringPool::Id> name_override;
     std::vector<uint8_t> pruned_proto;    // proto without children submessages
     const StringPool::Id container_type;  // container proto type e.g.
                                           // DisplayContent, ActivityRecord
@@ -136,15 +137,15 @@ class WindowManagerHierarchyWalker {
   StringPool* pool_{nullptr};
   int32_t current_display_id_{-1};
   uint32_t current_rect_depth_{0};
-  const StringPool::Id k_root_window_container_id_;
-  const StringPool::Id k_display_content_id_;
-  const StringPool::Id k_display_area_id_;
-  const StringPool::Id k_task_id_;
-  const StringPool::Id k_task_fragment_id_;
-  const StringPool::Id k_activity_id_;
-  const StringPool::Id k_window_token_id_;
-  const StringPool::Id k_window_state_id_;
-  const StringPool::Id k_window_container_id_;
+  const StringPool::Id kRootWindowContainerId;
+  const StringPool::Id kDisplayContentId;
+  const StringPool::Id kDisplayAreaId;
+  const StringPool::Id kTaskId;
+  const StringPool::Id kTaskFragmentId;
+  const StringPool::Id kActivityId;
+  const StringPool::Id kWindowTokenId;
+  const StringPool::Id kWindowStateId;
+  const StringPool::Id kWindowContainerId;
 };
 
 }  // namespace perfetto::trace_processor::winscope

--- a/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
@@ -92,6 +92,7 @@ void WindowManagerParser::InsertWindowContainerRows(
     row.child_index = window_container.child_index;
     row.is_visible = window_container.is_visible;
     row.container_type = window_container.container_type;
+    row.name_override = window_container.name_override;
 
     if (window_container.rect) {
       row.window_rect_id = InsertRectRows(*window_container.rect);

--- a/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
@@ -54,7 +54,9 @@ CREATE PERFETTO VIEW android_windowmanager_windowcontainer (
   -- The rect corresponding to this window container
   window_rect_id LONG,
   -- The window container type e.g. DisplayContent, TaskFragment
-  container_type STRING
+  container_type STRING,
+  -- Optional name override for some container types
+  name_override STRING
 ) AS
 SELECT
   id,
@@ -67,5 +69,6 @@ SELECT
   child_index,
   is_visible,
   window_rect_id,
-  container_type
+  container_type,
+  name_override
 FROM __intrinsic_windowmanager_windowcontainer;

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -806,6 +806,10 @@ WINDOW_MANAGER_WINDOW_CONTAINER_TABLE = Table(
             'container_type',
             CppString(),
         ),
+        C(
+            'name_override',
+            CppOptional(CppString()),
+        ),
     ],
     wrapping_sql_view=WrappingSqlView('windowmanager_windowcontainer'),
     tabledoc=TableDoc(
@@ -832,6 +836,8 @@ WINDOW_MANAGER_WINDOW_CONTAINER_TABLE = Table(
                 "The rect corresponding to this window container",
             'container_type':
                 "The window container type e.g. DisplayContent, TaskFragment",
+            'name_override':
+                "Optional name override for some container types",
         }))
 
 PROTOLOG_TABLE = Table(


### PR DESCRIPTION
Required to build hierarchy.

Bug: 438681230

Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=WindowManager*

Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell --name-filter="PerfettoTable:winscope|WindowManager"