### PR TITLE
ep: Don't disable suspend checks

### DIFF
--- a/python/perfetto/trace_data_checks.py
+++ b/python/perfetto/trace_data_checks.py
@@ -49,8 +49,6 @@ MODULE_DATA_CHECK_SQL = {
         'SELECT EXISTS(SELECT 1 FROM process LIMIT 1) AS has_data',
     'android.screenshots':
         'SELECT EXISTS(SELECT 1 FROM slice WHERE name = \'Screenshot\' AND category = \'android_screenshot\' LIMIT 1) AS has_data',
-    'android.suspend':
-        'SELECT EXISTS(SELECT 1 FROM track WHERE name IN (\'Suspend/Resume Minimal\', \'Suspend/Resume Latency\') LIMIT 1) AS has_data',
     'android.statsd':
         'SELECT EXISTS(SELECT 1 FROM track WHERE name = \'Statsd Atoms\' LIMIT 1) AS has_data',
     'android.wakeups':


### PR DESCRIPTION
android_suspend_state is always filled, as we UNION ALL with whole trace as awake, if there are no suspend events. Disabling this module (when there were no suspends) disabled all of the modules depending on it, e.g android_monitor_contention. 