### PR TITLE
ui: Tweak explore page styles

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.scss
@@ -18,7 +18,6 @@
   position: relative;
   height: 100%;
   overflow: hidden;
-  border: 1px solid var(--pf-color-border);
   background-color: var(--pf-color-background);
 
   // Ensure NodeGraph takes full height

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.scss
@@ -18,7 +18,6 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  border-left: 1px solid var(--pf-color-border);
 
   &__header {
     display: flex;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
@@ -23,7 +23,6 @@
   height: 100%;
   position: relative;
   overflow: auto;
-  padding: 0.25rem;
 
   &__header {
     display: flex;


### PR DESCRIPTION
- Remove margin around entire page
- Remove border around graph area
- Remove left border from sidebar (which doubles up with the resize handle and looks a little odd)