### PR TITLE
ui: DataGrid: Fix loading spinner not showing up

### DIFF
--- a/ui/src/assets/widgets/linear_progress.scss
+++ b/ui/src/assets/widgets/linear_progress.scss
@@ -16,7 +16,7 @@
   // Make the progress bar 1px high but -1px margin which makes it render over
   // the top of the element above it to save space.
   height: 1px;
-  margin-top: -1px;
+  margin-bottom: -1px;
   z-index: 10;
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
The linear 'spinner' that shows up when the DataGrid is loading disappeared at some point. This patch fixes it by moving it below rather than above the top of the bounds of the DataGrid element, so that it overlaps the DataGrid's header bar by 1px instead of whatever is above it. This makes it more resilient to clipping/overflow/isolation CSS rules.
