### PR TITLE
exp: Expose ORDER BY, LIMIT and OFFSET and UNION nodes

### DIFF
--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator.cc
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator.cc
@@ -222,7 +222,21 @@ base::StatusOr<std::string> GeneratorImpl::Generate(
     }
     state_[state_index_].sql = *sql;
   }
+
+  // Check if the root query is just an inner_query wrapper with operations
+  // (ORDER BY, LIMIT, OFFSET). If so, we should apply those in the final
+  // SELECT instead of creating a duplicate CTE.
+  StructuredQuery::Decoder root_query(state_[0].bytes);
+  bool root_only_has_inner_query_and_operations =
+      root_query.has_inner_query() && !root_query.has_table() &&
+      !root_query.has_simple_slices() && !root_query.has_interval_intersect() &&
+      !root_query.has_experimental_join() &&
+      !root_query.has_experimental_union() && !root_query.has_sql() &&
+      !root_query.has_inner_query_id() && !root_query.filters() &&
+      !root_query.has_group_by() && !root_query.select_columns();
+
   std::string sql = "WITH ";
+  size_t cte_count = 0;
   for (size_t i = 0; i < state_.size(); ++i) {
     QueryState& state = state_[state_.size() - i - 1];
     if (state.type == QueryType::kShared) {
@@ -230,12 +244,25 @@ base::StatusOr<std::string> GeneratorImpl::Generate(
           Query{state.id_from_proto.value(), state.table_name, state.sql});
       continue;
     }
-    sql += state.table_name + " AS (" + state.sql + ")";
-    if (i < state_.size() - 1) {
+    // Skip the root query if it's just a wrapper for inner_query + operations
+    if (&state == &state_[0] && root_only_has_inner_query_and_operations) {
+      continue;
+    }
+    if (cte_count > 0) {
       sql += ", ";
     }
+    sql += state.table_name + " AS (" + state.sql + ")";
+    cte_count++;
   }
-  sql += " SELECT * FROM " + state_[0].table_name;
+
+  // Build the final SELECT
+  if (root_only_has_inner_query_and_operations) {
+    // The root query is just wrapping an inner query with operations.
+    // Apply those operations directly in the final SELECT.
+    sql += " " + state_[0].sql;
+  } else {
+    sql += " SELECT * FROM " + state_[0].table_name;
+  }
   return sql;
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -48,8 +48,8 @@ import {
 import {
   LimitAndOffsetNode,
   LimitAndOffsetNodeState,
-} from './query_builder/nodes/dev/limit_and_offset_node';
-import {SortNode, SortNodeState} from './query_builder/nodes/dev/sort_node';
+} from './query_builder/nodes/limit_and_offset_node';
+import {SortNode, SortNodeState} from './query_builder/nodes/sort_node';
 
 type SerializedNodeState =
   | TableSourceSerializedState

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -26,8 +26,8 @@ import {
   SqlTable,
 } from '../../plugins/dev.perfetto.SqlModules/sql_modules';
 import {AddColumnsNode} from './query_builder/nodes/dev/add_columns_node';
-import {LimitAndOffsetNode} from './query_builder/nodes/dev/limit_and_offset_node';
-import {SortNode} from './query_builder/nodes/dev/sort_node';
+import {LimitAndOffsetNode} from './query_builder/nodes/limit_and_offset_node';
+import {SortNode} from './query_builder/nodes/sort_node';
 import {PerfettoSqlType} from '../../trace_processor/perfetto_sql_type';
 
 describe('JSON serialization/deserialization', () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -30,6 +30,12 @@ import {
   IntervalIntersectNodeState,
 } from './nodes/interval_intersect_node';
 import {MergeNode, MergeNodeState} from './nodes/merge_node';
+import {SortNode, SortNodeState} from './nodes/sort_node';
+import {UnionNode, UnionNodeState} from './nodes/union_node';
+import {
+  LimitAndOffsetNode,
+  LimitAndOffsetNodeState,
+} from './nodes/limit_and_offset_node';
 
 export function registerCoreNodes() {
   nodeRegistry.register('slice', {
@@ -126,5 +132,39 @@ export function registerCoreNodes() {
       };
       return new MergeNode(fullState);
     },
+  });
+
+  nodeRegistry.register('sort_node', {
+    name: 'Sort',
+    description: 'Sort rows by one or more columns.',
+    icon: 'sort',
+    type: 'modification',
+    factory: (state) => new SortNode(state as SortNodeState),
+  });
+
+  nodeRegistry.register('union_node', {
+    name: 'Union',
+    description: 'Combine rows from multiple sources.',
+    icon: 'merge_type',
+    type: 'multisource',
+    factory: (state) => {
+      const fullState: UnionNodeState = {
+        ...state,
+        prevNodes: state.prevNodes ?? [],
+        selectedColumns: [],
+      };
+      const node = new UnionNode(fullState);
+      node.onPrevNodesUpdated();
+      return node;
+    },
+  });
+
+  nodeRegistry.register('limit_and_offset_node', {
+    name: 'Limit and Offset',
+    description: 'Limit the number of rows returned and optionally skip rows.',
+    icon: 'filter_list',
+    type: 'modification',
+    factory: (state) =>
+      new LimitAndOffsetNode(state as LimitAndOffsetNodeState),
   });
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/dev_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/dev_nodes.ts
@@ -19,12 +19,6 @@ import {
 } from './nodes/dev/add_columns_node';
 import {modalForTableSelection} from './nodes/sources/table_source';
 import {TestNode} from './nodes/dev/test_node';
-import {
-  LimitAndOffsetNode,
-  LimitAndOffsetNodeState,
-} from './nodes/dev/limit_and_offset_node';
-import {SortNode, SortNodeState} from './nodes/dev/sort_node';
-import {UnionNode, UnionNodeState} from './nodes/dev/union_node';
 
 export function registerDevNodes() {
   nodeRegistry.register('test_source', {
@@ -50,43 +44,6 @@ export function registerDevNodes() {
       return {
         sqlTable: table.sqlTable,
       };
-    },
-    devOnly: true,
-  });
-
-  nodeRegistry.register('limit_and_offset_node', {
-    name: 'Limit and Offset',
-    description: 'Limits number of rows and offsets them.',
-    icon: 'filter_list',
-    type: 'modification',
-    factory: (state) =>
-      new LimitAndOffsetNode(state as LimitAndOffsetNodeState),
-    devOnly: true,
-  });
-
-  nodeRegistry.register('sort_node', {
-    name: 'Sort',
-    description: 'Sorts by a column.',
-    icon: 'sort',
-    type: 'modification',
-    factory: (state) => new SortNode(state as SortNodeState),
-    devOnly: true,
-  });
-
-  nodeRegistry.register('union_node', {
-    name: 'Union',
-    description: 'Union multiple sources.',
-    icon: 'merge_type',
-    type: 'multisource',
-    factory: (state) => {
-      const fullState: UnionNodeState = {
-        ...state,
-        prevNodes: state.prevNodes ?? [],
-        selectedColumns: [],
-      };
-      const node = new UnionNode(fullState);
-      node.onPrevNodesUpdated();
-      return node;
     },
     devOnly: true,
   });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/limit_and_offset_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/limit_and_offset_node.ts
@@ -19,11 +19,11 @@ import {
   nextNodeId,
   NodeType,
   ModificationNode,
-} from '../../../query_node';
-import {ColumnInfo} from '../../column_info';
-import protos from '../../../../../protos';
-import {Card} from '../../../../../widgets/card';
-import {TextInput} from '../../../../../widgets/text_input';
+} from '../../query_node';
+import {ColumnInfo} from '../column_info';
+import protos from '../../../../protos';
+import {Card} from '../../../../widgets/card';
+import {TextInput} from '../../../../widgets/text_input';
 
 export interface LimitAndOffsetNodeState extends QueryNodeState {
   prevNode: QueryNode;
@@ -109,8 +109,29 @@ export class LimitAndOffsetNode implements ModificationNode {
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (this.prevNode === undefined) return undefined;
-    // TODO(mayzner): Implement this.
-    return this.prevNode.getStructuredQuery();
+    const prevQuery = this.prevNode.getStructuredQuery();
+    if (!prevQuery) return undefined;
+
+    const hasLimit = this.state.limit !== undefined && this.state.limit > 0;
+    const hasOffset = this.state.offset !== undefined && this.state.offset > 0;
+
+    if (!hasLimit && !hasOffset) {
+      return prevQuery;
+    }
+
+    const query = protos.PerfettoSqlStructuredQuery.create({
+      innerQuery: prevQuery,
+    });
+
+    if (hasLimit) {
+      query.limit = this.state.limit!;
+    }
+
+    if (hasOffset) {
+      query.offset = this.state.offset!;
+    }
+
+    return query;
   }
 
   serializeState(): object {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
@@ -20,14 +20,14 @@ import {
   NodeType,
   MultiSourceNode,
   notifyNextNodes,
-} from '../../../query_node';
-import protos from '../../../../../protos';
-import {ColumnInfo, newColumnInfoList} from '../../column_info';
-import {Callout} from '../../../../../widgets/callout';
-import {NodeIssues} from '../../node_issues';
-import {UIFilter} from '../../operations/filter';
-import {Card, CardStack} from '../../../../../widgets/card';
-import {Checkbox} from '../../../../../widgets/checkbox';
+} from '../../query_node';
+import protos from '../../../../protos';
+import {ColumnInfo, newColumnInfoList} from '../column_info';
+import {Callout} from '../../../../widgets/callout';
+import {NodeIssues} from '../node_issues';
+import {UIFilter} from '../operations/filter';
+import {Card, CardStack} from '../../../../widgets/card';
+import {Checkbox} from '../../../../widgets/checkbox';
 
 export interface UnionSerializedState {
   unionNodes: string[];
@@ -240,7 +240,22 @@ export class UnionNode implements MultiSourceNode {
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
-    return undefined;
+    if (this.prevNodes.length < 2) return undefined;
+
+    const queries: protos.IPerfettoSqlStructuredQuery[] = [];
+    for (const prevNode of this.prevNodes) {
+      if (prevNode === undefined) return undefined;
+      const query = prevNode.getStructuredQuery();
+      if (!query) return undefined;
+      queries.push(query);
+    }
+
+    return protos.PerfettoSqlStructuredQuery.create({
+      experimentalUnion: protos.PerfettoSqlStructuredQuery.ExperimentalUnion.create({
+        queries,
+        useUnionAll: true,
+      }),
+    });
   }
 
   serializeState(): UnionSerializedState {


### PR DESCRIPTION
  This commit promoted three experimental query builder nodes from dev-only to core features:

  1. Moved nodes from dev to core: SortNode, LimitAndOffsetNode, and UnionNode were moved from query_builder/nodes/dev/ to query_builder/nodes/ and registered in core_nodes.ts (removing devOnly: true)
  2. Implemented structured query generation: Added proper getStructuredQuery() implementations for all three nodes to generate protobuf queries (ORDER BY, LIMIT/OFFSET, and UNION ALL)
  3. Backend optimization: Modified the C++ structured query generator to avoid creating unnecessary CTEs when the root query only has ORDER BY, LIMIT, or OFFSET operations