### PR TITLE
pprof: fix proto annotations and update pprof handling tools

### DIFF
--- a/protos/third_party/pprof/profile.proto
+++ b/protos/third_party/pprof/profile.proto
@@ -90,7 +90,7 @@ message Profile {
   int64 period = 12;
   // Freeform text associated to the profile.
   // Indices into string table.
-  repeated int64 comment = 13;
+  repeated int64 comment = 13 [packed = false];
   // Index into the string table of the type of the preferred sample
   // value. If unset, clients should default to the last sample value.
   int64 default_sample_type = 14;
@@ -111,14 +111,14 @@ message ValueType {
 message Sample {
   // The ids recorded here correspond to a Profile.location.id.
   // The leaf is at location_id[0].
-  repeated uint64 location_id = 1;
+  repeated uint64 location_id = 1 [packed = true];
   // The type and unit of each value is defined by the corresponding
   // entry in Profile.sample_type. All samples must have the same
   // number of values, the same as the length of Profile.sample_type.
   // When aggregating multiple samples into a single sample, the
   // result has a list of values that is the elemntwise sum of the
   // lists of the originals.
-  repeated int64 value = 2;
+  repeated int64 value = 2 [packed = false];
   // label includes additional context for this sample. It can include
   // things like a thread id, allocation size, etc
   repeated Label label = 3;

--- a/src/tools/protoprofile/BUILD.gn
+++ b/src/tools/protoprofile/BUILD.gn
@@ -33,5 +33,8 @@ source_set("common") {
     "../../trace_processor/util:proto_profiler",
   ]
   sources = [ "main.cc" ]
-  deps = [ "../../trace_processor/importers/proto:gen_cc_trace_descriptor" ]
+  deps = [
+    "../../trace_processor/importers/proto:gen_cc_trace_descriptor",
+    "../../trace_processor/util:descriptors",
+  ]
 }

--- a/src/tools/protoprofile/main.cc
+++ b/src/tools/protoprofile/main.cc
@@ -14,18 +14,24 @@
  * limitations under the License.
  */
 
+#include <fcntl.h>
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/scoped_file.h"
-#include "perfetto/protozero/field.h"
 #include "perfetto/protozero/packed_repeated_fields.h"
-#include "perfetto/protozero/proto_decoder.h"
-#include "perfetto/protozero/proto_utils.h"
 #include "perfetto/protozero/scattered_heap_buffer.h"
 #include "src/trace_processor/importers/proto/trace.descriptor.h"
+#include "src/trace_processor/util/descriptors.h"
 #include "src/trace_processor/util/proto_profiler.h"
 
 #include "protos/third_party/pprof/profile.pbzero.h"
@@ -128,9 +134,8 @@ std::string PprofProfileComputer::Compute(
 
     protozero::PackedVarInt location_ids;
     auto* sample = profile->add_sample();
-    for (auto loc_it = field_path.rbegin(); loc_it != field_path.rend();
-         ++loc_it) {
-      location_ids.Append(InternLocation(*loc_it));
+    for (auto l = field_path.rbegin(); l != field_path.rend(); ++l) {
+      location_ids.Append(static_cast<uint64_t>(InternLocation(*l)));
     }
     sample->set_location_id(location_ids);
 
@@ -143,13 +148,11 @@ std::string PprofProfileComputer::Compute(
     for (size_t i = 0; i < count; ++i)
       total_size += samples[i];
     // These have to be in the same order as the sample types above:
-    protozero::PackedVarInt values;
-    values.Append(static_cast<int64_t>(count));
-    values.Append(static_cast<int64_t>(max_size));
-    values.Append(static_cast<int64_t>(min_size));
-    values.Append(static_cast<int64_t>(median_size));
-    values.Append(static_cast<int64_t>(total_size));
-    sample->set_value(values);
+    sample->add_value(static_cast<int64_t>(count));
+    sample->add_value(static_cast<int64_t>(max_size));
+    sample->add_value(static_cast<int64_t>(min_size));
+    sample->add_value(static_cast<int64_t>(median_size));
+    sample->add_value(static_cast<int64_t>(total_size));
   }
 
   // The proto profile has a two step mapping where samples are associated with

--- a/src/trace_processor/util/profile_builder.cc
+++ b/src/trace_processor/util/profile_builder.cc
@@ -230,14 +230,11 @@ bool GProfileBuilder::SampleAggregator::AddSample(
 }
 
 void GProfileBuilder::SampleAggregator::WriteTo(Profile& profile) {
-  protozero::PackedVarInt values;
   for (auto it = samples_.GetIterator(); it; ++it) {
-    values.Reset();
-    for (int64_t value : it.value()) {
-      values.Append(value);
-    }
     Sample* sample = profile.add_sample();
-    sample->set_value(values);
+    for (int64_t value : it.value()) {
+      sample->add_value(value);
+    }
     // Map key is the serialized varint. Just append the bytes.
     sample->AppendBytes(Sample::kLocationIdFieldNumber, it.key().data(),
                         it.key().size());


### PR DESCRIPTION
Fix packed field annotations in pprof profile.proto for proper compatibility.
Update protoprofile tool with correct dependencies and sample handling.
Fix pprof builder sample value serialization to use add_value() instead of packed values.
