### PR TITLE
perfetto: static_libs -> whole_static_libs for cc_static_library

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -727,7 +727,7 @@ cc_library_shared {
             ],
         },
         host: {
-            static_libs: [
+            whole_static_libs: [
                 "libz",
             ],
         },
@@ -1207,7 +1207,7 @@ cc_library_static {
     min_sdk_version: "30",
     target: {
         android: {
-            static_libs: [
+            whole_static_libs: [
                 "perfetto_flags_c_lib",
             ],
         },
@@ -1780,13 +1780,11 @@ cc_library_static {
         "test/cts/producer_to_consumer_integrationtest_cts.cc",
         "test/cts/traced_perf_test_cts.cc",
     ],
-    static_libs: [
+    whole_static_libs: [
         "libgmock",
         "libgtest",
         "libperfetto_client_experimental",
         "perfetto_flags_c_lib",
-    ],
-    whole_static_libs: [
         "perfetto_gtest_logcat_printer",
     ],
     generated_headers: [
@@ -2104,12 +2102,10 @@ cc_library_static {
         ":perfetto_src_tracing_service_service",
         ":perfetto_test_test_helper",
     ],
-    static_libs: [
+    whole_static_libs: [
         "libgmock",
         "libgtest",
         "perfetto_flags_c_lib",
-    ],
-    whole_static_libs: [
         "perfetto_gtest_logcat_printer",
     ],
     generated_headers: [
@@ -2324,7 +2320,7 @@ cc_library_static {
     srcs: [
         "test/gtest_logcat_printer.cc",
     ],
-    static_libs: [
+    whole_static_libs: [
         "libgmock",
         "libgtest",
     ],
@@ -14048,7 +14044,7 @@ cc_library_static {
     ],
     target: {
         android: {
-            static_libs: [
+            whole_static_libs: [
                 "perfetto_flags_c_lib",
             ],
         },
@@ -15855,7 +15851,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_zip_reader",
         "src/trace_processor/trace_processor_shell.cc",
     ],
-    static_libs: [
+    whole_static_libs: [
         "perfetto_src_trace_processor_demangle",
     ],
     host_supported: true,
@@ -16003,7 +15999,7 @@ cc_library_static {
                 "libutils",
                 "libz",
             ],
-            static_libs: [
+            whole_static_libs: [
                 "perfetto_flags_c_lib",
                 "sqlite_ext_percentile",
             ],
@@ -18564,12 +18560,10 @@ cc_library_static {
         ":perfetto_src_tracing_service_service",
         ":perfetto_test_test_helper",
     ],
-    static_libs: [
+    whole_static_libs: [
         "libgmock",
         "libgtest",
         "perfetto_flags_c_lib",
-    ],
-    whole_static_libs: [
         "perfetto_gtest_logcat_printer",
     ],
     generated_headers: [
@@ -18764,7 +18758,7 @@ cc_library_static {
     ],
     target: {
         android: {
-            static_libs: [
+            whole_static_libs: [
                 "perfetto_flags_c_lib",
             ],
         },
@@ -18959,12 +18953,8 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_winscope_proto_mapping",
         ":perfetto_src_trace_processor_util_zip_reader",
     ],
-    static_libs: [
-        "perfetto_src_trace_processor_demangle",
-    ],
     whole_static_libs: [
         "perfetto_src_trace_processor_demangle",
-        "sqlite_ext_percentile",
     ],
     host_supported: true,
     generated_headers: [
@@ -19106,7 +19096,7 @@ cc_library_static {
                 "libutils",
                 "libz",
             ],
-            static_libs: [
+            whole_static_libs: [
                 "perfetto_flags_c_lib",
                 "sqlite_ext_percentile",
             ],

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -306,10 +306,6 @@ additional_args = {
         ('test_config', 'PerfettoIntegrationTests.xml'),
     ],
     'libperfetto_android_internal': [('static_libs', {'libhealthhalutils'}),],
-    'trace_processor': [
-        ('whole_static_libs',
-         {'perfetto_src_trace_processor_demangle', 'sqlite_ext_percentile'}),
-    ],
     'trace_processor_shell': [
         ('strip', {
             'all': True
@@ -366,17 +362,17 @@ def enable_base_platform(module):
 
 
 def enable_gtest_and_gmock(module):
-  module.static_libs.add('libgmock')
-  module.static_libs.add('libgtest')
+  module.add_static_lib('libgmock')
+  module.add_static_lib('libgtest')
   if module.name != 'perfetto_gtest_logcat_printer':
     module.whole_static_libs.add('perfetto_gtest_logcat_printer')
 
 
 def enable_protobuf_full(module):
   if module.type == 'cc_binary_host':
-    module.static_libs.add('libprotobuf-cpp-full')
+    module.add_static_lib('libprotobuf-cpp-full')
   elif module.host_supported:
-    module.host.static_libs.add('libprotobuf-cpp-full')
+    module.add_host_static_lib('libprotobuf-cpp-full')
     module.android.shared_libs.add('libprotobuf-cpp-full')
   else:
     module.shared_libs.add('libprotobuf-cpp-full')
@@ -388,7 +384,7 @@ def enable_protobuf_lite(module):
 
 def enable_protoc_lib(module):
   if module.type == 'cc_binary_host':
-    module.static_libs.add('libprotoc')
+    module.add_static_lib('libprotoc')
   else:
     module.shared_libs.add('libprotoc')
 
@@ -399,11 +395,11 @@ def enable_libunwindstack(module):
     module.shared_libs.add('libprocinfo')
     module.shared_libs.add('libbase')
   else:
-    module.static_libs.add('libunwindstack')
-    module.static_libs.add('libprocinfo')
-    module.static_libs.add('libbase')
-    module.static_libs.add('liblzma')
-    module.static_libs.add('libdexfile_support')
+    module.add_static_lib('libunwindstack')
+    module.add_static_lib('libprocinfo')
+    module.add_static_lib('libbase')
+    module.add_static_lib('liblzma')
+    module.add_static_lib('libdexfile_support')
     module.runtime_libs.add('libdexfile')  # libdexfile_support dependency
     module.shared_libs.add('libz')  # libunwindstack dependency
 
@@ -415,41 +411,41 @@ def enable_libunwind(module):
 
 def enable_sqlite(module):
   if module.type == 'cc_binary_host':
-    module.static_libs.add('libsqlite_static_noicu')
-    module.static_libs.add('sqlite_ext_percentile')
+    module.add_static_lib('libsqlite_static_noicu')
+    module.add_static_lib('sqlite_ext_percentile')
   elif module.host_supported:
     # Copy what the sqlite3 command line tool does.
     module.android.shared_libs.add('libsqlite')
     module.android.shared_libs.add('libicu')
     module.android.shared_libs.add('liblog')
     module.android.shared_libs.add('libutils')
-    module.android.static_libs.add('sqlite_ext_percentile')
-    module.host.static_libs.add('libsqlite_static_noicu')
-    module.host.static_libs.add('sqlite_ext_percentile')
+    module.add_android_static_lib('sqlite_ext_percentile')
+    module.add_host_static_lib('libsqlite_static_noicu')
+    module.add_host_static_lib('sqlite_ext_percentile')
   else:
     module.shared_libs.add('libsqlite')
     module.shared_libs.add('libicu')
     module.shared_libs.add('liblog')
     module.shared_libs.add('libutils')
-    module.static_libs.add('sqlite_ext_percentile')
+    module.add_static_lib('sqlite_ext_percentile')
 
 
 def enable_zlib(module):
   if module.type == 'cc_binary_host':
-    module.static_libs.add('libz')
+    module.add_static_lib('libz')
   elif module.host_supported:
     module.android.shared_libs.add('libz')
-    module.host.static_libs.add('libz')
+    module.add_host_static_lib('libz')
   else:
     module.shared_libs.add('libz')
 
 
 def enable_expat(module):
   if module.type == 'cc_binary_host':
-    module.static_libs.add('libexpat')
+    module.add_static_lib('libexpat')
   elif module.host_supported:
     module.android.shared_libs.add('libexpat')
-    module.host.static_libs.add('libexpat')
+    module.add_host_static_lib('libexpat')
   else:
     module.shared_libs.add('libexpat')
 
@@ -463,10 +459,10 @@ def enable_bionic_libc_platform_headers_on_android(module):
 
 
 def enable_android_test_common(module):
-  module.static_libs.add('junit')
-  module.static_libs.add('truth')
-  module.static_libs.add('androidx.test.runner')
-  module.static_libs.add('androidx.test.ext.junit')
+  module.add_static_lib('junit')
+  module.add_static_lib('truth')
+  module.add_static_lib('androidx.test.runner')
+  module.add_static_lib('androidx.test.ext.junit')
 
 
 # Android equivalents for third-party libraries that the upstream project
@@ -740,9 +736,32 @@ class Module(object):
         return
       raise Exception('Adding Android static lib for host tool is unsupported')
     elif self.host_supported:
-      self.android.static_libs.add(lib)
+      # The motivation for this change is b/169779783: cc_library_static do not
+      # correctly propogate their static_library deps. The suggested workaround
+      # is to use whole_static_libs.
+      # TODO(169779783): remove this workaround when b/169779783 is fixed.
+      if self.type == 'cc_library_static':
+        self.android.whole_static_libs.add(lib)
+      else:
+        self.android.static_libs.add(lib)
+    else:
+      self.add_static_lib(lib)
+
+  def add_static_lib(self, lib):
+    # See above for context.
+    # TODO(169779783): remove this workaround when b/169779783 is fixed.
+    if self.type == 'cc_library_static':
+      self.whole_static_libs.add(lib)
     else:
       self.static_libs.add(lib)
+
+  def add_host_static_lib(self, lib):
+    # See above for context.
+    # TODO(169779783): remove this workaround when b/169779783 is fixed.
+    if self.type == 'cc_library_static':
+      self.host.static_libs.add(lib)
+    else:
+      self.host.whole_static_libs.add(lib)
 
   def add_android_shared_lib(self, lib):
     if self.type == 'cc_binary_host':
@@ -1203,7 +1222,7 @@ class AndroidJavaSDKModulesGenerator:
             target.android_bp_copy_java_target_jarjar)
         self.blueprint.add_module(java_copy_module)
 
-      module.static_libs.add(java_library_module_name)
+      module.add_static_lib(java_library_module_name)
     else:
       module.srcs = [gn_utils.label_to_path(src) for src in target.sources]
 
@@ -1232,7 +1251,7 @@ class AndroidJavaSDKModulesGenerator:
     for dep in android_test_deps:
       assert (dep.custom_action_type == 'perfetto_android_library')
       create_modules_from_target(self.blueprint, self.gn, dep.name)
-      module.static_libs.add(self._bp_module_name_from_gn_target(dep))
+      module.add_static_lib(self._bp_module_name_from_gn_target(dep))
 
     module.jni_libs = self._collect_jni_lib_deps(android_test_deps)
 
@@ -1255,7 +1274,7 @@ class AndroidJavaSDKModulesGenerator:
         continue
       create_modules_from_target(self.blueprint, self.gn, dep.name)
       if not is_target_android_jni_lib(dep):
-        module.static_libs.add(self._bp_module_name_from_gn_target(dep))
+        module.add_static_lib(self._bp_module_name_from_gn_target(dep))
 
   def _bp_module_name_from_gn_target(self, target: GnParser.Target):
     module = create_modules_from_target(self.blueprint, self.gn, target.name)
@@ -1489,13 +1508,13 @@ def create_modules_from_target(blueprint: Blueprint, gn: GnParser,
     if dep_module.type == 'cc_library_shared':
       module.shared_libs.add(dep_module.name)
     elif dep_module.type == 'cc_library_static':
-      module.static_libs.add(dep_module.name)
+      module.add_static_lib(dep_module.name)
     elif dep_module.type == 'cc_library':
       dep_gn_target = gn.get_target(dep_name)
       if dep_gn_target.type == 'shared_library':
         module.shared_libs.add(dep_module.name)
       elif dep_gn_target.type == 'static_library':
-        module.static_libs.add(dep_module.name)
+        module.add_static_lib(dep_module.name)
       else:
         raise Error('Unknown gn type %s for cc_library dep %s' %
                     (dep_gn_target.type, dep_module.name))


### PR DESCRIPTION
This is necessary to unblock the roll into Android. The root cause is
b/169779783 (i.e. soong does not propogate transitive deps of
static_library targets). The suggested workaround is whole_static_libs
which is what we've done for all targets consistently in this change.

Bug: 169779783