### PR TITLE
buildtools: add x64 emscripten for macos

### DIFF
--- a/tools/install-build-deps
+++ b/tools/install-build-deps
@@ -443,7 +443,12 @@ UI_DEPS = [
         'buildtools/mac/emsdk.tgz',
         'https://storage.googleapis.com/perfetto/emscripten-4.0.8-mac.tgz',
         '2682c43580ae2265b4c7f3c7963629f7f501eb24a8ffa01be0059f9f5b3b8cd0',
-        'darwin', 'all'),
+        'darwin', 'arm64'),
+    Dependency(
+        'buildtools/mac/emsdk.tgz',
+        'https://storage.googleapis.com/perfetto/emscripten-4.0.8-mac-x64.tgz',
+        'e1b2e6d4797338ed884f9d8a8419f93fc42cfcdea5e8a8b29fe13c6fd3fe7f7a',
+        'darwin', 'x64'),
     Dependency(
         'buildtools/linux64/emsdk.tgz',
         'https://storage.googleapis.com/perfetto/emscripten-4.0.8-linux.tgz',


### PR DESCRIPTION
Turns out we were trying to use the arm64 binary on x64 which obviously
would not work as there's no "reverse Rosetta". Use the x64 version
where appropriate.

Fixes: https://github.com/google/perfetto/issues/3166
