### PR TITLE
Fix Chromium build - set is_freebsd variable

### DIFF
--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -66,10 +66,6 @@ if (!defined(build_with_chromium)) {
   build_with_chromium = false
 }
 
-if (!defined(is_freebsd)) {
-  is_freebsd = false
-}
-
 if (!defined(is_nacl)) {
   is_nacl = false
 }


### PR DESCRIPTION
https://github.com/google/perfetto/pull/3467 broke Chromium builds because Chromium intentionally doesn't define is_freebsd.

Example failure: https://chromium-review.googlesource.com/c/chromium/src/+/7122439

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
