### PR TITLE
ui: Fix table use-after-drop in QueryFlamegraph

### DIFF
--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -603,7 +603,7 @@ function createSliceFlameGraphPanel(trace: Trace) {
         return undefined;
       }
 
-      return {isLoading: false, content: currentFlamegraph.flamegraph.render()};
+      return {isLoading: false, content: currentFlamegraph.render()};
     },
   };
 }
@@ -611,7 +611,7 @@ function createSliceFlameGraphPanel(trace: Trace) {
 async function computeSliceFlamegraph(
   trace: Trace,
   currentSelection: AreaSelection,
-): Promise<(AsyncDisposable & {flamegraph: QueryFlamegraph}) | undefined> {
+): Promise<QueryFlamegraph | undefined> {
   const trackIds = [];
   for (const trackInfo of currentSelection.tracks) {
     if (!trackInfo?.tags?.kinds?.includes(SLICE_TRACK_KIND)) {
@@ -689,10 +689,12 @@ async function computeSliceFlamegraph(
       },
     ],
   );
-  return {
-    ...iiTable,
-    flamegraph: new QueryFlamegraph(trace, metrics, {
+  return new QueryFlamegraph(
+    trace,
+    metrics,
+    {
       state: Flamegraph.createDefaultState(metrics),
-    }),
-  };
+    },
+    [iiTable],
+  );
 }


### PR DESCRIPTION
Right now, a temporary table is created containing the slice data for the flamegraph every time a new area selection is created (i.e. every time the area selection is created, or an existing one is modified). QueryFlamegraph runs long-running asynchronous operations internally, which depend on this temporary table.

Every time a new area selection is created, the old table is dropped in order to avoid leaking memory. However, since we have no idea what the QueryFlamegraph is doing internally, we can drop this table while the QueryFlamegraph is in the middle of using it, which causes issues.

This change essentially shifts ownership of the underlying source table into the QueryFlamegraph itself, so that it can be only dropped once it's actually no longer being used.

Fixes: https://buganizer.corp.google.com/issues/447414248
