### PR TITLE
LockFreeTaskRunner: fix race on Quit

### DIFF
--- a/src/base/task_runner_unittest.cc
+++ b/src/base/task_runner_unittest.cc
@@ -586,6 +586,29 @@ TEST_F(LockFreeTaskRunnerTest, NoSlabLeaks) {
   EXPECT_LE(task_runner.slabs_allocated(), 2u);
 }
 
+TYPED_TEST(TaskRunnerTest, RaceOnQuit) {
+  std::atomic<LockFreeTaskRunner*> task_runnner{};
+
+  std::thread thread([&]() {
+    LockFreeTaskRunner tr;
+
+    std::function<void()> keep_tr_pumped;
+    keep_tr_pumped = [&] { tr.PostTask(keep_tr_pumped); };
+    tr.PostTask([&] { task_runnner.store(&tr); });
+    tr.PostTask(keep_tr_pumped);
+    tr.Run();
+  });
+
+  LockFreeTaskRunner* tr = nullptr;
+  for (; !tr; tr = task_runnner.load()) {
+    std::this_thread::yield();
+  }
+
+  tr->Quit();
+
+  thread.join();
+}
+
 TEST_F(LockFreeTaskRunnerTest, HashSpreading) {
   constexpr uint32_t kBuckets = task_runner_internal::kNumRefcountBuckets;
   constexpr uint32_t kSamples = kBuckets * 16;


### PR DESCRIPTION
Some tests where hitting the following race:
 - Thread1 (!= main thread) invokes Quit, which in turn becomes a PostTask.
 - This function sees quit_=true and returns from Run().
 - The owner of the LFTR at that point is entitled to destroy LFTR.
 - Thread1 is still executing the epilogue of the PostTask, decrementing the
   refcount, and ends up operating on invalid memory.

Fix it by waiting that the refcounts go to 0 before returning from Run().