### PR TITLE
exp: Fix SQL node columns

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -528,6 +528,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         node.state.issues = undefined;
       }
 
+      // Update columns for SQL source nodes and trigger re-analysis
       if (node instanceof SqlSourceNode) {
         node.onQueryExecuted(this.response.columns);
       }
@@ -540,6 +541,12 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
           console.error('Failed to materialize node:', e);
           // Don't block the UI on materialization errors
         }
+      }
+
+      // Force re-analysis for SQL source nodes so downstream nodes can see updated columns
+      if (node instanceof SqlSourceNode) {
+        this.query = undefined;
+        this.queryExecuted = false;
       }
     } catch (e) {
       console.error('Failed to run query:', e);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -21,6 +21,7 @@ import {
   createFinalColumns,
   MultiSourceNode,
   nextNodeId,
+  setOperationChanged,
 } from '../../../query_node';
 import {columnInfoFromName} from '../../column_info';
 import protos from '../../../../../protos';
@@ -77,6 +78,8 @@ export class SqlSourceNode implements MultiSourceNode {
 
   onQueryExecuted(columns: string[]) {
     this.setSourceColumns(columns);
+    // Mark node as changed to trigger re-analysis with updated columns
+    setOperationChanged(this);
   }
 
   clone(): QueryNode {
@@ -109,7 +112,9 @@ export class SqlSourceNode implements MultiSourceNode {
       query: prevNode.getStructuredQuery(),
     }));
 
-    const columnNames = this.finalCols.map((c) => c.column.name);
+    // Pass empty array for column names - the engine will discover them when analyzing the query
+    // Using this.finalCols here would pass stale columns from the previous execution
+    const columnNames: string[] = [];
 
     const sq = StructuredQueryBuilder.fromSql(
       this.state.sql || '',


### PR DESCRIPTION
Fix: when writing the query and reexecuting for the second time with different set of columns, the new columns would not be fetched and propagated further