### PR TITLE
ui: avoid multiple reloads of the live-server watch

### DIFF
--- a/ui/config/rollup.config.js
+++ b/ui/config/rollup.config.js
@@ -33,6 +33,10 @@ function defBundle(tsRoot, bundle, distDir) {
       file: `${OUT_SYMLINK}/${distDir}/${bundle}_bundle.js`,
       sourcemap: true,
     },
+    watch: {
+      exclude: ['out/**'],
+      buildDelay: 250,
+    },
     plugins: [
       replace({
         patterns:


### PR DESCRIPTION
Today when touching a single .ts file we can get >1
reload notifications in the UI when using run-dev-server.
I tracked it down and the issue seems to be a mixture of:
1. Rollup writes the output file non-atomically. This is hard to
   fix. So we pick up >1 file changes as rollup is writing one file.
2. Rollup seems to get feedback loops from out/ being written.
   Add debounce + exclude out from the watch list.
3. Mitigate 1 in our build.js dev server logic, by adding some
   250ms debounce.