### PR TITLE
de: Don't show mid importance table chip

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/table_list.ts
@@ -202,6 +202,7 @@ class TableCard
               className: classNames('pf-no-data-chip'),
             }),
           table.importance &&
+            table.importance !== 'mid' &&
             m(Chip, {
               label: getImportanceLabel(table.importance),
               compact: true,


### PR DESCRIPTION
Showing this level of importance was just confusing - we should still know about it, as some hierarchy might be important for other usages.