### PR TITLE
rust-sdk: more cargo fixes for publishing

### DIFF
--- a/contrib/rust-sdk/perfetto-derive/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-derive/Cargo.toml
@@ -9,7 +9,7 @@ keywords = [
     "tracing",
     "perfetto",
 ]
-categories = ["profiling"]
+categories = ["development-tools::profiling"]
 license = "Apache-2.0"
 homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"

--- a/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
@@ -9,7 +9,7 @@ keywords = [
     "tracing",
     "perfetto",
 ]
-categories = ["profiling"]
+categories = ["development-tools::profiling"]
 license = "Apache-2.0"
 homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -9,7 +9,7 @@ keywords = [
     "tracing",
     "perfetto",
 ]
-categories = ["profiling"]
+categories = ["development-tools::profiling"]
 license = "Apache-2.0"
 homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"


### PR DESCRIPTION
s/profiling/development-tools::profiling/ as top level profiling category doesn't exist.

Issue: https://github.com/google/perfetto/issues/3446