### PR TITLE
CI: Fix GCS permission error on re-runs by making artifact path unique

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -31,8 +31,8 @@ jobs:
     timeout-minutes: 45
     env:
       PERFETTO_CI_BUILD_CACHE_KEY: build-cache-ui
-      PERFETTO_CI_JOB_ID: gh-${{ github.run_id }}-ui
-      PERFETTO_GCS_DST: perfetto-ci-artifacts/gh-${{ github.run_id }}-ui
+      PERFETTO_CI_JOB_ID: gh-${{ github.run_id }}-${{ github.run_attempt }}-ui
+      PERFETTO_GCS_DST: perfetto-ci-artifacts/gh-${{ github.run_id }}-${{ github.run_attempt }}-ui
       CI: 1
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Append github.run_attempt to PERFETTO_CI_JOB_ID and PERFETTO_GCS_DST to ensure that each workflow run attempt writes to a unique GCS path. 

As seen from existing issue for https://github.com/google/perfetto/actions/runs/20035060995/job/57540712189:

```
ERROR: [None] does not have permission to access b instance [perfetto-ci-artifacts] (or it may not exist): gce-ci-sandbox@perfetto-ci.iam.gserviceaccount.com does not have storage.objects.delete access to the Google Cloud Storage object. This command is authenticated with an access token from /tmp/.svc_token specified by the [auth/access_token_file] property.
```

```
latest attempt 6:
   PERFETTO_CI_BUILD_CACHE_KEY: build-cache-ui
    PERFETTO_CI_JOB_ID: gh-20035060995-ui
    PERFETTO_GCS_DST: perfetto-ci-artifacts/gh-20035060995-ui
    CI: 1

attempt 5:
    PERFETTO_CI_BUILD_CACHE_KEY: build-cache-ui
    PERFETTO_CI_JOB_ID: gh-20035060995-ui
    PERFETTO_GCS_DST: perfetto-ci-artifacts/gh-20035060995-ui

attempt 3:
    PYTHONUNBUFFERED: 1
    PERFETTO_CI_BUILD_CACHE_KEY: build-cache-ui
    PERFETTO_CI_JOB_ID: gh-20035060995-ui
    PERFETTO_GCS_DST: perfetto-ci-artifacts/gh-20035060995-ui
    CI: 1
```