### PR TITLE
tp: fix bug with != on non-existent string in dataframe

### DIFF
--- a/src/trace_processor/core/dataframe/impl/bytecode_interpreter_impl.h
+++ b/src/trace_processor/core/dataframe/impl/bytecode_interpreter_impl.h
@@ -1007,7 +1007,7 @@ inline PERFETTO_ALWAYS_INLINE uint32_t* StringFilterNe(
   std::optional<StringPool::Id> id =
       state.string_pool->GetId(base::StringView(val));
   if (!id) {
-    memcpy(output, begin, size_t(end - begin));
+    memcpy(output, begin, size_t(end - begin) * sizeof(*begin));
     return output + (end - begin);
   }
   static_assert(sizeof(StringPool::Id) == 4, "Id should be 4 bytes");


### PR DESCRIPTION
sashwinbalaji@ spotted that this memcpy would only copy 1/4 the number
of elements that it should! Very nice find!

Added a test for this which fails before as well and passes now.
