### PR TITLE
exp: Noop refactor to make QueryNode::filters optional

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -77,7 +77,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         trace,
         sqlModules,
         sqlTable: selection.sqlTable,
-        filters: [],
       });
       onStateUpdate({
         ...state,
@@ -93,7 +92,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       prevNodes: [node],
       groupByColumns: [],
       aggregations: [],
-      filters: [],
     });
     node.nextNodes.push(newNode);
     onStateUpdate({
@@ -108,7 +106,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       prevNodes: [node],
       newColumns: [],
       selectedColumns: [],
-      filters: [],
     });
     node.nextNodes.push(newNode);
     onStateUpdate({
@@ -123,7 +120,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       prevNodes: [node],
       allNodes: state.rootNodes,
       intervalNodes: [],
-      filters: [],
     });
     node.nextNodes.push(newNode);
     onStateUpdate({
@@ -134,9 +130,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
 
   handleAddSlicesSource(attrs: ExplorePageAttrs) {
     const {state, onStateUpdate} = attrs;
-    const newNode = new SlicesSourceNode({
-      filters: [],
-    });
+    const newNode = new SlicesSourceNode({});
     onStateUpdate({
       ...state,
       rootNodes: [...state.rootNodes, newNode],
@@ -148,7 +142,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     const {state, onStateUpdate} = attrs;
     const newNode = new SqlSourceNode({
       trace: attrs.trace,
-      filters: [],
     });
     onStateUpdate({
       ...state,
@@ -352,9 +345,11 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         onImportWithStatement: () => this.handleImportWithStatement(attrs),
         onExport: () => this.handleExport(state, trace),
         onRemoveFilter: (node, filter) => {
-          const filterIndex = node.state.filters.indexOf(filter);
-          if (filterIndex > -1) {
-            node.state.filters.splice(filterIndex, 1);
+          if (node.state.filters) {
+            const filterIndex = node.state.filters.indexOf(filter);
+            if (filterIndex > -1) {
+              node.state.filters.splice(filterIndex, 1);
+            }
           }
           attrs.onStateUpdate({...state});
         },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -82,7 +82,6 @@ describe('JSON serialization/deserialization', () => {
   test('serializes and deserializes a simple graph', () => {
     const sliceNode = new SlicesSourceNode({
       slice_name: 'test_slice',
-      filters: [],
     });
     const initialState: ExplorePageState = {
       rootNodes: [sliceNode],
@@ -103,11 +102,9 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
     const sliceNode = new SlicesSourceNode({
       slice_name: 'test_slice',
-      filters: [],
     });
     tableNode.nextNodes.push(sliceNode);
     sliceNode.prevNodes.push(tableNode);
@@ -142,7 +139,6 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     const sliceTable = sqlModules.getTable('slice')!;
@@ -168,7 +164,6 @@ describe('JSON serialization/deserialization', () => {
           newColumnName: 'total_dur',
         },
       ],
-      filters: [],
     });
     tableNode.nextNodes.push(aggregationNode);
 
@@ -204,7 +199,6 @@ describe('JSON serialization/deserialization', () => {
   test('serializes and deserializes sql source node', () => {
     const sqlNode = new SqlSourceNode({
       sql: 'SELECT * FROM slice',
-      filters: [],
       trace,
     });
     const initialState: ExplorePageState = {
@@ -226,21 +220,18 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     const tableNode2 = new TableSourceNode({
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     const intervalIntersectNode = new IntervalIntersectNode({
       prevNodes: [tableNode1],
       intervalNodes: [tableNode1, tableNode2],
       allNodes: [tableNode1, tableNode2],
-      filters: [],
     });
     tableNode1.nextNodes.push(intervalIntersectNode);
     intervalIntersectNode.prevNodes.length = 0;
@@ -280,12 +271,10 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     const sqlNode = new SqlSourceNode({
       sql: `SELECT * FROM \${tableNode.nodeId}`,
-      filters: [],
       trace,
     });
     tableNode.nextNodes.push(sqlNode);
@@ -356,12 +345,10 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     const sliceNode = new SlicesSourceNode({
       slice_name: 'test_slice',
-      filters: [],
     });
 
     const initialState: ExplorePageState = {
@@ -450,14 +437,12 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     const nodeB = new TableSourceNode({
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     nodeA.nextNodes.push(nodeB);
@@ -498,11 +483,9 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
     const sliceNode = new SlicesSourceNode({
       slice_name: 'test_slice',
-      filters: [],
     });
     tableNode.nextNodes.push(sliceNode);
     sliceNode.prevNodes.push(tableNode);
@@ -550,7 +533,6 @@ describe('JSON serialization/deserialization', () => {
   test('serializes and deserializes custom title', () => {
     const sliceNode = new SlicesSourceNode({
       slice_name: 'test_slice',
-      filters: [],
       customTitle: 'My Custom Title',
     });
     const initialState: ExplorePageState = {
@@ -572,7 +554,6 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
-      filters: [],
     });
 
     const modifyColumnsNode = new ModifyColumnsNode({
@@ -604,7 +585,11 @@ describe('JSON serialization/deserialization', () => {
       .nextNodes[0] as ModifyColumnsNode;
     expect(deserializedNode.state.newColumns.length).toBe(1);
     expect(deserializedNode.state.newColumns[0].name).toBe('new_col');
-    expect(deserializedNode.state.filters.length).toBe(1);
-    expect(deserializedNode.state.filters[0].column).toBe('new_col');
+    const filters = deserializedNode.state.filters;
+    expect(filters).toBeDefined();
+    if (filters) {
+      expect(filters.length).toBe(1);
+      expect(filters[0].column).toBe('new_col');
+    }
   });
 });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_box.ts
@@ -119,11 +119,11 @@ function renderAddButton(attrs: NodeBoxAttrs): m.Child {
 
 function renderFilters(attrs: NodeBoxAttrs): m.Child {
   const {node, onRemoveFilter} = attrs;
-  if (node.state.filters.length === 0) return null;
+  if (!node.state.filters || node.state.filters.length === 0) return null;
 
   return m(
     '.pf-node-box__filters',
-    node.state.filters.map((filter) => {
+    node.state.filters?.map((filter) => {
       const label =
         'value' in filter
           ? `${filter.column} ${filter.op} ${filter.value}`

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
@@ -43,7 +43,7 @@ export interface AggregationSerializedState {
     isValid?: boolean;
     isEditing?: boolean;
   }[];
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
   customTitle?: string;
 }
 
@@ -210,7 +210,7 @@ export class AggregationNode implements QueryNode {
       prevNodes: this.state.prevNodes,
       groupByColumns: newColumnInfoList(this.state.groupByColumns),
       aggregations: this.state.aggregations.map((a) => ({...a})),
-      filters: [],
+      filters: this.state.filters ? [...this.state.filters] : undefined,
       customTitle: this.state.customTitle,
       onchange: this.state.onchange,
       issues: this.state.issues,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -29,7 +29,7 @@ import {FilterDefinition} from '../../../../components/widgets/data_grid/common'
 
 export interface IntervalIntersectSerializedState {
   intervalNodes: string[];
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
   customTitle?: string;
 }
 
@@ -144,7 +144,7 @@ export class IntervalIntersectNode implements QueryNode {
       prevNodes: this.state.prevNodes,
       allNodes: this.state.allNodes,
       intervalNodes: [...this.state.intervalNodes],
-      filters: [],
+      filters: this.state.filters ? [...this.state.filters] : undefined,
       customTitle: this.state.customTitle,
       onchange: this.state.onchange,
       onExecute: this.state.onExecute,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -40,7 +40,7 @@ export interface ModifyColumnsSerializedState {
   prevNodeIds: string[];
   newColumns: NewColumn[];
   selectedColumns: ColumnInfo[];
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
   customTitle?: string;
 }
 
@@ -48,7 +48,7 @@ export interface ModifyColumnsState extends QueryNodeState {
   prevNodes: QueryNode[];
   newColumns: NewColumn[];
   selectedColumns: ColumnInfo[];
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
   customTitle?: string;
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -33,7 +33,7 @@ export interface SlicesSourceSerializedState {
   thread_name?: string;
   process_name?: string;
   track_name?: string;
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
   customTitle?: string;
 }
 
@@ -69,7 +69,7 @@ export class SlicesSourceNode extends SourceNode {
       thread_name: this.state.thread_name?.slice(),
       process_name: this.state.process_name?.slice(),
       track_name: this.state.track_name?.slice(),
-      filters: this.state.filters.map((f) => ({...f})),
+      filters: this.state.filters ? [...this.state.filters] : undefined,
       customTitle: this.state.customTitle,
     };
     return new SlicesSourceNode(stateCopy);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -35,7 +35,7 @@ import {FilterDefinition} from '../../../../../components/widgets/data_grid/comm
 
 export interface SqlSourceSerializedState {
   sql?: string;
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
   customTitle?: string;
 }
 
@@ -77,7 +77,7 @@ export class SqlSourceNode extends SourceNode {
   clone(): QueryNode {
     const stateCopy: SqlSourceState = {
       sql: this.state.sql,
-      filters: [],
+      filters: this.state.filters ? [...this.state.filters] : undefined,
       customTitle: this.state.customTitle,
       issues: this.state.issues,
       trace: this.state.trace,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -37,7 +37,7 @@ import {SourceNode} from '../../source_node';
 
 export interface TableSourceSerializedState {
   sqlTable?: string;
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
   customTitle?: string;
 }
 
@@ -123,7 +123,7 @@ export class TableSourceNode extends SourceNode {
       trace: this.state.trace,
       sqlModules: this.state.sqlModules,
       sqlTable: this.state.sqlTable,
-      filters: this.state.filters.map((f) => ({...f})),
+      filters: this.state.filters?.map((f) => ({...f})),
       customTitle: this.state.customTitle,
       onchange: this.state.onchange,
     };

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.ts
@@ -39,7 +39,7 @@ export interface UIFilter {
  */
 export interface FilterAttrs {
   readonly sourceCols: ColumnInfo[];
-  readonly filters: ReadonlyArray<FilterDefinition>;
+  readonly filters?: ReadonlyArray<FilterDefinition>;
   readonly onFiltersChanged?: (
     filters: ReadonlyArray<FilterDefinition>,
   ) => void;
@@ -52,13 +52,13 @@ export class FilterOperation implements m.ClassComponent<FilterAttrs> {
   private editingFilter?: UIFilter;
 
   oncreate({attrs}: m.Vnode<FilterAttrs>) {
-    this.uiFilters = [...attrs.filters];
+    this.uiFilters = [...(attrs.filters ?? [])];
   }
 
   onbeforeupdate({attrs}: m.Vnode<FilterAttrs>) {
     // If we are not in editing mode, sync with the parent.
     if (this.editingFilter === undefined) {
-      this.uiFilters = [...attrs.filters];
+      this.uiFilters = [...(attrs.filters ?? [])];
     }
   }
 
@@ -495,10 +495,10 @@ export const ALL_FILTER_OPS: FilterOp[] = [
 ];
 
 export function createFiltersProto(
-  filters: FilterDefinition[],
+  filters: FilterDefinition[] | undefined,
   sourceCols: ColumnInfo[],
 ): protos.PerfettoSqlStructuredQuery.Filter[] | undefined {
-  if (filters.length === 0) {
+  if (filters === undefined || filters.length === 0) {
     return undefined;
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -45,7 +45,7 @@ export interface QueryNodeState {
   customTitle?: string;
 
   // Operations
-  filters: FilterDefinition[];
+  filters?: FilterDefinition[];
 
   issues?: NodeIssues;
 


### PR DESCRIPTION
Make filters optional to cleanup boilerplate code. Noop change.