### PR TITLE
ep: Fix clearing the nodes

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
@@ -109,6 +109,12 @@ export default class implements PerfettoPlugin {
       // Load saved state from localStorage (preserves work across page refreshes)
       this.state = savedState;
       this.hasAttemptedStateLoad = true;
+      // Only mark as auto-initialized if the saved state has nodes
+      // This allows base JSON to load after a reload when state is empty,
+      // but prevents it from loading after manual "Clear all nodes" in the same session
+      if (savedState.rootNodes.length > 0) {
+        this.hasAutoInitialized = true;
+      }
     } else if (
       trace.plugins.getPlugin(SqlModulesPlugin).getSqlModules() !== undefined
     ) {


### PR DESCRIPTION
Bug:
1. Open the Explore Page for the first time in the UI
2. Click `Clear all nodes`

EXPECTED RESULTS:
See empty canvas

OBSERVED RESULTS:
See empty canvas and then nearly immediately see the loaded base graph

ADDITIONAL INFORMATION:
This happens on the first `Clear all nodes`. Subsequent ones work properly. We should load this base json only when the state was empty and then we reloaded the UI - the goal was to never start with the empty canvas.

Fix:
We didn't set autoinitialized properly