### PR TITLE
protozero: Apply string filter rules to UNSPECIFIED semantic type fields

### DIFF
--- a/src/protozero/filtering/string_filter.cc
+++ b/src/protozero/filtering/string_filter.cc
@@ -138,7 +138,9 @@ bool StringFilter::MaybeFilterInternal(char* ptr,
   bool atrace_find_tried = false;
   const char* atrace_payload_ptr = nullptr;
   for (const Rule& rule : rules_) {
-    if (!rule.semantic_type_mask.IsSet(semantic_type)) {
+    // UNSPECIFIED (0) fields always match - we don't know what they contain,
+    // so apply rules conservatively. For other types, check the mask.
+    if (semantic_type != 0 && !rule.semantic_type_mask.IsSet(semantic_type)) {
       continue;
     }
     switch (rule.policy) {


### PR DESCRIPTION
Previously, a rule with semantic_type=[ATRACE] would skip fields with
SEMANTIC_TYPE_UNSPECIFIED (0). This was surprising: adding semantic
type targeting to a rule made it *more* restrictive, potentially
leaving unannotated fields unredacted.

New behavior: UNSPECIFIED fields match all rules regardless of the
rule's semantic type mask. Rationale: UNSPECIFIED means "we don't
know what this field contains", so apply rules conservatively.

Example:
  Rule: semantic_type=[ATRACE], pattern="secret:(.*)"

  Before:
    Field semantic_type=ATRACE  -> redacted
    Field semantic_type=0       -> NOT redacted (surprising)

  After:
    Field semantic_type=ATRACE  -> redacted
    Field semantic_type=0       -> redacted (conservative)
    Field semantic_type=JOB     -> NOT redacted (explicit exclusion)
