### PR TITLE
exp: Add examples card

### DIFF
--- a/ui/build.js
+++ b/ui/build.js
@@ -119,6 +119,7 @@ const RULES = [
   {r: /ui\/src\/assets\/bigtrace.html/, f: copyBigtraceHtml},
   {r: /ui\/src\/open_perfetto_trace\/index.html/, f: copyOpenPerfettoTraceHtml},
   {r: /ui\/src\/assets\/((.*)[.]png)/, f: copyAssets},
+  {r: /ui\/src\/assets\/(explore_page\/examples\/(.*)[.]json)/, f: copyAssets},
   {r: /buildtools\/typefaces\/(.+[.]woff2)/, f: copyAssets},
   {r: /buildtools\/catapult_trace_viewer\/(.+(js|html))/, f: copyAssets},
   {r: /ui\/src\/assets\/.+[.]scss|ui\/src\/(?:plugins|core_plugins)\/.+[.]scss/, f: compileScss},

--- a/ui/src/assets/explore_page/examples/slices_example.json
+++ b/ui/src/assets/explore_page/examples/slices_example.json
@@ -1,0 +1,176 @@
+{
+  "nodes": [
+    {
+      "nodeId": "0",
+      "type": 1,
+      "state": {},
+      "nextNodes": [
+        "5"
+      ]
+    },
+    {
+      "nodeId": "1",
+      "type": 0,
+      "state": {
+        "sqlTable": "thread_state"
+      },
+      "nextNodes": [
+        "4"
+      ]
+    },
+    {
+      "nodeId": "5",
+      "type": 10,
+      "state": {
+        "primaryInputId": "0",
+        "filters": [
+          {
+            "column": "process_name",
+            "op": "=",
+            "value": "com.android.systemui"
+          },
+          {
+            "column": "process_name",
+            "op": "=",
+            "value": "com.android.vending"
+          },
+          {
+            "column": "process_name",
+            "op": "=",
+            "value": "com.breel.wallpapers"
+          }
+        ],
+        "filterOperator": "OR"
+      },
+      "nextNodes": [
+        "2"
+      ]
+    },
+    {
+      "nodeId": "4",
+      "type": 10,
+      "state": {
+        "primaryInputId": "1",
+        "filters": [
+          {
+            "column": "state",
+            "op": "=",
+            "value": "Running"
+          }
+        ]
+      },
+      "nextNodes": [
+        "2"
+      ]
+    },
+    {
+      "nodeId": "2",
+      "type": 7,
+      "state": {
+        "primaryInputId": "5",
+        "secondaryInputNodeIds": [
+          "4"
+        ],
+        "filterNegativeDurPrimary": true,
+        "filterNegativeDurSecondary": true
+      },
+      "nextNodes": [
+        "3"
+      ]
+    },
+    {
+      "nodeId": "3",
+      "type": 4,
+      "state": {
+        "primaryInputId": "2",
+        "groupByColumns": [
+          {
+            "name": "id",
+            "checked": false
+          },
+          {
+            "name": "ts",
+            "checked": false
+          },
+          {
+            "name": "dur",
+            "checked": false
+          },
+          {
+            "name": "name",
+            "checked": false
+          },
+          {
+            "name": "track_id",
+            "checked": false
+          },
+          {
+            "name": "process_name",
+            "checked": true
+          },
+          {
+            "name": "upid",
+            "checked": false
+          },
+          {
+            "name": "thread_name",
+            "checked": false
+          },
+          {
+            "name": "utid",
+            "checked": false
+          },
+          {
+            "name": "depth",
+            "checked": false
+          },
+          {
+            "name": "parent_id",
+            "checked": false
+          },
+          {
+            "name": "category",
+            "checked": false
+          }
+        ],
+        "aggregations": [
+          {
+            "aggregationOp": "COUNT(*)",
+            "isValid": true
+          },
+          {
+            "column": {
+              "name": "dur",
+              "type": "DURATION",
+              "column": {
+                "name": "dur",
+                "type": {
+                  "kind": "duration"
+                }
+              },
+              "checked": false
+            },
+            "aggregationOp": "SUM",
+            "isValid": true
+          }
+        ]
+      },
+      "nextNodes": []
+    }
+  ],
+  "rootNodeIds": [
+    "0",
+    "1"
+  ],
+  "selectedNodeId": "3",
+  "nodeLayouts": {
+    "0": {
+      "x": 521.3976440429688,
+      "y": 194.96255493164062
+    },
+    "1": {
+      "x": 265.76727294921875,
+      "y": 182.5362548828125
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/example_graphs.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/example_graphs.ts
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export interface ExampleGraph {
+  name: string;
+  description: string;
+  jsonPath: string;
+}
+
+export const EXAMPLE_GRAPHS: ExampleGraph[] = [
+  {
+    name: 'Slice Analysis Pipeline',
+    description:
+      'Example data analysis of finding the total duration of specific process slices when any CPU was active ',
+    jsonPath: 'assets/explore_page/examples/slices_example.json',
+  },
+];

--- a/ui/src/plugins/dev.perfetto.ExplorePage/examples_modal.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/examples_modal.ts
@@ -1,0 +1,70 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {closeModal, showModal} from '../../widgets/modal';
+import {EXAMPLE_GRAPHS, ExampleGraph} from './example_graphs';
+import {Card} from '../../widgets/card';
+import {Icon} from '../../widgets/icon';
+
+export function showExamplesModal(): Promise<ExampleGraph | undefined> {
+  return new Promise((resolve) => {
+    const handleExampleClick = (example: ExampleGraph) => {
+      resolve(example);
+      closeModal();
+    };
+
+    showModal({
+      key: 'examples-modal',
+      title: 'Example Graphs',
+      content: () => {
+        return m(
+          '.pf-examples-modal',
+          m(
+            '.pf-examples-grid',
+            EXAMPLE_GRAPHS.map((example) =>
+              m(
+                Card,
+                {
+                  'interactive': true,
+                  'onclick': () => handleExampleClick(example),
+                  'tabindex': 0,
+                  'role': 'button',
+                  'aria-label': `Load ${example.name} example`,
+                  'className': 'pf-example-card',
+                  'onkeydown': (e: KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      handleExampleClick(example);
+                    }
+                  },
+                },
+                m(
+                  '.pf-example-card-content',
+                  m(Icon, {icon: 'description'}),
+                  m('h3', example.name),
+                ),
+                m('p', example.description),
+              ),
+            ),
+          ),
+        );
+      },
+      buttons: [],
+      onClose: () => {
+        resolve(undefined);
+      },
+    });
+  });
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -279,3 +279,64 @@
     margin-top: 4px;
   }
 }
+
+.pf-examples-modal {
+  padding: 16px;
+}
+
+.pf-examples-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 16px;
+  max-width: 800px;
+}
+
+.pf-example-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .pf-example-card-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+    transition: transform 0.1s ease;
+
+    .pf-icon {
+      font-size: 32px;
+      color: var(--pf-color-primary);
+      transition: color 0.1s ease;
+    }
+
+    h3 {
+      margin: 0;
+      font-size: 16px;
+      font-weight: 500;
+      color: var(--pf-color-on-surface);
+      transition: color 0.1s ease;
+    }
+  }
+
+  &:hover .pf-example-card-content,
+  &:focus-within .pf-example-card-content {
+    transform: translateY(-2px);
+
+    .pf-icon {
+      color: var(--pf-color-accent);
+    }
+
+    h3 {
+      color: var(--pf-color-accent);
+    }
+  }
+
+  p {
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--pf-color-text-muted);
+    text-align: center;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -129,6 +129,8 @@ export interface BuilderAttrs {
   readonly onImport: () => void;
   readonly onExport: () => void;
 
+  readonly onLoadExample: () => void;
+
   // Node state change callback
   readonly onNodeStateChange?: () => void;
 
@@ -214,11 +216,36 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         );
       });
 
+    // Add Examples card at the end
+    const examplesCard = m(
+      Card,
+      {
+        'interactive': true,
+        'onclick': () => attrs.onLoadExample(),
+        'tabindex': 0,
+        'role': 'button',
+        'aria-label': 'Load example graph',
+        'className': 'pf-source-card',
+        'onkeydown': (e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            attrs.onLoadExample();
+          }
+        },
+      },
+      m(
+        '.pf-source-card-clickable',
+        m(Icon, {icon: 'auto_stories'}),
+        m('h3', 'Examples'),
+      ),
+      m('p', 'Load an example graph'),
+    );
+
     if (sourceNodes.length === 0) {
-      return m('p', 'No source nodes available');
+      return [examplesCard];
     }
 
-    return sourceNodes;
+    return [examplesCard, ...sourceNodes];
   }
 
   view({attrs}: m.CVnode<BuilderAttrs>) {


### PR DESCRIPTION
 This change adds an "Examples" card to the Explore Page that allows users to load pre-built example graphs. When clicked, it opens a modal displaying available examples with descriptions. Users can select an example to load its graph configuration into the Explore Page.

  **Changes:**
  - Added `EXAMPLE_GRAPHS` registry with metadata for example graphs
  - Created `showExamplesModal()` to display example selection UI
  - Added build rule to copy example JSON files from assets
  - Added comprehensive unit tests validating example metadata and deserialization
  - Updated Builder component to include Examples card in the source nodes section
  - Added styling for examples modal and card components

  **Notes:**
The Examples card is positioned first in the source nodes section and displays even when no other source nodes are available, ensuring users always have quick access to examples.