### PR TITLE
tp: populate WM/SF has_invalid_elapsed_ts columns

### DIFF
--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
@@ -116,6 +116,9 @@ const SnapshotId SurfaceFlingerLayersParser::ParseSnapshot(
   auto* storage = context_->trace_processor_context_->storage.get();
   tables::SurfaceFlingerLayersSnapshotTable::Row snapshot;
   snapshot.ts = timestamp;
+  protos::pbzero::LayersSnapshotProto::Decoder snapshot_decoder(blob);
+  snapshot.has_invalid_elapsed_ts =
+      snapshot_decoder.elapsed_realtime_nanos() == 0;
   snapshot.base64_proto_id = storage->mutable_string_pool()
                                  ->InternString(base::StringView(
                                      base::Base64Encode(blob.data, blob.size)))

--- a/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/windowmanager_parser.cc
@@ -53,11 +53,12 @@ tables::WindowManagerTable::Id WindowManagerParser::InsertSnapshotRow(
   auto* trace_processor_context = context_->trace_processor_context_;
   tables::WindowManagerTable::Row row;
   row.ts = timestamp;
+  protos::pbzero::WindowManagerTraceEntry::Decoder entry(blob);
+  row.has_invalid_elapsed_ts = entry.elapsed_realtime_nanos() == 0;
   row.base64_proto_id = trace_processor_context->storage->mutable_string_pool()
                             ->InternString(base::StringView(
                                 base::Base64Encode(blob.data, blob.size)))
                             .raw_id();
-  protos::pbzero::WindowManagerTraceEntry::Decoder entry(blob);
   protos::pbzero::WindowManagerServiceDumpProto::Decoder service(
       entry.window_manager_service());
   row.focused_display_id = static_cast<uint32_t>(service.focused_display_id());

--- a/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/winscope/windowmanager.sql
@@ -23,15 +23,18 @@ CREATE PERFETTO VIEW android_windowmanager (
   arg_set_id ARGSETID,
   -- Raw proto message
   base64_proto_id LONG,
-  -- Focused display id for this entry
-  focused_display_id LONG
+  -- Focused display id for this snapshot
+  focused_display_id LONG,
+  -- Indicates whether snapshot was recorded without elapsed timestamp
+  has_invalid_elapsed_ts BOOL
 ) AS
 SELECT
   id,
   ts,
   arg_set_id,
   base64_proto_id,
-  focused_display_id
+  focused_display_id,
+  has_invalid_elapsed_ts
 FROM __intrinsic_windowmanager;
 
 -- Android WindowManager WindowContainer (from android.windowmanager data source).

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -204,16 +204,26 @@ SURFACE_FLINGER_LAYERS_SNAPSHOT_TABLE = Table(
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
             cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
         ),
-        C('sequence_id', CppUint32())
+        C('sequence_id', CppUint32()),
+        C(
+            'has_invalid_elapsed_ts',
+            CppOptional(CppUint32()),
+        ),
     ],
     tabledoc=TableDoc(
         doc='SurfaceFlinger layers snapshot',
         group='Winscope',
         columns={
-            'ts': 'Timestamp of the snapshot',
-            'arg_set_id': 'Extra args parsed from the proto message',
-            'base64_proto_id': 'String id for raw proto message',
-            'sequence_id': 'Sequence id of the trace packet'
+            'ts':
+                'Timestamp of the snapshot',
+            'arg_set_id':
+                'Extra args parsed from the proto message',
+            'base64_proto_id':
+                'String id for raw proto message',
+            'sequence_id':
+                'Sequence id of the trace packet',
+            'has_invalid_elapsed_ts':
+                'Indicates whether snapshot was recorded without elapsed timestamp',
         }))
 
 SURFACE_FLINGER_DISPLAY_TABLE = Table(
@@ -748,16 +758,26 @@ WINDOW_MANAGER_TABLE = Table(
             'focused_display_id',
             CppUint32(),
         ),
+        C(
+            'has_invalid_elapsed_ts',
+            CppUint32(),
+        ),
     ],
     wrapping_sql_view=WrappingSqlView('windowmanager'),
     tabledoc=TableDoc(
         doc='WindowManager',
         group='Winscope',
         columns={
-            'ts': 'The timestamp the state snapshot was captured',
-            'arg_set_id': 'Extra args parsed from the proto message',
-            'base64_proto_id': 'String id for raw proto message',
-            'focused_display_id': 'Focused display id for this entry',
+            'ts':
+                'The timestamp the state snapshot was captured',
+            'arg_set_id':
+                'Extra args parsed from the proto message',
+            'base64_proto_id':
+                'String id for raw proto message',
+            'focused_display_id':
+                'Focused display id for this snapshot',
+            'has_invalid_elapsed_ts':
+                'Indicates whether snapshot was recorded without elapsed timestamp',
         }))
 
 WINDOW_MANAGER_WINDOW_CONTAINER_TABLE = Table(

--- a/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
+++ b/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
@@ -17,7 +17,7 @@ packet {
   timestamp: 2748300281655
   timestamp_clock_id: 3
   surfaceflinger_layers_snapshot {
-    elapsed_realtime_nanos: 2748300281655
+    elapsed_realtime_nanos: 123
     where: "visibleRegionsDirty"
     layers {
       layers {
@@ -285,7 +285,7 @@ packet {
   timestamp: 2749700000000
   timestamp_clock_id: 3
   surfaceflinger_layers_snapshot {
-    elapsed_realtime_nanos: 2749700000000
+    elapsed_realtime_nanos: 0
     excludes_composition_state: true
     layers {
       layers { parent: -1 }

--- a/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
@@ -26,14 +26,15 @@ class SurfaceFlingerLayers(TestSuite):
         trace=Path('surfaceflinger_layers.textproto'),
         query="""
         SELECT
-          id, ts
+          id, ts, has_invalid_elapsed_ts
         FROM
-          surfaceflinger_layers_snapshot LIMIT 2;
+          surfaceflinger_layers_snapshot LIMIT 3;
         """,
         out=Csv("""
-        "id","ts"
-        0,2748300281655
-        1,2749500341063
+        "id","ts","has_invalid_elapsed_ts"
+        0,2748300281655,0
+        1,2749500341063,0
+        2,2749700000000,1
         """))
 
   def test_snapshot_args(self):
@@ -60,7 +61,7 @@ class SurfaceFlingerLayers(TestSuite):
         "displays[0].size.h","2400"
         "displays[0].size.w","1080"
         "displays[0].transform.type","0"
-        "elapsed_realtime_nanos","2748300281655"
+        "elapsed_realtime_nanos","123"
         "vsync_id","24766"
         "where","visibleRegionsDirty"
         """))

--- a/test/trace_processor/diff_tests/parser/android/tests_windowmanager.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_windowmanager.py
@@ -27,14 +27,14 @@ class WindowManager(TestSuite):
         query="""
         INCLUDE PERFETTO MODULE android.winscope.windowmanager;
         SELECT
-          ts, focused_display_id
+          ts, focused_display_id, has_invalid_elapsed_ts
         FROM
           android_windowmanager;
         """,
         out=Csv("""
-        "ts","focused_display_id"
-        558296470731,0
-        558884171862,2
+        "ts","focused_display_id","has_invalid_elapsed_ts"
+        558296470731,0,0
+        558884171862,2,1
         """))
 
   def test_snapshot_has_expected_args(self):
@@ -52,7 +52,7 @@ class WindowManager(TestSuite):
         """,
         out=Csv("""
         "key","display_value"
-        "elapsed_realtime_nanos","558296470731"
+        "elapsed_realtime_nanos","123"
         "where","trace.enable"
         "window_manager_service.focused_app","com.google.android.apps.nexuslauncher/.NexusLauncherActivity"
         "window_manager_service.focused_window.hash_code","160447612"

--- a/test/trace_processor/diff_tests/parser/android/windowmanager.textproto
+++ b/test/trace_processor/diff_tests/parser/android/windowmanager.textproto
@@ -35,7 +35,7 @@ packet {
   timestamp: 558296470731
   winscope_extensions {
     [perfetto.protos.WinscopeExtensionsImpl.windowmanager] {
-      elapsed_realtime_nanos: 558296470731
+      elapsed_realtime_nanos: 123
       where: "trace.enable"
       window_manager_service {
         policy {
@@ -4076,7 +4076,7 @@ packet {
   timestamp: 558884171862
   winscope_extensions {
     [perfetto.protos.WinscopeExtensionsImpl.windowmanager] {
-      elapsed_realtime_nanos: 558884171862
+      elapsed_realtime_nanos: 0
       where: "WindowAnimator"
       window_manager_service {
         focused_display_id: 2


### PR DESCRIPTION
We need to know if the elapsed timestamp value on the proto is 0 (only relevant for converted legacy SF/WM dumps).

Bug: 455539357
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="WindowManager|SurfaceFlinger|PerfettoTable:winscope"
