### PR TITLE
ui: Position flamegraph tooltip on the right side

### DIFF
--- a/ui/src/widgets/flamegraph.ts
+++ b/ui/src/widgets/flamegraph.ts
@@ -376,7 +376,7 @@ export class Flamegraph implements m.ClassComponent<FlamegraphAttrs> {
               // We have a wide set of buttons that would overflow given the
               // normal width constraints of the popup.
               fitContent: true,
-              position: PopupPosition.Bottom,
+              position: PopupPosition.Right,
               isOpen:
                 this.tooltipPos?.state === 'HOVER' ||
                 this.tooltipPos?.state === 'CLICK',


### PR DESCRIPTION
Change tooltip position from bottom to right to avoid obscuring slices
below the cursor when reading the flamegraph vertically. This allows
users to see the vertical stack without moving the cursor away.
