### PR TITLE
c_sdk: fix C++ code in C-clean headers

### DIFF
--- a/include/perfetto/public/pb_decoder.h
+++ b/include/perfetto/public/pb_decoder.h
@@ -65,7 +65,7 @@ static inline void PerfettoPbDecoderIterateNext(
 }
 
 static inline bool PerfettoPbDecoderFieldGetUint32(
-    const PerfettoPbDecoderField* field,
+    const struct PerfettoPbDecoderField* field,
     uint32_t* out) {
   switch (field->wire_type) {
     case PERFETTO_PB_WIRE_TYPE_VARINT:
@@ -80,7 +80,7 @@ static inline bool PerfettoPbDecoderFieldGetUint32(
 }
 
 static inline bool PerfettoPbDecoderFieldGetInt32(
-    const PerfettoPbDecoderField* field,
+    const struct PerfettoPbDecoderField* field,
     int32_t* out) {
   switch (field->wire_type) {
     case PERFETTO_PB_WIRE_TYPE_VARINT:
@@ -95,7 +95,7 @@ static inline bool PerfettoPbDecoderFieldGetInt32(
 }
 
 static inline bool PerfettoPbDecoderFieldGetUint64(
-    const PerfettoPbDecoderField* field,
+    const struct PerfettoPbDecoderField* field,
     uint64_t* out) {
   switch (field->wire_type) {
     case PERFETTO_PB_WIRE_TYPE_VARINT:
@@ -110,7 +110,7 @@ static inline bool PerfettoPbDecoderFieldGetUint64(
 }
 
 static inline bool PerfettoPbDecoderFieldGetInt64(
-    const PerfettoPbDecoderField* field,
+    const struct PerfettoPbDecoderField* field,
     int64_t* out) {
   switch (field->wire_type) {
     case PERFETTO_PB_WIRE_TYPE_VARINT:
@@ -125,7 +125,7 @@ static inline bool PerfettoPbDecoderFieldGetInt64(
 }
 
 static inline bool PerfettoPbDecoderFieldGetBool(
-    const PerfettoPbDecoderField* field,
+    const struct PerfettoPbDecoderField* field,
     bool* out) {
   switch (field->wire_type) {
     case PERFETTO_PB_WIRE_TYPE_VARINT:
@@ -140,7 +140,7 @@ static inline bool PerfettoPbDecoderFieldGetBool(
 }
 
 static inline bool PerfettoPbDecoderFieldGetFloat(
-    const PerfettoPbDecoderField* field,
+    const struct PerfettoPbDecoderField* field,
     float* out) {
   switch (field->wire_type) {
     case PERFETTO_PB_WIRE_TYPE_FIXED64:
@@ -154,7 +154,7 @@ static inline bool PerfettoPbDecoderFieldGetFloat(
 }
 
 static inline bool PerfettoPbDecoderFieldGetDouble(
-    const PerfettoPbDecoderField* field,
+    const struct PerfettoPbDecoderField* field,
     double* out) {
   switch (field->wire_type) {
     case PERFETTO_PB_WIRE_TYPE_FIXED64:

--- a/include/perfetto/public/tracing_session.h
+++ b/include/perfetto/public/tracing_session.h
@@ -19,6 +19,7 @@
 
 #include "perfetto/public/abi/backend_type.h"
 #include "perfetto/public/abi/tracing_session_abi.h"
+#include "perfetto/public/compiler.h"
 
 static inline struct PerfettoTracingSessionImpl* PerfettoTracingSessionCreate(
     PerfettoBackendTypes backend) {
@@ -28,7 +29,7 @@ static inline struct PerfettoTracingSessionImpl* PerfettoTracingSessionCreate(
   if (backend == PERFETTO_BACKEND_SYSTEM) {
     return PerfettoTracingSessionSystemCreate();
   }
-  return nullptr;
+  return PERFETTO_NULL;
 }
 
 #endif  // INCLUDE_PERFETTO_PUBLIC_TRACING_SESSION_H_


### PR DESCRIPTION
There were some small issues in the C headers which i found as I was
testing this code for https://github.com/google/perfetto/pull/3701.

Basically it seems like we were not correctly doing struct X and we were
accidentally using nullptr which is fine on C++ but strict C compilers
fail.
