### PR TITLE
sdk: add missing TracingSession forward declare

### DIFF
--- a/src/tracing/service/tracing_service_endpoints_impl.h
+++ b/src/tracing/service/tracing_service_endpoints_impl.h
@@ -51,6 +51,7 @@ namespace tracing_service {
 
 class TracingServiceImpl;
 struct DataSourceInstance;
+struct TracingSession;
 struct TriggerInfo;
 
 // The implementation behind the service endpoint exposed to each producer.


### PR DESCRIPTION
Needed for `friend struct TracingSession` in ConsumerEndpointImpl.

Causing problems when compiling amalgamated C ABI sources for Android on Windows.
doesn't seem to be causing any issues.

