### PR TITLE
perfetto_winscope-lite: make host supported

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20181,6 +20181,7 @@ java_library {
         "libprotobuf-java-lite",
     ],
     sdk_version: "current",
+    host_supported: true,
 }
 
 java_library {

--- a/Android.bp.extras
+++ b/Android.bp.extras
@@ -254,6 +254,7 @@ java_library {
         "libprotobuf-java-lite",
     ],
     sdk_version: "current",
+    host_supported: true,
 }
 
 java_library {


### PR DESCRIPTION
Mark the perfetto_winscope-lite proto library as
host_supported to use it from host-side tests.