### PR TITLE
tp: temporarily work around perf records with zero timestamps

### DIFF
--- a/src/trace_processor/importers/perf/perf_data_tokenizer.cc
+++ b/src/trace_processor/importers/perf/perf_data_tokenizer.cc
@@ -358,7 +358,7 @@ base::StatusOr<int64_t> PerfDataTokenizer::ExtractTraceTimestamp(
     return base::ErrStatus("Failed to read time");
   }
 
-  // TODO(lalitm): `*time > 0` is a temporary hack to work around the fact that
+  // TODO(449973773): `*time > 0` is a temporary hack to work around the fact that
   // some perf record types which actually don't have a timestamp. They should
   // have been procesed during tokenization time (e.g. MMAP/MMAP2/COMM) but
   // were incorrectly written to be handled with at parsing time. So by setting


### PR DESCRIPTION
We should come back and do this properly by moving parsing of certain
events to tokenization time but that would be a signifcant undertaking.
Let's just do the essential thing to get this unblocked.

Fixes: b/449973773
