### PR TITLE
sma: fix unnecessary extra calls to FlushPendingCommitDataRequests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ Unreleased:
       by default (set it explicitly to false to revert to previous encoding,
       which is now deprecated). This reduces trace size when recording events
       that aren't know by perfetto at compile time.
+    * SharedMemoryArbiter: Reduced CPU usage when tracing high-throughput
+      workloads by preventing duplicate immediate flush tasks when the shared
+      memory buffer is more than half full.
   SQL Standard library:
     *
   Trace Processor:
@@ -24,7 +27,8 @@ Unreleased:
       from JSON traces. Processes and threads with lower sort index values
       will appear first in the UI.
   SDK:
-    *
+    * Reduced CPU usage when tracing high-throughput workloads by preventing
+      duplicate immediate flush tasks in the shared memory arbiter.
 
 v52.0 - 2025-09-16:
   Tracing service and probes:

--- a/include/perfetto/ext/base/flags.h
+++ b/include/perfetto/ext/base/flags.h
@@ -45,7 +45,8 @@ namespace perfetto::base::flags {
         : NonAndroidPlatformDefault_FALSE)                             \
   X(use_rt_mutex, NonAndroidPlatformDefault_FALSE)                     \
   X(use_rt_futex, NonAndroidPlatformDefault_FALSE)                     \
-  X(buffer_clone_preserve_read_iter, NonAndroidPlatformDefault_TRUE)
+  X(buffer_clone_preserve_read_iter, NonAndroidPlatformDefault_TRUE)   \
+  X(sma_prevent_duplicate_immediate_flushes, NonAndroidPlatformDefault_TRUE)
 
 ////////////////////////////////////////////////////////////////////////////////
 //                                                                            //

--- a/perfetto_flags.aconfig
+++ b/perfetto_flags.aconfig
@@ -56,3 +56,10 @@ flag {
   bug: "448604718"
   is_fixed_read_only: true
 }
+flag {
+  name: "sma_prevent_duplicate_immediate_flushes"
+  namespace: "perfetto"
+  description: "Controls whether SharedMemoryArbiter will prevent posting duplicate immediate flush tasks when the shared memory buffer is more than half full. When enabled, only one immediate flush task is posted until it completes, preventing excessive CPU usage from task runner spam."
+  bug: "330580374"
+  is_fixed_read_only: true
+}

--- a/src/tracing/core/shared_memory_arbiter_impl.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl.cc
@@ -23,6 +23,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/task_runner.h"
 #include "perfetto/base/time.h"
+#include "perfetto/ext/base/flags.h"
 #include "perfetto/ext/tracing/core/commit_data_request.h"
 #include "perfetto/ext/tracing/core/shared_memory.h"
 #include "perfetto/ext/tracing/core/shared_memory_abi.h"
@@ -385,9 +386,20 @@ void SharedMemoryArbiterImpl::UpdateCommitDataRequest(
     // trace.
     if (fully_bound_ &&
         (last_patch_req || bytes_pending_commit_ >= shmem_abi_.size() / 2)) {
-      weak_this = weak_ptr_factory_.GetWeakPtr();
-      task_runner_to_post_delayed_callback_on = task_runner_;
-      flush_delay_ms = 0;
+      bool should_post_immediate_flush = true;
+      if (base::flags::sma_prevent_duplicate_immediate_flushes) {
+        // Only post an immediate flush task if we haven't already posted one.
+        // This prevents spamming the task runner with immediate flushes when
+        // the buffer remains over 50% full while chunks continue to be
+        // committed. See b/330580374.
+        should_post_immediate_flush = !immediate_flush_scheduled_;
+      }
+      if (should_post_immediate_flush) {
+        weak_this = weak_ptr_factory_.GetWeakPtr();
+        task_runner_to_post_delayed_callback_on = task_runner_;
+        flush_delay_ms = 0;
+        immediate_flush_scheduled_ = true;
+      }
     }
 
     // When using shmem emulation we commit the completed chunks immediately
@@ -401,6 +413,9 @@ void SharedMemoryArbiterImpl::UpdateCommitDataRequest(
         // Allow next call to UpdateCommitDataRequest to start
         // another batching period.
         delayed_flush_scheduled_ = false;
+        // We're flushing synchronously, so any scheduled immediate flush is
+        // no longer needed.
+        immediate_flush_scheduled_ = false;
         // We can't flush while holding the lock
         scoped_lock.unlock();
         FlushPendingCommitDataRequests();
@@ -424,9 +439,11 @@ void SharedMemoryArbiterImpl::UpdateCommitDataRequest(
             return;
           {
             std::lock_guard<base::MaybeRtMutex> scoped_lock(weak_this->lock_);
-            // Clear |delayed_flush_scheduled_|, allowing the next call to
+            // Clear |delayed_flush_scheduled_| and
+            // |immediate_flush_scheduled_|, allowing the next call to
             // UpdateCommitDataRequest to start another batching period.
             weak_this->delayed_flush_scheduled_ = false;
+            weak_this->immediate_flush_scheduled_ = false;
           }
           weak_this->FlushPendingCommitDataRequests();
         },

--- a/src/tracing/core/shared_memory_arbiter_impl.h
+++ b/src/tracing/core/shared_memory_arbiter_impl.h
@@ -329,6 +329,13 @@ class SharedMemoryArbiterImpl : public SharedMemoryArbiter {
   // batching period.
   bool delayed_flush_scheduled_ = false;
 
+  // Indicates whether we have already scheduled an immediate flush due to the
+  // shared memory buffer being more than half full. Set to true when the first
+  // immediate flush is posted and cleared when the flush completes. This
+  // prevents posting multiple immediate flush tasks when chunks continue to be
+  // committed while the buffer remains over 50% full.
+  bool immediate_flush_scheduled_ = false;
+
   // Stores target buffer reservations for writers created via
   // CreateStartupTraceWriter(). A bound reservation sets
   // TargetBufferReservation::resolved to true and is associated with the actual


### PR DESCRIPTION
In the case where the SMA was >50% full, we were accidentally spamming the task running
with FlushPendingCommitDataRequests calls. There's no point in doing this as one call
to this basically does the same as n calls. However, it *does* cause a bunch of CPU
usage in various processes using the SDK (traced_probes, surfaceflinger) unnecessarily

Remove this excessive spamming of the task runner by only posting the task *once*
to the queue. Any future calls are simply ignored. We put this behind an Android flag
to incrementally roll out this change.
