### PR TITLE
ep: Ignore hidden tables when showing which tags have tables

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
@@ -233,6 +233,13 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
     const allTagsSet = new Set<string>();
     for (const module of allModules) {
       if (module.tables.length > 0) {
+        // Skip disabled modules when collecting tags if hideDisabledModules is enabled
+        if (
+          this.hideDisabledModules &&
+          attrs.sqlModules.isModuleDisabled(module.includeKey)
+        ) {
+          continue;
+        }
         for (const tag of module.tags) {
           allTagsSet.add(tag);
         }


### PR DESCRIPTION
We were showing all tags that have tables with this tag. This was not invalid when we were hiding the disabled modules, as enabling the second tag would hide all of the tags from us.