### PR TITLE
ui: NodeGraph: Tweak automatic node placement

### DIFF
--- a/ui/src/widgets/nodegraph.ts
+++ b/ui/src/widgets/nodegraph.ts
@@ -1766,8 +1766,8 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
 
         // Find non-overlapping position starting from center
         const finalPos = findNearestNonOverlappingPosition(
-          centerX,
-          centerY,
+          centerX - dims.width / 2,
+          centerY - dims.height / 2,
           tempNode.id,
           nodes,
           dims.width,


### PR DESCRIPTION
- Make new nodes start their auto-placement search in the center of the viewport, rather than have their top left corner in the center.
- Fix a bug where the incomplete nodes were not being passed properly to the auto placement function in the NodeGraph demo, so nodes were often being placed overlapping.