### PR TITLE
ui: forcefully update branch on canary/stable releases and make PR

### DIFF
--- a/.github/workflows/merge-canary-to-stable.yml
+++ b/.github/workflows/merge-canary-to-stable.yml
@@ -18,7 +18,8 @@ on:
   workflow_dispatch:  # Manual trigger via GitHub UI button
 
 permissions:
-  contents: write  # Required to push to stable branch
+  contents: write  # Required to push branch
+  pull-requests: write  # Required to create PR
 
 jobs:
   merge-canary-to-stable:
@@ -39,11 +40,25 @@ jobs:
       - name: Fetch origin/canary
         run: git fetch origin canary
 
-      - name: Merge canary into stable (replace stable tree with canary)
+      - name: Create merge branch
+        run: |
+          BRANCH_NAME="dev/github-actions/merge-canary-to-stable-$(date +%Y%m%d-%H%M%S)"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          git checkout -b "$BRANCH_NAME"
+
+      - name: Merge canary into branch (replace tree with canary)
         run: |
           git merge -s ours origin/canary --no-commit
           git read-tree -m -u origin/canary
           git commit -m "Merge canary into stable (automated)"
 
-      - name: Push to stable
-        run: git push origin stable
+      - name: Push branch and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git push origin "$BRANCH_NAME"
+          gh pr create \
+            --base stable \
+            --head "$BRANCH_NAME" \
+            --title "Merge canary into stable (automated)" \
+            --body "Automated PR to merge canary into stable."

--- a/.github/workflows/merge-main-to-canary.yml
+++ b/.github/workflows/merge-main-to-canary.yml
@@ -18,7 +18,8 @@ on:
   workflow_dispatch:  # Manual trigger via GitHub UI button
 
 permissions:
-  contents: write  # Required to push to canary branch
+  contents: write  # Required to push branch
+  pull-requests: write  # Required to create PR
 
 jobs:
   merge-main-to-canary:
@@ -39,11 +40,25 @@ jobs:
       - name: Fetch origin/main
         run: git fetch origin main
 
-      - name: Merge main into canary (replace canary tree with main)
+      - name: Create merge branch
+        run: |
+          BRANCH_NAME="dev/github-actions/merge-main-to-canary-$(date +%Y%m%d-%H%M%S)"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          git checkout -b "$BRANCH_NAME"
+
+      - name: Merge main into branch (replace tree with main)
         run: |
           git merge -s ours origin/main --no-commit
           git read-tree -m -u origin/main
           git commit -m "Merge main into canary (automated)"
 
-      - name: Push to canary
-        run: git push origin canary
+      - name: Push branch and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git push origin "$BRANCH_NAME"
+          gh pr create \
+            --base canary \
+            --head "$BRANCH_NAME" \
+            --title "Merge main into canary (automated)" \
+            --body "Automated PR to merge main into canary."


### PR DESCRIPTION
We need a PR because Github does not let us protect branches enough to let automated merges but not our own merges.