### PR TITLE
exp: Polish the add columns modals

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -322,9 +322,10 @@
   flex-wrap: wrap;
   gap: 12px;
   align-items: stretch;
+  flex: 1;
 
-  // When container is narrow (< 500px), stack vertically
-  @container (max-width: 500px) {
+  // When container is narrow (< 400px), stack vertically
+  @container (max-width: 400px) {
     flex-direction: column;
 
     .pf-exp-equal-width-row__separator {
@@ -670,4 +671,9 @@
   justify-content: flex-end;
   gap: 8px;
   margin-bottom: 12px;
+}
+
+// Wider modal for computed column forms
+.pf-computed-column-modal-wide {
+  min-width: 30vw;
 }


### PR DESCRIPTION
  ## Summary
 Refactor the add columns modals (Switch and If components) to use reusable UI widgets instead of custom CSS and inline structures. This improves consistency across the ExplorePage UI and makes the modals more maintainable. Additionally, reorganize form layouts to place validation messages at the top for better visibility.

  ## Changes
  - Replace custom Switch component UI with `OutlinedField`, `FormListItem`, and `AddItemPlaceholder` widgets
  - Replace custom If component UI with the same reusable widgets
  - Add wider modal variant for Switch/If computed column forms
  - Move validation messages (errors, warnings, callouts) to the top of forms instead of bottom
  - Remove unnecessary `FormSection` wrappers in computed column modals
  - Adjust responsive breakpoint for equal-width rows from 500px to 400px
  - Add `flex: 1` to equal-width rows for better layout flexibility