### PR TITLE
tp: fix invalid packet in test

### DIFF
--- a/test/trace_processor/diff_tests/parser/profiling/heap_profile_deobfuscate.textproto
+++ b/test/trace_processor/diff_tests/parser/profiling/heap_profile_deobfuscate.textproto
@@ -87,6 +87,8 @@ packet {
       }
     }
   }
+}
+packet {
   deobfuscation_mapping {
     package_name: "com.google.android.webview"
     version_code: 1234


### PR DESCRIPTION
deobfuscation_mapping is *not* a repeated field so we cannot just
specify it multiple times in a single packet.

This only works because of some very obscure proto merging rules.
An upcoming CL breaks this so fix this test upfront
