### PR TITLE
perfetto: fix SEGV in ComputePacketHash

### DIFF
--- a/src/trace_processor/importers/common/args_tracker.h
+++ b/src/trace_processor/importers/common/args_tracker.h
@@ -84,15 +84,15 @@ class ArgsTracker {
     // track the next array index for an array under a specific key.
     size_t GetNextArrayEntryIndex(StringId key) {
       // Zero-initializes |key| in the map if it doesn't exist yet.
-      return args_tracker_
-          ->array_indexes_[std::make_tuple(ptr_, col_, row_, key)];
+      return args_tracker_->array_indexes_[std::make_tuple(
+          reinterpret_cast<uintptr_t>(ptr_), col_, row_, key)];
     }
 
     // Returns the next available array index after increment.
     size_t IncrementArrayEntryIndex(StringId key) {
       // Zero-initializes |key| in the map if it doesn't exist yet.
-      return ++args_tracker_
-                   ->array_indexes_[std::make_tuple(ptr_, col_, row_, key)];
+      return ++args_tracker_->array_indexes_[std::make_tuple(
+          reinterpret_cast<uintptr_t>(ptr_), col_, row_, key)];
     }
 
    protected:
@@ -300,7 +300,7 @@ class ArgsTracker {
   base::SmallVector<GlobalArgsTracker::Arg, 16> args_;
   TraceProcessorContext* context_ = nullptr;
 
-  using ArrayKeyTuple = std::tuple<void* /*ptr*/,
+  using ArrayKeyTuple = std::tuple<uintptr_t /*ptr*/,
                                    uint32_t /*col*/,
                                    uint32_t /*row*/,
                                    StringId /*key*/>;

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc
@@ -63,7 +63,7 @@ inline void HashSqlValue(base::MurmurHashCombiner& h, const SqlValue& v) {
   h.Combine(v.type);
   switch (v.type) {
     case SqlValue::Type::kString:
-      h.Combine(v.AsString());
+      h.Combine(base::StringView(v.AsString()));
       break;
     case SqlValue::Type::kDouble:
       h.Combine(v.AsDouble());

--- a/src/trace_processor/trace_summary/summary.cc
+++ b/src/trace_processor/trace_summary/summary.cc
@@ -326,7 +326,7 @@ base::Status WriteDimension(
             dimension_value.type);
       }
       const char* dimension_str = dimension_value.string_value;
-      hasher->Combine(dimension_str);
+      hasher->Combine(base::StringView(dimension_str));
       dimension->set_string_value(dimension_str);
       break;
     }
@@ -387,7 +387,7 @@ base::Status WriteDimension(
         dimension->set_double_value(dim_value);
       } else if (dimension_value.type == SqlValue::kString) {
         const char* dimension_str = dimension_value.string_value;
-        hasher->Combine(dimension_str);
+        hasher->Combine(base::StringView(dimension_str));
         dimension->set_string_value(dimension_str);
       } else if (dimension_value.type == SqlValue::kBytes) {
         return base::ErrStatus(

--- a/src/tracing/service/trace_buffer_v1_with_v2_shadow.cc
+++ b/src/tracing/service/trace_buffer_v1_with_v2_shadow.cc
@@ -38,7 +38,8 @@ uint64_t ComputePacketHash(
     const TraceBuffer::PacketSequenceProperties& seq_props) {
   base::MurmurHashCombiner hasher;
   for (const Slice& slice : packet.slices()) {
-    hasher.Combine(reinterpret_cast<const char*>(slice.start), slice.size);
+    hasher.Combine(std::string_view(reinterpret_cast<const char*>(slice.start),
+                                    slice.size));
   }
   hasher.Combine(seq_props.producer_id_trusted);
   hasher.Combine(seq_props.writer_id);


### PR DESCRIPTION
Update MurmurHash Combine from taking pointers.

Bug: b/477506828

Pass std::string_view to MurmurHashCombiner instead of (ptr, size). The previous code was calling hasher.Combine(ptr, size), which was interpreted as two separate calls to CombineOne(). The first call CombineOne(const char*) was invoking the std::string_view(const char*) constructor, which calls strlen(). Since trace buffer slices are not null-terminated, this resulted in a SEGV.
