### PR TITLE
ui: Switch to using factory function to create union datasets

### DIFF
--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -23,7 +23,7 @@ import {
 } from '../public/selection';
 import {Trace} from '../public/trace';
 import {Track} from '../public/track';
-import {Dataset, DatasetSchema, UnionDataset} from '../trace_processor/dataset';
+import {UnionDataset, Dataset, DatasetSchema} from '../trace_processor/dataset';
 import {Engine} from '../trace_processor/engine';
 import {EmptyState} from '../widgets/empty_state';
 import {Spinner} from '../widgets/spinner';
@@ -130,7 +130,7 @@ export function selectTracksAndGetDataset<T extends DatasetSchema>(
   tracks: ReadonlyArray<Track>,
   spec: T,
   kind?: string,
-): Dataset<T> | undefined {
+) {
   const datasets = tracks
     .filter((t) => kind === undefined || t.tags?.kinds?.includes(kind))
     .map((t) => t.renderer.getDataset?.())
@@ -138,8 +138,7 @@ export function selectTracksAndGetDataset<T extends DatasetSchema>(
     .filter((d) => d.implements(spec));
 
   if (datasets.length > 0) {
-    // TODO(stevegolton): Avoid typecast in UnionDataset.
-    return (new UnionDataset(datasets) as unknown as Dataset<T>).optimize();
+    return UnionDataset.create(datasets).optimize();
   } else {
     return undefined;
   }

--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -34,7 +34,7 @@ import m from 'mithril';
 import {SerializedSelection} from './state_serialization_schema';
 import {showModal} from '../widgets/modal';
 import {NUM, SqlValue, UNKNOWN} from '../trace_processor/query_result';
-import {SourceDataset, UnionDataset} from '../trace_processor/dataset';
+import {UnionDataset, SourceDataset} from '../trace_processor/dataset';
 import {Track} from '../public/track';
 
 interface SelectionDetailsPanel {
@@ -284,7 +284,7 @@ export class SelectionManagerImpl implements SelectionManager {
       });
 
       const datasets = values.map(([dataset]) => dataset);
-      const union = new UnionDataset(datasets).optimize();
+      const union = UnionDataset.create(datasets).optimize();
 
       // Make sure to include the filter value in the schema.
       const schema = {...union.schema, [colName]: UNKNOWN};

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -20,7 +20,7 @@ import {
   createIITable,
 } from '../../components/aggregation_adapter';
 import {AreaSelection} from '../../public/selection';
-import {Dataset, createUnionDataset} from '../../trace_processor/dataset';
+import {Dataset, UnionDataset} from '../../trace_processor/dataset';
 import {Engine} from '../../trace_processor/engine';
 import {
   LONG,
@@ -77,7 +77,7 @@ export class SliceSelectionAggregator implements Aggregator {
         if (sliceDatasets.length > 0) {
           const query = await this.buildSliceQuery(
             engine,
-            createUnionDataset(sliceDatasets).optimize(),
+            UnionDataset.create(sliceDatasets).optimize(),
             area,
             trash,
           );
@@ -87,7 +87,7 @@ export class SliceSelectionAggregator implements Aggregator {
         if (slicelikeDatasets.length > 0) {
           const query = await this.buildSlicelikeQuery(
             engine,
-            createUnionDataset(slicelikeDatasets).optimize(),
+            UnionDataset.create(slicelikeDatasets).optimize(),
             area,
             trash,
           );

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -199,26 +199,27 @@ export class SourceDataset<T extends DatasetSchema = DatasetSchema>
 const MAX_SUBQUERIES_PER_UNION = 500;
 
 /**
- * Classes are useless in TypeScript so we need to provide a factory function
- * helper which provides the correct typing for the resultant union dataset
- * based on the input datasets.
- *
- * @param datasets - The datasets to union together.
- * @returns - A new union dataset representing the union of the input datasets.
- */
-export function createUnionDataset<T extends readonly Dataset[]>(
-  datasets: T,
-): UnionDataset<T[number]['schema']> {
-  return new UnionDataset(datasets);
-}
-
-/**
  * A dataset that represents the union of multiple datasets.
  */
 export class UnionDataset<T extends DatasetSchema = DatasetSchema>
   implements Dataset<T>
 {
-  constructor(readonly union: ReadonlyArray<Dataset>) {}
+  /**
+   * This factory method creates a new union dataset but retains the specific
+   * types of the input datasets. It's a factory function because it's not
+   * possible to do this with a constructor.
+   *
+   * @param datasets - The datasets to union together.
+   * @returns - A new union dataset representing the union of the input
+   * datasets.
+   */
+  static create<T extends readonly Dataset[]>(
+    datasets: T,
+  ): UnionDataset<T[number]['schema']> {
+    return new UnionDataset(datasets);
+  }
+
+  private constructor(readonly union: ReadonlyArray<Dataset>) {}
 
   get schema(): T {
     // Find the minimal set of columns that are supported by all datasets of

--- a/ui/src/trace_processor/dataset_unittest.ts
+++ b/ui/src/trace_processor/dataset_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {SourceDataset, UnionDataset} from './dataset';
+import {UnionDataset, SourceDataset} from './dataset';
 import {
   BLOB,
   BLOB_NULL,
@@ -63,7 +63,7 @@ test("get query for simple dataset with an 'in' filter", () => {
 });
 
 test('get query for union dataset', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {id: NUM},
@@ -102,7 +102,7 @@ test('union dataset batches large numbers of unions', () => {
     );
   }
 
-  const query = new UnionDataset(datasets).query();
+  const query = UnionDataset.create(datasets).query();
 
   // Verify query structure with CTE batching.
   expect(query).toContain('with');
@@ -177,7 +177,7 @@ test('find the schema of a simple dataset', () => {
 });
 
 test('find the schema of a union where source sets differ in their names', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {foo: NUM},
@@ -192,7 +192,7 @@ test('find the schema of a union where source sets differ in their names', () =>
 });
 
 test('find the schema of a union with differing source sets', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {foo: NUM},
@@ -207,7 +207,7 @@ test('find the schema of a union with differing source sets', () => {
 });
 
 test('find the schema of a union with one column in common', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {foo: NUM, bar: NUM},
@@ -222,7 +222,7 @@ test('find the schema of a union with one column in common', () => {
 });
 
 test('optimize a union dataset', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {},
@@ -252,7 +252,7 @@ test('optimize a union dataset', () => {
 });
 
 test('optimize a union dataset with different types of filters', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {},
@@ -282,7 +282,7 @@ test('optimize a union dataset with different types of filters', () => {
 });
 
 test('optimize a union dataset with different schemas', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {foo: NUM},
@@ -306,7 +306,7 @@ test('optimize a union dataset with different schemas', () => {
 });
 
 test('union type widening', () => {
-  const dataset = new UnionDataset([
+  const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
       schema: {foo: NUM, bar: STR_NULL, baz: BLOB, missing: UNKNOWN},


### PR DESCRIPTION
The factory function `UnionDataset.create(...)` preserves types from the input set of datasets, which is impossible to do with the raw constructor `new UnionDataset(...)` in TypeScript.

This patch makes the constructor private and replaces `new UnionDataset()` with `UnionDataset.create()` everywhere, which addresses one old TODO!

E.g.:
```ts
const foo = new SourceDataset<{foo: number}>(...);
const bar = new SourceDataset<{foo: number, bar: string}>(...);
const union = new UnionDataset([foo, bar]); // -> has type Record<string, SqlValue> (the most generic dataset type)
const typedUnion = UnionDataset.create([foo, bar]); // -> has type {foo: number} (the union of the two input types)
```