### PR TITLE
tp: Report border settings in Winscope rect table.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_rect_computation.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_rect_computation.cc
@@ -367,6 +367,15 @@ TraceRectTableId RectComputation::InsertLayerTraceRectRow(
     row.opacity = opacity;
   }
 
+  if (layer_decoder.has_border_settings()) {
+    protos::pbzero::BorderSettings::Decoder border_settings(
+        layer_decoder.border_settings());
+    if (border_settings.stroke_width() > 0) {
+      row.border_width = border_settings.stroke_width();
+      row.border_color = border_settings.color();
+    }
+  }
+
   row.transform_id = transform_tracker_.GetOrInsertRow(matrix);
   row.is_spy = false;
   return rect_tracker_.context_->storage->mutable_winscope_trace_rect_table()

--- a/src/trace_processor/perfetto_sql/stdlib/android/winscope/rect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/winscope/rect.sql
@@ -74,7 +74,11 @@ CREATE PERFETTO VIEW android_winscope_trace_rect (
   -- Opacity
   opacity DOUBLE,
   -- Transform id
-  transform_id LONG
+  transform_id LONG,
+  -- Border width
+  border_width LONG,
+  -- Border color
+  border_color DOUBLE
 ) AS
 SELECT
   *

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -83,6 +83,8 @@ WINSCOPE_TRACE_RECT_TABLE = Table(
         C('is_visible', CppInt64()),
         C('opacity', CppOptional(CppDouble())),
         C('transform_id', CppTableId(WINSCOPE_TRANSFORM_TABLE)),
+        C('border_width', CppOptional(CppDouble())),
+        C('border_color', CppOptional(CppUint32())),
     ],
     tabledoc=TableDoc(
         doc='WinscopeTraceRect',
@@ -104,6 +106,10 @@ WINSCOPE_TRACE_RECT_TABLE = Table(
                 'Opacity',
             'transform_id':
                 'Used to match trace rect to transform in __intrinsic_winscope_transform',
+            'border_width':
+                'Border width',
+            'border_color':
+                'Border color',
         }))
 
 INPUTMETHOD_CLIENTS_TABLE = Table(

--- a/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
+++ b/test/trace_processor/diff_tests/parser/android/surfaceflinger_layers.textproto
@@ -307,6 +307,7 @@ packet {
         }
         corner_radius: 1
         hwc_composition_type: 2
+        border_settings { stroke_width: 0.45 color: -65536 }
       }
       layers {
         id: 2
@@ -324,6 +325,7 @@ packet {
           frame { left: 0 top: 0 right: 2 bottom: 2 }
           visible: false
         }
+        border_settings { stroke_width: 1.2 }
       }
       layers {
         id: 3
@@ -341,6 +343,7 @@ packet {
           frame { left: -999, top: -999, right: 999, bottom: 999 }
           visible: true
         }
+        border_settings { stroke_width: 0 color: 1234 }
       }
       layers {
         id: 4

--- a/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_surfaceflinger_layers.py
@@ -189,7 +189,17 @@ class SurfaceFlingerLayers(TestSuite):
         INCLUDE PERFETTO MODULE android.winscope.rect;
 
         SELECT
-          sfl.layer_id, wtr.group_id, wtr.depth, wtr.is_visible, wtr.opacity, rect.x, rect.y, rect.w, rect.h
+          sfl.layer_id,
+          wtr.group_id,
+          wtr.depth,
+          wtr.is_visible,
+          wtr.opacity,
+          wtr.border_width,
+          wtr.border_color,
+          rect.x,
+          rect.y,
+          rect.w,
+          rect.h
         FROM surfaceflinger_layer AS sfl
         INNER JOIN android_winscope_trace_rect AS wtr
           ON sfl.layer_rect_id = wtr.id
@@ -198,15 +208,15 @@ class SurfaceFlingerLayers(TestSuite):
           ON rect.id = wtr.rect_id
         """,
         out=Csv("""
-        "layer_id","group_id","depth","is_visible","opacity","x","y","w","h"
-        1,0,1,0,"[NULL]",0.000000,0.000000,1.000000,1.000000
-        2,0,2,1,1.000000,0.000000,0.000000,2.000000,2.000000
-        3,0,3,1,0.500000,0.000000,0.000000,2.000000,2.000000
-        4,1,1,1,1.000000,0.000000,0.000000,1.000000,1.000000
-        5,0,4,1,1.000000,0.000000,0.000000,1.000000,1.000000
-        6,0,5,1,1.000000,2.000000,2.000000,1.000000,1.000000
-        7,0,6,1,1.000000,2.000000,2.000000,1.000000,1.000000
-        9,2,1,1,1.000000,-50.000000,-100.000000,100.000000,200.000000
+        "layer_id","group_id","depth","is_visible","opacity","border_width","border_color","x","y","w","h"
+        1,0,1,0,"[NULL]",0.450000,4294901760,0.000000,0.000000,1.000000,1.000000
+        2,0,2,1,1.000000,1.200000,0,0.000000,0.000000,2.000000,2.000000
+        3,0,3,1,0.500000,"[NULL]","[NULL]",0.000000,0.000000,2.000000,2.000000
+        4,1,1,1,1.000000,"[NULL]","[NULL]",0.000000,0.000000,1.000000,1.000000
+        5,0,4,1,1.000000,"[NULL]","[NULL]",0.000000,0.000000,1.000000,1.000000
+        6,0,5,1,1.000000,"[NULL]","[NULL]",2.000000,2.000000,1.000000,1.000000
+        7,0,6,1,1.000000,"[NULL]","[NULL]",2.000000,2.000000,1.000000,1.000000
+        9,2,1,1,1.000000,"[NULL]","[NULL]",-50.000000,-100.000000,100.000000,200.000000
         """))
 
   def test_display_rects(self):


### PR DESCRIPTION
Bug: 417759869
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="WindowManager|SurfaceFlinger|PerfettoTable:winscope" Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=Sf*
