### PR TITLE
tp: Optimize callstack

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/appleos/instruments/samples.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/appleos/instruments/samples.sql
@@ -25,6 +25,9 @@ FROM _callstacks_for_callsites!((
 ORDER BY
   c.id;
 
+-- This index is added to optimize the creation of the
+-- appleos_instruments_samples_summary_tree table by speeding up the
+-- leaf-finding query in _callstacks_self_to_cumulative.
 CREATE PERFETTO INDEX _appleos_instruments_raw_callstacks_parent_id_idx ON _appleos_instruments_raw_callstacks(parent_id);
 
 -- Table summarising the callstacks captured during all

--- a/src/trace_processor/perfetto_sql/stdlib/callstacks/stack_profile.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/callstacks/stack_profile.sql
@@ -115,8 +115,14 @@ LEFT JOIN _callstack_spc_raw_forest AS p
 ORDER BY
   c._auto_id;
 
+-- This index is used to efficiently join the callstack forest with the
+-- sample data on callsite_id. This is a key operation in the
+-- _callstacks_for_callsites and _callstacks_for_stack_profile_samples macros.
 CREATE PERFETTO INDEX _callstack_spc_index ON _callstack_spc_forest(callsite_id);
 
+-- This index is necessary to optimize the leaf-finding query in
+-- _callstacks_self_to_cumulative. Without this index, the anti-join on
+-- parent_id can be very slow on large traces.
 CREATE PERFETTO INDEX _callstack_spc_parent_index ON _callstack_spc_forest(parent_id);
 
 CREATE PERFETTO MACRO _callstacks_for_stack_profile_samples(

--- a/src/trace_processor/perfetto_sql/stdlib/v8/jit.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/v8/jit.sql
@@ -148,7 +148,12 @@ SELECT
   col
 FROM __intrinsic_v8_js_function;
 
-CREATE PERFETTO INDEX _intrinsic_v8_js_code_jit_code_id_idx ON __intrinsic_v8_js_code(jit_code_id);
+-- This index is crucial for the performance of the callstack profiling standard
+-- library (`callstacks.stack_profile`). The library performs a join with the
+-- `_v8_js_code` view on `jit_code_id`. Without this index on the underlying
+-- table, the join becomes a major performance bottleneck, causing long module
+-- import times on traces with V8 data.
+CREATE PERFETTO INDEX _intrinsic_v8_js_code_jit_code_id_index ON __intrinsic_v8_js_code(jit_code_id);
 
 -- Represents a v8 code snippet for a Javascript function. A given function can
 -- have multiple code snippets (e.g. for different compilation tiers, or as the


### PR DESCRIPTION
- Add index on parent_id for _appleos_instruments_raw_callstacks
- Add index on parent_id for _callstack_spc_forest
- Update join query to IN check

Fixes: b/451557166

Just adding the indexes is not enough:

With only indexes:
```
> INCLUDE PERFETTO MODULE callstacks.stack_profile;

Query executed in 88019.122 ms

> CREATE PERFETTO TABLE _appleos_instruments_raw_callstacks AS SELECT * FROM _callstacks_for_callsites!(( SELECT p.callsite_id FROM instruments_sample p )) AS c ORDER BY c.id;

Query executed in 2834.731 ms

> SELECT r.*, a.cumulative_count FROM _callstacks_self_to_cumulative!(( SELECT id, parent_id, self_count FROM _appleos_instruments_raw_callstacks )) AS a JOIN _appleos_instruments_raw_callstacks AS r USING (id) ORDER BY r.id;
^X^CFully expanded statement
  SELECT r.*, a.cumulative_count FROM (
  ^
Traceback (most recent call last):
  File "stdin" line 1 col 1
    SELECT r.*, a.cumulative_count FROM _callstacks_self_to_cumulative!(( SELECT id, parent_id, self_count FROM _appleos_instruments
    ^
interrupted

Query executed in 312428.001 ms
```


After changing join to not in

```
> INCLUDE PERFETTO MODULE callstacks.stack_profile;

Query executed in 87391.652 ms

> CREATE PERFETTO TABLE _appleos_instruments_raw_callstacks AS SELECT * FROM _callstacks_for_callsites!(( SELECT p.callsite_id FROM instruments_sample p )) AS c ORDER BY c.id;


Query executed in 2717.048 ms

> SELECT r.*, a.cumulative_count FROM _callstacks_self_to_cumulative!(( SELECT id, parent_id, self_count FROM _appleos_instruments_raw_callstacks )) AS a JOIN _appleos_instruments_raw_callstacks AS r USING (id) ORDER BY r.id;
id                   parent_id            name                 mapping_name         source_file          line_number          self_count           cumulative_count     
-------------------- -------------------- -------------------- -------------------- -------------------- -------------------- -------------------- -------------------- 
...
Type 'q' to stop, Enter for more records: q

Query executed in 3352.755 ms
```


After adding index on jit_code_id
```
[169.175] processor_shell.cc:1934 Trace loaded: 274.42 MB in 7.44s (36.9 MB/s)
Error stats for this trace:
                                    name                                      idx                                   source                                    value 
---------------------------------------- ---------------------------------------- ---------------------------------------- ---------------------------------------- 
v8_unknown_code_type                     [NULL]                                   analysis                                                                        2 
jit_unknown_frame                        [NULL]                                   trace                                                                         290 
> INCLUDE PERFETTO MODULE callstacks.stack_profile;

Query executed in 23250.089 ms

```