### PR TITLE
traced_relay: guard remote clock sync behind disable flag

### DIFF
--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -2751,8 +2751,11 @@ std::vector<TracePacket> TracingServiceImpl::ReadBuffers(
 
   // In a multi-machine tracing session, emit clock synchronization messages for
   // remote machines.
-  if (!relay_clients_.empty())
+  if (!tracing_session->config.builtin_data_sources()
+           .disable_clock_snapshotting() &&
+      !relay_clients_.empty()) {
     MaybeEmitRemoteClockSync(tracing_session, &packets);
+  }
 
   size_t packets_bytes = 0;  // SUM(slice.size() for each slice in |packets|).
 


### PR DESCRIPTION
Before:
```
-rw-rw---- 1 u0_a123 ext_data_rw 1254 2026-01-14 13:44 3360fe16-9977-ff56-3e80-867f59647901
```

After :
```
-rw-rw---- 1 u0_a124 ext_data_rw  362 2026-01-14 15:11 79f173af-3e1b-6c95-e89e-090fd94df6f5
```

thanks @KirillTim for testing