### PR TITLE
Grid: Add option to remove white-space: nowrap from GridCell components

### DIFF
--- a/ui/src/assets/widgets/grid.scss
+++ b/ui/src/assets/widgets/grid.scss
@@ -23,6 +23,7 @@ $border-3: 2px solid var(--pf-color-border);
   flex-direction: column;
   overflow: hidden;
   height: 100%;
+  white-space: nowrap;
 
   &__main-content {
     display: flex;
@@ -67,6 +68,7 @@ $border-3: 2px solid var(--pf-color-border);
   align-items: baseline;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 
   &--padded {
     padding: 0.3em 0.5em;
@@ -104,10 +106,14 @@ $border-3: 2px solid var(--pf-color-border);
   &[active] {
     background: color_active(transparent);
   }
+
+  &--wrap {
+    white-space: normal;
+  }
 }
 
 .pf-grid {
-  white-space: nowrap;
+  // white-space: nowrap;
   font-family: var(--pf-font-compact);
   font-size: 14px;
   overflow: auto;
@@ -155,6 +161,7 @@ $border-3: 2px solid var(--pf-color-border);
     align-items: stretch;
     justify-content: flex-start;
     flex-direction: row;
+    overflow: hidden;
   }
 
   &__cell-container {

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/grid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/grid_demo.ts
@@ -78,7 +78,7 @@ export function renderGridDemo() {
       column sizing.
     `,
     wide: true,
-    renderWidget: ({virtualize}) => {
+    renderWidget: ({virtualize, wrap}) => {
       if (virtualize) {
         return m(VirtualGridDemo);
       }
@@ -95,16 +95,19 @@ export function renderGridDemo() {
             {key: 'typing', header: m(GridHeaderCell, 'Typing')},
           ],
           rowData: languages.map((row) => [
-            m(GridCell, {align: 'right'}, row.id),
-            m(GridCell, row.lang),
-            m(GridCell, {align: 'right'}, row.year),
-            m(GridCell, row.creator),
-            m(GridCell, row.typing),
+            m(GridCell, {wrap, align: 'right'}, row.id),
+            m(GridCell, {wrap}, row.lang),
+            m(GridCell, {wrap, align: 'right'}, row.year),
+            m(GridCell, {wrap}, row.creator),
+            m(GridCell, {wrap}, row.typing),
           ]),
           fillHeight: true,
         }),
       );
     },
-    initialOpts: {virtualize: false},
+    initialOpts: {
+      virtualize: false,
+      wrap: false,
+    },
   });
 }

--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -138,6 +138,7 @@ export interface GridCellAttrs extends HTMLAttrs {
   readonly align?: CellAlignment;
   readonly nullish?: boolean;
   readonly padding?: boolean;
+  readonly wrap?: boolean;
 }
 
 export class GridCell implements m.ClassComponent<GridCellAttrs> {
@@ -148,6 +149,7 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
       nullish,
       className,
       padding = true,
+      wrap,
       ...rest
     } = attrs;
 
@@ -160,6 +162,7 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
           align && `pf-grid-cell--align-${align}`,
           padding && 'pf-grid-cell--padded',
           nullish && 'pf-grid-cell--nullish',
+          wrap && 'pf-grid-cell--wrap',
         ),
       },
       m('.pf-grid-cell__content-wrapper', children),


### PR DESCRIPTION
Add a new option to GridCell which allows text to wrap (removes `white-space: nowrap`).

Usage:
```ts
m(GridCell, {wrap: true}, 'Some really long text...');
```

Example:

<img width="375" height="447" alt="image" src="https://github.com/user-attachments/assets/f1caa395-6cbc-4c20-ab65-3e6651fec727" />
