### PR TITLE
ui: Fix pivot table indentation

### DIFF
--- a/ui/src/assets/components/pivot_table.scss
+++ b/ui/src/assets/components/pivot_table.scss
@@ -20,8 +20,7 @@
   }
 
   &__cell--indent {
-    // 16px is more of less the width of expand_more/expand_less icon to pad out
-    // cells without the button
-    width: 16px;
+    display: inline-block;
+    width: 24px;
   }
 }


### PR DESCRIPTION
The pivot table indentation broke due to an unrelated CSS change.