### PR TITLE
tp: switch to using rowid virtual tables

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/dataframe_module.h
+++ b/src/trace_processor/perfetto_sql/engine/dataframe_module.h
@@ -105,12 +105,14 @@ struct DataframeModule : sqlite::Module<DataframeModule> {
     sqlite::ModuleStateManager<DataframeModule>::PerVtabState* state;
     std::string name;
     int best_idx_num = 0;
+    uint32_t id_col_idx = 0;
   };
   using DfCursor = dataframe::Cursor<SqliteValueFetcher>;
   struct Cursor : sqlite::Module<DataframeModule>::Cursor {
     const dataframe::Dataframe* dataframe;
     DfCursor df_cursor;
     const char* last_idx_str = nullptr;
+    uint32_t id_col_idx = 0;
   };
 
   static int Create(sqlite3*,


### PR DESCRIPTION
Context is http://g/sqlite-support-copy/5b4ath4a30A and b/467067357

For external folks: it seems like without rowid tables have some subtle
performance bugs in SQLite which are signifcantly mitigated to normal
virtual tables.

We only use WITHOUT ROWID for legacy reasons dating back to ~2019 when
we first implemented out own custom tables. These days, there's no
reason to do this at all as we always have an id or _auto_id columns

This change makes a huge difference to queries like:

```sql
SELECT DISTINCT arg_set_id FROM slice
```

and similar (basically anything to do with DISTINCT).
