### PR TITLE
Fix SubProcess::StdinThread() signature to match implementation

### DIFF
--- a/include/perfetto/ext/base/subprocess.h
+++ b/include/perfetto/ext/base/subprocess.h
@@ -264,7 +264,7 @@ class Subprocess {
   };
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-  static void StdinThread(MovableState*, std::string input);
+  static void StdinThread(MovableState*, const std::string& input);
   static void StdoutErrThread(MovableState*);
 #else
   void TryPushStdin();


### PR DESCRIPTION
A recent change to subprocess_windows.cc broke the Windows build of Perfetto, discovered in our downstream dependency this morning. Upstreaming the fix.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
