### PR TITLE
tp: Interval intersect didn't handle partition by string columns

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.h
@@ -34,7 +34,8 @@ class StringPool;
 //    creates a data structure allowing efficient lookups of rows by id.
 // TODO(lalitm): once we have some stability here, expand the comments
 // here.
-base::Status RegisterTypeBuilderFunctions(PerfettoSqlEngine& engine);
+base::Status RegisterTypeBuilderFunctions(PerfettoSqlEngine& engine,
+                                          StringPool* pool);
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/perfetto_sql/intrinsics/types/partitioned_intervals.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/types/partitioned_intervals.h
@@ -26,6 +26,10 @@
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/interval_intersector.h"
 
+namespace perfetto::trace_processor {
+class StringPool;
+}
+
 namespace perfetto::trace_processor::perfetto_sql {
 
 struct Partition {
@@ -41,8 +45,12 @@ using Partitions =
 
 struct PartitionedTable {
   static constexpr char kName[] = "INTERVAL_TREE_PARTITIONS";
-  Partitions partitions_map;
 
+  struct UserData {
+    StringPool* pool;
+  };
+
+  Partitions partitions_map;
   std::vector<std::string> partition_column_names;
 };
 

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -1338,7 +1338,8 @@ std::unique_ptr<PerfettoSqlEngine> TraceProcessorImpl::InitPerfettoSqlEngine(
       PERFETTO_FATAL("%s", status.c_message());
   }
   {
-    base::Status status = RegisterTypeBuilderFunctions(*engine);
+    base::Status status =
+        RegisterTypeBuilderFunctions(*engine, storage->mutable_string_pool());
     if (!status.ok())
       PERFETTO_FATAL("%s", status.c_message());
   }


### PR DESCRIPTION
 Interval intersect with string partition columns was producing nonsensical garbage output instead of the actual string values. For example, querying with _interval_intersect!((s, s), (process_name, thread_name)) would return gibberish like "����U" instead of actual process/thread names like "mdss_fb0".

This was a dangling pointer bug for string partition columns, non-string partition columns (integers, etc.) worked correctly.

Root Cause

In src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc, the IntervalTreeIntervalsAgg::Step() function was storing SqlValue objects containing raw string pointers from SQLite (sqlite3_value_text()). These pointers are only valid during the current SQLite function call, as documented in basic_types.h:

  // This string will be owned by the iterator that returned it and is valid
  // as long until the subsequent call to Next().

When the partition values were accessed later in interval_intersect.cc, the pointers pointed to invalid/freed memory, resulting in garbage output.

The Fix

  - Modified RegisterTypeBuilderFunctions() to accept StringPool* pool parameter
  - Added UserData struct to PartitionedTable to carry the StringPool pointer
  - String values are interned during Step() before being stored in partition keys