### PR TITLE
tp: Use effective radii when constructing SF layer corner radii.

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14693,6 +14693,7 @@ filegroup {
     name: "perfetto_src_trace_processor_importers_proto_winscope_unittests",
     srcs: [
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor_unittest.cc",
+        "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils_unittest.cc",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation_unittest.cc",
         "src/trace_processor/importers/proto/winscope/test/windowmanager_hierarchy_walker_unittest.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor_unittest.cc",

--- a/src/trace_processor/importers/proto/winscope/BUILD.gn
+++ b/src/trace_processor/importers/proto/winscope/BUILD.gn
@@ -112,6 +112,7 @@ perfetto_unittest_source_set("unittests") {
   sources = [
     "surfaceflinger_layers_extractor_unittest.cc",
     "surfaceflinger_layers_test_utils.h",
+    "surfaceflinger_layers_utils_unittest.cc",
     "surfaceflinger_layers_visibility_computation_unittest.cc",
     "test/windowmanager_hierarchy_walker_unittest.cc",
     "test/windowmanager_sample_protos.h",

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_test_utils.h
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_test_utils.h
@@ -22,6 +22,7 @@
 
 #include "protos/perfetto/trace/android/surfaceflinger_common.gen.h"
 #include "protos/perfetto/trace/android/surfaceflinger_layers.gen.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry.h"
 #include "src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h"
 
 namespace perfetto::trace_processor::winscope::surfaceflinger_layers::test {
@@ -132,6 +133,21 @@ class Layer {
     return *this;
   }
 
+  Layer& SetEffectiveRadii(geometry::CornerRadii value) {
+    effective_radii_ = value;
+    return *this;
+  }
+
+  Layer& SetCornerRadii(geometry::CornerRadii value) {
+    corner_radii_ = value;
+    return *this;
+  }
+
+  Layer& SetCornerRadius(float value) {
+    corner_radius_ = value;
+    return *this;
+  }
+
   Layer& SetId(int32_t value) {
     id_ = value;
     return *this;
@@ -154,6 +170,9 @@ class Layer {
   std::optional<bool> is_opaque_;
   std::optional<uint32_t> layer_stack_;
   std::optional<int32_t> z_;
+  std::optional<geometry::CornerRadii> effective_radii_;
+  std::optional<geometry::CornerRadii> corner_radii_;
+  std::optional<float> corner_radius_;
   std::optional<int32_t> id_;
   bool nullify_id_ = false;
 };
@@ -228,6 +247,19 @@ class SnapshotProtoBuilder {
       }
       if (layer.z_.has_value()) {
         layer_proto->set_z(layer.z_.value());
+      }
+      if (layer.effective_radii_.has_value()) {
+        auto effective_radii_proto = layer_proto->mutable_effective_radii();
+        geometry::test::UpdateCornerRadii(effective_radii_proto,
+                                          layer.effective_radii_.value());
+      }
+      if (layer.corner_radii_.has_value()) {
+        auto corner_radii_proto = layer_proto->mutable_corner_radii();
+        geometry::test::UpdateCornerRadii(corner_radii_proto,
+                                          layer.corner_radii_.value());
+      }
+      if (layer.corner_radius_.has_value()) {
+        layer_proto->set_corner_radius(layer.corner_radius_.value());
       }
     }
 

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
@@ -197,12 +197,26 @@ inline geometry::CornerRadii GetCornerRadii(const LayerDecoder& layer) {
       corner_radii.br = static_cast<double>(radii_decoder.br());
     }
   }
+
+  // Fallback to legacy corner_radius field
   if (!has_corner_radii && layer.has_corner_radius()) {
     auto radius = static_cast<double>(layer.corner_radius());
     corner_radii.tl = radius;
     corner_radii.tr = radius;
     corner_radii.bl = radius;
     corner_radii.br = radius;
+  }
+
+  // If the client draws rounded corners instead of SurfaceFlinger, the
+  // effective_radii field is populated and should be added to any existing
+  // corner radii data.
+  if (layer.has_effective_radii()) {
+    protos::pbzero::CornerRadiiProto::Decoder radii_decoder(
+        layer.effective_radii());
+    corner_radii.tl += static_cast<double>(radii_decoder.tl());
+    corner_radii.tr += static_cast<double>(radii_decoder.tr());
+    corner_radii.bl += static_cast<double>(radii_decoder.bl());
+    corner_radii.br += static_cast<double>(radii_decoder.br());
   }
 
   return corner_radii;

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils_unittest.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils_unittest.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h"
+
+#include <optional>
+
+#include "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_test_utils.h"
+#include "src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::winscope::surfaceflinger_layers::test {
+
+namespace {
+const Color test_color{0, 0, 0, 1};
+
+protos::pbzero::LayerProto::Decoder ConvertToLayerProto(std::string& snapshot) {
+  protos::pbzero::LayersSnapshotProto::Decoder snapshot_decoder(snapshot);
+  protos::pbzero::LayersProto::Decoder layers_decoder(
+      snapshot_decoder.layers());
+  auto it = layers_decoder.layers();
+  protos::pbzero::LayerProto::Decoder layer_decoder(*it);
+  return layer_decoder;
+}
+}  // namespace
+
+TEST(SfLayersUtils, IsRootLayerNoParent) {
+  auto layer = Layer();
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  ASSERT_TRUE(layer::IsRootLayer(layer_proto));
+}
+
+TEST(SfLayersUtils, IsRootLayerInvalidParent) {
+  auto layer = Layer().SetParent(-1);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  ASSERT_TRUE(layer::IsRootLayer(layer_proto));
+}
+
+TEST(SfLayersUtils, IsRootLayerValidParent) {
+  auto layer = Layer().SetParent(1);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  ASSERT_FALSE(layer::IsRootLayer(layer_proto));
+}
+
+TEST(SfLayersUtils, IsHiddenByPolicyFlagSet) {
+  auto layer = Layer().SetFlags(0x01);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  ASSERT_TRUE(layer::IsHiddenByPolicy(layer_proto));
+}
+
+TEST(SfLayersUtils, IsHiddenByPolicyOffscreenLayer) {
+  auto layer = Layer().SetId(0x7ffffffd);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  ASSERT_TRUE(layer::IsHiddenByPolicy(layer_proto));
+}
+
+TEST(SfLayersUtils, IsHiddenByPolicyFalse) {
+  auto layer = Layer();
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  ASSERT_FALSE(layer::IsHiddenByPolicy(layer_proto));
+}
+
+TEST(SfLayersUtils, GetBounds) {
+  auto rect = geometry::Rect(1, 2, 3, 4);
+  auto layer = Layer().SetBounds(rect).SetColor(test_color);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  const auto& extracted_bounds = layer::GetBounds(layer_proto);
+  ASSERT_TRUE(extracted_bounds == rect);
+}
+
+TEST(SfLayersUtils, GetCroppedScreenBoundsNoCrop) {
+  auto rect = geometry::Rect(1, 2, 3, 4);
+  auto layer = Layer().SetScreenBounds(rect).SetColor(test_color);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  const auto& extracted_bounds =
+      layer::GetCroppedScreenBounds(layer_proto, std::nullopt);
+  ASSERT_TRUE(extracted_bounds.value() == rect);
+}
+
+TEST(SfLayersUtils, GetCroppedScreenBoundsValidCrop) {
+  auto rect = geometry::Rect(1, 2, 3, 4);
+  auto crop = geometry::Rect(0, 0, 2, 3);
+  auto layer = Layer().SetScreenBounds(rect).SetColor(test_color);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  const auto& extracted_bounds =
+      layer::GetCroppedScreenBounds(layer_proto, crop);
+  ASSERT_TRUE(extracted_bounds == geometry::Rect(1, 2, 2, 3));
+}
+
+TEST(SfLayersUtils, GetCornerRadiiFromCornerRadiiField) {
+  auto radii = geometry::CornerRadii{0.1, 0.2, 0.3, 0.4};
+  auto layer = Layer().SetColor(test_color).SetCornerRadii(radii);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  auto extracted_radii = layer::GetCornerRadii(layer_proto);
+  ASSERT_TRUE(geometry::test::IsCornerRadiiEqual(extracted_radii, radii));
+}
+
+TEST(SfLayersUtils, GetCornerRadiiFromCornerRadiusField) {
+  auto layer = Layer().SetColor(test_color).SetCornerRadius(0.25);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  auto extracted_radii = layer::GetCornerRadii(layer_proto);
+  ASSERT_TRUE(geometry::test::IsCornerRadiiEqual(extracted_radii,
+                                                 {0.25, 0.25, 0.25, 0.25}));
+}
+
+TEST(SfLayersUtils, GetCornerRadiiFromEffectiveRadiiField) {
+  auto radii = geometry::CornerRadii{0.1, 0.2, 0.3, 0.4};
+  auto layer = Layer().SetColor(test_color).SetEffectiveRadii(radii);
+  auto snapshot = SnapshotProtoBuilder().AddLayer(layer).Build();
+  const auto& layer_proto = ConvertToLayerProto(snapshot);
+  auto extracted_radii = layer::GetCornerRadii(layer_proto);
+  ASSERT_TRUE(geometry::test::IsCornerRadiiEqual(extracted_radii, radii));
+}
+}  // namespace perfetto::trace_processor::winscope::surfaceflinger_layers::test

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.cc
@@ -25,10 +25,6 @@ namespace {
 const double CLOSE_THRESHOLD = 0.01;
 const double EQUAL_THRESHOLD = 0.000001;
 
-bool IsEqual(double a, double b) {
-  return std::abs(a - b) < EQUAL_THRESHOLD;
-}
-
 bool IsClose(double a, double b) {
   return std::abs(a - b) < CLOSE_THRESHOLD;
 }
@@ -46,6 +42,10 @@ bool IsPointInCircle(Point point, Point center, double r) {
   return dx * dx + dy * dy <= r * r + CLOSE_THRESHOLD;
 }
 }  // namespace
+
+bool IsEqual(double a, double b) {
+  return std::abs(a - b) < EQUAL_THRESHOLD;
+}
 
 Rect::Rect() = default;
 

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry.h
@@ -22,6 +22,9 @@
 
 namespace perfetto::trace_processor::winscope::geometry {
 
+// Equality function for double values.
+bool IsEqual(double a, double b);
+
 // Represents a corner of a 2D rect from a Winscope trace.
 struct Point {
   double x;

--- a/src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h
+++ b/src/trace_processor/importers/proto/winscope/winscope_geometry_test_utils.h
@@ -43,6 +43,20 @@ inline void UpdateRect(protos::gen::RectProto* rect_proto,
   rect_proto->set_right(static_cast<int32_t>(rect.x + rect.w));
   rect_proto->set_bottom(static_cast<int32_t>(rect.y + rect.h));
 }
+
+inline void UpdateCornerRadii(protos::gen::CornerRadiiProto* corner_radii_proto,
+                              geometry::CornerRadii corner_radii) {
+  corner_radii_proto->set_bl(static_cast<float>(corner_radii.bl));
+  corner_radii_proto->set_br(static_cast<float>(corner_radii.br));
+  corner_radii_proto->set_tl(static_cast<float>(corner_radii.tl));
+  corner_radii_proto->set_tr(static_cast<float>(corner_radii.tr));
+}
+
+inline bool IsCornerRadiiEqual(geometry::CornerRadii value,
+                               geometry::CornerRadii other) {
+  return IsEqual(value.bl, other.bl) && IsEqual(value.br, other.br) &&
+         IsEqual(value.tl, other.tl) && IsEqual(value.tr, other.tr);
+}
 }  // namespace perfetto::trace_processor::winscope::geometry::test
 
 #endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_WINSCOPE_WINSCOPE_GEOMETRY_TEST_UTILS_H_


### PR DESCRIPTION
Bug: 455498995
Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=SfLayersUtils*
