### PR TITLE
exp: Port names are a property of the spec

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils_unittest.ts
@@ -106,6 +106,7 @@ describe('graph_utils', () => {
         ]),
         min: 2,
         max: 'unbounded',
+        portNames: (portIndex: number) => `Input ${portIndex}`,
       };
 
       const result = getAllNodes([node3]);
@@ -243,6 +244,7 @@ describe('graph_utils', () => {
         ]),
         min: 2,
         max: 'unbounded',
+        portNames: (portIndex: number) => `Input ${portIndex}`,
       };
 
       const result = getAllUpstreamNodes(node3);
@@ -280,6 +282,7 @@ describe('graph_utils', () => {
         ]),
         min: 2,
         max: 'unbounded',
+        portNames: (portIndex: number) => `Input ${portIndex}`,
       };
       node2.primaryInput = node1;
       node3.primaryInput = node1;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -20,6 +20,7 @@ import {
   getSecondaryInput,
   analyzeNode,
   isAQuery,
+  SecondaryInputSpec,
 } from '../../query_node';
 import {
   ColumnInfo,
@@ -452,11 +453,7 @@ export class AddColumnsNode implements QueryNode {
   readonly nodeId: string;
   readonly type = NodeType.kAddColumns;
   primaryInput?: QueryNode;
-  secondaryInputs: {
-    connections: Map<number, QueryNode>;
-    min: 1;
-    max: 1;
-  };
+  secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
   readonly state: AddColumnsNodeState;
 
@@ -467,6 +464,7 @@ export class AddColumnsNode implements QueryNode {
       connections: new Map(),
       min: 1,
       max: 1,
+      portNames: ['Table'],
     };
     this.nextNodes = [];
     this.state.selectedColumns = this.state.selectedColumns ?? [];

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_during_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_during_node.ts
@@ -82,6 +82,7 @@ import {
   QueryNodeState,
   nextNodeId,
   NodeType,
+  SecondaryInputSpec,
 } from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
@@ -114,11 +115,7 @@ export class FilterDuringNode implements QueryNode {
   readonly nodeId: string;
   readonly type = NodeType.kFilterDuring;
   primaryInput?: QueryNode;
-  secondaryInputs: {
-    connections: Map<number, QueryNode>;
-    min: 1;
-    max: 6;
-  };
+  secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
   readonly state: FilterDuringNodeState;
 
@@ -129,6 +126,7 @@ export class FilterDuringNode implements QueryNode {
       connections: new Map(),
       min: 1,
       max: 6,
+      portNames: (portIndex: number) => `Input ${portIndex}`,
     };
     this.nextNodes = [];
     this.state.autoExecute = this.state.autoExecute ?? false;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -239,6 +239,7 @@ export class IntervalIntersectNode implements QueryNode {
       connections: new Map(),
       min: 2,
       max: 6,
+      portNames: (portIndex: number) => `Input ${portIndex}`,
     };
     // Initialize connections from state.inputNodes
     for (let i = 0; i < state.inputNodes.length; i++) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node.ts
@@ -160,6 +160,10 @@ export class JoinNode implements QueryNode {
       connections: new Map(),
       min: 2,
       max: 2,
+      portNames: (portIndex: number) =>
+        portIndex === 0
+          ? this.state.leftQueryAlias
+          : this.state.rightQueryAlias,
     };
     // Initialize connections from state
     if (state.leftNode) {
@@ -251,10 +255,6 @@ export class JoinNode implements QueryNode {
 
   nodeInfo(): m.Children {
     return loadNodeDoc('join');
-  }
-
-  getInputLabels(): string[] {
-    return [this.state.leftQueryAlias, this.state.rightQueryAlias];
   }
 
   nodeDetails(): NodeDetailsAttrs {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node_unittest.ts
@@ -581,7 +581,7 @@ describe('JoinNode', () => {
     });
   });
 
-  describe('getInputLabels', () => {
+  describe('secondaryInputs.portNames', () => {
     it('should return the left and right query aliases', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
@@ -598,7 +598,12 @@ describe('JoinNode', () => {
         sqlExpression: '',
       });
 
-      expect(joinNode.getInputLabels()).toEqual(['foo', 'bar']);
+      const portNames = joinNode.secondaryInputs.portNames;
+      expect(typeof portNames).toBe('function');
+      if (typeof portNames === 'function') {
+        expect(portNames(0)).toBe('foo');
+        expect(portNames(1)).toBe('bar');
+      }
     });
   });
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
@@ -76,6 +76,7 @@ export class UnionNode implements QueryNode {
       connections: new Map(),
       min: 2,
       max: 'unbounded',
+      portNames: (portIndex: number) => `Input ${portIndex}`,
     };
     // Initialize connections from state.inputNodes
     for (let i = 0; i < state.inputNodes.length; i++) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -83,6 +83,10 @@ export interface SecondaryInputSpec {
   // Cardinality requirements for validation
   readonly min: number; // Minimum required (e.g., 2 for IntervalIntersect)
   readonly max: number | 'unbounded'; // Maximum allowed (e.g., 2 for Join, unbounded for IntervalIntersect)
+
+  // Port names for UI display
+  // Can be an array of names or a function that generates a name for a given port index
+  readonly portNames: string[] | ((portIndex: number) => string);
 }
 
 // All information required to create a new node.


### PR DESCRIPTION
The responsibility for the port naming should be on a SecondaryInputsSpec, not query_nodes