### PR TITLE
stdlib: Make frame_id an ID

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/frames/per_frame_metrics.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frames/per_frame_metrics.sql
@@ -56,7 +56,7 @@ GROUP BY
 -- For Googlers: more details in go/android-performance-metrics-glossary.
 CREATE PERFETTO TABLE android_frames_overrun (
   -- Frame id.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Difference between `expected` and `actual` frame ends. Negative if frame
   -- didn't miss deadline.
   overrun LONG
@@ -83,9 +83,9 @@ JOIN slice AS exp_slice
 -- How much time did the frame's Choreographer callbacks take.
 CREATE PERFETTO TABLE android_frames_ui_time (
   -- Frame id
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- UI time duration
-  ui_time LONG
+  ui_time DURATION
 ) AS
 SELECT
   frame_id,
@@ -102,9 +102,9 @@ JOIN slice
 -- For Googlers: more details in go/android-performance-metrics-glossary.
 CREATE PERFETTO TABLE android_app_vsync_delay_per_frame (
   -- Frame id
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- App VSYNC delay.
-  app_vsync_delay LONG
+  app_vsync_delay DURATION
 ) AS
 -- As there can be multiple `DrawFrame` slices, the `frames_surface_slices`
 -- table contains multiple rows for the same `frame_id` which only differ on
@@ -142,17 +142,17 @@ JOIN slice AS act
 -- For Googlers: more details in go/android-performance-metrics-glossary.
 CREATE PERFETTO TABLE android_cpu_time_per_frame (
   -- Frame id
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Difference between actual timeline of the frame and
   -- `Choreographer#doFrame`. See `android_app_vsync_delay_per_frame` table for more details.
-  app_vsync_delay LONG,
+  app_vsync_delay DURATION,
   -- Duration of `Choreographer#doFrame` slice.
   do_frame_dur DURATION,
   -- Duration of `DrawFrame` slice. Summed duration of all `DrawFrame`
   -- slices, if more than one. See `android_frames_draw_frame` for more details.
   draw_frame_dur DURATION,
   -- CPU time across the UI Thread + RenderThread.
-  cpu_time LONG
+  cpu_time DURATION
 ) AS
 WITH
   all_draw_frames AS (
@@ -195,9 +195,9 @@ JOIN slice AS do_frame
 -- For Googlers: more details in go/android-performance-metrics-glossary.
 CREATE PERFETTO TABLE _cpu_time_per_frame_fallback (
   -- Frame id.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Estimated cpu time.
-  estimated_cpu_time LONG
+  estimated_cpu_time DURATION
 ) AS
 SELECT
   frame_id,
@@ -220,14 +220,14 @@ LEFT JOIN android_cpu_time_per_frame AS r
 -- For Googlers: more details in go/android-performance-metrics-glossary.
 CREATE PERFETTO TABLE android_frame_stats (
   -- Frame id.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- The amount by which each frame missed of hit its deadline. See
   -- `android_frames_overrun` for details.
-  overrun LONG,
+  overrun DURATION,
   -- How much time did the frame take across the UI Thread + RenderThread.
-  cpu_time LONG,
+  cpu_time DURATION,
   -- How much time did the frame's Choreographer callbacks take.
-  ui_time LONG,
+  ui_time DURATION,
   -- Was frame janky.
   was_jank BOOL,
   -- CPU time of the frame took over 20ms.

--- a/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frames/timeline.sql
@@ -28,7 +28,7 @@ RETURNS TABLE (
   -- Frame slice.
   id ID(slice.id),
   -- Parsed frame id.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Utid.
   utid JOINID(thread.id),
   -- Upid.
@@ -65,7 +65,7 @@ CREATE PERFETTO TABLE android_frames_choreographer_do_frame (
   id ID(slice.id),
   -- Frame id. Taken as the value behind "Choreographer#doFrame" in slice
   -- name.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Utid of the UI thread
   ui_thread_utid JOINID(thread.id),
   -- Upid of application process
@@ -92,7 +92,7 @@ CREATE PERFETTO TABLE android_frames_draw_frame (
   id ID(slice.id),
   -- Frame id. Taken as the value behind "DrawFrame" in slice
   -- name.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Utid of the render thread
   render_thread_utid JOINID(thread.id),
   -- Upid of application process
@@ -144,7 +144,7 @@ GROUP BY
 -- captures the layer_id for each actual timeline slice too.
 CREATE PERFETTO TABLE android_frames_layers (
   -- Frame id.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Timestamp of the frame. Start of the frame as defined by the start of
   -- "Choreographer#doFrame" slice and the same as the start of the frame in
   -- `actual_frame_timeline_slice if present.
@@ -274,7 +274,7 @@ WHERE
 -- information across different layers for a given frame_id in a given process.
 CREATE PERFETTO TABLE android_frames (
   -- Frame id.
-  frame_id LONG,
+  frame_id ID,
   -- Timestamp of the frame. Start of the frame as defined by the start of
   -- "Choreographer#doFrame" slice and the same as the start of the frame in
   -- `actual_frame_timeline_slice if present.
@@ -326,7 +326,9 @@ SELECT
 FROM android_frames_layers AS frames_layers
 GROUP BY
   frame_id,
-  upid;
+  upid
+ORDER BY
+  frame_id;
 
 -- Returns first frame after the provided timestamp. The returning table has at
 -- most one row.
@@ -336,7 +338,7 @@ CREATE PERFETTO FUNCTION android_first_frame_after(
 )
 RETURNS TABLE (
   -- Frame id.
-  frame_id LONG,
+  frame_id JOINID(android_frames.frame_id),
   -- Start of the frame, the timestamp of the "Choreographer#doFrame" slice.
   ts TIMESTAMP,
   -- Duration of the frame.

--- a/src/trace_processor/perfetto_sql/stdlib/android/input.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/input.sql
@@ -231,7 +231,7 @@ CREATE PERFETTO TABLE android_input_events (
   -- Duration of input event receipt.
   receive_dur DURATION,
   -- Vsync Id associated with the input. Null if an input event has no associated frame event.
-  frame_id LONG
+  frame_id JOINID(android_frames.frame_id)
 ) AS
 WITH
   dispatch AS MATERIALIZED (

--- a/src/trace_processor/perfetto_sql/stdlib/android/startup/time_to_display.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/startup/time_to_display.sql
@@ -185,13 +185,13 @@ CREATE PERFETTO TABLE android_startup_time_to_display (
   -- Startup id.
   startup_id LONG,
   -- Time to initial display (TTID)
-  time_to_initial_display LONG,
+  time_to_initial_display DURATION,
   -- Time to full display (TTFD)
-  time_to_full_display LONG,
+  time_to_full_display DURATION,
   -- `android_frames.frame_id` of frame for initial display
-  ttid_frame_id LONG,
+  ttid_frame_id JOINID(android_frames.frame_id),
   -- `android_frames.frame_id` of frame for full display
-  ttfd_frame_id LONG,
+  ttfd_frame_id JOINID(android_frames.frame_id),
   -- `process.upid` of the startup
   upid JOINID(process.id)
 ) AS


### PR DESCRIPTION
Frame ID was treated just as long, which made it difficult to use it for joining with other tables. As it is unique and sorted, we make it an ID column on android_frames, and make usages type by JOINID(android_frames.frame_id)