### PR TITLE
tp: Add COUNT(*) aggregation to StructuredQuery

### DIFF
--- a/docs/analysis/trace-summary.md
+++ b/docs/analysis/trace-summary.md
@@ -805,7 +805,7 @@ The `group_by` operation allows you to use the following aggregate functions:
 
 | Operator                 | Description                                                                                                                                            |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `COUNT`                  | Counts the number of rows in each group.                                                                                                               |
+| `COUNT`                  | Counts the number of rows in each group. If no `column_name` is specified, this becomes `COUNT(*)` (count all rows). |
 | `SUM`                    | Calculates the sum of a numerical column.                                                                                                              |
 | `MIN`                    | Finds the minimum value of a numerical column.                                                                                                         |
 | `MAX`                    | Finds the maximum value of a numerical column.                                                                                                         |
@@ -813,6 +813,12 @@ The `group_by` operation allows you to use the following aggregate functions:
 | `MEDIAN`                 | Calculates the 50th percentile of a numerical column.                                                                                                  |
 | `DURATION_WEIGHTED_MEAN` | Calculates the duration-weighted average of a numerical column. This is useful for time-series data where values should be weighted by their duration. |
 | `PERCENTILE`             | Calculates a given percentile of a numerical column. The percentile is specified in the `percentile` field of the `Aggregate` message.                   |
+
+##### Aggregation Field Requirements
+
+- **`COUNT`**: `column_name` is optional. If omitted, it defaults to `COUNT(*)`.
+- **`SUM`, `MIN`, `MAX`, `MEAN`, `MEDIAN`, `DURATION_WEIGHTED_MEAN`**: `column_name` is required.
+- **`PERCENTILE`**: Both `column_name` and `percentile` are required.
 
 ##### Example: Calculating the 99th Percentile
 

--- a/protos/perfetto/perfetto_sql/structured_query.proto
+++ b/protos/perfetto/perfetto_sql/structured_query.proto
@@ -268,19 +268,31 @@ message PerfettoSqlStructuredQuery {
     message Aggregate {
       enum Op {
         UNSPECIFIED = 0;
+
+        // If no column_name is specified, this is a COUNT(*).
         COUNT = 1;
+
+        // Requires a column_name to be specified.
         SUM = 2;
         MIN = 3;
         MAX = 4;
         MEAN = 5;
         MEDIAN = 6;
         DURATION_WEIGHTED_MEAN = 7;
+
+        // Requires a column_name and a percentile to be specified.
         PERCENTILE = 8;
       }
 
+      // The name of the column to aggregate. Not required for COUNT.
       optional string column_name = 1;
+
+      // Required.
       optional Op op = 2;
+
+      // Optional.
       optional string result_column_name = 3;
+
       // The percentile to compute when `op` is `PERCENTILE`. Must be between 0
       // and 100.
       optional double percentile = 4;

--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
@@ -738,4 +738,93 @@ TEST(StructuredQueryGeneratorTest, TableSourceWithDeprecatedModuleName) {
               UnorderedElementsAre("linux.memory.process"));
 }
 
+TEST(StructuredQueryGeneratorTest, CountAllAggregation) {
+  StructuredQueryGenerator gen;
+  auto proto = ToProto(R"(
+    table: {
+      table_name: "slice"
+    }
+    group_by: {
+      column_names: "name"
+      aggregates: {
+        op: COUNT
+        result_column_name: "slice_count"
+      }
+    }
+  )");
+  auto ret = gen.Generate(proto.data(), proto.size());
+  ASSERT_OK_AND_ASSIGN(std::string res, ret);
+  ASSERT_THAT(res, EqualsIgnoringWhitespace(R"(
+    WITH sq_0 AS (
+      SELECT
+        name,
+        COUNT(*) AS slice_count
+      FROM slice
+      GROUP BY name
+    )
+    SELECT * FROM sq_0
+  )"));
+}
+
+TEST(StructuredQueryGeneratorTest, AggregateToStringValidation) {
+  // SUM without column name.
+  {
+    StructuredQueryGenerator gen;
+    auto proto = ToProto(R"(
+      table: {
+        table_name: "slice"
+      }
+      group_by: {
+        column_names: "name"
+        aggregates: {
+          op: SUM
+          result_column_name: "slice_sum"
+        }
+      }
+    )");
+    auto ret = gen.Generate(proto.data(), proto.size());
+    ASSERT_FALSE(ret.ok());
+  }
+
+  // PERCENTILE without percentile.
+  {
+    StructuredQueryGenerator gen;
+    auto proto = ToProto(R"(
+      table: {
+        table_name: "slice"
+      }
+      group_by: {
+        column_names: "name"
+        aggregates: {
+          op: PERCENTILE
+          column_name: "dur"
+          result_column_name: "slice_percentile"
+        }
+      }
+    )");
+    auto ret = gen.Generate(proto.data(), proto.size());
+    ASSERT_FALSE(ret.ok());
+  }
+
+  // PERCENTILE without column name.
+  {
+    StructuredQueryGenerator gen;
+    auto proto = ToProto(R"(
+      table: {
+        table_name: "slice"
+      }
+      group_by: {
+        column_names: "name"
+        aggregates: {
+          op: PERCENTILE
+          percentile: 99
+          result_column_name: "slice_percentile"
+        }
+      }
+    )");
+    auto ret = gen.Generate(proto.data(), proto.size());
+    ASSERT_FALSE(ret.ok());
+  }
+}
+
 }  // namespace perfetto::trace_processor::perfetto_sql::generator


### PR DESCRIPTION
When no column_name was specified in the aggregation we would just silently treat column_name as an empty string. It made COUNT() work by mistake.

Now it's explicit, with tests, and proper difinition of optional/required fields with checks in code.