### PR TITLE
ui: Preserve 'Current Selection' tab panel state

### DIFF
--- a/ui/src/frontend/timeline_page/tab_panel.ts
+++ b/ui/src/frontend/timeline_page/tab_panel.ts
@@ -87,11 +87,9 @@ export class TabPanel implements m.ClassComponent<TabPanelAttrs> {
 
     // Add the permanent current selection tab to the front of the list of tabs
     const active = currentTabUri === 'current_selection';
-    if (active) {
-      drawerContent.push(
-        m(Gate, {open: active}, m(CurrentSelectionTab, {trace})),
-      );
-    }
+    drawerContent.unshift(
+      m(Gate, {open: active}, m(CurrentSelectionTab, {trace})),
+    );
 
     tabs.unshift(
       m(


### PR DESCRIPTION
While other tab's state is preserved when switching tabs, the 'Current Selection' tab was left out, so switching away from it would cause it to lose state.

This patch fixes this, allowing the current selection tab's state to be preserved including the currently selected sub-tab in aggregations.

Fixes: https://buganizer.corp.google.com/issues/453942809

Note: This fix doesn't persist state between sub-tabs in the current selection tab. This is a different issue, and will be fixed in a followup.