### PR TITLE
ep: Add hotkeys to labels in Add button menu items

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/common.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/common.scss
@@ -65,3 +65,16 @@
   border: 1px solid var(--pf-color-border);
   border-radius: 4px;
 }
+
+// Menu label with hotkey
+.pf-exp-menu-label-with-hotkey {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+
+  .pf-keycap {
+    opacity: 0.7;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
@@ -15,6 +15,7 @@
 import m from 'mithril';
 import {MenuItem} from '../../../../widgets/menu';
 import {NodeDescriptor, nodeRegistry} from '../node_registry';
+import {Keycap} from '../../../../widgets/hotkey_glyphs';
 
 /**
  * Build menu items for a specific node type.
@@ -32,6 +33,28 @@ export function buildMenuItems(
     .filter(([_id, descriptor]) => descriptor.type === nodeType);
 
   return buildCategorizedMenuItems(nodes, onAddNode);
+}
+
+/**
+ * Generate label with optional hotkey for a node descriptor.
+ *
+ * @param descriptor - Node descriptor
+ * @returns Mithril children for the label with hotkey if available
+ */
+function getLabelWithHotkey(descriptor: NodeDescriptor): m.Children {
+  const hotkey =
+    descriptor.hotkey && typeof descriptor.hotkey === 'string'
+      ? descriptor.hotkey.toUpperCase()
+      : undefined;
+
+  if (hotkey) {
+    return m('.pf-exp-menu-label-with-hotkey', [
+      m('span', descriptor.name),
+      m(Keycap, hotkey),
+    ]);
+  }
+
+  return descriptor.name;
 }
 
 /**
@@ -73,7 +96,7 @@ export function buildCategorizedMenuItems(
       const [id, descriptor] = catNodes[0];
       menuItems.push(
         m(MenuItem, {
-          label: descriptor.name,
+          label: getLabelWithHotkey(descriptor),
           onclick: () => onClickHandler(id),
         }),
       );
@@ -87,7 +110,7 @@ export function buildCategorizedMenuItems(
           },
           catNodes.map(([id, descriptor]) =>
             m(MenuItem, {
-              label: descriptor.name,
+              label: getLabelWithHotkey(descriptor),
               onclick: () => onClickHandler(id),
             }),
           ),
@@ -101,7 +124,7 @@ export function buildCategorizedMenuItems(
   for (const [id, descriptor] of uncategorized) {
     menuItems.push(
       m(MenuItem, {
-        label: descriptor.name,
+        label: getLabelWithHotkey(descriptor),
         onclick: () => onClickHandler(id),
       }),
     );


### PR DESCRIPTION
Adds keyboard shortcut indicators to menu items in the Explore Page's Add button menu. When a node has an associated hotkey, it now displays alongside the node name using the Keycap component, improving discoverability of available keyboard shortcuts.