### PR TITLE
perfetto sdk: Add ID and Parent UUID checks for NamedTrack reuse

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
@@ -395,7 +395,8 @@ public final class PerfettoTrackEventBuilder {
     }
 
     NamedTrack track = mObjectsCache.mNamedTrackCache.get(name.hashCode());
-    if (track == null || !track.getName().equals(name)) {
+    if (track == null || !track.getName().equals(name) || track.getId() != id
+          || track.getParentUuid() != parentUuid) {
       track = new NamedTrack(id, name, parentUuid, mNativeMemoryCleaner);
       mObjectsCache.mNamedTrackCache.put(name.hashCode(), track);
     }

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
@@ -117,14 +117,16 @@ final class PerfettoTrackEventExtra {
   static final class NamedTrack implements PerfettoPointer {
     private final long mPtr;
     private final long mExtraPtr;
-    private final String mName;
     private final long mId;
+    private final String mName;
+    private final long mParentUuid;
 
     NamedTrack(long id, String name, long parentUuid, PerfettoNativeMemoryCleaner memoryCleaner) {
       mPtr = native_init(id, name, parentUuid);
       mExtraPtr = native_get_extra_ptr(mPtr);
-      mName = name;
       mId = id;
+      mName = name;
+      mParentUuid = parentUuid;
       memoryCleaner.registerNativeAllocation(this, mPtr, native_delete());
     }
 
@@ -133,8 +135,16 @@ final class PerfettoTrackEventExtra {
       return mExtraPtr;
     }
 
+    public long getId() {
+      return mId;
+    }
+
     public String getName() {
       return mName;
+    }
+
+    public long getParentUuid() {
+      return mParentUuid;
     }
 
     @FastNative


### PR DESCRIPTION
Updates the condition in `usingNamedTrack`(from `PerfettoTrackEventBuilder.java`) to also check `id` and `parentUuid` before reusing a cached `NamedTrack` instance. This ensures tracks with the same name but different IDs or parent UUIDs are treated as distinct.

Added new test cases in `PerfettoTraceTest.java` (`testTwoNamedTrackWithDifferentIds`, `testTwoNamedTrackWithDifferentParentUuids`) to validate that distinct tracks are created when IDs or parent UUIDs differ for the same name.

Test: bazelisk test //:src_android_sdk_java_test_perfetto_trace_instrumentation_test
