### PR TITLE
docs: Add --workers=1 to the pixeltest instructions

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -138,7 +138,7 @@ googlers have access to, googlers can install gcloud
 [here](https://g3doc.corp.google.com/cloud/sdk/g3doc/index.md#installing-and-using-the-cloud-sdk)).
 
 ```
-ui/run-integrationtests --rebaseline
+ui/run-integrationtests --rebaseline --workers=1
 tools/test_data upload
 ```
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -38,7 +38,7 @@ run-integrationtests
 To rebaseline screenshots after a UI change
 
 ```bash
-ui/run-integrationtests --rebaseline
+ui/run-integrationtests --rebaseline --workers=1
 
 tools/test_data upload
 


### PR DESCRIPTION
Unfortunately this seems to be required for the pixel tests to pass now