### PR TITLE
ui: Add AddColumn and Remove column callbacks

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -281,7 +281,7 @@ function createNodeInstance(
         ),
       );
     case NodeType.kSimpleSlices:
-      return new SlicesSourceNode({});
+      return new SlicesSourceNode({trace, sqlModules});
     case NodeType.kSqlSource:
       return new SqlSourceNode({
         ...(state as SqlSourceSerializedState),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -128,6 +128,7 @@ import {NodeIssues} from './node_issues';
 import {DataExplorerEmptyState, RoundActionButton} from './widgets';
 import {UIFilter} from './operations/filter';
 import {QueryExecutionService} from './query_execution_service';
+import {Column} from '../../../components/widgets/datagrid/model';
 import {ResizeHandle} from '../../../widgets/resize_handle';
 import {getAllDownstreamNodes} from './graph_utils';
 import {Popup, PopupPosition} from '../../../widgets/popup';
@@ -194,6 +195,7 @@ export interface BuilderAttrs {
     filter: UIFilter | UIFilter[],
     filterOperator?: 'AND' | 'OR',
   ) => void;
+  readonly onColumnAdd?: (node: QueryNode, column: Column) => void;
 
   // Import / Export JSON
   readonly onImport: () => void;
@@ -438,6 +440,9 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               onFilterAdd: (filter, filterOperator) => {
                 attrs.onFilterAdd(selectedNode, filter, filterOperator);
               },
+              onColumnAdd: attrs.onColumnAdd
+                ? (column) => attrs.onColumnAdd?.(selectedNode, column)
+                : undefined,
               isFullScreen:
                 this.drawerVisibility === DrawerPanelVisibility.FULLSCREEN,
               onFullScreenToggle: () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -64,6 +64,8 @@ export class SlicesSourceNode implements QueryNode {
   clone(): QueryNode {
     const stateCopy: SlicesSourceState = {
       onchange: this.state.onchange,
+      trace: this.state.trace,
+      sqlModules: this.state.sqlModules,
     };
     return new SlicesSourceNode(stateCopy);
   }


### PR DESCRIPTION
  Add callbacks to the DataGrid component for column add/remove events, enabling the ExplorePage                                                                                                                                                                         to automatically create AddColumnsNode when users add columns from joinid table references.                                                                                                                                                                                This creates a guided flow where selecting a column from a related table (via joinid)                                                                                                                                                                            automatically sets up the necessary join configuration.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                              
  - Add `onColumnAdd`, `onColumnRemove`, `canAddColumnForField`, and `canRemoveColumns` props to DataGrid                                                                                                                                                                     
  - Extend ColumnMenu to support `canAdd` flag and per-field add restrictions via `canAddColumnForField`                                                                                                                                                                      
  - Implement `handleColumnAdd` in ExplorePage to create AddColumnsNode when adding joinid columns                                                                                                                                                                            
  - Add `canAddColumnForField` validation to prevent duplicate columns and invalid additions                                                                                                                                                                                  
  - Generate SchemaRef entries in DataExplorer for joinid columns, enabling nested column menus                                                                                                                                                                                                                                                                                                                                                                  