### PR TITLE
Replace `text-weight: bolder` with `500` to improve text clarity

### DIFF
--- a/ui/src/assets/components/pivot_table.scss
+++ b/ui/src/assets/components/pivot_table.scss
@@ -16,7 +16,7 @@
 
 .pf-pivot-table {
   &__total-values {
-    font-weight: bolder;
+    font-weight: 500;
   }
 
   &__cell--indent {

--- a/ui/src/assets/widgets/empty_state.scss
+++ b/ui/src/assets/widgets/empty_state.scss
@@ -41,7 +41,7 @@
 
   &__title {
     text-align: center;
-    font-weight: bolder;
+    font-weight: 500;
     margin-bottom: 8px;
   }
 

--- a/ui/src/assets/widgets/tree.scss
+++ b/ui/src/assets/widgets/tree.scss
@@ -33,7 +33,7 @@ $chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' 
       background: inherit;
       min-width: max-content;
       border-radius: $border-radius 0 0 $border-radius;
-      font-weight: bolder;
+      font-weight: 500;
     }
 
     .pf-tree-right {

--- a/ui/src/assets/widgets/treetable.scss
+++ b/ui/src/assets/widgets/treetable.scss
@@ -23,7 +23,7 @@ $chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' 
     text-align: left;
     padding: 2px 8px;
     border-bottom: solid 1px grey;
-    font-weight: bolder;
+    font-weight: 500;
   }
   td {
     padding: 2px 8px;
@@ -40,7 +40,7 @@ $chevron-svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' 
     }
   }
   td.pf-treetable-maincol {
-    font-weight: bolder;
+    font-weight: 500;
   }
   td.pf-treetable-node {
     .pf-treetable-gutter {

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/styles.scss
@@ -70,7 +70,7 @@
   &__options-title {
     margin-bottom: 8px;
     font-size: larger;
-    font-weight: bolder;
+    font-weight: 500;
   }
 
   &__widget-container {


### PR DESCRIPTION
Currently we use `font-weight: bolder` in a few places to make some text bolder relative to the parent. This is fine but the actual implementation of bolder is uses banding to determine which level is chosen. See: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-weight#meaning_of_relative_weights. In short, the only outputs of bolder are 400, 700, and 900.

Since we only have a handful of Roboto weights available, the boldest of which being 500, it makes sense to just hard code these fonts to weight 500 instead of using bolder.