### PR TITLE
ui: nodegraph: Add labels

### DIFF
--- a/ui/src/assets/widgets/nodegraph.scss
+++ b/ui/src/assets/widgets/nodegraph.scss
@@ -419,3 +419,110 @@
 .pf-node.pf-invalid.pf-node--has-accent-bar::before {
   background-color: var(--pf-color-danger);
 }
+
+// Label styles
+.pf-label {
+  position: absolute;
+  background: color-mix(
+    in srgb,
+    var(--pf-color-background-secondary) 85%,
+    var(--pf-color-accent) 15%
+  );
+  border: 2px solid var(--pf-color-border);
+  cursor: move;
+  pointer-events: auto;
+  box-sizing: border-box;
+
+  &.pf-dragging {
+    opacity: 0.7;
+    cursor: grabbing;
+  }
+
+  &.pf-selected {
+    border-color: var(--pf-color-accent);
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--pf-color-accent) 50%, transparent);
+  }
+
+  .pf-label-resize-handle {
+    position: absolute;
+    right: -5px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 10px;
+    height: 20px;
+    background: var(--pf-color-accent);
+    border-radius: 3px;
+    cursor: ew-resize;
+    opacity: 0;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  &:hover .pf-label-resize-handle {
+    opacity: 0.6;
+  }
+
+  &.pf-selected .pf-label-resize-handle {
+    opacity: 1;
+  }
+
+  .pf-label-delete-button {
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--pf-color-danger);
+    color: white;
+    border-radius: 3px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s;
+
+    &:hover {
+      opacity: 1;
+      background: color-mix(in srgb, var(--pf-color-danger) 85%, black 15%);
+    }
+
+    .pf-icon {
+      font-size: 12px;
+    }
+  }
+
+  &:hover .pf-label-delete-button,
+  &.pf-selected .pf-label-delete-button {
+    opacity: 1;
+  }
+}
+
+.pf-label-content {
+  width: 100%;
+  max-height: 400px;
+  overflow-y: auto;
+  box-sizing: border-box;
+
+  > .pf-simple-label-text {
+    padding: 12px;
+    font-family: var(--pf-font-compact);
+    font-size: 14px;
+    line-height: 1.4;
+    color: var(--pf-color-text);
+  }
+
+  > .pf-simple-label-button {
+    padding: 8px;
+  }
+
+  > .pf-label-placeholder {
+    padding: 8px;
+    color: var(--pf-color-text-secondary);
+    font-style: italic;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -151,6 +151,13 @@ export interface ExplorePageState {
   rootNodes: QueryNode[];
   selectedNode?: QueryNode;
   nodeLayouts: Map<string, {x: number; y: number}>;
+  labels?: Array<{
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    text: string;
+  }>;
 }
 
 interface ExplorePageAttrs {
@@ -891,6 +898,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         rootNodes: state.rootNodes,
         selectedNode: state.selectedNode,
         nodeLayouts: state.nodeLayouts,
+        labels: state.labels,
         onRootNodeCreated: (node) => {
           wrappedAttrs.onStateUpdate((currentState) => ({
             ...currentState,
@@ -911,6 +919,12 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
               nodeLayouts: newNodeLayouts,
             };
           });
+        },
+        onLabelsChange: (labels) => {
+          wrappedAttrs.onStateUpdate((currentState) => ({
+            ...currentState,
+            labels,
+          }));
         },
         onAddSourceNode: (id) => {
           this.handleAddSourceNode(wrappedAttrs, id);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -96,6 +96,13 @@ export interface SerializedGraph {
   rootNodeIds: string[];
   selectedNodeId?: string;
   nodeLayouts?: {[key: string]: {x: number; y: number}};
+  labels?: Array<{
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    text: string;
+  }>;
 }
 
 function serializeNode(node: QueryNode): SerializedNode {
@@ -133,6 +140,7 @@ export function serializeState(state: ExplorePageState): string {
     rootNodeIds: state.rootNodes.map((n) => n.nodeId),
     selectedNodeId: state.selectedNode?.nodeId,
     nodeLayouts: Object.fromEntries(state.nodeLayouts),
+    labels: state.labels,
   };
 
   const replacer = (key: string, value: unknown) => {
@@ -435,6 +443,7 @@ export function deserializeState(
     rootNodes,
     selectedNode,
     nodeLayouts,
+    labels: serializedGraph.labels,
   };
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -2489,4 +2489,93 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedNode.state.start).toEqual(Time.fromRaw(1000n));
     expect(deserializedNode.state.end).toEqual(Time.fromRaw(2000n));
   });
+
+  test('serializes and deserializes labels', () => {
+    const sliceNode = new SlicesSourceNode({});
+    const labels = [
+      {
+        id: 'label-1',
+        x: 100,
+        y: 200,
+        width: 300,
+        text: 'First label',
+      },
+      {
+        id: 'label-2',
+        x: 400,
+        y: 500,
+        width: 250,
+        text: 'Second label',
+      },
+    ];
+
+    const initialState: ExplorePageState = {
+      rootNodes: [sliceNode],
+      nodeLayouts: new Map(),
+      labels,
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    expect(deserializedState.labels).toEqual(labels);
+  });
+
+  test('handles state without labels', () => {
+    const sliceNode = new SlicesSourceNode({});
+    const initialState: ExplorePageState = {
+      rootNodes: [sliceNode],
+      nodeLayouts: new Map(),
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    expect(deserializedState.labels).toBeUndefined();
+  });
+
+  test('handles empty labels array', () => {
+    const sliceNode = new SlicesSourceNode({});
+    const initialState: ExplorePageState = {
+      rootNodes: [sliceNode],
+      nodeLayouts: new Map(),
+      labels: [],
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    expect(deserializedState.labels).toEqual([]);
+  });
+
+  test('labels survive JSON round-trip with special characters', () => {
+    const sliceNode = new SlicesSourceNode({});
+    const labels = [
+      {
+        id: 'label-1',
+        x: 0,
+        y: 0,
+        width: 200,
+        text: 'Label with "quotes" and \n newlines \t tabs',
+      },
+      {
+        id: 'label-2',
+        x: 0,
+        y: 0,
+        width: 200,
+        text: 'Unicode: 你好 🎉',
+      },
+    ];
+
+    const initialState: ExplorePageState = {
+      rootNodes: [sliceNode],
+      nodeLayouts: new Map(),
+      labels,
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    expect(deserializedState.labels).toEqual(labels);
+  });
 });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -14,6 +14,7 @@
 
 @import "common";
 @import "./graph/graph.scss";
+@import "./graph/text_label.scss";
 @import "./help.scss";
 @import "./graph/node_box.scss";
 @import "./node_styling_widgets.scss";

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -99,6 +99,13 @@ export interface BuilderAttrs {
   readonly rootNodes: QueryNode[];
   readonly selectedNode?: QueryNode;
   readonly nodeLayouts: Map<string, {x: number; y: number}>;
+  readonly labels?: ReadonlyArray<{
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    text: string;
+  }>;
 
   // Add nodes.
   readonly onAddSourceNode: (id: string) => void;
@@ -110,6 +117,15 @@ export interface BuilderAttrs {
   readonly onNodeLayoutChange: (
     nodeId: string,
     layout: {x: number; y: number},
+  ) => void;
+  readonly onLabelsChange?: (
+    labels: Array<{
+      id: string;
+      x: number;
+      y: number;
+      width: number;
+      text: string;
+    }>,
   ) => void;
 
   readonly onDeleteNode: (node: QueryNode) => void;
@@ -399,7 +415,9 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
           selectedNode,
           onNodeSelected,
           nodeLayouts: attrs.nodeLayouts,
+          labels: attrs.labels,
           onNodeLayoutChange: attrs.onNodeLayoutChange,
+          onLabelsChange: attrs.onLabelsChange,
           onDeselect: attrs.onDeselect,
           onAddSourceNode: attrs.onAddSourceNode,
           onClearAllNodes,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/text_label.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/text_label.scss
@@ -1,0 +1,36 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-text-label-textarea {
+  width: 100%;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  overflow: hidden;
+  line-height: 1.2;
+
+  &:read-only {
+    cursor: move;
+  }
+
+  &:not(:read-only) {
+    cursor: text;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/text_label.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/text_label.ts
@@ -1,0 +1,78 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Label} from '../../../../widgets/nodegraph';
+
+// Helper function to auto-resize textarea to fit content
+function autoResizeTextarea(textarea: HTMLTextAreaElement) {
+  textarea.style.height = 'auto';
+  textarea.style.height = textarea.scrollHeight + 'px';
+}
+
+// Helper function to create labels with editable textarea content
+// Double-click to start editing, blur to finish
+export function createEditableTextLabels(
+  labels: ReadonlyArray<Omit<Label, 'content'>>,
+  labelTexts: Map<string, string>,
+  editingLabels: Set<string>,
+  onTextChange?: () => void,
+): Label[] {
+  return labels.map((label) => ({
+    ...label,
+    content: m('textarea.pf-text-label-textarea', {
+      value: labelTexts.get(label.id) ?? '',
+      readonly: !editingLabels.has(label.id),
+      rows: 1,
+      oncreate: (vnode: m.VnodeDOM) => {
+        const textarea = vnode.dom as HTMLTextAreaElement;
+        autoResizeTextarea(textarea);
+      },
+      onupdate: (vnode: m.VnodeDOM) => {
+        const textarea = vnode.dom as HTMLTextAreaElement;
+        autoResizeTextarea(textarea);
+      },
+      onpointerdown: (e: PointerEvent) => {
+        const target = e.target as HTMLTextAreaElement;
+        // If editing (not readonly), stop propagation to prevent dragging
+        if (!target.readOnly) {
+          e.stopPropagation();
+        }
+      },
+      ondblclick: (e: Event) => {
+        const target = e.target as HTMLTextAreaElement;
+        editingLabels.add(label.id);
+        target.focus();
+        m.redraw();
+      },
+      oninput: (e: InputEvent) => {
+        const target = e.target as HTMLTextAreaElement;
+        labelTexts.set(label.id, target.value);
+        autoResizeTextarea(target);
+      },
+      onblur: () => {
+        editingLabels.delete(label.id);
+        if (onTextChange) {
+          onTextChange();
+        }
+        m.redraw();
+      },
+      onchange: (e: Event) => {
+        const target = e.target as HTMLTextAreaElement;
+        labelTexts.set(label.id, target.value);
+        m.redraw();
+      },
+    }),
+  }));
+}

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/nodegraph_demo.ts
@@ -20,6 +20,7 @@ import {Checkbox} from '../../../widgets/checkbox';
 import {MenuItem, PopupMenu} from '../../../widgets/menu';
 import {
   Connection,
+  Label,
   Node,
   NodeGraph,
   NodeGraphApi,
@@ -90,6 +91,7 @@ type NodeData =
 interface NodeGraphStore {
   readonly nodes: Map<string, NodeData>;
   readonly connections: Connection[];
+  readonly labels: Label[];
   readonly invalidNodes: Set<string>; // Track which nodes are marked as invalid
 }
 
@@ -435,6 +437,30 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
   let store: NodeGraphStore = {
     nodes: new Map([[initialId, createTableNode(initialId, 150, 100)]]),
     connections: [],
+    labels: [
+      {
+        id: uuidv4(),
+        x: 400,
+        y: 100,
+        width: 180,
+        content: m('.pf-simple-label-text', 'Simple text label'),
+      },
+      {
+        id: uuidv4(),
+        x: 400,
+        y: 200,
+        width: 180,
+        content: m(
+          '.pf-simple-label-button',
+          m(Button, {
+            label: 'Click me!',
+            onclick: () => {
+              console.log('Label button clicked!');
+            },
+          }),
+        ),
+      },
+    ],
     invalidNodes: new Set<string>(),
   };
 
@@ -562,6 +588,20 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
     selectedNodeIds.delete(nodeId);
 
     console.log(`removeNode: ${nodeId}`);
+  };
+
+  const removeLabel = (labelId: string) => {
+    updateStore((draft) => {
+      const labelIndex = draft.labels.findIndex((l) => l.id === labelId);
+      if (labelIndex !== -1) {
+        draft.labels.splice(labelIndex, 1);
+      }
+    });
+
+    // Clear from selection (outside of store update)
+    selectedNodeIds.delete(labelId);
+
+    console.log(`removeLabel: ${labelId}`);
   };
 
   // Stress test function
@@ -1234,6 +1274,30 @@ export function NodeGraphDemo(): m.Component<NodeGraphDemoAttrs> {
               );
             }
           });
+        },
+        labels: store.labels,
+        onLabelMove: (labelId: string, x: number, y: number) => {
+          updateStore((draft) => {
+            const label = draft.labels.find((l) => l.id === labelId);
+            if (label) {
+              label.x = x;
+              label.y = y;
+              console.log(`onLabelMove: ${labelId} to (${x}, ${y})`);
+            }
+          });
+        },
+        onLabelResize: (labelId: string, width: number) => {
+          updateStore((draft) => {
+            const label = draft.labels.find((l) => l.id === labelId);
+            if (label) {
+              label.width = width;
+              console.log(`onLabelResize: ${labelId} to width ${width}`);
+            }
+          });
+        },
+        onLabelRemove: (labelId: string) => {
+          removeLabel(labelId);
+          console.log(`onLabelRemove: ${labelId}`);
         },
       };
 

--- a/ui/src/widgets/nodegraph.ts
+++ b/ui/src/widgets/nodegraph.ts
@@ -49,9 +49,13 @@
  */
 import m from 'mithril';
 import {Button, ButtonVariant} from './button';
+import {Icon} from './icon';
 import {PopupMenu} from './menu';
 import {classNames} from '../base/classnames';
 import {Icons} from '../base/semantic_icons';
+
+// Default height estimate for labels (used for box selection calculations)
+const DEFAULT_LABEL_MIN_HEIGHT = 30;
 
 interface Position {
   x: number;
@@ -94,6 +98,15 @@ export interface Node {
   readonly canDockBottom?: boolean;
   readonly contextMenuItems?: m.Children;
   readonly invalid?: boolean; // Whether this node is in an invalid state
+}
+
+export interface Label {
+  readonly id: string;
+  x: number;
+  y: number;
+  width: number; // Width of the label box (user can resize)
+  content?: m.Children; // Content to render inside the label (optional, defaults to empty)
+  selectable?: boolean; // Whether clicking the label selects it (default: false, only shift+click works)
 }
 
 interface ConnectingState {
@@ -149,6 +162,13 @@ interface CanvasState {
   selectionRect: SelectionRect | null; // Box selection state
   canvasMouseDownPos: Position;
   tempNodePositions: Map<string, Position>; // Temporary positions during drag
+  tempLabelPositions: Map<string, Position>; // Temporary label positions during drag
+  tempLabelWidths: Map<string, number>; // Temporary label widths during resize
+  draggedLabel: string | null; // ID of label being dragged
+  labelDragStartPos: Position | null; // Position where label drag started
+  resizingLabel: string | null; // ID of label being resized
+  resizeStartWidth: number; // Width when resize started
+  resizeStartX: number; // Mouse X position when resize started
 }
 
 export interface NodeGraphApi {
@@ -160,13 +180,19 @@ export interface NodeGraphApi {
 export interface NodeGraphAttrs {
   readonly nodes: ReadonlyArray<Node>;
   readonly connections: ReadonlyArray<Connection>;
+  readonly labels?: ReadonlyArray<Label>;
   readonly onConnect?: (connection: Connection) => void;
   readonly onNodeMove?: (nodeId: string, x: number, y: number) => void;
   readonly onConnectionRemove?: (index: number) => void;
   readonly onReady?: (api: NodeGraphApi) => void;
+  // Selection state and callbacks apply to both nodes and labels.
+  // selectedNodeIds should contain IDs of both selected nodes and labels.
   readonly selectedNodeIds?: ReadonlySet<string>;
+  // Called when a node or label is selected (replacing current selection).
   readonly onNodeSelect?: (nodeId: string) => void;
+  // Called when a node or label is added to the current selection (multiselect).
   readonly onNodeAddToSelection?: (nodeId: string) => void;
+  // Called when a node or label is removed from the current selection.
   readonly onNodeRemoveFromSelection?: (nodeId: string) => void;
   readonly onSelectionClear?: () => void;
   readonly onDock?: (
@@ -180,6 +206,9 @@ export interface NodeGraphAttrs {
     y: number,
   ) => void;
   readonly onNodeRemove?: (nodeId: string) => void;
+  readonly onLabelMove?: (labelId: string, x: number, y: number) => void;
+  readonly onLabelResize?: (labelId: string, width: number) => void;
+  readonly onLabelRemove?: (labelId: string) => void;
   readonly hideControls?: boolean;
   readonly multiselect?: boolean; // Enable multi-node selection (default: true)
   readonly contextMenuOnHover?: boolean; // Show context menu on hover (default: false)
@@ -308,6 +337,13 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
     selectionRect: null,
     canvasMouseDownPos: {x: 0, y: 0},
     tempNodePositions: new Map<string, Position>(),
+    tempLabelPositions: new Map<string, Position>(),
+    tempLabelWidths: new Map<string, number>(),
+    draggedLabel: null,
+    labelDragStartPos: null,
+    resizingLabel: null,
+    resizeStartWidth: 0,
+    resizeStartX: 0,
   };
 
   // Track drag state for batching updates
@@ -368,6 +404,28 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
         canvasState.mousePos.transformedX ?? 0;
       canvasState.selectionRect.currentY =
         canvasState.mousePos.transformedY ?? 0;
+      m.redraw();
+    } else if (canvasState.draggedLabel !== null) {
+      // Handle label dragging - store temp position, don't call callback yet
+      const newX =
+        (canvasState.mousePos.transformedX ?? 0) - canvasState.dragOffset.x;
+      const newY =
+        (canvasState.mousePos.transformedY ?? 0) - canvasState.dragOffset.y;
+
+      // Store temporary position during drag
+      canvasState.tempLabelPositions.set(canvasState.draggedLabel, {
+        x: newX,
+        y: newY,
+      });
+      m.redraw();
+    } else if (canvasState.resizingLabel !== null) {
+      // Handle label resizing - store temp width, don't call callback yet
+      const currentX = canvasState.mousePos.transformedX ?? 0;
+      const deltaX = currentX - canvasState.resizeStartX;
+      const newWidth = Math.max(100, canvasState.resizeStartWidth + deltaX);
+
+      // Store temporary width during resize
+      canvasState.tempLabelWidths.set(canvasState.resizingLabel, newWidth);
       m.redraw();
     } else if (canvasState.isPanning) {
       // Pan the canvas
@@ -457,7 +515,7 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
 
     // Handle box selection completion
     if (canvasState.selectionRect) {
-      const {nodes = []} = vnode.attrs;
+      const {nodes = [], labels = []} = vnode.attrs;
       const rect = canvasState.selectionRect;
       const minX = Math.min(rect.startX, rect.currentX);
       const maxX = Math.max(rect.startX, rect.currentX);
@@ -476,6 +534,19 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
 
         return (
           nodeX < maxX && nodeRight > minX && nodeY < maxY && nodeBottom > minY
+        );
+      };
+
+      // Helper to check if a label overlaps with selection rectangle
+      const labelOverlapsRect = (label: Label): boolean => {
+        const labelRight = label.x + label.width;
+        const labelBottom = label.y + DEFAULT_LABEL_MIN_HEIGHT;
+
+        return (
+          label.x < maxX &&
+          labelRight > minX &&
+          label.y < maxY &&
+          labelBottom > minY
         );
       };
 
@@ -501,12 +572,19 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
         });
       });
 
-      // Add all selected nodes to selection
+      // Find all labels that intersect with the selection rectangle
+      labels.forEach((label) => {
+        if (labelOverlapsRect(label)) {
+          selectedInRect.push(label.id);
+        }
+      });
+
+      // Add all selected nodes and labels to selection
       const {onNodeAddToSelection} = vnode.attrs;
-      selectedInRect.forEach((nodeId) => {
-        if (!canvasState.selectedNodes.has(nodeId)) {
+      selectedInRect.forEach((id) => {
+        if (!canvasState.selectedNodes.has(id)) {
           if (onNodeAddToSelection !== undefined) {
-            onNodeAddToSelection(nodeId);
+            onNodeAddToSelection(id);
           }
         }
       });
@@ -594,6 +672,34 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
         }
       }
     }
+
+    // Handle label callbacks with final values
+    const {onLabelMove, onLabelResize} = vnode.attrs;
+
+    if (canvasState.draggedLabel !== null) {
+      const finalPos = canvasState.tempLabelPositions.get(
+        canvasState.draggedLabel,
+      );
+      if (finalPos && onLabelMove) {
+        onLabelMove(canvasState.draggedLabel, finalPos.x, finalPos.y);
+      }
+    }
+
+    if (canvasState.resizingLabel !== null) {
+      const finalWidth = canvasState.tempLabelWidths.get(
+        canvasState.resizingLabel,
+      );
+      if (finalWidth !== undefined && onLabelResize) {
+        onLabelResize(canvasState.resizingLabel, finalWidth);
+      }
+    }
+
+    // Cleanup label state
+    canvasState.draggedLabel = null;
+    canvasState.labelDragStartPos = null;
+    canvasState.resizingLabel = null;
+    canvasState.tempLabelPositions.clear();
+    canvasState.tempLabelWidths.clear();
 
     canvasState.draggedNode = null;
     dragStartPosition = null;
@@ -1655,6 +1761,123 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
     );
   }
 
+  function renderLabel(label: Label, vnode: m.Vnode<NodeGraphAttrs>): m.Vnode {
+    const {id, x, y, width, content, selectable = false} = label;
+    const isDragging = canvasState.draggedLabel === id;
+    const isSelected = canvasState.selectedNodes.has(id);
+
+    // Use temporary position/width during drag if available
+    const tempPos = canvasState.tempLabelPositions.get(id);
+    const tempWidth = canvasState.tempLabelWidths.get(id);
+    const renderX = tempPos?.x ?? x;
+    const renderY = tempPos?.y ?? y;
+    const renderWidth = tempWidth ?? width;
+
+    return m(
+      '.pf-label',
+      {
+        'key': `label-${id}`,
+        'data-label': id,
+        'className': classNames(
+          isDragging && 'pf-dragging',
+          isSelected && 'pf-selected',
+        ),
+        'style': {
+          left: `${renderX}px`,
+          top: `${renderY}px`,
+          width: `${renderWidth}px`,
+        },
+        'onpointerdown': (e: PointerEvent) => {
+          const target = e.target as HTMLElement;
+
+          // Check if clicking on the resize handle or delete button
+          if (
+            target.closest('.pf-label-resize-handle') ||
+            target.closest('.pf-label-delete-button')
+          ) {
+            e.stopPropagation();
+            return;
+          }
+
+          // Check if clicking on a textarea that is being edited (not readonly)
+          // Allow normal text selection behavior in edit mode
+          if (target instanceof HTMLTextAreaElement && !target.readOnly) {
+            // Don't start dragging, allow text selection
+            return;
+          }
+
+          const {multiselect = true} = vnode.attrs;
+
+          // Handle multi-selection with Shift or Cmd/Ctrl (only if multiselect is enabled)
+          if (multiselect && (e.shiftKey || e.metaKey || e.ctrlKey)) {
+            // Toggle selection
+            if (isSelected) {
+              const {onNodeRemoveFromSelection} = vnode.attrs;
+              if (onNodeRemoveFromSelection !== undefined) {
+                onNodeRemoveFromSelection(id);
+              }
+            } else {
+              const {onNodeAddToSelection} = vnode.attrs;
+              if (onNodeAddToSelection !== undefined) {
+                onNodeAddToSelection(id);
+              }
+            }
+            e.stopPropagation();
+            return;
+          }
+
+          // Start dragging the label
+          canvasState.draggedLabel = id;
+          canvasState.dragOffset = {
+            x: (canvasState.mousePos.transformedX ?? 0) - x,
+            y: (canvasState.mousePos.transformedY ?? 0) - y,
+          };
+
+          // Select the label if selectable (replace current selection)
+          if (selectable) {
+            const {onNodeSelect} = vnode.attrs;
+            if (onNodeSelect !== undefined) {
+              onNodeSelect(id);
+            }
+          }
+
+          e.stopPropagation();
+        },
+      },
+      [
+        // Render the content (or placeholder if not provided)
+        m(
+          '.pf-label-content',
+          content ?? m('.pf-label-placeholder', 'Empty label'),
+        ),
+        // Resize handle (always rendered)
+        m('.pf-label-resize-handle', {
+          onpointerdown: (e: PointerEvent) => {
+            // Start resizing
+            canvasState.resizingLabel = id;
+            canvasState.resizeStartWidth = width;
+            canvasState.resizeStartX = canvasState.mousePos.transformedX ?? 0;
+            e.stopPropagation();
+          },
+        }),
+        // Delete button (always rendered, visible on hover/selection)
+        m(
+          '.pf-label-delete-button',
+          {
+            onclick: (e: PointerEvent) => {
+              const {onLabelRemove} = vnode.attrs;
+              if (onLabelRemove !== undefined) {
+                onLabelRemove(id);
+              }
+              e.stopPropagation();
+            },
+          },
+          m(Icon, {icon: 'close'}),
+        ),
+      ],
+    );
+  }
+
   return {
     oncreate: (vnode: m.VnodeDOM<NodeGraphAttrs>) => {
       latestVnode = vnode;
@@ -1895,19 +2118,29 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
           },
           onkeydown: (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
-              // Deselect all nodes with Escape key
-              if (canvasState.selectedNodes.size > 0) {
+              // Deselect all nodes and labels
+              const hasSelection = canvasState.selectedNodes.size > 0;
+              if (hasSelection) {
                 const {onSelectionClear} = vnode.attrs;
                 if (onSelectionClear !== undefined) {
                   onSelectionClear();
                 }
               }
             } else if (e.key === 'Delete' || e.key === 'Backspace') {
-              const {onNodeRemove} = vnode.attrs;
-              if (canvasState.selectedNodes.size > 0 && onNodeRemove) {
-                // Delete all selected nodes
-                canvasState.selectedNodes.forEach((nodeId) => {
-                  onNodeRemove(nodeId);
+              const {onNodeRemove, onLabelRemove, labels = []} = vnode.attrs;
+
+              if (canvasState.selectedNodes.size > 0) {
+                // Create Sets for O(1) lookups instead of O(n) array.some()
+                const nodeIds = new Set(nodes.map((n) => n.id));
+                const labelIds = new Set(labels.map((l) => l.id));
+
+                // Delete selected nodes and labels
+                canvasState.selectedNodes.forEach((id) => {
+                  if (nodeIds.has(id) && onNodeRemove !== undefined) {
+                    onNodeRemove(id);
+                  } else if (labelIds.has(id) && onLabelRemove !== undefined) {
+                    onLabelRemove(id);
+                  }
                 });
               }
             }
@@ -2044,6 +2277,11 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
                   }
                 })
                 .filter((vnode) => vnode !== null),
+
+              // Render all labels
+              (vnode.attrs.labels ?? []).map((label: Label) => {
+                return renderLabel(label, vnode);
+              }),
             ],
           ),
         ],


### PR DESCRIPTION
Add support for text labels in the NodeGraph widget. Labels are movable, resizable text boxes that can be placed on the canvas to annotate it. They pan and zoom like the nodes.

  ### Changes
  - Add `Label` interface with id, position, width, and text
  - Implement label rendering with drag, resize, and edit functionality
  - Add label-specific event handlers (move, resize, text change, select, remove)
  - Add label selection state (separate from node selection)
  - Support keyboard shortcuts (Delete/Backspace to remove, Escape to deselect/exit edit mode)
  - Add SCSS styling for labels with hover states, resize handles, and delete buttons
  - Update NodeGraph demo with example labels

  ### Features
  - Click to edit, click outside or Ctrl+Enter to finish editing
  - Drag labels by clicking anywhere on the label body
  - Resize labels using the handle on the right edge
  - Delete via button or keyboard shortcuts
  - Auto-focus and select text when entering edit mode