### PR TITLE
rust-sdk: cargo fixes to prepare for publishing

### DIFF
--- a/contrib/rust-sdk/perfetto-derive/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-derive/Cargo.toml
@@ -11,6 +11,7 @@ keywords = [
 ]
 categories = ["profiling"]
 license = "Apache-2.0"
+homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"
 
 [lib]

--- a/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
@@ -11,6 +11,7 @@ keywords = [
 ]
 categories = ["profiling"]
 license = "Apache-2.0"
+homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"
 
 [dependencies]

--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -7,13 +7,13 @@ build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"
 readme = "README.md"
 keywords = [
-    "trace processor",
     "tracing",
     "perfetto",
     "ffi",
 ]
 categories = ["external-ffi-bindings"]
 license = "Apache-2.0"
+homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"
 exclude = ["include/perfetto/public/abi/BUILD.gn"]
 

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -11,6 +11,7 @@ keywords = [
 ]
 categories = ["profiling"]
 license = "Apache-2.0"
+homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"
 
 [features]


### PR DESCRIPTION
Add homepage entry for each crate and remove invalid keyword entry.

Issue: https://github.com/google/perfetto/issues/3446