### PR TITLE
docs/stdlib: Add dependencies to modules

### DIFF
--- a/infra/perfetto.dev/src/gen_stdlib_docs_md.py
+++ b/infra/perfetto.dev/src/gen_stdlib_docs_md.py
@@ -20,7 +20,8 @@ from __future__ import print_function
 import argparse
 import sys
 import json
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Set
+from collections import defaultdict
 
 INTRODUCTION = '''
 # PerfettoSQL standard library
@@ -60,6 +61,82 @@ More information on importing modules is available in the
 for the `INCLUDE PERFETTO MODULE` statement.
 
 <!-- TODO(b/290185551): talk about experimental module and contributions. -->
+
+<style>
+/* Make module names bold only when expanded */
+details[open] > summary h3 {
+  font-weight: bold;
+}
+details:not([open]) > summary h3 {
+  font-weight: normal;
+}
+
+/* Add spacing and visual separation between modules */
+details {
+  margin-bottom: 1em;
+  padding: 0.5em;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background-color: #fafafa;
+}
+
+/* Expanded module gets different styling */
+details[open] {
+  background-color: #ffffff;
+  padding-bottom: 2em;
+}
+
+/* Module summary cursor */
+details > summary {
+  cursor: pointer;
+  padding: 0.5em;
+}
+
+/* Indent all content inside an open module */
+details[open] > *:not(summary) {
+  margin-left: 2em;
+  margin-right: 1em;
+}
+
+/* Add spacing between artifact sections within a module */
+details h4 {
+  margin-top: 2em;
+  margin-bottom: 1em;
+  padding-bottom: 0.5em;
+  border-bottom: 1px solid #e8e8e8;
+  color: #333;
+}
+
+/* First h4 in a module shouldn't have as much top margin */
+details > h4:first-of-type {
+  margin-top: 1em;
+}
+
+/* Add spacing between individual artifacts */
+details > details {
+  margin-bottom: 1.5em;
+  background-color: #f9f9f9;
+  padding: 0.5em;
+  border-left: 3px solid #d0d0d0;
+}
+</style>
+
+<script>
+// Auto-expand details when navigating to an anchor
+function openDetailsOnHash() {
+  const hash = window.location.hash;
+  if (hash) {
+    const element = document.querySelector(hash);
+    if (element && element.tagName === 'DETAILS') {
+      element.open = true;
+    }
+  }
+}
+
+// Run on page load and hash change
+window.addEventListener('DOMContentLoaded', openDetailsOnHash);
+window.addEventListener('hashchange', openDetailsOnHash);
+</script>
 '''
 
 
@@ -89,17 +166,114 @@ def _bold(s: str) -> str:
   return f"<strong>{s}</strong>"
 
 
+def _build_dependency_maps(
+    stdlib_json: List[Dict]) -> tuple[Dict[str, Set[str]], Dict[str, Set[str]]]:
+  """Build maps of module dependencies.
+
+  Returns:
+    (dependencies, dependents) where:
+    - dependencies[module] = set of modules that 'module' includes
+    - dependents[module] = set of modules that include 'module'
+  """
+  dependencies = defaultdict(set)
+  dependents = defaultdict(set)
+
+  for package in stdlib_json:
+    for module_dict in package['modules']:
+      module_name = module_dict['module_name']
+      includes = module_dict.get('includes', [])
+
+      for included in includes:
+        dependencies[module_name].add(included)
+        dependents[included].add(module_name)
+
+  return dict(dependencies), dict(dependents)
+
+
+def _generate_dependency_graph(module_name: str, dependencies: Dict[str,
+                                                                    Set[str]],
+                               dependents: Dict[str, Set[str]]) -> str:
+  """Generate Mermaid dependency graph for a module.
+
+  Args:
+    module_name: The module to generate graph for
+    dependencies: Map of module -> modules it includes
+    dependents: Map of module -> modules that include it
+
+  Returns:
+    Mermaid graph markdown or empty string if no dependencies
+  """
+  module_deps = dependencies.get(module_name, set())
+  module_dependents = dependents.get(module_name, set())
+
+  # Only show public dependents (filter out internal modules)
+  public_dependents = {d for d in module_dependents if not d.startswith('_')}
+
+  # Only generate graph if there are dependencies or dependents
+  if not module_deps and not public_dependents:
+    return ''
+
+  lines = ['```mermaid', 'graph TD']
+
+  # Sanitize node names for Mermaid (replace dots with underscores)
+  def sanitize(name: str) -> str:
+    return name.replace('.', '_').replace('-', '_')
+
+  # Generate anchor link for a module
+  # The markdown renderer converts dots to hyphens but keeps underscores
+  def get_anchor(name: str) -> str:
+    # Replace dots with hyphens, keep underscores as-is
+    return '#' + name.replace('.', '-')
+
+  current = sanitize(module_name)
+
+  # Add the current module as a styled node
+  lines.append(f'  {current}["{module_name}"]')
+  lines.append(f'  class {current} currentModule')
+
+  # Add modules this module includes with click events
+  # Arrow points FROM dependency TO current (dependency provides to current)
+  for dep in sorted(module_deps):
+    dep_sanitized = sanitize(dep)
+    lines.append(f'  {dep_sanitized}["{dep}"]')
+    lines.append(f'  click {dep_sanitized} "{get_anchor(dep)}" _self')
+    lines.append(f'  {dep_sanitized} --> {current}')
+
+  # Add modules that include this module (public only) with click events
+  # Arrow points FROM current TO dependent (current provides to dependent)
+  for dependent in sorted(public_dependents):
+    dependent_sanitized = sanitize(dependent)
+    lines.append(f'  {dependent_sanitized}["{dependent}"]')
+    lines.append(
+        f'  click {dependent_sanitized} "{get_anchor(dependent)}" _self')
+    lines.append(f'  {current} --> {dependent_sanitized}')
+
+  # Add styling
+  lines.append(
+      '  classDef currentModule fill:#e1f5ff,stroke:#01579b,stroke-width:2px')
+
+  lines.append('```')
+  return '\n'.join(lines)
+
+
 class ModuleMd:
   """Responsible for module level markdown generation."""
 
-  def __init__(self, package_name: str, module_dict: Dict):
+  def __init__(self,
+               package_name: str,
+               module_dict: Dict,
+               dependencies: Dict[str, Set[str]] = None,
+               dependents: Dict[str, Set[str]] = None):
     self.module_name = module_dict['module_name']
     self.include_str = self.module_name if package_name != 'prelude' else 'N/A'
     self.objs, self.funs, self.view_funs, self.macros = [], [], [], []
+    self.dependencies = dependencies or {}
+    self.dependents = dependents or {}
+    self.dependency_graph = ''
 
-    # Views/tables
+    # Views/tables (only public)
     for data in module_dict['data_objects']:
-      if not data['cols']:
+      if not data['cols'] or data.get('visibility') != 'public':
         continue
 
       obj_summary = (f'''{_bold(data['name'])}. {data['summary_desc']}\n''')
@@ -180,65 +354,57 @@ class ModuleMd:
       self.macros.append(_md_rolldown(obj_summary, '\n'.join(content)))
       self.macros.append('\n\n')
 
+    # Generate dependency graph if module has any public content
+    if any((self.objs, self.funs, self.view_funs, self.macros)):
+      self.dependency_graph = _generate_dependency_graph(
+          self.module_name, self.dependencies, self.dependents)
+
 
 class PackageMd:
   """Responsible for package level markdown generation."""
 
-  def __init__(self, package_name: str, module_files: List[Dict[str,
-                                                                Any]]) -> None:
+  def __init__(self,
+               package_name: str,
+               module_files: List[Dict[str, Any]],
+               dependencies: Dict[str, Set[str]] = None,
+               dependents: Dict[str, Set[str]] = None) -> None:
     self.package_name = package_name
-    self.modules_md = sorted(
-        [ModuleMd(package_name, file_dict) for file_dict in module_files],
-        key=lambda x: x.module_name)
-
-  def get_prelude_description(self) -> str:
-    if not self.package_name == 'prelude':
-      raise ValueError("Only callable on prelude module")
-
-    lines = []
-    lines.append(f'## Package: {self.package_name}')
-
-    # Prelude is a special module which is automatically imported and doesn't
-    # have any include keys.
-    objs = '\n'.join(obj for module in self.modules_md for obj in module.objs)
-    if objs:
-      lines.append('#### Views/Tables')
-      lines.append(objs)
-
-    funs = '\n'.join(fun for module in self.modules_md for fun in module.funs)
-    if funs:
-      lines.append('#### Functions')
-      lines.append(funs)
-
-    table_funs = '\n'.join(
-        view_fun for module in self.modules_md for view_fun in module.view_funs)
-    if table_funs:
-      lines.append('#### Table Functions')
-      lines.append(table_funs)
-
-    macros = '\n'.join(
-        macro for module in self.modules_md for macro in module.macros)
-    if macros:
-      lines.append('#### Macros')
-      lines.append(macros)
-
-    return '\n'.join(lines)
+    self.modules_md = sorted([
+        ModuleMd(package_name, file_dict, dependencies, dependents)
+        for file_dict in module_files
+    ],
+                             key=lambda x: x.module_name)
 
   def get_md(self) -> str:
     if not self.modules_md:
       return ''
 
-    if self.package_name == 'prelude':
-      raise ValueError("Can't be called with prelude module")
-
     lines = []
     lines.append(f'## Package: {self.package_name}')
 
     for file in self.modules_md:
+      # Skip modules with no public artifacts (objs, funs, view_funs, macros)
+      # The dependency graph alone is not enough - we only show modules with actual public content
       if not any((file.objs, file.funs, file.view_funs, file.macros)):
         continue
 
-      lines.append(f'### {file.module_name}')
+      # Wrap each module in a collapsible details section
+      # Add id to the details element for anchor links to work
+      module_anchor = file.module_name.replace('.', '-')
+      # Prelude is always open by default
+      open_attr = ' open' if self.package_name == 'prelude' else ''
+      lines.append(f'<details id="{module_anchor}"{open_attr}>')
+      lines.append(
+          f'<summary style="cursor: pointer;"><h3 style="display: inline;">{file.module_name}</h3></summary>'
+      )
+      lines.append('')
+
+      # Add dependency graph if available
+      if file.dependency_graph:
+        lines.append('#### Module Dependencies')
+        lines.append(file.dependency_graph)
+        lines.append('')
+
       if file.objs:
         lines.append('#### Views/Tables')
         lines.append('\n'.join(file.objs))
@@ -251,6 +417,9 @@ class PackageMd:
       if file.macros:
         lines.append('#### Macros')
         lines.append('\n'.join(file.macros))
+
+      lines.append('</details>')
+      lines.append('')
 
     return '\n'.join(lines)
 
@@ -270,6 +439,35 @@ def main():
   with open(args.input) as f:
     stdlib_json = json.load(f)
 
+  # Build dependency maps for all modules
+  dependencies, dependents = _build_dependency_maps(stdlib_json)
+
+  # Merge prelude modules into one synthetic module
+  for package in stdlib_json:
+    if package["name"] == "prelude":
+      # Collect all artifacts from all prelude modules
+      merged_module = {
+          'module_name': 'prelude',
+          'module_doc': None,
+          'tags': [],
+          'includes': [],
+          'data_objects': [],
+          'functions': [],
+          'table_functions': [],
+          'macros': []
+      }
+
+      for module in package["modules"]:
+        merged_module['data_objects'].extend(module.get('data_objects', []))
+        merged_module['functions'].extend(module.get('functions', []))
+        merged_module['table_functions'].extend(
+            module.get('table_functions', []))
+        merged_module['macros'].extend(module.get('macros', []))
+
+      # Replace all prelude modules with one synthetic module
+      package["modules"] = [merged_module]
+      break
+
   # Fetch the modules from json documentation.
   packages: Dict[str, PackageMd] = {}
   for package in stdlib_json:
@@ -277,15 +475,16 @@ def main():
     modules = package["modules"]
     # Remove 'common' when it has been removed from the code.
     if package_name not in ['deprecated', 'common']:
-      package = PackageMd(package_name, modules)
+      package = PackageMd(package_name, modules, dependencies, dependents)
       if (not package.is_empty()):
         packages[package_name] = package
 
+  # Get prelude first, then all other packages
   prelude = packages.pop('prelude')
 
   with open(args.output, 'w') as f:
     f.write(INTRODUCTION)
-    f.write(prelude.get_prelude_description())
+    f.write(prelude.get_md())
     f.write('\n')
     f.write('\n'.join(module.get_md() for module in packages.values()))
 


### PR DESCRIPTION
  ## Summary

  This change adds interactive dependency graphs to the PerfettoSQL standard library documentation. Each module now displays a Mermaid diagram showing its dependencies (modules it includes) and dependents (modules that include it), with clickable nodes for navigation.

Also an aesthetic overwhaul, with each module being a separate section and collapsed by default.

  ## Changes

  - Built dependency tracking system that maps module includes/included-by relationships
  - Generated Mermaid graphs for each module showing dependency tree
  - Made module sections collapsible with `<details>` elements to improve navigation
  - Merged all prelude modules into a single synthetic module for cleaner presentation
  - Added CSS styling for collapsible modules and visual hierarchy
  - Added JavaScript for auto-expanding modules when navigating via anchor links
  - Filtered out internal modules (starting with `_`) from dependency graphs

  ## Notes

  The prelude module is expanded by default since it contains commonly used functionality. All other modules start collapsed to keep the documentation scannable.
