### PR TITLE
ui: Fix pgup/pgdown scrolling in the timeline

### DIFF
--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -363,11 +363,23 @@ function onCssLoaded() {
       }
 
       return m(ThemeProvider, {theme: themeSetting.get() as 'dark' | 'light'}, [
-        m(HotkeyContext, {hotkeys, fillHeight: true, autoFocus: true}, [
-          m(OverlayContainer, {fillParent: true}, [
-            m(UiMain, {key: themeSetting.get()}),
-          ]),
-        ]),
+        m(
+          HotkeyContext,
+          {
+            hotkeys,
+            fillHeight: true,
+            // When embedded, hotkeys should be scoped to the context element to
+            // avoid interfering with the parent page. In standalone mode,
+            // document-level binding provides better UX (e.g., PGUP/PGDN scroll
+            // behavior).
+            focusable: false,
+          },
+          [
+            m(OverlayContainer, {fillParent: true}, [
+              m(UiMain, {key: themeSetting.get()}),
+            ]),
+          ],
+        ),
       ]);
     },
   });


### PR DESCRIPTION
https://github.com/google/perfetto/pull/3028 added a focusable div around the entire UI to handle hotkeys more elegantly in embedded applications. It transpires, however, that when the body is focused, the browser does some magic such scrolling scrollable containers when pgup/pgdown is pressed, that it doesn't do when a div is focused, even if the scrollable element is inside it.

The PR was also causing some other issues such as the focusable div would lose focus every now and again meaning that hotkeys would randomly stop working, including when blurring any element programmatically with `element.blur()`.

This patch adds a `focusable` property to the HotkeyContext component which, when disabled, makes the HotkeyContext un-focusable and binds the keydown event handlers to the document instead. This effectively restores the previous functionality but allows the focusable functionality to be enabled e.g. for embedded applications.

Fixes: https://b.corp.google.com/issues/449770609
