### PR TITLE
ui: Fix copying grid items now context menu buttons are present

### DIFF
--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -559,6 +559,10 @@ export class Grid implements m.ClassComponent<GridAttrs> {
     const tempDiv = document.createElement('div');
     tempDiv.appendChild(fragment);
 
+    // Remove all button elements to exclude them from the copy
+    const buttons = tempDiv.querySelectorAll('button');
+    buttons.forEach((button) => button.remove());
+
     // Find all rows in the cloned content
     const rows = Array.from(
       tempDiv.querySelectorAll('.pf-grid__row'),


### PR DESCRIPTION
Adding context menus in https://github.com/google/perfetto/pull/3876 broke copying grid cell content as you'd also get the cell content + the button icon names.

This patch just removes any button elements from the selection before copying.