### PR TITLE
exp: Interval intersect polishing

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -240,6 +240,8 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
                 }
               },
               onExecute: () => {
+                // Reset queryExecuted flag to allow re-execution after errors or config changes
+                this.queryExecuted = false;
                 this.runQuery(selectedNode);
               },
             })

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -140,6 +140,24 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       );
     }
 
+    // Show spinner overlay when query is running
+    if (attrs.isQueryRunning) {
+      return m(
+        '.pf-data-explorer-empty-state',
+        m(
+          '.pf-exp-query-running-spinner',
+          {
+            style: {
+              fontSize: '64px',
+            },
+          },
+          m(Spinner, {
+            easing: true,
+          }),
+        ),
+      );
+    }
+
     if (message) {
       return m(TextParagraph, {text: message});
     }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -19,7 +19,6 @@ import {
   nextNodeId,
   NodeType,
   MultiSourceNode,
-  removeConnection,
 } from '../../query_node';
 import protos from '../../../../protos';
 import {ColumnInfo, newColumnInfoList} from '../column_info';
@@ -27,15 +26,24 @@ import {Button} from '../../../../widgets/button';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
 import {UIFilter} from '../operations/filter';
+import {
+  PopupMultiSelect,
+  MultiSelectOption,
+  MultiSelectDiff,
+} from '../../../../widgets/multiselect';
 
 export interface IntervalIntersectSerializedState {
   intervalNodes: string[];
   filters?: UIFilter[];
   comment?: string;
+  filterNegativeDur?: boolean[]; // Per-input filter to exclude negative durations
+  partitionColumns?: string[]; // Columns to partition by during interval intersection
 }
 
 export interface IntervalIntersectNodeState extends QueryNodeState {
   readonly prevNodes: QueryNode[];
+  filterNegativeDur?: boolean[]; // Per-input filter to exclude negative durations
+  partitionColumns?: string[]; // Columns to partition by during interval intersection
 }
 
 export class IntervalIntersectNode implements MultiSourceNode {
@@ -79,7 +87,7 @@ export class IntervalIntersectNode implements MultiSourceNode {
 
     if (this.prevNodes.length < 2) {
       this.setValidationError(
-        'Interval intersect node requires one base source and at least one interval source.',
+        'Interval intersect node requires at least two inputs.',
       );
       return false;
     }
@@ -129,32 +137,215 @@ export class IntervalIntersectNode implements MultiSourceNode {
     return 'Interval Intersect';
   }
 
+  private renderPartitionSelector(compact: boolean = false): m.Child {
+    // Initialize partition columns if needed
+    if (!this.state.partitionColumns) {
+      this.state.partitionColumns = [];
+    }
+
+    // Get common columns for partition selection
+    const commonColumns = this.getCommonColumns();
+    if (commonColumns.length === 0) {
+      return null;
+    }
+
+    const partitionOptions: MultiSelectOption[] = commonColumns.map((col) => ({
+      id: col,
+      name: col,
+      checked: this.state.partitionColumns?.includes(col) ?? false,
+    }));
+
+    const label =
+      this.state.partitionColumns.length > 0
+        ? this.state.partitionColumns.join(', ')
+        : 'None';
+
+    return m(
+      '.pf-exp-partition-columns',
+      {
+        style: compact
+          ? {marginTop: '4px', marginBottom: '4px'}
+          : {marginTop: '8px', marginBottom: '8px'},
+      },
+      m(
+        'label',
+        {
+          style: compact
+            ? {marginRight: '8px', fontSize: '12px'}
+            : {marginRight: '8px'},
+        },
+        'Partition by:',
+      ),
+      m(PopupMultiSelect, {
+        label,
+        options: partitionOptions,
+        showNumSelected: false,
+        compact,
+        onChange: (diffs: MultiSelectDiff[]) => {
+          if (!this.state.partitionColumns) {
+            this.state.partitionColumns = [];
+          }
+          for (const diff of diffs) {
+            if (diff.checked) {
+              if (!this.state.partitionColumns.includes(diff.id)) {
+                this.state.partitionColumns.push(diff.id);
+              }
+            } else {
+              const index = this.state.partitionColumns.indexOf(diff.id);
+              if (index !== -1) {
+                this.state.partitionColumns.splice(index, 1);
+              }
+            }
+          }
+          this.state.onchange?.();
+        },
+      }),
+    );
+  }
+
+  nodeDetails(): m.Child {
+    return this.renderPartitionSelector(true);
+  }
+
+  onPrevNodesUpdated(): void {
+    // Compact filterNegativeDur array to match prevNodes length
+    // When nodes are removed, prevNodes is compacted, so we need to match that
+    if (
+      this.state.filterNegativeDur &&
+      this.state.filterNegativeDur.length > this.prevNodes.length
+    ) {
+      this.state.filterNegativeDur = this.state.filterNegativeDur.slice(
+        0,
+        this.prevNodes.length,
+      );
+    }
+  }
+
+  private checkDuplicateColumns(): string[] {
+    const EXCLUDED_COLUMNS = new Set(['id', 'ts', 'dur']);
+    const columnToInputs = new Map<string, number[]>();
+
+    // Also exclude columns used for partitioning (they're intentionally in all inputs)
+    const partitionColumns = new Set(this.state.partitionColumns ?? []);
+
+    // Track which inputs each column appears in
+    for (let i = 0; i < this.prevNodes.length; i++) {
+      const node = this.prevNodes[i];
+      const columns = node.finalCols.map((c) => c.name);
+      for (const col of columns) {
+        if (!EXCLUDED_COLUMNS.has(col) && !partitionColumns.has(col)) {
+          if (!columnToInputs.has(col)) {
+            columnToInputs.set(col, []);
+          }
+          columnToInputs.get(col)!.push(i + 1); // +1 for user-friendly "Input 1, Input 2" labels
+        }
+      }
+    }
+
+    // Build warning message for columns that appear in multiple inputs
+    const warnings: string[] = [];
+    for (const [col, inputs] of columnToInputs.entries()) {
+      if (inputs.length > 1) {
+        const inputLabels = inputs.map((i) => `Input ${i}`).join(', ');
+        warnings.push(`'${col}' in ${inputLabels}`);
+      }
+    }
+
+    return warnings;
+  }
+
+  private getCommonColumns(): string[] {
+    const EXCLUDED_COLUMNS = new Set(['id', 'ts', 'dur']);
+
+    if (this.prevNodes.length === 0) return [];
+
+    // Start with columns from the first input
+    const firstNode = this.prevNodes[0];
+    const commonColumns = new Set(
+      firstNode.finalCols
+        .map((c) => c.name)
+        .filter((name) => !EXCLUDED_COLUMNS.has(name)),
+    );
+
+    // Intersect with columns from remaining inputs
+    for (let i = 1; i < this.prevNodes.length; i++) {
+      const node = this.prevNodes[i];
+      const nodeColumns = new Set(node.finalCols.map((c) => c.name));
+      // Keep only columns that exist in this node too
+      for (const col of commonColumns) {
+        if (!nodeColumns.has(col)) {
+          commonColumns.delete(col);
+        }
+      }
+    }
+
+    return Array.from(commonColumns).sort();
+  }
+
   nodeSpecificModify(): m.Child {
     this.validate();
     const error = this.state.issues?.queryError;
+    const duplicateWarnings = this.checkDuplicateColumns();
+
+    // Initialize filterNegativeDur array if needed
+    if (!this.state.filterNegativeDur) {
+      this.state.filterNegativeDur = [];
+    }
+
+    // Map prevNodes to UI elements with their indices
+    const connectedInputs: Array<{node: QueryNode; index: number}> =
+      this.prevNodes.map((node, index) => ({node, index}));
 
     return m(
       '.pf-exp-query-operations',
       error && m(Callout, {icon: 'error'}, error.message),
+      duplicateWarnings.length > 0 &&
+        m(
+          Callout,
+          {icon: 'warning'},
+          m('div', 'Duplicate columns found:'),
+          m(
+            'ul',
+            {style: {marginTop: '4px', marginBottom: '0', paddingLeft: '20px'}},
+            duplicateWarnings.map((warning) => m('li', warning)),
+          ),
+        ),
+      this.renderPartitionSelector(false),
       m(
         '.pf-exp-section',
         m(
           '.pf-exp-operations-container',
-          m('h2', 'Interval Intersect'),
-          this.prevNodes.slice(1).map((intervalNode, index) =>
-            m(
+          connectedInputs.map(({node, index}) => {
+            const label = `Input ${index + 1}`;
+            const filterEnabled =
+              this.state.filterNegativeDur?.[index] ?? false;
+
+            return m(
               '.pf-exp-interval-node',
-              m('span', `Interval ${index + 1}: ${intervalNode.getTitle()}`),
+              {
+                key: node.nodeId,
+                style: {
+                  display: 'flex',
+                  gap: '8px',
+                  alignItems: 'center',
+                  marginBottom: '8px',
+                },
+              },
+              m('span', {style: {flex: 1}}, `${label}: ${node.getTitle()}`),
               m(Button, {
-                icon: 'delete',
+                label: 'Filter unfinished intervals',
+                icon: filterEnabled ? 'check_box' : 'check_box_outline_blank',
+                title: 'Filter out intervals with negative duration',
                 onclick: () => {
-                  // Remove the connection between intervalNode and this node
-                  removeConnection(intervalNode, this);
+                  if (!this.state.filterNegativeDur) {
+                    this.state.filterNegativeDur = [];
+                  }
+                  this.state.filterNegativeDur[index] = !filterEnabled;
                   this.state.onchange?.();
                 },
               }),
-            ),
-          ),
+            );
+          }),
         ),
       ),
     );
@@ -164,6 +355,12 @@ export class IntervalIntersectNode implements MultiSourceNode {
     const stateCopy: IntervalIntersectNodeState = {
       prevNodes: [...this.state.prevNodes],
       filters: this.state.filters ? [...this.state.filters] : undefined,
+      filterNegativeDur: this.state.filterNegativeDur
+        ? [...this.state.filterNegativeDur]
+        : undefined,
+      partitionColumns: this.state.partitionColumns
+        ? [...this.state.partitionColumns]
+        : undefined,
       onchange: this.state.onchange,
     };
     return new IntervalIntersectNode(stateCopy);
@@ -176,19 +373,49 @@ export class IntervalIntersectNode implements MultiSourceNode {
     const baseSq = this.prevNodes[0]?.getStructuredQuery();
     if (baseSq === undefined) return undefined;
 
-    const intervalSqs = this.prevNodes
-      .slice(1)
-      .filter((node): node is QueryNode => node !== undefined)
-      .map((node) => node.getStructuredQuery());
-    if (intervalSqs.some((sq) => sq === undefined)) return undefined;
+    // Add dur >= 0 filter to base if enabled
+    if (this.state.filterNegativeDur?.[0]) {
+      const filter = new protos.PerfettoSqlStructuredQuery.Filter();
+      filter.columnName = 'dur';
+      filter.op =
+        protos.PerfettoSqlStructuredQuery.Filter.Operator.GREATER_THAN_EQUAL;
+      filter.int64Rhs = [0];
+      if (baseSq.filters === undefined) baseSq.filters = [];
+      baseSq.filters.push(filter);
+    }
+
+    const intervalSqs: protos.PerfettoSqlStructuredQuery[] = [];
+    for (let i = 1; i < this.prevNodes.length; i++) {
+      const node = this.prevNodes[i];
+      const sq = node.getStructuredQuery();
+      if (sq === undefined) return undefined;
+
+      // Add dur >= 0 filter if enabled for this interval
+      if (this.state.filterNegativeDur?.[i]) {
+        const filter = new protos.PerfettoSqlStructuredQuery.Filter();
+        filter.columnName = 'dur';
+        filter.op =
+          protos.PerfettoSqlStructuredQuery.Filter.Operator.GREATER_THAN_EQUAL;
+        filter.int64Rhs = [0];
+        if (sq.filters === undefined) sq.filters = [];
+        sq.filters.push(filter);
+      }
+
+      intervalSqs.push(sq);
+    }
 
     const sq = new protos.PerfettoSqlStructuredQuery();
     sq.id = this.nodeId;
     sq.intervalIntersect =
       new protos.PerfettoSqlStructuredQuery.IntervalIntersect();
     sq.intervalIntersect.base = baseSq;
-    sq.intervalIntersect.intervalIntersect =
-      intervalSqs as protos.PerfettoSqlStructuredQuery[];
+    sq.intervalIntersect.intervalIntersect = intervalSqs;
+
+    // Add partition columns if specified
+    if (this.state.partitionColumns && this.state.partitionColumns.length > 0) {
+      sq.intervalIntersect.partitionColumns = [...this.state.partitionColumns];
+    }
+
     return sq;
   }
 
@@ -200,6 +427,8 @@ export class IntervalIntersectNode implements MultiSourceNode {
         .map((n) => n.nodeId),
       filters: this.state.filters,
       comment: this.state.comment,
+      filterNegativeDur: this.state.filterNegativeDur,
+      partitionColumns: this.state.partitionColumns,
     };
   }
 
@@ -207,12 +436,18 @@ export class IntervalIntersectNode implements MultiSourceNode {
     nodes: Map<string, QueryNode>,
     state: IntervalIntersectSerializedState,
     baseNode: QueryNode,
-  ): {prevNodes: QueryNode[]} {
+  ): {
+    prevNodes: QueryNode[];
+    filterNegativeDur?: boolean[];
+    partitionColumns?: string[];
+  } {
     const intervalNodes = state.intervalNodes
       .map((id) => nodes.get(id))
       .filter((node): node is QueryNode => node !== undefined);
     return {
       prevNodes: [baseNode, ...intervalNodes],
+      filterNegativeDur: state.filterNegativeDur,
+      partitionColumns: state.partitionColumns,
     };
   }
 }


### PR DESCRIPTION
Summary

  Adds polish and new functionality to the Interval Intersect query builder node, including partition support, filtering of unfinished intervals,
  improved UX, and fixes for port handling bugs.

  Changes

  New Features

  - Partition columns: Users can now select columns to partition by during interval intersection, enabling per-partition overlap analysis
  - Filter unfinished intervals: Per-input toggle to exclude intervals with negative duration (unfinished/ongoing intervals)
  - Duplicate column warnings: Automatically detects and warns when non-id/ts/dur columns appear in multiple inputs, helping prevent ambiguous query
  results

  UX Improvements

  - Query spinner overlay now displays while queries are running
  - Query can be re-executed after errors or configuration changes (reset queryExecuted flag on execute button)
  - Better labeling and error messages for interval intersect nodes

  Bug Fixes

  - Fixed 0-indexed vs 1-indexed confusion in multi-source node port handling
  - Corrected port calculations to be consistently 0-indexed for multi-source nodes
  - Fixed connection logic to properly handle port replacement and appending

  Architecture Improvements

  - Changed MultiSourceNode.prevNodes from (QueryNode | undefined)[] to QueryNode[] - eliminates undefined holes in array
  - removeConnection now uses splice() to maintain compact arrays instead of leaving undefined gaps
  - addConnection properly handles both replacement at specific ports and appending to end

  Testing

  - Verify interval intersect with 2+ inputs works correctly
  - Test partition column selection with common columns across inputs
  - Verify "Filter unfinished intervals" checkbox filters dur < 0 correctly for each input
  - Check that duplicate column warnings appear when appropriate
  - Test adding/removing connections to multi-source nodes