### PR TITLE
ui: table viewer: add "analyze" submenu.

### DIFF
--- a/ui/src/base/semantic_icons.ts
+++ b/ui/src/base/semantic_icons.ts
@@ -40,7 +40,6 @@ export class Icons {
   static readonly Star = 'star';
   static readonly ChangeTab = 'tab';
   static readonly Crashed = 'warning';
-  static readonly Chart = 'bar_chart';
   static readonly Change = 'change_circle';
   static readonly GoTo = 'arrow_forward';
   static readonly ContextMenuAlt = 'more_vert';
@@ -63,6 +62,11 @@ export class Icons {
   static readonly SortDesc = 'arrow_downward';
   static readonly ResetState = 'restart_alt';
   static readonly Remove = 'clear';
+
+  // Data analysis
+  static readonly Analyze = 'analytics';
+  static readonly Chart = 'bar_chart';
+  static readonly Pivot = 'pivot_table_chart';
 
   static readonly Play = 'play_arrow';
   static readonly Edit = 'edit';

--- a/ui/src/components/details/sql_table_tab.ts
+++ b/ui/src/components/details/sql_table_tab.ts
@@ -37,6 +37,7 @@ import {SqlHistogram, SqlHistogramState} from '../widgets/charts/sql_histogram';
 import {sqlColumnId} from '../widgets/sql/table/sql_column';
 import {TabOption, TabStrip} from '../../widgets/tabs';
 import {Gate} from '../../base/mithril_utils';
+import {isQuantitativeType} from '../../trace_processor/perfetto_sql_type';
 
 export interface AddSqlTableTabParams {
   table: SqlTableDescription;
@@ -136,9 +137,15 @@ class SqlTableTab implements Tab {
   }
 
   private tableMenuItems(column: TableColumn) {
-    return [
+    return m(
+      MenuItem,
+      {
+        label: 'Analyze',
+        icon: Icons.Analyze,
+      },
       m(MenuItem, {
         label: 'Pivot',
+        icon: Icons.Pivot,
         onclick: () => {
           const state = new PivotTableState({
             pivots: [column],
@@ -152,6 +159,7 @@ class SqlTableTab implements Tab {
       }),
       m(MenuItem, {
         label: 'Add bar chart',
+        icon: Icons.Chart,
         onclick: () => {
           const state = new SqlBarChartState({
             trace: this.tableState.trace,
@@ -163,20 +171,22 @@ class SqlTableTab implements Tab {
           this.barCharts.push(state);
         },
       }),
-      m(MenuItem, {
-        label: 'Add histogram',
-        onclick: () => {
-          const state = new SqlHistogramState({
-            trace: this.tableState.trace,
-            sqlSource: this.tableState.config.name,
-            column: column.column,
-            filters: this.tableState.filters,
-          });
-          this.selectedTab = state.uuid;
-          this.histograms.push(state);
-        },
-      }),
-    ];
+      (column.type === undefined ? true : isQuantitativeType(column.type)) &&
+        m(MenuItem, {
+          label: 'Add histogram',
+          icon: Icons.Chart,
+          onclick: () => {
+            const state = new SqlHistogramState({
+              trace: this.tableState.trace,
+              sqlSource: this.tableState.config.name,
+              column: column.column,
+              filters: this.tableState.filters,
+            });
+            this.selectedTab = state.uuid;
+            this.histograms.push(state);
+          },
+        }),
+    );
   }
 
   render() {


### PR DESCRIPTION
Move pivot, add bar chart and add histogram options into a dedicated submenu ("analyze"),
beautify it by adding menu icons and do not show "add histogram" for non-quantative options.

Old menu:
<img width="160" height="293" alt="Screenshot 2025-10-20 at 01 03 51" src="https://github.com/user-attachments/assets/1b3dc981-f400-428a-82a5-c21cfb5d954f" />

New menu:
<img width="296" height="250" alt="Screenshot 2025-10-20 at 01 04 03" src="https://github.com/user-attachments/assets/5515535e-efd0-4c5b-a620-764175a01d40" />
