### PR TITLE
tp: downgrade common errors to warnings

### DIFF
--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -245,7 +245,7 @@ namespace perfetto::trace_processor::stats {
       "TrackEventRangeOfInterest packet, and track event dropping is "         \
       "enabled."),                                                             \
   F(track_event_tokenizer_errors,         kSingle,  kInfo,     kAnalysis, ""), \
-  F(track_hierarchy_missing_uuid,         kSingle,  kError,    kAnalysis,      \
+  F(track_hierarchy_missing_uuid,         kSingle,  kInfo,     kAnalysis,      \
       "Upper bound on the number of events dropped due to track hierarchy "    \
       "validation failures where a parent UUID was not found. This stat is "   \
       "incremented each time trace processor attempts to resolve a track "     \
@@ -776,14 +776,14 @@ namespace perfetto::trace_processor::stats {
       "require a ThreadDescriptor to establish a baseline. Root cause: "       \
       "packet loss in the trace (check packet loss stats) or a bug in the "    \
       "trace producer (missing ThreadDescriptor)."),                           \
-  F(packet_skipped_seq_needs_incremental_state_invalid, kSingle, kError,       \
+  F(packet_skipped_seq_needs_incremental_state_invalid, kSingle, kInfo,        \
       kAnalysis,                                                               \
       "A packet with SEQ_NEEDS_INCREMENTAL_STATE flag was skipped because "    \
       "incremental state is invalid. Packets that depend on incremental "      \
       "state cannot be processed until state is reestablished. Root cause: "   \
       "packet loss in the trace (check packet loss stats) or a bug in the "    \
       "trace producer (missing incremental_state_cleared packet)."),           \
-  F(interned_data_skipped_incremental_state_invalid, kSingle, kError,          \
+  F(interned_data_skipped_incremental_state_invalid, kSingle, kInfo,           \
       kAnalysis,                                                               \
       "An InternedData packet was skipped because incremental state is "       \
       "invalid. InternedData must be associated with the correct state "       \


### PR DESCRIPTION
These are errors in many contexts but aslo intentionally appear and are
working as intended in other cases. Since we don't have bandwidth to do
this properly, just downgrade to this properly
