### PR TITLE
tools: gen_stdlib_docs_json can return internal artifacts

### DIFF
--- a/python/generators/sql_processing/docs_parse.py
+++ b/python/generators/sql_processing/docs_parse.py
@@ -35,6 +35,8 @@ class DocParseOptions:
   # TODO(lalitm): set this to true and/or remove this check once Google3 modules
   # adhere to this check.
   enforce_every_column_set_is_documented: bool = False
+  # Include internal artifacts (those starting with _) in the output
+  include_internal: bool = False
 
 
 def _is_internal(name: str) -> bool:
@@ -289,8 +291,8 @@ class FunctionDocParser(AbstractDocParser):
           f'as standard library modules can only included once. Please just '
           f'use CREATE instead.')
 
-    # Ignore internal functions.
-    if _is_internal(self.name):
+    # Ignore internal functions unless explicitly requested.
+    if _is_internal(self.name) and not self.options.include_internal:
       return None
 
     name = self._parse_name()
@@ -341,8 +343,8 @@ class TableFunctionDocParser(AbstractDocParser):
           f'use CREATE instead.')
       return
 
-    # Ignore internal functions.
-    if _is_internal(self.name):
+    # Ignore internal functions unless explicitly requested.
+    if _is_internal(self.name) and not self.options.include_internal:
       return None
 
     name = self._parse_name()
@@ -390,8 +392,8 @@ class MacroDocParser(AbstractDocParser):
           f'as standard library modules can only included once. Please just '
           f'use CREATE instead.')
 
-    # Ignore internal macros.
-    if _is_internal(self.name):
+    # Ignore internal macros unless explicitly requested.
+    if _is_internal(self.name) and not self.options.include_internal:
       return None
 
     name = self._parse_name()

--- a/tools/gen_stdlib_docs_json.py
+++ b/tools/gen_stdlib_docs_json.py
@@ -19,7 +19,7 @@ import sys
 import json
 import re
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, Tuple, Optional
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(os.path.join(ROOT_DIR))
@@ -27,12 +27,24 @@ sys.path.append(os.path.join(ROOT_DIR))
 from python.generators.sql_processing.docs_parse import DocParseOptions, parse_file
 
 
+def _is_internal(name: str) -> bool:
+  """Check if a name represents an internal artifact (starts with _)."""
+  return name.startswith('_')
+
+
 def _summary_desc(s: str) -> str:
+  """Extract the first sentence from a description."""
   return s.split('. ')[0].replace('\n', ' ')
 
 
-def _long_type_to_table(s: str):
-  pattern = r'(?:[A-Z]*)\(([a-z_]*).([a-z_]*)\)'
+def _long_type_to_table(s: str) -> Tuple[Optional[str], Optional[str]]:
+  """Parse a long type string to extract table and column references.
+
+  Expected format: "TYPE(table_name.column_name)"
+  Returns (table_name, column_name) or (None, None) if no match.
+  """
+  # Match pattern like "JOIN_TYPE(table.column)" where the period is literal
+  pattern = r'[A-Z]*\(([a-z_]*)\.([a-z_]*)\)'
   m = re.match(pattern, s)
   if not m:
     return (None, None)
@@ -40,21 +52,44 @@ def _long_type_to_table(s: str):
   return (g[0], g[1])
 
 
+def _create_field_dict(name: str, obj, include_desc: bool = True) -> dict:
+  """Create a dictionary for a column or argument with table/column references."""
+  table, column = _long_type_to_table(obj.long_type)
+  result = {
+      'name': name,
+      'type': obj.long_type,
+      'table': table,
+      'column': column,
+  }
+  if include_desc:
+    result['desc'] = obj.description
+  return result
+
+
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument('--json-out', required=True)
   parser.add_argument('--input-list-file')
-  parser.add_argument('--minify')
+  parser.add_argument(
+      '--minify',
+      action='store_true',
+      help='Minify JSON output (removes indentation and whitespace)')
+  parser.add_argument(
+      '--with-internal',
+      action='store_true',
+      help='Include internal artifacts (those starting with _) in output')
   parser.add_argument('sql_files', nargs='*')
   args = parser.parse_args()
 
   if args.input_list_file and args.sql_files:
-    print("Only one of --input-list-file and list of SQL files expected")
+    print(
+        "Only one of --input-list-file and list of SQL files expected",
+        file=sys.stderr)
     return 1
 
   sql_files = []
   if args.input_list_file:
-    with open(args.input_list_file, 'r') as input_list_file:
+    with open(args.input_list_file, 'r', encoding='utf-8') as input_list_file:
       for line in input_list_file.read().splitlines():
         sql_files.append(line)
   else:
@@ -69,18 +104,19 @@ def main():
   # Extract the SQL output from each file.
   sql_outputs: Dict[str, str] = {}
   for file_name in sql_files:
-    with open(file_name, 'r') as f:
+    with open(file_name, 'r', encoding='utf-8') as f:
       relpath = os.path.relpath(file_name, root_dir)
 
       # We've had bugs (e.g. b/264711057) when Soong's common path logic breaks
       # and ends up with a bunch of ../ prefixing the path: disallow any ../
       # as this should never be a valid in our C++ output.
-      assert '../' not in relpath
+      if '../' in relpath:
+        raise ValueError(
+            f"Invalid path with parent directory reference: {relpath}")
 
       sql_outputs[relpath] = f.read()
 
   packages = defaultdict(list)
-  # Add documentation from each file
   for path, sql in sql_outputs.items():
     package_name = path.split("/")[0]
     module_name = path.split(".sql")[0].replace("/", ".")
@@ -88,7 +124,9 @@ def main():
     docs = parse_file(
         path,
         sql,
-        options=DocParseOptions(enforce_every_column_set_is_documented=True),
+        options=DocParseOptions(
+            enforce_every_column_set_is_documented=True,
+            include_internal=args.with_internal),
     )
 
     # Some modules (i.e `deprecated`) should not generate docs.
@@ -97,7 +135,7 @@ def main():
 
     if len(docs.errors) > 0:
       for e in docs.errors:
-        print(e)
+        print(e, file=sys.stderr)
       return 1
 
     module_dict = {
@@ -116,28 +154,33 @@ def main():
                 _summary_desc(table.desc),
             'type':
                 table.type,
-            'cols': [{
-                'name': col_name,
-                'type': col.long_type,
-                'desc': col.description,
-                'table': _long_type_to_table(col.long_type)[0],
-                'column': _long_type_to_table(col.long_type)[1],
-            } for (col_name, col) in table.cols.items()]
-        } for table in docs.table_views],
+            'visibility':
+                'private' if _is_internal(table.name) else 'public',
+            'cols': [
+                _create_field_dict(col_name, col)
+                for (col_name, col) in table.cols.items()
+            ]
+        }
+                         for table in docs.table_views],
         'functions': [{
-            'name': function.name,
-            'desc': function.desc,
-            'summary_desc': _summary_desc(function.desc),
-            'args': [{
-                'name': arg_name,
-                'type': arg.long_type,
-                'desc': arg.description,
-                'table': _long_type_to_table(arg.long_type)[0],
-                'column': _long_type_to_table(arg.long_type)[1],
-            } for (arg_name, arg) in function.args.items()],
-            'return_type': function.return_type,
-            'return_desc': function.return_desc,
-        } for function in docs.functions],
+            'name':
+                function.name,
+            'desc':
+                function.desc,
+            'summary_desc':
+                _summary_desc(function.desc),
+            'visibility':
+                'private' if _is_internal(function.name) else 'public',
+            'args': [
+                _create_field_dict(arg_name, arg)
+                for (arg_name, arg) in function.args.items()
+            ],
+            'return_type':
+                function.return_type,
+            'return_desc':
+                function.return_desc,
+        }
+                      for function in docs.functions],
         'table_functions': [{
             'name':
                 function.name,
@@ -145,21 +188,18 @@ def main():
                 function.desc,
             'summary_desc':
                 _summary_desc(function.desc),
-            'args': [{
-                'name': arg_name,
-                'type': arg.long_type,
-                'desc': arg.description,
-                'table': _long_type_to_table(arg.long_type)[0],
-                'column': _long_type_to_table(arg.long_type)[1],
-            } for (arg_name, arg) in function.args.items()],
-            'cols': [{
-                'name': col_name,
-                'type': col.long_type,
-                'table': _long_type_to_table(col.long_type)[0],
-                'column': _long_type_to_table(col.long_type)[1],
-                'desc': col.description
-            } for (col_name, col) in function.cols.items()]
-        } for function in docs.table_functions],
+            'visibility':
+                'private' if _is_internal(function.name) else 'public',
+            'args': [
+                _create_field_dict(arg_name, arg)
+                for (arg_name, arg) in function.args.items()
+            ],
+            'cols': [
+                _create_field_dict(col_name, col)
+                for (col_name, col) in function.cols.items()
+            ]
+        }
+                            for function in docs.table_functions],
         'macros': [{
             'name':
                 macro.name,
@@ -167,18 +207,18 @@ def main():
                 macro.desc,
             'summary_desc':
                 _summary_desc(macro.desc),
+            'visibility':
+                'private' if _is_internal(macro.name) else 'public',
             'return_desc':
                 macro.return_desc,
             'return_type':
                 macro.return_type,
-            'args': [{
-                'name': arg_name,
-                'type': arg.long_type,
-                'desc': arg.description,
-                'table': _long_type_to_table(arg.long_type)[0],
-                'column': _long_type_to_table(arg.long_type)[1],
-            } for (arg_name, arg) in macro.args.items()],
-        } for macro in docs.macros],
+            'args': [
+                _create_field_dict(arg_name, arg)
+                for (arg_name, arg) in macro.args.items()
+            ],
+        }
+                   for macro in docs.macros],
     }
     packages[package_name].append(module_dict)
 
@@ -187,7 +227,7 @@ def main():
       "modules": modules
   } for name, modules in packages.items()]
 
-  with open(args.json_out, 'w+') as f:
+  with open(args.json_out, 'w+', encoding='utf-8') as f:
     json.dump(packages_list, f, indent=None if args.minify else 4)
 
   return 0


### PR DESCRIPTION
# Summary

  Adds `--with-internal` flag to `gen_stdlib_docs_json.py` to optionally include internal artifacts (those starting with `_`) in the generated JSON documentation. Also adds a `visibility` field to all artifacts indicating whether they are "public" or "private".

  ## Behavior

  - **Default (without `--with-internal`)**: Only public artifacts are included, all marked with `visibility: "public"`
  - **With `--with-internal`**: Both public and internal artifacts are included, labeled as `visibility: "public"` or `visibility: "private"` respectively
