### PR TITLE
Add support for print_args(arg_set_id) column to the SQLTable

### DIFF
--- a/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
+++ b/ui/src/components/widgets/sql/pivot_table/pivot_table.ts
@@ -274,16 +274,14 @@ export class PivotTable implements m.ClassComponent<PivotTableAttrs> {
             key: tableColumnId(column),
             column,
           })),
-          manager: {
-            filters: state.filters,
-            trace: state.trace,
-            getSqlQuery: (columns: {[key: string]: SqlColumn}) =>
-              buildSqlQuery({
-                table: state.table.name,
-                columns,
-                filters: state.filters.get(),
-              }),
-          },
+          filters: state.filters,
+          trace: state.trace,
+          getSqlQuery: (columns: {[key: string]: SqlColumn}) =>
+            buildSqlQuery({
+              table: state.table.name,
+              columns,
+              filters: state.filters.get(),
+            }),
           existingColumnIds: new Set(state.getPivots().map(pivotId)),
           onColumnSelected: (column) => state.addPivot(column, index),
         }),
@@ -370,16 +368,14 @@ export class PivotTable implements m.ClassComponent<PivotTableAttrs> {
             key: tableColumnId(column),
             column,
           })),
-          manager: {
-            filters: state.filters,
-            trace: state.trace,
-            getSqlQuery: (columns: {[key: string]: SqlColumn}) =>
-              buildSqlQuery({
-                table: state.table.name,
-                columns,
-                filters: state.filters.get(),
-              }),
-          },
+          filters: state.filters,
+          trace: state.trace,
+          getSqlQuery: (columns: {[key: string]: SqlColumn}) =>
+            buildSqlQuery({
+              table: state.table.name,
+              columns,
+              filters: state.filters.get(),
+            }),
           columnMenu: (column) => ({
             rightIcon: Icons.ContextMenuAlt,
             children: AGGREGATIONS.map((agg) =>

--- a/ui/src/components/widgets/sql/table/menus/cast_column_menu.ts
+++ b/ui/src/components/widgets/sql/table/menus/cast_column_menu.ts
@@ -15,7 +15,12 @@
 import m from 'mithril';
 import {Icons} from '../../../../../base/semantic_icons';
 import {MenuItem} from '../../../../../widgets/menu';
-import {TableColumn, RenderedCell, TableManager} from '../table_column';
+import {
+  TableColumn,
+  RenderedCell,
+  RenderCellContext,
+  ListColumnsContext,
+} from '../table_column';
 import {SqlTableState} from '../state';
 import {
   PerfettoSqlType,
@@ -94,14 +99,14 @@ export class CastColumn implements TableColumn {
     return this.wrappedColumn.getTitle?.();
   }
 
-  renderCell(value: SqlValue, tableManager?: TableManager): RenderedCell {
+  renderCell(value: SqlValue, context?: RenderCellContext): RenderedCell {
     // Delegate rendering to the appropriate column type based on the cast type
     // This allows proper formatting for timestamps, durations, etc.
-    return this.wrappedColumn.renderCell(value, tableManager);
+    return this.wrappedColumn.renderCell(value, context);
   }
 
-  listDerivedColumns(manager: TableManager) {
-    return this.wrappedColumn.listDerivedColumns?.(manager);
+  listDerivedColumns(context: ListColumnsContext) {
+    return this.wrappedColumn.listDerivedColumns?.(context);
   }
 
   getColumnSpecificMenuItems(args: {

--- a/ui/src/components/widgets/sql/table/table_column.ts
+++ b/ui/src/components/widgets/sql/table/table_column.ts
@@ -26,6 +26,22 @@ export interface TableManager {
   getSqlQuery(data: {[key: string]: SqlColumn}): string;
 }
 
+// Context passed to renderCell to allow interaction with the table.
+export interface RenderCellContext {
+  filters: Filters;
+  trace: Trace;
+  getSqlQuery(data: {[key: string]: SqlColumn}): string;
+  hasColumn(column: TableColumn): boolean;
+  addColumn(column: TableColumn): void;
+}
+
+// Context passed to listDerivedColumns to provide information about the table.
+export interface ListColumnsContext {
+  filters: Filters;
+  trace: Trace;
+  getSqlQuery(data: {[key: string]: SqlColumn}): string;
+}
+
 export interface TableColumnParams {
   // See TableColumn.tag.
   tag?: string;
@@ -59,12 +75,12 @@ export interface TableColumn {
   }): m.Children;
 
   /**
-   * Render a table cell. tableManager can be undefined, in which case the cell should provide basic rendering (e.g. for pivot table).
+   * Render a table cell. context can be undefined, in which case the cell should provide basic rendering (e.g. for pivot table).
    *
    * @param value The value to be rendered.
-   * @param tableManager Optional table manager to allow interaction with the table (e.g. adding filters).
+   * @param context Optional context to allow interaction with the table (e.g. adding filters).
    */
-  renderCell(value: SqlValue, tableManager?: TableManager): RenderedCell;
+  renderCell(value: SqlValue, context?: RenderCellContext): RenderedCell;
 
   // A set of columns to be added when opening this table.
   // It has two primary purposes:
@@ -75,7 +91,7 @@ export interface TableColumn {
   // Some columns / values (arg_set_ids, table ids, etc) are primarily used to reference other data.
   // This method allows showing the user list of additional columns which can be fetched using this column.
   listDerivedColumns?(
-    manager: TableManager,
+    context: ListColumnsContext,
   ): undefined | (() => Promise<Map<string, TableColumn>>);
 }
 

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_details_panel.ts
@@ -33,7 +33,7 @@ import {fromSqlBool, renderSliceRef, renderSqlRef} from './utils';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
 import {
   TableColumn,
-  TableManager,
+  RenderCellContext,
 } from '../../components/widgets/sql/table/table_column';
 import {renderStandardCell} from '../../components/widgets/sql/table/render_cell_utils';
 import {ScrollTimelineModel} from './scroll_timeline_model';
@@ -50,9 +50,9 @@ function createPluginSliceIdColumn(
   name: string,
 ): TableColumn {
   const col = new StandardColumn(name, undefined);
-  col.renderCell = (value: SqlValue, tableManager: TableManager) => {
+  col.renderCell = (value: SqlValue, context?: RenderCellContext) => {
     if (value === null || typeof value !== 'bigint') {
-      return renderStandardCell(value, name, tableManager);
+      return renderStandardCell(value, name, context);
     }
     return {
       content: renderSliceRef({


### PR DESCRIPTION
Add support for a new column type, which prints the entire arg set at the same time
and allows the user to select individual columns for further analysis. This is convenient
to be able to see the entire arg set at a glance rather than selecting individual columns manually.

Refactor TableManager interface, splitting it into more specific RenderCellContext
and ListColumnsContext and integrating the necessary bits directly into SelectColumnMenu.

<img width="732" height="574" alt="Screenshot 2025-12-06 at 22 26 56" src="https://github.com/user-attachments/assets/300a589b-95fa-477d-8330-98baac04b933" />