### PR TITLE
de: Don't delete the node when editing the label

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/text_label.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/text_label.ts
@@ -50,6 +50,14 @@ export function createEditableTextLabels(
           e.stopPropagation();
         }
       },
+      onkeydown: (e: KeyboardEvent) => {
+        const target = e.target as HTMLTextAreaElement;
+        // If editing (not readonly), stop propagation to prevent
+        // Delete/Backspace from triggering label deletion
+        if (!target.readOnly) {
+          e.stopPropagation();
+        }
+      },
       ondblclick: (e: Event) => {
         const target = e.target as HTMLTextAreaElement;
         editingLabels.add(label.id);


### PR DESCRIPTION
As interacting with the label doesn't change the selected node, clicking `Delete` deletes it. Disable deletion on the hotkey, when in the label TextInput