### PR TITLE
ui: Switch to SVG for the sched diagram in order to support theme colors

### DIFF
--- a/ui/src/assets/widgets/nodegraph.scss
+++ b/ui/src/assets/widgets/nodegraph.scss
@@ -56,6 +56,13 @@
 
   svg {
     isolation: isolate;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: visible;
   }
 }
 
@@ -309,16 +316,6 @@
 
 .pf-port.pf-output {
   right: -9px;
-}
-
-svg {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  overflow: visible;
 }
 
 .pf-connection {

--- a/ui/src/plugins/dev.perfetto.Sched/sched_details_tab.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/sched_details_tab.ts
@@ -34,7 +34,6 @@ import {Trace} from '../../public/trace';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {TrackEventSelection} from '../../public/selection';
 import {ThreadDesc, ThreadMap} from '../dev.perfetto.Thread/threads';
-import {assetSrc} from '../../base/assets';
 
 const MIN_NORMAL_SCHED_PRIORITY = 100;
 
@@ -106,14 +105,23 @@ export class SchedSliceDetailsPanel implements TrackEventDetailsPanel {
     ) {
       return null;
     }
+
+    const svgString = `
+      <svg class="pf-sched-latency__background" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 300" width="200" height="300">
+        <line x1="40" y1="20" x2="40" y2="280" stroke="currentColor" stroke-width="3"/>
+        <polygon points="40,65 50,80 40,95 30,80" fill="currentColor"/>
+        <line x1="40" y1="200" x2="180" y2="200" stroke="currentColor" stroke-width="3"/>
+        <polygon points="40,200 52,193 52,207" fill="currentColor"/>
+        <polygon points="180,200 168,193 168,207" fill="currentColor"/>
+      </svg>
+    `;
+
     return m(
       Section,
       {title: 'Scheduling Latency'},
       m(
         '.pf-sched-latency',
-        m('img.pf-sched-latency__background', {
-          src: assetSrc('assets/scheduling_latency.png'),
-        }),
+        m.trust(svgString),
         this.renderWakeupText(data),
         this.renderDisplayLatencyText(data),
       ),

--- a/ui/src/plugins/dev.perfetto.Sched/styles.scss
+++ b/ui/src/plugins/dev.perfetto.Sched/styles.scss
@@ -34,7 +34,7 @@
 
   &__background {
     user-select: none;
-    width: 180px;
+    width: 100px;
     height: 150px;
   }
 }


### PR DESCRIPTION
Using SVG means we can apply CSS styles and colors from the theme.

Before:
<img width="429" height="233" alt="image" src="https://github.com/user-attachments/assets/48209f85-88dd-4496-ada6-94ae04885ae2" />

After:
<img width="444" height="216" alt="image" src="https://github.com/user-attachments/assets/c9724d36-0ef9-407e-93fb-13fa21dad01d" />