### PR TITLE
tp: improve error handling of clock synchronization and use import logs

### DIFF
--- a/src/trace_processor/importers/android_bugreport/android_battery_stats_reader.cc
+++ b/src/trace_processor/importers/android_bugreport/android_battery_stats_reader.cc
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <cstdint>
 #include <ctime>
+#include <memory>
 #include <optional>
 #include <utility>
 
@@ -151,11 +152,11 @@ base::Status AndroidBatteryStatsReader::ProcessBatteryStatsHistoryEvent(
 base::Status AndroidBatteryStatsReader::SendToSorter(
     std::chrono::nanoseconds event_ts,
     AndroidDumpstateEvent event) {
-  ASSIGN_OR_RETURN(
-      int64_t trace_ts,
-      context_->clock_tracker->ToTraceTime(
-          protos::pbzero::ClockSnapshot::Clock::REALTIME, event_ts.count()));
-  stream_->Push(trace_ts, std::move(event));
+  std::optional<int64_t> trace_ts = context_->clock_tracker->ToTraceTime(
+      protos::pbzero::ClockSnapshot::Clock::REALTIME, event_ts.count());
+  if (trace_ts) {
+    stream_->Push(*trace_ts, std::move(event));
+  }
   return base::OkStatus();
 }
 

--- a/src/trace_processor/importers/android_bugreport/android_log_reader.cc
+++ b/src/trace_processor/importers/android_bugreport/android_log_reader.cc
@@ -272,10 +272,11 @@ base::Status AndroidLogReader::SendToSorter(std::chrono::nanoseconds event_ts,
                                             AndroidLogEvent event) {
   int64_t ts =
       event_ts.count() - context_->clock_tracker->timezone_offset().value_or(0);
-  ASSIGN_OR_RETURN(int64_t trace_ts,
-                   context_->clock_tracker->ToTraceTime(
-                       protos::pbzero::ClockSnapshot::Clock::REALTIME, ts));
-  stream_->Push(trace_ts, event);
+  std::optional<int64_t> trace_ts = context_->clock_tracker->ToTraceTime(
+      protos::pbzero::ClockSnapshot::Clock::REALTIME, ts);
+  if (trace_ts) {
+    stream_->Push(*trace_ts, event);
+  }
   return base::OkStatus();
 }
 

--- a/src/trace_processor/importers/art_method/art_method_tokenizer.cc
+++ b/src/trace_processor/importers/art_method/art_method_tokenizer.cc
@@ -215,10 +215,11 @@ base::Status ArtMethodTokenizer::ParseRecord(uint32_t tid,
       evt.action = ArtMethodEvent::kExit;
       break;
   }
-  ASSIGN_OR_RETURN(int64_t ts, context_->clock_tracker->ToTraceTime(
-                                   protos::pbzero::BUILTIN_CLOCK_MONOTONIC,
-                                   (ts_ + ts_delta) * 1000));
-  stream_->Push(ts, evt);
+  std::optional<int64_t> ts = context_->clock_tracker->ToTraceTime(
+      protos::pbzero::BUILTIN_CLOCK_MONOTONIC, (ts_ + ts_delta) * 1000);
+  if (ts) {
+    stream_->Push(*ts, evt);
+  }
   return base::OkStatus();
 }
 

--- a/src/trace_processor/importers/common/clock_tracker.cc
+++ b/src/trace_processor/importers/common/clock_tracker.cc
@@ -16,32 +16,34 @@
 
 #include "src/trace_processor/importers/common/clock_tracker.h"
 
-#include <algorithm>
-#include <cinttypes>
 #include <cstdint>
 #include <ctime>
-#include <iterator>
-#include <limits>
 #include <optional>
-#include <vector>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/fnv_hash.h"
-#include "perfetto/ext/base/status_or.h"
-#include "perfetto/public/compiler.h"
+#include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
+#include "src/trace_processor/importers/common/metadata_tracker.h"
+#include "src/trace_processor/storage/metadata.h"
 #include "src/trace_processor/storage/stats.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/types/trace_processor_context.h"
-
-#include "protos/perfetto/common/builtin_clock.pbzero.h"
-#include "protos/perfetto/trace/clock_snapshot.pbzero.h"
+#include "src/trace_processor/types/variadic.h"
+#include "src/trace_processor/util/clock_synchronizer.h"
 
 namespace perfetto::trace_processor {
 
 ClockSynchronizerListenerImpl::ClockSynchronizerListenerImpl(
-    TraceProcessorContext* context) {
-  context_ = context;
-}
+    TraceProcessorContext* context)
+    : context_(context),
+      source_clock_id_key_(context->storage->InternString("source_clock_id")),
+      target_clock_id_key_(context->storage->InternString("target_clock_id")),
+      source_timestamp_key_(context->storage->InternString("source_timestamp")),
+      source_sequence_id_key_(
+          context->storage->InternString("source_sequence_id")),
+      target_sequence_id_key_(
+          context->storage->InternString("target_sequence_id")) {}
 
 base::Status ClockSynchronizerListenerImpl::OnClockSyncCacheMiss() {
   context_->storage->IncrementStats(stats::clock_sync_cache_miss);
@@ -54,19 +56,67 @@ base::Status ClockSynchronizerListenerImpl::OnInvalidClockSnapshot() {
 }
 
 base::Status ClockSynchronizerListenerImpl::OnTraceTimeClockIdChanged(
-    ClockSynchronizer<ClockSynchronizerListenerImpl>::ClockId
-        trace_time_clock_id) {
-  context_->metadata_tracker->SetMetadata(
-      metadata::trace_time_clock_id, Variadic::Integer(trace_time_clock_id));
+    ClockSynchronizerBase::ClockId clock_id) {
+  context_->metadata_tracker->SetMetadata(metadata::trace_time_clock_id,
+                                          Variadic::Integer(clock_id));
   return base::OkStatus();
 }
 
 base::Status ClockSynchronizerListenerImpl::OnSetTraceTimeClock(
-    ClockSynchronizer<ClockSynchronizerListenerImpl>::ClockId
-        trace_time_clock_id) {
-  context_->metadata_tracker->SetMetadata(
-      metadata::trace_time_clock_id, Variadic::Integer(trace_time_clock_id));
+    ClockSynchronizerBase::ClockId clock_id) {
+  context_->metadata_tracker->SetMetadata(metadata::trace_time_clock_id,
+                                          Variadic::Integer(clock_id));
   return base::OkStatus();
+}
+
+void ClockSynchronizerListenerImpl::RecordConversionError(
+    ClockSynchronizerBase::ErrorType error_type,
+    ClockSynchronizerBase::ClockId source_clock_id,
+    ClockSynchronizerBase::ClockId target_clock_id,
+    int64_t source_timestamp,
+    std::optional<size_t> byte_offset) {
+  size_t stat_key;
+  switch (error_type) {
+    case ClockSynchronizerBase::ErrorType::kUnknownSourceClock:
+      stat_key = stats::clock_sync_failure_unknown_source_clock;
+      break;
+    case ClockSynchronizerBase::ErrorType::kUnknownTargetClock:
+      stat_key = stats::clock_sync_failure_unknown_target_clock;
+      break;
+    case ClockSynchronizerBase::ErrorType::kNoPath:
+      stat_key = stats::clock_sync_failure_no_path;
+      break;
+    case ClockSynchronizerBase::ErrorType::kOk:
+      PERFETTO_FATAL("RecordConversionError called with kOk");
+      return;
+  }
+  auto args = [&](ArgsTracker::BoundInserter& inserter) {
+    if (ClockTracker::IsSequenceClock(static_cast<uint32_t>(source_clock_id))) {
+      auto [seq_id, seq_clock_id] =
+          ClockTracker::ExtractSequenceClockId(source_clock_id);
+      inserter.AddArg(source_sequence_id_key_,
+                      Variadic::UnsignedInteger(seq_id));
+      inserter.AddArg(source_clock_id_key_, Variadic::Integer(seq_clock_id));
+    } else {
+      inserter.AddArg(source_clock_id_key_, Variadic::Integer(source_clock_id));
+    }
+    inserter.AddArg(source_timestamp_key_, Variadic::Integer(source_timestamp));
+    if (ClockTracker::IsSequenceClock(static_cast<uint32_t>(target_clock_id))) {
+      auto [seq_id, seq_clock_id] =
+          ClockTracker::ExtractSequenceClockId(target_clock_id);
+      inserter.AddArg(target_sequence_id_key_,
+                      Variadic::UnsignedInteger(seq_id));
+      inserter.AddArg(target_clock_id_key_, Variadic::Integer(seq_clock_id));
+    } else {
+      inserter.AddArg(target_clock_id_key_, Variadic::Integer(target_clock_id));
+    }
+  };
+  if (byte_offset) {
+    context_->import_logs_tracker->RecordTokenizationError(stat_key,
+                                                           *byte_offset, args);
+  } else {
+    context_->import_logs_tracker->RecordAnalysisError(stat_key, args);
+  }
 }
 
 // Returns true if this is a local host, false otherwise.

--- a/src/trace_processor/importers/common/clock_tracker.h
+++ b/src/trace_processor/importers/common/clock_tracker.h
@@ -17,9 +17,12 @@
 #ifndef SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_CLOCK_TRACKER_H_
 #define SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_CLOCK_TRACKER_H_
 
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include "perfetto/base/status.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/util/clock_synchronizer.h"
-
-#include "src/trace_processor/importers/common/metadata_tracker.h"
 
 namespace perfetto::trace_processor {
 
@@ -29,6 +32,11 @@ class TraceProcessorContext;
 class ClockSynchronizerListenerImpl {
  private:
   TraceProcessorContext* context_;
+  StringId source_clock_id_key_;
+  StringId target_clock_id_key_;
+  StringId source_timestamp_key_;
+  StringId source_sequence_id_key_;
+  StringId target_sequence_id_key_;
 
  public:
   explicit ClockSynchronizerListenerImpl(TraceProcessorContext* context);
@@ -37,15 +45,16 @@ class ClockSynchronizerListenerImpl {
 
   base::Status OnInvalidClockSnapshot();
 
-  base::Status OnTraceTimeClockIdChanged(
-      ClockSynchronizer<ClockSynchronizerListenerImpl>::ClockId
-          trace_time_clock_id);
+  base::Status OnTraceTimeClockIdChanged(ClockSynchronizerBase::ClockId);
 
-  base::Status OnSetTraceTimeClock(
-      ClockSynchronizer<ClockSynchronizerListenerImpl>::ClockId
-          trace_time_clock_id);
+  base::Status OnSetTraceTimeClock(ClockSynchronizerBase::ClockId);
 
-  // Returns true if this is a local host, false otherwise.
+  void RecordConversionError(ClockSynchronizerBase::ErrorType,
+                             ClockSynchronizerBase::ClockId source_clock_id,
+                             ClockSynchronizerBase::ClockId target_clock_id,
+                             int64_t source_timestamp,
+                             std::optional<size_t>);
+
   bool IsLocalHost();
 };
 

--- a/src/trace_processor/importers/common/import_logs_tracker.cc
+++ b/src/trace_processor/importers/common/import_logs_tracker.cc
@@ -15,8 +15,17 @@
  */
 
 #include "src/trace_processor/importers/common/import_logs_tracker.h"
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <utility>
 
 #include "perfetto/base/logging.h"
+#include "perfetto/ext/base/string_view.h"
+#include "src/trace_processor/importers/common/args_tracker.h"
+#include "src/trace_processor/storage/stats.h"
+#include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/metadata_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
 
@@ -71,6 +80,14 @@ void ImportLogsTracker::RecordParserError(
     int64_t timestamp,
     std::function<void(ArgsTracker::BoundInserter&)> args_callback) {
   RecordImportLog(stat_key, timestamp,
+                  /*byte_offset=*/std::nullopt, std::move(args_callback));
+}
+
+void ImportLogsTracker::RecordAnalysisError(
+    size_t stat_key,
+    std::function<void(ArgsTracker::BoundInserter&)> args_callback) {
+  RecordImportLog(stat_key,
+                  /*timestamp=*/std::nullopt,
                   /*byte_offset=*/std::nullopt, std::move(args_callback));
 }
 

--- a/src/trace_processor/importers/etm/etm_v4_stream.cc
+++ b/src/trace_processor/importers/etm/etm_v4_stream.cc
@@ -17,7 +17,7 @@
 #include "src/trace_processor/importers/etm/etm_v4_stream.h"
 
 #include <cstdint>
-#include <memory>
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -29,12 +29,16 @@
 #include "src/trace_processor/importers/common/event_tracker.h"
 #include "src/trace_processor/importers/common/track_tracker.h"
 #include "src/trace_processor/importers/common/tracks.h"
-#include "src/trace_processor/importers/common/tracks_common.h"
 #include "src/trace_processor/importers/etm/etm_v4_stream_demultiplexer.h"
 #include "src/trace_processor/importers/etm/frame_decoder.h"
 #include "src/trace_processor/importers/etm/opencsd.h"
 #include "src/trace_processor/importers/etm/storage_handle.h"
+#include "src/trace_processor/importers/perf/aux_record.h"
+#include "src/trace_processor/importers/perf/itrace_start_record.h"
+#include "src/trace_processor/importers/perf/perf_event.h"
 #include "src/trace_processor/importers/perf/util.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/etm_tables_py.h"
 
 namespace perfetto::trace_processor::etm {
 namespace {
@@ -129,9 +133,8 @@ base::Status EtmV4Stream::OnItraceStartRecord(
     perf_importer::ItraceStartRecord start) {
   std::optional<int64_t> start_ts;
   if (start.time().has_value()) {
-    ASSIGN_OR_RETURN(start_ts, context_->clock_tracker->ToTraceTime(
-                                   start.attr->clock_id(),
-                                   static_cast<int64_t>(*start.time())));
+    start_ts = context_->clock_tracker->ToTraceTime(
+        start.attr->clock_id(), static_cast<int64_t>(*start.time()));
   }
   if (session_.has_value()) {
     EndSession();

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -34,6 +34,7 @@
 #include "src/trace_processor/importers/common/event_tracker.h"
 #include "src/trace_processor/importers/common/flow_tracker.h"
 #include "src/trace_processor/importers/common/global_args_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/common/process_track_translation_table.h"
@@ -47,7 +48,6 @@
 #include "src/trace_processor/importers/fuchsia/fuchsia_trace_parser.h"
 #include "src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.h"
 #include "src/trace_processor/importers/proto/additional_modules.h"
-#include "src/trace_processor/importers/proto/default_modules.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/proto_trace_parser_impl.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
@@ -173,6 +173,8 @@ class FuchsiaTraceParserTest : public ::testing::Test {
     context_.track_tracker = std::make_unique<TrackTracker>(&context_);
     context_.global_args_tracker =
         std::make_unique<GlobalArgsTracker>(context_.storage.get());
+    context_.import_logs_tracker =
+        std::make_unique<ImportLogsTracker>(&context_, 1);
     context_.stack_profile_tracker.reset(new StackProfileTracker(&context_));
     context_.args_translation_table.reset(new ArgsTranslationTable(storage_));
     context_.metadata_tracker =
@@ -190,10 +192,8 @@ class FuchsiaTraceParserTest : public ::testing::Test {
     context_.slice_tracker = std::make_unique<SliceTracker>(&context_);
     context_.slice_translation_table =
         std::make_unique<SliceTranslationTable>(storage_);
-    std::unique_ptr<ClockSynchronizerListenerImpl> clock_tracker_listener =
-        std::make_unique<ClockSynchronizerListenerImpl>(&context_);
-    context_.clock_tracker =
-        std::make_unique<ClockTracker>(std::move(clock_tracker_listener));
+    context_.clock_tracker = std::make_unique<ClockTracker>(
+        std::make_unique<ClockSynchronizerListenerImpl>(&context_));
     clock_ = context_.clock_tracker.get();
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
     context_.sorter = std::make_unique<TraceSorter>(

--- a/src/trace_processor/importers/gecko/gecko_trace_tokenizer.cc
+++ b/src/trace_processor/importers/gecko/gecko_trace_tokenizer.cc
@@ -155,13 +155,13 @@ base::Status GeckoTraceTokenizer::NotifyEndOfFile() {
                     context_->storage->InternString(t["name"].asCString())}});
         added_metadata = true;
       }
-      ASSIGN_OR_RETURN(
-          int64_t converted,
-          context_->clock_tracker->ToTraceTime(
-              protos::pbzero::ClockSnapshot::Clock::MONOTONIC, ts));
-      stream_->Push(converted,
-                    GeckoEvent{GeckoEvent::StackSample{
-                        t["tid"].asUInt(), callsites[stack_idx].id}});
+      std::optional<int64_t> converted = context_->clock_tracker->ToTraceTime(
+          protos::pbzero::ClockSnapshot::Clock::MONOTONIC, ts);
+      if (converted) {
+        stream_->Push(*converted,
+                      GeckoEvent{GeckoEvent::StackSample{
+                          t["tid"].asUInt(), callsites[stack_idx].id}});
+      }
     }
   }
   return base::OkStatus();

--- a/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
+++ b/src/trace_processor/importers/instruments/instruments_xml_tokenizer.cc
@@ -16,6 +16,7 @@
 
 #include "src/trace_processor/importers/instruments/instruments_xml_tokenizer.h"
 
+#include "perfetto/ext/base/murmur_hash.h"
 #include "src/trace_processor/importers/instruments/row_parser.h"
 
 #include <expat.h>
@@ -27,6 +28,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <map>
+#include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -35,7 +38,6 @@
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/fnv_hash.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/public/compiler.h"
@@ -148,7 +150,6 @@ class InstrumentsXmlTokenizer::Impl {
  public:
   explicit Impl(TraceProcessorContext* context)
       : context_(context),
-        data_(),
         parser_(XML_ParserCreate(nullptr)),
         stream_(context->sorter->CreateStream(
             std::make_unique<RowParser>(context, data_))) {
@@ -372,13 +373,10 @@ class InstrumentsXmlTokenizer::Impl {
     if (tag_name == "row") {
       if (current_row_.backtrace) {
         // Rows with backtraces are assumed to be time samples.
-        base::StatusOr<int64_t> trace_ts =
+        std::optional<int64_t> trace_ts =
             ToTraceTimestamp(current_row_.timestamp_);
-        if (!trace_ts.ok()) {
-          PERFETTO_DLOG("Skipping timestamp %" PRId64 ", no clock snapshot yet",
-                        current_row_.timestamp_);
-        } else {
-          stream_->Push(*trace_ts, std::move(current_row_));
+        if (trace_ts) {
+          stream_->Push(*trace_ts, current_row_);
         }
       } else if (current_subsystem_ref_ != nullptr) {
         // Rows without backtraces are assumed to be signpost events -- filter
@@ -452,14 +450,12 @@ class InstrumentsXmlTokenizer::Impl {
     }
   }
 
-  base::StatusOr<int64_t> ToTraceTimestamp(int64_t time) {
-    base::StatusOr<int64_t> trace_ts =
+  std::optional<int64_t> ToTraceTimestamp(int64_t time) {
+    std::optional<int64_t> trace_ts =
         context_->clock_tracker->ToTraceTime(clock_, time);
-
-    if (PERFETTO_LIKELY(trace_ts.ok())) {
+    if (PERFETTO_LIKELY(trace_ts.has_value())) {
       latest_timestamp_ = std::max(latest_timestamp_, *trace_ts);
     }
-
     return trace_ts;
   }
 

--- a/src/trace_processor/importers/perf/perf_data_tokenizer.h
+++ b/src/trace_processor/importers/perf/perf_data_tokenizer.h
@@ -89,7 +89,7 @@ class PerfDataTokenizer : public ChunkedTraceReader {
   base::Status ProcessTimeConvRecord(Record record);
   base::Status ProcessItraceStartRecord(Record record);
 
-  base::StatusOr<int64_t> ExtractTraceTimestamp(const Record& record);
+  std::optional<int64_t> ExtractTraceTimestamp(const Record& record);
 
   TraceProcessorContext* context_;
   PerfTracker perf_tracker_;

--- a/src/trace_processor/importers/perf/spe_tokenizer.cc
+++ b/src/trace_processor/importers/perf/spe_tokenizer.cc
@@ -153,13 +153,11 @@ class SpeStream : public AuxDataStream {
       return;
     }
 
-    base::StatusOr<int64_t> trace_time = context_->clock_tracker->ToTraceTime(
+    std::optional<int64_t> trace_time = context_->clock_tracker->ToTraceTime(
         last_aux_record_->attr->clock_id(), static_cast<int64_t>(*perf_time));
-    if (!trace_time.ok()) {
-      context_->storage->IncrementStats(stats::spe_record_dropped);
-      return;
+    if (trace_time) {
+      record_stream_->Push(*trace_time, std::move(record));
     }
-    record_stream_->Push(*trace_time, std::move(record));
   }
 
   TraceProcessorContext* const context_;

--- a/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
+++ b/src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc
@@ -172,11 +172,11 @@ base::Status PerfTextTraceTokenizer::Parse(TraceBlobView blob) {
     evt.pid = sample->pid;
     evt.callsite_id = *parent_callsite;
 
-    ASSIGN_OR_RETURN(
-        int64_t trace_ts,
-        context_->clock_tracker->ToTraceTime(
-            protos::pbzero::ClockSnapshot::Clock::MONOTONIC, sample->ts));
-    stream_->Push(trace_ts, evt);
+    std::optional<int64_t> trace_ts = context_->clock_tracker->ToTraceTime(
+        protos::pbzero::ClockSnapshot::Clock::MONOTONIC, sample->ts);
+    if (trace_ts) {
+      stream_->Push(*trace_ts, evt);
+    }
     reader_.PopFrontUntil(it.file_offset());
   }
 }

--- a/src/trace_processor/importers/proto/profile_module.cc
+++ b/src/trace_processor/importers/proto/profile_module.cc
@@ -131,9 +131,9 @@ ModuleResult ProfileModule::TokenizeStreamingProfilePacket(
   // the current timestamp of the packet sequence.
   auto packet_ts =
       sequence_state->IncrementAndGetTrackEventTimeNs(/*delta_ns=*/0);
-  base::StatusOr<int64_t> trace_ts = context_->clock_tracker->ToTraceTime(
+  std::optional<int64_t> trace_ts = context_->clock_tracker->ToTraceTime(
       protos::pbzero::BUILTIN_CLOCK_MONOTONIC, packet_ts);
-  if (trace_ts.ok())
+  if (trace_ts)
     packet_ts = *trace_ts;
 
   // Increment the sequence's timestamp by all deltas.
@@ -338,13 +338,11 @@ void ProfileModule::ParseProfilePacket(
   for (auto it = packet.process_dumps(); it; ++it) {
     protos::pbzero::ProfilePacket::ProcessHeapSamples::Decoder entry(*it);
 
-    base::StatusOr<int64_t> maybe_timestamp =
+    std::optional<int64_t> maybe_timestamp =
         context_->clock_tracker->ToTraceTime(
             protos::pbzero::BUILTIN_CLOCK_MONOTONIC_COARSE,
             static_cast<int64_t>(entry.timestamp()));
-
-    // ToTraceTime() increments the clock_sync_failure error stat in this case.
-    if (!maybe_timestamp.ok())
+    if (!maybe_timestamp)
       continue;
 
     int64_t timestamp = *maybe_timestamp;

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -40,6 +40,7 @@
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/event_tracker.h"
+#include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/proto/default_modules.h"
@@ -349,8 +350,8 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
       // chrome and then remove this.
       auto trace_ts = context_->clock_tracker->ToTraceTime(
           protos::pbzero::BUILTIN_CLOCK_MONOTONIC, timestamp);
-      if (trace_ts.ok())
-        timestamp = trace_ts.value();
+      if (trace_ts)
+        timestamp = *trace_ts;
     } else if (timestamp_clock_id) {
       // If the TracePacket specifies a non-zero clock-id, translate the
       // timestamp into the trace-time clock domain.
@@ -366,9 +367,9 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
         converted_clock_id =
             ClockTracker::SequenceToGlobalClock(seq_id, timestamp_clock_id);
       }
-      auto trace_ts =
-          context_->clock_tracker->ToTraceTime(converted_clock_id, timestamp);
-      if (!trace_ts.ok()) {
+      auto trace_ts = context_->clock_tracker->ToTraceTime(
+          converted_clock_id, timestamp, packet.offset());
+      if (!trace_ts) {
         // We need to switch to full sorting mode to ensure that packets with
         // missing timestamp are handled correctly. Don't save the packet unless
         // switching to full sorting mode succeeded.
@@ -378,12 +379,11 @@ base::Status ProtoTraceReader::TimestampTokenizeAndPushToSorter(
           return base::OkStatus();
         }
         // We don't return an error here as it will cause the trace to stop
-        // parsing. Instead, we rely on the stat increment to inform the user
-        // about the error.
-        context_->storage->IncrementStats(stats::clock_sync_failure);
+        // parsing. Instead, we rely on the stat increment (which happened
+        // automatically in ToTraceTime) to inform the user about the error.
         return base::OkStatus();
       }
-      timestamp = trace_ts.value();
+      timestamp = *trace_ts;
     }
   } else {
     timestamp = std::max(latest_timestamp_, context_->sorter->max_timestamp());
@@ -554,28 +554,31 @@ base::Status ProtoTraceReader::ParseClockSnapshot(ConstBytes blob,
     int64_t ts_to_convert =
         clock_timestamp.clock.is_incremental ? 0 : clock_timestamp.timestamp;
     // Even if we have trace time from snapshot, we still run ToTraceTime to
-    // optimise future conversions.
-    base::StatusOr<int64_t> opt_trace_ts = context_->clock_tracker->ToTraceTime(
+    // optimise future conversions. Don't pass byte_offset since we expect
+    // failures here (e.g., non-monotonic clocks).
+    auto opt_trace_ts = context_->clock_tracker->ToTraceTime(
         clock_timestamp.clock.id, ts_to_convert);
 
-    if (!opt_trace_ts.ok()) {
+    int64_t trace_ts_value;
+    if (!opt_trace_ts) {
       // This can happen if |AddSnapshot| failed to resolve this clock, e.g. if
       // clock is not monotonic. Try to fetch trace time from snapshot.
       if (!trace_time_from_snapshot) {
-        PERFETTO_DLOG("%s", opt_trace_ts.status().c_message());
         continue;
       }
-      opt_trace_ts = *trace_time_from_snapshot;
+      trace_ts_value = *trace_time_from_snapshot;
+    } else {
+      trace_ts_value = *opt_trace_ts;
     }
 
     // Double check that all the clocks in this snapshot resolve to the same
     // trace timestamp value.
     PERFETTO_DCHECK(!trace_ts_for_check ||
-                    opt_trace_ts.value() == trace_ts_for_check.value());
-    trace_ts_for_check = *opt_trace_ts;
+                    trace_ts_value == trace_ts_for_check.value());
+    trace_ts_for_check = trace_ts_value;
 
     tables::ClockSnapshotTable::Row row;
-    row.ts = *opt_trace_ts;
+    row.ts = trace_ts_value;
     row.clock_id = static_cast<int64_t>(clock_timestamp.clock.id);
     row.clock_value =
         clock_timestamp.timestamp * clock_timestamp.clock.unit_multiplier_ns;

--- a/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
@@ -29,10 +29,13 @@
 #include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/trace/trace.pbzero.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
+#include "src/trace_processor/importers/common/global_args_tracker.h"
+#include "src/trace_processor/importers/common/import_logs_tracker.h"
 #include "src/trace_processor/importers/common/machine_tracker.h"
 #include "src/trace_processor/importers/proto/additional_modules.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
 #include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/descriptors.h"
 #include "test/gtest_and_gmock.h"
 
@@ -51,10 +54,12 @@ class ProtoTraceReaderTest : public ::testing::Test {
     context_.storage = std::make_unique<TraceStorage>();
     context_.machine_tracker =
         std::make_unique<MachineTracker>(&context_, 0x1001);
-    std::unique_ptr<ClockSynchronizerListenerImpl> clock_tracker_listener =
-        std::make_unique<ClockSynchronizerListenerImpl>(&context_);
-    context_.clock_tracker =
-        std::make_unique<ClockTracker>(std::move(clock_tracker_listener));
+    context_.global_args_tracker =
+        std::make_unique<GlobalArgsTracker>(context_.storage.get());
+    context_.import_logs_tracker =
+        std::make_unique<ImportLogsTracker>(&context_, 1);
+    context_.clock_tracker = std::make_unique<ClockTracker>(
+        std::make_unique<ClockSynchronizerListenerImpl>(&context_));
     context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kDefault);
     context_.descriptor_pool_ = std::make_unique<DescriptorPool>();

--- a/src/trace_processor/importers/proto/system_probes_parser.cc
+++ b/src/trace_processor/importers/proto/system_probes_parser.cc
@@ -693,10 +693,10 @@ void SystemProbesParser::ParseProcessTree(int64_t ts, ConstBytes blob) {
 
     // note: early kernel threads can have an age of zero (at tick resolution)
     if (proc.has_process_start_from_boot()) {
-      base::StatusOr<int64_t> start_ts = context_->clock_tracker->ToTraceTime(
+      std::optional<int64_t> start_ts = context_->clock_tracker->ToTraceTime(
           protos::pbzero::BUILTIN_CLOCK_BOOTTIME,
           static_cast<int64_t>(proc.process_start_from_boot()));
-      if (start_ts.ok()) {
+      if (start_ts) {
         context_->process_tracker->SetStartTsIfUnset(upid, *start_ts);
       }
     }

--- a/src/trace_processor/importers/proto/track_event_tokenizer.h
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.h
@@ -90,6 +90,13 @@ class TrackEventTokenizer {
       const protos::pbzero::TrackEvent_LegacyEvent_Decoder&,
       PacketSequenceStateGeneration& state);
 
+  // Helper to record tokenization errors with packet offset
+  void RecordTokenizationError(size_t stat_key, TraceBlobView* packet);
+  // Helper to record tokenization errors with track_uuid arg
+  void RecordTokenizationErrorWithTrackUuid(size_t stat_key,
+                                            uint64_t track_uuid,
+                                            TraceBlobView* packet);
+
   TraceProcessorContext* const context_;
   TrackEventTracker* const track_event_tracker_;
   ProtoImporterModuleContext* const module_context_;

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -263,6 +263,24 @@ namespace perfetto::trace_processor::stats {
   F(vulkan_allocations_invalid_string_id,                                      \
                                           kSingle,  kError,    kTrace,    ""), \
   F(clock_sync_failure,                   kSingle,  kError,    kAnalysis, ""), \
+  F(clock_sync_failure_unknown_source_clock, kSingle, kError, kAnalysis,      \
+      "A packet with a timestamp could not be converted to trace time "        \
+      "because the source clock ID has never appeared in any ClockSnapshot. "  \
+      "This indicates the trace producer emitted packets with a clock_id but " \
+      "never provided a ClockSnapshot for that clock. Check that "             \
+      "ClockSnapshots are emitted before any packets using that clock_id. "    \
+      "For sequence-scoped clocks (64-128), ensure each packet sequence "      \
+      "emits its own ClockSnapshot."),                                         \
+  F(clock_sync_failure_unknown_target_clock, kSingle, kError, kAnalysis,      \
+      "A packet timestamp could not be converted because the target trace "    \
+      "time clock has never appeared in any ClockSnapshot. This is an "        \
+      "internal error that should not occur."),                                \
+  F(clock_sync_failure_no_path, kSingle, kError, kAnalysis,                   \
+      "A packet timestamp could not be converted to trace time because no "    \
+      "ClockSnapshot path exists connecting the source clock to the trace "    \
+      "time clock. Both clocks exist in snapshots, but never together or "     \
+      "via a common intermediate clock. Ensure ClockSnapshots link all used "  \
+      "clocks to the trace time clock."),                                      \
   F(clock_sync_cache_miss,                kSingle,  kInfo,     kAnalysis, ""), \
   F(process_tracker_errors,               kSingle,  kError,    kAnalysis, ""), \
   F(namespaced_thread_missing_process,    kSingle,  kError,    kAnalysis,      \

--- a/src/trace_processor/trace_processor_storage_impl.cc
+++ b/src/trace_processor/trace_processor_storage_impl.cc
@@ -30,6 +30,7 @@
 #include "src/trace_processor/forwarding_trace_parser.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/event_tracker.h"
+#include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/common/slice_tracker.h"
 #include "src/trace_processor/importers/common/stack_profile_tracker.h"

--- a/src/trace_processor/util/clock_synchronizer.h
+++ b/src/trace_processor/util/clock_synchronizer.h
@@ -29,6 +29,7 @@
 #include <random>
 #include <set>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 #include "perfetto/base/logging.h"
@@ -36,7 +37,6 @@
 #include "perfetto/ext/base/circular_queue.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/murmur_hash.h"
-#include "perfetto/ext/base/status_macros.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/public/compiler.h"
 
@@ -121,11 +121,25 @@ class TraceProcessorContext;
 //   S2                        {t: 2000, id: 2}   |
 //   S3                                           {t:5000, id:3}
 
-template <typename TClockEventListener>
-class ClockSynchronizer {
+// Base class for ClockSynchronizer containing non-templated types.
+// This allows listener implementations to reference these types without
+// depending on the template instantiation.
+class ClockSynchronizerBase {
  public:
   using ClockId = int64_t;
 
+  // Error type when clock conversion fails (used internally for listener)
+  enum class ErrorType {
+    kOk = 0,
+    kUnknownSourceClock,  // Source clock never seen in any snapshot
+    kUnknownTargetClock,  // Target clock never seen in any snapshot
+    kNoPath,              // No snapshot path connects source to target
+  };
+};
+
+template <typename TClockEventListener>
+class ClockSynchronizer : public ClockSynchronizerBase {
+ public:
   explicit ClockSynchronizer(
       std::unique_ptr<TClockEventListener> clock_event_listener)
       : trace_time_clock_id_(protos::pbzero::BUILTIN_CLOCK_BOOTTIME),
@@ -166,24 +180,41 @@ class ClockSynchronizer {
     return (static_cast<int64_t>(seq_id) << 32) | clock_id;
   }
 
+  // Extracts the sequence ID and raw clock ID from a converted sequence-scoped
+  // clock (i.e., one created via SequenceToGlobalClock).
+  // Returns {sequence_id, raw_clock_id}.
+  static std::pair<uint32_t, uint32_t> ExtractSequenceClockId(
+      ClockId global_clock_id) {
+    PERFETTO_DCHECK(!IsSequenceClock(global_clock_id));  // Must be converted
+    auto raw_clock_id = static_cast<uint32_t>(global_clock_id & 0xFFFFFFFF);
+    PERFETTO_DCHECK(
+        IsSequenceClock(raw_clock_id));  // Raw ID must be sequence-scoped
+    auto seq_id = static_cast<uint32_t>(global_clock_id >> 32);
+    return {seq_id, raw_clock_id};
+  }
+
   // Converts a timestamp from an arbitrary clock domain to the trace time.
   // On the first call, it also "locks" the trace time clock, preventing it
   // from being changed later.
-  PERFETTO_ALWAYS_INLINE base::StatusOr<int64_t> ToTraceTime(
+  // If byte_offset is provided and conversion fails, records the error via
+  // the listener.
+  PERFETTO_ALWAYS_INLINE std::optional<int64_t> ToTraceTime(
       ClockId clock_id,
-      int64_t timestamp) {
+      int64_t timestamp,
+      std::optional<size_t> byte_offset = std::nullopt) {
     if (PERFETTO_UNLIKELY(!trace_time_clock_id_used_for_conversion_)) {
       clock_event_listener_->OnTraceTimeClockIdChanged(trace_time_clock_id_);
     }
     trace_time_clock_id_used_for_conversion_ = true;
-
     if (clock_id == trace_time_clock_id_) {
       return ToHostTraceTime(timestamp);
     }
-
-    ASSIGN_OR_RETURN(int64_t ts,
-                     Convert(clock_id, timestamp, trace_time_clock_id_));
-    return ToHostTraceTime(ts);
+    std::optional<int64_t> ts =
+        Convert(clock_id, timestamp, trace_time_clock_id_, byte_offset);
+    if (ts) {
+      return ToHostTraceTime(*ts);
+    }
+    return ts;
   }
 
   // Appends a new snapshot for the given clock domains.
@@ -481,21 +512,30 @@ class ClockSynchronizer {
   ClockSynchronizer(const ClockSynchronizer&) = delete;
   ClockSynchronizer& operator=(const ClockSynchronizer&) = delete;
 
-  base::StatusOr<int64_t> ConvertSlowpath(
+  std::optional<int64_t> ConvertSlowpath(
       ClockId src_clock_id,
       int64_t src_timestamp,
       std::optional<int64_t> src_timestamp_ns,
-      ClockId target_clock_id) {
+      ClockId target_clock_id,
+      std::optional<size_t> byte_offset) {
     PERFETTO_DCHECK(!IsSequenceClock(src_clock_id));
     PERFETTO_DCHECK(!IsSequenceClock(target_clock_id));
     clock_event_listener_->OnClockSyncCacheMiss();
 
     ClockPath path = FindPath(src_clock_id, target_clock_id);
     if (!path.valid()) {
-      // Too many logs maybe emitted when path is invalid.
-      return base::ErrStatus("No path from clock %" PRId64 " to %" PRId64
-                             " at timestamp %" PRId64,
-                             src_clock_id, target_clock_id, src_timestamp);
+      // Determine which clock(s) are unknown and record error
+      ErrorType error;
+      if (clocks_.find(src_clock_id) == clocks_.end()) {
+        error = ErrorType::kUnknownSourceClock;
+      } else if (clocks_.find(target_clock_id) == clocks_.end()) {
+        error = ErrorType::kUnknownTargetClock;
+      } else {
+        error = ErrorType::kNoPath;
+      }
+      clock_event_listener_->RecordConversionError(
+          error, src_clock_id, target_clock_id, src_timestamp, byte_offset);
+      return std::nullopt;
     }
 
     // Iterate trough the path found and translate timestamps onto the new clock
@@ -606,9 +646,10 @@ class ClockSynchronizer {
   // Converts a timestamp between two clock domains. Tries to use the cache
   // first (only for single-path resolutions), then falls back on path finding
   // as described in the header.
-  base::StatusOr<int64_t> Convert(ClockId src_clock_id,
-                                  int64_t src_timestamp,
-                                  ClockId target_clock_id) {
+  std::optional<int64_t> Convert(ClockId src_clock_id,
+                                 int64_t src_timestamp,
+                                 ClockId target_clock_id,
+                                 std::optional<size_t> byte_offset) {
     std::optional<int64_t> ns;
     if (PERFETTO_LIKELY(!cache_lookups_disabled_for_testing_)) {
       for (const auto& cached_clock_path : cache_) {
@@ -626,7 +667,8 @@ class ClockSynchronizer {
         }
       }
     }
-    return ConvertSlowpath(src_clock_id, src_timestamp, ns, target_clock_id);
+    return ConvertSlowpath(src_clock_id, src_timestamp, ns, target_clock_id,
+                           byte_offset);
   }
 
   // Returns whether |global_clock_id| represents a sequence-scoped clock, i.e.


### PR DESCRIPTION
This CL improves how clock synchronization erorrs works: instead of just
having a single "clock sync failed" error, break it down into multiple
smaller errors. Also use the new error logging system of trace processor
to track those errors with much more fine grained details plumbed to the
import log tables. This makes it easier to understand what is going on
without needing to use traceconv text.

To be able to do this, the ClockTracker API has been refactored to no longer
return a hard error but a soft error via std::optional (as realistically, it should
never be the case that a single clock sync causes a whole trace to fail,
especially in the presence of merged traces). We move the logging inside
clock tracker as we can pass fine grained information which it would be
cumbersome to make the caller deal with.