### PR TITLE
ui: Retain page when loading a trace

### DIFF
--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -230,7 +230,23 @@ async function loadTraceIntoEngine(
   trace.timeline.updateVisibleTime(visibleTimeSpan);
 
   const cacheUuid = traceDetails.cached ? traceDetails.uuid : '';
-  Router.navigate(`#!/viewer?local_cache_key=${cacheUuid}`);
+
+  // Attempt to preserve the existing page, only add/change the local_cache_key.
+  //
+  // This is so that if the user opens a trace from a URL or has navigated to a
+  // page before opening a trace, we stay on that page. This allows links to
+  // e.g. #!/explore to work as expected.
+  //
+  // Only navigate to the timeline page if we are currently on the home page.
+  const route = Router.parseUrl(window.location.href);
+
+  let nextPage = route.page;
+  if (route.page === '/' || route.page === '') {
+    // Current'y on the home page, navigate to the timeline page.
+    nextPage = '/viewer';
+  }
+
+  Router.navigate(`#!${nextPage}?local_cache_key=${cacheUuid}`);
 
   // Make sure the helper views are available before we start adding tracks.
   await includeSummaryTables(trace);


### PR DESCRIPTION
The UI currently always switches to the timeline page after loading a trace, which makes it impossible to share a link to a specific page. Now that more and more pages are being added to the UI, some pages are going to be equally as important as the timeline page, so it no longer makes sense to switch to hard switch to the timeline page.

This patch makes it so that we attempt to preseve the current page, only switching to the timeline page if we are currently on the home page.
