### PR TITLE
perfetto_cmd_android: make `kStateDir` private

### DIFF
--- a/src/perfetto_cmd/perfetto_cmd.cc
+++ b/src/perfetto_cmd/perfetto_cmd.cc
@@ -119,8 +119,6 @@ void ArgsAppend(std::string* str, const std::string& arg) {
 }
 }  // namespace
 
-const char* kStateDir = "/data/misc/perfetto-traces";
-
 PerfettoCmd::PerfettoCmd() {
   // Only the main thread instance on the main thread will receive ctrl-c.
   PerfettoCmd* set_if_null = nullptr;

--- a/src/perfetto_cmd/perfetto_cmd.h
+++ b/src/perfetto_cmd/perfetto_cmd.h
@@ -42,10 +42,6 @@
 
 namespace perfetto {
 
-// Directory for local state and temporary files. This is automatically
-// created by the system by setting setprop persist.traced.enable=1.
-extern const char* kStateDir;
-
 class PerfettoCmd : public Consumer {
  public:
   PerfettoCmd();

--- a/src/perfetto_cmd/perfetto_cmd_android.cc
+++ b/src/perfetto_cmd/perfetto_cmd_android.cc
@@ -33,6 +33,10 @@
 namespace perfetto {
 namespace {
 
+// Directory for local state and temporary files. This is automatically
+// created by the system by setting setprop persist.traced.enable=1.
+const char* kStateDir = "/data/misc/perfetto-traces";
+
 constexpr int64_t kSendfileTimeoutNs = 10UL * 1000 * 1000 * 1000;  // 10s
 
 }  // namespace


### PR DESCRIPTION
This directory is used only on android, so move it away from the common code.
