### PR TITLE
exp: Fix aggregation columns not propagating to ModifyColumns

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_propagation_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_propagation_unittest.ts
@@ -582,4 +582,536 @@ describe('Node Propagation', () => {
       expect(aggOnPrevNodesUpdatedSpy).toHaveBeenCalled();
     });
   });
+
+  describe('aggregation to modify columns propagation', () => {
+    it('REGRESSION: should propagate aggregation column name changes to downstream ModifyColumnsNode', () => {
+      // This test reproduces the exact user workflow:
+      // 1. Create aggregation node with COUNT(*) AS "count"
+      // 2. Add modify columns node below it (sees "count")
+      // 3. Go back to aggregation and rename "count" to "my_count"
+      // 4. Go back to modify columns - should ONLY see "my_count", not "count"
+
+      // Setup: Source -> Aggregation -> ModifyColumns
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect the nodes
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = aggNode;
+
+      // Initialize the aggregation node
+      aggNode.onPrevNodesUpdated?.();
+
+      // User adds an aggregation: COUNT(*) AS "count"
+      aggNode.state.aggregations.push({
+        aggregationOp: 'COUNT(*)',
+        newColumnName: 'count',
+      });
+
+      // Check a column to include in output
+      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+
+      // User adds a modify columns node below
+      // Initialize it - it should see 'id' and 'count' from aggregation
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Verify modify node initially sees 'id' and 'count'
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+        'count',
+      ]);
+
+      // User goes back to aggregation and renames "count" to "my_count"
+      aggNode.state.aggregations[0].newColumnName = 'my_count';
+
+      // Simulate the builder's onchange behavior: notify downstream nodes
+      // This is what SHOULD happen automatically when user edits in UI
+      modifyNode.onPrevNodesUpdated?.();
+
+      // EXPECTED BEHAVIOR:
+      // - Old "count" column should be GONE
+      // - New "my_count" column should appear
+      // - It should be checked by default (all new columns are checked)
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+        'my_count',
+      ]);
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'count',
+      );
+
+      // Verify the new column is checked by default
+      const myCountCol = modifyNode.state.selectedColumns.find(
+        (c) => c.name === 'my_count',
+      );
+      expect(myCountCol?.checked).toBe(true);
+    });
+
+    it('should propagate multiple aggregation column name changes', () => {
+      // Setup: Source -> Aggregation -> ModifyColumns
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect the nodes
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = aggNode;
+
+      // Initialize the aggregation node
+      aggNode.onPrevNodesUpdated?.();
+
+      // Add multiple aggregations
+      aggNode.state.aggregations.push({
+        aggregationOp: 'COUNT(*)',
+        newColumnName: 'count',
+      });
+      aggNode.state.aggregations.push({
+        aggregationOp: 'SUM',
+        column: aggNode.state.groupByColumns.find((c) => c.name === 'value'),
+        newColumnName: 'total',
+      });
+
+      // Check a group by column
+      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+
+      // Initialize the modify node
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Verify initial state
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+        'count',
+        'total',
+      ]);
+
+      // Rename both aggregation columns
+      aggNode.state.aggregations[0].newColumnName = 'num_rows';
+      aggNode.state.aggregations[1].newColumnName = 'sum_value';
+
+      // Propagate changes
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Verify the changes propagated
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+        'num_rows',
+        'sum_value',
+      ]);
+    });
+
+    it('should handle propagation through: Source -> Agg -> ModifyColumns1 -> ModifyColumns2', () => {
+      // Setup: Source -> Aggregation -> Modify1 -> Modify2
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modify1 = new ModifyColumnsNode({selectedColumns: []});
+      const modify2 = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect the nodes
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(modify1);
+      modify1.primaryInput = aggNode;
+      modify1.nextNodes.push(modify2);
+      modify2.primaryInput = modify1;
+
+      // Initialize
+      aggNode.onPrevNodesUpdated?.();
+      aggNode.state.groupByColumns[1].checked = true; // Check 'name'
+      aggNode.state.aggregations.push({
+        aggregationOp: 'COUNT(*)',
+        newColumnName: 'count',
+      });
+
+      modify1.onPrevNodesUpdated?.();
+      modify2.onPrevNodesUpdated?.();
+
+      // Verify initial state - both modify nodes should see 'name' and 'count'
+      expect(modify1.finalCols.map((c) => c.name)).toEqual(['name', 'count']);
+      expect(modify2.finalCols.map((c) => c.name)).toEqual(['name', 'count']);
+
+      // Rename aggregation column
+      aggNode.state.aggregations[0].newColumnName = 'total_count';
+
+      // Propagate to both downstream nodes
+      modify1.onPrevNodesUpdated?.();
+      modify2.onPrevNodesUpdated?.();
+
+      // Both should see the change
+      expect(modify1.finalCols.map((c) => c.name)).toEqual([
+        'name',
+        'total_count',
+      ]);
+      expect(modify2.finalCols.map((c) => c.name)).toEqual([
+        'name',
+        'total_count',
+      ]);
+    });
+
+    it('should handle propagation with filter node between: Source -> Agg -> Filter -> ModifyColumns', () => {
+      // This test requires FilterNode, but we'll use ModifyColumns as a proxy
+      // to test the general propagation pattern
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const middleNode = new ModifyColumnsNode({selectedColumns: []});
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect: Source -> Agg -> MiddleNode -> ModifyColumns
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(middleNode);
+      middleNode.primaryInput = aggNode;
+      middleNode.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = middleNode;
+
+      // Initialize
+      aggNode.onPrevNodesUpdated?.();
+      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.state.aggregations.push({
+        aggregationOp: 'COUNT(*)',
+        newColumnName: 'count',
+      });
+
+      middleNode.onPrevNodesUpdated?.();
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Verify initial state
+      expect(modifyNode.finalCols.map((c) => c.name)).toEqual(['id', 'count']);
+
+      // Rename aggregation column
+      aggNode.state.aggregations[0].newColumnName = 'row_count';
+
+      // Propagate through middle node to modify node
+      middleNode.onPrevNodesUpdated?.();
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Verify change propagated through the chain
+      expect(modifyNode.finalCols.map((c) => c.name)).toEqual([
+        'id',
+        'row_count',
+      ]);
+    });
+
+    it('should handle multiple stacked aggregations: Source -> Agg1 -> Agg2 -> ModifyColumns', () => {
+      const sourceNode = createMockSourceNode();
+      const agg1 = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const agg2 = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect: Source -> Agg1 -> Agg2 -> ModifyColumns
+      sourceNode.nextNodes.push(agg1);
+      agg1.primaryInput = sourceNode;
+      agg1.nextNodes.push(agg2);
+      agg2.primaryInput = agg1;
+      agg2.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = agg2;
+
+      // Initialize agg1
+      agg1.onPrevNodesUpdated?.();
+      agg1.state.groupByColumns[0].checked = true; // Group by 'id'
+      agg1.state.aggregations.push({
+        aggregationOp: 'SUM',
+        column: agg1.state.groupByColumns.find((c) => c.name === 'value'),
+        newColumnName: 'total',
+      });
+
+      // Initialize agg2 - it should see 'id' and 'total' from agg1
+      agg2.onPrevNodesUpdated?.();
+      expect(agg2.state.groupByColumns.map((c) => c.name)).toEqual([
+        'id',
+        'total',
+      ]);
+
+      // In agg2, do another aggregation
+      agg2.state.groupByColumns[0].checked = true; // Group by 'id'
+      agg2.state.aggregations.push({
+        aggregationOp: 'COUNT(*)',
+        newColumnName: 'count',
+      });
+
+      // Initialize modify node
+      modifyNode.onPrevNodesUpdated?.();
+      expect(modifyNode.finalCols.map((c) => c.name)).toEqual(['id', 'count']);
+
+      // Now change column name in FIRST aggregation (agg1)
+      agg1.state.aggregations[0].newColumnName = 'sum_value';
+
+      // Propagate through the chain
+      agg2.onPrevNodesUpdated?.();
+      // Note: agg2's aggregation now needs to be validated since input changed
+      // But it should still work since it's COUNT(*) which doesn't depend on columns
+      modifyNode.onPrevNodesUpdated?.();
+
+      // The modify node should still see 'id' and 'count'
+      // because agg2 is doing COUNT(*) which doesn't depend on agg1's output column names
+      expect(modifyNode.finalCols.map((c) => c.name)).toEqual(['id', 'count']);
+
+      // Now also change column name in SECOND aggregation (agg2)
+      agg2.state.aggregations[0].newColumnName = 'num_groups';
+
+      // Propagate to modify node
+      modifyNode.onPrevNodesUpdated?.();
+      expect(modifyNode.finalCols.map((c) => c.name)).toEqual([
+        'id',
+        'num_groups',
+      ]);
+    });
+
+    it('REGRESSION: should not propagate invalid aggregations to downstream nodes', () => {
+      // This test verifies that only VALID aggregations appear in downstream nodes
+      // When you're editing an aggregation and it becomes invalid (incomplete),
+      // it should NOT appear in the modify columns node below
+
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect the nodes
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = aggNode;
+
+      // Initialize
+      aggNode.onPrevNodesUpdated?.();
+
+      // Add a valid aggregation
+      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.state.aggregations.push({
+        aggregationOp: 'COUNT(*)',
+        newColumnName: 'count',
+      });
+
+      // Initialize modify node
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Should see 'id' and 'count'
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+        'count',
+      ]);
+
+      // Now make the aggregation INVALID by removing the operation
+      // (simulating user deleting the operation while editing)
+      aggNode.state.aggregations[0].aggregationOp = undefined;
+
+      // Notify downstream
+      modifyNode.onPrevNodesUpdated?.();
+
+      // EXPECTED: The invalid aggregation should NOT appear in modify node
+      // Should only see 'id', NOT 'count'
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+      ]);
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'count',
+      );
+    });
+
+    it('REGRESSION: should propagate when invalid aggregation becomes valid again', () => {
+      // When an aggregation transitions from invalid to valid,
+      // it should appear in downstream nodes
+
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect the nodes
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = aggNode;
+
+      // Initialize
+      aggNode.onPrevNodesUpdated?.();
+      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+
+      // Start with an INVALID aggregation (no operation selected)
+      aggNode.state.aggregations.push({
+        aggregationOp: undefined, // Invalid!
+        newColumnName: 'my_agg',
+      });
+
+      // Initialize modify node
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Should only see 'id', not the invalid aggregation
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+      ]);
+
+      // Now make it valid by adding an operation
+      aggNode.state.aggregations[0].aggregationOp = 'COUNT(*)';
+
+      // Notify downstream
+      modifyNode.onPrevNodesUpdated?.();
+
+      // EXPECTED: Now that it's valid, it should appear
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+        'my_agg',
+      ]);
+    });
+
+    it('REGRESSION: should handle mix of valid and invalid aggregations', () => {
+      // When there are multiple aggregations, only valid ones should propagate
+
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect the nodes
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = aggNode;
+
+      // Initialize
+      aggNode.onPrevNodesUpdated?.();
+      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+
+      // Add multiple aggregations: some valid, some invalid
+      aggNode.state.aggregations.push({
+        aggregationOp: 'COUNT(*)',
+        newColumnName: 'count', // VALID
+      });
+      aggNode.state.aggregations.push({
+        aggregationOp: undefined, // INVALID - no operation
+        newColumnName: 'invalid1',
+      });
+      aggNode.state.aggregations.push({
+        aggregationOp: 'SUM',
+        column: aggNode.state.groupByColumns.find((c) => c.name === 'value'),
+        newColumnName: 'sum_value', // VALID
+      });
+      aggNode.state.aggregations.push({
+        aggregationOp: 'SUM',
+        column: undefined, // INVALID - SUM requires a column
+        newColumnName: 'invalid2',
+      });
+
+      // Initialize modify node
+      modifyNode.onPrevNodesUpdated?.();
+
+      // EXPECTED: Should only see 'id' and the two valid aggregations
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+        'id',
+        'count',
+        'sum_value',
+      ]);
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'invalid1',
+      );
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'invalid2',
+      );
+    });
+
+    it('should handle manual column names taking precedence over placeholders', () => {
+      // This test demonstrates what happens when someone manually enters their own name
+      // vs using the placeholder. Manual names should always take precedence.
+
+      // Setup: Source -> Aggregation -> ModifyColumns
+      const sourceNode = createMockSourceNode();
+      const aggNode = new AggregationNode({
+        groupByColumns: [],
+        aggregations: [],
+      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+
+      // Connect the nodes
+      sourceNode.nextNodes.push(aggNode);
+      aggNode.primaryInput = sourceNode;
+      aggNode.nextNodes.push(modifyNode);
+      modifyNode.primaryInput = aggNode;
+
+      // Initialize
+      aggNode.onPrevNodesUpdated?.();
+      aggNode.state.groupByColumns[0].checked = true;
+
+      // Scenario 1: User creates aggregation WITHOUT manual name (uses placeholder)
+      aggNode.state.aggregations.push({
+        aggregationOp: 'SUM',
+        column: aggNode.state.groupByColumns.find((c) => c.name === 'value'),
+        // No newColumnName - should use placeholder "sum_value"
+      });
+
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Should see the placeholder name "sum_value"
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+        'sum_value',
+      );
+
+      // Scenario 2: User manually enters their own name "my_custom_sum"
+      aggNode.state.aggregations[0].newColumnName = 'my_custom_sum';
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Should now see manual name, NOT placeholder
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+        'my_custom_sum',
+      );
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'sum_value',
+      );
+
+      // Scenario 3: User changes manual name to something else
+      aggNode.state.aggregations[0].newColumnName = 'total_amount';
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Should see the new manual name
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+        'total_amount',
+      );
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'my_custom_sum',
+      );
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'sum_value',
+      );
+
+      // Scenario 4: User changes the operation (manual name still takes precedence)
+      aggNode.state.aggregations[0].aggregationOp = 'AVG';
+      modifyNode.onPrevNodesUpdated?.();
+
+      // Should STILL see "total_amount" (manual name), NOT "avg_value" (placeholder)
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+        'total_amount',
+      );
+      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+        'avg_value',
+      );
+    });
+  });
 });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node_unittest.ts
@@ -84,7 +84,7 @@ describe('AggregationNode', () => {
         column: createColumnInfo('dur', 'INT'),
         percentile: 95,
       };
-      expect(placeholderNewColumnName(agg)).toBe('dur_percentile');
+      expect(placeholderNewColumnName(agg)).toBe('percentile_dur');
     });
 
     it('should generate placeholder for MEDIAN with column', () => {
@@ -92,7 +92,7 @@ describe('AggregationNode', () => {
         aggregationOp: 'MEDIAN',
         column: createColumnInfo('value', 'DOUBLE'),
       };
-      expect(placeholderNewColumnName(agg)).toBe('value_median');
+      expect(placeholderNewColumnName(agg)).toBe('median_value');
     });
 
     it('should generate placeholder for SUM with column', () => {
@@ -100,7 +100,7 @@ describe('AggregationNode', () => {
         aggregationOp: 'SUM',
         column: createColumnInfo('dur', 'INT'),
       };
-      expect(placeholderNewColumnName(agg)).toBe('dur_sum');
+      expect(placeholderNewColumnName(agg)).toBe('sum_dur');
     });
 
     it('should generate placeholder for COUNT with column', () => {
@@ -108,7 +108,7 @@ describe('AggregationNode', () => {
         aggregationOp: 'COUNT',
         column: createColumnInfo('name', 'STRING'),
       };
-      expect(placeholderNewColumnName(agg)).toBe('name_count');
+      expect(placeholderNewColumnName(agg)).toBe('count_name');
     });
 
     it('should handle aggregation without operation', () => {
@@ -128,7 +128,7 @@ describe('AggregationNode', () => {
         aggregationOp: 'MEAN',
         column: createColumnInfo('Value', 'DOUBLE'),
       };
-      expect(placeholderNewColumnName(agg)).toBe('Value_mean');
+      expect(placeholderNewColumnName(agg)).toBe('mean_Value');
     });
   });
 
@@ -998,7 +998,7 @@ describe('AggregationNode', () => {
         percentile: 0,
       };
 
-      expect(placeholderNewColumnName(agg)).toBe('dur_percentile');
+      expect(placeholderNewColumnName(agg)).toBe('percentile_dur');
 
       // Validation
       const isValid =
@@ -1016,7 +1016,7 @@ describe('AggregationNode', () => {
         percentile: 100,
       };
 
-      expect(placeholderNewColumnName(agg)).toBe('dur_percentile');
+      expect(placeholderNewColumnName(agg)).toBe('percentile_dur');
 
       // Validation
       const isValid =
@@ -1049,7 +1049,7 @@ describe('AggregationNode', () => {
         column: createColumnInfo('dur_ns', 'INT'),
       };
 
-      expect(placeholderNewColumnName(agg)).toBe('dur_ns_sum');
+      expect(placeholderNewColumnName(agg)).toBe('sum_dur_ns');
     });
   });
 });


### PR DESCRIPTION
Fix: Changing the name of a column in an aggregation does not propagate down to the modify columns node below