### PR TITLE
ui: Consistently update TargetSelector and TargetDetails in record view

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
@@ -379,9 +379,6 @@ class TargetSelector implements m.ClassComponent<TargetSelectorAttrs> {
       .then(() => this.refreshTargets());
     this.recMgr.listTargets().then((targets) => {
       this.targets = targets;
-      if (!this.recMgr.currentTarget && targets.length > 0) {
-        this.recMgr.setTarget(targets[0]);
-      }
       m.redraw();
     });
   }


### PR DESCRIPTION
Add the currentPlatform as key to the TargetSelector and TargetDetails to force consistent updates.

The chrome ChromeExtensionTarget and ChromeExtensionTargetProvider are shared between Chrome, ChromeOS and Linux and thus switching between these targets didn't update the view consistently. Switching between Android and any of the platform with just chrome extension targets did however always work.
