### PR TITLE
ui: Fix 2 bugs in datagrid

### DIFF
--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -1556,14 +1556,14 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           const value = row[alias];
 
           // For aggregates with a field, we can use the field's cell renderer
-          let cellRenderer;
-          if ('field' in agg) {
-            const aggColInfo = getColumnInfo(schema, rootSchema, agg.field);
-            cellRenderer = aggColInfo?.cellRenderer;
-          }
+          let cellRenderer =
+            'field' in agg
+              ? getColumnInfo(schema, rootSchema, agg.field)?.cellRenderer
+              : undefined;
+          cellRenderer ??= (v: SqlValue) => renderCell(v, alias);
 
-          const rendered = cellRenderer?.(value, row);
-          const isRich = rendered !== undefined && isCellRenderResult(rendered);
+          const rendered = cellRenderer(value, row);
+          const isRich = isCellRenderResult(rendered);
 
           cells.push(
             m(
@@ -1575,7 +1575,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
                   ? rendered.nullish ?? value === null
                   : value === null,
               },
-              isRich ? rendered.content : rendered ?? String(value ?? ''),
+              isRich ? rendered.content : rendered,
             ),
           );
         }

--- a/ui/src/components/widgets/datagrid/in_memory_data_source.ts
+++ b/ui/src/components/widgets/datagrid/in_memory_data_source.ts
@@ -672,10 +672,8 @@ function compareNumeric(a: SqlValue, b: SqlValue): number {
 function arePivotsEqual(a?: Pivot, b?: Pivot): boolean {
   if (a === b) return true;
   if (a === undefined || b === undefined) return false;
-  // Compare groupBy fields
-  const aGroupBy = a.groupBy.map(({field}) => field).join(',');
-  const bGroupBy = b.groupBy.map(({field}) => field).join(',');
-  if (aGroupBy !== bGroupBy) return false;
+  // Compare groupBy fields (including sort)
+  if (JSON.stringify(a.groupBy) !== JSON.stringify(b.groupBy)) return false;
   // Compare aggregates
   if (JSON.stringify(a.aggregates) !== JSON.stringify(b.aggregates)) {
     return false;


### PR DESCRIPTION
- Sorting by groupby column doesn't work when using an in-memory datasource.
- Broken null rendering (shows empty string) in aggregate columns in pivot mode.