### PR TITLE
exp: Simplify execution

### DIFF
--- a/protos/perfetto/perfetto_sql/structured_query.proto
+++ b/protos/perfetto/perfetto_sql/structured_query.proto
@@ -238,9 +238,17 @@ message PerfettoSqlStructuredQuery {
   //      processes.
   //    * use_union_all = true to keep all events even if there are duplicates.
   //
-  // Schema:
-  //  All queries must have the same number of columns with compatible types.
-  //  The column names from the first query will be used in the result.
+  // Schema Requirements:
+  //  IMPORTANT: All queries MUST have the same set of columns.
+  //  - All queries must have the same number of columns
+  //  - Column names must match exactly (after applying aliases)
+  //  - Columns can be in any order - the order from the first query will be
+  //    used in the result
+  //  - If select_columns is specified, the validation is performed at query
+  //    generation time. Otherwise, validation happens at SQL execution time.
+  //
+  // The generator will return an error if queries have mismatched columns
+  // when explicit select_columns are specified.
   message ExperimentalUnion {
     // The queries to union together. At least two queries are required.
     repeated PerfettoSqlStructuredQuery queries = 1;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -172,11 +172,6 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               this.runQuery(selectedNode);
             }
           },
-          onExecute: () => {
-            this.queryExecuted = false;
-            this.runQuery(selectedNode);
-            m.redraw();
-          },
           onchange: () => {},
         })
       : m(ExplorePageHelp, {
@@ -240,6 +235,11 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
             onFullScreenToggle: () => {
               this.isNodeDataViewerFullScreen =
                 !this.isNodeDataViewerFullScreen;
+            },
+            onExecute: () => {
+              this.queryExecuted = false;
+              this.runQuery(selectedNode);
+              m.redraw();
             },
           }),
         ),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -34,13 +34,11 @@ import {SqlSourceNode} from './nodes/sources/sql_source';
 import {CodeSnippet} from '../../../widgets/code_snippet';
 import {AggregationNode} from './nodes/aggregation_node';
 import {NodeIssues} from './node_issues';
-import {Intent} from '../../../widgets/common';
 
 export interface NodeExplorerAttrs {
   readonly node?: QueryNode;
   readonly trace: Trace;
   readonly onQueryAnalyzed: (query: Query | Error) => void;
-  readonly onExecute: () => void;
   readonly onchange?: () => void;
   readonly resolveNode: (nodeId: string) => QueryNode | undefined;
 }
@@ -61,12 +59,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
   private currentQuery?: Query | Error;
   private sqlForDisplay?: string;
 
-  private renderTitleRow(
-    node: QueryNode,
-    attrs: NodeExplorerAttrs,
-    renderMenu: () => m.Child,
-  ): m.Child {
-    const autoExecute = node.state.autoExecute ?? true;
+  private renderTitleRow(node: QueryNode, renderMenu: () => m.Child): m.Child {
     return m(
       '.pf-exp-node-explorer__title-row',
       m(
@@ -86,12 +79,6 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
         ),
       ),
       m('span.spacer'), // Added spacer to push menu to the right
-      !autoExecute &&
-        m(Button, {
-          label: 'Run',
-          onclick: attrs.onExecute,
-          intent: Intent.Primary,
-        }),
       renderMenu(),
     );
   }
@@ -151,7 +138,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
     }
   }
 
-  private renderContent(node: QueryNode, attrs: NodeExplorerAttrs): m.Child {
+  private renderContent(node: QueryNode): m.Child {
     const sql: string =
       this.sqlForDisplay ??
       (isAQuery(this.currentQuery)
@@ -166,7 +153,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
     return m(
       'article',
       this.selectedView === SelectedView.kModify && [
-        node.nodeSpecificModify(attrs.onExecute),
+        node.nodeSpecificModify(),
         m('textarea.pf-exp-node-explorer__comment', {
           'aria-label': 'Comment',
           'placeholder': 'Add a comment...',
@@ -231,8 +218,8 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
       `.pf-exp-node-explorer${
         node instanceof SqlSourceNode ? '.pf-exp-node-explorer-sql-source' : ''
       }`,
-      this.renderTitleRow(node, attrs, renderModeMenu),
-      this.renderContent(node, attrs),
+      this.renderTitleRow(node, renderModeMenu),
+      this.renderContent(node),
     );
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -127,7 +127,7 @@ export class IntervalIntersectNode implements MultiSourceNode {
     return 'Interval Intersect';
   }
 
-  nodeSpecificModify(onExecute?: () => void): m.Child {
+  nodeSpecificModify(): m.Child {
     this.validate();
     const error = this.state.issues?.queryError;
 
@@ -153,10 +153,6 @@ export class IntervalIntersectNode implements MultiSourceNode {
               }),
             ),
           ),
-          m(Button, {
-            label: 'Run',
-            onclick: onExecute,
-          }),
         ),
       ),
     );

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -128,7 +128,7 @@ export class SqlSourceNode implements MultiSourceNode {
     return sq;
   }
 
-  nodeSpecificModify(onExecute: () => void): m.Child {
+  nodeSpecificModify(): m.Child {
     const runQuery = (sql: string) => {
       this.state.sql = sql.trim();
       m.redraw();
@@ -154,7 +154,8 @@ export class SqlSourceNode implements MultiSourceNode {
           onExecute: (text: string) => {
             queryHistoryStorage.saveQuery(text);
             this.state.sql = text.trim();
-            onExecute();
+            // Note: Execution is now handled by the Run button in DataExplorer
+            // This callback only saves to query history and updates the SQL text
             m.redraw();
           },
           autofocus: true,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -107,7 +107,7 @@ export interface BaseNode {
 
   validate(): boolean;
   getTitle(): string;
-  nodeSpecificModify(onExecute?: () => void): m.Child;
+  nodeSpecificModify(): m.Child;
   nodeDetails?(): m.Child | undefined;
   clone(): QueryNode;
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined;


### PR DESCRIPTION
 Backend (C++):
  - Added column validation for UNION queries - ensures all queries have matching column sets
  - Changed UNION SQL generation to use local WITH clauses to avoid CTE name conflicts
  - Added comprehensive tests for UNION validation scenarios

  Frontend (TypeScript):
  - Auto-execute toggle: New switch in DataExplorer lets users control when queries run
  - Manual "Run Query" button: Appears when auto-execute is off
  - Simplified node interface: Removed onExecute parameter from nodeSpecificModify()
  - Centralized execution: All query execution now happens through DataExplorer's onExecute callback
  - Better validation feedback: Shows validation errors before attempting execution

  Affected nodes:
  - SqlSourceNode: No longer tries to execute on Cmd+Enter
  - IntervalIntersectNode: Removed inline Run button
  - UnionNode: Removed inline Run button