### PR TITLE
TraceBuffer: don't reset read iterators in CloneReadOnly()

### DIFF
--- a/include/perfetto/ext/base/flags.h
+++ b/include/perfetto/ext/base/flags.h
@@ -44,7 +44,8 @@ namespace perfetto::base::flags {
         ? NonAndroidPlatformDefault_TRUE                               \
         : NonAndroidPlatformDefault_FALSE)                             \
   X(use_rt_mutex, NonAndroidPlatformDefault_FALSE)                     \
-  X(use_rt_futex, NonAndroidPlatformDefault_FALSE)
+  X(use_rt_futex, NonAndroidPlatformDefault_FALSE)                     \
+  X(buffer_clone_preserve_read_iter, NonAndroidPlatformDefault_TRUE)
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //

--- a/perfetto_flags.aconfig
+++ b/perfetto_flags.aconfig
@@ -49,3 +49,10 @@ flag {
   bug: "443948543"
   is_fixed_read_only: true
 }
+flag {
+  name: "buffer_clone_preserve_read_iter"
+  namespace: "perfetto"
+  description: "Controls whether TraceBuffer::CloneReadOnly() will preserve the read state (true, new behavior) or clear it (false, legacy behavior)."
+  bug: "448604718"
+  is_fixed_read_only: true
+}

--- a/src/tracing/service/trace_buffer_v1.h
+++ b/src/tracing/service/trace_buffer_v1.h
@@ -247,8 +247,7 @@ class TraceBufferV1 : public TraceBuffer {
                            PacketSequenceProperties* sequence_properties,
                            bool* previous_packet_on_sequence_dropped) override;
 
-  // Creates a read-only clone of the trace buffer. The read iterators of the
-  // new buffer will be reset, as if no Read() had been called. Calls to
+  // Creates a read-only clone of the trace buffer. Calls to
   // CopyChunkUntrusted() and TryPatchChunkContents() on the returned cloned
   // TraceBuffer will CHECK().
   std::unique_ptr<TraceBuffer> CloneReadOnly() const override;

--- a/src/tracing/service/trace_buffer_v1_unittest.cc
+++ b/src/tracing/service/trace_buffer_v1_unittest.cc
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <vector>
 
+#include "perfetto/ext/base/flags.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/tracing/core/basic_types.h"
 #include "perfetto/ext/tracing/core/client_identity.h"
@@ -1894,7 +1895,13 @@ TEST_F(TraceBufferTest, MissingPacketsOnSequence) {
   ASSERT_TRUE(previous_packet_dropped);
 }
 
-TEST_F(TraceBufferTest, Clone_NoFragments) {
+// This test covers only the old behavior of CloneReadOnly() which used to reset
+// the read iterators on clone. This will be deprecated once the
+// buffer_clone_preserve_read_iter flag rollout sticks. See b/448604718.
+TEST_F(TraceBufferTest, Clone_NoFragments_NoPreserveReadIter) {
+  if (base::flags::buffer_clone_preserve_read_iter)
+    GTEST_SKIP() << "This test requires buffer_clone_preserve_read_iter=false";
+
   const char kNumWriters = 3;
   for (char num_pre_reads = 0; num_pre_reads < kNumWriters; num_pre_reads++) {
     ResetBuffer(4096);
@@ -1926,6 +1933,36 @@ TEST_F(TraceBufferTest, Clone_NoFragments) {
     }
     ASSERT_THAT(ReadPacket(snap), IsEmpty());
   }
+}
+
+TEST_F(TraceBufferTest, Clone_NoFragments_PreserveReadIter) {
+  if (!base::flags::buffer_clone_preserve_read_iter)
+    GTEST_SKIP() << "This test requires buffer_clone_preserve_read_iter=true";
+
+  ResetBuffer(4096);
+  ASSERT_EQ(32u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+                     .AddPacket(32 - 16, 'A')
+                     .CopyIntoTraceBuffer());
+  ASSERT_EQ(32u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+                     .AddPacket(32 - 16, 'B')
+                     .CopyIntoTraceBuffer());
+  ASSERT_EQ(32u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
+                     .AddPacket(32 - 16, 'C')
+                     .CopyIntoTraceBuffer());
+  ASSERT_EQ(trace_buffer()->used_size(), 32u * 3);
+
+  // Make some reads *before* cloning. This is to check that destructive
+  // reads are propagated into the cloned buffer.
+  // On every round (|num_pre_reads|), read a different number of packets.
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32 - 16, 'A')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32 - 16, 'B')));
+
+  // Now create a snapshot and make sure we always read all the packets.
+  std::unique_ptr<TraceBuffer> snap = trace_buffer()->CloneReadOnly();
+  snap->BeginRead();
+  ASSERT_THAT(ReadPacket(snap), ElementsAre(FakePacketFragment(32 - 16, 'C')));
+  ASSERT_THAT(ReadPacket(snap), IsEmpty());
 }
 
 TEST_F(TraceBufferTest, Clone_FragmentsOutOfOrder) {


### PR DESCRIPTION
Bug: b/382209797