### PR TITLE
temporarily disable custom descriptor loading due to bug

### DIFF
--- a/src/trace_processor/trace_processor_storage_impl.cc
+++ b/src/trace_processor/trace_processor_storage_impl.cc
@@ -56,12 +56,6 @@ TraceProcessorStorageImpl::TraceProcessorStorageImpl(const Config& cfg)
       kProtoTraceType);
   context()->reader_registry->RegisterTraceReader<ProtoTraceReader>(
       kSymbolsTraceType);
-  for (const std::string& raw_bytes : cfg.extra_parsing_descriptors) {
-    // We add to the main, shared pool.
-    context_.descriptor_pool_->AddFromFileDescriptorSet(
-        reinterpret_cast<const uint8_t*>(raw_bytes.data()), raw_bytes.size(),
-        {}, /*replace=*/true);
-  }
 }
 
 TraceProcessorStorageImpl::~TraceProcessorStorageImpl() {}


### PR DESCRIPTION
Bug has been found with new extra parsing descriptor feature. This PR is to rollback what is breaking normal trace viewing.
