### PR TITLE
UI: Link official Wattson documentation and update crude_estimate

### DIFF
--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -283,6 +283,7 @@ async function addWattsonCpuElements(
   const warningDesc = createCpuWarnings(missingEvents, hasCpuIdleCounters);
 
   // CPUs estimate as part of CPU subsystem
+  const estimateSuffix = `${hasCpuIdleCounters ? '' : ' crude'} estimate`;
   const schedPlugin = ctx.plugins.getPlugin(SchedPlugin);
   const schedCpus = schedPlugin.schedCpus;
   for (const cpu of schedCpus) {
@@ -305,13 +306,12 @@ async function addWattsonCpuElements(
     group.addChildInOrder(
       new TrackNode({
         uri,
-        name: `Cpu${cpu.toString()} Estimate`,
+        name: `Cpu${cpu.toString()}${estimateSuffix}`,
       }),
     );
   }
 
   const uri = `/wattson/cpu_subsystem_estimate_dsu_scu`;
-  const title = `DSU/SCU Estimate`;
   ctx.tracks.registerTrack({
     uri,
     renderer: new WattsonSubsystemEstimateTrack(
@@ -325,7 +325,7 @@ async function addWattsonCpuElements(
       wattson: 'Dsu_Scu',
     },
   });
-  group.addChildInOrder(new TrackNode({uri, name: title}));
+  group.addChildInOrder(new TrackNode({uri, name: `DSU/SCU${estimateSuffix}`}));
 
   // Register selection aggregators.
   // NOTE: the registration order matters because the laste two aggregators

--- a/ui/src/test/wattson.test.ts
+++ b/ui/src/test/wattson.test.ts
@@ -43,7 +43,7 @@ test('wattson aggregations', async () => {
   const wattsonGrp = pth.locateTrack('Wattson');
   await wattsonGrp.scrollIntoViewIfNeeded();
   await pth.toggleTrackGroup(wattsonGrp);
-  const cpuEstimate = pth.locateTrack('Wattson/Cpu0 Estimate', wattsonGrp);
+  const cpuEstimate = pth.locateTrack('Wattson/Cpu0 estimate', wattsonGrp);
   const coords = assertExists(await cpuEstimate.boundingBox());
   await page.keyboard.press('Escape');
   await page.mouse.move(600, coords.y + 10);


### PR DESCRIPTION
1. Link to official Wattson doc page for more detailed information.
2. Call "estimate" tracks as "crude estimates" tracks if using swapper to get idle state

Bug: 448182021
Signed-off-by: Samuel Wu <wusamuel@google.com>