### PR TITLE
fix build

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -16,15 +16,12 @@
 
 #include "src/tracing/service/trace_buffer_v2.h"
 
-#include <limits>
-
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/tracing/core/client_identity.h"
 #include "perfetto/ext/tracing/core/shared_memory_abi.h"
 #include "perfetto/ext/tracing/core/trace_packet.h"
 #include "perfetto/protozero/proto_utils.h"
-#include "src/base/intrusive_list.h"
 
 // Set manually when debugging test failures.
 // TRACE_BUFFER_V2_DLOG is too verbose, even for debug builds.


### PR DESCRIPTION
Internal autorolls failing with error and this header is not needed so simple remove it

```
trace_buffer_v2.cc:27:10: error: use of private header from outside its module: '...src/base/intrusive_list.h'; [-Wprivate-header]
   27 | #include "third_party/perfetto/src/base/intrusive_list.h"
      |          ^
1 error generated.
  ```