### PR TITLE
de: Don't delete the sql node when editing the Editor

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -81,8 +81,10 @@ class SqlEditor implements m.ClassComponent<SqlEditorAttrs> {
             if (canvas !== null) {
               canvas.focus();
             }
-            e.stopPropagation();
           }
+          // Stop propagation for all keyboard events to prevent them from
+          // reaching the graph (e.g., Delete/Backspace would delete the node)
+          e.stopPropagation();
         },
       },
       [


### PR DESCRIPTION
When adding the sql node, modifying the input and clicking delete (to delete the letter) we would delete the node