### PR TITLE
ui: remove navigate-to from CSP

### DIFF
--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -187,7 +187,6 @@ function setupContentSecurityPolicy() {
       'https://*.googleapis.com',
     ],
     'style-src': [`'self'`, `'unsafe-inline'`],
-    'navigate-to': ['https://*.perfetto.dev', 'self'],
   };
   const meta = document.createElement('meta');
   meta.httpEquiv = 'Content-Security-Policy';


### PR DESCRIPTION
navigate-to was part of an early CSP3 draft, never actually
implemented anywhere, and has since been removed from the spec.
Browsers now just warn and ignore it.
This gets rid of a noisy devtools warning.