### PR TITLE
ui: Allow all aggregation functions for unknown column types

### DIFF
--- a/ui/src/components/widgets/datagrid/add_column_menu.ts
+++ b/ui/src/components/widgets/datagrid/add_column_menu.ts
@@ -364,14 +364,21 @@ const TEXT_SAFE_AGGREGATE_FUNCTIONS: AggregateFunction[] = ['ANY'];
  * Returns the available aggregate functions for a column based on its type.
  * Numeric aggregates (SUM, AVG, MIN, MAX) are only available for quantitative
  * and identifier columns. ANY is available for all column types.
+ * When the column type is unknown (undefined), all aggregates are allowed.
  */
 export function getAggregateFunctionsForColumnType(
   columnType: 'text' | 'quantitative' | 'identifier' | undefined,
 ): AggregateFunction[] {
-  if (columnType === 'quantitative' || columnType === 'identifier') {
+  // For unknown types (undefined), allow all aggregates since we can't
+  // determine restrictions
+  if (
+    columnType === undefined ||
+    columnType === 'quantitative' ||
+    columnType === 'identifier'
+  ) {
     return [...NUMERIC_AGGREGATE_FUNCTIONS, ...TEXT_SAFE_AGGREGATE_FUNCTIONS];
   }
-  // For 'text' columns or undefined, only text-safe aggregates
+  // For 'text' columns, only text-safe aggregates
   return TEXT_SAFE_AGGREGATE_FUNCTIONS;
 }
 


### PR DESCRIPTION
Fixes issue where when column are unknown (e.g. query results page) we cannot choose aggregation functions (ANY is the only one present). Now, all functions are selectable.

E.g. see the following screenshot from the query page - 'dur' can now have any of the aggregate functions applied.

<img width="1656" height="570" alt="image" src="https://github.com/user-attachments/assets/07cdfa78-52cf-49a1-b49b-e8f7d0afadfc" />
