### PR TITLE
python: Update deprecated arg

### DIFF
--- a/python/tools/batch_trace_processor_shell.py
+++ b/python/tools/batch_trace_processor_shell.py
@@ -80,7 +80,7 @@ class TpBatchShell(cmd.Cmd):
 
   def print_percentiles(self, data):
     percentiles = [25, 50, 75, 95, 99, 99.9]
-    nearest = np.percentile(data, percentiles, interpolation='nearest')
+    nearest = np.percentile(data, percentiles, method='nearest')
     logging.info("Representative traces for percentiles")
     for i, near in enumerate(nearest):
       print("{}%: {}".format(percentiles[i], self.files[data.index(near)]))


### PR DESCRIPTION
[numpy] Replace `interpolation=` with `method=` on numpy's `percentile`, `quantile`, `nanpercentile` and `nanquantile` APIs.

The `interpolation` keyword argument is removed in NumPy 2.4.
