### PR TITLE
exp: Summarize details for modifyColumns page

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
@@ -95,6 +95,7 @@
     display: flex;
     flex-direction: column;
     padding: 12px 16px;
+    gap: 4px;
   }
 
   .pf-column {
@@ -134,6 +135,24 @@
 
   .pf-drag-handle:hover {
     opacity: 1 !important;
+  }
+
+  .pf-column-type {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--pf-text-color-secondary);
+    font-family: var(--pf-monospace-font);
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--background-color);
+    cursor: pointer;
+    white-space: nowrap;
+    user-select: none;
+
+    &:hover {
+      background: var(--separator-color);
+      color: var(--pf-text-color-primary);
+    }
   }
 
   .pf-exp-modify-columns-node-buttons {
@@ -179,6 +198,10 @@
 .pf-exp-node-details-card {
   padding: 4px;
   font-size: var(--pf-exp-font-size-sm);
+}
+
+.pf-exp-node-details-spacer {
+  height: 8px;
 }
 
 .pf-exp-if-component {

--- a/ui/src/trace_processor/perfetto_sql_type.ts
+++ b/ui/src/trace_processor/perfetto_sql_type.ts
@@ -116,6 +116,18 @@ const SIMPLE_TYPES: Record<string, SimpleType['kind']> = {
   argsetid: 'arg_set_id',
 };
 
+// List of all simple PerfettoSQL type kinds (excluding ID types).
+export const SIMPLE_TYPE_KINDS: SimpleType['kind'][] = [
+  'int',
+  'double',
+  'string',
+  'boolean',
+  'timestamp',
+  'duration',
+  'bytes',
+  'arg_set_id',
+];
+
 export function parsePerfettoSqlTypeFromString(args: {
   type: string;
   table: string;


### PR DESCRIPTION
  Add type selector UI to the Modify Columns node and simplify the node details summary logic. Users can now click on a column's type to change it via a popup menu, which is useful for casting columns to different types.

  ## Changes

  - Add type selector popup menu to each column row in the Modify Columns node
  - Simplify and refactor `nodeDetails()` logic for cleaner code flow
  - Export `SIMPLE_TYPE_KINDS` array from `perfetto_sql_type.ts` for type options
  - Add SCSS styling for the new type selector element