### PR TITLE
ui: Use semantic <kbd> element for hotkey glyphs

### DIFF
--- a/ui/src/widgets/hotkey_glyphs.ts
+++ b/ui/src/widgets/hotkey_glyphs.ts
@@ -75,7 +75,7 @@ export class Keycap implements m.ClassComponent<KeycapAttrs> {
   view({attrs, children}: m.Vnode<KeycapAttrs>) {
     const {spacing = 'medium'} = attrs;
     return m(
-      'span.pf-keycap',
+      'kbd.pf-keycap',
       {className: classNames(classForSpacing(spacing)), ...attrs},
       children,
     );


### PR DESCRIPTION
Change Keycap widget from `<span>` to `<kbd>` element for better semantic HTML. The `<kbd>` element is the standard HTML element for representing keyboard input.