### PR TITLE
ui: Rename fillParent to fillHeight everywhere for consistency

### DIFF
--- a/ui/src/assets/widgets/details_shell.scss
+++ b/ui/src/assets/widgets/details_shell.scss
@@ -58,7 +58,7 @@
     overflow-x: auto;
   }
 
-  &.pf-fill-parent {
+  &.pf-fill-height {
     height: 100%;
     overflow-y: hidden;
 

--- a/ui/src/assets/widgets/overlay_container.scss
+++ b/ui/src/assets/widgets/overlay_container.scss
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 .pf-overlay-container {
-  &--fill-parent {
+  &--fill-height {
     height: 100%;
   }
 }

--- a/ui/src/components/details/sql_table_tab.ts
+++ b/ui/src/components/details/sql_table_tab.ts
@@ -215,7 +215,7 @@ class LegacySqlTableTab implements Tab {
         title: 'Table',
         description: this.getDisplayName(),
         buttons: this.getTableButtons(),
-        fillParent: true,
+        fillHeight: true,
       },
       m('.pf-sql-table', [
         (hasFilters || showViewButtons) &&

--- a/ui/src/components/query_table/query_result_tab.ts
+++ b/ui/src/components/query_table/query_result_tab.ts
@@ -93,7 +93,7 @@ export class QueryResultTab implements Tab {
       trace: this.trace,
       query: this.args.query,
       resp: this.queryResponse,
-      fillParent: true,
+      fillHeight: true,
       contextButtons: [
         this.sqlViewName === undefined
           ? null

--- a/ui/src/components/query_table/query_table.ts
+++ b/ui/src/components/query_table/query_table.ts
@@ -83,7 +83,7 @@ interface QueryTableAttrs {
   readonly query: string;
   readonly resp?: QueryResponse;
   readonly contextButtons?: m.Child[];
-  readonly fillParent: boolean;
+  readonly fillHeight: boolean;
 }
 
 export class QueryTable implements m.ClassComponent<QueryTableAttrs> {
@@ -111,7 +111,7 @@ export class QueryTable implements m.ClassComponent<QueryTableAttrs> {
   }
 
   view({attrs}: m.CVnode<QueryTableAttrs>) {
-    const {resp, query, contextButtons = [], fillParent} = attrs;
+    const {resp, query, contextButtons = [], fillHeight} = attrs;
 
     return m(
       DetailsShell,
@@ -120,7 +120,7 @@ export class QueryTable implements m.ClassComponent<QueryTableAttrs> {
         title: this.renderTitle(resp),
         description: query,
         buttons: this.renderButtons(query, contextButtons, resp),
-        fillParent,
+        fillHeight,
       },
       resp && this.dataSource && this.renderTableContent(resp, this.dataSource),
     );

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -389,7 +389,7 @@ function onCssLoaded() {
             focusable: false,
           },
           [
-            m(OverlayContainer, {fillParent: true}, [
+            m(OverlayContainer, {fillHeight: true}, [
               m(UiMain, {key: themeSetting.get()}),
             ]),
           ],

--- a/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/cpu_profile_details_panel.ts
@@ -89,7 +89,7 @@ export class CpuProfileSampleFlamegraphDetailsPanel
       m(
         DetailsShell,
         {
-          fillParent: true,
+          fillHeight: true,
           title: 'CPU Profile Samples',
           buttons: m(
             'span',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -63,7 +63,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       DetailsShell,
       {
         title: 'Query data',
-        fillParent: true,
+        fillHeight: true,
         buttons: this.renderMenu(attrs),
       },
       this.renderContent(attrs, message),

--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
@@ -150,7 +150,7 @@ export class FtraceExplorer implements m.ClassComponent<FtraceExplorerAttrs> {
       {
         title: this.renderTitle(),
         buttons: this.renderFilterPanel(attrs),
-        fillParent: true,
+        fillHeight: true,
       },
       m(Grid, {
         className: 'pf-ftrace-explorer',

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -109,7 +109,7 @@ export class HeapProfileFlamegraphDetailsPanel
       m(
         DetailsShell,
         {
-          fillParent: true,
+          fillHeight: true,
           title: m(
             'span',
             getFlamegraphTitle(type),

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/instruments_samples_profile_track.ts
@@ -206,7 +206,7 @@ function renderDetailsPanel(
     m(
       DetailsShell,
       {
-        fillParent: true,
+        fillHeight: true,
         title: 'Instruments Samples',
         buttons: m(Stack, {orientation: 'horizontal', spacing: 'large'}, [
           m('span', [

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/perf_samples_profile_track.ts
@@ -135,7 +135,7 @@ function renderDetailsPanel(
     m(
       DetailsShell,
       {
-        fillParent: true,
+        fillHeight: true,
         title: 'Perf sample',
         buttons: m(Stack, {orientation: 'horizontal', spacing: 'large'}, [
           m('span', [

--- a/ui/src/plugins/dev.perfetto.QueryPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/index.ts
@@ -167,7 +167,7 @@ class QueryPageMini implements m.ClassComponent<QueryPageMiniAttrs> {
             trace: attrs.trace,
             query: attrs.executedQuery,
             resp: attrs.queryResult,
-            fillParent: false,
+            fillHeight: false,
           }),
     );
   }

--- a/ui/src/widgets/details_shell.ts
+++ b/ui/src/widgets/details_shell.ts
@@ -25,18 +25,18 @@ interface DetailsShellAttrs {
   // Buttons to be rendered on the right side of the header bar.
   readonly buttons?: m.Children;
   // Vertically fill parent container and disable scrolling
-  readonly fillParent?: boolean;
+  readonly fillHeight?: boolean;
 }
 
 // A shell for details panels to be more visually consistent.
 // It provides regular placement for the header bar and placement of buttons
 export class DetailsShell implements m.ClassComponent<DetailsShellAttrs> {
   view({attrs, children}: m.Vnode<DetailsShellAttrs>) {
-    const {title, description, buttons, fillParent = true, className} = attrs;
+    const {title, description, buttons, fillHeight = true, className} = attrs;
 
     return m(
       'section.pf-details-shell',
-      {class: classNames(fillParent && 'pf-fill-parent', className)},
+      {class: classNames(fillHeight && 'pf-fill-height', className)},
       m(
         'header.pf-header-bar',
         m('h1.pf-header-title', title),

--- a/ui/src/widgets/overlay_container.ts
+++ b/ui/src/widgets/overlay_container.ts
@@ -17,19 +17,19 @@ import {classNames} from '../base/classnames';
 
 export interface OverlayContainerAttrs {
   // Fill parent container vertically.
-  readonly fillParent?: boolean;
+  readonly fillHeight?: boolean;
 }
 
 export class OverlayContainer
   implements m.ClassComponent<OverlayContainerAttrs>
 {
   view({attrs, children}: m.Vnode<OverlayContainerAttrs>) {
-    const {fillParent = false} = attrs as OverlayContainerAttrs;
+    const {fillHeight = false} = attrs as OverlayContainerAttrs;
     return m(
       '.pf-overlay-container',
       {
         className: classNames(
-          fillParent && 'pf-overlay-container--fill-parent',
+          fillHeight && 'pf-overlay-container--fill-height',
         ),
       },
       children,


### PR DESCRIPTION
Small tidy-up to make the API more consistent across widgets.