### PR TITLE
ui: Tidy up logic in frames plugin around the experimental track

### DIFF
--- a/ui/src/plugins/dev.perfetto.Frames/index.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/index.ts
@@ -30,10 +30,7 @@ import {Setting} from '../../public/settings';
 import {z} from 'zod';
 
 // Build a standardized URI for a frames track
-function makeUri(
-  upid: number,
-  kind: 'expected_frames' | 'actual_frames' | 'actual_frames_experimental',
-) {
+function makeUri(upid: number, kind: string) {
   return `/process_${upid}/${kind}`;
 }
 
@@ -55,10 +52,7 @@ export default class Frames implements PerfettoPlugin {
 
   async onTraceLoad(ctx: Trace): Promise<void> {
     this.addExpectedFrames(ctx);
-    this.addActualFrames(ctx, false);
-    if (Frames.showExperimentalJankClassification.get()) {
-      this.addActualFrames(ctx, true);
-    }
+    this.addActualFrames(ctx);
     ctx.selection.registerAreaSelectionTab(
       createAggregationTab(ctx, new FrameSelectionAggregator(), 10),
     );
@@ -118,10 +112,7 @@ export default class Frames implements PerfettoPlugin {
     }
   }
 
-  async addActualFrames(
-    ctx: Trace,
-    useExperimentalTrack: boolean,
-  ): Promise<void> {
+  async addActualFrames(ctx: Trace): Promise<void> {
     const {engine} = ctx;
     const result = await engine.query(`
       with summary as (
@@ -146,44 +137,67 @@ export default class Frames implements PerfettoPlugin {
       trackIds: STR,
       maxDepth: NUM,
     });
+
     for (; it.valid(); it.next()) {
       const upid = it.upid;
       const rawTrackIds = it.trackIds;
       const trackIds = rawTrackIds.split(',').map((v) => Number(v));
       const maxDepth = it.maxDepth;
+      const group = ctx.plugins
+        .getPlugin(ProcessThreadGroupsPlugin)
+        .getGroupForProcess(upid);
 
-      const uriKind = useExperimentalTrack
-        ? 'actual_frames_experimental'
-        : 'actual_frames';
-      const trackKinds = [SLICE_TRACK_KIND];
-      if (!useExperimentalTrack) {
-        trackKinds.push(ACTUAL_FRAMES_SLICE_TRACK_KIND);
-      }
-      const uri = makeUri(upid, uriKind);
+      // Standard actual frames track
+      const standardUri = makeUri(upid, 'actual_frames');
       ctx.tracks.registerTrack({
-        uri,
+        uri: standardUri,
         renderer: createActualFramesTrack(
           ctx,
-          uri,
+          standardUri,
           maxDepth,
           trackIds,
-          useExperimentalTrack,
+          false,
         ),
         tags: {
           upid,
           trackIds,
-          kinds: trackKinds,
+          kinds: [SLICE_TRACK_KIND, ACTUAL_FRAMES_SLICE_TRACK_KIND],
         },
       });
-      const group = ctx.plugins
-        .getPlugin(ProcessThreadGroupsPlugin)
-        .getGroupForProcess(upid);
-      const track = new TrackNode({
-        uri,
-        name: 'Actual Timeline',
-        sortOrder: -50,
-      });
-      group?.addChildInOrder(track);
+      group?.addChildInOrder(
+        new TrackNode({
+          uri: standardUri,
+          name: 'Actual Timeline',
+          sortOrder: -50,
+        }),
+      );
+
+      // Experimental jank classification track (if enabled)
+      if (Frames.showExperimentalJankClassification.get()) {
+        const experimentalUri = makeUri(upid, 'actual_frames_experimental');
+        ctx.tracks.registerTrack({
+          uri: experimentalUri,
+          renderer: createActualFramesTrack(
+            ctx,
+            experimentalUri,
+            maxDepth,
+            trackIds,
+            true,
+          ),
+          tags: {
+            upid,
+            trackIds,
+            kinds: [SLICE_TRACK_KIND],
+          },
+        });
+        group?.addChildInOrder(
+          new TrackNode({
+            uri: experimentalUri,
+            name: 'Actual Timeline (Experimental)',
+            sortOrder: -49,
+          }),
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
This change makes it so that each track gets its own clear definition. This might seem like duplication but it's much easier to see the properties of each track when each one is clearly laid out in full.