### PR TITLE
tools: Set VENV_PYTHON as abspath

### DIFF
--- a/tools/release/release_python.py
+++ b/tools/release/release_python.py
@@ -30,9 +30,9 @@ NC = '\033[0m'  # No Color
 
 # Constants for paths. Assumes the script is run from the repository root.
 SETUP_PY_PATH = os.path.join('python', 'setup.py')
-VENV_PYTHON = os.path.join(
-    '.venv', 'bin', 'python') if sys.platform != 'win32' else os.path.join(
-        '.venv', 'Scripts', 'python.exe')
+VENV_PYTHON = (
+    os.path.abspath(os.path.join('.venv', 'bin', 'python')) if sys.platform
+    != 'win32' else os.path.join('.venv', 'Scripts', 'python.exe'))
 
 
 def info(msg: str) -> None:


### PR DESCRIPTION
Reason being: script changes its working directory, but the path to the Python executable is relative.

Cherry-pick of go/pgh/2600

