### PR TITLE
CI: fix `linux-tests.yml` syntax in `if` condition

### DIFF
--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -190,8 +190,6 @@ ssize_t WriteAll(int fd, const void* buf, size_t count) {
 }
 
 base::Status CopyFileContents(int fd_in, int fd_out) {
-  // TRIGGER CI OLOLOL AGAIN!
-
   off_t original_offset = lseek(fd_in, 0, SEEK_CUR);
   if (original_offset == -1) {
     return base::ErrStatus(


### PR DESCRIPTION
This fixes the condition if we need to run benchmarks.

Also relax the condition to also run on the `asan` configuration.

Bug: b/458316023