### PR TITLE
exp: TimeRange node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -419,7 +419,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
   async handleDeleteNode(attrs: ExplorePageAttrs, node: QueryNode) {
     const {state, onStateUpdate} = attrs;
 
-    // Clean up materialized table if it exists using CleanupManager
+    // Clean up all node resources (both JS and SQL) using CleanupManager
     if (this.cleanupManager !== undefined) {
       await this.cleanupManager.cleanupNode(node);
     }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -28,6 +28,10 @@ import {
   SqlSourceSerializedState,
 } from './query_builder/nodes/sources/sql_source';
 import {
+  TimeRangeSourceNode,
+  TimeRangeSourceSerializedState,
+} from './query_builder/nodes/sources/timerange_source';
+import {
   AggregationNode,
   AggregationSerializedState,
 } from './query_builder/nodes/aggregation_node';
@@ -65,6 +69,7 @@ type SerializedNodeState =
   | TableSourceSerializedState
   | SlicesSourceSerializedState
   | SqlSourceSerializedState
+  | TimeRangeSourceSerializedState
   | AggregationSerializedState
   | ModifyColumnsSerializedState
   | IntervalIntersectSerializedState
@@ -182,6 +187,13 @@ function createNodeInstance(
         ...(state as SqlSourceSerializedState),
         trace,
       });
+    case NodeType.kTimeRangeSource:
+      return new TimeRangeSourceNode(
+        TimeRangeSourceNode.deserializeState(
+          trace,
+          state as TimeRangeSourceSerializedState,
+        ),
+      );
     case NodeType.kAggregation:
       return new AggregationNode(
         AggregationNode.deserializeState(state as AggregationSerializedState),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -21,6 +21,7 @@
 @import "./operations/operation_component.scss";
 @import "./nodes/sources/slices_source.scss";
 @import "./nodes/sources/table_source.scss";
+@import "./nodes/sources/timerange_source.scss";
 @import "./nodes/aggregation_node.scss";
 @import "./nodes/modify_columns_node.scss";
 @import "./table_list.scss";

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -20,6 +20,10 @@ import {
   TableSourceState,
 } from './nodes/sources/table_source';
 import {SqlSourceNode, SqlSourceState} from './nodes/sources/sql_source';
+import {
+  TimeRangeSourceNode,
+  TimeRangeSourceState,
+} from './nodes/sources/timerange_source';
 import {AggregationNode, AggregationNodeState} from './nodes/aggregation_node';
 import {
   ModifyColumnsNode,
@@ -76,6 +80,54 @@ export function registerCoreNodes() {
     hotkey: 'q',
     type: 'source',
     factory: (state) => new SqlSourceNode(state as SqlSourceState),
+  });
+
+  nodeRegistry.register('timerange', {
+    name: 'Time Range',
+    description:
+      'Import time range from timeline selection. Can be dynamic (syncs with selection) or static (snapshot).',
+    icon: 'schedule',
+    type: 'source',
+    showOnLandingPage: false, // Available in menus but not on landing page
+    factory: (state) => {
+      // If start/end are already set, this is being restored from serialization
+      // or created programmatically - use those values
+      if (
+        'start' in state &&
+        state.start !== undefined &&
+        'end' in state &&
+        state.end !== undefined
+      ) {
+        if (!state.trace) {
+          throw new Error('TimeRange node requires a trace instance');
+        }
+        return new TimeRangeSourceNode({
+          ...state,
+          trace: state.trace,
+          isDynamic:
+            'isDynamic' in state && state.isDynamic === true ? true : false,
+        } as TimeRangeSourceState);
+      }
+
+      // New node - initialize from current selection
+      if (!state.trace) {
+        throw new Error('TimeRange node requires a trace instance');
+      }
+
+      const timeRange = state.trace.selection.getTimeSpanOfSelection();
+      // Note: If there's no selection, start/end will be undefined and the node
+      // will be in an invalid state (validate() will return false and show error).
+      // This is intentional - the user can fix it by clicking "Update from Selection"
+      // or by entering times manually.
+      const fullState: TimeRangeSourceState = {
+        ...state,
+        start: timeRange?.start,
+        end: timeRange?.end,
+        isDynamic: false, // Default to static mode
+        trace: state.trace,
+      };
+      return new TimeRangeSourceNode(fullState);
+    },
   });
 
   nodeRegistry.register('aggregation', {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/empty_graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/empty_graph.ts
@@ -61,7 +61,11 @@ export class EmptyGraph implements m.ClassComponent<EmptyGraphAttrs> {
   view({attrs}: m.CVnode<EmptyGraphAttrs>) {
     const sourceNodes = nodeRegistry
       .list()
-      .filter(([_id, node]) => node.type === 'source')
+      .filter(
+        ([_id, node]) =>
+          node.type === 'source' &&
+          (node.showOnLandingPage === undefined || node.showOnLandingPage),
+      )
       .map(([id, node]) => {
         return m(SourceCard, {
           title: node.name,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
@@ -57,6 +57,17 @@ export interface NodeDescriptor {
 
   // Whether this node is only available in dev mode.
   devOnly?: boolean;
+
+  /**
+   * Whether this node should be shown on the landing page.
+   *
+   * If false, the node is still available in menus but not on the landing page.
+   * This is useful for nodes that are better accessed via commands or menus
+   * rather than being a primary entry point.
+   *
+   * @default true for source nodes
+   */
+  showOnLandingPage?: boolean;
 }
 
 export class NodeRegistry {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source.scss
@@ -1,0 +1,97 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Section title styling
+.pf-timerange-section-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--primary-foreground-color);
+  margin: 0 0 12px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+// Dynamic mode helper text
+.pf-timerange-dynamic-info {
+  font-size: 13px;
+  color: var(--secondary-foreground-color);
+  padding: 12px 0;
+  line-height: 1.5;
+  font-style: italic;
+}
+
+// Mode selection section
+.pf-timerange-mode-section {
+  padding: 16px;
+  margin-bottom: 20px;
+  background: var(--apc-selection-fill-secondary-color, rgba(0, 0, 0, 0.02));
+  border: 1px solid var(--divider-color, rgba(0, 0, 0, 0.08));
+  border-radius: 4px;
+}
+
+// Mode selection row (switch + button)
+.pf-timerange-mode-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+
+  // Make the switch larger and more prominent
+  .pf-switch {
+    transform: scale(1.3);
+    transform-origin: left center;
+  }
+}
+
+// Time values section
+.pf-timerange-values-section {
+  margin-top: 20px;
+}
+
+// List of time values (Start, End, Duration)
+.pf-timerange-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px; // Spacing between list items (same as filters)
+}
+
+// Duration display (read-only)
+.pf-timerange-duration-display {
+  font-family: var(--monospace-font);
+  font-size: 13px;
+  color: var(--primary-foreground-color);
+  padding: 4px 0;
+}
+
+// Info title
+.pf-timerange-info-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--primary-foreground-color);
+  margin: 0 0 16px 0;
+}
+
+// Info mode display
+.pf-timerange-info-mode {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--divider-color, rgba(0, 0, 0, 0.08));
+  font-size: 12px;
+  color: var(--secondary-foreground-color);
+}
+
+.pf-node-info-empty {
+  color: var(--disabled-foreground-color, #999);
+  font-style: italic;
+  padding: 8px 0;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source.ts
@@ -1,0 +1,514 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {
+  QueryNode,
+  QueryNodeState,
+  NodeType,
+  nextNodeId,
+  createFinalColumns,
+} from '../../../query_node';
+import {ColumnInfo, columnInfoFromName} from '../../column_info';
+import {time, TimeSpan, Time} from '../../../../../base/time';
+import {Trace} from '../../../../../public/trace';
+import {Button} from '../../../../../widgets/button';
+import {TextInput} from '../../../../../widgets/text_input';
+import {Switch} from '../../../../../widgets/switch';
+import {StructuredQueryBuilder} from '../../structured_query_builder';
+import protos from '../../../../../protos';
+import {ListItem} from '../../widgets';
+import {showModal} from '../../../../../widgets/modal';
+import {Callout} from '../../../../../widgets/callout';
+import {NodeIssues} from '../../node_issues';
+
+// Poll interval for dynamic mode selection updates (in milliseconds)
+const SELECTION_POLL_INTERVAL_MS = 200;
+
+export interface TimeRangeSourceSerializedState {
+  start?: string;
+  end?: string;
+  isDynamic?: boolean;
+  comment?: string;
+}
+
+export interface TimeRangeSourceState extends QueryNodeState {
+  start?: time;
+  end?: time;
+  isDynamic?: boolean;
+  trace: Trace;
+  onchange?: () => void;
+}
+
+export class TimeRangeSourceNode implements QueryNode {
+  readonly nodeId: string;
+  readonly state: TimeRangeSourceState;
+  readonly finalCols: ColumnInfo[];
+  nextNodes: QueryNode[] = [];
+  private selectionCheckInterval?: number;
+
+  constructor(attrs: TimeRangeSourceState) {
+    this.nodeId = nextNodeId();
+    this.state = {
+      ...attrs,
+      isDynamic: attrs.isDynamic ?? false,
+    };
+
+    // Initialize columns: id, ts, dur
+    this.finalCols = createFinalColumns([
+      columnInfoFromName('id'),
+      columnInfoFromName('ts'),
+      columnInfoFromName('dur'),
+    ]);
+
+    // If dynamic mode is enabled, subscribe to selection changes
+    if (this.state.isDynamic) {
+      this.subscribeToSelectionChanges();
+    }
+  }
+
+  get type() {
+    return NodeType.kTimeRangeSource;
+  }
+
+  validate(): boolean {
+    // Initialize issues if not present
+    if (!this.state.issues) {
+      this.state.issues = new NodeIssues();
+    }
+    this.state.issues.queryError = undefined;
+
+    if (this.state.start === undefined || this.state.end === undefined) {
+      this.state.issues.queryError = new Error(
+        'Time range not set. Use "Update from Selection" or enable Dynamic mode to sync with timeline selection.',
+      );
+      return false;
+    }
+
+    if (this.state.end < this.state.start) {
+      this.state.issues.queryError = new Error(
+        'End time must be greater than or equal to start time.',
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  clone(): QueryNode {
+    const stateCopy: TimeRangeSourceState = {
+      start: this.state.start,
+      end: this.state.end,
+      isDynamic: false, // Clone always creates a static snapshot
+      trace: this.state.trace,
+      comment: this.state.comment,
+      onchange: this.state.onchange,
+    };
+    return new TimeRangeSourceNode(stateCopy);
+  }
+
+  getTitle(): string {
+    return this.state.isDynamic ? 'Current time range' : 'Time range';
+  }
+
+  serializeState(): TimeRangeSourceSerializedState {
+    return {
+      start: this.state.start?.toString(),
+      end: this.state.end?.toString(),
+      isDynamic: this.state.isDynamic,
+      comment: this.state.comment,
+    };
+  }
+
+  static deserializeState(
+    trace: Trace,
+    serialized: TimeRangeSourceSerializedState,
+  ): TimeRangeSourceState {
+    return {
+      trace,
+      start: serialized.start
+        ? Time.fromRaw(BigInt(serialized.start))
+        : undefined,
+      end: serialized.end ? Time.fromRaw(BigInt(serialized.end)) : undefined,
+      isDynamic: serialized.isDynamic ?? false,
+      comment: serialized.comment,
+    };
+  }
+
+  private static generateSql(start: time, dur: bigint): string {
+    return `SELECT 0 AS id, ${start} AS ts, ${dur} AS dur`;
+  }
+
+  getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
+    if (!this.validate()) {
+      return undefined;
+    }
+
+    // Type narrowing - validate() already checked that start and end are defined
+    const start = this.state.start;
+    const end = this.state.end;
+    if (start === undefined || end === undefined) {
+      return undefined;
+    }
+
+    const dur = end - start;
+
+    const sql = TimeRangeSourceNode.generateSql(start, dur);
+
+    return StructuredQueryBuilder.fromSql(
+      sql,
+      [], // no dependencies
+      ['id', 'ts', 'dur'], // column names
+      this.nodeId,
+    );
+  }
+
+  getTimeRange(): TimeSpan | undefined {
+    if (!this.validate()) {
+      return undefined;
+    }
+    const start = this.state.start;
+    const end = this.state.end;
+    if (start === undefined || end === undefined) {
+      return undefined;
+    }
+    return new TimeSpan(start, end);
+  }
+
+  private subscribeToSelectionChanges() {
+    this.selectionCheckInterval = window.setInterval(() => {
+      this.updateFromSelection();
+    }, SELECTION_POLL_INTERVAL_MS);
+  }
+
+  private unsubscribeFromSelectionChanges() {
+    if (this.selectionCheckInterval !== undefined) {
+      window.clearInterval(this.selectionCheckInterval);
+      this.selectionCheckInterval = undefined;
+    }
+  }
+
+  private updateFromSelection() {
+    // Get selection time span, or fall back to full trace if no selection
+    let timeSpan = this.state.trace.selection.getTimeSpanOfSelection();
+    if (!timeSpan) {
+      // No selection - use full trace
+      timeSpan = new TimeSpan(
+        this.state.trace.traceInfo.start,
+        this.state.trace.traceInfo.end,
+      );
+    }
+
+    // Only update if the values have actually changed to avoid unnecessary redraws
+    if (
+      this.state.start === timeSpan.start &&
+      this.state.end === timeSpan.end
+    ) {
+      return; // No change needed
+    }
+
+    this.state.start = timeSpan.start;
+    this.state.end = timeSpan.end;
+    this.state.onchange?.();
+    m.redraw();
+  }
+
+  private toggleDynamicMode() {
+    this.state.isDynamic = !this.state.isDynamic;
+
+    if (this.state.isDynamic) {
+      this.subscribeToSelectionChanges();
+      this.updateFromSelection(); // Immediately sync with current selection
+    } else {
+      this.unsubscribeFromSelectionChanges();
+    }
+
+    this.state.onchange?.();
+    m.redraw();
+  }
+
+  private showEditStartModal(): void {
+    let tempValue = this.state.start?.toString() ?? '';
+
+    showModal({
+      title: 'Edit Start Time',
+      content: () =>
+        m(
+          'div',
+          m(TextInput, {
+            value: tempValue,
+            oninput: (e: Event) => {
+              tempValue = (e.target as HTMLInputElement).value;
+            },
+            placeholder: 'Start timestamp (ns)',
+          }),
+        ),
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {},
+        },
+        {
+          text: 'Apply',
+          primary: true,
+          action: () => {
+            try {
+              const parsed = BigInt(tempValue.trim());
+              this.state.start = Time.fromRaw(parsed);
+              this.state.onchange?.();
+            } catch (e) {
+              console.warn('Invalid start timestamp:', tempValue, e);
+            }
+          },
+        },
+      ],
+    });
+  }
+
+  private showEditEndModal(): void {
+    let tempValue = this.state.end?.toString() ?? '';
+
+    showModal({
+      title: 'Edit End Time',
+      content: () =>
+        m(
+          'div',
+          m(TextInput, {
+            value: tempValue,
+            oninput: (e: Event) => {
+              tempValue = (e.target as HTMLInputElement).value;
+            },
+            placeholder: 'End timestamp (ns)',
+          }),
+        ),
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {},
+        },
+        {
+          text: 'Apply',
+          primary: true,
+          action: () => {
+            try {
+              const parsed = BigInt(tempValue.trim());
+              this.state.end = Time.fromRaw(parsed);
+              this.state.onchange?.();
+            } catch (e) {
+              console.warn('Invalid end timestamp:', tempValue, e);
+            }
+          },
+        },
+      ],
+    });
+  }
+
+  private showEditDurationModal(): void {
+    const currentDur =
+      this.state.start && this.state.end
+        ? this.state.end - this.state.start
+        : 0n;
+    let tempValue = currentDur.toString();
+
+    showModal({
+      title: 'Edit Duration',
+      content: () =>
+        m(
+          'div',
+          m(TextInput, {
+            value: tempValue,
+            oninput: (e: Event) => {
+              tempValue = (e.target as HTMLInputElement).value;
+            },
+            placeholder: 'Duration (ns)',
+          }),
+        ),
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {},
+        },
+        {
+          text: 'Apply',
+          primary: true,
+          action: () => {
+            try {
+              const parsed = BigInt(tempValue.trim());
+              if (this.state.start !== undefined) {
+                // Keep start fixed, update end based on duration
+                this.state.end = Time.fromRaw(this.state.start + parsed);
+                this.state.onchange?.();
+              }
+            } catch (e) {
+              console.warn('Invalid duration:', tempValue, e);
+            }
+          },
+        },
+      ],
+    });
+  }
+
+  nodeSpecificModify(): m.Child {
+    const isDynamic = this.state.isDynamic ?? false;
+    const isValid = this.validate();
+    const dur =
+      isValid && this.state.start !== undefined && this.state.end !== undefined
+        ? this.state.end - this.state.start
+        : 0n;
+    const error = this.state.issues?.queryError;
+
+    return m(
+      'div',
+      // Error message
+      error && m(Callout, {icon: 'error'}, error.message),
+      // Dynamic mode helper text
+      isDynamic &&
+        m(
+          '.pf-timerange-dynamic-info',
+          'Dynamic mode: Your timeline selection will automatically update this node. Go back to the timeline and select a time range to see it here.',
+        ),
+      // Mode selection section with header
+      m(
+        '.pf-timerange-mode-section',
+        m('h3.pf-timerange-section-title', 'Mode'),
+        m(
+          '.pf-timerange-mode-row',
+          m(Switch, {
+            checked: isDynamic,
+            label: isDynamic ? 'Dynamic (syncs with selection)' : 'Static',
+            onchange: () => this.toggleDynamicMode(),
+          }),
+          !isDynamic &&
+            m(Button, {
+              label: 'Update from Selection',
+              onclick: () => this.updateFromSelection(),
+            }),
+        ),
+      ),
+      // Time values section with header
+      m(
+        '.pf-timerange-values-section',
+        m('h3.pf-timerange-section-title', 'Time Values'),
+        m(
+          '.pf-timerange-list',
+          m(ListItem, {
+            icon: 'start',
+            name: 'Start (ns)',
+            description: this.state.start?.toString() ?? 'Not set',
+            actions: !isDynamic
+              ? [
+                  {
+                    icon: 'edit',
+                    onclick: () => this.showEditStartModal(),
+                  },
+                ]
+              : undefined,
+          }),
+          m(ListItem, {
+            icon: 'stop',
+            name: 'End (ns)',
+            description: this.state.end?.toString() ?? 'Not set',
+            actions: !isDynamic
+              ? [
+                  {
+                    icon: 'edit',
+                    onclick: () => this.showEditEndModal(),
+                  },
+                ]
+              : undefined,
+          }),
+          isValid &&
+            m(ListItem, {
+              icon: 'timelapse',
+              name: 'Duration (ns)',
+              description: dur.toString(),
+              actions: !isDynamic
+                ? [
+                    {
+                      icon: 'edit',
+                      onclick: () => this.showEditDurationModal(),
+                    },
+                  ]
+                : undefined,
+            }),
+        ),
+      ),
+    );
+  }
+
+  nodeInfo(): m.Children {
+    if (!this.validate()) {
+      return m(
+        'div',
+        m(
+          '.pf-node-info-empty',
+          'No time range set. Use "Update from Selection" or enter times manually.',
+        ),
+      );
+    }
+
+    const start = this.state.start;
+    const end = this.state.end;
+    if (start === undefined || end === undefined) {
+      return m('div', m('.pf-node-info-empty', 'No time range set.'));
+    }
+
+    const dur = end - start;
+    const isDynamic = this.state.isDynamic ?? false;
+    const title = isDynamic ? 'Current time selection' : 'Time selection';
+
+    return m(
+      'div',
+      m('h3.pf-timerange-info-title', title),
+      m(
+        'table.pf-table.pf-table-striped',
+        m(
+          'thead',
+          m('tr', m('th', 'Column'), m('th', 'Value'), m('th', 'Description')),
+        ),
+        m(
+          'tbody',
+          m(
+            'tr',
+            m('td', 'id'),
+            m('td', '0'),
+            m('td', 'Row identifier (always 0)'),
+          ),
+          m(
+            'tr',
+            m('td', 'ts'),
+            m('td', start.toString()),
+            m('td', 'Start timestamp (ns)'),
+          ),
+          m(
+            'tr',
+            m('td', 'dur'),
+            m('td', dur.toString()),
+            m('td', 'Duration (ns)'),
+          ),
+        ),
+      ),
+      m(
+        '.pf-timerange-info-mode',
+        `Mode: ${this.state.isDynamic ? 'Dynamic (synced with selection)' : 'Static'}`,
+      ),
+    );
+  }
+
+  // Cleanup when node is destroyed. This is called by CleanupManager
+  // when the node is deleted from the graph.
+  dispose() {
+    this.unsubscribeFromSelectionChanges();
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source_unittest.ts
@@ -1,0 +1,679 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  TimeRangeSourceNode,
+  TimeRangeSourceState,
+  TimeRangeSourceSerializedState,
+} from './timerange_source';
+import {Trace} from '../../../../../public/trace';
+import {Time, TimeSpan} from '../../../../../base/time';
+
+describe('TimeRangeSourceNode', () => {
+  function createMockTrace(): Trace {
+    return {
+      traceInfo: {
+        start: Time.fromRaw(0n),
+        end: Time.fromRaw(1000000n),
+      },
+      selection: {
+        getTimeSpanOfSelection: () => undefined,
+      },
+    } as unknown as Trace;
+  }
+
+  describe('constructor', () => {
+    it('should create node with start and end', () => {
+      const state: TimeRangeSourceState = {
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      };
+
+      const node = new TimeRangeSourceNode(state);
+
+      expect(node.state.start).toEqual(Time.fromRaw(100n));
+      expect(node.state.end).toEqual(Time.fromRaw(500n));
+      expect(node.state.isDynamic).toBe(false);
+    });
+
+    it('should create node with undefined start/end', () => {
+      const state: TimeRangeSourceState = {
+        trace: createMockTrace(),
+        isDynamic: false,
+      };
+
+      const node = new TimeRangeSourceNode(state);
+
+      expect(node.state.start).toBeUndefined();
+      expect(node.state.end).toBeUndefined();
+    });
+
+    it('should default isDynamic to false', () => {
+      const state: TimeRangeSourceState = {
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+      };
+
+      const node = new TimeRangeSourceNode(state);
+
+      expect(node.state.isDynamic).toBe(false);
+    });
+
+    it('should create node in dynamic mode', () => {
+      const state: TimeRangeSourceState = {
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: true,
+      };
+
+      const node = new TimeRangeSourceNode(state);
+
+      expect(node.state.isDynamic).toBe(true);
+    });
+  });
+
+  describe('validation', () => {
+    it('should validate when start and end are set', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(true);
+    });
+
+    it('should invalidate when start is missing', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(false);
+    });
+
+    it('should invalidate when end is missing', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(false);
+    });
+
+    it('should invalidate when both start and end are missing', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(false);
+    });
+
+    it('should invalidate when end is before start', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(500n),
+        end: Time.fromRaw(100n),
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(false);
+    });
+
+    it('should validate when end equals start (zero duration)', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(100n),
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(true);
+    });
+  });
+
+  describe('getTimeRange', () => {
+    it('should return TimeSpan when valid', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      const timeRange = node.getTimeRange();
+
+      expect(timeRange).toBeDefined();
+      expect(timeRange?.start).toEqual(Time.fromRaw(100n));
+      expect(timeRange?.end).toEqual(Time.fromRaw(500n));
+    });
+
+    it('should return undefined when invalid', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        isDynamic: false,
+      });
+
+      const timeRange = node.getTimeRange();
+
+      expect(timeRange).toBeUndefined();
+    });
+  });
+
+  describe('getStructuredQuery', () => {
+    it('should generate SQL with single row for valid time range', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      const query = node.getStructuredQuery();
+
+      expect(query).toBeDefined();
+      // Query should contain the start, duration calculation
+      expect(query?.sql?.sql).toBe('SELECT 0 AS id, 100 AS ts, 400 AS dur');
+    });
+
+    it('should return undefined for invalid node', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        isDynamic: false,
+      });
+
+      const query = node.getStructuredQuery();
+
+      expect(query).toBeUndefined();
+    });
+
+    it('should handle zero duration', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(100n),
+        isDynamic: false,
+      });
+
+      const query = node.getStructuredQuery();
+
+      expect(query).toBeDefined();
+      expect(query?.sql?.sql).toBe('SELECT 0 AS id, 100 AS ts, 0 AS dur');
+    });
+  });
+
+  describe('serialization', () => {
+    it('should serialize static node with start and end', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      const serialized = node.serializeState();
+
+      expect(serialized.start).toBe('100');
+      expect(serialized.end).toBe('500');
+      expect(serialized.isDynamic).toBe(false);
+    });
+
+    it('should serialize dynamic node', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(200n),
+        end: Time.fromRaw(800n),
+        isDynamic: true,
+      });
+
+      const serialized = node.serializeState();
+
+      expect(serialized.start).toBe('200');
+      expect(serialized.end).toBe('800');
+      expect(serialized.isDynamic).toBe(true);
+    });
+
+    it('should serialize node with undefined start/end', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        isDynamic: false,
+      });
+
+      const serialized = node.serializeState();
+
+      expect(serialized.start).toBeUndefined();
+      expect(serialized.end).toBeUndefined();
+      expect(serialized.isDynamic).toBe(false);
+    });
+
+    it('should serialize comment if present', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+        comment: 'Test comment',
+      });
+
+      const serialized = node.serializeState();
+
+      expect(serialized.comment).toBe('Test comment');
+    });
+  });
+
+  describe('deserialization', () => {
+    it('should deserialize static node with start and end', () => {
+      const serialized: TimeRangeSourceSerializedState = {
+        start: '100',
+        end: '500',
+        isDynamic: false,
+      };
+
+      const state = TimeRangeSourceNode.deserializeState(
+        createMockTrace(),
+        serialized,
+      );
+
+      expect(state.start).toEqual(Time.fromRaw(100n));
+      expect(state.end).toEqual(Time.fromRaw(500n));
+      expect(state.isDynamic).toBe(false);
+    });
+
+    it('should deserialize dynamic node', () => {
+      const serialized: TimeRangeSourceSerializedState = {
+        start: '200',
+        end: '800',
+        isDynamic: true,
+      };
+
+      const state = TimeRangeSourceNode.deserializeState(
+        createMockTrace(),
+        serialized,
+      );
+
+      expect(state.start).toEqual(Time.fromRaw(200n));
+      expect(state.end).toEqual(Time.fromRaw(800n));
+      expect(state.isDynamic).toBe(true);
+    });
+
+    it('should deserialize with undefined start/end', () => {
+      const serialized: TimeRangeSourceSerializedState = {
+        isDynamic: false,
+      };
+
+      const state = TimeRangeSourceNode.deserializeState(
+        createMockTrace(),
+        serialized,
+      );
+
+      expect(state.start).toBeUndefined();
+      expect(state.end).toBeUndefined();
+      expect(state.isDynamic).toBe(false);
+    });
+
+    it('should default isDynamic to false when undefined', () => {
+      const serialized: TimeRangeSourceSerializedState = {
+        start: '100',
+        end: '500',
+      };
+
+      const state = TimeRangeSourceNode.deserializeState(
+        createMockTrace(),
+        serialized,
+      );
+
+      expect(state.isDynamic).toBe(false);
+    });
+
+    it('should deserialize comment if present', () => {
+      const serialized: TimeRangeSourceSerializedState = {
+        start: '100',
+        end: '500',
+        isDynamic: false,
+        comment: 'Test comment',
+      };
+
+      const state = TimeRangeSourceNode.deserializeState(
+        createMockTrace(),
+        serialized,
+      );
+
+      expect(state.comment).toBe('Test comment');
+    });
+
+    it('should preserve trace reference', () => {
+      const mockTrace = createMockTrace();
+      const serialized: TimeRangeSourceSerializedState = {
+        start: '100',
+        end: '500',
+        isDynamic: false,
+      };
+
+      const state = TimeRangeSourceNode.deserializeState(mockTrace, serialized);
+
+      expect(state.trace).toBe(mockTrace);
+    });
+  });
+
+  describe('clone', () => {
+    it('should clone node as static snapshot', () => {
+      const originalNode = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: true, // Original is dynamic
+      });
+
+      const clonedNode = originalNode.clone() as TimeRangeSourceNode;
+
+      expect(clonedNode.state.start).toEqual(originalNode.state.start);
+      expect(clonedNode.state.end).toEqual(originalNode.state.end);
+      expect(clonedNode.state.isDynamic).toBe(false); // Clone is always static
+      expect(clonedNode.nodeId).not.toBe(originalNode.nodeId);
+    });
+
+    it('should clone with comment', () => {
+      const originalNode = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+        comment: 'Original comment',
+      });
+
+      const clonedNode = originalNode.clone() as TimeRangeSourceNode;
+
+      expect(clonedNode.state.comment).toBe('Original comment');
+    });
+  });
+
+  describe('getTitle', () => {
+    it('should return "Time range" for static mode', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      expect(node.getTitle()).toBe('Time range');
+    });
+
+    it('should return "Current time range" for dynamic mode', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: true,
+      });
+
+      expect(node.getTitle()).toBe('Current time range');
+    });
+  });
+
+  describe('finalCols', () => {
+    it('should have id, ts, and dur columns', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      expect(node.finalCols.length).toBe(3);
+      expect(node.finalCols[0].name).toBe('id');
+      expect(node.finalCols[1].name).toBe('ts');
+      expect(node.finalCols[2].name).toBe('dur');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle very large timestamps', () => {
+      const largeStart = Time.fromRaw(9223372036854775000n);
+      const largeEnd = Time.fromRaw(9223372036854775807n); // Near max int64
+
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: largeStart,
+        end: largeEnd,
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(true);
+      const serialized = node.serializeState();
+      expect(serialized.start).toBe('9223372036854775000');
+      expect(serialized.end).toBe('9223372036854775807');
+    });
+
+    it('should handle timestamp at zero', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(0n),
+        end: Time.fromRaw(1000n),
+        isDynamic: false,
+      });
+
+      expect(node.validate()).toBe(true);
+      const query = node.getStructuredQuery();
+      expect(query?.sql?.sql).toBe('SELECT 0 AS id, 0 AS ts, 1000 AS dur');
+    });
+
+    it('should serialize and deserialize round-trip correctly', () => {
+      const originalNode = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(12345n),
+        end: Time.fromRaw(67890n),
+        isDynamic: true,
+        comment: 'Round-trip test',
+      });
+
+      const serialized = originalNode.serializeState();
+      const deserializedState = TimeRangeSourceNode.deserializeState(
+        createMockTrace(),
+        serialized,
+      );
+      const newNode = new TimeRangeSourceNode(deserializedState);
+
+      expect(newNode.state.start).toEqual(originalNode.state.start);
+      expect(newNode.state.end).toEqual(originalNode.state.end);
+      expect(newNode.state.isDynamic).toBe(originalNode.state.isDynamic);
+      expect(newNode.state.comment).toBe(originalNode.state.comment);
+    });
+  });
+
+  describe('dispose', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should clean up interval when dispose is called on dynamic node', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: true,
+      });
+
+      // Verify interval is set up
+      expect(jest.getTimerCount()).toBeGreaterThan(0);
+
+      node.dispose();
+
+      // Verify interval is cleared
+      expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('should not throw when dispose is called on static node', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      expect(() => node.dispose()).not.toThrow();
+    });
+
+    it('should allow multiple calls to dispose', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: true,
+      });
+
+      node.dispose();
+      expect(() => node.dispose()).not.toThrow();
+      expect(() => node.dispose()).not.toThrow();
+    });
+
+    it('should stop polling after dispose', () => {
+      const mockTrace = createMockTrace();
+      let callCount = 0;
+      mockTrace.selection.getTimeSpanOfSelection = jest.fn(() => {
+        callCount++;
+        return undefined;
+      });
+
+      const node = new TimeRangeSourceNode({
+        trace: mockTrace,
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: true,
+      });
+
+      // Advance time to trigger some polls
+      jest.advanceTimersByTime(600); // 3 polls (200ms interval)
+      const pollsBeforeDispose = callCount;
+
+      node.dispose();
+
+      // Advance time again - should not trigger more polls
+      jest.advanceTimersByTime(600);
+      expect(callCount).toBe(pollsBeforeDispose);
+    });
+  });
+
+  describe('dynamic mode behavior', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should update times from selection in dynamic mode', () => {
+      const mockTrace = createMockTrace();
+      let currentTime = 100n;
+      mockTrace.selection.getTimeSpanOfSelection = jest.fn(() => {
+        return new TimeSpan(
+          Time.fromRaw(currentTime),
+          Time.fromRaw(currentTime + 400n),
+        );
+      });
+
+      const node = new TimeRangeSourceNode({
+        trace: mockTrace,
+        start: Time.fromRaw(0n),
+        end: Time.fromRaw(0n),
+        isDynamic: true,
+      });
+
+      // Advance timer to trigger first poll
+      jest.advanceTimersByTime(200);
+
+      // Values should be updated after first poll
+      expect(node.state.start).toEqual(Time.fromRaw(100n));
+      expect(node.state.end).toEqual(Time.fromRaw(500n));
+
+      // Change the selection
+      currentTime = 200n;
+
+      // Advance timer to trigger poll
+      jest.advanceTimersByTime(200);
+
+      // Values should be updated
+      expect(node.state.start).toEqual(Time.fromRaw(200n));
+      expect(node.state.end).toEqual(Time.fromRaw(600n));
+
+      node.dispose();
+    });
+
+    it('should not update times in static mode', () => {
+      const mockTrace = createMockTrace();
+      let currentTime = 100n;
+      mockTrace.selection.getTimeSpanOfSelection = jest.fn(() => {
+        return new TimeSpan(
+          Time.fromRaw(currentTime),
+          Time.fromRaw(currentTime + 400n),
+        );
+      });
+
+      const node = new TimeRangeSourceNode({
+        trace: mockTrace,
+        start: Time.fromRaw(50n),
+        end: Time.fromRaw(150n),
+        isDynamic: false,
+      });
+
+      // Values should remain unchanged
+      expect(node.state.start).toEqual(Time.fromRaw(50n));
+      expect(node.state.end).toEqual(Time.fromRaw(150n));
+
+      // Change the selection
+      currentTime = 200n;
+
+      // Advance timer (should have no effect in static mode)
+      jest.advanceTimersByTime(1000);
+
+      // Values should still be unchanged
+      expect(node.state.start).toEqual(Time.fromRaw(50n));
+      expect(node.state.end).toEqual(Time.fromRaw(150n));
+    });
+
+    it('should use full trace range when no selection exists in dynamic mode', () => {
+      const mockTrace = createMockTrace();
+      mockTrace.selection.getTimeSpanOfSelection = jest.fn(() => undefined);
+
+      const node = new TimeRangeSourceNode({
+        trace: mockTrace,
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: true,
+      });
+
+      // Advance timer to trigger first poll
+      jest.advanceTimersByTime(200);
+
+      // Should fall back to full trace range after first poll
+      expect(node.state.start).toEqual(mockTrace.traceInfo.start);
+      expect(node.state.end).toEqual(mockTrace.traceInfo.end);
+
+      node.dispose();
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -32,6 +32,7 @@ export enum NodeType {
   kTable,
   kSimpleSlices,
   kSqlSource,
+  kTimeRangeSource,
 
   // Single node operations
   kAggregation,


### PR DESCRIPTION
 ## Summary

Adds a TimeRange source node to the Explore Page query builder that imports time ranges from timeline selections. The node supports both static (snapshot) and dynamic (continuously synced) modes, enabling users to quickly move their timelin selection into SQL queries. Also adds a command for quick access to this functionality.

  ## Changes

  ### New TimeRange Source Node
  - **Core implementation** (`timerange_source.ts`, 515 lines):
    - Creates a single-row table with `id`, `ts`, and `dur` columns representing a time range
    - Supports static mode (captures snapshot of selection) and dynamic mode (polls selection every 200ms to stay in sync)
    - Full validation with clear error messages when time range is invalid
    - Editable time values (start, end, duration) via modal dialogs
    - Proper cleanup via dispose pattern (clears intervals when node is deleted)

  ### Integration
  - **Node registration** (`core_nodes.ts`): Registers TimeRange node with factory supporting both initialization paths (from selection or from serialized state)
  - **Dispose pattern** (`explore_page.ts`): Added type guard and cleanup call when nodes are deleted to prevent memory leaks from dynamic mode intervals

  ### Command Integration
  - **"Move selection to Explore Page"** command (`index.ts`):
    - Captures current timeline selection
    - Clears selection **before** creating node to prevent UI artifacts (handles/tooltips persisting)
    - Creates TimeRange node with captured values
    - Navigates to Explore Page
    - Uses public API (`trace.navigate()`) instead of internal router

  ### Node Registry Enhancement
  - **`showOnLandingPage` property** (`node_registry.ts`, `empty_graph.ts`):
    - New optional property for node descriptors
    - TimeRange nodes available in menus but not shown on landing page (better UX - primarily accessed via command)
