### PR TITLE
exp: Nicer columns selection and error handling

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
@@ -133,17 +133,17 @@ export class AggregationNode implements ModificationNode {
   }
 
   validate(): boolean {
+    // Clear any previous errors at the start of validation
     if (this.state.issues) {
-      this.state.issues.queryError = undefined;
+      this.state.issues.clear();
     }
+
     if (this.prevNode === undefined) {
-      if (!this.state.issues) this.state.issues = new NodeIssues();
-      this.state.issues.queryError = new Error('No input node connected');
+      this.setValidationError('No input node connected');
       return false;
     }
     if (!this.prevNode.validate()) {
-      if (!this.state.issues) this.state.issues = new NodeIssues();
-      this.state.issues.queryError = new Error('Previous node is invalid');
+      this.setValidationError('Previous node is invalid');
       return false;
     }
     const sourceColNames = new Set(
@@ -157,21 +157,26 @@ export class AggregationNode implements ModificationNode {
     }
 
     if (missingCols.length > 0) {
-      if (!this.state.issues) this.state.issues = new NodeIssues();
-      this.state.issues.queryError = new Error(
+      this.setValidationError(
         `Group by columns ['${missingCols.join(', ')}'] not found in input`,
       );
       return false;
     }
 
     if (!this.state.groupByColumns.find((c) => c.checked)) {
-      if (!this.state.issues) this.state.issues = new NodeIssues();
-      this.state.issues.queryError = new Error(
+      this.setValidationError(
         'Aggregation node has no group by columns selected',
       );
       return false;
     }
     return true;
+  }
+
+  private setValidationError(message: string): void {
+    if (!this.state.issues) {
+      this.state.issues = new NodeIssues();
+    }
+    this.state.issues.queryError = new Error(message);
   }
 
   getTitle(): string {


### PR DESCRIPTION
This commit improves the column selection in modifyColumnsNode details on the node and standardizes error handling across multiple node types.

  Key Changes

1. Standardized Error Handling (All 5 files)

  All node validation methods now follow a consistent pattern:
  - Added private setValidationError(message: string) helper method
  - Validation clears previous errors at the start with this.state.issues.clear()
  - Cleaner, more DRY error handling code

  Example pattern:
  validate(): boolean {
    if (this.state.issues) {
      this.state.issues.clear();
    }
    // ... validation logic ...
    this.setValidationError('Error message');
    return false;
  }

2. Enhanced ModifyColumnsNode (modify_columns_node.ts:103)

  New validation messages:
  - 'Empty alias not allowed' - for blank column aliases
  - 'Duplicate column names' - when column names conflict
  - 'New column must have a name' - for expressions without names
  - 'No columns selected...' - when no columns are selected

  UI Improvements:
- Added "Deselect All" button (modify_columns_node.ts:691) - allows quickly clearing all column selections
- Smart column summary display (modify_columns_node.ts:537-577):
    - When >5 columns are selected and some are unselected, shows summary like "5 of 10 columns selected"
    - Still shows up to 3 renamed columns explicitly even in summary mode
    - Prevents UI clutter when dealing with tables with many columns