### PR TITLE
NodeGraph: Remove blue top border and node from docked children

### DIFF
--- a/ui/src/assets/widgets/nodegraph.scss
+++ b/ui/src/assets/widgets/nodegraph.scss
@@ -134,7 +134,6 @@
 
 // Docked child: flush top edge with no rounded corners or border
 .pf-node.pf-docked-child {
-  border-top-color: var(--pf-color-accent);
   border-top-left-radius: 0;
   border-top-right-radius: 0;
   margin-top: -2px; // Overlap border with parent

--- a/ui/src/widgets/nodegraph.ts
+++ b/ui/src/widgets/nodegraph.ts
@@ -1636,7 +1636,7 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
         // Bottom output ports (if no docked child below)
         bottomOutputs.map((port) => {
           const portIndex = outputs.indexOf(port);
-          return renderPort(port, portIndex, 'output', hasDockedChild);
+          return renderPort(port, portIndex, 'output');
         }),
       ],
     );


### PR DESCRIPTION
Before:
<img width="428" height="243" alt="image" src="https://github.com/user-attachments/assets/d3906e88-985e-43f1-8d0b-571be69ac0e8" />

After:
<img width="482" height="301" alt="image" src="https://github.com/user-attachments/assets/726834d4-519e-4977-ac3b-312ef499ad94" />
