### PR TITLE
de: Defer trace data checks to first explore page rendering

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
@@ -130,6 +130,9 @@ export default class implements PerfettoPlugin {
     trace.pages.registerPage({
       route: '/explore',
       render: () => {
+        // Ensure SQL modules initialization is triggered (no-op if already started)
+        trace.plugins.getPlugin(SqlModulesPlugin).ensureInitialized();
+
         // Try to load saved state lazily (waits for SQL modules to be ready)
         this.tryLoadState(trace);
 

--- a/ui/src/plugins/dev.perfetto.SqlModules/index.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/index.ts
@@ -42,10 +42,9 @@ export default class implements PerfettoPlugin {
   async onTraceLoad(trace: Trace): Promise<void> {
     docs.then(async (resolvedDocs) => {
       const impl = new SqlModulesImpl(trace, resolvedDocs);
-      impl.waitForInit().then(() => {
-        this.sqlModules = impl;
-        m.redraw();
-      });
+      // Don't initialize immediately - let consumers trigger it when needed
+      this.sqlModules = impl;
+      m.redraw();
     });
 
     trace.commands.registerCommand({
@@ -105,6 +104,13 @@ export default class implements PerfettoPlugin {
 
   getSqlModules(): SqlModules | undefined {
     return this.sqlModules;
+  }
+
+  ensureInitialized(): Promise<void> {
+    if (this.sqlModules) {
+      return this.sqlModules.ensureInitialized();
+    }
+    return Promise.resolve();
   }
 }
 

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
@@ -41,6 +41,11 @@ export interface SqlModules {
 
   // Returns the set of all disabled module names.
   getDisabledModules(): ReadonlySet<string>;
+
+  // Triggers the data availability checks if not already started.
+  // Safe to call multiple times - subsequent calls are no-ops.
+  // Returns a promise that resolves when initialization is complete.
+  ensureInitialized(): Promise<void>;
 }
 
 // Handles the access to a specific Perfetto SQL Package. Package consists of


### PR DESCRIPTION
Defers the expensive data availability checks in SqlModulesPlugin until the Explore page is first rendered, rather than running them immediately on trace load. This improves initial trace load performance by avoiding unnecessary work when users don't visit the Explore page.