### PR TITLE
sdk: don't run clear incremental state tests when flag is disabled

### DIFF
--- a/src/shared_lib/test/api_integrationtest.cc
+++ b/src/shared_lib/test/api_integrationtest.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "perfetto/base/time.h"
+#include "perfetto/ext/base/flags.h"
 #include "perfetto/public/abi/atomic.h"
 #include "perfetto/public/abi/backend_type.h"
 #include "perfetto/public/abi/data_source_abi.h"
@@ -1034,6 +1035,12 @@ TEST_F(SharedLibDataSourceTest, IncrementalState) {
 }
 
 TEST_F(SharedLibDataSourceTest, IncrementalStateClearSuccess) {
+  if constexpr (
+      !PERFETTO_FLAGS_TRACK_EVENT_INCREMENTAL_STATE_CLEAR_NOT_DESTROY) {
+    GTEST_SKIP()
+        << "Test requires flag to be set:"
+           "PERFETTO_FLAGS_TRACK_EVENT_INCREMENTAL_STATE_CLEAR_NOT_DESTROY";
+  }
   bool ignored = false;
   void* const kIncrPtr = &ignored;
   WaitableEvent clear_notification;
@@ -1099,6 +1106,12 @@ TEST_F(SharedLibDataSourceTest, IncrementalStateClearSuccess) {
 }
 
 TEST_F(SharedLibDataSourceTest, IncrementalStateClearFailure) {
+  if constexpr (
+      !PERFETTO_FLAGS_TRACK_EVENT_INCREMENTAL_STATE_CLEAR_NOT_DESTROY) {
+    GTEST_SKIP()
+        << "Test requires flag to be set:"
+           "PERFETTO_FLAGS_TRACK_EVENT_INCREMENTAL_STATE_CLEAR_NOT_DESTROY";
+  }
   bool ignored1 = false;
   bool ignored2 = false;
   void* const kIncrPtr1 = &ignored1;

--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -27,6 +27,7 @@
 #include <thread>
 #include <unordered_set>
 #include <vector>
+#include "perfetto/ext/base/flags.h"
 
 // We also want to test legacy trace events.
 #define PERFETTO_ENABLE_LEGACY_TRACE_EVENTS 1
@@ -1743,6 +1744,13 @@ TEST_P(PerfettoApiTest, ClearIncrementalStateMultipleInstances) {
 }
 
 TEST_P(PerfettoApiTest, ClearIncrementalStateTraitSuccess) {
+  if constexpr (
+      !PERFETTO_FLAGS_TRACK_EVENT_INCREMENTAL_STATE_CLEAR_NOT_DESTROY) {
+    GTEST_SKIP()
+        << "Test requires flag to be set:"
+           "PERFETTO_FLAGS_TRACK_EVENT_INCREMENTAL_STATE_CLEAR_NOT_DESTROY";
+  }
+
   // Test that when the ClearIncrementalState trait method returns true,
   // the state is cleared in place (not destroyed and recreated).
 


### PR DESCRIPTION
Tests cannot pass in this configuration
