### PR TITLE
tp: fix json parsing when string ends with \\

### DIFF
--- a/src/trace_processor/util/json_parser_unittest.cc
+++ b/src/trace_processor/util/json_parser_unittest.cc
@@ -132,6 +132,33 @@ TEST_F(JsonParserTest, ParseStringWithEscapes) {
   EXPECT_EQ(std::get<std::string_view>(value), "hello \"world\"");
 }
 
+TEST_F(JsonParserTest, ParseStringEndingWithBackslash) {
+  constexpr std::string_view kJson = "\"value\\\\\"";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(value));
+  EXPECT_EQ(std::get<std::string_view>(value), "value\\");
+}
+
+TEST_F(JsonParserTest, ParseStringWithEscapesInMiddle) {
+  constexpr std::string_view kJson = "\"hello\\nworld\"";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(value));
+  EXPECT_EQ(std::get<std::string_view>(value), "hello\nworld");
+}
+
+TEST_F(JsonParserTest, ParseEmptyString) {
+  constexpr std::string_view kJson = "\"\"";
+  JsonValue value;
+  std::string str;
+  Parse(kJson, value, str);
+  ASSERT_TRUE(std::holds_alternative<std::string_view>(value));
+  EXPECT_EQ(std::get<std::string_view>(value), "");
+}
+
 TEST_F(JsonParserTest, ParseObject) {
   constexpr std::string_view kJson = "{\"key\": \"value\"}";
   JsonValue value;


### PR DESCRIPTION
This is perfectly valid to have in a string. We were being too zealous
and rejecting the string.

Also fix a critical bug in ScanString for HasEscapes when the escape
was *not* the last escape in the string.

Fixes: https://github.com/google/perfetto/issues/3361
