### PR TITLE
ui: Fix crash when selecting tracks that contain slices with negative durations

### DIFF
--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -94,7 +94,7 @@ function computeTrackEventCallstackFlamegraph(
             (
               select id, ts, dur
               from slice
-              where track_id in (${trackIds.join()})
+              where track_id in (${trackIds.join()}) and dur >= 0
             )
           )
         )


### PR DESCRIPTION
Fixes https://b.corp.google.com/issues/454605888