### PR TITLE
intrinsics: Optimize interval_intersect

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/interval_intersect.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/interval_intersect.cc
@@ -315,9 +315,11 @@ struct IntervalIntersect : public sqlite::Function<IntervalIntersect> {
 
     // For each partition insert into table.
     uint32_t rows = 0;
+    std::vector<Partition*> cur_partition_in_table;
+    cur_partition_in_table.reserve(tabc);
     for (auto p_it = p_intervals->GetIterator(); p_it; ++p_it) {
-      std::vector<Partition*> cur_partition_in_table;
       bool all_have_p = true;
+      cur_partition_in_table.clear();
 
       // From each table get all vectors of intervals.
       for (uint32_t i = 0; i < tabc; i++) {


### PR DESCRIPTION
interval_intersect() is used quite a bit for Wattson (and other stdlib tables), so optimizing its performance is desirable. This patchset reduces heap allocations. In theory, this mean less overhead when allocating memory, and better cache locality when accessing the memory.

In practice, I am seeing 8-10% improvement in interval_intersect(cpu_frequency_counters, cpu_idle_counters) compute time for traces ranging from 10s to 40min.

On Wattson side, it is about 1-2% improvement.
  WattsonStdlib:wattson_dsu_devfreq_system_state: 6376.75ms -> 6103.50ms
  AndroidMetrics:wattson_atrace_apps_threads_output: 4798.64ms -> 4668.68ms
  WattsonStdlib:wattson_syscore_suspend: 4725.85ms -> 4659.67ms
  AndroidMetrics:wattson_atrace_apps_rails_output: 3561.84ms -> 3507.49ms
  WattsonStdlib:wattson_idle_attribution: 3407.19ms -> 3339.31ms

Bug: 454944449
Signed-off-by: Samuel Wu <wusamuel@google.com>