### PR TITLE
gn: Link with -fsanitize=vptr if is_ubsan is true

### DIFF
--- a/gn/standalone/sanitizers/BUILD.gn
+++ b/gn/standalone/sanitizers/BUILD.gn
@@ -128,7 +128,10 @@ config("sanitizers_ldflags") {
       ldflags += [ "-fsanitize=memory" ]
     }
     if (is_ubsan) {
-      ldflags += [ "-fsanitize=undefined" ]
+      ldflags += [
+        "-fsanitize=undefined",
+        "-fsanitize=vptr",
+      ]
     }
     configs = [ ":sanitizer_options_link_helper" ]
   }


### PR DESCRIPTION
Code that was compiled with -fsanitize=vptr needs to be linked in such a way that the UBSAN C++ runtime is linked in. Failing to do so leads to errors such as

  undefined reference: __ubsan_vptr_type_cache

When is_ubsan is true, we can expect that the libraries we link in are also built with UBSAN and may therefore require the UBSAN C++ runtime. Passing -fsanitize=vptr when linking ensures that the UBSAN C++ runtime is linked in.
