### PR TITLE
Reapply "DynamicString avoid dangling pointer (#3775)" (#3782)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,8 @@ Unreleased:
       automatically snaps to nearby slice boundaries to enable exact
       measurement of slice durations. Hold Alt to temporarily disable snapping.
   SDK:
-    *
+    * Breaking change: `DynamicString` no longer accepts temporary `std::string`
+      arguments to prevent use-after-free bugs.
 
 v53.0 - 2025-11-12:
   SDK:

--- a/include/perfetto/tracing/string_helpers.h
+++ b/include/perfetto/tracing/string_helpers.h
@@ -55,6 +55,8 @@ class PERFETTO_EXPORT_COMPONENT DynamicString {
   }
   DynamicString(const char* str, size_t len) : value(str), length(len) {}
   constexpr DynamicString() : value(nullptr), length(0) {}
+  // Disallow construction from temporary strings to avoid use-after-free.
+  DynamicString(std::string&&) = delete;
 
   operator bool() const { return !!value; }
 


### PR DESCRIPTION
This reverts commit 4164eebab5e341d655e79a8a76f4cf7a4b228382.
