### PR TITLE
ui: Cast 'tid' to BigInt instead of number to avoid losing precision

### DIFF
--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -29,6 +29,7 @@ import {TrackNode} from '../../public/workspace';
 import {Engine} from '../../trace_processor/engine';
 import {
   LONG,
+  LONG_NULL,
   NUM,
   NUM_NULL,
   STR_NULL,
@@ -258,7 +259,7 @@ export default class SchedPlugin implements PerfettoPlugin {
     const it = result.iter({
       utid: NUM,
       upid: NUM_NULL,
-      tid: NUM_NULL,
+      tid: LONG_NULL,
       threadName: STR_NULL,
       isMainThread: NUM_NULL,
       isKernelThread: NUM,

--- a/ui/src/public/utils.ts
+++ b/ui/src/public/utils.ts
@@ -23,7 +23,7 @@ export function getTrackName(
     processName: string | null;
     pid: number | null;
     threadName: string | null;
-    tid: number | null;
+    tid: number | bigint | null;
     upid: number | null;
     userName: string | null;
     uid: number | null;


### PR DESCRIPTION
Fixes: https://buganizer.corp.google.com/issues/451700544
