### PR TITLE
proto_merger: fix file reolution

### DIFF
--- a/src/tools/proto_merger/proto_file.cc
+++ b/src/tools/proto_merger/proto_file.cc
@@ -151,7 +151,7 @@ std::vector<ProtoFile::Option> OptionsFromMessage(
     for (int j = 0; j < count; j++) {
       std::string name;
       if (fields[i]->is_extension()) {
-        name = "(" + std::string(fields[i]->full_name()) + ")";
+        name = "(." + std::string(fields[i]->full_name()) + ")";
       } else {
         name = fields[i]->name();
       }


### PR DESCRIPTION
Need this as "The innermost scope is searched first in name resolution. Consider using a leading '.'(i.e., "(.perfetto.protos.proto_filter)") to start from the outermost scope."
