### PR TITLE
fix absiel-cpp compiler errors with latest Apple Clang

### DIFF
--- a/buildtools/BUILD.gn
+++ b/buildtools/BUILD.gn
@@ -140,6 +140,7 @@ config("abseil_config") {
       "-Wno-deprecated-builtins",
       "-Wno-deprecated-pragma",
       "-Wno-gcc-compat",
+      "-Wno-nullability-extension",
       "-Wno-unknown-warning-option",
     ]
   }


### PR DESCRIPTION
fix issues of the form:
```
../../buildtools/abseil-cpp/absl/base/internal/endian.h:250:36: error: type nullability specifier '_Nonnull' is a Clang extension [-Werror,-Wnullability-extension]
  250 | inline uint16_t Load16(const void* absl_nonnull p) {
      |                                    ^
../../buildtools/abseil-cpp/absl/base/nullability.h:241:22: note: expanded from macro 'absl_nonnull'
  241 | #define absl_nonnull _Nonnull
      |                      ^
```

this fixes builds compiled with the latest apple clang:
```
% clang --version
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin25.1.0
```
