### PR TITLE
rust-sdk: prefer clang when compiling shared lib

### DIFF
--- a/.github/workflows/rust-sdk-tests.yml
+++ b/.github/workflows/rust-sdk-tests.yml
@@ -56,6 +56,13 @@ jobs:
         shell: bash
         run: tools/gen_amalgamated --sdk c --output contrib/rust-sdk/perfetto-sys/libperfetto_c/perfetto
 
+      - name: Setup compiler path
+        shell: bash
+        run: |
+          if [[ -e buildtools/linux64/clang/bin/clang++ ]]; then
+            echo "PATH=$(readlink -f buildtools/linux64/clang/bin):$PATH" >> $GITHUB_ENV
+          fi
+
       - name: Build and run tests
         run: .cargo/bin/cargo test --manifest-path=contrib/rust-sdk/Cargo.toml --features=intrinsics
 

--- a/contrib/rust-sdk/Cargo.lock
+++ b/contrib/rust-sdk/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-sys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen",
  "cc",


### PR DESCRIPTION
Also avoid disabling all warnings and instead disable just the warning needed.