### PR TITLE
ep: No silent returns

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -411,6 +411,9 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               },
               onExecute: async () => {
                 if (!selectedNode.validate()) {
+                  console.warn(
+                    `Cannot execute query: node ${selectedNode.nodeId} failed validation`,
+                  );
                   return;
                 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -526,6 +526,9 @@ function handleConnect(conn: Connection, rootNodes: QueryNode[]): void {
   const toNode = findQueryNode(conn.toNode, rootNodes);
 
   if (!fromNode || !toNode) {
+    console.warn(
+      `Cannot create connection: node not found (from: ${conn.fromNode}, to: ${conn.toNode})`,
+    );
     return;
   }
 
@@ -549,6 +552,9 @@ function handleConnectionRemove(
   const toNode = findQueryNode(conn.toNode, rootNodes);
 
   if (!fromNode || !toNode) {
+    console.warn(
+      `Cannot remove connection: node not found (from: ${conn.fromNode}, to: ${conn.toNode})`,
+    );
     return;
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -678,6 +678,9 @@ export class AddColumnsNode implements QueryNode {
     const argSetIdCols = this.getArgSetIdColumns();
 
     if (argSetIdCols.length === 0) {
+      console.warn(
+        'Cannot show args modal: no arg_set_id columns found in input',
+      );
       return;
     }
 


### PR DESCRIPTION
  Add warning logs before early returns in ExplorePage to improve debugging. Previously, many operations could fail silently when preconditions weren't met (e.g., SQL modules not loaded, nodes not found in registry). This change adds descriptive console.warn() messages before each early return to make failures visible and easier to diagnose.
