### PR TITLE
rust-sdk: bump perfetto-sdk-sys version number

### DIFF
--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-sys"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["David Reveman <dreveman@gmail.com>"]
 build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -20,7 +20,7 @@ intrinsics = []
 vendored = ["perfetto-sdk-sys/vendored"]
 
 [dependencies]
-perfetto-sdk-sys = { path = "../perfetto-sys", version = "0.1.0", default-features = false }
+perfetto-sdk-sys = { path = "../perfetto-sys", version = "0.1", default-features = false }
 bitflags = "2"
 paste = "1"
 thiserror = "1"


### PR DESCRIPTION
This is in preparation for a v53 release and publishing a crate that includes amalgamated shared library sources that matches that release.