### PR TITLE
tp: freeze current set of public top-level packages in stdlib

### DIFF
--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -689,7 +689,9 @@ def CheckSqlModules(changed_files: List[str]) -> List[str]:
     return []
 
   try:
-    run_command([sys.executable, tool, '--check-includes'], cwd=REPO_ROOT)
+    run_command(
+        [sys.executable, tool, '--check-includes', '--check-new-packages'],
+        cwd=REPO_ROOT)
   except FileNotFoundError:
     return [f"Tool not found: {tool}"]
   except subprocess.CalledProcessError:


### PR DESCRIPTION
With the advent of server extensions, more and more things will end up
being "top level packages" from the perspective of trace processor and
increases the scope of clashes. If we expand the scope ourselves it
will make namespacing for server extension maintainers very difficult.

Looking back, anything which is really core to TP should have been
in the "std" toplevel package but that ship has long sailed and doing
any sort of migration would be super painful. So instead just freeze
things where they are today and say that any *future* ones should be in
std.

Note that this doesn't mean *no* top-level packages will ever be added:
for example, if "android" was proposed as a top level package today,
I'd still allow it as in some sense that package is "closer to Android"
than it is core to Perfetto. But things like "intervals", "graphs",
"counters", "slices" etc: these are the things which *should* have been
put in the std top-level package.
