### PR TITLE
ui: fix sidebar accidentally opening links on a new window

### DIFF
--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -482,6 +482,7 @@ export class Sidebar implements m.ClassComponent<OptionalTraceImplAttrs> {
     }
     return m(
       'li',
+      {key: item.id}, // This is to work around a mithril bug (b/449784590).
       m(
         'a',
         {


### PR DESCRIPTION
This is a workaround for a mithril bug.
The bug is somewhere in the logic that recycles DOM nodes and applies the differences.

If you flip back and forth between null and '_blank' eventually
mithril will get in a weird state and promote null to 'null'.

The minified repro is the following:
    cnt++;
    const repro =[
      m('a', {href: '#', target: null}, 'one'),
      m('a', {href: '#', target: (cnt % 2 == 0) ? null : '_blank'}, 'two'),
      m('a', {href: '#', target: null}, 'three'),
    ];
After 2 render passes the second entry becomes target="null"

Bug: b/449784590