### PR TITLE
ui: fix memory <-> proc stats conflict crash in recording page

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/advanced.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/advanced.ts
@@ -19,6 +19,7 @@ import {Slider} from './widgets/slider';
 import {Toggle} from './widgets/toggle';
 
 export const ADV_PROC_ASSOC_PROBE_ID = 'adv_proc_thread_assoc';
+export const ADV_PROC_ASSOC_BUF_ID = 'proc_assoc';
 export const PROC_STATS_DS_NAME = 'linux.process_stats';
 export const ADV_FTRACE_PROBE_ID = 'advanced_ftrace';
 
@@ -138,16 +139,15 @@ function procThreadAssociation(): RecordProbe {
     settings,
     genConfig: function (tc: TraceConfigBuilder) {
       tc.addFtraceEvents(...ftraceEvents);
-      const bufId = 'proc_assoc';
       // Set to 1/16th of the main buffer size, with reasonable limits.
       const minMax = [256, 8 * 1024];
       const bufSizeKb = Math.min(
         Math.max(tc.defaultBuffer.sizeKb / 16, minMax[0]),
         minMax[1],
       );
-      tc.addBuffer(bufId, bufSizeKb);
+      tc.addBuffer(ADV_PROC_ASSOC_BUF_ID, bufSizeKb);
 
-      const ds = tc.addDataSource(PROC_STATS_DS_NAME, bufId);
+      const ds = tc.addDataSource(PROC_STATS_DS_NAME, ADV_PROC_ASSOC_BUF_ID);
       const cfg = (ds.processStatsConfig ??= {});
       cfg.scanAllProcessesOnStart = settings.initialScan.enabled || undefined;
     },

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/memory.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/memory.ts
@@ -15,7 +15,11 @@
 import {assertExists} from '../../../base/logging';
 import {splitLinesNonEmpty} from '../../../base/string_utils';
 import protos from '../../../protos';
-import {ADV_PROC_ASSOC_PROBE_ID, PROC_STATS_DS_NAME} from './advanced';
+import {
+  ADV_PROC_ASSOC_BUF_ID,
+  ADV_PROC_ASSOC_PROBE_ID,
+  PROC_STATS_DS_NAME,
+} from './advanced';
 import {RecordProbe, RecordSubpage} from '../config/config_interfaces';
 import {TraceConfigBuilder} from '../config/trace_config_builder';
 import {TypedMultiselect} from './widgets/multiselect';
@@ -334,7 +338,7 @@ function polledProcStats(): RecordProbe {
     supportedPlatforms: ['ANDROID', 'LINUX', 'CHROME_OS'],
     settings,
     genConfig: function (tc: TraceConfigBuilder) {
-      const ds = tc.addDataSource(PROC_STATS_DS_NAME);
+      const ds = tc.addDataSource(PROC_STATS_DS_NAME, ADV_PROC_ASSOC_BUF_ID);
       // Because of the dependency on ADV_PROC_ASSOC_PROBE_ID, we expect
       // procThreadAssociation() to create the config first.
       const cfg = assertExists(ds.processStatsConfig);


### PR DESCRIPTION
This appears to be caused by https://github.com/google/perfetto/pull/2656.

Seems like there is now a desync between the buffer used by ADV_PROC_ASSOC_PROBE_ID
and mem_proc_stat leading to a desync and different values being returned.

Fixes: https://github.com/google/perfetto/issues/3395
