### PR TITLE
exp: Better SQL editor

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -36,6 +36,9 @@ import {Trace} from '../../../../../public/trace';
 import {ColumnInfo} from '../../column_info';
 import {setValidationError} from '../../node_issues';
 import {NodeDetailsAttrs} from '../../node_explorer_types';
+import {findRef, toHTMLElement} from '../../../../../base/dom_utils';
+import {assertExists} from '../../../../../base/logging';
+import {ResizeHandle} from '../../../../../widgets/resize_handle';
 
 export interface SqlSourceSerializedState {
   sql?: string;
@@ -45,6 +48,43 @@ export interface SqlSourceSerializedState {
 export interface SqlSourceState extends QueryNodeState {
   sql?: string;
   trace: Trace;
+}
+
+interface SqlEditorAttrs {
+  sql: string;
+  onUpdate: (text: string) => void;
+  onExecute: (text: string) => void;
+}
+
+class SqlEditor implements m.ClassComponent<SqlEditorAttrs> {
+  private editorHeight: number = 0;
+  private editorElement?: HTMLElement;
+
+  oncreate({dom}: m.VnodeDOM<SqlEditorAttrs>) {
+    this.editorElement = toHTMLElement(assertExists(findRef(dom, 'editor')));
+    this.editorElement.style.height = '400px';
+  }
+
+  view({attrs}: m.CVnode<SqlEditorAttrs>) {
+    return [
+      m(Editor, {
+        ref: 'editor',
+        text: attrs.sql,
+        onUpdate: attrs.onUpdate,
+        onExecute: attrs.onExecute,
+        autofocus: true,
+      }),
+      m(ResizeHandle, {
+        onResize: (deltaPx: number) => {
+          this.editorHeight += deltaPx;
+          this.editorElement!.style.height = `${this.editorHeight}px`;
+        },
+        onResizeStart: () => {
+          this.editorHeight = this.editorElement!.clientHeight;
+        },
+      }),
+    ];
+  }
 }
 
 export class SqlSourceNode implements QueryNode {
@@ -153,31 +193,20 @@ export class SqlSourceNode implements QueryNode {
 
     return m(
       '.sql-source-node',
-      m(
-        'div',
-        {
-          style: {
-            minHeight: '400px',
-            backgroundColor: '#282c34',
-            position: 'relative',
-          },
+      m(SqlEditor, {
+        sql: this.state.sql ?? '',
+        onUpdate: (text: string) => {
+          this.state.sql = text;
+          m.redraw();
         },
-        m(Editor, {
-          text: this.state.sql ?? '',
-          onUpdate: (text: string) => {
-            this.state.sql = text;
-            m.redraw();
-          },
-          onExecute: (text: string) => {
-            queryHistoryStorage.saveQuery(text);
-            this.state.sql = text.trim();
-            // Note: Execution is now handled by the Run button in DataExplorer
-            // This callback only saves to query history and updates the SQL text
-            m.redraw();
-          },
-          autofocus: true,
-        }),
-      ),
+        onExecute: (text: string) => {
+          queryHistoryStorage.saveQuery(text);
+          this.state.sql = text.trim();
+          // Note: Execution is now handled by the Run button in DataExplorer
+          // This callback only saves to query history and updates the SQL text
+          m.redraw();
+        },
+      }),
       m(QueryHistoryComponent, {
         className: '.pf-query-history-container',
         trace: this.state.trace,


### PR DESCRIPTION
  Fixed an issue where the SQL source node editor required clicking precisely on "row 1" to gain focus. The rest of the editor area was not clickable.

  **Root cause**: The editor was wrapped in a div with inline styles that prevented clicks from reaching the CodeMirror editor properly.

  **Solution**: Refactored the SQL source editor to match the query page implementation:
  - Created a `SqlEditor` wrapper component with proper lifecycle management
  - Used refs and `oncreate` hook to directly access and style the editor DOM element
  - Removed the problematic wrapper div with inline styles
  - Added `ResizeHandle` for consistent resize behavior