### PR TITLE
ui: Include ii() module in TrackEvent

### DIFF
--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -130,7 +130,10 @@ function computeTrackEventCallstackFlamegraph(
         columnName: 'self_count',
       },
     ],
-    'include perfetto module callstacks.stack_profile',
+    `
+     include perfetto module callstacks.stack_profile;
+     include perfetto module intervals.intersect;
+    `,
     [{name: 'mapping_name', displayName: 'Mapping'}],
     [
       {


### PR DESCRIPTION
Track event uses interval_intersect!(), so include the module.

Bug: 455640723
Signed-off-by: Samuel Wu <wusamuel@google.com>