### PR TITLE
ui: Format Grid copy as TSV for spreadsheet compatibility

### DIFF
--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -380,7 +380,53 @@ export class Grid implements m.ClassComponent<GridAttrs> {
   > = new Map();
   private fieldToId: Map<string, number> = new Map();
   private nextId = 0;
+  private boundHandleCopy = this.handleCopy.bind(this);
+  private handleCopy(e: ClipboardEvent): void {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
 
+    const range = selection.getRangeAt(0);
+    const container = range.commonAncestorContainer;
+
+    // Find the grid element
+    const gridElement =
+      container.nodeType === Node.ELEMENT_NODE
+        ? (container as Element).closest('.pf-grid')
+        : (container.parentElement?.closest('.pf-grid') as Element | null);
+
+    if (!gridElement) return;
+
+    // Clone the selection's content
+    const fragment = range.cloneContents();
+    const tempDiv = document.createElement('div');
+    tempDiv.appendChild(fragment);
+
+    // Find all rows in the cloned content
+    const rows = Array.from(
+      tempDiv.querySelectorAll('.pf-grid__row'),
+    ) as HTMLElement[];
+
+    if (rows.length === 0) return;
+
+    // Extract text from cells in TSV format
+    const tsvRows = rows
+      .map((row) => {
+        const cells = Array.from(
+          row.querySelectorAll('.pf-grid__cell-container'),
+        ) as HTMLElement[];
+        const cellTexts = cells
+          .map((cell) => cell.textContent?.trim() || '')
+          .filter((text) => text.length > 0);
+        return cellTexts.join('\t');
+      })
+      .filter((row) => row.length > 0);
+
+    if (tsvRows.length > 0) {
+      const tsvData = tsvRows.join('\n');
+      e.clipboardData?.setData('text/plain', tsvData);
+      e.preventDefault();
+    }
+  }
   private getColumnId(field: string): number {
     if (!this.fieldToId.has(field)) {
       this.fieldToId.set(field, this.nextId++);
@@ -506,6 +552,10 @@ export class Grid implements m.ClassComponent<GridAttrs> {
 
     // Extract rows from rowData
     const rows = isPartialRowData(rowData) ? rowData.data : rowData;
+
+    // Add copy event handler for spreadsheet-friendly formatting
+    const gridDom = vnode.dom as HTMLElement;
+    gridDom.addEventListener('copy', this.boundHandleCopy);
 
     if (rows.length > 0) {
       // Check if there are new columns that need sizing
@@ -637,6 +687,11 @@ export class Grid implements m.ClassComponent<GridAttrs> {
         );
       }
     }
+  }
+
+  onremove(vnode: m.VnodeDOM<GridAttrs, this>) {
+    const gridDom = vnode.dom as HTMLElement;
+    gridDom.removeEventListener('copy', this.boundHandleCopy);
   }
 
   private measureAndApplyWidths(


### PR DESCRIPTION
Previously we used a `<table>` element to show tabular data but we now use flexboxes. Since switching to flexboxes, the select-copy-paste functionality has regressed as the data is no longer formatted correctly for pasting into spreadsheets. The browser natively formats selections inside `<table>`s but it doesn't do the same for flexboxes.

This patch adds a custom copy handler to the Grid component that formats copied cells with tab separators between cells and newline separators between rows, which emulates how `<table>` copy and paste works.

For example:
<img width="702" height="168" alt="image" src="https://github.com/user-attachments/assets/a130186d-aaa2-44dd-8979-3a91c8729cdc" />

Will be copied as:
```
er	1.255s	3.138ms	8.256ms	152
Window_GLFW::finish	1.023s	1.023s	6.730ms	152
Window_GLFW_ImGui::render_views	195.9ms	990.0µs	1.297ms	151
Graph::draw	194.5ms	687.8µs	1.288ms	151
View::draw	194.2
```
Which looks like this when copied into a spreadsheet application:
<img width="561" height="140" alt="image" src="https://github.com/user-attachments/assets/ffe5182b-73a5-4108-9124-49413f1d9d08" />

Note 1: It may well be better in the future to have a higher level selection UX (whole cell selection + rectangular selection box) when selecting cells in a table, more akin to how selections are handled in spreadsheet apps.

Note 2: Most Grid users enable virtualization which means it's not possible to select the entire grid all at once. This was also not possible previously in the paginated version since you could only see only page at a time, but now it give the impression that this _could_ be possible when you click, drag, and scroll down to the bottom, so this could be considered a regression. However, this is an orthogonal issue.

Fixes: https://github.com/google/perfetto/issues/3530