### PR TITLE
Revert "sdk: add privacy-safe string interning support (#4062)"

### DIFF
--- a/include/perfetto/public/abi/track_event_hl_abi.h
+++ b/include/perfetto/public/abi/track_event_hl_abi.h
@@ -46,7 +46,6 @@ enum PerfettoTeHlProtoFieldType {
   PERFETTO_TE_HL_PROTO_TYPE_FIXED32 = 5,
   PERFETTO_TE_HL_PROTO_TYPE_DOUBLE = 6,
   PERFETTO_TE_HL_PROTO_TYPE_FLOAT = 7,
-  PERFETTO_TE_HL_PROTO_TYPE_CSTR_INTERNED = 8,
 };
 
 // Common header for all the proto fields.
@@ -61,18 +60,6 @@ struct PerfettoTeHlProtoFieldCstr {
   struct PerfettoTeHlProtoField header;
   // Null terminated string.
   const char* str;
-};
-
-// PERFETTO_TE_HL_PROTO_TYPE_CSTR_INTERNED
-struct PerfettoTeHlProtoFieldCstrInterned {
-  struct PerfettoTeHlProtoField header;
-  // Null terminated string.
-  const char* str;
-  // The field id of the interned data message (e.g., InternedData.event_names).
-  // `str` will be interned and the resulting iid will be written in the proto
-  // field `header.id`. If zero, `str` is written directly and no interning
-  // occurs.
-  uint32_t interned_type_id;
 };
 
 // PERFETTO_TE_HL_PROTO_TYPE_BYTES

--- a/include/perfetto/public/protos/trace/interned_data/interned_data.pzc.h
+++ b/include/perfetto/public/protos/trace/interned_data/interned_data.pzc.h
@@ -25,7 +25,6 @@
 
 #include "perfetto/public/pb_macros.h"
 
-PERFETTO_PB_MSG_DECL(perfetto_protos_AndroidJobName);
 PERFETTO_PB_MSG_DECL(perfetto_protos_AppWakelockInfo);
 PERFETTO_PB_MSG_DECL(perfetto_protos_Callstack);
 PERFETTO_PB_MSG_DECL(perfetto_protos_DebugAnnotationName);
@@ -47,10 +46,6 @@ PERFETTO_PB_MSG_DECL(perfetto_protos_Mapping);
 PERFETTO_PB_MSG_DECL(perfetto_protos_NetworkPacketContext);
 PERFETTO_PB_MSG_DECL(perfetto_protos_SourceLocation);
 PERFETTO_PB_MSG_DECL(perfetto_protos_UnsymbolizedSourceLocation);
-
-PERFETTO_PB_MSG(perfetto_protos_AndroidJobName);
-PERFETTO_PB_FIELD(perfetto_protos_AndroidJobName, VARINT, uint64_t, iid, 1);
-PERFETTO_PB_FIELD(perfetto_protos_AndroidJobName, STRING, const char*, name, 2);
 
 PERFETTO_PB_MSG(perfetto_protos_InternedData);
 PERFETTO_PB_FIELD(perfetto_protos_InternedData,
@@ -223,10 +218,5 @@ PERFETTO_PB_FIELD(perfetto_protos_InternedData,
                   perfetto_protos_InternedString,
                   correlation_id_str,
                   43);
-PERFETTO_PB_FIELD(perfetto_protos_InternedData,
-                  MSG,
-                  perfetto_protos_AndroidJobName,
-                  android_job_name,
-                  44);
 
 #endif  // INCLUDE_PERFETTO_PUBLIC_PROTOS_TRACE_INTERNED_DATA_INTERNED_DATA_PZC_H_

--- a/protos/perfetto/trace/interned_data/interned_data.proto
+++ b/protos/perfetto/trace/interned_data/interned_data.proto
@@ -56,7 +56,7 @@ package perfetto.protos;
 // emitted proactively in advance of referring to them in later packets.
 //
 // Next reserved id: 8 (up to 15).
-// Next id: 45.
+// Next id: 44.
 message InternedData {
   // TODO(eseckler): Replace iid fields inside interned messages with
   // map<iid, message> type fields in InternedData.
@@ -148,15 +148,6 @@ message InternedData {
   // Interned correlation ids in track_event.
   repeated InternedString correlation_id_str = 43;
 
-  // Interned job names for Android Job Names. These are separate from
-  // other strings because they are under app control.
-  repeated AndroidJobName android_job_name = 44;
-
   // removed ProfiledFrameSymbols profiled_frame_symbols
   reserved 21;
-}
-
-message AndroidJobName {
-  optional uint64 iid = 1;
-  optional string name = 2;
 }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -15256,7 +15256,7 @@ message EventName {
 // emitted proactively in advance of referring to them in later packets.
 //
 // Next reserved id: 8 (up to 15).
-// Next id: 45.
+// Next id: 44.
 message InternedData {
   // TODO(eseckler): Replace iid fields inside interned messages with
   // map<iid, message> type fields in InternedData.
@@ -15348,17 +15348,8 @@ message InternedData {
   // Interned correlation ids in track_event.
   repeated InternedString correlation_id_str = 43;
 
-  // Interned job names for Android Job Names. These are separate from
-  // other strings because they are under app control.
-  repeated AndroidJobName android_job_name = 44;
-
   // removed ProfiledFrameSymbols profiled_frame_symbols
   reserved 21;
-}
-
-message AndroidJobName {
-  optional uint64 iid = 1;
-  optional string name = 2;
 }
 
 // End of protos/perfetto/trace/interned_data/interned_data.proto

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventBuilder.java
@@ -538,24 +538,6 @@ public final class PerfettoTrackEventBuilder {
   }
 
   /**
-   * Adds a proto field with field id {@code id} and value {@code val}.
-   * If {@code internedTypeId} is non-zero, the string {@code val} will be interned
-   * with the given type ID. If {@code internedTypeId} is zero, no interning occurs.
-   */
-  public PerfettoTrackEventBuilder addFieldWithInterning(long id, String val, long internedTypeId) {
-    if (!mIsCategoryEnabled) {
-      return this;
-    }
-    if (mIsDebug) {
-      checkBuildingProto();
-    }
-    FieldString field = mObjectsPool.mFieldStringPool.get(fieldStringSupplier);
-    field.setValueWithInterning(id, val, internedTypeId);
-    addFieldToContainer(field);
-    return this;
-  }
-
-  /**
    * Begins a proto field. Fields can be added from this point and there must be a corresponding
    * {@link #endProto}.
    *

--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrackEventExtra.java
@@ -545,10 +545,6 @@ final class PerfettoTrackEventExtra {
       native_set_value(mPtr, id, val);
     }
 
-    public void setValueWithInterning(long id, String val, long internedTypeId) {
-      native_set_value_with_interning(mPtr, id, val, internedTypeId);
-    }
-
     @CriticalNative
     private static native long native_init();
 
@@ -560,10 +556,6 @@ final class PerfettoTrackEventExtra {
 
     @FastNative
     private static native void native_set_value(long ptr, long id, String val);
-
-    @FastNative
-    private static native void native_set_value_with_interning(
-        long ptr, long id, String val, long internedTypeId);
   }
 
   static final class FieldNested implements PerfettoPointer, FieldContainer {

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -473,48 +473,6 @@ public class PerfettoTraceTest {
   }
 
   @Test
-  public void testProtoWithInterning() throws Exception {
-    TraceConfig traceConfig = getTraceConfig(FOO);
-
-    PerfettoTrace.Session session = new PerfettoTrace.Session(true, traceConfig.toByteArray());
-
-    final long fieldId = 1;
-    final long internedTypeId = 44; // InternedData.android_job_name
-    final String stringToIntern = "my_interned_string";
-
-    PerfettoTrace.instant(FOO_CATEGORY, "event_with_interning")
-        .beginProto()
-        .addFieldWithInterning(fieldId, stringToIntern, internedTypeId)
-        .endProto()
-        .emit();
-
-    byte[] traceBytes = session.close();
-
-    Trace trace = Trace.parseFrom(traceBytes);
-
-    boolean hasTrackEvent = false;
-    boolean hasInternedString = false;
-
-    for (TracePacket packet : trace.getPacketList()) {
-      if (packet.hasInternedData()) {
-        InternedData internedData = packet.getInternedData();
-        if (internedData.getAndroidJobNameCount() > 0) {
-          if (internedData.getAndroidJobName(0).getName().equals(stringToIntern)) {
-            hasInternedString = true;
-          }
-        }
-      }
-
-      if (packet.hasTrackEvent()) {
-        hasTrackEvent = true;
-      }
-    }
-
-    assertThat(hasTrackEvent).isTrue();
-    assertThat(hasInternedString).isTrue();
-  }
-
-  @Test
   public void testProtoWithSlowPath() throws Exception {
     TraceConfig traceConfig = getTraceConfig(FOO);
 

--- a/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc
+++ b/src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc
@@ -365,20 +365,6 @@ static void dev_perfetto_sdk_PerfettoTrackEventExtraFieldString_set_value(
   field->set_value(id, StringBuffer::utf16_to_ascii(env, val).data());
 }
 
-static void
-dev_perfetto_sdk_PerfettoTrackEventExtraFieldString_set_value_with_interning(
-    JNIEnv* env,
-    jclass,
-    jlong ptr,
-    jlong id,
-    jstring val,
-    jlong interned_type_id) {
-  sdk_for_jni::ProtoField<const char*, true>* field =
-      toPointer<sdk_for_jni::ProtoField<const char*, true>>(ptr);
-  field->set_value(id, StringBuffer::utf16_to_ascii(env, val).data(),
-                   interned_type_id);
-}
-
 static void dev_perfetto_sdk_PerfettoTrackEventExtraFieldNested_add_field(
     jlong field_ptr,
     jlong arg_ptr) {
@@ -668,9 +654,6 @@ static const JNINativeMethod gFieldStringMethods[] = {
      (void*)dev_perfetto_sdk_PerfettoTrackEventExtraFieldString_get_extra_ptr},
     {"native_set_value", "(JJLjava/lang/String;)V",
      (void*)dev_perfetto_sdk_PerfettoTrackEventExtraFieldString_set_value},
-    {"native_set_value_with_interning", "(JJLjava/lang/String;J)V",
-     (void*)
-         dev_perfetto_sdk_PerfettoTrackEventExtraFieldString_set_value_with_interning},
 };
 
 static const JNINativeMethod gFieldNestedMethods[] = {


### PR DESCRIPTION
This reverts commit a2c5efe7f8cbb386fb87516edf820e6214747835.

The problem is that only one FieldString type (is_interned=false) is created at init and stored in the pool. When we then try to set_value with interned_type on an ProtoField object with is_interned=false from the pool, we crash