### PR TITLE
Presubmit: improve merge-base detection

### DIFF
--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -895,7 +895,7 @@ def CheckUiRatchet(changed_files: List[str]) -> List[str]:
 
 def main():
   parser = argparse.ArgumentParser()
-  parser.add_argument('--merge-base', default='origin/main')
+  parser.add_argument('--merge-base', default=None)
   parser.add_argument(
       '--skip-formatters',
       default='',
@@ -906,6 +906,10 @@ def main():
 
   # 1. Determine files to check
   merge_base = args.merge_base
+  if merge_base is None:
+    merge_base = subprocess.check_output(
+        ['git', 'merge-base', 'HEAD', 'origin/main'], text=True).strip()
+
   changed_files = get_changed_files(merge_base)
 
   if not changed_files:


### PR DESCRIPTION
Today run-presubmit uses origin/main as a merge-base to figure
out the list of changed files. That creates problems if you git fetch
and your branch goes behind newer changes as all the files changed
by the new changes are also considered.
Instead use git merge-base to figure out the common
ancestor and diff against that.

This does NOT affect CI, as the CI passes an explicit --merge-base