### PR TITLE
ui: AndroidStartup plugin URL deep linking

### DIFF
--- a/ui/src/plugins/com.android.AndroidStartup/index.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/index.ts
@@ -175,7 +175,6 @@ export default class AndroidStartup implements PerfettoPlugin {
       whereClause =
         'WHERE ' + whereFilters.join(' AND ') + ' AND t.is_main_thread = 1';
     } else if (args.autoSelect) {
-      // Default to the last startup
       whereClause = 'WHERE t.is_main_thread = 1';
     } else {
       return;


### PR DESCRIPTION
This change enhances the AndroidStartup plugin to select a startup and navigate to it's main thread track.

- Parses `app.initialRouteArgs` in `onActivate` to capture the following URL params:
  	- `com.android.AndroidStartup` (flag)
  	- `com.android.AndroidStartup.packageName`
  	- `com.android.AndroidStartup.startupId`

- If specific filters (packageName, startupId) are provided, the last startup matching these filters is selected.
- If only `com.android.AndroidStartup` flag is present, the last startup in the trace is selected. This would be the *implicit behaviour*.
- The UI navigates to the main thread's slice track for the selected startup, adjusting the viewport and creating an area selection.
- The "Android App Startups" track is pinned only when a startup is selected.

Small refactoring: STARTUP_TRACK_URI and BREAKDOWN_TRACK_URI are defined as constants.

Tested manually:
- go to http://localhost:10000/#!?com.android.AndroidStartup, open a trace and it will automatically select and navigate to the main thread of the last startup.
- go to http://localhost:10000/#!?com.android.AndroidStartup.packageName=com.android.example, open a trace and it will automatically select and navigate to the main thread of the last startup that has the package_name = `com.android.example'
- go to http://localhost:10000/#!?com.android.AndroidStartup.startupId=123, open a trace and it will automatically select and navigate to the main thread of the last startup that has the startup_id = 123
