### PR TITLE
Use machine table to identify machine ids in Android logs

### DIFF
--- a/ui/src/plugins/com.android.AndroidLog/index.ts
+++ b/ui/src/plugins/com.android.AndroidLog/index.ts
@@ -47,16 +47,14 @@ interface AndroidLogPluginState {
 
 async function getMachineIds(engine: Engine): Promise<number[]> {
   // A machine might not provide Android logs, even if configured to do so.
-  // Hence, the |process| table might have ids not present in the logs. Given this
+  // Hence, the |machine| table might have ids not present in the logs. Given this
   // is highly unlikely and going through all logs is expensive, we will get
-  // the ids from |process|, even if filter shows ids not present in logs.
-  const result = await engine.query(
-    `SELECT DISTINCT(machine_id) FROM process ORDER BY machine_id`,
-  );
+  // the ids from |machine|, even if filter shows ids not present in logs.
+  const result = await engine.query(`SELECT id FROM machine ORDER BY id`);
   const machineIds: number[] = [];
-  const it = result.iter({machine_id: NUM_NULL});
+  const it = result.iter({id: NUM_NULL});
   for (; it.valid(); it.next()) {
-    machineIds.push(it.machine_id ?? 0);
+    machineIds.push(it.id ?? 0);
   }
   return machineIds;
 }


### PR DESCRIPTION
When ftrace isn't set as a data source during a multi-VM tracing session, the CPU table won't be populated. This means that if Android logs were indeed set as a data source, then the AndroidLog panel won't show the machine id column and filter button, even though there are logs from multiple machines, because it uses the CPU table to identify the machines involved in the table.

Instead we use the machine table which stores all the machines involved in the multi-VM trace.

Bug: 459819089
