### PR TITLE
ep: Fix the freeform SQL not usable bug

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -60,9 +60,46 @@
 // STATE MANAGEMENT
 // ---------------
 // - this.query: Current validated query (from analysis phase)
+//   * Single source of truth for query state
+//   * Updated by both automatic analysis (NodeExplorer) and manual execution (Builder)
+//   * Passed to NodeExplorer as a prop for rendering SQL/Proto tabs
 // - this.queryExecuted: Flag to prevent duplicate execution
 // - this.response: Query results from execution
 // - this.dataSource: Wrapped data source for DataGrid display
+//
+// QUERY STATE FLOW
+// ----------------
+// Automatic execution (autoExecute=true):
+//   1. NodeExplorer.updateQuery() → processNode({ manual: false })
+//   2. onAnalysisComplete → sets NodeExplorer.currentQuery
+//   3. onAnalysisComplete → calls onQueryAnalyzed callback → sets Builder.query
+//   4. Builder passes query as prop to NodeExplorer
+//   5. NodeExplorer.renderContent() uses attrs.query ?? this.currentQuery
+//
+// Manual execution (autoExecute=false):
+//   1. User clicks "Run Query" button → Builder calls processNode({ manual: true })
+//   2. onAnalysisComplete → sets Builder.query
+//   3. onAnalysisComplete → calls onNodeQueryAnalyzed callback → sets Builder.query
+//   4. Builder passes query as prop to NodeExplorer
+//   5. NodeExplorer.renderContent() uses attrs.query (this.currentQuery may be undefined)
+//
+// This ensures SQL/Proto tabs display correctly for both automatic and manual execution.
+//
+// RACE CONDITION PREVENTION
+// -------------------------
+// The onNodeQueryAnalyzed callback captures the selected node at creation time to prevent
+// stale query leakage when rapidly switching between nodes:
+//
+// Without validation:
+//   1. User selects Node A → async analysis starts → captures callback
+//   2. User quickly switches to Node B → Node A destroyed, new callback created
+//   3. Node A's analysis completes in background → old callback fires
+//   4. Old callback sets this.query = queryForNodeA
+//   5. Node B incorrectly displays Node A's query
+//
+// With validation (callbackNode === this.previousSelectedNode):
+//   - Old callbacks from destroyed nodes are ignored
+//   - Only queries from the currently selected node update the display
 
 import m from 'mithril';
 import {classNames} from '../../../base/classnames';
@@ -196,6 +233,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
   private readonly MAX_SIDEBAR_WIDTH = 800;
   private readonly DEFAULT_SIDEBAR_WIDTH = 500;
   private hasEverSelectedNode = false;
+  private onNodeQueryAnalyzed?: (query: Query | Error | undefined) => void;
 
   constructor({attrs}: m.Vnode<BuilderAttrs>) {
     this.trace = attrs.trace;
@@ -258,6 +296,17 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         isExplorerCollapsed && 'explorer-collapsed',
       ) || '';
 
+    // Create the onQueryAnalyzed callback and save it so manual execution can also use it
+    // Capture the current selected node to prevent race conditions when switching nodes rapidly
+    const callbackNode = selectedNode;
+    this.onNodeQueryAnalyzed = (query: Query | Error | undefined) => {
+      // Only update query if we're still on the same node
+      // This prevents stale queries from Node A being applied when we've switched to Node B
+      if (callbackNode === this.previousSelectedNode) {
+        this.query = query;
+      }
+    };
+
     const explorer = selectedNode
       ? m(NodeExplorer, {
           // The key to force mithril to re-create the component when the
@@ -269,9 +318,8 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
           queryExecutionService: this.queryExecutionService,
           resolveNode: (nodeId: string) => this.resolveNode(nodeId, rootNodes),
           hasExistingResult: this.queryExecuted,
-          onQueryAnalyzed: (query: Query | Error | undefined) => {
-            this.query = query;
-          },
+          query: this.query, // Pass the query state from Builder (single source of truth)
+          onQueryAnalyzed: this.onNodeQueryAnalyzed,
           onAnalysisStateChange: (isAnalyzing: boolean) => {
             this.isAnalyzing = isAnalyzing;
           },
@@ -605,7 +653,8 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         m.redraw();
       },
       onAnalysisComplete: (query: Query | Error | undefined) => {
-        this.query = query;
+        // Update query state via callback (with validation to prevent stale query leakage)
+        this.onNodeQueryAnalyzed?.(query);
         this.isAnalyzing = false;
         m.redraw();
       },

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -53,6 +53,8 @@ export interface NodeExplorerAttrs {
   readonly onViewChange?: (view: number) => void;
   /** Whether there's already a result displayed (for reuse optimization) */
   readonly hasExistingResult?: boolean;
+  /** The current query state from Builder (single source of truth) */
+  readonly query?: Query | Error;
 }
 
 enum SelectedView {
@@ -266,16 +268,20 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
     return 'info' in obj;
   }
 
-  private renderContent(node: QueryNode, selectedView: number): m.Child {
+  private renderContent(
+    node: QueryNode,
+    selectedView: number,
+    attrs: NodeExplorerAttrs,
+  ): m.Child {
+    // Use query from attrs (single source of truth from Builder)
+    const query = attrs.query ?? this.currentQuery;
     const sql: string =
       this.sqlForDisplay ??
-      (isAQuery(this.currentQuery)
-        ? queryToRun(this.currentQuery)
-        : 'SQL not available.');
-    const textproto: string = isAQuery(this.currentQuery)
-      ? this.currentQuery.textproto
-      : this.currentQuery instanceof Error
-        ? this.currentQuery.message
+      (isAQuery(query) ? queryToRun(query) : 'SQL not available.');
+    const textproto: string = isAQuery(query)
+      ? query.textproto
+      : query instanceof Error
+        ? query.message
         : 'Proto not available.';
 
     return m(
@@ -301,13 +307,13 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
             },
           }),
           this.resultTabMode === 'sql'
-            ? isAQuery(this.currentQuery)
+            ? isAQuery(query)
               ? m(CodeSnippet, {language: 'SQL', text: sql})
               : m(DataExplorerEmptyState, {
                   icon: 'info',
                   title: 'SQL not available',
                 })
-            : isAQuery(this.currentQuery)
+            : isAQuery(query)
               ? m(CodeSnippet, {text: textproto, language: 'textproto'})
               : m(DataExplorerEmptyState, {
                   icon: 'info',
@@ -342,7 +348,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
         node instanceof SqlSourceNode ? '.pf-exp-node-explorer-sql-source' : ''
       }`,
       m('.pf-exp-node-explorer__header', this.renderTitleRow(node)),
-      this.renderContent(node, selectedView),
+      this.renderContent(node, selectedView, attrs),
     );
   }
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node.ts
@@ -418,7 +418,11 @@ export class JoinNode implements QueryNode {
               sql: this.state.sqlExpression,
               onUpdate: (text: string) => {
                 this.state.sqlExpression = text;
-                this.state.onchange?.();
+                m.redraw();
+              },
+              onExecute: (text: string) => {
+                this.state.sqlExpression = text.trim();
+                m.redraw();
               },
             }),
     });


### PR DESCRIPTION
Fixes a bug where freeform SQL nodes were not usable in the Explore Page. The issue occurred because query state was not properly propagated from the Builder to the NodeExplorer, causing SQL/Proto tabs to display "SQL not available" for manually-executed queries. Additionally, rapid node switching could cause stale queries from old nodes to leak into newly selected nodes.

  ## Changes

  - **Query State Management**: Established Builder.query as the single source of truth, passed down to NodeExplorer as a prop
  - **Race Condition Prevention**: Added node capture in callback to prevent stale queries when rapidly switching between nodes
  - **Flow Documentation**: Added comprehensive inline documentation explaining query state flow for both automatic (autoExecute=true) and manual (autoExecute=false) execution paths
  - **JoinNode Fix**: Changed onUpdate callback to use m.redraw() directly instead of onchange, added onExecute callback for proper SQL expression handling

  ## Notes

The fix ensures that both automatically-executed nodes and manually-executed (freeform SQL) nodes correctly display their queries in the SQL/Proto tabs by maintaining a consistent query state flow through the component hierarchy.
