### PR TITLE
exp: Migrate to advanced filters

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/common.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/common.scss
@@ -38,6 +38,7 @@
   background-color: var(--pf-color-background);
   box-shadow: 0 2px 4px var(--pf-color-box-shadow);
   max-width: 300px;
+  box-sizing: border-box;
 
   &--selected {
     border-color: var(--pf-color-primary);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.scss
@@ -23,6 +23,7 @@
   gap: 0.375rem;
   padding: 0.625rem 0.75rem;
   cursor: grab;
+  overflow: hidden;
   transition:
     border-color 0.2s ease-in-out,
     box-shadow 0.2s ease-in-out;
@@ -90,6 +91,9 @@
 .pf-exp-node-box__content {
   display: flex;
   flex-direction: column;
+  max-width: 100%;
+  min-width: 0;
+  flex: 1;
 }
 
 .pf-exp-node-box__filters {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
@@ -19,8 +19,7 @@ import {Icons} from '../../../../base/semantic_icons';
 import {Button} from '../../../../widgets/button';
 import {MenuItem, PopupMenu} from '../../../../widgets/menu';
 import {QueryNode, singleNodeOperation, NodeType} from '../../query_node';
-import {UIFilter} from '../operations/filter';
-import {Chip} from '../../../../widgets/chip';
+import {UIFilter, formatFilterDetails} from '../operations/filter';
 import {Icon} from '../../../../widgets/icon';
 import {Callout} from '../../../../widgets/callout';
 import {Intent} from '../../../../widgets/common';
@@ -103,21 +102,11 @@ export function renderAddButton(attrs: NodeBoxAttrs): m.Child {
 
 export function renderFilters(attrs: NodeBoxAttrs): m.Child {
   const {node, onRemoveFilter} = attrs;
-  if (!node.state.filters || node.state.filters.length === 0) return null;
-
-  return m(
-    '.pf-exp-node-box__filters',
-    node.state.filters?.map((filter) => {
-      const label =
-        'value' in filter
-          ? `${filter.column} ${filter.op} ${filter.value}`
-          : `${filter.column} ${filter.op}`;
-      return m(Chip, {
-        label,
-        removable: true,
-        onRemove: () => onRemoveFilter(node, filter),
-      });
-    }),
+  return formatFilterDetails(
+    node.state.filters,
+    node.state.filterOperator,
+    node.state,
+    (filter) => onRemoveFilter(node, filter),
   );
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
@@ -89,6 +89,9 @@
     border-radius: 4px;
     background-color: var(--pf-color-background);
     resize: vertical;
+    font-family: var(--pf-font);
+    font-size: var(--pf-exp-font-size-sm);
+    padding: 0.5rem;
   }
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.scss
@@ -25,3 +25,100 @@
     margin: 0;
   }
 }
+
+// Filter chip wrapper for enabled/disabled state
+.pf-filter-chip-wrapper {
+  display: inline-flex;
+  max-width: 100%;
+  min-width: 0;
+  flex-shrink: 1;
+
+  // Override chip's min-width to allow shrinking
+  .pf-chip {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  &--disabled {
+    opacity: 0.5;
+    text-decoration: line-through;
+  }
+}
+
+// OR filter group container
+.pf-filter-or-group {
+  border: 2px solid #9e9e9e;
+  border-radius: 8px;
+  padding: 8px;
+  background-color: rgba(158, 158, 158, 0.1);
+  position: relative;
+  margin-top: 12px;
+  max-width: 250px;
+  box-sizing: border-box;
+}
+
+// OR badge at the top of the filter group
+.pf-filter-or-badge {
+  position: absolute;
+  top: -10px;
+  left: 12px;
+  background-color: #9e9e9e;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: bold;
+}
+
+// Enabled count indicator
+.pf-filter-enabled-count {
+  font-size: 11px;
+  color: #9e9e9e;
+  margin-bottom: 4px;
+  margin-top: 4px;
+}
+
+// Filter chips container
+.pf-filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  max-width: 250px;
+
+  &--with-count {
+    margin-top: 4px;
+  }
+
+  &--no-count {
+    margin-top: 8px;
+  }
+}
+
+// Filter container base
+.pf-filter-container {
+  max-width: 250px;
+  box-sizing: border-box;
+  overflow: visible;
+}
+
+// AND filters header
+.pf-filter-and-header {
+  margin-bottom: 8px;
+  font-size: 11px;
+  color: #616161;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+// AND/OR operator badge
+.pf-filter-operator-badge {
+  background-color: #616161;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-weight: bold;
+  text-transform: uppercase;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -76,6 +76,7 @@ export interface QueryNodeState {
 
   // Operations
   filters?: UIFilter[];
+  filterOperator?: 'AND' | 'OR'; // How to combine filters (default: AND)
 
   issues?: NodeIssues;
 


### PR DESCRIPTION
 Add support for advanced filtering capabilities in the query builder,
  including filter enable/disable toggles and AND/OR operators between
  filters.

  Key changes:

  - Add `enabled` property to UIFilter types to allow toggling filters
    on/off without removing them from the list

  - Add `filterOperator` ('AND' | 'OR') to control logical operations
    between multiple filters

  - Migrate protobuf layer from `filters` field to `experimentalFilterGroup`
    which wraps filters with an operator. The new createExperimentalFiltersProto()
    function automatically filters out disabled filters before serialization.

  - Update all node types (AddColumnsNode, AggregationNode, ModifyColumnsNode,
    SlicesSourceNode, TableSourceNode) to:
    * Store filterOperator in serialized state
    * Use renderFilterOperation() helper for consistent rendering
    * Pass operator changes through callbacks

  - Add UI improvements:
    * Checkboxes on filter chips to enable/disable individual filters
    * Switch control to toggle between AND/OR operators (shown when multiple
      filters exist)
    * Visual distinction for OR filter groups with bordered containers and badges
    * Smart display logic in formatFilterDetails(): shows individual chips for
      ≤4 filters, summary text for >4 filters
    * Disabled filters shown with 50% opacity

  - Add CSS for new filter visualization components including .pf-filter-or-group,
    .pf-filter-chip-wrapper, and operator badges

  - Fix overflow and box-sizing issues in node boxes to properly contain
    filter display