### PR TITLE
tracing: allow targeting buffers with target_buffer_name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,8 +20,12 @@ Unreleased:
       dragging selection handles or creating area selections, the cursor
       automatically snaps to nearby slice boundaries to enable exact
       measurement of slice durations. Hold Alt to temporarily disable snapping.
+  Tracing service and probes:
+    * Updated TraceConfig proto to allow referring to target buffers by name
+      rather than index.
   SDK:
     *
+
 
 v53.0 - 2025-11-12:
   SDK:

--- a/protos/perfetto/config/data_source_config.proto
+++ b/protos/perfetto/config/data_source_config.proto
@@ -76,12 +76,30 @@ message DataSourceConfig {
   optional string name = 1;
 
   // The index of the logging buffer where TracePacket(s) will be stored.
-  // This field doesn't make a major difference for the Producer(s). The final
-  // logging buffers, in fact, are completely owned by the Service. We just ask
-  // the Producer to copy this number into the chunk headers it emits, so that
-  // the Service can quickly identify the buffer where to move the chunks into
-  // without expensive lookups on its fastpath.
+  // This field is quite subtle as it has a double semantic:
+  // 1) When the config is passed, this field is a 0-based index relative to the
+  //    buffer array in the TraceConfig and defines the mapping between data
+  //    sources and config. From v54 this is optional because the user can
+  //    instead use target_buffer_name.
+  // 2) When the TracingService issues a SetupDataSource/StartDataSource to the
+  //    producer, it overwrites this field with the global buffer index (which
+  //    depends on other tracing sessions active). This tells the producer which
+  //    buffer id should be passed to CreateTraceWriter. In this case, the trace
+  //    service always sets the resolved global id, even when using
+  //    `target_buffer_name`.
+  // In hindsight we should have used two different fields given even in v0 they
+  // had a different semantic. But now it's too late as this would be a major
+  // protocol breaking change.
   optional uint32 target_buffer = 2;
+
+  // Alternative to |target_buffer|. References a buffer by name (as specified
+  // in TraceConfig.BufferConfig.name) rather than by index. This is more
+  // readable and less error-prone than using buffer indices.
+  // If both |target_buffer| and |target_buffer_name| are specified, they must
+  // refer to the same buffer, otherwise the service will reject the config.
+  // Using both fields allows configs to work with both old and new versions
+  // of the tracing service. Introduced in v54.
+  optional string target_buffer_name = 11;
 
   // Set by the service to indicate the duration of the trace.
   // DO NOT SET in consumer as this will be overridden by the service.

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -4031,12 +4031,30 @@ message DataSourceConfig {
   optional string name = 1;
 
   // The index of the logging buffer where TracePacket(s) will be stored.
-  // This field doesn't make a major difference for the Producer(s). The final
-  // logging buffers, in fact, are completely owned by the Service. We just ask
-  // the Producer to copy this number into the chunk headers it emits, so that
-  // the Service can quickly identify the buffer where to move the chunks into
-  // without expensive lookups on its fastpath.
+  // This field is quite subtle as it has a double semantic:
+  // 1) When the config is passed, this field is a 0-based index relative to the
+  //    buffer array in the TraceConfig and defines the mapping between data
+  //    sources and config. From v54 this is optional because the user can
+  //    instead use target_buffer_name.
+  // 2) When the TracingService issues a SetupDataSource/StartDataSource to the
+  //    producer, it overwrites this field with the global buffer index (which
+  //    depends on other tracing sessions active). This tells the producer which
+  //    buffer id should be passed to CreateTraceWriter. In this case, the trace
+  //    service always sets the resolved global id, even when using
+  //    `target_buffer_name`.
+  // In hindsight we should have used two different fields given even in v0 they
+  // had a different semantic. But now it's too late as this would be a major
+  // protocol breaking change.
   optional uint32 target_buffer = 2;
+
+  // Alternative to |target_buffer|. References a buffer by name (as specified
+  // in TraceConfig.BufferConfig.name) rather than by index. This is more
+  // readable and less error-prone than using buffer indices.
+  // If both |target_buffer| and |target_buffer_name| are specified, they must
+  // refer to the same buffer, otherwise the service will reject the config.
+  // Using both fields allows configs to work with both old and new versions
+  // of the tracing service. Introduced in v54.
+  optional string target_buffer_name = 11;
 
   // Set by the service to indicate the duration of the trace.
   // DO NOT SET in consumer as this will be overridden by the service.
@@ -4284,6 +4302,13 @@ message TraceConfig {
     // clone-related flush, we don't end up with a mixture of leftovers from
     // the previous write and new data.
     optional bool clear_before_clone = 6;
+
+    // Optional name for this buffer. If set, data sources can reference this
+    // buffer by name using |target_buffer_name| in DataSourceConfig instead of
+    // using the buffer index. Buffer names must be unique within a tracing
+    // session. This provides a more human-readable and less error-prone way to
+    // configure which buffer a data source writes to.
+    optional string name = 7;
   }
   repeated BufferConfig buffers = 1;
 

--- a/protos/perfetto/config/trace_config.proto
+++ b/protos/perfetto/config/trace_config.proto
@@ -68,6 +68,13 @@ message TraceConfig {
     // clone-related flush, we don't end up with a mixture of leftovers from
     // the previous write and new data.
     optional bool clear_before_clone = 6;
+
+    // Optional name for this buffer. If set, data sources can reference this
+    // buffer by name using |target_buffer_name| in DataSourceConfig instead of
+    // using the buffer index. Buffer names must be unique within a tracing
+    // session. This provides a more human-readable and less error-prone way to
+    // configure which buffer a data source writes to.
+    optional string name = 7;
   }
   repeated BufferConfig buffers = 1;
 

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -4031,12 +4031,30 @@ message DataSourceConfig {
   optional string name = 1;
 
   // The index of the logging buffer where TracePacket(s) will be stored.
-  // This field doesn't make a major difference for the Producer(s). The final
-  // logging buffers, in fact, are completely owned by the Service. We just ask
-  // the Producer to copy this number into the chunk headers it emits, so that
-  // the Service can quickly identify the buffer where to move the chunks into
-  // without expensive lookups on its fastpath.
+  // This field is quite subtle as it has a double semantic:
+  // 1) When the config is passed, this field is a 0-based index relative to the
+  //    buffer array in the TraceConfig and defines the mapping between data
+  //    sources and config. From v54 this is optional because the user can
+  //    instead use target_buffer_name.
+  // 2) When the TracingService issues a SetupDataSource/StartDataSource to the
+  //    producer, it overwrites this field with the global buffer index (which
+  //    depends on other tracing sessions active). This tells the producer which
+  //    buffer id should be passed to CreateTraceWriter. In this case, the trace
+  //    service always sets the resolved global id, even when using
+  //    `target_buffer_name`.
+  // In hindsight we should have used two different fields given even in v0 they
+  // had a different semantic. But now it's too late as this would be a major
+  // protocol breaking change.
   optional uint32 target_buffer = 2;
+
+  // Alternative to |target_buffer|. References a buffer by name (as specified
+  // in TraceConfig.BufferConfig.name) rather than by index. This is more
+  // readable and less error-prone than using buffer indices.
+  // If both |target_buffer| and |target_buffer_name| are specified, they must
+  // refer to the same buffer, otherwise the service will reject the config.
+  // Using both fields allows configs to work with both old and new versions
+  // of the tracing service. Introduced in v54.
+  optional string target_buffer_name = 11;
 
   // Set by the service to indicate the duration of the trace.
   // DO NOT SET in consumer as this will be overridden by the service.
@@ -4284,6 +4302,13 @@ message TraceConfig {
     // clone-related flush, we don't end up with a mixture of leftovers from
     // the previous write and new data.
     optional bool clear_before_clone = 6;
+
+    // Optional name for this buffer. If set, data sources can reference this
+    // buffer by name using |target_buffer_name| in DataSourceConfig instead of
+    // using the buffer index. Buffer names must be unique within a tracing
+    // session. This provides a more human-readable and less error-prone way to
+    // configure which buffer a data source writes to.
+    optional string name = 7;
   }
   repeated BufferConfig buffers = 1;
 

--- a/src/android_stats/perfetto_atoms.h
+++ b/src/android_stats/perfetto_atoms.h
@@ -78,6 +78,7 @@ enum class PerfettoStatsdAtom {
   kTracedEnablePriorityBoostOtherError = 62,
   kTracedEnableTracingExclusiveSessionRejected = 63,
   kTracedEnableTracingExclusiveSessionNotAllowed = 64,
+  kTracedEnableTracingDuplicateBufferName = 65,
 
   // Checkpoints inside perfetto_cmd after tracing has finished.
   kOnTracingDisabled = 4,

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -7402,6 +7402,234 @@ TEST_F(TracingServiceImplTest, ExclusiveSessionHigherPriorityAbortsLower) {
   new_exclusive_consumer->WaitForTracingDisabled();
 }
 
+// Tests for named buffer addressing (target_buffer_name).
+TEST_F(TracingServiceImplTest, NamedBufferTargeting) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  std::unique_ptr<MockProducer> producer = CreateMockProducer();
+  producer->Connect(svc.get(), "mock_producer");
+  producer->RegisterDataSource("data_source");
+
+  TraceConfig trace_config;
+  auto* buf0 = trace_config.add_buffers();
+  buf0->set_size_kb(4);  // 4KB - too small to hold our data
+  buf0->set_name("small_buffer");
+  auto* buf1 = trace_config.add_buffers();
+  buf1->set_size_kb(128);  // 128KB - large enough
+  buf1->set_name("large_buffer");
+
+  auto* ds_config = trace_config.add_data_sources()->mutable_config();
+  ds_config->set_name("data_source");
+  ds_config->set_target_buffer_name("large_buffer");
+
+  consumer->EnableTracing(trace_config);
+
+  producer->WaitForTracingSetup();
+  producer->WaitForDataSourceSetup("data_source");
+  producer->WaitForDataSourceStart("data_source");
+
+  // Verify the data source was assigned to the correct global buffer ID.
+  // Global buffer IDs are allocated sequentially: small_buffer=1,
+  // large_buffer=2.
+  auto* ds_instance = producer->GetDataSourceInstance("data_source");
+  ASSERT_NE(ds_instance, nullptr);
+  EXPECT_EQ(ds_instance->target_buffer, 2u);  // large_buffer's global ID
+
+  // Write ~10KB of data (10 packets x 1KB each), which exceeds the 4KB
+  // small_buffer. If we were incorrectly writing to small_buffer, we'd lose
+  // data.
+  auto writer = producer->CreateTraceWriter("data_source");
+  std::vector<std::string> expected_payloads;
+  for (int i = 0; i < 10; i++) {
+    std::string payload = "payload_" + std::to_string(i) + "_" +
+                          std::string(1000, 'x');  // ~1KB per packet
+    expected_payloads.push_back(payload);
+    auto packet = writer->NewTracePacket();
+    packet->set_for_testing()->set_str(payload);
+  }
+  writer->Flush();
+  writer.reset();
+
+  consumer->DisableTracing();
+  producer->WaitForDataSourceStop("data_source");
+  consumer->WaitForTracingDisabled();
+
+  auto packets = consumer->ReadBuffers();
+  EXPECT_THAT(GetForTestingStrings(packets),
+              ::testing::UnorderedElementsAreArray(expected_payloads));
+}
+
+// Test that both target_buffer and target_buffer_name can be specified
+// if they resolve to the same buffer.
+TEST_F(TracingServiceImplTest, NamedBufferWithMatchingIndex) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  std::unique_ptr<MockProducer> producer = CreateMockProducer();
+  producer->Connect(svc.get(), "mock_producer");
+  producer->RegisterDataSource("data_source");
+
+  TraceConfig trace_config;
+  auto* buf0 = trace_config.add_buffers();
+  buf0->set_size_kb(128);
+  buf0->set_name("buffer_zero");
+  auto* buf1 = trace_config.add_buffers();
+  buf1->set_size_kb(256);
+  buf1->set_name("buffer_one");
+
+  auto* ds_config = trace_config.add_data_sources()->mutable_config();
+  ds_config->set_name("data_source");
+  ds_config->set_target_buffer(1);
+  ds_config->set_target_buffer_name("buffer_one");
+
+  consumer->EnableTracing(trace_config);
+
+  producer->WaitForTracingSetup();
+  producer->WaitForDataSourceSetup("data_source");
+  producer->WaitForDataSourceStart("data_source");
+
+  // Verify the data source was assigned to the correct global buffer ID.
+  // Global buffer IDs are allocated sequentially: buffer_zero=1, buffer_one=2.
+  auto* ds_instance = producer->GetDataSourceInstance("data_source");
+  ASSERT_NE(ds_instance, nullptr);
+  EXPECT_EQ(ds_instance->target_buffer, 2u);  // buffer_one's global ID
+
+  consumer->DisableTracing();
+  producer->WaitForDataSourceStop("data_source");
+  consumer->WaitForTracingDisabled();
+}
+
+// Test that the service rejects configs with target_buffer_name that
+// doesn't match any buffer.
+TEST_F(TracingServiceImplTest, NamedBufferNotFound) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  TraceConfig trace_config;
+  trace_config.add_buffers()->set_size_kb(128);
+
+  auto* ds_config = trace_config.add_data_sources()->mutable_config();
+  ds_config->set_name("data_source");
+  ds_config->set_target_buffer_name("nonexistent_buffer");
+
+  consumer->EnableTracing(trace_config);
+
+  auto checkpoint = task_runner.CreateCheckpoint("tracing_disabled");
+  EXPECT_CALL(*consumer,
+              OnTracingDisabled(HasSubstr("does not match any buffer")))
+      .WillOnce(checkpoint);
+  task_runner.RunUntilCheckpoint("tracing_disabled");
+}
+
+// Test that the service rejects configs where target_buffer and
+// target_buffer_name resolve to different buffers.
+// Note: target_buffer=0 is treated as "unset" for backwards compatibility,
+// so we use non-zero indices to test the mismatch detection.
+TEST_F(TracingServiceImplTest, NamedBufferIndexMismatch) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  TraceConfig trace_config;
+  auto* buf0 = trace_config.add_buffers();
+  buf0->set_size_kb(128);
+  buf0->set_name("buffer_zero");
+  auto* buf1 = trace_config.add_buffers();
+  buf1->set_size_kb(128);
+  buf1->set_name("buffer_one");
+  auto* buf2 = trace_config.add_buffers();
+  buf2->set_size_kb(128);
+  buf2->set_name("buffer_two");
+
+  auto* ds_config = trace_config.add_data_sources()->mutable_config();
+  ds_config->set_name("data_source");
+  ds_config->set_target_buffer(1);                  // Points to buffer_one
+  ds_config->set_target_buffer_name("buffer_two");  // Points to index 2
+
+  consumer->EnableTracing(trace_config);
+
+  auto checkpoint = task_runner.CreateCheckpoint("tracing_disabled");
+  EXPECT_CALL(*consumer, OnTracingDisabled(HasSubstr("don't match")))
+      .WillOnce(checkpoint);
+  task_runner.RunUntilCheckpoint("tracing_disabled");
+}
+
+// Test that the service rejects configs with duplicate buffer names.
+TEST_F(TracingServiceImplTest, DuplicateBufferNames) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  TraceConfig trace_config;
+  auto* buf0 = trace_config.add_buffers();
+  buf0->set_size_kb(128);
+  buf0->set_name("same_name");
+  auto* buf1 = trace_config.add_buffers();
+  buf1->set_size_kb(256);
+  buf1->set_name("same_name");  // Duplicate!
+
+  auto* ds_config = trace_config.add_data_sources()->mutable_config();
+  ds_config->set_name("data_source");
+  ds_config->set_target_buffer(0);
+
+  consumer->EnableTracing(trace_config);
+
+  auto checkpoint = task_runner.CreateCheckpoint("tracing_disabled");
+  EXPECT_CALL(*consumer, OnTracingDisabled(HasSubstr("Duplicate buffer name")))
+      .WillOnce(checkpoint);
+  task_runner.RunUntilCheckpoint("tracing_disabled");
+}
+
+// Test that named and unnamed buffers can coexist in the same config.
+TEST_F(TracingServiceImplTest, NamedBufferMixedWithUnnamed) {
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  std::unique_ptr<MockProducer> producer = CreateMockProducer();
+  producer->Connect(svc.get(), "mock_producer");
+  producer->RegisterDataSource("ds_1");
+  producer->RegisterDataSource("ds_2");
+
+  TraceConfig trace_config;
+  auto* buf0 = trace_config.add_buffers();
+  buf0->set_size_kb(128);
+
+  auto* buf1 = trace_config.add_buffers();
+  buf1->set_size_kb(128);
+  buf1->set_name("named_buffer");
+
+  auto* buf2 = trace_config.add_buffers();
+  buf2->set_size_kb(128);
+
+  // ds_1 uses index-based addressing
+  auto* ds1_config = trace_config.add_data_sources()->mutable_config();
+  ds1_config->set_name("ds_1");
+  ds1_config->set_target_buffer(2);
+
+  // ds_2 uses name-based addressing
+  auto* ds2_config = trace_config.add_data_sources()->mutable_config();
+  ds2_config->set_name("ds_2");
+  ds2_config->set_target_buffer_name("named_buffer");
+
+  consumer->EnableTracing(trace_config);
+
+  producer->WaitForTracingSetup();
+  producer->WaitForDataSourceSetup("ds_1");
+  producer->WaitForDataSourceSetup("ds_2");
+  producer->WaitForDataSourceStart("ds_1");
+  producer->WaitForDataSourceStart("ds_2");
+
+  auto* ds_1 = producer->GetDataSourceInstance("ds_1");
+  EXPECT_EQ(ds_1->target_buffer, 3u);  // Global ID of the third buffer
+
+  auto* ds_2 = producer->GetDataSourceInstance("ds_2");
+  EXPECT_EQ(ds_2->target_buffer, 2u);  // Global ID of the 2nd buffer.
+
+  consumer->DisableTracing();
+  producer->WaitForDataSourceStop("ds_1");
+  producer->WaitForDataSourceStop("ds_2");
+  consumer->WaitForTracingDisabled();
+}
+
 }  // namespace
 
 }  // namespace perfetto


### PR DESCRIPTION
This is helpful when generating programmatically configs.
See RFC-0013
