### PR TITLE
ui: support TS type definitions for embedders

### DIFF
--- a/ui/src/components/widgets/duration.ts
+++ b/ui/src/components/widgets/duration.ts
@@ -23,7 +23,7 @@ import {formatDuration} from '../time_utils';
 import {DurationPrecisionMenuItem} from './duration_precision_menu_items';
 import {TimestampFormatMenuItem} from './timestamp_format_menu';
 
-interface DurationWidgetAttrs {
+export interface DurationWidgetAttrs {
   trace: Trace;
   dur: duration;
   extraMenuItems?: m.Child[];

--- a/ui/src/components/widgets/sched.ts
+++ b/ui/src/components/widgets/sched.ts
@@ -18,7 +18,7 @@ import {Anchor} from '../../widgets/anchor';
 import {Icons} from '../../base/semantic_icons';
 import {Trace} from '../../public/trace';
 
-interface SchedRefAttrs {
+export interface SchedRefAttrs {
   readonly trace: Trace;
 
   // The id of the referenced sched slice in the sched_slice table.

--- a/ui/src/components/widgets/thread_state.ts
+++ b/ui/src/components/widgets/thread_state.ts
@@ -19,7 +19,7 @@ import {Icons} from '../../base/semantic_icons';
 import {ThreadState} from '../sql_utils/thread_state';
 import {Trace} from '../../public/trace';
 
-interface ThreadStateRefAttrs {
+export interface ThreadStateRefAttrs {
   readonly trace: Trace;
 
   id: ThreadStateSqlId;

--- a/ui/src/components/widgets/timestamp.ts
+++ b/ui/src/components/widgets/timestamp.ts
@@ -25,7 +25,7 @@ import {TimestampFormat} from '../../public/timeline';
 
 // import {MenuItem, PopupMenu2} from './menu';
 
-interface TimestampAttrs {
+export interface TimestampAttrs {
   trace: Trace;
   // The timestamp to print, this should be the absolute, raw timestamp as
   // found in trace processor.

--- a/ui/src/widgets/anchor.ts
+++ b/ui/src/widgets/anchor.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {HTMLAnchorAttrs} from './common';
 import {Icon} from './icon';
 
-interface AnchorAttrs extends HTMLAnchorAttrs {
+export interface AnchorAttrs extends HTMLAnchorAttrs {
   // Optional icon to show at the end of the content.
   icon?: string;
 }

--- a/ui/src/widgets/details_shell.ts
+++ b/ui/src/widgets/details_shell.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {classNames} from '../base/classnames';
 
-interface DetailsShellAttrs {
+export interface DetailsShellAttrs {
   // Additional class names to apply to the shell
   readonly className?: string;
   // Main title of the details shell.

--- a/ui/src/widgets/menu.ts
+++ b/ui/src/widgets/menu.ts
@@ -137,7 +137,7 @@ export class Menu implements m.ClassComponent<HTMLAttrs> {
   }
 }
 
-interface PopupMenuAttrs extends PopupAttrs {
+export interface PopupMenuAttrs extends PopupAttrs {
   // The trigger is mithril component which is used to toggle the popup when
   // clicked, and provides the anchor on the page which the popup shall hover
   // next to, and to which the popup's arrow shall point. The popup shall move

--- a/ui/src/widgets/spinner.ts
+++ b/ui/src/widgets/spinner.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {classNames} from '../base/classnames';
 
-interface SpinnerAttrs {
+export interface SpinnerAttrs {
   // Whether to use an ease-in-ease-out animation rather than a linear one.
   // Defaults to false.
   easing?: boolean;

--- a/ui/src/widgets/stack.ts
+++ b/ui/src/widgets/stack.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {classNames} from '../base/classnames';
 import {classForSpacing, HTMLAttrs, Spacing} from './common';
 
-interface StackAttrs extends HTMLAttrs {
+export interface StackAttrs extends HTMLAttrs {
   readonly orientation?: 'horizontal' | 'vertical';
   readonly fillHeight?: boolean;
   readonly spacing?: Spacing;

--- a/ui/tsconfig.base.json
+++ b/ui/tsconfig.base.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     // Lints and checks.
     "allowJs": true,
-    "declaration": false,                  // Generates corresponding '.d.ts' file.
+    "declaration": true,                   // Generates corresponding '.d.ts' file.
     "sourceMap": true,                     // Generates corresponding '.map' file.
     "inlineSources": true,                 // Adds source code to the '.map' file.
     "removeComments": false,               // Do not emit comments to output.

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -20,5 +20,8 @@
     },
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
   }
 }


### PR DESCRIPTION
An application that wishes to embed the Perfetto UI in its own UI may need to invoke various public (and non-public) APIs within Perfetto UI to achieve these ends. And when that embedding application is implemented in TypeScript, it needs TS definitions for those APIs.

This commit ensures consistent generation of TS type definition files, especially correcting missing exports of types that are exposed by other exported signatures.

Excised from PR #2337 for issue #2336.
