### PR TITLE
metrics: Maintain original protobuf tag order

### DIFF
--- a/protos/perfetto/metrics/android/wattson_in_time_period.proto
+++ b/protos/perfetto/metrics/android/wattson_in_time_period.proto
@@ -25,12 +25,12 @@ message AndroidWattsonTimePeriodMetric {
   // might change for the exact same input. Don't compare estimates across
   // different power model versions.
   optional int32 power_model_version = 2;
+  repeated AndroidWattsonEstimateInfo period_info = 3;
   // Best effort power estimate made without all the essential traces, but with
   // enough information to make an educated extrapolation of a HW state. The
   // only example right now is for cpu_idle, of which the cpu_idle state can be
   // extrapolated from the swapper thread (aka idle thread).
-  optional bool is_crude_estimate = 3;
-  repeated AndroidWattsonEstimateInfo period_info = 4;
+  optional bool is_crude_estimate = 4;
 }
 
 message AndroidWattsonEstimateInfo {

--- a/protos/perfetto/metrics/android/wattson_tasks_attribution.proto
+++ b/protos/perfetto/metrics/android/wattson_tasks_attribution.proto
@@ -25,13 +25,13 @@ message AndroidWattsonTasksAttributionMetric {
   // might change for the exact same input. Don't compare estimates across
   // different power model versions.
   optional int32 power_model_version = 2;
+  // Lists tasks (e.g. threads, process, package) and associated estimates
+  repeated AndroidWattsonTaskPeriodInfo period_info = 3;
   // Best effort power estimate made without all the essential traces, but with
   // enough information to make an educated extrapolation of a HW state. The
   // only example right now is for cpu_idle, of which the cpu_idle state can be
   // extrapolated from the swapper thread (aka idle thread).
-  optional bool is_crude_estimate = 3;
-  // Lists tasks (e.g. threads, process, package) and associated estimates
-  repeated AndroidWattsonTaskPeriodInfo period_info = 4;
+  optional bool is_crude_estimate = 4;
 }
 
 // Groups of power per task for each period

--- a/protos/perfetto/metrics/perfetto_merged_metrics.proto
+++ b/protos/perfetto/metrics/perfetto_merged_metrics.proto
@@ -3150,12 +3150,12 @@ message AndroidWattsonTimePeriodMetric {
   // might change for the exact same input. Don't compare estimates across
   // different power model versions.
   optional int32 power_model_version = 2;
+  repeated AndroidWattsonEstimateInfo period_info = 3;
   // Best effort power estimate made without all the essential traces, but with
   // enough information to make an educated extrapolation of a HW state. The
   // only example right now is for cpu_idle, of which the cpu_idle state can be
   // extrapolated from the swapper thread (aka idle thread).
-  optional bool is_crude_estimate = 3;
-  repeated AndroidWattsonEstimateInfo period_info = 4;
+  optional bool is_crude_estimate = 4;
 }
 
 message AndroidWattsonEstimateInfo {
@@ -3220,13 +3220,13 @@ message AndroidWattsonTasksAttributionMetric {
   // might change for the exact same input. Don't compare estimates across
   // different power model versions.
   optional int32 power_model_version = 2;
+  // Lists tasks (e.g. threads, process, package) and associated estimates
+  repeated AndroidWattsonTaskPeriodInfo period_info = 3;
   // Best effort power estimate made without all the essential traces, but with
   // enough information to make an educated extrapolation of a HW state. The
   // only example right now is for cpu_idle, of which the cpu_idle state can be
   // extrapolated from the swapper thread (aka idle thread).
-  optional bool is_crude_estimate = 3;
-  // Lists tasks (e.g. threads, process, package) and associated estimates
-  repeated AndroidWattsonTaskPeriodInfo period_info = 4;
+  optional bool is_crude_estimate = 4;
 }
 
 // Groups of power per task for each period

--- a/python/perfetto/trace_processor/metrics.descriptor
+++ b/python/perfetto/trace_processor/metrics.descriptor
@@ -1537,10 +1537,10 @@ destBucket
 <protos/perfetto/metrics/android/wattson_in_time_period.protoperfetto.protos"ñ
 AndroidWattsonTimePeriodMetric%
 metric_version (RmetricVersion.
-power_model_version (RpowerModelVersion*
-is_crude_estimate (RisCrudeEstimateL
-period_info (2+.perfetto.protos.AndroidWattsonEstimateInfoR
-periodInfo"­
+power_model_version (RpowerModelVersionL
+period_info (2+.perfetto.protos.AndroidWattsonEstimateInfoR
+periodInfo*
+is_crude_estimate (RisCrudeEstimate"­
 AndroidWattsonEstimateInfo
 	period_id (RperiodId
 period_name (	R
@@ -1602,10 +1602,10 @@ period_dur (R	periodDurX
 ?protos/perfetto/metrics/android/wattson_tasks_attribution.protoperfetto.protos"ù
 $AndroidWattsonTasksAttributionMetric%
 metric_version (RmetricVersion.
-power_model_version (RpowerModelVersion*
-is_crude_estimate (RisCrudeEstimateN
-period_info (2-.perfetto.protos.AndroidWattsonTaskPeriodInfoR
-periodInfo"¢
+power_model_version (RpowerModelVersionN
+period_info (2-.perfetto.protos.AndroidWattsonTaskPeriodInfoR
+periodInfo*
+is_crude_estimate (RisCrudeEstimate"¢
 AndroidWattsonTaskPeriodInfo
 	period_id (RperiodId
 period_name (	R


### PR DESCRIPTION
Protobuf uses the tag order (e.g. = 1, = 2) and not the field name to identify fields. Revert back to the original tag order, and move the newly added tag (from https://github.com/google/perfetto/pull/3178) to be appended to the original tag order.

Some teams use the tag order and others use the field name to identify key-value pairs, so moving forward, both need to be consistent for backwards compatibility.

Bug: 371634124
Signed-off-by: Samuel Wu <wusamuel@google.com>