### PR TITLE
print path for diff test --keep-input option

### DIFF
--- a/python/generators/diff_tests/runner.py
+++ b/python/generators/diff_tests/runner.py
@@ -183,9 +183,10 @@ class DiffTestsRunner:
         gen_trace_file.close()
         os.remove(trace_path)
 
+    print_trace_path = gen_trace_file and self.config.keep_input
     run_str = self._process_test_result(result, trace_path,
                                         extension_descriptor_paths,
-                                        trace_descriptor_path)
+                                        trace_descriptor_path, print_trace_path)
     return test.name, run_str, result
 
   def _process_test_result(
@@ -194,6 +195,7 @@ class DiffTestsRunner:
       trace_path: str,
       extension_descriptor_paths: List[str],
       trace_descriptor_path: str,
+      print_trace_path: bool,
   ) -> str:
     colors = ColorFormatter(self.config.no_colors)
 
@@ -219,6 +221,7 @@ class DiffTestsRunner:
       return res
 
     run_str = f"{colors.yellow('[ RUN      ]')} {result.test.name}\n"
+    run_diagnostics = [f"trace_path: {trace_path}"] if print_trace_path else []
     if result.exit_code != 0 or not result.passed:
       result.passed = False
       run_str += result.stderr
@@ -230,13 +233,15 @@ class DiffTestsRunner:
       else:
         run_str += write_cmdlines()
 
-      run_str += (f"{colors.red('[  FAILED  ]')} {result.test.name}\n")
+      run_str += (f"{colors.red('[  FAILED  ]')} {result.test.name}")
     else:
       assert result.perf_result
-      run_str += (
-          f"{colors.green('[       OK ]')} {result.test.name} "
-          f"(ingest: {result.perf_result.ingest_time_ns / 1000000:.2f} ms "
-          f"query: {result.perf_result.real_time_ns / 1000000:.2f} ms)\n")
+      run_str += f"{colors.green('[       OK ]')} {result.test.name}"
+      run_diagnostics.append(
+          f"ingest: {result.perf_result.ingest_time_ns / 1000000:.2f} ms")
+      run_diagnostics.append(
+          f"query: {result.perf_result.real_time_ns / 1000000:.2f} ms")
+    run_str += f" ({' '.join(run_diagnostics)})\n" if run_diagnostics else "\n"
     return run_str
 
   def _get_build_config(self) -> Set[str]:


### PR DESCRIPTION
diff test framework has a --keep-input option to keep the generated
trace, however it is often in some difficult to discover file in /tmp
like `/tmp/tmpyeoiui86`

Print the path to make the location obvious to the user.


# Before

```
$  tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell --keep-input --name-filter="PowerPowerRails.power_rails"

...

[  FAILED  ] PowerPowerRails:power_rails_session_uuid
[ RUN      ] PowerPowerRails:power_rails_power_rails
[       OK ] PowerPowerRails:power_rails_power_rails (ingest: 114.00 ms query: 0.52 ms)
[ RUN      ] PowerPowerRails:power_rails_session_uuid_same_index_same_name
[       OK ] PowerPowerRails:power_rails_session_uuid_same_index_same_name (ingest: 97.09 ms query: 0.28 ms)

...
```
# After

```
$  tools/diff_test_trace_processor.py out/linux_clang_debug/trace_processor_shell --keep-input --name-filter="PowerPowerRails.power_rails"

...

[  FAILED  ] PowerPowerRails:power_rails_session_uuid (trace_path: /tmp/tmpdgqttrtc)
[ RUN      ] PowerPowerRails:power_rails_session_uuid_same_index_same_name
[       OK ] PowerPowerRails:power_rails_session_uuid_same_index_same_name (trace_path: /tmp/tmpkbiznewm ingest: 92.65 ms query: 0.28 ms)
[ RUN      ] PowerPowerRails:power_rails_well_known_power_rails
[       OK ] PowerPowerRails:power_rails_well_known_power_rails (trace_path: /tmp/tmpn9secvgj ingest: 92.34 ms query: 0.28 ms)

...
```
