### PR TITLE
perfetto_cmd: fix a race on shutdown

### DIFF
--- a/src/perfetto_cmd/perfetto_cmd.cc
+++ b/src/perfetto_cmd/perfetto_cmd.cc
@@ -127,6 +127,9 @@ PerfettoCmd::PerfettoCmd() {
 
 PerfettoCmd::~PerfettoCmd() {
   PerfettoCmd* self = this;
+  // The clear will Quit() and join the task runner threads. We need to do this
+  // before tearing down the main instance to prevent races like b/465349270.
+  snapshot_threads_.clear();
   if (g_perfetto_cmd.compare_exchange_strong(self, nullptr)) {
     if (ctrl_c_handler_installed_) {
       task_runner_.RemoveFileDescriptorWatch(ctrl_c_evt_.fd());


### PR DESCRIPTION
sashwinbalaji@ found this corner case:

- We reach the natural expiry of a tracing session like AOT
- Just before that moment, a trigger happens and a new clone
  task gets enqueued in the snapshot_tasks_
- The main thread finishes, and reaches the destructor of
  the main PerfettoCmd instance.
- That destructor, due to dtor order will:
  - First clear the g_perfetto_cmd
  - Then clear the snapshot_tasks, which will do a join()
- Then a snapshot thread runs, and passes the check
  `if (g_perfetto_cmd != this)`
- InstallCtrlCHandler fails because the sig handler is already
  installed.

For now I'm only adding a .clear() as it will linearize the
thread destruction sequence and make the problem go away.
In future we should reorganize perfetto_cmd and fix this more
properly as part of it.
The real underlying issue is that using 'g_perfetto_cmd != this'
is too brittle. We should pass a "is_main_instance" bool to the
constructor. But that's a larger refactoring.

Bug: b/465349270