### PR TITLE
ui: Use fieldset and legend for form sections

### DIFF
--- a/ui/src/assets/widgets/form.scss
+++ b/ui/src/assets/widgets/form.scss
@@ -30,7 +30,6 @@
     margin-bottom: 6px;
     font-size: smaller;
     font-weight: 500;
-    color: var(--pf-color-text-muted);
   }
 
   &__section {
@@ -38,20 +37,13 @@
     display: flex;
     flex-direction: column;
     border-radius: 4px;
-    padding-inline: 8px;
-    padding-top: 16px;
-    position: relative;
+    padding: 8px;
     margin-block: 8px;
 
     &-label {
-      position: absolute;
       font-weight: 500;
       text-transform: uppercase;
       font-size: 0.7em;
-      margin-bottom: 8px;
-      top: -0.5em;
-      left: 4px;
-      background: var(--pf-color-background);
       color: var(--pf-color-text-muted);
       padding: 0 2px;
     }

--- a/ui/src/widgets/form.ts
+++ b/ui/src/widgets/form.ts
@@ -156,9 +156,9 @@ export class FormSection implements m.ClassComponent<FormSectionAttrs> {
   view({attrs, children}: m.CVnode<FormSectionAttrs>) {
     const {label, ...rest} = attrs;
     return m(
-      '.pf-form__section',
+      'fieldset.pf-form__section',
       rest,
-      m('.pf-form__section-label', label),
+      m('legend.pf-form__section-label', label),
       children,
     );
   }


### PR DESCRIPTION
Use `<fieldset>` and `<legend>` in form sections rather than attempting to hack it using absolute positioning