### PR TITLE
ui: Fix jittery area selection box rect when zoomed in

### DIFF
--- a/ui/src/frontend/timeline_page/track_view.ts
+++ b/ui/src/frontend/timeline_page/track_view.ts
@@ -520,16 +520,21 @@ export class TrackView {
     }
 
     if (selected) {
-      const selectedAreaDuration = selection.end - selection.start;
-      ctx.globalAlpha = 0.3;
-      ctx.fillStyle = COLOR_ACCENT;
-      ctx.fillRect(
-        timescale.timeToPx(selection.start),
-        0,
-        timescale.durationToPx(selectedAreaDuration),
-        size.height,
-      );
-      ctx.globalAlpha = 1.0;
+      const startPx = timescale.timeToPx(selection.start);
+      const endPx = timescale.timeToPx(selection.end);
+
+      // Clamp to viewport bounds [0, size.width]
+      const clampedStartPx = Math.max(0, startPx);
+      const clampedEndPx = Math.min(size.width, endPx);
+      const clampedWidth = clampedEndPx - clampedStartPx;
+
+      // Only draw if there's a visible portion
+      if (clampedWidth > 0) {
+        ctx.globalAlpha = 0.3;
+        ctx.fillStyle = COLOR_ACCENT;
+        ctx.fillRect(clampedStartPx, 0, clampedWidth, size.height);
+        ctx.globalAlpha = 1.0;
+      }
     }
   }
 


### PR DESCRIPTION
Clamp the selection ends of the area selection rect to the bounds of the viewport before rendering to avoid 32bit float precision issues with super wide rects.

Fixes: https://b.corp.google.com/issues/462389449