### PR TITLE
ui: return a trace promise from the openTraceFromXyz() APIs

### DIFF
--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -24,6 +24,7 @@ import {PageHandler} from '../public/page';
 import {Raf} from '../public/raf';
 import {RouteArg, RouteArgs} from '../public/route_schema';
 import {Setting, SettingDescriptor, SettingsManager} from '../public/settings';
+import {TraceStream} from '../public/stream';
 import {DurationPrecision, TimestampFormat} from '../public/timeline';
 import {NewEngineMode} from '../trace_processor/engine';
 import {AnalyticsInternal, initAnalytics} from './analytics_impl';
@@ -41,7 +42,6 @@ import {SidebarManagerImpl} from './sidebar_manager';
 import {SerializedAppState} from './state_serialization_schema';
 import {TraceContext, TraceImpl} from './trace_impl';
 import {TraceArrayBufferSource, TraceSource} from './trace_source';
-import {TraceStream} from './trace_stream';
 
 export type OpenTraceArrayBufArgs = Omit<
   Omit<TraceArrayBufferSource, 'type'>,

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -35,8 +35,8 @@ import {
   TraceFileStream,
   TraceHttpStream,
   TraceMultipleFilesStream,
-  TraceStream,
 } from '../core/trace_stream';
+import {TraceStream} from '../public/stream';
 import {
   deserializeAppStatePhase1,
   deserializeAppStatePhase2,

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -56,7 +56,7 @@ import {Setting, SettingDescriptor, SettingsManager} from '../public/settings';
 import {SettingsManagerImpl} from './settings_manager';
 import {MinimapManagerImpl} from './minimap_manager';
 import {isStartupCommandAllowed} from './startup_command_allowlist';
-import {TraceStream} from './trace_stream';
+import {TraceStream} from '../public/stream';
 
 /**
  * Handles the per-trace state of the UI

--- a/ui/src/core/trace_source.ts
+++ b/ui/src/core/trace_source.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {SerializedAppState} from './state_serialization_schema';
-import {TraceStream} from './trace_stream';
+import {TraceStream} from '../public/stream';
 
 interface CommonTraceProps {
   serializedAppState?: SerializedAppState;

--- a/ui/src/core/trace_stream.ts
+++ b/ui/src/core/trace_stream.ts
@@ -15,22 +15,9 @@
 import {defer, Deferred} from '../base/deferred';
 import {assertExists, assertTrue} from '../base/logging';
 import {exists} from '../base/utils';
+import {TraceChunk, TraceStream} from '../public/stream';
 
 export const TRACE_SLICE_SIZE = 32 * 1024 * 1024;
-
-// The object returned by TraceStream.readChunk() promise.
-export interface TraceChunk {
-  data: Uint8Array;
-  eof: boolean;
-  bytesRead: number;
-  bytesTotal: number;
-}
-
-// Base interface for loading trace data in chunks.
-// The caller has to call readChunk() until TraceChunk.eof == true.
-export interface TraceStream {
-  readChunk(): Promise<TraceChunk>;
-}
 
 // Loads a trace from a File object. For the "open file" use case.
 export class TraceFileStream implements TraceStream {

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -23,7 +23,7 @@ import {PageManager} from './page';
 import {FeatureFlagManager} from './feature_flag';
 import {Raf} from './raf';
 import {SettingsManager} from './settings';
-import {TraceStream} from '../core/trace_stream';
+import {TraceStream} from './stream';
 
 /**
  * The API endpoint to interact programmaticaly with the UI before a trace has

--- a/ui/src/public/stream.ts
+++ b/ui/src/public/stream.ts
@@ -1,0 +1,27 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The object returned by TraceStream.readChunk() promise.
+export interface TraceChunk {
+  data: Uint8Array;
+  eof: boolean;
+  bytesRead: number;
+  bytesTotal: number;
+}
+
+// Base interface for loading trace data in chunks.
+// The caller has to call readChunk() until TraceChunk.eof == true.
+export interface TraceStream {
+  readChunk(): Promise<TraceChunk>;
+}


### PR DESCRIPTION
Return promises of the future trace object to callers of the APIs on the App that open traces so that they may act upon the opened trace.

Also, an application that embeds the Perfetto UI may need to hand over a stream of trace data obtained in its own way from a non-URL source and not gathered into a buffer.

Excised from PR #2337 for issue #2336.
