### PR TITLE
rust-sdk: update perfetto-sdk-sys crate version

### DIFF
--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-sys"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["David Reveman <dreveman@gmail.com>"]
 build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"


### PR DESCRIPTION
To allow publishing of crate with correct amalgamated sources.