### PR TITLE
traced_probes: Enable reading GPU frequency from the Intel xe driver.

### DIFF
--- a/src/traced/probes/sys_stats/sys_stats_data_source.cc
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.cc
@@ -190,6 +190,10 @@ SysStatsDataSource::SysStatsDataSource(
   thermal_ticks_ = ticks[8];
   cpuidle_ticks_ = ticks[9];
   gpufreq_ticks_ = ticks[10];
+
+  if (gpufreq_ticks_) {
+    OpenGpuFreqFiles(open_fn);
+  }
 }
 
 void SysStatsDataSource::Start() {
@@ -289,7 +293,13 @@ std::optional<uint64_t> SysStatsDataSource::ReadFileToUInt64(
   if (!fd) {
     return std::nullopt;
   }
-  size_t rsize = ReadFile(&fd, path.c_str());
+  return ReadFileToUInt64(&fd, path.c_str());
+}
+
+std::optional<uint64_t> SysStatsDataSource::ReadFileToUInt64(
+    base::ScopedFile* fd,
+    const char* path) {
+  size_t rsize = ReadFile(fd, path);
   if (!rsize)
     return std::nullopt;
 
@@ -381,13 +391,18 @@ void SysStatsDataSource::ReadCpuIdleStates(
   }
 }
 
-std::optional<uint64_t> SysStatsDataSource::ReadAMDGpuFreq() {
-  std::optional<std::string> amd_gpu_freq =
-      ReadFileToString("/sys/class/drm/card0/device/pp_dpm_sclk");
-  if (!amd_gpu_freq) {
+std::optional<uint64_t> SysStatsDataSource::ReadAmdGpuFreq() {
+  if (!amd_gpufreq_fd_) {
     return std::nullopt;
   }
-  for (base::StringSplitter lines(*amd_gpu_freq, '\n'); lines.Next();) {
+  size_t rsize =
+      ReadFile(&amd_gpufreq_fd_, "/sys/class/drm/card0/device/pp_dpm_sclk");
+  if (!rsize) {
+    return std::nullopt;
+  }
+
+  char* buf = static_cast<char*>(read_buf_.Get());
+  for (base::StringSplitter lines(buf, '\n'); lines.Next();) {
     base::StringView line(lines.cur_token(), lines.cur_token_size());
     // Current frequency indicated with asterisk.
     if (line.EndsWith("*")) {
@@ -406,25 +421,49 @@ std::optional<uint64_t> SysStatsDataSource::ReadAMDGpuFreq() {
 }
 
 void SysStatsDataSource::ReadGpuFrequency(protos::pbzero::SysStats* sys_stats) {
-  // For Adreno GPUs.
-  auto freq = ReadFileToUInt64("/sys/class/kgsl/kgsl-3d0/devfreq/cur_freq");
-  if (freq) {
+  if (adreno_gpufreq_fd_) {
+    auto freq = ReadFileToUInt64(&adreno_gpufreq_fd_,
+                                 "/sys/class/kgsl/kgsl-3d0/devfreq/cur_freq");
     sys_stats->add_gpufreq_mhz((*freq) / 1'000'000);
-    return;
   }
-
-  // For Intel GPUs.
-  freq = ReadFileToUInt64("/sys/class/drm/card0/gt_act_freq_mhz");
-  if (freq) {
-    sys_stats->add_gpufreq_mhz(*freq);
-    return;
+  for (auto& [fd, path] : intel_gpufreq_fds_) {
+    auto freq = ReadFileToUInt64(&fd, path.c_str());
+    if (freq) {
+      sys_stats->add_gpufreq_mhz((*freq));
+    }
   }
-
-  // For AMD GPUs.
-  freq = ReadAMDGpuFreq();
+  auto freq = ReadAmdGpuFreq();
   if (freq) {
     sys_stats->add_gpufreq_mhz(*freq);
   }
+}
+
+void SysStatsDataSource::OpenGpuFreqFiles(OpenFunction open_fn) {
+  for (size_t tile = 0;; ++tile) {
+    bool found = false;
+    for (size_t gt = 0;; ++gt) {
+      base::StackString<256> freq_path(
+          "/sys/class/drm/card0/device/tile%zu/gt%zu/freq0/act_freq", tile, gt);
+      auto fd = open_fn(freq_path.c_str());
+      if (fd) {
+        intel_gpufreq_fds_.emplace_back(std::move(fd), freq_path.ToStdString());
+        found = true;
+      } else {
+        break;
+      }
+    }
+    if (!found) {
+      break;
+    }
+  }
+
+  auto fd = open_fn("/sys/class/drm/card0/gt_act_freq_mhz");
+  if (fd) {
+    intel_gpufreq_fds_.emplace_back(std::move(fd),
+                                    "/sys/class/drm/card0/gt_act_freq_mhz");
+  }
+  amd_gpufreq_fd_ = open_fn("/sys/class/drm/card0/device/pp_dpm_sclk");
+  adreno_gpufreq_fd_ = open_fn("/sys/class/kgsl/kgsl-3d0/devfreq/cur_freq");
 }
 
 void SysStatsDataSource::ReadDiskStat(protos::pbzero::SysStats* sys_stats) {

--- a/src/traced/probes/sys_stats/sys_stats_data_source.h
+++ b/src/traced/probes/sys_stats/sys_stats_data_source.h
@@ -103,9 +103,12 @@ class SysStatsDataSource : public ProbesDataSource {
   void ReadThermalZones(protos::pbzero::SysStats* sys_stats);
   void ReadCpuIdleStates(protos::pbzero::SysStats* sys_stats);
   void ReadGpuFrequency(protos::pbzero::SysStats* sys_stats);
-  std::optional<uint64_t> ReadAMDGpuFreq();
+  std::optional<uint64_t> ReadAmdGpuFreq();
+
+  void OpenGpuFreqFiles(OpenFunction open_fn);
 
   size_t ReadFile(base::ScopedFile*, const char* path);
+  std::optional<uint64_t> ReadFileToUInt64(base::ScopedFile*, const char* path);
 
   base::TaskRunner* const task_runner_;
   std::unique_ptr<TraceWriter> writer_;
@@ -117,6 +120,9 @@ class SysStatsDataSource : public ProbesDataSource {
   base::ScopedFile psi_cpu_fd_;
   base::ScopedFile psi_io_fd_;
   base::ScopedFile psi_memory_fd_;
+  std::vector<std::pair<base::ScopedFile, std::string>> intel_gpufreq_fds_;
+  base::ScopedFile amd_gpufreq_fd_;
+  base::ScopedFile adreno_gpufreq_fd_;
   base::PagedMemory read_buf_;
   TraceWriter::TracePacketHandle cur_packet_;
   std::map<const char*, int, CStrCmp> meminfo_counters_;


### PR DESCRIPTION
The xe driver exposes GPU clock frequencies under a different path than the i915 driver. Further, it only exposes them at a per-tile/gt granularity, without a single global GPU frequency. Scan for all tiles and GTs reporting frequencies. Generate the potential paths manually rather than performing a directory scan to reduce the permissions required.

Also, refactor the GPU frequency polling to open the files once instead of for each poll to avoid unnecessary work and chatty error logging for each absent potential GPU frequency file.

Bug: 449028300
