### PR TITLE
Fix nullptr to std::string conversion

### DIFF
--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -7855,7 +7855,7 @@ struct BackendTypeAsString {
       case perfetto::kUnspecifiedBackend:
         return "Unspec";
     }
-    return nullptr;
+    return "";
   }
 };
 


### PR DESCRIPTION
With C++23, you can only assign std::string non-null values (string, c-string, char) so it cannot be assigned nullptr. I fixed it by changing nullptr to empty string so it can fix the below C++23 build error. I tested this in Android by building `m perfetto_integrationtests`.

Error:
external/perfetto/src/tracing/test/api_integrationtest.cc:7858:12: error: conversion function from 'std::nullptr_t' to 'std::string' (aka 'basic_string<char>') invokes a deleted function
 7858 |     return nullptr;