### PR TITLE
tp: fix build on Android with fnv->murmur flag disabled

### DIFF
--- a/src/trace_processor/importers/systrace/systrace_line_parser.cc
+++ b/src/trace_processor/importers/systrace/systrace_line_parser.cc
@@ -18,6 +18,7 @@
 
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/string_splitter.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
@@ -76,7 +77,8 @@ base::Status SystraceLineParser::ParseLine(const SystraceLine& line) {
     }
   }
 
-  base::FlatHashMap<std::string, std::string> args;
+  base::FlatHashMap<std::string, std::string, base::MurmurHash<std::string>>
+      args;
   for (base::StringSplitter ss(line.args_str, ' '); ss.Next();) {
     std::string key;
     std::string value;


### PR DESCRIPTION
Fix the issue by forcing Murmur: code is in trace processor
so should be very safe.

```
In file included from external/perfetto/src/trace_processor/importers/systrace/systrace_line_parser.cc:17:
In file included from external/perfetto/src/trace_processor/importers/systrace/systrace_line_parser.h:22:
In file included from external/perfetto/src/trace_processor/importers/ftrace/rss_stat_tracker.h:23:
In file included from external/perfetto/include/perfetto/ext/base/flat_hash_map.h:22:
external/perfetto/include/perfetto/ext/base/fnv_hash.h:137:12: error: call to implicitly-deleted default constructor of 'std::hash<char[4]>'
  137 |     return std::hash<U>()(x);
      |            ^
external/perfetto/include/perfetto/ext/base/flat_hash_map.h:354:29: note: in instantiation of function template specialization 'perfetto::base::FnvHash<std::string>::operator()<char[4]>' requested here
  354 |     const size_t key_hash = Hasher{}(key);
      |                             ^
external/perfetto/include/perfetto/ext/base/flat_hash_map.h:298:24: note: in instantiation of function template specialization 'perfetto::base::FlatHashMap<std::string, std::string>::FindInternal<char[4]>' requested here
  298 |     const size_t idx = FindInternal(key);
      |                        ^
external/perfetto/src/trace_processor/importers/systrace/systrace_line_parser.cc:158:14: note: in instantiation of function template specialization 'perfetto::base::FlatHashMap<std::string, std::string>::Find<char[4]>' requested here
  158 |         args.Find("max") != nullptr ? base::StringToDouble(args["max"])
      |              ^
prebuilts/clang/host/linux-x86/clang-r574158/include/c++/v1/__functional/hash.h:519:15: note: default constructor of 'hash<char[4]>' is implicitly deleted because base class '__enum_hash<char[4]>' has a deleted default constructor
  519 | struct hash : public __enum_hash<_Tp> {};
      |               ^
prebuilts/clang/host/linux-x86/clang-r574158/include/c++/v1/__functional/hash.h:513:3: note: '__enum_hash' has been explicitly marked deleted here
  513 |   __enum_hash()                              = delete;

```
