### PR TITLE
ui: add support for closing views to the SqlTable

### DIFF
--- a/ui/src/assets/widgets/sql_table.scss
+++ b/ui/src/assets/widgets/sql_table.scss
@@ -36,6 +36,15 @@
   gap: 4px;
   padding: 2px;
   border-bottom: solid 1px var(--pf-color-border);
+
+  .pf-tabs {
+    .pf-button {
+      padding: 0px;
+    }
+    .pf-tabs__tab-icon--right {
+      margin-left: 0px;
+    }
+  }
 }
 
 .pf-sql-table__table {

--- a/ui/src/components/details/sql_table_tab.ts
+++ b/ui/src/components/details/sql_table_tab.ts
@@ -197,6 +197,12 @@ class SqlTableTab implements Tab {
       tabs.push({
         key: pivot.uuid,
         title: `Pivot: ${pivot.getPivots().map(pivotId).join(', ')}`,
+        rightIcon: m(Button, {
+          icon: Icons.Close,
+          onclick: () => {
+            this.pivots = this.pivots.filter((p) => p.uuid !== pivot.uuid);
+          },
+        }),
         content: m(PivotTable, {
           state: pivot,
           extraRowButton: (node) =>
@@ -232,6 +238,14 @@ class SqlTableTab implements Tab {
       tabs.push({
         key: chart.uuid,
         title: `Bar chart: ${sqlColumnId(chart.args.column)}`,
+        rightIcon: m(Button, {
+          icon: Icons.Close,
+          onclick: () => {
+            this.barCharts = this.barCharts.filter(
+              (c) => c.uuid !== chart.uuid,
+            );
+          },
+        }),
         content: m(SqlBarChart, {state: chart}),
       });
     }
@@ -240,8 +254,21 @@ class SqlTableTab implements Tab {
       tabs.push({
         key: histogram.uuid,
         title: `Histogram: ${sqlColumnId(histogram.args.column)}`,
+        rightIcon: m(Button, {
+          icon: Icons.Close,
+          onclick: () => {
+            this.histograms = this.histograms.filter(
+              (h) => h.uuid !== histogram.uuid,
+            );
+          },
+        }),
         content: m(SqlHistogram, {state: histogram}),
       });
+    }
+
+    // Fall back to the table view if the selected tab was closed.
+    if (!tabs.some((tab) => tab.key === this.selectedTab)) {
+      this.selectedTab = this.tableState.uuid;
     }
 
     return m(


### PR DESCRIPTION
Add a close button to the secondary views (pivot tables, bar charts and histograms)
to the tab strip to allow user to close secondary views.

<img width="340" height="100" alt="Screenshot 2025-10-29 at 00 08 58" src="https://github.com/user-attachments/assets/0f5cc0f1-04fe-4ee5-9680-21b358b485e7" />
