### PR TITLE
docs: update SQL Macro usecase

### DIFF
--- a/docs/analysis/perfetto-sql-syntax.md
+++ b/docs/analysis/perfetto-sql-syntax.md
@@ -209,7 +209,7 @@ above.
 If only passing around scalar SQL values, functions are generally preferred
 for their clarity. However, for simple constants used many times in a
 performance-sensitive query, a macro can be more efficient as it avoids the
-potential overhead of massive function calls.
+potential overhead of function calls in a large number.
 
 NOTE: Macros are expanded with a pre-processing step *before* any execution
 happens. Expansion is a purely syntatic operation involves replacing the macro


### PR DESCRIPTION
In PR#3276, we found a MACRO usecase which wasn't listed before. Therefore adding this usecase and explainations of it in the doc.

Basically, it would be ok to use `MACRO` for a constant if it would be referenced massive times and it would be bad to use `FUNCTION` for it which will bring massive performance overhead since SQL `FUNCTION` can't do inlining.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
