### PR TITLE
exp: Enable aggregation without group by and limit set to 0

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/limit_and_offset_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/limit_and_offset_node.ts
@@ -204,7 +204,7 @@ export class LimitAndOffsetNode implements ModificationNode {
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (this.prevNode === undefined) return undefined;
 
-    const hasLimit = this.state.limit !== undefined && this.state.limit > 0;
+    const hasLimit = this.state.limit !== undefined && this.state.limit >= 0;
     const hasOffset = this.state.offset !== undefined && this.state.offset > 0;
 
     if (!hasLimit && !hasOffset) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/structured_query_builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/structured_query_builder.ts
@@ -167,7 +167,7 @@ export class StructuredQueryBuilder {
     sq.id = nodeId ?? nextNodeId();
     sq.innerQuery = query;
 
-    if (limit !== undefined && limit > 0) {
+    if (limit !== undefined && limit >= 0) {
       sq.limit = limit;
     }
 


### PR DESCRIPTION
Aggregation operations without requiring GROUP BY columns and allows LIMIT to be set to 0.

Key Changes:

  1. Aggregation Node Logic
  - Before: Required at least one GROUP BY column to be selected
  - After: Requires at least one of: GROUP BY columns OR aggregation functions
  - This allows queries like SELECT COUNT(*) FROM table without grouping and using just group by to fetch distinct sets

  2. LIMIT=0 Support, as sqlite supports it
