### PR TITLE
ui: support searching int args

### DIFF
--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -246,8 +246,11 @@ export class SearchManagerImpl implements SearchManager {
           track_id as sourceId,
           0 as utid
         from slice
-        join args using(arg_set_id)
-        where string_value glob ${searchLiteral} or key glob ${searchLiteral}
+        join (
+          select arg_set_id from args where display_value glob ${searchLiteral}
+          union
+          select arg_set_id from args where key glob ${searchLiteral}
+        ) using(arg_set_id)
       )
       union all
       select

--- a/ui/src/test/chrome_rendering_desktop.test.ts
+++ b/ui/src/test/chrome_rendering_desktop.test.ts
@@ -45,3 +45,11 @@ test('slice with flows', async () => {
   await pth.waitForPerfettoIdle();
   await pth.waitForIdleAndScreenshot('slice_with_flows.png');
 });
+
+test('search int arg', async () => {
+  await pth.searchSlice('5292083664613144124');
+  await pth.resetFocus();
+  await page.keyboard.press('f');
+  await pth.waitForPerfettoIdle();
+  await pth.waitForIdleAndScreenshot('search_int_arg.png');
+});


### PR DESCRIPTION
and also make it faster.

The current implementation takes ~250ms on example Chrome trace:

```
select
  slice_id as sliceId,
  ts,
  'slice' as source,
  track_id as sourceId,
  0 as utid
from slice
join args using(arg_set_id)
where string_value glob '*[mM][aA][iI][nN]*' or key glob '*[mM][aA][iI][nN]*'
```

Naive support for ints would take ~320ms:
```
select
  slice_id as sliceId,
  ts,
  'slice' as source,
  track_id as sourceId,
  0 as utid
from slice
join args using(arg_set_id)
where display_value glob '*[mM][aA][iI][nN]*' or key glob '*[mM][aA][iI][nN]*'
```

This patch filters `args` first, taking the total time down to 90ms:
```
select
  slice_id as sliceId,
  ts,
  'slice' as source,
  track_id as sourceId,
  0 as utid
from slice
join (
  select arg_set_id from args where display_value glob '*[mM][aA][iI][nN]*'
  union
  select arg_set_id from args where key glob '*[mM][aA][iI][nN]*'
) using (arg_set_id)
```
