### PR TITLE
Fix typo in contributing guidelines

### DIFF
--- a/docs/contributing/common-tasks.md
+++ b/docs/contributing/common-tasks.md
@@ -168,7 +168,7 @@ was built with we prompt the user to update.
 6. If special handling in `trace_processor` is desired update [src/trace_processor/importers/ftrace/ftrace_parser.cc](/src/trace_processor/importers/ftrace/ftrace_parser.cc) to parse the event.
 7. Upload and land your change as normal.
 
-Here is an [example change](https://android-review.googlesource.com/c/platform/external/perfetto/+/3343525) which added a new event. Note: Perfetto's source of truth has moved to Github sent the change was made so while the content of that change is accurate, you should send the patch via Github *not* on AOSP Gerrit.
+Here is an [example change](https://android-review.googlesource.com/c/platform/external/perfetto/+/3343525) which added a new event. Note: Perfetto's source of truth has moved to Github since the change was made so while the content of that change is accurate, you should send the patch via Github *not* on AOSP Gerrit.
 
 To test your changes, you can sideload your locally built `tracebox` binary on an Android device. See [Sideloading on Android](#sideloading) for more details.
 


### PR DESCRIPTION
Credit to @vitorgalvao who pointed this out in https://github.com/google/perfetto/pull/3828
