### PR TITLE
tp: add new fields to view capture args

### DIFF
--- a/protos/perfetto/trace/android/viewcapture.proto
+++ b/protos/perfetto/trace/android/viewcapture.proto
@@ -48,5 +48,7 @@ message ViewCapture {
     optional int32 visibility = 19;
 
     optional float elevation = 20;
+    optional int32 content_description_iid = 21;
+    optional int32 text_iid = 22;
   }
 }

--- a/protos/perfetto/trace/interned_data/interned_data.proto
+++ b/protos/perfetto/trace/interned_data/interned_data.proto
@@ -141,6 +141,8 @@ message InternedData {
   repeated InternedString viewcapture_window_name = 39;
   repeated InternedString viewcapture_view_id = 40;
   repeated InternedString viewcapture_class_name = 41;
+  repeated InternedString viewcapture_content_description = 45;
+  repeated InternedString viewcapture_text = 46;
 
   // Interned context for android.app_wakelocks.
   repeated AppWakelockInfo app_wakelock_info = 42;

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -15570,6 +15570,8 @@ message InternedData {
   repeated InternedString viewcapture_window_name = 39;
   repeated InternedString viewcapture_view_id = 40;
   repeated InternedString viewcapture_class_name = 41;
+  repeated InternedString viewcapture_content_description = 45;
+  repeated InternedString viewcapture_text = 46;
 
   // Interned context for android.app_wakelocks.
   repeated AppWakelockInfo app_wakelock_info = 42;

--- a/src/trace_processor/importers/proto/winscope/viewcapture_args_parser.h
+++ b/src/trace_processor/importers/proto/winscope/viewcapture_args_parser.h
@@ -19,6 +19,7 @@
 
 #include <optional>
 
+#include "perfetto/protozero/field.h"
 #include "src/trace_processor/importers/proto/args_parser.h"
 #include "src/trace_processor/tables/winscope_tables_py.h"
 
@@ -44,6 +45,9 @@ class ViewCaptureArgsParser : public ArgsParser {
  private:
   bool TryAddDeinternedString(const Key&, uint64_t);
   std::optional<protozero::ConstChars> TryDeinternString(const Key&, uint64_t);
+
+  template <uint32_t FieldNumber>
+  std::optional<protozero::ConstChars> DeinternString(uint64_t);
 
   template <uint32_t FieldNumber, typename RowRef>
   std::optional<protozero::ConstChars>

--- a/test/trace_processor/diff_tests/parser/android/tests_viewcapture.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_viewcapture.py
@@ -87,17 +87,19 @@ class ViewCapture(TestSuite):
           android_viewcapture_view AS vc JOIN args ON vc.arg_set_id = args.arg_set_id
           WHERE vc.snapshot_id = 1
         ORDER BY args.arg_set_id, args.key
-        LIMIT 10;
+        LIMIT 12;
         """,
         out=Csv("""
         "key","display_value"
         "alpha","1.0"
         "class_name","com.android.internal.policy.PhoneWindow@6cec234"
+        "content_description","Content Description 1"
         "hashcode","182652084"
         "height","2400"
         "parent_id","-1"
         "scale_x","1.0"
         "scale_y","1.0"
+        "text","Text 1"
         "view_id","NO_ID"
         "width","1080"
         "will_not_draw","true"

--- a/test/trace_processor/diff_tests/parser/android/viewcapture.textproto
+++ b/test/trace_processor/diff_tests/parser/android/viewcapture.textproto
@@ -63,6 +63,8 @@ packet {
     viewcapture_window_name { iid: 2 str: "PhoneWindow" }
     viewcapture_view_id { iid: 1 str: "NO_ID" }
     viewcapture_view_id { iid: 2 str: "TEST_VIEW_ID" }
+    viewcapture_content_description { iid: 1 str: "Content Description 1" }
+    viewcapture_text { iid: 1 str: "Text 1" }
   }
   trusted_uid: 10230
   trusted_packet_sequence_id: 2
@@ -87,6 +89,8 @@ packet {
         scale_y: 1.000000
         alpha: 1.000000
         will_not_draw: true
+        content_description_iid: 1
+        text_iid: 1
       }
       views {
         id: 1

--- a/test/trace_processor/diff_tests/syntax/table_tests.py
+++ b/test/trace_processor/diff_tests/syntax/table_tests.py
@@ -693,19 +693,30 @@ class PerfettoTable(TestSuite):
           flat_key GLOB '*_iid'
           OR flat_key GLOB '*_name'
           OR flat_key GLOB '*view_id'
+          OR flat_key GLOB '*content_description'
+          OR flat_key GLOB '*text'
         ORDER BY base64_proto_id, key
-        LIMIT 8
+        LIMIT 17
         """,
         out=Csv("""
         "flat_key","key","int_value","string_value"
         "class_name","class_name","[NULL]","com.android.internal.policy.PhoneWindow@6cec234"
+        "content_description","content_description","[NULL]","STRING DE-INTERNING ERROR"
+        "content_description_iid","content_description_iid",0,"[NULL]"
+        "text","text","[NULL]","STRING DE-INTERNING ERROR"
+        "text_iid","text_iid",0,"[NULL]"
         "view_id","view_id","[NULL]","NO_ID"
         "class_name","class_name","[NULL]","com.android.internal.policy.DecorView"
+        "content_description","content_description","[NULL]","STRING DE-INTERNING ERROR"
+        "content_description_iid","content_description_iid",0,"[NULL]"
+        "text","text","[NULL]","STRING DE-INTERNING ERROR"
+        "text_iid","text_iid",0,"[NULL]"
         "view_id","view_id","[NULL]","STRING DE-INTERNING ERROR"
         "view_id_iid","view_id_iid",3,"[NULL]"
-        "class_name","class_name","[NULL]","STRING DE-INTERNING ERROR"
-        "class_name_iid","class_name_iid",3,"[NULL]"
-        "view_id","view_id","[NULL]","TEST_VIEW_ID"
+        "class_name","class_name","[NULL]","com.android.internal.policy.PhoneWindow@6cec234"
+        "content_description","content_description","[NULL]","Content Description 1"
+        "text","text","[NULL]","Text 1"
+        "view_id","view_id","[NULL]","NO_ID"
         """))
 
   def test_winscope_surfaceflinger_hierarchy_paths(self):


### PR DESCRIPTION
This PR adds two new fields to the `viewcapture` args proto definition. It also adds makes sure that the fields can be parsed by the trace processor. See: b/436963256

