### PR TITLE
rust-sdk: remove redundant closure

### DIFF
--- a/contrib/rust-sdk/perfetto-protos-gpu/examples/gpu_counters.rs
+++ b/contrib/rust-sdk/perfetto-protos-gpu/examples/gpu_counters.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .lock()
             .unwrap()
             .counter_period_ns
-            .map(|ns| Duration::from_nanos(ns))
+            .map(Duration::from_nanos)
             .unwrap_or(Duration::from_secs(1));
         std::thread::sleep(counter_period);
     }


### PR DESCRIPTION
Needed for clippy test to pass in CI job.

Bug: https://github.com/google/perfetto/issues/3497