### PR TITLE
ui: Grid: Added indentation and chevrons to grid cells

### DIFF
--- a/ui/src/assets/widgets/grid.scss
+++ b/ui/src/assets/widgets/grid.scss
@@ -19,6 +19,8 @@ $border-2: 1px solid var(--pf-color-border-secondary);
 $border-3: 2px solid var(--pf-color-border);
 $inline-padding: 0.5em;
 $block-padding: 0.3em;
+$indent-size: 16px;
+$indent-guide-offset: 12px;
 
 .pf-grid-header-cell {
   display: flex;
@@ -73,17 +75,32 @@ $block-padding: 0.3em;
 .pf-grid-cell {
   display: flex;
   flex-direction: row;
+  align-items: baseline;
+  overflow: hidden;
   --pf-cell-padding-block: 0;
   --pf-cell-padding-inline: 0;
+  --pf-grid-cell-indent: 0;
 
   &__menu-button {
     // Eliminate the extra space between the menu button and the cell content added by the content padding.
     margin-left: calc(-1 * var(--pf-cell-padding-inline));
   }
 
+  &__indent {
+    flex-shrink: 0;
+  }
+
+  &__chevron {
+    flex-shrink: 0;
+    margin-right: calc(var(--pf-cell-padding-inline) * -1);
+
+    &--leaf {
+      visibility: hidden;
+    }
+  }
+
   &__content {
     flex: 1 1 auto;
-
     padding: var(--pf-cell-padding-block) var(--pf-cell-padding-inline);
     align-items: baseline;
     overflow: hidden;
@@ -97,15 +114,14 @@ $block-padding: 0.3em;
   }
 
   &--align-right {
-    // Move the menu button to the left when right-aligned.
-    flex-direction: row-reverse;
-
     .pf-grid-cell__menu-button {
       margin-left: 0;
       margin-right: calc(-1 * var(--pf-cell-padding-inline));
+      order: 2;
     }
 
     .pf-grid-cell__content {
+      order: 3;
       text-align: right;
     }
   }

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/grid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/grid_demo.ts
@@ -14,8 +14,11 @@
 
 import m from 'mithril';
 import {Grid, GridCell, GridHeaderCell, GridRow} from '../../../widgets/grid';
+import {MenuItem} from '../../../widgets/menu';
 import {renderWidgetShowcase} from '../widgets_page_utils';
 import {languages} from '../sample_data';
+import {Anchor} from '../../../widgets/anchor';
+import {CodeSnippet} from '../../../widgets/code_snippet';
 
 export function renderGrid(): m.Children {
   return [
@@ -23,90 +26,546 @@ export function renderGrid(): m.Children {
       '.pf-widget-intro',
       m('h1', 'Grid'),
       m('p', [
-        'Grid is a purely presentational component for rendering tabular data with ',
-        'virtual scrolling and column resizing. Unlike DataGrid, it provides no automatic ',
-        'features like sorting or filtering - you must provide all content as GridCell and ',
-        'GridHeaderCell components. It is useful as a replacement for simple HTML tables or ',
-        'for building higher level grid experiences.',
+        'Grid is a ',
+        m('code', '<table>'),
+        ' on steroids! It adds quality of life features such as:',
+      ]),
+      m('ul', [
+        m('li', 'Virtualization'),
+        m('li', 'Column resizing with auto sizing functionality'),
+        m('li', 'Cell and header level context menus'),
+        m('li', 'Indentation + chevrons for representing tree-like data grids'),
+      ]),
+      m('p', [
+        'Grid is utterly unopinionated about the data it displays, ',
+        'and does not impose any structure on how that data should look ',
+        'and where it should be loaded from. ',
+        'Because of this, it can be used as-is to simply throw some data ',
+        'up on the screen, or it can be used as a foundational building block ',
+        'for more complex widgets. See ',
+        m(Anchor, {href: '#!/widgets/datagrid'}, 'DataGrid'),
+        '.',
       ]),
     ),
 
+    m('h2', 'Interactive Demo'),
+
     renderWidgetShowcase({
-      renderWidget: ({virtualize, wrap}) => {
+      renderWidget: ({
+        virtualize,
+        wrap,
+        treeDemo,
+        contextMenus,
+        sortArrows,
+      }) => {
         if (virtualize) {
-          return m(VirtualGridDemo);
+          return m(VirtualGridDemo, {
+            contextMenus,
+            sortArrows,
+          });
         } else {
-          return renderSimpleGridDemo(wrap);
+          return renderSimpleGridDemo(wrap, treeDemo, contextMenus, sortArrows);
         }
       },
       initialOpts: {
+        contextMenus: false,
+        sortArrows: false,
         virtualize: false,
         wrap: false,
+        treeDemo: false,
       },
       noPadding: true,
     }),
+
+    m('h2', 'Basic Usage'),
+    m('p', [
+      'At its simplest, Grid requires just ',
+      m('code', 'columns'),
+      ' and ',
+      m('code', 'rowData'),
+      '. Each row is an array of GridCell elements. ',
+      'Columns and rows can contain absolutely any mithril vnodes at all, ',
+      'and still take advantage of column sizing and virtualization, ',
+      'but the pre-packaged GridHeaderCell and GridCell components provide ',
+      'bootstrapped cells with some useful functionality such as context menus, ',
+      'sorting, and indentation.',
+    ]),
+    m(
+      'p',
+      m(CodeSnippet, {
+        text: `m(Grid, {
+  columns: [
+    {key: 'name', header: m(GridHeaderCell, 'Name')},
+    {key: 'value', header: m(GridHeaderCell, 'Value')},
+  ],
+  rowData: [
+    [m(GridCell, 'Row 1'), m(GridCell, 'Data 1')],
+    [m(GridCell, 'Row 2'), m(GridCell, 'Data 2')],
+    [m(GridCell, 'Row 3'), m(GridCell, 'Data 3')],
+  ],
+  fillHeight: true,
+});`,
+      }),
+    ),
   ];
 }
 
-function renderSimpleGridDemo(wrap: boolean) {
+interface TreeNode {
+  readonly id: string;
+  readonly type: 'decade' | 'typing' | 'language';
+  readonly decade?: string;
+  readonly typing?: string;
+  readonly langData?: (typeof languages)[number];
+}
+
+function HierarchicalGridDemo(): m.ClassComponent<{
+  readonly contextMenus: boolean;
+  readonly sortArrows: boolean;
+}> {
+  const expandedNodes = new Set<string>(['1970s', '1980s']);
+
+  // Build tree structure
+  const buildTree = (): TreeNode[] => {
+    const tree: TreeNode[] = [];
+    type LanguagesByTyping = Map<string, (typeof languages)[number][]>;
+    const byDecade = new Map<string, LanguagesByTyping>();
+
+    // Group languages by decade and typing
+    languages.forEach((lang) => {
+      const decade = `${Math.floor(lang.year / 10) * 10}s`;
+      if (!byDecade.has(decade)) {
+        byDecade.set(decade, new Map());
+      }
+      const decadeMap = byDecade.get(decade)!;
+      if (!decadeMap.has(lang.typing)) {
+        decadeMap.set(lang.typing, []);
+      }
+      decadeMap.get(lang.typing)!.push(lang);
+    });
+
+    // Convert to tree nodes
+    const sortedDecades = Array.from(byDecade.keys()).sort();
+    sortedDecades.forEach((decade) => {
+      tree.push({id: decade, type: 'decade', decade});
+
+      if (expandedNodes.has(decade)) {
+        const typingMap = byDecade.get(decade)!;
+        const typings = Array.from(typingMap.keys()).sort();
+
+        typings.forEach((typing) => {
+          const typingId = `${decade}-${typing}`;
+          tree.push({id: typingId, type: 'typing', decade, typing});
+
+          if (expandedNodes.has(typingId)) {
+            const langs = typingMap.get(typing)!;
+            langs.forEach((lang) => {
+              tree.push({
+                id: `${typingId}-${lang.lang}`,
+                type: 'language',
+                decade,
+                typing,
+                langData: lang,
+              });
+            });
+          }
+        });
+      }
+    });
+
+    return tree;
+  };
+
+  const toggleNode = (nodeId: string) => {
+    if (expandedNodes.has(nodeId)) {
+      expandedNodes.delete(nodeId);
+    } else {
+      expandedNodes.add(nodeId);
+    }
+  };
+
+  return {
+    view: ({attrs}) => {
+      const {contextMenus, sortArrows} = attrs;
+      const tree = buildTree();
+
+      const makeHeaderMenuItems = (columnKey: string) => {
+        if (!contextMenus) return undefined;
+        return [
+          m(MenuItem, {
+            label: `Hide "${columnKey}" column`,
+            onclick: () => alert(`Menu: Hide ${columnKey} column`),
+          }),
+          m(MenuItem, {
+            label: 'Auto-fit width',
+            onclick: () => alert(`Menu: Auto-fit ${columnKey}`),
+          }),
+        ];
+      };
+
+      return m(Grid, {
+        key: 'hierarchical-grid-demo',
+        columns: [
+          {
+            key: 'name',
+            header: m(
+              GridHeaderCell,
+              {
+                sort: sortArrows ? 'ASC' : undefined,
+                onSort: sortArrows ? () => alert('Sort clicked') : undefined,
+                menuItems: makeHeaderMenuItems('name'),
+              },
+              'Name',
+            ),
+          },
+          {
+            key: 'year',
+            header: m(
+              GridHeaderCell,
+              {
+                sort: sortArrows ? 'DESC' : undefined,
+                onSort: sortArrows ? () => alert('Sort clicked') : undefined,
+                menuItems: makeHeaderMenuItems('year'),
+              },
+              'Year',
+            ),
+          },
+          {
+            key: 'creator',
+            header: m(
+              GridHeaderCell,
+              {
+                menuItems: makeHeaderMenuItems('creator'),
+              },
+              'Creator',
+            ),
+          },
+        ],
+        rowData: tree.map((node) => {
+          const isExpanded = expandedNodes.has(node.id);
+
+          // Determine indent, chevron, and lastChild based on node type
+          let indent: number | undefined;
+          let chevron: 'expanded' | 'collapsed' | 'leaf' | undefined;
+
+          if (node.type === 'decade') {
+            indent = 0;
+            chevron = isExpanded ? 'expanded' : 'collapsed';
+          } else if (node.type === 'typing') {
+            indent = 1;
+            chevron = isExpanded ? 'expanded' : 'collapsed';
+            // Check if this is the last typing in its decade
+          } else {
+            // language
+            indent = 2;
+            chevron = undefined;
+            // Check if this is the last language in its typing group
+          }
+
+          const menuItems = contextMenus
+            ? [
+                m(MenuItem, {
+                  label: `Copy "${node.id}"`,
+                  onclick: () => navigator.clipboard.writeText(node.id),
+                }),
+                m(MenuItem, {
+                  label: 'Show details',
+                  onclick: () => alert(`Node: ${node.id}`),
+                }),
+              ]
+            : undefined;
+
+          if (node.type === 'decade') {
+            return [
+              m(
+                GridCell,
+                {
+                  indent,
+                  chevron,
+                  onChevronClick: () => toggleNode(node.id),
+                  menuItems,
+                },
+                node.decade,
+              ),
+              m(GridCell, {menuItems}, ''),
+              m(GridCell, {menuItems}, ''),
+            ];
+          } else if (node.type === 'typing') {
+            return [
+              m(
+                GridCell,
+                {
+                  indent,
+                  chevron,
+                  onChevronClick: () => toggleNode(node.id),
+                  menuItems,
+                },
+                node.typing,
+              ),
+              m(GridCell, {menuItems}, ''),
+              m(GridCell, {menuItems}, ''),
+            ];
+          } else {
+            // language
+            const lang = node.langData!;
+            return [
+              m(
+                GridCell,
+                {
+                  indent,
+                  chevron,
+                  menuItems,
+                },
+                lang.lang,
+              ),
+              m(GridCell, {align: 'right', menuItems}, lang.year),
+              m(GridCell, {menuItems}, lang.creator),
+            ];
+          }
+        }),
+        fillHeight: true,
+      });
+    },
+  };
+}
+
+function renderSimpleGridDemo(
+  wrap: boolean,
+  treeDemo: boolean,
+  contextMenus: boolean,
+  sortArrows: boolean,
+) {
+  // If tree demo is enabled, show the hierarchical tree demo
+  if (treeDemo) {
+    return m(HierarchicalGridDemo, {contextMenus, sortArrows});
+  }
+
+  // Otherwise show the simple flat demo
+  const makeHeaderMenuItems = (columnKey: string) => {
+    if (!contextMenus) return undefined;
+    return [
+      m(MenuItem, {
+        label: `Hide "${columnKey}" column`,
+        onclick: () => alert(`Menu: Hide ${columnKey} column`),
+      }),
+      m(MenuItem, {
+        label: 'Auto-fit width',
+        onclick: () => alert(`Menu: Auto-fit ${columnKey}`),
+      }),
+    ];
+  };
+
   return m(Grid, {
     key: 'grid-demo-no-virt',
     columns: [
-      {key: 'id', header: m(GridHeaderCell, 'ID')},
-      {key: 'lang', header: m(GridHeaderCell, 'Language')},
-      {key: 'year', header: m(GridHeaderCell, 'Year')},
-      {key: 'creator', header: m(GridHeaderCell, 'Creator')},
-      {key: 'typing', header: m(GridHeaderCell, 'Typing')},
+      {
+        key: 'id',
+        header: m(
+          GridHeaderCell,
+          {
+            sort: sortArrows ? 'ASC' : undefined,
+            onSort: sortArrows ? () => alert('Sort clicked') : undefined,
+            menuItems: makeHeaderMenuItems('id'),
+          },
+          'ID',
+        ),
+      },
+      {
+        key: 'lang',
+        header: m(
+          GridHeaderCell,
+          {
+            menuItems: makeHeaderMenuItems('lang'),
+          },
+          'Language',
+        ),
+      },
+      {
+        key: 'year',
+        header: m(
+          GridHeaderCell,
+          {
+            sort: sortArrows ? 'DESC' : undefined,
+            onSort: sortArrows ? () => alert('Sort clicked') : undefined,
+            menuItems: makeHeaderMenuItems('year'),
+          },
+          'Year',
+        ),
+      },
+      {
+        key: 'creator',
+        header: m(
+          GridHeaderCell,
+          {
+            menuItems: makeHeaderMenuItems('creator'),
+          },
+          'Creator',
+        ),
+      },
+      {
+        key: 'typing',
+        header: m(
+          GridHeaderCell,
+          {
+            menuItems: makeHeaderMenuItems('typing'),
+          },
+          'Typing',
+        ),
+      },
     ],
-    rowData: languages.map((row) => [
-      m(GridCell, {wrap, align: 'right'}, row.id),
-      m(GridCell, {wrap}, row.lang),
-      m(GridCell, {wrap, align: 'right'}, row.year),
-      m(GridCell, {wrap}, row.creator),
-      m(GridCell, {wrap}, row.typing),
-    ]),
+    rowData: languages.map((row) => {
+      const menuItems = contextMenus
+        ? [
+            m(MenuItem, {
+              label: `Copy "${row.lang}"`,
+              onclick: () => navigator.clipboard.writeText(row.lang),
+            }),
+            m(MenuItem, {
+              label: 'Show details',
+              onclick: () => alert(`${row.lang} (${row.year})`),
+            }),
+          ]
+        : undefined;
+
+      return [
+        m(GridCell, {wrap, align: 'right', menuItems}, row.id),
+        m(GridCell, {wrap, menuItems}, row.lang),
+        m(GridCell, {wrap, align: 'right', menuItems}, row.year),
+        m(GridCell, {wrap, menuItems}, row.creator),
+        m(GridCell, {wrap, menuItems}, row.typing),
+      ];
+    }),
     fillHeight: true,
   });
 }
 
-function VirtualGridDemo() {
+interface VirtualGridDemoAttrs {
+  readonly contextMenus: boolean;
+  readonly sortArrows: boolean;
+}
+
+function VirtualGridDemo(): m.ClassComponent<VirtualGridDemoAttrs> {
   const totalRows = 10_000;
   let currentOffset = 0;
   let loadedRows: GridRow[] = [];
 
-  const loadData = (offset: number, limit: number) => {
+  const loadData = (offset: number, limit: number, contextMenus: boolean) => {
     currentOffset = offset;
     loadedRows = [];
     for (let i = 0; i < limit && offset + i < totalRows; i++) {
       const idx = offset + i;
       const langData = languages[idx % languages.length];
+
+      const menuItems = contextMenus
+        ? [
+            m(MenuItem, {
+              label: `Copy "${langData.lang}"`,
+              onclick: () => navigator.clipboard.writeText(langData.lang),
+            }),
+            m(MenuItem, {
+              label: 'Show row details',
+              onclick: () => alert(`Row ${idx + 1}: ${langData.lang}`),
+            }),
+          ]
+        : undefined;
+
       loadedRows.push([
-        m(GridCell, {align: 'right'}, idx + 1),
-        m(GridCell, langData.lang),
-        m(GridCell, {align: 'right'}, langData.year),
-        m(GridCell, langData.creator),
-        m(GridCell, langData.typing),
+        m(GridCell, {align: 'right', menuItems}, idx + 1),
+        m(GridCell, {menuItems}, langData.lang),
+        m(GridCell, {align: 'right', menuItems}, langData.year),
+        m(GridCell, {menuItems}, langData.creator),
+        m(GridCell, {menuItems}, langData.typing),
       ]);
     }
     m.redraw();
   };
 
+  const makeHeaderMenuItems = (columnKey: string) => {
+    return [
+      m(MenuItem, {
+        label: `Hide "${columnKey}" column`,
+        onclick: () => alert(`Menu: Hide ${columnKey} column`),
+      }),
+      m(MenuItem, {
+        label: 'Auto-fit width',
+        onclick: () => alert(`Menu: Auto-fit ${columnKey}`),
+      }),
+    ];
+  };
+
   return {
-    view: () => {
+    view: ({attrs}) => {
+      const {contextMenus, sortArrows} = attrs;
       return m(Grid, {
         key: 'virtual-grid',
         columns: [
-          {key: 'id', header: m(GridHeaderCell, 'ID')},
-          {key: 'lang', header: m(GridHeaderCell, 'Language')},
-          {key: 'year', header: m(GridHeaderCell, 'Year')},
-          {key: 'creator', header: m(GridHeaderCell, 'Creator')},
-          {key: 'typing', header: m(GridHeaderCell, 'Typing')},
+          {
+            key: 'id',
+            header: m(
+              GridHeaderCell,
+              {
+                sort: sortArrows ? 'ASC' : undefined,
+                onSort: sortArrows ? () => alert('Sort clicked') : undefined,
+                menuItems: contextMenus ? makeHeaderMenuItems('id') : undefined,
+              },
+              'ID',
+            ),
+          },
+          {
+            key: 'lang',
+            header: m(
+              GridHeaderCell,
+              {
+                menuItems: contextMenus
+                  ? makeHeaderMenuItems('lang')
+                  : undefined,
+              },
+              'Language',
+            ),
+          },
+          {
+            key: 'year',
+            header: m(
+              GridHeaderCell,
+              {
+                sort: sortArrows ? 'DESC' : undefined,
+                onSort: sortArrows ? () => alert('Sort clicked') : undefined,
+                menuItems: contextMenus
+                  ? makeHeaderMenuItems('year')
+                  : undefined,
+              },
+              'Year',
+            ),
+          },
+          {
+            key: 'creator',
+            header: m(
+              GridHeaderCell,
+              {
+                menuItems: contextMenus
+                  ? makeHeaderMenuItems('creator')
+                  : undefined,
+              },
+              'Creator',
+            ),
+          },
+          {
+            key: 'typing',
+            header: m(
+              GridHeaderCell,
+              {
+                menuItems: contextMenus
+                  ? makeHeaderMenuItems('typing')
+                  : undefined,
+              },
+              'Typing',
+            ),
+          },
         ],
         rowData: {
           data: loadedRows,
           total: totalRows,
           offset: currentOffset,
-          onLoadData: loadData,
+          onLoadData: (offset, limit) => loadData(offset, limit, contextMenus),
         },
         virtualization: {
           rowHeightPx: 24,

--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -154,6 +154,9 @@ export interface GridCellAttrs extends HTMLAttrs {
   readonly padding?: boolean;
   readonly wrap?: boolean;
   readonly label?: string;
+  readonly indent?: number;
+  readonly chevron?: 'expanded' | 'collapsed' | 'leaf';
+  readonly onChevronClick?: () => void;
 }
 
 export class GridCell implements m.ClassComponent<GridCellAttrs> {
@@ -165,8 +168,44 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
       className,
       padding = true,
       wrap,
+      indent,
+      chevron,
+      onChevronClick,
       ...htmlAttrs
     } = attrs;
+
+    const renderChevron = () => {
+      if (chevron === undefined) return undefined;
+
+      const icon = chevron === 'expanded' ? Icons.ExpandDown : Icons.GoForward;
+      const ariaLabel = chevron === 'expanded' ? 'Collapse row' : 'Expand row';
+
+      return m(Button, {
+        className: classNames(
+          'pf-grid-cell__chevron',
+          chevron === 'leaf' && 'pf-grid-cell__chevron--leaf',
+        ),
+        icon,
+        rounded: true,
+        ariaLabel,
+        onclick: (e: MouseEvent) => {
+          if (onChevronClick) {
+            onChevronClick();
+            e.stopPropagation();
+          }
+        },
+      });
+    };
+
+    const renderIndent = () => {
+      if (indent === undefined || indent === 0) return undefined;
+
+      return m('.pf-grid-cell__indent', {
+        style: {
+          width: `${indent * 16}px`,
+        },
+      });
+    };
 
     return m(
       '.pf-grid-cell',
@@ -174,13 +213,15 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
         ...htmlAttrs,
         className: classNames(
           className,
-          align === 'right' && 'pf-grid-cell--align-right',
+          align === 'right' && !chevron && 'pf-grid-cell--align-right',
           padding && 'pf-grid-cell--padded',
           nullish && 'pf-grid-cell--nullish',
           wrap && 'pf-grid-cell--wrap',
         ),
         role: 'cell',
       },
+      renderIndent(),
+      renderChevron(),
       m('.pf-grid-cell__content', children),
       Boolean(menuItems) &&
         m(


### PR DESCRIPTION
This change adds a new feature to `GridCell`s which allows indentations and expand/collapse chevrons to be injected. 

Note: This doesn't manage data-loading or even storing the collapsed/expanded states, it simply provides the raw building blocks that can be used to build tree-like components based on `Grid`.

Example screenshot from the demo page:
<img width="622" height="529" alt="image" src="https://github.com/user-attachments/assets/cb3188a5-a807-4f2a-be8e-f8e94cba5656" />