### PR TITLE
ui: Remove the term 'experimental' from theme settings

### DIFF
--- a/ui/src/frontend/home_page.ts
+++ b/ui/src/frontend/home_page.ts
@@ -33,10 +33,7 @@ export class Hints implements m.ClassComponent {
         'ul',
         m('li', [
           m(Switch, {
-            label: [
-              'Try the new dark mode (experimental).',
-              isDarkMode && ' \u{1F60E}',
-            ],
+            label: ['Try the new dark mode.', isDarkMode && ' \u{1F60E}'],
             checked: isDarkMode,
             onchange: (e) => {
               themeSetting?.set(

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -380,8 +380,8 @@ function onCssLoaded() {
 
   const themeSetting = AppImpl.instance.settings.register({
     id: 'theme',
-    name: '[Experimental] UI Theme',
-    description: 'Warning: Dark mode is not fully supported yet.',
+    name: 'UI Theme',
+    description: 'Changes the color palette used throughout the UI.',
     schema: z.enum(['dark', 'light']),
     defaultValue: 'light',
   } as const);
@@ -398,7 +398,7 @@ function onCssLoaded() {
   // Add command to toggle the theme.
   AppImpl.instance.commands.registerCommand({
     id: 'dev.perfetto.ToggleTheme',
-    name: '[Experimental] Toggle UI Theme',
+    name: 'Toggle UI Theme (Dark/Light)',
     callback: () => {
       const currentTheme = themeSetting.get();
       themeSetting.set(currentTheme === 'dark' ? 'light' : 'dark');


### PR DESCRIPTION
The following issues fixed some of the last minor issues with dark mode, so this PR removes the 'experimental' text around the theme settings.

- https://github.com/google/perfetto/pull/3788
- https://github.com/google/perfetto/pull/3785
- https://github.com/google/perfetto/pull/3756

Fixes: https://b.corp.google.com/issues/461794273