### PR TITLE
ep: Disable adding column if no join column specifies

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_configuration_modal.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_configuration_modal.ts
@@ -61,6 +61,7 @@ export class AddColumnsConfigurationModal
     } = attrs;
 
     const noColumnsSelected = selectedColumns.length === 0;
+    const missingJoinColumns = !leftColumn || !rightColumn;
 
     // Create rightCols with checked state based on selectedColumns
     const rightColsWithChecked = rightCols.map((col) => ({
@@ -71,6 +72,12 @@ export class AddColumnsConfigurationModal
 
     return m(
       Form,
+      missingJoinColumns &&
+        m(
+          Callout,
+          {icon: 'warning'},
+          'Select join columns from both sources to enable the join.',
+        ),
       noColumnsSelected &&
         m(
           Callout,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -328,7 +328,7 @@ export class AddColumnsNode implements QueryNode {
   }
 
   // Check if the Apply button should be disabled in the join modal
-  private isApplyDisabled(): boolean {
+  isApplyDisabled(): boolean {
     // When no rightNode exists, require table and columns selection
     if (!this.rightNode) {
       const selectedTable = this.state.selectedSuggestionTable;
@@ -339,7 +339,11 @@ export class AddColumnsNode implements QueryNode {
       // Also disable if there are duplicate column name errors
       return this.getJoinColumnErrors(selectedColumns, true).length > 0;
     }
-    // When rightNode exists, require columns to be selected
+    // When rightNode exists, require both join columns to be specified
+    if (!this.state.leftColumn || !this.state.rightColumn) {
+      return true;
+    }
+    // Require columns to be selected
     if (
       !this.state.selectedColumns ||
       this.state.selectedColumns.length === 0

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node_unittest.ts
@@ -273,4 +273,96 @@ describe('AddColumnsNode', () => {
       expect(query?.referencedModules).toContain('android');
     });
   });
+
+  describe('isApplyDisabled', () => {
+    it('should disable Apply when rightNode exists but leftColumn is not set', () => {
+      const primaryNode = createMockPrimaryNode();
+      const secondaryNode = createMockSecondaryNode();
+      const node = createAddColumnsNodeWithInputs(
+        {
+          selectedColumns: ['name'],
+          leftColumn: '', // Empty string (user cleared the field)
+          rightColumn: 'id',
+        },
+        primaryNode,
+        secondaryNode,
+      );
+
+      const isDisabled = node.isApplyDisabled();
+
+      expect(isDisabled).toBe(true);
+    });
+
+    it('should disable Apply when rightNode exists but rightColumn is not set', () => {
+      const primaryNode = createMockPrimaryNode();
+      const secondaryNode = createMockSecondaryNode();
+      const node = createAddColumnsNodeWithInputs(
+        {
+          selectedColumns: ['name'],
+          leftColumn: 'id',
+          rightColumn: '', // Empty string (user cleared the field)
+        },
+        primaryNode,
+        secondaryNode,
+      );
+
+      const isDisabled = node.isApplyDisabled();
+
+      expect(isDisabled).toBe(true);
+    });
+
+    it('should disable Apply when rightNode exists but both join columns are not set', () => {
+      const primaryNode = createMockPrimaryNode();
+      const secondaryNode = createMockSecondaryNode();
+      const node = createAddColumnsNodeWithInputs(
+        {
+          selectedColumns: ['name'],
+          leftColumn: '', // Empty string (user cleared the field)
+          rightColumn: '', // Empty string (user cleared the field)
+        },
+        primaryNode,
+        secondaryNode,
+      );
+
+      const isDisabled = node.isApplyDisabled();
+
+      expect(isDisabled).toBe(true);
+    });
+
+    it('should enable Apply when rightNode exists with both join columns and selected columns', () => {
+      const primaryNode = createMockPrimaryNode();
+      const secondaryNode = createMockSecondaryNode();
+      const node = createAddColumnsNodeWithInputs(
+        {
+          selectedColumns: ['name', 'category'],
+          leftColumn: 'id',
+          rightColumn: 'id',
+        },
+        primaryNode,
+        secondaryNode,
+      );
+
+      const isDisabled = node.isApplyDisabled();
+
+      expect(isDisabled).toBe(false);
+    });
+
+    it('should disable Apply when rightNode exists with join columns but no selected columns', () => {
+      const primaryNode = createMockPrimaryNode();
+      const secondaryNode = createMockSecondaryNode();
+      const node = createAddColumnsNodeWithInputs(
+        {
+          selectedColumns: [], // Empty
+          leftColumn: 'id',
+          rightColumn: 'id',
+        },
+        primaryNode,
+        secondaryNode,
+      );
+
+      const isDisabled = node.isApplyDisabled();
+
+      expect(isDisabled).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Fix the bug when you could add a column without specifying the join column