### PR TITLE
ep: Don't change selected node when interacting with filter chips

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.ts
@@ -619,12 +619,22 @@ export function formatFilterDetails(
           alignItems: 'center',
           gap: '4px',
         },
+        onpointerdown: (e: PointerEvent) => {
+          // Stop propagation to prevent node selection in the graph
+          e.preventDefault();
+          e.stopPropagation();
+        },
       },
       m(Chip, {
         label,
         rounded: true,
         removable: !!effectiveOnRemove,
         intent: isEnabled ? Intent.Primary : Intent.None,
+        onpointerdown: (e: PointerEvent) => {
+          // Stop propagation to prevent node selection in the graph
+          e.preventDefault();
+          e.stopPropagation();
+        },
         onclick: onFilterToggle
           ? (e: MouseEvent) => {
               e.preventDefault();


### PR DESCRIPTION
Interacting with filters when focused on a different node improves the quality of exploration, when the selected node is down the stream. 