### PR TITLE
pbzero: add support for specifiying fields which should be in v2

### DIFF
--- a/src/protozero/filtering/filter_bytecode_generator.cc
+++ b/src/protozero/filtering/filter_bytecode_generator.cc
@@ -60,7 +60,8 @@ void FilterBytecodeGenerator::AddFilterStringField(uint32_t field_id) {
 // Allows a string field with a semantic type.
 void FilterBytecodeGenerator::AddFilterStringFieldWithType(
     uint32_t field_id,
-    uint32_t semantic_type) {
+    uint32_t semantic_type,
+    bool add_to_v2) {
   // String filtering is only available if bytecode v2+ is targeted.
   PERFETTO_CHECK(min_version_ >= BytecodeVersion::kV2);
   PERFETTO_CHECK(field_id > last_field_id_);
@@ -70,8 +71,10 @@ void FilterBytecodeGenerator::AddFilterStringFieldWithType(
     bytecode_.push_back(field_id << 3 | kFilterOpcode_FilterStringWithType);
     bytecode_.push_back(semantic_type);
   } else {
-    // On bytecode v2, the field will just be totally denied. Just don't add
-    // anything.
+    // Add the v2 opcode if requested.
+    if (add_to_v2) {
+      bytecode_.push_back(field_id << 3 | kFilterOpcode_FilterString);
+    }
 
     // On v54 it will allowed.
     v54_overlay_.push_back(num_messages_);

--- a/src/protozero/filtering/filter_bytecode_generator.h
+++ b/src/protozero/filtering/filter_bytecode_generator.h
@@ -78,7 +78,13 @@ class FilterBytecodeGenerator {
   // Allows a string field which needs to be filtered with a specific semantic
   // type. The semantic type tells the filter what kind of data the field
   // contains, so it can apply type-specific rules.
-  void AddFilterStringFieldWithType(uint32_t field_id, uint32_t semantic_type);
+  //
+  // `add_to_v2` indicates whether this field should also be added to the v2
+  // bytecode. Note that semantic types are not supported in v2, so all string
+  // filtering rules will be applied without knowledge of the semantic type.
+  void AddFilterStringFieldWithType(uint32_t field_id,
+                                    uint32_t semantic_type,
+                                    bool add_to_v2);
 
   // Allows a range of simple fields. |range_start| is the id of the first field
   // in range, |range_len| the number of fields in the range.

--- a/src/protozero/filtering/filter_util.cc
+++ b/src/protozero/filtering/filter_util.cc
@@ -95,7 +95,7 @@ bool FilterUtil::LoadMessageDefinition(
     const std::string& proto_dir_path,
     const std::set<std::string>& passthrough_fields,
     const std::set<std::string>& string_filter_fields,
-    const std::map<std::string, uint32_t>& filter_string_semantic_types) {
+    const std::map<std::string, SemanticType>& filter_string_semantic_types) {
   passthrough_fields_ = passthrough_fields;
   passthrough_fields_seen_.clear();
   filter_string_fields_ = string_filter_fields;
@@ -242,7 +242,9 @@ FilterUtil::Message* FilterUtil::ParseProtoDescriptor(
       // Check if this field has a semantic type.
       auto it = filter_string_semantic_types_.find(message_and_field);
       if (it != filter_string_semantic_types_.end()) {
-        field.semantic_type = it->second;
+        field.semantic_type = it->second.type;
+        field.filter_string_with_semantic_type_add_to_v2 =
+            it->second.should_add_to_v2;
       }
     }
     if (proto_field->message_type() && !passthrough) {
@@ -416,8 +418,9 @@ FilterBytecodeGenerator::SerializeResult FilterUtil::GenerateFilterBytecode(
       }
       if (field.filter_string) {
         if (field.semantic_type != 0) {
-          bytecode_gen.AddFilterStringFieldWithType(field_id,
-                                                    field.semantic_type);
+          bytecode_gen.AddFilterStringFieldWithType(
+              field_id, field.semantic_type,
+              field.filter_string_with_semantic_type_add_to_v2);
         } else {
           bytecode_gen.AddFilterStringField(field_id);
         }

--- a/src/protozero/filtering/filter_util.h
+++ b/src/protozero/filtering/filter_util.h
@@ -40,6 +40,15 @@ namespace protozero {
 // a cmdline interface.
 class FilterUtil {
  public:
+  // Semantic type info for string fields that need filtering.
+  struct SemanticType {
+    // The semantic type value for this field.
+    uint32_t type = 0;
+
+    // Whether this field should be added to v2 bytecode as well.
+    bool should_add_to_v2 = false;
+  };
+
   FilterUtil();
   ~FilterUtil();
 
@@ -57,15 +66,15 @@ class FilterUtil {
   //     Syntax: same as passthrough
   // filter_string_semantic_types: an optional map from field name to semantic
   //     type value. Fields in this map must also be in filter_string_fields.
-  //     Syntax: key is "perfetto.protos.MessageName:field_name",
-  //             value is the semantic type (uint32_t from SemanticType enum).
+  //     Syntax: key is "perfetto.protos.MessageName:field_name".
   bool LoadMessageDefinition(
       const std::string& proto_file,
       const std::string& root_message,
       const std::string& proto_dir_path,
       const std::set<std::string>& passthrough_fields = {},
       const std::set<std::string>& filter_string_fields = {},
-      const std::map<std::string, uint32_t>& filter_string_semantic_types = {});
+      const std::map<std::string, SemanticType>& filter_string_semantic_types =
+          {});
 
   // Deduplicates leaf messages having the same sets of field ids.
   // It changes the internal state and affects the behavior of next calls to
@@ -110,6 +119,9 @@ class FilterUtil {
       // 0 = unspecified/unset. Only meaningful when filter_string == true.
       // Maps to TraceConfig.TraceFilter.SemanticType enum values.
       uint32_t semantic_type = 0;
+      // If semantic_type != 0, should this field be added to v2 bytecode as
+      // well?
+      bool filter_string_with_semantic_type_add_to_v2 = false;
       // Only when type == "message". Note that when using Dedupe() this can
       // be aliased against a different submessage which happens to have the
       // same set of field ids.
@@ -137,7 +149,7 @@ class FilterUtil {
   std::list<Message> descriptors_;
   std::set<std::string> passthrough_fields_;
   std::set<std::string> filter_string_fields_;
-  std::map<std::string, uint32_t> filter_string_semantic_types_;
+  std::map<std::string, SemanticType> filter_string_semantic_types_;
 
   // Used only for debugging aid, to print out an error message when the user
   // specifies a field to pass through but it doesn't exist.


### PR DESCRIPTION
atrace buf field for example, we need to have available in v2 as well as
v54 even thoguh it has a semantic type.
