### PR TITLE
rust-sdk: update perfetto-sdk-sys crate version

### DIFF
--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-sys"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["David Reveman <dreveman@gmail.com>"]
 build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -20,7 +20,7 @@ intrinsics = []
 vendored = ["perfetto-sdk-sys/vendored"]
 
 [dependencies]
-perfetto-sdk-sys = { path = "../perfetto-sys", version = "0.1", default-features = false }
+perfetto-sdk-sys = { path = "../perfetto-sys", version = "0.2", default-features = false }
 bitflags = "2"
 paste = "1"
 thiserror = "1"


### PR DESCRIPTION
To allow publishing of crate with PerfettoDsSetOnClearIncr API.