### PR TITLE
ep: Adjust layouts to left corner

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -128,9 +128,12 @@ describe('JSON serialization/deserialization', () => {
     expect(
       (deserializedModifyNode as ModifyColumnsNode).primaryInput?.nodeId,
     ).toBe(deserializedTableNode.nodeId);
+    // Coordinates are normalized so top-left is at (minX, minY)
+    // Original: tableNode (10, 20), modifyNode (100, 200)
+    // After normalization: tableNode (0, 0), modifyNode (90, 180)
     expect(
       deserializedState.nodeLayouts.get(deserializedTableNode.nodeId),
-    ).toEqual({x: 10, y: 20});
+    ).toEqual({x: 0, y: 0});
   });
 
   test('serializes and deserializes aggregation node', () => {
@@ -504,12 +507,15 @@ describe('JSON serialization/deserialization', () => {
     const deserializedTableNode = deserializedState.rootNodes[0];
     const deserializedSliceNode = deserializedState.rootNodes[1];
 
+    // Coordinates are normalized so top-left is at (minX, minY)
+    // Original: tableNode (10, 20), sliceNode (100, 200)
+    // After normalization: tableNode (0, 0), sliceNode (90, 180)
     expect(
       deserializedState.nodeLayouts.get(deserializedTableNode.nodeId),
-    ).toEqual({x: 10, y: 20});
+    ).toEqual({x: 0, y: 0});
     expect(
       deserializedState.nodeLayouts.get(deserializedSliceNode.nodeId),
-    ).toEqual({x: 100, y: 200});
+    ).toEqual({x: 90, y: 180});
   });
 
   test('serializes and deserializes node with BigInt filter', () => {
@@ -759,16 +765,19 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedAddColumnsNode.state.leftColumn).toBe('id');
     expect(deserializedAddColumnsNode.state.rightColumn).toBe('id');
 
-    // Verify layouts are preserved
+    // Verify layouts are preserved (after normalization)
+    // Original: tableNode1 (0, 0), addColumnsNode (0, 100), tableNode2 (-200, 100)
+    // After normalization (minX=-200, minY=0):
+    // tableNode1 (200, 0), addColumnsNode (200, 100), tableNode2 (0, 100)
     expect(
       deserializedState.nodeLayouts.get(deserializedTableNode1.nodeId),
-    ).toEqual({x: 0, y: 0});
+    ).toEqual({x: 200, y: 0});
     expect(
       deserializedState.nodeLayouts.get(deserializedAddColumnsNode.nodeId),
-    ).toEqual({x: 0, y: 100});
+    ).toEqual({x: 200, y: 100});
     expect(
       deserializedState.nodeLayouts.get(deserializedTableNode2.nodeId),
-    ).toEqual({x: -200, y: 100});
+    ).toEqual({x: 0, y: 100});
   });
 
   test('add columns node uses renamed columns from modify columns node', () => {
@@ -2504,7 +2513,25 @@ describe('JSON serialization/deserialization', () => {
     const json = serializeState(initialState);
     const deserializedState = deserializeState(json, trace, sqlModules);
 
-    expect(deserializedState.labels).toEqual(labels);
+    // Labels are normalized so top-left is at (minX, minY)
+    // Original: label-1 (100, 200), label-2 (400, 500)
+    // After normalization: label-1 (0, 0), label-2 (300, 300)
+    expect(deserializedState.labels).toEqual([
+      {
+        id: 'label-1',
+        x: 0,
+        y: 0,
+        width: 300,
+        text: 'First label',
+      },
+      {
+        id: 'label-2',
+        x: 300,
+        y: 300,
+        width: 250,
+        text: 'Second label',
+      },
+    ]);
   });
 
   test('handles state without labels', () => {
@@ -2563,5 +2590,117 @@ describe('JSON serialization/deserialization', () => {
     const deserializedState = deserializeState(json, trace, sqlModules);
 
     expect(deserializedState.labels).toEqual(labels);
+  });
+
+  test('normalizes coordinates so top-left corner starts at minimum coordinates', () => {
+    const tableNode = new TableSourceNode({
+      sqlTable: sqlModules.getTable('slice'),
+      trace,
+      sqlModules,
+    });
+    const sliceNode = new SlicesSourceNode({});
+
+    const initialState: ExplorePageState = {
+      rootNodes: [tableNode, sliceNode],
+      nodeLayouts: new Map([
+        [tableNode.nodeId, {x: 500, y: 300}],
+        [sliceNode.nodeId, {x: 800, y: 600}],
+      ]),
+      labels: [
+        {
+          id: 'label-1',
+          x: 400,
+          y: 250,
+          width: 100,
+          text: 'Test label',
+        },
+      ],
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    // After normalization, the minimum coordinates (400, 250) become (0, 0)
+    // All other coordinates are shifted accordingly
+    const tableNodeId = deserializedState.rootNodes[0].nodeId;
+    const sliceNodeId = deserializedState.rootNodes[1].nodeId;
+
+    expect(deserializedState.nodeLayouts.get(tableNodeId)).toEqual({
+      x: 100,
+      y: 50,
+    }); // (500-400, 300-250)
+    expect(deserializedState.nodeLayouts.get(sliceNodeId)).toEqual({
+      x: 400,
+      y: 350,
+    }); // (800-400, 600-250)
+    expect(deserializedState.labels?.[0]).toEqual({
+      id: 'label-1',
+      x: 0,
+      y: 0,
+      width: 100,
+      text: 'Test label',
+    }); // (400-400, 250-250)
+  });
+
+  test('does not modify coordinates when already normalized at (0, 0)', () => {
+    const tableNode = new TableSourceNode({
+      sqlTable: sqlModules.getTable('slice'),
+      trace,
+      sqlModules,
+    });
+
+    const initialState: ExplorePageState = {
+      rootNodes: [tableNode],
+      nodeLayouts: new Map([[tableNode.nodeId, {x: 0, y: 0}]]),
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    const tableNodeId = deserializedState.rootNodes[0].nodeId;
+    expect(deserializedState.nodeLayouts.get(tableNodeId)).toEqual({
+      x: 0,
+      y: 0,
+    });
+  });
+
+  test('serializeState normalizes coordinates in the exported JSON', () => {
+    const tableNode = new TableSourceNode({
+      sqlTable: sqlModules.getTable('slice'),
+      trace,
+      sqlModules,
+    });
+    const sliceNode = new SlicesSourceNode({});
+
+    // State with non-zero minimum coordinates
+    const initialState: ExplorePageState = {
+      rootNodes: [tableNode, sliceNode],
+      nodeLayouts: new Map([
+        [tableNode.nodeId, {x: 500, y: 300}],
+        [sliceNode.nodeId, {x: 800, y: 600}],
+      ]),
+      labels: [{id: 'label-1', x: 400, y: 250, width: 100, text: 'Test label'}],
+    };
+
+    const json = serializeState(initialState);
+    const parsed = JSON.parse(json);
+
+    // The exported JSON should have normalized coordinates
+    // Minimum is (400, 250) from the label, so all coordinates shift by that
+    expect(parsed.nodeLayouts[tableNode.nodeId]).toEqual({
+      x: 100,
+      y: 50,
+    }); // (500-400, 300-250)
+    expect(parsed.nodeLayouts[sliceNode.nodeId]).toEqual({
+      x: 400,
+      y: 350,
+    }); // (800-400, 600-250)
+    expect(parsed.labels[0]).toEqual({
+      id: 'label-1',
+      x: 0,
+      y: 0,
+      width: 100,
+      text: 'Test label',
+    }); // (400-400, 250-250)
   });
 });


### PR DESCRIPTION
Bug: when you create a graph you might start anywhere on the canvas - as it is infinite, there are no "special points". Unfortunatelly under the hood everything has fixed layout values. This makes is so that loading json that someone created might start with values very off from your current view of the canvas. It can be fixed with recentering, but there is no reason for the json to have such off values.

Fix: While importing and exporting of JSONs, update the layouts to normalize them to the top left corner.