### PR TITLE
ui: Allow nullable durs in slice tracks

### DIFF
--- a/ui/src/components/tracks/slice_track_unittest.ts
+++ b/ui/src/components/tracks/slice_track_unittest.ts
@@ -1,0 +1,69 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {SourceDataset} from '../../trace_processor/dataset';
+import {LONG, LONG_NULL, NUM} from '../../trace_processor/query_result';
+import {generateRenderQuery} from './slice_track';
+
+describe('generateRenderQuery', () => {
+  test('minimal query', () => {
+    const dataset = new SourceDataset({
+      src: 'foo',
+      schema: {ts: LONG},
+    });
+    expect(generateRenderQuery(dataset)).toBe(
+      `SELECT ts AS ts, ROW_NUMBER() OVER (ORDER BY ts) AS id, 0 AS layer, 0 AS depth, 0 AS dur FROM (${dataset.query()})`,
+    );
+  });
+
+  test('full query', () => {
+    const dataset = new SourceDataset({
+      src: 'foo',
+      schema: {id: NUM, ts: LONG, dur: LONG, depth: NUM, layer: NUM},
+    });
+    expect(generateRenderQuery(dataset)).toBe(
+      `SELECT id AS id, ts AS ts, dur AS dur, depth AS depth, layer AS layer FROM (${dataset.query()})`,
+    );
+  });
+
+  test('no dur, no depth', () => {
+    const dataset = new SourceDataset({
+      src: 'foo',
+      schema: {id: NUM, ts: LONG, layer: NUM},
+    });
+    expect(generateRenderQuery(dataset)).toBe(
+      `SELECT id AS id, ts AS ts, layer AS layer, 0 AS depth, 0 AS dur FROM (${dataset.query()})`,
+    );
+  });
+
+  test('no depth', () => {
+    const dataset = new SourceDataset({
+      src: 'foo',
+      schema: {id: NUM, ts: LONG, layer: NUM, dur: LONG},
+    });
+    expect(generateRenderQuery(dataset)).toBe(
+      `SELECT id AS id, ts AS ts, layer AS layer, dur AS dur, internal_layout(ts, dur) OVER (ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS depth FROM (${dataset.query()})`,
+    );
+  });
+
+  test('nullable dur, do depth', () => {
+    const dataset = new SourceDataset({
+      src: 'foo',
+      schema: {id: NUM, ts: LONG, layer: NUM, dur: LONG_NULL},
+    });
+    expect(generateRenderQuery(dataset)).toBe(
+      `SELECT id AS id, ts AS ts, layer AS layer, COALESCE(dur, -1) AS dur, internal_layout(ts, COALESCE(dur, -1)) OVER (ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS depth FROM (${dataset.query()})`,
+    );
+  });
+});

--- a/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
@@ -15,7 +15,13 @@
 import {Trace} from '../../public/trace';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PerfettoPlugin} from '../../public/plugin';
-import {STR, LONG, UNKNOWN, SqlValue} from '../../trace_processor/query_result';
+import {
+  STR,
+  LONG,
+  UNKNOWN,
+  SqlValue,
+  LONG_NULL,
+} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
 
@@ -592,7 +598,7 @@ export default class implements PerfettoPlugin {
           `,
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
             uid: UNKNOWN,
           },

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -157,12 +157,12 @@ export class SourceDataset<T extends DatasetSchema = DatasetSchema>
   query(schema?: DatasetSchema) {
     schema = schema ?? this.schema;
     const cols = Object.keys(schema);
-    const selectSql = `select ${cols.join(', ')} from (${this.src})`;
+    const selectSql = `SELECT ${cols.join(', ')} FROM (${this.src})`;
     const filterSql = this.filterQuery();
     if (filterSql === undefined) {
       return selectSql;
     }
-    return `${selectSql} where ${filterSql}`;
+    return `${selectSql} WHERE ${filterSql}`;
   }
 
   optimize() {
@@ -184,7 +184,7 @@ export class SourceDataset<T extends DatasetSchema = DatasetSchema>
     if ('eq' in this.filter) {
       return `${this.filter.col} = ${sqlValueToSqliteString(this.filter.eq)}`;
     } else if ('in' in this.filter) {
-      return `${this.filter.col} in (${sqlValueToSqliteString(this.filter.in)})`;
+      return `${this.filter.col} IN (${sqlValueToSqliteString(this.filter.in)})`;
     } else {
       assertUnreachable(this.filter);
     }

--- a/ui/src/trace_processor/dataset_unittest.ts
+++ b/ui/src/trace_processor/dataset_unittest.ts
@@ -31,7 +31,7 @@ test('get query for simple dataset', () => {
     schema: {id: NUM},
   });
 
-  expect(dataset.query()).toEqual('select id from (slice)');
+  expect(dataset.query()).toEqual('SELECT id FROM (slice)');
 });
 
 test("get query for simple dataset with 'eq' filter", () => {
@@ -44,7 +44,7 @@ test("get query for simple dataset with 'eq' filter", () => {
     },
   });
 
-  expect(dataset.query()).toEqual('select id from (slice) where id = 123');
+  expect(dataset.query()).toEqual('SELECT id FROM (slice) WHERE id = 123');
 });
 
 test("get query for simple dataset with an 'in' filter", () => {
@@ -58,7 +58,7 @@ test("get query for simple dataset with an 'in' filter", () => {
   });
 
   expect(dataset.query()).toEqual(
-    'select id from (slice) where id in (123,456)',
+    'SELECT id FROM (slice) WHERE id IN (123,456)',
   );
 });
 
@@ -83,7 +83,7 @@ test('get query for union dataset', () => {
   ]);
 
   expect(dataset.query()).toEqual(
-    'select id from (slice) where id = 123\nunion all\nselect id from (slice) where id = 456',
+    'SELECT id FROM (slice) WHERE id = 123\nunion all\nSELECT id FROM (slice) WHERE id = 456',
   );
 });
 


### PR DESCRIPTION
This patch allows the `dur` column to be nullable (e.g. have NUM_NULL type) when creating a slice track using `SliceTrack`. Rows with a null duration are treated as incomplete slices.

Fixes: https://buganizer.corp.google.com/issues/447606601