### PR TITLE
ui: Allow downloading .gz trace files with SafeFilePicker

### DIFF
--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -99,7 +99,7 @@ function downloadTrace(trace: TraceImpl) {
   const filePickerAcceptTypes = [
     {
       description: 'Perfetto trace',
-      accept: {'*/*': ['.pftrace', '..gz']},
+      accept: {'*/*': ['.pftrace', '.gz']},
     },
   ];
   if (src.type === 'URL') {


### PR DESCRIPTION
window.showSaveFilePicker complains when trying to download a trace with '.pftrace.gz' file ending.
Allowing '.gz' file ending in filePickerAcceptTypes solves this problem