### PR TITLE
exp: Fix styling of columns lists

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -19,7 +19,6 @@ import {
   nextNodeId,
   NodeType,
 } from '../../query_node';
-import {Button, ButtonVariant} from '../../../../widgets/button';
 import {Checkbox} from '../../../../widgets/checkbox';
 import {MenuItem, PopupMenu} from '../../../../widgets/menu';
 import {TextInput} from '../../../../widgets/text_input';
@@ -32,7 +31,7 @@ import {
 import protos from '../../../../protos';
 import {NodeIssues} from '../node_issues';
 import {StructuredQueryBuilder, ColumnSpec} from '../structured_query_builder';
-import {DraggableItem} from '../widgets';
+import {DraggableItem, SelectDeselectAllButtons} from '../widgets';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
 import {
   NodeDetailsMessage,
@@ -271,37 +270,26 @@ export class ModifyColumnsNode implements QueryNode {
         title: `Select and Rename Columns (${selectedCount} / ${totalCount} selected)`,
         content: m(
           '.pf-modify-columns-content',
-          m(
-            '.pf-modify-columns-actions',
-            m(Button, {
-              label: 'Select All',
-              onclick: () => {
-                this.state.selectedColumns = this.state.selectedColumns.map(
-                  (col) => ({
-                    ...col,
-                    checked: true,
-                  }),
-                );
-                this.state.onchange?.();
-              },
-              variant: ButtonVariant.Outlined,
-              compact: true,
-            }),
-            m(Button, {
-              label: 'Deselect All',
-              onclick: () => {
-                this.state.selectedColumns = this.state.selectedColumns.map(
-                  (col) => ({
-                    ...col,
-                    checked: false,
-                  }),
-                );
-                this.state.onchange?.();
-              },
-              variant: ButtonVariant.Outlined,
-              compact: true,
-            }),
-          ),
+          m(SelectDeselectAllButtons, {
+            onSelectAll: () => {
+              this.state.selectedColumns = this.state.selectedColumns.map(
+                (col) => ({
+                  ...col,
+                  checked: true,
+                }),
+              );
+              this.state.onchange?.();
+            },
+            onDeselectAll: () => {
+              this.state.selectedColumns = this.state.selectedColumns.map(
+                (col) => ({
+                  ...col,
+                  checked: false,
+                }),
+              );
+              this.state.onchange?.();
+            },
+          }),
           this.renderColumnList(),
         ),
       },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
@@ -27,11 +27,10 @@ import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
 import {Card, CardStack} from '../../../../widgets/card';
 import {Checkbox} from '../../../../widgets/checkbox';
-import {Button, ButtonVariant} from '../../../../widgets/button';
 import {StructuredQueryBuilder, ColumnSpec} from '../structured_query_builder';
 import {loadNodeDoc} from '../node_doc_loader';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
-import {InfoBox, DraggableItem} from '../widgets';
+import {InfoBox, DraggableItem, SelectDeselectAllButtons} from '../widgets';
 import {
   NodeDetailsMessage,
   NodeTitle,
@@ -252,37 +251,26 @@ export class UnionNode implements QueryNode {
       title: `Select Common Columns (${selectedCount} / ${totalCount} selected)`,
       content: m(
         '.pf-modify-columns-content',
-        m(
-          '.pf-modify-columns-actions',
-          m(Button, {
-            label: 'Select All',
-            onclick: () => {
-              this.state.selectedColumns = this.state.selectedColumns.map(
-                (col) => ({
-                  ...col,
-                  checked: true,
-                }),
-              );
-              this.state.onchange?.();
-            },
-            variant: ButtonVariant.Outlined,
-            compact: true,
-          }),
-          m(Button, {
-            label: 'Deselect All',
-            onclick: () => {
-              this.state.selectedColumns = this.state.selectedColumns.map(
-                (col) => ({
-                  ...col,
-                  checked: false,
-                }),
-              );
-              this.state.onchange?.();
-            },
-            variant: ButtonVariant.Outlined,
-            compact: true,
-          }),
-        ),
+        m(SelectDeselectAllButtons, {
+          onSelectAll: () => {
+            this.state.selectedColumns = this.state.selectedColumns.map(
+              (col) => ({
+                ...col,
+                checked: true,
+              }),
+            );
+            this.state.onchange?.();
+          },
+          onDeselectAll: () => {
+            this.state.selectedColumns = this.state.selectedColumns.map(
+              (col) => ({
+                ...col,
+                checked: false,
+              }),
+            );
+            this.state.onchange?.();
+          },
+        }),
         m(
           '.pf-modify-columns-node',
           m(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -635,3 +635,39 @@
     }
   }
 }
+
+// Column list container - used by modify columns and union nodes
+.pf-column-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+// Column type selector - aligns to the right in modify columns rows
+.pf-column-type {
+  margin-left: auto;
+  padding: 2px 4px;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--pf-color-text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease-in-out;
+  flex-shrink: 0;
+
+  &:hover {
+    color: var(--pf-color-primary);
+  }
+
+  &:focus {
+    outline: 2px solid var(--pf-color-primary);
+    outline-offset: 2px;
+  }
+}
+
+// Select/Deselect All buttons - aligns to the right with gap between buttons
+.pf-select-deselect-all-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-bottom: 12px;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
@@ -877,3 +877,33 @@ export class InlineField implements m.ClassComponent<InlineFieldAttrs> {
     );
   }
 }
+
+// Select/Deselect All buttons widget
+export interface SelectDeselectAllButtonsAttrs {
+  readonly onSelectAll: () => void;
+  readonly onDeselectAll: () => void;
+}
+
+export class SelectDeselectAllButtons
+  implements m.ClassComponent<SelectDeselectAllButtonsAttrs>
+{
+  view({attrs}: m.CVnode<SelectDeselectAllButtonsAttrs>): m.Children {
+    const {onSelectAll, onDeselectAll} = attrs;
+
+    return m(
+      '.pf-select-deselect-all-buttons',
+      m(Button, {
+        label: 'Select All',
+        onclick: onSelectAll,
+        variant: ButtonVariant.Outlined,
+        compact: true,
+      }),
+      m(Button, {
+        label: 'Deselect All',
+        onclick: onDeselectAll,
+        variant: ButtonVariant.Outlined,
+        compact: true,
+      }),
+    );
+  }
+}


### PR DESCRIPTION
The rows of columns are styled in a specific way, coherent inside the Explore Page: 
- improve and organize the styling
- move it into the builder widgets.scss
- extract select/deselect all buttons to be a separate widget there