### PR TITLE
ui: DataGrid: Clean up supportedFilters attrs

### DIFF
--- a/ui/src/components/widgets/data_grid/common.ts
+++ b/ui/src/components/widgets/data_grid/common.ts
@@ -17,23 +17,6 @@ import {SqlValue} from '../../../trace_processor/query_result';
 
 export type AggregationFunction = 'SUM' | 'AVG' | 'COUNT' | 'MIN' | 'MAX';
 
-export type FilterType = DataGridFilter['op'];
-
-export const DEFAULT_SUPPORTED_FILTERS: ReadonlyArray<FilterType> = [
-  '=',
-  '!=',
-  '<',
-  '<=',
-  '>',
-  '>=',
-  'glob',
-  'not glob',
-  'in',
-  'not in',
-  'is null',
-  'is not null',
-];
-
 export type CellRenderer = (value: SqlValue, row: RowDef) => m.Children;
 export type CellFormatter = (value: SqlValue, row: RowDef) => string;
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -306,20 +306,6 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
             })
           : null;
 
-      const supportedOps = [
-        '=',
-        '!=',
-        '<',
-        '<=',
-        '>',
-        '>=',
-        'glob',
-        'in',
-        'not in',
-        'is null',
-        'is not null',
-      ] as const;
-
       return [
         warning,
         m(DataGrid, {
@@ -347,7 +333,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
           }),
           data: attrs.dataSource,
           showFiltersInToolbar: true,
-          supportedFilters: supportedOps,
+          structuredQueryCompatMode: true,
           // We don't actually want the datagrid to display or apply any filters
           // to the datasource itself, so we define this but fix it as an empty
           // array.

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -18,7 +18,6 @@ import {
   DataGridAttrs,
 } from '../../../components/widgets/data_grid/data_grid';
 import {SQLDataSource} from '../../../components/widgets/data_grid/sql_data_source';
-import {FilterType} from '../../../components/widgets/data_grid/common';
 import {Engine} from '../../../trace_processor/engine';
 import {renderDocSection, renderWidgetShowcase} from '../widgets_page_utils';
 import {App} from '../../../public/app';
@@ -63,35 +62,9 @@ export function renderDataGrid(app: App): m.Children {
         aggregation,
         demoToolbarItems,
         distinctValues,
-        filterIsNull,
-        filterIsNotNull,
-        filterIn,
-        filterNotIn,
-        filterGlob,
-        filterNotGlob,
-        filterEquals,
-        filterNotEquals,
-        filterLessThan,
-        filterLessThanOrEqual,
-        filterGreaterThan,
-        filterGreaterThanOrEqual,
+        structuredQueryCompatMode,
         ...rest
       }) => {
-        // Build supportedFilters array based on selected options
-        const supportedFilters: FilterType[] = [];
-        if (filterIsNull) supportedFilters.push('is null');
-        if (filterIsNotNull) supportedFilters.push('is not null');
-        if (filterIn) supportedFilters.push('in');
-        if (filterNotIn) supportedFilters.push('not in');
-        if (filterGlob) supportedFilters.push('glob');
-        if (filterNotGlob) supportedFilters.push('not glob');
-        if (filterEquals) supportedFilters.push('=');
-        if (filterNotEquals) supportedFilters.push('!=');
-        if (filterLessThan) supportedFilters.push('<');
-        if (filterLessThanOrEqual) supportedFilters.push('<=');
-        if (filterGreaterThan) supportedFilters.push('>');
-        if (filterGreaterThanOrEqual) supportedFilters.push('>=');
-
         return m(DataGrid, {
           ...rest,
           toolbarItemsLeft: demoToolbarItems
@@ -109,7 +82,7 @@ export function renderDataGrid(app: App): m.Children {
           fillHeight: true,
           filters: readonlyFilters ? [] : undefined,
           sorting: readonlySorting ? {direction: 'UNSORTED'} : undefined,
-          supportedFilters,
+          structuredQueryCompatMode,
           columns: [
             {
               name: 'id',
@@ -178,18 +151,7 @@ export function renderDataGrid(app: App): m.Children {
         demoToolbarItems: false,
         showExportButton: false,
         showRowCount: true,
-        filterIsNull: true,
-        filterIsNotNull: true,
-        filterIn: true,
-        filterNotIn: true,
-        filterGlob: true,
-        filterNotGlob: true,
-        filterEquals: true,
-        filterNotEquals: true,
-        filterLessThan: true,
-        filterLessThanOrEqual: true,
-        filterGreaterThan: true,
-        filterGreaterThanOrEqual: true,
+        structuredQueryCompatMode: false,
       },
       noPadding: true,
     }),


### PR DESCRIPTION
Replace fiddly supportedFilters with a single attribute to disable 'not glob' filters called `structuredQueryCompatMode`. Also added a note to clean this up when SQ adds support.