### PR TITLE
ui: DataGrid: Schema-based column definitions

### DIFF
--- a/ui/src/assets/components/data_grid.scss
+++ b/ui/src/assets/components/data_grid.scss
@@ -122,3 +122,10 @@
   font-weight: 600;
   color: var(--pf-color-primary);
 }
+
+.pf-data-grid__title-separator {
+  font-size: 14px;
+  color: var(--pf-color-text-muted);
+  vertical-align: middle;
+  margin: 0 2px;
+}

--- a/ui/src/base/utils.ts
+++ b/ui/src/base/utils.ts
@@ -90,3 +90,11 @@ export function sleepMs(ms: number): Promise<void> {
     setTimeout(() => resolve(), ms);
   });
 }
+
+// Widens a type to include undefined. Useful for array index lookups where
+// TypeScript doesn't account for out-of-bounds access.
+// Example usage:
+//   const arr = [1, 2, 3];
+//   const x = undefinable(arr[10]); // x is number | undefined
+//   if (exists(x)) { /* x is number here */ }
+export const maybeUndefined = <T>(value: T) => value as T | undefined;

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -19,7 +19,12 @@ import {Box} from '../widgets/box';
 import {Stack, StackAuto, StackFixed} from '../widgets/stack';
 import {BarChartData, ColumnDef, Sorting} from './aggregation';
 import {ColumnDefinition, DataGridDataSource} from './widgets/data_grid/common';
-import {DataGrid, renderCell, DataGridApi} from './widgets/data_grid/data_grid';
+import {
+  DataGrid,
+  renderCell,
+  DataGridApi,
+  columnsToSchema,
+} from './widgets/data_grid/data_grid';
 import {defaultValueFormatter} from './widgets/data_grid/export_utils';
 
 export interface AggregationPanelAttrs {
@@ -48,9 +53,8 @@ export class AggregationPanel
     columns: ReadonlyArray<ColumnDef>,
     onReady?: (api: DataGridApi) => void,
   ) {
-    return m(DataGrid, {
-      fillHeight: true,
-      columns: columns.map((c): ColumnDefinition => {
+    const columnDefs: ColumnDefinition[] = columns.map(
+      (c): ColumnDefinition => {
         return {
           name: c.columnId,
           title: c.title,
@@ -70,7 +74,12 @@ export class AggregationPanel
           },
           cellFormatter: (value) => valueFormatter(value, c.formatHint),
         };
-      }),
+      },
+    );
+
+    return m(DataGrid, {
+      ...columnsToSchema(columnDefs),
+      fillHeight: true,
       data: dataSource,
       initialSorting: sorting,
       onReady,

--- a/ui/src/components/query_table/query_table.ts
+++ b/ui/src/components/query_table/query_table.ts
@@ -23,8 +23,13 @@ import {
   DataGrid,
   renderCell,
   DataGridApi,
+  columnsToSchema,
 } from '../widgets/data_grid/data_grid';
-import {DataGridDataSource, CellRenderer} from '../widgets/data_grid/common';
+import {
+  DataGridDataSource,
+  CellRenderer,
+  ColumnDefinition,
+} from '../widgets/data_grid/common';
 import {InMemoryDataSource} from '../widgets/data_grid/in_memory_data_source';
 import {Anchor} from '../../widgets/anchor';
 import {Box} from '../../widgets/box';
@@ -168,39 +173,41 @@ export class QueryTable implements m.ClassComponent<QueryTableAttrs> {
       return m('.pf-query-panel__query-error', `SQL error: ${resp.error}`);
     }
 
+    const columnDefs: ColumnDefinition[] = resp.columns.map((column) => {
+      const cellRenderer: CellRenderer | undefined =
+        column === 'id'
+          ? (value, row) => {
+              const sliceId = getSliceId(row);
+              const cell = renderCell(value, column);
+              if (sliceId !== undefined && isSliceish(row)) {
+                return m(
+                  Anchor,
+                  {
+                    title: 'Go to slice',
+                    icon: Icons.UpdateSelection,
+                    onclick: () => this.goToSlice(sliceId, false),
+                    ondblclick: () => this.goToSlice(sliceId, true),
+                  },
+                  cell,
+                );
+              } else {
+                return renderCell(value, column);
+              }
+            }
+          : undefined;
+
+      return {
+        name: column,
+        cellRenderer,
+      };
+    });
+
     return m(DataGrid, {
+      ...columnsToSchema(columnDefs),
       // If filters are defined by no onFilterChanged handler, the grid operates
       // in filter read only mode.
       fillHeight: true,
       filters: [],
-      columns: resp.columns.map((column) => {
-        const cellRenderer: CellRenderer | undefined =
-          column === 'id'
-            ? (value, row) => {
-                const sliceId = getSliceId(row);
-                const cell = renderCell(value, column);
-                if (sliceId !== undefined && isSliceish(row)) {
-                  return m(
-                    Anchor,
-                    {
-                      title: 'Go to slice',
-                      icon: Icons.UpdateSelection,
-                      onclick: () => this.goToSlice(sliceId, false),
-                      ondblclick: () => this.goToSlice(sliceId, true),
-                    },
-                    cell,
-                  );
-                } else {
-                  return renderCell(value, column);
-                }
-              }
-            : undefined;
-
-        return {
-          name: column,
-          cellRenderer,
-        };
-      }),
       data: dataSource,
       onReady: (api) => {
         this.dataGridApi = api;

--- a/ui/src/components/widgets/data_grid/column_schema.ts
+++ b/ui/src/components/widgets/data_grid/column_schema.ts
@@ -1,0 +1,478 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {maybeUndefined} from '../../../base/utils';
+import {SqlValue} from '../../../trace_processor/query_result';
+import {
+  AggregationFunction,
+  CellFormatter,
+  CellRenderer,
+  RowDef,
+} from './common';
+
+/**
+ * A registry of named schemas that can reference each other.
+ * This allows defining complex relational schemas with self-references
+ * (e.g., parent.parent.parent.name) and cross-references between tables.
+ */
+export interface SchemaRegistry {
+  [schemaName: string]: ColumnSchema;
+}
+
+/**
+ * A schema defining the available columns in a data source.
+ * Each key is a column name, and the value describes how to render it
+ * or references another schema for nested data.
+ */
+export type ColumnSchema = {
+  [columnName: string]: ColumnDef | SchemaRef | ParameterizedColumnDef;
+};
+
+/**
+ * Builtins provided to contextMenuRenderer for column header menus.
+ */
+export interface ContextMenuBuiltins {
+  readonly sorting?: m.Children;
+  readonly filters?: m.Children;
+  readonly fitToContent?: m.Children;
+  readonly columnManagement?: m.Children;
+}
+
+/**
+ * Builtins provided to cellContextMenuRenderer for cell menus.
+ */
+export interface CellContextMenuBuiltins {
+  readonly addFilter?: m.Children;
+}
+
+/**
+ * A leaf column definition with rendering configuration.
+ * This replaces the old ColumnDefinition type.
+ */
+export interface ColumnDef {
+  // Human readable title to display instead of the column name.
+  readonly title?: m.Children;
+
+  // Plain string title for exports. Used when title is m.Children.
+  // Falls back to column path if not provided.
+  readonly titleString?: string;
+
+  // Control which types of filters are available for this column.
+  // - 'numeric': Shows comparison filters (=, !=, <, <=, >, >=) and null filters
+  // - 'string': Shows text filters (contains, glob) and equals/null filters
+  readonly filterType?: 'numeric' | 'string';
+
+  // Custom renderer for this column's cells
+  readonly cellRenderer?: CellRenderer;
+
+  // Optional value formatter for this column, used when exporting data.
+  readonly cellFormatter?: CellFormatter;
+
+  // An optional aggregation for data in this column displayed in the header bar.
+  readonly aggregation?: AggregationFunction;
+
+  // Enable distinct values filtering for this column.
+  readonly distinctValues?: boolean;
+
+  // Optional function for custom column header context menu.
+  readonly contextMenuRenderer?: (builtins: ContextMenuBuiltins) => m.Children;
+
+  // Optional function for custom cell context menu.
+  readonly cellContextMenuRenderer?: (
+    value: SqlValue,
+    row: RowDef,
+    builtins: CellContextMenuBuiltins,
+  ) => m.Children;
+}
+
+/**
+ * A reference to another named schema in the registry.
+ * Used for nested relationships like parent -> slice or thread -> process.
+ */
+export interface SchemaRef {
+  // Name of the schema in the registry to reference
+  readonly ref: string;
+
+  // Override the title for this reference (e.g., "Parent Slice" instead of "Slice")
+  readonly title?: string;
+
+  // Override filter type for all columns accessed through this reference
+  readonly filterType?: 'numeric' | 'string';
+}
+
+/**
+ * A parameterized column where the key is determined at runtime.
+ * Used for things like args.foo, args.bar where keys are data-dependent.
+ */
+export interface ParameterizedColumnDef {
+  readonly parameterized: true;
+
+  // Title can be a static string or a function that takes the key
+  readonly title?: string | ((key: string) => string);
+
+  // Plain string title for exports. Falls back to column path if not provided.
+  readonly titleString?: string;
+
+  readonly filterType?: 'numeric' | 'string';
+  readonly cellRenderer?: CellRenderer;
+  readonly cellFormatter?: CellFormatter;
+  readonly aggregation?: AggregationFunction;
+  readonly distinctValues?: boolean;
+  readonly contextMenuRenderer?: (builtins: ContextMenuBuiltins) => m.Children;
+  readonly cellContextMenuRenderer?: (
+    value: SqlValue,
+    row: RowDef,
+    builtins: CellContextMenuBuiltins,
+  ) => m.Children;
+}
+
+/**
+ * Type guard to check if a schema entry is a leaf ColumnDef.
+ */
+export function isColumnDef(
+  entry: ColumnDef | SchemaRef | ParameterizedColumnDef,
+): entry is ColumnDef {
+  return !('ref' in entry) && !('parameterized' in entry);
+}
+
+/**
+ * Type guard to check if a schema entry is a SchemaRef.
+ */
+export function isSchemaRef(
+  entry: ColumnDef | SchemaRef | ParameterizedColumnDef,
+): entry is SchemaRef {
+  return 'ref' in entry;
+}
+
+/**
+ * Type guard to check if a schema entry is a ParameterizedColumnDef.
+ */
+export function isParameterizedColumnDef(
+  entry: ColumnDef | SchemaRef | ParameterizedColumnDef,
+): entry is ParameterizedColumnDef {
+  return 'parameterized' in entry;
+}
+
+/**
+ * Gets the default visible columns for a schema.
+ * Returns all leaf columns (ColumnDef) at the root level.
+ * Does not include schema references or parameterized columns by default.
+ *
+ * @param registry The schema registry
+ * @param rootSchema The root schema name
+ * @returns Array of column names that are leaf columns
+ */
+export function getDefaultVisibleColumns(
+  registry: SchemaRegistry,
+  rootSchema: string,
+): string[] {
+  const schema = maybeUndefined(registry[rootSchema]);
+  if (!schema) return [];
+
+  const columns: string[] = [];
+  for (const [columnName, entry] of Object.entries(schema)) {
+    if (isColumnDef(entry)) {
+      columns.push(columnName);
+    }
+  }
+  return columns;
+}
+
+/**
+ * Result of resolving a column path against a schema.
+ */
+export interface ResolvedColumn {
+  // The resolved column definition (leaf or parameterized)
+  readonly def: ColumnDef | ParameterizedColumnDef;
+
+  // For parameterized columns, the key that was extracted from the path
+  readonly paramKey?: string;
+}
+
+/**
+ * Resolves a dot-separated column path to its definition in the schema.
+ *
+ * Examples:
+ * - "id" -> resolves to slice.id
+ * - "parent.name" -> follows ref to slice, then resolves name
+ * - "parent.parent.dur" -> follows ref twice, then resolves dur
+ * - "thread.process.pid" -> follows thread ref, then process ref, then pid
+ * - "args.foo" -> resolves to parameterized column with key "foo"
+ *
+ * @param registry The schema registry containing all named schemas
+ * @param rootSchema The name of the root schema to start from
+ * @param path The dot-separated path to resolve (e.g., "parent.parent.name")
+ * @returns The resolved column definition, or undefined if path is invalid
+ */
+export function resolveColumnPath(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): ResolvedColumn | undefined {
+  const parts = path.split('.');
+  const initialSchema = maybeUndefined(registry[rootSchema]);
+
+  if (!initialSchema) {
+    return undefined;
+  }
+
+  let currentSchema = initialSchema;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const entry = maybeUndefined(currentSchema[part]);
+
+    if (!entry) {
+      // Check if we're at the last level and the current schema has a
+      // parameterized entry that could match any key
+      // This handles cases like "args.foo" where "args" is parameterized
+      // and "foo" is the parameter key
+      // Actually, we need to check if the previous entry was parameterized
+      return undefined;
+    }
+
+    if (isSchemaRef(entry)) {
+      // Follow the reference to another schema
+      const referencedSchema = maybeUndefined(registry[entry.ref]);
+      if (!referencedSchema) {
+        return undefined;
+      }
+      currentSchema = referencedSchema;
+      // Continue to next part of path
+    } else if (isParameterizedColumnDef(entry)) {
+      // For parameterized columns, the remaining path parts are the parameter key
+      const remainingParts = parts.slice(i + 1);
+      if (remainingParts.length === 0) {
+        // Just "args" with no key - return the parameterized def without a key
+        return {def: entry};
+      }
+      // The remaining parts form the parameter key (e.g., "foo" or "foo.bar")
+      return {def: entry, paramKey: remainingParts.join('.')};
+    } else if (isColumnDef(entry)) {
+      // Leaf column - should be the last part of the path
+      if (i === parts.length - 1) {
+        return {def: entry};
+      }
+      // Trying to navigate deeper into a leaf column - invalid
+      return undefined;
+    }
+  }
+
+  // We ended on a schema ref without resolving to a leaf
+  // This means the path ended at a nested object, not a column
+  return undefined;
+}
+
+/**
+ * Gets the display title parts for a column path.
+ *
+ * Builds up an array of title parts by traversing the path.
+ * For example, "manager.manager.name" -> ["Manager", "Manager", "Name"]
+ * Uses schema-defined titles where available.
+ *
+ * @param registry The schema registry
+ * @param rootSchema The root schema name
+ * @param path The column path
+ * @returns Array of title parts for the column
+ */
+export function getColumnTitleParts(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): m.Children[] {
+  const parts = path.split('.');
+  const titleParts: m.Children[] = [];
+  const initialSchema = maybeUndefined(registry[rootSchema]);
+
+  if (!initialSchema) {
+    // Fallback: return parts as-is
+    return parts;
+  }
+
+  let currentSchema = initialSchema;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const entry = maybeUndefined(currentSchema[part]);
+
+    if (!entry) {
+      // Unknown entry - use the part name as-is
+      titleParts.push(part);
+      break;
+    }
+
+    if (isSchemaRef(entry)) {
+      // Use ref's title or the part name as-is
+      titleParts.push(entry.title ?? part);
+      // Follow the reference
+      const referencedSchema = maybeUndefined(registry[entry.ref]);
+      if (!referencedSchema) {
+        break;
+      }
+      currentSchema = referencedSchema;
+    } else if (isParameterizedColumnDef(entry)) {
+      // For parameterized columns, remaining parts are the key
+      const remainingParts = parts.slice(i + 1);
+      const paramKey = remainingParts.join('.');
+
+      if (typeof entry.title === 'function' && paramKey) {
+        titleParts.push(entry.title(paramKey));
+      } else if (typeof entry.title === 'string') {
+        titleParts.push(paramKey ? `${entry.title}[${paramKey}]` : entry.title);
+      } else {
+        titleParts.push(paramKey ? `${part}[${paramKey}]` : part);
+      }
+      break;
+    } else if (isColumnDef(entry)) {
+      // Leaf column - use its title or the part name as-is
+      titleParts.push(entry.title ?? part);
+      break;
+    }
+  }
+
+  return titleParts;
+}
+
+/**
+ * Gets the display title for a column path as renderable content.
+ * Parts are joined with a separator element.
+ *
+ * @param registry The schema registry
+ * @param rootSchema The root schema name
+ * @param path The column path
+ * @returns The display title as m.Children
+ */
+export function getColumnTitle(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): m.Children {
+  const parts = getColumnTitleParts(registry, rootSchema, path);
+  if (parts.length === 0) return path;
+  if (parts.length === 1) return parts[0];
+
+  // Join with separator
+  const result: m.Children[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    if (i > 0) {
+      result.push(m('span.pf-data-grid__title-separator', ' > '));
+    }
+    result.push(parts[i]);
+  }
+  return result;
+}
+
+/**
+ * Gets the string title for a column path, suitable for exports.
+ * Returns titleString if available, otherwise falls back to the column path.
+ */
+export function getColumnTitleString(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): string {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.titleString ?? path;
+}
+
+/**
+ * Gets the filter type for a column path.
+ */
+export function getColumnFilterType(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): 'numeric' | 'string' | undefined {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.filterType;
+}
+
+/**
+ * Gets the cell renderer for a column path.
+ */
+export function getColumnCellRenderer(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): CellRenderer | undefined {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.cellRenderer;
+}
+
+/**
+ * Gets the cell formatter for a column path.
+ */
+export function getColumnCellFormatter(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): CellFormatter | undefined {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.cellFormatter;
+}
+
+/**
+ * Gets the aggregation function for a column path.
+ */
+export function getColumnAggregation(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): AggregationFunction | undefined {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.aggregation;
+}
+
+/**
+ * Gets whether distinct values filtering is enabled for a column path.
+ */
+export function getColumnDistinctValues(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): boolean | undefined {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.distinctValues;
+}
+
+/**
+ * Gets the context menu renderer for a column path.
+ */
+export function getColumnContextMenuRenderer(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+): ((builtins: ContextMenuBuiltins) => m.Children) | undefined {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.contextMenuRenderer;
+}
+
+/**
+ * Gets the cell context menu renderer for a column path.
+ */
+export function getColumnCellContextMenuRenderer(
+  registry: SchemaRegistry,
+  rootSchema: string,
+  path: string,
+):
+  | ((
+      value: SqlValue,
+      row: RowDef,
+      builtins: CellContextMenuBuiltins,
+    ) => m.Children)
+  | undefined {
+  const resolved = resolveColumnPath(registry, rootSchema, path);
+  return resolved?.def.cellContextMenuRenderer;
+}

--- a/ui/src/components/widgets/data_grid/common.ts
+++ b/ui/src/components/widgets/data_grid/common.ts
@@ -17,6 +17,23 @@ import {SqlValue} from '../../../trace_processor/query_result';
 
 export type AggregationFunction = 'SUM' | 'AVG' | 'COUNT' | 'MIN' | 'MAX';
 
+/**
+ * Represents a column that can be added to the grid via the "Add Column" menu.
+ * Used to build hierarchical menus of available columns, supporting both static
+ * columns and dynamically-discovered ones (e.g., arg keys, parent chains).
+ */
+export interface AvailableColumn {
+  // Display name for the menu item
+  readonly label: string;
+
+  // The column name to add when selected (e.g., "parent.ts", "arg[foo]")
+  readonly columnName: string;
+
+  // If defined, this item has a submenu with lazy-loaded children.
+  // The function is called when the user expands the submenu.
+  readonly getChildren?: () => Promise<AvailableColumn[]>;
+}
+
 export type CellRenderer = (value: SqlValue, row: RowDef) => m.Children;
 export type CellFormatter = (value: SqlValue, row: RowDef) => string;
 
@@ -114,6 +131,8 @@ export interface DataSourceResult {
   readonly aggregates: RowDef;
   readonly isLoading?: boolean;
   readonly distinctValues?: ReadonlyMap<string, readonly SqlValue[]>;
+  // Available parameter keys for parameterized columns (e.g., for 'args' -> ['foo', 'bar'])
+  readonly parameterKeys?: ReadonlyMap<string, readonly string[]>;
 }
 
 export type RowDef = {[key: string]: SqlValue};
@@ -135,6 +154,8 @@ export interface DataGridModel {
   readonly pagination?: Pagination;
   readonly aggregates?: ReadonlyArray<AggregateSpec>;
   readonly distinctValuesColumns?: ReadonlySet<string>;
+  // Request parameter keys for these parameterized column prefixes (e.g., 'args', 'skills')
+  readonly parameterKeyColumns?: ReadonlySet<string>;
 }
 
 export interface DataGridDataSource {

--- a/ui/src/components/widgets/data_grid/data_grid_toolbar.ts
+++ b/ui/src/components/widgets/data_grid/data_grid_toolbar.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {Box} from '../../../widgets/box';
 import {Chip} from '../../../widgets/chip';
 import {Stack, StackAuto} from '../../../widgets/stack';
-import {ColumnDefinition, DataGridFilter} from './common';
+import {DataGridFilter} from './common';
 import {DataGridApi} from './data_grid';
 import {DataGridExportButton} from './export_button';
 
@@ -48,7 +48,8 @@ export type OnFilterRemove = (index: number) => void;
 
 export interface DataGridToolbarAttrs {
   readonly filters: ReadonlyArray<DataGridFilter>;
-  readonly columns: ReadonlyArray<ColumnDefinition>;
+  readonly schema: unknown; // SchemaRegistry - avoid circular import
+  readonly rootSchema: string;
   readonly totalRows: number;
   readonly showFilters: boolean;
   readonly showRowCount: boolean;
@@ -57,17 +58,13 @@ export interface DataGridToolbarAttrs {
   readonly toolbarItemsRight?: m.Children;
   readonly dataGridApi: DataGridApi;
   readonly onFilterRemove: OnFilterRemove;
-  readonly formatFilter: (
-    filter: DataGridFilter,
-    columns: ReadonlyArray<ColumnDefinition>,
-  ) => string;
+  readonly formatFilter: (filter: DataGridFilter) => string;
 }
 
 export class DataGridToolbar implements m.ClassComponent<DataGridToolbarAttrs> {
   view({attrs}: m.Vnode<DataGridToolbarAttrs>): m.Children {
     const {
       filters,
-      columns,
       totalRows,
       showFilters,
       showRowCount,
@@ -93,7 +90,7 @@ export class DataGridToolbar implements m.ClassComponent<DataGridToolbarAttrs> {
           m(GridFilterBar, [
             filters.map((filter) => {
               return m(GridFilterChip, {
-                content: formatFilter(filter, columns),
+                content: formatFilter(filter),
                 onRemove: () => {
                   const filterIndex = filters.indexOf(filter);
                   onFilterRemove(filterIndex);

--- a/ui/src/core_plugins/dev.perfetto.SearchUtils/search_results_tab.ts
+++ b/ui/src/core_plugins/dev.perfetto.SearchUtils/search_results_tab.ts
@@ -17,7 +17,10 @@ import {SearchManagerImpl} from '../../core/search_manager';
 import {Trace} from '../../public/trace';
 import {Anchor} from '../../widgets/anchor';
 import {DetailsShell} from '../../widgets/details_shell';
-import {DataGrid} from '../../components/widgets/data_grid/data_grid';
+import {
+  DataGrid,
+  columnsToSchema,
+} from '../../components/widgets/data_grid/data_grid';
 import {
   ColumnDefinition,
   RowDef,
@@ -99,7 +102,7 @@ export class SearchResultsTab implements m.ClassComponent<TabAttrs> {
         fillHeight: true,
       },
       m(DataGrid, {
-        columns,
+        ...columnsToSchema(columns),
         data: rowData,
         fillHeight: true,
       }),

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -19,11 +19,13 @@ import {Icons} from '../../base/semantic_icons';
 import {QueryResponse} from '../../components/query_table/queries';
 import {
   CellRenderer,
+  ColumnDefinition,
   DataGridDataSource,
 } from '../../components/widgets/data_grid/common';
 import {
   DataGrid,
   renderCell,
+  columnsToSchema,
 } from '../../components/widgets/data_grid/data_grid';
 import {InMemoryDataSource} from '../../components/widgets/data_grid/in_memory_data_source';
 import {QueryHistoryComponent} from '../../components/widgets/query_history';
@@ -219,53 +221,58 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
               'Only the results for the last statement are displayed.',
             ]),
           ]),
-        m(DataGrid, {
-          className: 'pf-query-page__results',
-          data: dataSource,
-          columns: queryResult.columns.map((column) => {
-            const cellRenderer: CellRenderer | undefined =
-              column === 'id'
-                ? (value, row) => {
-                    const sliceId = getSliceId(row);
-                    const cell = renderCell(value, column);
-                    if (sliceId !== undefined && isSliceish(row)) {
-                      return m(
-                        Anchor,
-                        {
-                          title: 'Go to slice on the timeline',
-                          icon: Icons.UpdateSelection,
-                          onclick: () => {
-                            // Navigate to the timeline page
-                            trace.navigate('#!/viewer');
-                            trace.selection.selectSqlEvent('slice', sliceId, {
-                              switchToCurrentSelectionTab: false,
-                              scrollToSelection: true,
-                            });
+        (() => {
+          const columnDefs: ColumnDefinition[] = queryResult.columns.map(
+            (column) => {
+              const cellRenderer: CellRenderer | undefined =
+                column === 'id'
+                  ? (value, row) => {
+                      const sliceId = getSliceId(row);
+                      const cell = renderCell(value, column);
+                      if (sliceId !== undefined && isSliceish(row)) {
+                        return m(
+                          Anchor,
+                          {
+                            title: 'Go to slice on the timeline',
+                            icon: Icons.UpdateSelection,
+                            onclick: () => {
+                              // Navigate to the timeline page
+                              trace.navigate('#!/viewer');
+                              trace.selection.selectSqlEvent('slice', sliceId, {
+                                switchToCurrentSelectionTab: false,
+                                scrollToSelection: true,
+                              });
+                            },
                           },
-                        },
-                        cell,
-                      );
-                    } else {
-                      return renderCell(value, column);
+                          cell,
+                        );
+                      } else {
+                        return renderCell(value, column);
+                      }
                     }
-                  }
-                : undefined;
-            return {
-              name: column,
-              cellRenderer,
-            };
-          }),
-          showExportButton: true,
-          toolbarItemsLeft: m(
-            'span.pf-query-page__results-summary',
-            `Returned ${queryResult.totalRowCount.toLocaleString()} rows in ${queryTimeString}`,
-          ),
-          toolbarItemsRight: m(CopyToClipboardButton, {
-            textToCopy: queryResult.query,
-            title: 'Copy executed query to clipboard',
-            label: 'Copy Query',
-          }),
-        }),
+                  : undefined;
+              return {
+                name: column,
+                cellRenderer,
+              };
+            },
+          );
+          return m(DataGrid, {
+            ...columnsToSchema(columnDefs),
+            className: 'pf-query-page__results',
+            data: dataSource,
+            showExportButton: true,
+            toolbarItemsLeft: m(
+              'span.pf-query-page__results-summary',
+              `Returned ${queryResult.totalRowCount.toLocaleString()} rows in ${queryTimeString}`,
+            ),
+            toolbarItemsRight: m(CopyToClipboardButton, {
+              textToCopy: queryResult.query,
+              title: 'Copy executed query to clipboard',
+              label: 'Copy Query',
+            }),
+          });
+        })(),
       ];
     }
   }

--- a/ui/src/plugins/org.kernel.Wattson/aggregation_panel.ts
+++ b/ui/src/plugins/org.kernel.Wattson/aggregation_panel.ts
@@ -24,6 +24,7 @@ import {
 import {
   DataGrid,
   renderCell,
+  columnsToSchema,
 } from '../../components/widgets/data_grid/data_grid';
 import {Box} from '../../widgets/box';
 import {SegmentedButtons} from '../../widgets/segmented_buttons';
@@ -48,20 +49,8 @@ export class WattsonAggregationPanel
     sorting: Sorting,
     columns: ReadonlyArray<ColumnDef>,
   ) {
-    return m(DataGrid, {
-      toolbarItemsLeft: m(
-        Box,
-        m(SegmentedButtons, {
-          options: [{label: 'µW'}, {label: 'mW'}],
-          selectedOption: this.scaleNumericData ? 0 : 1,
-          onOptionSelected: (index) => {
-            this.scaleNumericData = index === 0;
-          },
-          title: 'Select power units',
-        }),
-      ),
-      fillHeight: true,
-      columns: columns.map((c): ColumnDefinition => {
+    const columnDefs: ColumnDefinition[] = columns.map(
+      (c): ColumnDefinition => {
         const displayTitle = this.scaleNumericData
           ? c.title.replace('estimated mW', 'estimated µW')
           : c.title;
@@ -95,7 +84,23 @@ export class WattsonAggregationPanel
             }
           },
         };
-      }),
+      },
+    );
+
+    return m(DataGrid, {
+      ...columnsToSchema(columnDefs),
+      toolbarItemsLeft: m(
+        Box,
+        m(SegmentedButtons, {
+          options: [{label: 'µW'}, {label: 'mW'}],
+          selectedOption: this.scaleNumericData ? 0 : 1,
+          onOptionSelected: (index) => {
+            this.scaleNumericData = index === 0;
+          },
+          title: 'Select power units',
+        }),
+      ),
+      fillHeight: true,
       data: dataSource,
       initialSorting: sorting,
     });

--- a/ui/src/widgets/menu.ts
+++ b/ui/src/widgets/menu.ts
@@ -21,7 +21,7 @@ import {Popup, PopupAttrs, PopupPosition} from './popup';
 
 export interface MenuItemAttrs extends HTMLAttrs {
   // Text to display on the menu button.
-  label: string;
+  label: m.Children;
   // Optional left icon.
   icon?: string;
   // Optional right icon.


### PR DESCRIPTION
- Introduce a new schema based column definition map to DataGrid which can allow adding of both nested and parameterized columns.
- Add the UX to add and remove columns using the schema.
- Change naming convention to 'Add and Remove columns' instead of 'Show and hide columns'.
- This patch makes no changes to the SQLDataSource, this will be tackled in an upcoming patch.