### PR TITLE
exp: Simplify the ports

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/history_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/history_manager_unittest.ts
@@ -93,7 +93,6 @@ describe('HistoryManager', () => {
 
     // Add an aggregation node
     const aggNode = new AggregationNode({
-      prevNode: tableNode,
       groupByColumns: [],
       aggregations: [],
     });
@@ -146,7 +145,6 @@ describe('HistoryManager', () => {
     });
 
     const aggNode = new AggregationNode({
-      prevNode: tableNode,
       groupByColumns: [],
       aggregations: [],
     });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -32,7 +32,7 @@ import {FilterNode} from './query_builder/nodes/filter_node';
 import {MergeNode} from './query_builder/nodes/merge_node';
 import {UnionNode} from './query_builder/nodes/union_node';
 import {PerfettoSqlType} from '../../trace_processor/perfetto_sql_type';
-import {QueryNode, NodeType} from './query_node';
+import {NodeType, addConnection} from './query_node';
 
 describe('JSON serialization/deserialization', () => {
   let trace: Trace;
@@ -100,10 +100,9 @@ describe('JSON serialization/deserialization', () => {
       sqlModules,
     });
     const modifyNode = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: [],
     });
-    tableNode.nextNodes.push(modifyNode);
+    addConnection(tableNode, modifyNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -120,9 +119,9 @@ describe('JSON serialization/deserialization', () => {
     const deserializedTableNode = deserializedState.rootNodes[0];
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedModifyNode = deserializedTableNode.nextNodes[0];
-    expect((deserializedModifyNode as ModifyColumnsNode).prevNode?.nodeId).toBe(
-      deserializedTableNode.nodeId,
-    );
+    expect(
+      (deserializedModifyNode as ModifyColumnsNode).primaryInput?.nodeId,
+    ).toBe(deserializedTableNode.nodeId);
     expect(
       deserializedState.nodeLayouts.get(deserializedTableNode.nodeId),
     ).toEqual({x: 10, y: 20});
@@ -137,7 +136,6 @@ describe('JSON serialization/deserialization', () => {
 
     const sliceTable = sqlModules.getTable('slice')!;
     const aggregationNode = new AggregationNode({
-      prevNode: tableNode,
       groupByColumns: [
         {
           name: 'name',
@@ -159,7 +157,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    tableNode.nextNodes.push(aggregationNode);
+    addConnection(tableNode, aggregationNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -174,7 +172,7 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedAggregationNode = deserializedTableNode
       .nextNodes[0] as AggregationNode;
-    expect(deserializedAggregationNode.prevNode?.nodeId).toBe(
+    expect(deserializedAggregationNode.primaryInput?.nodeId).toBe(
       deserializedTableNode.nodeId,
     );
     expect(deserializedAggregationNode.state.groupByColumns[0].name).toBe(
@@ -204,7 +202,6 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedState.rootNodes.length).toBe(1);
     const deserializedNode = deserializedState.rootNodes[0] as SqlSourceNode;
     expect(deserializedNode.state.sql).toBe('SELECT * FROM slice');
-    expect(deserializedNode.prevNodes).toEqual([]);
   });
 
   test('serializes and deserializes interval intersect node', () => {
@@ -221,7 +218,7 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const intervalIntersectNode = new IntervalIntersectNode({
-      prevNodes: [tableNode1, tableNode2],
+      inputNodes: [tableNode1, tableNode2],
     });
     tableNode1.nextNodes.push(intervalIntersectNode);
     tableNode2.nextNodes.push(intervalIntersectNode);
@@ -240,14 +237,20 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode1.nextNodes.length).toBe(1);
     const deserializedIntervalIntersectNode = deserializedTableNode1
       .nextNodes[0] as IntervalIntersectNode;
-    expect(deserializedIntervalIntersectNode.prevNodes).toBeDefined();
-    expect(deserializedIntervalIntersectNode.prevNodes?.length).toBe(2);
-    expect(deserializedIntervalIntersectNode.prevNodes?.[0].nodeId).toBe(
-      deserializedTableNode1.nodeId,
-    );
-    expect(deserializedIntervalIntersectNode.prevNodes?.[1].nodeId).toBe(
-      deserializedTableNode2.nodeId,
-    );
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections,
+    ).toBeDefined();
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections.size,
+    ).toBe(2);
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections.get(0)
+        ?.nodeId,
+    ).toBe(deserializedTableNode1.nodeId);
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections.get(1)
+        ?.nodeId,
+    ).toBe(deserializedTableNode2.nodeId);
   });
 
   test('serializes and deserializes interval intersect node with partition columns and filters', () => {
@@ -270,7 +273,7 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const intervalIntersectNode = new IntervalIntersectNode({
-      prevNodes: [tableNode1, tableNode2, tableNode3],
+      inputNodes: [tableNode1, tableNode2, tableNode3],
       partitionColumns: ['name'],
       filterNegativeDur: [true, false, true],
       comment: 'Intersect intervals partitioned by name',
@@ -295,18 +298,25 @@ describe('JSON serialization/deserialization', () => {
     const deserializedIntervalIntersectNode = deserializedTableNode1
       .nextNodes[0] as IntervalIntersectNode;
 
-    // Verify prevNodes connections
-    expect(deserializedIntervalIntersectNode.prevNodes).toBeDefined();
-    expect(deserializedIntervalIntersectNode.prevNodes?.length).toBe(3);
-    expect(deserializedIntervalIntersectNode.prevNodes?.[0].nodeId).toBe(
-      deserializedTableNode1.nodeId,
-    );
-    expect(deserializedIntervalIntersectNode.prevNodes?.[1].nodeId).toBe(
-      deserializedTableNode2.nodeId,
-    );
-    expect(deserializedIntervalIntersectNode.prevNodes?.[2].nodeId).toBe(
-      deserializedTableNode3.nodeId,
-    );
+    // Verify secondaryInputs connections
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections,
+    ).toBeDefined();
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections.size,
+    ).toBe(3);
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections.get(0)
+        ?.nodeId,
+    ).toBe(deserializedTableNode1.nodeId);
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections.get(1)
+        ?.nodeId,
+    ).toBe(deserializedTableNode2.nodeId);
+    expect(
+      deserializedIntervalIntersectNode.secondaryInputs.connections.get(2)
+        ?.nodeId,
+    ).toBe(deserializedTableNode3.nodeId);
 
     // Verify partition columns
     expect(
@@ -357,9 +367,10 @@ describe('JSON serialization/deserialization', () => {
 
     // Create interval intersect node WITHOUT specifying filterNegativeDur
     const intervalIntersectNode = new IntervalIntersectNode({
-      prevNodes: [tableNode1, tableNode2],
+      inputNodes: [tableNode1, tableNode2],
     });
     tableNode1.nextNodes.push(intervalIntersectNode);
+    tableNode2.nextNodes.push(intervalIntersectNode);
 
     // Verify that filterNegativeDur is initialized to true for all inputs
     // This is the key fix - the array should be initialized with explicit true values
@@ -405,10 +416,9 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const modifyNode = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: [],
     });
-    tableNode.nextNodes.push(modifyNode);
+    addConnection(tableNode, modifyNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -423,7 +433,7 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedModifyNode = deserializedTableNode
       .nextNodes[0] as ModifyColumnsNode;
-    expect(deserializedModifyNode.prevNode?.nodeId).toBe(
+    expect(deserializedModifyNode.primaryInput?.nodeId).toBe(
       deserializedTableNode.nodeId,
     );
   });
@@ -436,7 +446,6 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const filterNode = new FilterNode({
-      prevNode: tableNode,
       filters: [
         {
           column: 'name',
@@ -445,7 +454,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    tableNode.nextNodes.push(filterNode);
+    addConnection(tableNode, filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -511,7 +520,6 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const filterNode = new FilterNode({
-      prevNode: tableNode,
       filters: [
         {
           column: 'id',
@@ -520,7 +528,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    tableNode.nextNodes.push(filterNode);
+    addConnection(tableNode, filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -564,34 +572,34 @@ describe('JSON serialization/deserialization', () => {
     expect(() => deserializeState(invalidJson, trace, sqlModules)).toThrow();
   });
 
-  test('deserializes graph with and without prevNodes', () => {
+  test('deserializes graph with primaryInput connections', () => {
     const tableNode = new TableSourceNode({
       sqlTable: sqlModules.getTable('slice'),
       trace,
       sqlModules,
     });
     const modifyNode = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: [],
     });
-    tableNode.nextNodes.push(modifyNode);
+    addConnection(tableNode, modifyNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
       nodeLayouts: new Map(),
     };
 
-    // Test with prevNode
-    const jsonWithPrevNode = serializeState(initialState);
-    const deserializedStateWithPrevNode = deserializeState(
-      jsonWithPrevNode,
+    // Test with primaryInput
+    const jsonWithPrimaryInput = serializeState(initialState);
+    const deserializedStateWithPrimaryInput = deserializeState(
+      jsonWithPrimaryInput,
       trace,
       sqlModules,
     );
-    const deserializedTableNode1 = deserializedStateWithPrevNode.rootNodes[0];
+    const deserializedTableNode1 =
+      deserializedStateWithPrimaryInput.rootNodes[0];
     const deserializedModifyNode1 = deserializedTableNode1
       .nextNodes[0] as ModifyColumnsNode;
-    expect(deserializedModifyNode1.prevNode?.nodeId).toBe(
+    expect(deserializedModifyNode1.primaryInput?.nodeId).toBe(
       deserializedTableNode1.nodeId,
     );
   });
@@ -604,13 +612,11 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const modifyColumnsNode = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: [],
     });
-    tableNode.nextNodes.push(modifyColumnsNode);
+    addConnection(tableNode, modifyColumnsNode);
 
     const filterNode = new FilterNode({
-      prevNode: modifyColumnsNode,
       filters: [
         {
           column: 'new_col',
@@ -619,7 +625,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    modifyColumnsNode.nextNodes.push(filterNode);
+    addConnection(modifyColumnsNode, filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -650,10 +656,12 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const addColumnsNode = new AddColumnsNode({
-      prevNode: tableNode,
       selectedColumns: ['name'],
     });
+    // Manually connect without triggering onPrevNodesUpdated to preserve
+    // the test's explicitly provided selectedColumns
     tableNode.nextNodes.push(addColumnsNode);
+    addColumnsNode.primaryInput = tableNode;
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -681,12 +689,14 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const addColumnsNode = new AddColumnsNode({
-      prevNode: tableNode1,
       selectedColumns: ['name', 'ts'],
       leftColumn: 'id',
       rightColumn: 'id',
     });
+    // Manually connect without triggering onPrevNodesUpdated to preserve
+    // the test's explicitly provided selectedColumns
     tableNode1.nextNodes.push(addColumnsNode);
+    addColumnsNode.primaryInput = tableNode1;
 
     // Create the side input: tableNode2 connected to inputNodes[0]
     const tableNode2 = new TableSourceNode({
@@ -695,11 +705,8 @@ describe('JSON serialization/deserialization', () => {
       sqlModules,
     });
 
-    // Connect tableNode2 to addColumnsNode's inputNodes[0] (left-side port)
-    if (!addColumnsNode.inputNodes) {
-      addColumnsNode.inputNodes = [];
-    }
-    addColumnsNode.inputNodes[0] = tableNode2;
+    // Connect tableNode2 to addColumnsNode's secondaryInputs port 0 (left-side port)
+    addColumnsNode.secondaryInputs.connections.set(0, tableNode2);
     tableNode2.nextNodes.push(addColumnsNode);
 
     const initialState: ExplorePageState = {
@@ -719,20 +726,24 @@ describe('JSON serialization/deserialization', () => {
     const deserializedTableNode1 = deserializedState.rootNodes[0];
     const deserializedTableNode2 = deserializedState.rootNodes[1];
 
-    // Verify main connection (prevNode)
+    // Verify main connection (primaryInput)
     expect(deserializedTableNode1.nextNodes.length).toBe(1);
     const deserializedAddColumnsNode = deserializedTableNode1
       .nextNodes[0] as AddColumnsNode;
-    expect(deserializedAddColumnsNode.prevNode?.nodeId).toBe(
+    expect(deserializedAddColumnsNode.primaryInput?.nodeId).toBe(
       deserializedTableNode1.nodeId,
     );
 
-    // Verify inputNodes connection (THIS IS THE BUG - this will fail before the fix)
-    expect(deserializedAddColumnsNode.inputNodes).toBeDefined();
-    expect(deserializedAddColumnsNode.inputNodes?.length).toBeGreaterThan(0);
-    expect(deserializedAddColumnsNode.inputNodes?.[0]?.nodeId).toBe(
-      deserializedTableNode2.nodeId,
-    );
+    // Verify secondaryInputs connection (THIS IS THE BUG - this will fail before the fix)
+    expect(
+      deserializedAddColumnsNode.secondaryInputs.connections,
+    ).toBeDefined();
+    expect(
+      deserializedAddColumnsNode.secondaryInputs.connections.size,
+    ).toBeGreaterThan(0);
+    expect(
+      deserializedAddColumnsNode.secondaryInputs.connections.get(0)?.nodeId,
+    ).toBe(deserializedTableNode2.nodeId);
 
     // Verify tableNode2 has the connection back to addColumnsNode
     expect(deserializedTableNode2.nextNodes.length).toBe(1);
@@ -784,10 +795,9 @@ describe('JSON serialization/deserialization', () => {
     ];
 
     const modifyColumnsNode = new ModifyColumnsNode({
-      prevNode: tableNode1,
       selectedColumns: selectedColumnsWithAlias,
     });
-    tableNode1.nextNodes.push(modifyColumnsNode);
+    addConnection(tableNode1, modifyColumnsNode);
 
     // Create another table to join with
     const tableNode2 = new TableSourceNode({
@@ -798,16 +808,12 @@ describe('JSON serialization/deserialization', () => {
 
     // Create add columns node that should see the renamed column 'duration_ns'
     const addColumnsNode = new AddColumnsNode({
-      prevNode: tableNode2,
       selectedColumns: [],
     });
-    tableNode2.nextNodes.push(addColumnsNode);
+    addConnection(tableNode2, addColumnsNode);
 
-    // Connect modifyColumnsNode to addColumnsNode's inputNodes[0]
-    if (!addColumnsNode.inputNodes) {
-      addColumnsNode.inputNodes = [];
-    }
-    addColumnsNode.inputNodes[0] = modifyColumnsNode;
+    // Connect modifyColumnsNode to addColumnsNode's secondaryInputs port 0
+    addColumnsNode.secondaryInputs.connections.set(0, modifyColumnsNode);
     modifyColumnsNode.nextNodes.push(addColumnsNode);
 
     // Check that addColumnsNode can see the renamed column
@@ -847,9 +853,15 @@ describe('JSON serialization/deserialization', () => {
       .nextNodes[0] as AddColumnsNode;
 
     // Verify the connection is restored
-    expect(deserializedAddColumnsNode.inputNodes).toBeDefined();
-    expect(deserializedAddColumnsNode.inputNodes?.length).toBeGreaterThan(0);
-    expect(deserializedAddColumnsNode.inputNodes?.[0]).toBeDefined();
+    expect(
+      deserializedAddColumnsNode.secondaryInputs.connections,
+    ).toBeDefined();
+    expect(
+      deserializedAddColumnsNode.secondaryInputs.connections.size,
+    ).toBeGreaterThan(0);
+    expect(
+      deserializedAddColumnsNode.secondaryInputs.connections.get(0),
+    ).toBeDefined();
 
     // Most importantly: verify that renamed columns are still accessible
     const deserializedRightCols = deserializedAddColumnsNode.rightCols;
@@ -878,7 +890,6 @@ describe('JSON serialization/deserialization', () => {
 
     // Create a ModifyColumnsNode that aliases a column
     const modifyNode = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: tableNode.finalCols.map((col) => {
         // Alias the 'ts' column to 'timestamp_alias'
         if (col.name === 'ts') {
@@ -887,7 +898,10 @@ describe('JSON serialization/deserialization', () => {
         return col;
       }),
     });
+    // Manually connect without triggering onPrevNodesUpdated to preserve
+    // the test's explicitly provided selectedColumns
     tableNode.nextNodes.push(modifyNode);
+    modifyNode.primaryInput = tableNode;
 
     // Verify that the alias is in finalCols and the original name is not
     const tsColumn = modifyNode.finalCols.find((c) => c.name === 'ts');
@@ -900,11 +914,13 @@ describe('JSON serialization/deserialization', () => {
 
     // Create an AggregationNode that groups by the aliased column
     const aggregationNode = new AggregationNode({
-      prevNode: modifyNode,
       groupByColumns: [aliasedColumn!],
       aggregations: [],
     });
+    // Manually connect without triggering onPrevNodesUpdated to preserve
+    // the test's explicitly provided groupByColumns
     modifyNode.nextNodes.push(aggregationNode);
+    aggregationNode.primaryInput = modifyNode;
 
     // Verify the aggregation node sees the aliased column
     expect(aggregationNode.state.groupByColumns.length).toBe(1);
@@ -970,11 +986,10 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const limitAndOffsetNode = new LimitAndOffsetNode({
-      prevNode: tableNode,
       limit: 100,
       offset: 20,
     });
-    tableNode.nextNodes.push(limitAndOffsetNode);
+    addConnection(tableNode, limitAndOffsetNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1001,10 +1016,9 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const sortNode = new SortNode({
-      prevNode: tableNode,
       sortColNames: ['name', 'ts'],
     });
-    tableNode.nextNodes.push(sortNode);
+    addConnection(tableNode, sortNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1029,7 +1043,6 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const filterNode = new FilterNode({
-      prevNode: tableNode,
       filters: [
         {
           column: 'name',
@@ -1045,7 +1058,7 @@ describe('JSON serialization/deserialization', () => {
       filterOperator: 'AND',
       comment: 'Filter by name and duration',
     });
-    tableNode.nextNodes.push(filterNode);
+    addConnection(tableNode, filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1086,8 +1099,8 @@ describe('JSON serialization/deserialization', () => {
     // Verify comment
     expect(deserializedNode.state.comment).toBe('Filter by name and duration');
 
-    // Verify prevNode connection
-    expect(deserializedNode.prevNode?.nodeId).toBe(
+    // Verify primaryInput connection
+    expect(deserializedNode.primaryInput?.nodeId).toBe(
       deserializedTableNode.nodeId,
     );
   });
@@ -1100,7 +1113,6 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const filterNode = new FilterNode({
-      prevNode: tableNode,
       filters: [
         {
           column: 'name',
@@ -1108,7 +1120,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    tableNode.nextNodes.push(filterNode);
+    addConnection(tableNode, filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1146,7 +1158,8 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const mergeNode = new MergeNode({
-      prevNodes: [tableNode1, tableNode2],
+      leftNode: tableNode1,
+      rightNode: tableNode2,
       leftQueryAlias: 'left',
       rightQueryAlias: 'right',
       conditionType: 'equality',
@@ -1171,14 +1184,14 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode1.nextNodes.length).toBe(1);
     const deserializedMergeNode = deserializedTableNode1
       .nextNodes[0] as MergeNode;
-    expect(deserializedMergeNode.prevNodes).toBeDefined();
-    expect(deserializedMergeNode.prevNodes?.length).toBe(2);
-    expect(deserializedMergeNode.prevNodes?.[0].nodeId).toBe(
-      deserializedTableNode1.nodeId,
-    );
-    expect(deserializedMergeNode.prevNodes?.[1].nodeId).toBe(
-      deserializedTableNode2.nodeId,
-    );
+    expect(deserializedMergeNode.secondaryInputs.connections).toBeDefined();
+    expect(deserializedMergeNode.secondaryInputs.connections.size).toBe(2);
+    expect(
+      deserializedMergeNode.secondaryInputs.connections.get(0)?.nodeId,
+    ).toBe(deserializedTableNode1.nodeId);
+    expect(
+      deserializedMergeNode.secondaryInputs.connections.get(1)?.nodeId,
+    ).toBe(deserializedTableNode2.nodeId);
     expect(deserializedMergeNode.state.leftQueryAlias).toBe('left');
     expect(deserializedMergeNode.state.rightQueryAlias).toBe('right');
     expect(deserializedMergeNode.state.conditionType).toBe('equality');
@@ -1200,7 +1213,8 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const mergeNode = new MergeNode({
-      prevNodes: [tableNode1, tableNode2],
+      leftNode: tableNode1,
+      rightNode: tableNode2,
       leftQueryAlias: 't1',
       rightQueryAlias: 't2',
       conditionType: 'freeform',
@@ -1253,7 +1267,7 @@ describe('JSON serialization/deserialization', () => {
 
     const sliceTable = sqlModules.getTable('slice')!;
     const unionNode = new UnionNode({
-      prevNodes: [tableNode1, tableNode2, tableNode3],
+      inputNodes: [tableNode1, tableNode2, tableNode3],
       selectedColumns: [
         {
           name: 'name',
@@ -1288,17 +1302,17 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode1.nextNodes.length).toBe(1);
     const deserializedUnionNode = deserializedTableNode1
       .nextNodes[0] as UnionNode;
-    expect(deserializedUnionNode.prevNodes).toBeDefined();
-    expect(deserializedUnionNode.prevNodes?.length).toBe(3);
-    expect(deserializedUnionNode.prevNodes?.[0].nodeId).toBe(
-      deserializedTableNode1.nodeId,
-    );
-    expect(deserializedUnionNode.prevNodes?.[1].nodeId).toBe(
-      deserializedTableNode2.nodeId,
-    );
-    expect(deserializedUnionNode.prevNodes?.[2].nodeId).toBe(
-      deserializedTableNode3.nodeId,
-    );
+    expect(deserializedUnionNode.secondaryInputs.connections).toBeDefined();
+    expect(deserializedUnionNode.secondaryInputs.connections.size).toBe(3);
+    expect(
+      deserializedUnionNode.secondaryInputs.connections.get(0)?.nodeId,
+    ).toBe(deserializedTableNode1.nodeId);
+    expect(
+      deserializedUnionNode.secondaryInputs.connections.get(1)?.nodeId,
+    ).toBe(deserializedTableNode2.nodeId);
+    expect(
+      deserializedUnionNode.secondaryInputs.connections.get(2)?.nodeId,
+    ).toBe(deserializedTableNode3.nodeId);
     expect(deserializedUnionNode.state.selectedColumns.length).toBe(2);
     expect(deserializedUnionNode.state.selectedColumns[0].name).toBe('name');
     expect(deserializedUnionNode.state.selectedColumns[0].checked).toBe(true);
@@ -1320,7 +1334,8 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const mergeNode = new MergeNode({
-      prevNodes: [tableNode1, tableNode2],
+      leftNode: tableNode1,
+      rightNode: tableNode2,
       leftQueryAlias: 'left',
       rightQueryAlias: 'right',
       conditionType: 'equality',
@@ -1333,7 +1348,6 @@ describe('JSON serialization/deserialization', () => {
     tableNode2.nextNodes.push(mergeNode);
 
     const filterNode = new FilterNode({
-      prevNode: mergeNode,
       filters: [
         {
           column: 'dur',
@@ -1342,7 +1356,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    mergeNode.nextNodes.push(filterNode);
+    addConnection(mergeNode, filterNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode1, tableNode2],
@@ -1384,7 +1398,7 @@ describe('JSON serialization/deserialization', () => {
 
     const sliceTable = sqlModules.getTable('slice')!;
     const unionNode = new UnionNode({
-      prevNodes: [tableNode1, tableNode2],
+      inputNodes: [tableNode1, tableNode2],
       selectedColumns: [
         {
           name: 'name',
@@ -1442,7 +1456,8 @@ describe('JSON serialization/deserialization', () => {
     // - Include 'name' once (the equality column)
     // - Exclude 'ts' and 'dur' (duplicated across both inputs)
     const mergeNode = new MergeNode({
-      prevNodes: [tableNode1, tableNode2],
+      leftNode: tableNode1,
+      rightNode: tableNode2,
       leftQueryAlias: 'left',
       rightQueryAlias: 'right',
       conditionType: 'equality',
@@ -1484,7 +1499,6 @@ describe('JSON serialization/deserialization', () => {
 
     const sliceTable = sqlModules.getTable('slice')!;
     const modifyColumnsNode = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: [
         {
           name: 'name',
@@ -1500,7 +1514,10 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
+    // Manually connect without triggering onPrevNodesUpdated to preserve
+    // the test's explicitly provided selectedColumns
     tableNode.nextNodes.push(modifyColumnsNode);
+    modifyColumnsNode.primaryInput = tableNode;
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1520,10 +1537,9 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedNode.state.selectedColumns[1].name).toBe('ts');
   });
 
-  test('serializes modify columns node without prevNode', () => {
-    // Create a modify columns node without a prevNode (edge case)
+  test('serializes modify columns node without primaryInput', () => {
+    // Create a modify columns node without a primaryInput (edge case)
     const modifyColumnsNode = new ModifyColumnsNode({
-      prevNode: undefined as unknown as QueryNode,
       selectedColumns: [],
     });
 
@@ -1536,12 +1552,12 @@ describe('JSON serialization/deserialization', () => {
     const json = serializeState(initialState);
     const serialized = JSON.parse(json);
 
-    // Verify prevNodeId is undefined in serialized state
+    // Verify primaryInputId is undefined in serialized state
     const serializedNode = serialized.nodes.find(
       (n: SerializedNode) => n.nodeId === modifyColumnsNode.nodeId,
     );
     expect(serializedNode).toBeDefined();
-    expect(serializedNode.state.prevNodeId).toBeUndefined();
+    expect(serializedNode.state.primaryInputId).toBeUndefined();
   });
 
   test('serializes and deserializes aggregation node with multiple aggregations', () => {
@@ -1553,7 +1569,6 @@ describe('JSON serialization/deserialization', () => {
 
     const sliceTable = sqlModules.getTable('slice')!;
     const aggregationNode = new AggregationNode({
-      prevNode: tableNode,
       groupByColumns: [
         {
           name: 'name',
@@ -1601,7 +1616,10 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
+    // Manually connect without triggering onPrevNodesUpdated to preserve
+    // the test's explicitly provided groupByColumns
     tableNode.nextNodes.push(aggregationNode);
+    aggregationNode.primaryInput = tableNode;
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1644,7 +1662,6 @@ describe('JSON serialization/deserialization', () => {
     });
 
     const filterNode = new FilterNode({
-      prevNode: tableNode,
       filters: [
         {
           column: 'name',
@@ -1653,11 +1670,10 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    tableNode.nextNodes.push(filterNode);
+    addConnection(tableNode, filterNode);
 
     const sliceTable = sqlModules.getTable('slice')!;
     const modifyNode = new ModifyColumnsNode({
-      prevNode: filterNode,
       selectedColumns: [
         {
           name: 'name',
@@ -1667,10 +1683,9 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    filterNode.nextNodes.push(modifyNode);
+    addConnection(filterNode, modifyNode);
 
     const aggregationNode = new AggregationNode({
-      prevNode: modifyNode,
       groupByColumns: [
         {
           name: 'name',
@@ -1692,20 +1707,18 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-    modifyNode.nextNodes.push(aggregationNode);
+    addConnection(modifyNode, aggregationNode);
 
     const sortNode = new SortNode({
-      prevNode: aggregationNode,
       sortColNames: ['total_dur_ms'],
     });
-    aggregationNode.nextNodes.push(sortNode);
+    addConnection(aggregationNode, sortNode);
 
     const limitNode = new LimitAndOffsetNode({
-      prevNode: sortNode,
       limit: 10,
       offset: 0,
     });
-    sortNode.nextNodes.push(limitNode);
+    addConnection(sortNode, limitNode);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1728,24 +1741,24 @@ describe('JSON serialization/deserialization', () => {
     expect(node1.nextNodes.length).toBe(1);
 
     const node2 = node1.nextNodes[0] as FilterNode;
-    expect(node2.prevNode?.nodeId).toBe(node1.nodeId);
+    expect(node2.primaryInput?.nodeId).toBe(node1.nodeId);
     expect(node2.state.filters?.length).toBe(1);
     expect(node2.nextNodes.length).toBe(1);
 
     const node3 = node2.nextNodes[0] as ModifyColumnsNode;
-    expect(node3.prevNode?.nodeId).toBe(node2.nodeId);
+    expect(node3.primaryInput?.nodeId).toBe(node2.nodeId);
     expect(node3.nextNodes.length).toBe(1);
 
     const node4 = node3.nextNodes[0] as AggregationNode;
-    expect(node4.prevNode?.nodeId).toBe(node3.nodeId);
+    expect(node4.primaryInput?.nodeId).toBe(node3.nodeId);
     expect(node4.nextNodes.length).toBe(1);
 
     const node5 = node4.nextNodes[0] as SortNode;
-    expect(node5.prevNode?.nodeId).toBe(node4.nodeId);
+    expect(node5.primaryInput?.nodeId).toBe(node4.nodeId);
     expect(node5.nextNodes.length).toBe(1);
 
     const node6 = node5.nextNodes[0] as LimitAndOffsetNode;
-    expect(node6.prevNode?.nodeId).toBe(node5.nodeId);
+    expect(node6.primaryInput?.nodeId).toBe(node5.nodeId);
     expect(node6.state.limit).toBe(10);
 
     // Verify all layouts preserved
@@ -1761,7 +1774,6 @@ describe('JSON serialization/deserialization', () => {
 
     const sliceTable = sqlModules.getTable('slice')!;
     const modifyNode1 = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: [
         {
           name: 'name',
@@ -1771,9 +1783,9 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
+    addConnection(tableNode, modifyNode1);
 
     const modifyNode2 = new ModifyColumnsNode({
-      prevNode: tableNode,
       selectedColumns: [
         {
           name: 'ts',
@@ -1783,8 +1795,7 @@ describe('JSON serialization/deserialization', () => {
         },
       ],
     });
-
-    tableNode.nextNodes.push(modifyNode1, modifyNode2);
+    addConnection(tableNode, modifyNode2);
 
     const initialState: ExplorePageState = {
       rootNodes: [tableNode],
@@ -1801,8 +1812,8 @@ describe('JSON serialization/deserialization', () => {
     const branch1 = deserializedTableNode.nextNodes[0] as ModifyColumnsNode;
     const branch2 = deserializedTableNode.nextNodes[1] as ModifyColumnsNode;
 
-    expect(branch1.prevNode?.nodeId).toBe(deserializedTableNode.nodeId);
-    expect(branch2.prevNode?.nodeId).toBe(deserializedTableNode.nodeId);
+    expect(branch1.primaryInput?.nodeId).toBe(deserializedTableNode.nodeId);
+    expect(branch2.primaryInput?.nodeId).toBe(deserializedTableNode.nodeId);
   });
 
   test('deserializes graph without nodeLayouts field (auto-layout)', () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -106,7 +106,6 @@ export function registerCoreNodes() {
     factory: (state) => {
       const fullState: AddColumnsNodeState = {
         ...state,
-        prevNode: state.prevNode!,
         selectedColumns: (state as AddColumnsNodeState).selectedColumns ?? [],
         leftColumn: (state as AddColumnsNodeState).leftColumn ?? 'id',
         rightColumn: (state as AddColumnsNodeState).rightColumn ?? 'id',
@@ -129,7 +128,7 @@ export function registerCoreNodes() {
       }
       const fullState: IntervalIntersectNodeState = {
         ...state,
-        prevNodes: state.prevNodes ?? [],
+        inputNodes: [],
       };
       return new IntervalIntersectNode(fullState);
     },
@@ -144,7 +143,6 @@ export function registerCoreNodes() {
     factory: (state) => {
       const fullState: MergeNodeState = {
         ...state,
-        prevNodes: state.prevNodes ?? [],
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -180,7 +178,7 @@ export function registerCoreNodes() {
     factory: (state) => {
       const fullState: UnionNodeState = {
         ...state,
-        prevNodes: state.prevNodes ?? [],
+        inputNodes: [],
         selectedColumns: [],
       };
       const node = new UnionNode(fullState);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -53,9 +53,6 @@ import {
 import {
   QueryNode,
   singleNodeOperation,
-  SourceNode,
-  MultiSourceNode,
-  ModificationNode,
   NodeType,
   addConnection,
   removeConnection,
@@ -84,21 +81,14 @@ const LAYOUT_CONSTANTS = {
 // TYPE GUARDS
 // ========================================
 
-function isSourceNode(node: QueryNode): node is SourceNode {
-  return (
-    node.type === NodeType.kTable ||
-    node.type === NodeType.kSimpleSlices ||
-    node.type === NodeType.kSqlSource
-  );
+// Source nodes have no inputs (no primaryInput, no secondaryInputs)
+function isSourceNode(node: QueryNode): boolean {
+  return node.primaryInput === undefined && node.secondaryInputs === undefined;
 }
 
-// Multi-input nodes (have prevNodes array, cannot be docked)
-function isMultiSourceNode(node: QueryNode): node is MultiSourceNode {
-  return (
-    node.type === NodeType.kIntervalIntersect ||
-    node.type === NodeType.kUnion ||
-    node.type === NodeType.kMerge
-  );
+// Multi-source nodes have secondaryInputs but no primaryInput
+function isMultiSourceNode(node: QueryNode): boolean {
+  return node.secondaryInputs !== undefined && node.primaryInput === undefined;
 }
 
 // ========================================
@@ -181,22 +171,15 @@ function getInputLabels(node: QueryNode): NodePort[] {
   }
 
   if (isMultiSourceNode(node)) {
-    const multiSourceNode = node as MultiSourceNode;
-
     // Check if node has custom input labels
-    if (
-      'getInputLabels' in multiSourceNode &&
-      typeof multiSourceNode.getInputLabels === 'function'
-    ) {
-      return (
-        multiSourceNode as MultiSourceNode & {getInputLabels: () => string[]}
-      )
+    if ('getInputLabels' in node && typeof node.getInputLabels === 'function') {
+      return (node as QueryNode & {getInputLabels: () => string[]})
         .getInputLabels()
-        .map((label) => ({content: label, direction: 'left'}));
+        .map((label) => ({content: label, direction: 'left' as const}));
     }
 
     // Always show one extra empty port for adding new connections
-    const numPorts = multiSourceNode.prevNodes.length + 1;
+    const numPorts = (node.secondaryInputs?.connections.size ?? 0) + 1;
     const labels: NodePort[] = [];
     for (let i = 0; i < numPorts; i++) {
       labels.push({content: `Input ${i + 1}`, direction: 'left'});
@@ -204,43 +187,37 @@ function getInputLabels(node: QueryNode): NodePort[] {
     return labels;
   }
 
-  // Check if ModificationNode has inputNodes (additional left-side inputs)
-  if ('inputNodes' in node) {
-    const modNode = node as ModificationNode;
-    if (modNode.inputNodes !== undefined && Array.isArray(modNode.inputNodes)) {
-      // Check if node has custom input labels
-      if (
-        'getInputLabels' in modNode &&
-        typeof modNode.getInputLabels === 'function'
-      ) {
-        return modNode.getInputLabels();
-      }
+  // Check if modification node has secondaryInputs (additional left-side inputs)
+  if (node.secondaryInputs) {
+    // Check if node has custom input labels
+    if ('getInputLabels' in node && typeof node.getInputLabels === 'function') {
+      return (
+        node as QueryNode & {getInputLabels: () => NodePort[]}
+      ).getInputLabels();
+    }
 
-      const labels: NodePort[] = [];
+    const labels: NodePort[] = [];
 
-      // Add top port for prevNode (main data flow)
-      labels.push({content: 'Input', direction: 'top'});
+    // Add top port for primaryInput (main data flow)
+    labels.push({content: 'Input', direction: 'top'});
 
-      // For AddColumnsNode, show exactly one left-side port
-      // (it only supports connecting one table to add columns from)
-      if ('type' in modNode && modNode.type === NodeType.kAddColumns) {
-        labels.push({content: 'Table', direction: 'left'});
-        return labels;
-      }
-
-      // For other nodes with inputNodes, dynamically show ports
-      const numConnected = modNode.inputNodes.filter(
-        (it: QueryNode | undefined) => it,
-      ).length;
-      // Always show one extra empty port for adding new connections
-      const numLeftPorts = numConnected + 1;
-
-      // Add left-side ports for inputNodes (additional table inputs)
-      for (let i = 0; i < numLeftPorts; i++) {
-        labels.push({content: `Table ${i + 1}`, direction: 'left'});
-      }
+    // For AddColumnsNode, show exactly one left-side port
+    // (it only supports connecting one table to add columns from)
+    if (node.type === NodeType.kAddColumns) {
+      labels.push({content: 'Table', direction: 'left'});
       return labels;
     }
+
+    // For other nodes with secondaryInputs, dynamically show ports
+    const numConnected = node.secondaryInputs.connections.size;
+    // Always show one extra empty port for adding new connections
+    const numLeftPorts = numConnected + 1;
+
+    // Add left-side ports for secondaryInputs (additional table inputs)
+    for (let i = 0; i < numLeftPorts; i++) {
+      labels.push({content: `Table ${i + 1}`, direction: 'left'});
+    }
+    return labels;
   }
 
   return [{content: 'Input', direction: 'top'}];
@@ -290,13 +267,13 @@ function getRootNodes(
 
   // A node is docked (not a root) if:
   // 1. It's a single-node operation (modification node)
-  // 2. It has a prevNode (parent in the primary flow)
+  // 2. It has a primaryInput (parent in the primary flow)
   // 3. It doesn't have a layout position (purely visual property)
   for (const node of allNodes) {
     if (
       singleNodeOperation(node.type) &&
-      'prevNode' in node &&
-      node.prevNode !== undefined &&
+      'primaryInput' in node &&
+      node.primaryInput !== undefined &&
       isChildDocked(node, nodeLayouts)
     ) {
       dockedNodes.add(node);
@@ -401,8 +378,8 @@ function getNextDockedNode(
   ) {
     const child = qnode.nextNodes[0];
     // Only dock the child if it's part of the primary flow chain
-    // (i.e., the child's prevNode points back to this parent)
-    if ('prevNode' in child && child.prevNode === qnode) {
+    // (i.e., the child's primaryInput points back to this parent)
+    if ('primaryInput' in child && child.primaryInput === qnode) {
       return renderChildNode(child, attrs);
     }
   }
@@ -485,30 +462,36 @@ function renderNodes(
 // CONNECTION HANDLING
 // ========================================
 
-// For multi-source nodes, finds which input port (0-indexed) the parent is connected to
-function calculateInputPort(child: QueryNode, parent: QueryNode): number {
-  if (isMultiSourceNode(child)) {
-    const index = child.prevNodes.indexOf(parent);
-    return index !== -1 ? index : 0;
-  }
+// Single-input nodes use port 0 for primaryInput, multi-source nodes don't have primaryInput
+function hasPrimaryInputPort(node: QueryNode): boolean {
+  return singleNodeOperation(node.type);
+}
 
-  // Check if modification node has inputNodes (additional left-side inputs)
-  if ('inputNodes' in child && 'prevNode' in child) {
-    const modNode = child as ModificationNode;
-    if (modNode.inputNodes !== undefined && Array.isArray(modNode.inputNodes)) {
-      // Check if parent is the main prevNode (port 0)
-      if (modNode.prevNode === parent) {
-        return 0;
-      }
-      // Check if parent is in inputNodes array (ports 1+)
-      const index = modNode.inputNodes.indexOf(parent);
-      if (index !== -1) {
-        return index + 1; // Port 1 = inputNodes[0], Port 2 = inputNodes[1], etc.
+// Find which visual port a parent node is connected to
+function getInputPort(child: QueryNode, parent: QueryNode): number {
+  if (child.primaryInput === parent) {
+    return 0;
+  }
+  if (child.secondaryInputs) {
+    const offset = hasPrimaryInputPort(child) ? 1 : 0;
+    for (const [index, node] of child.secondaryInputs.connections) {
+      if (node === parent) {
+        return index + offset;
       }
     }
   }
-
   return 0;
+}
+
+// Convert visual port to secondary input index (undefined means primary input)
+function toSecondaryIndex(
+  node: QueryNode,
+  visualPort: number,
+): number | undefined {
+  if (hasPrimaryInputPort(node)) {
+    return visualPort === 0 ? undefined : visualPort - 1;
+  }
+  return visualPort;
 }
 
 // Builds visual connections between nodes (skips docked chains since they use 'next' property)
@@ -524,13 +507,13 @@ function buildConnections(
       if (child === undefined) continue;
 
       // Skip docked children - they're rendered via 'next' property, not as connections
-      // But only skip if it's part of the primary flow chain (child's prevNode points back)
+      // But only skip if it's part of the primary flow chain (child's primaryInput points back)
       if (
         qnode.nextNodes.length === 1 &&
         singleNodeOperation(child.type) &&
         isChildDocked(child, nodeLayouts) &&
-        'prevNode' in child &&
-        child.prevNode === qnode
+        'primaryInput' in child &&
+        child.primaryInput === qnode
       ) {
         continue;
       }
@@ -539,7 +522,7 @@ function buildConnections(
         fromNode: qnode.nodeId,
         fromPort: 0,
         toNode: child.nodeId,
-        toPort: calculateInputPort(child, qnode),
+        toPort: getInputPort(child, qnode),
       });
     }
   }
@@ -556,15 +539,8 @@ function handleConnect(conn: Connection, rootNodes: QueryNode[]): void {
     return;
   }
 
-  // For multisource nodes, all ports are left-side and 0-indexed (port 0 = prevNodes[0])
-  // For modification nodes, port 0 is top (prevNode), ports 1+ are left-side (inputNodes[0], inputNodes[1], ...)
-  let portIndex: number | undefined;
-  if (isMultiSourceNode(toNode)) {
-    portIndex = conn.toPort;
-  } else {
-    portIndex = conn.toPort > 0 ? conn.toPort - 1 : undefined;
-  }
-  addConnection(fromNode, toNode, portIndex);
+  const secondaryIndex = toSecondaryIndex(toNode, conn.toPort);
+  addConnection(fromNode, toNode, secondaryIndex);
 
   m.redraw();
 }
@@ -779,7 +755,7 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
             const childQueryNode = findQueryNode(childNode.id, rootNodes);
 
             if (parentNode && childQueryNode) {
-              // Add connection (this will update both nextNodes and prevNode/prevNodes)
+              // Add connection (this will update both nextNodes and primaryInput/secondaryInputs)
               addConnection(parentNode, childQueryNode);
             }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
@@ -44,6 +44,20 @@ describe('AggregationNode', () => {
     } as QueryNode;
   }
 
+  function createAggregationNodeWithInput(
+    state: AggregationNodeState,
+    inputNode?: QueryNode,
+  ): AggregationNode {
+    const node = new AggregationNode(state);
+    if (inputNode) {
+      // Directly set the connection without triggering onPrevNodesUpdated
+      // to preserve the test's explicitly provided columns
+      inputNode.nextNodes.push(node);
+      node.primaryInput = inputNode;
+    }
+    return node;
+  }
+
   function createColumnInfo(name: string, type: string): ColumnInfo {
     return {
       name,
@@ -121,12 +135,14 @@ describe('AggregationNode', () => {
     let node: AggregationNode;
 
     beforeEach(() => {
-      node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [],
-      });
+      node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [],
+        },
+        createMockPrevNode(),
+      );
     });
 
     it('should validate COUNT_ALL without column', () => {
@@ -312,12 +328,14 @@ describe('AggregationNode', () => {
 
   describe('serialization', () => {
     it('should serialize PERCENTILE aggregation with percentile value', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [],
+        },
+        createMockPrevNode(),
+      );
 
       node.state.aggregations = [
         {
@@ -339,12 +357,14 @@ describe('AggregationNode', () => {
     });
 
     it('should serialize COUNT_ALL aggregation without column', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [],
+        },
+        createMockPrevNode(),
+      );
 
       node.state.aggregations = [
         {
@@ -364,12 +384,14 @@ describe('AggregationNode', () => {
     });
 
     it('should serialize MEDIAN aggregation', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [],
+        },
+        createMockPrevNode(),
+      );
 
       node.state.aggregations = [
         {
@@ -390,12 +412,14 @@ describe('AggregationNode', () => {
     });
 
     it('should serialize multiple aggregations including new types', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [],
+        },
+        createMockPrevNode(),
+      );
 
       node.state.aggregations = [
         {
@@ -430,22 +454,22 @@ describe('AggregationNode', () => {
 
   describe('deserialization', () => {
     it('should deserialize PERCENTILE aggregation with percentile value', () => {
-      const state: AggregationNodeState = {
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [
-          {
-            aggregationOp: 'PERCENTILE',
-            column: createColumnInfo('dur', 'INT'),
-            percentile: 95,
-            newColumnName: 'p95_dur',
-            isValid: true,
-          },
-        ],
-      };
-
-      const node = new AggregationNode(state);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'PERCENTILE',
+              column: createColumnInfo('dur', 'INT'),
+              percentile: 95,
+              newColumnName: 'p95_dur',
+              isValid: true,
+            },
+          ],
+        },
+        createMockPrevNode(),
+      );
 
       expect(node.state.aggregations.length).toBe(1);
       expect(node.state.aggregations[0].aggregationOp).toBe('PERCENTILE');
@@ -454,20 +478,20 @@ describe('AggregationNode', () => {
     });
 
     it('should deserialize COUNT_ALL aggregation without column', () => {
-      const state: AggregationNodeState = {
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [
-          {
-            aggregationOp: 'COUNT_ALL',
-            newColumnName: 'total_count',
-            isValid: true,
-          },
-        ],
-      };
-
-      const node = new AggregationNode(state);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'COUNT_ALL',
+              newColumnName: 'total_count',
+              isValid: true,
+            },
+          ],
+        },
+        createMockPrevNode(),
+      );
 
       expect(node.state.aggregations.length).toBe(1);
       expect(node.state.aggregations[0].aggregationOp).toBe('COUNT_ALL');
@@ -476,21 +500,21 @@ describe('AggregationNode', () => {
     });
 
     it('should deserialize MEDIAN aggregation', () => {
-      const state: AggregationNodeState = {
-        trace: createMockTrace(),
-        prevNode: createMockPrevNode(),
-        groupByColumns: [],
-        aggregations: [
-          {
-            aggregationOp: 'MEDIAN',
-            column: createColumnInfo('value', 'DOUBLE'),
-            newColumnName: 'median_value',
-            isValid: true,
-          },
-        ],
-      };
-
-      const node = new AggregationNode(state);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'MEDIAN',
+              column: createColumnInfo('value', 'DOUBLE'),
+              newColumnName: 'median_value',
+              isValid: true,
+            },
+          ],
+        },
+        createMockPrevNode(),
+      );
 
       expect(node.state.aggregations.length).toBe(1);
       expect(node.state.aggregations[0].aggregationOp).toBe('MEDIAN');
@@ -511,68 +535,76 @@ describe('AggregationNode', () => {
     });
 
     it('should validate node with only group by columns (no aggregations)', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: mockPrevNode,
-        groupByColumns: [
-          {...createColumnInfo('name', 'STRING'), checked: true},
-          {...createColumnInfo('dur', 'INT'), checked: false},
-        ],
-        aggregations: [],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [
+            {...createColumnInfo('name', 'STRING'), checked: true},
+            {...createColumnInfo('dur', 'INT'), checked: false},
+          ],
+          aggregations: [],
+        },
+        mockPrevNode,
+      );
 
       expect(node.validate()).toBe(true);
     });
 
     it('should validate node with only aggregations (no group by)', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: mockPrevNode,
-        groupByColumns: [
-          {...createColumnInfo('name', 'STRING'), checked: false},
-          {...createColumnInfo('dur', 'INT'), checked: false},
-        ],
-        aggregations: [
-          {
-            aggregationOp: 'COUNT_ALL',
-            isValid: true,
-          },
-        ],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [
+            {...createColumnInfo('name', 'STRING'), checked: false},
+            {...createColumnInfo('dur', 'INT'), checked: false},
+          ],
+          aggregations: [
+            {
+              aggregationOp: 'COUNT_ALL',
+              isValid: true,
+            },
+          ],
+        },
+        mockPrevNode,
+      );
 
       expect(node.validate()).toBe(true);
     });
 
     it('should validate node with both group by and aggregations', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: mockPrevNode,
-        groupByColumns: [
-          {...createColumnInfo('name', 'STRING'), checked: true},
-          {...createColumnInfo('dur', 'INT'), checked: false},
-        ],
-        aggregations: [
-          {
-            aggregationOp: 'SUM',
-            column: createColumnInfo('dur', 'INT'),
-            isValid: true,
-          },
-        ],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [
+            {...createColumnInfo('name', 'STRING'), checked: true},
+            {...createColumnInfo('dur', 'INT'), checked: false},
+          ],
+          aggregations: [
+            {
+              aggregationOp: 'SUM',
+              column: createColumnInfo('dur', 'INT'),
+              isValid: true,
+            },
+          ],
+        },
+        mockPrevNode,
+      );
 
       expect(node.validate()).toBe(true);
     });
 
     it('should invalidate node with neither group by nor aggregations', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: mockPrevNode,
-        groupByColumns: [
-          {...createColumnInfo('name', 'STRING'), checked: false},
-          {...createColumnInfo('dur', 'INT'), checked: false},
-        ],
-        aggregations: [],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [
+            {...createColumnInfo('name', 'STRING'), checked: false},
+            {...createColumnInfo('dur', 'INT'), checked: false},
+          ],
+          aggregations: [],
+        },
+        mockPrevNode,
+      );
 
       expect(node.validate()).toBe(false);
       expect(node.state.issues?.queryError?.message).toContain(
@@ -581,62 +613,68 @@ describe('AggregationNode', () => {
     });
 
     it('should invalidate node with invalid aggregations and no group by', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: mockPrevNode,
-        groupByColumns: [
-          {...createColumnInfo('name', 'STRING'), checked: false},
-        ],
-        aggregations: [
-          {
-            aggregationOp: 'SUM',
-            // Missing column - invalid
-            isValid: false,
-          },
-        ],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [
+            {...createColumnInfo('name', 'STRING'), checked: false},
+          ],
+          aggregations: [
+            {
+              aggregationOp: 'SUM',
+              // Missing column - invalid
+              isValid: false,
+            },
+          ],
+        },
+        mockPrevNode,
+      );
 
       expect(node.validate()).toBe(false);
     });
 
     it('should validate multiple aggregations without group by', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: mockPrevNode,
-        groupByColumns: [
-          {...createColumnInfo('name', 'STRING'), checked: false},
-        ],
-        aggregations: [
-          {
-            aggregationOp: 'COUNT_ALL',
-            isValid: true,
-          },
-          {
-            aggregationOp: 'SUM',
-            column: createColumnInfo('dur', 'INT'),
-            isValid: true,
-          },
-          {
-            aggregationOp: 'MAX',
-            column: createColumnInfo('ts', 'INT'),
-            isValid: true,
-          },
-        ],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [
+            {...createColumnInfo('name', 'STRING'), checked: false},
+          ],
+          aggregations: [
+            {
+              aggregationOp: 'COUNT_ALL',
+              isValid: true,
+            },
+            {
+              aggregationOp: 'SUM',
+              column: createColumnInfo('dur', 'INT'),
+              isValid: true,
+            },
+            {
+              aggregationOp: 'MAX',
+              column: createColumnInfo('ts', 'INT'),
+              isValid: true,
+            },
+          ],
+        },
+        mockPrevNode,
+      );
 
       expect(node.validate()).toBe(true);
     });
 
     it('should invalidate node when group by columns are missing from input', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        prevNode: mockPrevNode,
-        groupByColumns: [
-          {...createColumnInfo('name', 'STRING'), checked: true},
-          {...createColumnInfo('missing_col', 'INT'), checked: true},
-        ],
-        aggregations: [],
-      });
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [
+            {...createColumnInfo('name', 'STRING'), checked: true},
+            {...createColumnInfo('missing_col', 'INT'), checked: true},
+          ],
+          aggregations: [],
+        },
+        mockPrevNode,
+      );
 
       expect(node.validate()).toBe(false);
       expect(node.state.issues?.queryError?.message).toContain(
@@ -644,10 +682,9 @@ describe('AggregationNode', () => {
       );
     });
 
-    it('should invalidate node without prevNode', () => {
+    it('should invalidate node without primaryInput', () => {
       const node = new AggregationNode({
         trace: createMockTrace(),
-        prevNode: undefined as unknown as QueryNode,
         groupByColumns: [],
         aggregations: [
           {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/dev/test_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/dev/test_node.ts
@@ -18,13 +18,12 @@ import {
   QueryNodeState,
   NodeType,
   createFinalColumns,
-  SourceNode,
   nextNodeId,
 } from '../../../query_node';
 import {ColumnInfo} from '../../column_info';
 import protos from '../../../../../protos';
 
-export class TestNode implements SourceNode {
+export class TestNode implements QueryNode {
   readonly nodeId: string;
   readonly state: QueryNodeState;
   isDevNode = true;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node_unittest.ts
@@ -61,7 +61,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       expect(node.state.filterNegativeDur).toEqual([true, true]);
@@ -80,7 +80,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
         filterNegativeDur: [false, true],
       });
 
@@ -105,7 +105,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2, node3],
+        inputNodes: [node1, node2, node3],
         filterNegativeDur: [false],
       });
 
@@ -114,7 +114,7 @@ describe('IntervalIntersectNode', () => {
 
     it('should set autoExecute to false by default', () => {
       const node = new IntervalIntersectNode({
-        prevNodes: [],
+        inputNodes: [],
       });
 
       expect(node.state.autoExecute).toBe(false);
@@ -124,7 +124,7 @@ describe('IntervalIntersectNode', () => {
   describe('finalCols', () => {
     it('should return empty array when no prev nodes', () => {
       const node = new IntervalIntersectNode({
-        prevNodes: [],
+        inputNodes: [],
       });
 
       expect(node.finalCols).toEqual([]);
@@ -143,7 +143,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       const cols = node.finalCols;
@@ -166,7 +166,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
         partitionColumns: ['utid'],
       });
 
@@ -194,7 +194,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2, node3],
+        inputNodes: [node1, node2, node3],
       });
 
       const cols = node.finalCols;
@@ -240,7 +240,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       const cols = node.finalCols;
@@ -287,7 +287,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       const cols = node.finalCols;
@@ -317,7 +317,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
         partitionColumns: ['utid'],
       });
 
@@ -350,7 +350,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
         partitionColumns: ['utid', 'upid'],
       });
 
@@ -375,7 +375,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       const cols = node.finalCols;
@@ -409,7 +409,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2, node3],
+        inputNodes: [node1, node2, node3],
       });
 
       const cols = node.finalCols;
@@ -468,7 +468,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       const cols = node.finalCols;
@@ -491,7 +491,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1],
+        inputNodes: [node1],
       });
 
       expect(node.validate()).toBe(false);
@@ -513,7 +513,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       expect(node.validate()).toBe(true);
@@ -531,7 +531,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       expect(node.validate()).toBe(false);
@@ -553,7 +553,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       expect(node.validate()).toBe(false);
@@ -575,7 +575,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       expect(node.validate()).toBe(false);
@@ -599,7 +599,7 @@ describe('IntervalIntersectNode', () => {
       node2.validate = () => false;
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       expect(node.validate()).toBe(false);
@@ -614,7 +614,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1],
+        inputNodes: [node1],
       });
 
       // First validation should fail
@@ -627,7 +627,7 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
       ]);
-      node.prevNodes.push(node2);
+      node.secondaryInputs.connections.set(1, node2);
 
       // Second validation should pass and clear errors
       expect(node.validate()).toBe(true);
@@ -638,7 +638,7 @@ describe('IntervalIntersectNode', () => {
   describe('getTitle', () => {
     it('should return "Interval Intersect"', () => {
       const node = new IntervalIntersectNode({
-        prevNodes: [],
+        inputNodes: [],
       });
 
       expect(node.getTitle()).toBe('Interval Intersect');
@@ -659,7 +659,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
         filterNegativeDur: [true, false],
         partitionColumns: ['utid'],
       });
@@ -685,7 +685,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
         filterNegativeDur: [true, false],
         partitionColumns: ['utid'],
       });
@@ -721,14 +721,15 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2, node3],
+        inputNodes: [node1, node2, node3],
         filterNegativeDur: [true, false, true],
         partitionColumns: ['utid'],
       });
 
       const serialized = node.serializeState();
 
-      expect(serialized.intervalNodes).toEqual(['node2', 'node3']);
+      // All input node IDs are now serialized
+      expect(serialized.intervalNodes).toEqual(['node1', 'node2', 'node3']);
       expect(serialized.filterNegativeDur).toEqual([true, false, true]);
       expect(serialized.partitionColumns).toEqual(['utid']);
     });
@@ -746,12 +747,13 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       const serialized = node.serializeState();
 
-      expect(serialized.intervalNodes).toEqual(['node2']);
+      // All input node IDs are now serialized
+      expect(serialized.intervalNodes).toEqual(['node1', 'node2']);
       expect(serialized.partitionColumns).toBeUndefined();
     });
   });
@@ -781,7 +783,8 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const serialized = {
-        intervalNodes: ['node2', 'node3'],
+        // All input node IDs are stored
+        intervalNodes: ['node1', 'node2', 'node3'],
         filterNegativeDur: [true, false, true],
         partitionColumns: ['utid'],
       };
@@ -789,10 +792,9 @@ describe('IntervalIntersectNode', () => {
       const deserialized = IntervalIntersectNode.deserializeState(
         nodes,
         serialized,
-        node1,
       );
 
-      expect(deserialized.prevNodes).toEqual([node1, node2, node3]);
+      expect(deserialized.inputNodes).toEqual([node1, node2, node3]);
       expect(deserialized.filterNegativeDur).toEqual([true, false, true]);
       expect(deserialized.partitionColumns).toEqual(['utid']);
     });
@@ -815,20 +817,20 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const serialized = {
-        intervalNodes: ['node2', 'node_missing'],
-        filterNegativeDur: [true, false],
+        // Include a missing node ID to test graceful handling
+        intervalNodes: ['node1', 'node2', 'node_missing'],
+        filterNegativeDur: [true, false, true],
         partitionColumns: ['utid'],
       };
 
       const deserialized = IntervalIntersectNode.deserializeState(
         nodes,
         serialized,
-        node1,
       );
 
-      // Should only include found nodes
-      expect(deserialized.prevNodes).toEqual([node1, node2]);
-      expect(deserialized.filterNegativeDur).toEqual([true, false]);
+      // Should only include found nodes (node_missing is filtered out)
+      expect(deserialized.inputNodes).toEqual([node1, node2]);
+      expect(deserialized.filterNegativeDur).toEqual([true, false, true]);
     });
   });
 
@@ -846,7 +848,7 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
       });
 
       // Clear filterNegativeDur
@@ -858,7 +860,7 @@ describe('IntervalIntersectNode', () => {
       expect(node.state.filterNegativeDur).toEqual([true, true]);
     });
 
-    it('should compact filterNegativeDur when prevNodes shrinks', () => {
+    it('should compact filterNegativeDur when inputNodes shrinks', () => {
       const node1 = createMockPrevNode('node1', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
@@ -876,19 +878,19 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2, node3],
+        inputNodes: [node1, node2, node3],
         filterNegativeDur: [true, false, true],
       });
 
-      // Remove one prev node
-      node.prevNodes.pop();
+      // Remove one input node
+      node.secondaryInputs.connections.delete(2);
 
       node.onPrevNodesUpdated();
 
       expect(node.state.filterNegativeDur).toEqual([true, false]);
     });
 
-    it('should expand filterNegativeDur when prevNodes grows', () => {
+    it('should expand filterNegativeDur when inputNodes grows', () => {
       const node1 = createMockPrevNode('node1', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
@@ -906,12 +908,12 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       const node = new IntervalIntersectNode({
-        prevNodes: [node1, node2],
+        inputNodes: [node1, node2],
         filterNegativeDur: [true, false],
       });
 
-      // Add another prev node
-      node.prevNodes.push(node3);
+      // Add another input node
+      node.secondaryInputs.connections.set(2, node3);
 
       node.onPrevNodesUpdated();
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/merge_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/merge_node_unittest.ts
@@ -60,7 +60,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -82,7 +83,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: undefined!,
         rightQueryAlias: undefined!,
         conditionType: 'equality',
@@ -97,13 +99,14 @@ describe('MergeNode', () => {
   });
 
   describe('finalCols', () => {
-    it('should return empty array when prevNodes length is not 2', () => {
+    it('should return empty array when only one node is provided', () => {
       const node1 = createMockPrevNode('node1', [
         createColumnInfo('id', 'INT'),
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1],
+        leftNode: node1,
+        rightNode: undefined,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -126,7 +129,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -155,7 +159,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -193,7 +198,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -225,7 +231,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -263,7 +270,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -300,7 +308,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 't1',
         rightQueryAlias: 't2',
         conditionType: 'freeform',
@@ -328,7 +337,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -351,7 +361,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -367,11 +378,12 @@ describe('MergeNode', () => {
   });
 
   describe('validation', () => {
-    it('should fail when prevNodes length is not 2', () => {
+    it('should fail when only one node is provided', () => {
       const node1 = createMockPrevNode('node1', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1],
+        leftNode: node1,
+        rightNode: undefined,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -395,7 +407,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: undefined!,
         rightQueryAlias: undefined!,
         conditionType: 'equality',
@@ -413,7 +426,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -433,7 +447,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'freeform',
@@ -457,7 +472,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -483,7 +499,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'freeform',
@@ -510,7 +527,8 @@ describe('MergeNode', () => {
       ]);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 't1',
         rightQueryAlias: 't2',
         conditionType: 'freeform',
@@ -529,7 +547,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -548,7 +567,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'foo',
         rightQueryAlias: 'bar',
         conditionType: 'equality',
@@ -567,7 +587,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -591,7 +612,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -615,7 +637,8 @@ describe('MergeNode', () => {
       const node1 = createMockPrevNode('node1', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1],
+        leftNode: node1,
+        rightNode: undefined,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -649,7 +672,8 @@ describe('MergeNode', () => {
       } as QueryNode;
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -687,7 +711,8 @@ describe('MergeNode', () => {
       } as QueryNode;
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -721,7 +746,8 @@ describe('MergeNode', () => {
       } as QueryNode;
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 't1',
         rightQueryAlias: 't2',
         conditionType: 'freeform',
@@ -753,7 +779,8 @@ describe('MergeNode', () => {
       const node2 = createMockPrevNode('node2', []);
 
       const mergeNode = new MergeNode({
-        prevNodes: [node1, node2],
+        leftNode: node1,
+        rightNode: node2,
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -796,9 +823,8 @@ describe('MergeNode', () => {
         sqlExpression: '',
       });
 
-      expect(state.prevNodes.length).toBe(2);
-      expect(state.prevNodes[0]).toBe(node1);
-      expect(state.prevNodes[1]).toBe(node2);
+      expect(state.leftNode).toBe(node1);
+      expect(state.rightNode).toBe(node2);
       expect(state.leftQueryAlias).toBe('left');
       expect(state.rightQueryAlias).toBe('right');
       expect(state.conditionType).toBe('equality');
@@ -820,7 +846,8 @@ describe('MergeNode', () => {
         sqlExpression: '',
       });
 
-      expect(state.prevNodes.length).toBe(0);
+      expect(state.leftNode).toBeUndefined();
+      expect(state.rightNode).toBeUndefined();
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ModifyColumnsNode} from './modify_columns_node';
+import {ModifyColumnsNode, ModifyColumnsState} from './modify_columns_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 
@@ -53,6 +53,20 @@ describe('ModifyColumnsNode', () => {
     } as QueryNode;
   }
 
+  function createModifyColumnsNodeWithInput(
+    state: ModifyColumnsState,
+    inputNode?: QueryNode,
+  ): ModifyColumnsNode {
+    const node = new ModifyColumnsNode(state);
+    if (inputNode) {
+      // Directly set the connection without triggering onPrevNodesUpdated
+      // to preserve the test's explicitly provided selectedColumns
+      inputNode.nextNodes.push(node);
+      node.primaryInput = inputNode;
+    }
+    return node;
+  }
+
   function createColumnInfo(name: string, type: string): ColumnInfo {
     return {
       name,
@@ -64,19 +78,23 @@ describe('ModifyColumnsNode', () => {
 
   describe('validation', () => {
     it('should validate when at least one column is selected', () => {
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [createColumnInfo('id', 'INT')],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [createColumnInfo('id', 'INT')],
+        },
+        createMockPrevNode(),
+      );
 
       expect(node.validate()).toBe(true);
     });
 
     it('should fail validation when no columns selected', () => {
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [],
+        },
+        createMockPrevNode(),
+      );
 
       // Uncheck all auto-populated columns
       node.state.selectedColumns.forEach((col) => {
@@ -89,10 +107,12 @@ describe('ModifyColumnsNode', () => {
     it('should fail validation for empty alias', () => {
       const col = createColumnInfo('id', 'INT');
       col.alias = '';
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [col],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [col],
+        },
+        createMockPrevNode(),
+      );
 
       expect(node.validate()).toBe(false);
     });
@@ -101,10 +121,12 @@ describe('ModifyColumnsNode', () => {
       const col1 = createColumnInfo('id', 'INT');
       const col2 = createColumnInfo('status', 'STRING');
       col2.alias = 'id'; // Same as col1's name
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [col1, col2],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [col1, col2],
+        },
+        createMockPrevNode(),
+      );
 
       expect(node.validate()).toBe(false);
     });
@@ -113,10 +135,12 @@ describe('ModifyColumnsNode', () => {
       const col1 = createColumnInfo('id', 'INT');
       const col2 = createColumnInfo('status', 'STRING');
       col2.alias = 'status_renamed';
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [col1, col2],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [col1, col2],
+        },
+        createMockPrevNode(),
+      );
 
       expect(node.validate()).toBe(true);
     });
@@ -124,13 +148,15 @@ describe('ModifyColumnsNode', () => {
 
   describe('serialization', () => {
     it('should serialize selected columns correctly', () => {
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [
-          createColumnInfo('id', 'INT'),
-          createColumnInfo('status', 'STRING'),
-        ],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [
+            createColumnInfo('id', 'INT'),
+            createColumnInfo('status', 'STRING'),
+          ],
+        },
+        createMockPrevNode(),
+      );
 
       const serialized = node.serializeState();
 
@@ -144,10 +170,12 @@ describe('ModifyColumnsNode', () => {
       const col1 = createColumnInfo('id', 'INT');
       const col2 = createColumnInfo('status', 'STRING');
       col2.alias = 'status_renamed';
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [col1, col2],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [col1, col2],
+        },
+        createMockPrevNode(),
+      );
 
       const serialized = node.serializeState();
 
@@ -159,10 +187,12 @@ describe('ModifyColumnsNode', () => {
       const col1 = createColumnInfo('id', 'INT');
       const col2 = createColumnInfo('status', 'STRING');
       col2.checked = false;
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [col1, col2],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [col1, col2],
+        },
+        createMockPrevNode(),
+      );
 
       const serialized = node.serializeState();
 
@@ -177,10 +207,12 @@ describe('ModifyColumnsNode', () => {
       const col2 = createColumnInfo('status', 'STRING');
       col2.checked = false;
       const col3 = createColumnInfo('value', 'INT');
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [col1, col2, col3],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [col1, col2, col3],
+        },
+        createMockPrevNode(),
+      );
 
       const finalCols = node.finalCols;
 
@@ -192,10 +224,12 @@ describe('ModifyColumnsNode', () => {
     it('should use alias as column name in finalCols', () => {
       const col1 = createColumnInfo('id', 'INT');
       col1.alias = 'identifier';
-      const node = new ModifyColumnsNode({
-        prevNode: createMockPrevNode(),
-        selectedColumns: [col1],
-      });
+      const node = createModifyColumnsNodeWithInput(
+        {
+          selectedColumns: [col1],
+        },
+        createMockPrevNode(),
+      );
 
       const finalCols = node.finalCols;
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -18,7 +18,6 @@ import {
   QueryNodeState,
   NodeType,
   createFinalColumns,
-  SourceNode,
   nextNodeId,
 } from '../../../query_node';
 import {ColumnInfo, columnInfoFromSqlColumn} from '../../column_info';
@@ -34,7 +33,7 @@ export interface SlicesSourceState extends QueryNodeState {
   onchange?: () => void;
 }
 
-export class SlicesSourceNode implements SourceNode {
+export class SlicesSourceNode implements QueryNode {
   readonly nodeId: string;
   readonly state: SlicesSourceState;
   readonly finalCols: ColumnInfo[];

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -19,7 +19,6 @@ import {
   QueryNodeState,
   NodeType,
   createFinalColumns,
-  MultiSourceNode,
   nextNodeId,
   notifyNextNodes,
 } from '../../../query_node';
@@ -47,10 +46,9 @@ export interface SqlSourceState extends QueryNodeState {
   trace: Trace;
 }
 
-export class SqlSourceNode implements MultiSourceNode {
+export class SqlSourceNode implements QueryNode {
   readonly nodeId: string;
   readonly state: SqlSourceState;
-  prevNodes: QueryNode[] = [];
   finalCols: ColumnInfo[];
   nextNodes: QueryNode[];
 
@@ -63,7 +61,6 @@ export class SqlSourceNode implements MultiSourceNode {
     };
     this.finalCols = createFinalColumns([]);
     this.nextNodes = [];
-    this.prevNodes = attrs.prevNodes ?? [];
   }
 
   get type() {
@@ -120,10 +117,11 @@ export class SqlSourceNode implements MultiSourceNode {
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
-    const dependencies = this.prevNodes.map((prevNode) => ({
-      alias: prevNode.nodeId,
-      query: prevNode.getStructuredQuery(),
-    }));
+    // Source nodes don't have dependencies
+    const dependencies: Array<{
+      alias: string;
+      query: protos.PerfettoSqlStructuredQuery | undefined;
+    }> = [];
 
     // Pass empty array for column names - the engine will discover them when analyzing the query
     // Using this.finalCols here would pass stale columns from the previous execution

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -23,7 +23,6 @@ import {
   QueryNodeState,
   NodeType,
   createFinalColumns,
-  SourceNode,
   nextNodeId,
 } from '../../../query_node';
 import {StructuredQueryBuilder} from '../../structured_query_builder';
@@ -94,10 +93,9 @@ export function modalForTableSelection(
   });
 }
 
-export class TableSourceNode implements SourceNode {
+export class TableSourceNode implements QueryNode {
   readonly nodeId: string;
   readonly state: TableSourceState;
-  readonly prevNodes: QueryNode[] = [];
   readonly finalCols: ColumnInfo[];
   nextNodes: QueryNode[];
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -69,10 +69,18 @@ export interface NodeActions {
   onInsertModifyColumnsNode?: (portIndex: number) => void;
 }
 
+// Specification for secondary inputs with clear cardinality requirements
+export interface SecondaryInputSpec {
+  // The actual connections (no undefined holes - indexed by port number)
+  readonly connections: Map<number, QueryNode>;
+
+  // Cardinality requirements for validation
+  readonly min: number; // Minimum required (e.g., 2 for IntervalIntersect)
+  readonly max: number | 'unbounded'; // Maximum allowed (e.g., 2 for Merge, unbounded for IntervalIntersect)
+}
+
 // All information required to create a new node.
 export interface QueryNodeState {
-  prevNode?: QueryNode;
-  prevNodes?: QueryNode[];
   comment?: string;
   trace?: Trace;
   sqlModules?: SqlModules;
@@ -104,7 +112,7 @@ export interface QueryNodeState {
   materializedQueryHash?: string;
 }
 
-export interface BaseNode {
+export interface QueryNode {
   readonly nodeId: string;
   readonly type: NodeType;
   nextNodes: QueryNode[];
@@ -116,6 +124,15 @@ export interface BaseNode {
   // to fully recover the node.
   readonly state: QueryNodeState;
 
+  // Primary input from above (data flows vertically down)
+  // Used by single-input operations (Filter, Sort, Aggregation, etc.)
+  primaryInput?: QueryNode;
+
+  // Secondary inputs from the side (horizontal connections)
+  // Used by multi-input operations (Union, Merge, IntervalIntersect) and
+  // for side joins (AddColumns)
+  secondaryInputs?: SecondaryInputSpec;
+
   validate(): boolean;
   getTitle(): string;
   nodeSpecificModify(): m.Child;
@@ -126,21 +143,6 @@ export interface BaseNode {
   serializeState(): object;
   onPrevNodesUpdated?(): void;
 }
-
-export interface SourceNode extends BaseNode {}
-
-export interface ModificationNode extends BaseNode {
-  prevNode?: QueryNode;
-  // Optional input nodes that appear on the left side of the node
-  // (as opposed to prevNode which comes from above)
-  inputNodes?: (QueryNode | undefined)[];
-}
-
-export interface MultiSourceNode extends BaseNode {
-  prevNodes: QueryNode[];
-}
-
-export type QueryNode = SourceNode | ModificationNode | MultiSourceNode;
 
 export function notifyNextNodes(node: QueryNode) {
   for (const nextNode of node.nextNodes) {
@@ -193,18 +195,22 @@ function getStructuredQueries(
     }
     revStructuredQueries.push(curSq);
 
-    let prevNode: QueryNode | undefined;
-    if ('prevNode' in curNode) {
-      prevNode = curNode.prevNode;
-    } else if ('prevNodes' in curNode && curNode.prevNodes.length > 0) {
-      prevNode = curNode.prevNodes[0];
+    // Navigate up the graph - prefer primaryInput, fall back to first secondary
+    let inputNode: QueryNode | undefined = curNode.primaryInput;
+    if (!inputNode && curNode.secondaryInputs) {
+      // No primary input - follow first secondary input (arbitrary choice for traversal)
+      const connections: Map<number, QueryNode> =
+        curNode.secondaryInputs.connections;
+      if (connections.size > 0) {
+        inputNode = connections.get(0);
+      }
     }
 
-    if (prevNode) {
-      if (!prevNode.validate()) {
+    if (inputNode) {
+      if (!inputNode.validate()) {
         return;
       }
-      curNode = prevNode;
+      curNode = inputNode;
     } else {
       curNode = undefined;
     }
@@ -327,6 +333,80 @@ export function isAQuery(
 // between nodes, ensuring consistency when adding/removing connections.
 
 /**
+ * Helper: Get all input nodes from a node (both primary and secondary)
+ */
+export function getInputNodes(node: QueryNode): QueryNode[] {
+  const inputs: QueryNode[] = [];
+
+  if (node.primaryInput) {
+    inputs.push(node.primaryInput);
+  }
+
+  if (node.secondaryInputs) {
+    for (const inputNode of node.secondaryInputs.connections.values()) {
+      inputs.push(inputNode);
+    }
+  }
+
+  return inputs;
+}
+
+/**
+ * Helper: Get secondary input at specific port
+ */
+export function getSecondaryInput(
+  node: QueryNode,
+  portIndex: number,
+): QueryNode | undefined {
+  return node.secondaryInputs?.connections.get(portIndex);
+}
+
+/**
+ * Helper: Set secondary input at specific port
+ */
+export function setSecondaryInput(
+  node: QueryNode,
+  portIndex: number,
+  inputNode: QueryNode,
+): void {
+  if (!node.secondaryInputs) {
+    throw new Error('Node does not support secondary inputs');
+  }
+  node.secondaryInputs.connections.set(portIndex, inputNode);
+}
+
+/**
+ * Helper: Remove secondary input at specific port
+ */
+export function removeSecondaryInput(node: QueryNode, portIndex: number): void {
+  if (!node.secondaryInputs) return;
+  node.secondaryInputs.connections.delete(portIndex);
+}
+
+/**
+ * Validates that secondary inputs meet cardinality requirements.
+ * Returns an error message if validation fails, undefined if valid.
+ */
+export function validateSecondaryInputs(node: QueryNode): string | undefined {
+  if (!node.secondaryInputs) {
+    return undefined;
+  }
+
+  const {connections, min, max} = node.secondaryInputs;
+  const count = connections.size;
+
+  if (count < min) {
+    return `Requires at least ${min} input${min === 1 ? '' : 's'}, but only ${count} connected`;
+  }
+
+  if (max !== 'unbounded' && count > max) {
+    return `Allows at most ${max} input${max === 1 ? '' : 's'}, but ${count} connected`;
+  }
+
+  return undefined;
+}
+
+/**
  * Adds a connection from one node to another, updating both forward and
  * backward links. For multi-source nodes, adds to the specified port index.
  */
@@ -340,44 +420,36 @@ export function addConnection(
     fromNode.nextNodes.push(toNode);
   }
 
-  // Update backward link based on node type
-  if ('prevNode' in toNode && singleNodeOperation(toNode.type)) {
-    // ModificationNode
-    const modNode = toNode as ModificationNode;
-
-    // If portIndex is specified and node supports inputNodes
-    if (portIndex !== undefined && 'inputNodes' in modNode) {
-      // portIndex maps directly to inputNodes array
-      // portIndex=0 → inputNodes[0], portIndex=1 → inputNodes[1], etc.
-      if (!modNode.inputNodes) {
-        modNode.inputNodes = [];
+  // Determine connection type based on node characteristics
+  if (singleNodeOperation(toNode.type)) {
+    // Single-input operation node (Filter, Sort, etc.)
+    // If portIndex is specified, connect to secondary input
+    if (portIndex !== undefined) {
+      if (!toNode.secondaryInputs) {
+        throw new Error(
+          `Node ${toNode.nodeId} does not support secondary inputs`,
+        );
       }
-      // Expand array if needed
-      while (modNode.inputNodes.length <= portIndex) {
-        modNode.inputNodes.push(undefined);
+      setSecondaryInput(toNode, portIndex, fromNode);
+    } else {
+      // Otherwise connect to primary input (default from above)
+      toNode.primaryInput = fromNode;
+    }
+    toNode.onPrevNodesUpdated?.();
+  } else if (toNode.secondaryInputs) {
+    // Multi-source node (Union, Merge, IntervalIntersect)
+    if (portIndex !== undefined) {
+      // Set at specific port
+      setSecondaryInput(toNode, portIndex, fromNode);
+    } else {
+      // Find first available port
+      let nextPort = 0;
+      while (toNode.secondaryInputs.connections.has(nextPort)) {
+        nextPort++;
       }
-      modNode.inputNodes[portIndex] = fromNode;
-      modNode.onPrevNodesUpdated?.();
-    } else {
-      // Otherwise connect to prevNode (default single input from above)
-      modNode.prevNode = fromNode;
-      modNode.onPrevNodesUpdated?.();
+      setSecondaryInput(toNode, nextPort, fromNode);
     }
-  } else if ('prevNodes' in toNode && Array.isArray(toNode.prevNodes)) {
-    // MultiSourceNode - multiple inputs
-    const multiSourceNode = toNode as MultiSourceNode;
-
-    if (
-      portIndex !== undefined &&
-      portIndex < multiSourceNode.prevNodes.length
-    ) {
-      // Replace existing connection at this port
-      multiSourceNode.prevNodes[portIndex] = fromNode;
-    } else {
-      // Append to end (ignore portIndex if out of bounds)
-      multiSourceNode.prevNodes.push(fromNode);
-    }
-    multiSourceNode.onPrevNodesUpdated?.();
+    toNode.onPrevNodesUpdated?.();
   }
 }
 
@@ -392,32 +464,20 @@ export function removeConnection(fromNode: QueryNode, toNode: QueryNode): void {
     fromNode.nextNodes.splice(nextIndex, 1);
   }
 
-  // Remove backward link based on node type
-  if ('prevNode' in toNode && singleNodeOperation(toNode.type)) {
-    // ModificationNode
-    const modNode = toNode as ModificationNode;
+  // Check if it's in primary input
+  if (toNode.primaryInput === fromNode) {
+    toNode.primaryInput = undefined;
+    toNode.onPrevNodesUpdated?.();
+  }
 
-    // Check if it's in prevNode
-    if (modNode.prevNode === fromNode) {
-      modNode.prevNode = undefined;
-    }
-
-    // Also check if it's in inputNodes
-    if ('inputNodes' in modNode && modNode.inputNodes) {
-      const inputIndex = modNode.inputNodes.indexOf(fromNode);
-      if (inputIndex !== -1) {
-        modNode.inputNodes[inputIndex] = undefined;
-        modNode.onPrevNodesUpdated?.();
+  // Also check if it's in secondary inputs
+  if (toNode.secondaryInputs) {
+    for (const [portIndex, inputNode] of toNode.secondaryInputs.connections) {
+      if (inputNode === fromNode) {
+        removeSecondaryInput(toNode, portIndex);
+        toNode.onPrevNodesUpdated?.();
+        break;
       }
-    }
-  } else if ('prevNodes' in toNode && Array.isArray(toNode.prevNodes)) {
-    // MultiSourceNode - multiple inputs
-    const multiSourceNode = toNode as MultiSourceNode;
-    const prevIndex = multiSourceNode.prevNodes.indexOf(fromNode);
-    if (prevIndex !== -1) {
-      // Remove from array, compacting it (no undefined holes)
-      multiSourceNode.prevNodes.splice(prevIndex, 1);
-      multiSourceNode.onPrevNodesUpdated?.();
     }
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler.ts
@@ -231,7 +231,7 @@ export function createGraphFromSql(sql: string): string {
         filters: [],
       },
       nextNodes: [],
-      prevNodes: [],
+      inputNodeIds: [],
     };
     serializedNodes.push(node);
     nodeMap.set(nodeId, node);
@@ -242,10 +242,10 @@ export function createGraphFromSql(sql: string): string {
     for (const dep of parsedNode.dependencies) {
       const depNode = nodeMap.get(dep)!;
       depNode.nextNodes.push(node.nodeId);
-      if (!node.prevNodes) {
-        node.prevNodes = [];
+      if (!node.inputNodeIds) {
+        node.inputNodeIds = [];
       }
-      node.prevNodes.push(depNode.nodeId);
+      node.inputNodeIds.push(depNode.nodeId);
     }
     if (parsedNode.dependencies.length === 0) {
       rootNodeIds.push(node.nodeId);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/sql_json_handler_unittest.ts
@@ -46,28 +46,28 @@ describe('createGraphFromSql', () => {
     expect(nodeA!.type).toBe(NodeType.kSqlSource);
     expect((nodeA!.state as SqlSourceSerializedState).sql).toBe('SELECT 1');
     expect(nodeA!.nextNodes).toEqual(['b']);
-    expect(nodeA!.prevNodes).toEqual([]);
+    expect(nodeA!.inputNodeIds).toEqual([]);
 
     expect(nodeB!.type).toBe(NodeType.kSqlSource);
     expect((nodeB!.state as SqlSourceSerializedState).sql).toBe(
       'SELECT * FROM $a',
     );
     expect(nodeB!.nextNodes).toEqual(['c']);
-    expect(nodeB!.prevNodes).toEqual(['a']);
+    expect(nodeB!.inputNodeIds).toEqual(['a']);
 
     expect(nodeC!.type).toBe(NodeType.kSqlSource);
     expect((nodeC!.state as SqlSourceSerializedState).sql).toBe(
       'SELECT * FROM $b',
     );
     expect(nodeC!.nextNodes).toEqual(['output']);
-    expect(nodeC!.prevNodes).toEqual(['b']);
+    expect(nodeC!.inputNodeIds).toEqual(['b']);
 
     expect(nodeOutput!.type).toBe(NodeType.kSqlSource);
     expect((nodeOutput!.state as SqlSourceSerializedState).sql).toBe(
       'SELECT * FROM $c',
     );
     expect(nodeOutput!.nextNodes).toEqual([]);
-    expect(nodeOutput!.prevNodes).toEqual(['c']);
+    expect(nodeOutput!.inputNodeIds).toEqual(['c']);
   });
 
   it('should throw an error for malformed SQL without SELECT', () => {
@@ -201,12 +201,12 @@ describe('createGraphFromSql', () => {
     expect(nodeOutput).toBeDefined();
 
     expect(nodeA!.nextNodes).toEqual(['timeline_filtered']);
-    expect(nodeA!.prevNodes).toEqual([]);
+    expect(nodeA!.inputNodeIds).toEqual([]);
 
     expect(nodeB!.nextNodes).toEqual(['output']);
-    expect(nodeB!.prevNodes).toEqual(['actual_timeline_with_vsync']);
+    expect(nodeB!.inputNodeIds).toEqual(['actual_timeline_with_vsync']);
 
-    expect(nodeOutput!.prevNodes).toEqual(['timeline_filtered']);
+    expect(nodeOutput!.inputNodeIds).toEqual(['timeline_filtered']);
   });
 
   it('should handle real-world query with ROW_NUMBER and OVER', () => {
@@ -282,15 +282,15 @@ describe('createGraphFromSql', () => {
     expect(nodeOutput).toBeDefined();
 
     expect(nodeA!.nextNodes).toEqual(['frame_with_gpu']);
-    expect(nodeA!.prevNodes).toEqual([]);
+    expect(nodeA!.inputNodeIds).toEqual([]);
 
     expect(nodeB!.nextNodes).toEqual(['frame_with_numbers']);
-    expect(nodeB!.prevNodes).toEqual(['frame_base']);
+    expect(nodeB!.inputNodeIds).toEqual(['frame_base']);
 
     expect(nodeC!.nextNodes).toEqual(['output']);
-    expect(nodeC!.prevNodes).toEqual(['frame_with_gpu']);
+    expect(nodeC!.inputNodeIds).toEqual(['frame_with_gpu']);
 
-    expect(nodeOutput!.prevNodes).toEqual(['frame_with_numbers']);
+    expect(nodeOutput!.inputNodeIds).toEqual(['frame_with_numbers']);
   });
 
   it('should handle real-world query with multiple joins and COALESCE', () => {
@@ -388,15 +388,17 @@ describe('createGraphFromSql', () => {
     expect(nodeOutput).toBeDefined();
 
     expect(nodeA!.nextNodes).toEqual(['sf_frames_with_jank']);
-    expect(nodeA!.prevNodes).toEqual([]);
+    expect(nodeA!.inputNodeIds).toEqual([]);
 
     expect(nodeB!.nextNodes).toEqual(['android_jank_cuj_sf_frame_base']);
-    expect(nodeB!.prevNodes).toEqual(['android_jank_cuj_timeline_sf_frame']);
+    expect(nodeB!.inputNodeIds).toEqual(['android_jank_cuj_timeline_sf_frame']);
 
     expect(nodeC!.nextNodes).toEqual(['output']);
-    expect(nodeC!.prevNodes).toEqual(['sf_frames_with_jank']);
+    expect(nodeC!.inputNodeIds).toEqual(['sf_frames_with_jank']);
 
-    expect(nodeOutput!.prevNodes).toEqual(['android_jank_cuj_sf_frame_base']);
+    expect(nodeOutput!.inputNodeIds).toEqual([
+      'android_jank_cuj_sf_frame_base',
+    ]);
   });
 
   it('should handle comments with commas', () => {
@@ -437,15 +439,15 @@ describe('createGraphFromSql', () => {
     expect(nodeOutput).toBeDefined();
 
     expect(nodeA!.nextNodes).toEqual(['c']);
-    expect(nodeA!.prevNodes).toEqual([]);
+    expect(nodeA!.inputNodeIds).toEqual([]);
 
     expect(nodeB!.nextNodes).toEqual(['c']);
-    expect(nodeB!.prevNodes).toEqual([]);
+    expect(nodeB!.inputNodeIds).toEqual([]);
 
     expect(nodeC!.nextNodes).toEqual(['output']);
-    expect(nodeC!.prevNodes).toEqual(['a', 'b']);
+    expect(nodeC!.inputNodeIds).toEqual(['a', 'b']);
 
-    expect(nodeOutput!.prevNodes).toEqual(['c']);
+    expect(nodeOutput!.inputNodeIds).toEqual(['c']);
   });
 
   it('should handle a node referencing a previously referenced node', () => {
@@ -475,17 +477,17 @@ describe('createGraphFromSql', () => {
     expect(nodeOutput).toBeDefined();
 
     expect(nodeA!.nextNodes).toEqual(['b', 'c']);
-    expect(nodeA!.prevNodes).toEqual([]);
+    expect(nodeA!.inputNodeIds).toEqual([]);
 
     expect(nodeB!.nextNodes).toEqual(['d']);
-    expect(nodeB!.prevNodes).toEqual(['a']);
+    expect(nodeB!.inputNodeIds).toEqual(['a']);
 
     expect(nodeC!.nextNodes).toEqual(['d']);
-    expect(nodeC!.prevNodes).toEqual(['a']);
+    expect(nodeC!.inputNodeIds).toEqual(['a']);
 
     expect(nodeD!.nextNodes).toEqual(['output']);
-    expect(nodeD!.prevNodes).toEqual(['b', 'c']);
+    expect(nodeD!.inputNodeIds).toEqual(['b', 'c']);
 
-    expect(nodeOutput!.prevNodes).toEqual(['d']);
+    expect(nodeOutput!.inputNodeIds).toEqual(['d']);
   });
 });


### PR DESCRIPTION
  ## Summary
Refactors the query node port system to use a clearer, more explicit model with `primaryInput` for single-input operations and `secondaryInputs` (with cardinality constraints) for multi-input operations. This replaces the previous confusing mix of `prevNode`, `prevNodes`, and `inputNodes` properties.

  ## Changes
  - Introduces `SecondaryInputSpec` interface with a `Map<number, QueryNode>` for connections and explicit `min`/`max` cardinality requirements
  - Replaces `prevNode` → `primaryInput` for single-input operations (Filter, Sort, Aggregation, etc.)
  - Replaces `prevNodes`/`inputNodes` → `secondaryInputs.connections` for multi-input operations (Union, Merge, IntervalIntersect)
  - Adds `singleNodeOperation()` helper to classify node types
  - Updates all node implementations, serialization/deserialization, and tests to use the new model

  ## Notes
  - Multi-source nodes (Union, Merge, IntervalIntersect) now use only `secondaryInputs` with no `primaryInput`
  - AddColumnsNode uses both `primaryInput` (for the main data flow) and `secondaryInputs` (for the join source)
  - Serialization stores `primaryInputId` and node-specific input IDs rather than generic `prevNode`/`prevNodes` arrays