### PR TITLE
pbzero: remove invalid check and fix conditions checking

### DIFF
--- a/src/protozero/filtering/filter_util.cc
+++ b/src/protozero/filtering/filter_util.cc
@@ -401,7 +401,8 @@ void FilterUtil::PrintAsText(std::optional<std::string> filter_bytecode) {
           stripped_nested +=
               std::string("  # SEMANTIC TYPE ") +
               perfetto::protos::pbzero::SemanticType_Name(
-                  static_cast<perfetto::protos::pbzero::SemanticType>(semantic));
+                  static_cast<perfetto::protos::pbzero::SemanticType>(
+                      semantic));
         }
       }
       fprintf(print_stream_, "%-60s %3u %-8s %-32s%s\n", stripped_name.c_str(),


### PR DESCRIPTION
With v1/v2 backcompot, it's no longer guaranteed that if filter_string
is set in input it will also be set in output. Fix this by removing the
check

Also passthrough does not make sense, it will just be treated as bytes so remove

Also use the result rather than the input to determine semantic type/filter string