### PR TITLE
ui: Navigate to timeline page  after recording a trace

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/recording_manager.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/recording_manager.ts
@@ -267,6 +267,7 @@ export class CurrentTracingSession {
       ) {
         this.autoOpenedTriggered = true;
         this.openTrace();
+        window.location.hash = '#!/viewer';
       }
     });
   }


### PR DESCRIPTION
Since https://github.com/google/perfetto/pull/3133, we no longer navigate to the timeline page when a trace loads. However this is confusing when recording a trace on the recording page because we stay on the recording page so it looks like nothing has happened, even if 'Open trace when done' is checked.

<img width="595" height="144" alt="image" src="https://github.com/user-attachments/assets/1cb868a4-8f93-4129-97f0-cdc7d3a43346" />

This patch just adds an explicit navigation to the timeline page when the trace loads when this checkbox is checked.

Fixes: https://buganizer.corp.google.com/issues/459332077
