### PR TITLE
Fix ETW CSwitch wait reason parsing

### DIFF
--- a/src/trace_processor/importers/etw/etw_parser.cc
+++ b/src/trace_processor/importers/etw/etw_parser.cc
@@ -99,8 +99,8 @@ void EtwParser::ParseCswitch(int64_t timestamp, uint32_t cpu, ConstBytes blob) {
   // Extract the wait reason. If not present in the trace, default to 0
   // (Executive).
   uint8_t old_thread_wait_reason =
-      cs.has_old_thread_wait_reason()
-          ? static_cast<uint8_t>(cs.old_thread_wait_reason())
+      cs.has_old_thread_wait_reason_int()
+          ? static_cast<uint8_t>(cs.old_thread_wait_reason_int())
           : 0;
 
   PushSchedSwitch(cpu, timestamp, old_thread_id, old_thread_state,


### PR DESCRIPTION
The ETW parser for CSwitch events was attempting to read an incorrect field to determine the thread wait reason. The etw.proto defines this as a oneof field, old_thread_wait_reason_enum_or_int.

This change updates the parser to correctly handle this oneof. It now prioritizes the integer representation (old_thread_wait_reason_int) for broader compatibility and defaults to 0 if the field is not present, ensuring robust parsing of the wait reason.