### PR TITLE
exp: Polish addColumns node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.scss
@@ -96,6 +96,12 @@
   flex: 1;
 }
 
+.pf-exp-node-box__details {
+  .pf-exp-column-name {
+    font-weight: 600;
+  }
+}
+
 .pf-exp-node-box__filters {
   margin-top: 0.5rem;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
@@ -141,35 +141,6 @@
     gap: 8px;
   }
 
-  .pf-exp-switch-wrapper,
-  .pf-exp-if-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    padding: 8px;
-    margin: 4px 0;
-    background: var(--surface-color);
-    border: 1px solid var(--separator-color);
-    border-radius: 4px;
-  }
-
-  .pf-exp-switch-name-row,
-  .pf-exp-if-name-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding-bottom: 4px;
-    border-bottom: 1px solid var(--separator-color);
-
-    label {
-      font-weight: 600;
-      font-size: var(--pf-exp-font-size-sm);
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      color: var(--pf-text-color-secondary);
-    }
-  }
-
   .pf-exp-switch-component {
     display: flex;
     flex-direction: column;
@@ -208,34 +179,6 @@
 .pf-exp-node-details-card {
   padding: 4px;
   font-size: var(--pf-exp-font-size-sm);
-}
-
-.pf-exp-switch-summary,
-.pf-exp-if-summary {
-  font-size: var(--pf-exp-font-size-sm);
-  padding: 2px 0;
-}
-
-.pf-exp-switch-keyword,
-.pf-exp-if-keyword {
-  font-weight: 600;
-  color: var(--pf-primary-color);
-}
-
-.pf-exp-column-name {
-  font-family: var(--pf-font-family-monospace);
-  font-weight: 500;
-}
-
-.pf-exp-as-keyword {
-  font-style: italic;
-  color: var(--pf-text-color-light);
-}
-
-.pf-exp-alias-name {
-  font-family: var(--pf-font-family-monospace);
-  font-weight: 500;
-  color: var(--pf-primary-color);
 }
 
 .pf-exp-if-component {
@@ -278,4 +221,35 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+// Glob toggle styling
+.pf-exp-switch-glob-toggle {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+// Join modal two-column layout
+.pf-join-modal-layout {
+  display: flex;
+  gap: 24px;
+  min-height: 300px;
+}
+
+// Wide modal for join configuration
+.pf-join-modal-wide {
+  min-width: 700px;
+}
+
+.pf-join-modal-controls {
+  flex: 0 0 300px;
+  min-width: 250px;
+}
+
+.pf-join-modal-info {
+  flex: 1;
+  border-left: 1px solid var(--separator-color);
+  padding-left: 24px;
+  overflow: auto;
+  max-height: 400px;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.scss
@@ -20,6 +20,10 @@
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
     margin-bottom: 1rem;
   }
+}
+
+// Table description component styles (used in table source info and join modal)
+.pf-exp-table-description {
   table {
     width: 100%;
     border-collapse: collapse;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -28,13 +28,12 @@ import {
 import {StructuredQueryBuilder} from '../../structured_query_builder';
 import {ColumnInfo, columnInfoFromSqlColumn} from '../../column_info';
 import protos from '../../../../../protos';
-import {TextParagraph} from '../../../../../widgets/text_paragraph';
 import {Trace} from '../../../../../public/trace';
 import {closeModal, showModal} from '../../../../../widgets/modal';
 import {TableList} from '../../table_list';
 import {redrawModal} from '../../../../../widgets/modal';
-import {perfettoSqlTypeToString} from '../../../../../trace_processor/perfetto_sql_type';
 import {setValidationError} from '../../node_issues';
+import {TableDescription} from '../../widgets';
 
 export interface TableSourceSerializedState {
   sqlTable?: string;
@@ -176,36 +175,9 @@ export class TableSourceNode implements QueryNode {
 
   nodeInfo(): m.Children {
     if (this.state.sqlTable != null) {
-      const table = this.state.sqlTable;
       return m(
         '.pf-stdlib-table-node',
-        m(
-          '.pf-details-box',
-          m(TextParagraph, {text: table.description}),
-          m(
-            'table.pf-table.pf-table-striped',
-            m(
-              'thead',
-              m(
-                'tr',
-                m('th', 'Column'),
-                m('th', 'Type'),
-                m('th', 'Description'),
-              ),
-            ),
-            m(
-              'tbody',
-              table.columns.map((col) => {
-                return m(
-                  'tr',
-                  m('td', col.name),
-                  m('td', perfettoSqlTypeToString(col.type)),
-                  m('td', col.description),
-                );
-              }),
-            ),
-          ),
-        ),
+        m('.pf-details-box', m(TableDescription, {table: this.state.sqlTable})),
       );
     }
     return m(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -154,11 +154,20 @@
 .pf-exp-labeled-control {
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
   gap: 8px;
 
   span {
     font-weight: 500;
     color: var(--pf-color-text);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  // Allow inputs to shrink and not overflow
+  .pf-text-input {
+    min-width: 0;
+    flex: 1 1 auto;
   }
 }
 
@@ -181,5 +190,24 @@
     cursor: grab;
     color: var(--pf-color-text-muted);
     user-select: none;
+  }
+}
+
+// Issue list widget - bulleted list inside a callout
+.pf-exp-issue-list {
+  margin-top: 4px;
+  margin-bottom: 0;
+  padding-left: 20px;
+}
+
+// Interval node input row widget
+.pf-exp-interval-node {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+
+  span {
+    flex: 1;
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
@@ -17,6 +17,10 @@ import {Button, ButtonVariant} from '../../../widgets/button';
 import {Card} from '../../../widgets/card';
 import {TextInput} from '../../../widgets/text_input';
 import {Icon} from '../../../widgets/icon';
+import {TextParagraph} from '../../../widgets/text_paragraph';
+import {SqlTable} from '../../dev.perfetto.SqlModules/sql_modules';
+import {perfettoSqlTypeToString} from '../../../trace_processor/perfetto_sql_type';
+import {Callout} from '../../../widgets/callout';
 
 // Generic widget for a row with name input, validation, and remove button
 // Used by all "new column" types
@@ -256,6 +260,71 @@ export class DraggableItem implements m.ClassComponent<DraggableItemAttrs> {
       },
       m('span.pf-exp-drag-handle', '☰'),
       children,
+    );
+  }
+}
+
+// Widget for displaying a list of issues (errors or warnings) in a callout
+// Used for validation errors, duplicate column warnings, etc.
+export interface IssueListAttrs {
+  icon: 'error' | 'warning' | 'info';
+  title: string;
+  items: string[];
+}
+
+export class IssueList implements m.ClassComponent<IssueListAttrs> {
+  view({attrs}: m.Vnode<IssueListAttrs>) {
+    const {icon, title, items} = attrs;
+
+    if (items.length === 0) {
+      return null;
+    }
+
+    return m(
+      Callout,
+      {icon},
+      m('div', title),
+      m(
+        'ul.pf-exp-issue-list',
+        items.map((item) => m('li', item)),
+      ),
+    );
+  }
+}
+
+// Widget for displaying a SQL table's description and columns
+// Used in table source node info and join modal
+export interface TableDescriptionAttrs {
+  table: SqlTable;
+}
+
+export class TableDescription
+  implements m.ClassComponent<TableDescriptionAttrs>
+{
+  view({attrs}: m.Vnode<TableDescriptionAttrs>) {
+    const {table} = attrs;
+
+    return m(
+      '.pf-exp-table-description',
+      m(TextParagraph, {text: table.description}),
+      m(
+        'table.pf-table.pf-table-striped',
+        m(
+          'thead',
+          m('tr', m('th', 'Column'), m('th', 'Type'), m('th', 'Description')),
+        ),
+        m(
+          'tbody',
+          table.columns.map((col) => {
+            return m(
+              'tr',
+              m('td', col.name),
+              m('td', perfettoSqlTypeToString(col.type)),
+              m('td', col.description),
+            );
+          }),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
Improve the user interface for the "Add Columns" node, focusing on the modal for adding columns from another source. The primary goal is to create a more intuitive and guided user experience, especially when using join suggestions.

Key improvements include:

   * Redesigned Join Suggestion UI: The previous expandable list has been replaced with a cleaner two-column layout. Users now select a suggested table from a dropdown on the left, and details about that table appear on the right.
   * Improved Column Selection: Replaced the MultiselectInput with a more compact PopupMultiSelect widget for a better user experience.
   * Enhanced Conflict Handling: The UI now provides immediate feedback on column name conflicts (both with the source and within the selected columns), disabling the "Apply" button until the issues are resolved by creating aliases.
   * Reusable Widgets: Introduced a new IssueList widget to display validation errors and a TableDescription widget to show table schemas, promoting UI consistency.
   * General UI Polish: Added various styling improvements to enhance the overall look and feel of the query builder nodes and modals.