### PR TITLE
rust-sdk: enable vendored feature by default in perfetto-sdk crate

### DIFF
--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -15,7 +15,7 @@ homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"
 
 [features]
-default = []
+default = ["vendored"]
 intrinsics = []
 vendored = ["perfetto-sdk-sys/vendored"]
 


### PR DESCRIPTION
This makes it easier to use in an application that doesn't depend on other crates that makes this the default.

Issue: https://github.com/google/perfetto/issues/3446