### PR TITLE
ui: Add duplicate column name validation to aggregation node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -232,7 +232,8 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
           onQueryAnalyzed: (query: Query | Error) => {
             this.query = query;
             const shouldAutoExecute = selectedNode.state.autoExecute ?? true;
-            if (isAQuery(this.query)) {
+            // Don't execute if validation fails (e.g., duplicate column names)
+            if (isAQuery(this.query) && selectedNode.validate()) {
               // Check if we have an existing materialized table for this exact query
               const currentQueryHash = hashNodeQuery(selectedNode);
               const hasMatchingMaterialization = this.canReuseMaterialization(
@@ -316,6 +317,10 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
                 }
               },
               onExecute: () => {
+                // Don't execute if validation fails (e.g., duplicate column names)
+                if (!selectedNode.validate()) {
+                  return;
+                }
                 // Reset queryExecuted flag to allow execution
                 // Analysis has already happened, this.query is already set
                 this.queryExecuted = false;


### PR DESCRIPTION
Add form-level validation to prevent duplicate column names in the Explore Page query builder's aggregation node. This catches conflicts between:
- Aggregation result names and GROUP BY columns
- Aggregation result names and other aggregation results

Also adds a `validation` prop to the Form widget to support custom
validation functions that can disable the submit button.
