### PR TITLE
exp: stdlib: Add data checks for core modules

### DIFF
--- a/python/generators/sql_processing/stdlib_parser.py
+++ b/python/generators/sql_processing/stdlib_parser.py
@@ -27,6 +27,7 @@ from typing import List, Tuple, Optional
 from python.generators.sql_processing.docs_parse import DocParseOptions, ParsedModule, parse_file
 from python.generators.sql_processing.utils import is_internal
 from python.generators.sql_processing.stdlib_tags import get_tags, get_table_importance
+from python.perfetto.trace_data_checks import MODULE_DATA_CHECK_SQL
 
 ROOT_DIR = os.path.dirname(
     os.path.dirname(
@@ -201,6 +202,9 @@ def format_docs(modules: List[Tuple[str, str, str, ParsedModule]]) -> list:
   Output format matches what gen_stdlib_docs_json currently produces.
   """
 
+  # Use the curated data check SQL map
+  data_check_sql_map = MODULE_DATA_CHECK_SQL
+
   def _summary_desc(s: str) -> str:
     """Extract the first sentence from a description."""
     s = s.replace('\n', ' ')
@@ -245,14 +249,12 @@ def format_docs(modules: List[Tuple[str, str, str, ParsedModule]]) -> list:
     package_name = module_name.split(".")[0]
 
     module_dict = {
-        'module_name':
-            module_name,
+        'module_name': module_name,
         'module_doc': {
             'name': parsed.module_doc.name,
             'desc': parsed.module_doc.desc,
         } if parsed.module_doc else None,
-        'tags':
-            get_tags(module_name),
+        'tags': get_tags(module_name),
         'includes': [inc.module for inc in parsed.includes],
         'data_objects': [{
             'name':
@@ -324,6 +326,7 @@ def format_docs(modules: List[Tuple[str, str, str, ParsedModule]]) -> list:
             ],
         }
                    for macro in parsed.macros],
+        'data_check_sql': data_check_sql_map.get(module_name),
     }
     packages[package_name].append(module_dict)
 

--- a/python/perfetto/trace_data_checks.py
+++ b/python/perfetto/trace_data_checks.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# Copyright (C) 2024 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Data availability checks for high and mid importance SQL modules.
+
+These are modules that create tables marked as 'high' or 'mid' importance
+in stdlib_tags.py TABLE_IMPORTANCE dict.
+
+Auto-generated - do not edit manually.
+"""
+
+# Module name -> SQL query that checks if data exists
+# Query returns 1 if data present, 0 if not
+MODULE_DATA_CHECK_SQL = {
+    # HIGH IMPORTANCE TABLES
+    'android.binder':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name GLOB \'binder *\' LIMIT 1) AS has_data',
+    'android.cujs.cujs_base':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name GLOB \'J<*>\' LIMIT 1) AS has_data',
+    'android.frames.timeline':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name GLOB \'Choreographer#doFrame*\' OR name GLOB \'DrawFrame*\' LIMIT 1) AS has_data',
+    'android.startup.startups':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name IN (\'bindApplication\', \'activityStart\', \'activityResume\') LIMIT 1) AS has_data',
+    'slices.with_context':
+        'SELECT EXISTS(SELECT 1 FROM slice JOIN thread_track ON slice.track_id = thread_track.id LIMIT 1) AS has_data',
+
+    # MID IMPORTANCE TABLES
+    'android.anrs':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name GLOB \'*ApplicationNotResponding*\' LIMIT 1) AS has_data',
+    'android.battery':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name GLOB \'batt.*\' LIMIT 1) AS has_data',
+    'android.battery.charging_states':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name = \'BatteryStatus\' LIMIT 1) AS has_data',
+    'android.battery_stats':
+        'SELECT EXISTS(SELECT 1 FROM counter_track WHERE name GLOB \'battery_stats.*\' LIMIT 1) AS has_data',
+    'android.process_metadata':
+        'SELECT EXISTS(SELECT 1 FROM process LIMIT 1) AS has_data',
+    'android.screenshots':
+        'SELECT EXISTS(SELECT 1 FROM slice WHERE name = \'Screenshot\' AND category = \'android_screenshot\' LIMIT 1) AS has_data',
+    'android.suspend':
+        'SELECT EXISTS(SELECT 1 FROM track WHERE name IN (\'Suspend/Resume Minimal\', \'Suspend/Resume Latency\') LIMIT 1) AS has_data',
+    'android.wakeups':
+        'SELECT EXISTS(SELECT 1 FROM track WHERE name = \'wakeup_reason\' LIMIT 1) AS has_data',
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.scss
@@ -39,12 +39,59 @@
   }
 }
 
+.pf-search-and-filter {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--divider-color);
+  background-color: var(--surface);
+
+  .pf-search {
+    flex: 1;
+    margin-bottom: 0;
+  }
+}
+
 .pf-table-card-header {
   .pf-match-type-chip {
     background-color: var(--surface-variant);
     color: var(--on-surface-variant);
     font-size: 11px;
     opacity: 0.8;
+  }
+
+  .pf-no-data-chip {
+    background-color: rgba(var(--rgb-error), 0.1);
+    color: var(--error);
+    font-size: 11px;
+    font-weight: 500;
+  }
+}
+
+// Styling for cards with disabled modules (no data)
+.pf-disabled-module {
+  opacity: 0.6;
+  background-color: var(--surface-variant) !important;
+
+  &:hover {
+    opacity: 0.7;
+  }
+
+  .pf-table-card {
+    .table-name {
+      color: var(--on-surface-variant);
+    }
+
+    .table-module {
+      color: var(--on-surface-variant);
+      opacity: 0.7;
+    }
+
+    .table-description {
+      color: var(--on-surface-variant);
+      opacity: 0.8;
+    }
   }
 }
 

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
@@ -35,6 +35,12 @@ export interface SqlModules {
   // Returns module that contains Perfetto SQL table/view if it was loaded in one of the Perfetto
   // SQL module.
   getModuleForTable(tableName: string): SqlModule | undefined;
+
+  // Returns true if the module is disabled due to missing data in the trace.
+  isModuleDisabled(moduleName: string): boolean;
+
+  // Returns the set of all disabled module names.
+  getDisabledModules(): ReadonlySet<string>;
 }
 
 // Handles the access to a specific Perfetto SQL Package. Package consists of

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_impl.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_impl.ts
@@ -36,9 +36,115 @@ import {createTableColumn} from '../../components/widgets/sql/table/create_colum
 
 export class SqlModulesImpl implements SqlModules {
   readonly packages: SqlPackage[];
+  private disabledModules: Set<string> = new Set();
+  private initPromise: Promise<void>;
 
   constructor(trace: Trace, docs: SqlModulesDocsSchema) {
     this.packages = docs.map((json) => new StdlibPackageImpl(trace, json));
+    // Start computing disabled modules based on data availability
+    this.initPromise = this.computeDisabledModules(trace, docs);
+  }
+
+  async waitForInit(): Promise<void> {
+    await this.initPromise;
+  }
+
+  private async computeDisabledModules(
+    trace: Trace,
+    docs: SqlModulesDocsSchema,
+  ): Promise<void> {
+    // Build dependency graph: module -> modules that include it
+    const dependents = new Map<string, Set<string>>();
+    const modulesWithChecks = new Map<string, string>();
+
+    for (const pkg of docs) {
+      for (const mod of pkg.modules) {
+        const moduleName = mod.module_name;
+
+        // Store data check SQL if present
+        if (mod.data_check_sql) {
+          modulesWithChecks.set(moduleName, mod.data_check_sql);
+        }
+
+        // Build reverse dependency graph
+        if (mod.includes) {
+          for (const includedModule of mod.includes) {
+            if (!dependents.has(includedModule)) {
+              dependents.set(includedModule, new Set());
+            }
+            dependents.get(includedModule)!.add(moduleName);
+          }
+        }
+      }
+    }
+
+    console.log(
+      `[SqlModules] Found ${modulesWithChecks.size} modules with data checks`,
+    );
+
+    // Check data availability for modules with checks
+    const missingDataModules = new Set<string>();
+    for (const [moduleName, checkSql] of modulesWithChecks) {
+      try {
+        const result = await trace.engine.query(checkSql);
+        // EXISTS returns 0 or 1
+        if (result.numRows() > 0) {
+          // Use iter() to avoid type checking issues with VARINT
+          const iter = result.iter({});
+          iter.next();
+          const hasDataValue = iter.get('has_data');
+          const hasData =
+            typeof hasDataValue === 'bigint'
+              ? hasDataValue !== 0n
+              : Number(hasDataValue) !== 0;
+          if (!hasData) {
+            console.log(`[SqlModules] Module "${moduleName}" has no data`);
+            missingDataModules.add(moduleName);
+          }
+        }
+      } catch (e) {
+        // If query fails, assume no data
+        console.warn(`[SqlModules] Data check failed for "${moduleName}":`, e);
+        missingDataModules.add(moduleName);
+      }
+    }
+
+    console.log(
+      `[SqlModules] ${missingDataModules.size} modules with missing data:`,
+      Array.from(missingDataModules),
+    );
+
+    // BFS to find all transitive dependents of modules with missing data
+    const queue = Array.from(missingDataModules);
+    const disabled = new Set(missingDataModules);
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const deps = dependents.get(current);
+
+      if (deps) {
+        for (const dependent of deps) {
+          if (!disabled.has(dependent)) {
+            disabled.add(dependent);
+            queue.push(dependent);
+          }
+        }
+      }
+    }
+
+    this.disabledModules = disabled;
+    console.log(
+      `[SqlModules] Total disabled modules (including transitive deps): ${disabled.size}`,
+      Array.from(disabled),
+    );
+  }
+
+  isModuleDisabled(moduleName: string): boolean {
+    return this.disabledModules.has(moduleName);
+  }
+
+  getDisabledModules(): ReadonlySet<string> {
+    return this.disabledModules;
   }
 
   getTable(tableName: string): SqlTable | undefined {
@@ -135,10 +241,14 @@ export class StdlibModuleImpl implements SqlModule {
   readonly functions: SqlFunction[];
   readonly tableFunctions: SqlTableFunction[];
   readonly macros: SqlMacro[];
+  readonly dataCheckSql?: string;
+  readonly includes: string[];
 
   constructor(trace: Trace, docs: DocsModuleSchemaType) {
     this.includeKey = docs.module_name;
     this.tags = docs.tags;
+    this.dataCheckSql = docs.data_check_sql ?? undefined;
+    this.includes = docs.includes ?? [];
 
     const neededInclude = this.includeKey.startsWith('prelude')
       ? undefined
@@ -349,6 +459,8 @@ const MODULE_SCHEMA = z.object({
   functions: z.array(FUNCTION_SCHEMA),
   table_functions: z.array(TABLE_FUNCTION_SCHEMA),
   macros: z.array(MACRO_SCHEMA),
+  data_check_sql: z.string().nullish(),
+  includes: z.array(z.string()).nullish(),
 });
 type DocsModuleSchemaType = z.infer<typeof MODULE_SCHEMA>;
 


### PR DESCRIPTION
This change introduces data availability checking for SQL modules in the Perfetto UI. When a trace is loaded, the UI now checks whether high and mid importance modules have data present in the trace, and provides visual indicators and filtering options accordingly.

  **Summary**: Adds data availability checks for SQL stdlib modules to improve UX when exploring traces. Modules without data are visually de-emphasized and can be filtered out, preventing users from wasting time on empty tables.

  **Changes**:
  - Created `trace_data_checks.py` with curated SQL queries to check data presence for 13 high/mid importance modules
  - Extended stdlib docs JSON to include `data_check_sql` field per module
  - Implemented `SqlModulesImpl.computeDisabledModules()` that:
    - Runs data check queries asynchronously on trace load
    - Builds transitive dependency graph to disable dependent modules
    - Exposes `isModuleDisabled()` API
  - Enhanced table list UI with:
    - "No data" chips on disabled module cards
    - Visual dimming of disabled modules
    - "Hide modules with no data" toggle switch
  - Added warnings in omnibox when selecting tables from disabled modules

  **Notes**: The data checks currently cover 13 modules (binder, CUJs, frames, startups, ANRs, battery, etc.). Additional modules can be added to `trace_data_checks.py` as needed.