### PR TITLE
exp: Proper TS and DUR datagrid formatting

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -335,6 +335,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         startingHeight: 300,
         drawerContent: selectedNode
           ? m(DataExplorer, {
+              trace: this.trace,
               query: this.query,
               node: selectedNode,
               response: this.response,


### PR DESCRIPTION
  ## Summary

  Add proper formatting for timestamp and duration columns in the ExplorePage query builder's data grid. Previously, these columns displayed raw bigint values. Now they use the Timestamp and DurationWidget components to display human-readable formatted values with hover tooltips.

  ## Changes

  - Pass `trace` object to DataExplorer component to enable timestamp/duration formatting
  - Add cell renderers for TIMESTAMP and DURATION column types
  - Create helper functions `createTimestampCellRenderer()` and `createDurationCellRenderer()`
  - Use column type metadata from `node.finalCols` to determine which columns need special formatting
  - Apply appropriate cell renderer to each column in the data grid
