### PR TITLE
RecordTraceV2: Add Graphics preset for Android

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/presets.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/presets.ts
@@ -281,7 +281,7 @@ export const ANDROID_PRESETS: Preset[] = [
             allApps: true,
           },
         },
-        advanced: {settings: {groups: FTRACE_GRAPHICS}},
+        advanced_ftrace: {settings: {groups: FTRACE_GRAPHICS}},
       },
     },
   },


### PR DESCRIPTION
Adds a new "Graphics" preset to the Android recording options which includes among others, Atrace categories relevant to rendering for all apps. CPU usage, scheduling, and frequency and Android frame timeline.

Bug: 474684589
Test: build and test ui
