### PR TITLE
Add relevant threads jank CUJ module to stdlib.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15304,6 +15304,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/cuj_frame_counters.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/desktop_mode.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/device.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/dumpsys/show_map.sql",

--- a/BUILD
+++ b/BUILD
@@ -3312,6 +3312,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/cuj_frame_counters.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/cujs/sysui_cujs.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql",
     ],
 )
 

--- a/python/generators/sql_processing/stdlib_tags.py
+++ b/python/generators/sql_processing/stdlib_tags.py
@@ -116,8 +116,9 @@ MODULE_TAGS = {
     'android.frame_blocking_calls.blocking_calls_aggregation': [
         'android', 'ui'
     ],
-    'android.cujs.cujs_base': ['android', 'ui'],
+    'android.cujs.base': ['android', 'ui'],
     'android.cujs.sysui_cujs': ['android', 'ui'],
+    'android.cujs.threads': ['android', 'ui'],
     'android.input': ['android', 'ui', 'input'],
     'android.screenshots': ['android', 'ui'],
     'android.surfaceflinger': ['android', 'ui'],

--- a/src/trace_processor/metrics/sql/android/jank/android_jank_cuj_init.sql
+++ b/src/trace_processor/metrics/sql/android/jank/android_jank_cuj_init.sql
@@ -23,7 +23,7 @@ SELECT RUN_METRIC('android/jank/cujs.sql');
 -- and GPU completion threads.
 -- Also stores the (not CUJ-specific) threads of SF: main, render engine,
 -- and GPU completion threads.
-SELECT RUN_METRIC('android/jank/relevant_threads.sql');
+INCLUDE PERFETTO MODULE android.cujs.threads;
 
 -- Create tables to store the main slices on each of the relevant threads
 -- * `Choreographer#doFrame` on the main thread

--- a/src/trace_processor/metrics/sql/android/jank/relevant_slices.sql
+++ b/src/trace_processor/metrics/sql/android/jank/relevant_slices.sql
@@ -13,8 +13,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
+INCLUDE PERFETTO MODULE android.cujs.base;
 INCLUDE PERFETTO MODULE android.surfaceflinger;
+
+SELECT RUN_METRIC('android/jank/relevant_threads.sql');
 
 CREATE OR REPLACE PERFETTO FUNCTION vsync_from_name(slice_name STRING)
 RETURNS STRING AS

--- a/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
+++ b/src/trace_processor/metrics/sql/android/jank/relevant_threads.sql
@@ -16,6 +16,7 @@
 INCLUDE PERFETTO MODULE android.frames.timeline;
 INCLUDE PERFETTO MODULE android.surfaceflinger;
 INCLUDE PERFETTO MODULE slices.with_context;
+INCLUDE PERFETTO MODULE android.cujs.threads;
 
 DROP TABLE IF EXISTS android_jank_cuj_main_thread;
 CREATE PERFETTO TABLE android_jank_cuj_main_thread AS
@@ -27,23 +28,6 @@ WHERE
   (cuj.ui_thread IS NULL AND thread.is_main_thread)
   -- Some CUJs use a dedicated thread for Choreographer callbacks
   OR (cuj.ui_thread = thread.utid);
-
-CREATE OR REPLACE PERFETTO FUNCTION android_jank_cuj_app_thread(thread_name STRING)
-RETURNS TABLE(cuj_id INT, upid INT, utid INT, name STRING, track_id INT) AS
-SELECT
-  cuj_id,
-  cuj.upid,
-  utid,
-  thread.name,
-  thread_track.id AS track_id
-FROM thread
-JOIN android_jank_cuj cuj USING (upid)
-JOIN thread_track USING (utid)
-WHERE thread.name = $thread_name;
-
-DROP TABLE IF EXISTS android_jank_cuj_render_thread;
-CREATE PERFETTO TABLE android_jank_cuj_render_thread AS
-SELECT * FROM ANDROID_JANK_CUJ_APP_THREAD('RenderThread');
 
 DROP TABLE IF EXISTS android_jank_cuj_gpu_completion_thread;
 CREATE PERFETTO TABLE android_jank_cuj_gpu_completion_thread AS

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/BUILD.gn
@@ -19,5 +19,6 @@ perfetto_sql_source_set("cujs") {
     "base.sql",
     "cuj_frame_counters.sql",
     "sysui_cujs.sql",
+    "threads.sql",
   ]
 }

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/threads.sql
@@ -1,0 +1,65 @@
+--
+-- Copyright 2025 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+INCLUDE PERFETTO MODULE android.cujs.base;
+
+-- Returns a table with all CUJs and an additional column for the track id of thread_name
+-- passed as parameter, if present in the same process of the cuj.
+CREATE PERFETTO FUNCTION android_jank_cuj_app_thread(
+    -- Name of the thread for which information needs to be extracted.
+    thread_name STRING
+)
+RETURNS TABLE (
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- process id.
+  upid JOINID(process.id),
+  -- thread id of the input thread.
+  utid LONG,
+  -- name of the thread.
+  name STRING,
+  -- track id associated with the thread.
+  track_id LONG
+) AS
+SELECT
+  cuj_id,
+  cuj.upid,
+  utid,
+  thread.name,
+  thread_track.id AS track_id
+FROM thread
+JOIN android_jank_cuj AS cuj
+  USING (upid)
+JOIN thread_track
+  USING (utid)
+WHERE
+  thread.name = $thread_name;
+
+-- Table captures thread information for 'RenderThread' for all CUJs.
+CREATE PERFETTO TABLE android_jank_cuj_render_thread (
+  -- Unique incremental ID for each CUJ.
+  cuj_id LONG,
+  -- process id.
+  upid JOINID(process.id),
+  -- thread id of the main/UI thread.
+  utid JOINID(thread.id),
+  -- thread name.
+  name STRING,
+  -- track_id for the thread.
+  track_id JOINID(track.id)
+) AS
+SELECT
+  *
+FROM android_jank_cuj_app_thread('RenderThread');


### PR DESCRIPTION
As part of migrating the android_jank_cuj metric to stdlib, move the dependent modules to stdlib first.

Bug: 400854991
Test: tools/diff_test_trace_processor.py --keep-input --name-filter ".*android_jank_cuj\b" out/linux_clang_debug/trace_processor_shell
