### PR TITLE
gn: automatically translate from x64 SIMD intrinsics to WASM

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -344,7 +344,14 @@ config("default") {
     # stable Chrome, Safari, and Firefox. See:
     # - https://webassembly.org/roadmap/
     # - https://emscripten.org/docs/porting/simd.html
-    cflags += [ "-msimd128" ]
+    #
+    # We pass -mavx2 also to make x86_64 hand-rolled SIMD code work when
+    # using WASM: see
+    # https://emscripten.org/docs/porting/simd.html#compiling-simd-code-targeting-x86-sse-instruction-sets.
+    cflags += [
+      "-msimd128",
+      "-mavx2",
+    ]
   }
 
   if (is_wasm_memory64) {


### PR DESCRIPTION
We weren't setting -mavx2 so weren't getting the advantage of
hand-rolled SIMD we had.
