### PR TITLE
ui: Enable dataset search by default

### DIFF
--- a/ui/src/core/search_manager.ts
+++ b/ui/src/core/search_manager.ts
@@ -33,7 +33,7 @@ const DATASET_SEARCH = featureFlags.register({
   name: 'Use dataset search',
   description:
     '[Experimental] use dataset for search, which allows searching all tracks with a matching dataset. Might be slower than normal search.',
-  defaultValue: false,
+  defaultValue: true,
 });
 
 interface SearchResults {


### PR DESCRIPTION
Set the dataset search flag to true by default.