### PR TITLE
ui: use crossorigin only on fonts in link rel="preload"

### DIFF
--- a/ui/src/assets/index.html
+++ b/ui/src/assets/index.html
@@ -118,16 +118,18 @@ Technical Information:
       // Preloading reduce latency of key assets requires for drawing the app.
       // We need to strike a balance here to avoid kicking off too many
       // concurrent requests and slowing down everything.
+      // Note: Fonts (and only fonts) require "crossorigin" as per
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload.
+      const fontAttrs = {crossOrigin: '', as: 'font', type: 'font/woff2'}
       const assetsPreload = {
         '/perfetto.css': {as: 'style'},
-        '/assets/MaterialSymbolsOutlined.woff2': {as: 'font', type: 'font/woff2'},
-        '/assets/RobotoCondensed-Regular.woff2': {as: 'font', type: 'font/woff2'},
-        '/assets/Roboto-400.woff2': {as: 'font', type: 'font/woff2'},
+        '/assets/MaterialSymbolsOutlined.woff2': fontAttrs,
+        '/assets/RobotoCondensed-Regular.woff2': fontAttrs,
+        '/assets/Roboto-400.woff2': fontAttrs,
       };
       for (const [preloadPath, preloadAttrs] of Object.entries(assetsPreload)) {
         const preloadLink = document.createElement('link');
         preloadLink.rel = 'preload';
-        preloadLink.crossOrigin = 'crossorigin';
         preloadLink.href = version + preloadPath;
         Object.assign(preloadLink, preloadAttrs);
         document.head.append(preloadLink);


### PR DESCRIPTION
Follow up to #3692. I misread the docs and didn't realize
that the crossorigin attribute is needed only for fonts
(Which are subject to CORS) but NOT css.
This ended up invalidating the preload for the CSS, showing
a devtools warning that Lalit spotted.
Also turns out that jsut setting "crossorigin" is enough.
See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#anonymous
```
Note: font and fetch preloading requires the crossorigin attribute to be set; see CORS-enabled fetches below.
```

Bug: b/458318781