### PR TITLE
ui: Improve the controlled popup demo on the widgets page

### DIFF
--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/popup_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/popup_demo.ts
@@ -35,34 +35,6 @@ function lorem() {
   return m('', {style: {width: '200px'}}, text);
 }
 
-function ControlledPopup() {
-  let popupOpen = false;
-
-  return {
-    view: function () {
-      return m(
-        Popup,
-        {
-          trigger: m(Button, {
-            label: `${popupOpen ? 'Close' : 'Open'} Popup`,
-            onclick: () => {
-              popupOpen = true;
-            },
-          }),
-          isOpen: popupOpen,
-          onChange: (shouldOpen: boolean) => (popupOpen = shouldOpen),
-        },
-        m(Button, {
-          label: 'Close Popup',
-          onclick: () => {
-            popupOpen = false;
-          },
-        }),
-      );
-    },
-  };
-}
-
 export function renderPopup(): m.Children {
   return [
     m(
@@ -81,7 +53,7 @@ export function renderPopup(): m.Children {
         m(
           Popup,
           {
-            trigger: m(Button, {label: 'Toggle Popup'}),
+            trigger: m(Button, {label: 'Toggle popup'}),
             ...rest,
           },
           lorem(),
@@ -98,7 +70,7 @@ export function renderPopup(): m.Children {
       },
     }),
 
-    renderDocSection('Controlled Popups', [
+    renderDocSection('Controlled Popup', [
       m('p', [
         `The open/close state of a controlled popup is passed in via
       the 'isOpen' attribute. This means we can get open or close the popup
@@ -112,8 +84,21 @@ export function renderPopup(): m.Children {
     ]),
 
     renderWidgetShowcase({
-      renderWidget: (opts) => m(ControlledPopup, opts),
-      initialOpts: {},
+      renderWidget: ({isOpen}) =>
+        m(
+          Popup,
+          {
+            trigger: m(Button, {
+              disabled: true,
+              label: `Popup is ${isOpen ? 'open' : 'closed'}`,
+            }),
+            isOpen,
+          },
+          lorem(),
+        ),
+      initialOpts: {
+        isOpen: false,
+      },
     }),
 
     renderDocSection('Nested Popups', [
@@ -125,7 +110,7 @@ export function renderPopup(): m.Children {
         m(
           Popup,
           {
-            trigger: m(Button, {label: 'Open the popup'}),
+            trigger: m(Button, {label: 'Toggle nested popup'}),
           },
           m(ButtonBar, [
             m(
@@ -136,10 +121,6 @@ export function renderPopup(): m.Children {
               m(MenuItem, {label: 'Option 1'}),
               m(MenuItem, {label: 'Option 2'}),
             ),
-            m(Button, {
-              label: 'Done',
-              dismissPopup: true,
-            }),
           ]),
         ),
     }),


### PR DESCRIPTION
Add a toggle switch to the controlled popup demo to make it clear that the state is controlled from outside. The previous incarnation of the demo was bad.