### PR TITLE
tracing: fix and re-enable TBV2 tests

### DIFF
--- a/buildtools/BUILD.gn
+++ b/buildtools/BUILD.gn
@@ -1449,7 +1449,7 @@ if (use_custom_libcxx) {
       "libcxx/src/vector.cpp",
       "libcxx/src/verbose_abort.cpp",
     ]
-    if (!using_sanitizer) {
+    if (!using_sanitizer || is_ubsan) {
       # In {a,t,m}san configurations, operator new and operator delete will be
       # provided by the sanitizer runtime library.  Since libc++ defines these
       # symbols with weak linkage, and the *san runtime uses strong linkage, it
@@ -1459,6 +1459,8 @@ if (use_custom_libcxx) {
       # perfetto, when cross-compiling, we build only targets with sanitizers,
       # but not host artifacts, and using_sanitizer is only true for the
       # target toolchain, while is_asan is globally true on all toolchains.
+      # However, ubsan standalone does not provide operator new/delete, so we
+      # need to include new.cpp for ubsan builds.
       sources += [ "libcxx/src/new.cpp" ]
     }
 

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -286,7 +286,7 @@ TEST_F(TraceBufferV2Test, ReadWrite_Padding) {
 // allowed (16 bytes). This is to exercise edge cases in the padding logic.
 // [c0: 2048               ][c1: 1024         ][c2: 1008       ][c3: 16]
 // [c4: 2032            ][c5: 1040                ][c6 :16][c7: 1080   ]
-TEST_F(TraceBufferV2Test, DISABLED_ReadWrite_MinimalPadding) {
+TEST_F(TraceBufferV2Test, ReadWrite_MinimalPadding) {
   ResetBuffer(4096);
 
   ASSERT_EQ(2048u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
@@ -363,7 +363,7 @@ TEST_F(TraceBufferV2Test, ReadWrite_RandomChunksNoWrapping) {
 
 // Tests the case of writing a chunk that leaves just sizeof(ChunkRecord) at
 // the end of the buffer.
-TEST_F(TraceBufferV2Test, DISABLED_ReadWrite_WrappingCases) {
+TEST_F(TraceBufferV2Test, ReadWrite_WrappingCases) {
   ResetBuffer(4096);
   ASSERT_EQ(4080u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
                        .AddPacket(4080 - 16, 'a')
@@ -581,7 +581,7 @@ TEST_F(TraceBufferV2Test, Fragments_OutOfOrderWithIdOverflowACBD) {
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 
-TEST_F(TraceBufferV2Test, DISABLED_Fragments_EmptyChunkBefore) {
+TEST_F(TraceBufferV2Test, Fragments_EmptyChunkBefore) {
   ResetBuffer(4096);
   CreateChunk(ProducerID(1), WriterID(1), ChunkID(0)).CopyIntoTraceBuffer();
   CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
@@ -599,7 +599,7 @@ TEST_F(TraceBufferV2Test, DISABLED_Fragments_EmptyChunkBefore) {
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 
-TEST_F(TraceBufferV2Test, DISABLED_Fragments_EmptyChunkAfter) {
+TEST_F(TraceBufferV2Test, Fragments_EmptyChunkAfter) {
   ResetBuffer(4096);
   CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
       .AddPacket(10, 'a')
@@ -613,7 +613,7 @@ TEST_F(TraceBufferV2Test, DISABLED_Fragments_EmptyChunkAfter) {
 
 // Set up a fragmented packet that happens to also have an empty chunk in the
 // middle of the sequence. Test that it just gets skipped.
-TEST_F(TraceBufferV2Test, DISABLED_Fragments_EmptyChunkInTheMiddle) {
+TEST_F(TraceBufferV2Test, Fragments_EmptyChunkInTheMiddle) {
   ResetBuffer(4096);
   CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
       .AddPacket(10, 'a', kContOnNextChunk)
@@ -980,8 +980,7 @@ TEST_F(TraceBufferV2Test, Malicious_ChunkTooBig) {
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 
-TEST_F(TraceBufferV2Test,
-       DISABLED_Malicious_DeclareMorePacketsBeyondBoundaries) {
+TEST_F(TraceBufferV2Test, Malicious_DeclareMorePacketsBeyondBoundaries) {
   ResetBuffer(4096);
   SuppressClientDchecksForTesting();
   CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
@@ -2241,7 +2240,7 @@ TEST_F(TraceBufferV2Test, Fragments_LargeFragment) {
 }
 
 // Test empty chunks in long fragmentation chain
-TEST_F(TraceBufferV2Test, DISABLED_Fragments_EmptyChunksInLongChain) {
+TEST_F(TraceBufferV2Test, Fragments_EmptyChunksInLongChain) {
   ResetBuffer(4096);
   std::vector<FakePacketFragment> expected;
 

--- a/src/tracing/test/fake_packet.cc
+++ b/src/tracing/test/fake_packet.cc
@@ -158,6 +158,8 @@ FakeChunk& FakeChunk::PadTo(size_t chunk_size) {
 }
 
 size_t FakeChunk::CopyIntoTraceBuffer(bool chunk_complete) {
+  // Ensure data.data() is non-null for tests where we do empty commits.
+  data.reserve(1);
   trace_buffer_->CopyChunkUntrusted(producer_id, ClientIdentity(uid, pid),
                                     writer_id, chunk_id, num_packets, flags,
                                     chunk_complete, data.data(), data.size());


### PR DESCRIPTION
Revert #4147 which disabled some failing UBSan tests.
Also fix ubsan (however our ubsan build did NOT catch
this anyways, because we don't use an annotated sysroot
like chromium does)

Test: I was able to repro adding a CHECK(src) in trace_buffer_v2.cc This makes it go away.