### PR TITLE
More cppcheck performance fixes

### DIFF
--- a/src/perfetto_cmd/config.cc
+++ b/src/perfetto_cmd/config.cc
@@ -44,7 +44,7 @@ bool SplitValueAndUnit(const std::string& arg, ValueUnit* out) {
 }
 
 bool ConvertValue(const std::string& arg,
-                  std::vector<UnitMultipler> units,
+                  const std::vector<UnitMultipler>& units,
                   uint64_t* out) {
   if (arg.empty()) {
     *out = 0;

--- a/src/perfetto_cmd/perfetto_cmd.cc
+++ b/src/perfetto_cmd/perfetto_cmd.cc
@@ -1435,7 +1435,7 @@ NAME                                     PRODUCER                     DETAILS
     }
     const size_t kCatsShortLen = 40;
     if (!query_service_long_ && cats.length() > kCatsShortLen) {
-      cats = cats.substr(0, kCatsShortLen);
+      cats.resize(kCatsShortLen);
       cats.append("... (use --long to expand)");
     }
     printf("%s\n", cats.c_str());

--- a/src/profiling/deobfuscator.cc
+++ b/src/profiling/deobfuscator.cc
@@ -121,7 +121,7 @@ std::optional<ProguardMember> ParseMember(std::string line) {
   auto paren_idx = deobfuscated_name.find('(');
   if (paren_idx != std::string::npos) {
     member_type = ProguardMemberType::kMethod;
-    deobfuscated_name = deobfuscated_name.substr(0, paren_idx);
+    deobfuscated_name.resize(paren_idx);
     auto colon_idx = type_name.find(':');
     if (colon_idx != std::string::npos) {
       type_name = type_name.substr(colon_idx + 1);

--- a/src/profiling/symbolizer/local_symbolizer.cc
+++ b/src/profiling/symbolizer/local_symbolizer.cc
@@ -913,8 +913,8 @@ LocalSymbolizer::~LocalSymbolizer() = default;
 #endif  // PERFETTO_BUILDFLAG(PERFETTO_LOCAL_SYMBOLIZER)
 
 std::unique_ptr<Symbolizer> MaybeLocalSymbolizer(
-    std::vector<std::string> directories,
-    std::vector<std::string> individual_files,
+    const std::vector<std::string>& directories,
+    const std::vector<std::string>& individual_files,
     const char* mode) {
   std::unique_ptr<Symbolizer> symbolizer;
 

--- a/src/profiling/symbolizer/local_symbolizer.h
+++ b/src/profiling/symbolizer/local_symbolizer.h
@@ -112,8 +112,8 @@ class LocalSymbolizer : public Symbolizer {
 };
 
 std::unique_ptr<Symbolizer> MaybeLocalSymbolizer(
-    std::vector<std::string> directories,
-    std::vector<std::string> individual_files,
+    const std::vector<std::string>& directories,
+    const std::vector<std::string>& individual_files,
     const char* mode);
 
 }  // namespace perfetto::profiling

--- a/src/protozero/text_to_proto/text_to_proto.cc
+++ b/src/protozero/text_to_proto/text_to_proto.cc
@@ -479,7 +479,7 @@ class ParserDelegate {
 
  private:
   template <typename T>
-  void VarIntField(const FieldDescriptorProto* field, Token t) {
+  void VarIntField(const FieldDescriptorProto* field, const Token& t) {
     auto field_id = static_cast<uint32_t>(field->number());
     uint64_t n = 0;
     PERFETTO_CHECK(ParseInteger(t.txt, &n));

--- a/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
+++ b/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
@@ -149,9 +149,9 @@ class InstrumentsXmlTokenizer::Impl {
   explicit Impl(TraceProcessorContext* context)
       : context_(context),
         data_(),
+        parser_(XML_ParserCreate(nullptr)),
         stream_(context->sorter->CreateStream(
             std::make_unique<RowParser>(context, data_))) {
-    parser_ = XML_ParserCreate(nullptr);
     XML_SetElementHandler(parser_, ElementStart, ElementEnd);
     XML_SetCharacterDataHandler(parser_, CharacterData);
     XML_SetUserData(parser_, this);

--- a/src/trace_processor/importers/perf/features.cc
+++ b/src/trace_processor/importers/perf/features.cc
@@ -294,7 +294,7 @@ base::StatusOr<std::vector<std::string>> ParseCmdline(TraceBlobView bytes) {
       return base::ErrStatus("Failed to parse string for CMDLINE");
     }
   }
-  return std::move(args);
+  return args;
 }
 
 base::StatusOr<std::string> ParseOsRelease(TraceBlobView bytes) {

--- a/src/trace_processor/importers/proto/pigweed_detokenizer.cc
+++ b/src/trace_processor/importers/proto/pigweed_detokenizer.cc
@@ -236,7 +236,7 @@ std::string DetokenizedString::Format() const {
   return result;
 }
 
-static size_t SkipFlags(std::string fmt, size_t ix) {
+static size_t SkipFlags(const std::string& fmt, size_t ix) {
   while (fmt[ix] == '-' || fmt[ix] == '+' || fmt[ix] == '#' || fmt[ix] == ' ' ||
          fmt[ix] == '0') {
     ix += 1;
@@ -244,7 +244,7 @@ static size_t SkipFlags(std::string fmt, size_t ix) {
   return ix;
 }
 
-static size_t SkipAsteriskOrInteger(std::string fmt, size_t ix) {
+static size_t SkipAsteriskOrInteger(const std::string& fmt, size_t ix) {
   if (fmt[ix] == '*') {
     return ix + 1;
   }

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/pprof_functions.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/pprof_functions.cc
@@ -114,7 +114,7 @@ class AggregateContext {
 
       sample_types.push_back({type->AsString(), units->AsString()});
     }
-    return std::move(sample_types);
+    return sample_types;
   }
 
   AggregateContext(TraceProcessorContext* tp_context,

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.cc
@@ -84,7 +84,8 @@ struct StripHexFunction : public sqlite::Function<StripHexFunction> {
                                            static_cast<int>(result.length()));
   }
 
-  static std::string StripHex(std::string input, int64_t min_repeated_digits) {
+  static std::string StripHex(const std::string& input,
+                              int64_t min_repeated_digits) {
     std::string result;
     result.reserve(input.length());
     for (size_t i = 0; i < input.length();) {
@@ -131,7 +132,7 @@ base::Status RegisterStripHexFunction(PerfettoSqlEngine* engine,
   return engine->RegisterFunction<StripHexFunction>(nullptr);
 }
 
-std::string SqlStripHex(std::string input, int64_t min_repeated_digits) {
+std::string SqlStripHex(const std::string& input, int64_t min_repeated_digits) {
   return StripHexFunction::StripHex(input, min_repeated_digits);
 }
 

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.h
@@ -55,7 +55,7 @@ base::Status RegisterStripHexFunction(PerfettoSqlEngine* engine,
 
 // Implementation of __intrinsic_strip_hex function
 // Visible for testing
-std::string SqlStripHex(std::string input, int64_t min_repeated_digits);
+std::string SqlStripHex(const std::string& input, int64_t min_repeated_digits);
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -1405,7 +1405,7 @@ base::Status ParseMetricExtensionPaths(
 base::Status IncludeSqlPackage(std::string root, bool allow_override) {
   // Remove trailing slash
   if (root.back() == '/')
-    root = root.substr(0, root.length() - 1);
+    root.resize(root.length() - 1);
 
   if (!base::FileExists(root))
     return base::ErrStatus("Directory %s does not exist.", root.c_str());
@@ -1457,7 +1457,7 @@ base::Status IncludeSqlPackage(std::string root, bool allow_override) {
 base::Status LoadOverridenStdlib(std::string root) {
   // Remove trailing slash
   if (root.back() == '/') {
-    root = root.substr(0, root.length() - 1);
+    root.resize(root.length() - 1);
   }
 
   if (!base::FileExists(root)) {

--- a/src/traceconv/pprof_builder.cc
+++ b/src/traceconv/pprof_builder.cc
@@ -139,7 +139,7 @@ uint64_t ToPprofId(int64_t id) {
   return static_cast<uint64_t>(id) + 1;
 }
 
-std::string AsCsvString(std::vector<uint64_t> vals) {
+std::string AsCsvString(const std::vector<uint64_t>& vals) {
   std::string ret;
   for (size_t i = 0; i < vals.size(); i++) {
     if (i != 0) {

--- a/src/traceconv/trace_to_profile.cc
+++ b/src/traceconv/trace_to_profile.cc
@@ -98,7 +98,7 @@ int TraceToProfile(
     std::vector<uint64_t> timestamps,
     ConversionMode conversion_mode,
     uint64_t conversion_flags,
-    std::string dirname_prefix,
+    const std::string& dirname_prefix,
     std::function<std::string(const SerializedProfile&)> filename_fn) {
   std::vector<SerializedProfile> profiles;
   trace_processor::Config config;
@@ -140,7 +140,7 @@ int TraceToProfile(
 int TraceToHeapProfile(std::istream* input,
                        std::ostream* output,
                        uint64_t pid,
-                       std::vector<uint64_t> timestamps,
+                       const std::vector<uint64_t>& timestamps,
                        bool annotate_frames) {
   int file_idx = 0;
   auto filename_fn = [&file_idx](const SerializedProfile& profile) {
@@ -156,7 +156,7 @@ int TraceToHeapProfile(std::istream* input,
 int TraceToPerfProfile(std::istream* input,
                        std::ostream* output,
                        uint64_t pid,
-                       std::vector<uint64_t> timestamps,
+                       const std::vector<uint64_t>& timestamps,
                        bool annotate_frames) {
   int file_idx = 0;
   auto filename_fn = [&file_idx](const SerializedProfile& profile) {

--- a/src/traceconv/trace_to_profile.h
+++ b/src/traceconv/trace_to_profile.h
@@ -28,14 +28,14 @@ namespace trace_to_text {
 int TraceToHeapProfile(std::istream* input,
                        std::ostream* output,
                        uint64_t pid,
-                       std::vector<uint64_t> timestamps,
+                       const std::vector<uint64_t>& timestamps,
                        bool annotate_frames);
 
 // 0: success
 int TraceToPerfProfile(std::istream* input,
                        std::ostream* output,
                        uint64_t pid,
-                       std::vector<uint64_t> timestamps,
+                       const std::vector<uint64_t>& timestamps,
                        bool annotate_frames);
 
 // 0: success

--- a/src/traced/probes/sys_stats/sys_stats_data_source.cc
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.cc
@@ -547,7 +547,7 @@ void SysStatsDataSource::ReadBuddyInfo(protos::pbzero::SysStats* sys_stats) {
     for (base::StringSplitter words(&lines, ' '); words.Next();) {
       if (index == 1) {
         std::string token = words.cur_token();
-        token = token.substr(0, token.find(","));
+        token.resize(token.find(","));
         buddy_info->set_node(token);
       } else if (index == 3) {
         buddy_info->set_zone(words.cur_token());

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -181,7 +181,7 @@ int32_t EncodeCommitDataRequest(ProducerID producer_id,
 }
 
 void SerializeAndAppendPacket(std::vector<TracePacket>* packets,
-                              std::vector<uint8_t> packet) {
+                              const std::vector<uint8_t>& packet) {
   Slice slice = Slice::Allocate(packet.size());
   memcpy(slice.own_data(), packet.data(), packet.size());
   packets->emplace_back();


### PR DESCRIPTION
This PR fixes many of the performance issues reported by cppcheck.

I have one question:
cppcheck mentions that using std::move() when returning by value prevents some compiler optimizations (copy elision).

Yet, the warning gets specifically mentioned as a code comment in
https://github.com/google/perfetto/blob/main/src/profiling/common/producer_support.cc#L48

Is there a reason for using `std::move` there?

To be fair, I saw `std::move` a couple times throughout the code I was fixing. I fixed some of the instances in this PR.