### PR TITLE
ui: Grid: Improve column reordering

### DIFF
--- a/ui/src/assets/widgets/grid.scss
+++ b/ui/src/assets/widgets/grid.scss
@@ -246,22 +246,23 @@ $indent-guide-offset: 12px;
       border-right: $border-3;
     }
 
-    &--drag-over {
-      &::after {
-        content: "";
-        position: absolute; // Control positioning within cell.
-        inset-block: 0; // Fill full height of cell.
-        width: 3px; // Visible width of the reorder indicator.
-        background-color: var(--pf-color-accent);
-      }
+    // Drag indicator shown on all cells in the target column (header and body)
+    &--drag-over-before::after,
+    &--drag-over-after::after {
+      content: "";
+      position: absolute;
+      inset-block: 0;
+      width: 3px;
+      background-color: var(--pf-color-accent);
+      pointer-events: none;
+    }
 
-      &-before::after {
-        left: -2px; // Show indicator on the left.
-      }
+    &--drag-over-before::after {
+      left: -2px;
+    }
 
-      &-after::after {
-        right: -2px; // Show indicator on the right.
-      }
+    &--drag-over-after::after {
+      right: -2px;
     }
   }
 


### PR DESCRIPTION
Currently you need to drag and drop a column header over the top of another column header in order to move the column.

This patch allows dragging the column header over any part of the grid, including past the last column to put it at the end, which wasn't supported before.

Plus, the blue column reorder indicator is now rendered down the entire height of the grid instead of just the header column, so it's much easier to see.
