### PR TITLE
exp: Small fixes

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/help.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/help.ts
@@ -47,7 +47,6 @@ export class ExplorePageHelp implements m.ClassComponent<ExplorePageHelpAttrs> {
         {direction: 'horizontal'},
         m(
           Card,
-          {interactive: true},
           m('h4', '1. Add a source node'),
           m(
             'p',
@@ -56,7 +55,6 @@ export class ExplorePageHelp implements m.ClassComponent<ExplorePageHelpAttrs> {
         ),
         m(
           Card,
-          {interactive: true},
           m('h4', '2. Configure the node'),
           m(
             'p',
@@ -65,7 +63,6 @@ export class ExplorePageHelp implements m.ClassComponent<ExplorePageHelpAttrs> {
         ),
         m(
           Card,
-          {interactive: true},
           m('h4', '3. View the results'),
           m(
             'p',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -360,7 +360,7 @@ interface NewColumn {
 }
 
 export interface ModifyColumnsSerializedState {
-  prevNodeId: string;
+  prevNodeId?: string;
   newColumns: NewColumn[];
   selectedColumns: {
     name: string;
@@ -1105,11 +1105,8 @@ export class ModifyColumnsNode implements ModificationNode {
   }
 
   serializeState(): ModifyColumnsSerializedState {
-    if (this.prevNode === undefined) {
-      throw new Error('Cannot serialize ModifyColumnsNode without a prevNode');
-    }
     return {
-      prevNodeId: this.prevNode.nodeId,
+      prevNodeId: this.prevNode?.nodeId,
       newColumns: this.state.newColumns.map((c) => ({
         expression: c.expression,
         name: c.name,


### PR DESCRIPTION
 1. Handle removing prevNode from modifyColumnsNode

  - Changes prevNodeId from required to optional in ModifyColumnsSerializedState
  - Removes the error throw when serializing without a prevNode
  - Uses optional chaining (this.prevNode?.nodeId) to safely handle the case where prevNode is undefined

Adds test coverage

  3. Filters STRING and BYTES columns from interval intersect 

Temporary fix for wasm memory issues + generally a good practice to not use string columns for partitioning

  4.  Removes {interactive: true} prop from three help Card components on landing page