### PR TITLE
tp: fix crash when namespace thread association without process

### DIFF
--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -675,19 +675,20 @@ void ProcessTracker::UpdateNamespacedProcess(int64_t pid,
   namespaced_processes_[pid] = {pid, std::move(nspid), {}};
 }
 
-void ProcessTracker::UpdateNamespacedThread(int64_t pid,
+bool ProcessTracker::UpdateNamespacedThread(int64_t pid,
                                             int64_t tid,
                                             std::vector<int64_t> nstid) {
   // It's possible with data loss that we collect the thread namespace
   // information but not the process. In that case, just ignore the thread
   // association.
   if (namespaced_processes_.find(pid) == namespaced_processes_.end()) {
-    return;
+    return false;
   }
   auto& process = namespaced_processes_[pid];
   process.threads.emplace(tid);
 
   namespaced_threads_[tid] = {pid, tid, std::move(nstid)};
+  return true;
 }
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -228,9 +228,10 @@ class ProcessTracker {
 
   // Tracks the namespace-local thread ids for a thread running in a pid
   // namespace.
-  void UpdateNamespacedThread(int64_t pid,
-                              int64_t tid,
-                              std::vector<int64_t> nstid);
+  // Returns false if the corresponding process was not found (likely due to
+  // data loss).
+  PERFETTO_WARN_UNUSED_RESULT bool
+  UpdateNamespacedThread(int64_t pid, int64_t tid, std::vector<int64_t> nstid);
 
   // The UniqueTid of the swapper thread, is 0 for the default machine and is
   // > 0 for remote machines.

--- a/src/trace_processor/importers/common/process_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/process_tracker_unittest.cc
@@ -277,23 +277,27 @@ TEST_F(ProcessTrackerTest, UpdateTrustedPid) {
 TEST_F(ProcessTrackerTest, NamespacedProcessesAndThreads) {
   context.process_tracker->UpdateNamespacedProcess(/*pid=*/1001,
                                                    /*nspid=*/{1001, 190, 1});
-  context.process_tracker->UpdateNamespacedThread(/*pid=*/1001, /*tid=*/1002,
-                                                  /*nstid=*/{1002, 192, 2});
-  context.process_tracker->UpdateNamespacedThread(1001, 1003, {1003, 193, 3});
+  ASSERT_TRUE(context.process_tracker->UpdateNamespacedThread(
+      /*pid=*/1001, /*tid=*/1002,
+      /*nstid=*/{1002, 192, 2}));
+  ASSERT_TRUE(context.process_tracker->UpdateNamespacedThread(1001, 1003,
+                                                              {1003, 193, 3}));
 
   context.process_tracker->UpdateNamespacedProcess(/*pid=*/1023,
                                                    /*nspid=*/{1023, 201, 21});
-  context.process_tracker->UpdateNamespacedThread(/*pid=*/1023, /*tid=*/1026,
-                                                  {1026, 196, 26});
-  context.process_tracker->UpdateNamespacedThread(/*pid=*/1023, /*tid=*/1027,
-                                                  {1027, 197, 27});
+  ASSERT_TRUE(context.process_tracker->UpdateNamespacedThread(
+      /*pid=*/1023, /*tid=*/1026, {1026, 196, 26}));
+  ASSERT_TRUE(context.process_tracker->UpdateNamespacedThread(
+      /*pid=*/1023, /*tid=*/1027, {1027, 197, 27}));
 
   context.process_tracker->UpdateNamespacedProcess(/*pid=*/1024,
                                                    /*nspid=*/{1024, 202, 22});
-  context.process_tracker->UpdateNamespacedThread(/*pid=*/1024, /*tid=*/1028,
-                                                  /*nstid=*/{1028, 198, 28});
-  context.process_tracker->UpdateNamespacedThread(/*pid=*/1024, /*tid=*/1029,
-                                                  /*nstid=*/{1029, 198, 29});
+  ASSERT_TRUE(context.process_tracker->UpdateNamespacedThread(
+      /*pid=*/1024, /*tid=*/1028,
+      /*nstid=*/{1028, 198, 28}));
+  ASSERT_TRUE(context.process_tracker->UpdateNamespacedThread(
+      /*pid=*/1024, /*tid=*/1029,
+      /*nstid=*/{1029, 198, 29}));
 
   // Don't resolve if the process/thread isn't namespaced.
   ASSERT_EQ(context.process_tracker->ResolveNamespacedTid(2001, 2002),
@@ -320,6 +324,16 @@ TEST_F(ProcessTrackerTest, NamespacedProcessesAndThreads) {
             1028u);
   ASSERT_EQ(context.process_tracker->ResolveNamespacedTid(1024, 29).value(),
             1029u);
+}
+
+TEST_F(ProcessTrackerTest, NamespacedThreadMissingProcess) {
+  // Try to update a namespaced thread without first registering the process.
+  // This should fail and return false.
+  ASSERT_FALSE(context.process_tracker->UpdateNamespacedThread(
+      /*pid=*/9999, /*tid=*/10000, /*nstid=*/{10000, 1}));
+
+  // The import error stat should be incremented by the caller in production.
+  // In this test, we just verify the function returns false.
 }
 
 }  // namespace

--- a/src/trace_processor/importers/proto/system_probes_module.cc
+++ b/src/trace_processor/importers/proto/system_probes_module.cc
@@ -66,7 +66,7 @@ void SystemProbesModule::ParseTracePacketData(
     uint32_t field_id) {
   switch (field_id) {
     case TracePacket::kProcessTreeFieldNumber:
-      parser_.ParseProcessTree(decoder.process_tree());
+      parser_.ParseProcessTree(ts, decoder.process_tree());
       return;
     case TracePacket::kProcessStatsFieldNumber:
       parser_.ParseProcessStats(ts, decoder.process_stats());

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -39,6 +39,7 @@
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/cpu_tracker.h"
 #include "src/trace_processor/importers/common/event_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
@@ -592,7 +593,7 @@ void SystemProbesParser::ParseCpuIdleStats(int64_t ts, ConstBytes blob) {
   }
 }
 
-void SystemProbesParser::ParseProcessTree(ConstBytes blob) {
+void SystemProbesParser::ParseProcessTree(int64_t ts, ConstBytes blob) {
   protos::pbzero::ProcessTree::Decoder ps(blob);
 
   for (auto it = ps.processes(); it; ++it) {
@@ -725,8 +726,11 @@ void SystemProbesParser::ParseProcessTree(ConstBytes blob) {
       for (auto nstid_it = thd.nstid(); nstid_it; nstid_it++) {
         nstid.emplace_back(static_cast<int64_t>(*nstid_it));
       }
-      context_->process_tracker->UpdateNamespacedThread(tgid, tid,
-                                                        std::move(nstid));
+      if (!context_->process_tracker->UpdateNamespacedThread(
+              tgid, tid, std::move(nstid))) {
+        context_->import_logs_tracker->RecordParserError(
+            stats::namespaced_thread_missing_process, ts);
+      }
     }
   }
 }

--- a/src/trace_processor/importers/proto/system_probes_parser.h
+++ b/src/trace_processor/importers/proto/system_probes_parser.h
@@ -36,7 +36,7 @@ class SystemProbesParser {
 
   explicit SystemProbesParser(TraceProcessorContext*);
 
-  void ParseProcessTree(ConstBytes);
+  void ParseProcessTree(int64_t ts, ConstBytes);
   void ParseProcessStats(int64_t ts, ConstBytes);
   void ParseSysStats(int64_t ts, ConstBytes);
   void ParseSystemInfo(ConstBytes);

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -265,6 +265,12 @@ namespace perfetto::trace_processor::stats {
   F(clock_sync_failure,                   kSingle,  kError,    kAnalysis, ""), \
   F(clock_sync_cache_miss,                kSingle,  kInfo,     kAnalysis, ""), \
   F(process_tracker_errors,               kSingle,  kError,    kAnalysis, ""), \
+  F(namespaced_thread_missing_process,    kSingle,  kError,    kAnalysis,      \
+      "A namespaced thread association was received but the corresponding "    \
+      "process association was not found. This can happen due to data losses " \
+      "during trace collection. The trace will be missing namespace "          \
+      "associations for some threads, which may affect analysis. To address "  \
+      "this issue, address the underlying data losses."),                      \
   F(json_tokenizer_failure,               kSingle,  kError,    kTrace,    ""), \
   F(json_parser_failure,                  kSingle,  kError,    kTrace,    ""), \
   F(json_display_time_unit,               kSingle,  kInfo,     kTrace,         \


### PR DESCRIPTION
This edge case can happen in the presence of data loss. Use the new
trace logging system to properly log this instead of just DCHECK-ing
or crashing on release builds.

Fixes: http://b/455539113