### PR TITLE
stdlib: Remove hardcoding of GPU_id in Wattson

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
@@ -301,3 +301,17 @@ SELECT
 FROM base
 ORDER BY
   cpu;
+
+-- Device specific mapping to GPU ID
+CREATE PERFETTO TABLE _gpuid_map AS
+WITH
+  data(device, gpu_id) AS (
+    SELECT
+      *
+    FROM (VALUES
+      ("Tensor G5", 0),
+      ("Tensor", 1)) AS _values
+  )
+SELECT
+  *
+FROM data;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/gpu/freq_idle.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/gpu/freq_idle.sql
@@ -19,6 +19,8 @@ INCLUDE PERFETTO MODULE android.gpu.mali_power_state;
 
 INCLUDE PERFETTO MODULE intervals.intersect;
 
+INCLUDE PERFETTO MODULE wattson.device_infos;
+
 -- Gapless time slices of GPU freq from trace_start() to trace_end()
 CREATE PERFETTO TABLE _gapless_gpu_freq AS
 WITH
@@ -32,9 +34,14 @@ WITH
       next_gpu_freq AS next_freq,
       gpu_id
     FROM android_gpu_frequency
-    -- Use gpu_id1 since there are multiple gpu_id1 freqs for each gpu_id0 freq
     WHERE
-      gpu_id = 1
+      gpu_id = (
+        SELECT
+          gpu_id
+        FROM _gpuid_map
+        JOIN _wattson_device
+          ON _gpuid_map.device = _wattson_device.name
+      )
     UNION ALL
     SELECT
       ts,
@@ -45,7 +52,13 @@ WITH
       gpu_id
     FROM android_gpu_frequency
     WHERE
-      gpu_id = 1
+      gpu_id = (
+        SELECT
+          gpu_id
+        FROM _gpuid_map
+        JOIN _wattson_device
+          ON _gpuid_map.device = _wattson_device.name
+      )
   )
 SELECT
   *


### PR DESCRIPTION
Introduced a device-specific mapping from device name to
GPU ID. This is to remove the hardcoded `gpu_id` from the
GPU frequency calculations.

Bug: 451737922
Test: Local perfetto UI test
