### PR TITLE
ui: Add direct links to flags, plugins and settings

### DIFF
--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -250,11 +250,11 @@ async function loadTraceIntoEngine(
 
   let nextPage = route.page;
   if (route.page === '/' || route.page === '') {
-    // Current'y on the home page, navigate to the timeline page.
+    // Currently on the home page, navigate to the timeline page.
     nextPage = '/viewer';
   }
 
-  Router.navigate(`#!${nextPage}?local_cache_key=${cacheUuid}`);
+  Router.navigate(`#!${nextPage}${route.subpage}?local_cache_key=${cacheUuid}`);
 
   // Make sure the helper views are available before we start adding tracks.
   await includeSummaryTables(trace);

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.scss
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.scss
@@ -17,14 +17,57 @@
     border-left: solid 3px var(--pf-color-primary);
   }
 
+  &__flag-id {
+    font-size: 0.7em;
+    color: var(--pf-color-text-muted);
+    font-family: var(--pf-font-monospace);
+    margin-bottom: 6px;
+  }
+
   &__description {
     font-size: smaller;
   }
 
+  &__link-button {
+    visibility: hidden;
+  }
+}
+
+.pf-card:hover .pf-flags-page__link-button {
+  visibility: visible;
+}
+
+.pf-flags-page {
   &__footer {
     margin-top: 12px;
     margin-bottom: 24px;
     display: flex;
     justify-content: center;
+  }
+
+  // Highlight the focused flag when navigating directly to it
+  &__card--focused {
+    background-color: color-mix(
+      in srgb,
+      var(--pf-color-highlight) 70%,
+      transparent
+    );
+    animation: highlight-flash 1s ease-out;
+  }
+}
+
+@keyframes highlight-flash {
+  0% {
+    background-color: transparent;
+  }
+  30% {
+    background-color: var(--pf-color-highlight);
+  }
+  100% {
+    background-color: color-mix(
+      in srgb,
+      var(--pf-color-highlight) 70%,
+      transparent
+    );
   }
 }

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/index.ts
@@ -38,7 +38,7 @@ export default class implements PerfettoPlugin {
     // Plugins page
     app.pages.registerPage({
       route: '/plugins',
-      render: () => m(PluginsPage),
+      render: (subpage) => m(PluginsPage, {subpage}),
     });
     app.sidebar.addMenuItem({
       section: 'settings',

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.scss
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.scss
@@ -41,6 +41,15 @@
     &--enabled {
       color: unset;
     }
+
+    &--focused {
+      background-color: color-mix(
+        in srgb,
+        var(--pf-color-highlight) 70%,
+        transparent
+      );
+      animation: highlight-flash 1s ease-out;
+    }
   }
 
   &__details {
@@ -58,5 +67,29 @@
     flex-direction: row;
     column-gap: 12px;
     align-items: center;
+  }
+
+  &__link-button {
+    visibility: hidden;
+  }
+}
+
+.pf-card:hover .pf-plugins-page__link-button {
+  visibility: visible;
+}
+
+@keyframes highlight-flash {
+  0% {
+    background-color: transparent;
+  }
+  30% {
+    background-color: var(--pf-color-highlight);
+  }
+  100% {
+    background-color: color-mix(
+      in srgb,
+      var(--pf-color-highlight) 70%,
+      transparent
+    );
   }
 }

--- a/ui/src/core_plugins/dev.perfetto.SettingsPage/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.SettingsPage/index.ts
@@ -32,7 +32,7 @@ export default class implements PerfettoPlugin {
 
     app.pages.registerPage({
       route: '/settings',
-      render: () => m(SettingsPage),
+      render: (subpage) => m(SettingsPage, {subpage}),
     });
 
     app.commands.registerCommand({

--- a/ui/src/core_plugins/dev.perfetto.SettingsPage/styles.scss
+++ b/ui/src/core_plugins/dev.perfetto.SettingsPage/styles.scss
@@ -41,6 +41,15 @@
     &--changed {
       border-left: solid 3px var(--pf-color-primary);
     }
+
+    &--focused {
+      background-color: color-mix(
+        in srgb,
+        var(--pf-color-highlight) 70%,
+        transparent
+      );
+      animation: highlight-flash 1s ease-out;
+    }
   }
 
   &__details {
@@ -49,9 +58,20 @@
     gap: 6px;
   }
 
+  &__setting-id {
+    font-size: 0.7em;
+    color: var(--pf-color-text-muted);
+    font-family: var(--pf-font-monospace);
+    margin-bottom: 6px;
+  }
+
   &__description {
     font-size: smaller;
     white-space: pre-line;
+  }
+
+  &__link-button {
+    visibility: hidden;
   }
 
   &__controls {
@@ -67,5 +87,25 @@
     gap: 4px;
     color: var(--pf-color-danger);
     font-size: 14px;
+  }
+}
+
+.pf-card:hover .pf-settings-page__link-button {
+  visibility: visible;
+}
+
+@keyframes highlight-flash {
+  0% {
+    background-color: transparent;
+  }
+  30% {
+    background-color: var(--pf-color-highlight);
+  }
+  100% {
+    background-color: color-mix(
+      in srgb,
+      var(--pf-color-highlight) 70%,
+      transparent
+    );
   }
 }


### PR DESCRIPTION
This PR enables/fixes direct links to flags, plugins and settings.

E.g.:
- #!/flags/<myFlagId>
- #!/plugins/<myPluginId>
- #!/settings/<mySettingId>

When entered into the URL bar manually or by clicking a link, the UI will load then scroll to the referenced entity and highlight it.

This PR also adds:
- A link button to each entity that changes the URL bar to the appropriate link so that it may be copied and shared easily.
- Add the entity id under the title for convenience.

## Screenshot
<img width="931" height="611" alt="image" src="https://github.com/user-attachments/assets/1a824e1c-4829-4d86-8ad4-30ed18c85b63" />

