### PR TITLE
ui: make proc_stat_runtime tracks use delta counters by default

### DIFF
--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_tracks.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_tracks.ts
@@ -321,6 +321,9 @@ export const COUNTER_TRACK_SCHEMAS: ReadonlyArray<CounterTrackTypeSchema> = [
     type: 'proc_stat_runtime',
     topLevelGroup: 'PROCESS',
     group: undefined,
+    // These are better visualized as deltas because they represent cumulative
+    // runtime.
+    mode: 'delta',
   },
   {
     type: 'process_gpu_memory',


### PR DESCRIPTION
More meaningful as these are cumulative counters.

Bug: https://github.com/google/perfetto/issues/4227
