### PR TITLE
tp: reorganize deobfuscation logic to be better organized

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14333,6 +14333,7 @@ filegroup {
         "src/trace_processor/importers/proto/android_probes_tracker.cc",
         "src/trace_processor/importers/proto/content_analyzer.cc",
         "src/trace_processor/importers/proto/deobfuscation_module.cc",
+        "src/trace_processor/importers/proto/deobfuscation_tracker.cc",
         "src/trace_processor/importers/proto/frame_timeline_event_parser.cc",
         "src/trace_processor/importers/proto/gpu_event_parser.cc",
         "src/trace_processor/importers/proto/graphics_event_module.cc",

--- a/BUILD
+++ b/BUILD
@@ -2311,6 +2311,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/content_analyzer.h",
         "src/trace_processor/importers/proto/deobfuscation_module.cc",
         "src/trace_processor/importers/proto/deobfuscation_module.h",
+        "src/trace_processor/importers/proto/deobfuscation_tracker.cc",
+        "src/trace_processor/importers/proto/deobfuscation_tracker.h",
         "src/trace_processor/importers/proto/frame_timeline_event_parser.cc",
         "src/trace_processor/importers/proto/frame_timeline_event_parser.h",
         "src/trace_processor/importers/proto/gpu_event_parser.cc",

--- a/src/trace_processor/importers/common/args_translation_table.h
+++ b/src/trace_processor/importers/common/args_translation_table.h
@@ -88,6 +88,14 @@ class ArgsTranslationTable {
       DeobfuscationMappingTable deobfuscation_mapping_table) {
     deobfuscation_mapping_table_ = std::move(deobfuscation_mapping_table);
   }
+  void MergeDeobfuscationMapping(
+      const DeobfuscationMappingTable::PackageId& package,
+      StringId obfuscated_class,
+      StringId deobfuscated_class,
+      base::FlatHashMap<StringId, StringId> members) {
+    deobfuscation_mapping_table_.AddClassTranslation(
+        package, obfuscated_class, deobfuscated_class, std::move(members));
+  }
 
   std::optional<base::StringView> TranslateChromeHistogramHashForTesting(
       uint64_t hash) const {

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -135,6 +135,8 @@ source_set("full") {
     "content_analyzer.h",
     "deobfuscation_module.cc",
     "deobfuscation_module.h",
+    "deobfuscation_tracker.cc",
+    "deobfuscation_tracker.h",
     "frame_timeline_event_parser.cc",
     "frame_timeline_event_parser.h",
     "gpu_event_parser.cc",

--- a/src/trace_processor/importers/proto/deobfuscation_module.cc
+++ b/src/trace_processor/importers/proto/deobfuscation_module.cc
@@ -16,29 +16,14 @@
 
 #include "src/trace_processor/importers/proto/deobfuscation_module.h"
 
-#include <cstdint>
-#include <optional>
-#include <string>
-#include <utility>
-#include <vector>
-
-#include "perfetto/base/logging.h"
 #include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/ext/base/string_view.h"
-#include "perfetto/protozero/field.h"
-#include "perfetto/trace_processor/trace_blob.h"
 #include "protos/perfetto/trace/profiling/deobfuscation.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "src/trace_processor/importers/common/args_translation_table.h"
 #include "src/trace_processor/importers/common/deobfuscation_mapping_table.h"
-#include "src/trace_processor/importers/common/parser_types.h"
-#include "src/trace_processor/importers/common/stack_profile_tracker.h"
-#include "src/trace_processor/importers/proto/heap_graph_tracker.h"
+#include "src/trace_processor/importers/proto/deobfuscation_tracker.h"
 #include "src/trace_processor/storage/trace_storage.h"
-#include "src/trace_processor/tables/metadata_tables_py.h"
-#include "src/trace_processor/tables/profiler_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
-#include "src/trace_processor/util/profiler_util.h"
 
 namespace perfetto::trace_processor {
 
@@ -69,264 +54,37 @@ void DeobfuscationModule::ParseTracePacketData(
 }
 
 void DeobfuscationModule::StoreDeobfuscationMapping(ConstBytes blob) {
-  packets_.emplace_back(TraceBlob::CopyFrom(blob.data, blob.size));
+  DeobfuscationTracker::Get(context_)->AddDeobfuscationMapping(blob);
+
+  protos::pbzero::DeobfuscationMapping::Decoder mapping(blob.data, blob.size);
+  BuildMappingTableIncremental(mapping);
 }
 
-void DeobfuscationModule::DeobfuscateHeapGraphClass(
-    std::optional<StringId> package_name_id,
-    StringId obfuscated_class_name_id,
-    const protos::pbzero::ObfuscatedClass::Decoder& cls) {
-  using ClassTable = tables::HeapGraphClassTable;
-
-  auto* heap_graph_tracker = HeapGraphTracker::Get(context_);
-  const std::vector<ClassTable::RowNumber>* cls_objects =
-      heap_graph_tracker->RowsForType(package_name_id,
-                                      obfuscated_class_name_id);
-  if (cls_objects) {
-    auto* class_table = context_->storage->mutable_heap_graph_class_table();
-    for (ClassTable::RowNumber class_row_num : *cls_objects) {
-      auto class_ref = class_row_num.ToRowReference(class_table);
-      const StringId obfuscated_type_name_id = class_ref.name();
-      const base::StringView obfuscated_type_name =
-          context_->storage->GetString(obfuscated_type_name_id);
-      NormalizedType normalized_type = GetNormalizedType(obfuscated_type_name);
-      std::string deobfuscated_type_name =
-          DenormalizeTypeName(normalized_type, cls.deobfuscated_name());
-      StringId deobfuscated_type_name_id = context_->storage->InternString(
-          base::StringView(deobfuscated_type_name));
-      class_ref.set_deobfuscated_name(deobfuscated_type_name_id);
-    }
-  } else {
-    PERFETTO_DLOG("Class %s not found",
-                  cls.obfuscated_name().ToStdString().c_str());
-  }
-}
-
-void DeobfuscationModule::ParseDeobfuscationMapping(
-    ConstBytes blob,
-    HeapGraphTracker* heap_graph_tracker) {
-  protos::pbzero::DeobfuscationMapping::Decoder deobfuscation_mapping(
-      blob.data, blob.size);
-  ParseDeobfuscationMappingForHeapGraph(deobfuscation_mapping,
-                                        heap_graph_tracker);
-  ParseDeobfuscationMappingForProfiles(deobfuscation_mapping);
-}
-
-void DeobfuscationModule::ParseDeobfuscationMappingForHeapGraph(
-    const protos::pbzero::DeobfuscationMapping::Decoder& deobfuscation_mapping,
-    HeapGraphTracker* heap_graph_tracker) {
-  using ReferenceTable = tables::HeapGraphReferenceTable;
-
-  std::optional<StringId> package_name_id;
-  if (deobfuscation_mapping.package_name().size > 0) {
-    package_name_id = context_->storage->string_pool().GetId(
-        deobfuscation_mapping.package_name());
-  }
-
-  auto* reference_table =
-      context_->storage->mutable_heap_graph_reference_table();
-  for (auto class_it = deobfuscation_mapping.obfuscated_classes(); class_it;
-       ++class_it) {
-    protos::pbzero::ObfuscatedClass::Decoder cls(*class_it);
-    auto obfuscated_class_name_id =
-        context_->storage->string_pool().GetId(cls.obfuscated_name());
-    if (!obfuscated_class_name_id) {
-      PERFETTO_DLOG("Class string %s not found",
-                    cls.obfuscated_name().ToStdString().c_str());
-    } else {
-      // TODO(b/153552977): Remove this work-around for legacy traces.
-      // For traces without location information, deobfuscate all matching
-      // classes.
-      DeobfuscateHeapGraphClass(std::nullopt, *obfuscated_class_name_id, cls);
-      if (package_name_id) {
-        DeobfuscateHeapGraphClass(package_name_id, *obfuscated_class_name_id,
-                                  cls);
-      }
-    }
-    for (auto member_it = cls.obfuscated_members(); member_it; ++member_it) {
-      protos::pbzero::ObfuscatedMember::Decoder member(*member_it);
-
-      std::string merged_obfuscated = cls.obfuscated_name().ToStdString() +
-                                      "." +
-                                      member.obfuscated_name().ToStdString();
-      std::string merged_deobfuscated =
-          FullyQualifiedDeobfuscatedName(cls, member);
-
-      auto obfuscated_field_name_id = context_->storage->string_pool().GetId(
-          base::StringView(merged_obfuscated));
-      if (!obfuscated_field_name_id) {
-        PERFETTO_DLOG("Field string %s not found", merged_obfuscated.c_str());
-        continue;
-      }
-
-      const std::vector<ReferenceTable::RowNumber>* field_references =
-          heap_graph_tracker->RowsForField(*obfuscated_field_name_id);
-      if (field_references) {
-        auto interned_deobfuscated_name = context_->storage->InternString(
-            base::StringView(merged_deobfuscated));
-        for (ReferenceTable::RowNumber row_number : *field_references) {
-          auto row_ref = row_number.ToRowReference(reference_table);
-          row_ref.set_deobfuscated_field_name(interned_deobfuscated_name);
-        }
-      } else {
-        PERFETTO_DLOG("Field %s not found", merged_obfuscated.c_str());
-      }
-    }
-  }
-}
-
-void DeobfuscationModule::ParseDeobfuscationMappingForProfiles(
-    const protos::pbzero::DeobfuscationMapping::Decoder&
-        deobfuscation_mapping) {
-  DeobfuscationMappingTable deobfuscation_mapping_table;
-  if (deobfuscation_mapping.package_name().size == 0)
+void DeobfuscationModule::BuildMappingTableIncremental(
+    const protos::pbzero::DeobfuscationMapping::Decoder& mapping) {
+  if (mapping.package_name().size == 0)
     return;
 
-  auto opt_package_name_id = context_->storage->string_pool().GetId(
-      deobfuscation_mapping.package_name());
-  auto opt_memfd_id = context_->storage->string_pool().GetId("memfd");
-  if (!opt_package_name_id && !opt_memfd_id)
-    return;
+  DeobfuscationMappingTable::PackageId package_id{
+      mapping.package_name().ToStdString(), mapping.version_code()};
 
-  for (auto class_it = deobfuscation_mapping.obfuscated_classes(); class_it;
-       ++class_it) {
+  for (auto class_it = mapping.obfuscated_classes(); class_it; ++class_it) {
     protos::pbzero::ObfuscatedClass::Decoder cls(*class_it);
-    base::FlatHashMap<StringId, StringId> obfuscated_to_deobfuscated_members;
+
+    base::FlatHashMap<StringId, StringId> members;
     for (auto member_it = cls.obfuscated_methods(); member_it; ++member_it) {
       protos::pbzero::ObfuscatedMember::Decoder member(*member_it);
-      std::string merged_obfuscated = cls.obfuscated_name().ToStdString() +
-                                      "." +
-                                      member.obfuscated_name().ToStdString();
-      auto merged_obfuscated_id = context_->storage->string_pool().GetId(
-          base::StringView(merged_obfuscated));
-      if (!merged_obfuscated_id)
-        continue;
-      std::string merged_deobfuscated =
-          FullyQualifiedDeobfuscatedName(cls, member);
-
-      std::vector<tables::StackProfileFrameTable::Id> frames;
-      if (opt_package_name_id) {
-        const std::vector<tables::StackProfileFrameTable::Id> pkg_frames =
-            context_->stack_profile_tracker->JavaFramesForName(
-                {*merged_obfuscated_id, *opt_package_name_id});
-        frames.insert(frames.end(), pkg_frames.begin(), pkg_frames.end());
-      }
-      if (opt_memfd_id) {
-        const std::vector<tables::StackProfileFrameTable::Id> memfd_frames =
-            context_->stack_profile_tracker->JavaFramesForName(
-                {*merged_obfuscated_id, *opt_memfd_id});
-        frames.insert(frames.end(), memfd_frames.begin(), memfd_frames.end());
-      }
-
-      for (tables::StackProfileFrameTable::Id frame_id : frames) {
-        auto* frames_tbl =
-            context_->storage->mutable_stack_profile_frame_table();
-        auto rr = *frames_tbl->FindById(frame_id);
-        rr.set_deobfuscated_name(context_->storage->InternString(
-            base::StringView(merged_deobfuscated)));
-      }
-      obfuscated_to_deobfuscated_members[context_->storage->InternString(
-          member.obfuscated_name())] =
+      members[context_->storage->InternString(member.obfuscated_name())] =
           context_->storage->InternString(member.deobfuscated_name());
     }
-    // Members can contain a class name (e.g "ClassA.FunctionF")
-    deobfuscation_mapping_table.AddClassTranslation(
-        DeobfuscationMappingTable::PackageId{
-            deobfuscation_mapping.package_name().ToStdString(),
-            deobfuscation_mapping.version_code()},
-        context_->storage->InternString(cls.obfuscated_name()),
+
+    context_->args_translation_table->MergeDeobfuscationMapping(
+        package_id, context_->storage->InternString(cls.obfuscated_name()),
         context_->storage->InternString(cls.deobfuscated_name()),
-        std::move(obfuscated_to_deobfuscated_members));
-  }
-  context_->args_translation_table->AddDeobfuscationMappingTable(
-      std::move(deobfuscation_mapping_table));
-}
-
-void DeobfuscationModule::GuessPackageForCallsite(
-    tables::ProcessTable::Id upid,
-    tables::StackProfileCallsiteTable::Id callsite_id) {
-  const auto& process_table = context_->storage->process_table();
-  auto* stack_profile_tracker = context_->stack_profile_tracker.get();
-
-  auto process = process_table.FindById(upid);
-  if (!process.has_value()) {
-    return;
-  }
-
-  if (!process->android_appid().has_value()) {
-    return;
-  }
-
-  std::optional<StringId> package;
-
-  for (auto it = context_->storage->package_list_table().IterateRows(); it;
-       ++it) {
-    if (it.uid() == *process->android_appid()) {
-      package = it.package_name();
-      break;
-    }
-  }
-
-  if (!package.has_value()) {
-    return;
-  }
-
-  const auto& callsite_table =
-      context_->storage->stack_profile_callsite_table();
-  auto callsite = callsite_table.FindById(callsite_id);
-  while (callsite.has_value()) {
-    auto frame_id = callsite->frame_id();
-
-    if (stack_profile_tracker->FrameHasUnknownPackage(frame_id) != 0) {
-      if (process->name().has_value()) {
-        stack_profile_tracker->SetPackageForFrame(*package, frame_id);
-      }
-    }
-
-    auto parent_id = callsite->parent_id();
-    callsite.reset();
-    if (parent_id.has_value()) {
-      callsite = callsite_table.FindById(*parent_id);
-    }
+        std::move(members));
   }
 }
 
-void DeobfuscationModule::GuessPackages() {
-  const auto& heap_profile_allocation_table =
-      context_->storage->heap_profile_allocation_table();
-  for (auto allocation = heap_profile_allocation_table.IterateRows();
-       allocation; ++allocation) {
-    auto upid = tables::ProcessTable::Id(allocation.upid());
-    auto callsite_id = allocation.callsite_id();
-
-    GuessPackageForCallsite(upid, callsite_id);
-  }
-
-  const auto& perf_sample_table = context_->storage->perf_sample_table();
-  for (auto sample = perf_sample_table.IterateRows(); sample; ++sample) {
-    auto thread = context_->storage->thread_table().FindById(
-        tables::ThreadTable::Id(sample.utid()));
-    if (!thread || !thread->upid().has_value() ||
-        !sample.callsite_id().has_value()) {
-      continue;
-    }
-    GuessPackageForCallsite(tables::ProcessTable::Id(*thread->upid()),
-                            *sample.callsite_id());
-  }
-}
-
-void DeobfuscationModule::NotifyEndOfFile() {
-  auto* heap_graph_tracker = HeapGraphTracker::Get(context_);
-  heap_graph_tracker->FinalizeAllProfiles();
-
-  if (context_->stack_profile_tracker->HasFramesWithoutKnownPackage()) {
-    GuessPackages();
-  }
-
-  for (const auto& packet : packets_) {
-    ParseDeobfuscationMapping(ConstBytes{packet.data(), packet.size()},
-                              heap_graph_tracker);
-  }
-}
+void DeobfuscationModule::NotifyEndOfFile() {}
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/deobfuscation_module.h
+++ b/src/trace_processor/importers/proto/deobfuscation_module.h
@@ -17,25 +17,14 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEOBFUSCATION_MODULE_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEOBFUSCATION_MODULE_H_
 
-#include <cstdint>
-#include <optional>
-#include <vector>
-
 #include "perfetto/protozero/field.h"
-#include "perfetto/trace_processor/trace_blob.h"
 #include "protos/perfetto/trace/profiling/deobfuscation.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
-#include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/importers/common/parser_types.h"
-#include "src/trace_processor/importers/proto/heap_graph_tracker.h"
-#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
-#include "src/trace_processor/tables/metadata_tables_py.h"
-#include "src/trace_processor/tables/profiler_tables_py.h"
 
 namespace perfetto::trace_processor {
 
-// Importer module for deobfuscation data.
 class DeobfuscationModule : public ProtoImporterModule {
  public:
   explicit DeobfuscationModule(ProtoImporterModuleContext* module_context,
@@ -52,24 +41,9 @@ class DeobfuscationModule : public ProtoImporterModule {
 
  private:
   void StoreDeobfuscationMapping(protozero::ConstBytes);
+  void BuildMappingTableIncremental(
+      const protos::pbzero::DeobfuscationMapping::Decoder& mapping);
 
-  void GuessPackages();
-  void GuessPackageForCallsite(tables::ProcessTable::Id,
-                               tables::StackProfileCallsiteTable::Id);
-
-  void DeobfuscateHeapGraphClass(
-      std::optional<StringPool::Id> package_name_id,
-      StringPool::Id obfuscated_class_id,
-      const protos::pbzero::ObfuscatedClass::Decoder& cls);
-
-  void ParseDeobfuscationMappingForHeapGraph(
-      const protos::pbzero::DeobfuscationMapping::Decoder&,
-      HeapGraphTracker*);
-  void ParseDeobfuscationMappingForProfiles(
-      const protos::pbzero::DeobfuscationMapping::Decoder&);
-  void ParseDeobfuscationMapping(protozero::ConstBytes, HeapGraphTracker*);
-
-  std::vector<TraceBlob> packets_;
   TraceProcessorContext* context_;
 };
 

--- a/src/trace_processor/importers/proto/deobfuscation_tracker.cc
+++ b/src/trace_processor/importers/proto/deobfuscation_tracker.cc
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/deobfuscation_tracker.h"
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/string_view.h"
+#include "perfetto/trace_processor/trace_blob.h"
+#include "protos/perfetto/trace/profiling/deobfuscation.pbzero.h"
+#include "src/trace_processor/importers/common/stack_profile_tracker.h"
+#include "src/trace_processor/importers/proto/heap_graph_tracker.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/metadata_tables_py.h"
+#include "src/trace_processor/tables/profiler_tables_py.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/util/profiler_util.h"
+
+namespace perfetto::trace_processor {
+
+using ::perfetto::protos::pbzero::DeobfuscationMapping;
+using ::perfetto::protos::pbzero::ObfuscatedClass;
+using ::perfetto::protos::pbzero::ObfuscatedMember;
+using ::protozero::ConstBytes;
+
+DeobfuscationTracker::DeobfuscationTracker(TraceProcessorContext* context)
+    : context_(context) {}
+
+DeobfuscationTracker::~DeobfuscationTracker() = default;
+
+void DeobfuscationTracker::AddDeobfuscationMapping(ConstBytes blob) {
+  packets_.emplace_back(TraceBlob::CopyFrom(blob.data, blob.size));
+}
+
+void DeobfuscationTracker::NotifyEndOfFile() {
+  if (context_->stack_profile_tracker->HasFramesWithoutKnownPackage()) {
+    GuessPackages();
+  }
+
+  for (const auto& packet : packets_) {
+    DeobfuscationMapping::Decoder mapping(packet.data(), packet.size());
+    DeobfuscateProfiles(mapping);
+    ParseDeobfuscationMappingForHeapGraph(mapping);
+  }
+}
+
+void DeobfuscationTracker::DeobfuscateProfiles(
+    const DeobfuscationMapping::Decoder& deobfuscation_mapping) {
+  if (deobfuscation_mapping.package_name().size == 0)
+    return;
+
+  auto opt_package_name_id = context_->storage->string_pool().GetId(
+      deobfuscation_mapping.package_name());
+  auto opt_memfd_id = context_->storage->string_pool().GetId("memfd");
+  if (!opt_package_name_id && !opt_memfd_id)
+    return;
+
+  for (auto class_it = deobfuscation_mapping.obfuscated_classes(); class_it;
+       ++class_it) {
+    ObfuscatedClass::Decoder cls(*class_it);
+
+    for (auto member_it = cls.obfuscated_methods(); member_it; ++member_it) {
+      ObfuscatedMember::Decoder member(*member_it);
+
+      std::string merged_obfuscated = cls.obfuscated_name().ToStdString() +
+                                      "." +
+                                      member.obfuscated_name().ToStdString();
+      auto merged_obfuscated_id = context_->storage->string_pool().GetId(
+          base::StringView(merged_obfuscated));
+      if (!merged_obfuscated_id)
+        continue;
+
+      std::string merged_deobfuscated =
+          FullyQualifiedDeobfuscatedName(cls, member);
+
+      std::vector<tables::StackProfileFrameTable::Id> frames;
+      if (opt_package_name_id) {
+        const std::vector<tables::StackProfileFrameTable::Id> pkg_frames =
+            context_->stack_profile_tracker->JavaFramesForName(
+                {*merged_obfuscated_id, *opt_package_name_id});
+        frames.insert(frames.end(), pkg_frames.begin(), pkg_frames.end());
+      }
+      if (opt_memfd_id) {
+        const std::vector<tables::StackProfileFrameTable::Id> memfd_frames =
+            context_->stack_profile_tracker->JavaFramesForName(
+                {*merged_obfuscated_id, *opt_memfd_id});
+        frames.insert(frames.end(), memfd_frames.begin(), memfd_frames.end());
+      }
+
+      for (tables::StackProfileFrameTable::Id frame_id : frames) {
+        auto* frames_tbl =
+            context_->storage->mutable_stack_profile_frame_table();
+        auto rr = *frames_tbl->FindById(frame_id);
+        rr.set_deobfuscated_name(context_->storage->InternString(
+            base::StringView(merged_deobfuscated)));
+      }
+    }
+  }
+}
+
+void DeobfuscationTracker::ParseDeobfuscationMappingForHeapGraph(
+    const DeobfuscationMapping::Decoder& deobfuscation_mapping) {
+  using ReferenceTable = tables::HeapGraphReferenceTable;
+
+  auto* heap_graph_tracker = HeapGraphTracker::Get(context_);
+
+  std::optional<StringId> package_name_id;
+  if (deobfuscation_mapping.package_name().size > 0) {
+    package_name_id = context_->storage->string_pool().GetId(
+        deobfuscation_mapping.package_name());
+  }
+
+  auto* reference_table =
+      context_->storage->mutable_heap_graph_reference_table();
+  for (auto class_it = deobfuscation_mapping.obfuscated_classes(); class_it;
+       ++class_it) {
+    ObfuscatedClass::Decoder cls(*class_it);
+    auto obfuscated_class_name_id =
+        context_->storage->string_pool().GetId(cls.obfuscated_name());
+    if (!obfuscated_class_name_id) {
+      PERFETTO_DLOG("Class string %s not found",
+                    cls.obfuscated_name().ToStdString().c_str());
+    } else {
+      // Deobfuscate heap graph classes
+      // TODO(b/153552977): Remove this work-around for legacy traces.
+      // For traces without location information, deobfuscate all matching
+      // classes.
+      DeobfuscateHeapGraphClass(std::nullopt, *obfuscated_class_name_id, cls);
+      if (package_name_id) {
+        DeobfuscateHeapGraphClass(package_name_id, *obfuscated_class_name_id,
+                                  cls);
+      }
+    }
+
+    for (auto member_it = cls.obfuscated_members(); member_it; ++member_it) {
+      ObfuscatedMember::Decoder member(*member_it);
+
+      std::string merged_obfuscated = cls.obfuscated_name().ToStdString() +
+                                      "." +
+                                      member.obfuscated_name().ToStdString();
+      std::string merged_deobfuscated =
+          FullyQualifiedDeobfuscatedName(cls, member);
+
+      auto obfuscated_field_name_id = context_->storage->string_pool().GetId(
+          base::StringView(merged_obfuscated));
+      if (!obfuscated_field_name_id) {
+        PERFETTO_DLOG("Field string %s not found", merged_obfuscated.c_str());
+        continue;
+      }
+
+      const std::vector<ReferenceTable::RowNumber>* field_references =
+          heap_graph_tracker->RowsForField(*obfuscated_field_name_id);
+      if (field_references) {
+        auto interned_deobfuscated_name = context_->storage->InternString(
+            base::StringView(merged_deobfuscated));
+        for (ReferenceTable::RowNumber row_number : *field_references) {
+          auto row_ref = row_number.ToRowReference(reference_table);
+          row_ref.set_deobfuscated_field_name(interned_deobfuscated_name);
+        }
+      } else {
+        PERFETTO_DLOG("Field %s not found", merged_obfuscated.c_str());
+      }
+    }
+  }
+}
+
+void DeobfuscationTracker::DeobfuscateHeapGraphClass(
+    std::optional<StringId> package_name_id,
+    StringId obfuscated_class_name_id,
+    const ObfuscatedClass::Decoder& cls) {
+  using ClassTable = tables::HeapGraphClassTable;
+
+  auto* heap_graph_tracker = HeapGraphTracker::Get(context_);
+  const std::vector<ClassTable::RowNumber>* cls_objects =
+      heap_graph_tracker->RowsForType(package_name_id,
+                                      obfuscated_class_name_id);
+  if (cls_objects) {
+    auto* class_table = context_->storage->mutable_heap_graph_class_table();
+    for (ClassTable::RowNumber class_row_num : *cls_objects) {
+      auto class_ref = class_row_num.ToRowReference(class_table);
+      const StringId obfuscated_type_name_id = class_ref.name();
+      const base::StringView obfuscated_type_name =
+          context_->storage->GetString(obfuscated_type_name_id);
+      NormalizedType normalized_type = GetNormalizedType(obfuscated_type_name);
+      std::string deobfuscated_type_name =
+          DenormalizeTypeName(normalized_type, cls.deobfuscated_name());
+      StringId deobfuscated_type_name_id = context_->storage->InternString(
+          base::StringView(deobfuscated_type_name));
+      class_ref.set_deobfuscated_name(deobfuscated_type_name_id);
+    }
+  } else {
+    PERFETTO_DLOG("Class %s not found",
+                  cls.obfuscated_name().ToStdString().c_str());
+  }
+}
+
+void DeobfuscationTracker::GuessPackageForCallsite(
+    tables::ProcessTable::Id upid,
+    tables::StackProfileCallsiteTable::Id callsite_id) {
+  const auto& process_table = context_->storage->process_table();
+  auto* stack_profile_tracker = context_->stack_profile_tracker.get();
+
+  auto process = process_table.FindById(upid);
+  if (!process.has_value()) {
+    return;
+  }
+
+  if (!process->android_appid().has_value()) {
+    return;
+  }
+
+  std::optional<StringId> package;
+
+  for (auto it = context_->storage->package_list_table().IterateRows(); it;
+       ++it) {
+    if (it.uid() == *process->android_appid()) {
+      package = it.package_name();
+      break;
+    }
+  }
+
+  if (!package.has_value()) {
+    return;
+  }
+
+  const auto& callsite_table =
+      context_->storage->stack_profile_callsite_table();
+  auto callsite = callsite_table.FindById(callsite_id);
+  while (callsite.has_value()) {
+    auto frame_id = callsite->frame_id();
+
+    if (stack_profile_tracker->FrameHasUnknownPackage(frame_id) != 0) {
+      if (process->name().has_value()) {
+        stack_profile_tracker->SetPackageForFrame(*package, frame_id);
+      }
+    }
+
+    auto parent_id = callsite->parent_id();
+    callsite.reset();
+    if (parent_id.has_value()) {
+      callsite = callsite_table.FindById(*parent_id);
+    }
+  }
+}
+
+void DeobfuscationTracker::GuessPackages() {
+  const auto& heap_profile_allocation_table =
+      context_->storage->heap_profile_allocation_table();
+  for (auto allocation = heap_profile_allocation_table.IterateRows();
+       allocation; ++allocation) {
+    auto upid = tables::ProcessTable::Id(allocation.upid());
+    auto callsite_id = allocation.callsite_id();
+
+    GuessPackageForCallsite(upid, callsite_id);
+  }
+
+  const auto& perf_sample_table = context_->storage->perf_sample_table();
+  for (auto sample = perf_sample_table.IterateRows(); sample; ++sample) {
+    auto thread = context_->storage->thread_table().FindById(
+        tables::ThreadTable::Id(sample.utid()));
+    if (!thread || !thread->upid().has_value() ||
+        !sample.callsite_id().has_value()) {
+      continue;
+    }
+    GuessPackageForCallsite(tables::ProcessTable::Id(*thread->upid()),
+                            *sample.callsite_id());
+  }
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/deobfuscation_tracker.h
+++ b/src/trace_processor/importers/proto/deobfuscation_tracker.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEOBFUSCATION_TRACKER_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEOBFUSCATION_TRACKER_H_
+
+#include <optional>
+#include <vector>
+
+#include "perfetto/protozero/field.h"
+#include "perfetto/trace_processor/trace_blob.h"
+#include "protos/perfetto/trace/profiling/deobfuscation.pbzero.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/metadata_tables_py.h"
+#include "src/trace_processor/tables/profiler_tables_py.h"
+#include "src/trace_processor/types/destructible.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor {
+
+class DeobfuscationTracker : public Destructible {
+ public:
+  explicit DeobfuscationTracker(TraceProcessorContext* context);
+  ~DeobfuscationTracker() override;
+
+  static DeobfuscationTracker* Get(TraceProcessorContext* context) {
+    return static_cast<DeobfuscationTracker*>(
+        context->deobfuscation_tracker.get());
+  }
+
+  void AddDeobfuscationMapping(protozero::ConstBytes blob);
+  void NotifyEndOfFile();
+
+ private:
+  void DeobfuscateProfiles(
+      const protos::pbzero::DeobfuscationMapping::Decoder& mapping);
+  void ParseDeobfuscationMappingForHeapGraph(
+      const protos::pbzero::DeobfuscationMapping::Decoder& mapping);
+  void DeobfuscateHeapGraphClass(
+      std::optional<StringId> package_name_id,
+      StringId obfuscated_class_name_id,
+      const protos::pbzero::ObfuscatedClass::Decoder& cls);
+  void GuessPackages();
+  void GuessPackageForCallsite(
+      tables::ProcessTable::Id upid,
+      tables::StackProfileCallsiteTable::Id callsite_id);
+
+  std::vector<TraceBlob> packets_;
+  TraceProcessorContext* context_;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_DEOBFUSCATION_TRACKER_H_

--- a/src/trace_processor/trace_processor_context.cc
+++ b/src/trace_processor/trace_processor_context.cc
@@ -86,7 +86,6 @@ void InitPerMachineState(TraceProcessorContext* context, uint32_t machine_id) {
       Ptr<ClockTracker>::MakeRoot(std::move(clock_tracker_listener));
   context->mapping_tracker = Ptr<MappingTracker>::MakeRoot(context);
   context->cpu_tracker = Ptr<CpuTracker>::MakeRoot(context);
-  context->stack_profile_tracker = Ptr<StackProfileTracker>::MakeRoot(context);
 }
 
 void CopyPerMachineState(const TraceProcessorContext* source,
@@ -97,7 +96,6 @@ void CopyPerMachineState(const TraceProcessorContext* source,
   dest->clock_tracker = source->clock_tracker.Fork();
   dest->mapping_tracker = source->mapping_tracker.Fork();
   dest->cpu_tracker = source->cpu_tracker.Fork();
-  dest->stack_profile_tracker = source->stack_profile_tracker.Fork();
 }
 
 void InitPerTraceState(TraceProcessorContext* context, uint32_t raw_trace_id) {
@@ -151,6 +149,8 @@ void InitGlobalState(TraceProcessorContext* context, const Config& config) {
   context->clock_converter = Ptr<ClockConverter>::MakeRoot(context);
   context->track_group_idx_state =
       Ptr<TrackCompressorGroupIdxState>::MakeRoot();
+  context->stack_profile_tracker = Ptr<StackProfileTracker>::MakeRoot(context);
+  context->deobfuscation_tracker = nullptr;
   context->register_additional_proto_modules = nullptr;
 
   // Per-Trace State (Miscategorized).
@@ -183,6 +183,8 @@ void CopyGlobalState(const TraceProcessorContext* source,
   dest->registered_file_tracker = source->registered_file_tracker.Fork();
   dest->uuid_state = source->uuid_state.Fork();
   dest->heap_graph_tracker = source->heap_graph_tracker.Fork();
+  dest->deobfuscation_tracker = source->deobfuscation_tracker.Fork();
+  dest->stack_profile_tracker = source->stack_profile_tracker.Fork();
 }
 
 }  // namespace

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -70,6 +70,7 @@
 #include "src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.h"
 #include "src/trace_processor/importers/pprof/pprof_trace_reader.h"
 #include "src/trace_processor/importers/proto/additional_modules.h"
+#include "src/trace_processor/importers/proto/deobfuscation_tracker.h"
 #include "src/trace_processor/importers/proto/heap_graph_tracker.h"
 #include "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_tokenizer.h"
 #include "src/trace_processor/importers/systrace/systrace_trace_parser.h"
@@ -534,6 +535,10 @@ TraceProcessorImpl::TraceProcessorImpl(const Config& cfg)
   context()->heap_graph_tracker =
       std::make_unique<HeapGraphTracker>(context()->storage.get());
 
+  // Initialize deobfuscation tracker.
+  context()->deobfuscation_tracker =
+      std::make_unique<DeobfuscationTracker>(context());
+
   const std::vector<std::string> sanitized_extension_paths =
       SanitizeMetricMountPaths(config_.skip_builtin_metric_paths);
   std::vector<std::string> skip_prefixes;
@@ -636,6 +641,9 @@ base::Status TraceProcessorImpl::NotifyEndOfFile() {
   FlushInternal(false);
 
   RETURN_IF_ERROR(TraceProcessorStorageImpl::NotifyEndOfFile());
+
+  HeapGraphTracker::Get(context())->FinalizeAllProfiles();
+  DeobfuscationTracker::Get(context())->NotifyEndOfFile();
 
   // Rebuild the bounds table once everything has been completed: we do this
   // so that if any data was added to tables in

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -141,6 +141,8 @@ class TraceProcessorContext {
   GlobalPtr<ForkedContextState> forked_context_state;
   GlobalPtr<ClockConverter> clock_converter;
   GlobalPtr<TrackCompressorGroupIdxState> track_group_idx_state;
+  GlobalPtr<StackProfileTracker> stack_profile_tracker;
+  GlobalPtr<Destructible> deobfuscation_tracker;  // DeobfuscationTracker
 
   // The registration function for additional proto modules.
   // This is populated by TraceProcessorImpl to allow for late registration of
@@ -161,7 +163,7 @@ class TraceProcessorContext {
   GlobalPtr<MetadataTracker> metadata_tracker;
   GlobalPtr<RegisteredFileTracker> registered_file_tracker;
   GlobalPtr<UuidState> uuid_state;
-  GlobalPtr<Destructible> heap_graph_tracker;  // HeapGraphTracker
+  GlobalPtr<Destructible> heap_graph_tracker;     // HeapGraphTracker
 
   // Per-Trace State
   // ==========================
@@ -185,7 +187,6 @@ class TraceProcessorContext {
   PerMachinePtr<MappingTracker> mapping_tracker;
   PerMachinePtr<MachineTracker> machine_tracker;
   PerMachinePtr<CpuTracker> cpu_tracker;
-  PerMachinePtr<StackProfileTracker> stack_profile_tracker;
 
   // Per-Machine, Per-Trace State
   // ==========================


### PR DESCRIPTION
* create DeobfuscationTracker to hold state which is global across
  machines
* break DeobfuscationModule -> HeapGraphTracker subtle dependency,
  instead rely on TraceProcessorImpl explicitly ordering them
