### PR TITLE
ui: Metrics page supports trace summary

### DIFF
--- a/ui/src/plugins/dev.perfetto.MetricsPage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/styles.scss
@@ -72,3 +72,21 @@
     }
   }
 }
+
+.pf-metricsv2-result {
+  &__header {
+    margin-bottom: 1rem;
+  }
+
+  &__tabs {
+    border: 1px solid var(--pf-color-border);
+    border-radius: 4px;
+  }
+
+  &__bundle {
+    .pf-datagrid {
+      min-height: 200px;
+      max-height: 400px;
+    }
+  }
+}


### PR DESCRIPTION
Extends the Metrics V2 page to support full trace summary specifications in addition to individual metric specs. Users can now switch between "Metric Spec" mode (for single metrics) and "Full Summary" mode (for complete TraceSummarySpec with multiple metrics, queries, and templates).                             
                                                                                                                                                              