### PR TITLE
ui: Fix record page spinner colors for dark mode

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/styles.scss
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/styles.scss
@@ -545,6 +545,10 @@
 
     .spinner {
       @include transition();
+      // Undo default number input styles.
+      background: none;
+      color: inherit;
+
       grid-area: label;
       border: 1px solid var(--pf-color-background);
       border-bottom: 2px solid var(--pf-color-border);


### PR DESCRIPTION
Spinners on the record page use the default background and text colors which don't work well in dark mode.
