### PR TITLE
tp: add changelog entry calling out arg_set_id addition to thread

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,11 @@ Unreleased:
     * Added support for parsing process_sort_index and thread_sort_index
       metadata from JSON traces. These are stored as process_sort_index_hint
       and thread_sort_index_hint in the args table for processes and threads.
+    * Added an `arg_set_id` column to the thread table. Queries joining
+      `thread` with other tables now need to disambiguate the column or they
+      may fail with "ambiguous column name: arg_set_id". Qualify the column
+      with the table name (e.g. `slice.arg_set_id` or `counter.arg_set_id`) to
+      resolve this.
   UI:
     * Perf sample callstack tracks: if a trace contains multiple callstack data
       sources, the thread and process level callstack tracks can now be


### PR DESCRIPTION
This can cause breakages so it's important we call this out.
