### PR TITLE
ui: NodeGraph: Add onNodeDragEnd to aid in undo/redo history

### DIFF
--- a/ui/src/assets/widgets/nodegraph.scss
+++ b/ui/src/assets/widgets/nodegraph.scss
@@ -210,7 +210,6 @@
   position: absolute;
   top: 6px;
   right: 6px;
-  z-index: 1;
 }
 
 .pf-node-content {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -47,6 +47,7 @@ import {
   Node,
   NodeGraph,
   NodeGraphApi,
+  NodeGraphAttrs,
   NodePort,
 } from '../../../../widgets/nodegraph';
 import {UIFilter} from '../operations/filter';
@@ -725,7 +726,7 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
           onSelectionClear: () => {
             attrs.onDeselect();
           },
-          onNodeDrag: (nodeId: string, x: number, y: number) => {
+          onNodeMove: (nodeId: string, x: number, y: number) => {
             attrs.onNodeLayoutChange(nodeId, {x, y});
           },
           onConnect: (conn: Connection) => {
@@ -754,7 +755,7 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
             attrs.nodeLayouts.delete(childNode.id);
             m.redraw();
           },
-        }),
+        } satisfies NodeGraphAttrs),
         this.renderControls(attrs),
       ],
     );


### PR DESCRIPTION
- Added onNodeDragEnd callback to NodeGraph, which is called when a drag ends. This can be used to differentiate between when undo history should be stored and when it should not. Storing it every onNodeDrag event would be too spammy, storing only onNodeDragEnd makes a lot more sense.
- Add undo/redo using immer to store the demo on the widgets page for testing.