### PR TITLE
tp: Don't have to specify the id, ts and dur columns

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/intersect.sql
@@ -156,12 +156,12 @@ RETURNS TableOrSubquery AS
 -- Each table can have different column names.
 --
 -- Example:
---   SELECT * FROM interval_intersect_with_col_names!(
+--   SELECT * FROM _interval_intersect_with_col_names!(
 --     table1, id1, ts1, dur1,
 --     table2, id2, ts2, dur2,
 --     (partition_col)
 --   )
-CREATE PERFETTO MACRO interval_intersect_with_col_names(
+CREATE PERFETTO MACRO _interval_intersect_with_col_names(
   -- First table to intersect.
   tab1 TableOrSubquery,
   -- Name of the id column in tab1.

--- a/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/intervals/intersect_tests.py
@@ -1291,7 +1291,7 @@ class IntervalsIntersect(TestSuite):
           SELECT * FROM data;
 
         SELECT ts, dur, id_0, id_1
-        FROM interval_intersect_with_col_names!(
+        FROM _interval_intersect_with_col_names!(
           A, row_id, start_ts, duration,
           B, event_id, begin_time, length,
           ()
@@ -1331,7 +1331,7 @@ class IntervalsIntersect(TestSuite):
           SELECT * FROM data;
 
         SELECT ts, dur, category
-        FROM interval_intersect_with_col_names!(
+        FROM _interval_intersect_with_col_names!(
           A, row_id, start_ts, duration,
           B, event_id, begin_time, len,
           (category)
@@ -1370,7 +1370,7 @@ class IntervalsIntersect(TestSuite):
           SELECT * FROM data;
 
         SELECT ts, dur, id_0, id_1
-        FROM interval_intersect_with_col_names!(
+        FROM _interval_intersect_with_col_names!(
           A, row_id, start_time, duration,
           B, event_id, begin_time, len,
           ()


### PR DESCRIPTION
Add another SQL function that allows you to specify the id, ts, dur