### PR TITLE
ep: Fix trying to dock second child rendering issue

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils_unittest.ts
@@ -17,11 +17,13 @@ import {
   getAllDownstreamNodes,
   getAllUpstreamNodes,
   findNodeById,
+  findDockedChildren,
 } from './graph_utils';
-import {QueryNode} from '../query_node';
+import {QueryNode, NodeType} from '../query_node';
 import {TableSourceNode} from './nodes/sources/table_source';
 import {Trace} from '../../../public/trace';
 import {SqlModules} from '../../dev.perfetto.SqlModules/sql_modules';
+import {createMockNode} from './testing/test_utils';
 
 describe('graph_utils', () => {
   let mockTrace: Trace;
@@ -43,7 +45,7 @@ describe('graph_utils', () => {
     } as unknown as SqlModules;
   });
 
-  // Helper to create a simple test node
+  // Helper to create a simple test node (source node)
   function createTestNode(): QueryNode {
     return new TableSourceNode({
       trace: mockTrace,
@@ -339,6 +341,76 @@ describe('graph_utils', () => {
 
       const result = findNodeById('999', [node1, node2]);
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('findDockedChildren', () => {
+    it('should return empty array when parent has no children', () => {
+      const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
+      const nodeLayouts = new Map<string, {x: number; y: number}>();
+
+      const result = findDockedChildren(parent, nodeLayouts);
+      expect(result).toEqual([]);
+    });
+
+    it('should return docked child when child has no layout', () => {
+      const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
+      // Create a modification node (single-node operation)
+      const child = createMockNode({nodeId: 'child', type: NodeType.kFilter});
+      child.primaryInput = parent;
+
+      // Setup: child is connected to parent via primaryInput
+      parent.nextNodes = [child];
+
+      // Child has no layout (docked)
+      const nodeLayouts = new Map<string, {x: number; y: number}>();
+      nodeLayouts.set(parent.nodeId, {x: 100, y: 100});
+
+      const result = findDockedChildren(parent, nodeLayouts);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBe(child);
+    });
+
+    it('should not return child when child has layout (undocked)', () => {
+      const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
+      const child = createMockNode({nodeId: 'child', type: NodeType.kFilter});
+      child.primaryInput = parent;
+
+      // Setup: child is connected to parent
+      parent.nextNodes = [child];
+
+      // Both have layouts (child is undocked)
+      const nodeLayouts = new Map<string, {x: number; y: number}>();
+      nodeLayouts.set(parent.nodeId, {x: 100, y: 100});
+      nodeLayouts.set(child.nodeId, {x: 200, y: 200});
+
+      const result = findDockedChildren(parent, nodeLayouts);
+      expect(result).toEqual([]);
+    });
+
+    it('should identify docked vs undocked children correctly', () => {
+      const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
+      // Create modification nodes (single-node operations)
+      const child1 = createMockNode({nodeId: 'child1', type: NodeType.kFilter});
+      const child2 = createMockNode({nodeId: 'child2', type: NodeType.kSort});
+
+      child1.primaryInput = parent;
+      child2.primaryInput = parent;
+
+      // Setup: both children are connected to parent
+      parent.nextNodes = [child1, child2];
+
+      // child1 is docked (no layout), child2 is undocked (has layout)
+      const nodeLayouts = new Map<string, {x: number; y: number}>();
+      nodeLayouts.set(parent.nodeId, {x: 100, y: 100});
+      nodeLayouts.set(child2.nodeId, {x: 250, y: 130});
+      // child1 has no layout (docked)
+
+      // Only child1 should be identified as docked
+      const result = findDockedChildren(parent, nodeLayouts);
+      expect(result).toHaveLength(1);
+      expect(result).toContain(child1);
+      expect(result).not.toContain(child2);
     });
   });
 });


### PR DESCRIPTION
Fix a rendering issue in the ExplorePage query builder where attempting to dock a second child to a parent node that already has children would cause problems. The fix adds validation to prevent multiple children from being docked to a single parent.

  ## Changes

  - Add validation in `onDock` callback to check if parent node already has children
  - Allow re-docking the same child (for position adjustments)
  - Validate that only single-node operations can be docked

  ## Notes

The fix prevents invalid dock operations early with clear console warnings to help with debugging if users encounter these edge cases.