### PR TITLE
ui: SplitPanel improvements

### DIFF
--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/split_panel_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/split_panel_demo.ts
@@ -42,9 +42,8 @@ export function renderSplitPanel(): m.Children {
           m(SplitPanel, {
             key: `${opts.vertical}-${opts.pixels}-${opts.controlledPanel}`,
             direction: opts.vertical ? 'vertical' : 'horizontal',
-            split: opts.pixels
-              ? {pixels: splitValue, panel: opts.controlledPanel}
-              : {percent: splitValue, panel: opts.controlledPanel},
+            split: opts.pixels ? {pixels: splitValue} : {percent: splitValue},
+            controlledPanel: opts.controlledPanel,
             minSize: 50,
             onResize: (size) => {
               splitValue = size;


### PR DESCRIPTION
Improve the SplitPanel component:
- Limit max size of split panels to 100% of the container - avoid ever getting into a situation where the resize handle disappears off the edge of the screen.
- Allow the split size to be controlled in both percent and pixel modes.
- Add initialSplit to define the initial split behavior in uncontrolled mode.
- Allow the first OR second panel to be controlled.
- Improve the demo on the widgets page.