### PR TITLE
exp: Fixes after feedback #1

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -506,6 +506,13 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       }
     }
 
+    // Also collect nodes from inputNodes (side ports)
+    if ('inputNodes' in node && node.inputNodes) {
+      for (const inputNode of node.inputNodes) {
+        if (inputNode !== undefined) parentNodes.push(inputNode);
+      }
+    }
+
     // Get child nodes
     const childNodes = [...node.nextNodes];
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_info.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_info.ts
@@ -51,10 +51,11 @@ export function newColumnInfo(
   col: ColumnInfo,
   checked?: boolean | undefined,
 ): ColumnInfo {
+  const finalName = col.alias ?? col.column.name;
   return {
-    name: col.alias ?? col.column.name,
+    name: finalName,
     type: perfettoSqlTypeToString(col.column.type),
-    column: col.column,
+    column: {...col.column, name: finalName},
     alias: undefined,
     checked: checked ?? col.checked,
   };

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_info_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_info_unittest.ts
@@ -119,7 +119,9 @@ describe('column_info utilities', () => {
       expect(result.name).toBe('id');
       expect(result.type).toBe('INT');
       expect(result.checked).toBe(false);
-      expect(result.column).toBe(original.column);
+      // column is now a copy with name updated (not same reference)
+      expect(result.column.name).toBe('id');
+      expect(result.column.type).toBe(intType);
       expect(result.alias).toBeUndefined();
     });
 
@@ -136,7 +138,8 @@ describe('column_info utilities', () => {
 
       expect(result.name).toBe('identifier');
       expect(result.type).toBe('INT');
-      expect(result.column.name).toBe('id');
+      // column.name should also be replaced with the alias so child nodes see the aliased name
+      expect(result.column.name).toBe('identifier');
       expect(result.alias).toBeUndefined();
     });
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -747,9 +747,19 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
             // The node relationships (nextNodes/prevNode) remain unchanged
             m.redraw();
           },
-          onDock: (_targetId: string, childNode: Omit<Node, 'x' | 'y'>) => {
+          onDock: (targetId: string, childNode: Omit<Node, 'x' | 'y'>) => {
             // Remove coordinates so node becomes "docked" (renders via parent's 'next')
             attrs.nodeLayouts.delete(childNode.id);
+
+            // Create the connection between parent and child
+            const parentNode = findQueryNode(targetId, rootNodes);
+            const childQueryNode = findQueryNode(childNode.id, rootNodes);
+
+            if (parentNode && childQueryNode) {
+              // Add connection (this will update both nextNodes and prevNode/prevNodes)
+              addConnection(parentNode, childQueryNode);
+            }
+
             m.redraw();
           },
         } satisfies NodeGraphAttrs),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
@@ -98,14 +98,14 @@ describe('AggregationNode', () => {
 
     it('should handle aggregation without operation', () => {
       const agg: Aggregation = {};
-      expect(placeholderNewColumnName(agg)).toBe('agg_result');
+      expect(placeholderNewColumnName(agg)).toBe('result');
     });
 
     it('should handle aggregation with operation but no column', () => {
       const agg: Aggregation = {
         aggregationOp: 'SUM',
       };
-      expect(placeholderNewColumnName(agg)).toBe('agg_sum');
+      expect(placeholderNewColumnName(agg)).toBe('sum');
     });
 
     it('should use lowercase in placeholder', () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -58,9 +58,20 @@ export class IntervalIntersectNode implements MultiSourceNode {
 
   constructor(state: IntervalIntersectNodeState) {
     this.nodeId = nextNodeId();
+
+    // Initialize filterNegativeDur array with true for each prevNode if not provided
+    const filterNegativeDur = state.filterNegativeDur ?? [];
+    // Fill missing indices with true (default to filtering enabled)
+    for (let i = 0; i < state.prevNodes.length; i++) {
+      if (filterNegativeDur[i] === undefined) {
+        filterNegativeDur[i] = true;
+      }
+    }
+
     this.state = {
       ...state,
       autoExecute: state.autoExecute ?? false,
+      filterNegativeDur,
     };
     this.prevNodes = state.prevNodes;
     this.nextNodes = [];
@@ -250,16 +261,25 @@ export class IntervalIntersectNode implements MultiSourceNode {
   }
 
   onPrevNodesUpdated(): void {
+    // Initialize filterNegativeDur if it doesn't exist
+    if (!this.state.filterNegativeDur) {
+      this.state.filterNegativeDur = [];
+    }
+
     // Compact filterNegativeDur array to match prevNodes length
     // When nodes are removed, prevNodes is compacted, so we need to match that
-    if (
-      this.state.filterNegativeDur &&
-      this.state.filterNegativeDur.length > this.prevNodes.length
-    ) {
+    if (this.state.filterNegativeDur.length > this.prevNodes.length) {
       this.state.filterNegativeDur = this.state.filterNegativeDur.slice(
         0,
         this.prevNodes.length,
       );
+    }
+
+    // Initialize missing indices with true (default to filtering enabled)
+    for (let i = 0; i < this.prevNodes.length; i++) {
+      if (this.state.filterNegativeDur[i] === undefined) {
+        this.state.filterNegativeDur[i] = true;
+      }
     }
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node_unittest.ts
@@ -213,7 +213,8 @@ describe('query_node utilities', () => {
 
       expect(result[0].name).toBe('identifier');
       expect(result[0].type).toBe('STRING');
-      expect(result[0].column.name).toBe('id');
+      // column.name should also be replaced with the alias so child nodes see the aliased name
+      expect(result[0].column.name).toBe('identifier');
     });
   });
 


### PR DESCRIPTION
1. Column Alias Handling

  - Issue: Child nodes couldn't use aliased column names from ModifyColumnsNode
  - Fix: Modified newColumnInfo() in column_info.ts to replace both top-level name and column.name with the
   aliased name
  - Test: Added test "aggregation node can group by aliased column from modify columns node"

  2. Interval Intersect Filter Initialization

  - Issue: "Filter unfinished intervals" checkbox appeared checked but filter wasn't actually applied until
   toggling
  - Fix: Modified IntervalIntersectNode constructor and onPrevNodesUpdated() to initialize
  filterNegativeDur array with explicit true values
  - Test: Added test "interval intersect node initializes filter to true by default"

  3. Node Deletion with InputNodes

  - Issue: Unable to delete ModifyColumnsNode when it has inputNodes connections
  - Fix: Modified handleDeleteNode() in explore_page.ts to collect nodes from inputNodes array in addition
  to prevNode/prevNodes

  4. Automatic Connection on Docking

  - Issue: Docking nodes didn't automatically create connections
  - Fix: Modified onDock callback in graph.ts to call addConnection() when nodes are docked

  5. Aggregation Query Re-execution on Keystroke

  - Issue: Typing in aggregation node fields caused queries to re-run on every letter (bad performance)
  - Fix: Migrated aggregation editor to use Form widget with submit/cancel pattern - queries only execute
  when "Apply" is clicked

  6. Form Widget Validation

  - Issue: Form didn't properly validate/disable Apply button for incomplete aggregations
  - Fix: Added required: true and validation: () => validateAggregation(agg) to Form widget, plus required
  attributes on Select widgets

  7. Aggregation Placeholder Naming Cleanup

  - Issue: Column names used "agg_" prefix (e.g., "agg_sum") and showed invalid placeholders
  - Fix: Cleaned up placeholderNewColumnName() to remove "agg_" prefix and show better defaults (e.g.,
  "duration_sum" instead of "agg_sum")