### PR TITLE
ep: Add proper support for all slices source columns

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -146,6 +146,12 @@ export function slicesSourceNodeColumns(checked: boolean): ColumnInfo[] {
       },
     },
     {
+      name: 'track_name',
+      type: {
+        kind: 'string',
+      },
+    },
+    {
       name: 'process_name',
       type: {
         kind: 'string',
@@ -162,6 +168,12 @@ export function slicesSourceNodeColumns(checked: boolean): ColumnInfo[] {
       },
     },
     {
+      name: 'pid',
+      type: {
+        kind: 'int',
+      },
+    },
+    {
       name: 'thread_name',
       type: {
         kind: 'string',
@@ -175,6 +187,12 @@ export function slicesSourceNodeColumns(checked: boolean): ColumnInfo[] {
           table: 'thread',
           column: 'id',
         },
+      },
+    },
+    {
+      name: 'tid',
+      type: {
+        kind: 'int',
       },
     },
     {


### PR DESCRIPTION
Not listing all of the columns properly was causing the bug when we weren't properly recognising duplicated columns in add columns/join