### PR TITLE
exp: Simplify styling

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -65,7 +65,6 @@
     display: flex;
     flex-direction: column;
     gap: 0;
-    background-color: var(--pf-color-surface);
     border-left: 1px solid var(--pf-color-border);
     padding: 0;
     align-items: stretch;
@@ -79,15 +78,10 @@
       border: none;
       border-radius: 0;
       border-bottom: 1px solid var(--pf-color-border);
-      background-color: var(--pf-color-surface);
-
-      &:hover {
-        background-color: var(--pf-color-hover);
-      }
 
       &.pf-active {
         background-color: var(--pf-color-primary);
-        color: white;
+        color: var(--pf-color-text-on-primary);
       }
     }
   }
@@ -169,41 +163,6 @@
   }
 }
 
-.pf-data-explorer-empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  gap: 1rem;
-  padding: 2rem;
-}
-
-.pf-data-explorer-warning-icon {
-  color: var(--pf-color-warning);
-  font-size: 64px;
-}
-
-.pf-data-explorer-warning-message {
-  text-align: center;
-  max-width: 600px;
-  font-size: 14px;
-  line-height: 1.5;
-  color: var(--pf-color-on-surface);
-}
-
-.pf-query-stats {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  font-size: 12px;
-  color: var(--pf-color-text-muted);
-
-  .pf-query-stats-separator {
-    user-select: none;
-  }
-}
-
 .pf-unselected-explorer {
   display: flex;
   flex-direction: column;
@@ -249,7 +208,6 @@
       margin: 0;
       font-size: 16px;
       font-weight: 500;
-      color: var(--pf-color-on-surface);
       transition: color 0.1s ease;
     }
   }
@@ -315,7 +273,6 @@
       margin: 0;
       font-size: 16px;
       font-weight: 500;
-      color: var(--pf-color-on-surface);
       transition: color 0.1s ease;
     }
   }
@@ -350,7 +307,6 @@
   padding: 12px;
   font-size: 13px;
   line-height: 1.5;
-  color: var(--pf-color-on-surface);
   white-space: pre-wrap;
   word-break: break-word;
   font-family: var(--pf-font-family-monospace, "Roboto Mono", monospace);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.scss
@@ -12,61 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Consistent padding value used throughout
-$panel-padding: 1rem;
-
-.pf-exp-data-explorer {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background-color: var(--pf-color-surface);
-
-  &__header {
-    display: flex;
-    align-items: center;
-    flex-shrink: 0;
-    padding: $panel-padding;
-    border-bottom: 1px solid var(--pf-color-border);
-  }
-
-  &__title-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-grow: 1;
-    gap: 0.75rem;
-
-    h2 {
-      font-weight: 600;
-      font-size: 1rem;
-      color: var(--pf-color-text);
-      margin: 0;
-    }
-  }
-
-  &__buttons {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  &__content {
-    flex-grow: 1;
-    flex-shrink: 1;
-    min-height: 0;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-  }
-}
-
 .pf-data-explorer-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
   height: 100%;
-  padding: $panel-padding;
+  padding: 0.5rem;
   color: var(--pf-color-text-muted);
   overflow-y: auto;
 
@@ -82,17 +34,18 @@ $panel-padding: 1rem;
   }
 
   &__icon {
-    font-size: 48px;
+    font-size: 32px;
   }
 
   &__message {
     text-align: center;
     max-width: 600px;
+    font-size: 0.875rem;
   }
 
   // Style children (spinner, buttons) to be prominent
   .pf-spinner {
-    font-size: 48px;
+    font-size: 32px;
   }
 
   &.pf-warning {
@@ -109,7 +62,7 @@ $panel-padding: 1rem;
   align-items: center;
   gap: 0.5rem;
   font-size: 0.875rem;
-  color: var(--pf-color-text-secondary);
+  color: var(--pf-color-text-muted);
 }
 
 .pf-query-stats-separator {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -34,6 +34,7 @@ import {Timestamp} from '../../../components/widgets/timestamp';
 import {DurationWidget} from '../../../components/widgets/duration';
 import {Time, Duration} from '../../../base/time';
 import {ColumnInfo} from './column_info';
+import {DetailsShell} from '../../../widgets/details_shell';
 
 export interface DataExplorerAttrs {
   readonly trace: Trace;
@@ -97,16 +98,13 @@ function getColumnInfo(
 export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
   view({attrs}: m.CVnode<DataExplorerAttrs>) {
     return m(
-      '.pf-exp-data-explorer',
-      m(
-        '.pf-exp-data-explorer__header',
-        m(
-          '.pf-exp-data-explorer__title-row',
-          m('h2', 'Query data'),
-          m('.pf-exp-data-explorer__buttons', this.renderMenu(attrs)),
-        ),
-      ),
-      m('.pf-exp-data-explorer__content', this.renderContent(attrs)),
+      DetailsShell,
+      {
+        title: 'Query data',
+        buttons: this.renderMenu(attrs),
+        fillHeight: true,
+      },
+      this.renderContent(attrs),
     );
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/help.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/help.scss
@@ -21,7 +21,7 @@
 .pf-exp-getting-started {
   position: sticky;
   top: 0;
-  background: var(--perfetto-primary-background);
+  background: var(--pf-color-background);
   padding: 0.5rem;
   z-index: 1;
   margin-bottom: 1rem;
@@ -80,15 +80,15 @@
     }
 
     .pf-importance-high {
-      background-color: #d32f2f; // Red - Very frequent
+      background-color: var(--pf-color-danger);
     }
 
     .pf-importance-mid {
-      background-color: var(--pf-color-primary); // Primary blue - Frequent
+      background-color: var(--pf-color-primary);
     }
 
     .pf-importance-low {
-      background-color: #757575; // Gray - Low
+      background-color: var(--pf-color-text-disabled);
     }
 
     .table-description {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
@@ -14,11 +14,7 @@
 
 @import "./common.scss";
 
-// Consistent padding value used throughout
-$panel-padding: 1rem;
-
 .pf-exp-node-explorer {
-  background-color: var(--pf-color-surface);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -28,7 +24,7 @@ $panel-padding: 1rem;
     display: flex;
     align-items: center;
     flex-shrink: 0;
-    padding: $panel-padding;
+    padding: 1rem;
   }
 
   &__title-row {
@@ -47,14 +43,14 @@ $panel-padding: 1rem;
         font-size: 1rem;
         text-transform: uppercase;
         letter-spacing: 0.05em;
-        color: var(--pf-color-text-secondary);
+        color: var(--pf-color-text-muted);
         margin: 0;
       }
     }
   }
 
   article {
-    padding: $panel-padding;
+    padding: 1rem;
     font-size: 0.875rem;
     flex-grow: 1;
     flex-shrink: 1;
@@ -62,7 +58,6 @@ $panel-padding: 1rem;
     overflow-y: auto;
     overflow-x: hidden;
     line-height: 1.5;
-    color: var(--pf-color-text);
 
     p {
       margin: 0 0 0.75rem 0;
@@ -84,7 +79,6 @@ $panel-padding: 1rem;
 
     strong {
       font-weight: 600;
-      color: var(--pf-color-text);
     }
 
     hr {
@@ -160,7 +154,7 @@ $panel-padding: 1rem;
   gap: 0.5rem;
 
   &:hover {
-    background-color: var(--pf-color-hover);
+    background-color: var(--pf-color-background-secondary);
   }
 
   span {
@@ -203,7 +197,7 @@ $panel-padding: 1rem;
   display: flex;
   justify-content: space-between;
   // Only vertical padding - horizontal padding comes from article
-  padding: $panel-padding 0;
+  padding: 1rem 0;
   gap: 0.5rem;
 }
 
@@ -227,7 +221,7 @@ $panel-padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  padding: $panel-padding 0;
+  padding: 1rem 0;
   border-top: 1px solid var(--pf-color-border);
 
   &:first-child {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_styling_widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_styling_widgets.scss
@@ -30,12 +30,12 @@
 
 // Message styling for informational text (e.g., "No columns added")
 .pf-exp-node-details-message {
-  color: var(--pf-color-text-lighter);
+  color: var(--pf-color-text-muted);
 }
 
 // Text styling for secondary/lighter text
 .pf-exp-node-details-text {
-  color: var(--pf-color-text-lighter);
+  color: var(--pf-color-text-muted);
 }
 
 // Spacer for consistent vertical spacing
@@ -53,7 +53,7 @@
   font-family: var(--pf-font-monospace);
   font-size: 0.9em;
   font-weight: 600;
-  background-color: var(--pf-minimal-background);
+  background-color: var(--pf-color-background-secondary);
   border-radius: 3px;
   color: var(--pf-color-text);
 }
@@ -67,7 +67,7 @@
 }
 
 .pf-exp-merge-equals {
-  color: var(--pf-color-text-lighter);
+  color: var(--pf-color-text-muted);
   font-weight: 500;
 }
 
@@ -75,7 +75,7 @@
 .pf-exp-sql-expression {
   font-family: var(--pf-font-monospace);
   font-size: var(--pf-exp-font-size-sm);
-  background-color: var(--pf-minimal-background);
+  background-color: var(--pf-color-background-secondary);
   padding: 0.5rem;
   border-radius: 4px;
   display: block;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.scss
@@ -12,263 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@import "../common";
-
-.pf-modify-columns-node {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-
-  .pf-exp-node-details-box strong {
-    display: block;
-    margin-bottom: 4px;
-  }
-
-  .pf-exp-node-details-box div {
-    font-size: var(--pf-exp-font-size-sm);
-    padding: 2px 0;
-  }
-
-  .pf-exp-node-details-message {
-    font-style: italic;
-    color: var(--pf-text-color-light);
-  }
-
-  .pf-new-columns-list {
-    margin-top: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .pf-modify-columns-header {
-    padding: 20px 16px;
-    background: var(--surface-color);
-    border-bottom: 1px solid var(--separator-color);
-  }
-
-  .pf-modify-columns-title {
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--pf-text-color-primary);
-    margin-bottom: 16px;
-  }
-
-  .pf-modify-columns-actions {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .pf-modify-columns-stats {
-    font-size: 14px;
-    font-weight: 500;
-    color: var(--pf-text-color-secondary);
-  }
-
-  .pf-modify-columns-buttons {
-    display: flex;
-    gap: 8px;
-  }
-
-  .pf-modify-columns-content {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .pf-modify-columns-actions {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
-    padding-left: 8px;
-  }
-
-  .pf-column-list-container {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .pf-column-list-help {
-    padding: 12px 0;
-    font-size: 13px;
-    color: var(--pf-text-color-secondary);
-    font-style: italic;
-    background: var(--background-color);
-    border-bottom: 1px solid var(--separator-color);
-  }
-
-  .pf-column-list {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    padding: 12px 0;
-  }
-
-  .pf-column {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 8px 12px;
-    margin-bottom: 4px;
-    background: var(--surface-color);
-    border-radius: 4px;
-    border: 1px solid transparent;
-    transition: all 0.15s ease-in-out;
-
-    &:hover {
-      border-color: var(--separator-color);
-      background: var(--background-color);
-    }
-
-    // Make the text input flexible but constrained
-    .pf-text-input {
-      min-width: 100px;
-      max-width: 250px;
-      flex: 1 1 auto;
-    }
-
-    // Keep type selector from being pushed out
-    .pf-column-type {
-      flex-shrink: 0;
-    }
-  }
-
-  .pf-drag-handle {
-    opacity: 0;
-    cursor: grab;
-    transition: opacity 0.2s ease-in-out;
-    width: 20px; // Fixed width for alignment
-    text-align: center;
-    color: var(--pf-text-color-secondary);
-    font-size: 16px;
-
-    &:active {
-      cursor: grabbing;
-    }
-  }
-
-  .pf-column:hover .pf-drag-handle {
-    opacity: 0.6;
-  }
-
-  .pf-drag-handle:hover {
-    opacity: 1 !important;
-  }
-
-  .pf-column-type {
-    margin-left: auto;
-    font-size: 11px;
-    color: var(--pf-text-color-secondary);
-    font-family: var(--pf-monospace-font);
-    padding: 2px 6px;
-    border-radius: 4px;
-    background: var(--background-color);
-    cursor: pointer;
-    white-space: nowrap;
-    user-select: none;
-
-    &:hover {
-      background: var(--separator-color);
-      color: var(--pf-text-color-primary);
-    }
-  }
-
-  .pf-exp-modify-columns-node-buttons {
-    display: flex;
-    gap: 8px;
-  }
-
-  .pf-exp-switch-component {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    padding: 8px 0 4px 0;
-  }
-
-  .pf-exp-switch-header {
-    font-weight: 600;
-    font-size: var(--pf-exp-font-size-sm);
-    margin-bottom: 4px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: var(--pf-text-color-secondary);
-  }
-
-  .pf-exp-switch-case {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: var(--pf-exp-font-size-sm);
-    color: var(--pf-text-color-secondary);
-  }
-
-  .pf-exp-switch-default-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: var(--pf-exp-font-size-sm);
-    color: var(--pf-text-color-secondary);
-    margin-bottom: 4px;
-  }
-}
-
-.pf-exp-node-details-card {
-  padding: 4px;
-  font-size: var(--pf-exp-font-size-sm);
-}
-
-.pf-exp-node-details-spacer {
-  height: 8px;
-}
-
+// Switch/If component layouts - just basic flex, let Form widgets handle spacing
+.pf-exp-switch-component,
 .pf-exp-if-component {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 8px 0 4px 0;
+  gap: 8px;
 }
 
+.pf-exp-switch-case,
+.pf-exp-switch-default-row,
 .pf-exp-if-clause,
 .pf-exp-else-clause {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: var(--pf-exp-font-size-sm);
-  color: var(--pf-text-color-secondary);
-}
-
-.pf-exp-if-buttons {
-  display: flex;
-  gap: 8px;
-  margin-top: 4px;
-}
-
-// Add Columns Actions Section (for AddColumnsNode)
-// Note: Uses .pf-exp-action-buttons from widgets.scss for button layout
-.pf-add-columns-actions-section {
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 20px;
-  padding: 20px;
-  background: var(--surface-color);
-  border: 1px solid var(--separator-color);
-  border-radius: 4px;
-}
-
-// Added Columns List (for AddColumnsNode)
-// Note: Uses .pf-exp-list-item, .pf-exp-empty-state from widgets.scss
-.pf-added-columns-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-// Glob toggle styling
-.pf-exp-switch-glob-toggle {
-  margin-top: 8px;
-  margin-bottom: 8px;
 }
 
 // Join modal two-column layout
@@ -278,19 +36,13 @@
   min-height: 300px;
 }
 
-// Wide modal for join configuration
-.pf-join-modal-wide {
-  min-width: 700px;
-}
-
 .pf-join-modal-controls {
   flex: 0 0 300px;
-  min-width: 250px;
 }
 
 .pf-join-modal-info {
   flex: 1;
-  border-left: 1px solid var(--separator-color);
+  border-left: 1px solid var(--pf-color-border);
   padding-left: 24px;
   overflow: auto;
   max-height: 400px;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/operation_component.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/operation_component.scss
@@ -23,7 +23,6 @@
 
   .pf-exp-section {
     padding: 1rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 
     h2 {
       margin-top: 0;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -404,13 +404,7 @@
   }
 
   &.pf-invalid {
-    background: rgba(255, 100, 100, 0.08);
-    border-color: rgba(255, 100, 100, 0.3);
-
-    &:hover {
-      background: rgba(255, 100, 100, 0.12);
-      border-color: rgba(255, 100, 100, 0.5);
-    }
+    border-color: var(--pf-color-danger);
   }
 }
 
@@ -463,7 +457,7 @@
   transition: border-color 0.15s ease-in-out;
 
   &:hover:not(:disabled) {
-    border-color: var(--pf-color-text-secondary);
+    border-color: var(--pf-color-text-muted);
   }
 
   &:focus-within:not(:disabled) {
@@ -487,7 +481,7 @@
     margin-left: 8px;
     font-size: 12px;
     font-weight: 500;
-    color: var(--pf-color-text-secondary);
+    color: var(--pf-color-text-muted);
     user-select: none;
     transition: color 0.15s ease-in-out;
   }
@@ -528,7 +522,7 @@
 
     &:hover {
       border-color: var(--pf-color-primary) !important;
-      background: var(--pf-color-hover) !important;
+      background: var(--pf-color-background-secondary) !important;
     }
 
     &:focus {
@@ -595,13 +589,7 @@
   }
 
   &.pf-invalid {
-    background: rgba(255, 100, 100, 0.08);
-    border-color: rgba(255, 100, 100, 0.3);
-
-    &:hover {
-      background: rgba(255, 100, 100, 0.12);
-      border-color: rgba(255, 100, 100, 0.5);
-    }
+    border-color: var(--pf-color-danger);
   }
 
   .pf-inline-field__label {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
@@ -40,7 +40,7 @@
     font-weight: 600;
     margin-top: 0;
     margin-bottom: 1rem;
-    border-bottom: 1px solid var(--stroke);
+    border-bottom: 1px solid var(--pf-color-border);
     padding-bottom: 0.5rem;
   }
 
@@ -65,11 +65,9 @@
 
   strong {
     font-weight: 600;
-    color: var(--content-primary);
   }
 
   code {
-    background-color: var(--surface-2);
     padding: 0.1rem 0.3rem;
     border-radius: 3px;
     font-family: var(--monospace-font);
@@ -77,14 +75,12 @@
   }
 
   pre {
-    background-color: var(--surface-2);
     padding: 1rem;
     border-radius: 4px;
     overflow-x: auto;
     margin: 1rem 0;
 
     code {
-      background-color: transparent;
       padding: 0;
     }
   }
@@ -100,12 +96,11 @@
   }
 
   &-loading {
-    color: var(--content-secondary);
     font-style: italic;
   }
 
   &-error {
-    color: var(--intent-error);
+    color: var(--pf-color-danger);
   }
 }
 
@@ -113,7 +108,7 @@
 .pf-table-source-selected {
   margin-top: 2rem;
   padding-top: 1rem;
-  border-top: 2px solid var(--stroke);
+  border-top: 2px solid var(--pf-color-border);
 
   h2 {
     font-size: 1.2em;
@@ -123,10 +118,9 @@
   }
 
   .pf-details-box {
-    background-color: var(--surface-1);
     padding: 1rem;
     border-radius: 4px;
-    border: 1px solid var(--stroke);
+    border: 1px solid var(--pf-color-border);
   }
 }
 
@@ -134,7 +128,7 @@
 .pf-timerange-current-data {
   margin-top: 2rem;
   padding-top: 1rem;
-  border-top: 2px solid var(--stroke);
+  border-top: 2px solid var(--pf-color-border);
 
   h2 {
     font-size: 1.2em;
@@ -152,22 +146,16 @@
     td {
       padding: 0.5rem;
       text-align: left;
-      border: 1px solid var(--stroke);
+      border: 1px solid var(--pf-color-border);
     }
 
     th {
-      background-color: var(--surface-2);
       font-weight: 600;
-    }
-
-    &.pf-table-striped tbody tr:nth-child(even) {
-      background-color: var(--surface-1);
     }
   }
 
   .pf-timerange-info-mode {
     font-style: italic;
-    color: var(--content-secondary);
     margin-top: 0.5rem;
   }
 }


### PR DESCRIPTION
A significant styling cleanup to the Explore Page. Removed a lot of duplicated or unused scss.
Also moved DataExplorer to use DetailsShell, to make it more similar to datagrids everywhere else