### PR TITLE
exp: Remove sourceCols from QueryNode

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -29,7 +29,6 @@ import {
 import {AddColumnsNode} from './query_builder/nodes/dev/add_columns_node';
 import {LimitAndOffsetNode} from './query_builder/nodes/dev/limit_and_offset_node';
 import {SortNode} from './query_builder/nodes/dev/sort_node';
-import {columnInfoFromName} from './query_builder/column_info';
 
 describe('JSON serialization/deserialization', () => {
   let trace: Trace;
@@ -96,8 +95,10 @@ describe('JSON serialization/deserialization', () => {
     const deserializedState = deserializeState(json, trace, sqlModules);
 
     expect(deserializedState.rootNodes.length).toBe(1);
-    const deserializedNode = deserializedState.rootNodes[0] as SlicesSourceNode;
-    expect(deserializedNode.state.slice_name).toBe('test_slice');
+    const deserializedNode = deserializedState.rootNodes[0];
+    expect((deserializedNode as SlicesSourceNode).state.slice_name).toBe(
+      'test_slice',
+    );
     expect(deserializedNode.prevNodes).toEqual([]);
   });
 
@@ -665,10 +666,6 @@ describe('JSON serialization/deserialization', () => {
       trace,
       sqlModules,
     });
-    tableNode.finalCols = [
-      columnInfoFromName('name'),
-      columnInfoFromName('ts'),
-    ];
 
     const sortNode = new SortNode({
       prevNodes: [tableNode],

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/dev/test_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/dev/test_node.ts
@@ -13,20 +13,25 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {QueryNode, QueryNodeState, NodeType} from '../../../query_node';
+import {
+  QueryNode,
+  QueryNodeState,
+  NodeType,
+  createFinalColumns,
+} from '../../../query_node';
 import {ColumnInfo} from '../../column_info';
 import protos from '../../../../../protos';
 import {SourceNode} from '../../source_node';
 
 export class TestNode extends SourceNode {
   isDevNode = true;
-
-  get sourceCols(): ColumnInfo[] {
-    return [];
-  }
+  readonly finalCols: ColumnInfo[];
+  nextNodes: QueryNode[];
 
   constructor(state: QueryNodeState) {
     super(state);
+    this.finalCols = createFinalColumns([]);
+    this.nextNodes = [];
   }
 
   get type(): NodeType {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -49,12 +49,8 @@ export class IntervalIntersectNode implements QueryNode {
   readonly state: IntervalIntersectNodeState;
   meterialisedAs?: string;
 
-  get sourceCols(): ColumnInfo[] {
-    return this.prevNodes[0]?.finalCols ?? this.prevNodes[0]?.sourceCols ?? [];
-  }
-
   get finalCols(): ColumnInfo[] {
-    return newColumnInfoList(this.sourceCols, true);
+    return newColumnInfoList(this.prevNodes[0]?.finalCols ?? [], true);
   }
 
   constructor(state: IntervalIntersectNodeState) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -18,6 +18,7 @@ import {
   QueryNode,
   QueryNodeState,
   NodeType,
+  createFinalColumns,
 } from '../../../query_node';
 import {ColumnInfo, columnInfoFromSqlColumn} from '../../column_info';
 import protos from '../../../../../protos';
@@ -48,16 +49,18 @@ export interface SlicesSourceState extends QueryNodeState {
 
 export class SlicesSourceNode extends SourceNode {
   readonly state: SlicesSourceState;
-
-  get sourceCols() {
-    return slicesSourceNodeColumns(true);
-  }
+  readonly finalCols: ColumnInfo[];
+  nextNodes: QueryNode[];
+  meterialisedAs?: string;
+  prevNodes: QueryNode[] = [];
 
   constructor(attrs: SlicesSourceState) {
     super(attrs);
     this.state = attrs;
     this.state.onchange = attrs.onchange;
+    this.finalCols = createFinalColumns(slicesSourceNodeColumns(true));
     this.nextNodes = [];
+    this.prevNodes = [];
   }
 
   get type() {
@@ -110,10 +113,7 @@ export class SlicesSourceNode extends SourceNode {
 
     sq.simpleSlices = ss;
 
-    const filtersProto = createFiltersProto(
-      this.state.filters,
-      this.sourceCols,
-    );
+    const filtersProto = createFiltersProto(this.state.filters, this.finalCols);
     if (filtersProto) sq.filters = filtersProto;
 
     const selectedColumns = createSelectColumnsProto(this);
@@ -215,7 +215,7 @@ export class SlicesSourceNode extends SourceNode {
       ),
       m(FilterOperation, {
         filters: this.state.filters,
-        sourceCols: this.sourceCols,
+        sourceCols: this.finalCols,
         onFiltersChanged: (newFilters: ReadonlyArray<FilterDefinition>) => {
           this.state.filters = newFilters as FilterDefinition[];
           this.state.onchange?.();

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/source_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/source_node.ts
@@ -13,31 +13,19 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  createFinalColumns,
-  NodeType,
-} from '../query_node';
+import {QueryNode, QueryNodeState, NodeType, nextNodeId} from '../query_node';
 import {ColumnInfo} from './column_info';
 import protos from '../../../protos';
 
 export abstract class SourceNode implements QueryNode {
   readonly nodeId: string;
-  prevNodes: QueryNode[] = [];
-  nextNodes: QueryNode[];
-  meterialisedAs?: string;
-
-  abstract readonly sourceCols: ColumnInfo[];
-  finalCols: ColumnInfo[];
-
   readonly state: QueryNodeState;
+  abstract readonly finalCols: ColumnInfo[];
+  nextNodes: QueryNode[];
 
   constructor(state: QueryNodeState) {
     this.nodeId = nextNodeId();
     this.state = state;
-    this.finalCols = createFinalColumns(this);
     this.nextNodes = [];
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -49,7 +49,6 @@ export interface QueryNodeState {
   prevNodes?: QueryNode[];
   customTitle?: string;
   comment?: string;
-  sourceCols?: ColumnInfo[];
   trace?: Trace;
   sqlModules?: SqlModules;
   sqlTable?: SqlTable;
@@ -73,9 +72,6 @@ export interface QueryNode {
   prevNodes?: QueryNode[];
   nextNodes: QueryNode[];
 
-  // Columns that are available in the source data.
-  readonly sourceCols: ColumnInfo[];
-
   // Columns that are available after applying all operations.
   readonly finalCols: ColumnInfo[];
 
@@ -91,6 +87,13 @@ export interface QueryNode {
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined;
   isMaterialised(): boolean;
   serializeState(): object;
+  onPrevNodesUpdated?(): void;
+}
+
+export function notifyNextNodes(node: QueryNode) {
+  for (const nextNode of node.nextNodes) {
+    nextNode.onPrevNodesUpdated?.();
+  }
 }
 
 export interface Query {
@@ -119,8 +122,8 @@ export function createSelectColumnsProto(
   return selectedColumns;
 }
 
-export function createFinalColumns(node: QueryNode) {
-  return newColumnInfoList(node.sourceCols, true);
+export function createFinalColumns(sourceCols: ColumnInfo[]) {
+  return newColumnInfoList(sourceCols, true);
 }
 
 function getStructuredQueries(


### PR DESCRIPTION
A cleanup of query nodes - we don't need to maintain a list of source columns, as we can just ask the parent for its list of the final columns
