### PR TITLE
tp: Add stack tables to stdlib

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15276,6 +15276,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/slices/flow.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/hierarchy.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/self_dur.sql",
+        "src/trace_processor/perfetto_sql/stdlib/slices/stack.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/time_in_state.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/with_context.sql",
         "src/trace_processor/perfetto_sql/stdlib/stack_trace/jit.sql",

--- a/BUILD
+++ b/BUILD
@@ -3648,6 +3648,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/slices/flow.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/hierarchy.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/self_dur.sql",
+        "src/trace_processor/perfetto_sql/stdlib/slices/stack.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/time_in_state.sql",
         "src/trace_processor/perfetto_sql/stdlib/slices/with_context.sql",
     ],

--- a/src/trace_processor/perfetto_sql/stdlib/slices/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/slices/BUILD.gn
@@ -21,6 +21,7 @@ perfetto_sql_source_set("slices") {
     "flow.sql",
     "hierarchy.sql",
     "self_dur.sql",
+    "stack.sql",
     "time_in_state.sql",
     "with_context.sql",
   ]

--- a/src/trace_processor/perfetto_sql/stdlib/slices/stack.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/slices/stack.sql
@@ -1,0 +1,210 @@
+--
+-- Copyright 2025 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+INCLUDE PERFETTO MODULE slices.hierarchy;
+
+-- View that provides stack_id and parent_stack_id for all slices by computing
+-- them on-demand.
+--
+-- Note: This is currently for internal use only and computes stack hashes
+-- on-demand, which may be slower than the C++ implementation.
+CREATE PERFETTO VIEW _slice_with_stack_id (
+  -- Slice id.
+  id ID(slice.id),
+  -- Alias of `slice.ts`.
+  ts TIMESTAMP,
+  -- Alias of `slice.dur`.
+  dur DURATION,
+  -- Alias of `slice.track_id`.
+  track_id JOINID(track.id),
+  -- Alias of `slice.category`.
+  category STRING,
+  -- Alias of `slice.name`.
+  name STRING,
+  -- Alias of `slice.depth`.
+  depth LONG,
+  -- Alias of `slice.parent_id`.
+  parent_id JOINID(slice.id),
+  -- Alias of `slice.arg_set_id`.
+  arg_set_id ARGSETID,
+  -- Alias of `slice.thread_ts`.
+  thread_ts TIMESTAMP,
+  -- Alias of `slice.thread_dur`.
+  thread_dur LONG,
+  -- Alias of `slice.thread_instruction_count`.
+  thread_instruction_count LONG,
+  -- Alias of `slice.thread_instruction_delta`.
+  thread_instruction_delta LONG,
+  -- A unique identifier obtained from the names and categories of all slices
+  -- in this stack. Computed on-demand.
+  stack_id LONG,
+  -- The stack_id for the parent of this slice. 0 if there is no parent.
+  parent_stack_id LONG
+) AS
+WITH
+  slice_stack_hashes AS (
+    SELECT
+      s.id,
+      coalesce(
+        (
+          SELECT
+            hash(GROUP_CONCAT(hash(coalesce(category, '') || '|' || name), '|'))
+          FROM _slice_ancestor_and_self(s.id)
+          ORDER BY
+            depth ASC
+        ),
+        0
+      ) AS stack_hash
+    FROM slice AS s
+  )
+SELECT
+  s.id,
+  s.ts,
+  s.dur,
+  s.track_id,
+  s.category,
+  s.name,
+  s.depth,
+  s.parent_id,
+  s.arg_set_id,
+  s.thread_ts,
+  s.thread_dur,
+  s.thread_instruction_count,
+  s.thread_instruction_delta,
+  sh.stack_hash AS stack_id,
+  coalesce(parent_sh.stack_hash, 0) AS parent_stack_id
+FROM slice AS s
+JOIN slice_stack_hashes AS sh
+  ON s.id = sh.id
+LEFT JOIN slice_stack_hashes AS parent_sh
+  ON s.parent_id = parent_sh.id;
+
+-- Returns all slices that have the given stack_id, along with their ancestors.
+--
+-- The stack_id can be obtained from the _slice_with_stack_id view.
+CREATE PERFETTO FUNCTION _ancestor_slice_by_stack(
+    -- The stack hash to search for.
+    stack_hash LONG
+)
+RETURNS TABLE (
+  -- Slice id.
+  id JOINID(slice.id),
+  -- Alias of `slice.ts`.
+  ts TIMESTAMP,
+  -- Alias of `slice.dur`.
+  dur DURATION,
+  -- Alias of `slice.track_id`.
+  track_id JOINID(track.id),
+  -- Alias of `slice.category`.
+  category STRING,
+  -- Alias of `slice.name`.
+  name STRING,
+  -- Alias of `slice.depth`.
+  depth LONG,
+  -- Alias of `slice.parent_id`.
+  parent_id JOINID(slice.id),
+  -- Alias of `slice.arg_set_id`.
+  arg_set_id ARGSETID,
+  -- Alias of `slice.thread_ts`.
+  thread_ts TIMESTAMP,
+  -- Alias of `slice.thread_dur`.
+  thread_dur LONG
+) AS
+-- Find all slices with the matching stack hash
+WITH
+  matching_slices AS (
+    SELECT
+      id
+    FROM _slice_with_stack_id
+    WHERE
+      stack_id = $stack_hash
+  )
+-- For each matching slice, get all ancestors and self
+SELECT DISTINCT
+  anc.id,
+  anc.ts,
+  anc.dur,
+  anc.track_id,
+  anc.category,
+  anc.name,
+  anc.depth,
+  anc.parent_id,
+  anc.arg_set_id,
+  anc.thread_ts,
+  anc.thread_dur
+FROM matching_slices AS ms
+JOIN _slice_ancestor_and_self(ms.id) AS anc
+  ON TRUE
+ORDER BY
+  anc.ts ASC;
+
+-- Returns all slices that have the given stack_id, along with their descendants.
+--
+-- The stack_id can be obtained from the _slice_with_stack_id view.
+CREATE PERFETTO FUNCTION _descendant_slice_by_stack(
+    -- The stack hash to search for.
+    stack_hash LONG
+)
+RETURNS TABLE (
+  -- Slice id.
+  id JOINID(slice.id),
+  -- Alias of `slice.ts`.
+  ts TIMESTAMP,
+  -- Alias of `slice.dur`.
+  dur DURATION,
+  -- Alias of `slice.track_id`.
+  track_id JOINID(track.id),
+  -- Alias of `slice.category`.
+  category STRING,
+  -- Alias of `slice.name`.
+  name STRING,
+  -- Alias of `slice.depth`.
+  depth LONG,
+  -- Alias of `slice.parent_id`.
+  parent_id JOINID(slice.id),
+  -- Alias of `slice.arg_set_id`.
+  arg_set_id ARGSETID,
+  -- Alias of `slice.thread_ts`.
+  thread_ts TIMESTAMP,
+  -- Alias of `slice.thread_dur`.
+  thread_dur LONG
+) AS
+-- Find all slices with the matching stack hash
+WITH
+  matching_slices AS (
+    SELECT
+      id
+    FROM _slice_with_stack_id
+    WHERE
+      stack_id = $stack_hash
+  )
+-- For each matching slice, get all descendants and self
+SELECT DISTINCT
+  desc.id,
+  desc.ts,
+  desc.dur,
+  desc.track_id,
+  desc.category,
+  desc.name,
+  desc.depth,
+  desc.parent_id,
+  desc.arg_set_id,
+  desc.thread_ts,
+  desc.thread_dur
+FROM matching_slices AS ms
+JOIN _slice_descendant_and_self(ms.id) AS desc
+  ON TRUE
+ORDER BY
+  desc.ts ASC;

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -156,6 +156,7 @@ from diff_tests.stdlib.prelude.slices_tests import PreludeSlices
 from diff_tests.stdlib.prelude.window_functions_tests import PreludeWindowFunctions
 from diff_tests.stdlib.sched.tests import StdlibSched
 from diff_tests.stdlib.slices.tests import Slices
+from diff_tests.stdlib.slices.tests_stack import SlicesStack
 from diff_tests.stdlib.span_join.tests_left_join import SpanJoinLeftJoin
 from diff_tests.stdlib.span_join.tests_outer_join import SpanJoinOuterJoin
 from diff_tests.stdlib.span_join.tests_regression import SpanJoinRegression
@@ -316,6 +317,7 @@ def fetch_all_diff_tests(
       PreludeSlices,
       StdlibSmoke,
       Slices,
+      SlicesStack,
       SpanJoinLeftJoin,
       SpanJoinOuterJoin,
       SpanJoinRegression,

--- a/test/trace_processor/diff_tests/parser/simpleperf/clocks_align_test.sql
+++ b/test/trace_processor/diff_tests/parser/simpleperf/clocks_align_test.sql
@@ -14,13 +14,15 @@
 -- limitations under the License.
 --
 
+INCLUDE PERFETTO MODULE slices.stack;
+
 CREATE PERFETTO VIEW perf_sample_in(ts TIMESTAMP, dur LONG)
 AS
 SELECT ts, 0 AS dur FROM perf_sample;
 
 CREATE VIRTUAL TABLE span
 USING
-  SPAN_JOIN(perf_sample_in, slice PARTITIONED depth);
+  SPAN_JOIN(perf_sample_in, _slice_with_stack_id PARTITIONED depth);
 
 CREATE PERFETTO TABLE slice_stack
 AS

--- a/test/trace_processor/diff_tests/stdlib/dynamic_tables/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/dynamic_tables/tests.py
@@ -47,8 +47,9 @@ class DynamicTables(TestSuite):
     return DiffTestBlueprint(
         trace=Path('slice_stacks.textproto'),
         query="""
-        SELECT ts, name FROM ancestor_slice_by_stack((
-          SELECT stack_id FROM slice
+        INCLUDE PERFETTO MODULE slices.stack;
+        SELECT ts, name FROM _ancestor_slice_by_stack((
+          SELECT stack_id FROM _slice_with_stack_id
           WHERE name = 'event_depth_2'
           LIMIT 1
           ));
@@ -57,8 +58,10 @@ class DynamicTables(TestSuite):
         "ts","name"
         1000,"event_depth_0"
         2000,"event_depth_1"
+        3000,"event_depth_2"
         8000,"event_depth_0"
         9000,"event_depth_1"
+        10000,"event_depth_2"
         """))
 
   # Descendant slice by stack table.
@@ -66,16 +69,19 @@ class DynamicTables(TestSuite):
     return DiffTestBlueprint(
         trace=Path('slice_stacks.textproto'),
         query="""
-        SELECT ts, name FROM descendant_slice_by_stack((
-          SELECT stack_id FROM slice
+        INCLUDE PERFETTO MODULE slices.stack;
+        SELECT ts, name FROM _descendant_slice_by_stack((
+          SELECT stack_id FROM _slice_with_stack_id
           WHERE name = 'event_depth_0'
           LIMIT 1
           ));
         """,
         out=Csv("""
         "ts","name"
+        1000,"event_depth_0"
         2000,"event_depth_1"
         3000,"event_depth_2"
+        8000,"event_depth_0"
         9000,"event_depth_1"
         10000,"event_depth_2"
         """))

--- a/test/trace_processor/diff_tests/stdlib/slices/tests_stack.py
+++ b/test/trace_processor/diff_tests/stdlib/slices/tests_stack.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Csv, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class SlicesStack(TestSuite):
+
+  def test_identical_stacks_same_stack_id(self):
+    # Tests that slices with identical call stacks get the same stack_id
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|A"
+              }
+            }
+            event {
+              timestamp: 1100
+              pid: 10
+              print {
+                buf: "B|10|B"
+              }
+            }
+            event {
+              timestamp: 1200
+              pid: 10
+              print {
+                buf: "B|10|C"
+              }
+            }
+            event {
+              timestamp: 1300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1400
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            # Second identical stack A->B->C
+            event {
+              timestamp: 2000
+              pid: 10
+              print {
+                buf: "B|10|A"
+              }
+            }
+            event {
+              timestamp: 2100
+              pid: 10
+              print {
+                buf: "B|10|B"
+              }
+            }
+            event {
+              timestamp: 2200
+              pid: 10
+              print {
+                buf: "B|10|C"
+              }
+            }
+            event {
+              timestamp: 2300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 2400
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 2500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT
+          s1.name AS name1,
+          s1.ts AS ts1,
+          s2.name AS name2,
+          s2.ts AS ts2,
+          s1.stack_id = s2.stack_id AS same_stack_id
+        FROM _slice_with_stack_id s1
+        JOIN _slice_with_stack_id s2
+        WHERE s1.name = 'C' AND s2.name = 'C' AND s1.ts < s2.ts;
+        """,
+        out=Csv("""
+        "name1","ts1","name2","ts2","same_stack_id"
+        "C",1200,"C",2200,1
+        """))
+
+  def test_different_stacks_different_stack_ids(self):
+    # Tests that slices with different call stacks get different stack_ids
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|A"
+              }
+            }
+            event {
+              timestamp: 1100
+              pid: 10
+              print {
+                buf: "B|10|B"
+              }
+            }
+            event {
+              timestamp: 1200
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            # Different stack A->C
+            event {
+              timestamp: 2000
+              pid: 10
+              print {
+                buf: "B|10|A"
+              }
+            }
+            event {
+              timestamp: 2100
+              pid: 10
+              print {
+                buf: "B|10|C"
+              }
+            }
+            event {
+              timestamp: 2200
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 2300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT
+          s1.name AS leaf1,
+          s2.name AS leaf2,
+          s1.stack_id != s2.stack_id AS different_stack_ids
+        FROM _slice_with_stack_id s1
+        JOIN _slice_with_stack_id s2
+        WHERE s1.name = 'B' AND s2.name = 'C' AND s1.depth = 1 AND s2.depth = 1;
+        """,
+        out=Csv("""
+        "leaf1","leaf2","different_stack_ids"
+        "B","C",1
+        """))
+
+  def test_parent_child_stack_id_relationship(self):
+    # Tests that parent_stack_id correctly points to parent's stack_id
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|Parent"
+              }
+            }
+            event {
+              timestamp: 1100
+              pid: 10
+              print {
+                buf: "B|10|Child"
+              }
+            }
+            event {
+              timestamp: 1200
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT
+          child.name AS child_name,
+          parent.name AS parent_name,
+          child.parent_stack_id = parent.stack_id AS correct_parent_stack_id
+        FROM _slice_with_stack_id child
+        JOIN _slice_with_stack_id parent ON child.parent_id = parent.id
+        WHERE child.name = 'Child';
+        """,
+        out=Csv("""
+        "child_name","parent_name","correct_parent_stack_id"
+        "Child","Parent",1
+        """))
+
+  def test_depth_zero_slices_parent_stack_id(self):
+    # Tests that depth 0 slices have parent_stack_id = 0
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|RootSlice"
+              }
+            }
+            event {
+              timestamp: 1500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT
+          name,
+          depth,
+          parent_stack_id
+        FROM _slice_with_stack_id
+        WHERE depth = 0;
+        """,
+        out=Csv("""
+        "name","depth","parent_stack_id"
+        "RootSlice",0,0
+        """))
+
+  def test_slice_stack_id_computed(self):
+    # Tests that stack_id is computed correctly in the view
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|A"
+              }
+            }
+            event {
+              timestamp: 1100
+              pid: 10
+              print {
+                buf: "B|10|B"
+              }
+            }
+            event {
+              timestamp: 1200
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT
+          name,
+          depth,
+          stack_id,
+          stack_id != 0 AS stack_id_nonzero
+        FROM _slice_with_stack_id
+        ORDER BY depth;
+        """,
+        out=Csv("""
+        "name","depth","stack_id","stack_id_nonzero"
+        "A",0,1905114530773834795,1
+        "B",1,6901956697539716495,1
+        """))
+
+  def test_ancestor_slice_by_stack(self):
+    # Tests _ancestor_slice_by_stack function
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|Root"
+              }
+            }
+            event {
+              timestamp: 1100
+              pid: 10
+              print {
+                buf: "B|10|Middle"
+              }
+            }
+            event {
+              timestamp: 1200
+              pid: 10
+              print {
+                buf: "B|10|Leaf"
+              }
+            }
+            event {
+              timestamp: 1300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1400
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            # Second identical stack
+            event {
+              timestamp: 2000
+              pid: 10
+              print {
+                buf: "B|10|Root"
+              }
+            }
+            event {
+              timestamp: 2100
+              pid: 10
+              print {
+                buf: "B|10|Middle"
+              }
+            }
+            event {
+              timestamp: 2200
+              pid: 10
+              print {
+                buf: "B|10|Leaf"
+              }
+            }
+            event {
+              timestamp: 2300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 2400
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 2500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT name, depth
+        FROM _ancestor_slice_by_stack((
+          SELECT stack_id FROM _slice_with_stack_id
+          WHERE name = 'Leaf' AND ts = 1200
+          LIMIT 1
+        ))
+        ORDER BY depth;
+        """,
+        out=Csv("""
+        "name","depth"
+        "Root",0
+        "Root",0
+        "Middle",1
+        "Middle",1
+        "Leaf",2
+        "Leaf",2
+        """))
+
+  def test_descendant_slice_by_stack(self):
+    # Tests _descendant_slice_by_stack function
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|Root"
+              }
+            }
+            event {
+              timestamp: 1100
+              pid: 10
+              print {
+                buf: "B|10|Child1"
+              }
+            }
+            event {
+              timestamp: 1200
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1300
+              pid: 10
+              print {
+                buf: "B|10|Child2"
+              }
+            }
+            event {
+              timestamp: 1400
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            # Second identical root
+            event {
+              timestamp: 2000
+              pid: 10
+              print {
+                buf: "B|10|Root"
+              }
+            }
+            event {
+              timestamp: 2100
+              pid: 10
+              print {
+                buf: "B|10|Child1"
+              }
+            }
+            event {
+              timestamp: 2200
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 2300
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT name, ts
+        FROM _descendant_slice_by_stack((
+          SELECT stack_id FROM _slice_with_stack_id
+          WHERE name = 'Root' AND ts = 1000
+          LIMIT 1
+        ))
+        ORDER BY ts;
+        """,
+        out=Csv("""
+        "name","ts"
+        "Root",1000
+        "Child1",1100
+        "Child2",1300
+        "Root",2000
+        "Child1",2100
+        """))
+
+  def test_stack_with_categories(self):
+    # Tests that categories are included in stack hash computation
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|A"
+              }
+            }
+            event {
+              timestamp: 1500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 2000
+          incremental_state_cleared: true
+          track_descriptor {
+            uuid: 1
+            parent_uuid: 10
+            thread {
+              pid: 5
+              tid: 1
+              thread_name: "t1"
+            }
+          }
+          trace_packet_defaults {
+            track_event_defaults {
+              track_uuid: 1
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 2000
+          track_descriptor {
+            uuid: 10
+            process {
+              pid: 5
+              process_name: "p1"
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 3000
+          track_event {
+            categories: "cat1"
+            name: "A"
+            type: 1
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 1
+          timestamp: 3500
+          track_event {
+            categories: "cat1"
+            name: "A"
+            type: 2
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT
+          s1.category AS cat1,
+          s2.category AS cat2,
+          s1.name AS name1,
+          s2.name AS name2,
+          s1.stack_id != s2.stack_id AS different_stacks
+        FROM _slice_with_stack_id s1
+        JOIN _slice_with_stack_id s2
+        WHERE s1.name = 'A' AND s2.name = 'A'
+          AND s1.category IS NULL AND s2.category = 'cat1';
+        """,
+        out=Csv("""
+        "cat1","cat2","name1","name2","different_stacks"
+        "[NULL]","cat1","A","A",1
+        """))
+
+  def test_multiple_depth_levels_stack_ids(self):
+    # Tests that each depth level has correct stack_id and parent_stack_id
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|D0"
+              }
+            }
+            event {
+              timestamp: 1100
+              pid: 10
+              print {
+                buf: "B|10|D1"
+              }
+            }
+            event {
+              timestamp: 1200
+              pid: 10
+              print {
+                buf: "B|10|D2"
+              }
+            }
+            event {
+              timestamp: 1300
+              pid: 10
+              print {
+                buf: "B|10|D3"
+              }
+            }
+            event {
+              timestamp: 1400
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1600
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+            event {
+              timestamp: 1700
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT
+          child.name AS child,
+          child.depth AS child_depth,
+          parent.name AS parent,
+          parent.depth AS parent_depth,
+          child.parent_stack_id = parent.stack_id AS valid_relationship
+        FROM _slice_with_stack_id child
+        LEFT JOIN _slice_with_stack_id parent ON child.parent_id = parent.id
+        ORDER BY child.depth;
+        """,
+        out=Csv("""
+        "child","child_depth","parent","parent_depth","valid_relationship"
+        "D0",0,"[NULL]","[NULL]","[NULL]"
+        "D1",1,"D0",0,1
+        "D2",2,"D1",1,1
+        "D3",3,"D2",2,1
+        """))
+
+  def test_empty_trace_stack_functions(self):
+    # Tests that stack functions work correctly with empty results
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          ftrace_events {
+            cpu: 0
+            event {
+              timestamp: 1000
+              pid: 10
+              print {
+                buf: "B|10|A"
+              }
+            }
+            event {
+              timestamp: 1500
+              pid: 10
+              print {
+                buf: "E|10"
+              }
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE slices.stack;
+
+        SELECT COUNT(*) AS count
+        FROM _ancestor_slice_by_stack(999999999);
+        """,
+        out=Csv("""
+        "count"
+        0
+        """))


### PR DESCRIPTION
  ## Summary

Add SQL-based stack table implementation to stdlib that computes `stack_id` and `parent_stack_id` o demand. This prepares for removing these columns from the C++ slice table.

  ## Changes

  - **`slices/stack.sql`**: New module with `_slice_with_stack_id` view and stack-based query functions
    - `_slice_with_stack_id`: Computes stack IDs by hashing concatenated ancestor slice names
    - `_ancestor_slice_by_stack()`: Returns all slices with a given stack_id plus their ancestors
    - `_descendant_slice_by_stack()`: Returns all slices with a given stack_id plus their descendants