### PR TITLE
exp: Widgets get vertical for small sidebar

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
@@ -254,4 +254,5 @@ $panel-padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  container-type: inline-size;
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -23,6 +23,7 @@
   gap: 8px;
   padding-bottom: 4px;
   border-bottom: 1px solid var(--pf-color-border);
+  flex-wrap: wrap;
 
   label {
     font-weight: 600;
@@ -30,6 +31,17 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
     color: var(--pf-color-text-muted);
+  }
+
+  // Stack vertically when container is narrow
+  @container (max-width: 400px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+
+    label {
+      width: 100%;
+    }
   }
 }
 
@@ -152,12 +164,25 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 
   span {
     font-weight: 500;
     font-size: 12px;
     color: var(--pf-color-text-muted);
     min-width: 100px;
+  }
+
+  // Stack vertically when container is narrow
+  @container (max-width: 400px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+
+    span {
+      width: 100%;
+      min-width: 0;
+    }
   }
 }
 
@@ -166,7 +191,7 @@
 .pf-exp-labeled-control {
   display: flex;
   align-items: center;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 8px;
   margin: 0; // Prevent margin stacking with section gaps
 
@@ -180,6 +205,22 @@
   .pf-text-input {
     min-width: 0;
     flex: 1 1 auto;
+  }
+
+  // Stack vertically when container is narrow
+  @container (max-width: 400px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+
+    span {
+      width: 100%;
+      white-space: normal;
+    }
+
+    .pf-text-input {
+      width: 100%;
+    }
   }
 }
 
@@ -258,6 +299,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  container-type: inline-size;
 }
 
 // Sort criteria list - list of draggable sort items with gaps
@@ -336,6 +378,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  container-type: inline-size;
 }
 
 // Form list item widget - inline form editing in a list item
@@ -377,11 +420,27 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
+  flex-wrap: wrap;
 
   // Ensure form controls don't overflow
   .pf-select,
   .pf-text-input {
     min-width: 80px;
+  }
+
+  // Stack vertically when container is narrow
+  @container (max-width: 400px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+
+    .pf-select,
+    .pf-text-input,
+    .pf-outlined-field,
+    .pf-outlined-multiselect {
+      width: 100%;
+      min-width: 0;
+    }
   }
 }
 


### PR DESCRIPTION
 ### Added Container Query Support
  - Added `container-type: inline-size` to parent containers (`.pf-exp-node-explorer__section-content`, `.pf-modifiable-item-list`, `.pf-inline-edit-list`) to enable container queries

  ### Made Row Widgets Responsive
  Updated the following widgets to stack vertically when container width < 400px:
  - **ColumnNameRow** (`.pf-exp-column-name-row`): Form rows with label, input, and buttons
  - **FormRow** (`.pf-exp-form-row`): Labeled form controls
  - **LabeledControl** (`.pf-exp-labeled-control`): Inline label with control
  - **FormListItem content** (`.pf-exp-form-list-item-content`): Form list item controls

  ### Responsive Behavior
  When containers are narrow (< 400px):
  - Elements stack vertically with consistent spacing
  - Labels and controls expand to full width
  - Better readability and usability in narrow sidebars
  - Consistent with existing `EqualWidthRow` pattern