### PR TITLE
ui: Configure search to work on arbitrary slice-like tracks

### DIFF
--- a/ui/src/components/tracks/debug_tracks.ts
+++ b/ui/src/components/tracks/debug_tracks.ts
@@ -32,6 +32,7 @@ import {
   SqlTableCounterTrack,
 } from './query_counter_track';
 import {getColorForSlice} from '../colorizer';
+import {SLICE_TRACK} from '../../public/track_kinds';
 
 export interface SqlDataSource {
   // SQL source selecting the necessary data.
@@ -232,6 +233,9 @@ async function addPivotedSliceTracks(
 
     trace.tracks.registerTrack({
       uri,
+      tags: {
+        kinds: [SLICE_TRACK],
+      },
       renderer: SliceTrack.create({
         trace,
         uri,
@@ -274,6 +278,9 @@ function addSingleSliceTrack(
 
   trace.tracks.registerTrack({
     uri,
+    tags: {
+      kinds: [SLICE_TRACK],
+    },
     renderer: SliceTrack.create({
       trace,
       uri,

--- a/ui/src/components/tracks/visualized_args_tracks.ts
+++ b/ui/src/components/tracks/visualized_args_tracks.ts
@@ -16,7 +16,7 @@ import {uuidv4} from '../../base/uuid';
 import {NUM} from '../../trace_processor/query_result';
 import {TrackNode} from '../../public/workspace';
 import {Trace} from '../../public/trace';
-import {SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {SLICE_TABLE_TRACK} from '../../public/track_kinds';
 import {createVisualizedArgsTrack} from './visualized_args_track';
 
 const VISUALIZED_ARGS_SLICE_TRACK_URI_PREFIX = 'perfetto.VisualizedArgs';
@@ -89,7 +89,7 @@ export async function addVisualizedArgTracks(trace: Trace, argName: string) {
         const track = trace.tracks.getTrack(trackNode.uri);
         return (
           track &&
-          track.tags?.kinds?.includes(SLICE_TRACK_KIND) &&
+          track.tags?.kinds?.includes(SLICE_TABLE_TRACK) &&
           track.tags?.trackIds?.includes(trackId)
         );
       },

--- a/ui/src/plugins/com.android.AndroidDmabuf/index.ts
+++ b/ui/src/plugins/com.android.AndroidDmabuf/index.ts
@@ -18,7 +18,11 @@ import {
 } from '../../components/tracks/query_counter_track';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
-import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {
+  COUNTER_TRACK_KIND,
+  SLICE_TABLE_TRACK,
+  SLICE_TRACK,
+} from '../../public/track_kinds';
 import {TrackNode} from '../../public/workspace';
 import {NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
 import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
@@ -141,7 +145,7 @@ async function addGlobalAllocs(ctx: Trace, parent: () => TrackNode) {
   ctx.tracks.registerTrack({
     uri,
     tags: {
-      kinds: [SLICE_TRACK_KIND],
+      kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
       trackIds: ids,
     },
     renderer: await createTraceProcessorSliceTrack({

--- a/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
+++ b/ui/src/plugins/com.android.GpuWorkPeriod/index.ts
@@ -16,7 +16,7 @@ import {LONG, LONG_NULL, NUM, STR} from '../../trace_processor/query_result';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {SLICE_TABLE_TRACK, SLICE_TRACK} from '../../public/track_kinds';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
 
@@ -77,7 +77,7 @@ export default class implements PerfettoPlugin {
         uri,
         tags: {
           trackIds: [trackId],
-          kinds: [SLICE_TRACK_KIND],
+          kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
         },
         renderer: track,
       });

--- a/ui/src/plugins/dev.perfetto.Frames/index.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/index.ts
@@ -16,7 +16,7 @@ import {App} from '../../public/app';
 import {createAggregationTab} from '../../components/aggregation_adapter';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
-import {SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {SLICE_TABLE_TRACK, SLICE_TRACK} from '../../public/track_kinds';
 import {TrackNode} from '../../public/workspace';
 import {NUM, STR} from '../../trace_processor/query_result';
 import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';
@@ -95,7 +95,7 @@ export default class FramesPlugin implements PerfettoPlugin {
         uri,
         renderer: createExpectedFramesTrack(ctx, uri, maxDepth, trackIds),
         tags: {
-          kinds: [SLICE_TRACK_KIND],
+          kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
           trackIds,
           upid,
         },
@@ -161,7 +161,11 @@ export default class FramesPlugin implements PerfettoPlugin {
         tags: {
           upid,
           trackIds,
-          kinds: [SLICE_TRACK_KIND, ACTUAL_FRAMES_SLICE_TRACK_KIND],
+          kinds: [
+            SLICE_TRACK,
+            SLICE_TABLE_TRACK,
+            ACTUAL_FRAMES_SLICE_TRACK_KIND,
+          ],
         },
       });
       group?.addChildInOrder(
@@ -187,7 +191,7 @@ export default class FramesPlugin implements PerfettoPlugin {
           tags: {
             upid,
             trackIds,
-            kinds: [SLICE_TRACK_KIND],
+            kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
           },
         });
         group?.addChildInOrder(

--- a/ui/src/plugins/dev.perfetto.KernelTrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.KernelTrackEvent/index.ts
@@ -15,7 +15,11 @@
 import {assertExists} from '../../base/logging';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
-import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {
+  COUNTER_TRACK_KIND,
+  SLICE_TABLE_TRACK,
+  SLICE_TRACK,
+} from '../../public/track_kinds';
 import {TrackNode} from '../../public/workspace';
 import {
   LONG_NULL,
@@ -142,7 +146,7 @@ export default class implements PerfettoPlugin {
         ctx.tracks.registerTrack({
           uri,
           tags: {
-            kinds: [SLICE_TRACK_KIND],
+            kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
             trackIds: [trackId],
             upid: upid ?? undefined,
             utid: utid ?? undefined,

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/pivot_table_tab.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/pivot_table_tab.ts
@@ -22,7 +22,7 @@ import {
   areaSelectionsEqual,
   AreaSelectionTab,
 } from '../../public/selection';
-import {SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {SLICE_TABLE_TRACK} from '../../public/track_kinds';
 import {Button} from '../../widgets/button';
 import {Trace} from '../../public/trace';
 import {extensions} from '../../components/extensions';
@@ -46,7 +46,10 @@ export class PivotTableTab implements AreaSelectionTab {
     ) {
       this.previousSelection = selection;
       this.trackIds = selection.tracks
-        .filter((track) => track.tags?.kinds?.includes(SLICE_TRACK_KIND))
+        // Can only work from slice table tracks.
+        // TODO(stevegolton): Remove this and just use the aggregations which
+        // can operate on any slice-like tracks.
+        .filter((track) => track.tags?.kinds?.includes(SLICE_TABLE_TRACK))
         .flatMap((track) => track.tags?.trackIds ?? []);
       this.getOrCreateState().filters.setFilters([
         {

--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -25,7 +25,11 @@ import {
 } from '../../trace_processor/query_result';
 import {TrackNode} from '../../public/workspace';
 import {assertExists, assertTrue} from '../../base/logging';
-import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {
+  COUNTER_TRACK_KIND,
+  SLICE_TABLE_TRACK,
+  SLICE_TRACK,
+} from '../../public/track_kinds';
 import {createTraceProcessorSliceTrack} from '../dev.perfetto.TraceProcessorTrack/trace_processor_slice_track';
 import {TraceProcessorCounterTrack} from '../dev.perfetto.TraceProcessorTrack/trace_processor_counter_track';
 import {getTrackName} from '../../public/utils';
@@ -178,7 +182,7 @@ export default class TrackEventPlugin implements PerfettoPlugin {
         continue;
       }
 
-      const kind = isCounter ? COUNTER_TRACK_KIND : SLICE_TRACK_KIND;
+      const kind = isCounter ? COUNTER_TRACK_KIND : SLICE_TABLE_TRACK;
       const trackIds = rawTrackIds.split(',').map((v) => Number(v));
       const trackName = getTrackName({
         name,
@@ -203,7 +207,9 @@ export default class TrackEventPlugin implements PerfettoPlugin {
           uri,
           description: description ?? undefined,
           tags: {
-            kinds: [kind],
+            kinds: isCounter
+              ? [COUNTER_TRACK_KIND]
+              : [SLICE_TRACK, SLICE_TABLE_TRACK],
             trackIds: [trackIds[0]],
             upid: upid ?? undefined,
             utid: utid ?? undefined,

--- a/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
+++ b/ui/src/plugins/org.kernel.LinuxKernelSubsystems/index.ts
@@ -16,7 +16,7 @@ import {NUM, STR_NULL} from '../../trace_processor/query_result';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {createTraceProcessorSliceTrack} from '../dev.perfetto.TraceProcessorTrack/trace_processor_slice_track';
-import {SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {SLICE_TABLE_TRACK, SLICE_TRACK} from '../../public/track_kinds';
 import {TrackNode} from '../../public/workspace';
 import TraceProcessorTrackPlugin from '../dev.perfetto.TraceProcessorTrack';
 
@@ -70,7 +70,7 @@ export default class implements PerfettoPlugin {
           trackIds: [trackId],
         }),
         tags: {
-          kinds: [SLICE_TRACK_KIND],
+          kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
           trackIds: [trackId],
         },
       });

--- a/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
+++ b/ui/src/plugins/org.kernel.SuspendResumeLatency/index.ts
@@ -17,7 +17,7 @@ import {createTraceProcessorSliceTrack} from '../dev.perfetto.TraceProcessorTrac
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {TrackNode} from '../../public/workspace';
-import {SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {SLICE_TABLE_TRACK, SLICE_TRACK} from '../../public/track_kinds';
 import {SuspendResumeDetailsPanel} from './suspend_resume_details';
 import ThreadPlugin from '../dev.perfetto.Thread';
 import TraceProcessorTrackPlugin from '../dev.perfetto.TraceProcessorTrack';
@@ -66,7 +66,7 @@ export default class implements PerfettoPlugin {
       uri,
       tags: {
         trackIds,
-        kinds: [SLICE_TRACK_KIND],
+        kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
       },
       renderer: await createTraceProcessorSliceTrack({
         trace: ctx,

--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -20,7 +20,7 @@ import {
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
-import {SLICE_TRACK_KIND} from '../../public/track_kinds';
+import {SLICE_TABLE_TRACK, SLICE_TRACK} from '../../public/track_kinds';
 import {TrackNode} from '../../public/workspace';
 import {Engine} from '../../trace_processor/engine';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -183,7 +183,7 @@ async function addWattsonMarkersElements(ctx: Trace, group: TrackNode) {
   ctx.tracks.registerTrack({
     uri,
     tags: {
-      kinds: [SLICE_TRACK_KIND],
+      kinds: [SLICE_TRACK, SLICE_TABLE_TRACK],
     },
     renderer: track,
   });

--- a/ui/src/public/track_kinds.ts
+++ b/ui/src/public/track_kinds.ts
@@ -17,6 +17,21 @@
 // ton of circular imports.
 export const CPU_SLICE_TRACK_KIND = 'CpuSliceTrack';
 export const THREAD_STATE_TRACK_KIND = 'ThreadStateTrack';
-export const SLICE_TRACK_KIND = 'SliceTrack';
 export const COUNTER_TRACK_KIND = 'CounterTrack';
 export const ANDROID_LOGS_TRACK_KIND = 'AndroidLogTrack';
+
+// This type indicates that a track represents slice-like data and that it's
+// dataset's columns are as such:
+// - id: A unique identifier for the slice
+// - ts: A timestamp indicating the start of the slice
+// - dur: (Optional) A duration indicating the length of the slice
+// - name: (Optional) The name of the slice
+export const SLICE_TRACK = 'SliceTrack';
+
+// This type indicates the id of each event in this track corresponds to a row
+// in the `slice` table. Users of this track kind can expect to be able to query
+// the `slice` table for more information about each event.
+// TODO(stevegolton): Eventually, users should not have to make this assumption
+// and should just be able to operate on the dataset provided by the track, but
+// some legacy systems still rely on this: e.g flows.
+export const SLICE_TABLE_TRACK = 'SliceTableTrack';


### PR DESCRIPTION
Currently searching only works on tracks with the 'SLICE_TRACK_KIND' kind tag, which was required for the previous search mechanism. Now, any tracks can be searched as long as they have name / args_set_id fields.

This patch replaces the SLICE_TRACK_KIND with two new kinds tags:
- SLICE_TRACK: Indicates that this track represents slice like events where ts, dur, name and args_set_id mean what you'd expect, but the ids do not necessarily correspond to ids in the slice table.
- SLICE_TABLE_TRACK: Subset of SLICE_TRACK where ids correspond to the relevant slices in the slice table.

All tracks that used to have kind SLICE_TRACK_KIND now have both ['SLICE_TRACK', and 'SLICE_TABLE_TRACK'].
Debug tracks now have only 'SLICE_TRACK', so search can now work on them.