### PR TITLE
de: Change the node descriptions on nodes

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.scss
@@ -20,3 +20,7 @@
   padding-top: 8px;
   padding-bottom: 8px;
 }
+
+.pf-section-spacer {
+  margin-top: 8px;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -438,28 +438,43 @@ export class AddColumnsNode implements QueryNode {
 
     // Add joined columns
     if (hasConnectedNode && hasSelectedColumns) {
+      items.push(m('div', 'Add columns from input node:'));
+      const columns = [];
       for (const col of this.state.selectedColumns ?? []) {
         const alias = this.state.columnAliases?.get(col);
         const displayName = alias || col;
-        items.push(m('div', [ColumnName(displayName), ': column from input']));
+        columns.push(displayName);
       }
+      items.push(
+        m('div', [
+          ...columns.flatMap((c, i) =>
+            i === 0 ? [ColumnName(c)] : [', ', ColumnName(c)],
+          ),
+        ]),
+      );
     }
 
     // Add computed columns
-    for (const col of this.state.computedColumns ?? []) {
-      const name = col.name || '(unnamed)';
-      let description = '';
-
-      if (col.type === 'switch') {
-        description = `SWITCH ON ${col.switchOn || '(not set)'}`;
-      } else if (col.type === 'if') {
-        const firstCondition = col.clauses?.[0]?.if || '(empty)';
-        description = `if ${firstCondition}`;
-      } else {
-        description = col.expression || '(empty)';
+    if (hasComputedColumns) {
+      if (hasConnectedNode && hasSelectedColumns) {
+        items.push(m('.pf-section-spacer'));
       }
+      items.push(m('div', 'Add computed columns:'));
+      for (const col of this.state.computedColumns ?? []) {
+        const name = col.name || '(unnamed)';
+        let description = '';
 
-      items.push(m('div', [ColumnName(name), `: ${description}`]));
+        if (col.type === 'switch') {
+          description = `SWITCH ON ${col.switchOn || '(not set)'}`;
+        } else if (col.type === 'if') {
+          const firstCondition = col.clauses?.[0]?.if || '(empty)';
+          description = `if ${firstCondition}`;
+        } else {
+          description = col.expression || '(empty)';
+        }
+
+        items.push(m('div', [ColumnName(name), `: ${description}`]));
+      }
     }
 
     return {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -218,7 +218,7 @@ export class ModifyColumnsNode implements QueryNode {
     const hasAlias = this.state.selectedColumns.some((c) => c.alias);
     if (!hasUnselected && !hasAlias) {
       return {
-        content: NodeDetailsMessage('Select all'),
+        content: NodeDetailsMessage('Select all columns'),
       };
     }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sort_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sort_node.ts
@@ -99,7 +99,7 @@ export class SortNode implements QueryNode {
       .join(', ');
 
     return {
-      content: m('div', label),
+      content: m('div', `Sort by ${label}`),
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -209,7 +209,7 @@ export class TableSourceNode implements QueryNode {
 
   nodeDetails(): NodeDetailsAttrs {
     return {
-      content: NodeTitle(this.state.sqlTable?.name ?? ''),
+      content: NodeTitle('Table ' + (this.state.sqlTable?.name ?? '')),
     };
   }
 


### PR DESCRIPTION
  This updates the query builder node descriptions to be more descriptive and user-friendly. Nodes now include clearer labels that explain their purpose at a glance, and the AddColumnsNode groups columns more compactly.                                                   
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  - Add descriptive prefixes to node types (e.g., "Sort by", "Table", "Select all columns")                                                                                                                                                                                   
  - Reorganize AddColumnsNode to display selected columns comma-separated instead of one per line                                                                                                                                                                             
