### PR TITLE
exp: Hide empty data tables by default

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
@@ -223,7 +223,7 @@ class TableCard
 // It orchestrates the search bar, the list of tables, and handles filtering.
 export class TableList implements m.ClassComponent<TableListAttrs> {
   private selectedTags: Set<string> = new Set();
-  private hideDisabledModules: boolean = false;
+  private hideDisabledModules: boolean = true;
   private onlyShowTimestampedTables: boolean = false;
 
   view({attrs}: m.CVnode<TableListAttrs>) {


### PR DESCRIPTION
This is the expected behaviour. As there are multiple mostly separated parts of exploration - chrome/android, it's better if we expose only one