### PR TITLE
exp: Cleanup landing page

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -194,6 +194,30 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         this.isExplorerCollapsed && 'explorer-collapsed',
       ) || '';
 
+    // When no nodes exist, show only the graph (which renders EmptyGraph)
+    // without any panels or split layout
+    if (rootNodes.length === 0) {
+      return m(Graph, {
+        rootNodes,
+        selectedNode,
+        onNodeSelected,
+        nodeLayouts: attrs.nodeLayouts,
+        onNodeLayoutChange: attrs.onNodeLayoutChange,
+        onDeselect: attrs.onDeselect,
+        onAddSourceNode: attrs.onAddSourceNode,
+        onClearAllNodes,
+        onDuplicateNode: attrs.onDuplicateNode,
+        onAddOperationNode: (id, node) => attrs.onAddOperationNode(id, node),
+        devMode: attrs.devMode,
+        onDevModeChange: attrs.onDevModeChange,
+        onDeleteNode: attrs.onDeleteNode,
+        onConnectionRemove: attrs.onConnectionRemove,
+        onImport: attrs.onImport,
+        onImportWithStatement: attrs.onImportWithStatement,
+        onExport: attrs.onExport,
+      });
+    }
+
     const explorer = selectedNode
       ? m(NodeExplorer, {
           // The key to force mithril to re-create the component when the

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/empty_graph.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/empty_graph.scss
@@ -14,9 +14,14 @@
 
 .pf-exp-node-graph-add-button-container {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   padding: 40px;
 }
@@ -53,10 +58,6 @@
   text-align: center;
   cursor: pointer;
 
-  &:hover {
-    background-color: var(--pf-color-hover-background);
-  }
-
   .pf-icon {
     font-size: 2em;
   }
@@ -71,10 +72,4 @@
     flex-grow: 1;
     color: var(--pf-color-text-muted);
   }
-}
-
-.dev-mode-switch {
-  position: absolute;
-  top: 16px;
-  right: 16px;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -606,9 +606,6 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
     return m(EmptyGraph, {
       onAddSourceNode: attrs.onAddSourceNode,
       onImport: attrs.onImport,
-      onImportWithStatement: attrs.onImportWithStatement,
-      devMode: attrs.devMode,
-      onDevModeChange: attrs.onDevModeChange,
     });
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -15,7 +15,6 @@
 import m from 'mithril';
 
 import {AsyncLimiter} from '../../../base/async_limiter';
-import {ExplorePageHelp} from './help';
 import {
   analyzeNode,
   isAQuery,
@@ -188,7 +187,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
   view({attrs}: m.CVnode<NodeExplorerAttrs>) {
     const {node, isCollapsed, selectedView = SelectedView.kInfo} = attrs;
     if (!node) {
-      return m(ExplorePageHelp);
+      return null;
     }
 
     // Update the node's onchange callback to point to our attrs.onchange


### PR DESCRIPTION
 Summary

  - Simplifies the Explore Page landing experience by removing dev mode functionality and cleaning up the empty state UI
  - Simplified the landing page by removing the side panel
  - Removes the "Import from WITH statement" feature and help panel
