### PR TITLE
ui: Invalid nodes in nodegraph

### DIFF
--- a/ui/src/assets/widgets/nodegraph.scss
+++ b/ui/src/assets/widgets/nodegraph.scss
@@ -378,3 +378,34 @@
   pointer-events: none;
   z-index: 2; // Render selection rectangle above nodes.
 }
+
+.pf-node.pf-invalid {
+  border-color: var(--pf-color-danger);
+  background: color-mix(
+    in srgb,
+    var(--pf-color-danger) 8%,
+    var(--pf-color-background-secondary)
+  );
+
+  .pf-node-header {
+    background: color-mix(
+      in srgb,
+      var(--pf-color-danger) 15%,
+      var(--pf-color-background)
+    );
+    border-bottom-color: var(--pf-color-danger);
+  }
+}
+
+// Invalid nodes override hue-based styling
+.pf-node.pf-invalid[style*="--pf-node-hue"] .pf-node-header {
+  background: color-mix(
+    in srgb,
+    var(--pf-color-danger) 15%,
+    var(--pf-color-background)
+  );
+}
+
+.pf-node.pf-invalid.pf-node--has-accent-bar::before {
+  background-color: var(--pf-color-danger);
+}

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
@@ -89,6 +89,7 @@ type NodeData =
 interface NodeGraphStore {
   readonly nodes: Map<string, NodeData>;
   readonly connections: Connection[];
+  readonly invalidNodes: Set<string>; // Track which nodes are marked as invalid
 }
 
 // Node metadata configuration
@@ -432,6 +433,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
   let store: NodeGraphStore = {
     nodes: new Map([[initialId, createTableNode(initialId, 150, 100)]]),
     connections: [],
+    invalidNodes: new Set<string>(),
   };
 
   // History management
@@ -566,6 +568,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
       // Clear existing state
       draft.nodes.clear();
       draft.connections.length = 0;
+      draft.invalidNodes.clear();
 
       // Node factory options
       const nodeFactories = [
@@ -797,7 +800,24 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
   }
 
   function renderNodeContextMenu(node: NodeData) {
+    const isInvalid = store.invalidNodes.has(node.id);
     return [
+      m(MenuItem, {
+        label: isInvalid ? 'Mark as Valid' : 'Mark as Invalid',
+        icon: isInvalid ? 'check_circle' : 'error',
+        onclick: () => {
+          updateStore((draft) => {
+            if (draft.invalidNodes.has(node.id)) {
+              draft.invalidNodes.delete(node.id);
+            } else {
+              draft.invalidNodes.add(node.id);
+            }
+          });
+          console.log(
+            `Context Menu: Toggle invalid state for ${node.id}: ${!isInvalid}`,
+          );
+        },
+      }),
       m(MenuItem, {
         label: 'Delete',
         icon: 'delete',
@@ -982,6 +1002,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
           contextMenuItems: attrs.contextMenus
             ? renderNodeContextMenu(nodeData)
             : undefined,
+          invalid: store.invalidNodes.has(nodeData.id),
         };
       }
 
@@ -1014,6 +1035,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
           contextMenuItems: attrs.contextMenus
             ? renderNodeContextMenu(nodeData)
             : undefined,
+          invalid: store.invalidNodes.has(nodeData.id),
         };
       }
 

--- a/ui/src/widgets/nodegraph.ts
+++ b/ui/src/widgets/nodegraph.ts
@@ -93,6 +93,7 @@ export interface Node {
   readonly canDockTop?: boolean;
   readonly canDockBottom?: boolean;
   readonly contextMenuItems?: m.Children;
+  readonly invalid?: boolean; // Whether this node is in an invalid state
 }
 
 interface ConnectingState {
@@ -1335,6 +1336,7 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
       hue,
       accentBar,
       contextMenuItems,
+      invalid,
     } = node;
     const {isDockedChild, hasDockedChild, isDockTarget, rootNode, multiselect} =
       options;
@@ -1352,6 +1354,7 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
       hasDockedChild && 'pf-has-docked-child',
       isDockTarget && 'pf-dock-target',
       accentBar && 'pf-node--has-accent-bar',
+      invalid && 'pf-invalid',
     );
 
     // Helper to render a port


### PR DESCRIPTION
Add another property (invalid) to the nodegraph, that renders the node in a special way, clearily informing that this node is invalid
