### PR TITLE
ci: Run ui-tests for googler PRs only

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -27,7 +27,6 @@ env:
   PYTHONUNBUFFERED: 1
 jobs:
   ui:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     timeout-minutes: 45
     env:
@@ -70,7 +69,7 @@ jobs:
           echo "UI_BUILD_URL=https://storage.googleapis.com/$PERFETTO_GCS_DST/ui/index.html" >> $GITHUB_ENV
 
       - name: Comment PR with UI build link
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
Short term fix to unblock https://github.com/google/perfetto/pull/3994

Current failing with error:

```
Run actions/github-script@v6
RequestError [HttpError]: Resource not accessible by integration
    at /tmp/github-action-runner/_work/_actions/actions/github-script/v6/dist/index.js:6842:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async eval (eval at callAsyncFunction (/tmp/github-action-runner/_work/_actions/actions/github-script/v6/dist/index.js:15143:16), <anonymous>:29:5)
    at async main (/tmp/github-action-runner/_work/_actions/actions/github-script/v6/dist/index.js:15236:20) {
  status: 403,
...
Error: Unhandled error: HttpError: Resource not accessible by integration
```