### PR TITLE
Clip start of wakelock slices to avoid negative timestamps

### DIFF
--- a/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
+++ b/ui/src/plugins/com.android.AndroidLongBatteryTracing/index.ts
@@ -554,8 +554,11 @@ export default class implements PerfettoPlugin {
       new SourceDataset({
         src: `
           SELECT
-            ts - 60000000000 AS ts,
-            safe_dur + 60000000000 AS dur,
+            -- Clamp start time to > 0 to avoid negative timestamps.
+            MAX(0, ts - 60000000000) AS ts,
+            -- The end time is (ts + safe_dur), so the duration is the original
+            -- end time minus the clamped start time.
+            (ts + safe_dur) - MAX(0, ts - 60000000000) AS dur,
             str_value AS name,
             package_name AS package
           FROM add_package_name!((


### PR DESCRIPTION
Fixes: https://buganizer.corp.google.com/issues/453734244