### PR TITLE
Add missing include to fix perfetto->chrome roll

### DIFF
--- a/include/perfetto/ext/base/circular_queue.h
+++ b/include/perfetto/ext/base/circular_queue.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <iterator>
 


### PR DESCRIPTION
This PR adds missing #include <algorithm>
The perfetto -> chromium roll broke in https://github.com/google/perfetto/commit/480bbd106393be590e294f0f13037f439892c9a8
See https://chromium-review.googlesource.com/c/chromium/src/+/7268747?tab=checks 
