### PR TITLE
ui: Tidy up Sidebar and UIMain components

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -44,6 +44,7 @@ import {Workspace} from '../../public/workspace';
 import {showModal} from '../../widgets/modal';
 import {assertExists} from '../../base/logging';
 import {Setting} from '../../public/settings';
+import {toggleHelp} from '../../frontend/help_modal';
 
 const QUICKSAVE_LOCALSTORAGE_KEY = 'quicksave';
 
@@ -140,6 +141,22 @@ export default class CoreCommands implements PerfettoPlugin {
   static macrosSetting: Setting<MacroConfig> | undefined = undefined;
 
   static onActivate(ctx: AppImpl) {
+    // Register global commands (commands that are required even without a trace
+    // loaded).
+    ctx.commands.registerCommand({
+      id: 'dev.perfetto.OpenCommandPalette',
+      name: 'Open command palette',
+      callback: () => ctx.omnibox.setMode(OmniboxMode.Command),
+      defaultHotkey: '!Mod+Shift+P',
+    });
+
+    ctx.commands.registerCommand({
+      id: 'dev.perfetto.ShowHelp',
+      name: 'Show help',
+      callback: () => toggleHelp(),
+      defaultHotkey: '?',
+    });
+
     if (ctx.sidebar.enabled) {
       ctx.commands.registerCommand({
         id: 'dev.perfetto.ToggleLeftSidebar',


### PR DESCRIPTION
- Remove command and sidebar registration in the lifecycle methods - ideally lifecycle methods should not have side effects.
  - Move command registration to plugins.
  - Build sidebar elements on the fly, don't bother to register them with the App at all.
- Avoid caching mutable state in component internal state.
- Remove the `UiMainPerTrace` abstraction, and just rely on passing a trace unique key from the frontend.
