### PR TITLE
ui: DataGrid: Rename showExportButtons -> showExportButton

### DIFF
--- a/ui/src/components/widgets/data_grid/data_grid.ts
+++ b/ui/src/components/widgets/data_grid/data_grid.ts
@@ -283,7 +283,7 @@ export interface DataGridAttrs {
    * buttons that export the current filtered/sorted data.
    * Default = false.
    */
-  readonly showExportButtons?: boolean;
+  readonly showExportButton?: boolean;
 
   /**
    * Optional value formatter for export. If not provided, uses the
@@ -399,7 +399,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
       toolbarItemsLeft,
       toolbarItemsRight,
       className,
-      showExportButtons = false,
+      showExportButton = false,
       valueFormatter,
       onReady,
     } = attrs;
@@ -904,7 +904,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
         showResetButton,
         toolbarItemsLeft,
         toolbarItemsRight,
-        showExportButtons,
+        showExportButton,
       ),
       m(LinearProgress, {
         className: 'pf-data-grid__loading',
@@ -985,13 +985,13 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
     showResetButton: boolean,
     toolbarItemsLeft: m.Children,
     toolbarItemsRight: m.Children,
-    showExportButtons: boolean,
+    showExportButton: boolean,
   ) {
     if (
       filters.length === 0 &&
       !(Boolean(toolbarItemsLeft) || Boolean(toolbarItemsRight)) &&
       showResetButton === false &&
-      showExportButtons === false
+      showExportButton === false
     ) {
       return undefined;
     }
@@ -1024,7 +1024,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
             ]),
         ]),
         toolbarItemsRight,
-        showExportButtons && m(DataGridExportButton, {api: this.dataGridApi}),
+        showExportButton && m(DataGridExportButton, {api: this.dataGridApi}),
       ]),
     ]);
   }

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -215,7 +215,7 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
           className: 'pf-query-page__results',
           data: dataSource,
           columns: queryResult.columns.map((c) => ({name: c})),
-          showExportButtons: true,
+          showExportButton: true,
           toolbarItemsLeft: m(
             'span.pf-query-page__results-summary',
             `Returned ${queryResult.totalRowCount.toLocaleString()} rows in ${queryTimeString}`,

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -117,7 +117,7 @@ export function renderDataGrid(app: App): m.Children {
         aggregation: false,
         showResetButton: false,
         demoToolbarItems: false,
-        showExportButtons: false,
+        showExportButton: false,
       },
       noPadding: true,
     }),


### PR DESCRIPTION
Simple property rename. There is only one export button on the DataGrid.