### PR TITLE
shared_lib: Set shmem_page_size_hint_kb to 4.

### DIFF
--- a/src/shared_lib/producer.cc
+++ b/src/shared_lib/producer.cc
@@ -62,6 +62,7 @@ void PerfettoProducerInProcessInit(
   perfetto::TracingInitArgs args;
   args.backends = perfetto::kInProcessBackend;
   args.shmem_size_hint_kb = backend_args->shmem_size_hint_kb;
+  args.shmem_page_size_hint_kb = 4;
   perfetto::Tracing::Initialize(args);
 }
 
@@ -70,6 +71,7 @@ void PerfettoProducerSystemInit(
   perfetto::TracingInitArgs args;
   args.backends = perfetto::kSystemBackend;
   args.shmem_size_hint_kb = backend_args->shmem_size_hint_kb;
+  args.shmem_page_size_hint_kb = 4;
   perfetto::Tracing::Initialize(args);
 }
 


### PR DESCRIPTION
Matches the PerfettoProducerBackendInitArgsSetShmemSizeHintKb documentation where callers are told to that a multiple of 4KB must be used.

No actual change in behavior with a release build of the tracing service as a 0 value will be adjusted to become 4KB but it removes an "Invalid configured SMB sizes" message when using a debug build of the tracing service.