### PR TITLE
exp: Introduce Filtering Node and migrate all filtering logic

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -50,6 +50,7 @@ import {
   LimitAndOffsetNodeState,
 } from './query_builder/nodes/limit_and_offset_node';
 import {SortNode, SortNodeState} from './query_builder/nodes/sort_node';
+import {FilterNode, FilterNodeState} from './query_builder/nodes/filter_node';
 import {
   MergeNode,
   MergeSerializedState,
@@ -69,6 +70,7 @@ type SerializedNodeState =
   | AddColumnsNodeState
   | LimitAndOffsetNodeState
   | SortNodeState
+  | FilterNodeState
   | MergeSerializedState
   | UnionSerializedState;
 
@@ -204,6 +206,10 @@ function createNodeInstance(
       );
     case NodeType.kSort:
       return new SortNode(SortNode.deserializeState(state as SortNodeState));
+    case NodeType.kFilter:
+      return new FilterNode(
+        FilterNode.deserializeState(state as FilterNodeState),
+      );
     case NodeType.kIntervalIntersect:
       const nodeState: IntervalIntersectNodeState = {
         ...(state as IntervalIntersectSerializedState),
@@ -220,7 +226,6 @@ function createNodeInstance(
         leftColumn: mergeState.leftColumn ?? '',
         rightColumn: mergeState.rightColumn ?? '',
         sqlExpression: mergeState.sqlExpression ?? '',
-        filters: mergeState.filters,
         comment: mergeState.comment,
       });
     case NodeType.kUnion:
@@ -229,7 +234,6 @@ function createNodeInstance(
         prevNodes: [],
         selectedColumns: unionState.selectedColumns,
       });
-      unionNode.filters = unionState.filters;
       unionNode.comment = unionState.comment;
       return unionNode;
     default:

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -28,6 +28,7 @@ import {
 import {AddColumnsNode} from './query_builder/nodes/add_columns_node';
 import {LimitAndOffsetNode} from './query_builder/nodes/limit_and_offset_node';
 import {SortNode} from './query_builder/nodes/sort_node';
+import {FilterNode} from './query_builder/nodes/filter_node';
 import {MergeNode} from './query_builder/nodes/merge_node';
 import {UnionNode} from './query_builder/nodes/union_node';
 import {PerfettoSqlType} from '../../trace_processor/perfetto_sql_type';
@@ -274,13 +275,6 @@ describe('JSON serialization/deserialization', () => {
       partitionColumns: ['name'],
       filterNegativeDur: [true, false, true],
       comment: 'Intersect intervals partitioned by name',
-      filters: [
-        {
-          column: 'dur',
-          op: '>',
-          value: '1000',
-        },
-      ],
     });
     tableNode1.nextNodes.push(intervalIntersectNode);
     tableNode2.nextNodes.push(intervalIntersectNode);
@@ -347,14 +341,6 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedIntervalIntersectNode.state.comment).toBe(
       'Intersect intervals partitioned by name',
     );
-
-    // Verify filters
-    expect(deserializedIntervalIntersectNode.state.filters).toBeDefined();
-    expect(deserializedIntervalIntersectNode.state.filters?.length).toBe(1);
-    expect(deserializedIntervalIntersectNode.state.filters?.[0].column).toBe(
-      'dur',
-    );
-    expect(deserializedIntervalIntersectNode.state.filters?.[0].op).toBe('>');
   });
 
   test('serializes and deserializes sql source node with reference', () => {
@@ -394,6 +380,10 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
+    });
+
+    const filterNode = new FilterNode({
+      prevNode: tableNode,
       filters: [
         {
           column: 'name',
@@ -402,6 +392,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
+    tableNode.nextNodes.push(filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -412,10 +403,12 @@ describe('JSON serialization/deserialization', () => {
     const deserializedState = deserializeState(json, trace, sqlModules);
 
     expect(deserializedState.rootNodes.length).toBe(1);
-    const deserializedTableNode = deserializedState
-      .rootNodes[0] as TableSourceNode;
-    expect(deserializedTableNode.state.filters?.length).toBe(1);
-    const filter = deserializedTableNode.state.filters?.[0];
+    const deserializedTableNode = deserializedState.rootNodes[0];
+    expect(deserializedTableNode.nextNodes.length).toBe(1);
+    const deserializedFilterNode = deserializedTableNode
+      .nextNodes[0] as FilterNode;
+    expect(deserializedFilterNode.state.filters?.length).toBe(1);
+    const filter = deserializedFilterNode.state.filters?.[0];
     expect(filter?.column).toBe('name');
     expect(filter?.op).toBe('=');
     if (filter !== undefined && 'value' in filter) {
@@ -462,6 +455,10 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
+    });
+
+    const filterNode = new FilterNode({
+      prevNode: tableNode,
       filters: [
         {
           column: 'id',
@@ -470,6 +467,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
+    tableNode.nextNodes.push(filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -480,10 +478,12 @@ describe('JSON serialization/deserialization', () => {
     const deserializedState = deserializeState(json, trace, sqlModules);
 
     expect(deserializedState.rootNodes.length).toBe(1);
-    const deserializedTableNode = deserializedState
-      .rootNodes[0] as TableSourceNode;
-    expect(deserializedTableNode.state.filters?.length).toBe(1);
-    const filter = deserializedTableNode.state.filters?.[0];
+    const deserializedTableNode = deserializedState.rootNodes[0];
+    expect(deserializedTableNode.nextNodes.length).toBe(1);
+    const deserializedFilterNode = deserializedTableNode
+      .nextNodes[0] as FilterNode;
+    expect(deserializedFilterNode.state.filters?.length).toBe(1);
+    const filter = deserializedFilterNode.state.filters?.[0];
     expect(filter?.column).toBe('id');
     expect(filter?.op).toBe('=');
     if (filter !== undefined && 'value' in filter) {
@@ -555,6 +555,11 @@ describe('JSON serialization/deserialization', () => {
       prevNode: tableNode,
       newColumns: [{expression: '1', name: 'new_col'}],
       selectedColumns: [],
+    });
+    tableNode.nextNodes.push(modifyColumnsNode);
+
+    const filterNode = new FilterNode({
+      prevNode: modifyColumnsNode,
       filters: [
         {
           column: 'new_col',
@@ -563,7 +568,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    tableNode.nextNodes.push(modifyColumnsNode);
+    modifyColumnsNode.nextNodes.push(filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -576,16 +581,16 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedState.rootNodes.length).toBe(1);
     const deserializedTableNode = deserializedState.rootNodes[0];
     expect(deserializedTableNode.nextNodes.length).toBe(1);
-    const deserializedNode = deserializedTableNode
+    const deserializedModifyNode = deserializedTableNode
       .nextNodes[0] as ModifyColumnsNode;
-    expect(deserializedNode.state.newColumns.length).toBe(1);
-    expect(deserializedNode.state.newColumns[0].name).toBe('new_col');
-    const filters = deserializedNode.state.filters;
-    expect(filters).toBeDefined();
-    if (filters) {
-      expect(filters.length).toBe(1);
-      expect(filters[0].column).toBe('new_col');
-    }
+    expect(deserializedModifyNode.state.newColumns.length).toBe(1);
+    expect(deserializedModifyNode.state.newColumns[0].name).toBe('new_col');
+    expect(deserializedModifyNode.nextNodes.length).toBe(1);
+    const deserializedFilterNode = deserializedModifyNode
+      .nextNodes[0] as FilterNode;
+    expect(deserializedFilterNode.state.filters).toBeDefined();
+    expect(deserializedFilterNode.state.filters?.length).toBe(1);
+    expect(deserializedFilterNode.state.filters?.[0].column).toBe('new_col');
   });
 
   test('serializes and deserializes add columns node', () => {
@@ -675,6 +680,117 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedNode = deserializedTableNode.nextNodes[0] as SortNode;
     expect(deserializedNode.state.sortColNames).toEqual(['name', 'ts']);
+  });
+
+  test('serializes and deserializes filter node', () => {
+    const tableNode = new TableSourceNode({
+      sqlTable: sqlModules.getTable('slice'),
+      trace,
+      sqlModules,
+    });
+
+    const filterNode = new FilterNode({
+      prevNode: tableNode,
+      filters: [
+        {
+          column: 'name',
+          op: '=',
+          value: 'test',
+        },
+        {
+          column: 'dur',
+          op: '>',
+          value: 1000,
+        },
+      ],
+      filterOperator: 'AND',
+      comment: 'Filter by name and duration',
+    });
+    tableNode.nextNodes.push(filterNode);
+
+    const initialState: ExplorePageState = {
+      rootNodes: [tableNode],
+      nodeLayouts: new Map(),
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    expect(deserializedState.rootNodes.length).toBe(1);
+    const deserializedTableNode = deserializedState.rootNodes[0];
+    expect(deserializedTableNode.nextNodes.length).toBe(1);
+    const deserializedNode = deserializedTableNode.nextNodes[0] as FilterNode;
+
+    // Verify filters
+    expect(deserializedNode.state.filters).toBeDefined();
+    expect(deserializedNode.state.filters?.length).toBe(2);
+    expect(deserializedNode.state.filters?.[0].column).toBe('name');
+    expect(deserializedNode.state.filters?.[0].op).toBe('=');
+    if (
+      deserializedNode.state.filters?.[0] &&
+      'value' in deserializedNode.state.filters[0]
+    ) {
+      expect(deserializedNode.state.filters[0].value).toBe('test');
+    }
+    expect(deserializedNode.state.filters?.[1].column).toBe('dur');
+    expect(deserializedNode.state.filters?.[1].op).toBe('>');
+    if (
+      deserializedNode.state.filters?.[1] &&
+      'value' in deserializedNode.state.filters[1]
+    ) {
+      expect(deserializedNode.state.filters[1].value).toBe(1000);
+    }
+
+    // Verify filter operator
+    expect(deserializedNode.state.filterOperator).toBe('AND');
+
+    // Verify comment
+    expect(deserializedNode.state.comment).toBe('Filter by name and duration');
+
+    // Verify prevNode connection
+    expect(deserializedNode.prevNode?.nodeId).toBe(
+      deserializedTableNode.nodeId,
+    );
+  });
+
+  test('serializes and deserializes filter node with null filter', () => {
+    const tableNode = new TableSourceNode({
+      sqlTable: sqlModules.getTable('slice'),
+      trace,
+      sqlModules,
+    });
+
+    const filterNode = new FilterNode({
+      prevNode: tableNode,
+      filters: [
+        {
+          column: 'name',
+          op: 'is null',
+        },
+      ],
+    });
+    tableNode.nextNodes.push(filterNode);
+
+    const initialState: ExplorePageState = {
+      rootNodes: [tableNode],
+      nodeLayouts: new Map(),
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    expect(deserializedState.rootNodes.length).toBe(1);
+    const deserializedTableNode = deserializedState.rootNodes[0];
+    expect(deserializedTableNode.nextNodes.length).toBe(1);
+    const deserializedNode = deserializedTableNode.nextNodes[0] as FilterNode;
+
+    // Verify filter
+    expect(deserializedNode.state.filters).toBeDefined();
+    expect(deserializedNode.state.filters?.length).toBe(1);
+    expect(deserializedNode.state.filters?.[0].column).toBe('name');
+    expect(deserializedNode.state.filters?.[0].op).toBe('is null');
+    // Null filters don't have a value property
+    expect('value' in deserializedNode.state.filters![0]).toBe(false);
   });
 
   test('serializes and deserializes merge node with equality condition', () => {
@@ -872,6 +988,13 @@ describe('JSON serialization/deserialization', () => {
       leftColumn: 'name',
       rightColumn: 'name',
       sqlExpression: '',
+      comment: 'Join on matching names with duration filter',
+    });
+    tableNode1.nextNodes.push(mergeNode);
+    tableNode2.nextNodes.push(mergeNode);
+
+    const filterNode = new FilterNode({
+      prevNode: mergeNode,
       filters: [
         {
           column: 'dur',
@@ -879,10 +1002,8 @@ describe('JSON serialization/deserialization', () => {
           value: '1000',
         },
       ],
-      comment: 'Join on matching names with duration filter',
     });
-    tableNode1.nextNodes.push(mergeNode);
-    tableNode2.nextNodes.push(mergeNode);
+    mergeNode.nextNodes.push(filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode1, tableNode2],
@@ -897,13 +1018,16 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode1.nextNodes.length).toBe(1);
     const deserializedMergeNode = deserializedTableNode1
       .nextNodes[0] as MergeNode;
-    expect(deserializedMergeNode.state.filters).toBeDefined();
-    expect(deserializedMergeNode.state.filters?.length).toBe(1);
-    expect(deserializedMergeNode.state.filters?.[0].column).toBe('dur');
-    expect(deserializedMergeNode.state.filters?.[0].op).toBe('>');
     expect(deserializedMergeNode.state.comment).toBe(
       'Join on matching names with duration filter',
     );
+    expect(deserializedMergeNode.nextNodes.length).toBe(1);
+    const deserializedFilterNode = deserializedMergeNode
+      .nextNodes[0] as FilterNode;
+    expect(deserializedFilterNode.state.filters).toBeDefined();
+    expect(deserializedFilterNode.state.filters?.length).toBe(1);
+    expect(deserializedFilterNode.state.filters?.[0].column).toBe('dur');
+    expect(deserializedFilterNode.state.filters?.[0].op).toBe('>');
   });
 
   test('serializes and deserializes union node with filters and comment', () => {
@@ -937,13 +1061,6 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    unionNode.filters = [
-      {
-        column: 'name',
-        op: '!=',
-        value: 'idle',
-      },
-    ];
     unionNode.comment = 'Union of slice sources excluding idle';
     tableNode1.nextNodes.push(unionNode);
     tableNode2.nextNodes.push(unionNode);
@@ -961,10 +1078,6 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode1.nextNodes.length).toBe(1);
     const deserializedUnionNode = deserializedTableNode1
       .nextNodes[0] as UnionNode;
-    expect(deserializedUnionNode.filters).toBeDefined();
-    expect(deserializedUnionNode.filters?.length).toBe(1);
-    expect(deserializedUnionNode.filters?.[0].column).toBe('name');
-    expect(deserializedUnionNode.filters?.[0].op).toBe('!=');
     expect(deserializedUnionNode.comment).toBe(
       'Union of slice sources excluding idle',
     );
@@ -1144,6 +1257,10 @@ describe('JSON serialization/deserialization', () => {
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
+    });
+
+    const filterNode = new FilterNode({
+      prevNode: tableNode,
       filters: [
         {
           column: 'name',
@@ -1152,10 +1269,11 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
+    tableNode.nextNodes.push(filterNode);
 
     const sliceTable = sqlModules.getTable('slice')!;
     const modifyNode = new ModifyColumnsNode({
-      prevNode: tableNode,
+      prevNode: filterNode,
       newColumns: [{expression: 'dur / 1000', name: 'dur_ms'}],
       selectedColumns: [
         {
@@ -1166,7 +1284,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    tableNode.nextNodes.push(modifyNode);
+    filterNode.nextNodes.push(modifyNode);
 
     const aggregationNode = new AggregationNode({
       prevNode: modifyNode,
@@ -1210,6 +1328,7 @@ describe('JSON serialization/deserialization', () => {
       rootNodes: [tableNode],
       nodeLayouts: new Map([
         [tableNode.nodeId, {x: 0, y: 0}],
+        [filterNode.nodeId, {x: 0, y: 50}],
         [modifyNode.nodeId, {x: 0, y: 100}],
         [aggregationNode.nodeId, {x: 0, y: 200}],
         [sortNode.nodeId, {x: 0, y: 300}],
@@ -1224,26 +1343,30 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedState.rootNodes.length).toBe(1);
     const node1 = deserializedState.rootNodes[0] as TableSourceNode;
     expect(node1.nextNodes.length).toBe(1);
-    expect(node1.state.filters?.length).toBe(1);
 
-    const node2 = node1.nextNodes[0] as ModifyColumnsNode;
+    const node2 = node1.nextNodes[0] as FilterNode;
     expect(node2.prevNode?.nodeId).toBe(node1.nodeId);
+    expect(node2.state.filters?.length).toBe(1);
     expect(node2.nextNodes.length).toBe(1);
 
-    const node3 = node2.nextNodes[0] as AggregationNode;
+    const node3 = node2.nextNodes[0] as ModifyColumnsNode;
     expect(node3.prevNode?.nodeId).toBe(node2.nodeId);
     expect(node3.nextNodes.length).toBe(1);
 
-    const node4 = node3.nextNodes[0] as SortNode;
+    const node4 = node3.nextNodes[0] as AggregationNode;
     expect(node4.prevNode?.nodeId).toBe(node3.nodeId);
     expect(node4.nextNodes.length).toBe(1);
 
-    const node5 = node4.nextNodes[0] as LimitAndOffsetNode;
+    const node5 = node4.nextNodes[0] as SortNode;
     expect(node5.prevNode?.nodeId).toBe(node4.nodeId);
-    expect(node5.state.limit).toBe(10);
+    expect(node5.nextNodes.length).toBe(1);
+
+    const node6 = node5.nextNodes[0] as LimitAndOffsetNode;
+    expect(node6.prevNode?.nodeId).toBe(node5.nodeId);
+    expect(node6.state.limit).toBe(10);
 
     // Verify all layouts preserved
-    expect(deserializedState.nodeLayouts.size).toBe(5);
+    expect(deserializedState.nodeLayouts.size).toBe(6);
   });
 
   test('serializes and deserializes branching graph', () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -111,8 +111,8 @@ export interface BuilderAttrs {
   readonly onDeleteNode: (node: QueryNode) => void;
   readonly onClearAllNodes: () => void;
   readonly onDuplicateNode: (node: QueryNode) => void;
-  readonly onRemoveFilter: (node: QueryNode, filter: UIFilter) => void;
   readonly onConnectionRemove: (fromNode: QueryNode, toNode: QueryNode) => void;
+  readonly onFilterAdd: (node: QueryNode, filter: UIFilter) => void;
 
   // Import / Export JSON
   readonly onImport: () => void;
@@ -245,6 +245,9 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               onchange: () => {
                 attrs.onNodeStateChange?.();
               },
+              onFilterAdd: (filter) => {
+                attrs.onFilterAdd(selectedNode, filter);
+              },
               isFullScreen:
                 this.drawerVisibility === SplitPanelDrawerVisibility.FULLSCREEN,
               onFullScreenToggle: () => {
@@ -285,7 +288,6 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
           onImport: attrs.onImport,
           onImportWithStatement: attrs.onImportWithStatement,
           onExport: attrs.onExport,
-          onRemoveFilter: attrs.onRemoveFilter,
         }),
         selectedNode &&
           m(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -32,6 +32,7 @@ import {
 } from './nodes/interval_intersect_node';
 import {MergeNode, MergeNodeState} from './nodes/merge_node';
 import {SortNode, SortNodeState} from './nodes/sort_node';
+import {FilterNode, FilterNodeState} from './nodes/filter_node';
 import {UnionNode, UnionNodeState} from './nodes/union_node';
 import {
   LimitAndOffsetNode,
@@ -159,6 +160,14 @@ export function registerCoreNodes() {
     icon: 'sort',
     type: 'modification',
     factory: (state) => new SortNode(state as SortNodeState),
+  });
+
+  nodeRegistry.register('filter_node', {
+    name: 'Filter',
+    description: 'Filter rows based on column values.',
+    icon: 'filter_alt',
+    type: 'modification',
+    factory: (state) => new FilterNode(state as FilterNodeState),
   });
 
   nodeRegistry.register('union_node', {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -52,6 +52,7 @@ export interface DataExplorerAttrs {
   readonly onFullScreenToggle: () => void;
   readonly onExecute: () => void;
   readonly onchange?: () => void;
+  readonly onFilterAdd?: (filter: FilterValue | FilterNull) => void;
 }
 
 export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
@@ -219,11 +220,17 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
               'is not null',
             ];
             if (supportedOps.includes(filter.op)) {
-              attrs.node.state.filters = [
-                ...(attrs.node.state.filters ?? []),
-                filter as FilterValue | FilterNull,
-              ];
-              attrs.onchange?.();
+              if (attrs.onFilterAdd) {
+                // Delegate to the parent handler which will create a FilterNode
+                attrs.onFilterAdd(filter as FilterValue | FilterNull);
+              } else {
+                // Fallback: add filter directly to node state (legacy behavior)
+                attrs.node.state.filters = [
+                  ...(attrs.node.state.filters ?? []),
+                  filter as FilterValue | FilterNull,
+                ];
+                attrs.onchange?.();
+              }
             }
           },
           cellRenderer: (value: SqlValue, name: string) => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -50,7 +50,6 @@ import {
   NodeGraphAttrs,
   NodePort,
 } from '../../../../widgets/nodegraph';
-import {UIFilter} from '../operations/filter';
 import {
   QueryNode,
   singleNodeOperation,
@@ -121,7 +120,6 @@ export interface GraphAttrs {
   readonly onImport: () => void;
   readonly onImportWithStatement: () => void;
   readonly onExport: () => void;
-  readonly onRemoveFilter: (node: QueryNode, filter: UIFilter) => void;
   readonly devMode?: boolean;
   readonly onDevModeChange?: (enabled: boolean) => void;
 }
@@ -418,7 +416,6 @@ function createNodeConfig(
       onDuplicateNode: attrs.onDuplicateNode,
       onDeleteNode: attrs.onDeleteNode,
       onAddOperationNode: attrs.onAddOperationNode,
-      onRemoveFilter: attrs.onRemoveFilter,
     }),
     next: getNextDockedNode(qnode, attrs),
   };

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
@@ -19,7 +19,6 @@ import {Icons} from '../../../../base/semantic_icons';
 import {Button} from '../../../../widgets/button';
 import {MenuItem, PopupMenu} from '../../../../widgets/menu';
 import {QueryNode, singleNodeOperation, NodeType} from '../../query_node';
-import {UIFilter, formatFilterDetails} from '../operations/filter';
 import {Icon} from '../../../../widgets/icon';
 import {Callout} from '../../../../widgets/callout';
 import {Intent} from '../../../../widgets/common';
@@ -29,7 +28,6 @@ export interface NodeActions {
   readonly onDuplicateNode: (node: QueryNode) => void;
   readonly onDeleteNode: (node: QueryNode) => void;
   readonly onAddOperationNode: (id: string, node: QueryNode) => void;
-  readonly onRemoveFilter: (node: QueryNode, filter: UIFilter) => void;
 }
 
 export interface NodeBoxAttrs extends NodeActions {
@@ -100,16 +98,6 @@ export function renderAddButton(attrs: NodeBoxAttrs): m.Child {
   );
 }
 
-export function renderFilters(attrs: NodeBoxAttrs): m.Child {
-  const {node, onRemoveFilter} = attrs;
-  return formatFilterDetails(
-    node.state.filters,
-    node.state.filterOperator,
-    node.state,
-    (filter) => onRemoveFilter(node, filter),
-  );
-}
-
 export const NodeBox: m.Component<NodeBoxAttrs> = {
   view({attrs}) {
     const {node} = attrs;
@@ -125,7 +113,6 @@ export const NodeBox: m.Component<NodeBoxAttrs> = {
         node.state.comment &&
           m(Callout, {intent: Intent.None}, node.state.comment),
         m('.pf-exp-node-box__details', node.nodeDetails?.()),
-        renderFilters(attrs),
       ),
       m(
         '.pf-exp-node-box__actions',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -23,7 +23,6 @@ import {ColumnInfo, columnInfoFromName} from '../column_info';
 import protos from '../../../../protos';
 import m from 'mithril';
 import {Card, CardStack} from '../../../../widgets/card';
-import {renderFilterOperation} from '../operations/filter';
 import {MultiselectInput} from '../../../../widgets/multiselect_input';
 import {Select} from '../../../../widgets/select';
 import {Button} from '../../../../widgets/button';
@@ -75,7 +74,6 @@ export class AddColumnsNode implements ModificationNode {
     this.prevNode = state.prevNode;
     this.inputNodes = [];
     this.nextNodes = [];
-    this.state.filters = this.state.filters ?? [];
     this.state.selectedColumns = this.state.selectedColumns ?? [];
     this.state.leftColumn = this.state.leftColumn ?? 'id';
     this.state.rightColumn = this.state.rightColumn ?? 'id';
@@ -668,19 +666,6 @@ export class AddColumnsNode implements ModificationNode {
           ),
         ),
       ),
-      renderFilterOperation(
-        this.state.filters,
-        this.state.filterOperator,
-        this.finalCols,
-        (newFilters) => {
-          this.state.filters = [...newFilters];
-          this.state.onchange?.();
-        },
-        (operator) => {
-          this.state.filterOperator = operator;
-          this.state.onchange?.();
-        },
-      ),
     ]);
   }
 
@@ -786,26 +771,6 @@ export class AddColumnsNode implements ModificationNode {
         ? Object.fromEntries(this.state.columnAliases)
         : undefined,
       isGuidedConnection: this.state.isGuidedConnection,
-      filters: this.state.filters?.map((f) => {
-        // Explicitly extract only serializable fields from filters
-        if ('value' in f) {
-          // FilterValue type
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          // FilterNull type
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
-      filterOperator: this.state.filterOperator,
       comment: this.state.comment,
       autoExecute: this.state.autoExecute,
     };

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
@@ -1,0 +1,176 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {
+  QueryNode,
+  QueryNodeState,
+  nextNodeId,
+  NodeType,
+  ModificationNode,
+} from '../../query_node';
+import {ColumnInfo} from '../column_info';
+import protos from '../../../../protos';
+import {
+  UIFilter,
+  renderFilterOperation,
+  createExperimentalFiltersProto,
+  formatFilterDetails,
+} from '../operations/filter';
+import {StructuredQueryBuilder} from '../structured_query_builder';
+
+export interface FilterNodeState extends QueryNodeState {
+  prevNode: QueryNode;
+  filters?: UIFilter[];
+  filterOperator?: 'AND' | 'OR';
+}
+
+export class FilterNode implements ModificationNode {
+  readonly nodeId: string;
+  readonly type = NodeType.kFilter;
+  readonly prevNode: QueryNode;
+  nextNodes: QueryNode[];
+  readonly state: FilterNodeState;
+
+  constructor(state: FilterNodeState) {
+    this.nodeId = nextNodeId();
+    this.state = state;
+    this.prevNode = state.prevNode;
+    this.nextNodes = [];
+  }
+
+  get sourceCols(): ColumnInfo[] {
+    return this.prevNode?.finalCols ?? [];
+  }
+
+  get finalCols(): ColumnInfo[] {
+    return this.sourceCols;
+  }
+
+  getTitle(): string {
+    return 'Filter';
+  }
+
+  nodeDetails(): m.Child {
+    if (!this.state.filters || this.state.filters.length === 0) {
+      return m('.pf-filter-node-details', 'No filters applied');
+    }
+
+    return formatFilterDetails(
+      this.state.filters,
+      this.state.filterOperator,
+      this.state,
+      (filter) => {
+        if (this.state.filters) {
+          const filterIndex = this.state.filters.indexOf(filter);
+          if (filterIndex > -1) {
+            this.state.filters.splice(filterIndex, 1);
+            this.state.onchange?.();
+          }
+        }
+      },
+    );
+  }
+
+  nodeSpecificModify(): m.Child {
+    return renderFilterOperation(
+      this.state.filters,
+      this.state.filterOperator,
+      this.sourceCols,
+      (newFilters) => {
+        this.state.filters = [...newFilters];
+        this.state.onchange?.();
+      },
+      (operator) => {
+        this.state.filterOperator = operator;
+        this.state.onchange?.();
+      },
+    );
+  }
+
+  validate(): boolean {
+    return this.prevNode !== undefined;
+  }
+
+  clone(): QueryNode {
+    return new FilterNode(this.state);
+  }
+
+  getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
+    if (this.prevNode === undefined) return undefined;
+
+    // If no filters are defined, just return the previous node's query
+    if (!this.state.filters || this.state.filters.length === 0) {
+      return this.prevNode.getStructuredQuery();
+    }
+
+    const filtersProto = createExperimentalFiltersProto(
+      this.state.filters,
+      this.sourceCols,
+      this.state.filterOperator,
+    );
+
+    if (!filtersProto) {
+      return this.prevNode.getStructuredQuery();
+    }
+
+    return StructuredQueryBuilder.withFilter(
+      this.prevNode,
+      filtersProto,
+      this.nodeId,
+    );
+  }
+
+  serializeState(): object {
+    return {
+      filters: this.state.filters?.map((f) => {
+        if ('value' in f) {
+          return {
+            column: f.column,
+            op: f.op,
+            value: f.value,
+            enabled: f.enabled,
+          };
+        } else {
+          return {
+            column: f.column,
+            op: f.op,
+            enabled: f.enabled,
+          };
+        }
+      }),
+      filterOperator: this.state.filterOperator,
+      comment: this.state.comment,
+    };
+  }
+
+  /**
+   * Deserializes a FilterNodeState from JSON.
+   *
+   * IMPORTANT: This method returns a state with prevNode set to undefined.
+   * The caller (typically json_handler.ts) is responsible for:
+   * 1. Creating all nodes first with undefined prevNode references
+   * 2. Reconnecting the graph by setting prevNode references based on serialized node IDs
+   * 3. Calling validate() on each node after reconnection to ensure graph integrity
+   *
+   * @param state The serialized state (prevNode will be ignored)
+   * @returns A FilterNodeState with prevNode set to undefined (to be set by caller)
+   */
+  static deserializeState(state: FilterNodeState): FilterNodeState {
+    return {
+      ...state,
+      prevNode: undefined as unknown as QueryNode,
+    };
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -25,7 +25,6 @@ import {ColumnInfo, newColumnInfoList} from '../column_info';
 import {Button} from '../../../../widgets/button';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
-import {UIFilter} from '../operations/filter';
 import {
   PopupMultiSelect,
   MultiSelectOption,
@@ -35,7 +34,6 @@ import {StructuredQueryBuilder} from '../structured_query_builder';
 
 export interface IntervalIntersectSerializedState {
   intervalNodes: string[];
-  filters?: UIFilter[];
   comment?: string;
   filterNegativeDur?: boolean[]; // Per-input filter to exclude negative durations
   partitionColumns?: string[]; // Columns to partition by during interval intersection
@@ -359,7 +357,6 @@ export class IntervalIntersectNode implements MultiSourceNode {
   clone(): QueryNode {
     const stateCopy: IntervalIntersectNodeState = {
       prevNodes: [...this.state.prevNodes],
-      filters: this.state.filters ? [...this.state.filters] : undefined,
       filterNegativeDur: this.state.filterNegativeDur
         ? [...this.state.filterNegativeDur]
         : undefined,
@@ -389,23 +386,6 @@ export class IntervalIntersectNode implements MultiSourceNode {
         .slice(1)
         .filter((n): n is QueryNode => n !== undefined)
         .map((n) => n.nodeId),
-      filters: this.state.filters?.map((f) => {
-        // Explicitly extract only serializable fields to avoid circular references
-        if ('value' in f) {
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
       comment: this.state.comment,
       filterNegativeDur: this.state.filterNegativeDur,
       partitionColumns: this.state.partitionColumns,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/merge_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/merge_node.ts
@@ -24,7 +24,6 @@ import protos from '../../../../protos';
 import {ColumnInfo} from '../column_info';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
-import {UIFilter} from '../operations/filter';
 import {Card, CardStack} from '../../../../widgets/card';
 import {TextInput} from '../../../../widgets/text_input';
 import {TabStrip} from '../../../../widgets/tabs';
@@ -44,7 +43,6 @@ export interface MergeSerializedState {
   leftColumn?: string;
   rightColumn?: string;
   sqlExpression?: string;
-  filters?: UIFilter[];
   comment?: string;
 }
 
@@ -349,7 +347,6 @@ export class MergeNode implements MultiSourceNode {
   clone(): QueryNode {
     const stateCopy: MergeNodeState = {
       prevNodes: [...this.state.prevNodes],
-      filters: this.state.filters ? [...this.state.filters] : undefined,
       onchange: this.state.onchange,
       leftQueryAlias: this.state.leftQueryAlias,
       rightQueryAlias: this.state.rightQueryAlias,
@@ -397,23 +394,6 @@ export class MergeNode implements MultiSourceNode {
       leftColumn: this.state.leftColumn,
       rightColumn: this.state.rightColumn,
       sqlExpression: this.state.sqlExpression,
-      filters: this.state.filters?.map((f) => {
-        // Explicitly extract only serializable fields to avoid circular references
-        if ('value' in f) {
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -33,11 +33,6 @@ import {
   newColumnInfoList,
 } from '../column_info';
 import protos from '../../../../protos';
-import {
-  createExperimentalFiltersProto,
-  renderFilterOperation,
-  UIFilter,
-} from '../operations/filter';
 import {NodeIssues} from '../node_issues';
 import {StructuredQueryBuilder, ColumnSpec} from '../structured_query_builder';
 
@@ -368,8 +363,6 @@ export interface ModifyColumnsSerializedState {
     checked: boolean;
     alias?: string;
   }[];
-  filters?: UIFilter[];
-  filterOperator?: 'AND' | 'OR';
   comment?: string;
 }
 
@@ -377,7 +370,6 @@ export interface ModifyColumnsState extends QueryNodeState {
   prevNode: QueryNode;
   newColumns: NewColumn[];
   selectedColumns: ColumnInfo[];
-  filters?: UIFilter[];
 }
 
 export class ModifyColumnsNode implements ModificationNode {
@@ -743,7 +735,6 @@ export class ModifyColumnsNode implements ModificationNode {
           ),
         ),
       ),
-      this.renderFilterOperation(),
     );
   }
 
@@ -1028,22 +1019,6 @@ export class ModifyColumnsNode implements ModificationNode {
     });
   }
 
-  private renderFilterOperation(): m.Child {
-    return renderFilterOperation(
-      this.state.filters,
-      this.state.filterOperator,
-      this.finalCols,
-      (newFilters) => {
-        this.state.filters = [...newFilters];
-        this.state.onchange?.();
-      },
-      (operator) => {
-        this.state.filterOperator = operator;
-        this.state.onchange?.();
-      },
-    );
-  }
-
   clone(): QueryNode {
     return new ModifyColumnsNode(this.state);
   }
@@ -1076,32 +1051,13 @@ export class ModifyColumnsNode implements ModificationNode {
       .filter((col) => col.module)
       .map((col) => col.module!);
 
-    // Handle filters
-    const filtersProto = createExperimentalFiltersProto(
-      this.state.filters,
-      this.finalCols,
-      this.state.filterOperator,
-    );
-
     // Apply column selection
-    const sq = StructuredQueryBuilder.withSelectColumns(
+    return StructuredQueryBuilder.withSelectColumns(
       this.prevNode,
       columns,
       referencedModules.length > 0 ? referencedModules : undefined,
-      filtersProto ? undefined : this.nodeId,
+      this.nodeId,
     );
-    if (!sq) return undefined;
-
-    if (filtersProto) {
-      // Wrap with filters and assign nodeId to outer query
-      const outerSq = new protos.PerfettoSqlStructuredQuery();
-      outerSq.id = this.nodeId;
-      outerSq.innerQuery = sq;
-      outerSq.experimentalFilterGroup = filtersProto;
-      return outerSq;
-    }
-
-    return sq;
   }
 
   serializeState(): ModifyColumnsSerializedState {
@@ -1128,26 +1084,6 @@ export class ModifyColumnsNode implements ModificationNode {
         checked: c.checked,
         alias: c.alias,
       })),
-      filters: this.state.filters?.map((f) => {
-        // Explicitly extract only serializable fields from filters
-        if ('value' in f) {
-          // FilterValue type
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          // FilterNull type
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
-      filterOperator: this.state.filterOperator,
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -25,15 +25,8 @@ import {ColumnInfo, columnInfoFromSqlColumn} from '../../column_info';
 import protos from '../../../../../protos';
 import {SqlColumn} from '../../../../dev.perfetto.SqlModules/sql_modules';
 import {StructuredQueryBuilder} from '../../structured_query_builder';
-import {
-  createExperimentalFiltersProto,
-  renderFilterOperation,
-  UIFilter,
-} from '../../operations/filter';
 
 export interface SlicesSourceSerializedState {
-  filters?: UIFilter[];
-  filterOperator?: 'AND' | 'OR';
   comment?: string;
 }
 
@@ -53,7 +46,6 @@ export class SlicesSourceNode implements SourceNode {
     this.state.onchange = attrs.onchange;
     this.finalCols = createFinalColumns(slicesSourceNodeColumns(true));
     this.nextNodes = [];
-    this.state.filters = attrs.filters ?? [];
   }
 
   get type() {
@@ -66,7 +58,6 @@ export class SlicesSourceNode implements SourceNode {
 
   clone(): QueryNode {
     const stateCopy: SlicesSourceState = {
-      filters: this.state.filters?.map((f) => ({...f})),
       onchange: this.state.onchange,
     };
     return new SlicesSourceNode(stateCopy);
@@ -78,24 +69,6 @@ export class SlicesSourceNode implements SourceNode {
 
   serializeState(): SlicesSourceSerializedState {
     return {
-      filters: this.state.filters?.map((f) => {
-        // Explicitly extract only serializable fields to avoid circular references
-        if ('value' in f) {
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
-      filterOperator: this.state.filterOperator,
       comment: this.state.comment,
     };
   }
@@ -110,13 +83,6 @@ export class SlicesSourceNode implements SourceNode {
       this.nodeId,
     );
 
-    const filtersProto = createExperimentalFiltersProto(
-      this.state.filters,
-      this.finalCols,
-      this.state.filterOperator,
-    );
-    if (filtersProto) sq.experimentalFilterGroup = filtersProto;
-
     // Manually create selectColumns for the specific columns we want
     const selectColumns: protos.PerfettoSqlStructuredQuery.SelectColumn[] = [];
     for (const col of this.finalCols) {
@@ -130,19 +96,7 @@ export class SlicesSourceNode implements SourceNode {
   }
 
   nodeSpecificModify(): m.Child {
-    return renderFilterOperation(
-      this.state.filters,
-      this.state.filterOperator,
-      this.finalCols,
-      (newFilters) => {
-        this.state.filters = [...newFilters];
-        this.state.onchange?.();
-      },
-      (operator) => {
-        this.state.filterOperator = operator;
-        this.state.onchange?.();
-      },
-    );
+    return undefined;
   }
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -34,11 +34,9 @@ import {
 import {Trace} from '../../../../../public/trace';
 
 import {ColumnInfo} from '../../column_info';
-import {UIFilter} from '../../operations/filter';
 
 export interface SqlSourceSerializedState {
   sql?: string;
-  filters?: UIFilter[];
   comment?: string;
 }
 
@@ -84,7 +82,6 @@ export class SqlSourceNode implements MultiSourceNode {
   clone(): QueryNode {
     const stateCopy: SqlSourceState = {
       sql: this.state.sql,
-      filters: this.state.filters ? [...this.state.filters] : undefined,
       issues: this.state.issues,
       trace: this.state.trace,
     };
@@ -102,23 +99,6 @@ export class SqlSourceNode implements MultiSourceNode {
   serializeState(): SqlSourceSerializedState {
     return {
       sql: this.state.sql,
-      filters: this.state.filters?.map((f) => {
-        // Explicitly extract only serializable fields to avoid circular references
-        if ('value' in f) {
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
       comment: this.state.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
@@ -25,7 +25,6 @@ import protos from '../../../../protos';
 import {ColumnInfo, newColumnInfoList} from '../column_info';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
-import {UIFilter} from '../operations/filter';
 import {Card, CardStack} from '../../../../widgets/card';
 import {Checkbox} from '../../../../widgets/checkbox';
 import {StructuredQueryBuilder} from '../structured_query_builder';
@@ -33,7 +32,6 @@ import {StructuredQueryBuilder} from '../structured_query_builder';
 export interface UnionSerializedState {
   unionNodes: string[];
   selectedColumns: ColumnInfo[];
-  filters?: UIFilter[];
   comment?: string;
 }
 
@@ -49,7 +47,6 @@ export class UnionNode implements MultiSourceNode {
   nextNodes: QueryNode[];
   readonly state: UnionNodeState;
   comment?: string;
-  filters?: UIFilter[];
 
   get finalCols(): ColumnInfo[] {
     return this.state.selectedColumns.filter((col) => col.checked);
@@ -247,7 +244,6 @@ export class UnionNode implements MultiSourceNode {
       selectedColumns: this.state.selectedColumns.map((c) => ({...c})),
     };
     const clone = new UnionNode(stateCopy);
-    clone.filters = this.filters ? [...this.filters] : undefined;
     clone.comment = this.comment;
     return clone;
   }
@@ -267,23 +263,6 @@ export class UnionNode implements MultiSourceNode {
     return {
       unionNodes: this.prevNodes.slice(1).map((n) => n.nodeId),
       selectedColumns: this.state.selectedColumns,
-      filters: this.filters?.map((f) => {
-        // Explicitly extract only serializable fields to avoid circular references
-        if ('value' in f) {
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
       comment: this.comment,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/structured_query_builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/structured_query_builder.ts
@@ -533,4 +533,29 @@ export class StructuredQueryBuilder {
     sq.experimentalAddColumns = addColumns;
     return sq;
   }
+
+  /**
+   * Creates a structured query with filters applied.
+   * Wraps the inner query and adds the filter group.
+   *
+   * @param innerQuery The query to filter (can be a QueryNode or structured query)
+   * @param filterGroup The filter group to apply
+   * @param nodeId The node id to assign
+   * @returns A new structured query with filters, or undefined if extraction fails
+   */
+  static withFilter(
+    innerQuery: QuerySource,
+    filterGroup: protos.PerfettoSqlStructuredQuery.ExperimentalFilterGroup,
+    nodeId?: string,
+  ): protos.PerfettoSqlStructuredQuery | undefined {
+    const query = extractQuery(innerQuery);
+    if (!query) return undefined;
+
+    const sq = new protos.PerfettoSqlStructuredQuery();
+    sq.id = nodeId ?? nextNodeId();
+    sq.innerQuery = query;
+    sq.experimentalFilterGroup = filterGroup;
+
+    return sq;
+  }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -38,6 +38,7 @@ export enum NodeType {
   kAddColumns,
   kLimitAndOffset,
   kSort,
+  kFilter,
 
   // Multi node operations
   kIntervalIntersect,
@@ -52,6 +53,7 @@ export function singleNodeOperation(type: NodeType): boolean {
     case NodeType.kAddColumns:
     case NodeType.kLimitAndOffset:
     case NodeType.kSort:
+    case NodeType.kFilter:
       return true;
     default:
       return false;


### PR DESCRIPTION
 1. New FilterNode Architecture
  - Creates a standalone FilterNode class that encapsulates filtering logic
  - Filters are now first-class nodes in the query graph rather than properties on other nodes
  - Registered in core_nodes.ts:165 as a new node type

  2. Smart Filter Management (explore_page.ts:327)
  - handleFilterAdd() intelligently reuses existing FilterNodes when possible:
   - If source is already a FilterNode → adds filter to it
   - If source has one child FilterNode → adds filter to child
   - Otherwise → creates new FilterNode after source
  - Changes onRemoveFilter → onFilterAdd callback pattern

  3. Serialization Updates (json_handler.ts)
  - Removes filters property from MergeNode and UnionNode serialization
  - Adds FilterNode serialization/deserialization support
  - Extensive test updates (34 test modifications) to reflect new architecture