### PR TITLE
Rename rust-sdk owners file

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -4,7 +4,9 @@ This directory contains code maintained by the Perfetto community,
 not the core Perfetto team.
 
 Code in this directory is:
-- **Community maintained**: Owned and supported by contributors listed in OWNERS
+- **Community maintained**: Owned and supported by contributors listed in 
+    OWNERS.github (please stick to this naming to avoid internal rollout
+    complications).
 - **Not officially supported**: The Perfetto core team does not guarantee
     maintenance
 - **Not part of Android/Google builds**: Not included in Android or
@@ -25,7 +27,7 @@ To add a new project to `contrib/`:
 1. Open a GitHub issue proposing the addition
 2. Demonstrate community need and maintainer commitment
 3. Get approval from Perfetto maintainers
-4. Submit PR with initial code and OWNERS file
+4. Submit PR with initial code and OWNERS.github file
 
 See [Contributing Guide](https://perfetto.dev/docs/contributing/getting-started)
 for general contribution guidelines.

--- a/contrib/rust-sdk/CODEOWNERS
+++ b/contrib/rust-sdk/CODEOWNERS
@@ -1,3 +1,0 @@
-dreveman@gmail.com
-jon.bailey45@gmail.com
-ziyi.elisa.tai@gmail.com

--- a/contrib/rust-sdk/OWNERS.github
+++ b/contrib/rust-sdk/OWNERS.github
@@ -1,0 +1,8 @@
+# This file is intended to define code ownership within the GitHub repository.
+# This file should be called OWNERS.github to prevent processing by internal tooling
+# that enforces stricter validation on OWNERS files, such as requiring internal
+# email domains. 
+
+dreveman@gmail.com
+jon.bailey45@gmail.com
+ziyi.elisa.tai@gmail.com


### PR DESCRIPTION
Internal android copybara is failing with below error, so to fix it rename it as CODEOWNERS

```
the domain of the code owner email 'dreveman@gmail.com' in '/contrib/rust-sdk/OWNERS' is not allowed for code owners.
```
