### PR TITLE
ui: DataGrid: Fix bug in filter comparison

### DIFF
--- a/ui/src/components/widgets/data_grid/in_memory_data_source.ts
+++ b/ui/src/components/widgets/data_grid/in_memory_data_source.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {stringifyJsonWithBigints} from '../../../base/json_utils';
 import {SqlValue} from '../../../trace_processor/query_result';
 import {
   DataGridDataSource,
@@ -140,8 +141,6 @@ export class InMemoryDataSource implements DataGridDataSource {
   }
 
   private isSortByEqual(a: Sorting, b: Sorting): boolean {
-    if (a === b) return true;
-
     if (a.direction === 'UNSORTED' && b.direction === 'UNSORTED') {
       return true;
     }
@@ -163,13 +162,14 @@ export class InMemoryDataSource implements DataGridDataSource {
     filtersA: ReadonlyArray<DataGridFilter>,
     filtersB: ReadonlyArray<DataGridFilter>,
   ): boolean {
-    if (filtersA === filtersB) return true;
     if (filtersA.length !== filtersB.length) return false;
 
     // Compare each filter
     return filtersA.every((filterA, index) => {
       const filterB = filtersB[index];
-      return JSON.stringify(filterA) === JSON.stringify(filterB);
+      return (
+        stringifyJsonWithBigints(filterA) === stringifyJsonWithBigints(filterB)
+      );
     });
   }
 


### PR DESCRIPTION
Filter comparison was done using JSON.stringify() to deep compare objects - but this crashes when presented with a bigint. Switch to stringigyJsonWithBigints().

Also, no longer compare for ref equality first - filters are not necessarily immutable.
