### PR TITLE
ui: fix^2 crash when selecting track event samples

### DIFF
--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -92,9 +92,16 @@ function computeTrackEventCallstackFlamegraph(
             ${selection.start},
             ${selection.end},
             (
-              select id, ts, dur
+              select
+                id,
+                ts,
+                -- We do this instead of filtering out negative durations
+                -- because we still want to include begin callsites for
+                -- incomplete slices. The code below will take care of
+                -- only looking at begin callsites for such slices.
+                max(dur, 0) as dur
               from slice
-              where track_id in (${trackIds.join()}) and dur >= 0
+              where track_id in (${trackIds.join()})
             )
           )
         )


### PR DESCRIPTION
Was playing around with this and I realised that there's a small edge
case: we don't want to totally exclude the slice when it has negative
duration, we just want to treat it the same as having an instant:
this is because the start of the slice might still have an associated
callstack which we want to include.

The rest of the logic of this query does the right thing if you
add a max here.
