### PR TITLE
rust-sdk: replace perfetto-sdk-sys exclude with include

### DIFF
--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -15,7 +15,15 @@ categories = ["external-ffi-bindings"]
 license = "Apache-2.0"
 homepage = "https://www.perfetto.dev"
 repository = "https://github.com/google/perfetto"
-exclude = ["include/perfetto/public/abi/BUILD.gn"]
+include = [
+    "build.rs",
+    "Cargo.toml",
+    "include/**",
+    "libperfetto_c/**",
+    "README.md",
+    "src/**",
+    "wrapper.h",
+]
 
 [features]
 default = ["vendored"]


### PR DESCRIPTION
This is needed to include amalgamated sources in the published crate now that they are in the .gitignore file.
