### PR TITLE
rust-sdk: fix features for protos-gpu crate

### DIFF
--- a/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
@@ -14,6 +14,10 @@ license = "Apache-2.0"
 homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"
 
+[features]
+default = ["vendored"]
+vendored = ["perfetto-sdk/vendored"]
+
 [dependencies]
 perfetto-sdk = { path = "../perfetto", version = "0.1.0", default-features = false }
 paste = "1"


### PR DESCRIPTION
To publish this crate we need to expose the vendored feature and forward it to perfetto-sdk crate.

Issue: https://github.com/google/perfetto/issues/3446