### PR TITLE
tp: fallback to task window container if fragment unavailable

### DIFF
--- a/src/trace_processor/importers/proto/winscope/test/windowmanager_hierarchy_walker_unittest.cc
+++ b/src/trace_processor/importers/proto/winscope/test/windowmanager_hierarchy_walker_unittest.cc
@@ -368,6 +368,22 @@ TEST_F(WindowManagerHierarchyWalkerTest, TaskNameOverride) {
       });
 }
 
+TEST_F(WindowManagerHierarchyWalkerTest, TaskWindowContainerFallback) {
+  auto containers = walker_.ExtractWindowContainers(
+      protos::pbzero::WindowManagerTraceEntry::Decoder(
+          WindowManagerSampleProtos::HierarchyWithTaskContainerFallback()));
+
+  CheckWindowContainers(
+      containers,
+      {
+          {"root", 1, std::nullopt, std::nullopt, false, std::nullopt,
+           "RootWindowContainer", std::nullopt},
+          {"child - Task", 2, 1, 0, false, std::nullopt, "Task", std::nullopt},
+          {"grandchild - WindowContainer", 3, 2, 0, false, std::nullopt,
+           "WindowContainer", std::nullopt},
+      });
+}
+
 TEST_F(WindowManagerHierarchyWalkerTest, WindowStateNameOverrides) {
   auto containers = walker_.ExtractWindowContainers(
       protos::pbzero::WindowManagerTraceEntry::Decoder(

--- a/src/trace_processor/importers/proto/winscope/test/windowmanager_sample_protos.h
+++ b/src/trace_processor/importers/proto/winscope/test/windowmanager_sample_protos.h
@@ -174,6 +174,24 @@ class WindowManagerSampleProtos {
     return entry.SerializeAsString();
   }
 
+  static std::string HierarchyWithTaskContainerFallback() {
+    protozero::HeapBuffered<protos::pbzero::WindowManagerTraceEntry> entry;
+
+    auto* root = AddRoot(&entry);
+
+    auto* task = root->add_children()->set_task();
+    auto* task_fragment = task->set_task_fragment();
+    auto* window_container = task_fragment->set_window_container();
+    auto* identifier = window_container->set_identifier();
+    identifier->set_hash_code(2);
+    identifier->set_title("child - Task");
+
+    auto* task_window_container = task->set_window_container();
+    AddGrandchild(task_window_container);
+
+    return entry.SerializeAsString();
+  }
+
   static std::string HierarchyWithActivityRecord() {
     protozero::HeapBuffered<protos::pbzero::WindowManagerTraceEntry> entry;
 


### PR DESCRIPTION
Bug: 438681230

Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=WindowManager*

Test: tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell --name-filter="PerfettoTable:winscope|WindowManager"