### PR TITLE
ui: Improve button loading state

### DIFF
--- a/ui/src/assets/widgets/button.scss
+++ b/ui/src/assets/widgets/button.scss
@@ -38,6 +38,16 @@
   }
 }
 
+@keyframes pf-spinner-rotation {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .pf-button {
   font-family: var(--pf-font-compact);
   line-height: 1;
@@ -46,6 +56,33 @@
   padding: 4px 8px;
   white-space: nowrap;
   min-width: max-content;
+  position: relative;
+
+  &--loading {
+    // The button is unclickable when loading
+    pointer-events: none;
+
+    .pf-button__label,
+    .pf-left-icon,
+    .pf-right-icon {
+      visibility: hidden;
+    }
+
+    &::after {
+      content: "";
+      height: 0.9em;
+      width: 0.9em;
+      border-radius: 100px;
+      border-style: solid;
+      border-width: 0.15em;
+      border-color: var(--pf-color-border);
+      border-top-color: var(--pf-color-primary);
+      position: absolute;
+      inset: 50%;
+      translate: -50% -50%;
+      animation: pf-spinner-rotation 1s infinite linear;
+    }
+  }
 
   &--shrink {
     min-width: 0;

--- a/ui/src/widgets/button.ts
+++ b/ui/src/widgets/button.ts
@@ -17,7 +17,6 @@ import {classNames} from '../base/classnames';
 import {HTMLAttrs, HTMLButtonAttrs, Intent, classForIntent} from './common';
 import {Icon} from './icon';
 import {Popup} from './popup';
-import {Spinner} from './spinner';
 import {assertUnreachable} from '../base/logging';
 
 export enum ButtonVariant {
@@ -100,6 +99,7 @@ export class Button implements m.ClassComponent<ButtonAttrs> {
       variant = ButtonVariant.Minimal,
       rounded,
       shrink,
+      loading,
       ...htmlAttrs
     } = attrs;
 
@@ -115,6 +115,7 @@ export class Button implements m.ClassComponent<ButtonAttrs> {
       dismissPopup && Popup.DISMISS_POPUP_GROUP_CLASS,
       rounded && 'pf-button--rounded',
       shrink && 'pf-button--shrink',
+      loading && 'pf-button--loading',
       className,
     );
 
@@ -138,9 +139,7 @@ export class Button implements m.ClassComponent<ButtonAttrs> {
   private renderIcon(attrs: ButtonAttrs): m.Children {
     const {icon, iconFilled} = attrs;
     const className = 'pf-left-icon';
-    if (attrs.loading) {
-      return m(Spinner, {className});
-    } else if (icon) {
+    if (icon) {
       return m(Icon, {className, icon, filled: iconFilled});
     } else {
       return undefined;


### PR DESCRIPTION
Before:
- Spinner too thin and off-center
- Awkward placement - makes the button taller
- Can still interact with button

<img width="108" height="47" alt="image" src="https://github.com/user-attachments/assets/8c376306-82b2-45f6-adf4-e3b8d4401ed6" />

After:
- More aesthetically pleasing spinner
- Overtakes entire button
- Button stays the same size
- Non interactive - cannot click while loading
<img width="94" height="35" alt="image" src="https://github.com/user-attachments/assets/019f1e77-af0e-4395-910e-80003bb9015c" />


Rationale:

The usual case for putting a button in loading mode is when the user clicks a button that performs some long running task. You don't usually want the user to click on it again so it makes sense to blank out the button and disable interactions, only showing the spinner. In addition it's nice that it stays the same width in order to avoid a layout shift.

This implementation is very common in established frameworks:
- https://mui.com/material-ui/react-button/#loading
- https://blueprintjs.com/docs/#core/components/buttons.button-states
- https://vrimar.github.io/construct-ui/#/components/button
