### PR TITLE
ep: Full rewrite of joining

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -23,10 +23,12 @@
 @import "./nodes/sources/slices_source.scss";
 @import "./nodes/sources/table_source.scss";
 @import "./nodes/sources/timerange_source.scss";
+@import "./nodes/add_columns_node.scss";
 @import "./nodes/aggregation_node.scss";
 @import "./nodes/modify_columns_node.scss";
 @import "./table_list.scss";
 @import "./widgets.scss";
+@import "./join_widgets.scss";
 
 .pf-query-builder-layout {
   // CSS variable for side panel width, used in both SCSS and TypeScript

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -239,6 +239,8 @@ export function registerCoreNodes() {
         leftColumn: '',
         rightColumn: '',
         sqlExpression: '',
+        leftColumns: undefined,
+        rightColumns: undefined,
       };
       return new JoinNode(fullState);
     },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/join_widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/join_widgets.scss
@@ -1,0 +1,281 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import "./common";
+
+// Join condition selector - two-card layout
+.pf-join-condition-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  container-type: inline-size;
+  width: 100%;
+
+  &.pf-join-condition--complete {
+    .pf-join-source-card {
+      border-color: var(--pf-color-primary);
+    }
+  }
+}
+
+.pf-join-condition-selector__cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+
+  // Stack vertically only on very narrow containers
+  @container (max-width: 500px) {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+}
+
+// Join source card
+.pf-join-source-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  transition: border-color 0.2s ease-in-out;
+}
+
+.pf-join-source-card__header {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--pf-color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 0 0 12px 0;
+  border-bottom: 1px solid var(--pf-color-border);
+  margin-bottom: 12px;
+}
+
+.pf-join-source-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+}
+
+// Other columns list
+.pf-join-source-card__columns {
+  margin-top: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--pf-color-border);
+}
+
+.pf-join-source-card__columns-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--pf-color-text-muted);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.pf-join-source-card__columns-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.pf-join-source-card__column-item {
+  font-size: 13px;
+  color: var(--pf-color-text);
+  font-family: "Roboto Mono", monospace;
+  padding: 4px 8px;
+  background: var(--pf-color-background-secondary);
+  border-radius: 3px;
+}
+
+// Join condition preview (shown when both columns are selected)
+.pf-join-condition-preview {
+  padding: 12px 16px;
+  background: var(--pf-color-background);
+  border: 1px solid var(--pf-color-primary);
+  border-radius: 4px;
+  border-left-width: 4px;
+}
+
+.pf-join-condition-preview__code {
+  font-family: "Roboto Mono", monospace;
+  font-size: 14px;
+  color: var(--pf-color-text);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+
+  .pf-join-column-ref {
+    color: var(--pf-color-primary);
+    font-weight: 600;
+  }
+
+  .pf-join-operator {
+    color: var(--pf-color-text-muted);
+    font-weight: 400;
+  }
+}
+
+// Compact join condition display (read-only, for node details)
+.pf-join-condition-display {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: var(--pf-color-background-secondary);
+  border-radius: 4px;
+  font-family: "Roboto Mono", monospace;
+  font-size: 13px;
+
+  .pf-join-column-ref {
+    color: var(--pf-color-primary);
+    font-weight: 600;
+  }
+
+  .pf-join-operator {
+    color: var(--pf-color-text-muted);
+    font-weight: 400;
+  }
+}
+
+// Additional styles for join-specific UI elements
+
+// Join modal - wider to accommodate two-column layout
+.pf-join-modal-wide {
+  min-width: min(1000px, 90vw);
+  max-width: 1200px;
+}
+
+// Join modal layout (for AddColumnsNode guided mode)
+.pf-join-modal-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+  min-height: 400px;
+
+  @media (max-width: 1000px) {
+    grid-template-columns: 1fr;
+
+    .pf-join-modal-info {
+      display: none; // Hide table info on narrow screens
+    }
+  }
+}
+
+.pf-join-modal-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pf-join-modal-info {
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+// Styles for the join condition in node details
+.pf-exp-join-condition {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px 0;
+}
+
+.pf-exp-join-equals {
+  color: var(--pf-color-text-muted);
+  font-weight: 600;
+  font-family: "Roboto Mono", monospace;
+}
+
+// Filter during clip row
+.pf-filter-during-clip-row {
+  padding: 12px 16px;
+  background: var(--pf-color-background-secondary);
+  border: 1px solid var(--pf-color-border);
+  border-radius: 4px;
+}
+
+// Join column selector - for selecting columns with checkboxes and aliasing
+.pf-join-column-selector {
+  display: flex;
+  gap: 24px;
+  flex-direction: column;
+}
+
+.pf-join-column-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pf-join-column-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--pf-color-border);
+
+  h4 {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--pf-color-text);
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+}
+
+.pf-join-column-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.pf-join-column-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px;
+  border-radius: 4px;
+  background: var(--pf-color-background);
+  border: 1px solid var(--pf-color-border);
+
+  &:hover {
+    background: var(--pf-color-background-secondary);
+  }
+
+  .pf-checkbox {
+    flex: 1;
+  }
+
+  .pf-text-input {
+    width: 150px;
+    flex-shrink: 0;
+  }
+}
+
+// Spacing for form components in configuration modal
+.pf-join-modal-info {
+  .pf-form {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/join_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/join_widgets.ts
@@ -1,0 +1,404 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {ColumnInfo} from './column_info';
+import {
+  OutlinedField,
+  DataExplorerEmptyState,
+  SelectDeselectAllButtons,
+} from './widgets';
+import {classNames} from '../../../base/classnames';
+import {Card} from '../../../widgets/card';
+import {Checkbox} from '../../../widgets/checkbox';
+import {TextInput} from '../../../widgets/text_input';
+
+/**
+ * Widget for displaying a join source as a card
+ * Shows join column selector and checkboxes for selecting other columns
+ */
+export interface JoinSourceCardAttrs {
+  label: string; // e.g., "Left", "Right"
+  columns: ColumnInfo[];
+  otherSideColumns: ColumnInfo[]; // Columns from the other side to check for duplicates
+  selectedColumn?: string;
+  joinColumnDisabled?: boolean; // Whether the join column selector should be disabled
+  onColumnChange: (columnName: string) => void;
+  onColumnToggle: (index: number, checked: boolean) => void;
+  onColumnAlias: (index: number, alias: string) => void;
+}
+
+export class JoinSourceCard implements m.ClassComponent<JoinSourceCardAttrs> {
+  view({attrs}: m.Vnode<JoinSourceCardAttrs>) {
+    const {
+      label,
+      columns,
+      otherSideColumns,
+      selectedColumn,
+      joinColumnDisabled,
+      onColumnChange,
+      onColumnToggle,
+      onColumnAlias,
+    } = attrs;
+
+    // Show empty state if no columns are available (no node connected)
+    if (columns.length === 0) {
+      return m(
+        Card,
+        {className: 'pf-join-source-card'},
+        m('.pf-join-source-card__header', label),
+        m(
+          '.pf-join-source-card__content',
+          m(DataExplorerEmptyState, {
+            icon: 'cable',
+            title: `Connect a node to the ${label} input`,
+          }),
+        ),
+      );
+    }
+
+    return m(
+      Card,
+      {className: 'pf-join-source-card'},
+      m('.pf-join-source-card__header', label),
+      m(
+        '.pf-join-source-card__content',
+        // Join column selector
+        m(
+          OutlinedField,
+          {
+            label: 'Join Column',
+            value: selectedColumn || '',
+            disabled: joinColumnDisabled,
+            onchange: (e: Event) => {
+              const target = e.target as HTMLSelectElement;
+              onColumnChange(target.value);
+            },
+          },
+          [
+            m(
+              'option',
+              {
+                value: '',
+                selected: !selectedColumn,
+                disabled: true,
+              },
+              'Select column',
+            ),
+            ...columns.map((col) =>
+              m(
+                'option',
+                {
+                  value: col.column.name,
+                  selected: col.column.name === selectedColumn,
+                },
+                col.column.name,
+              ),
+            ),
+          ],
+        ),
+        // Column selection with checkboxes and aliasing
+        columns.length > 0 &&
+          m(
+            '.pf-join-source-card__columns',
+            m(
+              '.pf-join-source-card__columns-label',
+              'Select columns to include:',
+            ),
+            m(
+              '.pf-join-source-card__columns-list',
+              columns.map((col, index) => {
+                // Check if this column's final name conflicts with the other side
+                // Use alias if available, otherwise use the column name
+                const finalName = col.alias ?? col.column.name;
+                const isDuplicate = otherSideColumns.some(
+                  (otherCol) =>
+                    otherCol.checked &&
+                    (otherCol.alias ?? otherCol.column.name) === finalName,
+                );
+                const isDisabled = isDuplicate && !col.checked;
+
+                return m(
+                  '.pf-join-column-row',
+                  {
+                    className: classNames(isDisabled && 'pf-disabled'),
+                  },
+                  m(Checkbox, {
+                    checked: col.checked,
+                    disabled: isDisabled,
+                    label: col.column.name,
+                    onchange: (e) => {
+                      onColumnToggle(
+                        index,
+                        (e.target as HTMLInputElement).checked,
+                      );
+                    },
+                  }),
+                  m(TextInput, {
+                    // Always allow editing alias - that's how users resolve conflicts
+                    oninput: (e: Event) => {
+                      const inputValue = (e.target as HTMLInputElement).value;
+                      onColumnAlias(
+                        index,
+                        inputValue.trim() === '' ? '' : inputValue,
+                      );
+                    },
+                    placeholder: 'alias',
+                    value: col.alias ?? '',
+                  }),
+                );
+              }),
+            ),
+          ),
+      ),
+    );
+  }
+}
+
+/**
+ * Widget for displaying the join condition between two sources
+ * Shows two cards side-by-side for left and right sources
+ */
+export interface JoinConditionSelectorAttrs {
+  leftLabel: string; // e.g., "Left", "Primary"
+  rightLabel: string; // e.g., "Right", "Secondary"
+  leftColumns: ColumnInfo[];
+  rightColumns: ColumnInfo[];
+  leftColumn?: string;
+  rightColumn?: string;
+  onLeftColumnChange: (columnName: string) => void;
+  onRightColumnChange: (columnName: string) => void;
+  onLeftColumnToggle: (index: number, checked: boolean) => void;
+  onRightColumnToggle: (index: number, checked: boolean) => void;
+  onLeftColumnAlias: (index: number, alias: string) => void;
+  onRightColumnAlias: (index: number, alias: string) => void;
+}
+
+export class JoinConditionSelector
+  implements m.ClassComponent<JoinConditionSelectorAttrs>
+{
+  view({attrs}: m.Vnode<JoinConditionSelectorAttrs>) {
+    const {
+      leftLabel,
+      rightLabel,
+      leftColumns,
+      rightColumns,
+      leftColumn,
+      rightColumn,
+      onLeftColumnChange,
+      onRightColumnChange,
+      onLeftColumnToggle,
+      onRightColumnToggle,
+      onLeftColumnAlias,
+      onRightColumnAlias,
+    } = attrs;
+
+    const hasValidJoin = leftColumn && rightColumn;
+
+    return m(
+      '.pf-join-condition-selector',
+      {
+        className: classNames(hasValidJoin && 'pf-join-condition--complete'),
+      },
+      m(
+        '.pf-join-condition-selector__cards',
+        // Left source card
+        m(JoinSourceCard, {
+          label: leftLabel,
+          columns: leftColumns,
+          otherSideColumns: rightColumns,
+          selectedColumn: leftColumn,
+          onColumnChange: onLeftColumnChange,
+          onColumnToggle: onLeftColumnToggle,
+          onColumnAlias: onLeftColumnAlias,
+        }),
+        // Right source card
+        m(JoinSourceCard, {
+          label: rightLabel,
+          columns: rightColumns,
+          otherSideColumns: leftColumns,
+          selectedColumn: rightColumn,
+          onColumnChange: onRightColumnChange,
+          onColumnToggle: onRightColumnToggle,
+          onColumnAlias: onRightColumnAlias,
+        }),
+      ),
+    );
+  }
+}
+
+/**
+ * Compact join condition display (read-only)
+ * Used in node details view to show the current join condition
+ */
+export interface JoinConditionDisplayAttrs {
+  leftAlias: string;
+  rightAlias: string;
+  leftColumn: string;
+  rightColumn: string;
+  operator?: string;
+}
+
+export class JoinConditionDisplay
+  implements m.ClassComponent<JoinConditionDisplayAttrs>
+{
+  view({attrs}: m.Vnode<JoinConditionDisplayAttrs>) {
+    const {
+      leftAlias,
+      rightAlias,
+      leftColumn,
+      rightColumn,
+      operator = '=',
+    } = attrs;
+
+    return m('.pf-join-condition-display', [
+      m('span.pf-join-column-ref', `${leftAlias}.${leftColumn}`),
+      m('span.pf-join-operator', ` ${operator} `),
+      m('span.pf-join-column-ref', `${rightAlias}.${rightColumn}`),
+    ]);
+  }
+}
+
+/**
+ * Component for selecting which columns to include from a join
+ * Shows columns from both left and right sources with checkboxes and aliasing
+ */
+export interface JoinColumnSelectorAttrs {
+  leftAlias: string;
+  rightAlias: string;
+  leftColumns: ColumnInfo[];
+  rightColumns: ColumnInfo[];
+  onLeftColumnToggle: (index: number, checked: boolean) => void;
+  onRightColumnToggle: (index: number, checked: boolean) => void;
+  onLeftColumnAlias: (index: number, alias: string) => void;
+  onRightColumnAlias: (index: number, alias: string) => void;
+  onSelectAllLeft: () => void;
+  onDeselectAllLeft: () => void;
+  onSelectAllRight: () => void;
+  onDeselectAllRight: () => void;
+}
+
+export class JoinColumnSelector
+  implements m.ClassComponent<JoinColumnSelectorAttrs>
+{
+  private renderColumnRow(
+    col: ColumnInfo,
+    index: number,
+    onToggle: (index: number, checked: boolean) => void,
+    onAlias: (index: number, alias: string) => void,
+  ): m.Child {
+    return m(
+      '.pf-join-column-row',
+      m(Checkbox, {
+        checked: col.checked,
+        label: col.column.name,
+        onchange: (e) => {
+          onToggle(index, (e.target as HTMLInputElement).checked);
+        },
+      }),
+      m(TextInput, {
+        oninput: (e: Event) => {
+          const inputValue = (e.target as HTMLInputElement).value;
+          // Normalize empty strings to undefined (no alias)
+          onAlias(index, inputValue.trim() === '' ? '' : inputValue);
+        },
+        placeholder: 'alias',
+        value: col.alias ?? '',
+      }),
+    );
+  }
+
+  view({attrs}: m.Vnode<JoinColumnSelectorAttrs>) {
+    const {
+      leftAlias,
+      rightAlias,
+      leftColumns,
+      rightColumns,
+      onLeftColumnToggle,
+      onRightColumnToggle,
+      onLeftColumnAlias,
+      onRightColumnAlias,
+      onSelectAllLeft,
+      onDeselectAllLeft,
+      onSelectAllRight,
+      onDeselectAllRight,
+    } = attrs;
+
+    const leftSelectedCount = leftColumns.filter((c) => c.checked).length;
+    const rightSelectedCount = rightColumns.filter((c) => c.checked).length;
+
+    return m('.pf-join-column-selector', [
+      // Left columns section
+      m('.pf-join-column-section', [
+        m(
+          '.pf-join-column-section__header',
+          m(
+            'h4',
+            `${leftAlias} (${leftSelectedCount} / ${leftColumns.length} selected)`,
+          ),
+          m(SelectDeselectAllButtons, {
+            onSelectAll: onSelectAllLeft,
+            onDeselectAll: onDeselectAllLeft,
+          }),
+        ),
+        m(
+          '.pf-join-column-list',
+          leftColumns.length === 0
+            ? m(DataExplorerEmptyState, {
+                icon: 'cable',
+                title: 'Connect left source',
+              })
+            : leftColumns.map((col, i) =>
+                this.renderColumnRow(
+                  col,
+                  i,
+                  onLeftColumnToggle,
+                  onLeftColumnAlias,
+                ),
+              ),
+        ),
+      ]),
+      // Right columns section
+      m('.pf-join-column-section', [
+        m(
+          '.pf-join-column-section__header',
+          m(
+            'h4',
+            `${rightAlias} (${rightSelectedCount} / ${rightColumns.length} selected)`,
+          ),
+          m(SelectDeselectAllButtons, {
+            onSelectAll: onSelectAllRight,
+            onDeselectAll: onDeselectAllRight,
+          }),
+        ),
+        m(
+          '.pf-join-column-list',
+          rightColumns.length === 0
+            ? m(DataExplorerEmptyState, {
+                icon: 'cable',
+                title: 'Connect right source',
+              })
+            : rightColumns.map((col, i) =>
+                this.renderColumnRow(
+                  col,
+                  i,
+                  onRightColumnToggle,
+                  onRightColumnAlias,
+                ),
+              ),
+        ),
+      ]),
+    ]);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
@@ -175,15 +175,12 @@
   position: relative;
 }
 
-.pf-exp-node-explorer__buttons {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+// Top buttons container - absolutely positioned overlay
+.pf-exp-node-explorer__buttons-top-container {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
   pointer-events: none;
   z-index: 10;
 
@@ -192,13 +189,28 @@
   }
 }
 
-.pf-exp-node-explorer__buttons-top,
+.pf-exp-node-explorer__buttons-top {
+  display: flex;
+  justify-content: space-between;
+  padding: 1rem 0;
+  gap: 0.5rem;
+}
+
+// Bottom buttons - sticky at bottom of scrolling container
 .pf-exp-node-explorer__buttons-bottom {
   display: flex;
   justify-content: space-between;
-  // Only vertical padding - horizontal padding comes from article
-  padding: 1rem 0;
+  padding: 1rem 0.5rem 0.5rem 0;
   gap: 0.5rem;
+  position: sticky;
+  bottom: -0.5rem;
+  margin-top: auto;
+  z-index: 10;
+  pointer-events: none;
+
+  .pf-button {
+    pointer-events: auto;
+  }
 }
 
 .pf-exp-node-explorer__buttons-top-left,
@@ -208,6 +220,14 @@
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
+}
+
+.pf-exp-node-explorer__buttons-bottom-left,
+.pf-exp-node-explorer__buttons-bottom-right {
+  .pf-button {
+    pointer-events: auto;
+    background-color: var(--pf-color-background);
+  }
 }
 
 .pf-exp-node-explorer__sections {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -181,17 +181,12 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
     return result;
   }
 
-  private renderCornerButtons(buttons: NodeModifyAttrs): m.Child {
-    if (
-      !buttons.topLeftButtons &&
-      !buttons.topRightButtons &&
-      !buttons.bottomLeftButtons &&
-      !buttons.bottomRightButtons
-    ) {
+  private renderTopButtons(buttons: NodeModifyAttrs): m.Child {
+    if (!buttons.topLeftButtons && !buttons.topRightButtons) {
       return null;
     }
 
-    return m('.pf-exp-node-explorer__buttons', [
+    return m('.pf-exp-node-explorer__buttons-top-container', [
       m('.pf-exp-node-explorer__buttons-top', [
         m(
           '.pf-exp-node-explorer__buttons-top-left',
@@ -202,16 +197,23 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
           this.renderButtons(buttons.topRightButtons),
         ),
       ]),
-      m('.pf-exp-node-explorer__buttons-bottom', [
-        m(
-          '.pf-exp-node-explorer__buttons-bottom-left',
-          this.renderButtons(buttons.bottomLeftButtons),
-        ),
-        m(
-          '.pf-exp-node-explorer__buttons-bottom-right',
-          this.renderButtons(buttons.bottomRightButtons),
-        ),
-      ]),
+    ]);
+  }
+
+  private renderBottomButtons(buttons: NodeModifyAttrs): m.Child {
+    if (!buttons.bottomLeftButtons && !buttons.bottomRightButtons) {
+      return null;
+    }
+
+    return m('.pf-exp-node-explorer__buttons-bottom', [
+      m(
+        '.pf-exp-node-explorer__buttons-bottom-left',
+        this.renderButtons(buttons.bottomLeftButtons),
+      ),
+      m(
+        '.pf-exp-node-explorer__buttons-bottom-right',
+        this.renderButtons(buttons.bottomRightButtons),
+      ),
     ]);
   }
 
@@ -241,8 +243,9 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
       const attrs = modifyResult as NodeModifyAttrs;
       return m('.pf-exp-node-explorer__modify', [
         m(InfoBox, attrs.info),
-        this.renderCornerButtons(attrs),
+        this.renderTopButtons(attrs),
         this.renderSections(attrs.sections),
+        this.renderBottomButtons(attrs),
       ]);
     }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_configuration_modal.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_configuration_modal.ts
@@ -1,0 +1,144 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Callout} from '../../../../widgets/callout';
+import {Form, FormSection} from '../../../../widgets/form';
+import {IssueList, OutlinedField} from '../widgets';
+import {JoinSourceCard} from '../join_widgets';
+import {ColumnInfo} from '../column_info';
+
+/**
+ * Modal for configuring column selection from an already-connected join source
+ * Shown when a secondary input is already connected
+ */
+export interface AddColumnsConfigurationModalAttrs {
+  // Data
+  readonly sourceCols: ColumnInfo[];
+  readonly rightCols: ColumnInfo[];
+  readonly leftColumn?: string;
+  readonly rightColumn?: string;
+  readonly selectedColumns: string[];
+  readonly columnAliases?: Map<string, string>;
+
+  // Callbacks
+  readonly getJoinColumnErrors: (
+    selectedColumns: string[],
+  ) => Array<{column: string; error: string}>;
+  readonly onLeftColumnChange: (columnName: string) => void;
+  readonly onRightColumnChange: (columnName: string) => void;
+  readonly onColumnToggle: (columnName: string, checked: boolean) => void;
+  readonly onColumnAlias: (columnName: string, alias: string) => void;
+}
+
+export class AddColumnsConfigurationModal
+  implements m.ClassComponent<AddColumnsConfigurationModalAttrs>
+{
+  view({attrs}: m.Vnode<AddColumnsConfigurationModalAttrs>) {
+    const {
+      sourceCols,
+      rightCols,
+      leftColumn,
+      rightColumn,
+      selectedColumns,
+      columnAliases,
+      getJoinColumnErrors,
+      onLeftColumnChange,
+      onRightColumnChange,
+      onColumnToggle,
+      onColumnAlias,
+    } = attrs;
+
+    const noColumnsSelected = selectedColumns.length === 0;
+
+    // Create rightCols with checked state based on selectedColumns
+    const rightColsWithChecked = rightCols.map((col) => ({
+      ...col,
+      checked: selectedColumns.includes(col.column.name),
+      alias: columnAliases?.get(col.column.name),
+    }));
+
+    return m(
+      Form,
+      noColumnsSelected &&
+        m(
+          Callout,
+          {icon: 'info'},
+          'Select at least one column to add from the joined source.',
+        ),
+      selectedColumns.length > 0 &&
+        m(IssueList, {
+          icon: 'error',
+          title: 'Column name conflicts:',
+          items: getJoinColumnErrors(selectedColumns).map((err) => err.error),
+        }),
+      // Primary join column selector
+      m(FormSection, {label: 'Join Condition'}, [
+        m(
+          OutlinedField,
+          {
+            label: 'Primary Join Column',
+            value: leftColumn || '',
+            onchange: (e: Event) => {
+              const target = e.target as HTMLSelectElement;
+              onLeftColumnChange(target.value);
+            },
+          },
+          [
+            m(
+              'option',
+              {
+                value: '',
+                selected: !leftColumn,
+                disabled: true,
+              },
+              'Select column',
+            ),
+            ...sourceCols.map((col) =>
+              m(
+                'option',
+                {
+                  value: col.column.name,
+                  selected: col.column.name === leftColumn,
+                },
+                col.column.name,
+              ),
+            ),
+          ],
+        ),
+      ]),
+      // Source card with join column and column selection
+      m(JoinSourceCard, {
+        label: 'Source',
+        columns: rightColsWithChecked,
+        otherSideColumns: sourceCols.map((col) => ({
+          ...col,
+          checked: true, // All primary columns are considered for conflict detection
+        })),
+        selectedColumn: rightColumn,
+        onColumnChange: (columnName: string) => {
+          onRightColumnChange(columnName);
+        },
+        onColumnToggle: (index: number, checked: boolean) => {
+          const colName = rightCols[index].column.name;
+          onColumnToggle(colName, checked);
+        },
+        onColumnAlias: (index: number, alias: string) => {
+          const colName = rightCols[index].column.name;
+          onColumnAlias(colName, alias);
+        },
+      }),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.scss
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// List of added columns in add columns node
+.pf-added-columns-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_suggestion_modal.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_suggestion_modal.ts
@@ -1,0 +1,201 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Select} from '../../../../widgets/select';
+import {Callout} from '../../../../widgets/callout';
+import {Form, FormSection} from '../../../../widgets/form';
+import {
+  TableDescription,
+  DataExplorerEmptyState,
+  IssueList,
+  OutlinedFieldReadOnly,
+} from '../widgets';
+import {JoinSourceCard} from '../join_widgets';
+import {ColumnInfo, columnInfoFromSqlColumn} from '../column_info';
+import {
+  SqlTable,
+  SqlColumn,
+} from '../../../dev.perfetto.SqlModules/sql_modules';
+
+/**
+ * Modal for suggesting and connecting a new table to join
+ * Shown when no secondary input is connected yet
+ */
+export interface AddColumnsSuggestionModalAttrs {
+  // Data
+  readonly suggestions: Array<{
+    colName: string;
+    suggestedTable: string;
+    targetColumn: string;
+  }>;
+  readonly sourceCols: ColumnInfo[];
+  readonly selectedTable?: string;
+  readonly selectedColumns: string[];
+  readonly suggestionAliases?: Map<string, string>;
+
+  // Callbacks
+  readonly getTable: (tableName: string) => SqlTable | undefined;
+  readonly getJoinColumnErrors: (
+    selectedColumns: string[],
+  ) => Array<{column: string; error: string}>;
+  readonly onTableSelect: (tableName: string | undefined) => void;
+  readonly onColumnToggle: (columnName: string, checked: boolean) => void;
+  readonly onColumnAlias: (columnName: string, alias: string) => void;
+}
+
+export class AddColumnsSuggestionModal
+  implements m.ClassComponent<AddColumnsSuggestionModalAttrs>
+{
+  oncreate({attrs}: m.VnodeDOM<AddColumnsSuggestionModalAttrs>) {
+    // Auto-select if there's only one suggestion and nothing is selected yet
+    if (attrs.suggestions.length === 1 && !attrs.selectedTable) {
+      attrs.onTableSelect(attrs.suggestions[0].suggestedTable);
+    }
+  }
+
+  view({attrs}: m.Vnode<AddColumnsSuggestionModalAttrs>) {
+    const {
+      suggestions,
+      sourceCols,
+      selectedTable,
+      selectedColumns,
+      suggestionAliases,
+      getTable,
+      getJoinColumnErrors,
+      onTableSelect,
+      onColumnToggle,
+      onColumnAlias,
+    } = attrs;
+
+    if (suggestions.length === 0) {
+      return m(
+        Form,
+        m(
+          'p',
+          'No JOINID columns found in your data. You can still connect any node to the left port.',
+        ),
+      );
+    }
+
+    const hasOnlyOneSuggestion = suggestions.length === 1;
+    const selectedSuggestion = suggestions.find(
+      (s) => s.suggestedTable === selectedTable,
+    );
+    const tableInfo = selectedTable ? getTable(selectedTable) : undefined;
+
+    // Create ColumnInfo objects from table columns with checked state
+    const tableColsWithChecked: ColumnInfo[] = tableInfo
+      ? tableInfo.columns.map((col: SqlColumn) => ({
+          ...columnInfoFromSqlColumn(col),
+          checked: selectedColumns.includes(col.name),
+          alias: suggestionAliases?.get(col.name),
+        }))
+      : [];
+
+    return m(
+      '.pf-join-modal-layout',
+      m(
+        '.pf-join-modal-controls',
+        m(
+          Form,
+          selectedSuggestion &&
+            selectedColumns.length === 0 &&
+            m(
+              Callout,
+              {icon: 'info'},
+              'Select at least one column to add from the joined table.',
+            ),
+          selectedSuggestion &&
+            selectedColumns.length > 0 &&
+            m(IssueList, {
+              icon: 'error',
+              title: 'Column name conflicts:',
+              items: getJoinColumnErrors(selectedColumns).map(
+                (err) => err.error,
+              ),
+            }),
+          // Only show selector if there are multiple suggestions
+          !hasOnlyOneSuggestion &&
+            m(FormSection, {label: 'Select Table to Join'}, [
+              m(
+                Select,
+                {
+                  onchange: (e: Event) => {
+                    const value = (e.target as HTMLSelectElement).value;
+                    onTableSelect(value || undefined);
+                  },
+                },
+                m(
+                  'option',
+                  {value: '', selected: !selectedTable},
+                  'Choose a table',
+                ),
+                suggestions.map((s) =>
+                  m(
+                    'option',
+                    {
+                      value: s.suggestedTable,
+                      selected: s.suggestedTable === selectedTable,
+                    },
+                    `${s.suggestedTable} (on ${s.colName})`,
+                  ),
+                ),
+              ),
+            ]),
+          // Show table name as read-only OutlinedField when there's only one option
+          hasOnlyOneSuggestion &&
+            selectedSuggestion &&
+            m(OutlinedFieldReadOnly, {
+              label: 'Joining Table',
+              value: `${selectedSuggestion.suggestedTable} (on ${selectedSuggestion.colName})`,
+            }),
+          selectedSuggestion &&
+            m(JoinSourceCard, {
+              label: selectedTable ?? 'Source',
+              columns: tableColsWithChecked,
+              otherSideColumns: sourceCols.map((col) => ({
+                ...col,
+                checked: true,
+              })),
+              selectedColumn: selectedSuggestion.targetColumn,
+              joinColumnDisabled: true,
+              onColumnChange: () => {
+                // Join column is auto-detected, no change needed
+              },
+              onColumnToggle: (index: number, checked: boolean) => {
+                if (!tableInfo) return;
+                const colName = tableInfo.columns[index].name;
+                onColumnToggle(colName, checked);
+              },
+              onColumnAlias: (index: number, alias: string) => {
+                if (!tableInfo) return;
+                const colName = tableInfo.columns[index].name;
+                onColumnAlias(colName, alias);
+              },
+            }),
+        ),
+      ),
+      m(
+        '.pf-join-modal-info',
+        tableInfo
+          ? m(TableDescription, {table: tableInfo})
+          : m(DataExplorerEmptyState, {
+              icon: 'table',
+              title: 'Table information will appear here',
+            }),
+      ),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_types.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_types.ts
@@ -1,0 +1,84 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {QueryNodeState} from '../../query_node';
+
+/**
+ * Represents an IF clause for conditional column expressions.
+ */
+export interface IfClause {
+  if: string;
+  then: string;
+}
+
+/**
+ * Represents a case branch for SWITCH column expressions.
+ */
+export interface SwitchCase {
+  when: string;
+  then: string;
+}
+
+/**
+ * Represents a computed column definition (expression, SWITCH, or IF).
+ */
+export interface NewColumn {
+  expression: string;
+  name: string;
+  module?: string;
+
+  // For switch columns
+  type?: 'switch' | 'if';
+  switchOn?: string;
+  cases?: SwitchCase[];
+  defaultValue?: string;
+  useGlob?: boolean;
+
+  // For if columns
+  clauses?: IfClause[];
+  elseValue?: string;
+
+  // SQL type for preserving type information across serialization
+  sqlType?: string;
+}
+
+/**
+ * State interface for the AddColumnsNode.
+ */
+export interface AddColumnsNodeState extends QueryNodeState {
+  selectedColumns?: string[];
+  leftColumn?: string;
+  rightColumn?: string;
+
+  // Pre-selected columns for each suggested table (before connecting)
+  suggestionSelections?: Map<string, string[]>;
+
+  // Track which suggestions are expanded to show column selection
+  expandedSuggestions?: Set<string>;
+
+  // Currently selected suggestion table (for single-selection UI)
+  selectedSuggestionTable?: string;
+
+  // Map from column name to its alias (for renaming added columns)
+  columnAliases?: Map<string, string>;
+
+  // Map from column name to its alias for suggestion mode (before applying)
+  suggestionAliases?: Map<string, string>;
+
+  // Track if connection was made through guided suggestion
+  isGuidedConnection?: boolean;
+
+  // Computed columns (expressions, SWITCH, IF)
+  computedColumns?: NewColumn[];
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/computed_column_components.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/computed_column_components.ts
@@ -1,0 +1,332 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {ColumnInfo} from '../column_info';
+import {Switch} from '../../../../widgets/switch';
+import {OutlinedField, FormListItem, AddItemPlaceholder} from '../widgets';
+import {NewColumn} from './add_columns_types';
+
+/**
+ * Attrs for the SwitchComponent.
+ */
+export interface SwitchComponentAttrs {
+  column: NewColumn;
+  columns: ColumnInfo[];
+  onchange: () => void;
+}
+
+/**
+ * Component for configuring a SWITCH/CASE computed column.
+ * Allows selecting a column to switch on, defining cases with when/then pairs,
+ * and an optional default value.
+ */
+export class SwitchComponent implements m.ClassComponent<SwitchComponentAttrs> {
+  view({attrs}: m.Vnode<SwitchComponentAttrs>) {
+    const {column, columns, onchange} = attrs;
+
+    if (column.type !== 'switch') {
+      return m('');
+    }
+
+    const setSwitchOn = (newSwitchOn: string) => {
+      column.switchOn = newSwitchOn;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setDefaultValue = (newDefaultValue: string) => {
+      column.defaultValue = newDefaultValue;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setCaseWhen = (index: number, newWhen: string) => {
+      if (!column.cases) return;
+      column.cases[index].when = newWhen;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setCaseThen = (index: number, newThen: string) => {
+      if (!column.cases) return;
+      column.cases[index].then = newThen;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const addCase = () => {
+      if (!column.cases) {
+        column.cases = [];
+      }
+      column.cases.push({when: '', then: ''});
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const removeCase = (index: number) => {
+      if (!column.cases) return;
+      column.cases.splice(index, 1);
+      this.updateExpression(column);
+      onchange();
+    };
+
+    if (column.switchOn === undefined || column.switchOn === '') {
+      const columnNames = columns.map((c) => c.column.name);
+      return m(
+        OutlinedField,
+        {
+          label: 'Switch on column',
+          value: '',
+          onchange: (e: Event) => {
+            setSwitchOn((e.target as HTMLSelectElement).value);
+          },
+        },
+        [
+          m('option', {value: ''}, 'Select column'),
+          ...columnNames.map((name) => m('option', {value: name}, name)),
+        ],
+      );
+    }
+
+    const columnNames = columns.map((c) => c.column.name);
+
+    const selectedColumn = columns.find(
+      (c) => c.column.name === column.switchOn,
+    );
+    const isStringColumn = selectedColumn?.type === 'STRING';
+
+    return m('.pf-inline-edit-list', [
+      m(
+        OutlinedField,
+        {
+          label: 'Switch on column',
+          value: column.switchOn,
+          onchange: (e: Event) => {
+            setSwitchOn((e.target as HTMLSelectElement).value);
+          },
+        },
+        columnNames.map((name) => m('option', {value: name}, name)),
+      ),
+      isStringColumn &&
+        m(Switch, {
+          label: 'Use glob matching',
+          checked: column.useGlob ?? false,
+          onchange: (e: Event) => {
+            column.useGlob = (e.target as HTMLInputElement).checked;
+            this.updateExpression(column);
+            onchange();
+          },
+        }),
+      m(OutlinedField, {
+        label: 'Default value',
+        placeholder: 'default value',
+        value: column.defaultValue || '',
+        oninput: (e: Event) => {
+          setDefaultValue((e.target as HTMLInputElement).value);
+        },
+      }),
+      ...(column.cases || []).map((c, i) =>
+        m(FormListItem, {
+          item: c,
+          isValid: c.when.trim() !== '' && c.then.trim() !== '',
+          onUpdate: () => {},
+          onRemove: () => removeCase(i),
+          children: [
+            m(OutlinedField, {
+              label: 'When',
+              placeholder: 'is equal to',
+              value: c.when,
+              oninput: (e: Event) => {
+                setCaseWhen(i, (e.target as HTMLInputElement).value);
+              },
+            }),
+            m(OutlinedField, {
+              label: 'Then',
+              placeholder: 'then value',
+              value: c.then,
+              oninput: (e: Event) => {
+                setCaseThen(i, (e.target as HTMLInputElement).value);
+              },
+            }),
+          ],
+        }),
+      ),
+      m(AddItemPlaceholder, {
+        label: 'Add case',
+        icon: 'add',
+        onclick: addCase,
+      }),
+    ]);
+  }
+
+  private updateExpression(col: NewColumn) {
+    if (col.type !== 'switch' || !col.switchOn) {
+      col.expression = '';
+      return;
+    }
+
+    const operator = col.useGlob ? 'GLOB' : '=';
+    const casesStr = (col.cases || [])
+      .filter((c) => c.when.trim() !== '' && c.then.trim() !== '')
+      .map((c) => `WHEN ${col.switchOn} ${operator} ${c.when} THEN ${c.then}`)
+      .join(' ');
+
+    const defaultStr = col.defaultValue ? `ELSE ${col.defaultValue}` : '';
+
+    if (casesStr === '' && defaultStr === '') {
+      col.expression = '';
+      return;
+    }
+
+    col.expression = `CASE ${casesStr} ${defaultStr} END`;
+  }
+}
+
+/**
+ * Attrs for the IfComponent.
+ */
+export interface IfComponentAttrs {
+  column: NewColumn;
+  onchange: () => void;
+}
+
+/**
+ * Component for configuring an IF/ELSE computed column.
+ * Allows defining multiple IF/ELSE IF conditions with then values,
+ * and an optional ELSE clause.
+ */
+export class IfComponent implements m.ClassComponent<IfComponentAttrs> {
+  view({attrs}: m.Vnode<IfComponentAttrs>) {
+    const {column, onchange} = attrs;
+
+    if (column.type !== 'if') {
+      return m('');
+    }
+
+    const setIfCondition = (index: number, newIf: string) => {
+      if (!column.clauses) return;
+      column.clauses[index].if = newIf;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setThenValue = (index: number, newThen: string) => {
+      if (!column.clauses) return;
+      column.clauses[index].then = newThen;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const setElseValue = (newElse: string) => {
+      column.elseValue = newElse;
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const addElseIf = () => {
+      if (!column.clauses) {
+        column.clauses = [];
+      }
+      column.clauses.push({if: '', then: ''});
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const removeClause = (index: number) => {
+      if (!column.clauses) return;
+      column.clauses.splice(index, 1);
+      this.updateExpression(column);
+      onchange();
+    };
+
+    const hasElse = column.elseValue !== undefined;
+
+    return m('.pf-inline-edit-list', [
+      ...(column.clauses || []).map((c, i) =>
+        m(FormListItem, {
+          item: c,
+          isValid: c.if.trim() !== '' && c.then.trim() !== '',
+          onUpdate: () => {},
+          onRemove: () => removeClause(i),
+          children: [
+            m(OutlinedField, {
+              label: i === 0 ? 'If' : 'Else If',
+              placeholder: 'condition',
+              value: c.if,
+              oninput: (e: Event) => {
+                setIfCondition(i, (e.target as HTMLInputElement).value);
+              },
+            }),
+            m(OutlinedField, {
+              label: 'Then',
+              placeholder: 'value',
+              value: c.then,
+              oninput: (e: Event) => {
+                setThenValue(i, (e.target as HTMLInputElement).value);
+              },
+            }),
+          ],
+        }),
+      ),
+      hasElse &&
+        m(OutlinedField, {
+          label: 'Else',
+          placeholder: 'value',
+          value: column.elseValue || '',
+          oninput: (e: Event) => {
+            setElseValue((e.target as HTMLInputElement).value);
+          },
+        }),
+      !hasElse &&
+        m(AddItemPlaceholder, {
+          label: 'Add ELSE IF',
+          icon: 'add',
+          onclick: addElseIf,
+        }),
+      !hasElse &&
+        m(AddItemPlaceholder, {
+          label: 'Add ELSE',
+          icon: 'add',
+          onclick: () => {
+            column.elseValue = '';
+            this.updateExpression(column);
+            onchange();
+          },
+        }),
+    ]);
+  }
+
+  private updateExpression(col: NewColumn) {
+    if (col.type !== 'if') {
+      col.expression = '';
+      return;
+    }
+
+    const clausesStr = (col.clauses || [])
+      .filter((c) => c.if.trim() !== '' && c.then.trim() !== '')
+      .map((c) => `WHEN ${c.if} THEN ${c.then}`)
+      .join(' ');
+
+    const elseStr =
+      col.elseValue !== undefined ? `ELSE ${col.elseValue.trim()}` : '';
+
+    if (clausesStr === '' && elseStr === '') {
+      col.expression = '';
+      return;
+    }
+
+    col.expression = `CASE ${clausesStr} ${elseStr} END`;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -677,3 +677,8 @@
 .pf-computed-column-modal-wide {
   min-width: 30vw;
 }
+
+// Callout with spacing below
+.pf-callout-with-spacing {
+  margin-bottom: 16px;
+}


### PR DESCRIPTION
Full rewrite of the join node functionality in the Query Builder. Previously, joins automatically merged duplicate columns and included equality columns by default. Now, joins require explicit column selection with support for aliasing to resolve conflicts.
This provides users with more control over which columns appear in the final result.

  ## Changes

  - **Join behavior**: Changed from automatic column deduplication to explicit column selection
    - Added `leftColumns` and `rightColumns` arrays to JoinNode state
    - Users must check which columns to include from each source
    - Default behavior: no columns selected (empty result)
  - **Column aliasing**: Added support for aliasing columns to resolve naming conflicts
  - **New join widgets** (`join_widgets.ts`, `join_widgets.scss`):
    - `JoinSourceCard` - displays join column selector and column checkboxes for one side
    - `JoinConditionSelector` - shows both sources side-by-side
    - `JoinColumnSelector` - checkbox interface for selecting columns from both sides
    - `JoinConditionDisplay` - compact read-only display of join condition
  - **Add Columns Node**: New node type for guided join column configuration
    - Modal interface with side-by-side layout
    - Real-time duplicate detection and aliasing
    - Visual feedback for conflicts
  - **UI improvements**:
    - Refactored node explorer button layout (separated top/bottom buttons)
    - Bottom buttons now sticky at bottom of scrolling content
    - Better z-index and pointer-events handling
  - **Tests updated**: All join-related tests updated to reflect explicit column selection model

  ## Notes

  This is a breaking change in join behavior - existing joins with `leftColumns: undefined` will show no columns until users explicitly select them.
