### PR TITLE
exp: Switch from Info to Modify in side bar when possible

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -176,8 +176,11 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
       this.queryExecuted = false;
       this.isQueryRunning = false;
       this.isAnalyzing = false;
-      // Keep the current selected view when switching nodes
       const hasModifyPanel = selectedNode.nodeSpecificModify() != null;
+      // If current view is Info, switch to Modify (if available) when selecting a new node
+      if (this.selectedView === SelectedView.kInfo && hasModifyPanel) {
+        this.selectedView = SelectedView.kModify;
+      }
       // If current view is Modify but modify panel is not available, switch to Info
       if (this.selectedView === SelectedView.kModify && !hasModifyPanel) {
         this.selectedView = SelectedView.kInfo;


### PR DESCRIPTION
Improves the user experience in the Query Builder by automatically switching to the "Modify" view when selecting a new node, making the modify panel more discoverable.

 What it does:
 - When a user selects a new node in the query builder, if they're currently viewing the "Info" tab and the new node has a "Modify" panel available, it automatically switches to the "Modify" view
 - This makes the modify functionality more discoverable since users don't need to manually click to see i modification options are available
- The existing logic that switches away from "Modify" to "Info" when no modify panel is available is preserved