### PR TITLE
Add missing includes

### DIFF
--- a/src/profiling/deobfuscator.cc
+++ b/src/profiling/deobfuscator.cc
@@ -16,6 +16,8 @@
 
 #include "src/profiling/deobfuscator.h"
 
+#include <stdlib.h>
+
 #include <optional>
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/file_utils.h"

--- a/src/protozero/descriptor_diff/main.cc
+++ b/src/protozero/descriptor_diff/main.cc
@@ -16,6 +16,7 @@
 
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
Chromium roll has been failing since https://github.com/google/perfetto/pull/3655 because of missing includes (see https://chromium-review.googlesource.com/c/chromium/src/+/7161358 for build failures).
This PR adds explicit stdlib includes where they are required.