### PR TITLE
perfetto: Add PERFETTO_TE_IS_CATEGORY_ENABLED macro

### DIFF
--- a/include/perfetto/public/te_category_macros.h
+++ b/include/perfetto/public/te_category_macros.h
@@ -176,4 +176,9 @@
     PerfettoTePublishCategories();                                             \
   } while (0)
 
+// Returns true if the category `NAME` is enabled. `NAME` should be a category
+// defined with PERFETTO_TE_CATEGORIES_DEFINE.
+#define PERFETTO_TE_IS_CATEGORY_ENABLED(NAME) \
+  PERFETTO_ATOMIC_LOAD_EXPLICIT((NAME).enabled, PERFETTO_MEMORY_ORDER_RELAXED)
+
 #endif  // INCLUDE_PERFETTO_PUBLIC_TE_CATEGORY_MACROS_H_

--- a/src/shared_lib/test/api_integrationtest.cc
+++ b/src/shared_lib/test/api_integrationtest.cc
@@ -2503,4 +2503,21 @@ TEST_F(SharedLibTrackEventTest, TrackEventHlNestedTrack) {
   EXPECT_EQ(counter_parent_uuid, registered_track_uuid);
 }
 
+TEST_F(SharedLibTrackEventTest, TrackEventIsCategoryEnabled) {
+  ASSERT_FALSE(PERFETTO_TE_IS_CATEGORY_ENABLED(cat1));
+
+  TracingSession tracing_session = TracingSession::Builder()
+                                       .set_data_source_name("track_event")
+                                       .add_enabled_category("cat1")
+                                       .add_disabled_category("*")
+                                       .Build();
+
+  EXPECT_TRUE(PERFETTO_TE_IS_CATEGORY_ENABLED(cat1));
+  EXPECT_FALSE(PERFETTO_TE_IS_CATEGORY_ENABLED(cat2));
+
+  tracing_session.StopBlocking();
+
+  EXPECT_FALSE(PERFETTO_TE_IS_CATEGORY_ENABLED(cat1));
+}
+
 }  // namespace


### PR DESCRIPTION
Add a new macro to the public track event API to allow users to check if a category is enabled.

The macro matches the fast-path check used in the PERFETTO_I_TE_IMPL macro.