### PR TITLE
Fix proto deps includes for embedders

### DIFF
--- a/gn/perfetto_cc_proto_descriptor.gni
+++ b/gn/perfetto_cc_proto_descriptor.gni
@@ -33,7 +33,8 @@ template("perfetto_cc_proto_descriptor") {
       descriptor_file_path =
           get_label_info(invoker.descriptor_target, "target_gen_dir") +
           "/${invoker.descriptor_name}"
-      if (build_with_chromium || perfetto_build_with_embedder) {
+      if (build_with_chromium ||
+          (perfetto_build_with_embedder && !is_perfetto_build_generator)) {
         deps = [ "${invoker.descriptor_target}_gen" ]
       } else {
         deps = [ invoker.descriptor_target ]

--- a/gn/protozero_descriptor_diff.gni
+++ b/gn/protozero_descriptor_diff.gni
@@ -15,7 +15,8 @@
 import("perfetto.gni")
 
 template("protozero_descriptor_diff") {
-  if (build_with_chromium || perfetto_build_with_embedder) {
+  if (build_with_chromium ||
+      (perfetto_build_with_embedder && !is_perfetto_build_generator)) {
     name = "${target_name}_gen"
   } else {
     name = "${target_name}"


### PR DESCRIPTION
https://github.com/google/perfetto/pull/1117 fixed proto deps includes for chromium builds. Other embedders (V8) use the same version of the protobuf library, so they need this fix too.

Bug: http://b/issues/402356473