### PR TITLE
ui: Add loading state to run query button on query page

### DIFF
--- a/ui/src/components/query_table/query_result_tab.ts
+++ b/ui/src/components/query_table/query_result_tab.ts
@@ -79,7 +79,6 @@ export class QueryResultTab implements Tab {
     return m(QueryResultsTable, {
       isLoading: this.isLoading(),
       trace: this.trace,
-      query: this.args.query,
       resp: this.queryResponse,
       fillHeight: true,
     });

--- a/ui/src/components/query_table/query_table.ts
+++ b/ui/src/components/query_table/query_table.ts
@@ -88,9 +88,6 @@ interface QueryResultsTableAttrs {
   // tracks, navigating to slices, etc.
   readonly trace: Trace;
 
-  // The executed query to display above the table and made available to copy.
-  readonly query?: string;
-
   // If true, a loading indicator is shown.
   readonly isLoading?: boolean;
 
@@ -136,15 +133,15 @@ export class QueryResultsTable
   }
 
   view({attrs}: m.CVnode<QueryResultsTableAttrs>) {
-    const {resp, query, fillHeight, trace, isLoading, emptyState} = attrs;
+    const {resp, fillHeight, trace, isLoading, emptyState} = attrs;
 
     return m(
       DetailsShell,
       {
         className: 'pf-query-table',
         title: this.renderTitle(isLoading, resp),
-        description: query,
-        buttons: this.renderButtons(trace, query, resp),
+        description: resp?.query,
+        buttons: this.renderButtons(trace, resp?.query, resp),
         fillHeight,
       },
       this.renderBody(trace, resp, isLoading, emptyState),

--- a/ui/src/plugins/dev.perfetto.QueryPage/index.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/index.ts
@@ -32,7 +32,6 @@ export default class QueryPagePlugin implements PerfettoPlugin {
 
   async onTraceLoad(trace: Trace): Promise<void> {
     // The query page and tab share the same query data.
-    let executedQuery: string | undefined;
     let queryResult: QueryResponse | undefined;
     let isLoading = false;
     let editorText = '';
@@ -40,7 +39,6 @@ export default class QueryPagePlugin implements PerfettoPlugin {
     async function onExecute(text: string) {
       if (!text) return;
 
-      executedQuery = text;
       queryResult = undefined;
       queryHistoryStorage.saveQuery(text);
 
@@ -55,9 +53,9 @@ export default class QueryPagePlugin implements PerfettoPlugin {
       route: '/query',
       render: () =>
         m(QueryPage, {
+          isLoading,
           trace,
           editorText,
-          executedQuery,
           queryResult,
           onEditorContentUpdate: (text) => (editorText = text),
           onExecute,
@@ -80,7 +78,6 @@ export default class QueryPagePlugin implements PerfettoPlugin {
           return m(QueryResultsTable, {
             trace,
             isLoading,
-            query: executedQuery,
             resp: queryResult,
             fillHeight: true,
             emptyState: m(

--- a/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/query_page.ts
@@ -45,13 +45,22 @@ import {AddDebugTrackMenu} from '../../components/tracks/add_debug_track_menu';
 const HIDE_PERFETTO_SQL_AGENT_BANNER_KEY = 'hidePerfettoSqlAgentBanner';
 
 export interface QueryPageAttrs {
+  // The trace to run queries against.
   readonly trace: Trace;
+
+  // Current text displayed in the query editor.
   readonly editorText: string;
-  readonly executedQuery?: string;
+
+  // The results of the last executed query, if any.
   readonly queryResult?: QueryResponse;
 
+  // Whether a query is currently being executed.
+  readonly isLoading: boolean;
+
+  // Called when the content of the editor is updated.
   onEditorContentUpdate?(content: string): void;
 
+  // Called when the user requests to execute a query.
   onExecute?(query: string): void;
 }
 
@@ -80,6 +89,15 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
   }
 
   view({attrs}: m.CVnode<QueryPageAttrs>) {
+    const {
+      isLoading,
+      editorText,
+      trace,
+      onEditorContentUpdate,
+      queryResult,
+      onExecute,
+    } = attrs;
+
     return m(
       '.pf-query-page',
       m(Box, {className: 'pf-query-page__toolbar'}, [
@@ -87,10 +105,11 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
           m(Button, {
             label: 'Run Query',
             icon: 'play_arrow',
-            intent: Intent.Primary,
+            loading: isLoading,
+            intent: isLoading ? Intent.None : Intent.Primary,
             variant: ButtonVariant.Filled,
             onclick: () => {
-              attrs.onExecute?.(attrs.editorText);
+              attrs.onExecute?.(editorText);
             },
           }),
           m(
@@ -103,7 +122,7 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
             m(HotkeyGlyphs, {hotkey: 'Mod+Enter'}),
           ),
           m(StackAuto), // The spacer pushes the following buttons to the right.
-          attrs.trace.isInternalUser &&
+          trace.isInternalUser &&
             m(Button, {
               icon: 'wand_stars',
               title:
@@ -114,7 +133,7 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
               },
             }),
           m(CopyToClipboardButton, {
-            textToCopy: attrs.editorText,
+            textToCopy: editorText,
             title: 'Copy query to clipboard',
             label: 'Copy Query',
           }),
@@ -157,7 +176,7 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
             ],
           ),
         ),
-      attrs.editorText.includes('"') &&
+      editorText.includes('"') &&
         m(
           Box,
           m(
@@ -171,9 +190,9 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
       m(Editor, {
         ref: 'editor',
         language: 'perfetto-sql',
-        text: attrs.editorText,
-        onUpdate: attrs.onEditorContentUpdate,
-        onExecute: attrs.onExecute,
+        text: editorText,
+        onUpdate: onEditorContentUpdate,
+        onExecute: onExecute,
       }),
       m(ResizeHandle, {
         onResize: (deltaPx: number) => {
@@ -185,16 +204,16 @@ export class QueryPage implements m.ClassComponent<QueryPageAttrs> {
         },
       }),
       this.dataSource &&
-        attrs.queryResult &&
-        this.renderQueryResult(attrs.trace, attrs.queryResult, this.dataSource),
+        queryResult &&
+        this.renderQueryResult(trace, queryResult, this.dataSource),
       m(QueryHistoryComponent, {
         className: 'pf-query-page__history',
-        trace: attrs.trace,
+        trace: trace,
         runQuery: (query: string) => {
-          attrs.onExecute?.(query);
+          onExecute?.(query);
         },
         setQuery: (query: string) => {
-          attrs.onEditorContentUpdate?.(query);
+          onEditorContentUpdate?.(query);
         },
       }),
     );


### PR DESCRIPTION
The 'Run Query' button on the query page now shows loading state while the query is loading.