### PR TITLE
ui: Fix typo in chrome category

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/chrome.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/chrome.ts
@@ -297,7 +297,7 @@ function defaultAndDisabled(category: string) {
 
 const GROUPS = {
   'Task Scheduling': [
-    'toplevJJJel',
+    'toplevel',
     'toplevel.flow',
     'scheduler',
     'sequence_manager',


### PR DESCRIPTION
It should have been "toplevel" instead.