### PR TITLE
TP: remove "lite" proto targets for metrics/

### DIFF
--- a/protos/perfetto/metrics/BUILD.gn
+++ b/protos/perfetto/metrics/BUILD.gn
@@ -16,10 +16,7 @@ import("../../../gn/perfetto.gni")
 import("../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [
-    "lite",
-    "zero",
-  ]
+  proto_generators = [ "zero" ]
   deps = [
     "android:@TYPE@",
     "common:@TYPE@",
@@ -32,10 +29,7 @@ perfetto_proto_library("@TYPE@") {
 }
 
 perfetto_proto_library("custom_options_@TYPE@") {
-  proto_generators = [
-    "lite",
-    "zero",
-  ]
+  proto_generators = [ "zero" ]
   sources = [ "custom_options.proto" ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]
 }

--- a/protos/perfetto/metrics/android/BUILD.gn
+++ b/protos/perfetto/metrics/android/BUILD.gn
@@ -15,10 +15,7 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [
-    "lite",
-    "zero",
-  ]
+  proto_generators = [ "zero" ]
   sources = [
     "ad_services_metric.proto",
     "android_anomaly_metric.proto",

--- a/protos/perfetto/metrics/chrome/BUILD.gn
+++ b/protos/perfetto/metrics/chrome/BUILD.gn
@@ -15,10 +15,7 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [
-    "lite",
-    "zero",
-  ]
+  proto_generators = [ "zero" ]
   import_dirs = [ "${perfetto_protobuf_src_dir}" ]
   deps = [
     "..:@TYPE@",

--- a/protos/perfetto/metrics/common/BUILD.gn
+++ b/protos/perfetto/metrics/common/BUILD.gn
@@ -15,9 +15,6 @@
 import("../../../../gn/proto_library.gni")
 
 perfetto_proto_library("@TYPE@") {
-  proto_generators = [
-    "lite",
-    "zero",
-  ]
+  proto_generators = [ "zero" ]
   sources = [ "clone_duration.proto" ]
 }


### PR DESCRIPTION
Follow up to #3786.
The "lite" targets seem unused in our repo.
I am not sure whether chrome need them
hence why a separate PR.
Note that this did NOT require any regeneration of
Android.bp or BUILD, hence the only risk is that
chromium autoroller might reject this.

**Stack:**
- [#3786](https://github.com/google/perfetto/pull/3786) (metrics_fix)
  - **[This PR] (metrics_fix_nolite)**
     -   [#3748](https://github.com/google/perfetto/pull/3748) (Split perfetto_unittests)
