### PR TITLE
Fix incorrect format string in filter_util.cc.

### DIFF
--- a/src/protozero/filtering/filter_util.cc
+++ b/src/protozero/filtering/filter_util.cc
@@ -53,7 +53,7 @@ class MultiFileErrorCollectorImpl
                      int line,
                      int column,
                      absl::string_view message) override {
-    PERFETTO_ELOG("Warning %s %d:%d: %s", static_cast<int>(filename.size()),
+    PERFETTO_ELOG("Warning %.*s %d:%d: %.*s", static_cast<int>(filename.size()),
                   filename.data(), line, column,
                   static_cast<int>(message.size()), message.data());
   }


### PR DESCRIPTION
Accidentally introduced in #3127

Verified by copying the file to the Android tree and building with Protobuf 26.1.