### PR TITLE
trace_processor: Rename anonymized ETW threads to 'Anonymized Process'

### DIFF
--- a/src/trace_processor/importers/etw/etw_parser.cc
+++ b/src/trace_processor/importers/etw/etw_parser.cc
@@ -44,6 +44,8 @@ namespace {
 
 using protozero::ConstBytes;
 
+constexpr uint32_t kAnonymizedThreadId = uint32_t(-1);
+
 constexpr uint8_t kEtwThreadStateWaiting = 5;
 constexpr uint8_t kEtwWaitReasonPageIn = 2;
 constexpr uint8_t kEtwWaitReasonWrExecutive = 7;
@@ -92,9 +94,22 @@ void EtwParser::ParseCswitch(int64_t timestamp, uint32_t cpu, ConstBytes blob) {
   // thread_id might be erased for privacy/security concerns, in this case, use
   // a dummy id since 0 means idle.
   uint32_t old_thread_id =
-      cs.has_old_thread_id() ? cs.old_thread_id() : uint32_t(-1);
+      cs.has_old_thread_id() ? cs.old_thread_id() : kAnonymizedThreadId;
   uint32_t new_thread_id =
-      cs.has_new_thread_id() ? cs.new_thread_id() : uint32_t(-1);
+      cs.has_new_thread_id() ? cs.new_thread_id() : kAnonymizedThreadId;
+
+  if (old_thread_id == kAnonymizedThreadId) {
+    context_->process_tracker->UpdateThreadName(
+        context_->process_tracker->GetOrCreateThread(kAnonymizedThreadId),
+        context_->storage->InternString("Anonymized Process"),
+        ThreadNamePriority::kEtwTrace);
+  }
+  if (new_thread_id == kAnonymizedThreadId) {
+    context_->process_tracker->UpdateThreadName(
+        context_->process_tracker->GetOrCreateThread(kAnonymizedThreadId),
+        context_->storage->InternString("Anonymized Process"),
+        ThreadNamePriority::kEtwTrace);
+  }
 
   // Extract the wait reason. If not present in the trace, default to 0
   // (Executive).


### PR DESCRIPTION
In ETW traces, threads from external processes are anonymized for privacy by assigning them a thread ID of -1.

This ID was displayed directly in the UI, which could be confusing. This change updates the ETW parser to explicitly name these threads "Anonymized Process". This improves trace readability by making it clear that these entries correspond to anonymized external processes.