### PR TITLE
Update protozero error reporter for Protobuf 26.x.

### DIFF
--- a/src/protozero/filtering/filter_util.cc
+++ b/src/protozero/filtering/filter_util.cc
@@ -39,28 +39,41 @@ namespace {
 class MultiFileErrorCollectorImpl
     : public google::protobuf::compiler::MultiFileErrorCollector {
  public:
-  ~MultiFileErrorCollectorImpl() override;
-  void AddError(const std::string&, int, int, const std::string&) override;
-  void AddWarning(const std::string&, int, int, const std::string&) override;
+  ~MultiFileErrorCollectorImpl() override = default;
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+  void RecordError(absl::string_view filename,
+                   int line,
+                   int column,
+                   absl::string_view message) override {
+    PERFETTO_ELOG("Error %.*s %d:%d: %.*s", static_cast<int>(filename.size()),
+                  filename.data(), line, column,
+                  static_cast<int>(message.size()), message.data());
+  }
+  void RecordWarning(absl::string_view filename,
+                     int line,
+                     int column,
+                     absl::string_view message) override {
+    PERFETTO_ELOG("Warning %s %d:%d: %s", static_cast<int>(filename.size()),
+                  filename.data(), line, column,
+                  static_cast<int>(message.size()), message.data());
+  }
+#else
+  void AddError(const std::string& filename,
+                int line,
+                int column,
+                const std::string& message) override {
+    PERFETTO_ELOG("Error %s %d:%d: %s", filename.c_str(), line, column,
+                  message.c_str());
+  }
+  void AddWarning(const std::string& filename,
+                  int line,
+                  int column,
+                  const std::string& message) override {
+    PERFETTO_ELOG("Warning %s %d:%d: %s", filename.c_str(), line, column,
+                  message.c_str());
+  }
+#endif
 };
-
-MultiFileErrorCollectorImpl::~MultiFileErrorCollectorImpl() = default;
-
-void MultiFileErrorCollectorImpl::AddError(const std::string& filename,
-                                           int line,
-                                           int column,
-                                           const std::string& message) {
-  PERFETTO_ELOG("Error %s %d:%d: %s", filename.c_str(), line, column,
-                message.c_str());
-}
-
-void MultiFileErrorCollectorImpl::AddWarning(const std::string& filename,
-                                             int line,
-                                             int column,
-                                             const std::string& message) {
-  PERFETTO_ELOG("Warning %s %d:%d: %s", filename.c_str(), line, column,
-                message.c_str());
-}
 
 }  // namespace
 

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -322,7 +322,7 @@ base::Status ExportTraceToDatabase(const std::string& output_name) {
 }
 
 class ErrorPrinter : public google::protobuf::io::ErrorCollector {
-#if GOOGLE_PROTOBUF_VERSION >= 5026000
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
   void RecordError(int line, int col, absl::string_view msg) override {
     PERFETTO_ELOG("%d:%d: %.*s", line, col, static_cast<int>(msg.size()),
                   msg.data());


### PR DESCRIPTION
The new RecordError and RecordWarning methods were added in version 4.22.0 of the C++ library and the old AddError and AddWarning methods were removed in version 5.26.0.

This was partially addressed in https://github.com/google/perfetto/pull/3082

Should fix issue #992