### PR TITLE
de: Show the failed query on

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.scss
@@ -69,3 +69,39 @@
   margin: 0 0.25rem;
   color: var(--pf-color-text-disabled);
 }
+
+.pf-failing-sql {
+  width: 100%;
+  max-width: 800px;
+  text-align: left;
+  margin-top: 0.5rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.25rem;
+  }
+
+  &__label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--pf-color-text-muted);
+  }
+
+  &__code {
+    background-color: var(--pf-color-surface-1);
+    border: 1px solid var(--pf-color-border);
+    border-radius: 4px;
+    padding: 0.75rem;
+    margin: 0;
+    font-family: var(--pf-font-family-mono);
+    font-size: 0.75rem;
+    line-height: 1.4;
+    overflow-x: auto;
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}


### PR DESCRIPTION
When the SQL was failing we were showing the Trace Processor error, but we didn't show the SQL that was failing, which made debugging difficult. 

Added a box with the copy button, that showed the SQL