### PR TITLE
cleanup: more ftrace->tracefs renames

### DIFF
--- a/src/traced/probes/ftrace/cpu_reader_unittest.cc
+++ b/src/traced/probes/ftrace/cpu_reader_unittest.cc
@@ -144,7 +144,7 @@ class MockTracefs : public Tracefs {
 
 class CpuReaderTableTest : public ::testing::Test {
  protected:
-  NiceMock<MockTracefs> ftrace_;
+  NiceMock<MockTracefs> tracefs_;
 };
 
 // Single class to manage the whole protozero -> scattered stream -> chunks ->
@@ -1439,7 +1439,7 @@ TEST_F(CpuReaderTableTest, ParseAllFields) {
   PrintkMap printk_formats;
   printk_formats.insert(0xffffff8504f51b23, "my_printk_format_string");
   ProtoTranslationTable table(
-      &ftrace_, events, std::move(common_fields),
+      &tracefs_, events, std::move(common_fields),
       ProtoTranslationTable::DefaultPageHeaderSpecForTesting(),
       InvalidCompactSchedEventFormatForTesting(), printk_formats);
   FtraceDataSourceConfig ds_config = EmptyConfig();

--- a/src/traced/probes/ftrace/ftrace_config_muxer.cc
+++ b/src/traced/probes/ftrace/ftrace_config_muxer.cc
@@ -190,7 +190,7 @@ std::set<GroupAndName> FtraceConfigMuxer::GetFtraceEvents(
     std::string name;
     std::tie(group, name) = EventToStringGroupAndName(config_value);
     if (name == "*") {
-      for (const auto& event : ReadEventsInGroupFromFs(*ftrace_, group))
+      for (const auto& event : ReadEventsInGroupFromFs(*tracefs_, group))
         events.insert(event);
     } else if (group.empty()) {
       // If there is no group specified, find an event with that name and
@@ -249,7 +249,7 @@ std::set<GroupAndName> FtraceConfigMuxer::GetFtraceEvents(
   }
 
   // If throttle_rss_stat: true, use the rss_stat_throttled event if supported
-  if (request.throttle_rss_stat() && ftrace_->SupportsRssStatThrottled()) {
+  if (request.throttle_rss_stat() && tracefs_->SupportsRssStatThrottled()) {
     auto it = std::find_if(
         events.begin(), events.end(), [](const GroupAndName& event) {
           return event.group() == "kmem" && event.name() == "rss_stat";
@@ -340,7 +340,7 @@ bool FtraceConfigMuxer::SetSyscallEventFilter(
   }
 
   if (current_state_.syscall_filter != filter_set) {
-    if (!ftrace_->SetSyscallFilter(filter_set)) {
+    if (!tracefs_->SetSyscallFilter(filter_set)) {
       return false;
     }
 
@@ -363,7 +363,7 @@ void FtraceConfigMuxer::EnableFtraceEvent(const Event* event,
     filter->AddEnabledEvent(event->ftrace_event_id);
     return;
   }
-  if (ftrace_->EnableEvent(event->group, event->name)) {
+  if (tracefs_->EnableEvent(event->group, event->name)) {
     current_state_.ftrace_events.AddEnabledEvent(event->ftrace_event_id);
     filter->AddEnabledEvent(event->ftrace_event_id);
   } else {
@@ -374,14 +374,14 @@ void FtraceConfigMuxer::EnableFtraceEvent(const Event* event,
 }
 
 FtraceConfigMuxer::FtraceConfigMuxer(
-    Tracefs* ftrace,
+    Tracefs* tracefs,
     AtraceWrapper* atrace_wrapper,
     ProtoTranslationTable* table,
     SyscallTable syscalls,
     std::map<std::string, base::FlatSet<GroupAndName>> predefined_events,
     std::map<std::string, std::vector<GroupAndName>> vendor_events,
     bool secondary_instance)
-    : ftrace_(ftrace),
+    : tracefs_(tracefs),
       atrace_wrapper_(atrace_wrapper),
       table_(table),
       syscalls_(syscalls),
@@ -402,24 +402,24 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
     // If someone outside of perfetto is using a non-nop tracer, yield. We can't
     // realistically figure out all notions of "in use" even if we look at
     // set_event or events/enable, so this is all we check for.
-    if (!request.preserve_ftrace_buffer() && !ftrace_->IsTracingAvailable()) {
+    if (!request.preserve_ftrace_buffer() && !tracefs_->IsTracingAvailable()) {
       PERFETTO_ELOG(
           "ftrace in use by non-Perfetto. Check that %s current_tracer is nop.",
-          ftrace_->GetRootPath().c_str());
+          tracefs_->GetRootPath().c_str());
       return false;
     }
 
     // Clear tracefs state, remembering which value of "tracing_on" to restore
     // to after we're done, though we won't restore the rest of the tracefs
     // state.
-    current_state_.saved_tracing_on = ftrace_->GetTracingOn();
+    current_state_.saved_tracing_on = tracefs_->GetTracingOn();
     if (!request.preserve_ftrace_buffer()) {
-      ftrace_->SetTracingOn(false);
+      tracefs_->SetTracingOn(false);
       // Android: this will fail on release ("user") builds due to ACLs, but
       // that's acceptable since the per-event enabling/disabling should still
       // be balanced.
-      ftrace_->DisableAllEvents();
-      ftrace_->ClearTrace();
+      tracefs_->DisableAllEvents();
+      tracefs_->ClearTrace();
     }
 
     // Set up the new tracefs state, without starting recording.
@@ -457,7 +457,7 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
       tid_strings.push_back(std::to_string(tid));
     }
 
-    if (!ftrace_->SetEventTidFilter(tid_strings)) {
+    if (!tracefs_->SetEventTidFilter(tid_strings)) {
       PERFETTO_ELOG("Failed to set event tid filter");
       return false;
     }
@@ -480,7 +480,7 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
         return false;
       }
       // Get the current option state and save it for later.
-      auto option_state = ftrace_->GetTracefsOption(name);
+      auto option_state = tracefs_->GetTracefsOption(name);
       if (!option_state.has_value()) {
         PERFETTO_ELOG("Tracefs option not found: %s", name.c_str());
         return false;
@@ -489,7 +489,7 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
 
       bool new_state =
           tracefs_option.state() == FtraceConfig::TracefsOption::STATE_ENABLED;
-      if (!ftrace_->SetTracefsOption(name, new_state)) {
+      if (!tracefs_->SetTracefsOption(name, new_state)) {
         PERFETTO_ELOG("Failed to set tracefs option: %s", name.c_str());
         return false;
       }
@@ -498,12 +498,12 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
   }
 
   if (!request.tracing_cpumask().empty()) {
-    auto current_tracing_cpumask = ftrace_->GetTracingCpuMask();
+    auto current_tracing_cpumask = tracefs_->GetTracingCpuMask();
     if (!current_tracing_cpumask.has_value()) {
       PERFETTO_ELOG("Failed to get tracing cpumask");
       return false;
     }
-    if (!ftrace_->SetTracingCpuMask(request.tracing_cpumask())) {
+    if (!tracefs_->SetTracingCpuMask(request.tracing_cpumask())) {
       PERFETTO_ELOG("Failed to set tracing cpumask: %s",
                     request.tracing_cpumask().c_str());
       return false;
@@ -545,7 +545,7 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
       continue;
     }
     // Create kprobe in the kernel by writing to the tracefs.
-    if (!ftrace_->CreateKprobeEvent(
+    if (!tracefs_->CreateKprobeEvent(
             group_and_name.group(), group_and_name.name(),
             group_and_name.group() == kKretprobeGroup)) {
       PERFETTO_ELOG("Failed creation of kprobes event %s",
@@ -561,7 +561,8 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
     }
     if (!event || event->proto_field_id !=
                       protos::pbzero::FtraceEvent::kKprobeEventFieldNumber) {
-      ftrace_->RemoveKprobeEvent(group_and_name.group(), group_and_name.name());
+      tracefs_->RemoveKprobeEvent(group_and_name.group(),
+                                  group_and_name.name());
 
       PERFETTO_ELOG("Can't enable kprobe %s",
                     group_and_name.ToString().c_str());
@@ -627,32 +628,33 @@ bool FtraceConfigMuxer::SetupConfig(FtraceConfigId id,
   // steering in the parser), and we don't want to remove functions midway
   // through a trace (but some might get added).
   if (request.enable_function_graph()) {
-    if (!current_state_.funcgraph_on && !ftrace_->ClearFunctionFilters()) {
+    if (!current_state_.funcgraph_on && !tracefs_->ClearFunctionFilters()) {
       PERFETTO_PLOG("Failed to clear .../set_ftrace_filter");
       return false;
     }
-    if (!current_state_.funcgraph_on && !ftrace_->ClearFunctionGraphFilters()) {
+    if (!current_state_.funcgraph_on &&
+        !tracefs_->ClearFunctionGraphFilters()) {
       PERFETTO_PLOG("Failed to clear .../set_graph_function");
       return false;
     }
-    if (!current_state_.funcgraph_on && !ftrace_->ClearMaxGraphDepth()) {
+    if (!current_state_.funcgraph_on && !tracefs_->ClearMaxGraphDepth()) {
       PERFETTO_PLOG("Failed to clear .../max_graph_depth");
       return false;
     }
-    if (!ftrace_->AppendFunctionFilters(request.function_filters())) {
+    if (!tracefs_->AppendFunctionFilters(request.function_filters())) {
       PERFETTO_PLOG("Failed to append to .../set_ftrace_filter");
       return false;
     }
-    if (!ftrace_->AppendFunctionGraphFilters(request.function_graph_roots())) {
+    if (!tracefs_->AppendFunctionGraphFilters(request.function_graph_roots())) {
       PERFETTO_PLOG("Failed to append to .../set_graph_function");
       return false;
     }
-    if (!ftrace_->SetMaxGraphDepth(request.function_graph_max_depth())) {
+    if (!tracefs_->SetMaxGraphDepth(request.function_graph_max_depth())) {
       PERFETTO_PLOG("Failed to write to .../max_graph_depth");
       return false;
     }
     if (!current_state_.funcgraph_on &&
-        !ftrace_->SetCurrentTracer("function_graph")) {
+        !tracefs_->SetCurrentTracer("function_graph")) {
       PERFETTO_LOG(
           "Unable to enable function_graph tracing since a concurrent ftrace "
           "data source is using a different tracer");
@@ -723,7 +725,7 @@ bool FtraceConfigMuxer::ActivateConfig(FtraceConfigId id) {
 
   // Enable kernel event writer.
   if (first_config) {
-    if (!ftrace_->SetTracingOn(true)) {
+    if (!tracefs_->SetTracingOn(true)) {
       PERFETTO_ELOG("Failed to enable ftrace.");
       active_configs_.erase(id);
       return false;
@@ -784,7 +786,7 @@ bool FtraceConfigMuxer::RemoveConfig(FtraceConfigId config_id) {
     const Event* event = table_->GetEventById(id);
     // Any event that was enabled must exist.
     PERFETTO_DCHECK(event);
-    if (ftrace_->DisableEvent(event->group, event->name))
+    if (tracefs_->DisableEvent(event->group, event->name))
       current_state_.ftrace_events.DisableEvent(event->ftrace_event_id);
   }
 
@@ -795,7 +797,7 @@ bool FtraceConfigMuxer::RemoveConfig(FtraceConfigId config_id) {
       // This was the last active config for now, but potentially more dormant
       // configs need to be activated. We are not interested in reading while no
       // active configs so disable tracing_on here.
-      ftrace_->SetTracingOn(false);
+      tracefs_->SetTracingOn(false);
     }
   }
 
@@ -806,30 +808,30 @@ bool FtraceConfigMuxer::RemoveConfig(FtraceConfigId config_id) {
   // configs around. Tear down the rest of the ftrace config only if all
   // configs are removed.
   if (ds_configs_.empty()) {
-    if (ftrace_->SetCpuBufferSizeInPages(1))
+    if (tracefs_->SetCpuBufferSizeInPages(1))
       current_state_.cpu_buffer_size_pages = 1;
-    ftrace_->SetBufferPercent(50);
-    ftrace_->DisableAllEvents();
-    ftrace_->ClearTrace();
-    ftrace_->SetTracingOn(current_state_.saved_tracing_on);
+    tracefs_->SetBufferPercent(50);
+    tracefs_->DisableAllEvents();
+    tracefs_->ClearTrace();
+    tracefs_->SetTracingOn(current_state_.saved_tracing_on);
 
     // Kprobe cleanup cannot happen while we're still tracing as uninstalling
     // kprobes clears all tracing buffers in the kernel.
     for (const GroupAndName& probe : current_state_.installed_kprobes) {
-      ftrace_->RemoveKprobeEvent(probe.group(), probe.name());
+      tracefs_->RemoveKprobeEvent(probe.group(), probe.name());
       table_->RemoveEvent(probe);
     }
 
     if (current_state_.exclusive_feature_active) {
-      ftrace_->ClearEventTidFilter();
+      tracefs_->ClearEventTidFilter();
       if (current_state_.saved_tracing_cpumask.has_value()) {
-        ftrace_->SetTracingCpuMask(
+        tracefs_->SetTracingCpuMask(
             current_state_.saved_tracing_cpumask.value());
         current_state_.saved_tracing_cpumask.reset();
       }
       for (auto it = current_state_.saved_tracefs_options.GetIterator(); it;
            ++it) {
-        ftrace_->SetTracefsOption(it.key(), it.value());
+        tracefs_->SetTracefsOption(it.key(), it.value());
       }
       current_state_.saved_tracefs_options.Clear();
       current_state_.exclusive_feature_active = false;
@@ -869,16 +871,16 @@ bool FtraceConfigMuxer::RemoveConfig(FtraceConfigId config_id) {
 bool FtraceConfigMuxer::ResetCurrentTracer() {
   if (!current_state_.funcgraph_on)
     return true;
-  if (!ftrace_->ResetCurrentTracer()) {
+  if (!tracefs_->ResetCurrentTracer()) {
     PERFETTO_PLOG("Failed to reset current_tracer to nop");
     return false;
   }
   current_state_.funcgraph_on = false;
-  if (!ftrace_->ClearFunctionFilters()) {
+  if (!tracefs_->ClearFunctionFilters()) {
     PERFETTO_PLOG("Failed to reset set_ftrace_filter.");
     return false;
   }
-  if (!ftrace_->ClearFunctionGraphFilters()) {
+  if (!tracefs_->ClearFunctionGraphFilters()) {
     PERFETTO_PLOG("Failed to reset set_function_graph.");
     return false;
   }
@@ -893,19 +895,19 @@ const FtraceDataSourceConfig* FtraceConfigMuxer::GetDataSourceConfig(
 }
 
 void FtraceConfigMuxer::SetupClock(const FtraceConfig& config) {
-  std::set<std::string> clocks = ftrace_->AvailableClocks();
+  std::set<std::string> clocks = tracefs_->AvailableClocks();
 
   if (config.use_monotonic_raw_clock() && clocks.count(kClockMonoRaw)) {
-    ftrace_->SetClock(kClockMonoRaw);
+    tracefs_->SetClock(kClockMonoRaw);
   } else {
-    std::string current_clock = ftrace_->GetClock();
+    std::string current_clock = tracefs_->GetClock();
     for (size_t i = 0; i < base::ArraySize(kClocks); i++) {
       std::string clock = std::string(kClocks[i]);
       if (!clocks.count(clock))
         continue;
       if (current_clock == clock)
         break;
-      ftrace_->SetClock(clock);
+      tracefs_->SetClock(clock);
       break;
     }
   }
@@ -914,7 +916,7 @@ void FtraceConfigMuxer::SetupClock(const FtraceConfig& config) {
 }
 
 void FtraceConfigMuxer::RememberActiveClock() {
-  std::string current_clock = ftrace_->GetClock();
+  std::string current_clock = tracefs_->GetClock();
   namespace pb0 = protos::pbzero;
   if (current_clock == "boot") {
     // "boot" is the default expectation on modern kernels, which is why we
@@ -937,7 +939,7 @@ void FtraceConfigMuxer::SetupBufferSize(const FtraceConfig& request) {
   size_t pages = ComputeCpuBufferSizeInPages(request.buffer_size_kb(),
                                              request.buffer_size_lower_bound(),
                                              phys_ram_pages);
-  ftrace_->SetCpuBufferSizeInPages(pages);
+  tracefs_->SetCpuBufferSizeInPages(pages);
   current_state_.cpu_buffer_size_pages = pages;
 }
 
@@ -986,7 +988,7 @@ bool FtraceConfigMuxer::UpdateBufferPercent() {
   if (min_percent == kUnsetPercent)
     return true;
   // Let the kernel ignore values >100.
-  return ftrace_->SetBufferPercent(min_percent);
+  return tracefs_->SetBufferPercent(min_percent);
 }
 
 void FtraceConfigMuxer::UpdateAtrace(const FtraceConfig& request,

--- a/src/traced/probes/ftrace/ftrace_config_muxer.h
+++ b/src/traced/probes/ftrace/ftrace_config_muxer.h
@@ -135,7 +135,7 @@ class FtraceConfigMuxer {
   // The Tracefs and ProtoTranslationTable
   // should outlive this instance.
   FtraceConfigMuxer(
-      Tracefs* ftrace,
+      Tracefs* tracefs,
       AtraceWrapper* atrace_wrapper,
       ProtoTranslationTable* table,
       SyscallTable syscalls,
@@ -285,7 +285,7 @@ class FtraceConfigMuxer {
   // so the filter can be updated before ds_configs_.
   bool SetSyscallEventFilter(const EventFilter& extra_syscalls);
 
-  Tracefs* ftrace_;
+  Tracefs* tracefs_;
   AtraceWrapper* atrace_wrapper_;
   ProtoTranslationTable* table_;
   SyscallTable syscalls_;

--- a/src/traced/probes/ftrace/predefined_tracepoints.cc
+++ b/src/traced/probes/ftrace/predefined_tracepoints.cc
@@ -17,7 +17,6 @@
 #include "src/traced/probes/ftrace/predefined_tracepoints.h"
 
 #include <map>
-#include <set>
 
 #include "src/traced/probes/ftrace/proto_translation_table.h"
 #include "src/traced/probes/ftrace/tracefs.h"
@@ -418,24 +417,24 @@ GeneratePredefinedTracePoints(const ProtoTranslationTable* table,
 
 std::map<std::string, base::FlatSet<GroupAndName>> GetPredefinedTracePoints(
     const ProtoTranslationTable* table,
-    Tracefs* ftrace) {
-  return GeneratePredefinedTracePoints(table, ftrace);
+    Tracefs* tracefs) {
+  return GeneratePredefinedTracePoints(table, tracefs);
 }
 
 std::map<std::string, base::FlatSet<GroupAndName>>
 GetAccessiblePredefinedTracePoints(const ProtoTranslationTable* table,
-                                   Tracefs* ftrace) {
-  auto tracepoints = GetPredefinedTracePoints(table, ftrace);
+                                   Tracefs* tracefs) {
+  auto tracepoints = GetPredefinedTracePoints(table, tracefs);
 
-  bool generic_enable = ftrace->IsGenericSetEventWritable();
+  bool generic_enable = tracefs->IsGenericSetEventWritable();
 
   std::map<std::string, base::FlatSet<GroupAndName>> accessible_tracepoints;
   for (const auto& [category, events] : tracepoints) {
     base::FlatSet<GroupAndName> accessible_events;
     for (const auto& event : events) {
       if (generic_enable
-              ? ftrace->IsEventFormatReadable(event.group(), event.name())
-              : ftrace->IsEventAccessible(event.group(), event.name())) {
+              ? tracefs->IsEventFormatReadable(event.group(), event.name())
+              : tracefs->IsEventAccessible(event.group(), event.name())) {
         accessible_events.insert(event);
       }
     }

--- a/src/traced/probes/ftrace/predefined_tracepoints.h
+++ b/src/traced/probes/ftrace/predefined_tracepoints.h
@@ -18,18 +18,17 @@
 #define SRC_TRACED_PROBES_FTRACE_PREDEFINED_TRACEPOINTS_H_
 
 #include <map>
-#include <set>
 
 #include "src/traced/probes/ftrace/proto_translation_table.h"
 
 namespace perfetto::predefined_tracepoints {
 std::map<std::string, base::FlatSet<GroupAndName>> GetPredefinedTracePoints(
     const ProtoTranslationTable* table,
-    Tracefs* ftrace);
+    Tracefs* tracefs);
 
 std::map<std::string, base::FlatSet<GroupAndName>>
 GetAccessiblePredefinedTracePoints(const ProtoTranslationTable* table,
-                                   Tracefs* ftrace);
+                                   Tracefs* tracefs);
 
 }  // namespace perfetto::predefined_tracepoints
 

--- a/src/traced/probes/ftrace/vendor_tracepoints.h
+++ b/src/traced/probes/ftrace/vendor_tracepoints.h
@@ -36,7 +36,7 @@ constexpr const char* kCategoriesFile =
 // Returns a map from vendor category to events we should enable. Queries the
 // atrace HAL.
 std::map<std::string, std::vector<GroupAndName>>
-DiscoverVendorTracepointsWithHal(AtraceHalWrapper* hal, Tracefs* ftrace);
+DiscoverVendorTracepointsWithHal(AtraceHalWrapper* hal, Tracefs* tracefs);
 
 // Fills `*categories_map` with a map from vendor category to events we should
 // enable. Queries the vendor categories file at
@@ -51,7 +51,7 @@ base::Status DiscoverVendorTracepointsWithFile(
 base::Status DiscoverAccessibleVendorTracepointsWithFile(
     const std::string& vendor_atrace_categories_path,
     std::map<std::string, std::vector<GroupAndName>>* categories_map,
-    Tracefs* ftrace);
+    Tracefs* tracefs);
 
 }  // namespace vendor_tracepoints
 }  // namespace perfetto

--- a/src/traced/probes/probes_producer.h
+++ b/src/traced/probes/probes_producer.h
@@ -102,7 +102,7 @@ class ProbesProducer : public Producer, public FtraceController::Observer {
   State state_ = kNotStarted;
   base::TaskRunner* task_runner_ = nullptr;
   std::unique_ptr<TracingService::ProducerEndpoint> endpoint_;
-  std::unique_ptr<FtraceController> ftrace_;
+  std::unique_ptr<FtraceController> ftrace_controller_;
   bool ftrace_creation_failed_ = false;
   uint32_t connection_backoff_ms_ = 0;
   const char* socket_name_ = nullptr;


### PR DESCRIPTION
Using "tracefs" is both more accurate, and less ambiguous when referring
to the virtual filesystem. Hence more "ftrace_" -> "tracefs_" renames.

One exception is probes_producer, where I renamed ftrace_ to 
ftrace_controller_ (as it's a different type).