### PR TITLE
tp: Extend WM tables with focused display id.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
@@ -57,6 +57,10 @@ tables::WindowManagerTable::Id WindowManagerParser::InsertSnapshotRow(
                             ->InternString(base::StringView(
                                 base::Base64Encode(blob.data, blob.size)))
                             .raw_id();
+  protos::pbzero::WindowManagerTraceEntry::Decoder entry(blob);
+  protos::pbzero::WindowManagerServiceDumpProto::Decoder service(
+      entry.window_manager_service());
+  row.focused_display_id = static_cast<uint32_t>(service.focused_display_id());
   auto row_id = trace_processor_context->storage->mutable_windowmanager_table()
                     ->Insert(row)
                     .id;

--- a/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
@@ -22,13 +22,16 @@ CREATE PERFETTO VIEW android_windowmanager (
   -- Extra args parsed from the proto message
   arg_set_id ARGSETID,
   -- Raw proto message
-  base64_proto_id LONG
+  base64_proto_id LONG,
+  -- Focused display id for this entry
+  focused_display_id LONG
 ) AS
 SELECT
   id,
   ts,
   arg_set_id,
-  base64_proto_id
+  base64_proto_id,
+  focused_display_id
 FROM __intrinsic_windowmanager;
 
 -- Android WindowManager WindowContainer (from android.windowmanager data source).

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -744,6 +744,10 @@ WINDOW_MANAGER_TABLE = Table(
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
             cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
         ),
+        C(
+            'focused_display_id',
+            CppUint32(),
+        ),
     ],
     wrapping_sql_view=WrappingSqlView('windowmanager'),
     tabledoc=TableDoc(
@@ -753,6 +757,7 @@ WINDOW_MANAGER_TABLE = Table(
             'ts': 'The timestamp the state snapshot was captured',
             'arg_set_id': 'Extra args parsed from the proto message',
             'base64_proto_id': 'String id for raw proto message',
+            'focused_display_id': 'Focused display id for this entry',
         }))
 
 WINDOW_MANAGER_WINDOW_CONTAINER_TABLE = Table(

--- a/test/trace_processor/diff_tests/parser/android/tests_windowmanager.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_windowmanager.py
@@ -27,14 +27,14 @@ class WindowManager(TestSuite):
         query="""
         INCLUDE PERFETTO MODULE android.winscope.windowmanager;
         SELECT
-          ts
+          ts, focused_display_id
         FROM
           android_windowmanager;
         """,
         out=Csv("""
-        "ts"
-        558296470731
-        558884171862
+        "ts","focused_display_id"
+        558296470731,0
+        558884171862,2
         """))
 
   def test_snapshot_has_expected_args(self):

--- a/test/trace_processor/diff_tests/parser/android/windowmanager.textproto
+++ b/test/trace_processor/diff_tests/parser/android/windowmanager.textproto
@@ -4079,6 +4079,7 @@ packet {
       elapsed_realtime_nanos: 558884171862
       where: "WindowAnimator"
       window_manager_service {
+        focused_display_id: 2
         policy {
           orientation: SCREEN_ORIENTATION_UNSPECIFIED
           screen_on_fully: true


### PR DESCRIPTION
Required for active display selection.

Bug: 438681230

Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=WindowManager*

Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell --name-filter="PerfettoTable:winscope|WindowManager"