### PR TITLE
ui: include machine_id in power rail plugin track ordering logic

### DIFF
--- a/ui/src/plugins/dev.perfetto.PowerRails/index.ts
+++ b/ui/src/plugins/dev.perfetto.PowerRails/index.ts
@@ -47,7 +47,7 @@ export default class implements PerfettoPlugin {
         COALESCE(friendly_name, raw_power_rail_name) as name,
         machine_id as machine
       FROM android_power_rails_metadata
-      ORDER BY name
+      ORDER BY machine_id, name
     `);
 
     if (result.numRows() === 0) {


### PR DESCRIPTION
Currently power rail tracks from different machines get mixed
together, since we're only sorting by track name. To provide better
ux and be consistent with the rest of the UI, make the machine_id
the primary sort key, so that we will group rails from the same
machine together before sorting them by name
