### PR TITLE
Declare forcibly_shown_types in windowlayoutparams.proto

### DIFF
--- a/protos/perfetto/trace/android/view/windowlayoutparams.proto
+++ b/protos/perfetto/trace/android/view/windowlayoutparams.proto
@@ -86,4 +86,7 @@ message WindowLayoutParamsProto {
       [(.perfetto.protos.typedef) =
            "android.view.WindowInsets.Side.InsetsSide"];
   optional bool fit_ignore_visibility = 33;
+  optional uint32 forcibly_shown_types = 34
+      [(.perfetto.protos.typedef) =
+           "android.view.WindowInsets.Type.InsetsType"];
 }


### PR DESCRIPTION
This CL helps find out which window forcibly shows insets during CTS tests.

Internal CL: ag/36351654
Bug: 450050213
Test: atest WindowInsetsAnimationTests
Change-Id: Ibbc2ae7180307b51b047356338fe581a165e7258 (cherry picked from commit 2499648e230780359d20955daa1dd6a7f89fcf0e)
