### PR TITLE
ui: Support GLOB in datagrid filters

### DIFF
--- a/ui/src/components/widgets/data_grid/data_grid.ts
+++ b/ui/src/components/widgets/data_grid/data_grid.ts
@@ -622,6 +622,51 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
                 );
               }
 
+              // Add glob filter option for string columns with text selection
+              if (typeof value === 'string') {
+                const selectedText = window.getSelection()?.toString().trim();
+                if (selectedText && selectedText.length > 0) {
+                  menuItems.push(
+                    m(
+                      MenuItem,
+                      {
+                        label: 'Filter glob',
+                      },
+                      m(MenuItem, {
+                        label: `"${selectedText}*"`,
+                        onclick: () => {
+                          onFilterAdd({
+                            column: column.name,
+                            op: 'glob',
+                            value: `${selectedText}*`,
+                          });
+                        },
+                      }),
+                      m(MenuItem, {
+                        label: `"*${selectedText}"`,
+                        onclick: () => {
+                          onFilterAdd({
+                            column: column.name,
+                            op: 'glob',
+                            value: `*${selectedText}`,
+                          });
+                        },
+                      }),
+                      m(MenuItem, {
+                        label: `"*${selectedText}*"`,
+                        onclick: () => {
+                          onFilterAdd({
+                            column: column.name,
+                            op: 'glob',
+                            value: `*${selectedText}*`,
+                          });
+                        },
+                      }),
+                    ),
+                  );
+                }
+              }
+
               if (isNumeric(value)) {
                 menuItems.push(
                   m(MenuItem, {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -177,6 +177,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
               '<=',
               '>',
               '>=',
+              'glob',
               'is null',
               'is not null',
             ];


### PR DESCRIPTION
Implements GLOB operator filtering for string columns in the datagrid component. When users select text within a string cell, a context menu now offers three GLOB pattern options: prefix matching (text*), suffix matching (*text), and substring matching (*text*). The GLOB operator has been added to the available filter operators in the data explorer query builder.

This enhancement provides users with more flexible pattern-matching capabilities for filtering data, complementing the existing equality and comparison operators.