### PR TITLE
CounterToIntervals type `dur` column properly

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/counter_to_intervals_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/counter_to_intervals_node.ts
@@ -67,9 +67,9 @@ export class CounterToIntervalsNode implements QueryNode {
     // dur: the duration until the next counter value
     cols.push({
       name: 'dur',
-      type: 'INT',
+      type: 'DURATION',
       checked: true,
-      column: {name: 'dur', type: PerfettoSqlTypes.INT},
+      column: {name: 'dur', type: PerfettoSqlTypes.DURATION},
     });
 
     // next_value: the value of the next counter

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/counter_to_intervals_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/counter_to_intervals_node_unittest.ts
@@ -136,7 +136,7 @@ describe('CounterToIntervalsNode', () => {
       const nextValueCol = finalCols.find((c) => c.name === 'next_value');
       const deltaValueCol = finalCols.find((c) => c.name === 'delta_value');
 
-      expect(durCol?.type).toBe('INT');
+      expect(durCol?.type).toBe('DURATION');
       expect(nextValueCol?.type).toBe('DOUBLE');
       expect(deltaValueCol?.type).toBe('DOUBLE');
     });


### PR DESCRIPTION
We were treating it as PerfettoSqlType.INT, which took the pretty formatting in datagrid from us