### PR TITLE
tp: fix binary size regression in Chrome due to import logs

### DIFF
--- a/src/trace_processor/importers/common/import_logs_tracker.h
+++ b/src/trace_processor/importers/common/import_logs_tracker.h
@@ -24,8 +24,6 @@
 #include <utility>
 
 #include "src/trace_processor/importers/common/args_tracker.h"
-#include "src/trace_processor/storage/stats.h"
-#include "src/trace_processor/storage/trace_storage.h"
 
 namespace perfetto::trace_processor {
 
@@ -82,13 +80,6 @@ class ImportLogsTracker {
 
   TraceProcessorContext* context_;
   uint32_t trace_id_;
-
-  // Cached string IDs for severity levels
-  StringId severity_info_id_;
-  StringId severity_data_loss_id_;
-  StringId severity_error_id_;
-
-  StringId SeverityToStringId(stats::Severity severity);
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/sqlite/stats_table.cc
+++ b/src/trace_processor/sqlite/stats_table.cc
@@ -40,6 +40,7 @@ int StatsModule::Connect(sqlite3* db,
       source TEXT,
       value BIGINT,
       description TEXT,
+      key BIGINT HIDDEN,
       PRIMARY KEY(name)
     ) WITHOUT ROWID
   )";
@@ -157,6 +158,9 @@ int StatsModule::Column(sqlite3_vtab_cursor* cursor,
       break;
     case Column::kDescription:
       sqlite::result::StaticString(ctx, stats::kDescriptions[c->key]);
+      break;
+    case Column::kKey:
+      sqlite::result::Long(ctx, static_cast<int64_t>(c->key));
       break;
     default:
       PERFETTO_FATAL("Unknown column %d", N);

--- a/src/trace_processor/sqlite/stats_table.h
+++ b/src/trace_processor/sqlite/stats_table.h
@@ -37,7 +37,15 @@ struct StatsModule : sqlite::Module<StatsModule> {
     size_t key = 0;
     TraceStorage::Stats::IndexMap::const_iterator it{};
   };
-  enum Column { kName = 0, kIndex, kSeverity, kSource, kValue, kDescription };
+  enum Column {
+    kName = 0,
+    kIndex,
+    kSeverity,
+    kSource,
+    kValue,
+    kDescription,
+    kKey
+  };
 
   static constexpr auto kType = kEponymousOnly;
   static constexpr bool kSupportsWrites = false;

--- a/src/trace_processor/tables/metadata_tables.py
+++ b/src/trace_processor/tables/metadata_tables.py
@@ -854,8 +854,7 @@ TRACE_IMPORT_LOGS_TABLE = Table(
         C('trace_id', CppUint32()),
         C('ts', CppOptional(CppInt64())),
         C('byte_offset', CppOptional(CppInt64())),
-        C('severity', CppString()),
-        C('name', CppString()),
+        C('stat_key', CppInt64()),
         C(
             'arg_set_id',
             CppOptional(CppUint32()),

--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/import_errors.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/import_errors.ts
@@ -80,7 +80,7 @@ export async function loadImportErrorsData(
         name,
         byte_offset,
         __intrinsic_arg_set_to_json(arg_set_id) as args
-      from __intrinsic_trace_import_logs
+      from _trace_import_logs
       where name = '${category.name}' AND severity = 'error'
       order by ts
     `);


### PR DESCRIPTION
Turns out adding a dep on stats arrays is a bad idea as it increases
binary sizes unnecessarily. Instead, just store the key and lookup the
mapping to severity/name in SQL.
