### PR TITLE
ui: Add color column support to debug tracks

### DIFF
--- a/ui/src/components/tracks/add_debug_track_menu.ts
+++ b/ui/src/components/tracks/add_debug_track_menu.ts
@@ -61,6 +61,7 @@ interface ConfigurationOptions {
   value: string;
   argSetId: string;
   pivot: string;
+  color: string;
 }
 
 export class AddDebugTrackMenu
@@ -81,6 +82,7 @@ export class AddDebugTrackMenu
       value: chooseDefaultColumn(columns, 'value'),
       argSetId: chooseDefaultColumn(columns, 'arg_set_id'),
       pivot: undefined,
+      color: '', // Empty string means "from slice name"
     };
   }
 
@@ -175,6 +177,7 @@ export class AddDebugTrackMenu
         ...availableColumns,
       ]),
       this.renderFormSelectInput('Name column', 'name', availableColumns),
+      this.renderColorSelect(availableColumns),
       this.renderFormSelectInput(
         'Arguments ID column (optional)',
         'argSetId',
@@ -205,6 +208,30 @@ export class AddDebugTrackMenu
         {
           optional: true,
         },
+      ),
+    ];
+  }
+
+  private renderColorSelect(availableColumns: ReadonlyArray<string>) {
+    return [
+      m(FormLabel, {for: 'color'}, 'Color'),
+      m(
+        Select,
+        {
+          id: 'color',
+          oninput: (e: Event) => {
+            if (!e.target) return;
+            this.options.color = (e.target as HTMLSelectElement).value;
+          },
+        },
+        m(
+          'option',
+          {selected: this.options.color === '', value: ''},
+          'Automatic (from slice name)',
+        ),
+        availableColumns.map((col) =>
+          m('option', {selected: this.options.color === col, value: col}, col),
+        ),
       ),
     ];
   }
@@ -278,6 +305,7 @@ export class AddDebugTrackMenu
           argSetIdColumn: this.options.argSetId,
           rawColumns: attrs.availableColumns,
           pivotOn: this.options.pivot,
+          colorColumn: this.options.color || undefined,
         });
         break;
       case 'counter':


### PR DESCRIPTION
Adds the ability to specify a custom column for coloring slices in debug
tracks, addressing issue #675. Users can now color slices based on any
column value (e.g., duration thresholds, status codes, severity levels)
instead of just the slice name.

Changes:
- Added optional `colorColumn` parameter to `addDebugSliceTrack()`
- Debug track UI now includes a "Color" dropdown with default "from slice name"
- Supports any column type (string, numeric, etc.) with automatic string conversion
- Color column value is passed to `getColorForSlice()` for consistent hashing

Example use case from issue: Color slices differently based on whether
their duration exceeds a threshold by using a computed column in the SQL query.

Fixes: #675
