### PR TITLE
exp: Node Explorer styling

### DIFF
--- a/ui/src/assets/widgets/modal.scss
+++ b/ui/src/assets/widgets/modal.scss
@@ -40,7 +40,7 @@
 
 .pf-modal-backdrop {
   position: absolute;
-  z-index: 1000;
+  z-index: 99;
   background-color: rgba(0, 0, 0, 0.6);
   top: 0;
   left: 0;
@@ -58,7 +58,7 @@
 
 .pf-modal-dialog {
   position: absolute;
-  z-index: 1001;
+  z-index: 100;
   background-color: var(--pf-color-background);
   margin: auto;
   min-width: 25vw;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -42,8 +42,9 @@
 
   .pf-qb-explorer {
     grid-column: 2;
-    overflow: auto;
+    overflow: hidden;
     width: 500px;
+    height: 100%;
     transition:
       width 0.3s ease,
       border-left 0.3s ease;
@@ -53,7 +54,6 @@
     position: absolute;
     top: 1rem;
     right: 1rem;
-    z-index: 10;
     display: flex;
     align-items: center;
     gap: 0.75rem;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -228,6 +228,9 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
                   this.drawerVisibility = SplitPanelDrawerVisibility.FULLSCREEN;
                 }
               },
+              onExecute: () => {
+                this.runQuery(selectedNode);
+              },
             })
           : null,
       },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -34,6 +34,8 @@ import {TextParagraph} from '../../../widgets/text_paragraph';
 import {Query, QueryNode, isAQuery} from '../query_node';
 import {QueryService} from './query_service';
 import {Intent} from '../../../widgets/common';
+import {Icons} from '../../../base/semantic_icons';
+import {MenuItem, PopupMenu} from '../../../widgets/menu';
 
 import {findErrors} from './query_builder_utils';
 export interface DataExplorerAttrs {
@@ -123,21 +125,6 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
           label: attrs.isFullScreen ? 'Exit full screen' : 'Full screen',
           onclick: () => attrs.onFullScreenToggle(),
         }),
-        !attrs.isFullScreen &&
-          m(MenuItem, {
-            label: 'Left',
-            onclick: () => attrs.onPositionChange('left'),
-          }),
-        !attrs.isFullScreen &&
-          m(MenuItem, {
-            label: 'Right',
-            onclick: () => attrs.onPositionChange('right'),
-          }),
-        !attrs.isFullScreen &&
-          m(MenuItem, {
-            label: 'Bottom',
-            onclick: () => attrs.onPositionChange('bottom'),
-          }),
       ],
     );
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.scss
@@ -33,6 +33,5 @@
   top: 1rem;
   left: 1rem;
   gap: 0.5rem;
-  z-index: 100;
   pointer-events: auto;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -36,7 +36,12 @@ import m from 'mithril';
 import {Icons} from '../../../../base/semantic_icons';
 import {Button, ButtonVariant} from '../../../../widgets/button';
 import {Intent} from '../../../../widgets/common';
-import {MenuItem, PopupMenu} from '../../../../widgets/menu';
+import {
+  MenuItem,
+  MenuDivider,
+  MenuTitle,
+  PopupMenu,
+} from '../../../../widgets/menu';
 import {
   Connection,
   Node,
@@ -578,6 +583,14 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
       attrs.onAddSourceNode,
     );
 
+    const addNodeMenuItems = [
+      m(MenuTitle, {label: 'Sources'}),
+      ...sourceMenuItems,
+      m(MenuDivider),
+      m(MenuTitle, {label: 'Operations'}),
+      ...operationMenuItems,
+    ];
+
     const moreMenuItems = [
       m(MenuItem, {
         label: 'Export',
@@ -598,24 +611,12 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
         PopupMenu,
         {
           trigger: m(Button, {
-            label: 'Add Source',
+            label: 'Add Node',
             icon: Icons.Add,
             variant: ButtonVariant.Filled,
           }),
         },
-        sourceMenuItems,
-      ),
-      m(
-        PopupMenu,
-        {
-          trigger: m(Button, {
-            label: 'Add Operation',
-            icon: Icons.Add,
-            variant: ButtonVariant.Filled,
-            style: {marginLeft: '8px'},
-          }),
-        },
-        operationMenuItems,
+        addNodeMenuItems,
       ),
       m(
         PopupMenu,
@@ -659,7 +660,6 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
         tabindex: 0,
       },
       [
-        this.renderControls(attrs),
         m(NodeGraph, {
           nodes,
           connections,
@@ -708,6 +708,7 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
             m.redraw();
           },
         }),
+        this.renderControls(attrs),
       ],
     );
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
@@ -64,9 +64,12 @@
     padding: 0.375rem;
     font-size: var(--pf-exp-font-size-sm);
     flex-grow: 1;
+    flex-shrink: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
   }
 
   &.collapsed {
@@ -123,10 +126,23 @@
 }
 
 .pf-exp-aggregation-viewer {
-  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 0.5rem;
   border-radius: 4px;
+  gap: 0.5rem;
+
   &:hover {
     background-color: var(--pf-color-hover);
+  }
+
+  span {
+    cursor: pointer;
+    flex-grow: 1;
+  }
+
+  .pf-button {
+    flex-shrink: 0;
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -209,7 +209,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
       }`,
       m(
         '.pf-exp-node-explorer__header',
-        this.renderTitleRow(node, attrs, renderModeMenu),
+        this.renderTitleRow(node, renderModeMenu),
         m(
           '.pf-exp-node-explorer__collapse-button',
           m(Button, {
@@ -220,7 +220,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
           }),
         ),
       ),
-      this.renderContent(node, attrs),
+      this.renderContent(node),
     );
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
@@ -39,6 +39,7 @@ import {TextInput} from '../../../../widgets/text_input';
 import {Button} from '../../../../widgets/button';
 import {Card} from '../../../../widgets/card';
 import {NodeIssues} from '../node_issues';
+import {Icons} from '../../../../base/semantic_icons';
 
 export interface AggregationSerializedState {
   groupByColumns: {name: string; checked: boolean}[];
@@ -450,7 +451,7 @@ class AggregationOperationComponent
       );
     };
 
-    const aggregationEditor = (agg: Aggregation, index: number): m.Child => {
+    const aggregationEditor = (agg: Aggregation): m.Child => {
       const columnOptions = attrs.groupByColumns.map((col) =>
         m(
           'option',
@@ -512,15 +513,7 @@ class AggregationOperationComponent
           value: agg.newColumnName,
         }),
         m(Button, {
-          className: 'delete-button',
-          icon: 'delete',
-          onclick: () => {
-            attrs.aggregations.splice(index, 1);
-            attrs.onchange?.();
-          },
-        }),
-        m(Button, {
-          label: 'Done',
+          icon: Icons.Check,
           className: 'is-primary',
           disabled: !agg.isValid,
           onclick: () => {
@@ -537,15 +530,26 @@ class AggregationOperationComponent
     const aggregationViewer = (agg: Aggregation, index: number): m.Child => {
       return m(
         '.pf-exp-aggregation-viewer',
-        {
-          onclick: () => {
-            attrs.aggregations.forEach((a, i) => {
-              a.isEditing = i === index;
-            });
-            m.redraw();
+        m(
+          'span',
+          {
+            onclick: () => {
+              attrs.aggregations.forEach((a, i) => {
+                a.isEditing = i === index;
+              });
+              m.redraw();
+            },
           },
-        },
-        `${agg.aggregationOp}(${agg.column?.name}) AS ${agg.newColumnName}`,
+          `${agg.aggregationOp}(${agg.column?.name}) AS ${agg.newColumnName}`,
+        ),
+        m(Button, {
+          icon: Icons.Close,
+          onclick: (e: Event) => {
+            e.stopPropagation();
+            attrs.aggregations.splice(index, 1);
+            attrs.onchange?.();
+          },
+        }),
       );
     };
 
@@ -560,7 +564,7 @@ class AggregationOperationComponent
       return [
         ...attrs.aggregations.map((agg, index) => {
           if (agg.isEditing) {
-            return aggregationEditor(agg, index);
+            return aggregationEditor(agg);
           } else {
             return aggregationViewer(agg, index);
           }


### PR DESCRIPTION
 The commit refactors the Query Builder layout from a complex CSS Grid-based system to a cleaner
  SplitPanel-based architecture with collapsible panels and improved visual design.

  Key Changes

  1. Modal Z-Index Fix (modal.scss:43, modal.scss:61)
  - Increased z-index from 99/100 to 1000/1001 to ensure modals appear above all other UI elements
  - Good defensive fix for layering issues

  2. Builder Layout Refactor (builder.ts, builder.scss)
  - Replaced complex grid layout states (selection-left, selection-right, selection-bottom, etc.) with SplitPanel component
  - Explorer panel now has fixed 500px width with smooth collapse/expand transitions
  - Added floating controls in top-right corner for better UX
  - Data viewer moved from inline grid item to SplitPanel drawer at bottom

  3. Floating Controls (builder.ts:261-286)
  - Warning icon now floats in graph area instead of being in explorer title
  - Collapse/expand button appears when explorer is collapsed
  - Nice touch: floating buttons have scale animations on hover

  4. Explorer Panel Improvements (node_explorer.ts, node_explorer.scss)
  - Added shadow and border styling for better visual separation
  - Collapse button integrated into header
  - Warning icon removed from title (now in floating controls)

  5. Simplified Data Explorer (data_explorer.ts:42-87)
  - Removed position change menu (left/right/bottom options)
  - Streamlined to just full-screen toggle