### PR TITLE
ep: Table source info polishing

### DIFF
--- a/ui/src/assets/explore_page/node_info/table_source.md
+++ b/ui/src/assets/explore_page/node_info/table_source.md
@@ -1,29 +1,12 @@
 # Table Source
 
-**Purpose:** Provides direct access to trace data tables like slices, processes, threads, counters, and more. This is the starting point for most queries.
-
-**How to use:**
-- Click the node to open the table selection modal
-- Browse or search for a table by name
-- View table descriptions and available columns
-- Select a table to use it as your data source
-- Ctrl+click to select multiple tables at once (creates multiple nodes)
+**Purpose:** Provides direct access to Perfetto tables.
 
 **Data transformation:**
 - No transformation - this is a source node
 - Provides raw access to the selected table's data
 - All rows and columns from the table are available
 - Use downstream nodes (Filter, Modify Columns, etc.) to transform the data
-
-**Common tables:**
-- `slice`: All slices in the trace (use `Slices with details` source for richer data)
-- `thread_slice`: Slices associated with threads
-- `process`: Process information
-- `thread`: Thread information
-- `counter`: Counter tracks (numeric values over time)
-- `thread_track`, `process_track`: Track metadata
-- `sched_slice`: CPU scheduling information
-- `args`: Key-value arguments associated with events
 
 **Example:** Start with the `slice` table to access all trace slices, then add Filter and Aggregation nodes to analyze specific patterns.
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -248,10 +248,7 @@ export class TableSourceNode implements QueryNode {
         m(
           '.pf-table-source-selected',
           m('h2', 'Selected Table'),
-          m(
-            '.pf-details-box',
-            m(TableDescription, {table: this.state.sqlTable}),
-          ),
+          m(TableDescription, {table: this.state.sqlTable}),
         ),
       );
     }


### PR DESCRIPTION
Shortened too long message above the table info, and removed the wrapping that caused overflows