### PR TITLE
TP: remove accidental dep on protobuf_full from TP unittests

### DIFF
--- a/protos/perfetto/metrics/BUILD.gn
+++ b/protos/perfetto/metrics/BUILD.gn
@@ -16,7 +16,10 @@ import("../../../gn/perfetto.gni")
 import("../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [ "lite" ]
+  proto_generators = [
+    "lite",
+    "zero",
+  ]
   deps = [
     "android:@TYPE@",
     "common:@TYPE@",
@@ -29,7 +32,10 @@ perfetto_proto_library("@TYPE@") {
 }
 
 perfetto_proto_library("custom_options_@TYPE@") {
-  proto_generators = [ "lite" ]
+  proto_generators = [
+    "lite",
+    "zero",
+  ]
   sources = [ "custom_options.proto" ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }

--- a/protos/perfetto/metrics/android/BUILD.gn
+++ b/protos/perfetto/metrics/android/BUILD.gn
@@ -15,7 +15,10 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [ "lite" ]
+  proto_generators = [
+    "lite",
+    "zero",
+  ]
   sources = [
     "ad_services_metric.proto",
     "android_anomaly_metric.proto",

--- a/protos/perfetto/metrics/chrome/BUILD.gn
+++ b/protos/perfetto/metrics/chrome/BUILD.gn
@@ -15,7 +15,10 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [ "lite" ]
+  proto_generators = [
+    "lite",
+    "zero",
+  ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   deps = [
     "..:@TYPE@",

--- a/protos/perfetto/metrics/common/BUILD.gn
+++ b/protos/perfetto/metrics/common/BUILD.gn
@@ -15,6 +15,9 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [ "lite" ]
+  proto_generators = [
+    "lite",
+    "zero",
+  ]
   sources = [ "clone_duration.proto" ]
 }

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -421,7 +421,7 @@ source_set("unittests") {
   ]
   if (perfetto_build_standalone) {
     deps += [
-      "../../../protos/perfetto/metrics/chrome:lite",
+      "../../../protos/perfetto/metrics/chrome:zero",
       "../metrics:gen_cc_all_chrome_metrics_descriptor",
     ]
   }

--- a/src/trace_processor/util/protozero_to_json_unittests.cc
+++ b/src/trace_processor/util/protozero_to_json_unittests.cc
@@ -28,7 +28,7 @@
 #include "protos/perfetto/trace/track_event/track_event.pbzero.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_STANDALONE_BUILD)
-#include "protos/perfetto/metrics/chrome/all_chrome_metrics.pb.h"  // nogncheck
+#include "protos/perfetto/metrics/chrome/test_chrome_metric.pbzero.h"  // nogncheck
 #include "src/trace_processor/metrics/all_chrome_metrics.descriptor.h"  // nogncheck
 #endif
 
@@ -126,9 +126,8 @@ TEST(ProtozeroToJsonTest, CustomDescriptorPoolNestedMsg) {
 // is very tricky to point to on the non-standalone build.
 #if PERFETTO_BUILDFLAG(PERFETTO_STANDALONE_BUILD)
 TEST(ProtozeroToJsonTest, CustomDescriptorPoolAnnotations) {
-  using perfetto::protos::TestChromeMetric;
-  TestChromeMetric msg;
-  msg.set_test_value(1);
+  protozero::HeapBuffered<perfetto::protos::pbzero::TestChromeMetric> msg;
+  msg->set_test_value(1);
   auto binary_proto = msg.SerializeAsString();
   protozero::ConstBytes binary_proto_bytes{
       reinterpret_cast<const uint8_t*>(binary_proto.data()),


### PR DESCRIPTION
Short version:
we ended up with an accidental dependency between
protozero_to_json_unittest.cc and protobuf_full.
@KirillTim found this while address b/447162132.
This dependency snuck in because:
- All unittests are built together
- some tools/ unittests legitimately need proto_full.

The only dependency chain is:
- One test in protozero_to_json_unittest depends on a metric.pb.h
  (which by itself does NOT warrant a pblite dependency)
- That specific metric is using a protobuf custom option
  for `[(unit) = "ms_biggerIsBetter"];`
- Unfortunately protobuf custom options end up requiring
  a dep on protobuf_full.
- So I changed the code to use pbzero.
- As part of this I needed to add "zero" to the list of
  generated metrics proto.

CONTROVERSIAL PART:
I think that was the only thing that was depending on metrics:lite.
I tried removing the "lite" targets from protos/metrics and everything
still worked.
I am bit unsure on why those "lite" targets existed in the first place.
But I worry that either chromium or google3 depend on them.
So I am doubtful on whether I should:
A) Keep lite and add "zero"
B) Replace "lite" with "zero"

I am going to do A in this PR and try B in a separate PR (#3787).

Bug: b/462688465