### PR TITLE
exp: Add mutliple tables from the modal

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -66,12 +66,13 @@ export function registerCoreNodes() {
     type: 'source',
     showOnLandingPage: true,
     preCreate: async ({sqlModules}) => {
-      const selection = await modalForTableSelection(sqlModules);
-      if (selection) {
-        return {
+      const selections = await modalForTableSelection(sqlModules);
+      if (selections && selections.length > 0) {
+        // Return an array of states, one for each selected table
+        return selections.map((selection) => ({
           sqlTable: selection.sqlTable,
           sqlModules,
-        };
+        }));
       }
       return null;
     },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -76,6 +76,7 @@ type LayoutMap = Map<string, Position>;
 const LAYOUT_CONSTANTS = {
   INITIAL_X: 100,
   INITIAL_Y: 100,
+  BATCH_NODE_HORIZONTAL_OFFSET: 250,
 };
 
 // ========================================
@@ -243,6 +244,7 @@ function ensureNodeLayouts(
   nodeGraphApi: NodeGraphApi | null,
 ): void {
   // Assign layouts to new nodes using smart placement
+  let nodeOffset = 0;
   for (const qnode of roots) {
     if (!attrs.nodeLayouts.has(qnode.nodeId)) {
       let placement: Position;
@@ -274,10 +276,15 @@ function ensureNodeLayouts(
         placement = nodeGraphApi.findPlacementForNode(nodeTemplate);
       } else {
         // Fallback to default position if API not ready yet
+        // Offset nodes horizontally by BATCH_NODE_HORIZONTAL_OFFSET
+        // when multiple nodes are created in a batch to prevent overlap
         placement = {
-          x: LAYOUT_CONSTANTS.INITIAL_X,
+          x:
+            LAYOUT_CONSTANTS.INITIAL_X +
+            nodeOffset * LAYOUT_CONSTANTS.BATCH_NODE_HORIZONTAL_OFFSET,
           y: LAYOUT_CONSTANTS.INITIAL_Y,
         };
+        nodeOffset++;
       }
 
       attrs.onNodeLayoutChange(qnode.nodeId, placement);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/help.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/help.ts
@@ -19,7 +19,7 @@ import {Card, CardStack} from '../../../widgets/card';
 
 export interface ExplorePageHelpAttrs {
   sqlModules: SqlModules;
-  onTableClick: (tableName: string) => void;
+  onTableClick: (tableName: string, event: MouseEvent) => void;
 }
 
 export class ExplorePageHelp implements m.ClassComponent<ExplorePageHelpAttrs> {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
@@ -25,6 +25,10 @@ export interface NodeFactoryContext {
   allNodes: QueryNode[];
 }
 
+// The initial state returned by preCreate, which will be merged with
+// trace and other runtime properties before node creation.
+export type PreCreateState = Record<string, unknown>;
+
 export interface NodeDescriptor {
   // The name of the node, as it appears in the UI.
   name: string;
@@ -48,9 +52,11 @@ export interface NodeDescriptor {
   // An optional, async function that runs before the node is created.
   // It can be used for interactive setup, like showing a modal.
   // If it returns null, the creation is aborted.
+  // Can return an array to create multiple nodes at once (source nodes only).
+  // Note: Operation nodes should only return a single state or null.
   preCreate?: (
     context: PreCreateContext,
-  ) => Promise<Partial<QueryNodeState> | null>;
+  ) => Promise<PreCreateState | PreCreateState[] | null>;
 
   // A function that creates a new instance of the node.
   factory: (state: QueryNodeState, context?: NodeFactoryContext) => QueryNode;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.scss
@@ -13,8 +13,31 @@
 // limitations under the License.
 
 // Override modal's main margin for table list
+// The :has() selector provides sufficient specificity to override the default margin
 .pf-modal-dialog main:has(.pf-exp-node-explorer-help) {
-  margin-top: 0 !important;
+  margin-top: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+
+// Make the table list scrollable
+.pf-exp-node-explorer-help {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pf-exp-table-list {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pf-table-cards-container {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .pf-tag-filter {
@@ -69,28 +92,45 @@
   }
 }
 
-// Styling for cards with disabled modules (no data)
-.pf-disabled-module {
-  opacity: 0.6;
-  background-color: var(--surface-variant) !important;
-
-  &:hover {
-    opacity: 0.7;
+// Styling for selected tables (multi-select mode)
+// Use same layer as cards but with higher specificity to override defaults
+@layer pf-widgets {
+  .pf-card-stack > .pf-card.pf-selected-table {
+    background: color-mix(in srgb, var(--pf-color-accent) 15%, transparent);
+    border: 2px solid var(--pf-color-accent);
+    box-shadow: 0 2px 8px var(--pf-color-box-shadow);
   }
 
-  .pf-table-card {
-    .table-name {
-      color: var(--on-surface-variant);
-    }
+  .pf-card-stack > .pf-card.pf-selected-table.pf-interactive:hover {
+    background: color-mix(in srgb, var(--pf-color-accent) 25%, transparent);
+    box-shadow: 0 4px 12px var(--pf-color-box-shadow);
+  }
+}
 
-    .table-module {
-      color: var(--on-surface-variant);
+// Styling for cards with disabled modules (no data)
+@layer pf-widgets {
+  .pf-card-stack > .pf-card.pf-disabled-module {
+    opacity: 0.6;
+    background-color: var(--surface-variant);
+
+    &:hover {
       opacity: 0.7;
     }
 
-    .table-description {
-      color: var(--on-surface-variant);
-      opacity: 0.8;
+    .pf-table-card {
+      .table-name {
+        color: var(--on-surface-variant);
+      }
+
+      .table-module {
+        color: var(--on-surface-variant);
+        opacity: 0.7;
+      }
+
+      .table-description {
+        color: var(--on-surface-variant);
+        opacity: 0.8;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

This change enables users to add multiple tables simultaneously in the Explore Page. Users can now Ctrl+click (or Cmd+click on Mac) to select multiple tables in the table selection modal, which creates multiple table source nodes at once. This significantly improves the workflow when users need to work with several tables, eliminating the need to repeatedly open and close the modal.

  ## Changes

  - **Multi-select modal support**: Modified table selection modal to support Ctrl+click for selecting multiple tables with visual
  feedback
  - **Batch node creation**: Extended `preCreate` to support returning arrays of states for creating multiple nodes at once (source nodes only)
  - **Smart layout positioning**: Implemented horizontal offsetting for batch-created nodes to prevent overlap when the node graph API isn't ready