### PR TITLE
Fix QueryResultIterator.Row.__repr__ to return string

### DIFF
--- a/python/perfetto/common/query_result_iterator.py
+++ b/python/perfetto/common/query_result_iterator.py
@@ -75,7 +75,7 @@ class QueryResultIterator(Sized):
       return str(self.__dict__)
 
     def __repr__(self):
-      return self.__dict__
+      return repr(self.__dict__)
 
   def __init__(self, column_names: List[str], batches: List):
     self.column_names = list(column_names)


### PR DESCRIPTION
The __repr__ method was returning a dict object instead of a string,
which violates Python's data model specification. This caused a
TypeError when attempting to inspect Row objects in REPL or debugger.

Changed to return repr(self.__dict__) to provide a proper string
representation.

Fixes #3558
