### PR TITLE
exp: Filter during takes only one input

### DIFF
--- a/ui/src/assets/explore_page/node_info/filter_during.md
+++ b/ui/src/assets/explore_page/node_info/filter_during.md
@@ -1,20 +1,20 @@
 # Filter During
 
-**Purpose:** Filter rows from the left input to only those whose time interval (ts, dur) overlaps with any row from the right input's time interval. This is useful for finding events that occur during specific time windows.
+**Purpose:** Filter rows from the primary input to only those whose time interval (ts, dur) overlaps with any interval from the "Filter intervals" input. This is useful for finding events that occur during specific time windows.
 
 **How to use:**
 - Connect your main data source to the primary input (top port)
-- Connect a time range or interval source to the secondary input (left port)
+- Connect a time range or interval source to the "Filter intervals" input (port on the left)
 - Choose partitioning options to filter within specific groups (e.g., per process or thread)
 - The node automatically filters rows based on time overlap.
 
 **Data transformation:**
-- Input rows are filtered to keep only those that temporally overlap with the right input
+- Input rows are filtered to keep only those that temporally overlap with the filter intervals
 - If partitioning is enabled, filtering is done separately for each partition group
-- Only rows from the left input are kept; the right input is used purely for filtering
-- The timestamp and duration columns can be clipped to the ranges from interval intersect or they can be preserved. 
-- All columns from the left input are preserved unchanged
+- Only rows from the primary input are kept; the filter intervals input is used purely for filtering
+- The timestamp and duration columns can either be clipped to the intersection ranges or preserved.
+- All columns from the primary input are preserved unchanged
 
 **Example:** Filter slices to only show those that occurred during a specific time selection. Or find all thread slices that overlap with specific process execution windows.
 
-**Time overlap logic:** A row overlaps if its interval `[ts, ts+dur)` has any intersection with an interval from the right input.
+**Time overlap logic:** A row overlaps if its interval `[ts, ts+dur)` has any intersection with an interval from the filter intervals input.

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -1952,7 +1952,7 @@ describe('JSON serialization/deserialization', () => {
       deserializedSlicesNode.nodeId,
     );
 
-    // Verify secondaryInputs connection
+    // Verify secondaryInput connection
     expect(deserializedFilterDuringNode.secondaryInputs.connections.size).toBe(
       1,
     );
@@ -1964,58 +1964,6 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedFilterDuringNode.state.filterNegativeDurSecondary).toBe(
       false,
     );
-  });
-
-  test('serializes and deserializes filter during node with multiple secondary inputs', () => {
-    const slicesNode = new SlicesSourceNode({});
-    const timeRangeNode1 = new TimeRangeSourceNode({trace});
-    const timeRangeNode2 = new TimeRangeSourceNode({trace});
-    const timeRangeNode3 = new TimeRangeSourceNode({trace});
-
-    const filterDuringNode = new FilterDuringNode({});
-
-    // Connect slicesNode as primaryInput
-    slicesNode.nextNodes.push(filterDuringNode);
-    filterDuringNode.primaryInput = slicesNode;
-
-    // Connect multiple timeRangeNodes as secondaryInputs
-    timeRangeNode1.nextNodes.push(filterDuringNode);
-    filterDuringNode.secondaryInputs.connections.set(0, timeRangeNode1);
-
-    timeRangeNode2.nextNodes.push(filterDuringNode);
-    filterDuringNode.secondaryInputs.connections.set(1, timeRangeNode2);
-
-    timeRangeNode3.nextNodes.push(filterDuringNode);
-    filterDuringNode.secondaryInputs.connections.set(2, timeRangeNode3);
-
-    const initialState: ExplorePageState = {
-      rootNodes: [slicesNode, timeRangeNode1, timeRangeNode2, timeRangeNode3],
-      nodeLayouts: new Map(),
-    };
-
-    const json = serializeState(initialState);
-    const deserializedState = deserializeState(json, trace, sqlModules);
-
-    expect(deserializedState.rootNodes.length).toBe(4);
-
-    // Find the deserialized filter during node
-    const deserializedSlicesNode = deserializedState.rootNodes[0];
-    const deserializedFilterDuringNode = deserializedSlicesNode
-      .nextNodes[0] as FilterDuringNode;
-
-    // Verify all secondary inputs are preserved
-    expect(deserializedFilterDuringNode.secondaryInputs.connections.size).toBe(
-      3,
-    );
-    expect(
-      deserializedFilterDuringNode.secondaryInputs.connections.get(0)?.nodeId,
-    ).toBe(deserializedState.rootNodes[1].nodeId);
-    expect(
-      deserializedFilterDuringNode.secondaryInputs.connections.get(1)?.nodeId,
-    ).toBe(deserializedState.rootNodes[2].nodeId);
-    expect(
-      deserializedFilterDuringNode.secondaryInputs.connections.get(2)?.nodeId,
-    ).toBe(deserializedState.rootNodes[3].nodeId);
   });
 
   // ========================================

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -135,6 +135,17 @@ function isChildDocked(child: QueryNode, nodeLayouts: LayoutMap): boolean {
 // NODE PORT AND MENU UTILITIES
 // ========================================
 
+// Calculate the number of ports to display for secondary inputs.
+// Shows one extra empty port for adding new connections, but respects max limit.
+function calculateNumPorts(
+  currentConnections: number,
+  max: number | 'unbounded',
+): number {
+  return max === 'unbounded'
+    ? currentConnections + 1
+    : Math.min(currentConnections + 1, max);
+}
+
 function getInputLabels(node: QueryNode): NodePort[] {
   // Single-input operation nodes always have a top port (even when disconnected)
   if (singleNodeOperation(node.type)) {
@@ -145,7 +156,11 @@ function getInputLabels(node: QueryNode): NodePort[] {
     if (node.secondaryInputs) {
       // Show side ports using the node's custom port names
       const portNames = node.secondaryInputs.portNames;
-      const numPorts = (node.secondaryInputs.connections.size ?? 0) + 1;
+      const currentConnections = node.secondaryInputs.connections.size ?? 0;
+      const numPorts = calculateNumPorts(
+        currentConnections,
+        node.secondaryInputs.max,
+      );
 
       for (let i = 0; i < numPorts; i++) {
         const portName = getPortName(portNames, i);
@@ -158,8 +173,11 @@ function getInputLabels(node: QueryNode): NodePort[] {
   // Multi-source nodes (IntervalIntersect, Join, Union) - no primaryInput
   if (node.secondaryInputs) {
     const portNames = node.secondaryInputs.portNames;
-    // Always show one extra empty port for adding new connections
-    const numPorts = (node.secondaryInputs.connections.size ?? 0) + 1;
+    const currentConnections = node.secondaryInputs.connections.size ?? 0;
+    const numPorts = calculateNumPorts(
+      currentConnections,
+      node.secondaryInputs.max,
+    );
     const labels: NodePort[] = [];
 
     for (let i = 0; i < numPorts; i++) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/connections_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/connections_unittest.ts
@@ -645,18 +645,13 @@ describe('Connection Management', () => {
       expect(primaryNode.nextNodes).toContain(filterNode);
     });
 
-    it('should connect multiple secondary inputs using addConnection', () => {
+    it('should connect secondary input using addConnection', () => {
       const primaryNode = createMockPrevNode('primary', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
       ]);
-      const intervalNode1 = createMockPrevNode('interval1', [
-        createColumnInfo('id', 'INT'),
-        createColumnInfo('ts', 'INT64'),
-        createColumnInfo('dur', 'INT64'),
-      ]);
-      const intervalNode2 = createMockPrevNode('interval2', [
+      const intervalNode = createMockPrevNode('interval', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
@@ -664,14 +659,11 @@ describe('Connection Management', () => {
 
       const filterNode = new FilterDuringNode({});
       addConnection(primaryNode, filterNode);
-      addConnection(intervalNode1, filterNode, 0);
-      addConnection(intervalNode2, filterNode, 1);
+      addConnection(intervalNode, filterNode, 0);
 
       expect(filterNode.primaryInput).toBe(primaryNode);
-      expect(filterNode.secondaryInputs.connections.size).toBe(2);
-      expect(filterNode.secondaryInputs.connections.get(0)).toBe(intervalNode1);
-      expect(filterNode.secondaryInputs.connections.get(1)).toBe(intervalNode2);
-      expect(filterNode.secondaryNodes.length).toBe(2);
+      expect(filterNode.secondaryInputs.connections.get(0)).toBe(intervalNode);
+      expect(filterNode.secondaryNodes.length).toBe(1);
     });
 
     it('should disconnect primary input using removeConnection', () => {
@@ -692,18 +684,13 @@ describe('Connection Management', () => {
       expect(primaryNode.nextNodes).not.toContain(filterNode);
     });
 
-    it('should disconnect one of multiple secondary inputs', () => {
+    it('should disconnect secondary input', () => {
       const primaryNode = createMockPrevNode('primary', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
       ]);
-      const intervalNode1 = createMockPrevNode('interval1', [
-        createColumnInfo('id', 'INT'),
-        createColumnInfo('ts', 'INT64'),
-        createColumnInfo('dur', 'INT64'),
-      ]);
-      const intervalNode2 = createMockPrevNode('interval2', [
+      const intervalNode = createMockPrevNode('interval', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
@@ -711,17 +698,14 @@ describe('Connection Management', () => {
 
       const filterNode = new FilterDuringNode({});
       addConnection(primaryNode, filterNode);
-      addConnection(intervalNode1, filterNode, 0);
-      addConnection(intervalNode2, filterNode, 1);
+      addConnection(intervalNode, filterNode, 0);
 
-      expect(filterNode.secondaryInputs.connections.size).toBe(2);
+      expect(filterNode.secondaryInputs.connections.get(0)).toBe(intervalNode);
 
-      removeConnection(intervalNode1, filterNode);
+      removeConnection(intervalNode, filterNode);
 
-      expect(filterNode.secondaryInputs.connections.size).toBe(1);
       expect(filterNode.secondaryInputs.connections.get(0)).toBeUndefined();
-      expect(filterNode.secondaryInputs.connections.get(1)).toBe(intervalNode2);
-      expect(filterNode.secondaryNodes.length).toBe(1);
+      expect(filterNode.secondaryNodes.length).toBe(0);
     });
 
     it('should have finalCols from primary input', () => {
@@ -773,12 +757,7 @@ describe('Connection Management', () => {
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
       ]);
-      const intervalNode1 = createMockPrevNode('interval1', [
-        createColumnInfo('id', 'INT'),
-        createColumnInfo('ts', 'INT64'),
-        createColumnInfo('dur', 'INT64'),
-      ]);
-      const intervalNode2 = createMockPrevNode('interval2', [
+      const intervalNode = createMockPrevNode('interval', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
@@ -786,54 +765,13 @@ describe('Connection Management', () => {
 
       const filterNode = new FilterDuringNode({});
       addConnection(primaryNode, filterNode);
-      addConnection(intervalNode1, filterNode, 0);
-      addConnection(intervalNode2, filterNode, 1);
+      addConnection(intervalNode, filterNode, 0);
 
-      removeConnection(intervalNode1, filterNode);
-      removeConnection(intervalNode2, filterNode);
+      removeConnection(intervalNode, filterNode);
 
       expect(filterNode.primaryInput).toBe(primaryNode);
-      expect(filterNode.secondaryInputs.connections.size).toBe(0);
+      expect(filterNode.secondaryInputs.connections.get(0)).toBeUndefined();
       expect(filterNode.secondaryNodes.length).toBe(0);
-    });
-
-    it('should add secondary input to next available port', () => {
-      const primaryNode = createMockPrevNode('primary', [
-        createColumnInfo('id', 'INT'),
-        createColumnInfo('ts', 'INT64'),
-        createColumnInfo('dur', 'INT64'),
-      ]);
-      const intervalNode1 = createMockPrevNode('interval1', [
-        createColumnInfo('id', 'INT'),
-        createColumnInfo('ts', 'INT64'),
-        createColumnInfo('dur', 'INT64'),
-      ]);
-      const intervalNode2 = createMockPrevNode('interval2', [
-        createColumnInfo('id', 'INT'),
-        createColumnInfo('ts', 'INT64'),
-        createColumnInfo('dur', 'INT64'),
-      ]);
-      const intervalNode3 = createMockPrevNode('interval3', [
-        createColumnInfo('id', 'INT'),
-        createColumnInfo('ts', 'INT64'),
-        createColumnInfo('dur', 'INT64'),
-      ]);
-
-      const filterNode = new FilterDuringNode({});
-      addConnection(primaryNode, filterNode);
-
-      // Add without specifying port - should auto-assign
-      addConnection(intervalNode1, filterNode, 0);
-      addConnection(intervalNode2, filterNode, 1);
-
-      // Remove the first one
-      removeConnection(intervalNode1, filterNode);
-
-      // Add a new one without specifying port - should use port 0
-      addConnection(intervalNode3, filterNode, 0);
-
-      expect(filterNode.secondaryInputs.connections.get(0)).toBe(intervalNode3);
-      expect(filterNode.secondaryInputs.connections.get(1)).toBe(intervalNode2);
     });
 
     it('should notify downstream nodes when primary disconnected', () => {
@@ -1514,7 +1452,7 @@ describe('Connection Management', () => {
       // - nodeX should be connected to nodeZ's SECONDARY input at port 0
       // - nodeZ's primary input should still be primaryNode (unchanged)
       expect(nodeZ.primaryInput).toBe(primaryNode); // primary unchanged
-      expect(nodeZ.secondaryInputs.connections.get(0)).toBe(nodeX); // nodeX at secondary port 0
+      expect(nodeZ.secondaryInputs.connections.get(0)).toBe(nodeX); // nodeX at secondary input
       expect(nodeX.nextNodes).toContain(nodeZ); // nodeX connected to nodeZ
     });
   });


### PR DESCRIPTION
Simplify FilterDuringNode to accept only one secondary input ("Filter intervals") instead of multiple. This change removes unnecessary complexity while maintaining the core filtering functionality.

The major reason was that it wasn't clear what the other sources were doing. Whether we should be using UNION (so it will create even more results) or AND (so it has to be during all of them)

  ## Changes

  - **UI/UX**: Changed FilterDuringNode to accept only 1 secondary input (down from 6), with clearer naming ("Filter intervals")
  - **Query generation**: Removed UNION ALL logic for combining multiple secondary inputs
  - **Validation**: Simplified validation to handle single input with better error messages
  - **Tests**: Removed tests for multiple secondary inputs, updated remaining tests to reflect single-input behavior
  - **Documentation**: Updated filter_during.md to reflect single-input architecture
  - **Graph rendering**: Updated port display logic to respect max limit when showing available input ports
