### PR TITLE
rust-sdk: update core proto bindings

### DIFF
--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["David Reveman <dreveman@gmail.com>"]
 description = "Bindings for the Perfetto tracing framework"
 readme = "README.md"

--- a/contrib/rust-sdk/perfetto/src/protos/config/trace_config.pz.rs
+++ b/contrib/rust-sdk/perfetto/src/protos/config/trace_config.pz.rs
@@ -100,6 +100,7 @@ pb_msg!(TraceConfig {
     priority_boost: PriorityBoostConfig, msg, 40,
     exclusive_prio: u32, primitive, 41,
     no_flush_before_write_into_file: bool, primitive, 42,
+    trace_all_machines: bool, primitive, 43,
 });
 
 pb_msg!(SessionSemaphore {

--- a/contrib/rust-sdk/perfetto/src/protos/trace/trace_packet.pz.rs
+++ b/contrib/rust-sdk/perfetto/src/protos/trace/trace_packet.pz.rs
@@ -15,11 +15,18 @@
 // Manually generated with bindings for a limited set of TracePacket
 // fields to limit core proto bindings.
 
+use crate::pb_enum;
 use crate::pb_msg;
 use crate::protos::trace::clock_snapshot::*;
 use crate::protos::trace::interned_data::interned_data::*;
 use crate::protos::trace::test_event::*;
 use crate::protos::trace::track_event::track_event::*;
+
+pb_enum!(TracePacketSequenceFlags {
+    SEQ_UNSPECIFIED: 0,
+    SEQ_INCREMENTAL_STATE_CLEARED: 1,
+    SEQ_NEEDS_INCREMENTAL_STATE: 2,
+});
 
 pb_msg!(TracePacket {
     timestamp: u64, primitive, 8,


### PR DESCRIPTION
Include TracePacketSequenceFlags enum in manually generated trace_packet bindings.
