### PR TITLE
FreeBSD: Small quality of life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 .venv
 .vscode
 *.code-workspace
+*.core
 *.iml
 *.LOCAL.md
 *.pyc

--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -230,7 +230,8 @@ declare_args() {
   # dllexport/import adds extra complexity for little benefit. Te only reason
   # for monolithic_binaries=false is saving binary size, which matters mainly on
   # Android. See also comments on PERFETTO_EXPORT_ENTRYPOINT in compiler.h.
-  monolithic_binaries = !perfetto_build_with_android && (is_win || is_mac)
+  monolithic_binaries =
+      !perfetto_build_with_android && (is_win || is_mac || is_freebsd)
 
   # Whether DLOG should be enabled on debug builds (""), all builds ("on"), or
   # none ("off"). We disable it by default for embedders to avoid spamming their

--- a/gn/standalone/toolchain/BUILD.gn
+++ b/gn/standalone/toolchain/BUILD.gn
@@ -70,6 +70,8 @@ declare_args() {
     }
   } else if (is_mac_host) {
     strip = "strip -x"
+  } else if (is_freebsd_host) {
+    ar = "llvm-ar"
   }
 
   if (is_clang) {

--- a/tools/format-cpp-sources
+++ b/tools/format-cpp-sources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2025 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/format-gn-sources
+++ b/tools/format-gn-sources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2025 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/format-python-sources
+++ b/tools/format-python-sources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2025 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/format-sources
+++ b/tools/format-sources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2025 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/format-sql-sources
+++ b/tools/format-sql-sources
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2025 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/node
+++ b/tools/node
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2021 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/npm
+++ b/tools/npm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2018 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/protos_from_genfs_contexts.sh
+++ b/tools/protos_from_genfs_contexts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2018 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/repackage_llvm_demangler.sh
+++ b/tools/repackage_llvm_demangler.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2022 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/roll-catapult-trace-viewer
+++ b/tools/roll-catapult-trace-viewer
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2018 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/run_buildtools_binary.py
+++ b/tools/run_buildtools_binary.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 
 import os
 import subprocess
+import shutil
 import sys
 
 from platform import system
@@ -54,6 +55,10 @@ def run_buildtools_binary(args):
   exe_path = os.path.join(ROOT_DIR, 'third_party', cmd, cmd) + ext
   if not os.path.exists(exe_path):
     exe_path = os.path.join(ROOT_DIR, 'buildtools', os_dir, cmd) + ext
+
+  # FreeBSD doesn't like prebuilts, so allow falling back to ports under PATH.
+  if not os.path.exists(exe_path) and sys_name == 'freebsd':
+    exe_path = shutil.which(cmd)
 
   if sys_name == 'windows':
     # execl() behaves oddly on Windows: the spawned process doesn't seem to

--- a/tools/run_ftrace_proto_gen
+++ b/tools/run_ftrace_proto_gen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script generates .proto files for ftrace events from the /format files
 # in src/traced/probes/ftrace/test/data/*/events/.

--- a/tools/screenrecordtest
+++ b/tools/screenrecordtest
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Rough script for screenrecord and trace
 # ./screenrecordtest [time limit in seconds - 180 seconds maximum]
 # Runs screenrecord along with a perfetto trace

--- a/tools/setup_minikube_cluster.sh
+++ b/tools/setup_minikube_cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2024 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tools/tmux
+++ b/tools/tmux
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2018 The Android Open Source Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- Use llvm-ar rather than ar, as freebsd's ar doesn't support response files
- Use "env bash" as freebsd's has bash under /usr/local/bin
- Fallback on /usr/local/bin when invoking gn/ninja as we don't have
  prebuilts for freebsd and likely never will, as that's the job of ports.
- use monolithic binaries as freebsd doesn't seem to pick up automatically the .so path