### PR TITLE
[SDK] Expose TrackEvent::IsCategoryEnabledBySession/Config

### DIFF
--- a/include/perfetto/tracing/internal/track_event_data_source.h
+++ b/include/perfetto/tracing/internal/track_event_data_source.h
@@ -412,7 +412,7 @@ class TrackEvent {
   static bool IsCategoryEnabledBySession(size_t internal_instance_index,
                                          size_t category_index) {
     std::atomic<uint8_t>* state = Registry->GetCategoryState(category_index);
-    return state->load(std::memory_order_release) &
+    return state->load(std::memory_order_relaxed) &
            static_cast<uint8_t>(1u << internal_instance_index);
   }
 


### PR DESCRIPTION
This is an alternative solution to https://github.com/google/perfetto/pull/4096#issuecomment-3646496843
To enables a common pattern chrome where an observer is interested in a specific category to control e.g. a timer.

Instead of depending on side-effect of OnStart/OnStop, this PR exposes IsCategoryEnabledByConfig that can be queried directly on the TrackEvent session being started/stopped.