### PR TITLE
ui: preload fonts and css in index.html

### DIFF
--- a/ui/src/assets/index.html
+++ b/ui/src/assets/index.html
@@ -115,11 +115,28 @@ Technical Information:
       // sub-directory directory, hence ./frontend_bundle.js.
       const version = versionMap[channel] || versionMap['stable'] || '.';
 
+      // Preloading reduce latency of key assets requires for drawing the app.
+      // We need to strike a balance here to avoid kicking off too many
+      // concurrent requests and slowing down everything.
+      const assetsPreload = {
+        '/perfetto.css': {as: 'style'},
+        '/assets/MaterialSymbolsOutlined.woff2': {as: 'font', type: 'font/woff2'},
+        '/assets/RobotoCondensed-Regular.woff2': {as: 'font', type: 'font/woff2'},
+        '/assets/Roboto-400.woff2': {as: 'font', type: 'font/woff2'},
+      };
+      for (const [preloadPath, preloadAttrs] of Object.entries(assetsPreload)) {
+        const preloadLink = document.createElement('link');
+        preloadLink.rel = 'preload';
+        preloadLink.crossOrigin = 'crossorigin';
+        preloadLink.href = version + preloadPath;
+        Object.assign(preloadLink, preloadAttrs);
+        document.head.append(preloadLink);
+      }
+
       const script = document.createElement('script');
       script.async = true;
       script.src = version + '/frontend_bundle.js';
       script.onerror = () => errHandler(`Failed to load ${script.src}`);
-
       document.head.append(script);
     })();
   </script>

--- a/ui/src/assets/typefaces.scss
+++ b/ui/src/assets/typefaces.scss
@@ -3,6 +3,7 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 100;
+  font-display: swap;
   src: url(assets/Roboto-100.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -14,6 +15,7 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url(assets/Roboto-300.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -25,6 +27,7 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url(assets/Roboto-400.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -36,6 +39,7 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
+  font-display: swap;
   src: url(assets/Roboto-500.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -47,6 +51,7 @@
   font-family: "Roboto Condensed";
   font-style: normal;
   font-weight: 300;
+  font-display: swap;
   src: url(assets/RobotoCondensed-Light.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -58,6 +63,7 @@
   font-family: "Roboto Condensed";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url(assets/RobotoCondensed-Regular.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -69,6 +75,7 @@
   font-family: "Roboto Mono";
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: url(assets/RobotoMono-Regular.woff2) format("woff2");
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
     U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
@@ -79,6 +86,7 @@
   font-family: "Material Symbols Sharp";
   font-style: normal;
   font-weight: 100 700;
+  font-display: block;
   src: url(assets/MaterialSymbolsOutlined.woff2) format("woff2");
 }
 


### PR DESCRIPTION
- Use link rel=preload to pre-fetch fonts and css without
  having to wait for frontend_bundle.ts
- Use font-display: block on the material design font to
  reduce the chance of showing the text if the font is still
  not loaded

I will tackle service worker installation and deferring engine
in a later PR.

Bug: b/458318781