### PR TITLE
exp: Cleanup execution

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -449,25 +449,6 @@ describe('JSON serialization/deserialization', () => {
     );
   });
 
-  test('serializes and deserializes custom title', () => {
-    const sliceNode = new SlicesSourceNode({
-      slice_name: 'test_slice',
-      customTitle: 'My Custom Title',
-    });
-    const initialState: ExplorePageState = {
-      rootNodes: [sliceNode],
-      nodeLayouts: new Map(),
-    };
-
-    const json = serializeState(initialState);
-    const deserializedState = deserializeState(json, trace, sqlModules);
-
-    expect(deserializedState.rootNodes.length).toBe(1);
-    const deserializedNode = deserializedState.rootNodes[0] as SlicesSourceNode;
-    expect(deserializedNode.state.customTitle).toBe('My Custom Title');
-    expect(deserializedNode.getTitle()).toBe('My Custom Title');
-  });
-
   test('serializes and deserializes modify columns node', () => {
     const tableNode = new TableSourceNode({
       sqlTable: sqlModules.getTable('slice'),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -30,6 +30,7 @@ import {Button} from '../../../widgets/button';
 import {Callout} from '../../../widgets/callout';
 import {DetailsShell} from '../../../widgets/details_shell';
 import {MenuItem, PopupMenu} from '../../../widgets/menu';
+import {Spinner} from '../../../widgets/spinner';
 import {TextParagraph} from '../../../widgets/text_paragraph';
 import {Query, QueryNode} from '../query_node';
 import {QueryService} from './query_service';
@@ -39,15 +40,8 @@ export interface DataExplorerAttrs {
   readonly queryService: QueryService;
   readonly node: QueryNode;
   readonly query?: Query | Error;
-  readonly executeQuery: boolean;
   readonly response?: QueryResponse;
   readonly dataSource?: DataGridDataSource;
-  readonly onQueryExecuted: (result: {
-    columns: string[];
-    error?: Error;
-    warning?: Error;
-    noDataWarning?: Error;
-  }) => void;
   readonly onPositionChange: (pos: 'left' | 'right' | 'bottom') => void;
   readonly isFullScreen: boolean;
   readonly onFullScreenToggle: () => void;
@@ -60,10 +54,16 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     const statusText = this.getStatusText(attrs.query, attrs.response);
     const message = errors ? `Error: ${errors.message}` : statusText;
 
+    // Show spinner when data is updating (query exists but response hasn't arrived yet)
+    const isUpdating =
+      attrs.query !== undefined &&
+      !(attrs.query instanceof Error) &&
+      attrs.response === undefined;
+
     return m(
       DetailsShell,
       {
-        title: 'Query data',
+        title: ['Query data', isUpdating && m(Spinner)],
         fillHeight: true,
         buttons: this.renderMenu(attrs),
       },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -38,6 +38,7 @@ import {Button, ButtonVariant} from '../../../../widgets/button';
 import {Intent} from '../../../../widgets/common';
 import {MenuItem, PopupMenu} from '../../../../widgets/menu';
 import {Connection, Node, NodeGraph} from '../../../../widgets/nodegraph';
+import {UIFilter} from '../operations/filter';
 import {
   QueryNode,
   singleNodeOperation,
@@ -49,7 +50,6 @@ import {
 import {EmptyGraph} from '../empty_graph';
 import {nodeRegistry} from '../node_registry';
 import {NodeBox} from './node_box';
-import {UIFilter} from '../operations/filter';
 
 // ========================================
 // TYPE DEFINITIONS

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
@@ -124,8 +124,7 @@ export function renderFilters(attrs: NodeBoxAttrs): m.Child {
 export const NodeBox: m.Component<NodeBoxAttrs> = {
   view({attrs}) {
     const {node} = attrs;
-    const hasCustomTitle = node.state.customTitle !== undefined;
-    const shouldShowTitle = !singleNodeOperation(node.type) || hasCustomTitle;
+    const shouldShowTitle = !singleNodeOperation(node.type);
 
     return [
       m(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
@@ -27,6 +27,22 @@
     justify-content: space-between;
     padding: 0.375rem;
     border-bottom: 1px solid var(--pf-color-border);
+
+    .pf-button {
+      margin-left: 0.5rem;
+    }
+
+    .title {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+
+      h2 {
+        font-weight: bold;
+        font-size: var(--pf-exp-font-size-md);
+        color: var(--pf-color-text);
+      }
+    }
   }
 
   article {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry_unittest.ts
@@ -300,39 +300,5 @@ describe('NodeRegistry', () => {
       expect(registry.list().length).toBe(2);
       expect(registry.get('source-node')).toBe(descriptor1Updated);
     });
-
-    it('should handle node descriptors with all field types', () => {
-      const registry = new NodeRegistry();
-      const preCreate = async (_context: PreCreateContext) => {
-        return {customTitle: 'Custom'};
-      };
-
-      const descriptor: NodeDescriptor = {
-        name: 'Complex Node',
-        description: 'A complex node with all features',
-        icon: 'complex-icon',
-        hotkey: 'ctrl+shift+c',
-        type: 'multisource',
-        devOnly: true,
-        preCreate,
-        factory: (state: QueryNodeState) => {
-          const node = createMockNode('complex');
-          node.state.customTitle = state.customTitle;
-          return node;
-        },
-      };
-
-      registry.register('complex-node', descriptor);
-
-      const retrieved = registry.get('complex-node');
-      expect(retrieved?.name).toBe('Complex Node');
-      expect(retrieved?.description).toBe('A complex node with all features');
-      expect(retrieved?.icon).toBe('complex-icon');
-      expect(retrieved?.hotkey).toBe('ctrl+shift+c');
-      expect(retrieved?.type).toBe('multisource');
-      expect(retrieved?.devOnly).toBe(true);
-      expect(retrieved?.preCreate).toBe(preCreate);
-      expect(typeof retrieved?.factory).toBe('function');
-    });
   });
 });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
@@ -50,7 +50,6 @@ export interface AggregationSerializedState {
     isEditing?: boolean;
   }[];
   filters?: UIFilter[];
-  customTitle?: string;
   comment?: string;
 }
 
@@ -169,7 +168,7 @@ export class AggregationNode implements ModificationNode {
   }
 
   getTitle(): string {
-    return this.state.customTitle ?? 'Aggregation';
+    return 'Aggregation';
   }
 
   nodeDetails?(): m.Child | undefined {
@@ -223,7 +222,6 @@ export class AggregationNode implements ModificationNode {
       groupByColumns: newColumnInfoList(this.state.groupByColumns),
       aggregations: this.state.aggregations.map((a) => ({...a})),
       filters: this.state.filters ? [...this.state.filters] : undefined,
-      customTitle: this.state.customTitle,
       onchange: this.state.onchange,
       issues: this.state.issues,
     };
@@ -303,7 +301,6 @@ export class AggregationNode implements ModificationNode {
         isEditing: a.isEditing,
       })),
       filters: this.state.filters,
-      customTitle: this.state.customTitle,
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/dev/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/dev/union_node.ts
@@ -33,7 +33,6 @@ export interface UnionSerializedState {
   unionNodes: string[];
   selectedColumns: ColumnInfo[];
   filters?: UIFilter[];
-  customTitle?: string;
   comment?: string;
 }
 
@@ -49,7 +48,6 @@ export class UnionNode implements MultiSourceNode {
   readonly prevNodes: QueryNode[];
   nextNodes: QueryNode[];
   readonly state: UnionNodeState;
-  customTitle?: string;
   comment?: string;
   filters?: UIFilter[];
 
@@ -61,6 +59,7 @@ export class UnionNode implements MultiSourceNode {
     this.nodeId = nextNodeId();
     this.state = {
       ...state,
+      autoExecute: state.autoExecute ?? false,
     };
     this.prevNodes = state.prevNodes;
     this.nextNodes = [];
@@ -141,7 +140,7 @@ export class UnionNode implements MultiSourceNode {
   }
 
   getTitle(): string {
-    return this.customTitle ?? 'Union';
+    return 'Union';
   }
 
   nodeDetails(): m.Child {
@@ -213,7 +212,6 @@ export class UnionNode implements MultiSourceNode {
     };
     const clone = new UnionNode(stateCopy);
     clone.filters = this.filters ? [...this.filters] : undefined;
-    clone.customTitle = this.customTitle;
     clone.comment = this.comment;
     return clone;
   }
@@ -227,7 +225,6 @@ export class UnionNode implements MultiSourceNode {
       unionNodes: this.prevNodes.slice(1).map((n) => n.nodeId),
       selectedColumns: this.state.selectedColumns,
       filters: this.filters,
-      customTitle: this.customTitle,
       comment: this.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -30,7 +30,6 @@ import {UIFilter} from '../operations/filter';
 export interface IntervalIntersectSerializedState {
   intervalNodes: string[];
   filters?: UIFilter[];
-  customTitle?: string;
   comment?: string;
 }
 
@@ -55,6 +54,7 @@ export class IntervalIntersectNode implements MultiSourceNode {
     this.nodeId = nextNodeId();
     this.state = {
       ...state,
+      autoExecute: state.autoExecute ?? false,
     };
     this.prevNodes = state.prevNodes;
     this.nextNodes = [];
@@ -107,7 +107,7 @@ export class IntervalIntersectNode implements MultiSourceNode {
   }
 
   getTitle(): string {
-    return this.state.customTitle ?? 'Interval Intersect';
+    return 'Interval Intersect';
   }
 
   nodeSpecificModify(onExecute?: () => void): m.Child {
@@ -153,7 +153,6 @@ export class IntervalIntersectNode implements MultiSourceNode {
       prevNodes: [...this.state.prevNodes],
       allNodes: this.state.allNodes,
       filters: this.state.filters ? [...this.state.filters] : undefined,
-      customTitle: this.state.customTitle,
       onchange: this.state.onchange,
       onExecute: this.state.onExecute,
     };
@@ -185,7 +184,6 @@ export class IntervalIntersectNode implements MultiSourceNode {
     return {
       intervalNodes: this.prevNodes.slice(1).map((n) => n.nodeId),
       filters: this.state.filters,
-      customTitle: this.state.customTitle,
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -362,7 +362,6 @@ export interface ModifyColumnsSerializedState {
   newColumns: NewColumn[];
   selectedColumns: ColumnInfo[];
   filters?: UIFilter[];
-  customTitle?: string;
   comment?: string;
 }
 
@@ -371,7 +370,6 @@ export interface ModifyColumnsState extends QueryNodeState {
   newColumns: NewColumn[];
   selectedColumns: ColumnInfo[];
   filters?: UIFilter[];
-  customTitle?: string;
 }
 
 export class ModifyColumnsNode implements ModificationNode {
@@ -480,7 +478,7 @@ export class ModifyColumnsNode implements ModificationNode {
   }
 
   getTitle(): string {
-    return this.state.customTitle ?? 'Modify Columns';
+    return 'Modify Columns';
   }
 
   nodeDetails(): m.Child {
@@ -949,6 +947,10 @@ export class ModifyColumnsNode implements ModificationNode {
     }
 
     for (const col of this.state.newColumns) {
+      // Only include valid columns (non-empty expression and name)
+      if (!this.isNewColumnValid(col)) {
+        continue;
+      }
       const selectColumn = new protos.PerfettoSqlStructuredQuery.SelectColumn();
       selectColumn.columnNameOrExpression = col.expression;
       selectColumn.alias = col.name;
@@ -989,7 +991,6 @@ export class ModifyColumnsNode implements ModificationNode {
       newColumns: this.state.newColumns,
       selectedColumns: this.state.selectedColumns,
       filters: this.state.filters,
-      customTitle: this.state.customTitle,
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -40,7 +40,6 @@ export interface SlicesSourceSerializedState {
   process_name?: string;
   track_name?: string;
   filters?: UIFilter[];
-  customTitle?: string;
   comment?: string;
 }
 
@@ -81,13 +80,12 @@ export class SlicesSourceNode implements SourceNode {
       process_name: this.state.process_name?.slice(),
       track_name: this.state.track_name?.slice(),
       filters: this.state.filters ? [...this.state.filters] : undefined,
-      customTitle: this.state.customTitle,
     };
     return new SlicesSourceNode(stateCopy);
   }
 
   getTitle(): string {
-    return this.state.customTitle ?? 'Simple slices';
+    return 'Simple slices';
   }
 
   serializeState(): SlicesSourceSerializedState {
@@ -97,7 +95,6 @@ export class SlicesSourceNode implements SourceNode {
       process_name: this.state.process_name,
       track_name: this.state.track_name,
       filters: this.state.filters,
-      customTitle: this.state.customTitle,
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -38,7 +38,6 @@ import {UIFilter} from '../../operations/filter';
 export interface SqlSourceSerializedState {
   sql?: string;
   filters?: UIFilter[];
-  customTitle?: string;
   comment?: string;
 }
 
@@ -56,7 +55,11 @@ export class SqlSourceNode implements MultiSourceNode {
 
   constructor(attrs: SqlSourceState) {
     this.nodeId = nextNodeId();
-    this.state = attrs;
+    this.state = {
+      ...attrs,
+      // SQL source nodes require manual execution since users write SQL
+      autoExecute: attrs.autoExecute ?? false,
+    };
     this.finalCols = createFinalColumns([]);
     this.nextNodes = [];
     this.prevNodes = attrs.prevNodes ?? [];
@@ -81,7 +84,6 @@ export class SqlSourceNode implements MultiSourceNode {
     const stateCopy: SqlSourceState = {
       sql: this.state.sql,
       filters: this.state.filters ? [...this.state.filters] : undefined,
-      customTitle: this.state.customTitle,
       issues: this.state.issues,
       trace: this.state.trace,
     };
@@ -93,14 +95,13 @@ export class SqlSourceNode implements MultiSourceNode {
   }
 
   getTitle(): string {
-    return this.state.customTitle ?? 'Sql source';
+    return 'Sql source';
   }
 
   serializeState(): SqlSourceSerializedState {
     return {
       sql: this.state.sql,
       filters: this.state.filters,
-      customTitle: this.state.customTitle,
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -43,7 +43,6 @@ import {redrawModal} from '../../../../../widgets/modal';
 export interface TableSourceSerializedState {
   sqlTable?: string;
   filters?: UIFilter[];
-  customTitle?: string;
   comment?: string;
 }
 
@@ -131,7 +130,6 @@ export class TableSourceNode implements SourceNode {
       sqlModules: this.state.sqlModules,
       sqlTable: this.state.sqlTable,
       filters: this.state.filters?.map((f) => ({...f})),
-      customTitle: this.state.customTitle,
       onchange: this.state.onchange,
     };
     return new TableSourceNode(stateCopy);
@@ -194,7 +192,7 @@ export class TableSourceNode implements SourceNode {
   }
 
   getTitle(): string {
-    return this.state.customTitle ?? `${this.state.sqlTable?.name}`;
+    return `${this.state.sqlTable?.name}`;
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -224,7 +222,6 @@ export class TableSourceNode implements SourceNode {
     return {
       sqlTable: this.state.sqlTable?.name,
       filters: this.state.filters,
-      customTitle: this.state.customTitle,
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -61,7 +61,6 @@ export function singleNodeOperation(type: NodeType): boolean {
 export interface QueryNodeState {
   prevNode?: QueryNode;
   prevNodes?: QueryNode[];
-  customTitle?: string;
   comment?: string;
   trace?: Trace;
   sqlModules?: SqlModules;
@@ -76,6 +75,11 @@ export interface QueryNodeState {
 
   // Caching
   hasOperationChanged?: boolean;
+
+  // Whether queries should automatically execute when this node changes.
+  // If false, the user must manually click "Run" to execute queries.
+  // Set by the node registry when the node is created.
+  autoExecute?: boolean;
 }
 
 export interface BaseNode {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler.ts
@@ -229,7 +229,6 @@ export function createGraphFromSql(sql: string): string {
       state: {
         sql: parsedNode.query,
         filters: [],
-        customTitle: nodeId,
       },
       nextNodes: [],
       prevNodes: [],

--- a/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler_unittest.ts
@@ -45,7 +45,6 @@ describe('createGraphFromSql', () => {
 
     expect(nodeA!.type).toBe(NodeType.kSqlSource);
     expect((nodeA!.state as SqlSourceSerializedState).sql).toBe('SELECT 1');
-    expect((nodeA!.state as SqlSourceSerializedState).customTitle).toBe('a');
     expect(nodeA!.nextNodes).toEqual(['b']);
     expect(nodeA!.prevNodes).toEqual([]);
 
@@ -53,7 +52,6 @@ describe('createGraphFromSql', () => {
     expect((nodeB!.state as SqlSourceSerializedState).sql).toBe(
       'SELECT * FROM $a',
     );
-    expect((nodeB!.state as SqlSourceSerializedState).customTitle).toBe('b');
     expect(nodeB!.nextNodes).toEqual(['c']);
     expect(nodeB!.prevNodes).toEqual(['a']);
 
@@ -61,16 +59,12 @@ describe('createGraphFromSql', () => {
     expect((nodeC!.state as SqlSourceSerializedState).sql).toBe(
       'SELECT * FROM $b',
     );
-    expect((nodeC!.state as SqlSourceSerializedState).customTitle).toBe('c');
     expect(nodeC!.nextNodes).toEqual(['output']);
     expect(nodeC!.prevNodes).toEqual(['b']);
 
     expect(nodeOutput!.type).toBe(NodeType.kSqlSource);
     expect((nodeOutput!.state as SqlSourceSerializedState).sql).toBe(
       'SELECT * FROM $c',
-    );
-    expect((nodeOutput!.state as SqlSourceSerializedState).customTitle).toBe(
-      'output',
     );
     expect(nodeOutput!.nextNodes).toEqual([]);
     expect(nodeOutput!.prevNodes).toEqual(['c']);


### PR DESCRIPTION
Cleaning up query execution into "analysis" and "execution", both on the outside and nodes layers. Removed a node specific behaviours.

Added autoExecute flag, set to true by default. When `true`, the Run button doesn't render.

Removed custom titles