### PR TITLE
exp: Expose execution/materialization errors

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -632,6 +632,8 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
       node.state.issues.queryError = error;
       node.state.issues.responseError = warning;
       node.state.issues.dataError = noDataWarning;
+      // Clear any previous execution error since we got a successful response
+      node.state.issues.clearExecutionError();
     } else {
       node.state.issues = undefined;
     }
@@ -650,11 +652,16 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
 
   private handleQueryError(node: QueryNode, e: unknown) {
     console.error('Failed to run query:', e);
-    this.resetQueryState();
+    // Clear response and data source but keep query so Retry can re-execute
+    this.dataSource = undefined;
+    this.response = undefined;
+    this.queryExecuted = false;
     if (!node.state.issues) {
       node.state.issues = new NodeIssues();
     }
-    node.state.issues.queryError =
+    // Use executionError (not queryError) so error persists across re-renders
+    // that trigger validate() - queryError gets cleared during validation
+    node.state.issues.executionError =
       e instanceof Error ? e : new Error(String(e));
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_issues.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_issues.ts
@@ -14,22 +14,34 @@
 // limitations under the License.
 
 export class NodeIssues {
+  // Validation errors - cleared by validate() when re-validating
   queryError?: Error;
   responseError?: Error;
   dataError?: Error;
   warnings: Error[] = [];
+
+  /**
+   * Errors from query execution (e.g., materialization failures).
+   * Unlike validation errors, this persists across validate() calls and is only
+   * cleared when a query returns a successful response.
+   */
+  executionError?: Error;
 
   hasIssues(): boolean {
     return (
       this.queryError !== undefined ||
       this.responseError !== undefined ||
       this.dataError !== undefined ||
+      this.executionError !== undefined ||
       this.warnings.length > 0
     );
   }
 
   getTitle(): string {
     let title = '';
+    if (this.executionError) {
+      title += `Execution Error: ${this.executionError.message}\n`;
+    }
     if (this.queryError) {
       title += `Query Error: ${this.queryError.message}\n`;
     }
@@ -45,11 +57,18 @@ export class NodeIssues {
     return title;
   }
 
+  // Clear validation errors only - executionError persists across these calls
   clear() {
     this.queryError = undefined;
     this.responseError = undefined;
     this.dataError = undefined;
     this.warnings = [];
+  }
+
+  // Clear execution error - called when query returns a response (even with
+  // validation errors), since receiving a response means execution succeeded
+  clearExecutionError() {
+    this.executionError = undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

  Add support for exposing execution and materialization errors in the Data Explorer query builder. Previously, errors from query execution (e.g., invalid column names during materialization) would be lost during re-renders because `validate()` clears `queryError`. This change introduces a separate `executionError` field that persists across validation calls.

  ## Changes

  - Add `executionError` field to `NodeIssues` that persists across `validate()` calls
  - Display execution errors with a Retry button in the Data Explorer UI
  - Update `handleQueryError` to use `executionError` instead of `queryError`
  - Clear `executionError` only when query execution succeeds (receives a response)
  - Add unit tests for the new `executionError` behavior