### PR TITLE
de: Interval intersect picks the ts/dur sources

### DIFF
--- a/ui/src/assets/explore_page/node_info/interval_intersect.md
+++ b/ui/src/assets/explore_page/node_info/interval_intersect.md
@@ -18,4 +18,10 @@
 
 **Intersection logic:** Two intervals overlap if `[ts1, ts1+dur1)` intersects with `[ts2, ts2+dur2)`. The output is the intersection `[max(ts1, ts2), min(ts1+dur1, ts2+dur2))`.
 
+**Source selection:** By default, the output `ts` and `dur` columns come from the intersection result (cut to intersection boundaries), and there is no `id` column since the intersection doesn't correspond to a single source row. You can change this to use the original values from a specific input instead:
+- **Intersection (no id):** Output `ts`/`dur` reflect the intersection boundaries, no `id` column (default)
+- **Input N:** Output `id`/`ts`/`dur` come from that input's original intervals
+
+This is useful when you want to filter intervals by overlap but preserve the original timing and identity from one of the sources.
+
 **NOTE:** This node does not support unfinished slices ("did not terminate"). They will be filtered out from the intersection.

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_info.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/column_info.ts
@@ -21,6 +21,9 @@ export interface ColumnInfo {
   checked: boolean;
   column: SqlColumn;
   alias?: string;
+  // When true, the type was explicitly modified by the user and should be
+  // preserved even when upstream columns change.
+  typeUserModified?: boolean;
 }
 
 export function columnInfoFromSqlColumn(
@@ -58,6 +61,7 @@ export function newColumnInfo(
     column: {...col.column, name: finalName},
     alias: undefined,
     checked: checked ?? col.checked,
+    typeUserModified: col.typeUserModified,
   };
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -44,6 +44,7 @@ export interface ModifyColumnsSerializedState {
     type: string;
     checked: boolean;
     alias?: string;
+    typeUserModified?: boolean;
   }[];
   comment?: string;
 }
@@ -90,7 +91,8 @@ export class ModifyColumnsNode implements QueryNode {
 
     const newSelectedColumns = newColumnInfoList(sourceCols);
 
-    // Preserve checked status, aliases, and types for columns that still exist.
+    // Preserve checked status and aliases for columns that still exist.
+    // Types are only preserved if the user explicitly modified them.
     for (const oldCol of this.state.selectedColumns) {
       const newCol = newSelectedColumns.find(
         (c) => c.column.name === oldCol.column.name,
@@ -98,11 +100,15 @@ export class ModifyColumnsNode implements QueryNode {
       if (newCol) {
         newCol.checked = oldCol.checked;
         newCol.alias = oldCol.alias;
-        newCol.type = oldCol.type;
-        newCol.column = {
-          ...newCol.column,
-          type: oldCol.column.type,
-        };
+        // Only preserve type if user explicitly modified it
+        if (oldCol.typeUserModified) {
+          newCol.type = oldCol.type;
+          newCol.column = {
+            ...newCol.column,
+            type: oldCol.column.type,
+          };
+          newCol.typeUserModified = true;
+        }
       }
     }
 
@@ -125,6 +131,7 @@ export class ModifyColumnsNode implements QueryNode {
         checked: c.checked,
         column: {name: c.name},
         alias: c.alias,
+        typeUserModified: c.typeUserModified,
       })),
     };
   }
@@ -359,6 +366,8 @@ export class ModifyColumnsNode implements QueryNode {
           ...newSelectedColumns[index].column,
           type: parsedType.ok ? parsedType.value : col.column.type,
         },
+        // Mark as user-modified so it's preserved when upstream changes
+        typeUserModified: true,
       };
       this.state.selectedColumns = newSelectedColumns;
       this.state.onchange?.();
@@ -447,6 +456,7 @@ export class ModifyColumnsNode implements QueryNode {
         type: c.type,
         checked: c.checked,
         alias: c.alias,
+        typeUserModified: c.typeUserModified,
       })),
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node_unittest.ts
@@ -241,6 +241,7 @@ describe('ModifyColumnsNode', () => {
         ...modifyNode.state.selectedColumns[2].column,
         type: {kind: 'duration'},
       };
+      modifyNode.state.selectedColumns[2].typeUserModified = true;
 
       // Verify the type was modified
       expect(modifyNode.state.selectedColumns[2].type).toBe('DURATION');


### PR DESCRIPTION
Adds a new feature to the IntervalIntersectNode that allows users to select where the output `id`, `ts`, and `dur` columns come from - either the intersection result (default) or one of the input sources. This is useful when filtering intervals by overlap while preserving the original timing and identity from a specific source.                                                                                                                             