### PR TITLE
tp: procfs process trees: set main thread name if "cmdline_is_comm"

### DIFF
--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -666,10 +666,24 @@ void SystemProbesParser::ParseProcessTree(ConstBytes blob) {
     UniquePid pupid = context_->process_tracker->GetOrCreateProcess(ppid);
     UniquePid upid = context_->process_tracker->GetOrCreateProcess(pid);
 
-    upid =
-        context_->process_tracker->UpdateProcessWithParent(upid, pupid, true);
+    upid = context_->process_tracker->UpdateProcessWithParent(
+        upid, pupid, /*associate_main_thread=*/true);
 
     context_->process_tracker->SetProcessMetadata(upid, argv0, joined_cmdline);
+
+    // perfetto v50+: additionally, if we know that the "cmdline" contents are
+    // coming from the main thread's name ("comm"), then set the thread name as
+    // well. This comes up with kernel threads, which are in fact single-thread
+    // processes without a /proc/pid/cmdline. The reuse of "cmdline" for this
+    // scenario is historical, but we maintain compatibility. Note:
+    // cmdline_is_comm is not equivalent to "is a kernel thread", as the field
+    // could also be set for e.g. zombie processes.
+    if (proc.cmdline_is_comm()) {
+      auto utid = context_->process_tracker->GetOrCreateThread(pid);
+      auto thread_name_id = context_->storage->InternString(joined_cmdline);
+      context_->process_tracker->UpdateThreadName(
+          utid, thread_name_id, ThreadNamePriority::kProcessTree);
+    }
 
     if (proc.has_uid()) {
       context_->process_tracker->SetProcessUid(


### PR DESCRIPTION
This came up for traces containing perf samples + procfs trees, but no sched_switch to supply thread names. The result is that the grouped kernel thread tracks end up mostly anonymous (since the procfs scraping is only supplying the process names). Additionally, a subset of those threads does end up with a name due to the trace including "task_rename" ftrace events.

On modern traces, we actually know if the "cmdline" field in the trace was set from /proc/pid/comm, so we can use that information to name the main thread as well.
