### PR TITLE
Fix protozero_descriptor_diff deps

### DIFF
--- a/gn/protozero_descriptor_diff.gni
+++ b/gn/protozero_descriptor_diff.gni
@@ -35,7 +35,7 @@ template("protozero_descriptor_diff") {
     binary_rebased_path = "./" + rebase_path(binary_path, root_build_dir)
 
     deps = [
-      "${perfetto_root_path}/src/protozero/descriptor_diff:protozero_descriptor_diff",
+      "${perfetto_root_path}/src/protozero/descriptor_diff:protozero_descriptor_diff($host_toolchain)",
       invoker.minuend_descriptor_target,
       invoker.subtrahend_descriptor_target,
     ]


### PR DESCRIPTION
The `deps` on the binary need to match the `binary_label`.

The mismatch appears to be causing Chromium's `win11-arm64-blink-rel` trybot to fail. This is a x86_64 host building for arm64. The build rules currently state to use the host binary for the action but then only depend on the target binary being built.