### PR TITLE
[TP] Fix extra statsd descriptors by enabling merging on main addFromFDS method

### DIFF
--- a/src/trace_processor/importers/proto/statsd_module.cc
+++ b/src/trace_processor/importers/proto/statsd_module.cc
@@ -114,10 +114,9 @@ StatsdModule::StatsdModule(ProtoImporterModuleContext* module_context,
       context_(context),
       args_parser_(*context_->descriptor_pool_) {
   RegisterForField(TracePacket::kStatsdAtomFieldNumber);
-  context_->descriptor_pool_->AddFromFileDescriptorSet(kAtomsDescriptor.data(),
-                                                       kAtomsDescriptor.size(),
-                                                       {},
-                                                       true); // To allow merging of extra descriptors from statsd
+  context_->descriptor_pool_->AddFromFileDescriptorSet(
+      kAtomsDescriptor.data(), kAtomsDescriptor.size(), {},
+      true);  // To allow merging of extra descriptors from statsd
   if (auto i = context_->descriptor_pool_->FindDescriptorIdx(kAtomProtoName)) {
     descriptor_idx_ = *i;
   } else {

--- a/src/trace_processor/trace_processor_storage_impl.cc
+++ b/src/trace_processor/trace_processor_storage_impl.cc
@@ -57,10 +57,9 @@ TraceProcessorStorageImpl::TraceProcessorStorageImpl(const Config& cfg)
   context()->reader_registry->RegisterTraceReader<ProtoTraceReader>(
       kSymbolsTraceType);
   for (const std::string& raw_bytes : cfg.extra_parsing_descriptors) {
-  context_.descriptor_pool_->AddFromFileDescriptorSet(
-      reinterpret_cast<const uint8_t*>(raw_bytes.data()), raw_bytes.size(),
-      {}, 
-      true);
+    context_.descriptor_pool_->AddFromFileDescriptorSet(
+        reinterpret_cast<const uint8_t*>(raw_bytes.data()), raw_bytes.size(),
+        {}, true);
   }
 }
 


### PR DESCRIPTION
Previously submitted code to enable extra statsd descriptors was rolled back last week due to a failing test case that was not covered prior to merging. The root cause appears to be a missing merge flag when adding the main kAtomsDescriptor to the descriptor pool through addFromFileDescriptor method
