### PR TITLE
ui: Standardize popup attribute names

### DIFF
--- a/python/tools/check_ratchet.py
+++ b/python/tools/check_ratchet.py
@@ -36,7 +36,7 @@ import dataclasses
 
 from dataclasses import dataclass
 
-EXPECTED_ANY_COUNT = 40
+EXPECTED_ANY_COUNT = 39
 EXPECTED_RUN_METRIC_COUNT = 4
 
 ROOT_DIR = os.path.dirname(

--- a/ui/src/components/query_table/query_result_tab.ts
+++ b/ui/src/components/query_table/query_result_tab.ts
@@ -101,7 +101,7 @@ export class QueryResultTab implements Tab {
               PopupMenu,
               {
                 trigger: m(Button, {label: 'Show debug track'}),
-                popupPosition: PopupPosition.Top,
+                position: PopupPosition.Top,
               },
               m(AddDebugTrackMenu, {
                 trace: this.trace,

--- a/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
+++ b/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
@@ -415,7 +415,7 @@ export class LogsFilters implements m.ClassComponent<LogsFiltersAttrs> {
     return m(PopupMultiSelect, {
       label: 'Filter by machine',
       icon: 'filter_list_alt',
-      popupPosition: PopupPosition.Top,
+      position: PopupPosition.Top,
       options,
       onChange: (diffs: MultiSelectDiff[]) => {
         const newList = new Set<number>(machineExcludeList);

--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
@@ -253,7 +253,7 @@ export class FtraceExplorer implements m.ClassComponent<FtraceExplorerAttrs> {
     return m(PopupMultiSelect, {
       label: 'Filter',
       icon: 'filter_list_alt',
-      popupPosition: PopupPosition.Top,
+      position: PopupPosition.Top,
       options,
       onChange: (diffs: MultiSelectDiff[]) => {
         const newList = new Set<string>(excludeList);

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/widgets_page.ts
@@ -918,7 +918,7 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
                 checked: value,
               };
             }),
-            popupPosition: PopupPosition.Top,
+            position: PopupPosition.Top,
             label: 'Multi Select',
             icon: arg(icon, Icons.LibraryAddCheck),
             onChange: (diffs: MultiSelectDiff[]) => {
@@ -1012,7 +1012,7 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
             ),
           ),
         initialOpts: {
-          popupPosition: new EnumOption(
+          position: new EnumOption(
             PopupPosition.Bottom,
             Object.values(PopupPosition),
           ),
@@ -1064,7 +1064,7 @@ export class WidgetsPage implements m.ClassComponent<{app: App}> {
               right: m(
                 PopupMenu,
                 {
-                  popupPosition: PopupPosition.RightStart,
+                  position: PopupPosition.RightStart,
                   trigger: m(
                     Anchor,
                     {

--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -172,7 +172,7 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
         {
           trigger: cell,
           isContextMenu: true,
-          popupPosition: PopupPosition.Bottom,
+          position: PopupPosition.Bottom,
         },
         menuItems,
       );

--- a/ui/src/widgets/menu.ts
+++ b/ui/src/widgets/menu.ts
@@ -63,7 +63,7 @@ export class MenuItem implements m.ClassComponent<MenuItemAttrs> {
     return m(
       PopupMenu,
       {
-        popupPosition: PopupPosition.RightStart,
+        position: PopupPosition.RightStart,
         trigger: m(MenuItem, {
           rightIcon: rightIcon,
           closePopupOnClick,
@@ -138,22 +138,6 @@ export class Menu implements m.ClassComponent<HTMLAttrs> {
 }
 
 interface PopupMenuAttrs extends PopupAttrs {
-  // The trigger is mithril component which is used to toggle the popup when
-  // clicked, and provides the anchor on the page which the popup shall hover
-  // next to, and to which the popup's arrow shall point. The popup shall move
-  // around the page with this component, as if attached to it.
-  // This trigger can be any mithril component, but it is typically a Button,
-  // an Icon, or some other interactive component.
-  // Beware this element will have its `onclick`, `ref`, and `active` attributes
-  // overwritten.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  trigger: m.Vnode<any, any>;
-  // Which side of the trigger to place to popup.
-  // Defaults to "bottom".
-  popupPosition?: PopupPosition;
-  // Whether we should show the little arrow pointing to the trigger.
-  // Defaults to true.
-  showArrow?: boolean;
   // Whether this popup should form a new popup group.
   // When nesting popups, grouping controls how popups are closed.
   // When closing popups via the Escape key, each group is closed one by one,
@@ -169,17 +153,13 @@ interface PopupMenuAttrs extends PopupAttrs {
 // MenuDividers, but really they can be any Mithril component.
 export class PopupMenu implements m.ClassComponent<PopupMenuAttrs> {
   view({attrs, children}: m.CVnode<PopupMenuAttrs>) {
-    const {
-      trigger,
-      popupPosition = PopupPosition.Bottom,
-      ...popupAttrs
-    } = attrs;
+    const {trigger, position = PopupPosition.Bottom, ...popupAttrs} = attrs;
 
     return m(
       Popup,
       {
         trigger,
-        position: popupPosition,
+        position,
         className: 'pf-popup-menu',
         ...popupAttrs,
       },

--- a/ui/src/widgets/multiselect.ts
+++ b/ui/src/widgets/multiselect.ts
@@ -49,7 +49,7 @@ export type PopupMultiSelectAttrs = MultiSelectAttrs & {
   compact?: boolean;
   icon?: string;
   label: string;
-  popupPosition?: PopupPosition;
+  position?: PopupPosition;
 };
 
 // A component which shows a list of items with checkboxes, allowing the user to
@@ -223,7 +223,7 @@ export class PopupMultiSelect
   implements m.ClassComponent<PopupMultiSelectAttrs>
 {
   view({attrs}: m.CVnode<PopupMultiSelectAttrs>) {
-    const {icon, popupPosition = PopupPosition.Auto, intent, compact} = attrs;
+    const {icon, position = PopupPosition.Auto, intent, compact} = attrs;
 
     return m(
       Popup,
@@ -234,7 +234,7 @@ export class PopupMultiSelect
           intent,
           compact,
         }),
-        position: popupPosition,
+        position,
       },
       m(MultiSelect, attrs as MultiSelectAttrs),
     );


### PR DESCRIPTION
Small API tweak to popup-like widgets to present consistent attribute names for popup controls.
