### PR TITLE
ui: Add option to disable pivot controls in DataGrid

### DIFF
--- a/ui/src/components/widgets/datagrid/add_column_menu.ts
+++ b/ui/src/components/widgets/datagrid/add_column_menu.ts
@@ -330,25 +330,20 @@ export class ColumnMenu implements m.ClassComponent<ColumnMenuAttrs> {
 
     const items: m.Children[] = [];
 
-    // Only show remove button if onRemove is provided
-    if (onRemove !== undefined) {
-      items.push(
+    return [
+      m(
+        MenuItem,
+        {label: addLabel, icon: Icons.AddColumnRight},
+        addColumnSubmenu,
+      ),
+      onRemove &&
         m(MenuItem, {
           label: removeLabel,
           disabled: !canRemove,
           icon: Icons.Remove,
           onclick: onRemove,
         }),
-      );
-    }
-
-    items.push(
-      m(
-        MenuItem,
-        {label: addLabel, icon: Icons.AddColumnRight},
-        addColumnSubmenu,
-      ),
-    );
+    ];
 
     return items;
   }
@@ -502,7 +497,7 @@ export class AggregateMenu implements m.ClassComponent<AggregateMenuAttrs> {
       rootSchema,
       onAddAggregate,
       existingAggregates,
-      label = 'Add aggregate',
+      label = 'Add column',
     } = attrs;
 
     const columnAggSubmenu = buildAggregateColumnMenuFromSchema(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -347,6 +347,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
           initialColumns: attrs.response.columns.map((col) => ({field: col})),
           fillHeight: true,
           data: attrs.dataSource,
+          enablePivotControls: false,
           structuredQueryCompatMode: true,
           // We don't actually want the datagrid to display or apply any filters
           // to the datasource itself, so we define this but fix it as an empty

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/datagrid_demo.ts
@@ -192,12 +192,9 @@ export function renderDataGrid(app: App): m.Children {
         });
       },
       initialOpts: {
-        enableSortControls: true,
-        enableFilterControls: true,
-        enablePivotControls: true,
-        showRowCount: true,
         showExportButton: false,
         structuredQueryCompatMode: false,
+        enablePivotControls: true,
       },
       noPadding: true,
     }),


### PR DESCRIPTION
And switch off pivot controls in explore page.

While in the area, also tidy up some of the column menus