### PR TITLE
exp: Interval intersect keeps columns types

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -100,6 +100,10 @@ export class ModifyColumnsNode implements QueryNode {
     }
 
     this.state.selectedColumns = newSelectedColumns;
+
+    // Trigger UI update and notify next nodes of the change
+    this.state.onchange?.();
+    m.redraw();
   }
 
   static deserializeState(


### PR DESCRIPTION
  The IntervalIntersectNode now properly preserves and propagates column type information through the query pipeline. Previously, column type metadata was being lost, causing downstream nodes to receive columns without proper PerfettoSqlType information.

  **Changes:**

  - Explicitly set `ts` and `dur` columns to TIMESTAMP and DURATION types
  - Preserve partition column types from first input node
  - Add validation for consistent partition column types across inputs
  - Populate `column.type` field with PerfettoSqlType for all output columns
  - Add `cleanupPartitionColumns()` to remove invalid partition columns when input nodes change
  - Call `notifyNextNodes()` when partition columns are added/removed to update downstream nodes
