### PR TITLE
tp: support multi-level package names with prefix ownership

### DIFF
--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.h
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.h
@@ -225,10 +225,17 @@ class PerfettoSqlEngine {
     packages_.Insert(name, std::move(package));
   }
 
+  // Removes a SQL package.
+  void ErasePackage(const std::string& name) { packages_.Erase(name); }
+
   // Fetches registered SQL package.
   sql_modules::RegisteredPackage* FindPackage(const std::string& name) {
     return packages_.Find(name);
   }
+
+  // Finds a package that owns the given module key (i.e., whose name is a
+  // prefix of the key).
+  sql_modules::RegisteredPackage* FindPackageForModule(const std::string& key);
 
   // Returns the number of objects (tables, views, functions etc) registered
   // with SQLite.

--- a/src/trace_processor/util/sql_modules.h
+++ b/src/trace_processor/util/sql_modules.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/string_view.h"
 
 namespace perfetto ::trace_processor::sql_modules {
@@ -62,6 +63,25 @@ inline std::string GetPackageName(const std::string& str) {
     return str;
   }
   return str.substr(0, found);
+}
+
+// Returns true if |prefix| is a prefix of |str| where the prefix must either
+// be the entire string or followed by a dot separator. Examples:
+//   IsPackagePrefixOf("foo", "foo") -> true
+//   IsPackagePrefixOf("foo", "foo.bar") -> true
+//   IsPackagePrefixOf("foo.bar", "foo.bar.baz") -> true
+//   IsPackagePrefixOf("foo", "foobar") -> false (no dot separator)
+//   IsPackagePrefixOf("foo.bar", "foo") -> false (prefix longer than str)
+inline bool IsPackagePrefixOf(const std::string& prefix,
+                              const std::string& str) {
+  if (prefix.size() > str.size()) {
+    return false;
+  }
+  if (!base::StartsWith(str, prefix)) {
+    return false;
+  }
+  // Must be exact match OR followed by a dot
+  return prefix.size() == str.size() || str[prefix.size()] == '.';
 }
 
 }  // namespace perfetto::trace_processor::sql_modules


### PR DESCRIPTION
Package names can now be multi-level (e.g., "android.camera" not just
"android"). Packages own their prefix exclusively:
- Package "foo.bar" prevents registration of "foo" (prefix clash)
- Package "foo" prevents registration of "foo.bar" (prefix clash)
- Prefix clashes with different packages always fail
- allow_override only allows replacing the exact same package name

Changes:
- Add IsPackagePrefixOf helper to sql_modules.h
- Add prefix clash checking in RegisterSqlPackage
- Update module name validation to check prefix (not just first component)
- Add FindPackageForModule to look up packages by prefix match
- Update ExecuteInclude to use FindPackageForModule