### PR TITLE
Revert "Support clone operation for 'write_into_file' sessions. (#2871)"

### DIFF
--- a/include/perfetto/ext/tracing/core/consumer.h
+++ b/include/perfetto/ext/tracing/core/consumer.h
@@ -86,7 +86,6 @@ class PERFETTO_EXPORT_COMPONENT Consumer {
     bool success;
     std::string error;
     base::Uuid uuid;  // UUID of the cloned session.
-    bool was_write_into_file;
   };
   virtual void OnSessionCloned(const OnSessionClonedArgs&);
 };

--- a/include/perfetto/ext/tracing/core/tracing_service.h
+++ b/include/perfetto/ext/tracing/core/tracing_service.h
@@ -226,11 +226,6 @@ class PERFETTO_EXPORT_COMPONENT ConsumerEndpoint {
     // If not zero, this is stored in the trace as the configured delay (in
     // milliseconds) of the trigger that caused the clone.
     uint64_t clone_trigger_delay_ms = 0;
-
-    // If valid, and the session that should be cloned is 'write_into_file'
-    // session, traced writes the cloned session content to this file
-    // descriptor, instead of writing it in the cloned session buffers.
-    base::ScopedFile output_file_fd;
   };
   virtual void CloneSession(CloneSessionArgs) = 0;
 

--- a/protos/perfetto/ipc/consumer_port.proto
+++ b/protos/perfetto/ipc/consumer_port.proto
@@ -322,10 +322,6 @@ message CloneSessionRequest {
   // If set, this is stored in the trace as the configured delay of the trigger
   // that caused the clone.
   optional uint64 clone_trigger_delay_ms = 9;
-  // Consumer may also send a file descriptor with this rpc message. If the
-  // descriptor is valid, and the session that should be cloned is
-  // 'write_into_file' session, traced writes the cloned session content to that
-  // file descriptor, instead of writing it in the cloned session buffers.
 }
 
 message CloneSessionResponse {
@@ -337,9 +333,4 @@ message CloneSessionResponse {
   // The UUID of the cloned session.
   optional int64 uuid_msb = 3;
   optional int64 uuid_lsb = 4;
-
-  // TracingService sets this when the cloned session was write_into_file=true.
-  // The consumer cannot know upfront if a session is WIF or not.
-  // Introduced in v53.
-  optional bool was_write_into_file = 5;
 }

--- a/src/perfetto_cmd/perfetto_cmd.cc
+++ b/src/perfetto_cmd/perfetto_cmd.cc
@@ -1039,15 +1039,6 @@ void PerfettoCmd::OnConnect() {
       args.clone_trigger_boot_time_ns = snapshot_trigger_info_->boot_time_ns;
       args.clone_trigger_delay_ms = snapshot_trigger_info_->trigger_delay_ms;
     }
-
-    if (trace_out_stream_) {
-      // We always send the file descriptor to the traced, because perfetto_cmd
-      // doesn't know if the session to clone is 'write_into_file' session.
-      // traced decides weither it writes the cloned buffers to this file
-      // descriptor or send them to the perfetto_cmd.
-      args.output_file_fd = base::ScopedFile(dup(fileno(*trace_out_stream_)));
-    }
-
     consumer_endpoint_->CloneSession(std::move(args));
     return;
   }
@@ -1177,8 +1168,9 @@ void PerfettoCmd::ReadbackTraceDataAndQuit(const std::string& error) {
   // and we don't want to log anything after that.
   LogUploadEvent(PerfettoStatsdAtom::kOnTracingDisabled);
 
-  if (trace_config_->write_into_file() || cloned_session_was_write_into_file_) {
-    // At this point the passed file already contains all the packets.
+  if (trace_config_->write_into_file()) {
+    // If write_into_file == true, at this point the passed file contains
+    // already all the packets.
     return FinalizeTraceAndExit();
   }
 
@@ -1361,8 +1353,6 @@ void PerfettoCmd::OnSessionCloned(const OnSessionClonedArgs& args) {
     LogUploadEvent(PerfettoStatsdAtom::kCmdOnTriggerSessionClone,
                    snapshot_trigger_info_->trigger_name);
   }
-
-  cloned_session_was_write_into_file_ = args.was_write_into_file;
   ReadbackTraceDataAndQuit(full_error);
 }
 

--- a/src/perfetto_cmd/perfetto_cmd.h
+++ b/src/perfetto_cmd/perfetto_cmd.h
@@ -183,7 +183,6 @@ class PerfettoCmd : public Consumer {
   std::string clone_name_;
   bool clone_for_bugreport_ = false;
   std::function<void()> on_session_cloned_;
-  bool cloned_session_was_write_into_file_ = false;
 
   // How long we expect to trace for or 0 if the trace is indefinite.
   uint32_t expected_duration_ms_ = 0;

--- a/src/tracing/internal/tracing_muxer_impl.cc
+++ b/src/tracing/internal/tracing_muxer_impl.cc
@@ -464,7 +464,7 @@ void TracingMuxerImpl::ConsumerImpl::OnConnect() {
     muxer_->QueryServiceState(session_id_, std::move(callback));
   }
   if (session_to_clone_) {
-    service_->CloneSession(std::move(*session_to_clone_));
+    service_->CloneSession(*session_to_clone_);
     session_to_clone_ = std::nullopt;
   }
 
@@ -1989,14 +1989,14 @@ void TracingMuxerImpl::CloneTracingSession(
   // Multiple concurrent cloning isn't supported.
   PERFETTO_DCHECK(!consumer->clone_trace_callback_);
   consumer->clone_trace_callback_ = std::move(callback);
-  ConsumerEndpoint::CloneSessionArgs consumer_args;
+  ConsumerEndpoint::CloneSessionArgs consumer_args{};
   consumer_args.unique_session_name = args.unique_session_name;
   if (!consumer->connected_) {
     consumer->session_to_clone_ = std::move(consumer_args);
     return;
   }
   consumer->session_to_clone_ = std::nullopt;
-  consumer->service_->CloneSession(std::move(consumer_args));
+  consumer->service_->CloneSession(consumer_args);
 }
 
 void TracingMuxerImpl::ChangeTracingSessionConfig(

--- a/src/tracing/ipc/consumer/consumer_ipc_client_impl.cc
+++ b/src/tracing/ipc/consumer/consumer_ipc_client_impl.cc
@@ -470,16 +470,6 @@ void ConsumerIPCClientImpl::CloneSession(CloneSessionArgs args) {
     return;
   }
 
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-  if (args.output_file_fd) {
-    consumer_->OnSessionCloned(
-        {false,
-         "Passing FDs into CloneSession is not supported on Windows",
-         {}});
-    return;
-  }
-#endif
-
   protos::gen::CloneSessionRequest req;
   if (args.tsid) {
     req.set_session_id(args.tsid);
@@ -517,17 +507,13 @@ void ConsumerIPCClientImpl::CloneSession(CloneSessionArgs args) {
           // If the IPC fails, we are talking to an older version of the service
           // that didn't support CloneSession at all.
           weak_this->consumer_->OnSessionCloned(
-              {false, "CloneSession IPC not supported", {}, false});
+              {false, "CloneSession IPC not supported", {}});
         } else {
           base::Uuid uuid(response->uuid_lsb(), response->uuid_msb());
           weak_this->consumer_->OnSessionCloned(
-              {response->success(), response->error(), uuid,
-               response->was_write_into_file()});
+              {response->success(), response->error(), uuid});
         }
       });
-  // |args.output_file_fd| will be closed when this function returns, but it's
-  // fine because the IPC layer dup()'s it when sending the IPC.
-  consumer_port_.CloneSession(req, std::move(async_response),
-                              *args.output_file_fd);
+  consumer_port_.CloneSession(req, std::move(async_response));
 }
 }  // namespace perfetto

--- a/src/tracing/ipc/service/consumer_ipc_service.cc
+++ b/src/tracing/ipc/service/consumer_ipc_service.cc
@@ -355,9 +355,6 @@ void ConsumerIPCService::CloneSession(
   if (req.has_clone_trigger_delay_ms()) {
     args.clone_trigger_delay_ms = req.clone_trigger_delay_ms();
   }
-  // The client (perfetto_cmd) always sends the file descriptor, but the traced
-  // uses it only if the session to clone is 'write_into_file' session.
-  args.output_file_fd = ipc::Service::TakeReceivedFD();
   remote_consumer->service_endpoint->CloneSession(std::move(args));
 }
 
@@ -520,7 +517,6 @@ void ConsumerIPCService::RemoteConsumer::OnSessionCloned(
   resp->set_error(args.error);
   resp->set_uuid_msb(args.uuid.msb());
   resp->set_uuid_lsb(args.uuid.lsb());
-  resp->set_was_write_into_file(args.was_write_into_file);
   std::move(clone_session_response).Resolve(std::move(resp));
 }
 

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -53,7 +53,6 @@
 #include "perfetto/ext/base/android_utils.h"
 #include "perfetto/ext/base/clock_snapshots.h"
 #include "perfetto/ext/base/file_utils.h"
-#include "perfetto/ext/base/flags.h"
 #include "perfetto/ext/base/metatrace.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
@@ -2880,7 +2879,7 @@ void TracingServiceImpl::FreeBuffers(TracingSessionID tsid,
           [weak_consumer = clone_op.weak_consumer] {
             if (weak_consumer) {
               weak_consumer->consumer_->OnSessionCloned(
-                  {false, "Original session ended", {}, false});
+                  {false, "Original session ended", {}});
             }
           });
     }
@@ -4141,38 +4140,6 @@ base::Status TracingServiceImpl::FlushAndCloneSession(
     return PERFETTO_SVC_ERR("Not allowed to clone a session from another UID");
   }
 
-  // The new logic we use to clone 'write_into_file' session relies on the
-  // 'buffer_clone_preserve_read_iter' flag being true; see b/448604718.
-  //
-  // The old logic ignored |session->write_into_file| when doing clone.
-  // Therefore, if the 'buffer_clone_preserve_read_iter' flag is false, we
-  // ignore the file to make the new logic behave like the old logic.
-  bool clone_session_write_into_file =
-      base::flags::buffer_clone_preserve_read_iter && session->write_into_file;
-
-  if (clone_session_write_into_file) {
-    if (!args.output_file_fd) {
-      return PERFETTO_SVC_ERR(
-          "Failed to clone 'write_into_file' session: a file descriptor is "
-          "required to copy existing file");
-    }
-    base::FlushFile(*session->write_into_file);
-    base::Status status =
-        base::CopyFileContents(*session->write_into_file, *args.output_file_fd);
-    if (!status.ok()) {
-      return PERFETTO_SVC_ERR(
-          "Failed to clone 'write_into_file' session: failed to copy existing "
-          "file: %s",
-          status.c_message());
-    }
-  } else {
-    // The client always sends a FD because when it asks to CloneSession,
-    // it doesn't know if the session being cloned is WIF or not. If it's
-    // not we should just ignore the file, the client will readback via IPC
-    // as usual in that case.
-    args.output_file_fd.reset();
-  }
-
   // If any of the buffers are marked as clear_before_clone, reset them before
   // issuing the Flush(kCloneReason).
   size_t buf_idx = 0;
@@ -4224,9 +4191,6 @@ base::Status TracingServiceImpl::FlushAndCloneSession(
         args.clone_trigger_boot_time_ns, args.clone_trigger_name,
         args.clone_trigger_producer_name,
         args.clone_trigger_trusted_producer_uid, args.clone_trigger_delay_ms};
-  }
-  if (args.output_file_fd) {
-    clone_op.output_file_fd = std::move(args.output_file_fd);
   }
 
   // Issue separate flush requests for separate buffer groups. The buffer marked
@@ -4314,7 +4278,6 @@ void TracingServiceImpl::OnFlushDoneForClone(TracingSessionID tsid,
     result = PERFETTO_SVC_ERR("Buffer allocation failed");
   }
 
-  bool was_write_into_file = false;
   if (result.ok()) {
     UpdateMemoryGuardrail();
 
@@ -4327,19 +4290,17 @@ void TracingServiceImpl::OnFlushDoneForClone(TracingSessionID tsid,
                  final_flush_outcome);
 
     if (clone_op.weak_consumer) {
-      was_write_into_file = static_cast<bool>(clone_op.output_file_fd);
       result = FinishCloneSession(
           &*clone_op.weak_consumer, tsid, std::move(clone_op.buffers),
           std::move(clone_op.buffer_cloned_timestamps),
           clone_op.skip_trace_filter, !clone_op.flush_failed,
-          clone_op.clone_trigger, &uuid, clone_op.clone_started_timestamp_ns,
-          std::move(clone_op.output_file_fd));
+          clone_op.clone_trigger, &uuid, clone_op.clone_started_timestamp_ns);
     }
   }  // if (result.ok())
 
   if (clone_op.weak_consumer) {
     clone_op.weak_consumer->consumer_->OnSessionCloned(
-        {result.ok(), result.message(), uuid, was_write_into_file});
+        {result.ok(), result.message(), uuid});
   }
 
   src->pending_clones.erase(it);
@@ -4394,8 +4355,7 @@ base::Status TracingServiceImpl::FinishCloneSession(
     bool final_flush_outcome,
     std::optional<TriggerInfo> clone_trigger,
     base::Uuid* new_uuid,
-    int64_t clone_started_timestamp_ns,
-    base::ScopedFile output_file_fd) {
+    int64_t clone_started_timestamp_ns) {
   PERFETTO_DLOG("CloneSession(%" PRIu64
                 ", skip_trace_filter=%d) started, consumer uid: %d",
                 src_tsid, skip_trace_filter, static_cast<int>(consumer->uid_));
@@ -4502,12 +4462,6 @@ base::Status TracingServiceImpl::FinishCloneSession(
   cloned_session->final_flush_outcome = final_flush_outcome
                                             ? TraceStats::FINAL_FLUSH_SUCCEEDED
                                             : TraceStats::FINAL_FLUSH_FAILED;
-  if (output_file_fd) {
-    cloned_session->write_into_file = std::move(output_file_fd);
-    cloned_session->write_period_ms = 0;
-    ReadBuffersIntoFile(cloned_session->id);
-  }
-
   return base::OkStatus();
 }
 
@@ -4873,7 +4827,7 @@ void TracingServiceImpl::ConsumerEndpointImpl::CloneSession(
   base::Status result = service_->FlushAndCloneSession(this, std::move(args));
 
   if (!result.ok()) {
-    consumer_->OnSessionCloned({false, result.message(), {}, false});
+    consumer_->OnSessionCloned({false, result.message(), {}});
   }
 }
 

--- a/src/tracing/service/tracing_service_impl.h
+++ b/src/tracing/service/tracing_service_impl.h
@@ -508,7 +508,6 @@ class TracingServiceImpl : public TracingService {
     bool skip_trace_filter = false;
     std::optional<TriggerInfo> clone_trigger;
     int64_t clone_started_timestamp_ns = 0;
-    base::ScopedFile output_file_fd;
   };
 
   // Holds the state of a tracing session. A tracing session is uniquely bound
@@ -872,8 +871,7 @@ class TracingServiceImpl : public TracingService {
                                   bool final_flush_outcome,
                                   std::optional<TriggerInfo> clone_trigger,
                                   base::Uuid*,
-                                  int64_t clone_started_timestamp_ns,
-                                  base::ScopedFile output_file_fd);
+                                  int64_t clone_started_timestamp_ns);
   void OnFlushDoneForClone(TracingSessionID src_tsid,
                            PendingCloneID clone_id,
                            const std::set<BufferID>& buf_ids,

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -33,7 +33,6 @@
 #include "perfetto/base/proc_utils.h"
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/file_utils.h"
-#include "perfetto/ext/base/flags.h"
 #include "perfetto/ext/base/pipe.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/sys_types.h"
@@ -143,13 +142,6 @@ MATCHER_P(HasTriggerMode, mode, "") {
   return HasTriggerModeInternal(arg, mode);
 }
 
-MATCHER_P(HasLifecycleField, field, "") {
-  return ExplainMatchResult(
-      Contains(Property(&protos::gen::TracePacket::service_event,
-                        Property(field, Eq(true)))),
-      arg, result_listener);
-}
-
 MATCHER_P(LowerCase,
           m,
           "Lower case " + testing::DescribeMatcher<std::string>(m, negation)) {
@@ -212,27 +204,6 @@ std::vector<std::string> GetReceivedTriggers(
     }
   }
   return triggers;
-}
-
-std::vector<std::string> GetForTestingStrings(
-    const std::vector<protos::gen::TracePacket>& trace) {
-  std::vector<std::string> strings;
-  for (const protos::gen::TracePacket& packet : trace) {
-    if (packet.has_for_testing()) {
-      strings.push_back(packet.for_testing().str());
-    }
-  }
-  return strings;
-}
-
-bool ParseNotEmptyTraceFromFile(base::TempFile& trace_file,
-                                protos::gen::Trace& out) {
-  std::string trace_str;
-  if (!base::ReadFile(trace_file.path(), &trace_str))
-    return false;
-  if (trace_str.empty())
-    return false;
-  return out.ParseFromString(trace_str);
 }
 
 class MockClock : public tracing_service::Clock {
@@ -2277,374 +2248,6 @@ TEST_F(TracingServiceImplTest, WriteIntoFileWithPath) {
               Contains(Property(
                   &protos::gen::TracePacket::for_testing,
                   Property(&protos::gen::TestEvent::str, Eq("payload")))));
-}
-
-TEST_F(TracingServiceImplTest, WriteIntoFileCloneSessionBeforeWrite) {
-  if (!base::flags::buffer_clone_preserve_read_iter) {
-    GTEST_SKIP() << "This test requires buffer_clone_preserve_read_iter=true";
-  }
-
-  auto write_into_file_session_file = base::TempFile::Create();
-  auto cloned_session_file = base::TempFile::Create();
-
-  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
-  consumer->Connect(svc.get());
-
-  std::unique_ptr<MockConsumer> clone_consumer = CreateMockConsumer();
-  clone_consumer->Connect(svc.get());
-
-  std::unique_ptr<MockProducer> producer = CreateMockProducer();
-  producer->Connect(svc.get(), "mock_producer");
-  producer->RegisterDataSource("data_source");
-
-  TraceConfig trace_config;
-  trace_config.add_buffers()->set_size_kb(128);
-  trace_config.add_data_sources()->mutable_config()->set_name("data_source");
-  trace_config.set_write_into_file(true);
-  trace_config.set_file_write_period_ms(100000);  // 100s
-
-  consumer->EnableTracing(
-      trace_config, base::ScopedFile(dup(write_into_file_session_file.fd())));
-
-  producer->WaitForTracingSetup();
-  producer->WaitForDataSourceSetup("data_source");
-  producer->WaitForDataSourceStart("data_source");
-
-  std::unique_ptr<TraceWriter> writer =
-      producer->CreateTraceWriter("data_source");
-  {
-    auto tp = writer->NewTracePacket();
-    tp->set_for_testing()->set_str("payload #1");
-  }
-  // Don't flush, keep data in the producer buffer.
-
-  auto clone_done = task_runner.CreateCheckpoint("clone_done");
-  EXPECT_CALL(*clone_consumer, OnSessionCloned(_))
-      .WillOnce([clone_done](const Consumer::OnSessionClonedArgs& args) {
-        ASSERT_TRUE(args.success);
-        ASSERT_TRUE(args.error.empty());
-        clone_done();
-      });
-  ConsumerEndpoint::CloneSessionArgs clone_args;
-  clone_args.tsid = GetLastTracingSessionId(consumer.get());
-  clone_args.output_file_fd = base::ScopedFile(dup(cloned_session_file.fd()));
-  clone_consumer->endpoint()->CloneSession(std::move(clone_args));
-  producer->ExpectFlush(writer.get());
-  task_runner.RunUntilCheckpoint("clone_done");
-
-  // Assert that clone doesn't trigger 'write_into_file' session to write it
-  // buffers to file.
-  ASSERT_EQ(base::GetFileSize(write_into_file_session_file.path()).value_or(-1),
-            0ul);
-
-  // ReadBuffers returns single service event, all the data is already written
-  // into the file.
-  auto clone_consumer_buffers = clone_consumer->ReadBuffers();
-  EXPECT_EQ(clone_consumer_buffers.size(), 1ul);
-  EXPECT_THAT(
-      clone_consumer_buffers,
-      HasLifecycleField(
-          &protos::gen::TracingServiceEvent::read_tracing_buffers_completed));
-
-  // Verify the content of the cloned session output file.
-  {
-    protos::gen::Trace trace;
-    ASSERT_TRUE(ParseNotEmptyTraceFromFile(cloned_session_file, trace));
-    EXPECT_THAT(GetForTestingStrings(trace.packet()),
-                ElementsAre("payload #1"));
-  }
-
-  // Write more data to the 'write_into_file' session after the clone.
-  {
-    auto tp = writer->NewTracePacket();
-    tp->set_for_testing()->set_str("payload #2");
-  }
-  writer->Flush();
-  writer.reset();
-
-  consumer->DisableTracing();
-  producer->WaitForDataSourceStop("data_source");
-  consumer->WaitForTracingDisabled();
-
-  {
-    protos::gen::Trace trace;
-    ASSERT_TRUE(
-        ParseNotEmptyTraceFromFile(write_into_file_session_file, trace));
-    EXPECT_THAT(GetForTestingStrings(trace.packet()),
-                ElementsAre("payload #1", "payload #2"));
-  }
-}
-
-TEST_F(TracingServiceImplTest, WriteIntoFileCloneSessionAfterWrite) {
-  if (!base::flags::buffer_clone_preserve_read_iter) {
-    GTEST_SKIP() << "This test requires buffer_clone_preserve_read_iter=true";
-  }
-
-  auto write_into_file_session_file = base::TempFile::Create();
-  auto cloned_session_file = base::TempFile::Create();
-
-  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
-  consumer->Connect(svc.get());
-
-  std::unique_ptr<MockConsumer> clone_consumer = CreateMockConsumer();
-  clone_consumer->Connect(svc.get());
-
-  std::unique_ptr<MockProducer> producer = CreateMockProducer();
-  producer->Connect(svc.get(), "mock_producer");
-  producer->RegisterDataSource("data_source");
-
-  TraceConfig trace_config;
-  trace_config.add_buffers()->set_size_kb(128);
-  trace_config.add_data_sources()->mutable_config()->set_name("data_source");
-  trace_config.set_write_into_file(true);
-  trace_config.set_file_write_period_ms(100000);  // 100s
-
-  consumer->EnableTracing(
-      trace_config, base::ScopedFile(dup(write_into_file_session_file.fd())));
-
-  producer->WaitForTracingSetup();
-  producer->WaitForDataSourceSetup("data_source");
-  producer->WaitForDataSourceStart("data_source");
-
-  std::unique_ptr<TraceWriter> writer =
-      producer->CreateTraceWriter("data_source");
-  {
-    auto tp = writer->NewTracePacket();
-    tp->set_for_testing()->set_str("payload #1");
-  }
-  writer->Flush();
-
-  // Advance timer, traced should write the data to the 'write_into_file'
-  // session output file.
-  AdvanceTimeAndRunUntilIdle(trace_config.file_write_period_ms());
-
-  {
-    auto tp = writer->NewTracePacket();
-    tp->set_for_testing()->set_str("payload #2");
-  }
-  writer->Flush();
-
-  // At this moment we have only 'payload #1' written into file.
-  {
-    protos::gen::Trace trace;
-    ASSERT_TRUE(
-        ParseNotEmptyTraceFromFile(write_into_file_session_file, trace));
-    EXPECT_THAT(GetForTestingStrings(trace.packet()),
-                ElementsAre("payload #1"));
-  }
-
-  // Now do the clone, cloned session should contains data both from the
-  // 'write_into_file' session output file and the session buffers.
-  auto clone_done = task_runner.CreateCheckpoint("clone_done");
-  EXPECT_CALL(*clone_consumer, OnSessionCloned(_))
-      .WillOnce([clone_done](const Consumer::OnSessionClonedArgs& args) {
-        ASSERT_TRUE(args.success);
-        ASSERT_TRUE(args.error.empty());
-        clone_done();
-      });
-  ConsumerEndpoint::CloneSessionArgs clone_args;
-  clone_args.tsid = GetLastTracingSessionId(consumer.get());
-  clone_args.output_file_fd = base::ScopedFile(dup(cloned_session_file.fd()));
-  clone_consumer->endpoint()->CloneSession(std::move(clone_args));
-  producer->ExpectFlush(writer.get());
-  task_runner.RunUntilCheckpoint("clone_done");
-
-  // ReadBuffers returns single service event, all the data is already written
-  // into the file.
-  auto clone_consumer_buffers = clone_consumer->ReadBuffers();
-  EXPECT_EQ(clone_consumer_buffers.size(), 1ul);
-  EXPECT_THAT(
-      clone_consumer_buffers,
-      HasLifecycleField(
-          &protos::gen::TracingServiceEvent::read_tracing_buffers_completed));
-
-  // Verify the content of the cloned session output file.
-  {
-    protos::gen::Trace trace;
-    ASSERT_TRUE(ParseNotEmptyTraceFromFile(cloned_session_file, trace));
-    EXPECT_THAT(GetForTestingStrings(trace.packet()),
-                ElementsAre("payload #1", "payload #2"));
-  }
-  clone_consumer->FreeBuffers();
-
-  writer.reset();
-  consumer->DisableTracing();
-  producer->WaitForDataSourceStop("data_source");
-  consumer->WaitForTracingDisabled();
-
-  {
-    protos::gen::Trace trace;
-    ASSERT_TRUE(
-        ParseNotEmptyTraceFromFile(write_into_file_session_file, trace));
-    EXPECT_THAT(GetForTestingStrings(trace.packet()),
-                ElementsAre("payload #1", "payload #2"));
-  }
-}
-
-// In this test we check that all the lifecycle events that we expect to have in
-// the regular clone session are also present in the cloned 'write_into_file'
-// session. This is test is needed, because we have a slightly different code
-// path when we clone the 'write_into_file' session.
-TEST_F(TracingServiceImplTest, WriteIntoFileCloneSessionLifecycleEvents) {
-  if (!base::flags::buffer_clone_preserve_read_iter) {
-    GTEST_SKIP() << "This test requires buffer_clone_preserve_read_iter=true";
-  }
-
-  using TracingServiceEvent = protos::gen::TracingServiceEvent;
-  std::unique_ptr<MockProducer> producer;
-  std::unique_ptr<MockConsumer> consumer;
-  std::unique_ptr<MockConsumer> clone_consumer;
-  std::unique_ptr<TraceWriter> writer;
-
-  base::TempFile write_into_file_session_file = base::TempFile::Create();
-  base::TempFile cloned_session_file = base::TempFile::Create();
-
-  auto create_trace_config_fn = []() {
-    TraceConfig trace_config;
-    trace_config.add_buffers()->set_size_kb(128);
-    trace_config.add_data_sources()->mutable_config()->set_name("data_source");
-    return trace_config;
-  };
-
-  auto clone_session_fn = [&](base::ScopedFile clone_fd = base::ScopedFile()) {
-    static int i = 0;
-    auto checkpoint_name = "on_clone_done_" + std::to_string(i++);
-    auto clone_done = task_runner.CreateCheckpoint(checkpoint_name);
-    EXPECT_CALL(*clone_consumer, OnSessionCloned(_))
-        .WillOnce([clone_done](const Consumer::OnSessionClonedArgs& args) {
-          ASSERT_TRUE(args.success);
-          ASSERT_TRUE(args.error.empty());
-          clone_done();
-        });
-    ConsumerEndpoint::CloneSessionArgs clone_args;
-    clone_args.tsid = GetLastTracingSessionId(consumer.get());
-    clone_args.output_file_fd = std::move(clone_fd);
-    clone_consumer->endpoint()->CloneSession(std::move(clone_args));
-    producer->ExpectFlush(writer.get());
-    task_runner.RunUntilCheckpoint(checkpoint_name);
-  };
-
-  auto shutdown_producer_and_consumers_fn = [&]() {
-    writer.reset();
-    clone_consumer->FreeBuffers();
-    consumer->FreeBuffers();
-    producer->WaitForDataSourceStop("data_source");
-    clone_consumer.reset();
-    consumer.reset();
-    producer.reset();
-  };
-
-  auto assert_packets_fn =
-      [&](const std::vector<protos::gen::TracePacket>& packets) {
-        EXPECT_THAT(GetForTestingStrings(packets), ElementsAre("payload"));
-        EXPECT_THAT(packets, Contains(Property(
-                                 &protos::gen::TracePacket::has_trace_config,
-                                 Eq(true))));
-        EXPECT_THAT(packets,
-                    HasLifecycleField(&TracingServiceEvent::tracing_started));
-        EXPECT_THAT(
-            packets,
-            HasLifecycleField(&TracingServiceEvent::all_data_sources_started));
-        EXPECT_THAT(packets,
-                    HasLifecycleField(&TracingServiceEvent::clone_started));
-        EXPECT_THAT(packets,
-                    HasLifecycleField(&TracingServiceEvent::flush_started));
-        EXPECT_THAT(packets,
-                    HasLifecycleField(&TracingServiceEvent::has_buffer_cloned));
-        EXPECT_THAT(
-            packets,
-            Contains(Property(
-                &protos::gen::TracePacket::trace_stats,
-                Property(&protos::gen::TraceStats::final_flush_outcome,
-                         Eq(protos::gen::TraceStats::FINAL_FLUSH_SUCCEEDED)))));
-      };
-
-  // Clone the regular session.
-  {
-    producer = CreateMockProducer();
-    producer->Connect(svc.get(), "mock_producer");
-    producer->RegisterDataSource("data_source");
-
-    consumer = CreateMockConsumer();
-    consumer->Connect(svc.get());
-    TraceConfig trace_config = create_trace_config_fn();
-    consumer->EnableTracing(trace_config);
-
-    producer->WaitForTracingSetup();
-    producer->WaitForDataSourceSetup("data_source");
-    producer->WaitForDataSourceStart("data_source");
-
-    clone_consumer = CreateMockConsumer();
-    clone_consumer->Connect(svc.get());
-
-    writer = producer->CreateTraceWriter("data_source");
-    {
-      auto tp = writer->NewTracePacket();
-      tp->set_for_testing()->set_str("payload");
-    }
-
-    clone_session_fn();
-
-    const auto& packets = clone_consumer->ReadBuffers();
-    assert_packets_fn(packets);
-
-    shutdown_producer_and_consumers_fn();
-  }
-
-  // Clone the 'write_into_file' session.
-  {
-    producer = CreateMockProducer();
-    producer->Connect(svc.get(), "mock_producer_1");
-    producer->RegisterDataSource("data_source");
-
-    consumer = CreateMockConsumer();
-    consumer->Connect(svc.get());
-    TraceConfig trace_config = create_trace_config_fn();
-    trace_config.set_write_into_file(true);
-    consumer->EnableTracing(
-        trace_config, base::ScopedFile(dup(write_into_file_session_file.fd())));
-
-    producer->WaitForTracingSetup();
-    producer->WaitForDataSourceSetup("data_source");
-    producer->WaitForDataSourceStart("data_source");
-
-    clone_consumer = CreateMockConsumer();
-    clone_consumer->Connect(svc.get());
-
-    writer = producer->CreateTraceWriter("data_source");
-    {
-      auto tp = writer->NewTracePacket();
-      tp->set_for_testing()->set_str("payload");
-    }
-
-    clone_session_fn(base::ScopedFile(dup(cloned_session_file.fd())));
-
-    // ReadBuffers returns single service event, all the data is already written
-    // into the file.
-    auto clone_consumer_buffers = clone_consumer->ReadBuffers();
-    EXPECT_EQ(clone_consumer_buffers.size(), 1ul);
-    EXPECT_THAT(
-        clone_consumer_buffers,
-        HasLifecycleField(
-            &protos::gen::TracingServiceEvent::read_tracing_buffers_completed));
-
-    {
-      // Verify the content of the cloned session output file.
-      protos::gen::Trace trace;
-      ASSERT_TRUE(ParseNotEmptyTraceFromFile(cloned_session_file, trace));
-      assert_packets_fn(trace.packet());
-    }
-
-    shutdown_producer_and_consumers_fn();
-    {
-      // Just in case, also verify that 'write_into_file' session write the
-      // payload to the file when stopped.
-      protos::gen::Trace trace;
-      ASSERT_TRUE(
-          ParseNotEmptyTraceFromFile(write_into_file_session_file, trace));
-      EXPECT_THAT(GetForTestingStrings(trace.packet()), ElementsAre("payload"));
-    }
-  }
 }
 
 TEST_F(TracingServiceImplTest, WriteIntoFileFilterMultipleChunks) {
@@ -6074,7 +5677,7 @@ TEST_F(TracingServiceImplTest, CloneSessionByName) {
         });
     ConsumerEndpoint::CloneSessionArgs args;
     args.unique_session_name = "my_unique_session_name";
-    consumer2->endpoint()->CloneSession(std::move(args));
+    consumer2->endpoint()->CloneSession(args);
     // CloneSession() will implicitly issue a flush. Linearize with that.
     producer->ExpectFlush(writer.get());
     task_runner.RunUntilCheckpoint("clone_done");
@@ -6119,7 +5722,7 @@ TEST_F(TracingServiceImplTest, CloneSessionByName) {
         });
     ConsumerEndpoint::CloneSessionArgs args_f;
     args_f.unique_session_name = "my_unique_session_name";
-    consumer3->endpoint()->CloneSession(std::move(args_f));
+    consumer3->endpoint()->CloneSession(args_f);
     task_runner.RunUntilCheckpoint("clone_failed");
 
     // But it should be possible to clone that by id.
@@ -6131,7 +5734,7 @@ TEST_F(TracingServiceImplTest, CloneSessionByName) {
         });
     ConsumerEndpoint::CloneSessionArgs args_s;
     args_s.tsid = GetLastTracingSessionId(consumer3.get());
-    consumer3->endpoint()->CloneSession(std::move(args_s));
+    consumer3->endpoint()->CloneSession(args_s);
     task_runner.RunUntilCheckpoint("clone_success");
   }
 }
@@ -6230,7 +5833,7 @@ TEST_F(TracingServiceImplTest, CloneSessionEmitsTrigger) {
     args.clone_trigger_trusted_producer_uid = kCloneTriggerProducerUid;
     args.clone_trigger_boot_time_ns = kCloneTriggerTimestamp;
     args.clone_trigger_delay_ms = kCloneTriggerDelayMs;
-    consumer2->endpoint()->CloneSession(std::move(args));
+    consumer2->endpoint()->CloneSession(args);
     // CloneSession() will implicitly issue a flush. Linearize with that.
     producer->ExpectFlush(writer.get());
     task_runner.RunUntilCheckpoint("clone_done");
@@ -6279,62 +5882,6 @@ TEST_F(TracingServiceImplTest, CloneSessionEmitsTrigger) {
       cloned_packets,
       Not(Contains(Property(
           &protos::gen::TracePacket::has_clone_snapshot_trigger, Eq(true)))));
-}
-
-TEST_F(TracingServiceImplTest, CloneWithFileDescriptorNoWriteIntoFile) {
-  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
-  consumer->Connect(svc.get());
-
-  std::unique_ptr<MockConsumer> clone_consumer = CreateMockConsumer();
-  clone_consumer->Connect(svc.get());
-
-  std::unique_ptr<MockProducer> producer = CreateMockProducer();
-  producer->Connect(svc.get(), "mock_producer");
-  producer->RegisterDataSource("data_source");
-
-  TraceConfig trace_config;
-  trace_config.add_buffers()->set_size_kb(128);
-  trace_config.add_data_sources()->mutable_config()->set_name("data_source");
-
-  consumer->EnableTracing(trace_config);
-
-  producer->WaitForTracingSetup();
-  producer->WaitForDataSourceSetup("data_source");
-  producer->WaitForDataSourceStart("data_source");
-
-  std::unique_ptr<TraceWriter> writer =
-      producer->CreateTraceWriter("data_source");
-  {
-    auto tp = writer->NewTracePacket();
-    tp->set_for_testing()->set_str("payload");
-  }
-  writer->Flush();
-
-  base::TempFile cloned_session_file = base::TempFile::Create();
-
-  auto clone_done = task_runner.CreateCheckpoint("clone_done");
-  EXPECT_CALL(*clone_consumer, OnSessionCloned(_))
-      .WillOnce([clone_done](const Consumer::OnSessionClonedArgs& args) {
-        ASSERT_TRUE(args.success);
-        ASSERT_TRUE(args.error.empty());
-        clone_done();
-      });
-  ConsumerEndpoint::CloneSessionArgs clone_args;
-  clone_args.tsid = GetLastTracingSessionId(consumer.get());
-  clone_args.output_file_fd = base::ScopedFile(dup(cloned_session_file.fd()));
-  clone_consumer->endpoint()->CloneSession(std::move(clone_args));
-  producer->ExpectFlush(writer.get());
-  task_runner.RunUntilCheckpoint("clone_done");
-
-  // Assert traced doesn't write buffers to the file descriptor if session to
-  // clone is not the 'write_into_file' session.
-  EXPECT_EQ(base::GetFileSize(cloned_session_file.path()).value_or(-1), 0ul);
-  auto clone_consumer_buffers = clone_consumer->ReadBuffers();
-  EXPECT_THAT(GetForTestingStrings(clone_consumer_buffers),
-              ElementsAre("payload"));
-
-  auto consumer_buffers = consumer->ReadBuffers();
-  EXPECT_THAT(GetForTestingStrings(consumer_buffers), ElementsAre("payload"));
 }
 
 TEST_F(TracingServiceImplTest, InvalidBufferSizes) {

--- a/src/tracing/test/mock_consumer.cc
+++ b/src/tracing/test/mock_consumer.cc
@@ -80,7 +80,7 @@ void MockConsumer::FreeBuffers() {
 void MockConsumer::CloneSession(TracingSessionID tsid) {
   ConsumerEndpoint::CloneSessionArgs args;
   args.tsid = tsid;
-  service_endpoint_->CloneSession(std::move(args));
+  service_endpoint_->CloneSession(args);
 }
 
 void MockConsumer::WaitForTracingDisabledWithError(

--- a/test/cmdline_integrationtest.cc
+++ b/test/cmdline_integrationtest.cc
@@ -20,7 +20,6 @@
 
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
-#include "perfetto/ext/base/flags.h"
 #include "perfetto/ext/base/pipe.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/utils.h"
@@ -1129,87 +1128,6 @@ TEST_F(PerfettoCmdlineTest, CloneByName) {
   ASSERT_TRUE(ParseNotEmptyTraceFromFile(path, trace));
   ExpectTraceContainsTestMessages(trace, kTestMessageCount);
   ExpectTraceContainsTestMessagesWithSize(trace, kTestMessageSize);
-}
-
-TEST_F(PerfettoCmdlineTest, CloneWriteIntoFileSession) {
-  protos::gen::TraceConfig trace_config =
-      CreateTraceConfigForTest(kTestMessageCount, kTestMessageSize);
-  trace_config.set_write_into_file(true);
-  trace_config.set_file_write_period_ms(10);
-  trace_config.set_unique_session_name("my_session_name");
-
-  const std::string write_into_file_path = RandomTraceFileName();
-  ScopedFileRemove remove_on_test_exit(write_into_file_path);
-  auto perfetto_proc = ExecPerfetto(
-      {
-          "-o",
-          write_into_file_path,
-          "-c",
-          "-",
-      },
-      trace_config.SerializeAsString());
-
-  const std::string cloned_file_path = RandomTraceFileName();
-  ScopedFileRemove remove_on_test_exit_1(cloned_file_path);
-  auto clone_proc = ExecPerfetto(
-      {"--out", cloned_file_path, "--clone-by-name", "my_session_name"});
-
-  StartServiceIfRequiredNoNewExecsAfterThis();
-
-  auto* fake_producer = test_helper().ConnectFakeProducer();
-  EXPECT_TRUE(fake_producer);
-
-  std::thread background_trace([&perfetto_proc]() {
-    std::string stderr_str;
-    EXPECT_EQ(0, perfetto_proc.Run(&stderr_str)) << stderr_str;
-  });
-
-  test_helper().WaitForProducerEnabled();
-  auto on_data_written = task_runner_.CreateCheckpoint("data_written");
-  fake_producer->ProduceEventBatch(test_helper().WrapTask(on_data_written));
-  task_runner_.RunUntilCheckpoint("data_written");
-
-  // Wait until all the data for the 'write_into_file' session is written into
-  // file.
-  bool write_into_file_data_ready = false;
-  for (int i = 0; i < 100; i++) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    protos::gen::Trace trace;
-    if (!ParseNotEmptyTraceFromFile(write_into_file_path, trace)) {
-      continue;
-    }
-    ssize_t test_packets_count =
-        std::count_if(trace.packet().begin(), trace.packet().end(),
-                      [](const protos::gen::TracePacket& tp) {
-                        return tp.has_for_testing();
-                      });
-    if (test_packets_count == kTestMessageCount) {
-      write_into_file_data_ready = true;
-      break;
-    }
-  }
-  ASSERT_TRUE(write_into_file_data_ready);
-
-  // Now we clone the session.
-  std::string stderr_str;
-  EXPECT_EQ(0, clone_proc.Run(&stderr_str)) << stderr_str;
-
-  perfetto_proc.SendSigterm();
-  background_trace.join();
-  // And now we assert that both original 'write_into_file' and the cloned
-  // session have the same events.
-  {
-    protos::gen::Trace trace;
-    ASSERT_TRUE(ParseNotEmptyTraceFromFile(write_into_file_path, trace));
-    ExpectTraceContainsTestMessages(trace, kTestMessageCount);
-    ExpectTraceContainsTestMessagesWithSize(trace, kTestMessageSize);
-  }
-  {
-    protos::gen::Trace cloned_trace;
-    ASSERT_TRUE(ParseNotEmptyTraceFromFile(cloned_file_path, cloned_trace));
-    ExpectTraceContainsTestMessages(cloned_trace, kTestMessageCount);
-    ExpectTraceContainsTestMessagesWithSize(cloned_trace, kTestMessageSize);
-  }
 }
 
 // Regression test for b/279753347: --save-for-bugreport would create an empty


### PR DESCRIPTION
This reverts commit b5a3a4b38331ca4b3362a664451799b437fcc5f5.

Needs accompanying selinux changes (traced to be able to receive additional fds from perfetto_cmd) to roll into Android. Reverting to unblock the roll until that patch is ready & reviewed.