### PR TITLE
Revert "android: disallow imports relative to protos folder (#3722)"

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -3518,6 +3518,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -3610,6 +3611,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -3704,6 +3706,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -3797,6 +3800,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -3888,6 +3892,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -3981,6 +3986,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4082,6 +4088,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4206,6 +4213,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4250,6 +4258,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4296,6 +4305,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4345,6 +4355,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4392,6 +4403,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4441,6 +4453,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4484,6 +4497,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4525,6 +4539,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4568,6 +4583,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4613,6 +4629,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4656,6 +4673,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4701,6 +4719,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4800,6 +4819,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4843,6 +4863,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4884,6 +4905,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4927,6 +4949,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -4970,6 +4993,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5011,6 +5035,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5054,6 +5079,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5097,6 +5123,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5138,6 +5165,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5181,6 +5209,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5232,6 +5261,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5281,6 +5311,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5332,6 +5363,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5378,6 +5410,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5422,6 +5455,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5468,6 +5502,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5513,6 +5548,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5556,6 +5592,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5601,6 +5638,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5644,6 +5682,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5685,6 +5724,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5728,6 +5768,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5771,6 +5812,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5812,6 +5854,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5855,6 +5898,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -5956,6 +6000,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6035,6 +6080,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6118,6 +6164,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6161,6 +6208,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6467,6 +6515,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6525,6 +6574,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6566,6 +6616,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6609,6 +6660,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6745,6 +6797,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6837,6 +6890,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6889,6 +6943,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6939,6 +6994,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -6991,6 +7047,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7238,6 +7295,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7297,6 +7355,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7354,6 +7413,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7413,6 +7473,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7507,6 +7568,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7562,6 +7624,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7615,6 +7678,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7670,6 +7734,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -7980,6 +8045,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -8027,6 +8093,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -8076,6 +8143,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -8119,6 +8187,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -8160,6 +8229,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -8203,6 +8273,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -8495,6 +8566,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -8785,6 +8857,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9077,6 +9150,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9123,6 +9197,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9167,6 +9242,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9213,6 +9289,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9270,6 +9347,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9325,6 +9403,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9382,6 +9461,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9441,6 +9521,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9498,6 +9579,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9557,6 +9639,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9636,6 +9719,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9713,6 +9797,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9792,6 +9877,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -9932,6 +10018,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10070,6 +10157,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10210,6 +10298,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10256,6 +10345,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10300,6 +10390,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10346,6 +10437,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10400,6 +10492,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10452,6 +10545,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10506,6 +10600,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10549,6 +10644,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10607,6 +10703,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10664,6 +10761,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10719,6 +10817,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10776,6 +10875,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10822,6 +10922,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10866,6 +10967,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10912,6 +11014,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -10957,6 +11060,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11000,6 +11104,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11045,6 +11150,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11110,6 +11216,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11155,6 +11262,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11198,6 +11306,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11243,6 +11352,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11286,6 +11396,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11327,6 +11438,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11370,6 +11482,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11491,6 +11604,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11651,6 +11765,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11772,6 +11887,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11815,6 +11931,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11856,6 +11973,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -11899,6 +12017,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -12007,6 +12126,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -12050,6 +12170,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -12096,6 +12217,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -12142,6 +12264,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -12491,6 +12614,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -12544,6 +12668,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -12681,6 +12806,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13069,6 +13195,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13294,6 +13421,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13372,6 +13500,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13415,6 +13544,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13456,6 +13586,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13499,6 +13630,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13542,6 +13674,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13583,6 +13716,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13626,6 +13760,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -13685,6 +13820,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -16488,6 +16624,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -16529,6 +16666,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 
@@ -16572,6 +16710,7 @@ genrule {
     ],
     export_include_dirs: [
         ".",
+        "protos",
     ],
 }
 

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -900,7 +900,13 @@ def create_proto_modules(blueprint: Blueprint, gn: GnParser,
                          target.name)
   blueprint.add_module(header_module)
   header_module.srcs = set(source_module.srcs)
-  header_module.export_include_dirs = {'.'}
+
+  # TODO(primiano): at some point we should remove this. This was introduced
+  # by aosp/1108421 when adding "protos/" to .proto include paths, in order to
+  # avoid doing multi-repo changes and allow old clients in the android tree
+  # to still do the old #include "perfetto/..." rather than
+  # #include "protos/perfetto/...".
+  header_module.export_include_dirs = {'.', 'protos'}
 
   source_module.genrule_srcs.add(':' + source_module.name)
   source_module.genrule_headers.add(header_module.name)


### PR DESCRIPTION
Breaking android build

This reverts commit 8396a0381cdd8e3991f33c9a9e3770761bf8df75.