### PR TITLE
ui: Normalize filter icons

### DIFF
--- a/ui/src/base/semantic_icons.ts
+++ b/ui/src/base/semantic_icons.ts
@@ -27,7 +27,8 @@ export class Icons {
   static readonly Add = 'add';
   static readonly Close = 'close';
   static readonly Hide = 'visibility_off';
-  static readonly Filter = 'filter_list';
+  static readonly Filter = 'filter_alt';
+  static readonly FilterOff = 'filter_alt_off';
   static readonly BlankCheckbox = 'check_box_outline_blank';
   static readonly Checkbox = 'check_box';
   static readonly IndeterminateCheckbox = 'indeterminate_check_box';

--- a/ui/src/components/widgets/data_grid/data_grid.ts
+++ b/ui/src/components/widgets/data_grid/data_grid.ts
@@ -956,7 +956,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
                 filters.length > 0 &&
                   m(Button, {
                     variant: ButtonVariant.Filled,
-                    icon: 'filter_alt_off',
+                    icon: Icons.FilterOff,
                     label: 'Clear filters',
                     onclick: clearFilters,
                   }),

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/flags_page.ts
@@ -128,12 +128,11 @@ export class FlagsPage implements m.ClassComponent<FlagsPageAttrs> {
       return m(
         EmptyState,
         {
-          icon: 'filter_alt_off',
           title: 'No settings match your search criteria',
         },
         m(Button, {
           label: 'Clear filter',
-          icon: 'clear',
+          icon: Icons.FilterOff,
           variant: ButtonVariant.Filled,
           onclick: () => {
             this.filterText = '';

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
@@ -31,6 +31,7 @@ import {TextInput} from '../../widgets/text_input';
 import {EmptyState} from '../../widgets/empty_state';
 import {Popup} from '../../widgets/popup';
 import {Box} from '../../widgets/box';
+import {Icons} from '../../base/semantic_icons';
 
 enum SortOrder {
   Name = 'name',
@@ -214,12 +215,11 @@ export class PluginsPage implements m.ClassComponent<PluginsPageAttrs> {
       return m(
         EmptyState,
         {
-          icon: 'filter_alt_off',
           title: 'No plugins match your search criteria',
         },
         m(Button, {
           label: 'Clear filter',
-          icon: 'clear',
+          icon: Icons.FilterOff,
           variant: ButtonVariant.Filled,
           intent: Intent.Primary,
           onclick: () => {
@@ -229,7 +229,7 @@ export class PluginsPage implements m.ClassComponent<PluginsPageAttrs> {
       );
     } else {
       return m(EmptyState, {
-        icon: 'search_off',
+        icon: Icons.NoData,
         title: 'No plugins found',
       });
     }

--- a/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.SettingsPage/settings_page.ts
@@ -30,6 +30,7 @@ import {Stack, StackAuto} from '../../widgets/stack';
 import {FuzzyFinder, FuzzySegment} from '../../base/fuzzy';
 import {Popup} from '../../widgets/popup';
 import {Box} from '../../widgets/box';
+import {Icons} from '../../base/semantic_icons';
 
 export interface SettingsPageAttrs {
   readonly subpage?: string;
@@ -190,12 +191,11 @@ export class SettingsPage implements m.ClassComponent<SettingsPageAttrs> {
       return m(
         EmptyState,
         {
-          icon: 'filter_alt_off',
           title: 'No settings match your search criteria',
         },
         m(Button, {
           label: 'Clear filter',
-          icon: 'clear',
+          icon: Icons.FilterOff,
           variant: ButtonVariant.Filled,
           intent: Intent.Primary,
           onclick: () => {

--- a/ui/src/frontend/timeline_page/timeline_toolbar.ts
+++ b/ui/src/frontend/timeline_page/timeline_toolbar.ts
@@ -212,7 +212,7 @@ export class TimelineToolbar implements m.ClassComponent<TimelineToolbarAttrs> {
       Popup,
       {
         trigger: m(Button, {
-          icon: 'filter_alt',
+          icon: Icons.Filter,
           title: 'Track filter',
           compact: COMPACT_BUTTONS,
           iconFilled: trackFilters.areFiltersSet(),
@@ -298,7 +298,7 @@ export class TimelineToolbar implements m.ClassComponent<TimelineToolbarAttrs> {
         m(Button, {
           type: 'reset',
           label: 'Clear All Filters',
-          icon: 'filter_alt_off',
+          icon: Icons.FilterOff,
           onclick: () => {
             trackFilters.clearAll();
           },

--- a/ui/src/frontend/timeline_page/track_tree_view.ts
+++ b/ui/src/frontend/timeline_page/track_tree_view.ts
@@ -74,6 +74,7 @@ import {Button, ButtonVariant} from '../../widgets/button';
 import {Intent} from '../../widgets/common';
 import {CursorTooltip} from '../../widgets/cursor_tooltip';
 import {CanvasColors} from '../../public/canvas_colors';
+import {Icons} from '../../base/semantic_icons';
 
 const VIRTUAL_TRACK_SCROLLING = featureFlags.register({
   id: 'virtualTrackScrolling',
@@ -244,13 +245,13 @@ export class TrackTreeView implements m.ClassComponent<TrackTreeViewAttrs> {
           EmptyState,
           {
             className,
-            icon: 'filter_alt_off',
             title: `No tracks match track filter`,
           },
           m(Button, {
             intent: Intent.Primary,
             variant: ButtonVariant.Filled,
             label: 'Clear track filter',
+            icon: Icons.FilterOff,
             onclick: () => trace.tracks.filters.clearAll(),
           }),
         );

--- a/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
+++ b/ui/src/plugins/com.android.AndroidLog/logs_panel.ts
@@ -45,6 +45,7 @@ import {classNames} from '../../base/classnames';
 import {TagInput} from '../../widgets/tag_input';
 import {Store} from '../../base/store';
 import {Trace} from '../../public/trace';
+import {Icons} from '../../base/semantic_icons';
 
 const ROW_H = 24;
 
@@ -334,7 +335,7 @@ interface FilterByTextWidgetAttrs {
 
 class FilterByTextWidget implements m.ClassComponent<FilterByTextWidgetAttrs> {
   view({attrs}: m.Vnode<FilterByTextWidgetAttrs>) {
-    const icon = attrs.hideNonMatching ? 'filter_alt' : 'filter_alt_off';
+    const icon = attrs.hideNonMatching ? Icons.Filter : Icons.FilterOff;
     const tooltip = attrs.hideNonMatching
       ? 'Show all logs and highlight matches'
       : 'Show only matching logs';
@@ -430,7 +431,7 @@ export class LogsFilters implements m.ClassComponent<LogsFiltersAttrs> {
 
     return m(PopupMultiSelect, {
       label: 'Filter by machine',
-      icon: 'filter_list_alt',
+      icon: Icons.Filter,
       position: PopupPosition.Top,
       options,
       onChange: (diffs: MultiSelectDiff[]) => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -46,6 +46,7 @@ import {
   LimitAndOffsetNode,
   LimitAndOffsetNodeState,
 } from './nodes/limit_and_offset_node';
+import {Icons} from '../../../base/semantic_icons';
 
 export function registerCoreNodes() {
   nodeRegistry.register('slice', {
@@ -176,7 +177,7 @@ export function registerCoreNodes() {
     name: 'Filter During',
     description:
       'Filter to only show intervals that occurred during intervals from another source.',
-    icon: 'filter_alt',
+    icon: Icons.Filter,
     type: 'modification',
     category: 'Filter',
     factory: (state) => {
@@ -241,7 +242,7 @@ export function registerCoreNodes() {
   nodeRegistry.register('filter_node', {
     name: 'Filter',
     description: 'Filter rows based on column values.',
-    icon: 'filter_alt',
+    icon: Icons.Filter,
     type: 'modification',
     factory: (state) => new FilterNode(state as FilterNodeState),
   });
@@ -266,7 +267,7 @@ export function registerCoreNodes() {
   nodeRegistry.register('limit_and_offset_node', {
     name: 'Limit and Offset',
     description: 'Limit the number of rows returned and optionally skip rows.',
-    icon: 'filter_list',
+    icon: Icons.Filter,
     type: 'modification',
     factory: (state) =>
       new LimitAndOffsetNode(state as LimitAndOffsetNodeState),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
@@ -40,6 +40,7 @@ import {classNames} from '../../../../base/classnames';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
 import {Button, ButtonVariant} from '../../../../widgets/button';
 import {NodeDetailsMessage} from '../node_styling_widgets';
+import {Icons} from '../../../../base/semantic_icons';
 
 // Maximum length for truncated SQL display
 const SQL_TRUNCATE_LENGTH = 50;
@@ -197,7 +198,7 @@ export class FilterNode implements QueryNode {
     bottomRightButtons.push({
       label:
         mode === 'structured' ? 'Switch to WHERE clause' : 'Switch to filters',
-      icon: mode === 'structured' ? 'code' : 'filter_alt',
+      icon: mode === 'structured' ? 'code' : Icons.Filter,
       onclick: () => this.handleModeSwitch(mode),
       compact: true,
     });
@@ -219,7 +220,7 @@ export class FilterNode implements QueryNode {
           }),
           m(TextInput, {
             placeholder: 'Type filter (e.g., dur > 1000)',
-            leftIcon: 'filter_alt',
+            leftIcon: Icons.Filter,
             onkeydown: (e: KeyboardEvent) => {
               if (e.key !== 'Enter') return;
               e.preventDefault();
@@ -330,7 +331,7 @@ export class FilterNode implements QueryNode {
 
       items.push(
         m(ListItem, {
-          icon: isEnabled ? 'filter_alt' : 'filter_alt_off',
+          icon: isEnabled ? Icons.Filter : Icons.FilterOff,
           name: filter.column,
           description: filterDescription,
           actions: [

--- a/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.Ftrace/ftrace_explorer.ts
@@ -38,6 +38,7 @@ import {
   GridRow,
 } from '../../widgets/grid';
 import {FtraceFilter, FtraceStat} from './common';
+import {Icons} from '../../base/semantic_icons';
 
 const ROW_H = 24;
 
@@ -268,7 +269,7 @@ export class FtraceExplorer implements m.ClassComponent<FtraceExplorerAttrs> {
 
     return m(PopupMultiSelect, {
       label: 'Filter',
-      icon: 'filter_list_alt',
+      icon: Icons.Filter,
       position: PopupPosition.Top,
       options,
       onChange: (diffs: MultiSelectDiff[]) => {

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -186,7 +186,6 @@ export function renderDataGrid(app: App): m.Children {
               style: {
                 height: '100%',
               },
-              icon: 'search_off',
             },
             'Load a trace to start',
           );

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
@@ -29,6 +29,7 @@ import {
 import {Select} from '../../../widgets/select';
 import {TextInput} from '../../../widgets/text_input';
 import {renderDocSection, renderWidgetShowcase} from '../widgets_page_utils';
+import {Icons} from '../../../base/semantic_icons';
 
 // Base node data interface
 interface BaseNodeData {
@@ -856,7 +857,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
         return [
           m(MenuItem, {
             label: 'Select',
-            icon: 'filter_alt',
+            icon: Icons.Filter,
             onclick: () => addNode(createSelectNode, toNode),
             style: {
               borderLeft: `4px solid hsl(${NODE_CONFIGS.select.hue}, 60%, 50%)`,
@@ -864,7 +865,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
           }),
           m(MenuItem, {
             label: 'Filter',
-            icon: 'filter_list',
+            icon: Icons.Filter,
             onclick: () => addNode(createFilterNode, toNode),
             style: {
               borderLeft: `4px solid hsl(${NODE_CONFIGS.filter.hue}, 60%, 50%)`,
@@ -1085,7 +1086,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
               }),
               m(MenuItem, {
                 label: 'Select',
-                icon: 'filter_alt',
+                icon: Icons.Filter,
                 onclick: () => addNode(createSelectNode),
                 style: {
                   borderLeft: `4px solid hsl(${NODE_CONFIGS.select.hue}, 60%, 50%)`,
@@ -1093,7 +1094,7 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
               }),
               m(MenuItem, {
                 label: 'Filter',
-                icon: 'filter_list',
+                icon: Icons.Filter,
                 onclick: () => addNode(createFilterNode),
                 style: {
                   borderLeft: `4px solid hsl(${NODE_CONFIGS.filter.hue}, 60%, 50%)`,

--- a/ui/src/widgets/multiselect_input.ts
+++ b/ui/src/widgets/multiselect_input.ts
@@ -184,7 +184,7 @@ export class MultiselectInput
 
     const filtered = this.filterOptions(attrs);
     if (filtered.length === 0) {
-      return m(EmptyState, {title: 'No results found', icon: 'search_off'});
+      return m(EmptyState, {title: 'No results found'});
     }
 
     return m(


### PR DESCRIPTION
Use semantic icons instead of hard coding filter icon names, and use 'filter_alt' and 'filter_alt_off' instead of 'filter_list' and 'filter_list_off' wherever icons are used to represent filters.