### PR TITLE
rust-sdk: use syn v2 instead of v1

### DIFF
--- a/contrib/rust-sdk/perfetto-derive/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-derive/Cargo.toml
@@ -22,7 +22,7 @@ vendored = ["perfetto/vendored"]
 
 [dependencies]
 perfetto = { path = "../perfetto", version = "0.1.0", default-features = false }
-syn = { version = "1.0.5", features = ["full"] }
+syn = { version = "2", features = ["full"] }
 quote = "1.0.8"
 proc-macro2 = "1.0"
 


### PR DESCRIPTION
v1 is old and depending on it can make it harder to use the SDK.

We already implicitly depend on v2 so this technically reduces the dependency graph for the derive crate and the SDK.

Issue: https://github.com/google/perfetto/issues/3329