### PR TITLE
ui: remove tooltip for trace name for copying

### DIFF
--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -588,7 +588,6 @@ function registerTraceMenuItems(trace: TraceImpl) {
       action: () => {
         // Do nothing (we need to supply an action to override the href).
       },
-      tooltip: 'Click to copy the URL',
       cssClass: 'pf-sidebar__trace-file-name',
     });
   trace.sidebar.addMenuItem({


### PR DESCRIPTION
This was removed in https://github.com/google/perfetto/pull/2979
