### PR TITLE
exp: Add node categorization and computed columns to query builder

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -92,6 +92,7 @@ export function registerCoreNodes() {
     description: 'Select, rename, and add new columns to the data.',
     icon: 'edit',
     type: 'modification',
+    category: 'Columns',
     factory: (state) => new ModifyColumnsNode(state as ModifyColumnsState),
   });
 
@@ -101,6 +102,7 @@ export function registerCoreNodes() {
       'Add columns from another node via LEFT JOIN. Connect a node to the left-side port.',
     icon: 'add_box',
     type: 'modification',
+    category: 'Columns',
     factory: (state) => {
       const fullState: AddColumnsNodeState = {
         ...state,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -63,6 +63,7 @@ import {
 import {EmptyGraph} from '../empty_graph';
 import {nodeRegistry} from '../node_registry';
 import {NodeBox} from './node_box';
+import {buildCategorizedMenuItems} from './menu_utils';
 
 // ========================================
 // TYPE DEFINITIONS
@@ -250,18 +251,12 @@ function buildMenuItems(
   devMode: boolean | undefined,
   onAddNode: (id: string) => void,
 ): m.Children[] {
-  return nodeRegistry
+  const nodes = nodeRegistry
     .list()
     .filter(([_id, descriptor]) => descriptor.type === nodeType)
-    .map(([id, descriptor]) => {
-      if (descriptor.devOnly && !devMode) {
-        return null;
-      }
-      return m(MenuItem, {
-        label: descriptor.name,
-        onclick: () => onAddNode(id),
-      });
-    });
+    .filter(([_id, descriptor]) => !descriptor.devOnly || devMode);
+
+  return buildCategorizedMenuItems(nodes, onAddNode);
 }
 
 function buildAddMenuItems(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
@@ -1,0 +1,93 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {MenuItem} from '../../../../widgets/menu';
+import {NodeDescriptor} from '../node_registry';
+
+/**
+ * Build categorized menu items from a list of node descriptors.
+ *
+ * Nodes with the same `category` will be grouped into a submenu.
+ * If a category only has one node, it will be shown directly without a submenu.
+ * Uncategorized nodes (category === undefined) will be shown at the end.
+ *
+ * @param nodes - Array of [id, descriptor] pairs
+ * @param onClickHandler - Callback when a menu item is clicked, receives the node id
+ * @returns Array of Mithril children representing the menu items
+ */
+export function buildCategorizedMenuItems(
+  nodes: Array<[string, NodeDescriptor]>,
+  onClickHandler: (id: string) => void,
+): m.Children[] {
+  // Group nodes by category
+  const grouped = new Map<
+    string | undefined,
+    Array<[string, NodeDescriptor]>
+  >();
+  for (const [id, descriptor] of nodes) {
+    const category = descriptor.category;
+    if (!grouped.has(category)) {
+      grouped.set(category, []);
+    }
+    grouped.get(category)!.push([id, descriptor]);
+  }
+
+  const menuItems: m.Child[] = [];
+
+  // First, add categorized nodes (like "Columns")
+  for (const [category, catNodes] of grouped.entries()) {
+    if (category === undefined) continue;
+
+    if (catNodes.length === 1) {
+      // Single node in category - show it directly without submenu
+      const [id, descriptor] = catNodes[0];
+      menuItems.push(
+        m(MenuItem, {
+          label: descriptor.name,
+          onclick: () => onClickHandler(id),
+        }),
+      );
+    } else {
+      // Multiple nodes in category - show submenu
+      menuItems.push(
+        m(
+          MenuItem,
+          {
+            label: category,
+          },
+          catNodes.map(([id, descriptor]) =>
+            m(MenuItem, {
+              label: descriptor.name,
+              onclick: () => onClickHandler(id),
+            }),
+          ),
+        ),
+      );
+    }
+  }
+
+  // Then, add uncategorized nodes
+  const uncategorized = grouped.get(undefined) ?? [];
+  for (const [id, descriptor] of uncategorized) {
+    menuItems.push(
+      m(MenuItem, {
+        label: descriptor.name,
+        onclick: () => onClickHandler(id),
+      }),
+    );
+  }
+
+  return menuItems;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
@@ -23,6 +23,7 @@ import {Icon} from '../../../../widgets/icon';
 import {Callout} from '../../../../widgets/callout';
 import {Intent} from '../../../../widgets/common';
 import {nodeRegistry} from '../node_registry';
+import {buildCategorizedMenuItems} from './menu_utils';
 
 export interface NodeActions {
   readonly onDuplicateNode: (node: QueryNode) => void;
@@ -81,6 +82,10 @@ export function renderAddButton(attrs: NodeBoxAttrs): m.Child {
     return null;
   }
 
+  const menuItems = buildCategorizedMenuItems(operationNodes, (id) =>
+    onAddOperationNode(id, node),
+  );
+
   return m(
     PopupMenu,
     {
@@ -89,12 +94,7 @@ export function renderAddButton(attrs: NodeBoxAttrs): m.Child {
         icon: 'add',
       }),
     },
-    ...operationNodes.map(([id, descriptor]) => {
-      return m(MenuItem, {
-        label: descriptor.name,
-        onclick: () => onAddOperationNode(id, node),
-      });
-    }),
+    ...menuItems,
   );
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
@@ -41,6 +41,10 @@ export interface NodeDescriptor {
   // Whether this node is a source, modification or a multi-source node.
   type: 'source' | 'modification' | 'multisource';
 
+  // Optional category for grouping related nodes in the UI.
+  // Nodes with the same category will be shown in a submenu.
+  category?: string;
+
   // An optional, async function that runs before the node is created.
   // It can be used for interactive setup, like showing a modal.
   // If it returns null, the creation is aborted.

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -25,24 +25,380 @@ import m from 'mithril';
 import {Card, CardStack} from '../../../../widgets/card';
 import {MultiselectInput} from '../../../../widgets/multiselect_input';
 import {Select} from '../../../../widgets/select';
-import {Button} from '../../../../widgets/button';
-import {TabStrip, TabOption} from '../../../../widgets/tabs';
+import {Button, ButtonVariant} from '../../../../widgets/button';
 import {TextInput} from '../../../../widgets/text_input';
+import {showModal} from '../../../../widgets/modal';
+import {Switch} from '../../../../widgets/switch';
+import {Icon} from '../../../../widgets/icon';
 import {
   StructuredQueryBuilder,
   ColumnSpec,
   JoinCondition,
 } from '../structured_query_builder';
 import {setValidationError} from '../node_issues';
+import {ColumnNameRow} from '../widgets';
 
-export type AddColumnsMode = 'guided' | 'free';
+// Helper components for computed columns (SWITCH and IF)
+class SwitchComponent
+  implements
+    m.ClassComponent<{
+      column: NewColumn;
+      columns: ColumnInfo[];
+      onchange: () => void;
+    }>
+{
+  view({
+    attrs,
+  }: m.Vnode<{
+    column: NewColumn;
+    columns: ColumnInfo[];
+    onchange: () => void;
+  }>) {
+    const {column, columns, onchange} = attrs;
+
+    if (column.type !== 'switch') {
+      return m('');
+    }
+
+    const setSwitchOn = (newSwitchOn: string) => {
+      column.switchOn = newSwitchOn;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setDefaultValue = (newDefaultValue: string) => {
+      column.defaultValue = newDefaultValue;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setCaseWhen = (index: number, newWhen: string) => {
+      if (!column.cases) return;
+      column.cases[index].when = newWhen;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setCaseThen = (index: number, newThen: string) => {
+      if (!column.cases) return;
+      column.cases[index].then = newThen;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const addCase = () => {
+      if (!column.cases) {
+        column.cases = [];
+      }
+      column.cases.push({when: '', then: ''});
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const removeCase = (index: number) => {
+      if (!column.cases) return;
+      column.cases.splice(index, 1);
+      this.updateExpression(column);
+      onchange();
+    };
+
+    if (column.switchOn === undefined || column.switchOn === '') {
+      const columnNames = columns.map((c) => c.column.name);
+      return m(
+        '.pf-exp-switch-component',
+        m(
+          '.pf-exp-switch-header',
+          'SWITCH ON ',
+          m(
+            Select,
+            {
+              onchange: (e: Event) => {
+                setSwitchOn((e.target as HTMLSelectElement).value);
+              },
+            },
+            m('option', {value: ''}, 'Select column'),
+            ...columnNames.map((name) => m('option', {value: name}, name)),
+          ),
+        ),
+      );
+    }
+
+    const columnNames = columns.map((c) => c.column.name);
+
+    const selectedColumn = columns.find(
+      (c) => c.column.name === column.switchOn,
+    );
+    const isStringColumn = selectedColumn?.type === 'STRING';
+
+    return m(
+      '.pf-exp-switch-component',
+      m(
+        '.pf-exp-switch-header',
+        'SWITCH ON ',
+        m(
+          Select,
+          {
+            value: column.switchOn,
+            onchange: (e: Event) => {
+              setSwitchOn((e.target as HTMLSelectElement).value);
+            },
+          },
+          ...columnNames.map((name) => m('option', {value: name}, name)),
+        ),
+      ),
+      isStringColumn &&
+        m(
+          '.pf-exp-switch-glob-toggle',
+          {style: {marginTop: '8px', marginBottom: '8px'}},
+          m(Switch, {
+            label: 'Use glob matching',
+            checked: column.useGlob ?? false,
+            onchange: (e: Event) => {
+              column.useGlob = (e.target as HTMLInputElement).checked;
+              this.updateExpression(column);
+              onchange();
+            },
+          }),
+        ),
+      m(
+        '.pf-exp-switch-default-row',
+        'Default ',
+        m(TextInput, {
+          placeholder: 'default value',
+          value: column.defaultValue || '',
+          oninput: (e: Event) => {
+            setDefaultValue((e.target as HTMLInputElement).value);
+          },
+        }),
+      ),
+      ...(column.cases || []).map((c, i) =>
+        m(
+          '.pf-exp-switch-case',
+          'WHEN ',
+          m(TextInput, {
+            placeholder: 'is equal to',
+            value: c.when,
+            oninput: (e: Event) => {
+              setCaseWhen(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          ' THEN ',
+          m(TextInput, {
+            placeholder: 'then value',
+            value: c.then,
+            oninput: (e: Event) => {
+              setCaseThen(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          m(Button, {
+            icon: 'close',
+            compact: true,
+            onclick: () => removeCase(i),
+          }),
+        ),
+      ),
+      m(Button, {
+        label: 'Add case',
+        onclick: addCase,
+      }),
+    );
+  }
+
+  private updateExpression(col: NewColumn) {
+    if (col.type !== 'switch' || !col.switchOn) {
+      col.expression = '';
+      return;
+    }
+
+    const operator = col.useGlob ? 'GLOB' : '=';
+    const casesStr = (col.cases || [])
+      .filter((c) => c.when.trim() !== '' && c.then.trim() !== '')
+      .map((c) => `WHEN ${col.switchOn} ${operator} ${c.when} THEN ${c.then}`)
+      .join(' ');
+
+    const defaultStr = col.defaultValue ? `ELSE ${col.defaultValue}` : '';
+
+    if (casesStr === '' && defaultStr === '') {
+      col.expression = '';
+      return;
+    }
+
+    col.expression = `CASE ${casesStr} ${defaultStr} END`;
+  }
+}
+
+class IfComponent
+  implements
+    m.ClassComponent<{
+      column: NewColumn;
+      onchange: () => void;
+    }>
+{
+  view({
+    attrs,
+  }: m.Vnode<{
+    column: NewColumn;
+    onchange: () => void;
+  }>) {
+    const {column, onchange} = attrs;
+
+    if (column.type !== 'if') {
+      return m('');
+    }
+
+    const setIfCondition = (index: number, newIf: string) => {
+      if (!column.clauses) return;
+      column.clauses[index].if = newIf;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setThenValue = (index: number, newThen: string) => {
+      if (!column.clauses) return;
+      column.clauses[index].then = newThen;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setElseValue = (newElse: string) => {
+      column.elseValue = newElse;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const addElseIf = () => {
+      if (!column.clauses) {
+        column.clauses = [];
+      }
+      column.clauses.push({if: '', then: ''});
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const removeClause = (index: number) => {
+      if (!column.clauses) return;
+      column.clauses.splice(index, 1);
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const hasElse = column.elseValue !== undefined;
+
+    return m(
+      '.pf-exp-if-component',
+      (column.clauses || []).map((c, i) =>
+        m(
+          '.pf-exp-if-clause',
+          i === 0 ? 'IF ' : 'ELSE IF',
+          m(TextInput, {
+            placeholder: 'condition',
+            value: c.if,
+            oninput: (e: Event) => {
+              setIfCondition(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          ' THEN ',
+          m(TextInput, {
+            placeholder: 'value',
+            value: c.then,
+            oninput: (e: Event) => {
+              setThenValue(i, (e.target as HTMLInputElement).value);
+            },
+          }),
+          m(Button, {
+            icon: 'close',
+            compact: true,
+            onclick: () => removeClause(i),
+          }),
+        ),
+      ),
+
+      hasElse &&
+        m(
+          '.pf-exp-else-clause',
+          'ELSE ',
+          m(TextInput, {
+            placeholder: 'value',
+            value: column.elseValue || '',
+            oninput: (e: Event) => {
+              setElseValue((e.target as HTMLInputElement).value);
+            },
+          }),
+        ),
+
+      m(
+        '.pf-exp-if-buttons',
+        !hasElse &&
+          m(Button, {
+            label: 'Add ELSE IF',
+            onclick: addElseIf,
+          }),
+        !hasElse &&
+          m(Button, {
+            label: 'Add ELSE',
+            onclick: () => {
+              column.elseValue = '';
+              this.updateExpression(column);
+              onchange();
+            },
+          }),
+      ),
+    );
+  }
+
+  private updateExpression(col: NewColumn) {
+    if (col.type !== 'if') {
+      col.expression = '';
+      return;
+    }
+
+    const clausesStr = (col.clauses || [])
+      .filter((c) => c.if.trim() !== '' && c.then.trim() !== '')
+      .map((c) => `WHEN ${c.if} THEN ${c.then}`)
+      .join(' ');
+
+    const elseStr =
+      col.elseValue !== undefined ? `ELSE ${col.elseValue.trim()}` : '';
+
+    if (clausesStr === '' && elseStr === '') {
+      col.expression = '';
+      return;
+    }
+
+    col.expression = `CASE ${clausesStr} ${elseStr} END`;
+  }
+}
+
+interface IfClause {
+  if: string;
+  then: string;
+}
+
+interface NewColumn {
+  expression: string;
+  name: string;
+  module?: string;
+
+  // For switch columns
+  type?: 'switch' | 'if';
+  switchOn?: string;
+  cases?: {when: string; then: string}[];
+  defaultValue?: string;
+  useGlob?: boolean;
+
+  // For if columns
+  clauses?: IfClause[];
+  elseValue?: string;
+
+  // SQL type for preserving type information across serialization
+  sqlType?: string;
+}
 
 export interface AddColumnsNodeState extends QueryNodeState {
   prevNode: QueryNode;
   selectedColumns?: string[];
   leftColumn?: string;
   rightColumn?: string;
-  mode?: AddColumnsMode; // 'guided' or 'free' mode
   // Note: sqlTable is no longer used - we get columns from the connected node
 
   // Note: onAddAndConnectTable callback is now provided through
@@ -59,6 +415,9 @@ export interface AddColumnsNodeState extends QueryNodeState {
 
   // Track if connection was made through guided suggestion
   isGuidedConnection?: boolean;
+
+  // Computed columns (expressions, SWITCH, IF)
+  computedColumns?: NewColumn[];
 }
 
 export class AddColumnsNode implements ModificationNode {
@@ -79,23 +438,18 @@ export class AddColumnsNode implements ModificationNode {
     this.state.leftColumn = this.state.leftColumn ?? 'id';
     this.state.rightColumn = this.state.rightColumn ?? 'id';
     this.state.autoExecute = this.state.autoExecute ?? false;
-    this.state.mode = this.state.mode ?? 'guided';
     this.state.suggestionSelections =
       this.state.suggestionSelections ?? new Map();
     this.state.expandedSuggestions =
       this.state.expandedSuggestions ?? new Set();
     this.state.columnAliases = this.state.columnAliases ?? new Map();
+    this.state.computedColumns = this.state.computedColumns ?? [];
   }
 
   // Called when a node is connected/disconnected to inputNodes
   onPrevNodesUpdated(): void {
     // Reset column selection when the right node changes
     this.state.selectedColumns = [];
-
-    // When a node is connected, always switch to Guided mode
-    if (this.rightNode) {
-      this.state.mode = 'guided';
-    }
 
     // If node is disconnected, reset the guided connection flag
     if (!this.rightNode) {
@@ -119,21 +473,46 @@ export class AddColumnsNode implements ModificationNode {
   }
 
   get finalCols(): ColumnInfo[] {
+    let cols = [...this.sourceCols];
+
+    // Add columns from connected node (JOIN)
     if (this.rightNode) {
-      // In free mode, add ALL columns from the connected node
-      if (this.state.mode === 'free') {
-        return [...this.sourceCols, ...this.rightCols];
-      }
-      // In guided mode, add only selected columns (with aliases if provided)
+      // Add only selected columns (with aliases if provided)
       const newCols =
         this.state.selectedColumns?.map((c) => {
           const alias = this.state.columnAliases?.get(c);
           // If an alias is provided, use it as the column name
           return columnInfoFromName(alias ?? c);
         }) ?? [];
-      return [...this.sourceCols, ...newCols];
+      cols = [...cols, ...newCols];
     }
-    return this.sourceCols;
+
+    // Add computed columns (expressions, SWITCH, IF)
+    const computedCols =
+      this.state.computedColumns
+        ?.filter((c) => this.isComputedColumnValid(c))
+        .map((col) => {
+          // Use stored sqlType if available (from deserialization)
+          if (col.sqlType) {
+            return columnInfoFromName(col.name);
+          }
+          // Try to preserve type information if the expression is a simple column reference
+          const sourceCol = this.sourceCols.find(
+            (c) => c.column.name === col.expression,
+          );
+          if (sourceCol) {
+            col.sqlType = sourceCol.type;
+            return columnInfoFromName(col.name);
+          }
+          // For complex expressions, use 'NA' as type
+          return columnInfoFromName(col.name, true);
+        }) ?? [];
+
+    return [...cols, ...computedCols];
+  }
+
+  private isComputedColumnValid(col: NewColumn): boolean {
+    return col.expression.trim() !== '' && col.name.trim() !== '';
   }
 
   // Suggest joinable tables based on JOINID column types
@@ -181,85 +560,406 @@ export class AddColumnsNode implements ModificationNode {
   }
 
   nodeDetails(): m.Child {
-    const details: m.Child[] = [];
+    const hasConnectedNode = this.rightNode !== undefined;
+    const hasComputedColumns = (this.state.computedColumns?.length ?? 0) > 0;
+    const hasSelectedColumns =
+      this.state.selectedColumns && this.state.selectedColumns.length > 0;
 
-    if (this.rightNode) {
-      if (this.state.mode === 'free') {
-        // Free mode: show that all columns are being added
-        const numCols = this.rightCols.length;
-        const plural = numCols > 1 ? 's' : '';
-        details.push(
-          m(
-            'div',
-            `Adding all ${numCols} column${plural} using `,
-            m('strong', 'id = id'),
-          ),
-        );
-      } else {
-        // Guided mode: show selected columns and join condition
-        if (
-          this.state.selectedColumns &&
-          this.state.selectedColumns.length > 0
-        ) {
-          const plural = this.state.selectedColumns.length > 1 ? 's' : '';
-          const joinCondition =
-            this.state.leftColumn && this.state.rightColumn
-              ? `${this.state.leftColumn} = ${this.state.rightColumn}`
-              : 'no join condition';
-          // Show column names with aliases if provided
-          const columnDisplay = this.state.selectedColumns
-            .map((col) => {
-              const alias = this.state.columnAliases?.get(col);
-              return alias ? `${col} as ${alias}` : col;
-            })
-            .join(', ');
-          details.push(
-            m(
-              'div',
-              `Add column${plural} `,
-              m('strong', columnDisplay),
-              ' using ',
-              m('strong', joinCondition),
-            ),
-          );
-        } else {
-          details.push(m('div', `No columns selected`));
-        }
-      }
-    } else {
-      details.push(m('div', 'Connect a node to add columns from'));
+    if (!hasSelectedColumns && !hasComputedColumns) {
+      return m('.pf-exp-node-details-message', 'No columns added');
     }
 
-    return m('.pf-aggregation-node-details', details);
+    const items: m.Child[] = [];
+
+    // Add joined columns
+    if (hasConnectedNode && hasSelectedColumns) {
+      for (const col of this.state.selectedColumns ?? []) {
+        const alias = this.state.columnAliases?.get(col);
+        const displayName = alias || col;
+        items.push(m('div', `${displayName}: column from input`));
+      }
+    }
+
+    // Add computed columns
+    for (const col of this.state.computedColumns ?? []) {
+      const name = col.name || '(unnamed)';
+      let description = '';
+
+      if (col.type === 'switch') {
+        description = `SWITCH ON ${col.switchOn || '(not set)'}`;
+      } else if (col.type === 'if') {
+        const firstCondition = col.clauses?.[0]?.if || '(empty)';
+        description = `if ${firstCondition}`;
+      } else {
+        description = col.expression || '(empty)';
+      }
+
+      items.push(m('div', `${name}: ${description}`));
+    }
+
+    return m('div', items);
   }
 
   nodeSpecificModify(): m.Child {
-    // If a node is connected, always show Guided mode (no tabs)
-    if (this.rightNode) {
-      return m('div', [this.renderGuidedMode()]);
+    return m('div', [
+      this.renderAddColumnsButtons(),
+      this.renderAddedColumnsList(),
+    ]);
+  }
+
+  private showJoinModal() {
+    const modalKey = 'add-join-modal';
+
+    showModal({
+      title: 'Add Columns from Another Source',
+      key: modalKey,
+      content: () => {
+        return m('div', this.renderGuidedMode());
+      },
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {
+            // Just close
+          },
+        },
+        {
+          text: 'Apply',
+          primary: true,
+          action: () => {
+            // If there's no rightNode, connect the first suggestion with selections
+            if (!this.rightNode && this.state.suggestionSelections) {
+              const suggestions = this.getJoinSuggestions();
+              for (const s of suggestions) {
+                const selectedColumns =
+                  this.state.suggestionSelections.get(s.suggestedTable) ?? [];
+                if (selectedColumns.length > 0) {
+                  // Found a suggestion with selections - connect it
+                  if (this.state.actions?.onAddAndConnectTable) {
+                    this.state.isGuidedConnection = true;
+                    this.state.actions.onAddAndConnectTable(
+                      s.suggestedTable,
+                      0,
+                    );
+                    this.state.leftColumn = s.colName;
+                    this.state.rightColumn = s.targetColumn;
+                    this.state.selectedColumns = [...selectedColumns];
+                  }
+                  break;
+                }
+              }
+            }
+            this.state.onchange?.();
+          },
+        },
+      ],
+    });
+  }
+
+  private showExpressionModal(columnIndex?: number) {
+    const modalKey = 'add-expression-modal';
+    const isEditing = columnIndex !== undefined;
+
+    // Create a temporary copy to work with in the modal
+    let tempColumn: NewColumn;
+    if (isEditing && this.state.computedColumns?.[columnIndex]) {
+      tempColumn = {...this.state.computedColumns[columnIndex]};
+    } else {
+      tempColumn = {expression: '', name: ''};
     }
 
-    // If no node is connected, show tabs to choose between Guided and Free
-    const currentMode = this.state.mode ?? 'guided';
-    const tabs: TabOption[] = [
-      {key: 'guided', title: 'Guided'},
-      {key: 'free', title: 'Free'},
-    ];
-
-    return m('div', [
-      m(TabStrip, {
-        tabs,
-        currentTabKey: currentMode,
-        onTabChange: (key: string) => {
-          this.state.mode = key === 'guided' || key === 'free' ? key : 'guided';
-          this.state.onchange?.();
-          m.redraw();
+    showModal({
+      title: isEditing ? 'Edit Expression Column' : 'Add Expression Column',
+      key: modalKey,
+      content: () => {
+        return this.renderComputedColumn(tempColumn);
+      },
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {
+            // Do nothing - changes are not applied
+          },
         },
-      }),
-      currentMode === 'guided'
-        ? this.renderGuidedMode()
-        : this.renderFreeMode(),
-    ]);
+        {
+          text: isEditing ? 'Save' : 'Add',
+          primary: true,
+          action: () => {
+            // Apply the temporary changes to the actual state
+            if (isEditing && columnIndex !== undefined) {
+              const newComputedColumns = [
+                ...(this.state.computedColumns ?? []),
+              ];
+              newComputedColumns[columnIndex] = tempColumn;
+              this.state.computedColumns = newComputedColumns;
+            } else {
+              this.state.computedColumns = [
+                ...(this.state.computedColumns ?? []),
+                tempColumn,
+              ];
+            }
+            this.state.onchange?.();
+          },
+        },
+      ],
+    });
+  }
+
+  private showSwitchModal(columnIndex?: number) {
+    const modalKey = 'add-switch-modal';
+    const isEditing = columnIndex !== undefined;
+
+    // Create a temporary copy to work with in the modal
+    let tempColumn: NewColumn;
+    if (isEditing && this.state.computedColumns?.[columnIndex]) {
+      tempColumn = {
+        ...this.state.computedColumns[columnIndex],
+        cases: this.state.computedColumns[columnIndex].cases?.map((c) => ({
+          ...c,
+        })),
+      };
+    } else {
+      tempColumn = {
+        type: 'switch' as const,
+        expression: '',
+        name: '',
+        cases: [],
+      };
+    }
+
+    showModal({
+      title: isEditing ? 'Edit Switch Column' : 'Add Switch Column',
+      key: modalKey,
+      content: () => {
+        return this.renderComputedColumn(tempColumn);
+      },
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {
+            // Do nothing - changes are not applied
+          },
+        },
+        {
+          text: isEditing ? 'Save' : 'Add',
+          primary: true,
+          action: () => {
+            // Apply the temporary changes to the actual state
+            if (isEditing && columnIndex !== undefined) {
+              const newComputedColumns = [
+                ...(this.state.computedColumns ?? []),
+              ];
+              newComputedColumns[columnIndex] = tempColumn;
+              this.state.computedColumns = newComputedColumns;
+            } else {
+              this.state.computedColumns = [
+                ...(this.state.computedColumns ?? []),
+                tempColumn,
+              ];
+            }
+            this.state.onchange?.();
+          },
+        },
+      ],
+    });
+  }
+
+  private showIfModal(columnIndex?: number) {
+    const modalKey = 'add-if-modal';
+    const isEditing = columnIndex !== undefined;
+
+    // Create a temporary copy to work with in the modal
+    let tempColumn: NewColumn;
+    if (isEditing && this.state.computedColumns?.[columnIndex]) {
+      tempColumn = {
+        ...this.state.computedColumns[columnIndex],
+        clauses: this.state.computedColumns[columnIndex].clauses?.map((c) => ({
+          ...c,
+        })),
+      };
+    } else {
+      tempColumn = {
+        type: 'if' as const,
+        expression: '',
+        name: '',
+        clauses: [{if: '', then: ''}],
+      };
+    }
+
+    showModal({
+      title: isEditing ? 'Edit If Column' : 'Add If Column',
+      key: modalKey,
+      content: () => {
+        return this.renderComputedColumn(tempColumn);
+      },
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {
+            // Do nothing - changes are not applied
+          },
+        },
+        {
+          text: isEditing ? 'Save' : 'Add',
+          primary: true,
+          action: () => {
+            // Apply the temporary changes to the actual state
+            if (isEditing && columnIndex !== undefined) {
+              const newComputedColumns = [
+                ...(this.state.computedColumns ?? []),
+              ];
+              newComputedColumns[columnIndex] = tempColumn;
+              this.state.computedColumns = newComputedColumns;
+            } else {
+              this.state.computedColumns = [
+                ...(this.state.computedColumns ?? []),
+                tempColumn,
+              ];
+            }
+            this.state.onchange?.();
+          },
+        },
+      ],
+    });
+  }
+
+  private renderAddColumnsButtons(): m.Child {
+    const hasConnectedNode = this.rightNode !== undefined;
+
+    return m(
+      '.pf-add-columns-actions-section',
+      m(
+        '.pf-add-columns-actions-buttons',
+        m(Button, {
+          label: hasConnectedNode
+            ? 'From another source ✓'
+            : 'From another source',
+          icon: 'table_chart',
+          variant: ButtonVariant.Outlined,
+          onclick: () => {
+            this.showJoinModal();
+          },
+        }),
+        m(Button, {
+          label: 'Expression',
+          icon: 'functions',
+          variant: ButtonVariant.Outlined,
+          onclick: () => {
+            this.showExpressionModal();
+          },
+        }),
+        m(Button, {
+          label: 'Switch',
+          icon: 'alt_route',
+          variant: ButtonVariant.Outlined,
+          onclick: () => {
+            this.showSwitchModal();
+          },
+        }),
+        m(Button, {
+          label: 'If',
+          icon: 'help_outline',
+          variant: ButtonVariant.Outlined,
+          onclick: () => {
+            this.showIfModal();
+          },
+        }),
+      ),
+    );
+  }
+
+  private renderAddedColumnsList(): m.Child {
+    const hasConnectedNode = this.rightNode !== undefined;
+    const hasComputedColumns = (this.state.computedColumns?.length ?? 0) > 0;
+
+    if (!hasConnectedNode && !hasComputedColumns) {
+      return m(
+        '.pf-added-columns-empty',
+        'No columns added yet. Use the buttons above to add columns.',
+      );
+    }
+
+    const items: m.Child[] = [];
+
+    // Show joined columns
+    if (hasConnectedNode) {
+      items.push(
+        m(
+          '.pf-added-column-item.pf-joined-source',
+          m(Icon, {icon: 'table_chart'}),
+          m(
+            '.pf-added-column-info',
+            m('.pf-added-column-name', 'Joined Source'),
+            m(
+              '.pf-added-column-description',
+              `${this.state.selectedColumns?.length ?? 0} selected columns`,
+            ),
+          ),
+          m(Button, {
+            label: 'Configure',
+            icon: 'settings',
+            variant: ButtonVariant.Outlined,
+            compact: true,
+            onclick: () => {
+              this.showJoinModal();
+            },
+          }),
+        ),
+      );
+    }
+
+    // Show computed columns
+    for (const [index, col] of (this.state.computedColumns ?? []).entries()) {
+      const icon =
+        col.type === 'switch'
+          ? 'alt_route'
+          : col.type === 'if'
+            ? 'help_outline'
+            : 'functions';
+      const typeName =
+        col.type === 'switch'
+          ? 'Switch'
+          : col.type === 'if'
+            ? 'If'
+            : 'Expression';
+
+      // Show the expression/preview for the column
+      const description =
+        col.type === 'switch' || col.type === 'if'
+          ? typeName
+          : col.expression
+            ? `${typeName}: ${col.expression}`
+            : `${typeName} (empty)`;
+
+      items.push(
+        m(
+          '.pf-added-column-item',
+          m(Icon, {icon}),
+          m(
+            '.pf-added-column-info',
+            m('.pf-added-column-name', col.name || '(unnamed)'),
+            m('.pf-added-column-description', description),
+          ),
+          m(Button, {
+            label: 'Edit',
+            icon: 'edit',
+            variant: ButtonVariant.Outlined,
+            compact: true,
+            onclick: () => {
+              if (col.type === 'switch') {
+                this.showSwitchModal(index);
+              } else if (col.type === 'if') {
+                this.showIfModal(index);
+              } else {
+                this.showExpressionModal(index);
+              }
+            },
+          }),
+        ),
+      );
+    }
+
+    return m('.pf-added-columns-list', items);
   }
 
   private renderGuidedMode(): m.Child {
@@ -384,36 +1084,6 @@ export class AddColumnsNode implements ModificationNode {
                                   ),
                               ],
                             ),
-                            isExpanded &&
-                              selectedColumns.length > 0 &&
-                              m(Button, {
-                                label: 'Add & Connect',
-                                icon: 'add_link',
-                                minimal: true,
-                                compact: true,
-                                onclick: (e: MouseEvent) => {
-                                  e.stopPropagation();
-                                  if (
-                                    this.state.actions?.onAddAndConnectTable
-                                  ) {
-                                    // Mark this as a guided connection
-                                    this.state.isGuidedConnection = true;
-                                    // Port index 0 = first left-side input port
-                                    this.state.actions.onAddAndConnectTable(
-                                      s.suggestedTable,
-                                      0,
-                                    );
-                                    // Pre-set the join columns based on the suggestion
-                                    this.state.leftColumn = s.colName;
-                                    this.state.rightColumn = s.targetColumn;
-                                    // Pre-set the selected columns
-                                    this.state.selectedColumns = [
-                                      ...selectedColumns,
-                                    ];
-                                    this.state.onchange?.();
-                                  }
-                                },
-                              }),
                           ],
                         ),
                         // Column selection (only when expanded)
@@ -494,7 +1164,7 @@ export class AddColumnsNode implements ModificationNode {
             : m(
                 'p',
                 {style: {color: '#888'}},
-                'No JOINID columns found in your data. You can still connect any node to the left port, or switch to Free mode.',
+                'No JOINID columns found in your data. You can still connect any node to the left port.',
               ),
         ),
       );
@@ -670,39 +1340,132 @@ export class AddColumnsNode implements ModificationNode {
     ]);
   }
 
-  private renderFreeMode(): m.Child {
-    if (!this.rightNode) {
+  private renderComputedColumn(col: NewColumn): m.Child {
+    if (col.type === 'switch') {
       return m(
-        'div',
-        m(
-          Card,
-          m('h3', 'Free Mode'),
-          m(
-            'p',
-            {style: {color: '#888'}},
-            'Connect any node to the left port. All columns from the connected node will be added via LEFT JOIN.',
-          ),
-        ),
+        '.pf-exp-switch-wrapper',
+        m(ColumnNameRow, {
+          label: 'New switch column name',
+          name: col.name,
+          isValid: this.isComputedColumnValid(col),
+          onNameChange: (name) => {
+            col.name = name;
+          },
+          onRemove: () => {
+            // No-op in modal mode
+          },
+        }),
+        m(SwitchComponent, {
+          column: col,
+          columns: this.sourceCols,
+          onchange: () => {
+            // No-op in modal mode - changes are already in col
+          },
+        }),
       );
     }
 
-    // Show simple UI when a node is connected
+    if (col.type === 'if') {
+      return m(
+        '.pf-exp-if-wrapper',
+        m(ColumnNameRow, {
+          label: 'New if column name',
+          name: col.name,
+          isValid: this.isComputedColumnValid(col),
+          onNameChange: (name) => {
+            col.name = name;
+          },
+          onRemove: () => {
+            // No-op in modal mode
+          },
+        }),
+        m(IfComponent, {
+          column: col,
+          onchange: () => {
+            // No-op in modal mode - changes are already in col
+          },
+        }),
+      );
+    }
+
+    const isValid = this.isComputedColumnValid(col);
+
     return m(
       'div',
+      {style: {display: 'flex', flexDirection: 'column', gap: '16px'}},
+      // Help text
       m(
-        Card,
-        m('h3', 'Connected Node'),
+        'div',
+        {
+          style: {
+            padding: '12px',
+            background: 'var(--background-color)',
+            borderRadius: '4px',
+            fontSize: '13px',
+            color: 'var(--pf-text-color-secondary)',
+          },
+        },
         m(
-          'p',
+          'div',
           {style: {marginBottom: '8px'}},
-          `All ${this.rightCols.length} columns from the connected node will be added.`,
+          'Create a computed column using any SQL expression.',
         ),
         m(
-          'p',
-          {style: {color: '#888', fontSize: '12px'}},
-          'Switch to Guided mode to select specific columns and configure the join condition.',
+          'div',
+          {style: {fontStyle: 'italic'}},
+          'Example: ',
+          m('code', 'dur / 1e6'),
+          ' to convert duration to milliseconds',
         ),
       ),
+      // Expression input
+      m(
+        'div',
+        {style: {display: 'flex', flexDirection: 'column', gap: '8px'}},
+        m(
+          'label',
+          {
+            style: {
+              fontSize: '14px',
+              fontWeight: 600,
+              color: 'var(--pf-text-color-primary)',
+            },
+          },
+          'SQL Expression',
+        ),
+        m(TextInput, {
+          oninput: (e: Event) => {
+            col.expression = (e.target as HTMLInputElement).value;
+          },
+          placeholder:
+            'Enter SQL expression (e.g., dur / 1e6, name || "_suffix")',
+          value: col.expression,
+        }),
+      ),
+      // Column name input
+      m(
+        'div',
+        {style: {display: 'flex', flexDirection: 'column', gap: '8px'}},
+        m(
+          'label',
+          {
+            style: {
+              fontSize: '14px',
+              fontWeight: 600,
+              color: 'var(--pf-text-color-primary)',
+            },
+          },
+          'Column Name',
+        ),
+        m(TextInput, {
+          oninput: (e: Event) => {
+            col.name = (e.target as HTMLInputElement).value;
+          },
+          placeholder: 'Enter column name (e.g., dur_ms)',
+          value: col.name,
+        }),
+      ),
+      !isValid && m(Icon, {icon: 'warning'}),
     );
   }
 
@@ -743,24 +1506,30 @@ export class AddColumnsNode implements ModificationNode {
       return false;
     }
 
-    // Require a node to be connected to add columns from
-    if (this.rightNode === undefined) {
-      setValidationError(this.state, 'No node connected to add columns from');
-      return false;
-    }
+    // Check if there are any valid computed columns
+    const hasValidComputedColumns = this.state.computedColumns?.some((col) =>
+      this.isComputedColumnValid(col),
+    );
 
-    // In free mode, we use default join columns, so it's always valid
-    if (this.state.mode === 'free') {
-      return true;
-    }
-
-    // In guided mode, we need valid join columns
-    if (!this.state.leftColumn || !this.state.rightColumn) {
+    // Require either a rightNode or valid computed columns
+    if (!this.rightNode && !hasValidComputedColumns) {
       setValidationError(
         this.state,
-        'Guided mode requires both left and right join columns to be selected',
+        'No node connected to add columns from and no valid computed columns',
       );
       return false;
+    }
+
+    // If there's a rightNode, validate the join configuration
+    if (this.rightNode) {
+      // We need valid join columns
+      if (!this.state.leftColumn || !this.state.rightColumn) {
+        setValidationError(
+          this.state,
+          'Join requires both left and right join columns to be selected',
+        );
+        return false;
+      }
     }
 
     return true;
@@ -772,27 +1541,79 @@ export class AddColumnsNode implements ModificationNode {
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (!this.validate()) return undefined;
-    if (!this.rightNode) return this.prevNode.getStructuredQuery();
 
-    // Prepare input columns based on mode
-    const inputColumns: ColumnSpec[] =
-      this.state.mode === 'free'
-        ? this.rightCols.map((col) => ({
-            columnNameOrExpression: col.column.name,
-          }))
-        : (this.state.selectedColumns ?? []).map((colName) => {
-            const alias = this.state.columnAliases?.get(colName);
-            return {
-              columnNameOrExpression: colName,
-              alias: alias && alias.trim() !== '' ? alias.trim() : undefined,
-            };
-          });
+    // If there's no rightNode, we only add computed columns (no JOIN)
+    if (!this.rightNode) {
+      const computedColumns: ColumnSpec[] = [];
+      for (const col of this.state.computedColumns ?? []) {
+        if (!this.isComputedColumnValid(col)) continue;
+        computedColumns.push({
+          columnNameOrExpression: col.expression,
+          alias: col.name,
+          referencedModule: col.module,
+        });
+      }
+
+      // If there are no computed columns, just pass through
+      if (computedColumns.length === 0) {
+        return this.prevNode.getStructuredQuery();
+      }
+
+      // Build column specifications including existing columns and computed columns
+      const allColumns: ColumnSpec[] = [
+        ...this.sourceCols.map((col) => ({
+          columnNameOrExpression: col.column.name,
+        })),
+        ...computedColumns,
+      ];
+
+      // Collect referenced modules
+      const referencedModules = this.state.computedColumns
+        ?.filter((col) => col.module)
+        .map((col) => col.module!);
+
+      // Use withSelectColumns to add computed columns without a JOIN
+      return StructuredQueryBuilder.withSelectColumns(
+        this.prevNode,
+        allColumns,
+        referencedModules && referencedModules.length > 0
+          ? referencedModules
+          : undefined,
+        this.nodeId,
+      );
+    }
+
+    // Prepare input columns (for JOIN)
+    const inputColumns: ColumnSpec[] = (this.state.selectedColumns ?? []).map(
+      (colName) => {
+        const alias = this.state.columnAliases?.get(colName);
+        return {
+          columnNameOrExpression: colName,
+          alias: alias && alias.trim() !== '' ? alias.trim() : undefined,
+        };
+      },
+    );
+
+    // Add computed columns to the JOIN
+    for (const col of this.state.computedColumns ?? []) {
+      if (!this.isComputedColumnValid(col)) continue;
+      inputColumns.push({
+        columnNameOrExpression: col.expression,
+        alias: col.name,
+        referencedModule: col.module,
+      });
+    }
+
+    // If no columns are selected from the JOIN and no computed columns, just pass through
+    if (inputColumns.length === 0) {
+      return this.prevNode.getStructuredQuery();
+    }
 
     // Prepare join condition
     const condition: JoinCondition = {
       type: 'equality',
-      leftColumn: this.state.mode === 'free' ? 'id' : this.state.leftColumn!,
-      rightColumn: this.state.mode === 'free' ? 'id' : this.state.rightColumn!,
+      leftColumn: this.state.leftColumn!,
+      rightColumn: this.state.rightColumn!,
     };
 
     return StructuredQueryBuilder.withAddColumns(
@@ -809,7 +1630,6 @@ export class AddColumnsNode implements ModificationNode {
       selectedColumns: this.state.selectedColumns,
       leftColumn: this.state.leftColumn,
       rightColumn: this.state.rightColumn,
-      mode: this.state.mode,
       suggestionSelections: this.state.suggestionSelections
         ? Object.fromEntries(this.state.suggestionSelections)
         : undefined,
@@ -822,6 +1642,23 @@ export class AddColumnsNode implements ModificationNode {
       isGuidedConnection: this.state.isGuidedConnection,
       comment: this.state.comment,
       autoExecute: this.state.autoExecute,
+      computedColumns: this.state.computedColumns?.map((c) => ({
+        expression: c.expression,
+        name: c.name,
+        module: c.module,
+        type: c.type,
+        switchOn: c.switchOn,
+        cases: c.cases
+          ? c.cases.map((cs) => ({when: cs.when, then: cs.then}))
+          : undefined,
+        defaultValue: c.defaultValue,
+        useGlob: c.useGlob,
+        clauses: c.clauses
+          ? c.clauses.map((cl) => ({if: cl.if, then: cl.then}))
+          : undefined,
+        elseValue: c.elseValue,
+        sqlType: c.sqlType,
+      })),
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
@@ -47,21 +47,93 @@
     gap: 0.5rem;
   }
 
+  .pf-modify-columns-header {
+    padding: 20px 16px;
+    background: var(--surface-color);
+    border-bottom: 1px solid var(--separator-color);
+  }
+
+  .pf-modify-columns-title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--pf-text-color-primary);
+    margin-bottom: 16px;
+  }
+
+  .pf-modify-columns-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .pf-modify-columns-stats {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--pf-text-color-secondary);
+  }
+
+  .pf-modify-columns-buttons {
+    display: flex;
+    gap: 8px;
+  }
+
+  .pf-column-list-container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .pf-column-list-help {
+    padding: 12px 16px;
+    font-size: 13px;
+    color: var(--pf-text-color-secondary);
+    font-style: italic;
+    background: var(--background-color);
+    border-bottom: 1px solid var(--separator-color);
+  }
+
+  .pf-column-list {
+    display: flex;
+    flex-direction: column;
+    padding: 12px 16px;
+  }
+
   .pf-column {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 1px 0;
+    gap: 12px;
+    padding: 8px 12px;
+    margin-bottom: 4px;
+    background: var(--surface-color);
+    border-radius: 4px;
+    border: 1px solid transparent;
+    transition: all 0.15s ease-in-out;
+
+    &:hover {
+      border-color: var(--separator-color);
+      background: var(--background-color);
+    }
   }
 
   .pf-drag-handle {
     opacity: 0;
     cursor: grab;
     transition: opacity 0.2s ease-in-out;
+    width: 20px; // Fixed width for alignment
+    text-align: center;
+    color: var(--pf-text-color-secondary);
+    font-size: 16px;
+
+    &:active {
+      cursor: grabbing;
+    }
   }
 
   .pf-column:hover .pf-drag-handle {
-    opacity: 1;
+    opacity: 0.6;
+  }
+
+  .pf-drag-handle:hover {
+    opacity: 1 !important;
   }
 
   .pf-exp-modify-columns-node-buttons {
@@ -186,4 +258,103 @@
   display: flex;
   gap: 8px;
   margin-top: 4px;
+}
+
+// Add Columns Actions Section (for AddColumnsNode)
+.pf-add-columns-actions-section {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 20px;
+  padding: 20px;
+  background: var(--surface-color);
+  border: 1px solid var(--separator-color);
+  border-radius: 4px;
+}
+
+.pf-add-columns-actions-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--separator-color);
+}
+
+.pf-add-columns-actions-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--pf-text-color-primary);
+}
+
+.pf-add-columns-actions-subtitle {
+  font-size: 13px;
+  color: var(--pf-text-color-secondary);
+  font-style: italic;
+}
+
+.pf-add-columns-actions-buttons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+
+  button {
+    justify-content: flex-start;
+  }
+}
+
+// Added Columns List (for AddColumnsNode)
+.pf-added-columns-empty {
+  padding: 40px 20px;
+  text-align: center;
+  color: var(--pf-text-color-secondary);
+  font-style: italic;
+  background: var(--background-color);
+  border: 1px dashed var(--separator-color);
+  border-radius: 4px;
+}
+
+.pf-added-columns-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.pf-added-column-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: var(--surface-color);
+  border: 1px solid var(--separator-color);
+  border-radius: 4px;
+  transition: all 0.15s ease-in-out;
+
+  &:hover {
+    background: var(--background-color);
+    border-color: var(--pf-primary-color);
+  }
+
+  &.pf-joined-source {
+    border-left: 4px solid var(--pf-primary-color);
+  }
+}
+
+.pf-added-column-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0; // Allow text truncation
+}
+
+.pf-added-column-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--pf-text-color-primary);
+  font-family: var(--pf-font-family-monospace);
+}
+
+.pf-added-column-description {
+  font-size: 12px;
+  color: var(--pf-text-color-secondary);
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -24,379 +24,14 @@ import {
 import {Button, ButtonVariant} from '../../../../widgets/button';
 import {Card, CardStack} from '../../../../widgets/card';
 import {Checkbox} from '../../../../widgets/checkbox';
-import {Icon} from '../../../../widgets/icon';
-import {Select} from '../../../../widgets/select';
 import {TextInput} from '../../../../widgets/text_input';
-import {Switch} from '../../../../widgets/switch';
-import {
-  ColumnInfo,
-  columnInfoFromName,
-  newColumnInfoList,
-} from '../column_info';
+import {ColumnInfo, newColumnInfoList} from '../column_info';
 import protos from '../../../../protos';
 import {NodeIssues} from '../node_issues';
 import {StructuredQueryBuilder, ColumnSpec} from '../structured_query_builder';
-import {ColumnNameRow, ButtonGroup, Section} from '../widgets';
-
-class SwitchComponent
-  implements
-    m.ClassComponent<{
-      column: NewColumn;
-      columns: ColumnInfo[];
-      onchange: () => void;
-    }>
-{
-  view({
-    attrs,
-  }: m.Vnode<{
-    column: NewColumn;
-    columns: ColumnInfo[];
-    onchange: () => void;
-  }>) {
-    const {column, columns, onchange} = attrs;
-
-    if (column.type !== 'switch') {
-      return m('');
-    }
-
-    const setSwitchOn = (newSwitchOn: string) => {
-      column.switchOn = newSwitchOn;
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const setDefaultValue = (newDefaultValue: string) => {
-      column.defaultValue = newDefaultValue;
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const setCaseWhen = (index: number, newWhen: string) => {
-      if (!column.cases) return;
-      column.cases[index].when = newWhen;
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const setCaseThen = (index: number, newThen: string) => {
-      if (!column.cases) return;
-      column.cases[index].then = newThen;
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const addCase = () => {
-      if (!column.cases) {
-        column.cases = [];
-      }
-      column.cases.push({when: '', then: ''});
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const removeCase = (index: number) => {
-      if (!column.cases) return;
-      column.cases.splice(index, 1);
-      this.updateExpression(column);
-      onchange();
-    };
-
-    if (column.switchOn === undefined || column.switchOn === '') {
-      const columnNames = columns.map((c) => c.column.name);
-      return m(
-        '.pf-exp-switch-component',
-        m(
-          '.pf-exp-switch-header',
-          'SWITCH ON ',
-          m(
-            Select,
-            {
-              onchange: (e: Event) => {
-                setSwitchOn((e.target as HTMLSelectElement).value);
-              },
-            },
-            m('option', {value: ''}, 'Select column'),
-            ...columnNames.map((name) => m('option', {value: name}, name)),
-          ),
-        ),
-      );
-    }
-
-    const columnNames = columns.map((c) => c.column.name);
-
-    // Check if the selected column is a string type
-    const selectedColumn = columns.find(
-      (c) => c.column.name === column.switchOn,
-    );
-    const isStringColumn = selectedColumn?.type === 'STRING';
-
-    return m(
-      '.pf-exp-switch-component',
-      m(
-        '.pf-exp-switch-header',
-        'SWITCH ON ',
-        m(
-          Select,
-          {
-            value: column.switchOn,
-            onchange: (e: Event) => {
-              setSwitchOn((e.target as HTMLSelectElement).value);
-            },
-          },
-          ...columnNames.map((name) => m('option', {value: name}, name)),
-        ),
-      ),
-      isStringColumn &&
-        m(
-          '.pf-exp-switch-glob-toggle',
-          {style: {marginTop: '8px', marginBottom: '8px'}},
-          m(Switch, {
-            label: 'Use glob matching',
-            checked: column.useGlob ?? false,
-            onchange: (e: Event) => {
-              column.useGlob = (e.target as HTMLInputElement).checked;
-              this.updateExpression(column);
-              onchange();
-            },
-          }),
-        ),
-      m(
-        '.pf-exp-switch-default-row',
-        'Default ',
-        m(TextInput, {
-          placeholder: 'default value',
-          value: column.defaultValue || '',
-          oninput: (e: Event) => {
-            setDefaultValue((e.target as HTMLInputElement).value);
-          },
-        }),
-      ),
-      ...(column.cases || []).map((c, i) =>
-        m(
-          '.pf-exp-switch-case',
-          'WHEN ',
-          m(TextInput, {
-            placeholder: 'is equal to',
-            value: c.when,
-            oninput: (e: Event) => {
-              setCaseWhen(i, (e.target as HTMLInputElement).value);
-            },
-          }),
-          ' THEN ',
-          m(TextInput, {
-            placeholder: 'then value',
-            value: c.then,
-            oninput: (e: Event) => {
-              setCaseThen(i, (e.target as HTMLInputElement).value);
-            },
-          }),
-          m(Button, {
-            icon: 'close',
-            compact: true,
-            onclick: () => removeCase(i),
-          }),
-        ),
-      ),
-      m(Button, {
-        label: 'Add case',
-        onclick: addCase,
-      }),
-    );
-  }
-
-  private updateExpression(col: NewColumn) {
-    if (col.type !== 'switch' || !col.switchOn) {
-      col.expression = '';
-      return;
-    }
-
-    const operator = col.useGlob ? 'GLOB' : '=';
-    const casesStr = (col.cases || [])
-      .filter((c) => c.when.trim() !== '' && c.then.trim() !== '')
-      .map((c) => `WHEN ${col.switchOn} ${operator} ${c.when} THEN ${c.then}`)
-      .join(' ');
-
-    const defaultStr = col.defaultValue ? `ELSE ${col.defaultValue}` : '';
-
-    if (casesStr === '' && defaultStr === '') {
-      col.expression = '';
-      return;
-    }
-
-    col.expression = `CASE ${casesStr} ${defaultStr} END`;
-  }
-}
-
-class IfComponent
-  implements
-    m.ClassComponent<{
-      column: NewColumn;
-      onchange: () => void;
-    }>
-{
-  view({
-    attrs,
-  }: m.Vnode<{
-    column: NewColumn;
-    onchange: () => void;
-  }>) {
-    const {column, onchange} = attrs;
-
-    if (column.type !== 'if') {
-      return m('');
-    }
-
-    const setIfCondition = (index: number, newIf: string) => {
-      if (!column.clauses) return;
-      column.clauses[index].if = newIf;
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const setThenValue = (index: number, newThen: string) => {
-      if (!column.clauses) return;
-      column.clauses[index].then = newThen;
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const setElseValue = (newElse: string) => {
-      column.elseValue = newElse;
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const addElseIf = () => {
-      if (!column.clauses) {
-        column.clauses = [];
-      }
-      column.clauses.push({if: '', then: ''});
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const removeClause = (index: number) => {
-      if (!column.clauses) return;
-      column.clauses.splice(index, 1);
-      this.updateExpression(column);
-      onchange();
-    };
-
-    const hasElse = column.elseValue !== undefined;
-
-    return m(
-      '.pf-exp-if-component',
-      (column.clauses || []).map((c, i) =>
-        m(
-          '.pf-exp-if-clause',
-          i === 0 ? 'IF ' : 'ELSE IF',
-          m(TextInput, {
-            placeholder: 'condition',
-            value: c.if,
-            oninput: (e: Event) => {
-              setIfCondition(i, (e.target as HTMLInputElement).value);
-            },
-          }),
-          ' THEN ',
-          m(TextInput, {
-            placeholder: 'value',
-            value: c.then,
-            oninput: (e: Event) => {
-              setThenValue(i, (e.target as HTMLInputElement).value);
-            },
-          }),
-          m(Button, {
-            icon: 'close',
-            compact: true,
-            onclick: () => removeClause(i),
-          }),
-        ),
-      ),
-
-      hasElse &&
-        m(
-          '.pf-exp-else-clause',
-          'ELSE ',
-          m(TextInput, {
-            placeholder: 'value',
-            value: column.elseValue || '',
-            oninput: (e: Event) => {
-              setElseValue((e.target as HTMLInputElement).value);
-            },
-          }),
-        ),
-
-      m(
-        '.pf-exp-if-buttons',
-        !hasElse &&
-          m(Button, {
-            label: 'Add ELSE IF',
-            onclick: addElseIf,
-          }),
-        !hasElse &&
-          m(Button, {
-            label: 'Add ELSE',
-            onclick: () => {
-              column.elseValue = '';
-              this.updateExpression(column);
-              onchange();
-            },
-          }),
-      ),
-    );
-  }
-
-  private updateExpression(col: NewColumn) {
-    if (col.type !== 'if') {
-      col.expression = '';
-      return;
-    }
-
-    const clausesStr = (col.clauses || [])
-      .filter((c) => c.if.trim() !== '' && c.then.trim() !== '')
-      .map((c) => `WHEN ${c.if} THEN ${c.then}`)
-      .join(' ');
-
-    const elseStr =
-      col.elseValue !== undefined ? `ELSE ${col.elseValue.trim()}` : '';
-
-    if (clausesStr === '' && elseStr === '') {
-      col.expression = '';
-      return;
-    }
-
-    col.expression = `CASE ${clausesStr} ${elseStr} END`;
-  }
-}
-
-interface IfClause {
-  if: string;
-  then: string;
-}
-
-interface NewColumn {
-  expression: string;
-  name: string;
-  module?: string;
-
-  // For switch columns
-  type?: 'switch' | 'if';
-  switchOn?: string;
-  cases?: {when: string; then: string}[];
-  defaultValue?: string;
-  useGlob?: boolean; // Use GLOB instead of = for string matching
-
-  // For if columns
-  clauses?: IfClause[];
-  elseValue?: string;
-
-  // SQL type for preserving type information across serialization
-  sqlType?: string;
-}
 
 export interface ModifyColumnsSerializedState {
   prevNodeId?: string;
-  newColumns: NewColumn[];
   selectedColumns: {
     name: string;
     type: string;
@@ -408,7 +43,6 @@ export interface ModifyColumnsSerializedState {
 
 export interface ModifyColumnsState extends QueryNodeState {
   prevNode: QueryNode;
-  newColumns: NewColumn[];
   selectedColumns: ColumnInfo[];
 }
 
@@ -426,7 +60,6 @@ export class ModifyColumnsNode implements ModificationNode {
 
     this.state = {
       ...state,
-      newColumns: state.newColumns ?? [],
       selectedColumns: state.selectedColumns ?? [],
     };
 
@@ -452,39 +85,6 @@ export class ModifyColumnsNode implements ModificationNode {
     const finalCols = newColumnInfoList(
       this.state.selectedColumns.filter((col) => col.checked),
     );
-    this.state.newColumns
-      .filter((c) => this.isNewColumnValid(c))
-      .forEach((col) => {
-        // Use stored sqlType if available (from deserialization)
-        if (col.sqlType) {
-          finalCols.push({
-            name: col.name,
-            type: col.sqlType,
-            checked: true,
-            column: {name: col.name},
-          });
-          return;
-        }
-
-        // Try to preserve type information if the expression is a simple column reference
-        const sourceCol = this.state.prevNode?.finalCols?.find(
-          (c) => c.column.name === col.expression,
-        );
-        if (sourceCol) {
-          // If the expression is a simple column reference, preserve the type
-          // Also store it in sqlType for future serialization
-          col.sqlType = sourceCol.type;
-          finalCols.push({
-            name: col.name,
-            type: sourceCol.type,
-            checked: true,
-            column: {...sourceCol.column, name: col.name},
-          });
-        } else {
-          // For complex expressions, use 'NA' as type
-          finalCols.push(columnInfoFromName(col.name, true));
-        }
-      });
     return finalCols;
   }
 
@@ -553,11 +153,12 @@ export class ModifyColumnsNode implements ModificationNode {
     const colNames = new Set<string>();
     for (const col of this.state.selectedColumns) {
       if (!col.checked) continue;
-      const name = col.alias ? col.alias.trim() : col.column.name;
-      if (col.alias && name === '') {
+      // Check for empty or whitespace-only alias
+      if (col.alias !== undefined && col.alias.trim() === '') {
         this.setValidationError('Empty alias not allowed');
         return false;
       }
+      const name = col.alias ? col.alias.trim() : col.column.name;
       if (colNames.has(name)) {
         this.setValidationError('Duplicate column names');
         return false;
@@ -565,28 +166,10 @@ export class ModifyColumnsNode implements ModificationNode {
       colNames.add(name);
     }
 
-    for (const col of this.state.newColumns) {
-      const name = col.name.trim();
-      const expression = col.expression.trim();
-
-      // If a column has an expression, it must have a name and be unique.
-      if (expression !== '') {
-        if (name === '') {
-          this.setValidationError('New column must have a name');
-          return false;
-        }
-        if (colNames.has(name)) {
-          this.setValidationError('Duplicate column names');
-          return false;
-        }
-        colNames.add(name);
-      }
-    }
-
-    // Check if there are no columns selected and no valid new columns
+    // Check if there are no columns selected
     if (colNames.size === 0) {
       this.setValidationError(
-        'No columns selected. Select at least one column or add a new column.',
+        'No columns selected. Select at least one column.',
       );
       return false;
     }
@@ -609,12 +192,7 @@ export class ModifyColumnsNode implements ModificationNode {
     // Determine the state of modifications.
     const hasUnselected = this.state.selectedColumns.some((c) => !c.checked);
     const hasAlias = this.state.selectedColumns.some((c) => c.alias);
-    const newValidColumns = this.state.newColumns.filter((c) =>
-      this.isNewColumnValid(c),
-    );
-
-    // If there are no modifications, show a default message.
-    if (!hasUnselected && !hasAlias && newValidColumns.length === 0) {
+    if (!hasUnselected && !hasAlias) {
       return m('.pf-exp-node-details-message', 'Select all');
     }
 
@@ -672,61 +250,6 @@ export class ModifyColumnsNode implements ModificationNode {
       }
     }
 
-    // If new columns have been added, list them.
-    if (newValidColumns.length > 0) {
-      if (!hasUnselected && !hasAlias) {
-        cards.push(m('span', '+'));
-      }
-      const switchColumns = newValidColumns.filter((c) => c.type === 'switch');
-      const ifColumns = newValidColumns.filter((c) => c.type === 'if');
-      const otherNewColumns = newValidColumns.filter(
-        (c) => c.type !== 'switch' && c.type !== 'if',
-      );
-
-      if (otherNewColumns.length > 0) {
-        const newItems = otherNewColumns.map((c) => {
-          const expression = c.expression.replace(' END', '');
-          return m('.', `${expression} AS ${c.name}`);
-        });
-        cards.push(
-          m(Card, {className: 'pf-exp-node-details-card'}, ...newItems),
-        );
-      }
-
-      if (switchColumns.length > 0) {
-        const switchItems = switchColumns.map((c) =>
-          m(
-            'div.pf-exp-switch-summary',
-            m('span.pf-exp-switch-keyword', 'SWITCH'),
-            ' on ',
-            m('span.pf-exp-column-name', c.switchOn),
-            ' ',
-            m('span.pf-exp-as-keyword', 'AS'),
-            ' ',
-            m('span.pf-exp-alias-name', c.name),
-          ),
-        );
-        cards.push(
-          m(Card, {className: 'pf-exp-node-details-card'}, ...switchItems),
-        );
-      }
-      if (ifColumns.length > 0) {
-        const ifItems = ifColumns.map((c) =>
-          m(
-            'div.pf-exp-if-summary',
-            m('span.pf-exp-if-keyword', 'IF'),
-            ' ',
-            m('span.pf-exp-as-keyword', 'AS'),
-            ' ',
-            m('span.pf-exp-alias-name', c.name),
-          ),
-        );
-        cards.push(
-          m(Card, {className: 'pf-exp-node-details-card'}, ...ifItems),
-        );
-      }
-    }
-
     // If all columns have been deselected, show a specific message.
     if (cards.length === 0) {
       return m('.pf-exp-node-details-message', 'All columns deselected');
@@ -738,31 +261,75 @@ export class ModifyColumnsNode implements ModificationNode {
   nodeSpecificModify(): m.Child {
     return m(
       'div.pf-modify-columns-node',
-      this.renderSelectedColumnsSection(),
-      this.renderAddNewColumnsSection(),
+      this.renderHeader(),
+      this.renderColumnList(),
     );
   }
 
-  private renderSelectedColumnsSection(): m.Child {
-    return m(Section, {
-      title: 'Selected Columns',
-      headerContent: m(Button, {
-        label: 'Deselect All',
-        variant: ButtonVariant.Outlined,
-        onclick: () => {
-          this.state.selectedColumns = this.state.selectedColumns.map(
-            (col) => ({...col, checked: false}),
-          );
-          this.state.onchange?.();
-        },
-      }),
-      children: m(
-        'div.pf-column-list',
+  private renderHeader(): m.Child {
+    const selectedCount = this.state.selectedColumns.filter(
+      (col) => col.checked,
+    ).length;
+    const totalCount = this.state.selectedColumns.length;
+
+    return m(
+      '.pf-modify-columns-header',
+      m('.pf-modify-columns-title', 'Select and Rename Columns'),
+      m(
+        '.pf-modify-columns-actions',
+        m(
+          '.pf-modify-columns-stats',
+          `${selectedCount} / ${totalCount} selected`,
+        ),
+        m(
+          '.pf-modify-columns-buttons',
+          m(Button, {
+            label: 'Select All',
+            variant: ButtonVariant.Outlined,
+            compact: true,
+            onclick: () => {
+              this.state.selectedColumns = this.state.selectedColumns.map(
+                (col) => ({
+                  ...col,
+                  checked: true,
+                }),
+              );
+              this.state.onchange?.();
+            },
+          }),
+          m(Button, {
+            label: 'Deselect All',
+            variant: ButtonVariant.Outlined,
+            compact: true,
+            onclick: () => {
+              this.state.selectedColumns = this.state.selectedColumns.map(
+                (col) => ({
+                  ...col,
+                  checked: false,
+                }),
+              );
+              this.state.onchange?.();
+            },
+          }),
+        ),
+      ),
+    );
+  }
+
+  private renderColumnList(): m.Child {
+    return m(
+      '.pf-column-list-container',
+      m(
+        '.pf-column-list-help',
+        'Check columns to include, add aliases to rename, and drag to reorder',
+      ),
+      m(
+        '.pf-column-list',
         this.state.selectedColumns.map((col, index) =>
           this.renderSelectedColumn(col, index),
         ),
       ),
-    });
+    );
   }
 
   private renderSelectedColumn(col: ColumnInfo, index: number): m.Child {
@@ -823,262 +390,25 @@ export class ModifyColumnsNode implements ModificationNode {
     );
   }
 
-  private renderAddNewColumnsSection(): m.Child {
-    return m(Section, {
-      title: 'Add New Columns',
-      headerContent: null,
-      children: [
-        m(ButtonGroup, {
-          buttons: [
-            {
-              label: 'Add column',
-              onclick: () => {
-                this.state.newColumns = [
-                  ...this.state.newColumns,
-                  {
-                    expression: '',
-                    name: '',
-                  },
-                ];
-                this.state.onchange?.();
-              },
-            },
-            {
-              label: 'Add SWITCH',
-              onclick: () => {
-                this.state.newColumns = [
-                  ...this.state.newColumns,
-                  {
-                    type: 'switch',
-                    expression: '',
-                    name: '',
-                  },
-                ];
-                this.state.onchange?.();
-              },
-            },
-            {
-              label: 'Add IF',
-              onclick: () => {
-                this.state.newColumns = [
-                  ...this.state.newColumns,
-                  {
-                    type: 'if',
-                    expression: '',
-                    name: '',
-                    clauses: [{if: '', then: ''}],
-                  },
-                ];
-                this.state.onchange?.();
-              },
-            },
-          ],
-        }),
-        this.state.newColumns.length > 0 &&
-          m(
-            '.pf-new-columns-list',
-            this.state.newColumns.map((col, index) =>
-              this.renderNewColumn(col, index),
-            ),
-          ),
-      ],
-    });
-  }
-
-  private renderNewColumn(col: NewColumn, index: number): m.Child {
-    if (col.type === 'switch') {
-      return m(
-        '.pf-exp-switch-wrapper',
-        m(ColumnNameRow, {
-          label: 'New switch column name',
-          name: col.name,
-          isValid: this.isNewColumnValid(col),
-          onNameChange: (name) => {
-            const newNewColumns = [...this.state.newColumns];
-            newNewColumns[index] = {
-              ...newNewColumns[index],
-              name,
-            };
-            this.state.newColumns = newNewColumns;
-            this.state.onchange?.();
-          },
-          onRemove: () => {
-            const newNewColumns = [...this.state.newColumns];
-            newNewColumns.splice(index, 1);
-            this.state.newColumns = newNewColumns;
-            this.state.onchange?.();
-          },
-        }),
-        m(SwitchComponent, {
-          column: col,
-          columns: this.prevNode?.finalCols ?? [],
-          onchange: () => {
-            const newNewColumns = [...this.state.newColumns];
-            newNewColumns[index] = {...col};
-            this.state.newColumns = newNewColumns;
-            this.state.onchange?.();
-          },
-        }),
-      );
-    }
-
-    if (col.type === 'if') {
-      return m(
-        '.pf-exp-if-wrapper',
-        m(ColumnNameRow, {
-          label: 'New if column name',
-          name: col.name,
-          isValid: this.isNewColumnValid(col),
-          onNameChange: (name) => {
-            const newNewColumns = [...this.state.newColumns];
-            newNewColumns[index] = {
-              ...newNewColumns[index],
-              name,
-            };
-            this.state.newColumns = newNewColumns;
-            this.state.onchange?.();
-          },
-          onRemove: () => {
-            const newNewColumns = [...this.state.newColumns];
-            newNewColumns.splice(index, 1);
-            this.state.newColumns = newNewColumns;
-            this.state.onchange?.();
-          },
-        }),
-        m(IfComponent, {
-          column: col,
-          onchange: () => {
-            const newNewColumns = [...this.state.newColumns];
-            newNewColumns[index] = {...col};
-            this.state.newColumns = newNewColumns;
-            this.state.onchange?.();
-          },
-        }),
-      );
-    }
-
-    const isValid = this.isNewColumnValid(col);
-
-    return m(
-      '.pf-column',
-      {
-        ondragover: (e: DragEvent) => {
-          e.preventDefault();
-        },
-        ondrop: (e: DragEvent) => {
-          e.preventDefault();
-          const from = parseInt(e.dataTransfer!.getData('text/plain'), 10);
-          const to = this.state.selectedColumns.length + index;
-
-          const newSelectedColumns = [...this.state.selectedColumns];
-          const newNewColumns = [...this.state.newColumns];
-
-          if (from < this.state.selectedColumns.length) {
-            const [removed] = newSelectedColumns.splice(from, 1);
-            newNewColumns.splice(to - this.state.selectedColumns.length, 0, {
-              expression: removed.column.name,
-              name: removed.alias || '',
-            });
-          } else {
-            const [removed] = newNewColumns.splice(
-              from - this.state.selectedColumns.length,
-              1,
-            );
-            newNewColumns.splice(
-              to - this.state.selectedColumns.length,
-              0,
-              removed,
-            );
-          }
-          this.state.selectedColumns = newSelectedColumns;
-          this.state.newColumns = newNewColumns;
-          this.state.onchange?.();
-        },
-      },
-      m(
-        'span.pf-drag-handle',
-        {
-          draggable: true,
-          ondragstart: (e: DragEvent) => {
-            e.dataTransfer!.setData(
-              'text/plain',
-              (this.state.selectedColumns.length + index).toString(),
-            );
-          },
-        },
-        '☰',
-      ),
-      m(TextInput, {
-        oninput: (e: Event) => {
-          const newNewColumns = [...this.state.newColumns];
-          newNewColumns[index] = {
-            ...newNewColumns[index],
-            expression: (e.target as HTMLInputElement).value,
-          };
-          this.state.newColumns = newNewColumns;
-          this.state.onchange?.();
-        },
-        placeholder: 'expression',
-        value: col.expression,
-      }),
-      m(TextInput, {
-        oninput: (e: Event) => {
-          const newNewColumns = [...this.state.newColumns];
-          newNewColumns[index] = {
-            ...newNewColumns[index],
-            name: (e.target as HTMLInputElement).value,
-          };
-          this.state.newColumns = newNewColumns;
-          this.state.onchange?.();
-        },
-        placeholder: 'name',
-        value: col.name,
-      }),
-      !isValid && m(Icon, {icon: 'warning'}),
-      m(Button, {
-        icon: 'close',
-        compact: true,
-        onclick: () => {
-          const newNewColumns = [...this.state.newColumns];
-          newNewColumns.splice(index, 1);
-          this.state.newColumns = newNewColumns;
-          this.state.onchange?.();
-        },
-      }),
-    );
-  }
-
-  private isNewColumnValid(col: NewColumn): boolean {
-    return col.expression.trim() !== '' && col.name.trim() !== '';
-  }
-
   nodeInfo(): m.Children {
     return m(
       'div',
       m(
         'p',
-        'Select which columns to include, rename columns, and create new computed columns using expressions.',
-      ),
-      m(
-        'p',
-        'Use expressions like ',
-        m('code', 'dur / 1000000'),
-        ' to convert nanoseconds to milliseconds, or ',
-        m('code', 'CASE WHEN ... THEN ... END'),
-        ' for conditional logic.',
+        'Select which columns to include from the previous node, rename columns using aliases, and reorder columns using drag and drop.',
       ),
       m(
         'p',
         m('strong', 'Example:'),
-        ' Create a new column ',
-        m('code', 'dur_ms'),
-        ' by computing ',
-        m('code', 'dur / 1000000'),
-        ', or rename ',
+        ' Select only ',
+        m('code', 'id'),
+        ' and ',
+        m('code', 'ts'),
+        ' columns, and rename ',
         m('code', 'ts'),
         ' to ',
         m('code', 'timestamp'),
-        '.',
+        ' using an alias.',
       ),
     );
   }
@@ -1101,25 +431,11 @@ export class ModifyColumnsNode implements ModificationNode {
       });
     }
 
-    for (const col of this.state.newColumns) {
-      if (!this.isNewColumnValid(col)) continue;
-      columns.push({
-        columnNameOrExpression: col.expression,
-        alias: col.name,
-        referencedModule: col.module,
-      });
-    }
-
-    // Collect referenced modules
-    const referencedModules = this.state.newColumns
-      .filter((col) => col.module)
-      .map((col) => col.module!);
-
     // Apply column selection
     return StructuredQueryBuilder.withSelectColumns(
       this.prevNode,
       columns,
-      referencedModules.length > 0 ? referencedModules : undefined,
+      undefined,
       this.nodeId,
     );
   }
@@ -1127,23 +443,6 @@ export class ModifyColumnsNode implements ModificationNode {
   serializeState(): ModifyColumnsSerializedState {
     return {
       prevNodeId: this.prevNode?.nodeId,
-      newColumns: this.state.newColumns.map((c) => ({
-        expression: c.expression,
-        name: c.name,
-        module: c.module,
-        type: c.type,
-        switchOn: c.switchOn,
-        cases: c.cases
-          ? c.cases.map((cs) => ({when: cs.when, then: cs.then}))
-          : undefined,
-        defaultValue: c.defaultValue,
-        useGlob: c.useGlob,
-        clauses: c.clauses
-          ? c.clauses.map((cl) => ({if: cl.if, then: cl.then}))
-          : undefined,
-        elseValue: c.elseValue,
-        sqlType: c.sqlType, // Preserve SQL type across serialization
-      })),
       selectedColumns: this.state.selectedColumns.map((c) => ({
         name: c.name,
         type: c.type,


### PR DESCRIPTION
Adds categorization to the query builder node menu and introduce computed column functionality to the Add Columns node.

Changes:
- Menu categorization: Adds optional category field to node descriptors, allowing related nodes to be grouped in submenus. Both "Modify Columns" and "Add Columns" nodes are now grouped under a "Columns" category.
- Moved all computed columns in Add Columns node: Users can now create computed columns using custom SQL expressions, SWITCH statements (with optional GLOB matching for strings), and IF/THEN/ELSE logic.
- (LOST FUNCTONALITY) Simplified Add Columns node: Removed "guided" vs "free" mode distinction - node now always shows explicit column selection

The new computed column UI provides a guided interface for building CASE statements without requiring users to write SQL directly. Column aliases and computed columns are now clearly distinguished in the node details view.
