### PR TITLE
ui: Remove 'extensions'

### DIFF
--- a/ui/src/components/details/thread_slice_details_tab.ts
+++ b/ui/src/components/details/thread_slice_details_tab.ts
@@ -39,11 +39,11 @@ import {assertIsInstance} from '../../base/logging';
 import {Trace} from '../../public/trace';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {TrackEventSelection} from '../../public/selection';
-import {extensions} from '../extensions';
 import {TraceImpl} from '../../core/trace_impl';
 import {renderSliceArguments} from './slice_args';
 import {openTableExplorer} from '../table_explorer';
 import {addDebugSliceTrack} from '../tracks/debug_tracks';
+import {addQueryResultsTab} from '../query_table/query_result_tab';
 
 interface ContextMenuItem {
   name: string;
@@ -128,7 +128,7 @@ const ITEMS: ContextMenuItem[] = [
     name: 'Average duration of slice name',
     shouldDisplay: (slice: SliceDetails) => hasName(slice),
     run: (slice: SliceDetails, trace: Trace) =>
-      extensions.addQueryResultsTab(trace, {
+      addQueryResultsTab(trace, {
         query: `SELECT AVG(dur) / 1e9 FROM slice WHERE name = '${slice.name!}'`,
         title: `${slice.name} average dur`,
       }),

--- a/ui/src/components/extensions.ts
+++ b/ui/src/components/extensions.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {type addVisualizedArgTracks} from './tracks/visualized_args_tracks';
-import {type addQueryResultsTab} from './query_table/query_result_tab';
 
 // TODO(primiano & stevegolton): This injection is to break the circular
 // dependency cycle that there is between various tabs and tracks.
@@ -27,7 +26,6 @@ import {type addQueryResultsTab} from './query_table/query_result_tab';
 
 export interface ExtensionApi {
   addVisualizedArgTracks: typeof addVisualizedArgTracks;
-  addQueryResultsTab: typeof addQueryResultsTab;
 }
 
 export let extensions: ExtensionApi;

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -48,7 +48,6 @@ import {IdleDetectorWindow} from './idle_detector_interface';
 import {AppImpl} from '../core/app_impl';
 import {configureExtensions} from '../components/extensions';
 import {addVisualizedArgTracks} from '../components/tracks/visualized_args_tracks';
-import {addQueryResultsTab} from '../components/query_table/query_result_tab';
 import {assetSrc, initAssets} from '../base/assets';
 import {
   PERFETTO_SETTINGS_STORAGE_KEY,
@@ -548,7 +547,6 @@ function maybeChangeRpcPortFromFragment() {
 // point for context menus.
 configureExtensions({
   addVisualizedArgTracks,
-  addQueryResultsTab,
 });
 
 main();


### PR DESCRIPTION
Extensions was a hack introduced to solve circular dependency issues - this patch aims to remove them.