### PR TITLE
UI: Add translation for ETW "Ready" and "Terminated" thread states.

### DIFF
--- a/ui/src/components/sql_utils/thread_state.ts
+++ b/ui/src/components/sql_utils/thread_state.ts
@@ -62,9 +62,9 @@ export function translateState(
     case 'Created':
     case 'Running':
     case 'Initialized':
-    case 'Deferred Ready':
+    case 'DeferredReady':
     case 'Transition':
-    case 'Stand By':
+    case 'Standby':
     case 'Waiting':
     case 'Ready':
     case 'Terminated':


### PR DESCRIPTION
The `translateState` function was missing translations for the "Ready" and "Terminated" thread states, which are specific to Event Tracing for Windows (ETW). This resulted in these states being displayed incorrectly when analyzing Windows traces. 

This change adds them to the list of self-describing states to ensure they are rendered accurately in the UI.