### PR TITLE
exp: Improve state management: validation, cleanups and materialization

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -14,6 +14,7 @@
 
 import {ExplorePageState} from './explore_page';
 import {QueryNode, NodeType, singleNodeOperation} from './query_node';
+import {getAllNodes as getAllNodesUtil} from './query_builder/graph_utils';
 import {
   TableSourceNode,
   TableSourceSerializedState,
@@ -112,14 +113,11 @@ function serializeNode(node: QueryNode): SerializedNode {
 }
 
 export function serializeState(state: ExplorePageState): string {
+  // Use utility function to get all nodes (bidirectional traversal)
+  const allNodesArray = getAllNodesUtil(state.rootNodes);
   const allNodes = new Map<string, QueryNode>();
-  const queue = [...state.rootNodes];
-  while (queue.length > 0) {
-    const node = queue.shift()!;
-    if (!allNodes.has(node.nodeId)) {
-      allNodes.set(node.nodeId, node);
-      queue.push(...node.nextNodes);
-    }
+  for (const node of allNodesArray) {
+    allNodes.set(node.nodeId, node);
   }
 
   const serializedNodes = Array.from(allNodes.values()).map(serializeNode);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -94,6 +94,7 @@ import {MaterializationService} from './materialization_service';
 export interface BuilderAttrs {
   readonly trace: Trace;
   readonly sqlModules: SqlModules;
+  readonly materializationService: MaterializationService;
 
   readonly devMode?: boolean;
 
@@ -162,9 +163,8 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
   constructor({attrs}: m.Vnode<BuilderAttrs>) {
     this.trace = attrs.trace;
     this.queryService = new QueryService(attrs.trace.engine);
-    this.materializationService = new MaterializationService(
-      attrs.trace.engine,
-    );
+    // Use the shared MaterializationService from parent
+    this.materializationService = attrs.materializationService;
   }
 
   view({attrs}: m.CVnode<BuilderAttrs>) {
@@ -237,8 +237,16 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
             const shouldAutoExecute = selectedNode.state.autoExecute ?? true;
             // Don't execute if validation fails (e.g., duplicate column names)
             if (isAQuery(this.query) && selectedNode.validate()) {
-              // Check if we have an existing materialized table for this exact query
+              // Compute and cache hash after successful analysis
               const currentQueryHash = hashNodeQuery(selectedNode);
+              if (currentQueryHash !== undefined) {
+                attrs.materializationService.setCachedQueryHash(
+                  selectedNode,
+                  currentQueryHash,
+                );
+              }
+
+              // Check if we have an existing materialized table for this exact query
               const hasMatchingMaterialization = this.canReuseMaterialization(
                 selectedNode,
                 currentQueryHash,
@@ -537,7 +545,9 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
     const queryStartMs = performance.now();
     let tableName: string | undefined;
     let createdNewMaterialization = false;
-    const currentQueryHash = hashNodeQuery(node);
+    // Use cached hash - it was already computed during analysis
+    const currentQueryHash =
+      this.materializationService.getCachedQueryHash(node);
 
     // If we can't get a hash, something is wrong with the node
     if (currentQueryHash === undefined) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/cleanup_manager.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/cleanup_manager.ts
@@ -1,0 +1,94 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {QueryNode} from '../query_node';
+import {MaterializationService} from './materialization_service';
+
+/**
+ * Centralized manager for resource cleanup in the Explore Page.
+ *
+ * Responsibilities:
+ * - Tracks all materialized tables
+ * - Provides cleanup on component unmount
+ * - Coordinates cleanup between multiple cleanup operations
+ * - Prevents orphaned resources
+ */
+export class CleanupManager {
+  private materializationService: MaterializationService;
+
+  constructor(materializationService: MaterializationService) {
+    this.materializationService = materializationService;
+  }
+
+  /**
+   * Cleans up a single node's resources.
+   *
+   * @param node The node to clean up
+   */
+  async cleanupNode(node: QueryNode): Promise<void> {
+    if (node.state.materialized === true) {
+      try {
+        await this.materializationService.dropMaterialization(node);
+      } catch (e) {
+        console.error(
+          `Failed to drop materialization for node ${node.nodeId}:`,
+          e,
+        );
+        // Continue - don't block cleanup on individual failures
+      }
+    }
+  }
+
+  /**
+   * Cleans up multiple nodes' resources in parallel.
+   *
+   * @param nodes The nodes to clean up
+   */
+  async cleanupNodes(nodes: QueryNode[]): Promise<void> {
+    const materialized = nodes.filter(
+      (node) => node.state.materialized === true,
+    );
+
+    if (materialized.length === 0) {
+      return;
+    }
+
+    // Drop all materializations in parallel
+    const results = await Promise.allSettled(
+      materialized.map((node) =>
+        this.materializationService.dropMaterialization(node),
+      ),
+    );
+
+    // Log failures but don't throw - cleanup should be best-effort
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        console.error(
+          `Failed to drop materialization for node ${materialized[index].nodeId}:`,
+          result.reason,
+        );
+      }
+    });
+  }
+
+  /**
+   * Cleans up all resources for the entire graph.
+   * Used when clearing all nodes or on component unmount.
+   *
+   * @param allNodes All nodes in the graph
+   */
+  async cleanupAll(allNodes: QueryNode[]): Promise<void> {
+    await this.cleanupNodes(allNodes);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/cleanup_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/cleanup_manager_unittest.ts
@@ -1,0 +1,267 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {CleanupManager} from './cleanup_manager';
+import {MaterializationService} from './materialization_service';
+import {QueryNode} from '../query_node';
+import {TableSourceNode} from './nodes/sources/table_source';
+import {Trace} from '../../../public/trace';
+import {SqlModules} from '../../dev.perfetto.SqlModules/sql_modules';
+
+describe('CleanupManager', () => {
+  let mockMaterializationService: jest.Mocked<MaterializationService>;
+  let cleanupManager: CleanupManager;
+  let mockTrace: Trace;
+  let mockSqlModules: SqlModules;
+
+  beforeEach(() => {
+    mockTrace = {
+      traceInfo: {
+        traceTitle: 'test_trace',
+      },
+    } as Trace;
+
+    mockSqlModules = {
+      listTables: () => [],
+      getTable: () => null,
+      listModules: () => [],
+      listTablesNames: () => [],
+      getModuleForTable: () => undefined,
+    } as unknown as SqlModules;
+
+    // Create a mock MaterializationService
+    mockMaterializationService = {
+      dropMaterialization: jest.fn().mockResolvedValue(undefined),
+      getEngine: jest.fn(),
+      materializeNode: jest.fn(),
+      isMaterialized: jest.fn(),
+      getMaterializedTableName: jest.fn(),
+    } as unknown as jest.Mocked<MaterializationService>;
+
+    cleanupManager = new CleanupManager(mockMaterializationService);
+  });
+
+  function createTestNode(
+    id: string,
+    materialized: boolean = false,
+  ): QueryNode {
+    const node = new TableSourceNode({
+      trace: mockTrace,
+      sqlModules: mockSqlModules,
+    }) as QueryNode;
+    node.state.materialized = materialized;
+    if (materialized) {
+      node.state.materializationTableName = `_exp_materialized_${id}`;
+    }
+    return node;
+  }
+
+  describe('cleanupNode', () => {
+    it('should call dropMaterialization for materialized node', async () => {
+      const node = createTestNode('1', true);
+
+      await cleanupManager.cleanupNode(node);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call dropMaterialization for non-materialized node', async () => {
+      const node = createTestNode('1', false);
+
+      await cleanupManager.cleanupNode(node);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully', async () => {
+      const node = createTestNode('1', true);
+      const error = new Error('Drop failed');
+      mockMaterializationService.dropMaterialization.mockRejectedValueOnce(
+        error,
+      );
+
+      // Should not throw
+      await expect(cleanupManager.cleanupNode(node)).resolves.not.toThrow();
+
+      expect(mockMaterializationService.dropMaterialization).toHaveBeenCalled();
+    });
+
+    it('should not call dropMaterialization when materialized is undefined', async () => {
+      const node = createTestNode('1', false);
+      node.state.materialized = undefined;
+
+      await cleanupManager.cleanupNode(node);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanupNodes', () => {
+    it('should cleanup multiple materialized nodes in parallel', async () => {
+      const node1 = createTestNode('1', true);
+      const node2 = createTestNode('2', true);
+      const node3 = createTestNode('3', true);
+
+      await cleanupManager.cleanupNodes([node1, node2, node3]);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledTimes(3);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node1);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node2);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node3);
+    });
+
+    it('should only cleanup materialized nodes', async () => {
+      const node1 = createTestNode('1', true);
+      const node2 = createTestNode('2', false);
+      const node3 = createTestNode('3', true);
+
+      await cleanupManager.cleanupNodes([node1, node2, node3]);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node1);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).not.toHaveBeenCalledWith(node2);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node3);
+    });
+
+    it('should handle empty array', async () => {
+      await cleanupManager.cleanupNodes([]);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should handle all non-materialized nodes', async () => {
+      const node1 = createTestNode('1', false);
+      const node2 = createTestNode('2', false);
+
+      await cleanupManager.cleanupNodes([node1, node2]);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should continue cleanup even if some fail', async () => {
+      const node1 = createTestNode('1', true);
+      const node2 = createTestNode('2', true);
+      const node3 = createTestNode('3', true);
+
+      // Make node2 cleanup fail
+      mockMaterializationService.dropMaterialization.mockImplementation(
+        (node) => {
+          if (node === node2) {
+            return Promise.reject(new Error('Drop failed'));
+          }
+          return Promise.resolve();
+        },
+      );
+
+      // Should not throw
+      await expect(
+        cleanupManager.cleanupNodes([node1, node2, node3]),
+      ).resolves.not.toThrow();
+
+      // All three should have been attempted
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledTimes(3);
+    });
+
+    it('should handle all cleanups failing', async () => {
+      const node1 = createTestNode('1', true);
+      const node2 = createTestNode('2', true);
+
+      mockMaterializationService.dropMaterialization.mockRejectedValue(
+        new Error('Drop failed'),
+      );
+
+      // Should not throw
+      await expect(
+        cleanupManager.cleanupNodes([node1, node2]),
+      ).resolves.not.toThrow();
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('cleanupAll', () => {
+    it('should cleanup all nodes', async () => {
+      const node1 = createTestNode('1', true);
+      const node2 = createTestNode('2', false);
+      const node3 = createTestNode('3', true);
+
+      await cleanupManager.cleanupAll([node1, node2, node3]);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node1);
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).toHaveBeenCalledWith(node3);
+    });
+
+    it('should handle empty array', async () => {
+      await cleanupManager.cleanupAll([]);
+
+      expect(
+        mockMaterializationService.dropMaterialization,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should be equivalent to cleanupNodes', async () => {
+      const nodes = [
+        createTestNode('1', true),
+        createTestNode('2', false),
+        createTestNode('3', true),
+      ];
+
+      const cleanupNodesSpy = jest.spyOn(cleanupManager, 'cleanupNodes');
+
+      await cleanupManager.cleanupAll(nodes);
+
+      expect(cleanupNodesSpy).toHaveBeenCalledWith(nodes);
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -61,6 +61,7 @@ import {EmptyGraph} from '../empty_graph';
 import {nodeRegistry} from '../node_registry';
 import {NodeBox} from './node_box';
 import {buildCategorizedMenuItems} from './menu_utils';
+import {getAllNodes, findNodeById} from '../graph_utils';
 
 // ========================================
 // TYPE DEFINITIONS
@@ -119,42 +120,8 @@ export interface GraphAttrs {
 // UTILITY FUNCTIONS
 // ========================================
 
-// Traverses the graph using BFS with cycle detection (visited set prevents infinite loops)
-export function getAllNodes(rootNodes: QueryNode[]): QueryNode[] {
-  const allNodes: QueryNode[] = [];
-  const visited = new Set<string>();
-
-  for (const root of rootNodes) {
-    const queue: QueryNode[] = [root];
-
-    while (queue.length > 0) {
-      const curr = queue.shift();
-      if (!curr) continue;
-
-      if (visited.has(curr.nodeId)) {
-        continue;
-      }
-
-      visited.add(curr.nodeId);
-      allNodes.push(curr);
-
-      for (const child of curr.nextNodes) {
-        if (child !== undefined && !visited.has(child.nodeId)) {
-          queue.push(child);
-        }
-      }
-    }
-  }
-  return allNodes;
-}
-
-function findQueryNode(
-  nodeId: string,
-  rootNodes: QueryNode[],
-): QueryNode | undefined {
-  const allNodes = getAllNodes(rootNodes);
-  return allNodes.find((n) => n.nodeId === nodeId);
-}
+// Alias for consistency with existing code in this file
+const findQueryNode = findNodeById;
 
 // A node is "docked" if it has no layout (rendered as part of parent's chain via 'next' property)
 function isChildDocked(child: QueryNode, nodeLayouts: LayoutMap): boolean {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils.ts
@@ -1,0 +1,143 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {QueryNode} from '../query_node';
+
+/**
+ * Graph traversal utilities for the Explore Page query builder.
+ * Consolidates graph traversal logic to eliminate code duplication.
+ */
+
+/**
+ * Gets all nodes reachable from the given root nodes (both forward and backward).
+ * Uses breadth-first traversal to avoid visiting the same node multiple times.
+ *
+ * @param rootNodes The starting nodes for traversal
+ * @returns All reachable nodes (including root nodes)
+ */
+export function getAllNodes(rootNodes: QueryNode[]): QueryNode[] {
+  const allNodes: QueryNode[] = [];
+  const visited = new Set<string>();
+  const queue = [...rootNodes];
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    if (visited.has(node.nodeId)) {
+      continue;
+    }
+    visited.add(node.nodeId);
+    allNodes.push(node);
+
+    // Traverse forward edges (next nodes)
+    queue.push(...node.nextNodes);
+
+    // Traverse backward edges (input nodes)
+    if (node.primaryInput) {
+      queue.push(node.primaryInput);
+    }
+    if (node.secondaryInputs) {
+      for (const inputNode of node.secondaryInputs.connections.values()) {
+        queue.push(inputNode);
+      }
+    }
+  }
+
+  return allNodes;
+}
+
+/**
+ * Gets all nodes downstream from the given node (including the node itself).
+ * Only traverses forward edges (nextNodes).
+ *
+ * @param node The starting node
+ * @returns All downstream nodes (including the starting node)
+ */
+export function getAllDownstreamNodes(node: QueryNode): QueryNode[] {
+  const downstreamNodes: QueryNode[] = [];
+  const visited = new Set<string>();
+  const queue: QueryNode[] = [node];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current.nodeId)) {
+      continue;
+    }
+    visited.add(current.nodeId);
+    downstreamNodes.push(current);
+
+    // Only traverse forward edges
+    queue.push(...current.nextNodes);
+  }
+
+  return downstreamNodes;
+}
+
+/**
+ * Gets all nodes upstream from the given node (not including the node itself).
+ * Only traverses backward edges (primaryInput and secondaryInputs).
+ *
+ * @param node The starting node
+ * @returns All upstream nodes (excluding the starting node)
+ */
+export function getAllUpstreamNodes(node: QueryNode): QueryNode[] {
+  const upstreamNodes: QueryNode[] = [];
+  const visited = new Set<string>();
+  const queue: QueryNode[] = [];
+
+  // Add all input nodes to the queue
+  if (node.primaryInput) {
+    queue.push(node.primaryInput);
+  }
+  if (node.secondaryInputs) {
+    for (const inputNode of node.secondaryInputs.connections.values()) {
+      queue.push(inputNode);
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current.nodeId)) {
+      continue;
+    }
+    visited.add(current.nodeId);
+    upstreamNodes.push(current);
+
+    // Only traverse backward edges
+    if (current.primaryInput) {
+      queue.push(current.primaryInput);
+    }
+    if (current.secondaryInputs) {
+      for (const inputNode of current.secondaryInputs.connections.values()) {
+        queue.push(inputNode);
+      }
+    }
+  }
+
+  return upstreamNodes;
+}
+
+/**
+ * Finds a node by its ID in the graph.
+ *
+ * @param nodeId The ID of the node to find
+ * @param rootNodes The root nodes to start searching from
+ * @returns The node if found, undefined otherwise
+ */
+export function findNodeById(
+  nodeId: string,
+  rootNodes: QueryNode[],
+): QueryNode | undefined {
+  const allNodes = getAllNodes(rootNodes);
+  return allNodes.find((n) => n.nodeId === nodeId);
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils_unittest.ts
@@ -1,0 +1,341 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  getAllNodes,
+  getAllDownstreamNodes,
+  getAllUpstreamNodes,
+  findNodeById,
+} from './graph_utils';
+import {QueryNode} from '../query_node';
+import {TableSourceNode} from './nodes/sources/table_source';
+import {Trace} from '../../../public/trace';
+import {SqlModules} from '../../dev.perfetto.SqlModules/sql_modules';
+
+describe('graph_utils', () => {
+  let mockTrace: Trace;
+  let mockSqlModules: SqlModules;
+
+  beforeEach(() => {
+    mockTrace = {
+      traceInfo: {
+        traceTitle: 'test_trace',
+      },
+    } as Trace;
+
+    mockSqlModules = {
+      listTables: () => [],
+      getTable: () => null,
+      listModules: () => [],
+      listTablesNames: () => [],
+      getModuleForTable: () => undefined,
+    } as unknown as SqlModules;
+  });
+
+  // Helper to create a simple test node
+  function createTestNode(): QueryNode {
+    return new TableSourceNode({
+      trace: mockTrace,
+      sqlModules: mockSqlModules,
+    }) as QueryNode;
+  }
+
+  describe('getAllNodes', () => {
+    it('should return empty array for empty root nodes', () => {
+      const result = getAllNodes([]);
+      expect(result).toEqual([]);
+    });
+
+    it('should return single node', () => {
+      const node = createTestNode();
+      const result = getAllNodes([node]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(node);
+    });
+
+    it('should traverse forward edges (nextNodes)', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node1.nextNodes = [node2];
+      node2.nextNodes = [node3];
+
+      const result = getAllNodes([node1]);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).toContain(node3);
+    });
+
+    it('should traverse backward edges (primaryInput)', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node3.primaryInput = node2;
+      node2.primaryInput = node1;
+
+      const result = getAllNodes([node3]);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).toContain(node3);
+    });
+
+    it('should traverse backward edges (secondaryInputs)', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node3.secondaryInputs = {
+        connections: new Map([
+          [0, node1],
+          [1, node2],
+        ]),
+        min: 2,
+        max: 'unbounded',
+      };
+
+      const result = getAllNodes([node3]);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).toContain(node3);
+    });
+
+    it('should handle cycles without infinite loop', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+
+      node1.nextNodes = [node2];
+      node2.nextNodes = [node1]; // Cycle
+
+      const result = getAllNodes([node1]);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+    });
+
+    it('should deduplicate nodes in complex graph', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      // Diamond pattern: 1 -> 2, 1 -> 3, 2 -> 4, 3 -> 4
+      const node4 = createTestNode();
+      node1.nextNodes = [node2, node3];
+      node2.nextNodes = [node4];
+      node3.nextNodes = [node4];
+
+      const result = getAllNodes([node1]);
+      expect(result).toHaveLength(4);
+      // node4 should only appear once
+      const node4Count = result.filter((n) => n === node4).length;
+      expect(node4Count).toBe(1);
+    });
+
+    it('should handle multiple root nodes', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      const result = getAllNodes([node1, node2, node3]);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).toContain(node3);
+    });
+  });
+
+  describe('getAllDownstreamNodes', () => {
+    it('should return only the node itself if no children', () => {
+      const node = createTestNode();
+      const result = getAllDownstreamNodes(node);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(node);
+    });
+
+    it('should return all downstream nodes', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node1.nextNodes = [node2];
+      node2.nextNodes = [node3];
+
+      const result = getAllDownstreamNodes(node1);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).toContain(node3);
+    });
+
+    it('should not traverse backward edges', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node2.primaryInput = node1;
+      node2.nextNodes = [node3];
+
+      const result = getAllDownstreamNodes(node2);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(node2);
+      expect(result).toContain(node3);
+      expect(result).not.toContain(node1); // Should not go backwards
+    });
+
+    it('should handle cycles', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+
+      node1.nextNodes = [node2];
+      node2.nextNodes = [node1];
+
+      const result = getAllDownstreamNodes(node1);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getAllUpstreamNodes', () => {
+    it('should return empty array if no inputs', () => {
+      const node = createTestNode();
+      const result = getAllUpstreamNodes(node);
+      expect(result).toEqual([]);
+    });
+
+    it('should return all upstream nodes via primaryInput', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node3.primaryInput = node2;
+      node2.primaryInput = node1;
+
+      const result = getAllUpstreamNodes(node3);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).not.toContain(node3); // Should not include starting node
+    });
+
+    it('should return all upstream nodes via secondaryInputs', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node3.secondaryInputs = {
+        connections: new Map([
+          [0, node1],
+          [1, node2],
+        ]),
+        min: 2,
+        max: 'unbounded',
+      };
+
+      const result = getAllUpstreamNodes(node3);
+      expect(result).toHaveLength(2);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).not.toContain(node3);
+    });
+
+    it('should not traverse forward edges', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node2.primaryInput = node1;
+      node2.nextNodes = [node3];
+
+      const result = getAllUpstreamNodes(node2);
+      expect(result).toHaveLength(1);
+      expect(result).toContain(node1);
+      expect(result).not.toContain(node3); // Should not go forward
+    });
+
+    it('should handle complex upstream graph', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+      const node4 = createTestNode();
+
+      // node4 depends on node2 and node3, which both depend on node1
+      node4.secondaryInputs = {
+        connections: new Map([
+          [0, node2],
+          [1, node3],
+        ]),
+        min: 2,
+        max: 'unbounded',
+      };
+      node2.primaryInput = node1;
+      node3.primaryInput = node1;
+
+      const result = getAllUpstreamNodes(node4);
+      expect(result).toHaveLength(3);
+      expect(result).toContain(node1);
+      expect(result).toContain(node2);
+      expect(result).toContain(node3);
+    });
+  });
+
+  describe('findNodeById', () => {
+    it('should return undefined for empty root nodes', () => {
+      const result = findNodeById('1', []);
+      expect(result).toBeUndefined();
+    });
+
+    it('should find node in root nodes', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+
+      const result = findNodeById(node1.nodeId, [node1, node2]);
+      expect(result).toBe(node1);
+    });
+
+    it('should find node in downstream nodes', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node1.nextNodes = [node2];
+      node2.nextNodes = [node3];
+
+      const result = findNodeById(node3.nodeId, [node1]);
+      expect(result).toBe(node3);
+    });
+
+    it('should find node in upstream nodes', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+      const node3 = createTestNode();
+
+      node3.primaryInput = node2;
+      node2.primaryInput = node1;
+
+      const result = findNodeById(node1.nodeId, [node3]);
+      expect(result).toBe(node1);
+    });
+
+    it('should return undefined if node not found', () => {
+      const node1 = createTestNode();
+      const node2 = createTestNode();
+
+      const result = findNodeById('999', [node1, node2]);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/materialization_service.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/materialization_service.ts
@@ -14,10 +14,14 @@
 
 import {Engine} from '../../../trace_processor/engine';
 import {Query, QueryNode} from '../query_node';
+import {getAllDownstreamNodes} from './graph_utils';
 
 /**
  * Service for managing materialized tables for Explore Page nodes.
  * Materialization creates persistent tables using CREATE OR REPLACE PERFETTO TABLE.
+ *
+ * Also manages query hash caching and invalidation to optimize re-materialization
+ * decisions and propagate changes through the query graph.
  *
  * Includes debouncing to prevent excessive materialization calls during rapid
  * user input (e.g., typing column names).
@@ -25,6 +29,9 @@ import {Query, QueryNode} from '../query_node';
 export class MaterializationService {
   private materializeTimer?: ReturnType<typeof setTimeout>;
   private static readonly MATERIALIZE_DEBOUNCE_MS = 300;
+
+  // Cache of computed query hashes to avoid redundant JSON.stringify() calls
+  private queryHashCache = new Map<string, string>();
 
   constructor(private engine: Engine) {}
 
@@ -186,5 +193,50 @@ export class MaterializationService {
    */
   getEngine(): Engine {
     return this.engine;
+  }
+
+  /**
+   * Gets the cached query hash for a node if it exists.
+   *
+   * @param node The node to get the cached hash for
+   * @returns The cached hash or undefined if not cached
+   */
+  getCachedQueryHash(node: QueryNode): string | undefined {
+    return this.queryHashCache.get(node.nodeId);
+  }
+
+  /**
+   * Sets the cached query hash for a node.
+   *
+   * @param node The node to cache the hash for
+   * @param hash The query hash to cache
+   */
+  setCachedQueryHash(node: QueryNode, hash: string): void {
+    this.queryHashCache.set(node.nodeId, hash);
+  }
+
+  /**
+   * Invalidates a node and all its downstream dependents.
+   * Clears cached query hashes and materialization state for the entire
+   * downstream subgraph.
+   *
+   * This should be called when a node's operation changes to ensure
+   * all dependent nodes are re-validated and re-materialized if needed.
+   *
+   * @param node The node that changed
+   */
+  invalidateNode(node: QueryNode): void {
+    // Get all downstream nodes (including the starting node)
+    const downstreamNodes = getAllDownstreamNodes(node);
+
+    for (const downstreamNode of downstreamNodes) {
+      // Clear cached query hash
+      this.queryHashCache.delete(downstreamNode.nodeId);
+
+      // Clear materialization state if materialized
+      if (downstreamNode.state.materialized) {
+        downstreamNode.state.materializedQueryHash = undefined;
+      }
+    }
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node_unittest.ts
@@ -322,7 +322,7 @@ describe('query_node utilities', () => {
       expect(state.hasOperationChanged).toBe(true);
     });
 
-    it('should propagate change to next nodes', () => {
+    it('should mark node as changed', () => {
       const state1: QueryNodeState = {hasOperationChanged: false};
       const state2: QueryNodeState = {hasOperationChanged: false};
       const state3: QueryNodeState = {hasOperationChanged: false};
@@ -336,46 +336,21 @@ describe('query_node utilities', () => {
 
       setOperationChanged(node1);
 
+      // Only the node itself should be marked, not children
+      // (propagation is handled by MaterializationService.invalidateNode)
       expect(state1.hasOperationChanged).toBe(true);
-      expect(state2.hasOperationChanged).toBe(true);
-      expect(state3.hasOperationChanged).toBe(true);
-    });
-
-    it('should stop propagation if node already marked as changed', () => {
-      const state1: QueryNodeState = {hasOperationChanged: false};
-      const state2: QueryNodeState = {hasOperationChanged: true};
-      const state3: QueryNodeState = {hasOperationChanged: false};
-
-      const node1 = createMockNode('node1', state1);
-      const node2 = createMockNode('node2', state2);
-      const node3 = createMockNode('node3', state3);
-
-      node1.nextNodes = [node2];
-      node2.nextNodes = [node3];
-
-      setOperationChanged(node1);
-
-      expect(state1.hasOperationChanged).toBe(true);
-      // Should stop at node2 since it was already marked as changed
+      expect(state2.hasOperationChanged).toBe(false);
       expect(state3.hasOperationChanged).toBe(false);
     });
 
-    it('should handle multiple next nodes', () => {
-      const state1: QueryNodeState = {hasOperationChanged: false};
-      const state2: QueryNodeState = {hasOperationChanged: false};
-      const state3: QueryNodeState = {hasOperationChanged: false};
+    it('should mark node as changed even if already changed', () => {
+      const state1: QueryNodeState = {hasOperationChanged: true};
 
       const node1 = createMockNode('node1', state1);
-      const node2 = createMockNode('node2', state2);
-      const node3 = createMockNode('node3', state3);
-
-      node1.nextNodes = [node2, node3];
 
       setOperationChanged(node1);
 
       expect(state1.hasOperationChanged).toBe(true);
-      expect(state2.hasOperationChanged).toBe(true);
-      expect(state3.hasOperationChanged).toBe(true);
     });
   });
 


### PR DESCRIPTION
 ## Summary

  Refactors Explore Page state management to centralize resource cleanup, eliminate code duplication, and optimize materialization. Introduces `CleanupManager` for coordinated cleanup of materialized tables, consolidates graph traversal utilities to fix a serialization bug, and adds query hash caching to avoid redundant computations.

  ## Changes

  - **Add `CleanupManager`**: Centralized cleanup of materialized tables with parallel execution via `Promise.allSettled` and best-effort error handling
  - **Add `graph_utils.ts`**: Consolidates graph traversal logic (eliminates duplication across 4+ files)
    - **Bug fix**: `json_handler` now uses bidirectional traversal, fixing missing nodes during serialization
    - Provides `getAllNodes()`, `getAllDownstreamNodes()`, `getAllUpstreamNodes()`, `findNodeById()`
  - **Cache query hashes**: Avoid redundant hash computation by caching after validation and reusing during execution
  - **Share `MaterializationService`**: Single instance between `ExplorePage` and `Builder` ensures consistent state and enables hash caching
  - **Add `onremove` lifecycle hook**: Clean up materialized tables when component unmounts (prevents resource leaks)
  - **Add comprehensive tests**: Full coverage for `CleanupManager` (267 lines) and `graph_utils` (341 lines)

  ## Notes

  The cleanup manager uses `Promise.allSettled` to run cleanup operations in parallel while ensuring individual failures don't block other cleanups. All 
  cleanup is best-effort with proper error logging.

  The bidirectional graph traversal in `getAllNodes()` fixes a bug where nodes reachable only via backward edges (through `primaryInput` or `secondaryInputs`) were missing during state serialization.