### PR TITLE
python: proto builder don't reuse trace object

### DIFF
--- a/python/perfetto/trace_builder/proto_builder.py
+++ b/python/perfetto/trace_builder/proto_builder.py
@@ -98,7 +98,6 @@ class StreamingTraceProtoBuilder:
             of `open('trace.pftrace', 'wb')`).
     """
     self._file = file
-    self._trace = Trace()
 
   def create_packet(self) -> TracePacket:
     """Creates a new, empty TracePacket object.
@@ -120,7 +119,6 @@ class StreamingTraceProtoBuilder:
     Args:
       packet: The `TracePacket` to be written to the file.
     """
-    # Clear the packet list.
-    del self._trace.packet[:]
-    self._trace.packet.append(packet)
-    self._file.write(self._trace.SerializeToString())
+    trace = Trace()
+    trace.packet.append(packet)
+    self._file.write(trace.SerializeToString())


### PR DESCRIPTION
 * Before Fix (Reusing `self._trace`):
       * Peak memory usage: 229.873MB
       * Total memory allocated: 1.123GB

* After Fix (new `Trace()` per packet):
       * Peak memory usage: 8.066MB
       * Total memory allocated: 1.344GB (Total allocation is higher because we create more objects, but they are garbage collected immediately).

Also verified that del self._trace.packet[:] is not actually releasing the underlying trace protos by checking resource usage:
```
usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
        print(f"[DEBUG] Packet {self._counter}: RSS Memory usage: {usage} KB")
```

* Before fix

```
[DEBUG] Packet 130000: RSS Memory usage: 88068 KB                                                                                                                
│ [DEBUG] Packet 140000: RSS Memory usage: 93188 KB                                                                                                                
│ [DEBUG] Packet 150000: RSS Memory usage: 98308 KB                                                                                                                
...
│ [DEBUG] Packet 1030000: RSS Memory usage: 553476 KB                                                                                                              
│ [DEBUG] Packet 1040000: RSS Memory usage: 558596 KB                                                                                                              
│ [DEBUG] Packet 1050000: RSS Memory usage: 563716 KB   
```

* after fix

```
[DEBUG] Packet 130000: RSS Memory usage: 21512 KB                                                                                                                │
[DEBUG] Packet 140000: RSS Memory usage: 21512 KB    
..
│ [DEBUG] Packet 1030000: RSS Memory usage: 21512 KB                                                                                                               
│ [DEBUG] Packet 1040000: RSS Memory usage: 21512 KB                                                                                                               
│ [DEBUG] Packet 1050000: RSS Memory usage: 21512 KB    
```
Fixes: https://github.com/google/perfetto/issues/4065
       