### PR TITLE
ui: Hide a popup when its trigger is no longer visible

### DIFF
--- a/ui/src/widgets/popper_utils.ts
+++ b/ui/src/widgets/popper_utils.ts
@@ -14,5 +14,7 @@
 
 import type {Modifier, StrictModifiers} from '@popperjs/core';
 
-export type CustomModifier = Modifier<'sameWidth', {}>;
+export type CustomModifier =
+  | Modifier<'sameWidth', {}>
+  | Modifier<'hideOnInvisible', {}>;
 export type ExtendedModifiers = StrictModifiers | CustomModifier;

--- a/ui/src/widgets/popup.ts
+++ b/ui/src/widgets/popup.ts
@@ -284,6 +284,48 @@ export class Popup implements m.ClassComponent<PopupAttrs> {
       matchWidthModifier = [];
     }
 
+    // Custom modifier to hide popup when trigger is not visible. This can be
+    // due to the trigger or one of its ancestors having display:none.
+    const hideOnInvisible: Modifier<'hideOnInvisible', {}> = {
+      name: 'hideOnInvisible',
+      enabled: true,
+      phase: 'main',
+      fn({state}) {
+        const reference = state.elements.reference;
+        if (!(reference instanceof HTMLElement)) {
+          return;
+        }
+
+        // Check if checkVisibility is supported
+        if (typeof reference.checkVisibility === 'function') {
+          const isVisible = reference.checkVisibility();
+
+          if (!isVisible) {
+            // Hide the popper by setting display to none
+            state.elements.popper.style.display = 'none';
+          } else {
+            // Show the popper
+            state.elements.popper.style.display = '';
+          }
+        } else {
+          // Fallback for browsers that don't support checkVisibility()
+          // Use intersection observer or other visibility checks
+          const rect = reference.getBoundingClientRect();
+          const isVisible =
+            rect.top >= 0 &&
+            rect.left >= 0 &&
+            rect.bottom <=
+              (window.innerHeight || document.documentElement.clientHeight) &&
+            rect.right <=
+              (window.innerWidth || document.documentElement.clientWidth) &&
+            window.getComputedStyle(reference).visibility !== 'hidden' &&
+            window.getComputedStyle(reference).display !== 'none';
+
+          state.elements.popper.style.display = isVisible ? '' : 'none';
+        }
+      },
+    };
+
     const options: Partial<OptionsGeneric<ExtendedModifiers>> = {
       placement: position,
       modifiers: [
@@ -307,6 +349,7 @@ export class Popup implements m.ClassComponent<PopupAttrs> {
         // Don't let the arrow reach the end of the popup, which looks odd when
         // the popup has rounded corners
         {name: 'arrow', options: {padding: 2}},
+        hideOnInvisible,
         ...matchWidthModifier,
       ],
     };


### PR DESCRIPTION
Since popups are rendered out-of-tree, if a trigger becomes invisible due to it or one of its parents having display:none set, then the popup itself doesn't automatically become invisible.

This causes issues when e.g. changing page. Since the previous page is kept in the DOM just with `display:none`, a trigger element with an open popup on that page is not actually removed, just made invisible. However the popup still persists and is left floating awkwardly anchored to (0, 0).

This patch adds a popper.js modifier which detects if the trigger element is visible or not with `element.checkVisibility()`, applying `display:none` to the popup as well.
