### PR TITLE
exp: Fix race condition

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -125,6 +125,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
   private query?: Query | Error;
   private queryExecuted: boolean = false;
   private isQueryRunning: boolean = false;
+  private isAnalyzing: boolean = false;
   private previousSelectedNode?: QueryNode;
   private isExplorerCollapsed: boolean = false;
   private response?: QueryResponse;
@@ -151,6 +152,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
       this.query = undefined;
       this.queryExecuted = false;
       this.isQueryRunning = false;
+      this.isAnalyzing = false;
     }
     this.previousSelectedNode = selectedNode;
 
@@ -176,6 +178,9 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               this.queryExecuted = false;
               this.runQuery(selectedNode);
             }
+          },
+          onAnalysisStateChange: (isAnalyzing: boolean) => {
+            this.isAnalyzing = isAnalyzing;
           },
           onchange: () => {},
           isCollapsed: this.isExplorerCollapsed,
@@ -220,6 +225,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               response: this.response,
               dataSource: this.dataSource,
               isQueryRunning: this.isQueryRunning,
+              isAnalyzing: this.isAnalyzing,
               onchange: () => {},
               isFullScreen:
                 this.drawerVisibility === SplitPanelDrawerVisibility.FULLSCREEN,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -37,6 +37,7 @@ export interface NodeExplorerAttrs {
   readonly node?: QueryNode;
   readonly trace: Trace;
   readonly onQueryAnalyzed: (query: Query | Error) => void;
+  readonly onAnalysisStateChange?: (isAnalyzing: boolean) => void;
   readonly onchange?: () => void;
   readonly resolveNode: (nodeId: string) => QueryNode | undefined;
   readonly isCollapsed?: boolean;
@@ -120,16 +121,33 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
       if (node.state.hasOperationChanged) {
         node.state.hasOperationChanged = false;
       }
+      attrs.onAnalysisStateChange?.(true);
       this.tableAsyncLimiter.schedule(async () => {
-        this.currentQuery = await analyzeNode(node, attrs.trace.engine);
-        if (!isAQuery(this.currentQuery)) {
-          return;
+        try {
+          this.currentQuery = await analyzeNode(node, attrs.trace.engine);
+          if (!isAQuery(this.currentQuery)) {
+            attrs.onAnalysisStateChange?.(false);
+            return;
+          }
+          if (node instanceof AggregationNode) {
+            node.updateGroupByColumns();
+          }
+          attrs.onQueryAnalyzed(this.currentQuery);
+          this.prevSqString = curSqString;
+          attrs.onAnalysisStateChange?.(false);
+        } catch (e) {
+          // Silently handle "Already analyzing" errors - the AsyncLimiter
+          // will retry when the current analysis completes
+          if (e instanceof Error && e.message.includes('Already analyzing')) {
+            // Keep isAnalyzing = true, will retry automatically
+            return;
+          }
+          // For other errors, set them as the current query and stop analyzing
+          const error = e instanceof Error ? e : new Error(String(e));
+          this.currentQuery = error;
+          attrs.onQueryAnalyzed(error);
+          attrs.onAnalysisStateChange?.(false);
         }
-        if (node instanceof AggregationNode) {
-          node.updateGroupByColumns();
-        }
-        attrs.onQueryAnalyzed(this.currentQuery);
-        this.prevSqString = curSqString;
       });
     }
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
@@ -29,3 +29,16 @@
     align-items: center;
   }
 }
+
+.pf-data-explorer-empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 300px;
+
+  button {
+    font-size: 1.2em;
+    padding: 1.5rem 2.5rem;
+  }
+}


### PR DESCRIPTION
The race condition occurs during query analysis and execution, where the UI couldn't distinguish between "analyzing/validating a query" vs "executing a query", leading to confusing UI states.

  Key improvements:

  1. State tracking (builder.ts:128, 155, 182-184, 228)
  - Added isAnalyzing flag to track when query analysis is in progress
  - Properly resets this state when the selected node changes
  - Threads the state through to child components

  2. Analysis lifecycle management (node_explorer.ts:124, 134, 136, 138-149)
  - Added onAnalysisStateChange callback to notify parent components
  - Sets isAnalyzing = true before scheduling analysis
  - Sets isAnalyzing = false after completion (success or error)
  - Smart error handling: Silently ignores "Already analyzing" errors from AsyncLimiter (letting it retry), but properly handles other errors

  3. Better UX (data_explorer.ts:72, 82-89, 197-216)
  - Shows "Queued..." when analyzing but not yet executing
  - Shows spinner only when actually running the query
  - Removed misleading "Typing..." text that appeared when response === undefined
  - Added prominent "Run Query" button in empty state when query is ready but not executed (in manual mode)

  4. Visual polish (styles.scss:33-44)
  - Added centered empty state styling for the Run Query button