### PR TITLE
ui: Improve dataset search performance

### DIFF
--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -138,7 +138,7 @@ export function selectTracksAndGetDataset<T extends DatasetSchema>(
     .filter((d) => d.implements(spec));
 
   if (datasets.length > 0) {
-    return UnionDataset.create(datasets).optimize();
+    return UnionDataset.create(datasets);
   } else {
     return undefined;
   }

--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -13,26 +13,18 @@
 // limitations under the License.
 
 import {AsyncLimiter} from '../base/async_limiter';
-import {sqliteString} from '../base/string_utils';
 import {Time} from '../base/time';
-import {exists} from '../base/utils';
 import {
   ResultStepEventHandler,
   SearchManager,
   SearchProvider,
 } from '../public/search';
-import {
-  ANDROID_LOGS_TRACK_KIND,
-  CPU_SLICE_TRACK_KIND,
-} from '../public/track_kinds';
 import {Workspace} from '../public/workspace';
 import {Engine} from '../trace_processor/engine';
-import {LONG, NUM, STR} from '../trace_processor/query_result';
-import {escapeSearchQuery} from '../trace_processor/query_utils';
 import {searchTrackEvents} from './dataset_search';
 import {featureFlags} from './feature_flags';
-import {raf} from './raf_scheduler';
-import {SearchSource} from './search_data';
+import {CurrentSearchResults, SearchSource} from './search_data';
+import {executeSqlSearch} from './sql_search';
 import {TimelineImpl} from './timeline';
 import {TrackManagerImpl} from './track_manager';
 
@@ -44,7 +36,7 @@ const DATASET_SEARCH = featureFlags.register({
   defaultValue: false,
 });
 
-export interface SearchResults {
+interface SearchResults {
   eventIds: Float64Array;
   tses: BigInt64Array;
   utids: Float64Array;
@@ -98,18 +90,90 @@ export class SearchManagerImpl implements SearchManager {
     this._results = undefined;
     this._resultIndex = -1;
     this._searchInProgress = false;
+
+    const generation = this._searchGeneration;
+    const engine = this._engine;
+    const trackManager = this._trackManager;
+    const workspace = this._workspace;
+    if (!engine || !trackManager || !workspace) {
+      return;
+    }
+
     if (text !== '') {
       this._searchInProgress = true;
       this._limiter.schedule(async () => {
-        if (DATASET_SEARCH.get()) {
-          await this.executeDatasetSearch();
-        } else {
-          await this.executeSearch();
+        const sqlSearchStartTime = performance.now();
+        const searchResults: CurrentSearchResults = DATASET_SEARCH.get()
+          ? await this.executeDatasetSearch(engine, trackManager, text)
+          : await executeSqlSearch(engine, trackManager, text);
+        const sqlSearchDuration = performance.now() - sqlSearchStartTime;
+
+        console.debug(
+          `${DATASET_SEARCH.get() ? 'Dataset' : 'SQL'} Search: Term: ${text} ${sqlSearchDuration.toFixed(2)}ms, ${searchResults.eventIds.length} results`,
+        );
+
+        if (generation !== this._searchGeneration) {
+          // We arrived too late. By the time we computed results the user issued
+          // another search.
+          return;
         }
+        this._results = searchResults;
+
+        // We have changed the search results - try and find the first result that's
+        // after the start of this visible window.
+        const visibleWindow = this._timeline?.visibleWindow.toTimeSpan();
+        if (visibleWindow) {
+          const foundIndex = searchResults.tses.findIndex(
+            (ts) => ts >= visibleWindow.start,
+          );
+          if (foundIndex === -1) {
+            this._resultIndex = -1;
+          } else {
+            // Store the value before the found one, so that when the user presses
+            // enter we navigate to the correct one.
+            this._resultIndex = foundIndex - 1;
+          }
+        } else {
+          this._resultIndex = -1;
+        }
+
         this._searchInProgress = false;
-        raf.scheduleFullRedraw();
       });
     }
+  }
+
+  private async executeDatasetSearch(
+    engine: Engine,
+    trackManager: TrackManagerImpl,
+    searchTerm: string,
+  ) {
+    const allResults = await searchTrackEvents(
+      engine,
+      trackManager.getAllTracks(),
+      this._providers,
+      searchTerm,
+    );
+
+    const numRows = allResults.length;
+    const searchResults: SearchResults = {
+      eventIds: new Float64Array(numRows),
+      tses: new BigInt64Array(numRows),
+      utids: new Float64Array(numRows).fill(-1), // Fill with -1 as utid is unknown
+      sources: [],
+      trackUris: [],
+      totalResults: numRows,
+    };
+
+    for (let i = 0; i < numRows; i++) {
+      const {id, ts, track} = allResults[i];
+      searchResults.eventIds[i] = id;
+      searchResults.tses[i] = ts;
+      searchResults.trackUris.push(track.uri);
+      // Assuming all results from datasets correspond to 'event' type search
+      searchResults.sources.push('event');
+    }
+
+    return searchResults;
   }
 
   reset() {
@@ -174,238 +238,5 @@ export class SearchManagerImpl implements SearchManager {
 
   get searchInProgress(): boolean {
     return this._searchInProgress;
-  }
-
-  private async executeSearch() {
-    const search = this._searchText;
-    const searchLiteral = escapeSearchQuery(this._searchText);
-    const generation = this._searchGeneration;
-
-    const engine = this._engine;
-    const trackManager = this._trackManager;
-    const workspace = this._workspace;
-    if (!engine || !trackManager || !workspace) {
-      return;
-    }
-
-    // TODO(stevegolton): Avoid recomputing these indexes each time.
-    const trackUrisByCpu = new Map<number, string>();
-    const allTracks = trackManager.getAllTracks();
-    allTracks.forEach((td) => {
-      const tags = td?.tags;
-      const cpu = tags?.cpu;
-      const kind = tags?.kind;
-      exists(cpu) &&
-        kind === CPU_SLICE_TRACK_KIND &&
-        trackUrisByCpu.set(cpu, td.uri);
-    });
-
-    const trackUrisByTrackId = new Map<number, string>();
-    allTracks.forEach((td) => {
-      const trackIds = td?.tags?.trackIds ?? [];
-      trackIds.forEach((trackId) => trackUrisByTrackId.set(trackId, td.uri));
-    });
-
-    const utidRes = await engine.query(`select utid from thread join process
-    using(upid) where
-      thread.name glob ${searchLiteral} or
-      process.name glob ${searchLiteral}`);
-    const utids = [];
-    for (const it = utidRes.iter({utid: NUM}); it.valid(); it.next()) {
-      utids.push(it.utid);
-    }
-
-    const res = await engine.query(`
-      select
-        id as sliceId,
-        ts,
-        'cpu' as source,
-        cpu as sourceId,
-        utid
-      from sched where utid in (${utids.join(',')})
-      union all
-      select *
-      from (
-        select
-          slice_id as sliceId,
-          ts,
-          'slice' as source,
-          track_id as sourceId,
-          0 as utid
-          from slice
-          where slice.name glob ${searchLiteral}
-            or (
-              0 != CAST(${sqliteString(search)} AS INT) and
-              sliceId = CAST(${sqliteString(search)} AS INT)
-            )
-        union
-        select
-          slice_id as sliceId,
-          ts,
-          'slice' as source,
-          track_id as sourceId,
-          0 as utid
-        from slice
-        join args using(arg_set_id)
-        where string_value glob ${searchLiteral} or key glob ${searchLiteral}
-      )
-      union all
-      select
-        id as sliceId,
-        ts,
-        'log' as source,
-        0 as sourceId,
-        utid
-      from android_logs where msg glob ${searchLiteral}
-      order by ts
-    `);
-
-    const searchResults: SearchResults = {
-      eventIds: new Float64Array(0),
-      tses: new BigInt64Array(0),
-      utids: new Float64Array(0),
-      sources: [],
-      trackUris: [],
-      totalResults: 0,
-    };
-
-    const lowerSearch = search.toLowerCase();
-    for (const track of workspace.flatTracksOrdered) {
-      // We don't support searching for tracks that don't have a URI.
-      if (!track.uri) continue;
-      if (track.name.toLowerCase().indexOf(lowerSearch) === -1) {
-        continue;
-      }
-      searchResults.totalResults++;
-      searchResults.sources.push('track');
-      searchResults.trackUris.push(track.uri);
-    }
-
-    const rows = res.numRows();
-    searchResults.eventIds = new Float64Array(
-      searchResults.totalResults + rows,
-    );
-    searchResults.tses = new BigInt64Array(searchResults.totalResults + rows);
-    searchResults.utids = new Float64Array(searchResults.totalResults + rows);
-    for (let i = 0; i < searchResults.totalResults; ++i) {
-      searchResults.eventIds[i] = -1;
-      searchResults.tses[i] = -1n;
-      searchResults.utids[i] = -1;
-    }
-
-    const it = res.iter({
-      sliceId: NUM,
-      ts: LONG,
-      source: STR,
-      sourceId: NUM,
-      utid: NUM,
-    });
-    for (; it.valid(); it.next()) {
-      let track: string | undefined = undefined;
-
-      if (it.source === 'cpu') {
-        track = trackUrisByCpu.get(it.sourceId);
-      } else if (it.source === 'slice') {
-        track = trackUrisByTrackId.get(it.sourceId);
-      } else if (it.source === 'log') {
-        track = trackManager
-          .getAllTracks()
-          .find((td) => td.tags?.kind === ANDROID_LOGS_TRACK_KIND)?.uri;
-      }
-      // The .get() calls above could return undefined, this isn't just an else.
-      if (track === undefined) {
-        continue;
-      }
-
-      const i = searchResults.totalResults++;
-      searchResults.trackUris.push(track);
-      searchResults.sources.push(it.source as SearchSource);
-      searchResults.eventIds[i] = it.sliceId;
-      searchResults.tses[i] = it.ts;
-      searchResults.utids[i] = it.utid;
-    }
-
-    if (generation !== this._searchGeneration) {
-      // We arrived too late. By the time we computed results the user issued
-      // another search.
-      return;
-    }
-    this._results = searchResults;
-
-    // We have changed the search results - try and find the first result that's
-    // after the start of this visible window.
-    const visibleWindow = this._timeline?.visibleWindow.toTimeSpan();
-    if (visibleWindow) {
-      const foundIndex = this._results.tses.findIndex(
-        (ts) => ts >= visibleWindow.start,
-      );
-      if (foundIndex === -1) {
-        this._resultIndex = -1;
-      } else {
-        // Store the value before the found one, so that when the user presses
-        // enter we navigate to the correct one.
-        this._resultIndex = foundIndex - 1;
-      }
-    } else {
-      this._resultIndex = -1;
-    }
-  }
-
-  private async executeDatasetSearch() {
-    const trackManager = this._trackManager;
-    const engine = this._engine;
-    if (!engine || !trackManager) {
-      return;
-    }
-
-    const generation = this._searchGeneration;
-
-    const allResults = await searchTrackEvents(
-      engine,
-      trackManager.getAllTracks(),
-      this._providers,
-      this._searchText,
-    );
-
-    const numRows = allResults.length;
-    const searchResults: SearchResults = {
-      eventIds: new Float64Array(numRows),
-      tses: new BigInt64Array(numRows),
-      utids: new Float64Array(numRows).fill(-1), // Fill with -1 as utid is unknown
-      sources: [],
-      trackUris: [],
-      totalResults: numRows,
-    };
-
-    for (let i = 0; i < numRows; i++) {
-      const {id, ts, track} = allResults[i];
-      searchResults.eventIds[i] = id;
-      searchResults.tses[i] = ts;
-      searchResults.trackUris.push(track.uri);
-      // Assuming all results from datasets correspond to 'event' type search
-      searchResults.sources.push('event');
-    }
-
-    if (generation !== this._searchGeneration) {
-      // We arrived too late.
-      return;
-    }
-    this._results = searchResults;
-
-    // Find first result after the start of the visible window
-    const visibleWindow = this._timeline?.visibleWindow.toTimeSpan();
-    if (visibleWindow && this._results.totalResults > 0) {
-      let foundIndex = -1;
-      for (let i = 0; i < this._results.tses.length; i++) {
-        if (this._results.tses[i] >= visibleWindow.start) {
-          foundIndex = i;
-          break;
-        }
-      }
-      // Store the index *before* the found one, so the first step lands on it.
-      this._resultIndex = foundIndex === -1 ? -1 : foundIndex - 1;
-    } else {
-      this._resultIndex = -1;
-    }
   }
 }

--- a/ui/src/core/search_result_utils.ts
+++ b/ui/src/core/search_result_utils.ts
@@ -1,0 +1,191 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Represents a single search result event.
+ */
+export interface SearchResultEvent {
+  id: number;
+  ts: bigint;
+  trackUri: string;
+}
+
+/**
+ * Detailed information about differences between two sets of search results.
+ */
+export interface SearchResultDifference {
+  type: 'count' | 'content';
+  result1Count: number;
+  result2Count: number;
+  missingInResult2: SearchResultEvent[];
+  missingInResult1: SearchResultEvent[];
+  different: Array<{
+    id: number;
+    result1Ts: bigint;
+    result2Ts: bigint;
+    result1TrackUri: string;
+    result2TrackUri: string;
+  }>;
+}
+
+/**
+ * Compares two sets of search results and returns detailed differences.
+ *
+ * @param result1 - First set of search results
+ * @param result2 - Second set of search results
+ * @returns Detailed difference information
+ */
+export function compareSearchResults(
+  result1: SearchResultEvent[],
+  result2: SearchResultEvent[],
+): SearchResultDifference {
+  const map1 = new Map<number, {ts: bigint; trackUri: string}>();
+  const map2 = new Map<number, {ts: bigint; trackUri: string}>();
+
+  // Build maps keyed by ID
+  result1.forEach((r) => map1.set(r.id, {ts: r.ts, trackUri: r.trackUri}));
+  result2.forEach((r) => map2.set(r.id, {ts: r.ts, trackUri: r.trackUri}));
+
+  const missingInResult2: SearchResultEvent[] = [];
+  const missingInResult1: SearchResultEvent[] = [];
+  const different: Array<{
+    id: number;
+    result1Ts: bigint;
+    result2Ts: bigint;
+    result1TrackUri: string;
+    result2TrackUri: string;
+  }> = [];
+
+  // Find items in result1 but not in result2, or with differences
+  map1.forEach((value, id) => {
+    const result2Value = map2.get(id);
+    if (!result2Value) {
+      missingInResult2.push({id, ts: value.ts, trackUri: value.trackUri});
+    } else if (
+      value.ts !== result2Value.ts ||
+      value.trackUri !== result2Value.trackUri
+    ) {
+      different.push({
+        id,
+        result1Ts: value.ts,
+        result2Ts: result2Value.ts,
+        result1TrackUri: value.trackUri,
+        result2TrackUri: result2Value.trackUri,
+      });
+    }
+  });
+
+  // Find items in result2 but not in result1
+  map2.forEach((value, id) => {
+    if (!map1.has(id)) {
+      missingInResult1.push({id, ts: value.ts, trackUri: value.trackUri});
+    }
+  });
+
+  return {
+    type:
+      missingInResult2.length > 0 || missingInResult1.length > 0
+        ? 'count'
+        : 'content',
+    result1Count: result1.length,
+    result2Count: result2.length,
+    missingInResult2,
+    missingInResult1,
+    different,
+  };
+}
+
+/**
+ * Checks if two sets of search results are identical.
+ *
+ * @param result1 - First set of search results
+ * @param result2 - Second set of search results
+ * @returns True if results are identical, false otherwise
+ */
+export function searchResultsAreEqual(
+  result1: SearchResultEvent[],
+  result2: SearchResultEvent[],
+): boolean {
+  const diff = compareSearchResults(result1, result2);
+  return (
+    diff.missingInResult2.length === 0 &&
+    diff.missingInResult1.length === 0 &&
+    diff.different.length === 0
+  );
+}
+
+/**
+ * Formats search result differences as a human-readable string.
+ *
+ * @param diff - The difference information
+ * @param result1Name - Name for the first result set (e.g., "SQL Search")
+ * @param result2Name - Name for the second result set (e.g., "Dataset Search")
+ * @returns Formatted string describing the differences
+ */
+export function formatSearchResultDifference(
+  diff: SearchResultDifference,
+  result1Name: string = 'Result 1',
+  result2Name: string = 'Result 2',
+): string {
+  if (
+    diff.missingInResult2.length === 0 &&
+    diff.missingInResult1.length === 0 &&
+    diff.different.length === 0
+  ) {
+    return 'Results are identical ✓';
+  }
+
+  let output = 'Results differ ✗\n\n';
+
+  if (diff.result1Count !== diff.result2Count) {
+    output += `Result count mismatch: ${result1Name} found ${diff.result1Count} results, ${result2Name} found ${diff.result2Count} results\n\n`;
+  }
+
+  if (diff.missingInResult2.length > 0) {
+    output += `${diff.missingInResult2.length} results in ${result1Name} but not in ${result2Name}:\n`;
+    diff.missingInResult2.slice(0, 5).forEach((item) => {
+      output += `  ID: ${item.id}, TS: ${item.ts}, Track: ${item.trackUri}\n`;
+    });
+    if (diff.missingInResult2.length > 5) {
+      output += `  ...and ${diff.missingInResult2.length - 5} more\n`;
+    }
+    output += '\n';
+  }
+
+  if (diff.missingInResult1.length > 0) {
+    output += `${diff.missingInResult1.length} results in ${result2Name} but not in ${result1Name}:\n`;
+    diff.missingInResult1.slice(0, 5).forEach((item) => {
+      output += `  ID: ${item.id}, TS: ${item.ts}, Track: ${item.trackUri}\n`;
+    });
+    if (diff.missingInResult1.length > 5) {
+      output += `  ...and ${diff.missingInResult1.length - 5} more\n`;
+    }
+    output += '\n';
+  }
+
+  if (diff.different.length > 0) {
+    output += `${diff.different.length} results with differences:\n`;
+
+    diff.different.slice(0, 5).forEach((item) => {
+      output += `  ID: ${item.id}\n`;
+      output += `    ${result1Name}: TS=${item.result1Ts}, Track=${item.result1TrackUri}\n`;
+      output += `    ${result2Name}: TS=${item.result2Ts}, Track=${item.result2TrackUri}\n`;
+    });
+    if (diff.different.length > 5) {
+      output += `  ...and ${diff.different.length - 5} more\n`;
+    }
+  }
+
+  return output;
+}

--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -284,7 +284,7 @@ export class SelectionManagerImpl implements SelectionManager {
       });
 
       const datasets = values.map(([dataset]) => dataset);
-      const union = UnionDataset.create(datasets).optimize();
+      const union = UnionDataset.create(datasets);
 
       // Make sure to include the filter value in the schema.
       const schema = {...union.schema, [colName]: UNKNOWN};

--- a/ui/src/core/sql_search.ts
+++ b/ui/src/core/sql_search.ts
@@ -1,0 +1,169 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {sqliteString} from '../base/string_utils';
+import {exists} from '../base/utils';
+import {
+  ANDROID_LOGS_TRACK_KIND,
+  CPU_SLICE_TRACK_KIND,
+} from '../public/track_kinds';
+import {Engine} from '../trace_processor/engine';
+import {LONG, NUM, STR} from '../trace_processor/query_result';
+import {escapeSearchQuery} from '../trace_processor/query_utils';
+import {CurrentSearchResults, SearchSource} from './search_data';
+import {TrackManagerImpl} from './track_manager';
+
+/**
+ * Executes a SQL-based search across the trace data.
+ *
+ * This function searches for matches in:
+ * - Thread and process names (via sched table)
+ * - Slice names and arguments
+ * - Android log messages
+ *
+ * @param engine - The trace processor engine
+ * @param trackManager - The track manager to resolve track URIs
+ * @param searchText - The search term
+ * @returns Search results containing matching events
+ */
+export async function executeSqlSearch(
+  engine: Engine,
+  trackManager: TrackManagerImpl,
+  searchText: string,
+): Promise<CurrentSearchResults> {
+  // Build indexes for track lookups
+  const trackUrisByCpu = new Map<number, string>();
+  const allTracks = trackManager.getAllTracks();
+  allTracks.forEach((td) => {
+    const tags = td?.tags;
+    const cpu = tags?.cpu;
+    const kinds = tags?.kinds;
+    exists(cpu) &&
+      kinds?.includes(CPU_SLICE_TRACK_KIND) &&
+      trackUrisByCpu.set(cpu, td.uri);
+  });
+
+  const trackUrisByTrackId = new Map<number, string>();
+  allTracks.forEach((td) => {
+    const trackIds = td?.tags?.trackIds ?? [];
+    trackIds.forEach((trackId) => trackUrisByTrackId.set(trackId, td.uri));
+  });
+
+  const searchLiteral = escapeSearchQuery(searchText);
+
+  // Find matching threads/processes
+  const utidRes = await engine.query(`select utid from thread join process
+    using(upid) where
+      thread.name GLOB ${searchLiteral} or
+      process.name GLOB ${searchLiteral}`);
+  const utids = [];
+  for (const it = utidRes.iter({utid: NUM}); it.valid(); it.next()) {
+    utids.push(it.utid);
+  }
+
+  // Execute main search query
+  const res = await engine.query(`
+    select
+      id as sliceId,
+      ts,
+      'cpu' as source,
+      cpu as sourceId,
+      utid
+    from sched where utid in (${utids.join(',')})
+    union all
+    select *
+    from (
+      select
+        slice_id as sliceId,
+        ts,
+        'slice' as source,
+        track_id as sourceId,
+        0 as utid
+        from slice
+        where slice.name GLOB ${searchLiteral}
+          or (
+            0 != CAST(${sqliteString(searchText)} AS INT) and
+            sliceId = CAST(${sqliteString(searchText)} AS INT)
+          )
+      union
+      select
+        slice_id as sliceId,
+        ts,
+        'slice' as source,
+        track_id as sourceId,
+        0 as utid
+      from slice
+      join args using(arg_set_id)
+      where string_value GLOB ${searchLiteral} or key GLOB ${searchLiteral}
+    )
+    union all
+    select
+      id as sliceId,
+      ts,
+      'log' as source,
+      0 as sourceId,
+      utid
+    from android_logs where msg GLOB ${searchLiteral}
+    order by ts
+  `);
+
+  // Process results
+  const searchResults: CurrentSearchResults = {
+    eventIds: new Float64Array(0),
+    tses: new BigInt64Array(0),
+    utids: new Float64Array(0),
+    sources: [],
+    trackUris: [],
+    totalResults: 0,
+  };
+
+  const rows = res.numRows();
+  searchResults.eventIds = new Float64Array(rows);
+  searchResults.tses = new BigInt64Array(rows);
+  searchResults.utids = new Float64Array(rows);
+
+  const it = res.iter({
+    sliceId: NUM,
+    ts: LONG,
+    source: STR,
+    sourceId: NUM,
+    utid: NUM,
+  });
+  for (; it.valid(); it.next()) {
+    let track: string | undefined = undefined;
+
+    if (it.source === 'cpu') {
+      track = trackUrisByCpu.get(it.sourceId);
+    } else if (it.source === 'slice') {
+      track = trackUrisByTrackId.get(it.sourceId);
+    } else if (it.source === 'log') {
+      track = trackManager
+        .getAllTracks()
+        .find((td) => td.tags?.kinds?.includes(ANDROID_LOGS_TRACK_KIND))?.uri;
+    }
+    // The .get() calls above could return undefined, this isn't just an else.
+    if (track === undefined) {
+      continue;
+    }
+
+    const i = searchResults.totalResults++;
+    searchResults.trackUris.push(track);
+    searchResults.sources.push(it.source as SearchSource);
+    searchResults.eventIds[i] = it.sliceId;
+    searchResults.tses[i] = it.ts;
+    searchResults.utids[i] = it.utid;
+  }
+
+  return searchResults;
+}

--- a/ui/src/core/timeline.ts
+++ b/ui/src/core/timeline.ts
@@ -34,7 +34,7 @@ import {raf} from './raf_scheduler';
 export class TimelineImpl implements Timeline {
   readonly MIN_DURATION = 10;
   private readonly ANIMATION_DURATION_MS = 300;
-  private readonly SPAM_DETECTION_THRESHOLD_MS = 500;
+  private readonly SPAM_DETECTION_THRESHOLD_MS = 300;
 
   private _visibleWindow: HighPrecisionTimeSpan;
   private _hoverCursorTimestamp?: time;

--- a/ui/src/core_plugins/dev.perfetto.SearchUtils/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.SearchUtils/index.ts
@@ -1,0 +1,63 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {PerfettoPlugin} from '../../public/plugin';
+import {Trace} from '../../public/trace';
+import {SearchBenchmarkPage} from './search_benchmark_page';
+import {SearchResultsTab} from './search_results_tab';
+import {featureFlags} from '../../core/feature_flags';
+
+const BENCHMARK_PAGE_FLAG = featureFlags.register({
+  id: 'searchBenchmarkPage',
+  name: 'Enable the Search Benchmark page',
+  description: 'A development tool for benchmarking search algorithms.',
+  defaultValue: false,
+});
+
+export default class SearchBenchmarkPlugin implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.SearchUtils';
+  static readonly description =
+    'Provides experimental search utilities such as a search results tab and a page that helps benchmarking search techniques.';
+
+  async onTraceLoad(trace: Trace): Promise<void> {
+    // Register the Search Results tab.
+    // TODO(stevegolton): This should become a standard feature rather than
+    // an experimental plugin once it's received a bit more polish.
+    trace.tabs.registerTab({
+      uri: 'dev.perfetto.SearchResultsTab',
+      isEphemeral: false,
+      content: {
+        getTitle: () => 'Search Results',
+        render: () => m(SearchResultsTab, {trace}),
+      },
+    });
+
+    // This benchmarking page is for development purposes only and should be
+    // removed once dataset search is the only search algorithm available.
+    if (BENCHMARK_PAGE_FLAG.get()) {
+      trace.pages.registerPage({
+        route: '/search_benchmark',
+        render: () => m(SearchBenchmarkPage, {trace}),
+      });
+      trace.sidebar.addMenuItem({
+        section: 'current_trace',
+        text: 'Search Benchmark',
+        href: '#!/search_benchmark',
+        icon: 'speed',
+        sortOrder: 100,
+      });
+    }
+  }
+}

--- a/ui/src/core_plugins/dev.perfetto.SearchUtils/search_benchmark_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.SearchUtils/search_benchmark_page.ts
@@ -1,0 +1,439 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {searchTrackEvents} from '../../core/dataset_search';
+import {
+  compareSearchResults,
+  SearchResultDifference,
+  SearchResultEvent,
+} from '../../core/search_result_utils';
+import {executeSqlSearch} from '../../core/sql_search';
+import {TrackManagerImpl} from '../../core/track_manager';
+import {SearchProvider} from '../../public/search';
+import {Trace} from '../../public/trace';
+import {Button, ButtonVariant} from '../../widgets/button';
+import {Callout} from '../../widgets/callout';
+import {Intent} from '../../widgets/common';
+import {Form, FormLabel} from '../../widgets/form';
+import {TextInput} from '../../widgets/text_input';
+
+interface PageAttrs {
+  trace: Trace;
+}
+
+interface BenchmarkResult {
+  method: string;
+  duration: number;
+  resultCount: number;
+}
+
+interface BenchmarkRun {
+  searchTerm: string;
+  iterations: number;
+  timestamp: Date;
+  sqlResults: BenchmarkResult[];
+  datasetResults: BenchmarkResult[];
+  sqlAvg: number;
+  datasetAvg: number;
+  differences?: SearchResultDifference;
+}
+
+export class SearchBenchmarkPage implements m.ClassComponent<PageAttrs> {
+  private searchTerm: string = '';
+  private iterations: number = 10;
+  private running: boolean = false;
+  private results: BenchmarkRun | undefined;
+  private showDiffDetails: boolean = false;
+
+  view({attrs}: m.CVnode<PageAttrs>) {
+    const trace = attrs.trace as Trace;
+
+    return m('.pf-search-benchmark-page', [
+      m('h1', 'Search Performance Benchmark'),
+      m(
+        Form,
+        m(FormLabel, {for: 'search-term'}, 'Search Term:'),
+        m(TextInput, {
+          id: 'search-term',
+          value: this.searchTerm,
+          onInput: (value: string) => {
+            this.searchTerm = value;
+          },
+          onkeydown: (e: KeyboardEvent) => {
+            if (e.key === 'Enter' && this.searchTerm && !this.running) {
+              e.preventDefault();
+              this.runBenchmark(trace);
+            }
+          },
+          placeholder: 'Enter search term...',
+          disabled: this.running,
+        }),
+        m(FormLabel, {for: 'iterations'}, 'Iterations:'),
+        m(TextInput, {
+          id: 'iterations',
+          value: String(this.iterations),
+          onInput: (value: string) => {
+            const num = parseInt(value, 10);
+            if (!isNaN(num) && num > 0) {
+              this.iterations = num;
+            }
+          },
+          disabled: this.running,
+        }),
+        m(Button, {
+          label: 'Run Benchmark',
+          intent: Intent.Primary,
+          loading: this.running,
+          variant: ButtonVariant.Filled,
+          disabled: !this.searchTerm,
+          onclick: (e) => {
+            e.preventDefault();
+            this.runBenchmark(trace);
+          },
+        }),
+      ),
+      this.results && this.renderResults(),
+    ]);
+  }
+
+  private renderDifferenceCallout() {
+    const diff = this.results?.differences;
+    if (!diff) return null;
+
+    const hasDifferences =
+      diff.missingInResult2.length > 0 ||
+      diff.missingInResult1.length > 0 ||
+      diff.different.length > 0;
+
+    if (!hasDifferences) {
+      return m(
+        Callout,
+        {
+          icon: 'check_circle',
+          intent: Intent.Primary,
+        },
+        'Results match! Both search methods returned identical results.',
+      );
+    }
+
+    return m('.pf-search-benchmark-diff', [
+      m(
+        Callout,
+        {
+          icon: 'warning',
+          intent: Intent.Warning,
+        },
+        [
+          m('div', [
+            m('strong', 'Results differ between SQL and Dataset search!'),
+            m(Button, {
+              label: this.showDiffDetails ? 'Hide Details' : 'Show Details',
+              minimal: true,
+              compact: true,
+              onclick: () => {
+                this.showDiffDetails = !this.showDiffDetails;
+              },
+            }),
+          ]),
+          this.showDiffDetails &&
+            m('.pf-diff-details', [
+              diff.result1Count !== diff.result2Count &&
+                m('p', [
+                  `Result count mismatch: SQL found ${diff.result1Count} results, Dataset found ${diff.result2Count} results`,
+                ]),
+              diff.missingInResult2.length > 0 &&
+                m('div', [
+                  m(
+                    'h4',
+                    `${diff.missingInResult2.length} results in SQL but not in Dataset:`,
+                  ),
+                  m(
+                    'ul',
+                    diff.missingInResult2
+                      .slice(0, 10)
+                      .map((item) =>
+                        m('li', [
+                          `ID: ${item.id}, TS: ${item.ts}, Track: ${item.trackUri}`,
+                        ]),
+                      ),
+                  ),
+                  diff.missingInResult2.length > 10 &&
+                    m('p', `...and ${diff.missingInResult2.length - 10} more`),
+                ]),
+              diff.missingInResult1.length > 0 &&
+                m('div', [
+                  m(
+                    'h4',
+                    `${diff.missingInResult1.length} results in Dataset but not in SQL:`,
+                  ),
+                  m(
+                    'ul',
+                    diff.missingInResult1
+                      .slice(0, 10)
+                      .map((item) =>
+                        m('li', [
+                          `ID: ${item.id}, TS: ${item.ts}, Track: ${item.trackUri}`,
+                        ]),
+                      ),
+                  ),
+                  diff.missingInResult1.length > 10 &&
+                    m('p', `...and ${diff.missingInResult1.length - 10} more`),
+                ]),
+              diff.different.length > 0 &&
+                m('div', [
+                  m('h4', `${diff.different.length} results with differences:`),
+                  m(
+                    'ul',
+                    diff.different
+                      .slice(0, 10)
+                      .map((item) =>
+                        m('li', [
+                          `ID: ${item.id}`,
+                          m('br'),
+                          `  SQL: TS=${item.result1Ts}, Track=${item.result1TrackUri}`,
+                          m('br'),
+                          `  Dataset: TS=${item.result2Ts}, Track=${item.result2TrackUri}`,
+                        ]),
+                      ),
+                  ),
+                  diff.different.length > 10 &&
+                    m('p', `...and ${diff.different.length - 10} more`),
+                ]),
+            ]),
+        ],
+      ),
+    ]);
+  }
+
+  private renderResults() {
+    if (!this.results) return null;
+
+    const {
+      searchTerm,
+      iterations,
+      timestamp,
+      sqlResults,
+      datasetResults,
+      sqlAvg,
+      datasetAvg,
+    } = this.results;
+
+    return m('.pf-search-benchmark-results', [
+      m('h2', 'Benchmark Results'),
+      this.renderDifferenceCallout(),
+      m('.pf-search-benchmark-summary', [
+        m('p', `Search Term: "${searchTerm}"`),
+        m('p', `Iterations: ${iterations}`),
+        m('p', `Run at: ${timestamp.toLocaleString()}`),
+      ]),
+      m('.pf-search-benchmark-comparison', [
+        m('h3', 'Performance Comparison'),
+        m('table', [
+          m('thead', [
+            m('tr', [
+              m('th', 'Method'),
+              m('th', 'Average Duration (ms)'),
+              m('th', 'Min (ms)'),
+              m('th', 'Max (ms)'),
+              m('th', 'Result Count'),
+            ]),
+          ]),
+          m('tbody', [
+            m('tr', [
+              m('td', 'SQL Search'),
+              m('td', sqlAvg.toFixed(2)),
+              m(
+                'td',
+                Math.min(...sqlResults.map((r) => r.duration)).toFixed(2),
+              ),
+              m(
+                'td',
+                Math.max(...sqlResults.map((r) => r.duration)).toFixed(2),
+              ),
+              m('td', sqlResults[0]?.resultCount ?? 0),
+            ]),
+            m('tr', [
+              m('td', 'Dataset Search'),
+              m('td', datasetAvg.toFixed(2)),
+              m(
+                'td',
+                Math.min(...datasetResults.map((r) => r.duration)).toFixed(2),
+              ),
+              m(
+                'td',
+                Math.max(...datasetResults.map((r) => r.duration)).toFixed(2),
+              ),
+              m('td', datasetResults[0]?.resultCount ?? 0),
+            ]),
+          ]),
+        ]),
+      ]),
+      m('.pf-search-benchmark-details', [
+        m('h3', 'Individual Run Results'),
+        m('.pf-search-benchmark-methods', [
+          this.renderMethodResults('SQL Search', sqlResults),
+          this.renderMethodResults('Dataset Search', datasetResults),
+        ]),
+      ]),
+    ]);
+  }
+
+  private renderMethodResults(methodName: string, results: BenchmarkResult[]) {
+    return m('.pf-search-benchmark-method', [
+      m('h4', methodName),
+      m('table', [
+        m('thead', [
+          m('tr', [
+            m('th', 'Run #'),
+            m('th', 'Duration (ms)'),
+            m('th', 'Results'),
+          ]),
+        ]),
+        m(
+          'tbody',
+          results.map((result, index) =>
+            m('tr', [
+              m('td', index + 1),
+              m('td', result.duration.toFixed(2)),
+              m('td', result.resultCount),
+            ]),
+          ),
+        ),
+      ]),
+    ]);
+  }
+
+  private async runBenchmark(trace: Trace) {
+    this.results = undefined;
+    this.running = true;
+    this.showDiffDetails = false;
+
+    const sqlResults: BenchmarkResult[] = [];
+    const datasetResults: BenchmarkResult[] = [];
+    let sqlResultsData: SearchResultEvent[] = [];
+    let datasetResultsData: SearchResultEvent[] = [];
+
+    try {
+      // Run SQL search benchmark
+      for (let i = 0; i < this.iterations; i++) {
+        const startTime = performance.now();
+        const result = await this.runSqlSearch(trace, this.searchTerm);
+        const duration = performance.now() - startTime;
+        sqlResults.push({
+          method: 'SQL',
+          duration,
+          resultCount: result.length,
+        });
+        if (i === 0) {
+          sqlResultsData = result;
+        }
+      }
+
+      // Run dataset search benchmark
+      for (let i = 0; i < this.iterations; i++) {
+        const startTime = performance.now();
+        const result = await this.runDatasetSearch(trace, this.searchTerm);
+        const duration = performance.now() - startTime;
+        datasetResults.push({
+          method: 'Dataset',
+          duration,
+          resultCount: result.length,
+        });
+        if (i === 0) {
+          datasetResultsData = result;
+        }
+      }
+
+      // Calculate averages
+      const sqlAvg =
+        sqlResults.reduce((sum, r) => sum + r.duration, 0) / sqlResults.length;
+      const datasetAvg =
+        datasetResults.reduce((sum, r) => sum + r.duration, 0) /
+        datasetResults.length;
+
+      // Compare results using shared utility
+      const differences = compareSearchResults(
+        sqlResultsData,
+        datasetResultsData,
+      );
+
+      this.results = {
+        searchTerm: this.searchTerm,
+        iterations: this.iterations,
+        timestamp: new Date(),
+        sqlResults,
+        datasetResults,
+        sqlAvg,
+        datasetAvg,
+        differences,
+      };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async runSqlSearch(
+    trace: Trace,
+    searchTerm: string,
+  ): Promise<SearchResultEvent[]> {
+    const engine = trace.engine;
+    const trackManager = trace.tracks as TrackManagerImpl;
+
+    const searchResults = await executeSqlSearch(
+      engine,
+      trackManager,
+      searchTerm,
+    );
+
+    const results: SearchResultEvent[] = [];
+    for (let i = 0; i < searchResults.totalResults; i++) {
+      results.push({
+        id: searchResults.eventIds[i],
+        ts: searchResults.tses[i],
+        trackUri: searchResults.trackUris[i],
+      });
+    }
+
+    return results;
+  }
+
+  private async runDatasetSearch(
+    trace: Trace,
+    searchTerm: string,
+  ): Promise<SearchResultEvent[]> {
+    const engine = trace.engine;
+    const trackManager = trace.tracks;
+
+    // Get the search providers from the trace's search manager
+    // Access the internal _providers array from SearchManagerImpl
+    const searchManager = trace.search as {
+      _providers?: SearchProvider[];
+    };
+    const searchProviders = searchManager._providers ?? [];
+
+    const allResults = await searchTrackEvents(
+      engine,
+      trackManager.getAllTracks(),
+      searchProviders,
+      searchTerm,
+    );
+
+    return allResults.map((r) => ({
+      id: r.id,
+      ts: r.ts,
+      trackUri: r.track.uri,
+    }));
+  }
+}

--- a/ui/src/core_plugins/dev.perfetto.SearchUtils/search_results_tab.ts
+++ b/ui/src/core_plugins/dev.perfetto.SearchUtils/search_results_tab.ts
@@ -1,0 +1,108 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {SearchManagerImpl} from '../../core/search_manager';
+import {Trace} from '../../public/trace';
+import {Anchor} from '../../widgets/anchor';
+import {DetailsShell} from '../../widgets/details_shell';
+import {DataGrid} from '../../components/widgets/data_grid/data_grid';
+import {
+  ColumnDefinition,
+  RowDef,
+} from '../../components/widgets/data_grid/common';
+
+interface TabAttrs {
+  trace: Trace;
+}
+
+export class SearchResultsTab implements m.ClassComponent<TabAttrs> {
+  view({attrs}: m.CVnode<TabAttrs>) {
+    const trace = attrs.trace;
+    const searchManager = trace.search as SearchManagerImpl;
+    const searchResults = searchManager.searchResults;
+    const searchText = searchManager.searchText;
+
+    const columns: ColumnDefinition[] = [
+      {
+        name: 'id',
+        title: 'Event ID',
+      },
+      {
+        name: 'ts',
+        title: 'Timestamp',
+      },
+      {
+        name: 'trackUri',
+        title: 'Track URI',
+      },
+    ];
+
+    const rowData: RowDef[] = [];
+
+    if (searchResults) {
+      for (let i = 0; i < searchResults.totalResults; i++) {
+        const eventId = searchResults.eventIds[i];
+        const ts = searchResults.tses[i];
+        const trackUri = searchResults.trackUris[i];
+
+        rowData.push({
+          id: eventId,
+          ts: ts,
+          trackUri: trackUri,
+        });
+      }
+    }
+
+    const description = searchResults
+      ? `Search Results for "${searchText}" - ${searchResults.totalResults} results`
+      : undefined;
+
+    return m(
+      DetailsShell,
+      {
+        title: 'Search Results',
+        description,
+        fillHeight: true,
+      },
+      m(DataGrid, {
+        columns,
+        data: rowData,
+        fillHeight: true,
+        cellRenderer: (value, columnName, row) => {
+          if (columnName === 'id' && typeof row.trackUri === 'string') {
+            return m(
+              Anchor,
+              {
+                onclick: () => {
+                  trace.selection.selectTrackEvent(
+                    row.trackUri as string,
+                    value as number,
+                    {
+                      switchToCurrentSelectionTab: false,
+                      clearSearch: false,
+                      scrollToSelection: true,
+                    },
+                  );
+                },
+              },
+              String(value),
+            );
+          }
+          return String(value);
+        },
+      }),
+    );
+  }
+}

--- a/ui/src/core_plugins/dev.perfetto.SearchUtils/styles.scss
+++ b/ui/src/core_plugins/dev.perfetto.SearchUtils/styles.scss
@@ -1,0 +1,147 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-search-benchmark-page {
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+
+  h1 {
+    margin-bottom: 20px;
+  }
+
+  h2 {
+    margin-top: 30px;
+    margin-bottom: 15px;
+  }
+
+  h3 {
+    margin-top: 20px;
+    margin-bottom: 10px;
+  }
+
+  h4 {
+    margin-top: 15px;
+    margin-bottom: 10px;
+  }
+}
+
+.pf-search-benchmark-results {
+  margin-top: 30px;
+}
+
+.pf-search-benchmark-summary {
+  background: var(--pf-color-surface-1);
+  padding: 15px;
+  border-radius: 4px;
+  margin-bottom: 20px;
+
+  p {
+    margin: 5px 0;
+  }
+}
+
+.pf-search-benchmark-comparison {
+  margin-bottom: 30px;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--pf-color-surface-0);
+
+    th,
+    td {
+      padding: 12px;
+      text-align: left;
+      border-bottom: 1px solid var(--pf-color-divider);
+    }
+
+    th {
+      background: var(--pf-color-surface-1);
+      font-weight: 600;
+    }
+
+    tr:hover {
+      background: var(--pf-color-surface-1);
+    }
+  }
+}
+
+.pf-search-benchmark-methods {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 20px;
+}
+
+.pf-search-benchmark-method {
+  background: var(--pf-color-surface-0);
+  padding: 15px;
+  border-radius: 4px;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+
+    th,
+    td {
+      padding: 8px;
+      text-align: left;
+      border-bottom: 1px solid var(--pf-color-divider);
+    }
+
+    th {
+      background: var(--pf-color-surface-1);
+      font-weight: 600;
+    }
+
+    tr:hover {
+      background: var(--pf-color-surface-1);
+    }
+  }
+}
+
+.pf-search-benchmark-diff {
+  margin-bottom: 24px;
+
+  .pf-diff-details {
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--line-color);
+
+    h4 {
+      margin: 12px 0 8px 0;
+      font-size: 14px;
+      font-weight: 500;
+    }
+
+    ul {
+      margin: 8px 0;
+      padding-left: 20px;
+      font-family: monospace;
+      font-size: 12px;
+
+      li {
+        margin: 4px 0;
+        line-height: 1.6;
+      }
+    }
+
+    p {
+      margin: 8px 0;
+      font-style: italic;
+      color: var(--subtle-foreground-color);
+    }
+  }
+}

--- a/ui/src/plugins/com.android.AndroidLog/index.ts
+++ b/ui/src/plugins/com.android.AndroidLog/index.ts
@@ -152,6 +152,7 @@ export default class implements PerfettoPlugin {
       async getSearchFilter(searchTerm) {
         return {
           where: `msg GLOB ${escapeSearchQuery(searchTerm)}`,
+          columns: {msg: STR_NULL},
         };
       },
     });

--- a/ui/src/plugins/dev.perfetto.Frames/expected_frames_track.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/expected_frames_track.ts
@@ -16,7 +16,7 @@ import {HSLColor} from '../../base/color';
 import {makeColorScheme} from '../../components/colorizer';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {LONG, NUM, STR} from '../../trace_processor/query_result';
+import {LONG, NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 
@@ -40,6 +40,8 @@ export function createExpectedFramesTrack(
         dur: LONG,
         name: STR,
         id: NUM,
+        track_id: NUM,
+        arg_set_id: NUM_NULL,
       },
       filter: {
         col: 'track_id',

--- a/ui/src/plugins/dev.perfetto.Sched/index.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/index.ts
@@ -146,6 +146,7 @@ export default class SchedPlugin implements PerfettoPlugin {
         }
         return {
           where: `utid IN (${utids.join()})`,
+          columns: {utid: NUM_NULL},
         };
       },
     });

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_track.ts
@@ -50,22 +50,18 @@ export function createThreadStateTrack(
         state: STR,
         depth: NUM,
       },
-      src: `
-        SELECT
-          id,
-          ts,
-          dur,
-          ucpu,
-          utid,
-          sched_state_io_to_human_readable_string(state, io_wait) AS state,
-          -- Move sleeping and idle slices to the back layer, others on top
-          CASE
-            WHEN state IN ('S', 'I') THEN 0
-            ELSE 1
-          END AS layer,
-          0 AS depth
-        FROM thread_state
-      `,
+      select: {
+        id: 'id',
+        ts: 'ts',
+        dur: 'dur',
+        ucpu: 'ucpu',
+        utid: 'utid',
+        state: 'sched_state_io_to_human_readable_string(state, io_wait)',
+        depth: '0',
+        // Move sleeping and idle slices to the back layer, others on top
+        layer: "CASE WHEN state IN ('S', 'I') THEN 0 ELSE 1 END",
+      },
+      src: 'thread_state',
       filter: {
         col: 'utid',
         eq: utid,

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -766,6 +766,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
       async getSearchFilter(searchTerm) {
         return {
           where: `name GLOB ${escapeSearchQuery(searchTerm)}`,
+          columns: {name: STR_NULL},
         };
       },
     });
@@ -810,6 +811,7 @@ export default class TraceProcessorTrackPlugin implements PerfettoPlugin {
             OR
             args.key GLOB ${searchLiteral}
           `,
+          columns: {arg_set_id: NUM_NULL},
         };
       },
     });

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -77,7 +77,7 @@ export class SliceSelectionAggregator implements Aggregator {
         if (sliceDatasets.length > 0) {
           const query = await this.buildSliceQuery(
             engine,
-            UnionDataset.create(sliceDatasets).optimize(),
+            UnionDataset.create(sliceDatasets),
             area,
             trash,
           );
@@ -87,7 +87,7 @@ export class SliceSelectionAggregator implements Aggregator {
         if (slicelikeDatasets.length > 0) {
           const query = await this.buildSlicelikeQuery(
             engine,
-            UnionDataset.create(slicelikeDatasets).optimize(),
+            UnionDataset.create(slicelikeDatasets),
             area,
             trash,
           );

--- a/ui/src/public/search.ts
+++ b/ui/src/public/search.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import {time} from '../base/time';
+import {SqlValue} from '../trace_processor/query_result';
 import {Track} from './track';
 
 export type SearchSource = 'cpu' | 'log' | 'slice' | 'track' | 'event';
@@ -38,6 +39,13 @@ export interface FilterExpression {
    * 'join' keyword is added automatically.
    */
   readonly join?: string;
+
+  /**
+   * Optional columns schema needed by the filter but not in the result.
+   * These columns will be available in the query for the WHERE clause to
+   * reference, but won't be included in the final result set.
+   */
+  readonly columns?: Readonly<Record<string, SqlValue>>;
 }
 
 export interface SearchProvider {

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -25,9 +25,9 @@ import {sqlValueToSqliteString} from './sql_utils';
  * the union of other datasets.
  *
  * The idea is that users can build arbitrarily complex trees of datasets, then
- * at any point call `optimize()` to create the smallest possible tree that
- * represents the same dataset, and `query()` which produces a select statement
- * for the resultant dataset.
+ * call `query()` which automatically optimizes the dataset and produces an
+ * optimal select statement. The `optimize()` method can also be called manually
+ * if you need a reference to the optimized dataset.
  *
  * Users can also use the `schema` property and `implements()` to get and test
  * the schema of a given dataset.
@@ -39,59 +39,16 @@ export interface Dataset<T extends DatasetSchema = DatasetSchema> {
   readonly schema: T;
 
   /**
-   * Produce a query for this dataset.
+   * Produce an optimized query for this dataset.
+   *
+   * This automatically optimizes the dataset before generating the query to
+   * ensure the most efficient SQL is produced.
    *
    * @param schema - The schema to use for extracting columns - if undefined,
    * the most specific possible schema is evaluated from the dataset first and
    * used instead.
    */
   query(schema?: DatasetSchema): string;
-
-  /**
-   * Optimizes a dataset into the smallest possible expression.
-   *
-   * For example by combining elements of union data sets that have the same src
-   * and similar filters into a single set.
-   *
-   * For example, the following 'union' dataset...
-   *
-   * ```
-   * {
-   *   union: [
-   *     {
-   *       src: 'foo',
-   *       schema: {
-   *         'a': NUM,
-   *         'b': NUM,
-   *       },
-   *       filter: {col: 'a', eq: 1},
-   *     },
-   *     {
-   *       src: 'foo',
-   *       schema: {
-   *         'a': NUM,
-   *         'b': NUM,
-   *       },
-   *       filter: {col: 'a', eq: 2},
-   *     },
-   *   ]
-   * }
-   * ```
-   *
-   * ...will be combined into a single 'source' dataset...
-   *
-   * ```
-   * {
-   *   src: 'foo',
-   *   schema: {
-   *     'a': NUM,
-   *     'b': NUM,
-   *   },
-   *   filter: {col: 'a', in: [1, 2]},
-   * },
-   * ```
-   */
-  optimize(): Dataset<T>;
 
   /**
    * Returns true if this dataset implements a given schema.
@@ -129,12 +86,63 @@ interface InFilter {
 type Filter = EqFilter | InFilter;
 
 /**
+ * Defines a join to be applied to the dataset.
+ */
+interface Join {
+  /**
+   * The SQL join expression, including the table name and join condition.
+   * Example: 'thread USING (utid)' or 'process ON slice.upid = process.id'
+   */
+  readonly from: string;
+  /**
+   * Optional hint indicating this is a unique (1:1) join. This can be used
+   * for query optimization.
+   */
+  readonly unique?: boolean;
+}
+
+/**
+ * Defines a column selection with an optional join reference.
+ */
+interface SelectColumn {
+  /**
+   * The SQL expression or column name to select.
+   */
+  readonly expr: string;
+  /**
+   * Optional join identifier that this column references.
+   * This helps track which join a column comes from for optimization.
+   */
+  readonly join?: string;
+}
+
+/**
+ * Column selection can be either a simple string (expression/column name)
+ * or an object with expr and optional join reference.
+ */
+type SelectValue = string | SelectColumn;
+
+/**
  * Named arguments for a SourceDataset.
  */
 interface SourceDatasetConfig<T extends DatasetSchema> {
   readonly src: string;
   readonly schema: T;
   readonly filter?: Filter;
+  /**
+   * Optional column mappings from schema column names to source expressions.
+   * Each value can be:
+   * - A string: simple column name or expression
+   * - An object: {expr: 'column', join: 'join-id'} to reference a specific join
+   * Example: {id: 'id', name: {expr: 'name', join: 'thread'}}
+   */
+  readonly select?: Readonly<Record<keyof T, SelectValue>>;
+  /**
+   * Optional joins to apply to the dataset. Each join is identified by a
+   * unique key and contains the join expression and optional optimization hints.
+   * Example: {thread: {from: 'thread USING (utid)', unique: true}}
+   */
+  readonly joins?: Readonly<Record<string, Join>>;
 }
 
 /**
@@ -147,27 +155,85 @@ export class SourceDataset<T extends DatasetSchema = DatasetSchema>
   readonly src: string;
   readonly schema: T;
   readonly filter?: Filter;
+  readonly select?: Readonly<Record<keyof T, SelectValue>>;
+  readonly joins?: Readonly<Record<string, Join>>;
 
   constructor(config: SourceDatasetConfig<T>) {
     this.src = config.src;
     this.schema = config.schema;
     this.filter = config.filter;
+    this.select = config.select;
+    this.joins = config.joins;
   }
 
   query(schema?: DatasetSchema) {
     schema = schema ?? this.schema;
     const cols = Object.keys(schema);
-    const selectSql = `SELECT ${cols.join(', ')} FROM (${this.src})`;
+
+    // Track which joins are referenced in select statements
+    const referencedJoins = new Set<string>();
+
+    // Build the SELECT clause with column mappings if provided
+    const selectCols = cols.map((col) => {
+      const selectValue = this.select?.[col as keyof T];
+      if (selectValue === undefined) {
+        return col;
+      }
+
+      // Extract the expression and join reference
+      let expr: string;
+      if (typeof selectValue === 'string') {
+        expr = selectValue;
+      } else {
+        expr = selectValue.expr;
+        // Track the join reference if specified
+        if (selectValue.join) {
+          referencedJoins.add(selectValue.join);
+        }
+      }
+
+      // Only add AS clause if the expression differs from the column name
+      if (expr !== col) {
+        return `${expr} AS ${col}`;
+      }
+      return col;
+    });
+
+    // Build the FROM clause with joins if provided
+    // Only include joins that are either:
+    // 1. Referenced in a select statement, OR
+    // 2. Not marked as unique (i.e., unique is false or undefined)
+    let fromClause = `(${this.src})`;
+    if (this.joins) {
+      for (const [joinId, join] of Object.entries(this.joins)) {
+        // Skip unique joins that aren't referenced
+        if (join.unique && !referencedJoins.has(joinId)) {
+          continue;
+        }
+
+        // Insert the alias (joinId) after the table name
+        // e.g., "thread USING (utid)" becomes "thread AS thread USING (utid)"
+        const spaceIndex = join.from.indexOf(' ');
+        let joinClause: string;
+        if (spaceIndex === -1) {
+          // No space found, just the table name
+          joinClause = `${join.from} AS ${joinId}`;
+        } else {
+          // Insert alias after first word (table name)
+          const tableName = join.from.substring(0, spaceIndex);
+          const rest = join.from.substring(spaceIndex);
+          joinClause = `${tableName} AS ${joinId}${rest}`;
+        }
+        fromClause += ` JOIN ${joinClause}`;
+      }
+    }
+
+    const selectSql = `SELECT ${selectCols.join(', ')} FROM ${fromClause}`;
     const filterSql = this.filterQuery();
     if (filterSql === undefined) {
       return selectSql;
     }
     return `${selectSql} WHERE ${filterSql}`;
-  }
-
-  optimize() {
-    // Cannot optimize SourceDataset
-    return this;
   }
 
   implements<T extends DatasetSchema>(required: T): this is Dataset<T> {
@@ -248,68 +314,57 @@ export class UnionDataset<T extends DatasetSchema = DatasetSchema>
   }
 
   query(schema?: DatasetSchema): string {
-    schema = schema ?? this.schema;
-    const subQueries = this.union.map((dataset) => dataset.query(schema));
+    const querySchema = schema ?? this.schema;
 
-    // If we have a small number of sub-queries, just use a single union all.
-    if (subQueries.length <= MAX_SUBQUERIES_PER_UNION) {
-      return subQueries.join('\nunion all\n');
-    }
+    // Flatten the entire union tree and extract all datasets
+    const allDatasets = this.flattenUnion();
 
-    // Handle large number of sub-queries by batching into multiple CTEs.
-    let sql = 'with\n';
-    const cteNames: string[] = [];
-
-    // Create CTEs for batches of sub-queries
-    for (let i = 0; i < subQueries.length; i += MAX_SUBQUERIES_PER_UNION) {
-      const batch = subQueries.slice(i, i + MAX_SUBQUERIES_PER_UNION);
-      const cteName = `union_batch_${Math.floor(i / MAX_SUBQUERIES_PER_UNION)}`;
-      cteNames.push(cteName);
-
-      sql += `${cteName} as (\n${batch.join('\nunion all\n')}\n)`;
-
-      // Add comma unless this is the last CTE.
-      if (i + MAX_SUBQUERIES_PER_UNION < subQueries.length) {
-        sql += ',\n';
-      }
-    }
-
-    const cols = Object.keys(schema);
-
-    // Union all the CTEs together in the final query.
-    sql += '\n';
-    sql += cteNames
-      .map((name) => `select ${cols.join(',')} from ${name}`)
-      .join('\nunion all\n');
-
-    return sql;
-  }
-
-  optimize(): Dataset<T> {
-    // Recursively optimize each dataset of this union
-    const optimizedUnion = this.union.map((ds) => ds.optimize());
-
-    // Find all source datasets and combine then based on src
+    // Group SourceDatasets by src and merge them
     const combinedSrcSets = new Map<string, SourceDataset[]>();
     const otherDatasets: Dataset[] = [];
-    for (const e of optimizedUnion) {
-      if (e instanceof SourceDataset) {
-        const set = getOrCreate(combinedSrcSets, e.src, () => []);
-        set.push(e);
+
+    for (const dataset of allDatasets) {
+      if (dataset instanceof SourceDataset) {
+        const set = getOrCreate(combinedSrcSets, dataset.src, () => []);
+        set.push(dataset);
       } else {
-        otherDatasets.push(e);
+        // Non-source datasets (shouldn't happen after flattening, but handle it)
+        otherDatasets.push(dataset);
       }
     }
 
-    const mergedSrcSets = Array.from(combinedSrcSets.values()).map(
-      (srcGroup) => {
-        if (srcGroup.length === 1) return srcGroup[0];
+    // Merge SourceDatasets with the same src
+    const mergedDatasets: Dataset[] = [];
 
+    for (const srcGroup of combinedSrcSets.values()) {
+      if (srcGroup.length === 1) {
+        mergedDatasets.push(srcGroup[0]);
+      } else {
         // Combine schema across all members in the union
         const combinedSchema = srcGroup.reduce((acc, e) => {
           Object.assign(acc, e.schema);
           return acc;
         }, {} as DatasetSchema);
+
+        // Merge select mappings - take the first one we find for each column
+        const combinedSelect: Record<string, SelectValue> = {};
+        for (const dataset of srcGroup) {
+          if (dataset.select) {
+            for (const [col, selectValue] of Object.entries(dataset.select)) {
+              if (!(col in combinedSelect)) {
+                combinedSelect[col] = selectValue;
+              }
+            }
+          }
+        }
+
+        // Merge joins - collect all unique joins
+        const combinedJoins: Record<string, Join> = {};
+        for (const dataset of srcGroup) {
+          if (dataset.joins) {
+            Object.assign(combinedJoins, dataset.joins);
+          }
+        }
 
         // Merge filters for the same src
         const inFilters: InFilter[] = [];
@@ -324,21 +379,88 @@ export class UnionDataset<T extends DatasetSchema = DatasetSchema>
         }
 
         const mergedFilter = mergeFilters(inFilters);
-        return new SourceDataset({
-          src: srcGroup[0].src,
-          schema: combinedSchema,
-          filter: mergedFilter,
-        });
-      },
+        mergedDatasets.push(
+          new SourceDataset({
+            src: srcGroup[0].src,
+            schema: combinedSchema,
+            filter: mergedFilter,
+            select:
+              Object.keys(combinedSelect).length > 0
+                ? combinedSelect
+                : undefined,
+            joins:
+              Object.keys(combinedJoins).length > 0 ? combinedJoins : undefined,
+          }),
+        );
+      }
+    }
+
+    mergedDatasets.push(...otherDatasets);
+
+    // If we merged everything into a single dataset, use its query directly
+    // Pass the querySchema to enable column and join elimination
+    if (mergedDatasets.length === 1) {
+      return mergedDatasets[0].query(querySchema);
+    }
+
+    // Generate union query from merged datasets
+    // Pass querySchema to each dataset to enable column and join elimination
+    const subQueries = mergedDatasets.map((dataset) =>
+      dataset.query(querySchema),
     );
 
-    const finalUnion = [...mergedSrcSets, ...otherDatasets];
-
-    if (finalUnion.length === 1) {
-      return finalUnion[0] as Dataset<T>;
-    } else {
-      return new UnionDataset(finalUnion);
+    // If we have a small number of sub-queries, just use a single union all.
+    if (subQueries.length <= MAX_SUBQUERIES_PER_UNION) {
+      return subQueries.join('\nUNION ALL\n');
     }
+
+    // Handle large number of sub-queries by batching into multiple CTEs.
+    let sql = 'with\n';
+    const cteNames: string[] = [];
+
+    // Create CTEs for batches of sub-queries
+    for (let i = 0; i < subQueries.length; i += MAX_SUBQUERIES_PER_UNION) {
+      const batch = subQueries.slice(i, i + MAX_SUBQUERIES_PER_UNION);
+      const cteName = `union_batch_${Math.floor(i / MAX_SUBQUERIES_PER_UNION)}`;
+      cteNames.push(cteName);
+
+      sql += `${cteName} as (\n${batch.join('\nUNION ALL\n')}\n)`;
+
+      // Add comma unless this is the last CTE.
+      if (i + MAX_SUBQUERIES_PER_UNION < subQueries.length) {
+        sql += ',\n';
+      }
+    }
+
+    const cols = Object.keys(querySchema);
+
+    // Union all the CTEs together in the final query.
+    sql += '\n';
+    sql += cteNames
+      .map((name) => `SELECT ${cols.join(', ')} FROM ${name}`)
+      .join('\nUNION ALL\n');
+
+    return sql;
+  }
+
+  /**
+   * Recursively flatten this union tree, extracting all leaf datasets.
+   * Nested UnionDatasets are recursively flattened.
+   */
+  private flattenUnion(): Dataset[] {
+    const result: Dataset[] = [];
+
+    for (const dataset of this.union) {
+      if (dataset instanceof UnionDataset) {
+        // Recursively flatten nested unions
+        result.push(...dataset.flattenUnion());
+      } else {
+        // Leaf dataset (SourceDataset or other)
+        result.push(dataset);
+      }
+    }
+
+    return result;
   }
 
   implements<T extends DatasetSchema>(required: T): this is Dataset<T> {

--- a/ui/src/trace_processor/dataset_query_utils.ts
+++ b/ui/src/trace_processor/dataset_query_utils.ts
@@ -1,0 +1,421 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {DatasetSchema, SourceDataset, UnionDataset} from './dataset';
+import {NUM, SqlValue} from './query_result';
+import {Engine} from './engine';
+
+/**
+ * Configuration for queryWithLineage function.
+ */
+export interface QueryWithLineageConfig<T, Schema extends DatasetSchema> {
+  /** The list of input objects (e.g., tracks) */
+  inputs: T[];
+
+  /** Function to extract dataset from each input */
+  datasetFetcher: (input: T) => SourceDataset;
+
+  /** Columns to select from the union */
+  columns: Schema;
+
+  /**
+   * Optional additional columns needed for filtering but not in result.
+   * These columns will be available in the base query for the queryBuilder
+   * to reference in WHERE clauses, but won't be included in the final result.
+   */
+  filterColumns?: DatasetSchema;
+
+  /**
+   * Skip partition filters (e.g., track_id IN (...)) when true.
+   * This is useful for search operations where you want to search across
+   * all data from the source table without partition filtering.
+   * The lineage will still be tracked.
+   * Default: false
+   */
+  skipPartitionFilters?: boolean;
+
+  /**
+   * Optional query builder to wrap the union.
+   * @param baseQuery - The optimized union query with result + partition + filter columns
+   * @param resultCols - The columns that should be selected in the final result
+   * Use this to add WHERE clauses, joins, or other SQL operations.
+   */
+  queryBuilder?: (baseQuery: string, resultCols: string[]) => string;
+}
+
+/**
+ * Result from queryWithLineage with source tracking.
+ */
+export interface QueryWithLineageResult<T, Schema extends DatasetSchema> {
+  /** The source input object this row came from */
+  readonly source: T;
+  /** The row data matching the requested schema */
+  readonly row: Schema;
+}
+
+/**
+ * Internal: Partition map for tracking which inputs map to which partition values.
+ */
+interface PartitionMap<T> {
+  /** For each partition column, map values to source inputs */
+  columns: Map<string, Map<SqlValue, Set<T>>>;
+}
+
+/**
+ * Internal: Group of inputs that share the same source dataset.
+ */
+interface SourceGroup<T> {
+  input: T;
+  dataset: SourceDataset;
+}
+
+/**
+ * Information about a planned query for a source group.
+ */
+export interface PlannedQuery<T = unknown> {
+  /** The source SQL statement/table being queried */
+  readonly src: string;
+  /** The inputs that belong to this group */
+  readonly inputs: ReadonlyArray<T>;
+  /** The generated SQL query */
+  readonly sql: string;
+  /** The partition columns used for lineage tracking */
+  readonly partitionColumns: ReadonlyArray<string>;
+  /** Map from partition column name to (value -> inputs) for lineage resolution */
+  readonly partitionMap: ReadonlyMap<
+    string,
+    ReadonlyMap<SqlValue, ReadonlySet<T>>
+  >;
+}
+
+/**
+ * A query plan that can be inspected before execution.
+ * Useful for testing and debugging.
+ */
+export interface QueryPlan<T, Schema extends DatasetSchema> {
+  /** Information about each planned query */
+  readonly queries: ReadonlyArray<PlannedQuery<T>>;
+
+  /** Execute the plan and return results with lineage */
+  execute(
+    engine: Engine,
+  ): Promise<readonly QueryWithLineageResult<T, Schema>[]>;
+}
+
+/**
+ * Build partition map from a group of datasets.
+ * Maps partition column values back to source inputs for O(1) lineage lookup.
+ * Also tracks inputs without filters (unpartitioned inputs).
+ */
+interface PartitionMapWithUnfiltered<T> extends PartitionMap<T> {
+  /** Inputs without filters that should match all rows */
+  unfilteredInputs: Set<T>;
+}
+
+function buildPartitionMap<T>(
+  group: Array<SourceGroup<T>>,
+): PartitionMapWithUnfiltered<T> {
+  const partitionMap: PartitionMapWithUnfiltered<T> = {
+    columns: new Map(),
+    unfilteredInputs: new Set(),
+  };
+
+  for (const {input, dataset} of group) {
+    if (!dataset.filter) {
+      // Track inputs without filters - they match all rows
+      partitionMap.unfilteredInputs.add(input);
+      continue;
+    }
+
+    const colName = dataset.filter.col;
+    const valueMap = partitionMap.columns.get(colName) ?? new Map();
+    partitionMap.columns.set(colName, valueMap);
+
+    const values =
+      'eq' in dataset.filter ? [dataset.filter.eq] : dataset.filter.in;
+
+    for (const value of values) {
+      const sourceSet = valueMap.get(value) ?? new Set();
+      sourceSet.add(input);
+      valueMap.set(value, sourceSet);
+    }
+  }
+
+  return partitionMap;
+}
+
+/**
+ * Build union dataset for a source group, optionally skipping partition filters.
+ */
+function buildUnionDataset<T>(
+  group: Array<SourceGroup<T>>,
+  skipPartitionFilters: boolean,
+): UnionDataset {
+  if (skipPartitionFilters) {
+    // Create datasets without filters for unfiltered search
+    const unfilteredDatasets = group.map((g) => {
+      return new SourceDataset({
+        src: g.dataset.src,
+        schema: g.dataset.schema,
+        select: g.dataset.select,
+        joins: g.dataset.joins,
+        // No filter - query entire table
+      });
+    });
+    return UnionDataset.create(unfilteredDatasets);
+  } else {
+    // Use original datasets with partition filters
+    const datasets = group.map((g) => g.dataset);
+    return UnionDataset.create(datasets);
+  }
+}
+
+/**
+ * Query a single source group (datasets with same src) and resolve lineage.
+ */
+async function querySourceGroup<T, Schema extends DatasetSchema>(
+  engine: Engine,
+  group: Array<SourceGroup<T>>,
+  unionDataset: UnionDataset,
+  partitionMap: PartitionMapWithUnfiltered<T>,
+  columns: Schema,
+  filterColumns: DatasetSchema | undefined,
+  queryBuilder?: (baseQuery: string, resultCols: string[]) => string,
+): Promise<Array<QueryWithLineageResult<T, Schema>>> {
+  // Include partition columns in query schema
+  const partitionColumns = Array.from(partitionMap.columns.keys());
+
+  // Build query schema: result columns + partition columns + filter columns
+  const querySchema: DatasetSchema = {
+    ...columns,
+    ...Object.fromEntries(partitionColumns.map((col) => [col, NUM])),
+    ...(filterColumns ?? {}),
+  };
+
+  // Query with only the columns we need (enables column & join elimination)
+  const baseQuery = unionDataset.query(querySchema);
+
+  // Build query with optional custom query builder
+  const resultCols = [...Object.keys(columns), ...partitionColumns];
+  const query = queryBuilder ? queryBuilder(baseQuery, resultCols) : baseQuery;
+
+  // Execute query
+  const result = await engine.query(query);
+
+  // Build schema for result iteration (columns + partitions)
+  const resultSchema: DatasetSchema = {
+    ...columns,
+    ...Object.fromEntries(partitionColumns.map((col) => [col, NUM])),
+  };
+
+  // Process results and resolve lineage
+  const results: Array<QueryWithLineageResult<T, Schema>> = [];
+
+  for (
+    const iter = result.iter(resultSchema);
+    iter.valid() === true;
+    iter.next()
+  ) {
+    // Extract row data
+    const row: Record<string, SqlValue> = {};
+    for (const col of Object.keys(columns)) {
+      row[col] = iter.get(col);
+    }
+
+    // Resolve source via partition values
+    let sources: Set<T> = new Set();
+
+    if (partitionColumns.length === 0) {
+      // No partition columns - this is non-partitioned data
+      // All inputs in the group contributed to this result
+      sources = new Set(group.map((g) => g.input));
+    } else {
+      // Try to find matching sources via partition values
+      for (const colName of partitionColumns) {
+        const partitionValue = iter.get(colName);
+        const valueMap = partitionMap.columns.get(colName);
+        const matchingSources = valueMap?.get(partitionValue);
+
+        if (matchingSources) {
+          // Add all inputs that match this partition value
+          for (const source of matchingSources) {
+            sources.add(source);
+          }
+          break;
+        }
+      }
+
+      // Also add unfiltered inputs - they match ALL rows
+      for (const unfilteredInput of partitionMap.unfilteredInputs) {
+        sources.add(unfilteredInput);
+      }
+
+      // If no sources matched at all, skip this row
+      if (sources.size === 0) {
+        continue;
+      }
+    }
+
+    // Push one result per source
+    for (const source of sources) {
+      results.push({source, row: row as Schema});
+    }
+  }
+
+  return results;
+}
+
+/**
+ * This function analyzes input datasets and generates optimized SQL queries by:
+ * 1. Grouping inputs by their source (e.g., all tracks from 'slice')
+ * 2. Merging filters into efficient IN clauses (e.g., WHERE track_id IN (1,2,3))
+ * 3. Including partition columns for lineage tracking
+ * 4. Eliminating unused joins and columns for performance
+ *
+ * Each generated query has the structure:
+ * ```sql
+ * SELECT <result_columns>, <partition_columns> FROM <source_table>
+ * [JOIN <tables>]
+ * WHERE <partition_col> IN (<values>)
+ * [AND <custom_filters>]
+ * ```
+ *
+ * For example, querying 3 tracks might produce:
+ * ```sql
+ * SELECT id, ts, track_id FROM slice WHERE track_id IN (1,2,3)
+ * ```
+ *
+ * The partition columns (like `track_id`) enable O(1) lineage resolution - mapping
+ * each result row back to its source input by matching partition values.
+ *
+ * @param config - Configuration including inputs, dataset fetcher, columns, and optional query builder
+ * @returns A query plan that can be inspected or executed
+ *
+ * @example
+ * ```ts
+ * const plan = planQuery({
+ *   inputs: tracks,
+ *   datasetFetcher: (track) => track.renderer.getDataset?.(),
+ *   columns: {id: NUM, ts: LONG},
+ *   queryBuilder: (q, cols) => `SELECT ${cols.join(', ')} FROM (${q}) WHERE name LIKE '%foo%'`,
+ * });
+ *
+ * // Inspect the plan
+ * console.log('Groups:', plan.groupCount);
+ * console.log('Total inputs:', plan.totalInputs);
+ * for (const query of plan.queries) {
+ *   console.log('Source:', query.src);
+ *   console.log('SQL:', query.sql);
+ *   console.log('Inputs:', query.inputs.map(i => i.id));
+ * }
+ *
+ * // Execute when ready
+ * const results = await plan.execute(engine);
+ * ```
+ */
+export function planQuery<T, Schema extends DatasetSchema>(
+  config: QueryWithLineageConfig<T, Schema>,
+): QueryPlan<T, Schema> {
+  // Group by source (SQL statement/table)
+  const sourceGroups = new Map<string, Array<SourceGroup<T>>>();
+
+  for (const input of config.inputs) {
+    const dataset = config.datasetFetcher(input);
+    const group = sourceGroups.get(dataset.src) ?? [];
+    group.push({input, dataset});
+    sourceGroups.set(dataset.src, group);
+  }
+
+  // Build plan information for each source group
+  const plannedQueries: PlannedQuery<T>[] = [];
+  const unionDatasets = new Map<string, UnionDataset>();
+  const partitionMaps = new Map<string, PartitionMapWithUnfiltered<T>>();
+
+  for (const [src, group] of sourceGroups.entries()) {
+    // Build and cache partition map
+    const partitionMap = buildPartitionMap(group);
+    partitionMaps.set(src, partitionMap);
+    const partitionColumns = Array.from(partitionMap.columns.keys());
+
+    // Build union dataset once and cache it for execution
+    const unionDataset = buildUnionDataset(
+      group,
+      config.skipPartitionFilters ?? false,
+    );
+    unionDatasets.set(src, unionDataset);
+
+    // Build query schema: result + partition + filter columns
+    const querySchema: DatasetSchema = {
+      ...config.columns,
+      ...Object.fromEntries(partitionColumns.map((col) => [col, NUM])),
+      ...(config.filterColumns ?? {}),
+    };
+
+    // Query with only needed columns (enables column & join elimination)
+    const baseQuery = unionDataset.query(querySchema);
+
+    // Select only result + partition columns
+    const resultCols = [...Object.keys(config.columns), ...partitionColumns];
+
+    // Apply query builder or use the base query directly (no need to wrap)
+    const sql = config.queryBuilder
+      ? config.queryBuilder(baseQuery, resultCols)
+      : baseQuery;
+
+    // Convert partition map to readonly format for external exposure
+    const readonlyPartitionMap = new Map<
+      string,
+      ReadonlyMap<SqlValue, ReadonlySet<T>>
+    >();
+    for (const [col, valueMap] of partitionMap.columns.entries()) {
+      readonlyPartitionMap.set(col, valueMap);
+    }
+
+    plannedQueries.push({
+      src,
+      inputs: group.map((g) => g.input),
+      sql,
+      partitionColumns,
+      partitionMap: readonlyPartitionMap,
+    });
+  }
+
+  // Return the query plan
+  return {
+    queries: plannedQueries,
+
+    async execute(
+      engine: Engine,
+    ): Promise<readonly QueryWithLineageResult<T, Schema>[]> {
+      let allResults: readonly QueryWithLineageResult<T, Schema>[] = [];
+
+      for (const [src, group] of sourceGroups.entries()) {
+        const partitionMap = partitionMaps.get(src)!;
+        const unionDataset = unionDatasets.get(src)!;
+        const groupResults = await querySourceGroup(
+          engine,
+          group,
+          unionDataset,
+          partitionMap,
+          config.columns,
+          config.filterColumns,
+          config.queryBuilder,
+        );
+        allResults = allResults.concat(groupResults);
+      }
+
+      return allResults;
+    },
+  };
+}

--- a/ui/src/trace_processor/dataset_query_utils_unittest.ts
+++ b/ui/src/trace_processor/dataset_query_utils_unittest.ts
@@ -1,0 +1,527 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {SourceDataset} from './dataset';
+import {LONG, NUM, STR} from './query_result';
+import {planQuery} from './dataset_query_utils';
+
+interface TestInput {
+  id: string;
+  dataset: SourceDataset;
+}
+
+test('planQuery groups inputs by source table', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'slice1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        filter: {col: 'track_id', eq: 1},
+      }),
+    },
+    {
+      id: 'slice2',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        filter: {col: 'track_id', eq: 2},
+      }),
+    },
+    {
+      id: 'counter1',
+      dataset: new SourceDataset({
+        src: 'counter',
+        schema: {id: NUM, ts: LONG},
+        filter: {col: 'track_id', eq: 3},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM, ts: LONG},
+  });
+
+  // We expect the plan to contain two queries: one for 'slice' and one for
+  // 'counter'
+  expect(plan.queries).toHaveLength(2);
+
+  // Find the slice query
+  const sliceQuery = plan.queries.find((q) => q.src === 'slice');
+  expect(sliceQuery).toBeDefined();
+  expect(sliceQuery!.inputs).toHaveLength(2);
+  expect(sliceQuery!.inputs).toContain(inputs[0]);
+  expect(sliceQuery!.inputs).toContain(inputs[1]);
+
+  expect(sliceQuery!.partitionColumns).toEqual(['track_id']);
+  const partitionMapForTrackId = sliceQuery!.partitionMap.get('track_id')!;
+  expect(partitionMapForTrackId).toBeDefined();
+  expect(partitionMapForTrackId.size).toBe(2);
+  expect(partitionMapForTrackId.get(1)!.has(inputs[0])).toBe(true);
+  expect(partitionMapForTrackId.get(2)!.has(inputs[1])).toBe(true);
+
+  expect(sliceQuery!.sql).toBe(
+    'SELECT id, ts, track_id FROM (slice) WHERE track_id IN (1, 2)',
+  );
+
+  // Find the counter query
+  const counterQuery = plan.queries.find((q) => q.src === 'counter');
+  expect(counterQuery).toBeDefined();
+
+  expect(counterQuery!.sql).toBe(
+    'SELECT id, ts, track_id FROM (counter) WHERE track_id = 3',
+  );
+
+  expect(counterQuery!.inputs).toHaveLength(1);
+  expect(counterQuery!.inputs).toContain(inputs[2]);
+
+  expect(counterQuery!.partitionColumns).toEqual(['track_id']);
+  const counterPartitionMapForTrackId =
+    counterQuery!.partitionMap.get('track_id')!;
+  expect(counterPartitionMapForTrackId).toBeDefined();
+  expect(counterPartitionMapForTrackId.size).toBe(1);
+  expect(counterPartitionMapForTrackId.get(3)!.has(inputs[2])).toBe(true);
+});
+
+test('planQuery generates optimized SQL with partition filters', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG, name: STR},
+        filter: {col: 'track_id', eq: 123},
+      }),
+    },
+    {
+      id: 'input2',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG, name: STR},
+        filter: {col: 'track_id', eq: 456},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM, ts: LONG},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Should optimize into a single flattened query with IN clause
+  expect(query.sql).toContain('WHERE track_id IN (123, 456)');
+  expect(query.sql).toContain('SELECT id, ts, track_id FROM');
+  expect(query.partitionColumns).toEqual(['track_id']);
+});
+
+test('planQuery handles IN filters', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        filter: {col: 'track_id', in: [1, 2, 3]},
+      }),
+    },
+    {
+      id: 'input2',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        filter: {col: 'track_id', in: [4, 5]},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Should merge all values into single IN clause
+  expect(query.sql).toContain('WHERE track_id IN (1, 2, 3, 4, 5)');
+  expect(query.partitionColumns).toEqual(['track_id']);
+});
+
+test('planQuery applies custom queryBuilder', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, name: STR},
+        filter: {col: 'track_id', eq: 1},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM},
+    queryBuilder: (baseQuery, resultCols) =>
+      `SELECT ${resultCols.join(', ')} FROM (${baseQuery}) WHERE name LIKE '%foo%'`,
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Custom query builder wraps the base query
+  expect(query.sql).toContain("WHERE name LIKE '%foo%'");
+  expect(query.sql).toContain('SELECT id, track_id FROM');
+});
+
+test('planQuery includes filter columns in base query', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG, name: STR},
+        filter: {col: 'track_id', eq: 1},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM},
+    filterColumns: {name: STR},
+    queryBuilder: (baseQuery, resultCols) =>
+      `SELECT ${resultCols.join(', ')} FROM (${baseQuery}) WHERE name = 'test'`,
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // With custom query builder, it wraps the base query
+  expect(query.sql).toContain('name');
+  expect(query.sql).toMatch(/^SELECT id, track_id FROM/);
+});
+
+test('planQuery skips partition filters when requested', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        filter: {col: 'track_id', eq: 123},
+      }),
+    },
+    {
+      id: 'input2',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        filter: {col: 'track_id', eq: 456},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM, ts: LONG},
+    skipPartitionFilters: true,
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Should not have WHERE clause when skipping partition filters
+  expect(query.sql).not.toContain('WHERE');
+  expect(query.sql).toBe('SELECT id, ts, track_id FROM (slice)');
+  expect(query.partitionColumns).toEqual(['track_id']);
+});
+
+test('planQuery handles no inputs', () => {
+  const plan = planQuery({
+    inputs: [],
+    datasetFetcher: (input: TestInput) => input.dataset,
+    columns: {id: NUM},
+  });
+
+  expect(plan.queries).toHaveLength(0);
+});
+
+test('planQuery handles inputs without filters', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        // No filter
+      }),
+    },
+    {
+      id: 'input2',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, ts: LONG},
+        // No filter
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Without filters, no partition columns
+  expect(query.partitionColumns).toEqual([]);
+  // Should still union the datasets
+  expect(query.inputs).toHaveLength(2);
+});
+
+test('planQuery with column mapping', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, name: STR},
+        select: {id: 'slice_id', name: 'slice_name'},
+        filter: {col: 'track_id', eq: 1},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM, name: STR},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Column mapping should be applied in the base query
+  expect(query.sql).toContain('slice_id AS id');
+  expect(query.sql).toContain('slice_name AS name');
+});
+
+test('planQuery with joins', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, thread_name: STR},
+        select: {
+          id: 'id',
+          thread_name: {expr: 'thread.name', join: 'thread'},
+        },
+        joins: {
+          thread: {from: 'thread USING (utid)', unique: true},
+        },
+        filter: {col: 'track_id', eq: 1},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM, thread_name: STR},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Join should be included when thread_name is selected
+  expect(query.sql).toContain('JOIN thread AS thread USING (utid)');
+});
+
+test('planQuery eliminates unused joins', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, thread_name: STR},
+        select: {
+          id: 'id',
+          thread_name: {expr: 'thread.name', join: 'thread'},
+        },
+        joins: {
+          thread: {from: 'thread USING (utid)', unique: true},
+        },
+        filter: {col: 'track_id', eq: 1},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM}, // Not selecting thread_name
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Join should be eliminated when thread_name is not selected
+  expect(query.sql).not.toContain('JOIN thread');
+});
+
+test('planQuery with multiple partition columns', () => {
+  const inputs: TestInput[] = [
+    {
+      id: 'input1',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, track_id: NUM, cpu: NUM},
+        filter: {col: 'track_id', eq: 1},
+      }),
+    },
+    {
+      id: 'input2',
+      dataset: new SourceDataset({
+        src: 'slice',
+        schema: {id: NUM, track_id: NUM, cpu: NUM},
+        filter: {col: 'cpu', eq: 0},
+      }),
+    },
+  ];
+
+  const plan = planQuery({
+    inputs,
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Both partition columns should be included
+  expect(query.partitionColumns).toHaveLength(2);
+  expect(query.partitionColumns).toContain('track_id');
+  expect(query.partitionColumns).toContain('cpu');
+});
+
+test('planQuery groups correctly match input identity', () => {
+  const input1 = {
+    id: 'input1',
+    dataset: new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM},
+      filter: {col: 'track_id', eq: 1},
+    }),
+  };
+
+  const input2 = {
+    id: 'input2',
+    dataset: new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM},
+      filter: {col: 'track_id', eq: 2},
+    }),
+  };
+
+  const plan = planQuery({
+    inputs: [input1, input2],
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Verify exact input objects are preserved
+  expect(query.inputs[0]).toBe(input1);
+  expect(query.inputs[1]).toBe(input2);
+});
+
+test('planQuery exposes partition map for lineage verification', () => {
+  const input1 = {
+    id: 'input1',
+    dataset: new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM},
+      filter: {col: 'track_id', eq: 100},
+    }),
+  };
+
+  const input2 = {
+    id: 'input2',
+    dataset: new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM},
+      filter: {col: 'track_id', eq: 200},
+    }),
+  };
+
+  const input3 = {
+    id: 'input3',
+    dataset: new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM},
+      filter: {col: 'track_id', in: [100, 300]},
+    }),
+  };
+
+  const plan = planQuery({
+    inputs: [input1, input2, input3],
+    datasetFetcher: (input) => input.dataset,
+    columns: {id: NUM},
+  });
+
+  expect(plan.queries).toHaveLength(1);
+  const query = plan.queries[0];
+
+  // Verify partition map structure
+  expect(query.partitionMap.size).toBe(1);
+  expect(query.partitionMap.has('track_id')).toBe(true);
+
+  const trackIdMap = query.partitionMap.get('track_id')!;
+  expect(trackIdMap.size).toBe(3);
+
+  // Verify track_id=100 maps to input1 and input3
+  const inputs100 = trackIdMap.get(100);
+  expect(inputs100).toBeDefined();
+  expect(inputs100!.size).toBe(2);
+  expect(inputs100!.has(input1)).toBe(true);
+  expect(inputs100!.has(input3)).toBe(true);
+
+  // Verify track_id=200 maps to input2 only
+  const inputs200 = trackIdMap.get(200);
+  expect(inputs200).toBeDefined();
+  expect(inputs200!.size).toBe(1);
+  expect(inputs200!.has(input2)).toBe(true);
+
+  // Verify track_id=300 maps to input3 only
+  const inputs300 = trackIdMap.get(300);
+  expect(inputs300).toBeDefined();
+  expect(inputs300!.size).toBe(1);
+  expect(inputs300!.has(input3)).toBe(true);
+});

--- a/ui/src/trace_processor/dataset_unittest.ts
+++ b/ui/src/trace_processor/dataset_unittest.ts
@@ -58,7 +58,277 @@ test("get query for simple dataset with an 'in' filter", () => {
   });
 
   expect(dataset.query()).toEqual(
-    'SELECT id FROM (slice) WHERE id IN (123,456)',
+    'SELECT id FROM (slice) WHERE id IN (123, 456)',
+  );
+});
+
+test('get query with column mapping', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR},
+    select: {id: 'id', name: 'slice_name'},
+  });
+
+  expect(dataset.query()).toEqual('SELECT id, slice_name AS name FROM (slice)');
+});
+
+test('get query with partial column mapping', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR, dur: LONG},
+    select: {id: 'id', name: 'slice_name', dur: 'dur'},
+  });
+
+  // Only 'name' is mapped, 'id' and 'dur' use their original names
+  expect(dataset.query()).toEqual(
+    'SELECT id, slice_name AS name, dur FROM (slice)',
+  );
+});
+
+test('get query with column mapping and filter', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR},
+    select: {id: 'slice_id', name: 'slice_name'},
+    filter: {
+      col: 'id',
+      eq: 123,
+    },
+  });
+
+  expect(dataset.query()).toEqual(
+    'SELECT slice_id AS id, slice_name AS name FROM (slice) WHERE id = 123',
+  );
+});
+
+test('get query with single join', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR, tid: NUM},
+    joins: {
+      thread: {from: 'thread USING (utid)'},
+    },
+  });
+
+  expect(dataset.query()).toEqual(
+    'SELECT id, name, tid FROM (slice) JOIN thread AS thread USING (utid)',
+  );
+});
+
+test('get query with multiple joins', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR, process_name: STR},
+    joins: {
+      thread: {from: 'thread USING (utid)'},
+      process: {from: 'process USING (upid)'},
+    },
+  });
+
+  expect(dataset.query()).toEqual(
+    'SELECT id, name, process_name FROM (slice) JOIN thread AS thread USING (utid) JOIN process AS process USING (upid)',
+  );
+});
+
+test('get query with joins and filter', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR},
+    joins: {
+      thread: {from: 'thread USING (utid)'},
+    },
+    filter: {
+      col: 'id',
+      eq: 123,
+    },
+  });
+
+  expect(dataset.query()).toEqual(
+    'SELECT id, name FROM (slice) JOIN thread AS thread USING (utid) WHERE id = 123',
+  );
+});
+
+test('get query with joins, column mapping, and filter', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, thread_name: STR},
+    select: {id: 'slice_id', thread_name: 'thread.name'},
+    joins: {
+      thread: {from: 'thread USING (utid)'},
+    },
+    filter: {
+      col: 'id',
+      in: [123, 456],
+    },
+  });
+
+  expect(dataset.query()).toEqual(
+    'SELECT slice_id AS id, thread.name AS thread_name FROM (slice) JOIN thread AS thread USING (utid) WHERE id IN (123, 456)',
+  );
+});
+
+test('get query with select using object format', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, thread_name: STR},
+    select: {
+      id: 'id',
+      thread_name: {expr: 'thread.name', join: 'thread'},
+    },
+    joins: {
+      thread: {from: 'thread USING (utid)'},
+    },
+  });
+
+  expect(dataset.query()).toEqual(
+    'SELECT id, thread.name AS thread_name FROM (slice) JOIN thread AS thread USING (utid)',
+  );
+});
+
+test('get query with mixed select formats', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR, thread_name: STR},
+    select: {
+      id: 'slice_id',
+      name: 'slice.name',
+      thread_name: {expr: 'thread.name', join: 'thread'},
+    },
+    joins: {
+      thread: {from: 'thread USING (utid)'},
+    },
+  });
+
+  expect(dataset.query()).toEqual(
+    'SELECT slice_id AS id, slice.name AS name, thread.name AS thread_name FROM (slice) JOIN thread AS thread USING (utid)',
+  );
+});
+
+test('unique joins not referenced in select are omitted', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR},
+    joins: {
+      thread: {from: 'thread USING (utid)', unique: true},
+      process: {from: 'process USING (upid)', unique: true},
+    },
+  });
+
+  // Neither join is referenced, so both should be omitted
+  expect(dataset.query()).toEqual('SELECT id, name FROM (slice)');
+});
+
+test('non-unique joins are always included', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR},
+    joins: {
+      thread: {from: 'thread USING (utid)', unique: false},
+      process: {from: 'process USING (upid)'},
+    },
+  });
+
+  // Both joins should be included even though not referenced
+  expect(dataset.query()).toEqual(
+    'SELECT id, name FROM (slice) JOIN thread AS thread USING (utid) JOIN process AS process USING (upid)',
+  );
+});
+
+test('unique joins referenced in select are included', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, thread_name: STR},
+    select: {
+      id: 'id',
+      thread_name: {expr: 'thread.name', join: 'thread'},
+    },
+    joins: {
+      thread: {from: 'thread USING (utid)', unique: true},
+      process: {from: 'process USING (upid)', unique: true},
+    },
+  });
+
+  // Only 'thread' join is referenced, so 'process' should be omitted
+  expect(dataset.query()).toEqual(
+    'SELECT id, thread.name AS thread_name FROM (slice) JOIN thread AS thread USING (utid)',
+  );
+});
+
+test('mixed unique and non-unique joins', () => {
+  const dataset = new SourceDataset({
+    src: 'slice',
+    schema: {id: NUM, name: STR},
+    joins: {
+      thread: {from: 'thread USING (utid)', unique: true},
+      process: {from: 'process USING (upid)', unique: false},
+    },
+  });
+
+  // 'thread' is unique and not referenced, so omitted
+  // 'process' is not unique, so included
+  expect(dataset.query()).toEqual(
+    'SELECT id, name FROM (slice) JOIN process AS process USING (upid)',
+  );
+});
+
+test('union query with column elimination', () => {
+  const dataset = UnionDataset.create([
+    new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM, name: STR, dur: LONG},
+      filter: {col: 'id', eq: 123},
+    }),
+    new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM, name: STR, dur: LONG},
+      filter: {col: 'id', eq: 456},
+    }),
+  ]);
+
+  // When querying with a subset of columns, only those columns are selected
+  expect(dataset.query({id: NUM, name: STR})).toEqual(
+    'SELECT id, name FROM (slice) WHERE id IN (123, 456)',
+  );
+});
+
+test('union query with join elimination', () => {
+  const dataset = UnionDataset.create([
+    new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM, name: STR, thread_name: STR},
+      select: {
+        id: 'id',
+        name: 'name',
+        thread_name: {expr: 'thread.name', join: 'thread'},
+      },
+      joins: {
+        thread: {from: 'thread USING (utid)', unique: true},
+      },
+      filter: {col: 'id', eq: 123},
+    }),
+    new SourceDataset({
+      src: 'slice',
+      schema: {id: NUM, name: STR, thread_name: STR},
+      select: {
+        id: 'id',
+        name: 'name',
+        thread_name: {expr: 'thread.name', join: 'thread'},
+      },
+      joins: {
+        thread: {from: 'thread USING (utid)', unique: true},
+      },
+      filter: {col: 'id', eq: 456},
+    }),
+  ]);
+
+  // When querying without thread_name, the unique thread join should be eliminated
+  expect(dataset.query({id: NUM, name: STR})).toEqual(
+    'SELECT id, name FROM (slice) WHERE id IN (123, 456)',
+  );
+
+  // When querying with thread_name, the thread join should be included
+  expect(dataset.query({id: NUM, name: STR, thread_name: STR})).toEqual(
+    'SELECT id, name, thread.name AS thread_name FROM (slice) JOIN thread AS thread USING (utid) WHERE id IN (123, 456)',
   );
 });
 
@@ -82,8 +352,9 @@ test('get query for union dataset', () => {
     }),
   ]);
 
+  // Query automatically optimizes the union into a single source with IN filter
   expect(dataset.query()).toEqual(
-    'SELECT id FROM (slice) WHERE id = 123\nunion all\nSELECT id FROM (slice) WHERE id = 456',
+    'SELECT id FROM (slice) WHERE id IN (123, 456)',
   );
 });
 
@@ -104,17 +375,17 @@ test('union dataset batches large numbers of unions', () => {
 
   const query = UnionDataset.create(datasets).query();
 
-  // Verify query structure with CTE batching.
-  expect(query).toContain('with');
+  // After optimization, all 800 datasets are merged into a single source with
+  // an IN filter, so the query should just be a simple SELECT with WHERE IN.
+  expect(query).toContain('SELECT bar FROM (foo) WHERE some_id IN (');
 
-  // Should have at least 2 CTE batches.
-  expect(query).toContain('union_batch_0 as');
-  expect(query).toContain('union_batch_1 as');
-
-  // 798 union alls within batches (for 800 datasets) + 1 union alls between the
-  // 2 CTEs.
-  const batchMatches = query.match(/union all/g);
-  expect(batchMatches?.length).toBe(799);
+  // The IN clause should contain all 800 values
+  const inMatch = query.match(/IN \(([\d, ]+)\)/);
+  expect(inMatch).toBeTruthy();
+  if (inMatch) {
+    const values = inMatch[1].split(',');
+    expect(values.length).toBe(800);
+  }
 });
 
 test('implements', () => {
@@ -225,7 +496,7 @@ test('optimize a union dataset', () => {
   const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
-      schema: {},
+      schema: {id: NUM},
       filter: {
         col: 'track_id',
         eq: 123,
@@ -233,7 +504,7 @@ test('optimize a union dataset', () => {
     }),
     new SourceDataset({
       src: 'slice',
-      schema: {},
+      schema: {id: NUM},
       filter: {
         col: 'track_id',
         eq: 456,
@@ -241,21 +512,17 @@ test('optimize a union dataset', () => {
     }),
   ]);
 
-  expect(dataset.optimize()).toEqual({
-    src: 'slice',
-    schema: {},
-    filter: {
-      col: 'track_id',
-      in: [123, 456],
-    },
-  });
+  // Optimization happens automatically in query()
+  expect(dataset.query()).toEqual(
+    'SELECT id FROM (slice) WHERE track_id IN (123, 456)',
+  );
 });
 
 test('optimize a union dataset with different types of filters', () => {
   const dataset = UnionDataset.create([
     new SourceDataset({
       src: 'slice',
-      schema: {},
+      schema: {id: NUM},
       filter: {
         col: 'track_id',
         eq: 123,
@@ -263,7 +530,7 @@ test('optimize a union dataset with different types of filters', () => {
     }),
     new SourceDataset({
       src: 'slice',
-      schema: {},
+      schema: {id: NUM},
       filter: {
         col: 'track_id',
         in: [456, 789],
@@ -271,14 +538,10 @@ test('optimize a union dataset with different types of filters', () => {
     }),
   ]);
 
-  expect(dataset.optimize()).toEqual({
-    src: 'slice',
-    schema: {},
-    filter: {
-      col: 'track_id',
-      in: [123, 456, 789],
-    },
-  });
+  // Optimization merges all values into a single IN filter
+  expect(dataset.query()).toEqual(
+    'SELECT id FROM (slice) WHERE track_id IN (123, 456, 789)',
+  );
 });
 
 test('optimize a union dataset with different schemas', () => {
@@ -293,16 +556,11 @@ test('optimize a union dataset with different schemas', () => {
     }),
   ]);
 
-  expect(dataset.optimize()).toEqual({
-    src: 'slice',
-    // The resultant schema is the combination of the union's member's schemas,
-    // as we know the source is the same as we know we can get all of the 'seen'
-    // columns from the source.
-    schema: {
-      foo: NUM,
-      bar: NUM,
-    },
-  });
+  // When querying with the union schema (which is empty {}), we get an empty
+  // SELECT. But we can query with a specific schema to get columns.
+  expect(dataset.query({foo: NUM, bar: NUM})).toEqual(
+    'SELECT foo, bar FROM (slice)',
+  );
 });
 
 test('union type widening', () => {

--- a/ui/src/trace_processor/sql_utils.ts
+++ b/ui/src/trace_processor/sql_utils.ts
@@ -110,7 +110,7 @@ export function sqlValueToSqliteString(
   val: SqlValue | ReadonlyArray<SqlValue>,
 ): string {
   if (Array.isArray(val)) {
-    return val.map((v) => sqlValueToSqliteString(v)).join(',');
+    return val.map((v) => sqlValueToSqliteString(v)).join(', ');
   }
   if (val instanceof Uint8Array) {
     throw new Error("Can't pass blob back to trace processor as value");

--- a/ui/src/widgets/text_input.ts
+++ b/ui/src/widgets/text_input.ts
@@ -21,6 +21,10 @@ export type TextInputAttrs = HTMLInputAttrs & {
   readonly autofocus?: boolean;
   // Optional icon to display on the left of the text field.
   readonly leftIcon?: string;
+  // Callback fired when the input value changes (on every keystroke).
+  readonly onInput?: (value: string) => void;
+  // Callback fired when the input loses focus or enter is pressed.
+  readonly onChange?: (value: string) => void;
 };
 
 export class TextInput implements m.ClassComponent<TextInputAttrs> {
@@ -35,17 +39,31 @@ export class TextInput implements m.ClassComponent<TextInputAttrs> {
   }
 
   view({attrs}: m.CVnode<TextInputAttrs>) {
-    const {leftIcon, className, ...inputAttrs} = attrs; // Destructure icon from other attrs
+    const {leftIcon, className, onInput, onChange, ...inputAttrs} = attrs;
 
     return m(
-      '.pf-text-input', // Add a wrapper div
+      '.pf-text-input',
       {
         className,
       },
       leftIcon &&
-        m(Icon, {icon: leftIcon, className: 'pf-text-input__left-icon'}), // Conditionally render icon
+        m(Icon, {icon: leftIcon, className: 'pf-text-input__left-icon'}),
       m('input.pf-text-input__input', {
-        ...inputAttrs, // Pass remaining attrs to the input
+        ...inputAttrs,
+        oninput: onInput
+          ? (e: InputEvent) => {
+              inputAttrs.oninput?.(e);
+              const target = e.target as HTMLInputElement;
+              onInput(target.value);
+            }
+          : inputAttrs.oninput,
+        onchange: onChange
+          ? (e: InputEvent) => {
+              inputAttrs.onchange?.(e);
+              const target = e.target as HTMLInputElement;
+              onChange(target.value);
+            }
+          : inputAttrs.onchange,
       }),
     );
   }


### PR DESCRIPTION
This patch essentially brings dataset search performance up to the same standard as the current search implementation.

List of changes:
- Add more information (join and select expressions) to datasets which is used optimize bulk queries over multiple tracks.
- Generalize the algorithm used to combine multiple datasets but retain lineage information (required for searching in order to keep track of which track an event belongs to) + add some unit tests.
- Add an optional search results tab + search benchmarking page to help with debugging (for development only, for now).