### PR TITLE
exp: Fix slow execution caused by moving data to timeline

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -607,12 +607,11 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
       }
 
       // Automatically show results in timeline tab (like query page does)
-      // Note: We don't pass prefetchedResponse because Explore page uses
-      // SQLDataSource with empty rows array. Let the tab fetch data itself.
+      // Use the materialized table instead of re-running the original query
       addQueryResultsTab(
         this.trace,
         {
-          query: this.query.sql,
+          query: `SELECT * FROM ${tableName}`,
           title: 'Explore Query',
         },
         'explore_page',


### PR DESCRIPTION
Moving to timeline requires rerunning the query (preparing the tab) on each execution. This approach was very costly for explore page, which creates a lot of executions. 

Change it to less costly approach, and later maybe fix the addQueryResults page to execute the query only when we actually open timeline.