### PR TITLE
ui: Preserve state between current selection tab sub-tabs

### DIFF
--- a/ui/src/frontend/timeline_page/current_selection_tab.ts
+++ b/ui/src/frontend/timeline_page/current_selection_tab.ts
@@ -28,6 +28,7 @@ import {
 import {assertUnreachable} from '../../base/logging';
 import {Button, ButtonBar} from '../../widgets/button';
 import {NoteEditor} from '../note_editor';
+import {Gate} from '../../base/mithril_utils';
 
 export interface CurrentSelectionTabAttrs {
   readonly trace: TraceImpl;
@@ -117,12 +118,15 @@ export class CurrentSelectionTab
 
     // Find the active tab or just pick the first one if that selected tab is
     // not available.
-    const [activeTab, tabContent] =
-      renderedTabs.find(([tab]) => tab.id === this.currentAreaSubTabId) ??
-      renderedTabs[0];
+    const activeTab =
+      renderedTabs.find(([tab]) => tab.id === this.currentAreaSubTabId)?.[0] ??
+      renderedTabs[0][0];
+
+    // Determine if any tab content is loading
+    const isLoading = renderedTabs.some(([_, content]) => content?.isLoading);
 
     return {
-      isLoading: tabContent?.isLoading ?? false,
+      isLoading,
       content: m(
         DetailsShell,
         {
@@ -139,7 +143,10 @@ export class CurrentSelectionTab
             ),
           ),
         },
-        tabContent?.content,
+        // Render all tabs but control visibility with Gate
+        renderedTabs.map(([tab, content]) =>
+          m(Gate, {open: activeTab === tab}, content?.content),
+        ),
       ),
     };
   }


### PR DESCRIPTION
All sub tabs of the current selection tab are rendered, but only the active one is visible. This persists DOM state between tab-flips, and follows how the rest of the UI works: e.g. tabs, pages