### PR TITLE
[Android Logcat] Fix process/tag contents order

### DIFF
--- a/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
+++ b/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
@@ -228,8 +228,8 @@ export class LogPanel implements m.ClassComponent<LogPanelAttrs> {
         m(GridCell, {className, align: 'right'}, String(pids[i])),
         m(GridCell, {className, align: 'right'}, String(tids[i])),
         m(GridCell, {className}, priorityLetter || '?'),
-        m(GridCell, {className}, tags[i]),
         hasProcessNames && m(GridCell, {className}, processNames[i]),
+        m(GridCell, {className}, tags[i]),
         m(GridCell, {className}, messages[i]),
       ].filter(Boolean);
 


### PR DESCRIPTION
Sorry, as part of https://github.com/google/perfetto/pull/3373 I forgot to update the cell order in the rows 😓

Attaching screenshot with the fix:

<img width="1776" height="328" alt="image" src="https://github.com/user-attachments/assets/56b83b56-cad4-49da-958b-aa7f30dedab6" />

