### PR TITLE
de: Set modals to be valign top by default

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -534,6 +534,7 @@ export class AddColumnsNode implements QueryNode {
         ? 'Configure Joined Columns'
         : 'Add Columns from Another Source',
       key: modalKey,
+      vAlign: 'TOP',
       className: 'pf-join-modal-wide',
       content: () => {
         return m('div', this.renderGuidedMode());
@@ -642,6 +643,7 @@ export class AddColumnsNode implements QueryNode {
     showModal({
       title: typeConfig.title,
       key: typeConfig.key,
+      vAlign: 'TOP',
       className:
         type === 'switch' || type === 'if'
           ? 'pf-computed-column-modal-wide'
@@ -753,6 +755,7 @@ export class AddColumnsNode implements QueryNode {
     showModal({
       title: 'Add Column from Args',
       key: modalKey,
+      vAlign: 'TOP',
       content: () => {
         const nameError = getColumnNameError();
         const hasMultipleArgSetIdCols = argSetIdCols.length > 1;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
@@ -381,6 +381,7 @@ export class FilterNode implements QueryNode {
     showModal({
       title: 'SQL Filter Expression',
       key: 'sql-expression-modal',
+      vAlign: 'TOP',
       content: () =>
         m(
           '.pf-filter-sql-editor',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -68,6 +68,7 @@ export function modalForTableSelection(
     const updateModal = () => {
       showModal({
         key: 'table-selection-modal',
+        vAlign: 'TOP',
         title:
           selectedTables.size > 0
             ? `Choose tables - ${selectedTables.size} selected`


### PR DESCRIPTION
Set vertical alignment of Data Explorer modals to top positioning. Previously, modals were centered vertically which could push content off screen when modals contained large amounts of data or when the contents of the modal drastically changed. 