### PR TITLE
exp: Show the join column

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -1516,7 +1516,7 @@ export class AddColumnsNode implements QueryNode {
                       value: s.suggestedTable,
                       selected: s.suggestedTable === selectedTable,
                     },
-                    s.suggestedTable,
+                    `${s.suggestedTable} (on ${s.colName})`,
                   ),
                 ),
               ),


### PR DESCRIPTION
 When multiple columns in the source data can join to the same table (e.g., both `utid` and `waker_utid` point to the `thread` table), the dropdown would show duplicate entries with no way to distinguish between them. This caused confusion about which join condition would be used.

  ## Solution

  Modified the dropdown option text to include the source column name:
  - Before: `thread`, `thread` (ambiguous duplicates)
  - After: `thread (on utid)`, `thread (on waker_utid)` (clear distinction)

  This makes it immediately clear which column will be used for the join operation.