### PR TITLE
Add is_idle field to generic kernel threads

### DIFF
--- a/protos/perfetto/trace/generic_kernel/generic_task.proto
+++ b/protos/perfetto/trace/generic_kernel/generic_task.proto
@@ -89,6 +89,9 @@ message GenericKernelProcessTree {
 
     // True if thread is the main thread.
     optional bool is_main_thread = 4;
+
+    // True if thread is an idle thread.
+    optional bool is_idle = 5;
   }
 
   // Representation of a process.

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -13582,6 +13582,9 @@ message GenericKernelProcessTree {
 
     // True if thread is the main thread.
     optional bool is_main_thread = 4;
+
+    // True if thread is an idle thread.
+    optional bool is_idle = 5;
   }
 
   // Representation of a process.

--- a/src/trace_processor/importers/common/process_tracker.cc
+++ b/src/trace_processor/importers/common/process_tracker.cc
@@ -639,6 +639,13 @@ void ProcessTracker::SetMainThread(UniqueTid utid, bool is_main_thread) {
   trr.set_is_main_thread(is_main_thread);
 }
 
+void ProcessTracker::SetIdleThread(UniqueTid utid, bool is_idle) {
+  auto& thread_table = *context_->storage->mutable_thread_table();
+
+  auto trr = thread_table[utid];
+  trr.set_is_idle(is_idle);
+}
+
 void ProcessTracker::SetPidZeroIsUpidZeroIdleProcess() {
   // Create a mapping from (t|p)id 0 -> u(t|p)id for the idle process.
   tids_.Insert(0, std::vector<UniqueTid>{swapper_utid_});

--- a/src/trace_processor/importers/common/process_tracker.h
+++ b/src/trace_processor/importers/common/process_tracker.h
@@ -103,6 +103,9 @@ class ProcessTracker {
   // Mark whether a thread is the main thread or not.
   void SetMainThread(UniqueTid utid, bool is_main_thread);
 
+  // Mark whether a thread is an idle thread or not.
+  void SetIdleThread(UniqueTid utid, bool is_idle);
+
   // Associates trusted_pid with track UUID.
   void UpdateTrustedPid(int64_t trusted_pid, uint64_t uuid);
 

--- a/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
+++ b/src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc
@@ -312,12 +312,14 @@ void GenericKernelParser::ParseGenericProcessTree(protozero::ConstBytes data) {
     const int64_t pid = thread.pid();
     const int64_t tid = thread.tid();
     const bool is_main_thread = thread.is_main_thread();
+    const bool is_idle = thread.is_idle();
 
     auto upid = process_tracker->GetOrCreateProcessWithoutMainThread(pid);
 
     auto utid = process_tracker->GetOrCreateThreadWithParent(tid, upid, false);
 
     process_tracker->SetMainThread(utid, is_main_thread);
+    process_tracker->SetIdleThread(utid, is_idle);
 
     if (thread.has_comm()) {
       StringId comm_id = context_->storage->InternString(thread.comm());

--- a/src/trace_processor/tables/metadata_tables.py
+++ b/src/trace_processor/tables/metadata_tables.py
@@ -323,7 +323,11 @@ THREAD_TABLE = Table(
             sql_access=SqlAccess.HIGH_PERF,
             cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
         ),
-        C('is_idle', CppUint32()),
+        C(
+            'is_idle',
+            CppUint32(),
+            cpp_access=CppAccess.READ_AND_HIGH_PERF_WRITE,
+        ),
         C(
             'machine_id',
             CppOptional(CppTableId(MACHINE_TABLE)),

--- a/test/trace_processor/diff_tests/parser/generic_kernel/tests.py
+++ b/test/trace_processor/diff_tests/parser/generic_kernel/tests.py
@@ -1325,6 +1325,12 @@ class GenericKernelParser(TestSuite):
                 tid: 5678
                 pid: 22
                 comm: "task2"
+              },
+              {
+                tid: 9012
+                pid: 33
+                comm: "idle"
+                is_idle: true
               }
             ]
           }
@@ -1345,4 +1351,5 @@ class GenericKernelParser(TestSuite):
         0,0,"swapper",0,1,1
         1,1234,"task1",2,1,0
         2,5678,"task2",3,0,0
+        3,9012,"idle",4,0,1
         """))


### PR DESCRIPTION
Currently trace_processor assumes that the generic kernel traces follow Android's swapper thread approach where the idle thread is assigned to pid/tid 0. To remove this Android/Linux assumption we added an is_idle field to the GenericKernelProcessTree::Thread such that producers emitting generic kernel trace packets can specify which threads are the idle thread. This also allows having multiple idle threads.

Bug: 477296575
