### PR TITLE
exp: Add warning when we might overwrite the current state of explore…

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -49,6 +49,7 @@ import {
 } from './query_builder/graph_utils';
 import {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 import {showExamplesModal} from './examples_modal';
+import {showStateOverwriteWarning} from './query_builder/widgets';
 
 registerCoreNodes();
 
@@ -877,7 +878,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     exportStateAsJson(state, trace);
   }
 
-  handleImport(attrs: ExplorePageAttrs) {
+  async handleImport(attrs: ExplorePageAttrs) {
     const {trace, sqlModulesPlugin, onStateUpdate} = attrs;
     const sqlModules = sqlModulesPlugin.getSqlModules();
     if (!sqlModules) return;
@@ -885,10 +886,15 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.json';
-    input.onchange = (event) => {
+    input.onchange = async (event) => {
       const files = (event.target as HTMLInputElement).files;
       if (files && files.length > 0) {
         const file = files[0];
+
+        // Show warning modal after file is selected
+        const confirmed = await showStateOverwriteWarning();
+        if (!confirmed) return;
+
         importStateFromJson(
           file,
           trace,
@@ -968,6 +974,10 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
 
     const selectedExample = await showExamplesModal();
     if (!selectedExample) return;
+
+    // Show warning modal after example is selected
+    const confirmed = await showStateOverwriteWarning();
+    if (!confirmed) return;
 
     try {
       // Fetch the JSON file from assets using assetSrc for proper path resolution

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
@@ -32,6 +32,7 @@ import {
 } from '../../../widgets/multiselect';
 import {classNames} from '../../../base/classnames';
 import {Tooltip} from '../../../widgets/tooltip';
+import {showModal} from '../../../widgets/modal';
 
 // Empty state widget for the data explorer with warning variant support
 export type DataExplorerEmptyStateVariant = 'default' | 'warning';
@@ -906,4 +907,46 @@ export class SelectDeselectAllButtons
       }),
     );
   }
+}
+
+/**
+ * Shows a confirmation modal warning the user that their current state will be lost.
+ * This modal is used when importing JSON or loading an example graph.
+ *
+ * @returns Promise that resolves to true if user confirms, false if cancelled
+ */
+export function showStateOverwriteWarning(): Promise<boolean> {
+  return new Promise((resolve) => {
+    showModal({
+      key: 'state-overwrite-warning',
+      title: 'Warning: Current State Will Be Lost',
+      icon: 'warning',
+      content: m(
+        '.pf-state-overwrite-warning',
+        m(
+          'p',
+          'This action will replace your current graph with a new one. All current nodes and connections will be lost.',
+        ),
+        m('p', 'Do you want to continue?'),
+      ),
+      buttons: [
+        {
+          text: 'Cancel',
+          action: () => {
+            resolve(false);
+          },
+        },
+        {
+          text: 'Continue',
+          primary: true,
+          action: () => {
+            resolve(true);
+          },
+        },
+      ],
+      onClose: () => {
+        resolve(false);
+      },
+    });
+  });
 }


### PR DESCRIPTION
Add warning modal before overwriting explore page state

This change adds a confirmation modal that warns users when they're about to lose their current explore page state. The warning appears when importing a JSON file or loading an example graph, preventing accidental data loss.

  **Changes:**
  - Modified `handleImport()` to show warning after file selection but before importing
  - Modified `loadExampleGraph()` to show warning after example selection but before loading
  - Made both handlers async to support the modal's Promise-based API

  **Notes:**
  The warning appears after the user selects a file/example but before any state changes occur, giving them a chance to cancel the operation if they didn't intend to lose their current work.
