### PR TITLE
ui: Remove defunct CSS rule

### DIFF
--- a/ui/src/assets/common.scss
+++ b/ui/src/assets/common.scss
@@ -109,7 +109,3 @@ button {
   cursor: pointer;
   outline: inherit;
 }
-
-button.close {
-  font-family: var(--pf-font-monospace);
-}


### PR DESCRIPTION
Remove a single CSS rule `button.close` which is not used anywhere.