### PR TITLE
[Android Logcat Viewer] Update filter icon and text

### DIFF
--- a/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
+++ b/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
@@ -328,10 +328,10 @@ interface FilterByTextWidgetAttrs {
 
 class FilterByTextWidget implements m.ClassComponent<FilterByTextWidgetAttrs> {
   view({attrs}: m.Vnode<FilterByTextWidgetAttrs>) {
-    const icon = attrs.hideNonMatching ? 'unfold_less' : 'unfold_more';
+    const icon = attrs.hideNonMatching ? 'filter_alt' : 'filter_alt_off';
     const tooltip = attrs.hideNonMatching
-      ? 'Expand all and view highlighted'
-      : 'Collapse all';
+      ? 'Show all logs and highlight matches'
+      : 'Show only matching logs';
     return m(Button, {
       icon,
       title: tooltip,


### PR DESCRIPTION
Updates text and icon for the logcat viewer search field to make it more clear what it does

Filtered state:
<img width="1845" height="309" alt="image" src="https://github.com/user-attachments/assets/bc163078-f7c7-4b6c-ac61-888c99f7c469" />

Non-filtered state:

<img width="1760" height="370" alt="image" src="https://github.com/user-attachments/assets/30c4809a-5b8f-49a1-8c52-4b64acd4bebb" />

Currently it shows the following icon:

<img width="210" height="100" alt="image" src="https://github.com/user-attachments/assets/d2f52c49-6850-4c86-b8ed-1baf323cf216" />

<img width="204" height="75" alt="image" src="https://github.com/user-attachments/assets/00b8d6b5-d1a8-4250-a739-859f0fbbbc6d" />
