### PR TITLE
ui: fix display issue with import logs with large int args

### DIFF
--- a/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/import_errors.ts
+++ b/ui/src/plugins/dev.perfetto.TraceInfoPage/tabs/import_errors.ts
@@ -26,6 +26,7 @@ import {
   groupByCategory,
   renderErrorCategoryCard,
 } from '../utils';
+import {parseJsonWithBigints} from '../../../base/json_utils';
 
 // Import log row spec
 const importLogSpec = {
@@ -228,7 +229,7 @@ export class ImportErrorsTab implements m.ClassComponent<ImportErrorsTabAttrs> {
       return null;
     }
     try {
-      const parsed = JSON.parse(args);
+      const parsed = parseJsonWithBigints(args);
       return Object.keys(parsed).length > 0 ? parsed : null;
     } catch {
       return null;


### PR DESCRIPTION
We were parsing the JSON blob from trace_processor using JSON.parse but
it's possible for us to get large integers which we want to preserve the
precision of. So instead parse using bigints instead.
