### PR TITLE
ui: Add confirmation when restoring defaults

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.ts
@@ -30,6 +30,8 @@ import {FuzzyFinder} from '../../base/fuzzy';
 import {classNames} from '../../base/classnames';
 import {Intent} from '../../widgets/common';
 import {Anchor} from '../../widgets/anchor';
+import {Popup} from '../../widgets/popup';
+import {Box} from '../../widgets/box';
 
 const RELEASE_PROCESS_URL =
   'https://perfetto.dev/docs/visualization/perfetto-ui-release-process';
@@ -169,11 +171,39 @@ export class FlagsPage implements m.ClassComponent<FlagsPageAttrs> {
         stickyHeaderContent: m(
           Stack,
           {orientation: 'horizontal'},
-          m(Button, {
-            icon: 'restore',
-            label: 'Restore Defaults',
-            onclick: () => featureFlags.resetAll(),
-          }),
+          m(
+            Popup,
+            {
+              trigger: m(Button, {
+                icon: 'restore',
+                label: 'Restore Defaults',
+              }),
+            },
+            m(
+              Box,
+              m(
+                Stack,
+                'Are you sure you want to restore all flags to their default values? This action cannot be undone!',
+                m(
+                  Stack,
+                  {orientation: 'horizontal'},
+                  m(StackAuto),
+                  m(Button, {
+                    className: Popup.DISMISS_POPUP_GROUP_CLASS,
+                    variant: ButtonVariant.Filled,
+                    label: 'Cancel',
+                  }),
+                  m(Button, {
+                    className: Popup.DISMISS_POPUP_GROUP_CLASS,
+                    intent: Intent.Danger,
+                    variant: ButtonVariant.Filled,
+                    label: 'Restore Defaults',
+                    onclick: () => featureFlags.resetAll(),
+                  }),
+                ),
+              ),
+            ),
+          ),
           needsReload &&
             m(Button, {
               icon: 'refresh',

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
@@ -29,6 +29,8 @@ import {FuzzyFinder} from '../../base/fuzzy';
 import {Stack, StackAuto} from '../../widgets/stack';
 import {TextInput} from '../../widgets/text_input';
 import {EmptyState} from '../../widgets/empty_state';
+import {Popup} from '../../widgets/popup';
+import {Box} from '../../widgets/box';
 
 enum SortOrder {
   Name = 'name',
@@ -114,19 +116,47 @@ export class PluginsPage implements m.ClassComponent {
           },
           m(
             ButtonBar,
-            m(Button, {
-              icon: 'restore',
-              disabled: !anyNonDefaults,
-              label: 'Restore Defaults',
-              title: anyNonDefaults
-                ? 'Restore all plugins to their default enabled/disabled state'
-                : 'All plugins are in their default state',
-              onclick: () => {
-                for (const plugin of registeredPlugins) {
-                  plugin.enableFlag.reset();
-                }
+            m(
+              Popup,
+              {
+                trigger: m(Button, {
+                  icon: 'restore',
+                  disabled: !anyNonDefaults,
+                  label: 'Restore Defaults',
+                  title: anyNonDefaults
+                    ? 'Restore all plugins to their default enabled/disabled state'
+                    : 'All plugins are in their default state',
+                }),
               },
-            }),
+              m(
+                Box,
+                m(
+                  Stack,
+                  'Are you sure you want to restore all plugins to their default enabled/disabled state? This action cannot be undone!',
+                  m(
+                    Stack,
+                    {orientation: 'horizontal'},
+                    m(StackAuto),
+                    m(Button, {
+                      className: Popup.DISMISS_POPUP_GROUP_CLASS,
+                      variant: ButtonVariant.Filled,
+                      label: 'Cancel',
+                    }),
+                    m(Button, {
+                      className: Popup.DISMISS_POPUP_GROUP_CLASS,
+                      intent: Intent.Danger,
+                      variant: ButtonVariant.Filled,
+                      label: 'Restore Defaults',
+                      onclick: () => {
+                        for (const plugin of registeredPlugins) {
+                          plugin.enableFlag.reset();
+                        }
+                      },
+                    }),
+                  ),
+                ),
+              ),
+            ),
             needsRestart && reloadButton(),
           ),
           m(StackAuto),

--- a/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
@@ -30,6 +30,8 @@ import {classNames} from '../../base/classnames';
 import {Stack, StackAuto} from '../../widgets/stack';
 import {FuzzyFinder, FuzzySegment} from '../../base/fuzzy';
 import {CORE_PLUGIN_ID} from '../../core/plugin_manager';
+import {Popup} from '../../widgets/popup';
+import {Box} from '../../widgets/box';
 
 export class SettingsPage implements m.ClassComponent {
   private filterText = '';
@@ -61,11 +63,39 @@ export class SettingsPage implements m.ClassComponent {
         stickyHeaderContent: m(
           Stack,
           {orientation: 'horizontal'},
-          m(Button, {
-            icon: 'restore',
-            label: 'Restore Defaults',
-            onclick: () => settingsManager.resetAll(),
-          }),
+          m(
+            Popup,
+            {
+              trigger: m(Button, {
+                icon: 'restore',
+                label: 'Restore Defaults',
+              }),
+            },
+            m(
+              Box,
+              m(
+                Stack,
+                'Are you sure you want to restore all settings to their default values? This action cannot be undone!',
+                m(
+                  Stack,
+                  {orientation: 'horizontal'},
+                  m(StackAuto),
+                  m(Button, {
+                    className: Popup.DISMISS_POPUP_GROUP_CLASS,
+                    variant: ButtonVariant.Filled,
+                    label: 'Cancel',
+                  }),
+                  m(Button, {
+                    className: Popup.DISMISS_POPUP_GROUP_CLASS,
+                    intent: Intent.Danger,
+                    variant: ButtonVariant.Filled,
+                    label: 'Restore Defaults',
+                    onclick: () => settingsManager.resetAll(),
+                  }),
+                ),
+              ),
+            ),
+          ),
           reloadRequired &&
             m(Button, {
               icon: 'refresh',


### PR DESCRIPTION
Now that settings are getting more complex and contain more information, accidentally restoring settings can be rather destructive.

This patch adds a confirmation dialog to each 'Restore Defaults' button on the settings, plugins and flags pages to avoid accidentally wiping away information that would be annoying to reconfigure.

<img width="488" height="235" alt="image" src="https://github.com/user-attachments/assets/17baeb00-263b-491d-8560-816b897d48d3" />
