### PR TITLE
ui: fix selecting columns for pivots

### DIFF
--- a/ui/src/components/details/sql_table_tab.ts
+++ b/ui/src/components/details/sql_table_tab.ts
@@ -20,7 +20,7 @@ import {Button} from '../../widgets/button';
 import {DetailsShell} from '../../widgets/details_shell';
 import {Popup, PopupPosition} from '../../widgets/popup';
 import {AddDebugTrackMenu} from '../tracks/add_debug_track_menu';
-import {SqlTableState} from '../widgets/sql/table/state';
+import {getSelectableColumns, SqlTableState} from '../widgets/sql/table/state';
 import {SqlTable} from '../widgets/sql/table/table';
 import {SqlTableDescription} from '../widgets/sql/table/table_description';
 import {Trace} from '../../public/trace';
@@ -215,6 +215,7 @@ class SqlTableTab implements Tab {
         }),
         content: m(PivotTable, {
           state: pivot,
+          getSelectableColumns: () => getSelectableColumns(this.tableState),
           extraRowButton: (node) =>
             // Do not show any buttons for root as it doesn't have any filters anyway.
             !node.isRoot() &&

--- a/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
+++ b/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
@@ -36,6 +36,7 @@ import {
 
 export interface PivotTableAttrs {
   readonly state: PivotTableState;
+  readonly getSelectableColumns: () => TableColumn[];
   // Additional button to render at the end of each row. Typically used
   // for adding new filters.
   extraRowButton?(node: PivotTreeNode): m.Children;
@@ -269,7 +270,7 @@ export class PivotTable implements m.ClassComponent<PivotTableAttrs> {
           icon: Icons.Add,
         },
         m(SelectColumnMenu, {
-          columns: state.table.columns.map((column) => ({
+          columns: attrs.getSelectableColumns().map((column) => ({
             key: tableColumnId(column),
             column,
           })),
@@ -365,7 +366,7 @@ export class PivotTable implements m.ClassComponent<PivotTableAttrs> {
           icon: Icons.Add,
         },
         m(SelectColumnMenu, {
-          columns: state.table.columns.map((column) => ({
+          columns: attrs.getSelectableColumns().map((column) => ({
             key: tableColumnId(column),
             column,
           })),
@@ -380,7 +381,7 @@ export class PivotTable implements m.ClassComponent<PivotTableAttrs> {
               }),
           },
           columnMenu: (column) => ({
-            rightIcon: '',
+            rightIcon: Icons.ContextMenuAlt,
             children: AGGREGATIONS.map((agg) =>
               m(MenuItem, {
                 label: agg,

--- a/ui/src/components/widgets/sql/table/state.ts
+++ b/ui/src/components/widgets/sql/table/state.ts
@@ -368,7 +368,18 @@ export class SqlTableState {
     moveArrayItem(this.columns, fromIndex, toIndex);
   }
 
-  getSelectedColumns(): TableColumn[] {
+  getSelectedColumns(): readonly TableColumn[] {
     return this.columns;
   }
+}
+
+export function getSelectableColumns(state: SqlTableState): TableColumn[] {
+  const columns = [...state.getSelectedColumns()];
+  const existingColumnIds = new Set<string>(columns.map(tableColumnId));
+  columns.concat(
+    state.config.columns.filter(
+      (c) => !existingColumnIds.has(tableColumnId(c)),
+    ),
+  );
+  return columns;
 }

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/pivot_table_tab.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/pivot_table_tab.ts
@@ -66,6 +66,7 @@ export class PivotTableTab implements AreaSelectionTab {
       isLoading: state?.getData() === undefined,
       content: m(PivotTable, {
         state,
+        getSelectableColumns: () => state.table.columns,
         extraRowButton: (node) =>
           m(Button, {
             icon: Icons.GoTo,


### PR DESCRIPTION
Before this patch, pivot table could only add pivots and aggregations
from the original columns of the table. With the ability to cast and
transform columns, this is not sufficient, so fix the selection menu
to also include the columns that have been added to the table by the user.

Before this patch:
<img width="318" height="436" alt="Screenshot 2025-11-09 at 19 02 19" src="https://github.com/user-attachments/assets/4f296517-b654-4738-b9bd-7a12332a7ee8" />

After this patch:
<img width="726" height="566" alt="Screenshot 2025-11-09 at 19 06 15" src="https://github.com/user-attachments/assets/055623f3-4065-455b-8196-1b7042581912" />

