### PR TITLE
tp: refactor semantictype enum to be extracted from traceconfig

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -33,6 +33,8 @@ cc_binary {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -128,6 +130,8 @@ cc_binary {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -316,6 +320,8 @@ cc_library_shared {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -419,6 +425,8 @@ cc_library_shared {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -534,6 +542,8 @@ cc_library_shared {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -652,6 +662,8 @@ cc_library_shared {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -802,6 +814,8 @@ cc_library {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -895,6 +909,8 @@ cc_library {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -989,6 +1005,8 @@ cc_library_static {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -1083,6 +1101,8 @@ cc_library_static {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -1141,6 +1161,8 @@ cc_library_static {
     ],
     export_generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -1314,6 +1336,8 @@ cc_binary {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -1400,6 +1424,8 @@ cc_binary {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -1490,6 +1516,7 @@ filegroup {
         "protos/perfetto/common/observable_events.proto",
         "protos/perfetto/common/perf_events.proto",
         "protos/perfetto/common/protolog_common.proto",
+        "protos/perfetto/common/semantic_type.proto",
         "protos/perfetto/common/sys_stats_counters.proto",
         "protos/perfetto/common/system_info.proto",
         "protos/perfetto/common/trace_stats.proto",
@@ -1562,6 +1589,7 @@ java_library {
         "protos/perfetto/common/observable_events.proto",
         "protos/perfetto/common/perf_events.proto",
         "protos/perfetto/common/protolog_common.proto",
+        "protos/perfetto/common/semantic_type.proto",
         "protos/perfetto/common/sys_stats_counters.proto",
         "protos/perfetto/common/system_info.proto",
         "protos/perfetto/common/trace_stats.proto",
@@ -1645,6 +1673,8 @@ cc_library_static {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -1796,6 +1826,8 @@ cc_library_static {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -1875,6 +1907,8 @@ cc_library_static {
     ],
     export_generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -1986,6 +2020,8 @@ cc_library_static {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -2126,6 +2162,8 @@ cc_library_static {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -2205,6 +2243,8 @@ cc_library_static {
     ],
     export_generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -2546,6 +2586,9 @@ cc_test {
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
         ":perfetto_protos_perfetto_common_lite_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_lite_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_lite_gen",
@@ -2878,6 +2921,9 @@ cc_test {
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
         "perfetto_protos_perfetto_common_lite_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_lite_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_lite_gen_headers",
@@ -3092,6 +3138,7 @@ filegroup {
         "protos/perfetto/common/observable_events.proto",
         "protos/perfetto/common/perf_events.proto",
         "protos/perfetto/common/protolog_common.proto",
+        "protos/perfetto/common/semantic_type.proto",
         "protos/perfetto/common/sys_stats_counters.proto",
         "protos/perfetto/common/system_info.proto",
         "protos/perfetto/common/trace_stats.proto",
@@ -3635,6 +3682,136 @@ genrule {
     ],
 }
 
+// GN: //protos/perfetto/common:semantic_type_cpp
+filegroup {
+    name: "perfetto_protos_perfetto_common_semantic_type_cpp",
+    srcs: [
+        "protos/perfetto/common/semantic_type.proto",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_cpp
+genrule {
+    name: "perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+    srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
+    ],
+    tools: [
+        "aprotoc",
+        "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_cpp)",
+    out: [
+        "external/perfetto/protos/perfetto/common/semantic_type.gen.cc",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_cpp
+genrule {
+    name: "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+    srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
+    ],
+    tools: [
+        "aprotoc",
+        "perfetto_src_protozero_protoc_plugin_cppgen_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location perfetto_src_protozero_protoc_plugin_cppgen_plugin) --plugin_out=wrapper_namespace=gen:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_cpp)",
+    out: [
+        "external/perfetto/protos/perfetto/common/semantic_type.gen.h",
+    ],
+    export_include_dirs: [
+        ".",
+        "protos",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_lite
+filegroup {
+    name: "perfetto_protos_perfetto_common_semantic_type_lite",
+    srcs: [
+        "protos/perfetto/common/semantic_type.proto",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_lite
+genrule {
+    name: "perfetto_protos_perfetto_common_semantic_type_lite_gen",
+    srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
+    ],
+    tools: [
+        "aprotoc",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_lite)",
+    out: [
+        "external/perfetto/protos/perfetto/common/semantic_type.pb.cc",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_lite
+genrule {
+    name: "perfetto_protos_perfetto_common_semantic_type_lite_gen_headers",
+    srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
+    ],
+    tools: [
+        "aprotoc",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --cpp_out=lite=true:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_lite)",
+    out: [
+        "external/perfetto/protos/perfetto/common/semantic_type.pb.h",
+    ],
+    export_include_dirs: [
+        ".",
+        "protos",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_zero
+filegroup {
+    name: "perfetto_protos_perfetto_common_semantic_type_zero",
+    srcs: [
+        "protos/perfetto/common/semantic_type.proto",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_zero
+genrule {
+    name: "perfetto_protos_perfetto_common_semantic_type_zero_gen",
+    srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_zero)",
+    out: [
+        "external/perfetto/protos/perfetto/common/semantic_type.pbzero.cc",
+    ],
+}
+
+// GN: //protos/perfetto/common:semantic_type_zero
+genrule {
+    name: "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
+    srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
+    ],
+    tools: [
+        "aprotoc",
+        "protozero_plugin",
+    ],
+    cmd: "mkdir -p $(genDir)/external/perfetto/ && $(location aprotoc) --proto_path=external/perfetto --plugin=protoc-gen-plugin=$(location protozero_plugin) --plugin_out=wrapper_namespace=pbzero:$(genDir)/external/perfetto/ $(locations :perfetto_protos_perfetto_common_semantic_type_zero)",
+    out: [
+        "external/perfetto/protos/perfetto/common/semantic_type.pbzero.h",
+    ],
+    export_include_dirs: [
+        ".",
+        "protos",
+    ],
+}
+
 // GN: //protos/perfetto/common:zero
 filegroup {
     name: "perfetto_protos_perfetto_common_zero",
@@ -4042,6 +4219,7 @@ genrule {
     name: "perfetto_protos_perfetto_config_cpp_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -4082,6 +4260,7 @@ genrule {
     name: "perfetto_protos_perfetto_config_cpp_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -4137,6 +4316,7 @@ genrule {
         "protos/perfetto/common/observable_events.proto",
         "protos/perfetto/common/perf_events.proto",
         "protos/perfetto/common/protolog_common.proto",
+        "protos/perfetto/common/semantic_type.proto",
         "protos/perfetto/common/sys_stats_counters.proto",
         "protos/perfetto/common/system_info.proto",
         "protos/perfetto/common/trace_stats.proto",
@@ -4776,6 +4956,7 @@ genrule {
     name: "perfetto_protos_perfetto_config_lite_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_lite",
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_config_ftrace_lite",
         ":perfetto_protos_perfetto_config_gpu_lite",
@@ -4815,6 +4996,7 @@ genrule {
     name: "perfetto_protos_perfetto_config_lite_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_lite",
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_config_ftrace_lite",
         ":perfetto_protos_perfetto_config_gpu_lite",
@@ -5954,6 +6136,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_config_zero_gen",
     srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_config_ftrace_zero",
@@ -5994,6 +6177,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_config_zero_gen_headers",
     srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_config_ftrace_zero",
@@ -6049,6 +6233,7 @@ genrule {
     name: "perfetto_protos_perfetto_ipc_cpp_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -6082,6 +6267,7 @@ genrule {
     name: "perfetto_protos_perfetto_ipc_cpp_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -6129,6 +6315,7 @@ genrule {
     name: "perfetto_protos_perfetto_ipc_ipc_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -6164,6 +6351,7 @@ genrule {
     name: "perfetto_protos_perfetto_ipc_ipc_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -7784,6 +7972,7 @@ genrule {
         "protos/perfetto/common/observable_events.proto",
         "protos/perfetto/common/perf_events.proto",
         "protos/perfetto/common/protolog_common.proto",
+        "protos/perfetto/common/semantic_type.proto",
         "protos/perfetto/common/sys_stats_counters.proto",
         "protos/perfetto/common/system_info.proto",
         "protos/perfetto/common/trace_stats.proto",
@@ -9689,6 +9878,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_minimal_cpp_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -9722,6 +9912,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_minimal_cpp_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -9769,6 +9960,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_minimal_lite_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_lite",
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_config_ftrace_lite",
         ":perfetto_protos_perfetto_config_gpu_lite",
@@ -9801,6 +9993,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_minimal_lite_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_lite",
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_config_ftrace_lite",
         ":perfetto_protos_perfetto_config_gpu_lite",
@@ -9846,6 +10039,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_zero_gen",
     srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_config_ftrace_zero",
@@ -9879,6 +10073,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_minimal_zero_gen_headers",
     srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_config_ftrace_zero",
@@ -9934,6 +10129,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_cpp_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -9994,6 +10190,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_cpp_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_cpp",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp",
         ":perfetto_protos_perfetto_config_android_cpp",
         ":perfetto_protos_perfetto_config_cpp",
         ":perfetto_protos_perfetto_config_ftrace_cpp",
@@ -10075,6 +10272,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_lite_gen",
     srcs: [
         ":perfetto_protos_perfetto_common_lite",
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_config_ftrace_lite",
         ":perfetto_protos_perfetto_config_gpu_lite",
@@ -10134,6 +10332,7 @@ genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_lite_gen_headers",
     srcs: [
         ":perfetto_protos_perfetto_common_lite",
+        ":perfetto_protos_perfetto_common_semantic_type_lite",
         ":perfetto_protos_perfetto_config_android_lite",
         ":perfetto_protos_perfetto_config_ftrace_lite",
         ":perfetto_protos_perfetto_config_gpu_lite",
@@ -10213,6 +10412,7 @@ filegroup {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_zero_gen",
     srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_config_ftrace_zero",
@@ -10273,6 +10473,7 @@ genrule {
 genrule {
     name: "perfetto_protos_perfetto_trace_non_minimal_zero_gen_headers",
     srcs: [
+        ":perfetto_protos_perfetto_common_semantic_type_zero",
         ":perfetto_protos_perfetto_common_zero",
         ":perfetto_protos_perfetto_config_android_zero",
         ":perfetto_protos_perfetto_config_ftrace_zero",
@@ -15757,6 +15958,7 @@ cc_library_static {
         ":perfetto_include_perfetto_trace_processor_trace_processor",
         ":perfetto_include_perfetto_trace_processor_util",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
         ":perfetto_protos_perfetto_config_ftrace_zero_gen",
@@ -15918,6 +16120,7 @@ cc_library_static {
     host_supported: true,
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_zero_gen_headers",
@@ -15981,6 +16184,7 @@ cc_library_static {
     ],
     export_generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_zero_gen_headers",
@@ -17383,6 +17587,7 @@ java_library {
         "protos/perfetto/common/observable_events.proto",
         "protos/perfetto/common/perf_events.proto",
         "protos/perfetto/common/protolog_common.proto",
+        "protos/perfetto/common/semantic_type.proto",
         "protos/perfetto/common/sys_stats_counters.proto",
         "protos/perfetto/common/system_info.proto",
         "protos/perfetto/common/trace_stats.proto",
@@ -17674,6 +17879,7 @@ cc_library_static {
     name: "perfetto_trace_protos",
     srcs: [
         ":perfetto_protos_perfetto_common_lite_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_lite_gen",
         ":perfetto_protos_perfetto_config_android_lite_gen",
         ":perfetto_protos_perfetto_config_ftrace_lite_gen",
         ":perfetto_protos_perfetto_config_gpu_lite_gen",
@@ -17717,6 +17923,7 @@ cc_library_static {
     vendor_available: true,
     generated_headers: [
         "perfetto_protos_perfetto_common_lite_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_lite_gen_headers",
         "perfetto_protos_perfetto_config_android_lite_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_lite_gen_headers",
         "perfetto_protos_perfetto_config_gpu_lite_gen_headers",
@@ -17755,6 +17962,7 @@ cc_library_static {
     ],
     export_generated_headers: [
         "perfetto_protos_perfetto_common_lite_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_lite_gen_headers",
         "perfetto_protos_perfetto_config_android_lite_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_lite_gen_headers",
         "perfetto_protos_perfetto_config_gpu_lite_gen_headers",
@@ -17853,6 +18061,9 @@ cc_test {
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
         ":perfetto_protos_perfetto_common_lite_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_lite_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_lite_gen",
@@ -18290,6 +18501,9 @@ cc_test {
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
         "perfetto_protos_perfetto_common_lite_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_lite_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_lite_gen_headers",
@@ -18502,6 +18716,8 @@ cc_library_static {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -18642,6 +18858,8 @@ cc_library_static {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -18721,6 +18939,8 @@ cc_library_static {
     ],
     export_generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -18883,6 +19103,7 @@ cc_library_static {
         ":perfetto_include_perfetto_trace_processor_trace_processor",
         ":perfetto_include_perfetto_trace_processor_util",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
         ":perfetto_protos_perfetto_config_ftrace_zero_gen",
@@ -19037,6 +19258,7 @@ cc_library_static {
     host_supported: true,
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_zero_gen_headers",
@@ -19099,6 +19321,7 @@ cc_library_static {
     ],
     export_generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_zero_gen_headers",
@@ -19251,6 +19474,7 @@ cc_binary {
         ":perfetto_include_perfetto_public_protozero",
         ":perfetto_include_perfetto_trace_processor_basic_types",
         ":perfetto_include_perfetto_trace_processor_util",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
         ":perfetto_protos_perfetto_config_ftrace_zero_gen",
@@ -19301,6 +19525,7 @@ cc_binary {
         "perfetto_flags_c_lib",
     ],
     generated_headers: [
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_zero_gen_headers",
@@ -19371,6 +19596,7 @@ cc_binary_host {
         ":perfetto_include_perfetto_trace_processor_trace_processor",
         ":perfetto_include_perfetto_trace_processor_util",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
         ":perfetto_protos_perfetto_config_ftrace_zero_gen",
@@ -19533,6 +19759,7 @@ cc_binary_host {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
         "perfetto_protos_perfetto_config_ftrace_zero_gen_headers",
@@ -19661,6 +19888,8 @@ cc_binary {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -19769,6 +19998,8 @@ cc_binary {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -19876,6 +20107,8 @@ cc_binary {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -19955,6 +20188,8 @@ cc_binary {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",
@@ -20036,6 +20271,8 @@ cc_binary {
         ":perfetto_include_perfetto_tracing_core_forward_decls",
         ":perfetto_include_perfetto_tracing_tracing",
         ":perfetto_protos_perfetto_common_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_cpp_gen",
+        ":perfetto_protos_perfetto_common_semantic_type_zero_gen",
         ":perfetto_protos_perfetto_common_zero_gen",
         ":perfetto_protos_perfetto_config_android_cpp_gen",
         ":perfetto_protos_perfetto_config_android_zero_gen",
@@ -20118,6 +20355,8 @@ cc_binary {
     ],
     generated_headers: [
         "perfetto_protos_perfetto_common_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_cpp_gen_headers",
+        "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
         "perfetto_protos_perfetto_config_android_cpp_gen_headers",
         "perfetto_protos_perfetto_config_android_zero_gen_headers",

--- a/BUILD
+++ b/BUILD
@@ -208,6 +208,8 @@ perfetto_cc_library(
     deps = [
         ":perfetto_ipc",
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_android_zero",
@@ -288,6 +290,8 @@ perfetto_cc_binary(
     ],
     deps = [
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_android_zero",
@@ -472,6 +476,7 @@ perfetto_cc_library(
     ],
     deps = [
                ":protos_perfetto_common_cpp",
+               ":protos_perfetto_common_semantic_type_zero",
                ":protos_perfetto_common_zero",
                ":protos_perfetto_config_android_zero",
                ":protos_perfetto_config_ftrace_zero",
@@ -676,6 +681,7 @@ perfetto_cc_library(
     ],
     deps = [
                ":protos_perfetto_common_cpp",
+               ":protos_perfetto_common_semantic_type_zero",
                ":protos_perfetto_common_zero",
                ":protos_perfetto_config_android_zero",
                ":protos_perfetto_config_ftrace_zero",
@@ -774,6 +780,7 @@ perfetto_cc_library(
     ],
     visibility = PERFETTO_CONFIG.public_visibility,
     deps = [
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_zero",
         ":protos_perfetto_config_ftrace_zero",
@@ -833,6 +840,8 @@ perfetto_cc_binary(
     deps = [
         ":libperfetto_client_experimental",
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_android_zero",
@@ -962,6 +971,8 @@ perfetto_cc_library(
     deps = [
         ":perfetto_ipc",
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_android_zero",
@@ -5106,6 +5117,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_protos",
+        ":protos_perfetto_common_semantic_type_protos",
         ":protos_perfetto_config_android_protos",
         ":protos_perfetto_config_ftrace_protos",
         ":protos_perfetto_config_gpu_protos",
@@ -5184,6 +5196,7 @@ perfetto_proto_library(
     visibility = PERFETTO_CONFIG.public_visibility,
     deps = [
         ":protos_perfetto_common_protos",
+        ":protos_perfetto_common_semantic_type_protos",
         ":protos_perfetto_config_android_protos",
         ":protos_perfetto_config_ftrace_protos",
         ":protos_perfetto_config_gpu_protos",
@@ -5618,6 +5631,7 @@ perfetto_dart_proto_library(
 perfetto_cc_library(
     name = "trace_zero",
     hdrs = [
+        ":protos_perfetto_common_semantic_type_zero_h",
         ":protos_perfetto_common_zero_h",
         ":protos_perfetto_config_android_zero_h",
         ":protos_perfetto_config_ftrace_zero_h",
@@ -5657,6 +5671,7 @@ perfetto_cc_library(
     ],
     visibility = PERFETTO_CONFIG.public_visibility,
     deps = [
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_zero",
         ":protos_perfetto_config_ftrace_zero",
@@ -5733,6 +5748,33 @@ perfetto_proto_library(
     ],
 )
 
+# GN target: //protos/perfetto/common:semantic_type_cpp
+perfetto_cc_protocpp_library(
+    name = "protos_perfetto_common_semantic_type_cpp",
+    deps = [
+        ":protos_perfetto_common_semantic_type_protos",
+    ],
+)
+
+# GN target: //protos/perfetto/common:semantic_type_source_set
+perfetto_proto_library(
+    name = "protos_perfetto_common_semantic_type_protos",
+    srcs = [
+        "protos/perfetto/common/semantic_type.proto",
+    ],
+    visibility = [
+        PERFETTO_CONFIG.proto_library_visibility,
+    ],
+)
+
+# GN target: //protos/perfetto/common:semantic_type_zero
+perfetto_cc_protozero_library(
+    name = "protos_perfetto_common_semantic_type_zero",
+    deps = [
+        ":protos_perfetto_common_semantic_type_protos",
+    ],
+)
+
 # GN target: //protos/perfetto/common:zero
 perfetto_cc_protozero_library(
     name = "protos_perfetto_common_zero",
@@ -5795,6 +5837,7 @@ perfetto_cc_protocpp_library(
     name = "protos_perfetto_config_cpp",
     deps = [
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_ftrace_cpp",
         ":protos_perfetto_config_gpu_cpp",
@@ -6075,6 +6118,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_protos",
+        ":protos_perfetto_common_semantic_type_protos",
         ":protos_perfetto_config_android_protos",
         ":protos_perfetto_config_ftrace_protos",
         ":protos_perfetto_config_gpu_protos",
@@ -6209,6 +6253,7 @@ perfetto_cc_protozero_library(
 perfetto_cc_protozero_library(
     name = "protos_perfetto_config_zero",
     deps = [
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_zero",
         ":protos_perfetto_config_ftrace_zero",
@@ -6232,6 +6277,7 @@ perfetto_cc_protocpp_library(
     name = "protos_perfetto_ipc_cpp",
     deps = [
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_cpp",
         ":protos_perfetto_config_ftrace_cpp",
@@ -6255,6 +6301,7 @@ perfetto_cc_ipc_library(
     name = "protos_perfetto_ipc_ipc",
     deps = [
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_cpp",
         ":protos_perfetto_config_ftrace_cpp",
@@ -6287,6 +6334,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_protos",
+        ":protos_perfetto_common_semantic_type_protos",
         ":protos_perfetto_config_android_protos",
         ":protos_perfetto_config_ftrace_protos",
         ":protos_perfetto_config_gpu_protos",
@@ -7026,6 +7074,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_protos",
+        ":protos_perfetto_common_semantic_type_protos",
         ":protos_perfetto_config_android_protos",
         ":protos_perfetto_config_ftrace_protos",
         ":protos_perfetto_config_gpu_protos",
@@ -7047,6 +7096,7 @@ perfetto_proto_library(
 perfetto_cc_protozero_library(
     name = "protos_perfetto_trace_minimal_zero",
     deps = [
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_zero",
         ":protos_perfetto_config_ftrace_zero",
@@ -7086,6 +7136,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_protos",
+        ":protos_perfetto_common_semantic_type_protos",
         ":protos_perfetto_config_android_protos",
         ":protos_perfetto_config_ftrace_protos",
         ":protos_perfetto_config_gpu_protos",
@@ -7130,6 +7181,7 @@ perfetto_proto_library(
 perfetto_cc_protozero_library(
     name = "protos_perfetto_trace_non_minimal_zero",
     deps = [
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_zero",
         ":protos_perfetto_config_ftrace_zero",
@@ -7299,6 +7351,7 @@ perfetto_proto_library(
     ],
     deps = [
         ":protos_perfetto_common_protos",
+        ":protos_perfetto_common_semantic_type_protos",
         ":protos_perfetto_config_android_protos",
         ":protos_perfetto_config_ftrace_protos",
         ":protos_perfetto_config_gpu_protos",
@@ -7712,6 +7765,8 @@ perfetto_cc_library(
     deps = [
         ":perfetto_ipc",
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_android_zero",
@@ -7811,6 +7866,8 @@ perfetto_cc_binary(
     deps = [
         ":perfetto_ipc",
         ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_semantic_type_cpp",
+        ":protos_perfetto_common_semantic_type_zero",
         ":protos_perfetto_common_zero",
         ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_android_zero",
@@ -7999,6 +8056,7 @@ perfetto_cc_library(
     ],
     deps = [
                ":protos_perfetto_common_cpp",
+               ":protos_perfetto_common_semantic_type_zero",
                ":protos_perfetto_common_zero",
                ":protos_perfetto_config_android_zero",
                ":protos_perfetto_config_ftrace_zero",
@@ -8217,6 +8275,7 @@ perfetto_cc_binary(
     ],
     deps = [
                ":protos_perfetto_common_cpp",
+               ":protos_perfetto_common_semantic_type_zero",
                ":protos_perfetto_common_zero",
                ":protos_perfetto_config_android_zero",
                ":protos_perfetto_config_ftrace_zero",

--- a/protos/perfetto/common/BUILD.gn
+++ b/protos/perfetto/common/BUILD.gn
@@ -44,3 +44,14 @@ perfetto_proto_library("@TYPE@") {
     "cpp",
   ]
 }
+
+# Semantic types for proto field filtering. This is separate from the main
+# common protos because it's used by the proto filtering system.
+perfetto_proto_library("semantic_type_@TYPE@") {
+  sources = [ "semantic_type.proto" ]
+  proto_generators = [
+    "cpp",
+    "lite",
+    "zero",
+  ]
+}

--- a/protos/perfetto/common/semantic_type.proto
+++ b/protos/perfetto/common/semantic_type.proto
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+
+package perfetto.protos;
+
+// Semantic types for string fields. This tells the filter what kind of
+// data the field contains, so it can apply the right filtering rules.
+// See /rfcs/0011-subset-string-filter-rules.md for design details.
+// Introduced in: Perfetto v54.
+enum SemanticType {
+  SEMANTIC_TYPE_UNSPECIFIED = 0;
+  SEMANTIC_TYPE_ATRACE = 1;
+  SEMANTIC_TYPE_JOB = 2;
+  SEMANTIC_TYPE_WAKELOCK = 3;
+}

--- a/protos/perfetto/config/BUILD.gn
+++ b/protos/perfetto/config/BUILD.gn
@@ -21,6 +21,7 @@ import("../../../gn/proto_library.gni")
 perfetto_proto_library("@TYPE@") {
   deps = [
     "../common:@TYPE@",
+    "../common:semantic_type_@TYPE@",
     "android:@TYPE@",
     "ftrace:@TYPE@",
     "gpu:@TYPE@",

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -353,6 +353,21 @@ enum BuiltinClock {
 
 // End of protos/perfetto/common/builtin_clock.proto
 
+// Begin of protos/perfetto/common/semantic_type.proto
+
+// Semantic types for string fields. This tells the filter what kind of
+// data the field contains, so it can apply the right filtering rules.
+// See /rfcs/0011-subset-string-filter-rules.md for design details.
+// Introduced in: Perfetto v54.
+enum SemanticType {
+  SEMANTIC_TYPE_UNSPECIFIED = 0;
+  SEMANTIC_TYPE_ATRACE = 1;
+  SEMANTIC_TYPE_JOB = 2;
+  SEMANTIC_TYPE_WAKELOCK = 3;
+}
+
+// End of protos/perfetto/common/semantic_type.proto
+
 // Begin of protos/perfetto/config/android/android_game_intervention_list_config.proto
 
 // Data source that lists game modes and game interventions of games
@@ -4895,17 +4910,6 @@ message TraceConfig {
       // If there are no partial matches, the string is left unchanged and the
       // next rule in chain is considered.
       SFP_ATRACE_REPEATED_SEARCH_REDACT_GROUPS = 5;
-    }
-
-    // Semantic types for string fields. This tells the filter what kind of
-    // data the field contains, so it can apply the right filtering rules.
-    // See /rfcs/0011-subset-string-filter-rules.md for design details.
-    // Introduced in: Perfetto v54.
-    enum SemanticType {
-      SEMANTIC_TYPE_UNSPECIFIED = 0;
-      SEMANTIC_TYPE_ATRACE = 1;
-      SEMANTIC_TYPE_JOB = 2;
-      SEMANTIC_TYPE_WAKELOCK = 3;
     }
 
     // A rule specifies how strings should be filtered.

--- a/protos/perfetto/config/trace_config.proto
+++ b/protos/perfetto/config/trace_config.proto
@@ -19,6 +19,7 @@ syntax = "proto2";
 package perfetto.protos;
 
 import "protos/perfetto/common/builtin_clock.proto";
+import "protos/perfetto/common/semantic_type.proto";
 import "protos/perfetto/config/data_source_config.proto";
 import "protos/perfetto/config/priority_boost/priority_boost_config.proto";
 
@@ -642,17 +643,6 @@ message TraceConfig {
       // If there are no partial matches, the string is left unchanged and the
       // next rule in chain is considered.
       SFP_ATRACE_REPEATED_SEARCH_REDACT_GROUPS = 5;
-    }
-
-    // Semantic types for string fields. This tells the filter what kind of
-    // data the field contains, so it can apply the right filtering rules.
-    // See /rfcs/0011-subset-string-filter-rules.md for design details.
-    // Introduced in: Perfetto v54.
-    enum SemanticType {
-      SEMANTIC_TYPE_UNSPECIFIED = 0;
-      SEMANTIC_TYPE_ATRACE = 1;
-      SEMANTIC_TYPE_JOB = 2;
-      SEMANTIC_TYPE_WAKELOCK = 3;
     }
 
     // A rule specifies how strings should be filtered.

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -353,6 +353,21 @@ enum BuiltinClock {
 
 // End of protos/perfetto/common/builtin_clock.proto
 
+// Begin of protos/perfetto/common/semantic_type.proto
+
+// Semantic types for string fields. This tells the filter what kind of
+// data the field contains, so it can apply the right filtering rules.
+// See /rfcs/0011-subset-string-filter-rules.md for design details.
+// Introduced in: Perfetto v54.
+enum SemanticType {
+  SEMANTIC_TYPE_UNSPECIFIED = 0;
+  SEMANTIC_TYPE_ATRACE = 1;
+  SEMANTIC_TYPE_JOB = 2;
+  SEMANTIC_TYPE_WAKELOCK = 3;
+}
+
+// End of protos/perfetto/common/semantic_type.proto
+
 // Begin of protos/perfetto/config/android/android_game_intervention_list_config.proto
 
 // Data source that lists game modes and game interventions of games
@@ -4895,17 +4910,6 @@ message TraceConfig {
       // If there are no partial matches, the string is left unchanged and the
       // next rule in chain is considered.
       SFP_ATRACE_REPEATED_SEARCH_REDACT_GROUPS = 5;
-    }
-
-    // Semantic types for string fields. This tells the filter what kind of
-    // data the field contains, so it can apply the right filtering rules.
-    // See /rfcs/0011-subset-string-filter-rules.md for design details.
-    // Introduced in: Perfetto v54.
-    enum SemanticType {
-      SEMANTIC_TYPE_UNSPECIFIED = 0;
-      SEMANTIC_TYPE_ATRACE = 1;
-      SEMANTIC_TYPE_JOB = 2;
-      SEMANTIC_TYPE_WAKELOCK = 3;
     }
 
     // A rule specifies how strings should be filtered.

--- a/src/protozero/filtering/BUILD.gn
+++ b/src/protozero/filtering/BUILD.gn
@@ -87,6 +87,7 @@ source_set("filter_util") {
     "..:protozero",
     "../../../gn:default_deps",
     "../../../gn:protobuf_full",
+    "../../../protos/perfetto/common:semantic_type_zero",
     "../../../protos/perfetto/config:zero",
     "../../base",
   ]

--- a/src/protozero/filtering/filter_util.cc
+++ b/src/protozero/filtering/filter_util.cc
@@ -37,7 +37,7 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/protozero/proto_utils.h"
-#include "protos/perfetto/config/trace_config.pbzero.h"
+#include "protos/perfetto/common/semantic_type.pbzero.h"
 #include "src/protozero/filtering/filter_bytecode_generator.h"
 #include "src/protozero/filtering/filter_bytecode_parser.h"
 
@@ -379,12 +379,12 @@ void FilterUtil::PrintAsText(std::optional<std::string> filter_bytecode) {
         stripped_nested += "  # PASSTHROUGH";
       if (field.filter_string)
         stripped_nested += "  # FILTER STRING";
-      using TraceFilter = perfetto::protos::pbzero::TraceConfig::TraceFilter;
       if (field.semantic_type) {
         stripped_nested +=
             std::string("  # SEMANTIC TYPE ") +
-            TraceFilter::SemanticType_Name(
-                static_cast<TraceFilter::SemanticType>(field.semantic_type));
+            perfetto::protos::pbzero::SemanticType_Name(
+                static_cast<perfetto::protos::pbzero::SemanticType>(
+                    field.semantic_type));
       }
       fprintf(print_stream_, "%-60s %3u %-8s %-32s%s\n", stripped_name.c_str(),
               field_id, field.type.c_str(), field.name.c_str(),

--- a/src/protozero/filtering/filter_util.h
+++ b/src/protozero/filtering/filter_util.h
@@ -108,7 +108,7 @@ class FilterUtil {
       bool filter_string;
       // Semantic type for string fields that need filtering.
       // 0 = unspecified/unset. Only meaningful when filter_string == true.
-      // Maps to TraceConfig.TraceFilter.SemanticType enum values.
+      // Maps to perfetto.protos.SemanticType enum values.
       uint32_t semantic_type = 0;
       // Only when type == "message". Note that when using Dedupe() this can
       // be aliased against a different submessage which happens to have the


### PR DESCRIPTION
Pure refactoring change, no behavior change at all.

Allows it to be usable in upcoming CLs.
