### PR TITLE
frametimeline: add jank type for display mode changes

### DIFF
--- a/protos/perfetto/trace/android/frame_timeline_event.proto
+++ b/protos/perfetto/trace/android/frame_timeline_event.proto
@@ -46,6 +46,7 @@ message FrameTimelineEvent {
     JANK_NON_ANIMATING = 2048;
     JANK_APP_RESYNCED_JITTER = 4096;
     JANK_DISPLAY_NOT_ON = 8192;
+    JANK_DISPLAY_MODE_CHANGE_IN_PROGRESS = 16384;
   };
 
   // Specifies the severity of a jank.

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -5886,6 +5886,7 @@ message FrameTimelineEvent {
     JANK_NON_ANIMATING = 2048;
     JANK_APP_RESYNCED_JITTER = 4096;
     JANK_DISPLAY_NOT_ON = 8192;
+    JANK_DISPLAY_MODE_CHANGE_IN_PROGRESS = 16384;
   };
 
   // Specifies the severity of a jank.

--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
@@ -86,6 +86,8 @@ StringId JankTypeBitmaskToStringId(TraceProcessorContext* context,
     jank_reasons.emplace_back("Non Animating");
   if (jank_type & FrameTimelineEvent::JANK_DISPLAY_NOT_ON)
     jank_reasons.emplace_back("Display not ON");
+  if (jank_type & FrameTimelineEvent::JANK_DISPLAY_MODE_CHANGE_IN_PROGRESS)
+    jank_reasons.emplace_back("ModeChange in progress");
 
   std::string jank_str(
       std::accumulate(jank_reasons.begin(), jank_reasons.end(), std::string(),


### PR DESCRIPTION
Add a new jank type to annotate when display mode changes and new vsync cadence is learned 

Bug: 465786055