### PR TITLE
ui: Add custom menu items support to DataGrid columns

### DIFF
--- a/ui/src/components/widgets/data_grid/common.ts
+++ b/ui/src/components/widgets/data_grid/common.ts
@@ -26,6 +26,14 @@ export interface ColumnDefinition {
   // An optional aggregation for data in this column displayed in the header
   // bar.
   readonly aggregation?: AggregationFunction;
+
+  // Optional extra menu items to add to the header column's context menu.
+  readonly headerMenuItems?: m.Children;
+
+  // Optional function that returns extra menu items to add to each data cell's
+  // context menu. The function receives the cell value and the complete row
+  // data.
+  readonly cellMenuItems?: (value: SqlValue, row: RowDef) => m.Children;
 }
 
 export interface FilterValue {

--- a/ui/src/components/widgets/data_grid/data_grid.ts
+++ b/ui/src/components/widgets/data_grid/data_grid.ts
@@ -382,6 +382,13 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
                   );
                 }
 
+                if (Boolean(column.headerMenuItems)) {
+                  if (menuItems.length > 0) {
+                    menuItems.push(m(MenuDivider));
+                  }
+                  menuItems.push(column.headerMenuItems);
+                }
+
                 return m(
                   GridHeaderCell,
                   {
@@ -654,6 +661,16 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
                     },
                   }),
                 );
+              }
+            }
+
+            if (column.cellMenuItems !== undefined) {
+              const extraItems = column.cellMenuItems(value, row);
+              if (extraItems !== undefined) {
+                if (menuItems.length > 0) {
+                  menuItems.push(m(MenuDivider));
+                }
+                menuItems.push(extraItems);
               }
             }
 

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -2017,6 +2017,11 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
                 name: 'id',
                 title: 'ID',
                 aggregation: aggregation ? 'COUNT' : undefined,
+                headerMenuItems: m(MenuItem, {
+                  label: 'Log column name',
+                  icon: 'info',
+                  onclick: () => console.log('Column: id'),
+                }),
               },
               {name: 'ts', title: 'Timestamp'},
               {
@@ -2024,7 +2029,25 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
                 aggregation: aggregation ? 'SUM' : undefined,
                 title: 'Duration',
               },
-              {name: 'name', title: 'Name'},
+              {
+                name: 'name',
+                title: 'Name',
+                cellMenuItems: (value, row) => [
+                  m(MenuItem, {
+                    label: `Copy "${value}"`,
+                    icon: 'content_copy',
+                    onclick: () => {
+                      navigator.clipboard.writeText(String(value));
+                      console.log(`Copied: ${value}`);
+                    },
+                  }),
+                  m(MenuItem, {
+                    label: `Log full row`,
+                    icon: 'bug_report',
+                    onclick: () => console.log('Row:', row),
+                  }),
+                ],
+              },
               {name: 'data', title: 'Data'},
               {name: 'maybe_null', title: 'Maybe Null?'},
               {name: 'category', title: 'Category'},


### PR DESCRIPTION
This patch extends ColumnDefinition with two new optional properties:
- headerMenuItems: for adding custom context menu items to headers.
- cellMenuItems: for adding dynamic menu items to cells based on their values.

This allows developers to extend the DataGrid with custom actions without modifying the core component. Includes example usage in the widgets showcase page.