### PR TITLE
ep: Fix stale error

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -104,6 +104,8 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
       );
       this.currentQuery = error;
       attrs.onQueryAnalyzed(error);
+      // Clear prevSqString so that when node becomes valid again, we'll re-process it
+      this.prevSqString = undefined;
       return;
     }
 


### PR DESCRIPTION
When node reconnects and becomes valid again, it will re-process the query instead of showing stale error