### PR TITLE
[SDK] Fix Flow::FromPointer API

### DIFF
--- a/include/perfetto/tracing/track_event_args.h
+++ b/include/perfetto/tracing/track_event_args.h
@@ -49,13 +49,13 @@ class FlowImpl {
   // Please ensure that you emit a trace event with the flow id of
   // perfetto::TerminatingFlow::FromPointer(this) from the destructor of the
   // object to avoid accidental conflicts.
-  static PERFETTO_ALWAYS_INLINE inline FlowImpl FromPointer(void* ptr) {
+  static PERFETTO_ALWAYS_INLINE inline FlowImpl FromPointer(const void* ptr) {
     return ProcessScoped(reinterpret_cast<uintptr_t>(ptr));
   }
 
   // Same as above, but combines the flow id with an extra `named_scope`'s hash.
   static PERFETTO_ALWAYS_INLINE inline FlowImpl FromPointer(
-      void* ptr,
+      const void* ptr,
       const char* named_scope) {
     return ProcessScoped(reinterpret_cast<uintptr_t>(ptr), named_scope);
   }


### PR DESCRIPTION
This PR fixes Flow::FromPointer: taking void* is incompatible with const ptr, but non-const ptr is not needed.
This shouldn't break any existing usage, because conversion to const void* is implicit (but not the other way around)