### PR TITLE
ui: Limit filter chip size

### DIFF
--- a/ui/src/assets/widgets/chip.scss
+++ b/ui/src/assets/widgets/chip.scss
@@ -20,6 +20,9 @@
     background: color-mix(in srgb, $base-color 15%, transparent);
   }
 
+  display: inline-flex;
+  align-items: baseline;
+
   font-family: var(--pf-font-compact);
   line-height: 1;
   user-select: none;
@@ -28,6 +31,13 @@
   white-space: nowrap;
   min-width: max-content;
   border: solid 1px color-mix(in srgb, currentColor, transparent 50%);
+  overflow: hidden;
+
+  &__label {
+    flex-shrink: 1;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
 
   &--rounded {
     border-radius: 100px;

--- a/ui/src/assets/widgets/chip.scss
+++ b/ui/src/assets/widgets/chip.scss
@@ -43,11 +43,12 @@
     border-radius: 100px;
   }
 
-  & > .pf-left-icon {
-    margin-right: 6px; // Make some room between the icon and label
+  &__icon {
+    align-self: center;
+    margin-right: 6px;
   }
 
-  & > .pf-button {
+  .pf-button {
     margin-left: 6px; // Make some room between the icon and label
   }
 
@@ -80,11 +81,11 @@
   // Reduce padding when compact
   &.pf-compact {
     padding: 0px 4px;
-    & > .pf-left-icon {
+    .pf-chip__icon {
       margin-right: 2px;
     }
 
-    & > .pf-button {
+    .pf-button {
       margin-left: 2px;
     }
   }

--- a/ui/src/assets/widgets/grid.scss
+++ b/ui/src/assets/widgets/grid.scss
@@ -208,3 +208,9 @@ $border-3: 2px solid var(--pf-color-border);
 .pf-drag-over > * {
   pointer-events: none;
 }
+
+.pf-grid-filter {
+  .pf-chip__label {
+    max-width: 300px;
+  }
+}

--- a/ui/src/assets/widgets/ui_main.scss
+++ b/ui/src/assets/widgets/ui_main.scss
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 .pf-ui-main {
+  isolation: isolate;
   display: grid;
   grid-template-areas:
     "sidebar topbar"

--- a/ui/src/components/widgets/data_grid/data_grid.ts
+++ b/ui/src/components/widgets/data_grid/data_grid.ts
@@ -27,7 +27,6 @@ import {
   AggregationFunction,
 } from './common';
 import {MenuDivider, MenuItem} from '../../../widgets/menu';
-import {Chip} from '../../../widgets/chip';
 import {Icons} from '../../../base/semantic_icons';
 import {InMemoryDataSource} from './in_memory_data_source';
 import {Stack, StackAuto} from '../../../widgets/stack';
@@ -43,6 +42,8 @@ import {
   renderSortMenuItems,
   PageControl,
   SortDirection,
+  GridFilterBar,
+  GridFilterChip,
 } from '../../../widgets/grid';
 import {classNames} from '../../../base/classnames';
 
@@ -468,19 +469,18 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           }),
         m(StackAuto, [
           showFilters &&
-            m(Stack, {orientation: 'horizontal', wrap: true}, [
-              filters.map((filter) =>
-                m(Chip, {
-                  label: this.formatFilter(filter),
-                  removable: true,
+            m(GridFilterBar, [
+              filters.map((filter) => {
+                return m(GridFilterChip, {
+                  content: this.formatFilter(filter),
                   onRemove: () => {
                     const newFilters = filters.filter((f) => f !== filter);
                     this.filters = newFilters;
                     onFiltersChanged(newFilters);
                     this.currentPage = 0;
                   },
-                }),
-              ),
+                });
+              }),
             ]),
         ]),
         m(PageControl, {

--- a/ui/src/components/widgets/sql/table/filters.ts
+++ b/ui/src/components/widgets/sql/table/filters.ts
@@ -16,8 +16,7 @@ import m from 'mithril';
 import {isSqlColumnEqual, SqlColumn, sqlColumnId} from './sql_column';
 import {sqlValueToSqliteString} from '../../../../trace_processor/sql_utils';
 import {SqlValue} from '../../../../trace_processor/query_result';
-import {Chip} from '../../../../widgets/chip';
-import {Stack} from '../../../../widgets/stack';
+import {GridFilterChip, GridFilterBar} from '../../../../widgets/grid';
 
 // A filter which can be applied to the table.
 export interface Filter {
@@ -111,14 +110,14 @@ export function areFiltersEqual(
 }
 
 export function renderFilters(filters: Filters): m.Children {
-  return m(Stack, {orientation: 'horizontal'}, [
-    filters.get().map((filter) =>
-      m(Chip, {
-        label: filterTitle(filter),
-        removable: true,
+  return m(GridFilterBar, [
+    filters.get().map((filter) => {
+      const filterText = filterTitle(filter);
+      return m(GridFilterChip, {
+        content: filterText,
         onRemove: () => filters.removeFilter(filter),
-      }),
-    ),
+      });
+    }),
   ]);
 }
 

--- a/ui/src/widgets/chip.ts
+++ b/ui/src/widgets/chip.ts
@@ -16,15 +16,16 @@ import m from 'mithril';
 import {classNames} from '../base/classnames';
 import {HTMLAttrs, Intent, classForIntent} from './common';
 import {Icon} from './icon';
-import {Spinner} from './spinner';
 import {Button} from './button';
 
-interface CommonAttrs extends HTMLAttrs {
+export interface ChipAttrs extends HTMLAttrs {
+  // Chips require a label.
+  readonly label: string;
+  // Chips can have an optional icon.
+  readonly icon?: string;
   // Use minimal padding, reducing the overall size of the chip by a few px.
   // Defaults to false.
   readonly compact?: boolean;
-  // Optional right icon.
-  readonly rightIcon?: string;
   // List of space separated class names forwarded to the icon.
   readonly className?: string;
   // Show loading spinner instead of icon.
@@ -45,45 +46,24 @@ interface CommonAttrs extends HTMLAttrs {
   readonly onRemove?: () => void;
 }
 
-interface IconChipAttrs extends CommonAttrs {
-  // Icon chips require an icon.
-  icon: string;
-}
-
-interface LabelChipAttrs extends CommonAttrs {
-  // Label chips require a label.
-  label: string;
-  // Label chips can have an optional icon.
-  icon?: string;
-}
-
-export type ChipAttrs = LabelChipAttrs | IconChipAttrs;
-
-function isLabelChipAttrs(attrs: ChipAttrs): attrs is LabelChipAttrs {
-  return (attrs as LabelChipAttrs).label !== undefined;
-}
-
 export class Chip implements m.ClassComponent<ChipAttrs> {
   view({attrs}: m.CVnode<ChipAttrs>) {
     const {
       icon,
       compact,
-      rightIcon,
       className,
       iconFilled,
       intent = Intent.None,
       rounded,
       removable,
       onRemove,
+      label,
       ...htmlAttrs
     } = attrs;
-
-    const label = isLabelChipAttrs(attrs) ? attrs.label : undefined;
 
     const classes = classNames(
       compact && 'pf-compact',
       classForIntent(intent),
-      icon && !label && 'pf-icon-only',
       className,
       rounded && 'pf-chip--rounded',
     );
@@ -94,14 +74,13 @@ export class Chip implements m.ClassComponent<ChipAttrs> {
         ...htmlAttrs,
         className: classes,
       },
-      this.renderIcon(attrs),
-      rightIcon &&
+      icon &&
         m(Icon, {
-          className: 'pf-right-icon',
-          icon: rightIcon,
+          className: 'pf-chip__icon',
+          icon: icon,
           filled: iconFilled,
         }),
-      m('span.pf-chip__label', label || '\u200B'), // Zero width space keeps chip in-flow
+      m('span.pf-chip__label', label),
       removable &&
         m(Button, {
           compact: true,
@@ -110,17 +89,5 @@ export class Chip implements m.ClassComponent<ChipAttrs> {
           onclick: () => onRemove?.(),
         }),
     );
-  }
-
-  private renderIcon(attrs: ChipAttrs): m.Children {
-    const {icon, iconFilled} = attrs;
-    const className = 'pf-left-icon';
-    if (attrs.loading) {
-      return m(Spinner, {className});
-    } else if (icon) {
-      return m(Icon, {className, icon, filled: iconFilled});
-    } else {
-      return undefined;
-    }
   }
 }

--- a/ui/src/widgets/chip.ts
+++ b/ui/src/widgets/chip.ts
@@ -101,7 +101,7 @@ export class Chip implements m.ClassComponent<ChipAttrs> {
           icon: rightIcon,
           filled: iconFilled,
         }),
-      label || '\u200B', // Zero width space keeps chip in-flow
+      m('span.pf-chip__label', label || '\u200B'), // Zero width space keeps chip in-flow
       removable &&
         m(Button, {
           compact: true,

--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -333,6 +333,7 @@ export interface PageControlAttrs {
 }
 
 import {Stack} from './stack';
+import {Chip} from './chip';
 
 export class PageControl implements m.ClassComponent<PageControlAttrs> {
   view({attrs}: m.Vnode<PageControlAttrs>) {
@@ -376,5 +377,28 @@ export class PageControl implements m.ClassComponent<PageControlAttrs> {
         onclick: lastPageClick,
       }),
     ]);
+  }
+}
+
+export class GridFilterBar implements m.ClassComponent {
+  view({children}: m.Vnode) {
+    return m(Stack, {orientation: 'horizontal', wrap: true}, children);
+  }
+}
+
+export interface GridFilterAttrs {
+  readonly content: string;
+  onRemove(): void;
+}
+
+export class GridFilterChip implements m.ClassComponent<GridFilterAttrs> {
+  view({attrs}: m.Vnode<GridFilterAttrs>): m.Children {
+    return m(Chip, {
+      className: 'pf-grid-filter',
+      label: attrs.content,
+      removable: true,
+      onRemove: attrs.onRemove,
+      title: attrs.content,
+    });
   }
 }


### PR DESCRIPTION
- Use a common component for filter chip bars and filter chips:
  - GridFilterBar
  - GridFilterChip
- Use in DataGrid and SqlTable for a common and consistent UX.
- Limit filter chip text to 300px (ellipsizing if larger)
- Add the label as a title (browser controlled popup on hover showing
  the full filter text).
- Wrap filters when they overflow (rather than scroll).

<img width="1788" height="318" alt="image" src="https://github.com/user-attachments/assets/3149a3ef-409b-4de9-9d10-26e95165d32a" />

