### PR TITLE
exp: Fix no longer valid partition columns

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -289,6 +289,22 @@ export class IntervalIntersectNode implements QueryNode {
       if (!checkColumns(inputNode, ['id', 'ts', 'dur'])) return false;
     }
 
+    // Validate partition columns exist in all inputs
+    if (this.state.partitionColumns && this.state.partitionColumns.length > 0) {
+      for (const partitionCol of this.state.partitionColumns) {
+        for (let i = 0; i < inputNodes.length; i++) {
+          const node = inputNodes[i];
+          const cols = new Set(node.finalCols.map((c) => c.name));
+          if (!cols.has(partitionCol)) {
+            this.setValidationError(
+              `Partition column '${partitionCol}' is missing from Input ${i}. Please remove the partitioning or ensure all inputs have this column.`,
+            );
+            return false;
+          }
+        }
+      }
+    }
+
     return true;
   }
 
@@ -354,11 +370,22 @@ export class IntervalIntersectNode implements QueryNode {
 
     // Get common columns for partition selection
     const commonColumns = this.getCommonColumns();
-    if (commonColumns.length === 0) {
+
+    // Build options: include both common columns AND currently selected partition columns
+    // This ensures we show invalid partition columns so the user can deselect them
+    const allPartitionOptions = new Set([
+      ...commonColumns,
+      ...(this.state.partitionColumns ?? []),
+    ]);
+
+    // If there are no options at all (no common columns and no partitions set), don't show
+    if (allPartitionOptions.size === 0) {
       return null;
     }
 
-    const partitionOptions: MultiSelectOption[] = commonColumns.map((col) => ({
+    const partitionOptions: MultiSelectOption[] = Array.from(
+      allPartitionOptions,
+    ).map((col) => ({
       id: col,
       name: col,
       checked: this.state.partitionColumns?.includes(col) ?? false,
@@ -416,7 +443,7 @@ export class IntervalIntersectNode implements QueryNode {
     }
 
     const inputNodes = this.inputNodesList;
-    if (inputNodes.length === 0 || inputNodes[0] === undefined) {
+    if (inputNodes.length === 0) {
       if (this.state.partitionColumns.length > 0) {
         console.warn(
           '[IntervalIntersect] Clearing partition columns - no input nodes available',
@@ -426,23 +453,9 @@ export class IntervalIntersectNode implements QueryNode {
       return;
     }
 
-    const firstNodeCols = inputNodes[0].finalCols;
-    const availablePartitionCols = new Set(firstNodeCols.map((c) => c.name));
-
-    // Remove partition columns that no longer exist in input nodes
-    const validPartitionCols = this.state.partitionColumns.filter((colName) =>
-      availablePartitionCols.has(colName),
-    );
-
-    if (validPartitionCols.length !== this.state.partitionColumns.length) {
-      const removed = this.state.partitionColumns.filter(
-        (c) => !validPartitionCols.includes(c),
-      );
-      console.warn(
-        `[IntervalIntersect] Removing partition columns no longer available in input: ${removed.join(', ')}`,
-      );
-      this.state.partitionColumns = validPartitionCols;
-    }
+    // Don't automatically remove partition columns that become invalid.
+    // Instead, keep them and let validation fail so the user sees the error
+    // and can manually remove the partitioning.
   }
 
   onPrevNodesUpdated(): void {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node_unittest.ts
@@ -655,6 +655,117 @@ describe('IntervalIntersectNode', () => {
       expect(node.validate()).toBe(true);
       expect(node.state.issues?.queryError).toBeUndefined();
     });
+
+    it('should fail validation when partition column is missing from an input', () => {
+      const node1 = createMockPrevNode('node1', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+      ]);
+      const node2 = createMockPrevNode('node2', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+      ]);
+      const node3 = createMockPrevNode('node3', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        // Missing 'utid' column
+      ]);
+
+      const node = new IntervalIntersectNode({
+        inputNodes: [node1, node2, node3],
+        partitionColumns: ['utid'],
+      });
+
+      expect(node.validate()).toBe(false);
+      expect(node.state.issues?.queryError?.message).toContain(
+        "Partition column 'utid' is missing from Input 2",
+      );
+      expect(node.state.issues?.queryError?.message).toContain(
+        'remove the partitioning',
+      );
+    });
+
+    it('should pass validation when all inputs have partition columns', () => {
+      const node1 = createMockPrevNode('node1', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+      ]);
+      const node2 = createMockPrevNode('node2', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+      ]);
+      const node3 = createMockPrevNode('node3', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+      ]);
+
+      const node = new IntervalIntersectNode({
+        inputNodes: [node1, node2, node3],
+        partitionColumns: ['utid'],
+      });
+
+      expect(node.validate()).toBe(true);
+    });
+
+    it('should fail validation when only some partition columns are missing', () => {
+      const node1 = createMockPrevNode('node1', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+        createColumnInfo('upid', 'INT'),
+      ]);
+      const node2 = createMockPrevNode('node2', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+        // Missing 'upid' column
+      ]);
+
+      const node = new IntervalIntersectNode({
+        inputNodes: [node1, node2],
+        partitionColumns: ['utid', 'upid'],
+      });
+
+      expect(node.validate()).toBe(false);
+      expect(node.state.issues?.queryError?.message).toContain(
+        "Partition column 'upid' is missing from Input 1",
+      );
+    });
+
+    it('should pass validation with empty partition columns array', () => {
+      const node1 = createMockPrevNode('node1', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+        createColumnInfo('utid', 'INT'),
+      ]);
+      const node2 = createMockPrevNode('node2', [
+        createColumnInfo('id', 'INT'),
+        createColumnInfo('ts', 'INT64'),
+        createColumnInfo('dur', 'INT64'),
+      ]);
+
+      const node = new IntervalIntersectNode({
+        inputNodes: [node1, node2],
+        partitionColumns: [],
+      });
+
+      expect(node.validate()).toBe(true);
+      expect(node.state.issues?.queryError).toBeUndefined();
+    });
   });
 
   describe('getTitle', () => {


### PR DESCRIPTION
  ## Summary

Fix handling of invalid partition columns in the Interval Intersect node. Previously, partition columns that became invalid (missing from input nodes) were silently removed, which could be confusing to users. Now, the node shows a validation error and keeps the invalid columns visible in the UI so users can manually remove them.

  ## Changes

  - Add validation that checks all partition columns exist in all input nodes
  - Show invalid partition columns in the multi-select UI so they can be deselected
  - Remove automatic cleanup logic that silently removed invalid columns
