### PR TITLE
tp: Fix crash in IsPerfTextFormatTrace

### DIFF
--- a/src/trace_processor/importers/perf_text/perf_text_sample_line_parser.cc
+++ b/src/trace_processor/importers/perf_text/perf_text_sample_line_parser.cc
@@ -101,6 +101,11 @@ std::optional<SampleLine> ParseSampleLine(std::string_view line) {
     std::optional<uint32_t> cpu;
     if (base::StartsWith(pieces[pos], "[") &&
         base::EndsWith(pieces[pos], "]")) {
+      // If there is only one piece and it's enclosed in brackets, skip this
+      // line as it lacks other required fields (e.g. TID/PID).
+      if (pos == 0) {
+        continue;
+      }
       cpu = base::StringToUInt32(pieces[pos].substr(1, pieces[pos].size() - 2));
       if (!cpu) {
         continue;


### PR DESCRIPTION
ParseSampleLine would underflow the `pos` index (a size_t) if the metadata before the timestamp only contained a CPU field.

Example trace line causing the crash: [1] .055555:

Bug: https://crbug.com/oss-fuzz/471415257
