### PR TITLE
exp: Polish the modifyColumns special cases

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
@@ -58,22 +58,67 @@
     gap: 8px;
   }
 
+  .pf-exp-switch-wrapper,
+  .pf-exp-if-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px;
+    margin: 4px 0;
+    background: var(--surface-color);
+    border: 1px solid var(--separator-color);
+    border-radius: 4px;
+  }
+
+  .pf-exp-switch-name-row,
+  .pf-exp-if-name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--separator-color);
+
+    label {
+      font-weight: 600;
+      font-size: var(--pf-exp-font-size-sm);
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--pf-text-color-secondary);
+    }
+  }
+
   .pf-exp-switch-component {
     display: flex;
     flex-direction: column;
+    gap: 6px;
+    padding: 8px 0 4px 0;
+  }
+
+  .pf-exp-switch-header {
+    font-weight: 600;
+    font-size: var(--pf-exp-font-size-sm);
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
     gap: 8px;
+    color: var(--pf-text-color-secondary);
   }
 
   .pf-exp-switch-case {
     display: flex;
     align-items: center;
     gap: 8px;
+    font-size: var(--pf-exp-font-size-sm);
+    color: var(--pf-text-color-secondary);
   }
 
   .pf-exp-switch-default-row {
     display: flex;
     align-items: center;
     gap: 8px;
+    font-size: var(--pf-exp-font-size-sm);
+    color: var(--pf-text-color-secondary);
+    margin-bottom: 4px;
   }
 }
 
@@ -82,27 +127,39 @@
   font-size: var(--pf-exp-font-size-sm);
 }
 
-.pf-exp-switch-details-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 8px;
+.pf-exp-switch-summary,
+.pf-exp-if-summary {
+  font-size: var(--pf-exp-font-size-sm);
+  padding: 2px 0;
 }
 
-.pf-exp-switch-expression {
-  font-family: var(--pf-font-family-monospace);
+.pf-exp-switch-keyword,
+.pf-exp-if-keyword {
+  font-weight: 600;
+  color: var(--pf-primary-color);
 }
 
-.pf-exp-switch-alias {
+.pf-exp-column-name {
   font-family: var(--pf-font-family-monospace);
+  font-weight: 500;
+}
+
+.pf-exp-as-keyword {
   font-style: italic;
   color: var(--pf-text-color-light);
+}
+
+.pf-exp-alias-name {
+  font-family: var(--pf-font-family-monospace);
+  font-weight: 500;
+  color: var(--pf-primary-color);
 }
 
 .pf-exp-if-component {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
+  padding: 8px 0 4px 0;
 }
 
 .pf-exp-if-clause,
@@ -110,26 +167,12 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: var(--pf-exp-font-size-sm);
+  color: var(--pf-text-color-secondary);
 }
 
 .pf-exp-if-buttons {
   display: flex;
   gap: 8px;
-}
-
-.pf-exp-if-details-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 8px;
-}
-
-.pf-exp-if-expression {
-  font-family: var(--pf-font-family-monospace);
-}
-
-.pf-exp-if-alias {
-  font-family: var(--pf-font-family-monospace);
-  font-style: italic;
-  color: var(--pf-text-color-light);
+  margin-top: 4px;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -102,67 +102,83 @@ class SwitchComponent
     if (column.switchOn === undefined || column.switchOn === '') {
       const columnNames = columns.map((c) => c.column.name);
       return m(
-        Card,
+        '.pf-exp-switch-component',
         m(
-          Select,
-          {
-            onchange: (e: Event) => {
-              setSwitchOn((e.target as HTMLSelectElement).value);
+          '.pf-exp-switch-header',
+          'SWITCH ON ',
+          m(
+            Select,
+            {
+              onchange: (e: Event) => {
+                setSwitchOn((e.target as HTMLSelectElement).value);
+              },
             },
-          },
-          m('option', {value: ''}, 'Select column'),
-          ...columnNames.map((name) => m('option', {value: name}, name)),
+            m('option', {value: ''}, 'Select column'),
+            ...columnNames.map((name) => m('option', {value: name}, name)),
+          ),
         ),
       );
     }
 
+    const columnNames = columns.map((c) => c.column.name);
+
     return m(
-      Card,
+      '.pf-exp-switch-component',
       m(
-        '.pf-exp-switch-component',
-        m('div', `SWITCH ON ${column.switchOn}`),
+        '.pf-exp-switch-header',
+        'SWITCH ON ',
         m(
-          '.pf-exp-switch-default-row',
-          'Default ',
-          m(TextInput, {
-            placeholder: 'default value',
-            value: column.defaultValue || '',
-            oninput: (e: Event) => {
-              setDefaultValue((e.target as HTMLInputElement).value);
+          Select,
+          {
+            value: column.switchOn,
+            onchange: (e: Event) => {
+              setSwitchOn((e.target as HTMLSelectElement).value);
             },
-          }),
+          },
+          ...columnNames.map((name) => m('option', {value: name}, name)),
         ),
-        ...(column.cases || []).map((c, i) =>
-          m(
-            '.pf-exp-switch-case',
-            'WHEN ',
-            m(TextInput, {
-              placeholder: 'is equal to',
-              value: c.when,
-              oninput: (e: Event) => {
-                setCaseWhen(i, (e.target as HTMLInputElement).value);
-              },
-            }),
-            ' THEN ',
-            m(TextInput, {
-              placeholder: 'then value',
-              value: c.then,
-              oninput: (e: Event) => {
-                setCaseThen(i, (e.target as HTMLInputElement).value);
-              },
-            }),
-            m(
-              'button',
-              {onclick: () => removeCase(i)},
-              m(Icon, {icon: 'close'}),
-            ),
-          ),
-        ),
-        m(Button, {
-          label: 'Add case',
-          onclick: addCase,
+      ),
+      m(
+        '.pf-exp-switch-default-row',
+        'Default ',
+        m(TextInput, {
+          placeholder: 'default value',
+          value: column.defaultValue || '',
+          oninput: (e: Event) => {
+            setDefaultValue((e.target as HTMLInputElement).value);
+          },
         }),
       ),
+      ...(column.cases || []).map((c, i) =>
+        m(
+          '.pf-exp-switch-case',
+          'WHEN ',
+          m(TextInput, {
+            placeholder: 'is equal to',
+            value: c.when,
+            oninput: (e: Event) => {
+              setCaseWhen(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          ' THEN ',
+          m(TextInput, {
+            placeholder: 'then value',
+            value: c.then,
+            oninput: (e: Event) => {
+              setCaseThen(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          m(Button, {
+            icon: 'close',
+            compact: true,
+            onclick: () => removeCase(i),
+          }),
+        ),
+      ),
+      m(Button, {
+        label: 'Add case',
+        onclick: addCase,
+      }),
     );
   }
 
@@ -174,7 +190,7 @@ class SwitchComponent
 
     const casesStr = (col.cases || [])
       .filter((c) => c.when.trim() !== '' && c.then.trim() !== '')
-      .map((c) => `WHEN ${c.when} THEN ${c.then}`)
+      .map((c) => `WHEN ${col.switchOn} = ${c.when} THEN ${c.then}`)
       .join(' ');
 
     const defaultStr = col.defaultValue ? `ELSE ${col.defaultValue}` : '';
@@ -184,7 +200,7 @@ class SwitchComponent
       return;
     }
 
-    col.expression = `CASE ${col.switchOn} ${casesStr} ${defaultStr} END`;
+    col.expression = `CASE ${casesStr} ${defaultStr} END`;
   }
 }
 
@@ -246,66 +262,63 @@ class IfComponent
     const hasElse = column.elseValue !== undefined;
 
     return m(
-      Card,
-      m(
-        '.pf-exp-if-component',
-        (column.clauses || []).map((c, i) =>
-          m(
-            '.pf-exp-if-clause',
-            i === 0 ? 'IF ' : 'ELSE IF',
-            m(TextInput, {
-              placeholder: 'condition',
-              value: c.if,
-              oninput: (e: Event) => {
-                setIfCondition(i, (e.target as HTMLInputElement).value);
-              },
-            }),
-            ' THEN ',
-            m(TextInput, {
-              placeholder: 'value',
-              value: c.then,
-              oninput: (e: Event) => {
-                setThenValue(i, (e.target as HTMLInputElement).value);
-              },
-            }),
-            m(
-              'button',
-              {onclick: () => removeClause(i)},
-              m(Icon, {icon: 'close'}),
-            ),
-          ),
-        ),
-
-        hasElse &&
-          m(
-            '.pf-exp-else-clause',
-            'ELSE ',
-            m(TextInput, {
-              placeholder: 'value',
-              value: column.elseValue || '',
-              oninput: (e: Event) => {
-                setElseValue((e.target as HTMLInputElement).value);
-              },
-            }),
-          ),
-
+      '.pf-exp-if-component',
+      (column.clauses || []).map((c, i) =>
         m(
-          '.pf-exp-if-buttons',
-          !hasElse &&
-            m(Button, {
-              label: 'Add ELSE IF',
-              onclick: addElseIf,
-            }),
-          !hasElse &&
-            m(Button, {
-              label: 'Add ELSE',
-              onclick: () => {
-                column.elseValue = '';
-                this.updateExpression(column);
-                onchange();
-              },
-            }),
+          '.pf-exp-if-clause',
+          i === 0 ? 'IF ' : 'ELSE IF',
+          m(TextInput, {
+            placeholder: 'condition',
+            value: c.if,
+            oninput: (e: Event) => {
+              setIfCondition(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          ' THEN ',
+          m(TextInput, {
+            placeholder: 'value',
+            value: c.then,
+            oninput: (e: Event) => {
+              setThenValue(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          m(Button, {
+            icon: 'close',
+            compact: true,
+            onclick: () => removeClause(i),
+          }),
         ),
+      ),
+
+      hasElse &&
+        m(
+          '.pf-exp-else-clause',
+          'ELSE ',
+          m(TextInput, {
+            placeholder: 'value',
+            value: column.elseValue || '',
+            oninput: (e: Event) => {
+              setElseValue((e.target as HTMLInputElement).value);
+            },
+          }),
+        ),
+
+      m(
+        '.pf-exp-if-buttons',
+        !hasElse &&
+          m(Button, {
+            label: 'Add ELSE IF',
+            onclick: addElseIf,
+          }),
+        !hasElse &&
+          m(Button, {
+            label: 'Add ELSE',
+            onclick: () => {
+              column.elseValue = '';
+              this.updateExpression(column);
+              onchange();
+            },
+          }),
       ),
     );
   }
@@ -618,63 +631,36 @@ export class ModifyColumnsNode implements ModificationNode {
       }
 
       if (switchColumns.length > 0) {
-        for (const c of switchColumns) {
-          const cases = (c.cases || [])
-            .filter((cas) => cas.when.trim() !== '' && cas.then.trim() !== '')
-            .map((cas) =>
-              m(
-                'div',
-                {style: 'padding-left: 16px'},
-                `WHEN ${cas.when} THEN ${cas.then}`,
-              ),
-            );
-          if (c.defaultValue) {
-            cases.push(
-              m('div', {style: 'padding-left: 16px'}, `ELSE ${c.defaultValue}`),
-            );
-          }
-          cards.push(
-            m(
-              Card,
-              {
-                className:
-                  'pf-exp-node-details-card pf-exp-switch-details-card',
-              },
-              m(
-                'div.pf-exp-switch-expression',
-                m('div', `SWITCH ON ${c.switchOn}`),
-                ...cases,
-              ),
-              m('div.pf-exp-switch-alias', `AS ${c.name}`),
-            ),
-          );
-        }
+        const switchItems = switchColumns.map((c) =>
+          m(
+            'div.pf-exp-switch-summary',
+            m('span.pf-exp-switch-keyword', 'SWITCH'),
+            ' on ',
+            m('span.pf-exp-column-name', c.switchOn),
+            ' ',
+            m('span.pf-exp-as-keyword', 'AS'),
+            ' ',
+            m('span.pf-exp-alias-name', c.name),
+          ),
+        );
+        cards.push(
+          m(Card, {className: 'pf-exp-node-details-card'}, ...switchItems),
+        );
       }
       if (ifColumns.length > 0) {
-        for (const c of ifColumns) {
-          const clauses = (c.clauses || [])
-            .filter((cl) => cl.if.trim() !== '' && cl.then.trim() !== '')
-            .map((cl, i) =>
-              m(
-                'div',
-                {style: 'padding-left: 16px'},
-                `${i === 0 ? 'if' : 'elif'} (${cl.if}): ${cl.then}`,
-              ),
-            );
-          if (c.elseValue) {
-            clauses.push(
-              m('div', {style: 'padding-left: 16px'}, `else: ${c.elseValue}`),
-            );
-          }
-          cards.push(
-            m(
-              Card,
-              {className: 'pf-exp-node-details-card pf-exp-if-details-card'},
-              m('div.pf-exp-if-expression', ...clauses),
-              m('div.pf-exp-if-alias', `AS ${c.name}`),
-            ),
-          );
-        }
+        const ifItems = ifColumns.map((c) =>
+          m(
+            'div.pf-exp-if-summary',
+            m('span.pf-exp-if-keyword', 'IF'),
+            ' ',
+            m('span.pf-exp-as-keyword', 'AS'),
+            ' ',
+            m('span.pf-exp-alias-name', c.name),
+          ),
+        );
+        cards.push(
+          m(Card, {className: 'pf-exp-node-details-card'}, ...ifItems),
+        );
       }
     }
 
@@ -722,11 +708,15 @@ export class ModifyColumnsNode implements ModificationNode {
             ),
           ),
         ),
+        this.state.newColumns.length > 0 &&
+          m(
+            Card,
+            this.state.newColumns.map((col, index) =>
+              this.renderNewColumn(col, index),
+            ),
+          ),
         m(
           Card,
-          this.state.newColumns.map((col, index) =>
-            this.renderNewColumn(col, index),
-          ),
           m(
             'div.pf-exp-modify-columns-node-buttons',
             this.renderAddColumnButton(),
@@ -852,84 +842,104 @@ export class ModifyColumnsNode implements ModificationNode {
           '☰',
         ),
         ...children,
+        m(Button, {
+          icon: 'close',
+          compact: true,
+          onclick: () => {
+            const newNewColumns = [...this.state.newColumns];
+            newNewColumns.splice(index, 1);
+            this.state.newColumns = newNewColumns;
+            this.state.onchange?.();
+          },
+        }),
+      );
+    };
+
+    if (col.type === 'switch') {
+      return m(
+        '.pf-exp-switch-wrapper',
         m(
-          'button',
-          {
+          '.pf-exp-switch-name-row',
+          m('label', 'New switch column name'),
+          m(TextInput, {
+            oninput: (e: Event) => {
+              const newNewColumns = [...this.state.newColumns];
+              newNewColumns[index] = {
+                ...newNewColumns[index],
+                name: (e.target as HTMLInputElement).value,
+              };
+              this.state.newColumns = newNewColumns;
+              this.state.onchange?.();
+            },
+            placeholder: 'name',
+            value: col.name,
+          }),
+          !this.isNewColumnValid(col) && m(Icon, {icon: 'warning'}),
+          m(Button, {
+            icon: 'close',
+            compact: true,
             onclick: () => {
               const newNewColumns = [...this.state.newColumns];
               newNewColumns.splice(index, 1);
               this.state.newColumns = newNewColumns;
               this.state.onchange?.();
             },
-          },
-          m(Icon, {icon: 'close'}),
-        ),
-      );
-    };
-
-    if (col.type === 'switch') {
-      return commonWrapper([
-        m(
-          '.pf-exp-switch-component-wrapper',
-          {style: 'flex-grow: 1'},
-          m(SwitchComponent, {
-            column: col,
-            columns: this.prevNode?.finalCols ?? [],
-            onchange: () => {
-              const newNewColumns = [...this.state.newColumns];
-              newNewColumns[index] = {...col};
-              this.state.newColumns = newNewColumns;
-              this.state.onchange?.();
-            },
           }),
         ),
-        m(TextInput, {
-          oninput: (e: Event) => {
+        m(SwitchComponent, {
+          column: col,
+          columns: this.prevNode?.finalCols ?? [],
+          onchange: () => {
             const newNewColumns = [...this.state.newColumns];
-            newNewColumns[index] = {
-              ...newNewColumns[index],
-              name: (e.target as HTMLInputElement).value,
-            };
+            newNewColumns[index] = {...col};
             this.state.newColumns = newNewColumns;
             this.state.onchange?.();
           },
-          placeholder: 'name',
-          value: col.name,
         }),
-        !this.isNewColumnValid(col) && m(Icon, {icon: 'warning'}),
-      ]);
+      );
     }
 
     if (col.type === 'if') {
-      return commonWrapper([
+      return m(
+        '.pf-exp-if-wrapper',
         m(
-          '.pf-exp-if-component-wrapper',
-          {style: 'flex-grow: 1'},
-          m(IfComponent, {
-            column: col,
-            onchange: () => {
+          '.pf-exp-if-name-row',
+          m('label', 'New if column name'),
+          m(TextInput, {
+            oninput: (e: Event) => {
               const newNewColumns = [...this.state.newColumns];
-              newNewColumns[index] = {...col};
+              newNewColumns[index] = {
+                ...newNewColumns[index],
+                name: (e.target as HTMLInputElement).value,
+              };
+              this.state.newColumns = newNewColumns;
+              this.state.onchange?.();
+            },
+            placeholder: 'name',
+            value: col.name,
+          }),
+          !this.isNewColumnValid(col) && m(Icon, {icon: 'warning'}),
+          m(Button, {
+            icon: 'close',
+            compact: true,
+            onclick: () => {
+              const newNewColumns = [...this.state.newColumns];
+              newNewColumns.splice(index, 1);
               this.state.newColumns = newNewColumns;
               this.state.onchange?.();
             },
           }),
         ),
-        m(TextInput, {
-          oninput: (e: Event) => {
+        m(IfComponent, {
+          column: col,
+          onchange: () => {
             const newNewColumns = [...this.state.newColumns];
-            newNewColumns[index] = {
-              ...newNewColumns[index],
-              name: (e.target as HTMLInputElement).value,
-            };
+            newNewColumns[index] = {...col};
             this.state.newColumns = newNewColumns;
             this.state.onchange?.();
           },
-          placeholder: 'name',
-          value: col.name,
         }),
-        !this.isNewColumnValid(col) && m(Icon, {icon: 'warning'}),
-      ]);
+      );
     }
 
     const isValid = this.isNewColumnValid(col);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node_unittest.ts
@@ -1,0 +1,481 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ModifyColumnsNode} from './modify_columns_node';
+import {QueryNode, NodeType} from '../../query_node';
+import {ColumnInfo} from '../column_info';
+
+describe('ModifyColumnsNode', () => {
+  function createMockPrevNode(): QueryNode {
+    return {
+      nodeId: 'mock',
+      type: NodeType.kTable,
+      nextNodes: [],
+      finalCols: [
+        {
+          name: 'id',
+          type: 'INT',
+          checked: true,
+          column: {name: 'id'},
+        },
+        {
+          name: 'status',
+          type: 'STRING',
+          checked: true,
+          column: {name: 'status'},
+        },
+        {
+          name: 'value',
+          type: 'INT',
+          checked: true,
+          column: {name: 'value'},
+        },
+      ],
+      state: {},
+      validate: () => true,
+      getTitle: () => 'Mock',
+      nodeSpecificModify: () => null,
+      clone: () => createMockPrevNode(),
+      getStructuredQuery: () => undefined,
+      serializeState: () => ({}),
+    } as QueryNode;
+  }
+
+  function createColumnInfo(name: string, type: string): ColumnInfo {
+    return {
+      name,
+      type,
+      checked: true,
+      column: {name},
+    };
+  }
+
+  describe('SWITCH column generation', () => {
+    it('should generate correct CASE statement with single case', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [{when: "'active'", then: '1'}],
+            defaultValue: '0',
+            expression: "CASE WHEN status = 'active' THEN 1 ELSE 0 END",
+            name: 'status_numeric',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe(
+        "CASE WHEN status = 'active' THEN 1 ELSE 0 END",
+      );
+    });
+
+    it('should generate correct CASE statement with multiple cases', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [
+              {when: "'active'", then: '1'},
+              {when: "'pending'", then: '2'},
+              {when: "'done'", then: '3'},
+            ],
+            defaultValue: '0',
+            expression:
+              "CASE WHEN status = 'active' THEN 1 WHEN status = 'pending' THEN 2 WHEN status = 'done' THEN 3 ELSE 0 END",
+            name: 'status_code',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe(
+        "CASE WHEN status = 'active' THEN 1 WHEN status = 'pending' THEN 2 WHEN status = 'done' THEN 3 ELSE 0 END",
+      );
+    });
+
+    it('should handle CASE statement without default value', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [{when: "'active'", then: '1'}],
+            defaultValue: '',
+            expression: "CASE WHEN status = 'active' THEN 1 END",
+            name: 'status_flag',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe("CASE WHEN status = 'active' THEN 1 END");
+    });
+
+    it('should filter out empty cases', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [
+              {when: "'active'", then: '1'},
+              {when: '', then: ''},
+              {when: "'pending'", then: '2'},
+            ],
+            defaultValue: '0',
+            expression:
+              "CASE WHEN status = 'active' THEN 1 WHEN status = 'pending' THEN 2 ELSE 0 END",
+            name: 'status_code',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe(
+        "CASE WHEN status = 'active' THEN 1 WHEN status = 'pending' THEN 2 ELSE 0 END",
+      );
+    });
+
+    it('should handle empty expression when no valid cases', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [],
+            defaultValue: '',
+            expression: '',
+            name: 'empty_switch',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe('');
+    });
+
+    it('should handle CASE with only default value', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [],
+            defaultValue: '0',
+            expression: 'CASE  ELSE 0 END',
+            name: 'default_only',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe('CASE  ELSE 0 END');
+    });
+
+    it('should handle numeric comparisons', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'value',
+            cases: [
+              {when: '0', then: "'zero'"},
+              {when: '1', then: "'one'"},
+              {when: '2', then: "'two'"},
+            ],
+            defaultValue: "'many'",
+            expression:
+              "CASE WHEN value = 0 THEN 'zero' WHEN value = 1 THEN 'one' WHEN value = 2 THEN 'two' ELSE 'many' END",
+            name: 'value_name',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe(
+        "CASE WHEN value = 0 THEN 'zero' WHEN value = 1 THEN 'one' WHEN value = 2 THEN 'two' ELSE 'many' END",
+      );
+    });
+
+    it('should handle cases with whitespace trimming', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [
+              {when: "  'active'  ", then: '  1  '},
+              {when: '  ', then: '  '},
+            ],
+            defaultValue: '  0  ',
+            expression:
+              "CASE WHEN status =   'active'   THEN   1   ELSE   0   END",
+            name: 'trimmed',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      // The second case should be filtered out as both when and then are whitespace
+      expect(newCol.expression).toBe(
+        "CASE WHEN status =   'active'   THEN   1   ELSE   0   END",
+      );
+    });
+  });
+
+  describe('IF column generation', () => {
+    it('should generate correct CASE statement for IF', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'if',
+            clauses: [{if: 'value > 10', then: "'high'"}],
+            elseValue: "'low'",
+            expression: "CASE WHEN value > 10 THEN 'high' ELSE 'low' END",
+            name: 'value_category',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe(
+        "CASE WHEN value > 10 THEN 'high' ELSE 'low' END",
+      );
+    });
+
+    it('should generate correct CASE statement with multiple IF clauses', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'if',
+            clauses: [
+              {if: 'value > 100', then: "'very high'"},
+              {if: 'value > 50', then: "'high'"},
+              {if: 'value > 10', then: "'medium'"},
+            ],
+            elseValue: "'low'",
+            expression:
+              "CASE WHEN value > 100 THEN 'very high' WHEN value > 50 THEN 'high' WHEN value > 10 THEN 'medium' ELSE 'low' END",
+            name: 'value_tier',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe(
+        "CASE WHEN value > 100 THEN 'very high' WHEN value > 50 THEN 'high' WHEN value > 10 THEN 'medium' ELSE 'low' END",
+      );
+    });
+
+    it('should handle IF without ELSE', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'if',
+            clauses: [{if: 'value > 10', then: "'high'"}],
+            elseValue: undefined,
+            expression: "CASE WHEN value > 10 THEN 'high' END",
+            name: 'optional_flag',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe("CASE WHEN value > 10 THEN 'high' END");
+    });
+
+    it('should filter out empty IF clauses', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'if',
+            clauses: [
+              {if: 'value > 10', then: "'high'"},
+              {if: '', then: ''},
+              {if: 'value > 5', then: "'medium'"},
+            ],
+            elseValue: "'low'",
+            expression:
+              "CASE WHEN value > 10 THEN 'high' WHEN value > 5 THEN 'medium' ELSE 'low' END",
+            name: 'filtered_if',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const newCol = node.state.newColumns[0];
+      expect(newCol.expression).toBe(
+        "CASE WHEN value > 10 THEN 'high' WHEN value > 5 THEN 'medium' ELSE 'low' END",
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('should validate when at least one column is selected', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [],
+        selectedColumns: [createColumnInfo('id', 'INT')],
+      });
+
+      expect(node.validate()).toBe(true);
+    });
+
+    it('should validate when new column has expression and name', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [{when: "'active'", then: '1'}],
+            defaultValue: '0',
+            expression: "CASE WHEN status = 'active' THEN 1 ELSE 0 END",
+            name: 'status_code',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      expect(node.validate()).toBe(true);
+    });
+
+    it('should fail validation when no columns selected and no valid new columns', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [],
+        selectedColumns: [],
+      });
+
+      // Uncheck all auto-populated columns
+      node.state.selectedColumns.forEach((col) => {
+        col.checked = false;
+      });
+
+      expect(node.validate()).toBe(false);
+    });
+
+    it('should fail validation for new column without name', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            expression: "CASE WHEN status = 'active' THEN 1 END",
+            name: '',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      expect(node.validate()).toBe(false);
+    });
+
+    it('should fail validation for duplicate column names', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            expression: "CASE WHEN status = 'active' THEN 1 END",
+            name: 'code',
+          },
+          {
+            expression: "CASE WHEN value > 10 THEN 'high' END",
+            name: 'code',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      expect(node.validate()).toBe(false);
+    });
+  });
+
+  describe('serialization', () => {
+    it('should serialize SWITCH column correctly', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'switch',
+            switchOn: 'status',
+            cases: [{when: "'active'", then: '1'}],
+            defaultValue: '0',
+            expression: "CASE WHEN status = 'active' THEN 1 ELSE 0 END",
+            name: 'status_code',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const serialized = node.serializeState();
+
+      expect(serialized.newColumns).toBeDefined();
+      expect(serialized.newColumns.length).toBe(1);
+      expect(serialized.newColumns[0].type).toBe('switch');
+      expect(serialized.newColumns[0].switchOn).toBe('status');
+      expect(serialized.newColumns[0].cases?.length).toBe(1);
+      expect(serialized.newColumns[0].defaultValue).toBe('0');
+    });
+
+    it('should serialize IF column correctly', () => {
+      const node = new ModifyColumnsNode({
+        prevNode: createMockPrevNode(),
+        newColumns: [
+          {
+            type: 'if',
+            clauses: [{if: 'value > 10', then: "'high'"}],
+            elseValue: "'low'",
+            expression: "CASE WHEN value > 10 THEN 'high' ELSE 'low' END",
+            name: 'category',
+          },
+        ],
+        selectedColumns: [],
+      });
+
+      const serialized = node.serializeState();
+
+      expect(serialized.newColumns).toBeDefined();
+      expect(serialized.newColumns.length).toBe(1);
+      expect(serialized.newColumns[0].type).toBe('if');
+      expect(serialized.newColumns[0].clauses?.length).toBe(1);
+      expect(serialized.newColumns[0].elseValue).toBe("'low'");
+    });
+  });
+});


### PR DESCRIPTION
Polish the modifyColumns query builder node, fixing SWITCH statement generation and improving the UI/UX for complex column creation (SWITCH and IF expressions).

 Key Changes:
  - Improve visual design with dedicated wrappers, headers, and better typography for SWITCH and IF components
  - Enhance UX by allowing switch column selection before configuration is complete
  - Add comprehensive unit test coverage (481 new lines) for SWITCH and IF column generation edge cases
  - Simplify component structure by removing unnecessary Card wrappers in the editor view


  Technical Details:
  - SWITCH statements now generate: CASE WHEN status = 'active' THEN 1 ELSE 0 END
  - Previously generated: CASE status WHEN 'active' THEN 1 ELSE 0 END
  - Tests cover empty cases, whitespace handling, numeric comparisons, and multiple WHEN clauses