### PR TITLE
rust-sdk: add version to local dependencies (#3446)

### DIFF
--- a/contrib/rust-sdk/perfetto-derive/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-derive/Cargo.toml
@@ -21,7 +21,7 @@ default = ["vendored"]
 vendored = ["perfetto/vendored"]
 
 [dependencies]
-perfetto = { path = "../perfetto", default-features = false  }
+perfetto = { path = "../perfetto", version = "0.1.0", default-features = false }
 syn = { version = "1.0.5", features = ["full"] }
 quote = "1.0.8"
 proc-macro2 = "1.0"

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -19,7 +19,7 @@ intrinsics = []
 vendored = ["perfetto-sys/vendored"]
 
 [dependencies]
-perfetto-sys = { path = "../perfetto-sys", default-features = false }
+perfetto-sys = { path = "../perfetto-sys", version = "0.1.0", default-features = false }
 bitflags = "2"
 paste = "1"
 thiserror = "1"


### PR DESCRIPTION
Cargo will use the local path dependency for development but ignore the path key and instead use the specified version to resolve the dependency when published.
