### PR TITLE
tp: Better SQ SQL formatting

### DIFF
--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator.cc
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator.cc
@@ -108,6 +108,38 @@ std::pair<SqlSource, SqlSource> GetPreambleAndSql(const std::string& sql) {
   return {tokenizer.Substr(first_tok, last_statement_start),
           tokenizer.Substr(last_statement_start, statement_end)};
 }
+
+// Indents each line of the input string by the specified number of spaces.
+std::string IndentLines(const std::string& input, size_t indent_spaces) {
+  if (input.empty()) {
+    return input;
+  }
+
+  std::string result;
+  result.reserve(input.size() + indent_spaces * 10);  // Estimate
+
+  std::string indent(indent_spaces, ' ');
+  size_t pos = 0;
+  size_t line_start = 0;
+
+  while (pos < input.size()) {
+    if (input[pos] == '\n') {
+      result.append(indent);
+      result.append(input, line_start, pos - line_start + 1);
+      line_start = pos + 1;
+    }
+    pos++;
+  }
+
+  // Handle last line if it doesn't end with newline
+  if (line_start < input.size()) {
+    result.append(indent);
+    result.append(input, line_start, std::string::npos);
+  }
+
+  return result;
+}
+
 struct QueryState {
   QueryState(QueryType _type,
              protozero::ConstBytes _bytes,
@@ -267,9 +299,9 @@ base::StatusOr<std::string> GeneratorImpl::Generate(
       continue;
     }
     if (cte_count > 0) {
-      sql += ", ";
+      sql += ",\n";
     }
-    sql += state.table_name + " AS (" + state.sql + ")";
+    sql += state.table_name + " AS (\n" + IndentLines(state.sql, 2) + "\n)";
     cte_count++;
   }
 
@@ -277,9 +309,9 @@ base::StatusOr<std::string> GeneratorImpl::Generate(
   if (root_only_has_inner_query_and_operations) {
     // The root query is just wrapping an inner query with operations.
     // Apply those operations directly in the final SELECT.
-    sql += " " + state_[0].sql;
+    sql += "\n" + state_[0].sql;
   } else {
-    sql += " SELECT * FROM " + state_[0].table_name;
+    sql += "\nSELECT *\nFROM " + state_[0].table_name;
   }
   return sql;
 }
@@ -351,17 +383,17 @@ base::StatusOr<std::string> GeneratorImpl::GenerateImpl() {
 
   // Assemble SQL clauses in standard evaluation order:
   // SELECT, FROM, WHERE, GROUP BY, ORDER BY, LIMIT, OFFSET.
-  std::string sql = "SELECT " + select + " FROM " + source;
+  std::string sql = "SELECT " + select + "\nFROM " + source;
   if (!filters.empty()) {
-    sql += " WHERE " + filters;
+    sql += "\nWHERE " + filters;
   }
   if (!group_by.empty()) {
-    sql += " " + group_by;
+    sql += "\n" + group_by;
   }
   if (q.has_order_by()) {
     StructuredQuery::OrderBy::Decoder order_by_decoder(q.order_by());
     ASSIGN_OR_RETURN(std::string order_by, OrderBy(order_by_decoder));
-    sql += " " + order_by;
+    sql += "\n" + order_by;
   }
   if (q.has_offset() && !q.has_limit()) {
     return base::ErrStatus("OFFSET requires LIMIT to be specified");
@@ -371,14 +403,14 @@ base::StatusOr<std::string> GeneratorImpl::GenerateImpl() {
       return base::ErrStatus("LIMIT must be non-negative, got %" PRId64,
                              q.limit());
     }
-    sql += " LIMIT " + std::to_string(q.limit());
+    sql += "\nLIMIT " + std::to_string(q.limit());
   }
   if (q.has_offset()) {
     if (q.offset() < 0) {
       return base::ErrStatus("OFFSET must be non-negative, got %" PRId64,
                              q.offset());
     }
-    sql += " OFFSET " + std::to_string(q.offset());
+    sql += "\nOFFSET " + std::to_string(q.offset());
   }
   return sql;
 }
@@ -452,8 +484,10 @@ base::StatusOr<std::string> GeneratorImpl::SqlSource(
     cols_str = base::Join(cols, ", ");
   }
 
-  std::string generated_sql = "(SELECT " + cols_str + " FROM (" +
-                              std::move(rewriter).Build().sql() + "))";
+  std::string user_sql = std::move(rewriter).Build().sql();
+  std::string inner =
+      "SELECT " + cols_str + "\nFROM (\n" + IndentLines(user_sql, 2) + "\n)";
+  std::string generated_sql = "(\n" + IndentLines(inner, 2) + ")";
   return generated_sql;
 }
 
@@ -537,10 +571,10 @@ base::StatusOr<std::string> GeneratorImpl::IntervalIntersect(
   auto ii = interval.interval_intersect();
   for (size_t i = 0; ii; ++ii, ++i) {
     sql += ", iisource" + std::to_string(i) + " AS (SELECT * FROM " +
-           NestedSource(*ii) + ") ";
+           NestedSource(*ii) + ")";
   }
 
-  sql += "SELECT ii.ts, ii.dur";
+  sql += "\nSELECT ii.ts, ii.dur";
   // Add partition columns from ii
   for (const auto& col : partition_cols) {
     sql += ", ii." + col;
@@ -550,7 +584,7 @@ base::StatusOr<std::string> GeneratorImpl::IntervalIntersect(
   for (size_t i = 0; ii; ++ii, ++i) {
     sql += ", iisource" + std::to_string(i) + ".*";
   }
-  sql += " FROM _interval_intersect!((iibase";
+  sql += "\nFROM _interval_intersect!((iibase";
   ii = interval.interval_intersect();
   for (size_t i = 0; ii; ++ii, ++i) {
     sql += ", iisource" + std::to_string(i);
@@ -564,14 +598,15 @@ base::StatusOr<std::string> GeneratorImpl::IntervalIntersect(
     }
     sql += partition_cols[i];
   }
-  sql += ")) ii JOIN iibase ON ii.id_0 = iibase.id";
+  sql += ")) ii\nJOIN iibase ON ii.id_0 = iibase.id";
 
   ii = interval.interval_intersect();
   for (size_t i = 0; ii; ++ii, ++i) {
-    sql += " JOIN iisource" + std::to_string(i) + " ON ii.id_" +
+    sql += "\nJOIN iisource" + std::to_string(i) + " ON ii.id_" +
            std::to_string(i + 1) + " = iisource" + std::to_string(i) + ".id";
   }
   sql += ")";
+
   return sql;
 }
 
@@ -726,22 +761,24 @@ base::StatusOr<std::string> GeneratorImpl::Union(
 
   // Build a local WITH clause to avoid CTE name conflicts with global scope.
   // Similar to IntervalIntersect, we create local CTEs with unique names.
-  std::string sql = "(WITH ";
+  std::string sql = "(\n  WITH ";
   size_t idx = 0;
   for (auto it = union_decoder.queries(); it; ++it, ++idx) {
     if (idx > 0) {
       sql += ", ";
     }
-    sql += "union_query_" + std::to_string(idx) + " AS (SELECT * FROM " +
-           NestedSource(*it) + ")";
+    sql += "union_query_" + std::to_string(idx) + " AS (\n  ";
+    sql += "SELECT *\n  ";
+    sql += "FROM " + NestedSource(*it) + ")";
   }
 
   // Build the UNION/UNION ALL query
   std::string union_keyword =
-      union_decoder.use_union_all() ? " UNION ALL " : " UNION ";
-  sql += " SELECT * FROM union_query_0";
+      union_decoder.use_union_all() ? "UNION ALL" : "UNION";
+  sql += "\n  SELECT *\n  FROM union_query_0";
   for (size_t i = 1; i < query_count; ++i) {
-    sql += union_keyword + "SELECT * FROM union_query_" + std::to_string(i);
+    sql += "\n  " + union_keyword + "\n  SELECT *\n  FROM union_query_" +
+           std::to_string(i);
   }
   sql += ")";
 

--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator_unittest.cc
@@ -1411,10 +1411,30 @@ TEST(StructuredQueryGeneratorTest, UnionWithDifferentColumnOrderSucceeds) {
   )");
   auto ret = gen.Generate(proto.data(), proto.size());
   ASSERT_TRUE(ret.ok()) << ret.status().message();
-  ASSERT_THAT(*ret, testing::HasSubstr("WITH union_query_0 AS"));
-  ASSERT_THAT(*ret, testing::HasSubstr("union_query_1 AS"));
-  ASSERT_THAT(*ret, testing::HasSubstr("SELECT * FROM union_query_0 UNION "
-                                       "SELECT * FROM union_query_1"));
+  EXPECT_EQ(*ret, R"(WITH sq_2 AS (
+  SELECT dur, id, ts
+  FROM sched
+),
+sq_1 AS (
+  SELECT id, ts, dur
+  FROM slice
+),
+sq_0 AS (
+  SELECT *
+  FROM (
+    WITH union_query_0 AS (
+    SELECT *
+    FROM sq_1), union_query_1 AS (
+    SELECT *
+    FROM sq_2)
+    SELECT *
+    FROM union_query_0
+    UNION
+    SELECT *
+    FROM union_query_1)
+)
+SELECT *
+FROM sq_0)");
 }
 
 TEST(StructuredQueryGeneratorTest, AddColumnsWithEqualityColumns) {
@@ -3171,7 +3191,7 @@ TEST(StructuredQueryGeneratorTest,
   )");
   auto ret = gen.Generate(proto.data(), proto.size());
   ASSERT_OK_AND_ASSIGN(std::string res, ret);
-  // Should include the whitespace in the generated SQL
+  // Should include the whitespace in the generated SQL as-is (no normalization)
   ASSERT_THAT(
       res.c_str(),
       testing::HasSubstr("_interval_intersect!((iibase, iisource0), (   ))"));
@@ -3749,6 +3769,170 @@ TEST(StructuredQueryGeneratorTest, StringIdCollisionWithIndexBasedName) {
     )
     SELECT * FROM sq_foo
   )"));
+}
+
+// Test that SQL is formatted with newlines for better readability
+TEST(StructuredQueryGeneratorTest, SqlFormattingWithNewlines) {
+  StructuredQueryGenerator gen;
+  auto proto = ToProto(R"(
+    table {
+      table_name: "test_table"
+    }
+    filters: {
+      column_name: "id"
+      op: GREATER_THAN
+      int64_rhs: 100
+    }
+    group_by: {
+      column_names: "category"
+      aggregates: {
+        column_name: "value"
+        op: SUM
+        result_column_name: "total_value"
+      }
+    }
+    order_by: {
+      ordering_specs: {
+        column_name: "total_value"
+        direction: DESC
+      }
+    }
+    limit: 10
+    offset: 5
+  )");
+  auto ret = gen.Generate(proto.data(), proto.size());
+  ASSERT_OK_AND_ASSIGN(std::string res, ret);
+
+  // Verify the SQL is formatted with newlines and indentation
+  // SELECT and FROM are always on separate lines at the same indentation
+  EXPECT_EQ(res, R"(WITH sq_0 AS (
+  SELECT category, SUM(value) AS total_value
+  FROM test_table
+  WHERE id > 100
+  GROUP BY category
+  ORDER BY total_value DESC
+  LIMIT 10
+  OFFSET 5
+)
+SELECT *
+FROM sq_0)");
+}
+
+// Test that CTEs with multiple queries are formatted with newlines
+TEST(StructuredQueryGeneratorTest, CteFormattingWithNewlines) {
+  StructuredQueryGenerator gen;
+  auto proto = ToProto(R"(
+    inner_query {
+      inner_query {
+        table {
+          table_name: "table1"
+        }
+      }
+      filters: {
+        column_name: "id"
+        op: GREATER_THAN
+        int64_rhs: 100
+      }
+    }
+    select_columns: {
+      column_name_or_expression: "id"
+    }
+  )");
+  auto ret = gen.Generate(proto.data(), proto.size());
+  ASSERT_OK_AND_ASSIGN(std::string res, ret);
+
+  // Verify CTEs are formatted with newlines, indentation, and proper separation
+  // SELECT and FROM are always on separate lines at the same indentation
+  EXPECT_EQ(res, R"(WITH sq_2 AS (
+  SELECT *
+  FROM table1
+),
+sq_1 AS (
+  SELECT *
+  FROM sq_2
+  WHERE id > 100
+),
+sq_0 AS (
+  SELECT id
+  FROM sq_1
+)
+SELECT *
+FROM sq_0)");
+}
+
+// Test nested WITH statements (a CTE containing a WITH statement)
+TEST(StructuredQueryGeneratorTest, NestedWithStatements) {
+  StructuredQueryGenerator gen;
+  auto proto = ToProto(R"(
+    inner_query {
+      sql: {
+        sql: "WITH inner_cte AS (SELECT id, name FROM table1) SELECT id FROM inner_cte WHERE id > 100"
+        column_names: "id"
+      }
+    }
+    select_columns: {
+      column_name_or_expression: "id"
+    }
+  )");
+  auto ret = gen.Generate(proto.data(), proto.size());
+  ASSERT_OK_AND_ASSIGN(std::string res, ret);
+
+  // Verify that SQL we generate is nicely formatted with SELECT/FROM on
+  // separate lines User-provided SQL (the WITH statement) is kept as-is
+  EXPECT_EQ(res, R"(WITH sq_1 AS (
+  SELECT *
+  FROM (
+    SELECT id
+    FROM (
+      WITH inner_cte AS (SELECT id, name FROM table1) SELECT id FROM inner_cte WHERE id > 100
+    ))
+),
+sq_0 AS (
+  SELECT id
+  FROM sq_1
+)
+SELECT *
+FROM sq_0)");
+}
+
+// Test that multi-line SQL inside CTEs is properly indented
+TEST(StructuredQueryGeneratorTest, MultiLineSqlIndentation) {
+  StructuredQueryGenerator gen;
+  auto proto = ToProto(R"(
+    inner_query {
+      sql: {
+        sql: "SELECT id, name
+FROM table1
+WHERE id > 100"
+        column_names: "id"
+        column_names: "name"
+      }
+    }
+    select_columns: {
+      column_name_or_expression: "id"
+    }
+  )");
+  auto ret = gen.Generate(proto.data(), proto.size());
+  ASSERT_OK_AND_ASSIGN(std::string res, ret);
+
+  // Verify that SQL we generate is nicely formatted with SELECT/FROM on
+  // separate lines User-provided SQL is indented but kept as-is
+  EXPECT_EQ(res, R"(WITH sq_1 AS (
+  SELECT *
+  FROM (
+    SELECT id, name
+    FROM (
+      SELECT id, name
+      FROM table1
+      WHERE id > 100
+    ))
+),
+sq_0 AS (
+  SELECT id
+  FROM sq_1
+)
+SELECT *
+FROM sq_0)");
 }
 
 }  // namespace perfetto::trace_processor::perfetto_sql::generator


### PR DESCRIPTION
Improves the readability of SQL generated by StructuredQueryGenerator by adding newlines and proper indentation. Generated SQL now has each major clause (FROM, WHERE, GROUP BY, etc.) on its own line with consistent 2-space indentation for nested queries and CTEs.