### PR TITLE
Add fields simSecure and trusted to Keyguard proto

### DIFF
--- a/protos/perfetto/trace/android/server/windowmanagerservice.proto
+++ b/protos/perfetto/trace/android/server/windowmanagerservice.proto
@@ -92,7 +92,7 @@ message WindowOrientationListenerProto {
 message KeyguardServiceDelegateProto {
   optional bool showing = 1;
   optional bool occluded = 2;
-  optional bool secure = 3;
+  optional bool secure = 3 [deprecated = true];
   enum ScreenState {
     SCREEN_STATE_OFF = 0;
     SCREEN_STATE_TURNING_ON = 1;
@@ -107,6 +107,8 @@ message KeyguardServiceDelegateProto {
     INTERACTIVE_STATE_GOING_TO_SLEEP = 3;
   }
   optional InteractiveState interactive_state = 5;
+  optional bool sim_secure = 6;
+  optional bool trusted = 7;
 }
 
 message KeyguardControllerProto {


### PR DESCRIPTION
Deprecate field secure as this isn't actually tracked data. It's a synthetic field made of simSecure || LockPatternUtils.isSecure(user) and we can keep track of that better with the raw values now.

Contributes to simplyifing KeyguardServiceDelegate. See b/469476683 for progress.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
