### PR TITLE
exp: Sidebar scrollable

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -28,6 +28,9 @@
 @import "./widgets.scss";
 
 .pf-query-builder-layout {
+  // CSS variable for side panel width, used in both SCSS and TypeScript
+  --pf-qb-side-panel-width: 60px;
+
   height: 100%;
 
   // SplitPanel's main section needs to have the grid layout
@@ -57,7 +60,7 @@
 
   .pf-qb-side-panel {
     grid-column: 4;
-    width: 60px;
+    width: var(--pf-qb-side-panel-width);
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -204,10 +207,21 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  height: 100%;
   gap: 16px;
+  height: 100%;
   padding: 24px;
+  overflow-y: auto;
+
+  // Center content when small, scroll when large
+  &::before {
+    content: "";
+    flex-grow: 1;
+  }
+
+  &::after {
+    content: "";
+    flex-grow: 1;
+  }
 }
 
 .pf-source-card {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -87,6 +87,9 @@ import {ResizeHandle} from '../../../widgets/resize_handle';
 import {nodeRegistry} from './node_registry';
 import {getAllDownstreamNodes} from './graph_utils';
 
+// Side panel width - must match --pf-qb-side-panel-width in builder.scss
+const SIDE_PANEL_WIDTH = 60;
+
 export interface BuilderAttrs {
   readonly trace: Trace;
   readonly sqlModules: SqlModules;
@@ -421,14 +424,16 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         '.pf-qb-explorer',
         {
           style: {
-            width: this.isExplorerCollapsed ? '0' : `${this.sidebarWidth}px`,
+            width: this.isExplorerCollapsed
+              ? '0'
+              : `${this.sidebarWidth + (selectedNode ? 0 : SIDE_PANEL_WIDTH)}px`,
           },
         },
         explorer,
       ),
-      m(
-        '.pf-qb-side-panel',
-        selectedNode &&
+      selectedNode &&
+        m(
+          '.pf-qb-side-panel',
           m(Button, {
             icon: Icons.Info,
             title: 'Info',
@@ -449,29 +454,27 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               }
             },
           }),
-        selectedNode &&
           selectedNode.nodeSpecificModify() != null &&
-          m(Button, {
-            icon: Icons.Edit,
-            title: 'Edit',
-            className:
-              this.selectedView === SelectedView.kModify &&
-              !this.isExplorerCollapsed
-                ? 'pf-active'
-                : '',
-            onclick: () => {
-              if (
+            m(Button, {
+              icon: Icons.Edit,
+              title: 'Edit',
+              className:
                 this.selectedView === SelectedView.kModify &&
                 !this.isExplorerCollapsed
-              ) {
-                this.isExplorerCollapsed = true;
-              } else {
-                this.selectedView = SelectedView.kModify;
-                this.isExplorerCollapsed = false;
-              }
-            },
-          }),
-        selectedNode &&
+                  ? 'pf-active'
+                  : '',
+              onclick: () => {
+                if (
+                  this.selectedView === SelectedView.kModify &&
+                  !this.isExplorerCollapsed
+                ) {
+                  this.isExplorerCollapsed = true;
+                } else {
+                  this.selectedView = SelectedView.kModify;
+                  this.isExplorerCollapsed = false;
+                }
+              },
+            }),
           m(Button, {
             icon: 'code',
             title: 'Result',
@@ -492,7 +495,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               }
             },
           }),
-      ),
+        ),
     );
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.scss
@@ -64,11 +64,22 @@ $panel-padding: 1rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 1rem;
   height: 100%;
   padding: $panel-padding;
   color: var(--pf-color-text-muted);
+  overflow-y: auto;
+
+  // Center content when small, scroll when large
+  &::before {
+    content: "";
+    flex-grow: 1;
+  }
+
+  &::after {
+    content: "";
+    flex-grow: 1;
+  }
 
   &__icon {
     font-size: 48px;


### PR DESCRIPTION
Sidebar is scrollable (but tries to keep the contents centered)

Remove the collapsed sidebar from appearing when no node is selected