### PR TITLE
Add g2d ftrace events to gfx category

### DIFF
--- a/src/traced/probes/ftrace/predefined_tracepoints.cc
+++ b/src/traced/probes/ftrace/predefined_tracepoints.cc
@@ -87,6 +87,8 @@ base::FlatSet<GroupAndName> GenerateGfxTracePoints(
   AddEventGroup(table, "g2d", &events);
   InsertEvent("g2d", "tracing_mark_write", &events);
   InsertEvent("g2d", "g2d_perf_update_qos", &events);
+  InsertEvent("g2d", "g2d_slice_instant", &events);
+  InsertEvent("g2d", "g2d_counter", &events);
 
   AddEventGroup(table, "panel", &events);
   InsertEvent("panel", "panel_write_generic", &events);


### PR DESCRIPTION
Bug: 442364828Test: can use gfx category record g2d events