### PR TITLE
rust-sdk: update amalgamated source instructions

### DIFF
--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Generate amalgamated shared library sources
         shell: bash
-        run: tools/gen_amalgamated --gn_args "is_debug=false is_clang=true use_custom_libcxx=false enable_perfetto_ipc=true perfetto_enable_git_rev_version_header=true is_perfetto_build_generator=true enable_perfetto_zlib=false" --output contrib/rust-sdk/perfetto-sys/libperfetto_c/perfetto_c //src/shared_lib:libperfetto_c
+        run: tools/gen_amalgamated --sdk c --output contrib/rust-sdk/perfetto-sys/libperfetto_c/perfetto
 
       - name: Build and run tests
         run: .cargo/bin/cargo test --manifest-path=contrib/rust-sdk/Cargo.toml --features=intrinsics

--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-sys"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["David Reveman <dreveman@gmail.com>"]
 build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"

--- a/contrib/rust-sdk/perfetto-sys/build.rs
+++ b/contrib/rust-sdk/perfetto-sys/build.rs
@@ -36,14 +36,8 @@ fn main() {
                 ❌ Missing amalgamated source file: {}.\n\n\
                 To fix this, run:\n\
                 \n\
-                $ tools/gen_amalgamated --gn_args \"is_debug=false \
-                is_clang=true use_custom_libcxx=false \
-                enable_perfetto_ipc=true \
-                perfetto_enable_git_rev_version_header=true \
-                is_perfetto_build_generator=true \
-                enable_perfetto_zlib=false\" \
-                --output contrib/rust-sdk/perfetto-sys/libperfetto_c/perfetto_c \
-                //src/shared_lib:libperfetto_c\n\
+                $ tools/gen_amalgamated --sdk c \
+                --output contrib/rust-sdk/perfetto-sys/libperfetto_c/perfetto\n\
                 \n\
                 💡 Tip: invoke cargo with --no-default-features to use an external library\n",
                 source_file.display()


### PR DESCRIPTION
Bump perfetto-sdk-sys crate version to publish crate that uses the new instructions for amalgamated source.
