### PR TITLE
ui: Theme aware selected slice outline and timeline overlays

### DIFF
--- a/ui/src/assets/theme_provider.scss
+++ b/ui/src/assets/theme_provider.scss
@@ -34,9 +34,6 @@
     --pf-color-border: #ccc;
     --pf-color-border-secondary: #e0e0e0;
     --pf-color-text-hint: #808080;
-    --pf-color-track-summary-collapsed: #f4fafb;
-    --pf-color-track-summary-expanded: #262f3b;
-    --pf-color-track-summary-expanded-text: #e8eaed;
     --pf-color-box-shadow: rgba(0, 0, 0, 0.2);
     --pf-color-neutral: gray;
     --pf-color-accent: #2667e7;
@@ -50,6 +47,11 @@
     --pf-color-text-on-success: white;
     --pf-color-warning: rgb(232, 158, 0);
     --pf-color-text-on-warning: var(--pf-color-text);
+
+    --pf-color-track-summary-collapsed: #f4fafb;
+    --pf-color-track-summary-expanded: #262f3b;
+    --pf-color-track-summary-expanded-text: #e8eaed;
+    --pf-color-timeline-overlay: black;
 
     // In light mode, the sidebar has a custom distinct blue color scheme.
     --pf-sidebar-surface: #262f3c;
@@ -70,13 +72,10 @@
     --pf-color-border: #626568;
     --pf-color-border-secondary: #404042;
     --pf-color-text-hint: #9aa0a6;
-    --pf-color-track-summary-collapsed: #2f3437;
-    --pf-color-track-summary-expanded: #454d55;
-    --pf-color-track-summary-expanded-text: #e8eaed;
     --pf-color-box-shadow: rgba(0, 0, 0, 0.4);
     --pf-color-neutral: gray;
     --pf-color-accent: #2667e7;
-    --pf-color-highlight: #9b7c00;
+    --pf-color-highlight: #5f4d06;
 
     --pf-color-primary: #7197e3;
     --pf-color-text-on-primary: #333;
@@ -86,6 +85,11 @@
     --pf-color-text-on-success: #333;
     --pf-color-warning: rgb(244, 188, 67);
     --pf-color-text-on-warning: #333;
+
+    --pf-color-track-summary-collapsed: #2f3437;
+    --pf-color-track-summary-expanded: #454d55;
+    --pf-color-track-summary-expanded-text: #e8eaed;
+    --pf-color-timeline-overlay: white;
 
     // In dark mode, the sidebar uses the same styles as the rest of the app
     --pf-sidebar-surface: var(--pf-color-background-secondary);

--- a/ui/src/base/canvas_utils.ts
+++ b/ui/src/base/canvas_utils.ts
@@ -21,8 +21,8 @@ export function drawDoubleHeadedArrow(
   y: number,
   length: number,
   showArrowHeads: boolean,
+  color: string,
   width = 2,
-  color = 'black',
 ) {
   ctx.beginPath();
   ctx.lineWidth = width;

--- a/ui/src/base/color.ts
+++ b/ui/src/base/color.ts
@@ -67,6 +67,7 @@ export interface Color {
   // Set one or more HSL values.
   setHSL(hsl: Partial<HSL>): Color;
 
+  // Set the alpha value (0-1) or remove it (undefined).
   setAlpha(alpha: number | undefined): Color;
 }
 

--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -748,7 +748,7 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     await this.maybeRequestData(rawCountersKey);
   }
 
-  render({ctx, size, timescale, theme}: TrackRenderContext): void {
+  render({ctx, size, timescale, colors}: TrackRenderContext): void {
     // In any case, draw whatever we have (which might be stale/incomplete).
     const limits = this.limits;
     const data = this.counters;
@@ -894,11 +894,11 @@ export abstract class BaseCounterTrack implements TrackRenderer {
 
     // Write the Y scale on the top left corner.
     ctx.textBaseline = 'alphabetic';
-    ctx.fillStyle = theme.COLOR_BACKGROUND;
+    ctx.fillStyle = colors.COLOR_BACKGROUND;
     ctx.globalAlpha = 0.6;
     ctx.fillRect(0, 0, 42, 18);
     ctx.globalAlpha = 1;
-    ctx.fillStyle = theme.COLOR_TEXT;
+    ctx.fillStyle = colors.COLOR_TEXT;
     ctx.textAlign = 'left';
     ctx.fillText(`${yLabel}`, 4, 14);
 

--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -420,7 +420,13 @@ export abstract class BaseSliceTrack<
     await this.maybeRequestData(rawSlicesKey);
   }
 
-  render({ctx, size, visibleWindow, timescale}: TrackRenderContext): void {
+  render({
+    ctx,
+    size,
+    visibleWindow,
+    timescale,
+    colors,
+  }: TrackRenderContext): void {
     // TODO(hjd): fonts and colors should come from the CSS and not hardcoded
     // here.
 
@@ -638,9 +644,8 @@ export abstract class BaseSliceTrack<
 
       // Draw a thicker border around the selected slice (or chevron).
       const slice = discoveredSelection;
-      const color = slice.colorScheme;
       const y = padding + slice.depth * (sliceHeight + rowSpacing);
-      ctx.strokeStyle = color.base.setHSL({s: 100, l: 10}).cssString;
+      ctx.strokeStyle = colors.COLOR_TIMELINE_OVERLAY;
       ctx.beginPath();
       const THICKNESS = 3;
       ctx.lineWidth = THICKNESS;

--- a/ui/src/core/track_manager_unittest.ts
+++ b/ui/src/core/track_manager_unittest.ts
@@ -52,7 +52,7 @@ const dummyCtx: TrackRenderContext = {
   visibleWindow,
   resolution: Duration.ZERO,
   timescale: new TimeScale(visibleWindow, {left: 0, right: 0}),
-  theme: {
+  colors: {
     COLOR_BORDER: 'hotpink',
     COLOR_BORDER_SECONDARY: 'hotpink',
     COLOR_BACKGROUND_SECONDARY: 'hotpink',
@@ -61,6 +61,7 @@ const dummyCtx: TrackRenderContext = {
     COLOR_TEXT: 'hotpink',
     COLOR_TEXT_MUTED: 'hotpink',
     COLOR_NEUTRAL: 'hotpink',
+    COLOR_TIMELINE_OVERLAY: 'hotpink',
   },
 };
 

--- a/ui/src/frontend/css_constants.ts
+++ b/ui/src/frontend/css_constants.ts
@@ -29,6 +29,7 @@ export let COLOR_TEXT = 'hotpink';
 export let COLOR_TEXT_MUTED = 'hotpink';
 export let COLOR_NEUTRAL = 'hotpink';
 export let COLOR_HIGHLIGHT = 'hotpink';
+export let COLOR_TIMELINE_OVERLAY = 'hotpink';
 
 export function initCssConstants(element?: Element) {
   function getCssStr(prop: string): string | undefined {
@@ -65,4 +66,6 @@ export function initCssConstants(element?: Element) {
   COLOR_TEXT_MUTED = getCssStr('--pf-color-text-muted') ?? COLOR_TEXT_MUTED;
   COLOR_NEUTRAL = getCssStr('--pf-color-neutral') ?? COLOR_NEUTRAL;
   COLOR_HIGHLIGHT = getCssStr('--pf-color-highlight') ?? COLOR_HIGHLIGHT;
+  COLOR_TIMELINE_OVERLAY =
+    getCssStr('--pf-color-timeline-overlay') ?? COLOR_TIMELINE_OVERLAY;
 }

--- a/ui/src/frontend/viewer_page/track_tree_view.ts
+++ b/ui/src/frontend/viewer_page/track_tree_view.ts
@@ -49,7 +49,14 @@ import {TrackNode} from '../../public/workspace';
 import {VirtualOverlayCanvas} from '../../widgets/virtual_overlay_canvas';
 import {
   COLOR_ACCENT,
+  COLOR_BACKGROUND,
+  COLOR_BACKGROUND_SECONDARY,
+  COLOR_BORDER,
   COLOR_BORDER_SECONDARY,
+  COLOR_NEUTRAL,
+  COLOR_TEXT,
+  COLOR_TEXT_MUTED,
+  COLOR_TIMELINE_OVERLAY,
   TRACK_SHELL_WIDTH,
 } from '../css_constants';
 import {renderFlows} from './flow_events_renderer';
@@ -65,6 +72,7 @@ import {EmptyState} from '../../widgets/empty_state';
 import {Button, ButtonVariant} from '../../widgets/button';
 import {Intent} from '../../widgets/common';
 import {CursorTooltip} from '../../widgets/cursor_tooltip';
+import {CanvasColors} from '../../public/canvas_colors';
 
 const VIRTUAL_TRACK_SCROLLING = featureFlags.register({
   id: 'virtualTrackScrolling',
@@ -373,6 +381,18 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
 
     this.drawGridLines(ctx, timescale, timelineRect);
 
+    const colors: CanvasColors = {
+      COLOR_BORDER,
+      COLOR_BORDER_SECONDARY,
+      COLOR_BACKGROUND_SECONDARY,
+      COLOR_ACCENT,
+      COLOR_BACKGROUND,
+      COLOR_NEUTRAL,
+      COLOR_TEXT,
+      COLOR_TEXT_MUTED,
+      COLOR_TIMELINE_OVERLAY,
+    };
+
     const tracksOnCanvas = this.drawTracks(
       renderedTracks,
       floatingCanvasRect,
@@ -380,6 +400,7 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
       ctx,
       timelineRect,
       visibleWindow,
+      colors,
     );
 
     renderFlows(this.trace, ctx, size, renderedTracks, rootNode, timescale);
@@ -390,7 +411,7 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
     this.updateInteractions(timelineRect, timescale, size, renderedTracks);
 
     this.trace.tracks.overlays.forEach((overlay) => {
-      overlay.render(ctx, timescale, size, renderedTracks);
+      overlay.render(ctx, timescale, size, renderedTracks, colors);
     });
 
     const renderTime = performance.now() - start;
@@ -431,6 +452,7 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
     ctx: CanvasRenderingContext2D,
     timelineRect: Rect2D,
     visibleWindow: HighPrecisionTimeSpan,
+    colors: CanvasColors,
   ) {
     let tracksOnCanvas = 0;
     for (const trackView of renderedTracks) {
@@ -448,6 +470,7 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
           visibleWindow,
           this.perfStatsEnabled,
           this.trackPerfStats,
+          colors,
         );
         ++tracksOnCanvas;
       }

--- a/ui/src/frontend/viewer_page/track_view.ts
+++ b/ui/src/frontend/viewer_page/track_view.ts
@@ -40,22 +40,13 @@ import {Button} from '../../widgets/button';
 import {MenuDivider, MenuItem, PopupMenu} from '../../widgets/menu';
 import {TrackShell} from '../../widgets/track_shell';
 import {Tree, TreeNode} from '../../widgets/tree';
-import {
-  COLOR_ACCENT,
-  COLOR_BACKGROUND,
-  COLOR_BACKGROUND_SECONDARY,
-  COLOR_BORDER,
-  COLOR_BORDER_SECONDARY,
-  COLOR_NEUTRAL,
-  COLOR_TEXT,
-  COLOR_TEXT_MUTED,
-} from '../css_constants';
+import {COLOR_ACCENT} from '../css_constants';
 import {calculateResolution} from './resolution';
 import {Trace} from '../../public/trace';
 import {Anchor, linkify} from '../../widgets/anchor';
 import {showModal} from '../../widgets/modal';
 import {Popup} from '../../widgets/popup';
-import {Theme} from '../../public/theme';
+import {CanvasColors} from '../../public/canvas_colors';
 import {CodeSnippet} from '../../widgets/code_snippet';
 
 const TRACK_HEIGHT_MIN_PX = 18;
@@ -268,6 +259,7 @@ export class TrackView {
     visibleWindow: HighPrecisionTimeSpan,
     perfStatsEnabled: boolean,
     trackPerfStats: WeakMap<TrackNode, PerfStats>,
+    colors: CanvasColors,
   ) {
     // For each track we rendered in view(), render it to the canvas. We know the
     // vertical bounds, so we just need to combine it with the horizontal bounds
@@ -301,17 +293,6 @@ export class TrackView {
       return;
     }
 
-    const theme: Theme = {
-      COLOR_BORDER,
-      COLOR_BORDER_SECONDARY,
-      COLOR_BACKGROUND_SECONDARY,
-      COLOR_ACCENT,
-      COLOR_BACKGROUND,
-      COLOR_NEUTRAL,
-      COLOR_TEXT,
-      COLOR_TEXT_MUTED,
-    };
-
     const start = performance.now();
     node.uri &&
       renderer?.render({
@@ -321,7 +302,7 @@ export class TrackView {
         resolution: maybeNewResolution.value,
         ctx,
         timescale,
-        theme,
+        colors,
       });
 
     this.highlightIfTrackInAreaSelection(ctx, timescale, trackRect);

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -259,7 +259,7 @@ export class CpuFreqTrack implements TrackRenderer {
     size,
     timescale,
     visibleWindow,
-    theme,
+    colors,
   }: TrackRenderContext): void {
     // TODO: fonts and colors should come from the CSS and not hardcoded here.
     const data = this.fetcher.data;
@@ -411,11 +411,11 @@ export class CpuFreqTrack implements TrackRenderer {
 
     // Write the Y scale on the top left corner.
     ctx.textBaseline = 'alphabetic';
-    ctx.fillStyle = theme.COLOR_BACKGROUND;
+    ctx.fillStyle = colors.COLOR_BACKGROUND;
     ctx.globalAlpha = 0.6;
     ctx.fillRect(0, 0, 42, 18);
     ctx.globalAlpha = 1;
-    ctx.fillStyle = theme.COLOR_TEXT;
+    ctx.fillStyle = colors.COLOR_TEXT;
     ctx.textAlign = 'left';
     ctx.fillText(`${yLabel}`, 4, 14);
 

--- a/ui/src/public/canvas_colors.ts
+++ b/ui/src/public/canvas_colors.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export interface Theme {
+export interface CanvasColors {
   COLOR_BORDER: string;
   COLOR_BORDER_SECONDARY: string;
   COLOR_BACKGROUND_SECONDARY: string;
@@ -21,4 +21,5 @@ export interface Theme {
   COLOR_TEXT: string;
   COLOR_TEXT_MUTED: string;
   COLOR_NEUTRAL: string;
+  COLOR_TIMELINE_OVERLAY: string;
 }

--- a/ui/src/public/track.ts
+++ b/ui/src/public/track.ts
@@ -22,7 +22,7 @@ import {TrackEventDetailsPanel} from './details_panel';
 import {TrackEventDetails, TrackEventSelection} from './selection';
 import {SourceDataset} from '../trace_processor/dataset';
 import {TrackNode} from './workspace';
-import {Theme} from './theme';
+import {CanvasColors} from './canvas_colors';
 import {z} from 'zod';
 
 export interface TrackFilterCriteria {
@@ -110,7 +110,10 @@ export interface TrackRenderContext extends TrackContext {
    */
   readonly timescale: TimeScale;
 
-  readonly theme: Theme;
+  /**
+   * Semantic colors which can vary depending on the current theme.
+   */
+  readonly colors: CanvasColors;
 }
 
 // A definition of a track, including a renderer implementation and metadata.
@@ -393,5 +396,6 @@ export interface Overlay {
     timescale: TimeScale,
     size: Size2D,
     tracks: ReadonlyArray<TrackBounds>,
+    theme: CanvasColors,
   ): void;
 }


### PR DESCRIPTION
Add a new theme color --pf-color-timeline-overlay for decorations that overlay the timeline and use it for selected slice outlines + waker overlays.

In light mode these colors are the same as before (black), but in dark mode the colors have been changed to white. This might not be the best color for this in dark mode, but using the opposite color avoids bikeshedding for the sake of this PR.

Light:
<img width="224" height="332" alt="image" src="https://github.com/user-attachments/assets/8029d9f3-2d92-4ca5-9bea-a399ab15eadc" />

<img width="325" height="241" alt="image" src="https://github.com/user-attachments/assets/57d346aa-66b8-4347-8d2d-98dcb088d660" />

Dark:
<img width="273" height="352" alt="image" src="https://github.com/user-attachments/assets/f7c5fc73-8024-4324-8d7a-2726df89fa22" />

<img width="390" height="203" alt="image" src="https://github.com/user-attachments/assets/9af1a889-0b81-48dd-81fd-1a95636e5ffc" />

