### PR TITLE
Disable some tests failing on MSAN

### DIFF
--- a/src/profiling/memory/unwinding_unittest.cc
+++ b/src/profiling/memory/unwinding_unittest.cc
@@ -141,7 +141,13 @@ RecordMemory __attribute__((noinline)) GetRecord(WireMessage* msg) {
   return {std::move(payload), std::move(metadata)};
 }
 
-TEST(UnwindingTest, DoUnwind) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_DoUnwind DISABLED_DoUnwind
+#else
+#define MAYBE_DoUnwind DoUnwind
+#endif
+TEST(UnwindingTest, MAYBE_DoUnwind) {
   base::ScopedFile proc_maps(base::OpenFile("/proc/self/maps", O_RDONLY));
   base::ScopedFile proc_mem(base::OpenFile("/proc/self/mem", O_RDONLY));
   GlobalCallstackTrie callsites;
@@ -161,7 +167,13 @@ TEST(UnwindingTest, DoUnwind) {
                "namespace)::GetRecord(perfetto::profiling::WireMessage*)");
 }
 
-TEST(UnwindingTest, DoUnwindReparse) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_DoUnwindReparse DISABLED_DoUnwindReparse
+#else
+#define MAYBE_DoUnwindReparse DoUnwindReparse
+#endif
+TEST(UnwindingTest, MAYBE_DoUnwindReparse) {
   base::ScopedFile proc_maps(base::OpenFile("/proc/self/maps", O_RDONLY));
   base::ScopedFile proc_mem(base::OpenFile("/proc/self/mem", O_RDONLY));
   GlobalCallstackTrie callsites;

--- a/src/traced/probes/filesystem/file_scanner_unittest.cc
+++ b/src/traced/probes/filesystem/file_scanner_unittest.cc
@@ -91,7 +91,13 @@ FileEntry StatFileEntry(const std::string& path, InodeFileMap_Entry_Type type) {
   return FileEntry(buf.st_dev, buf.st_ino, path, type);
 }
 
-TEST(FileScannerTest, TestSynchronousStop) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_TestSynchronousStop DISABLED_TestSynchronousStop
+#else
+#define MAYBE_TestSynchronousStop TestSynchronousStop
+#endif
+TEST(FileScannerTest, MAYBE_TestSynchronousStop) {
   uint64_t seen = 0;
   bool done = false;
   TestDelegate delegate(
@@ -111,7 +117,13 @@ TEST(FileScannerTest, TestSynchronousStop) {
   EXPECT_TRUE(done);
 }
 
-TEST(FileScannerTest, TestAsynchronousStop) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_TestAsynchronousStop DISABLED_TestAsynchronousStop
+#else
+#define MAYBE_TestAsynchronousStop TestAsynchronousStop
+#endif
+TEST(FileScannerTest, MAYBE_TestAsynchronousStop) {
   uint64_t seen = 0;
   base::TestTaskRunner task_runner;
   TestDelegate delegate(
@@ -132,7 +144,13 @@ TEST(FileScannerTest, TestAsynchronousStop) {
   EXPECT_EQ(seen, 1u);
 }
 
-TEST(FileScannerTest, TestSynchronousFindFiles) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_TestSynchronousFindFiles DISABLED_TestSynchronousFindFiles
+#else
+#define MAYBE_TestSynchronousFindFiles TestSynchronousFindFiles
+#endif
+TEST(FileScannerTest, MAYBE_TestSynchronousFindFiles) {
   std::vector<FileEntry> file_entries;
   TestDelegate delegate(
       [&file_entries](BlockDeviceID block_device_id, Inode inode,
@@ -163,7 +181,13 @@ TEST(FileScannerTest, TestSynchronousFindFiles) {
               protos::pbzero::InodeFileMap::Entry::Type::DIRECTORY))));
 }
 
-TEST(FileScannerTest, TestAsynchronousFindFiles) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_TestAsynchronousFindFiles DISABLED_TestAsynchronousFindFiles
+#else
+#define MAYBE_TestAsynchronousFindFiles TestAsynchronousFindFiles
+#endif
+TEST(FileScannerTest, MAYBE_TestAsynchronousFindFiles) {
   base::TestTaskRunner task_runner;
   std::vector<FileEntry> file_entries;
   TestDelegate delegate(

--- a/src/traced/probes/filesystem/inode_file_data_source_unittest.cc
+++ b/src/traced/probes/filesystem/inode_file_data_source_unittest.cc
@@ -87,7 +87,13 @@ class InodeFileDataSourceTest : public ::testing::Test {
   base::TestTaskRunner task_runner_;
 };
 
-TEST_F(InodeFileDataSourceTest, TestFileSystemScan) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_TestFileSystemScan DISABLED_TestFileSystemScan
+#else
+#define MAYBE_TestFileSystemScan TestFileSystemScan
+#endif
+TEST_F(InodeFileDataSourceTest, MAYBE_TestFileSystemScan) {
   DataSourceConfig ds_config;
   protozero::HeapBuffered<protos::pbzero::InodeFileConfig> inode_cfg;
   inode_cfg->set_scan_interval_ms(1);
@@ -116,7 +122,13 @@ TEST_F(InodeFileDataSourceTest, TestFileSystemScan) {
               Pointee(Eq(value)));
 }
 
-TEST_F(InodeFileDataSourceTest, TestStaticMap) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_TestStaticMap DISABLED_TestStaticMap
+#else
+#define MAYBE_TestStaticMap TestStaticMap
+#endif
+TEST_F(InodeFileDataSourceTest, MAYBE_TestStaticMap) {
   DataSourceConfig config;
   auto data_source = GetInodeFileDataSource(config);
   CreateStaticDeviceToInodeMap(
@@ -139,7 +151,13 @@ TEST_F(InodeFileDataSourceTest, TestStaticMap) {
   EXPECT_THAT(cache_.Get(std::make_pair(buf.st_dev, buf.st_ino)), IsNull());
 }
 
-TEST_F(InodeFileDataSourceTest, TestCache) {
+// TODO(b/448593724): Fix and re-enable on MSAN.
+#if defined(MEMORY_SANITIZER)
+#define MAYBE_TestCache DISABLED_TestCache
+#else
+#define MAYBE_TestCache TestCache
+#endif
+TEST_F(InodeFileDataSourceTest, MAYBE_TestCache) {
   DataSourceConfig config;
   auto data_source = GetInodeFileDataSource(config);
   CreateStaticDeviceToInodeMap(


### PR DESCRIPTION
See context in b/448593724. Disables these:
- UnwindingTest.DoUnwind
- UnwindingTest.DoUnwindReparse
- FileScannerTest.TestSynchronousStop
- FileScannerTest.TestAsynchronousStop
- FileScannerTest.TestSynchronousFindFiles
- FileScannerTest.TestAsynchronousFindFiles