### PR TITLE
tp: fix crash when updating trace bounds

### DIFF
--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -414,7 +414,7 @@ sql_modules::NameToPackage GetStdlibPackages() {
 std::pair<int64_t, int64_t> GetTraceTimestampBoundsNs(
     const TraceStorage& storage) {
   int64_t start_ns = std::numeric_limits<int64_t>::max();
-  int64_t end_ns = std::numeric_limits<int64_t>::min();
+  int64_t end_ns = 0;
   for (auto it = storage.ftrace_event_table().IterateRows(); it; ++it) {
     start_ns = std::min(it.ts(), start_ns);
     end_ns = std::max(it.ts(), end_ns);
@@ -568,10 +568,13 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
          /*allow_override=*/false});
   }
 
+  // Compute initial trace bounds before any tables are finalized.
+  cached_trace_bounds_ = GetTraceTimestampBoundsNs(*context()->storage);
+
   engine_ = InitPerfettoSqlEngine(
       context(), context()->storage.get(), config_, &dataframe_shared_storage_,
       registered_sql_packages_, sql_metrics_, &metrics_descriptor_pool_,
-      &proto_fn_name_to_path_, this, notify_eof_called_);
+      &proto_fn_name_to_path_, this, notify_eof_called_, cached_trace_bounds_);
 
   sqlite_objects_post_prelude_ = engine_->SqliteRegisteredObjectCount();
 
@@ -610,8 +613,9 @@ void TraceProcessorImpl::Flush() {
 void TraceProcessorImpl::FlushInternal(bool should_build_bounds_table) {
   TraceProcessorStorageImpl::Flush();
   if (should_build_bounds_table) {
-    BuildBoundsTable(engine_->sqlite_engine()->db(),
-                     GetTraceTimestampBoundsNs(*context()->storage));
+    // Update cached bounds and rebuild bounds table.
+    cached_trace_bounds_ = GetTraceTimestampBoundsNs(*context()->storage);
+    BuildBoundsTable(engine_->sqlite_engine()->db(), cached_trace_bounds_);
   }
 }
 
@@ -638,8 +642,11 @@ base::Status TraceProcessorImpl::NotifyEndOfFile() {
   // TraceProcessorStorageImpl::NotifyEndOfFile, this will be counted in
   // trace bounds: this is important for parsers like ninja which wait until
   // the end to flush all their data.
-  BuildBoundsTable(engine_->sqlite_engine()->db(),
-                   GetTraceTimestampBoundsNs(*context()->storage));
+  //
+  // Cache the bounds before finalization so we can reuse them in
+  // RestoreInitialTables without iterating over finalized dataframes.
+  cached_trace_bounds_ = GetTraceTimestampBoundsNs(*context()->storage);
+  BuildBoundsTable(engine_->sqlite_engine()->db(), cached_trace_bounds_);
 
   TraceProcessorStorageImpl::DestroyContext();
   context()->storage->ShrinkToFitTables();
@@ -888,11 +895,12 @@ size_t TraceProcessorImpl::RestoreInitialTables() {
   uint64_t registered_count_before = engine_->SqliteRegisteredObjectCount();
   PERFETTO_CHECK(registered_count_before >= sqlite_objects_post_prelude_);
 
-  // Reset the engine to its initial state.
+  // Reset the engine to its initial state. Pass cached bounds to avoid
+  // iterating over finalized dataframes.
   engine_ = InitPerfettoSqlEngine(
       context(), context()->storage.get(), config_, &dataframe_shared_storage_,
       registered_sql_packages_, sql_metrics_, &metrics_descriptor_pool_,
-      &proto_fn_name_to_path_, this, notify_eof_called_);
+      &proto_fn_name_to_path_, this, notify_eof_called_, cached_trace_bounds_);
 
   // The registered count should now be the same as it was in the constructor.
   uint64_t registered_count_after = engine_->SqliteRegisteredObjectCount();
@@ -1214,7 +1222,8 @@ std::unique_ptr<PerfettoSqlEngine> TraceProcessorImpl::InitPerfettoSqlEngine(
     const DescriptorPool* metrics_descriptor_pool,
     std::unordered_map<std::string, std::string>* proto_fn_name_to_path,
     TraceProcessor* trace_processor,
-    bool notify_eof_called) {
+    bool notify_eof_called,
+    std::pair<int64_t, int64_t> cached_trace_bounds) {
   auto engine = std::make_unique<PerfettoSqlEngine>(
       storage->mutable_string_pool(), dataframe_shared_storage,
       config.enable_extra_checks);
@@ -1444,8 +1453,9 @@ std::unique_ptr<PerfettoSqlEngine> TraceProcessorImpl::InitPerfettoSqlEngine(
     }
   }
 
-  // Fill trace bounds table.
-  BuildBoundsTable(db, GetTraceTimestampBoundsNs(*storage));
+  // Fill trace bounds table with the passed in bounds. The bounds should be
+  // computed in Flush/NotifyEndOfFile before tables are finalized.
+  BuildBoundsTable(db, cached_trace_bounds);
 
   return engine;
 }

--- a/src/trace_processor/trace_processor_impl.h
+++ b/src/trace_processor/trace_processor_impl.h
@@ -157,7 +157,8 @@ class TraceProcessorImpl : public TraceProcessor,
       const DescriptorPool* metrics_descriptor_pool,
       std::unordered_map<std::string, std::string>* proto_fn_name_to_path,
       TraceProcessor*,
-      bool notify_eof_called);
+      bool notify_eof_called,
+      std::pair<int64_t, int64_t> cached_trace_bounds);
 
   static std::vector<PerfettoSqlEngine::UnfinalizedStaticTable>
   GetUnfinalizedStaticTables(TraceStorage* storage);
@@ -196,6 +197,11 @@ class TraceProcessorImpl : public TraceProcessor,
   // NotifyEndOfFile should only be called once. Set to true whenever it is
   // called.
   bool notify_eof_called_ = false;
+
+  // Cached trace timestamp bounds. This is set in NotifyEndOfFile before
+  // tables are finalized and reused in RestoreInitialTables to avoid
+  // iterating over finalized dataframes.
+  std::pair<int64_t, int64_t> cached_trace_bounds_ = {0, 0};
 };
 
 }  // namespace perfetto::trace_processor


### PR DESCRIPTION
Cache the bounds so that we don't read them on RestoreInitialTables
post finalization

Fixes: https://github.com/google/perfetto/issues/3379
