### PR TITLE
NodeGraph: Remove will-change: transform; to avoid rasterization and retain sharpness

### DIFF
--- a/ui/src/assets/widgets/nodegraph.scss
+++ b/ui/src/assets/widgets/nodegraph.scss
@@ -51,7 +51,6 @@
   height: 100%;
   pointer-events: none;
   overflow: visible;
-  will-change: transform;
 
   svg {
     isolation: isolate;


### PR DESCRIPTION
A recent PR added `will-change: transform;` to the NodeGraph content container. This was a mistake as it doesn't improve performance, but has the side effect of rasterizing the nodes at 100% zoom which results in ugly pixelation when zoomed.

Before:
<img width="591" height="363" alt="image" src="https://github.com/user-attachments/assets/0d96136c-fd37-49b0-8b9c-98050bd07399" />

After:
<img width="583" height="405" alt="image" src="https://github.com/user-attachments/assets/bf32697d-cd1a-4bf2-90dc-9cd215f1d26d" />