### PR TITLE
stdlib: Add low prio tag to deprecated stdlib tables

### DIFF
--- a/python/generators/sql_processing/stdlib_tags.py
+++ b/python/generators/sql_processing/stdlib_tags.py
@@ -437,11 +437,12 @@ TABLE_IMPORTANCE = {
     'chrome_graphics_pipeline_display_frame_steps':
         'mid',  # Graphics pipeline post-surface aggregation
 
-    # LOW IMPORTANCE - Raw/specialized tables, less frequently needed
-    'slices':
-        'low',  # Raw slice table, prefer thread_or_process_slice for most use cases
-    'sched_slice':
-        'low',  # Raw scheduling slice table, prefer thread_state for most use cases
+    # LOW IMPORTANCE - Deprecated table names, kept for backward compatibility
+    'slices': 'low',  # Raw slice table, prefer thread_or_process_slice
+    'sched_slice': 'low',  # Raw scheduling slice table, prefer thread_state
+    'counters': 'low',  # Raw counter table, prefer counter table
+    'raw': 'low',
+    'gpu_track': 'low',
 }
 
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
@@ -59,7 +59,7 @@ function getImportanceLabel(importance: 'high' | 'mid' | 'low'): string {
     case 'mid':
       return 'Common';
     case 'low':
-      return 'Discouraged';
+      return 'Deprecated';
   }
 }
 


### PR DESCRIPTION
- Change `Discouraged` label to `Deprecated` in table list modal
-  Mark `sched_slice`, `counters`, `raw` and `gpu_track` tables as deprecated