### PR TITLE
ui: clear SQLDataSource when pivot changes to avoid stale data

### DIFF
--- a/ui/src/components/widgets/datagrid/sql_data_source.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source.ts
@@ -237,7 +237,9 @@ export class SQLDataSource implements DataSource {
   private shouldClearCache(newModel: DataSourceModel): boolean {
     if (!this.lastModel) return false;
     // Covering the most basic use-case.
-    return this.lastModel.pivot?.drillDown?.name !== newModel.pivot?.drillDown?.name;
+    return (
+      this.lastModel.pivot?.drillDown?.name !== newModel.pivot?.drillDown?.name
+    );
   }
 
   /**


### PR DESCRIPTION
This fixes an issue where the DataGrid temporarily displays stale data when switching to/from pivot views.