### PR TITLE
ui: Use LONG_NULL instead of LONG for queries where dur can be null

### DIFF
--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -15,10 +15,7 @@
 import {sqliteString} from '../../base/string_utils';
 import {uuidv4} from '../../base/uuid';
 import {SliceTrack} from './slice_track';
-import {
-  createQueryCounterTrack,
-  SqlTableCounterTrack,
-} from '../../components/tracks/query_counter_track';
+import {createQueryCounterTrack} from '../../components/tracks/query_counter_track';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -27,7 +24,9 @@ import {
   LONG,
   NUM_NULL,
   STR,
+  LONG_NULL,
 } from '../../trace_processor/query_result';
+import {TrackRenderer} from '../../public/track';
 
 /**
  * Aggregation types for the BreakdownTracks.
@@ -394,7 +393,7 @@ export class BreakdownTracks {
           dataset: new SourceDataset({
             schema: {
               ts: LONG,
-              dur: LONG,
+              dur: LONG_NULL,
               name: STR,
             },
             src: `
@@ -448,17 +447,7 @@ export class BreakdownTracks {
   private async createTrackNode(
     name: string,
     filters: Filter[],
-    createTrack: (
-      uri: string,
-      filtersClause: string,
-    ) => Promise<
-      | SqlTableCounterTrack
-      | SliceTrack<{
-          ts: bigint;
-          dur: bigint;
-          name: string;
-        }>
-    >,
+    createTrack: (uri: string, filtersClause: string) => Promise<TrackRenderer>,
     getSortOrder?: (filterClause: string) => Promise<number>,
   ) {
     const filtersClause =

--- a/ui/src/plugins/com.android.AndroidDesktopMode/index.ts
+++ b/ui/src/plugins/com.android.AndroidDesktopMode/index.ts
@@ -17,7 +17,7 @@ import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {LONG, STR} from '../../trace_processor/query_result';
+import {LONG, LONG_NULL, STR} from '../../trace_processor/query_result';
 
 const TRACK_NAME = 'Desktop Mode Windows';
 const TRACK_URI = '/desktop_windows';
@@ -36,7 +36,7 @@ export default class implements PerfettoPlugin {
         dataset: new SourceDataset({
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
           },
           src: `

--- a/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
@@ -84,7 +84,7 @@ const DEFAULT_NETWORK_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -130,7 +130,7 @@ const TETHERING_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -188,7 +188,7 @@ const SUSPEND_RESUME_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -229,7 +229,7 @@ const THERMAL_THROTTLING_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -392,7 +392,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -426,7 +426,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -472,7 +472,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -492,7 +492,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -519,7 +519,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -539,7 +539,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -568,7 +568,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
           package: STR,
         },
@@ -736,7 +736,7 @@ export default class implements PerfettoPlugin {
           `,
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
             ...argsSchema,
           },
@@ -867,7 +867,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -923,7 +923,7 @@ export default class implements PerfettoPlugin {
           `,
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
           },
         }),
@@ -1029,7 +1029,7 @@ export default class implements PerfettoPlugin {
           src: `${sqlPrefix} WHERE item="${it.item}"`,
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
             item: UNKNOWN,
             type: UNKNOWN,
@@ -1054,7 +1054,7 @@ export default class implements PerfettoPlugin {
         src: `${sqlPrefix} WHERE item NOT IN ('${items.join("','")}')`,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
           item: UNKNOWN,
           type: UNKNOWN,

--- a/ui/src/plugins/com.android.AndroidStartup/index.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {LONG, NUM, STR} from '../../trace_processor/query_result';
+import {LONG, LONG_NULL, NUM, STR} from '../../trace_processor/query_result';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {SliceTrack} from '../../components/tracks/slice_track';
@@ -48,7 +48,7 @@ export default class implements PerfettoPlugin {
           schema: {
             id: NUM,
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
           },
           src: `
@@ -80,7 +80,7 @@ export default class implements PerfettoPlugin {
         dataset: new SourceDataset({
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
           },
           src: `

--- a/ui/src/plugins/com.android.Bluetooth/index.ts
+++ b/ui/src/plugins/com.android.Bluetooth/index.ts
@@ -15,7 +15,12 @@
 import {Trace} from '../../public/trace';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PerfettoPlugin} from '../../public/plugin';
-import {STR, LONG, UNKNOWN} from '../../trace_processor/query_result';
+import {
+  STR,
+  LONG,
+  UNKNOWN,
+  LONG_NULL,
+} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
 
@@ -47,7 +52,7 @@ function bleScanDataset(condition: string) {
     `,
     schema: {
       ts: LONG,
-      dur: LONG,
+      dur: LONG_NULL,
       name: STR,
     },
   });
@@ -72,7 +77,7 @@ const BLE_RESULTS_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -107,7 +112,7 @@ const BT_A2DP_AUDIO_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -143,7 +148,7 @@ const BT_CONNS_ACL_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -180,7 +185,7 @@ const BT_CONNS_SCO_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -210,7 +215,7 @@ const BT_LINK_LEVEL_EVENTS_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
     direction: UNKNOWN,
     type: UNKNOWN,
@@ -257,7 +262,7 @@ const BT_QUALITY_REPORTS_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
     quality_report_id: UNKNOWN,
     packet_types: UNKNOWN,
@@ -300,7 +305,7 @@ const BT_RSSI_REPORTS_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
     connection_handle: UNKNOWN,
     hci_status: UNKNOWN,
@@ -328,7 +333,7 @@ const BT_CODE_PATH_COUNTER_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
     key: UNKNOWN,
     number: UNKNOWN,
@@ -355,7 +360,7 @@ const BT_HAL_CRASHES_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
     metric_id: UNKNOWN,
     error_code: UNKNOWN,
@@ -404,7 +409,7 @@ const BT_BYTES_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -577,7 +582,7 @@ export default class implements PerfettoPlugin {
               WHERE inquiry_active`,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -595,7 +600,7 @@ export default class implements PerfettoPlugin {
               WHERE sco_active`,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -613,7 +618,7 @@ export default class implements PerfettoPlugin {
               WHERE a2dp_active`,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),
@@ -631,7 +636,7 @@ export default class implements PerfettoPlugin {
               WHERE le_audio_active`,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),

--- a/ui/src/plugins/com.android.ContainedTraces/index.ts
+++ b/ui/src/plugins/com.android.ContainedTraces/index.ts
@@ -15,7 +15,7 @@
 import {Trace} from '../../public/trace';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PerfettoPlugin} from '../../public/plugin';
-import {STR, LONG} from '../../trace_processor/query_result';
+import {STR, LONG, LONG_NULL} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
 
@@ -68,7 +68,7 @@ export default class implements PerfettoPlugin {
             .join(' UNION ALL '),
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
             link: STR,
           },

--- a/ui/src/plugins/com.android.DayExplorer/index.ts
+++ b/ui/src/plugins/com.android.DayExplorer/index.ts
@@ -18,7 +18,7 @@ import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PerfettoPlugin} from '../../public/plugin';
 import {createQueryCounterTrack} from '../../components/tracks/query_counter_track';
 import {TrackNode} from '../../public/workspace';
-import {STR, LONG} from '../../trace_processor/query_result';
+import {STR, LONG, LONG_NULL} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {AreaSelection, areaSelectionsEqual} from '../../public/selection';
 import {Flamegraph} from '../../widgets/flamegraph';
@@ -234,7 +234,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),

--- a/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
+++ b/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {LONG, NUM, STR} from '../../trace_processor/query_result';
+import {LONG, LONG_NULL, NUM, STR} from '../../trace_processor/query_result';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
@@ -68,7 +68,7 @@ export default class implements PerfettoPlugin {
           `,
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
           },
         }),

--- a/ui/src/plugins/com.android.InputEvents/index.ts
+++ b/ui/src/plugins/com.android.InputEvents/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {LONG, STR} from '../../trace_processor/query_result';
+import {LONG, LONG_NULL, STR} from '../../trace_processor/query_result';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {SliceTrack} from '../../components/tracks/slice_track';
@@ -51,7 +51,7 @@ export default class implements PerfettoPlugin {
         `,
         schema: {
           ts: LONG,
-          dur: LONG,
+          dur: LONG_NULL,
           name: STR,
         },
       }),

--- a/ui/src/plugins/com.android.RilModem/index.ts
+++ b/ui/src/plugins/com.android.RilModem/index.ts
@@ -15,7 +15,12 @@
 import {Trace} from '../../public/trace';
 import StandardGroupsPlugin from '../dev.perfetto.StandardGroups';
 import {PerfettoPlugin} from '../../public/plugin';
-import {STR, LONG, UNKNOWN} from '../../trace_processor/query_result';
+import {
+  STR,
+  LONG,
+  UNKNOWN,
+  LONG_NULL,
+} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
 
@@ -119,7 +124,7 @@ const MODEM_RIL_CHANNELS_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
   },
 });
@@ -158,7 +163,7 @@ const MODEM_CELL_RESELECTION_DATASET = new SourceDataset({
   `,
   schema: {
     ts: LONG,
-    dur: LONG,
+    dur: LONG_NULL,
     name: STR,
     raw_ril: UNKNOWN,
   },
@@ -197,7 +202,7 @@ export default class implements PerfettoPlugin {
           `,
           schema: {
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
           },
         }),

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
@@ -28,7 +28,7 @@ import {createScrollTimelineModel} from './scroll_timeline_model';
 import {createFlatColoredDurationTrack} from './flat_colored_duration_track';
 import {createTopLevelScrollTrack} from './scroll_track';
 import {createScrollTimelineTrack} from './scroll_timeline_track';
-import {LONG, NUM, STR} from '../../trace_processor/query_result';
+import {LONG, LONG_NULL, NUM, STR} from '../../trace_processor/query_result';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {escapeQuery} from '../../trace_processor/query_utils';
@@ -249,7 +249,7 @@ export default class implements PerfettoPlugin {
           schema: {
             id: NUM,
             ts: LONG,
-            dur: LONG,
+            dur: LONG_NULL,
             name: STR,
           },
           src: vsyncTable,
@@ -322,7 +322,7 @@ export default class implements PerfettoPlugin {
             schema: {
               id: NUM,
               ts: LONG,
-              dur: LONG,
+              dur: LONG_NULL,
               name: STR,
             },
             src: `

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -26,7 +26,13 @@ import {SLICE_TRACK_KIND} from '../../public/track_kinds';
 import {TrackNode} from '../../public/workspace';
 import {Engine} from '../../trace_processor/engine';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {LONG, NUM, STR, STR_NULL} from '../../trace_processor/query_result';
+import {
+  LONG,
+  LONG_NULL,
+  NUM,
+  STR,
+  STR_NULL,
+} from '../../trace_processor/query_result';
 import {WattsonEstimateSelectionAggregator} from './estimate_aggregator';
 import {WattsonPackageSelectionAggregator} from './package_aggregator';
 import {WattsonProcessSelectionAggregator} from './process_aggregator';
@@ -201,7 +207,7 @@ async function addWattsonMarkersElements(ctx: Trace, group: TrackNode) {
     dataset: new SourceDataset({
       schema: {
         ts: LONG,
-        dur: LONG,
+        dur: LONG_NULL,
         name: STR,
       },
       src: '_wattson_markers_window',


### PR DESCRIPTION
This patch simply converts all the 'dur' columns to LONG_NULL in all the tracks modified in https://github.com/google/perfetto/pull/3096.
