### PR TITLE
Fix chromium build on Windows

### DIFF
--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -28,6 +28,7 @@
 #include "perfetto/base/export.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/scoped_file.h"
+#include "perfetto/ext/base/sys_types.h"
 
 namespace perfetto {
 namespace base {


### PR DESCRIPTION
Chromium roll is failing on Windows (see https://chromium-review.googlesource.com/c/chromium/src/+/7161429 for build failures) due to unknown type ssize_t. This PR adds the required include.