### PR TITLE
ep: Support setting JOINID type along simple types

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -219,12 +219,16 @@ function createNodeInstance(
     case NodeType.kModifyColumns:
       return new ModifyColumnsNode(
         ModifyColumnsNode.deserializeState(
+          sqlModules,
           state as ModifyColumnsSerializedState,
         ),
       );
     case NodeType.kAddColumns:
       return new AddColumnsNode(
-        AddColumnsNode.deserializeState(state as AddColumnsNodeState),
+        AddColumnsNode.deserializeState(
+          sqlModules,
+          state as AddColumnsNodeState,
+        ),
       );
     case NodeType.kLimitAndOffset:
       return new LimitAndOffsetNode(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -43,6 +43,7 @@ import {
 import {setValidationError} from '../node_issues';
 import {EmptyState} from '../../../../widgets/empty_state';
 import {Callout} from '../../../../widgets/callout';
+import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
 import {Form, FormSection} from '../../../../widgets/form';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
 import {NodeDetailsMessage, ColumnName} from '../node_styling_widgets';
@@ -1051,7 +1052,12 @@ export class AddColumnsNode implements QueryNode {
         placeholder: 'alias',
         value: alias ?? '',
       }),
-      renderTypeSelector(colInfo, index, handleTypeChange),
+      renderTypeSelector(
+        colInfo,
+        index,
+        this.state.sqlModules,
+        handleTypeChange,
+      ),
       m(Icon, {
         icon: 'close',
         className: 'pf-clickable',
@@ -1099,7 +1105,12 @@ export class AddColumnsNode implements QueryNode {
       ),
       m(
         '.pf-exp-list-item-actions',
-        renderTypeSelector(colInfo, index, handleTypeChange),
+        renderTypeSelector(
+          colInfo,
+          index,
+          this.state.sqlModules,
+          handleTypeChange,
+        ),
         m(Button, {
           label: 'Edit',
           icon: 'edit',
@@ -1570,10 +1581,12 @@ export class AddColumnsNode implements QueryNode {
   }
 
   static deserializeState(
+    sqlModules: SqlModules,
     serializedState: AddColumnsNodeState,
   ): AddColumnsNodeState {
     return {
       ...serializedState,
+      sqlModules,
       suggestionSelections:
         (serializedState.suggestionSelections as unknown as Record<
           string,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_utils.ts
@@ -20,17 +20,45 @@ import {
   perfettoSqlTypeToString,
 } from '../../../../trace_processor/perfetto_sql_type';
 import {ColumnInfo} from '../column_info';
+import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
+
+/**
+ * Gets list of tables with columns that have a pure ID type
+ * Returns array of {tableName, columnName} pairs
+ */
+function getTablesWithIdColumn(
+  sqlModules: SqlModules | undefined,
+): Array<{tableName: string; columnName: string}> {
+  if (!sqlModules) {
+    return [];
+  }
+
+  const tablesWithId: Array<{tableName: string; columnName: string}> = [];
+  const tables = sqlModules.listTables();
+
+  for (const table of tables) {
+    for (const col of table.columns) {
+      if (col.type === undefined) continue;
+      if (col.type.kind !== 'id') continue;
+      if (col.type.source.table !== table.name) continue;
+      tablesWithId.push({tableName: table.name, columnName: col.name});
+    }
+  }
+  return tablesWithId.sort((a, b) => a.tableName.localeCompare(b.tableName));
+}
 
 /**
  * Renders a type selector for a column
  * @param col The column information
  * @param index The column index
+ * @param sqlModules SQL modules for table lookup
  * @param onColumnType Optional callback when type is changed
  * @returns A mithril child with the type selector UI
  */
 export function renderTypeSelector(
   col: ColumnInfo,
   index: number,
+  sqlModules: SqlModules | undefined,
   onColumnType?: (index: number, type: string) => void,
 ): m.Child {
   // If no callback provided, don't render type selector
@@ -41,35 +69,69 @@ export function renderTypeSelector(
   const currentType = col.type ?? 'UNKNOWN';
   const originalType = col.column.type;
 
-  // Build the list of type options
-  const typeOptions: {label: string; value: string}[] = [];
+  // Build the list of menu items
+  const menuItems: m.Child[] = [];
 
   // If the original type is an ID type, include it as an option
   if (originalType !== undefined && isIdType(originalType)) {
     const idTypeStr = perfettoSqlTypeToString(originalType);
-    typeOptions.push({label: idTypeStr, value: idTypeStr});
+    menuItems.push(
+      m(MenuItem, {
+        label: idTypeStr,
+        active: currentType === idTypeStr,
+        onclick: () => onColumnType(index, idTypeStr),
+      }),
+    );
   }
 
   // Add all simple types
   for (const type of SIMPLE_TYPE_KINDS) {
-    typeOptions.push({label: type.toUpperCase(), value: type.toUpperCase()});
+    const typeUpper = type.toUpperCase();
+    menuItems.push(
+      m(MenuItem, {
+        label: typeUpper,
+        active: currentType === typeUpper,
+        onclick: () => onColumnType(index, typeUpper),
+      }),
+    );
   }
 
-  const handleTypeChange = (newType: string) => {
-    onColumnType(index, newType);
-  };
+  // Add JOINID submenu with tables that have a pure ID type column
+  const tablesWithId = getTablesWithIdColumn(sqlModules);
+  const joinidMenuItems =
+    tablesWithId.length > 0
+      ? tablesWithId.map(({tableName, columnName}) => {
+          const joinidType = `JOINID(${tableName}.${columnName})`;
+          return m(MenuItem, {
+            label: `${tableName}.${columnName}`,
+            active: currentType === joinidType,
+            onclick: () => onColumnType(index, joinidType),
+          });
+        })
+      : [
+          m(MenuItem, {
+            label: sqlModules
+              ? 'No tables with ID columns'
+              : 'Load a trace first',
+            disabled: true,
+          }),
+        ];
+
+  menuItems.push(
+    m(
+      MenuItem,
+      {
+        label: 'JOINID...',
+      },
+      joinidMenuItems,
+    ),
+  );
 
   return m(
     PopupMenu,
     {
       trigger: m('.pf-column-type', currentType),
     },
-    typeOptions.map((opt) =>
-      m(MenuItem, {
-        label: opt.label,
-        active: currentType === opt.value,
-        onclick: () => handleTypeChange(opt.value),
-      }),
-    ),
+    menuItems,
   );
 }


### PR DESCRIPTION
The last menu item when setting the type is JOINID type - when expanded allows you to pick from all of the tables that have a pure ID type, like slice.id.