### PR TITLE
exp: Migrate datagrid to sqlDataSource

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -181,3 +181,15 @@
   line-height: 1.5;
   color: var(--pf-color-on-surface);
 }
+
+.pf-query-stats {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--pf-color-text-muted);
+
+  .pf-query-stats-separator {
+    user-select: none;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import m from 'mithril';
-
 import {QueryResponse} from '../../../components/query_table/queries';
 import {
   DataGridDataSource,
@@ -37,7 +36,6 @@ import {Icons} from '../../../base/semantic_icons';
 import {MenuItem, PopupMenu} from '../../../widgets/menu';
 import {Icon} from '../../../widgets/icon';
 import {Tooltip} from '../../../widgets/tooltip';
-
 import {findErrors} from './query_builder_utils';
 export interface DataExplorerAttrs {
   readonly queryService: QueryService;
@@ -112,6 +110,26 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
           )
         : null;
 
+    // Helper to create separator dot
+    const separator = () =>
+      m(
+        'span.pf-query-stats-separator',
+        {
+          'aria-hidden': 'true',
+        },
+        '•',
+      );
+
+    // Add query stats display (row count and duration)
+    const queryStats =
+      attrs.response && !attrs.isQueryRunning
+        ? m('.pf-query-stats', [
+            m('span', `${attrs.response.totalRowCount.toLocaleString()} rows`),
+            separator(),
+            m('span', `${attrs.response.durationMs.toFixed(1)}ms`),
+          ])
+        : null;
+
     const positionMenu = m(
       PopupMenu,
       {
@@ -130,7 +148,12 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     return [
       runButton,
       statusIndicator,
+      queryStats,
+      queryStats !== null && materializationIndicator !== null
+        ? separator()
+        : null,
       materializationIndicator,
+      materializationIndicator !== null ? separator() : null,
       autoExecuteSwitch,
       positionMenu,
     ];

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/materialization_service.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/materialization_service.ts
@@ -18,19 +18,63 @@ import {Query, QueryNode} from '../query_node';
 /**
  * Service for managing materialized tables for Explore Page nodes.
  * Materialization creates persistent tables using CREATE OR REPLACE PERFETTO TABLE.
+ *
+ * Includes debouncing to prevent excessive materialization calls during rapid
+ * user input (e.g., typing column names).
  */
 export class MaterializationService {
+  private materializeTimer?: ReturnType<typeof setTimeout>;
+  private static readonly MATERIALIZE_DEBOUNCE_MS = 300;
+
   constructor(private engine: Engine) {}
 
   /**
-   * Materializes a node's query into a table.
-   * If the table already exists, it will be replaced.
+   * Materializes a node's query into a table with debouncing.
+   * Multiple rapid calls will be debounced to prevent excessive database operations.
    *
    * @param node The node to materialize
    * @param query The validated query to materialize
-   * @returns The name of the created materialized table
+   * @param queryHash Hash of the query for change detection
+   * @returns A promise that resolves to the name of the created materialized table
    */
-  async materializeNode(node: QueryNode, query: Query): Promise<string> {
+  async materializeNode(
+    node: QueryNode,
+    query: Query,
+    queryHash: string,
+  ): Promise<string> {
+    // Cancel any pending materialization
+    if (this.materializeTimer !== undefined) {
+      clearTimeout(this.materializeTimer);
+    }
+
+    // Return a promise that resolves after debouncing
+    return new Promise((resolve, reject) => {
+      this.materializeTimer = setTimeout(async () => {
+        try {
+          const tableName = await this.performMaterialization(
+            node,
+            query,
+            queryHash,
+          );
+          this.materializeTimer = undefined;
+          resolve(tableName);
+        } catch (error) {
+          this.materializeTimer = undefined;
+          reject(error);
+        }
+      }, MaterializationService.MATERIALIZE_DEBOUNCE_MS);
+    });
+  }
+
+  /**
+   * Performs the actual materialization without debouncing.
+   * Internal method called after debounce period.
+   */
+  private async performMaterialization(
+    node: QueryNode,
+    query: Query,
+    queryHash: string,
+  ): Promise<string> {
     const tableName = this.getTableName(node);
 
     // Build the full SQL with includes and preambles
@@ -56,6 +100,8 @@ export class MaterializationService {
     // Update node state
     node.state.materialized = true;
     node.state.materializationTableName = tableName;
+    // Store query hash for cache invalidation when query changes
+    node.state.materializedQueryHash = queryHash;
 
     return tableName;
   }
@@ -77,6 +123,7 @@ export class MaterializationService {
     // Only update state if drop succeeded
     node.state.materialized = false;
     node.state.materializationTableName = undefined;
+    node.state.materializedQueryHash = undefined;
   }
 
   /**
@@ -118,5 +165,18 @@ export class MaterializationService {
    */
   getMaterializedTableName(node: QueryNode): string | undefined {
     return node.state.materializationTableName;
+  }
+
+  /**
+   * Gets the engine instance for executing queries against materialized tables.
+   *
+   * This is used by SQLDataSource to query materialized tables with server-side
+   * pagination, filtering, and sorting. The engine has direct access to all
+   * materialized tables created by this service.
+   *
+   * @returns The Engine instance with access to all materialized tables
+   */
+  getEngine(): Engine {
+    return this.engine;
   }
 }


### PR DESCRIPTION
 This change migrates the Explore Page datagrid from in-memory data fetching to server-side pagination using SQLDataSource. Previously, all query results were loaded into memory and passed to InMemoryDataSource. Now, queries are materialized into perfetto tables and accessed on-demand via SQLDataSource.

  **Changes:**
  - Materialized tables are created once and reused until the query changes (tracked via query hash)
  - SQLDataSource handles server-side pagination, filtering, and sorting directly against materialized tables
  - Added query statistics display showing row count and execution duration
  - Improved materialization lifecycle: tables are only recreated when the query actually changes
  - Added debouncing (300ms) to prevent excessive materializations during rapid user input

  **Benefits:**
  - Reduced memory usage for large result sets
  - Better performance for filtering/sorting operations (handled by SQL engine)
  - Eliminates redundant materializations when switching between nodes or toggling auto-execute