### PR TITLE
pbzero: merge AddFilterStringField APIs and add v1 compatibility

### DIFF
--- a/protos/perfetto/proto_filtering/proto_filter_options.proto
+++ b/protos/perfetto/proto_filtering/proto_filter_options.proto
@@ -42,7 +42,12 @@ message ProtoFilterOptions {
   // If true and semantic_type is set, the field is also included in v2
   // bytecode (not just v54 overlay). This is useful for fields that
   // need to be filtered by older parsers. Defaults to false.
-  optional bool add_to_v2 = 4;
+  optional bool allow_v2_with_semantic_type = 4;
+
+  // If true and filter_string is set, the field is also included in v1
+  // bytecode. This is useful for fields that need to be filtered by older
+  // parsers. Defaults to false.
+  optional bool allow_v1_with_filter_string = 5;
 }
 
 // Extend google.protobuf.FieldOptions with filtering metadata.

--- a/src/protozero/filtering/filter_bytecode_generator.h
+++ b/src/protozero/filtering/filter_bytecode_generator.h
@@ -72,17 +72,17 @@ class FilterBytecodeGenerator {
   // Allows a simple field (varint, fixed32/64, string or bytes).
   void AddSimpleField(uint32_t field_id);
 
-  // Allows a string field which needs to be filtered.
-  void AddFilterStringField(uint32_t field_id);
-
-  // Allows a string field which needs to be filtered with a specific semantic
-  // type. The semantic type tells the filter what kind of data the field
-  // contains, so it can apply type-specific rules.
-  // If |add_to_v2| is true, the field is added to v2 bytecode (without type)
-  // in addition to the v54 overlay (with type).
-  void AddFilterStringFieldWithType(uint32_t field_id,
-                                    uint32_t semantic_type,
-                                    bool add_to_v2);
+  // Allows a string field which needs to be filtered. Optionally specifies a
+  // semantic type (0 = none) that tells the filter what kind of data the field
+  // contains.
+  // If `allow_in_v1` is true, the field is added to v1 bytecode as a simple
+  // field (string filtering not available in v1).
+  // If `allow_in_v2` is true and semantic_type != 0, the field is added to v2
+  // bytecode (without type) in addition to the v54 overlay (with type).
+  void AddFilterStringField(uint32_t field_id,
+                            uint32_t semantic_type,
+                            bool allow_in_v1,
+                            bool allow_in_v2);
 
   // Allows a range of simple fields. |range_start| is the id of the first field
   // in range, |range_len| the number of fields in the range.

--- a/src/protozero/filtering/filter_bytecode_generator_unittest.cc
+++ b/src/protozero/filtering/filter_bytecode_generator_unittest.cc
@@ -143,7 +143,8 @@ TEST(FilterBytecodeGeneratorTest, Nested) {
 TEST(FilterBytecodeGeneratorTest, SemanticTypeOverlayV2) {
   // Test that generating for v2 with semantic types creates an overlay
   FilterBytecodeGenerator gen(FilterBytecodeGenerator::BytecodeVersion::kV2);
-  gen.AddFilterStringFieldWithType(1u, 42u, /*add_to_v2=*/false);
+  gen.AddFilterStringField(1u, /*semantic_type=*/42u, /*allow_in_v1=*/false,
+                           /*allow_in_v2=*/false);
   gen.EndMessage();
 
   auto result = gen.Serialize();
@@ -175,7 +176,8 @@ TEST(FilterBytecodeGeneratorTest, SemanticTypeOverlayV2) {
 TEST(FilterBytecodeGeneratorTest, SemanticTypeV54NoOverlay) {
   // Test that generating for v54 with semantic types doesn't create an overlay
   FilterBytecodeGenerator gen(FilterBytecodeGenerator::BytecodeVersion::kV54);
-  gen.AddFilterStringFieldWithType(1u, 42u, /*add_to_v2=*/false);
+  gen.AddFilterStringField(1u, /*semantic_type=*/42u, /*allow_in_v1=*/false,
+                           /*allow_in_v2=*/false);
   gen.EndMessage();
 
   auto result = gen.Serialize();
@@ -191,6 +193,51 @@ TEST(FilterBytecodeGeneratorTest, SemanticTypeV54NoOverlay) {
   EXPECT_TRUE(query.allowed);
   EXPECT_TRUE(query.filter_string_field());
   EXPECT_EQ(query.semantic_type, 42u);
+}
+
+TEST(FilterBytecodeGeneratorTest, AllowInV1) {
+  // Test that allow_in_v1=true adds field as simple field in v1 bytecode
+  FilterBytecodeGenerator gen(FilterBytecodeGenerator::BytecodeVersion::kV1);
+  // Field 1: denied in v1 (allow_in_v1=false)
+  gen.AddFilterStringField(1u, /*semantic_type=*/0u, /*allow_in_v1=*/false,
+                           /*allow_in_v2=*/false);
+  // Field 2: allowed in v1 as simple field (allow_in_v1=true)
+  gen.AddFilterStringField(2u, /*semantic_type=*/0u, /*allow_in_v1=*/true,
+                           /*allow_in_v2=*/false);
+  // Field 3: with semantic type, denied in v1 (allow_in_v1=false)
+  gen.AddFilterStringField(3u, /*semantic_type=*/42u, /*allow_in_v1=*/false,
+                           /*allow_in_v2=*/false);
+  // Field 4: with semantic type, allowed in v1 (allow_in_v1=true)
+  gen.AddFilterStringField(4u, /*semantic_type=*/42u, /*allow_in_v1=*/true,
+                           /*allow_in_v2=*/false);
+  gen.EndMessage();
+
+  auto result = gen.Serialize();
+  EXPECT_GT(result.bytecode.size(), 0u);
+  EXPECT_EQ(result.v54_overlay.size(), 0u);  // No overlay for v1
+
+  FilterBytecodeParser parser;
+  ASSERT_TRUE(
+      parser.Load(reinterpret_cast<const uint8_t*>(result.bytecode.data()),
+                  result.bytecode.size()));
+
+  // Field 1: should be denied
+  EXPECT_FALSE(parser.Query(0, 1).allowed);
+
+  // Field 2: should be allowed as simple field (no filter_string in v1)
+  auto query2 = parser.Query(0, 2);
+  EXPECT_TRUE(query2.allowed);
+  EXPECT_TRUE(query2.simple_field());
+  EXPECT_FALSE(query2.filter_string_field());
+
+  // Field 3: should be denied
+  EXPECT_FALSE(parser.Query(0, 3).allowed);
+
+  // Field 4: should be allowed as simple field
+  auto query4 = parser.Query(0, 4);
+  EXPECT_TRUE(query4.allowed);
+  EXPECT_TRUE(query4.simple_field());
+  EXPECT_FALSE(query4.filter_string_field());
 }
 
 }  // namespace

--- a/src/protozero/filtering/filter_util.cc
+++ b/src/protozero/filtering/filter_util.cc
@@ -88,7 +88,8 @@ struct ProtoFilterOptions {
   uint32_t semantic_type = 0;
   bool filter_string = false;
   bool passthrough = false;
-  bool add_to_v2 = false;
+  bool allow_v2_with_semantic_type = false;
+  bool allow_v1_with_filter_string = false;
 };
 
 ProtoFilterOptions ReadProtoFilterAnnotation(
@@ -100,7 +101,8 @@ ProtoFilterOptions ReadProtoFilterAnnotation(
     opts.semantic_type = static_cast<uint32_t>(ext.semantic_type());
     opts.filter_string = ext.filter_string();
     opts.passthrough = ext.passthrough();
-    opts.add_to_v2 = ext.add_to_v2();
+    opts.allow_v2_with_semantic_type = ext.allow_v2_with_semantic_type();
+    opts.allow_v1_with_filter_string = ext.allow_v1_with_filter_string();
   }
   return opts;
 }
@@ -254,7 +256,10 @@ FilterUtil::Message* FilterUtil::ParseProtoDescriptor(
       }
       field.filter_string = true;
       field.semantic_type = filter_opts.semantic_type;
-      field.add_to_v2 = filter_opts.add_to_v2;
+      field.allow_v2_with_semantic_type =
+          filter_opts.allow_v2_with_semantic_type;
+      field.allow_v1_with_filter_string =
+          filter_opts.allow_v1_with_filter_string;
       msg->has_filter_string_fields = true;
     }
 
@@ -431,12 +436,9 @@ FilterBytecodeGenerator::SerializeResult FilterUtil::GenerateFilterBytecode(
         continue;
       }
       if (field.filter_string) {
-        if (field.semantic_type != 0) {
-          bytecode_gen.AddFilterStringFieldWithType(
-              field_id, field.semantic_type, field.add_to_v2);
-        } else {
-          bytecode_gen.AddFilterStringField(field_id);
-        }
+        bytecode_gen.AddFilterStringField(field_id, field.semantic_type,
+                                          field.allow_v1_with_filter_string,
+                                          field.allow_v2_with_semantic_type);
         ++it;
         continue;
       }

--- a/src/protozero/filtering/filter_util.h
+++ b/src/protozero/filtering/filter_util.h
@@ -110,8 +110,11 @@ class FilterUtil {
       // Maps to SemanticType enum values from semantic_type.proto.
       uint32_t semantic_type = 0;
       // If true and semantic_type is set, include this field in v2 bytecode
-      // (as simple filter_string) in addition to the v54 overlay.
-      bool add_to_v2 = false;
+      // (as simple filter_string).
+      bool allow_v2_with_semantic_type = false;
+      // If true and filter_string is set, include this field in v1 bytecode
+      // (as simple string).
+      bool allow_v1_with_filter_string = false;
       // Only when type == "message". Note that when using Dedupe() this can
       // be aliased against a different submessage which happens to have the
       // same set of field ids.

--- a/src/protozero/filtering/filter_util_test_messages.proto
+++ b/src/protozero/filtering/filter_util_test_messages.proto
@@ -230,18 +230,41 @@ message MsgFilterSemanticTypePacket {
       [(perfetto.protos.proto_filter).semantic_type = SEMANTIC_TYPE_JOB];
 }
 
-// Test: AddToV2 - semantic_type with add_to_v2=true should include field in v2
+// Test: AllowV2WithSemanticType - semantic_type with
+// allow_v2_with_semantic_type=true should include field in v2
 message AddToV2Root {
   optional AddToV2Packet packet = 1;
 }
 
 message AddToV2Packet {
-  // This field has semantic_type but NOT add_to_v2, so it's denied in v2.
+  // This field has semantic_type but NOT allow_v2_with_semantic_type, so it's
+  // denied in v2.
   optional string denied_in_v2 = 2
       [(perfetto.protos.proto_filter).semantic_type = SEMANTIC_TYPE_ATRACE];
-  // This field has semantic_type AND add_to_v2=true, so it's allowed in v2.
+  // This field has semantic_type AND allow_v2_with_semantic_type=true, so it's
+  // allowed in v2.
   optional string allowed_in_v2 = 3 [(perfetto.protos.proto_filter) = {
     semantic_type: SEMANTIC_TYPE_JOB
-    add_to_v2: true
+    allow_v2_with_semantic_type: true
+  }];
+}
+
+// Test: AllowV1WithFilterString - filter_string with
+// allow_v1_with_filter_string=true should include field in v1 bytecode as
+// simple field
+message AllowV1Root {
+  optional AllowV1Packet packet = 1;
+}
+
+message AllowV1Packet {
+  // This field has filter_string but NOT allow_v1_with_filter_string, so it's
+  // denied in v1.
+  optional string denied_in_v1 = 2
+      [(perfetto.protos.proto_filter).filter_string = true];
+  // This field has filter_string AND allow_v1_with_filter_string=true, so it's
+  // allowed in v1 as a simple field.
+  optional string allowed_in_v1 = 3 [(perfetto.protos.proto_filter) = {
+    filter_string: true
+    allow_v1_with_filter_string: true
   }];
 }

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -6681,8 +6681,10 @@ TEST_F(TracingServiceImplTest, StringFiltering) {
   // Message 1: TracePacket proto. Allow only the `for_testing` sub-field.
   filt.AddNestedField(protos::pbzero::TracePacket::kForTestingFieldNumber, 2);
   filt.EndMessage();
-  // Message 2: TestEvent proto. Allow only the `str` sub-field as a striong.
-  filt.AddFilterStringField(protos::pbzero::TestEvent::kStrFieldNumber);
+  // Message 2: TestEvent proto. Allow only the `str` sub-field as a string.
+  filt.AddFilterStringField(protos::pbzero::TestEvent::kStrFieldNumber,
+                            /*semantic_type=*/0, /*allow_in_v1=*/false,
+                            /*allow_in_v2=*/false);
   filt.EndMessage();
   trace_config.mutable_trace_filter()->set_bytecode_v2(
       filt.Serialize().bytecode);
@@ -6751,7 +6753,9 @@ TEST_F(TracingServiceImplTest, StringFilteringAndCloneSession) {
   filt.AddNestedField(protos::pbzero::TracePacket::kForTestingFieldNumber, 2);
   filt.EndMessage();
   // Message 2: TestEvent proto. Allow only the `str` sub-field as a string.
-  filt.AddFilterStringField(protos::pbzero::TestEvent::kStrFieldNumber);
+  filt.AddFilterStringField(protos::pbzero::TestEvent::kStrFieldNumber,
+                            /*semantic_type=*/0, /*allow_in_v1=*/false,
+                            /*allow_in_v2=*/false);
   filt.EndMessage();
   trace_config.mutable_trace_filter()->set_bytecode_v2(
       filt.Serialize().bytecode);


### PR DESCRIPTION
- Merge AddFilterStringField and AddFilterStringFieldWithType into
  single function with semantic_type=0 meaning no type
- Rename add_to_v2 to allow_v2_with_semantic_type for clarity
- Add allow_v1_with_filter_string option to include filter string
  fields in v1 bytecode as simple fields
- Add tests for new v1 compatibility option
