### PR TITLE
Add custom tokenizing on fwtp_perfetto_counter ftrace events

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
@@ -86,6 +86,10 @@ class FtraceTokenizer {
       uint32_t cpu,
       TraceBlobView event,
       RefPtr<PacketSequenceStateGeneration> state);
+  void TokenizeFtraceFwtpPerfettoCounter(
+      uint32_t cpu,
+      TraceBlobView event,
+      RefPtr<PacketSequenceStateGeneration> state);
   std::optional<protozero::Field> GetFtraceEventField(
       uint32_t event_id,
       const TraceBlobView& event);


### PR DESCRIPTION
The fwtp_perfetto_counter ftrace events have the correct timestamp embedded in them.

Bug: 386832373
Test: Verified Perfetto captures correct timestamp with
 fwtp_perfetto_counter traces.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
