### PR TITLE
ui: Remove "supporting columns" from SqlTable

### DIFF
--- a/python/tools/check_ratchet.py
+++ b/python/tools/check_ratchet.py
@@ -36,7 +36,7 @@ import dataclasses
 
 from dataclasses import dataclass
 
-EXPECTED_ANY_COUNT = 32
+EXPECTED_ANY_COUNT = 35
 EXPECTED_RUN_METRIC_COUNT = 4
 
 ROOT_DIR = os.path.dirname(

--- a/ui/src/base/json_utils.ts
+++ b/ui/src/base/json_utils.ts
@@ -27,3 +27,23 @@ export function stringifyJsonWithBigints(
     space,
   );
 }
+
+// Typescript bindings do not pass `context` to the reviver, so this helper works around that.
+function parseJson(
+  text: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reviver?: (key: string, value: any, context: {source: string}) => any,
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return JSON.parse(text, reviver as (key: string, value: any) => any);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function parseJsonWithBigints(text: string): any {
+  return parseJson(text, (_, value, context) => {
+    if (typeof value === 'number' && Number.isInteger(value)) {
+      return BigInt(context.source);
+    }
+    return value;
+  });
+}

--- a/ui/src/base/json_utils_unittest.ts
+++ b/ui/src/base/json_utils_unittest.ts
@@ -19,12 +19,3 @@ test('stringifyJsonWithBigints', () => {
   const expected = '{"foo":"bar","baz":"123"}';
   expect(stringifyJsonWithBigints(obj)).toEqual(expected);
 });
-
-test('stringifyJsonWithBigints with space', () => {
-  const obj = {foo: 'bar', baz: 123n};
-  const expected = `{
-  "foo": "bar",
-  "baz": "123"
-}`;
-  expect(stringifyJsonWithBigints(obj, 2)).toEqual(expected);
-});

--- a/ui/src/components/widgets/sql/table/menus/cast_column_menu.ts
+++ b/ui/src/components/widgets/sql/table/menus/cast_column_menu.ts
@@ -94,18 +94,10 @@ export class CastColumn implements TableColumn {
     return this.wrappedColumn.getTitle?.();
   }
 
-  renderCell(
-    value: SqlValue,
-    tableManager?: TableManager,
-    supportingValues?: {} | undefined,
-  ): RenderedCell {
+  renderCell(value: SqlValue, tableManager?: TableManager): RenderedCell {
     // Delegate rendering to the appropriate column type based on the cast type
     // This allows proper formatting for timestamps, durations, etc.
-    return this.wrappedColumn.renderCell(value, tableManager, supportingValues);
-  }
-
-  supportingColumns() {
-    return this.wrappedColumn.supportingColumns?.() || (() => {});
+    return this.wrappedColumn.renderCell(value, tableManager);
   }
 
   listDerivedColumns(manager: TableManager) {

--- a/ui/src/components/widgets/sql/table/menus/transform_column_menu.ts
+++ b/ui/src/components/widgets/sql/table/menus/transform_column_menu.ts
@@ -146,20 +146,8 @@ export class TransformColumn implements TableColumn {
     return this.args.transformed.getTitle?.();
   }
 
-  renderCell(
-    value: SqlValue,
-    tableManager?: TableManager,
-    supportingValues?: {} | undefined,
-  ): RenderedCell {
-    return this.args.transformed.renderCell(
-      value,
-      tableManager,
-      supportingValues,
-    );
-  }
-
-  supportingColumns() {
-    return this.args.transformed.supportingColumns?.() || (() => {});
+  renderCell(value: SqlValue, tableManager?: TableManager): RenderedCell {
+    return this.args.transformed.renderCell(value, tableManager);
   }
 
   listDerivedColumns(manager: TableManager) {

--- a/ui/src/components/widgets/sql/table/sql_column.ts
+++ b/ui/src/components/widgets/sql/table/sql_column.ts
@@ -65,6 +65,9 @@ export function sqlColumnId(column: SqlColumn): string {
     if (column.id !== undefined) return column.id;
     return `${column.op(column.columns.map(sqlColumnId))}`;
   }
+  if (column.id !== undefined) {
+    return column.id;
+  }
   // Special case: If the join is performed on a single column `id`, we can use a simpler representation (i.e. `table[id].column`).
   if (arrayEquals(Object.keys(column.source.joinOn), ['id'])) {
     return `${column.source.table}[${sqlColumnId(Object.values(column.source.joinOn)[0])}].${column.column}`;

--- a/ui/src/components/widgets/sql/table/state.ts
+++ b/ui/src/components/widgets/sql/table/state.ts
@@ -20,8 +20,6 @@ import {SortDirection} from '../../../../base/comparison_utils';
 import {assertTrue} from '../../../../base/logging';
 import {SqlTableDescription} from './table_description';
 import {Trace} from '../../../../public/trace';
-import {runQueryForQueryTable} from '../../../query_table/queries';
-import {AsyncLimiter} from '../../../../base/async_limiter';
 import {areFiltersEqual, Filter, Filters} from './filters';
 import {TableColumn, tableColumnAlias, tableColumnId} from './table_column';
 import {moveArrayItem} from '../../../../base/array_utils';
@@ -60,7 +58,6 @@ export class SqlTableState {
   public readonly uuid: string;
 
   private readonly additionalImports: string[];
-  private readonly asyncLimiter = new AsyncLimiter();
 
   // Columns currently displayed to the user. All potential columns can be found `this.table.columns`.
   private columns: TableColumn[];
@@ -72,8 +69,6 @@ export class SqlTableState {
   private request: Request;
   private data?: Data;
   private rowCount?: RowCount;
-
-  private _nonPaginatedData?: Data;
 
   constructor(
     readonly trace: Trace,
@@ -118,14 +113,6 @@ export class SqlTableState {
     this.reload();
   }
 
-  get nonPaginatedData() {
-    if (this._nonPaginatedData === undefined) {
-      this.getNonPaginatedData();
-    }
-
-    return this._nonPaginatedData;
-  }
-
   clone(): SqlTableState {
     return new SqlTableState(this.trace, this.config, {
       initialColumns: this.columns,
@@ -162,46 +149,16 @@ export class SqlTableState {
   }
 
   // We need column names to pass to the debug track creation logic.
-  private buildSqlSelectStatement(): {
+  private buildSqlSelectStatement(mode: 'display' | 'data'): {
     selectStatement: string;
     columns: {[key: string]: string};
   } {
-    const columns: {[key: string]: SqlColumn} = {};
-    // A set of columnIds for quick lookup.
-    const sqlColumnIds: Set<string> = new Set();
-    // We want to use the shortest posible name for each column, but we also need to mindful of potential collisions.
-    // To avoid collisions, we append a number to the column name if there are multiple columns with the same name.
-    const columnNameCount: {[key: string]: number} = {};
-
-    const tableColumns: {
-      column: SqlColumn;
-      name: string;
-      alias: string;
-    }[] = [];
-
-    for (const column of this.columns) {
-      // If TableColumn has an alias, use it. Otherwise, use the column name.
-      const name = tableColumnAlias(column);
-      if (!(name in columnNameCount)) {
-        columnNameCount[name] = 0;
-      }
-
-      // Note: this can break if the user specifies a column which ends with `__<number>`.
-      // We intentionally use two underscores to avoid collisions and will fix it down the line if it turns out to be a problem.
-      const alias = `${name}__${++columnNameCount[name]}`;
-      tableColumns.push({column: column.column, name, alias});
-    }
-
-    for (const column of tableColumns) {
-      const sqlColumn = column.column;
-      // If we have only one column with this name, we don't need to disambiguate it.
-      if (columnNameCount[column.name] === 1) {
-        columns[column.name] = sqlColumn;
-      } else {
-        columns[column.alias] = sqlColumn;
-      }
-      sqlColumnIds.add(sqlColumnId(sqlColumn));
-    }
+    const columns: {[key: string]: SqlColumn} = Object.fromEntries(
+      this.columns.map((c) => [
+        tableColumnAlias(c),
+        mode === 'data' ? c.column : c.display ?? c.column,
+      ]),
+    );
 
     return {
       selectStatement: this.getSqlQuery(columns),
@@ -218,12 +175,8 @@ export class SqlTableState {
     return `
       ${this.getSQLImports()}
 
-      ${this.buildSqlSelectStatement().selectStatement}
+      ${this.buildSqlSelectStatement('data').selectStatement}
     `;
-  }
-
-  getPaginatedSQLQuery(): Request {
-    return this.request;
   }
 
   canGoForward(): boolean {
@@ -267,7 +220,7 @@ export class SqlTableState {
   }
 
   private buildRequest(): Request {
-    const {selectStatement, columns} = this.buildSqlSelectStatement();
+    const {selectStatement, columns} = this.buildSqlSelectStatement('display');
     // We fetch one more row to determine if we can go forward.
     const query = `
       ${this.getSQLImports()}
@@ -331,22 +284,6 @@ export class SqlTableState {
     this.data = data;
 
     raf.scheduleFullRedraw();
-  }
-
-  private async getNonPaginatedData() {
-    this.asyncLimiter.schedule(async () => {
-      const queryRes = await runQueryForQueryTable(
-        this.getNonPaginatedSQLQuery(),
-        this.trace.engine,
-      );
-
-      this._nonPaginatedData = {
-        rows: queryRes.rows,
-        error: queryRes.error,
-      };
-
-      raf.scheduleFullRedraw();
-    });
   }
 
   getTotalRowCount(): number | undefined {

--- a/ui/src/components/widgets/sql/table/table.ts
+++ b/ui/src/components/widgets/sql/table/table.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {MenuDivider, MenuItem} from '../../../../widgets/menu';
 import {buildSqlQuery} from './query_builder';
 import {Icons} from '../../../../base/semantic_icons';
-import {Row, SqlValue} from '../../../../trace_processor/query_result';
+import {Row} from '../../../../trace_processor/query_result';
 import {Spinner} from '../../../../widgets/spinner';
 import {
   Grid,
@@ -62,20 +62,9 @@ function renderCell(
   state: SqlTableState,
 ): RenderedCell {
   const {columns} = state.getCurrentRequest();
-  const sqlValue = row[columns[sqlColumnId(column.column)]];
+  const sqlValue = row[columns[sqlColumnId(column.display ?? column.column)]];
 
-  const additionalValues: {[key: string]: SqlValue} = {};
-  const supportingColumns: {[key: string]: SqlColumn} =
-    column.supportingColumns?.() ?? {};
-  for (const [key, col] of Object.entries(supportingColumns)) {
-    additionalValues[key] = row[columns[sqlColumnId(col)]];
-  }
-
-  const result = column.renderCell(
-    sqlValue,
-    getTableManager(state),
-    additionalValues,
-  );
+  const result = column.renderCell(sqlValue, getTableManager(state));
 
   return result;
 }

--- a/ui/src/components/widgets/sql/table/table_column.ts
+++ b/ui/src/components/widgets/sql/table/table_column.ts
@@ -36,12 +36,14 @@ export interface TableColumnParams {
 }
 
 // Class which represents a column in a table, which can be displayed to the user.
-// It is based on the primary SQL column, but also contains additional information needed for displaying it as a part of a table.
-export interface TableColumn<
-  SupportingColumns extends {[key: string]: SqlColumn} = {},
-> {
+export interface TableColumn {
   readonly column: SqlColumn;
   readonly type: PerfettoSqlType | undefined;
+  // In some cases, the UI needs additional information to be able to render a given cell (e.g. for display arg values,
+  // we need to know arg type as well as arg value to generate a correct filter). In these cases, the common solution is fetch a JSON value
+  // or a protobuf from the SQL and render it accordingly, so if set, `display` column overrides which value is going to be passed to `renderCell`.
+  // `column` is still always going to be used for sorting, aggregation and casting.
+  readonly display?: SqlColumn;
 
   // Column title to be displayed.
   // If not set, then `alias` will be used if it's unique.
@@ -56,23 +58,13 @@ export interface TableColumn<
     replaceColumn: (column: TableColumn) => void;
   }): m.Children;
 
-  // In some cases to render a value in a table, we need information from additional columns.
-  // For example, args have three related columns: int_value, string_value and real_value. From the user perspective, we want to coalesce them into a single "value" column,
-  // but to do this correctly we need to fetch the `type` column.
-  supportingColumns?(): SupportingColumns;
-
   /**
    * Render a table cell. tableManager can be undefined, in which case the cell should provide basic rendering (e.g. for pivot table).
    *
    * @param value The value to be rendered.
    * @param tableManager Optional table manager to allow interaction with the table (e.g. adding filters).
-   * @param supportingValues Optional additional values needed to render the cell.
    */
-  renderCell(
-    value: SqlValue,
-    tableManager?: TableManager,
-    supportingValues?: {[key in keyof SupportingColumns]: SqlValue},
-  ): RenderedCell;
+  renderCell(value: SqlValue, tableManager?: TableManager): RenderedCell;
 
   // A set of columns to be added when opening this table.
   // It has two primary purposes:


### PR DESCRIPTION
Remove the concept of `supporting columns` from the SqlTable. It originally served
to allow richer visualisation of the data in the table (e.g. to render arg value
correctly we need to know its value, as well as its type). Supporting columns allowed
for multiple sql values to be fetched when rendering a given TableColumn.

A much better approach is to fetch a single complex value (in protobuf or json) and
render it. To support this, TableColumn.display is introduced: TableColumn.column is
still considered the "canonical" underlying value (used for aggregation, casting, etc),
while, if set, `TableColumn.display` is passed to `renderCell`.

This patch also converts the only existing use case for "supporting columns": a new
__intrinsic_serialise_arg(arg_set_id, key) SQL function is introduced, which returns
a ArgValue proto.

Also clean up some complexity in query generation which is no longer needed.
