### PR TITLE
ui: allow setting record time from keyboard

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/perfetto_sdk.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/perfetto_sdk.ts
@@ -50,7 +50,7 @@ function trackEvent(): RecordProbe {
     image: 'rec_atrace.png',
     description:
       'Enables C / C++ / Java annotations (PERFETTO_TE_SLICE_BEGIN(), TRACE_EVENT(), os.PerfettoTrace())',
-    supportedPlatforms: ['ANDROID', 'CHROME', 'CHROME_OS', 'LINUX'],
+    supportedPlatforms: ['ANDROID', 'LINUX'],
     settings,
     genConfig: function (tc: TraceConfigBuilder) {
       tc.addTrackEventDisabledCategories('*');

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
@@ -99,10 +99,21 @@ export class Slider implements ProbeSetting {
 
     let spinnerCfg = {};
     if (attrs.isTime) {
+      const timeStr = new Date(val).toISOString().substring(11, 11 + 8);
       spinnerCfg = {
         type: 'text',
         pattern: '(0[0-9]|1[0-9]|2[0-3])(:[0-5][0-9]){2}', // hh:mm:ss
-        value: new Date(val).toISOString().substring(11, 11 + 8),
+        defaultValue: timeStr,
+        oncreate: (vnode: m.VnodeDOM) => {
+          (vnode.dom as HTMLInputElement).value = timeStr;
+        },
+        onupdate: (vnode: m.VnodeDOM) => {
+          const input = vnode.dom as HTMLInputElement;
+          // Only update if the input is not focused (i.e., user is not typing)
+          if (document.activeElement !== input) {
+            input.value = new Date(val).toISOString().substring(11, 11 + 8);
+          }
+        },
         oninput: (e: InputEvent) => {
           this.onTimeValueChange((e.target as HTMLInputElement).value);
         },


### PR DESCRIPTION
Also remove track_event from Chrome/CrOS: I forgot that they have their
own dedicated section so there's no point enabling it for them.

Fixes: https://github.com/google/perfetto/issues/3243
