### PR TITLE
record: fix preset selection not working correctly for atrace

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/multiselect.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/multiselect.ts
@@ -59,8 +59,19 @@ export class TypedMultiselect<T> implements ProbeSetting {
   deserialize(state: unknown): void {
     if (Array.isArray(state) && state.every((x) => typeof x === 'string')) {
       this._selectedKeys.clear();
-      for (const key of state) {
-        this.attrs.options.has(key) && this._selectedKeys.add(key);
+      for (const item of state) {
+        // First, try direct key match
+        if (this.attrs.options.has(item)) {
+          this._selectedKeys.add(item);
+          continue;
+        }
+        // Otherwise, search for a key whose value matches
+        for (const [key, value] of this.attrs.options.entries()) {
+          if (value === item) {
+            this._selectedKeys.add(key);
+            break;
+          }
+        }
       }
     }
   }

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/presets.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/presets.ts
@@ -168,7 +168,7 @@ export const ANDROID_PRESETS: Preset[] = [
           settings: {
             categories: ATRACE_DEFAULT,
             apps: '',
-            allApps: false,
+            allApps: true,
           },
         },
         logcat: {
@@ -197,7 +197,7 @@ export const ANDROID_PRESETS: Preset[] = [
           settings: {
             categories: ATRACE_BATTERY,
             apps: '',
-            allApps: false,
+            allApps: true,
           },
         },
         power_rails: {settings: {pollMs: 1000}},
@@ -223,7 +223,7 @@ export const ANDROID_PRESETS: Preset[] = [
           settings: {
             categories: ATRACE_THERMAL,
             apps: '',
-            allApps: false,
+            allApps: true,
           },
         },
         power_rails: {settings: {pollMs: 1000}},


### PR DESCRIPTION
There is some subtle bug with ser/deser which menat that we were never
selecting any atrace cats with presets.

Also to make this as easy to use as possible, change the presets to do
allApps: true. Has more cost but OTOH makes it universally usable.
