### PR TITLE
tp: only allow missing clocks when full sort is enabled

### DIFF
--- a/include/perfetto/trace_processor/trace_processor_storage.h
+++ b/include/perfetto/trace_processor/trace_processor_storage.h
@@ -45,6 +45,9 @@ class PERFETTO_EXPORT_COMPONENT TraceProcessorStorage {
   // See comment on TraceProcessor::Flush.
   virtual void Flush() = 0;
 
+  // See comment on TraceProcessor::ProcessEndOfFileDeferredPackets.
+  virtual base::Status ProcessEndOfFileDeferredPackets() = 0;
+
   // See comment on TraceProcessor::NotifyEndOfFile.
   virtual base::Status NotifyEndOfFile() = 0;
 };

--- a/src/trace_processor/forwarding_trace_parser.cc
+++ b/src/trace_processor/forwarding_trace_parser.cc
@@ -146,6 +146,13 @@ base::Status ForwardingTraceParser::Parse(TraceBlobView blob) {
   return reader_->Parse(std::move(blob));
 }
 
+base::Status ForwardingTraceParser::ProcessEndOfFileDeferredPackets() {
+  if (reader_) {
+    RETURN_IF_ERROR(reader_->ProcessEndOfFileDeferredPackets());
+  }
+  return base::OkStatus();
+}
+
 base::Status ForwardingTraceParser::NotifyEndOfFile() {
   if (reader_) {
     RETURN_IF_ERROR(reader_->NotifyEndOfFile());

--- a/src/trace_processor/forwarding_trace_parser.h
+++ b/src/trace_processor/forwarding_trace_parser.h
@@ -38,6 +38,7 @@ class ForwardingTraceParser : public ChunkedTraceReader {
 
   // ChunkedTraceReader implementation
   base::Status Parse(TraceBlobView) override;
+  [[nodiscard]] base::Status ProcessEndOfFileDeferredPackets() override;
   [[nodiscard]] base::Status NotifyEndOfFile() override;
 
   TraceType trace_type() const { return trace_type_; }

--- a/src/trace_processor/importers/archive/gzip_trace_parser.cc
+++ b/src/trace_processor/importers/archive/gzip_trace_parser.cc
@@ -125,6 +125,10 @@ base::Status GzipTraceParser::ParseUnowned(const uint8_t* data, size_t size) {
   }
 }
 
+base::Status GzipTraceParser::ProcessEndOfFileDeferredPackets() {
+  return inner_ ? inner_->ProcessEndOfFileDeferredPackets() : base::OkStatus();
+}
+
 base::Status GzipTraceParser::NotifyEndOfFile() {
   if (output_state_ != kStreamBoundary || decompressor_.AvailIn() > 0) {
     return base::ErrStatus("GZIP stream incomplete, trace is likely corrupt");

--- a/src/trace_processor/importers/archive/gzip_trace_parser.h
+++ b/src/trace_processor/importers/archive/gzip_trace_parser.h
@@ -37,6 +37,7 @@ class GzipTraceParser : public ChunkedTraceReader {
 
   // ChunkedTraceReader implementation
   base::Status Parse(TraceBlobView) override;
+  base::Status ProcessEndOfFileDeferredPackets() override;
   base::Status NotifyEndOfFile() override;
 
   base::Status ParseUnowned(const uint8_t*, size_t);

--- a/src/trace_processor/importers/archive/tar_trace_reader.cc
+++ b/src/trace_processor/importers/archive/tar_trace_reader.cc
@@ -205,6 +205,7 @@ base::Status TarTraceReader::NotifyEndOfFile() {
     for (auto& data : file.second.data) {
       RETURN_IF_ERROR(parser.Parse(std::move(data)));
     }
+    RETURN_IF_ERROR(parser.ProcessEndOfFileDeferredPackets());
     RETURN_IF_ERROR(parser.NotifyEndOfFile());
     // Make sure the ForwardingTraceParser determined the same trace type as we
     // did.

--- a/src/trace_processor/importers/archive/zip_trace_reader.cc
+++ b/src/trace_processor/importers/archive/zip_trace_reader.cc
@@ -82,6 +82,7 @@ base::Status ZipTraceReader::NotifyEndOfFile() {
 
     RETURN_IF_ERROR(parser.Parse(std::move(file.second.data)));
     RETURN_IF_ERROR(parser.NotifyEndOfFile());
+    RETURN_IF_ERROR(parser.ProcessEndOfFileDeferredPackets());
     // Make sure the ForwardingTraceParser determined the same trace type as we
     // did.
     PERFETTO_CHECK(parser.trace_type() == file.first.trace_type);

--- a/src/trace_processor/importers/common/chunked_trace_reader.h
+++ b/src/trace_processor/importers/common/chunked_trace_reader.h
@@ -36,6 +36,11 @@ class ChunkedTraceReader {
   // The buffer size is guaranteed to be > 0.
   virtual base::Status Parse(TraceBlobView) = 0;
 
+  // Called after the last Parse() call and before NotifyEndOfFile() call.
+  [[nodiscard]] virtual base::Status ProcessEndOfFileDeferredPackets() {
+    return base::OkStatus();
+  }
+
   // Called after the last Parse() call.
   [[nodiscard]] virtual base::Status NotifyEndOfFile() = 0;
 };

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -300,7 +300,10 @@ class ProtoTraceParserTest : public ::testing::Test {
     auto status = reader_->Parse(TraceBlobView(
         TraceBlob::TakeOwnership(std::move(raw_trace), trace_bytes.size())));
     if (status.ok()) {
-      status = reader_->NotifyEndOfFile();
+      status = reader_->ProcessEndOfFileDeferredPackets();
+      if (status.ok()) {
+        status = reader_->NotifyEndOfFile();
+      }
     }
 
     ResetTraceBuffers();

--- a/src/trace_processor/importers/proto/proto_trace_reader.h
+++ b/src/trace_processor/importers/proto/proto_trace_reader.h
@@ -64,6 +64,7 @@ class ProtoTraceReader : public ChunkedTraceReader {
 
   // ChunkedTraceReader implementation.
   base::Status Parse(TraceBlobView) override;
+  base::Status ProcessEndOfFileDeferredPackets() override;
   base::Status NotifyEndOfFile() override;
 
   using SyncClockSnapshots = base::FlatHashMap<

--- a/src/trace_processor/minimal_shell.cc
+++ b/src/trace_processor/minimal_shell.cc
@@ -34,6 +34,7 @@ namespace {
 base::Status MinimalMain(int, char**) {
   std::unique_ptr<TraceProcessor> tp = TraceProcessor::CreateInstance({});
   RETURN_IF_ERROR(tp->Parse(std::unique_ptr<uint8_t[]>(new uint8_t[0]), 0));
+  RETURN_IF_ERROR(tp->ProcessEndOfFileDeferredPackets());
   RETURN_IF_ERROR(tp->NotifyEndOfFile());
 
   auto it = tp->ExecuteQuery("SELECT id FROM slice");

--- a/src/trace_processor/read_trace.cc
+++ b/src/trace_processor/read_trace.cc
@@ -79,6 +79,7 @@ base::Status ReadTrace(
     const std::function<void(uint64_t parsed_size)>& progress_callback,
     bool call_notify_end_of_file) {
   RETURN_IF_ERROR(ReadTraceUnfinalized(tp, filename, progress_callback));
+  RETURN_IF_ERROR(tp->ProcessEndOfFileDeferredPackets());
   if (call_notify_end_of_file) {
     return tp->NotifyEndOfFile();
   }
@@ -99,6 +100,7 @@ base::Status DecompressTrace(const uint8_t* data,
         new SerializingProtoTraceReader(output));
     GzipTraceParser parser(std::move(reader));
     RETURN_IF_ERROR(parser.ParseUnowned(data, size));
+    RETURN_IF_ERROR(parser.ProcessEndOfFileDeferredPackets());
     return parser.NotifyEndOfFile();
   }
 

--- a/src/trace_processor/rpc/httpd.cc
+++ b/src/trace_processor/rpc/httpd.cc
@@ -194,6 +194,7 @@ void Httpd::OnHttpRequest(const base::HttpRequest& req) {
   }
 
   if (req.uri == "/notify_eof") {
+    global_trace_processor_rpc_.ProcessEndOfFileDeferredPackets();
     global_trace_processor_rpc_.NotifyEndOfFile();
     return conn.SendResponse("200 OK", default_headers);
   }

--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -439,6 +439,15 @@ base::Status Rpc::Parse(const uint8_t* data, size_t len) {
   return trace_processor_->Parse(std::move(data_copy), len);
 }
 
+base::Status Rpc::ProcessEndOfFileDeferredPackets() {
+  PERFETTO_TP_TRACE(metatrace::Category::API_TIMELINE,
+                    "RPC_PROCESS_END_OF_FILE_DEFERRED_PACKETS");
+
+  RETURN_IF_ERROR(trace_processor_->ProcessEndOfFileDeferredPackets());
+  MaybePrintProgress();
+  return base::OkStatus();
+}
+
 base::Status Rpc::NotifyEndOfFile() {
   PERFETTO_TP_TRACE(metatrace::Category::API_TIMELINE,
                     "RPC_NOTIFY_END_OF_FILE");

--- a/src/trace_processor/rpc/rpc.h
+++ b/src/trace_processor/rpc/rpc.h
@@ -108,6 +108,7 @@ class Rpc {
   // the corresponding names in trace_processor.h . See that header for docs.
 
   base::Status Parse(const uint8_t*, size_t);
+  base::Status ProcessEndOfFileDeferredPackets();
   base::Status NotifyEndOfFile();
   std::string GetCurrentTraceName();
   std::vector<uint8_t> ComputeMetric(const uint8_t*, size_t);

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -625,6 +625,10 @@ void TraceProcessorImpl::FlushInternal(bool should_build_bounds_table) {
   }
 }
 
+base::Status TraceProcessorImpl::ProcessEndOfFileDeferredPackets() {
+  return TraceProcessorStorageImpl::ProcessEndOfFileDeferredPackets();
+}
+
 base::Status TraceProcessorImpl::NotifyEndOfFile() {
   if (notify_eof_called_) {
     const char kMessage[] =

--- a/src/trace_processor/trace_processor_impl.h
+++ b/src/trace_processor/trace_processor_impl.h
@@ -66,6 +66,7 @@ class TraceProcessorImpl : public TraceProcessor,
 
   base::Status Parse(TraceBlobView) override;
   void Flush() override;
+  base::Status ProcessEndOfFileDeferredPackets() override;
   base::Status NotifyEndOfFile() override;
 
   // =================================================================

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -1282,6 +1282,8 @@ base::Status LoadTrace(TraceProcessor* trace_processor,
                            trace_file_path.c_str(), load_status.c_message());
   }
 
+  RETURN_IF_ERROR(trace_processor->ProcessEndOfFileDeferredPackets());
+
   bool is_proto_trace = false;
   {
     auto it = trace_processor->ExecuteQuery(

--- a/src/trace_processor/trace_processor_storage_impl.cc
+++ b/src/trace_processor/trace_processor_storage_impl.cc
@@ -111,6 +111,16 @@ void TraceProcessorStorageImpl::Flush() {
   }
 }
 
+base::Status TraceProcessorStorageImpl::ProcessEndOfFileDeferredPackets() {
+  if (!parser_) {
+    return base::OkStatus();
+  }
+  if (unrecoverable_parse_error_) {
+    return base::ErrStatus("Unrecoverable parsing error already occurred");
+  }
+  return parser_->ProcessEndOfFileDeferredPackets();
+}
+
 base::Status TraceProcessorStorageImpl::NotifyEndOfFile() {
   if (!parser_) {
     return base::OkStatus();

--- a/src/trace_processor/trace_processor_storage_impl.h
+++ b/src/trace_processor/trace_processor_storage_impl.h
@@ -38,6 +38,7 @@ class TraceProcessorStorageImpl : public TraceProcessorStorage {
 
   base::Status Parse(TraceBlobView) override;
   void Flush() override;
+  base::Status ProcessEndOfFileDeferredPackets() override;
   base::Status NotifyEndOfFile() override;
 
   void DestroyContext();

--- a/src/trace_processor/util/clock_synchronizer.h
+++ b/src/trace_processor/util/clock_synchronizer.h
@@ -401,6 +401,13 @@ class ClockSynchronizer : public ClockSynchronizerBase {
     return base::OkStatus();
   }
 
+  bool HasPathToTraceTime(ClockId clock_id) {
+    if (clock_id == trace_time_clock_id_) {
+      return true;
+    }
+    return FindPath(clock_id, trace_time_clock_id_).valid();
+  }
+
   // Returns the timezone offset in seconds from UTC, if one has been set.
   std::optional<int64_t> timezone_offset() const { return timezone_offset_; }
 


### PR DESCRIPTION
This allows us to continue to generate errors for missing timestamps in the default case shen partial sorting is used and defer the errors until EOF when full sorting is used.

Also don't flush and force event extraction before EOF as that prevents deferred packages from being processed.
