### PR TITLE
Add CoreFoundation framework to protoc deps

### DIFF
--- a/buildtools/BUILD.gn
+++ b/buildtools/BUILD.gn
@@ -1221,6 +1221,12 @@ if (current_toolchain == host_toolchain) {
       # Protobuf does has its own #define WIN32_LEAN_AND_MEAN.
       configs -= [ "//gn/standalone:win32_lean_and_mean" ]
     }
+    if (is_mac) {
+      ldflags = [
+        "-framework",
+        "CoreFoundation",
+      ]
+    }
   }
 }  # host_toolchain
 


### PR DESCRIPTION
Building the Perfetto UI on MacOS fails with link error "undefined symbols" for Core Foundation functions like `_CFRelease`. This change adds `-framework CoreFoundation` to the link flags for protoc.

The full error output is as follows:
```
(.venv) jessemckenna-mac:perfetto jessemckenna$ ui/build
rm /Users/jessemckenna/src/perfetto/out/ui/ui
Entering /Users/jessemckenna/src/perfetto/out/ui
[0.932] 1/82    Waiting for first build to complete... 1 s
[0.932] 2/82    ../../tools/gn gen --args=is_debug=false
Done. Made 1777 targets from 277 files in 139ms
[1.120] 3/82    ../../tools/ninja -C  traceconv_wasm trace_config_utils_wasm trace_processor_mem
ninja: Entering directory `/Users/jessemckenna/src/perfetto/out/ui'
[6/1857] link ./protoc
FAILED: protoc stripped/protoc
clang++  -dead_strip   @./protoc.rsp   -o ./protoc && strip -x -o ./stripped/protoc ./protoc
Undefined symbols for architecture arm64:
  "_CFRelease", referenced from:
      absl::lts_20250512::time_internal::cctz::local_time_zone() in abseil_cpp.time_zone_lookup.o
  "_CFStringGetCString", referenced from:
      absl::lts_20250512::time_internal::cctz::local_time_zone() in abseil_cpp.time_zone_lookup.o
  "_CFStringGetLength", referenced from:
      absl::lts_20250512::time_internal::cctz::local_time_zone() in abseil_cpp.time_zone_lookup.o
  "_CFStringGetMaximumSizeForEncoding", referenced from:
      absl::lts_20250512::time_internal::cctz::local_time_zone() in abseil_cpp.time_zone_lookup.o
  "_CFTimeZoneCopyDefault", referenced from:
      absl::lts_20250512::time_internal::cctz::local_time_zone() in abseil_cpp.time_zone_lookup.o
  "_CFTimeZoneGetName", referenced from:
      absl::lts_20250512::time_internal::cctz::local_time_zone() in abseil_cpp.time_zone_lookup.o
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[11/1857] compile ../../src/base/version.cc
ninja: build stopped: subcommand failed.
/Users/jessemckenna/src/perfetto/tools/ninja -C /Users/jessemckenna/src/perfetto/out/ui traceconv_wasm trace_config_utils_wasm trace_processor_memory64_wasm trace_processor_wasm failed with code 1
```