### PR TITLE
ep: Fix the serialization of filter node numeric values

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/history_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/history_manager_unittest.ts
@@ -430,7 +430,8 @@ describe('HistoryManager', () => {
     expect(redoneFilterNode.state.filters?.length ?? 0).toBe(1);
     const redoneFilter = redoneFilterNode.state.filters?.[0];
     if (redoneFilter && 'value' in redoneFilter) {
-      expect(redoneFilter.value).toBe('123');
+      // Numeric strings are converted to numbers during deserialization
+      expect(redoneFilter.value).toBe(123);
     }
   });
 
@@ -489,7 +490,8 @@ describe('HistoryManager', () => {
     expect(filterNode1.state.filters?.length ?? 0).toBe(1);
     const undoneFilter1 = filterNode1.state.filters?.[0];
     if (undoneFilter1 && 'value' in undoneFilter1) {
-      expect(undoneFilter1.value).toBe('123');
+      // Numeric strings are converted to numbers during deserialization
+      expect(undoneFilter1.value).toBe(123);
     }
 
     // Undo again: should have 0 filters

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -438,7 +438,7 @@ describe('JSON serialization/deserialization', () => {
     );
   });
 
-  test('serializes and deserializes node with filters', () => {
+  test('serializes and deserializes node with string filters', () => {
     const tableNode = new TableSourceNode({
       sqlTable: sqlModules.getTable('slice'),
       trace,
@@ -475,6 +475,50 @@ describe('JSON serialization/deserialization', () => {
     expect(filter?.op).toBe('=');
     if (filter !== undefined && 'value' in filter) {
       expect(filter.value).toBe('test');
+    } else {
+      fail('Filter value not found');
+    }
+  });
+
+  test('serializes and deserializes node with numeric filters', () => {
+    const tableNode = new TableSourceNode({
+      sqlTable: sqlModules.getTable('slice'),
+      trace,
+      sqlModules,
+    });
+
+    const filterNode = new FilterNode({
+      filters: [
+        {
+          column: 'dur',
+          op: '>',
+          value: 1000,
+        },
+      ],
+    });
+    addConnection(tableNode, filterNode);
+
+    const initialState: ExplorePageState = {
+      rootNodes: [tableNode],
+      nodeLayouts: new Map(),
+    };
+
+    const json = serializeState(initialState);
+    const deserializedState = deserializeState(json, trace, sqlModules);
+
+    expect(deserializedState.rootNodes.length).toBe(1);
+    const deserializedTableNode = deserializedState.rootNodes[0];
+    expect(deserializedTableNode.nextNodes.length).toBe(1);
+    const deserializedFilterNode = deserializedTableNode
+      .nextNodes[0] as FilterNode;
+    expect(deserializedFilterNode.state.filters?.length).toBe(1);
+    const filter = deserializedFilterNode.state.filters?.[0];
+    expect(filter?.column).toBe('dur');
+    expect(filter?.op).toBe('>');
+    if (filter !== undefined && 'value' in filter) {
+      // Numeric filters should remain as numbers after serialization/deserialization
+      expect(typeof filter.value).toBe('number');
+      expect(filter.value).toBe(1000);
     } else {
       fail('Filter value not found');
     }
@@ -548,7 +592,10 @@ describe('JSON serialization/deserialization', () => {
     expect(filter?.column).toBe('id');
     expect(filter?.op).toBe('=');
     if (filter !== undefined && 'value' in filter) {
-      expect(filter.value).toBe('12345678901234567890');
+      // BigInt values are serialized as strings and then converted back to numbers.
+      // Note: Very large numbers may lose precision due to JavaScript Number limits.
+      expect(typeof filter.value).toBe('number');
+      expect(filter.value).toBe(Number('12345678901234567890'));
     } else {
       fail('Filter value not found');
     }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
@@ -41,6 +41,7 @@ import {Button, ButtonVariant} from '../../../../widgets/button';
 import {NodeDetailsMessage} from '../node_styling_widgets';
 import {Icons} from '../../../../base/semantic_icons';
 import {loadNodeDoc} from '../node_doc_loader';
+import {SqlValue} from '../../../../trace_processor/query_result';
 
 // Maximum length for truncated SQL display
 const SQL_TRUNCATE_LENGTH = 50;
@@ -316,9 +317,15 @@ export class FilterNode implements QueryNode {
                 enabled: filter.enabled,
               };
               // Add value if required
-              if (isValueRequired(newOp)) {
-                (updated as {value: string}).value =
-                  'value' in filter ? String(filter.value) : '';
+              if (isValueRequired(newOp) && 'value' in filter) {
+                // Extract single value (handle both single values and arrays)
+                const existingValue = filter.value;
+                const singleValue = Array.isArray(existingValue)
+                  ? existingValue[0]
+                  : existingValue;
+                if (singleValue !== undefined) {
+                  (updated as {value: SqlValue}).value = singleValue;
+                }
               }
               onUpdate(updated);
             }
@@ -543,6 +550,21 @@ export class FilterNode implements QueryNode {
    * @returns A FilterNodeState ready for construction
    */
   static deserializeState(state: FilterNodeState): FilterNodeState {
-    return {...state};
+    // Convert filter values from strings back to numbers when appropriate.
+    // This is needed because JSON serialization converts BigInt to string,
+    // and we want numeric values to be stored as numbers for proper filtering.
+    const filters = state.filters?.map((f): Partial<UIFilter> => {
+      if ('value' in f && typeof f.value === 'string') {
+        // Only convert single string values, not arrays (for 'in' / 'not in')
+        if (!Array.isArray(f.value)) {
+          const parsed = parseFilterValue(f.value);
+          if (parsed !== undefined && parsed !== f.value) {
+            return {...f, value: parsed} as Partial<UIFilter>;
+          }
+        }
+      }
+      return f;
+    });
+    return {...state, filters};
   }
 }


### PR DESCRIPTION
Serialization seems to save the numbers in filters as strings - which for numerical columns renders the filters unusable