### PR TITLE
exp: Propagate column types between nodes

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
@@ -701,6 +701,270 @@ describe('AggregationNode', () => {
     });
   });
 
+  describe('column type propagation', () => {
+    it('should set INT type for COUNT aggregation', () => {
+      const inputCols = [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('dur', 'DURATION'),
+      ];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: inputCols.map((c) => ({...c, checked: false})),
+          aggregations: [
+            {
+              aggregationOp: 'COUNT',
+              column: inputCols[1],
+              newColumnName: 'count_dur',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(1);
+      expect(node.finalCols[0].name).toBe('count_dur');
+      expect(node.finalCols[0].type).toBe('INT');
+    });
+
+    it('should set INT type for COUNT_ALL aggregation', () => {
+      const inputCols = [createColumnInfo('id', 'INT')];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: inputCols.map((c) => ({...c, checked: false})),
+          aggregations: [
+            {
+              aggregationOp: 'COUNT_ALL',
+              newColumnName: 'total_count',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(1);
+      expect(node.finalCols[0].name).toBe('total_count');
+      expect(node.finalCols[0].type).toBe('INT');
+    });
+
+    it('should preserve type for SUM aggregation', () => {
+      const inputCols = [
+        {
+          name: 'dur',
+          type: 'DURATION',
+          checked: false,
+          column: {
+            name: 'dur',
+            type: {kind: 'duration' as const},
+          },
+        },
+      ];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'SUM',
+              column: inputCols[0],
+              newColumnName: 'total_dur',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(1);
+      expect(node.finalCols[0].name).toBe('total_dur');
+      expect(node.finalCols[0].type).toBe('DURATION');
+    });
+
+    it('should preserve type for MIN/MAX aggregations', () => {
+      const inputCols = [
+        {
+          name: 'ts',
+          type: 'TIMESTAMP',
+          checked: false,
+          column: {
+            name: 'ts',
+            type: {kind: 'timestamp' as const},
+          },
+        },
+      ];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'MIN',
+              column: inputCols[0],
+              newColumnName: 'min_ts',
+              isValid: true,
+            },
+            {
+              aggregationOp: 'MAX',
+              column: inputCols[0],
+              newColumnName: 'max_ts',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(2);
+      expect(node.finalCols[0].name).toBe('min_ts');
+      expect(node.finalCols[0].type).toBe('TIMESTAMP');
+      expect(node.finalCols[1].name).toBe('max_ts');
+      expect(node.finalCols[1].type).toBe('TIMESTAMP');
+    });
+
+    it('should set DOUBLE type for MEAN aggregation', () => {
+      const inputCols = [createColumnInfo('value', 'INT')];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'MEAN',
+              column: inputCols[0],
+              newColumnName: 'avg_value',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(1);
+      expect(node.finalCols[0].name).toBe('avg_value');
+      expect(node.finalCols[0].type).toBe('DOUBLE');
+    });
+
+    it('should set DOUBLE type for MEDIAN aggregation', () => {
+      const inputCols = [createColumnInfo('dur', 'INT')];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'MEDIAN',
+              column: inputCols[0],
+              newColumnName: 'median_dur',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(1);
+      expect(node.finalCols[0].name).toBe('median_dur');
+      expect(node.finalCols[0].type).toBe('DOUBLE');
+    });
+
+    it('should set DOUBLE type for DURATION_WEIGHTED_MEAN aggregation', () => {
+      const inputCols = [createColumnInfo('dur', 'DURATION')];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'DURATION_WEIGHTED_MEAN',
+              column: inputCols[0],
+              newColumnName: 'weighted_avg_dur',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(1);
+      expect(node.finalCols[0].name).toBe('weighted_avg_dur');
+      expect(node.finalCols[0].type).toBe('DOUBLE');
+    });
+
+    it('should set DOUBLE type for PERCENTILE aggregation', () => {
+      const inputCols = [createColumnInfo('dur', 'INT')];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'PERCENTILE',
+              column: inputCols[0],
+              percentile: 95,
+              newColumnName: 'p95_dur',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      expect(node.finalCols.length).toBe(1);
+      expect(node.finalCols[0].name).toBe('p95_dur');
+      expect(node.finalCols[0].type).toBe('DOUBLE');
+    });
+
+    it('should include GROUP BY columns with their original types', () => {
+      const inputCols = [
+        {
+          name: 'name',
+          type: 'STRING',
+          checked: true,
+          column: {
+            name: 'name',
+            type: {kind: 'string' as const},
+          },
+        },
+        createColumnInfo('value', 'INT'),
+      ];
+      const mockInput = createMockPrevNode(inputCols);
+      const node = createAggregationNodeWithInput(
+        {
+          trace: createMockTrace(),
+          groupByColumns: inputCols.map((c) => ({...c})),
+          aggregations: [
+            {
+              aggregationOp: 'SUM',
+              column: inputCols[1],
+              newColumnName: 'total_value',
+              isValid: true,
+            },
+          ],
+        },
+        mockInput,
+      );
+
+      // First column should be the GROUP BY column (name) with preserved STRING type
+      // Second column should be the aggregation result (total_value) with INT type
+      expect(node.finalCols.length).toBe(2);
+      expect(node.finalCols[0].name).toBe('name');
+      expect(node.finalCols[0].type).toBe('STRING');
+      expect(node.finalCols[1].name).toBe('total_value');
+      expect(node.finalCols[1].type).toBe('INT');
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle PERCENTILE with 0 percentile', () => {
       const agg: Aggregation = {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source.ts
@@ -20,8 +20,9 @@ import {
   nextNodeId,
   createFinalColumns,
 } from '../../../query_node';
-import {ColumnInfo, columnInfoFromName} from '../../column_info';
+import {ColumnInfo, columnInfoFromSqlColumn} from '../../column_info';
 import {time, TimeSpan, Time} from '../../../../../base/time';
+import {PerfettoSqlTypes} from '../../../../../trace_processor/perfetto_sql_type';
 import {Trace} from '../../../../../public/trace';
 import {Button, ButtonVariant} from '../../../../../widgets/button';
 import {TextInput} from '../../../../../widgets/text_input';
@@ -68,9 +69,9 @@ export class TimeRangeSourceNode implements QueryNode {
 
     // Initialize columns: id, ts, dur
     this.finalCols = createFinalColumns([
-      columnInfoFromName('id'),
-      columnInfoFromName('ts'),
-      columnInfoFromName('dur'),
+      columnInfoFromSqlColumn({name: 'id', type: PerfettoSqlTypes.INT}),
+      columnInfoFromSqlColumn({name: 'ts', type: PerfettoSqlTypes.TIMESTAMP}),
+      columnInfoFromSqlColumn({name: 'dur', type: PerfettoSqlTypes.DURATION}),
     ]);
 
     // If dynamic mode is enabled, subscribe to selection changes

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/timerange_source_unittest.ts
@@ -438,6 +438,23 @@ describe('TimeRangeSourceNode', () => {
       expect(node.finalCols[1].name).toBe('ts');
       expect(node.finalCols[2].name).toBe('dur');
     });
+
+    it('should have correct column types', () => {
+      const node = new TimeRangeSourceNode({
+        trace: createMockTrace(),
+        start: Time.fromRaw(100n),
+        end: Time.fromRaw(500n),
+        isDynamic: false,
+      });
+
+      expect(node.finalCols.length).toBe(3);
+      expect(node.finalCols[0].name).toBe('id');
+      expect(node.finalCols[0].type).toBe('INT');
+      expect(node.finalCols[1].name).toBe('ts');
+      expect(node.finalCols[1].type).toBe('TIMESTAMP');
+      expect(node.finalCols[2].name).toBe('dur');
+      expect(node.finalCols[2].type).toBe('DURATION');
+    });
   });
 
   describe('edge cases', () => {

--- a/ui/src/trace_processor/perfetto_sql_type.ts
+++ b/ui/src/trace_processor/perfetto_sql_type.ts
@@ -130,8 +130,8 @@ export const SIMPLE_TYPE_KINDS: SimpleType['kind'][] = [
 
 export function parsePerfettoSqlTypeFromString(args: {
   type: string;
-  table: string;
-  column: string;
+  table?: string;
+  column?: string;
 }): Result<PerfettoSqlType> {
   const value = args.type.toLowerCase();
   const maybeSimpleType = SIMPLE_TYPES[value];
@@ -142,6 +142,11 @@ export function parsePerfettoSqlTypeFromString(args: {
   }
   if (value === 'id') {
     // The plain `ID` are resolved into `ID($current_table.$current_column)`.
+    if (args.table === undefined || args.column === undefined) {
+      return errResult(
+        `Cannot parse plain 'id' type without table and column context`,
+      );
+    }
     return okResult({
       kind: 'id',
       source: {

--- a/ui/src/trace_processor/perfetto_sql_type_unittest.ts
+++ b/ui/src/trace_processor/perfetto_sql_type_unittest.ts
@@ -34,11 +34,10 @@ test('PerfettoSqlType.ParseSimpleTypes', () => {
 
   for (const [rawInput, expectedKind] of Object.entries(TEST_CASES)) {
     for (const input of [rawInput, rawInput.toUpperCase()]) {
+      // Simple types don't need table/column parameters
       expect(
         parsePerfettoSqlTypeFromString({
           type: input,
-          table: 'my_table',
-          column: 'my_column',
         }),
       ).toEqual(okResult({kind: expectedKind}));
     }
@@ -140,6 +139,15 @@ test('PerfettoSqlType.ParseUnknownTypes', () => {
   );
 
   expect(parse('')).toEqual(errResult('Unknown type: '));
+
+  // Plain 'id' requires table and column context
+  expect(
+    parsePerfettoSqlTypeFromString({
+      type: 'id',
+    }),
+  ).toEqual(
+    errResult(`Cannot parse plain 'id' type without table and column context`),
+  );
 });
 
 test('PerfettoSqlType.ToString', () => {


### PR DESCRIPTION
  ## Summary

 Implements type propagation across query builder nodes to preserve column type information through transformations. Previously, column types were often lost when flowing through nodes (add columns, aggregations, etc.), leading to loss of semantic information like TIMESTAMP, DURATION, etc. The implementation includes proper type inference for aggregations and warnings when type information cannot be determined.

  ## Changes

  - **AddColumnsNode**: Preserves types from source columns when selecting columns and when creating computed columns with stored type information. Logs warnings whenstored type parsing fails.
  - **AggregationNode**: Adds `getAggregationResultType()` helper to determine correct result types based on operation semantics (COUNT→INT, MEAN/MEDIAN→DOUBLE, SUM/MIN/MAX preserve input type). Logs warnings when type information is missing for operations that should preserve it.
  - **TimeRangeSourceNode**: Explicitly specifies column types (id→INT, ts→TIMESTAMP, dur→DURATION) as a proper source node pattern.
  - **Type parser**: Made `table` and `column` parameters optional in `parsePerfettoSqlTypeFromString()` to support contexts where table/column info isn't available.
 Properly errors when plain 'id' type is parsed without context.
  - **Tests**: Added comprehensive unit tests for type propagation in aggregation and timerange source nodes, covering all aggregation operations and edge cases.
  - **Debugging**: Added console warnings when falling back to default INT type, helping developers identify and debug type propagation issues.

  ## Type Inference Rules

  The implementation follows these type inference rules for aggregations:
  - `COUNT`, `COUNT_ALL` → `INT`
  - `SUM`, `MIN`, `MAX` → Preserves input column type
  - `MEAN`, `MEDIAN`, `DURATION_WEIGHTED_MEAN`, `PERCENTILE` → `DOUBLE`
  - Unknown/missing type → `INT` (with warning)