### PR TITLE
Revert "Remove `stackCpuSampling` events. (#2745)"

### DIFF
--- a/src/trace_processor/export_json.cc
+++ b/src/trace_processor/export_json.cc
@@ -157,6 +157,7 @@ class JsonExporter {
     RETURN_IF_ERROR(ExportSlices());
     RETURN_IF_ERROR(ExportFlows());
     RETURN_IF_ERROR(ExportRawEvents());
+    RETURN_IF_ERROR(ExportCpuProfileSamples());
     RETURN_IF_ERROR(ExportMetadata());
     RETURN_IF_ERROR(ExportStats());
     RETURN_IF_ERROR(ExportMemorySnapshots());
@@ -1240,6 +1241,227 @@ class JsonExporter {
         writer_.MergeMetadata(args);
       }
     }
+    return base::OkStatus();
+  }
+
+  class MergedProfileSamplesEmitter {
+   public:
+    // The TraceFormatWriter must outlive this instance.
+    explicit MergedProfileSamplesEmitter(TraceFormatWriter& writer)
+        : writer_(writer) {}
+
+    MergedProfileSamplesEmitter(const MergedProfileSamplesEmitter&) = delete;
+    MergedProfileSamplesEmitter& operator=(const MergedProfileSamplesEmitter&) =
+        delete;
+    MergedProfileSamplesEmitter& operator=(
+        MergedProfileSamplesEmitter&& value) = delete;
+
+    uint64_t AddEventForUtid(UniqueTid utid,
+                             int64_t ts,
+                             CallsiteId callsite_id,
+                             const Json::Value& event) {
+      auto current_sample = current_events_.find(utid);
+
+      // If there's a current entry for our thread and it matches the callsite
+      // of the new sample, update the entry with the new timestamp. Otherwise
+      // create a new entry.
+      if (current_sample != current_events_.end() &&
+          current_sample->second.callsite_id() == callsite_id) {
+        current_sample->second.UpdateWithNewSample(ts);
+        return current_sample->second.event_id();
+      }
+
+      if (current_sample != current_events_.end()) {
+        current_events_.erase(current_sample);
+      }
+
+      auto new_entry = current_events_.emplace(
+          std::piecewise_construct, std::forward_as_tuple(utid),
+          std::forward_as_tuple(writer_, callsite_id, ts, event, this));
+      return new_entry.first->second.event_id();
+    }
+
+    uint64_t GenerateNewEventId() {
+      // "n"-phase events are nestable async events which get tied together
+      // with their id, so we need to give each one a unique ID as we only
+      // want the samples to show up on their own track in the trace-viewer
+      // but not nested together (unless they're nested under a merged event).
+      return ++id_counter_;
+    }
+
+   private:
+    class Sample {
+     public:
+      Sample(TraceFormatWriter& writer,
+             CallsiteId callsite_id,
+             int64_t ts,
+             Json::Value event,
+             MergedProfileSamplesEmitter* emitter)
+          : writer_(writer),
+            callsite_id_(callsite_id),
+            begin_ts_(ts),
+            end_ts_(ts),
+            event_(std::move(event)),
+            event_id_(emitter->GenerateNewEventId()),
+            sample_count_(1) {}
+
+      Sample(const Sample&) = delete;
+      Sample& operator=(const Sample&) = delete;
+
+      Sample(Sample&&) = delete;
+      Sample& operator=(Sample&& value) = delete;
+
+      ~Sample() {
+        // No point writing a merged event if we only got a single sample
+        // as ExportCpuProfileSamples will already be writing the instant event.
+        if (sample_count_ == 1)
+          return;
+
+        event_["id"] = base::Uint64ToHexString(event_id_);
+
+        // Write the BEGIN event.
+        event_["ph"] = "b";
+        // We subtract 1us as a workaround for the first async event not
+        // nesting underneath the parent event if the timestamp is identical.
+        int64_t begin_in_us_ = begin_ts_ / 1000;
+        event_["ts"] = Json::Int64(std::min(begin_in_us_ - 1, begin_in_us_));
+        writer_.WriteCommonEvent(event_);
+
+        // Write the END event.
+        event_["ph"] = "e";
+        event_["ts"] = Json::Int64(end_ts_ / 1000);
+        // No need for args for the end event; remove them to save some space.
+        event_["args"].clear();
+        writer_.WriteCommonEvent(event_);
+      }
+
+      void UpdateWithNewSample(int64_t ts) {
+        // We assume samples for a given thread will appear in timestamp
+        // order; if this assumption stops holding true, we'll have to sort the
+        // samples first.
+        if (ts < end_ts_ || begin_ts_ > ts) {
+          PERFETTO_ELOG(
+              "Got an timestamp out of sequence while merging stack samples "
+              "during JSON export!\n");
+          PERFETTO_DCHECK(false);
+        }
+
+        end_ts_ = ts;
+        sample_count_++;
+      }
+
+      uint64_t event_id() const { return event_id_; }
+      CallsiteId callsite_id() const { return callsite_id_; }
+
+      TraceFormatWriter& writer_;
+      CallsiteId callsite_id_;
+      int64_t begin_ts_;
+      int64_t end_ts_;
+      Json::Value event_;
+      uint64_t event_id_;
+      size_t sample_count_;
+    };
+
+    std::unordered_map<UniqueTid, Sample> current_events_;
+    TraceFormatWriter& writer_;
+    uint64_t id_counter_ = 0;
+  };
+
+  base::Status ExportCpuProfileSamples() {
+    MergedProfileSamplesEmitter merged_sample_emitter(writer_);
+
+    const tables::CpuProfileStackSampleTable& samples =
+        storage_->cpu_profile_stack_sample_table();
+    for (auto it = samples.IterateRows(); it; ++it) {
+      Json::Value event;
+      event["ts"] = Json::Int64(it.ts() / 1000);
+
+      UniqueTid utid = static_cast<UniqueTid>(it.utid());
+      auto pid_and_tid = UtidToPidAndTid(utid);
+      event["pid"] = Json::Int(pid_and_tid.first);
+      event["tid"] = Json::Int(pid_and_tid.second);
+
+      event["ph"] = "n";
+      event["cat"] = "disabled-by-default-cpu_profiler";
+      event["name"] = "StackCpuSampling";
+      event["s"] = "t";
+
+      // Add a dummy thread timestamp to this event to match the format of
+      // instant events. Useful in the UI to view args of a selected group of
+      // samples.
+      event["tts"] = Json::Int64(1);
+
+      const auto& callsites = storage_->stack_profile_callsite_table();
+      const auto& frames = storage_->stack_profile_frame_table();
+      const auto& mappings = storage_->stack_profile_mapping_table();
+
+      std::vector<std::string> callstack;
+      std::optional<CallsiteId> opt_callsite_id = it.callsite_id();
+
+      while (opt_callsite_id) {
+        CallsiteId callsite_id = *opt_callsite_id;
+        auto callsite_row = *callsites.FindById(callsite_id);
+
+        FrameId frame_id = callsite_row.frame_id();
+        auto frame_row = *frames.FindById(frame_id);
+
+        MappingId mapping_id = frame_row.mapping();
+        auto mapping_row = *mappings.FindById(mapping_id);
+
+        NullTermStringView symbol_name;
+        auto opt_symbol_set_id = frame_row.symbol_set_id();
+        if (opt_symbol_set_id) {
+          symbol_name = storage_->GetString(
+              storage_->symbol_table()[*opt_symbol_set_id].name());
+        }
+
+        base::StackString<1024> frame_entry(
+            "%s - %s [%s]\n",
+            (symbol_name.empty()
+                 ? base::Uint64ToHexString(
+                       static_cast<uint64_t>(frame_row.rel_pc()))
+                       .c_str()
+                 : symbol_name.c_str()),
+            GetNonNullString(storage_, mapping_row.name()),
+            GetNonNullString(storage_, mapping_row.build_id()));
+
+        callstack.emplace_back(frame_entry.ToStdString());
+
+        opt_callsite_id = callsite_row.parent_id();
+      }
+
+      std::string merged_callstack;
+      for (auto entry = callstack.rbegin(); entry != callstack.rend();
+           ++entry) {
+        merged_callstack += *entry;
+      }
+
+      event["args"]["frames"] = merged_callstack;
+      event["args"]["process_priority"] = it.process_priority();
+
+      // TODO(oysteine): Used for backwards compatibility with the memlog
+      // pipeline, should remove once we've switched to looking directly at the
+      // tid.
+      event["args"]["thread_id"] = Json::Int(pid_and_tid.second);
+
+      // Emit duration events for adjacent samples with the same callsite.
+      // For now, only do this when the trace has already been symbolized i.e.
+      // are not directly output by Chrome, to avoid interfering with other
+      // processing pipelines.
+      std::optional<CallsiteId> opt_current_callsite_id = it.callsite_id();
+
+      if (opt_current_callsite_id && storage_->symbol_table().row_count() > 0) {
+        uint64_t parent_event_id = merged_sample_emitter.AddEventForUtid(
+            utid, it.ts(), *opt_current_callsite_id, event);
+        event["id"] = base::Uint64ToHexString(parent_event_id);
+      } else {
+        event["id"] =
+            base::Uint64ToHexString(merged_sample_emitter.GenerateNewEventId());
+      }
+
+      writer_.WriteCommonEvent(event);
+    }
+
     return base::OkStatus();
   }
 

--- a/src/trace_processor/export_json_unittest.cc
+++ b/src/trace_processor/export_json_unittest.cc
@@ -1590,6 +1590,116 @@ TEST_F(ExportJsonTest, LegacyRawEvents) {
   EXPECT_EQ(result["systemTraceEvents"].asString(), kLegacyFtraceData);
 }
 
+TEST_F(ExportJsonTest, CpuProfileEvent) {
+  const uint32_t kProcessID = 100;
+  const uint32_t kThreadID = 200;
+  const int64_t kTimestamp = 10000000;
+  const int32_t kProcessPriority = 42;
+
+  TraceStorage* storage = context_.storage.get();
+
+  UniqueTid utid = context_.process_tracker->GetOrCreateThread(kThreadID);
+  UniquePid upid = context_.process_tracker->GetOrCreateProcess(kProcessID);
+
+  auto& tt = *context_.storage->mutable_thread_table();
+  tt[utid].set_upid(upid);
+
+  auto* mappings = storage->mutable_stack_profile_mapping_table();
+  auto& frames = *storage->mutable_stack_profile_frame_table();
+  auto* callsites = storage->mutable_stack_profile_callsite_table();
+
+  auto module_1 =
+      mappings->Insert({storage->InternString("foo_module_id"), 0, 0, 0, 0, 0,
+                        storage->InternString("foo_module_name")});
+
+  auto module_2 =
+      mappings->Insert({storage->InternString("bar_module_id"), 0, 0, 0, 0, 0,
+                        storage->InternString("bar_module_name")});
+
+  // TODO(140860736): Once we support null values for
+  // stack_profile_frame.symbol_set_id remove this hack
+  storage->mutable_symbol_table()->Insert({0, kNullStringId, kNullStringId, 0});
+
+  auto frame_1 = frames.Insert({/*in_name=*/kNullStringId, module_1.id, 0x42});
+
+  uint32_t symbol_set_id = storage->symbol_table().row_count();
+  storage->mutable_symbol_table()->Insert(
+      {symbol_set_id, storage->InternString("foo_func"),
+       storage->InternString("foo_file"), 66});
+  frames[frame_1.row].set_symbol_set_id(symbol_set_id);
+
+  auto frame_2 =
+      frames.Insert({/*in_name=*/kNullStringId, module_2.id, 0x4242});
+
+  symbol_set_id = storage->symbol_table().row_count();
+  storage->mutable_symbol_table()->Insert(
+      {symbol_set_id, storage->InternString("bar_func"),
+       storage->InternString("bar_file"), 77});
+  frames[frame_2.row].set_symbol_set_id(symbol_set_id);
+
+  auto frame_callsite_1 = callsites->Insert({0, std::nullopt, frame_1.id});
+
+  auto frame_callsite_2 =
+      callsites->Insert({1, frame_callsite_1.id, frame_2.id});
+
+  storage->mutable_cpu_profile_stack_sample_table()->Insert(
+      {kTimestamp, frame_callsite_2.id, utid, kProcessPriority});
+
+  storage->mutable_cpu_profile_stack_sample_table()->Insert(
+      {kTimestamp + 10000, frame_callsite_1.id, utid, kProcessPriority});
+
+  storage->mutable_cpu_profile_stack_sample_table()->Insert(
+      {kTimestamp + 20000, frame_callsite_1.id, utid, kProcessPriority});
+
+  base::TempFile temp_file = base::TempFile::Create();
+  FILE* output = fopen(temp_file.path().c_str(), "w+e");
+  base::Status status = ExportJson(storage, output);
+
+  EXPECT_TRUE(status.ok());
+
+  Json::Value result = ToJsonValue(ReadFile(output));
+
+  // The first sample should generate only a single instant event;
+  // the two following samples should also generate an additional [b, e] pair
+  // (the async duration event).
+  EXPECT_EQ(result["traceEvents"].size(), 5u);
+  Json::Value event = result["traceEvents"][0];
+  EXPECT_EQ(event["ph"].asString(), "n");
+  EXPECT_EQ(event["id"].asString(), "0x1");
+  EXPECT_EQ(event["ts"].asInt64(), kTimestamp / 1000);
+  EXPECT_EQ(event["tid"].asInt(), static_cast<int>(kThreadID));
+  EXPECT_EQ(event["cat"].asString(), "disabled-by-default-cpu_profiler");
+  EXPECT_EQ(event["name"].asString(), "StackCpuSampling");
+  EXPECT_EQ(event["s"].asString(), "t");
+  EXPECT_EQ(event["args"]["frames"].asString(),
+            "foo_func - foo_module_name [foo_module_id]\nbar_func - "
+            "bar_module_name [bar_module_id]\n");
+  EXPECT_EQ(event["args"]["process_priority"].asInt(), kProcessPriority);
+
+  event = result["traceEvents"][1];
+  EXPECT_EQ(event["ph"].asString(), "n");
+  EXPECT_EQ(event["id"].asString(), "0x2");
+  EXPECT_EQ(event["ts"].asInt64(), (kTimestamp + 10000) / 1000);
+
+  event = result["traceEvents"][2];
+  EXPECT_EQ(event["ph"].asString(), "n");
+  EXPECT_EQ(event["id"].asString(), "0x2");
+  EXPECT_EQ(event["ts"].asInt64(), (kTimestamp + 20000) / 1000);
+  Json::String second_callstack_ = event["args"]["frames"].asString();
+  EXPECT_EQ(second_callstack_, "foo_func - foo_module_name [foo_module_id]\n");
+
+  event = result["traceEvents"][3];
+  EXPECT_EQ(event["ph"].asString(), "b");
+  EXPECT_EQ(event["id"].asString(), "0x2");
+  EXPECT_EQ(event["ts"].asInt64(), (kTimestamp + 10000) / 1000 - 1);
+  EXPECT_EQ(event["args"]["frames"].asString(), second_callstack_);
+
+  event = result["traceEvents"][4];
+  EXPECT_EQ(event["ph"].asString(), "e");
+  EXPECT_EQ(event["id"].asString(), "0x2");
+  EXPECT_EQ(event["ts"].asInt64(), (kTimestamp + 20000) / 1000);
+}
+
 TEST_F(ExportJsonTest, ArgumentFilter) {
   UniqueTid utid = context_.process_tracker->GetOrCreateThread(0);
   TrackId track = context_.track_tracker->InternThreadTrack(utid);


### PR DESCRIPTION
This reverts commit 6dffc26f2442ba6b369ba8bacd6e37d400cd5b97.

Reason for revert: broken chrome cpu_profiler

This is the first commit to fix crbug.com/473398637, and will be followed by another commit.

