### PR TITLE
tp: disallow inlining of PrepareCursorInternal

### DIFF
--- a/src/trace_processor/dataframe/typed_cursor.h
+++ b/src/trace_processor/dataframe/typed_cursor.h
@@ -183,7 +183,7 @@ class TypedCursor {
     }
   }
 
-  void PrepareCursorInternal();
+  PERFETTO_NO_INLINE void PrepareCursorInternal();
 
   uint32_t GetMutations() const {
     uint32_t mutations = dataframe_->non_column_mutations_;


### PR DESCRIPTION
We *really* don't want this to be inlined, would bloat the size of all
of trace processor if it was.
