### PR TITLE
exp: Fix query node execution bug introduced when migrating to SQL backed datagrid

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -213,6 +213,8 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
     // This ensures that changes in the node's UI components trigger the callback chain
     node.state.onchange = attrs.onchange;
 
+    // Always analyze to generate the query object (needed to enable Run button)
+    // The autoExecute flag only controls whether we automatically execute after analysis
     this.updateQuery(node, attrs);
 
     if (isCollapsed) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -21,7 +21,7 @@ import {
   createFinalColumns,
   MultiSourceNode,
   nextNodeId,
-  setOperationChanged,
+  notifyNextNodes,
 } from '../../../query_node';
 import {columnInfoFromName} from '../../column_info';
 import protos from '../../../../../protos';
@@ -79,8 +79,10 @@ export class SqlSourceNode implements MultiSourceNode {
 
   onQueryExecuted(columns: string[]) {
     this.setSourceColumns(columns);
-    // Mark node as changed to trigger re-analysis with updated columns
-    setOperationChanged(this);
+    // Notify downstream nodes that our columns have changed, but don't mark
+    // this node as having an operation change (which would cause hash to change
+    // and trigger re-execution). Column discovery is metadata, not a query change.
+    notifyNextNodes(this);
   }
 
   clone(): QueryNode {


### PR DESCRIPTION
  This change fixes issues with query execution in the Explore page query builder, specifically
  addressing problems with auto-execution logic and result display clearing.

  **Changes:**
  - Simplified execution logic by combining materialization reuse and auto-execute conditions (both
  trigger execution, just for different reasons)
  - Fixed result clearing issue by avoiding unnecessary `resetQueryState()` calls after SQL source
  nodes execute
  - Changed `SqlSourceNode.onQueryExecuted()` to use `notifyNextNodes()` instead of
  `setOperationChanged()` to update downstream nodes without triggering hash changes
  - Ensured query analysis always happens (needed for Run button) while auto-execute flag only
  controls execution