### PR TITLE
[chrome] Fix descriptor serialization

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/chrome/chrome_extension_target.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/chrome/chrome_extension_target.ts
@@ -14,6 +14,7 @@
 
 import m from 'mithril';
 import protos from '../../../protos';
+import {base64Decode} from '../../../base/string_utils';
 import {defer, Deferred} from '../../../base/deferred';
 import {errResult, okResult, Result} from '../../../base/result';
 import {binaryEncode} from '../../../base/string_utils';
@@ -168,11 +169,10 @@ export class ChromeExtensionTarget implements RecordingTarget {
         }),
       );
     } else if (msg.type === 'GetTrackEventDescriptorResponse') {
-      const descriptor = (
-        msg as {type: string; serializedDescriptor: Uint8Array}
-      ).serializedDescriptor;
+      const descriptor = (msg as {type: string; encodedDescriptor: string})
+        .encodedDescriptor;
       this.trackEventDescriptorPromise.resolve(
-        protos.TrackEventDescriptor.decode(descriptor),
+        protos.TrackEventDescriptor.decode(base64Decode(descriptor)),
       );
     } else {
       this.session?.onExtensionMessage(`${msg.type}`, msg);


### PR DESCRIPTION
This fixes an issue introduced in getTrackEventDescriptor in chrome extension
https://github.com/google/perfetto/commit/8cf11c53e54d51f625f973be30fdd4b4bb3c9acf
chrome.runtime.Port converts Uint8Array to a json object.
This fixes the issue by forwarding the message as base64.
