### PR TITLE
tp: fully decouple interpreter from dataframe

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -2756,8 +2756,6 @@ cc_test {
         ":perfetto_src_trace_processor_containers_containers",
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
-        ":perfetto_src_trace_processor_core_dataframe_specs",
-        ":perfetto_src_trace_processor_core_dataframe_types",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
         ":perfetto_src_trace_processor_core_util_util",
         ":perfetto_src_trace_processor_export_json",
@@ -14312,16 +14310,6 @@ filegroup {
     ],
 }
 
-// GN: //src/trace_processor/core/dataframe:specs
-filegroup {
-    name: "perfetto_src_trace_processor_core_dataframe_specs",
-}
-
-// GN: //src/trace_processor/core/dataframe:types
-filegroup {
-    name: "perfetto_src_trace_processor_core_dataframe_types",
-}
-
 // GN: //src/trace_processor/core/dataframe:unittests
 filegroup {
     name: "perfetto_src_trace_processor_core_dataframe_unittests",
@@ -16134,8 +16122,6 @@ cc_library_static {
         ":perfetto_src_trace_processor_containers_containers",
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
-        ":perfetto_src_trace_processor_core_dataframe_specs",
-        ":perfetto_src_trace_processor_core_dataframe_types",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
         ":perfetto_src_trace_processor_core_util_util",
         ":perfetto_src_trace_processor_export_json",
@@ -18403,8 +18389,6 @@ cc_test {
         ":perfetto_src_trace_processor_containers_unittests",
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
-        ":perfetto_src_trace_processor_core_dataframe_specs",
-        ":perfetto_src_trace_processor_core_dataframe_types",
         ":perfetto_src_trace_processor_core_dataframe_unittests",
         ":perfetto_src_trace_processor_core_interpreter_bytecode_interpreter_test_utils",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
@@ -19284,8 +19268,6 @@ cc_library_static {
         ":perfetto_src_trace_processor_containers_containers",
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
-        ":perfetto_src_trace_processor_core_dataframe_specs",
-        ":perfetto_src_trace_processor_core_dataframe_types",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
         ":perfetto_src_trace_processor_core_util_util",
         ":perfetto_src_trace_processor_export_json",
@@ -19786,8 +19768,6 @@ cc_binary_host {
         ":perfetto_src_trace_processor_containers_containers",
         ":perfetto_src_trace_processor_core_common_common",
         ":perfetto_src_trace_processor_core_dataframe_dataframe",
-        ":perfetto_src_trace_processor_core_dataframe_specs",
-        ":perfetto_src_trace_processor_core_dataframe_types",
         ":perfetto_src_trace_processor_core_interpreter_interpreter",
         ":perfetto_src_trace_processor_core_util_util",
         ":perfetto_src_trace_processor_export_json",

--- a/BUILD
+++ b/BUILD
@@ -345,8 +345,6 @@ perfetto_cc_library(
         ":src_protozero_text_to_proto_text_to_proto",
         ":src_trace_processor_core_common_common",
         ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_dataframe_specs",
-        ":src_trace_processor_core_dataframe_types",
         ":src_trace_processor_core_interpreter_interpreter",
         ":src_trace_processor_core_util_util",
         ":src_trace_processor_export_json",
@@ -550,8 +548,6 @@ perfetto_cc_library(
         ":src_protozero_text_to_proto_text_to_proto",
         ":src_trace_processor_core_common_common",
         ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_dataframe_specs",
-        ":src_trace_processor_core_dataframe_types",
         ":src_trace_processor_core_interpreter_interpreter",
         ":src_trace_processor_core_util_util",
         ":src_trace_processor_export_json",
@@ -2022,23 +2018,9 @@ perfetto_filegroup(
         "src/trace_processor/core/dataframe/query_plan.cc",
         "src/trace_processor/core/dataframe/query_plan.h",
         "src/trace_processor/core/dataframe/runtime_dataframe_builder.h",
+        "src/trace_processor/core/dataframe/specs.h",
         "src/trace_processor/core/dataframe/typed_cursor.cc",
         "src/trace_processor/core/dataframe/typed_cursor.h",
-    ],
-)
-
-# GN target: //src/trace_processor/core/dataframe:specs
-perfetto_filegroup(
-    name = "src_trace_processor_core_dataframe_specs",
-    srcs = [
-        "src/trace_processor/core/dataframe/specs.h",
-    ],
-)
-
-# GN target: //src/trace_processor/core/dataframe:types
-perfetto_filegroup(
-    name = "src_trace_processor_core_dataframe_types",
-    srcs = [
         "src/trace_processor/core/dataframe/types.h",
     ],
 )
@@ -8055,8 +8037,6 @@ perfetto_cc_library(
         ":src_protozero_text_to_proto_text_to_proto",
         ":src_trace_processor_core_common_common",
         ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_dataframe_specs",
-        ":src_trace_processor_core_dataframe_types",
         ":src_trace_processor_core_interpreter_interpreter",
         ":src_trace_processor_core_util_util",
         ":src_trace_processor_export_json",
@@ -8289,8 +8269,6 @@ perfetto_cc_binary(
         ":src_protozero_text_to_proto_text_to_proto",
         ":src_trace_processor_core_common_common",
         ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_dataframe_specs",
-        ":src_trace_processor_core_dataframe_types",
         ":src_trace_processor_core_interpreter_interpreter",
         ":src_trace_processor_core_util_util",
         ":src_trace_processor_export_json",

--- a/src/trace_processor/core/common/BUILD.gn
+++ b/src/trace_processor/core/common/BUILD.gn
@@ -26,6 +26,7 @@ source_set("common") {
   deps = [
     "../../../../gn:default_deps",
     "../../../base",
+    "../../containers",
     "../util",
   ]
 }

--- a/src/trace_processor/core/common/storage_types.h
+++ b/src/trace_processor/core/common/storage_types.h
@@ -17,6 +17,9 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_COMMON_STORAGE_TYPES_H_
 #define SRC_TRACE_PROCESSOR_CORE_COMMON_STORAGE_TYPES_H_
 
+#include <cstdint>
+
+#include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core {
@@ -25,22 +28,34 @@ namespace perfetto::trace_processor::core {
 // the value. This allows for zero memory overhead as values don't need to be
 // explicitly stored. Operations on column with this type can be highly
 // optimized.
-struct Id {};
+struct Id {
+  using cpp_type = void;
+};
 
 // Represents values where the value is a 32-bit unsigned integer.
-struct Uint32 {};
+struct Uint32 {
+  using cpp_type = uint32_t;
+};
 
 // Represents values where the value is a 32-bit signed integer.
-struct Int32 {};
+struct Int32 {
+  using cpp_type = int32_t;
+};
 
 // Represents values where the value is a 64-bit signed integer.
-struct Int64 {};
+struct Int64 {
+  using cpp_type = int64_t;
+};
 
 // Represents values where the value is a double.
-struct Double {};
+struct Double {
+  using cpp_type = double;
+};
 
 // Represents values where the value is a string.
-struct String {};
+struct String {
+  using cpp_type = StringPool::Id;
+};
 
 // TypeSet of all possible storage value types.
 using StorageType = core::TypeSet<Id, Uint32, Int32, Int64, Double, String>;

--- a/src/trace_processor/core/dataframe/BUILD.gn
+++ b/src/trace_processor/core/dataframe/BUILD.gn
@@ -25,11 +25,12 @@ source_set("dataframe") {
     "query_plan.cc",
     "query_plan.h",
     "runtime_dataframe_builder.h",
+    "specs.h",
     "typed_cursor.cc",
     "typed_cursor.h",
+    "types.h",
   ]
   deps = [
-    ":types",
     "../../../../gn:default_deps",
     "../../../base",
     "../../containers",
@@ -39,30 +40,6 @@ source_set("dataframe") {
     "../interpreter",
     "../util",
   ]
-  public_deps = [ ":specs" ]
-}
-
-source_set("types") {
-  sources = [ "types.h" ]
-  deps = [
-    "../../../../gn:default_deps",
-    "../../../base",
-    "../../containers",
-    "../common",
-    "../util",
-  ]
-}
-
-source_set("specs") {
-  sources = [ "specs.h" ]
-  deps = [
-    "../../../../gn:default_deps",
-    "../../../base",
-    "../../containers",
-    "../common",
-    "../util",
-  ]
-  public_deps = [ ":types" ]
 }
 
 perfetto_unittest_source_set("unittests") {

--- a/src/trace_processor/core/dataframe/cursor_impl.h
+++ b/src/trace_processor/core/dataframe/cursor_impl.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "perfetto/base/logging.h"
 #include "src/trace_processor/core/dataframe/cursor.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_impl.h"  // IWYU pragma: keep
 #include "src/trace_processor/core/util/span.h"

--- a/src/trace_processor/core/dataframe/dataframe_unittest.cc
+++ b/src/trace_processor/core/dataframe/dataframe_unittest.cc
@@ -175,9 +175,9 @@ TEST_F(DataframeBytecodeTest, SingleFilter) {
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Id>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
-    SortedFilter<Id, EqualRange>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
-    AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-    Iota: [source_register=Register(0), update_register=Register(3)]
+    SortedFilter<Id, EqualRange>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
+    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+    Iota: [source_register=Register(0), update_register=Register(4)]
   )");
 }
 
@@ -198,11 +198,11 @@ TEST_F(DataframeBytecodeTest, MultipleFilters) {
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Id>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
-    SortedFilter<Id, EqualRange>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
-    CastFilterValue<Id>: [fval_handle=FilterValue(1), write_register=Register(2), op=NonNullOp(0)]
-    SortedFilter<Id, EqualRange>: [col=1, val_register=Register(2), update_register=Register(0), write_result_to=BoundModifier(0)]
-    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
-    Iota: [source_register=Register(0), update_register=Register(4)]
+    SortedFilter<Id, EqualRange>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
+    CastFilterValue<Id>: [fval_handle=FilterValue(1), write_register=Register(3), op=NonNullOp(0)]
+    SortedFilter<Id, EqualRange>: [storage_register=Register(4), val_register=Register(3), update_register=Register(0), write_result_to=BoundModifier(0)]
+    AllocateIndices: [size=0, dest_slab_register=Register(5), dest_span_register=Register(6)]
+    Iota: [source_register=Register(0), update_register=Register(6)]
   )");
 }
 
@@ -213,9 +213,9 @@ TEST_F(DataframeBytecodeTest, NumericSortedEq) {
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
-    SortedFilter<Uint32, EqualRange>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
-    AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-    Iota: [source_register=Register(0), update_register=Register(3)]
+    SortedFilter<Uint32, EqualRange>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
+    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+    Iota: [source_register=Register(0), update_register=Register(4)]
   )");
 }
 
@@ -228,7 +228,7 @@ TEST_F(DataframeBytecodeTest, InFilter) {
     CastFilterValueList<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
     Iota: [source_register=Register(0), update_register=Register(3)]
-    In<Uint32>: [col=0, value_list_register=Register(1), source_register=Register(3), update_register=Register(3)]
+    In<Uint32>: [storage_register=Register(4), value_list_register=Register(1), source_register=Register(3), update_register=Register(3)]
   )");
 }
 
@@ -241,9 +241,9 @@ TEST_F(DataframeBytecodeTest, NumericSortedInEq) {
     RunBytecodeTest(cols, filters, {}, {}, {}, R"(
       InitRange: [size=0, dest_register=Register(0)]
       CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(2)]
-      SortedFilter<Uint32, LowerBound>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(2)]
-      AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-      Iota: [source_register=Register(0), update_register=Register(3)]
+      SortedFilter<Uint32, LowerBound>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(2)]
+      AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+      Iota: [source_register=Register(0), update_register=Register(4)]
     )");
   }
   {
@@ -254,9 +254,9 @@ TEST_F(DataframeBytecodeTest, NumericSortedInEq) {
     RunBytecodeTest(cols, filters, {}, {}, {}, R"(
       InitRange: [size=0, dest_register=Register(0)]
       CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(3)]
-      SortedFilter<Uint32, UpperBound>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(2)]
-      AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-      Iota: [source_register=Register(0), update_register=Register(3)]
+      SortedFilter<Uint32, UpperBound>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(2)]
+      AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+      Iota: [source_register=Register(0), update_register=Register(4)]
     )");
   }
   {
@@ -267,9 +267,9 @@ TEST_F(DataframeBytecodeTest, NumericSortedInEq) {
     RunBytecodeTest(cols, filters, {}, {}, {}, R"(
       InitRange: [size=0, dest_register=Register(0)]
       CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(4)]
-      SortedFilter<Uint32, UpperBound>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
-      AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-      Iota: [source_register=Register(0), update_register=Register(3)]
+      SortedFilter<Uint32, UpperBound>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
+      AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+      Iota: [source_register=Register(0), update_register=Register(4)]
     )");
   }
   {
@@ -280,9 +280,9 @@ TEST_F(DataframeBytecodeTest, NumericSortedInEq) {
     RunBytecodeTest(cols, filters, {}, {}, {}, R"(
       InitRange: [size=0, dest_register=Register(0)]
       CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(5)]
-      SortedFilter<Uint32, LowerBound>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
-      AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-      Iota: [source_register=Register(0), update_register=Register(3)]
+      SortedFilter<Uint32, LowerBound>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
+      AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+      Iota: [source_register=Register(0), update_register=Register(4)]
     )");
   }
 }
@@ -298,7 +298,7 @@ TEST_F(DataframeBytecodeTest, Numeric) {
       InitRange: [size=0, dest_register=Register(0)]
       CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
       AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-      LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
+      LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
     )");
   }
   {
@@ -312,7 +312,7 @@ TEST_F(DataframeBytecodeTest, Numeric) {
       CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(5)]
       AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
       Iota: [source_register=Register(0), update_register=Register(3)]
-      NonStringFilter<Uint32, Ge>: [col=0, val_register=Register(1), source_register=Register(3), update_register=Register(3)]
+      NonStringFilter<Uint32, Ge>: [storage_register=Register(4), val_register=Register(1), source_register=Register(3), update_register=Register(3)]
   )");
   }
 }
@@ -337,23 +337,23 @@ TEST_F(DataframeBytecodeTest, SortingOfFilters) {
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Id>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
-    SortedFilter<Id, EqualRange>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
-    CastFilterValue<Id>: [fval_handle=FilterValue(1), write_register=Register(2), op=NonNullOp(3)]
-    SortedFilter<Id, UpperBound>: [col=0, val_register=Register(2), update_register=Register(0), write_result_to=BoundModifier(2)]
-    CastFilterValue<Uint32>: [fval_handle=FilterValue(2), write_register=Register(3), op=NonNullOp(0)]
-    SortedFilter<Uint32, EqualRange>: [col=1, val_register=Register(3), update_register=Register(0), write_result_to=BoundModifier(0)]
-    CastFilterValue<Uint32>: [fval_handle=FilterValue(3), write_register=Register(4), op=NonNullOp(3)]
-    SortedFilter<Uint32, UpperBound>: [col=1, val_register=Register(4), update_register=Register(0), write_result_to=BoundModifier(2)]
-    CastFilterValue<String>: [fval_handle=FilterValue(4), write_register=Register(5), op=NonNullOp(0)]
-    SortedFilter<String, EqualRange>: [col=3, val_register=Register(5), update_register=Register(0), write_result_to=BoundModifier(0)]
-    CastFilterValue<String>: [fval_handle=FilterValue(5), write_register=Register(6), op=NonNullOp(3)]
-    SortedFilter<String, UpperBound>: [col=3, val_register=Register(6), update_register=Register(0), write_result_to=BoundModifier(2)]
-    CastFilterValue<String>: [fval_handle=FilterValue(6), write_register=Register(7), op=NonNullOp(3)]
-    AllocateIndices: [size=0, dest_slab_register=Register(8), dest_span_register=Register(9)]
-    Iota: [source_register=Register(0), update_register=Register(9)]
-    StringFilter<Le>: [col=4, val_register=Register(7), source_register=Register(9), update_register=Register(9)]
-    CastFilterValue<Uint32>: [fval_handle=FilterValue(7), write_register=Register(10), op=NonNullOp(0)]
-    NonStringFilter<Uint32, Eq>: [col=2, val_register=Register(10), source_register=Register(9), update_register=Register(9)]
+    SortedFilter<Id, EqualRange>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(0)]
+    CastFilterValue<Id>: [fval_handle=FilterValue(1), write_register=Register(3), op=NonNullOp(3)]
+    SortedFilter<Id, UpperBound>: [storage_register=Register(2), val_register=Register(3), update_register=Register(0), write_result_to=BoundModifier(2)]
+    CastFilterValue<Uint32>: [fval_handle=FilterValue(2), write_register=Register(4), op=NonNullOp(0)]
+    SortedFilter<Uint32, EqualRange>: [storage_register=Register(5), val_register=Register(4), update_register=Register(0), write_result_to=BoundModifier(0)]
+    CastFilterValue<Uint32>: [fval_handle=FilterValue(3), write_register=Register(6), op=NonNullOp(3)]
+    SortedFilter<Uint32, UpperBound>: [storage_register=Register(5), val_register=Register(6), update_register=Register(0), write_result_to=BoundModifier(2)]
+    CastFilterValue<String>: [fval_handle=FilterValue(4), write_register=Register(7), op=NonNullOp(0)]
+    SortedFilter<String, EqualRange>: [storage_register=Register(8), val_register=Register(7), update_register=Register(0), write_result_to=BoundModifier(0)]
+    CastFilterValue<String>: [fval_handle=FilterValue(5), write_register=Register(9), op=NonNullOp(3)]
+    SortedFilter<String, UpperBound>: [storage_register=Register(8), val_register=Register(9), update_register=Register(0), write_result_to=BoundModifier(2)]
+    CastFilterValue<String>: [fval_handle=FilterValue(6), write_register=Register(10), op=NonNullOp(3)]
+    AllocateIndices: [size=0, dest_slab_register=Register(11), dest_span_register=Register(12)]
+    Iota: [source_register=Register(0), update_register=Register(12)]
+    StringFilter<Le>: [storage_register=Register(13), val_register=Register(10), source_register=Register(12), update_register=Register(12)]
+    CastFilterValue<Uint32>: [fval_handle=FilterValue(7), write_register=Register(14), op=NonNullOp(0)]
+    NonStringFilter<Uint32, Eq>: [storage_register=Register(15), val_register=Register(14), source_register=Register(12), update_register=Register(12)]
   )");
 }
 
@@ -371,7 +371,7 @@ TEST_F(DataframeBytecodeTest, StringFilter) {
     CastFilterValue<String>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(7)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
     Iota: [source_register=Register(0), update_register=Register(3)]
-    StringFilter<Regex>: [col=0, val_register=Register(1), source_register=Register(3), update_register=Register(3)]
+    StringFilter<Regex>: [storage_register=Register(4), val_register=Register(1), source_register=Register(3), update_register=Register(3)]
   )");
 }
 
@@ -386,7 +386,7 @@ TEST_F(DataframeBytecodeTest, StringFilterGlob) {
     CastFilterValue<String>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(6)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
     Iota: [source_register=Register(0), update_register=Register(3)]
-    StringFilter<Glob>: [col=0, val_register=Register(1), source_register=Register(3), update_register=Register(3)]
+    StringFilter<Glob>: [storage_register=Register(4), val_register=Register(1), source_register=Register(3), update_register=Register(3)]
   )");
 }
 
@@ -400,7 +400,7 @@ TEST_F(DataframeBytecodeTest, SparseNullFilters) {
     InitRange: [size=0, dest_register=Register(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
-    NullFilter<IsNull>: [col=0, update_register=Register(2)]
+    NullFilter<IsNull>: [null_bv_register=Register(3), update_register=Register(2)]
   )",
                     /*cols_used=*/0);
   }
@@ -416,7 +416,7 @@ TEST_F(DataframeBytecodeTest, SparseNullFilters) {
     InitRange: [size=0, dest_register=Register(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
-    NullFilter<IsNotNull>: [col=0, update_register=Register(2)]
+    NullFilter<IsNotNull>: [null_bv_register=Register(3), update_register=Register(2)]
   )",
                     /*cols_used=*/0);
   }
@@ -434,7 +434,7 @@ TEST_F(DataframeBytecodeTest, DenseNullFilters) {
     InitRange: [size=0, dest_register=Register(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
-    NullFilter<IsNull>: [col=0, update_register=Register(2)]
+    NullFilter<IsNull>: [null_bv_register=Register(3), update_register=Register(2)]
   )",
                     /*cols_used=*/0);
   }
@@ -450,7 +450,7 @@ TEST_F(DataframeBytecodeTest, DenseNullFilters) {
     InitRange: [size=0, dest_register=Register(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
-    NullFilter<IsNotNull>: [col=0, update_register=Register(2)]
+    NullFilter<IsNotNull>: [null_bv_register=Register(3), update_register=Register(2)]
   )",
                     /*cols_used=*/0);
   }
@@ -500,11 +500,11 @@ TEST_F(DataframeBytecodeTest, StandardFilterOnSparseNull) {
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
     Iota: [source_register=Register(0), update_register=Register(3)]
-    NullFilter<IsNotNull>: [col=0, update_register=Register(3)]
-    AllocateIndices: [size=0, dest_slab_register=Register(4), dest_span_register=Register(5)]
-    PrefixPopcount: [col=0, dest_register=Register(6)]
-    TranslateSparseNullIndices: [col=0, popcount_register=Register(6), source_register=Register(3), update_register=Register(5)]
-    NonStringFilter<Uint32, Eq>: [col=0, val_register=Register(1), source_register=Register(5), update_register=Register(3)]
+    NullFilter<IsNotNull>: [null_bv_register=Register(4), update_register=Register(3)]
+    AllocateIndices: [size=0, dest_slab_register=Register(5), dest_span_register=Register(6)]
+    PrefixPopcount: [null_bv_register=Register(4), dest_register=Register(7)]
+    TranslateSparseNullIndices: [null_bv_register=Register(4), popcount_register=Register(7), source_register=Register(3), update_register=Register(6)]
+    NonStringFilter<Uint32, Eq>: [storage_register=Register(8), val_register=Register(1), source_register=Register(6), update_register=Register(3)]
   )",
                   /*cols_used=*/0);
 }
@@ -523,8 +523,8 @@ TEST_F(DataframeBytecodeTest, StandardFilterOnDenseNull) {
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
     Iota: [source_register=Register(0), update_register=Register(3)]
-    NullFilter<IsNotNull>: [col=0, update_register=Register(3)]
-    NonStringFilter<Uint32, Eq>: [col=0, val_register=Register(1), source_register=Register(3), update_register=Register(3)]
+    NullFilter<IsNotNull>: [null_bv_register=Register(4), update_register=Register(3)]
+    NonStringFilter<Uint32, Eq>: [storage_register=Register(5), val_register=Register(1), source_register=Register(3), update_register=Register(3)]
   )",
                   /*cols_used=*/0);
 }
@@ -554,8 +554,8 @@ TEST_F(DataframeBytecodeTest, OutputSparseNullColumn) {
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
     StrideCopy: [source_register=Register(2), update_register=Register(4), stride=2]
-    PrefixPopcount: [col=1, dest_register=Register(5)]
-    StrideTranslateAndCopySparseNullIndices: [col=1, popcount_register=Register(5), update_register=Register(4), offset=1, stride=2]
+    PrefixPopcount: [null_bv_register=Register(6), dest_register=Register(5)]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(6), popcount_register=Register(5), update_register=Register(4), offset=1, stride=2]
   )",
                   cols_used);
 }
@@ -585,7 +585,7 @@ TEST_F(DataframeBytecodeTest, OutputDenseNullColumn) {
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
     StrideCopy: [source_register=Register(2), update_register=Register(4), stride=2]
-    StrideCopyDenseNullIndices: [col=1, update_register=Register(4), offset=1, stride=2]
+    StrideCopyDenseNullIndices: [null_bv_register=Register(5), update_register=Register(4), offset=1, stride=2]
   )",
                   cols_used);
 }
@@ -618,9 +618,9 @@ TEST_F(DataframeBytecodeTest, OutputMultipleNullableColumns) {
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
     StrideCopy: [source_register=Register(2), update_register=Register(4), stride=3]
-    PrefixPopcount: [col=1, dest_register=Register(5)]
-    StrideTranslateAndCopySparseNullIndices: [col=1, popcount_register=Register(5), update_register=Register(4), offset=1, stride=3]
-    StrideCopyDenseNullIndices: [col=2, update_register=Register(4), offset=2, stride=3]
+    PrefixPopcount: [null_bv_register=Register(6), dest_register=Register(5)]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(6), popcount_register=Register(5), update_register=Register(4), offset=1, stride=3]
+    StrideCopyDenseNullIndices: [null_bv_register=Register(7), update_register=Register(4), offset=2, stride=3]
   )",
                   cols_used);
 }
@@ -635,9 +635,9 @@ TEST_F(DataframeBytecodeTest, Uint32SetIdSortedEqGeneration) {
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
-    Uint32SetIdSortedEq: [col=0, val_register=Register(1), update_register=Register(0)]
-    AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-    Iota: [source_register=Register(0), update_register=Register(3)]
+    Uint32SetIdSortedEq: [storage_register=Register(2), val_register=Register(1), update_register=Register(0)]
+    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+    Iota: [source_register=Register(0), update_register=Register(4)]
   )");
 }
 // Test sorting by a single Uint32 column, ascending.
@@ -651,7 +651,7 @@ TEST_F(DataframeBytecodeTest, SortSingleUint32Asc) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    CopyToRowLayout<Uint32, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Uint32, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=4, indices_register=Register(2)]
   )",
                   /*cols_used=*/1);
@@ -668,11 +668,11 @@ TEST_F(DataframeBytecodeTest, SortSingleStringDesc) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     InitRankMap: [dest_register=Register(3)]
-    CollectIdIntoRankMap: [col=0, source_register=Register(2), rank_map_register=Register(3)]
+    CollectIdIntoRankMap: [storage_register=Register(4), source_register=Register(2), rank_map_register=Register(3)]
     FinalizeRanksInMap: [update_register=Register(3)]
-    AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(4)]
-    CopyToRowLayout<String, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(4), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(3)]
-    SortRowLayout: [buffer_register=Register(4), total_row_stride=4, indices_register=Register(2)]
+    AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(5)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(4), null_bv_register=Register(6), source_indices_register=Register(2), dest_buffer_register=Register(5), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(3)]
+    SortRowLayout: [buffer_register=Register(5), total_row_stride=4, indices_register=Register(2)]
   )",
                   /*cols_used=*/1);
 }
@@ -693,8 +693,8 @@ TEST_F(DataframeBytecodeTest, SortMultiColumnStable) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    CopyToRowLayout<Int64, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=16, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<Double, NonNull>: [col=1, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=8, row_layout_stride=16, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int64, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=16, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Double, NonNull>: [storage_register=Register(6), null_bv_register=Register(7), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=8, row_layout_stride=16, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=16, indices_register=Register(2)]
   )",
                   /*cols_used=*/3);
@@ -711,12 +711,12 @@ TEST_F(DataframeBytecodeTest, SortWithFilter) {
   RunBytecodeTest(cols, filters, {}, sorts, {}, R"(
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Id>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(4)]
-    SortedFilter<Id, UpperBound>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
-    AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-    Iota: [source_register=Register(0), update_register=Register(3)]
-    AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(4)]
-    CopyToRowLayout<Double, NonNull>: [col=1, source_indices_register=Register(3), dest_buffer_register=Register(4), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    SortRowLayout: [buffer_register=Register(4), total_row_stride=8, indices_register=Register(3)]
+    SortedFilter<Id, UpperBound>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
+    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
+    Iota: [source_register=Register(0), update_register=Register(4)]
+    AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(5)]
+    CopyToRowLayout<Double, NonNull>: [storage_register=Register(6), null_bv_register=Register(7), source_indices_register=Register(4), dest_buffer_register=Register(5), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    SortRowLayout: [buffer_register=Register(5), total_row_stride=8, indices_register=Register(4)]
   )",
                   /*cols_used=*/3);
 }
@@ -733,12 +733,12 @@ TEST_F(DataframeBytecodeTest, SortNullableColumn) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    PrefixPopcount: [col=0, dest_register=Register(4)]
-    CopyToRowLayout<Int32, SparseNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=5, invert_copied_bits=1, popcount_register=Register(4), rank_map_register=Register(4294967295)]
+    PrefixPopcount: [null_bv_register=Register(5), dest_register=Register(4)]
+    CopyToRowLayout<Int32, SparseNull>: [storage_register=Register(6), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=5, invert_copied_bits=1, popcount_register=Register(4), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=5, indices_register=Register(2)]
-    AllocateIndices: [size=0, dest_slab_register=Register(5), dest_span_register=Register(6)]
-    StrideCopy: [source_register=Register(2), update_register=Register(6), stride=2]
-    StrideTranslateAndCopySparseNullIndices: [col=0, popcount_register=Register(4), update_register=Register(6), offset=1, stride=2]
+    AllocateIndices: [size=0, dest_slab_register=Register(7), dest_span_register=Register(8)]
+    StrideCopy: [source_register=Register(2), update_register=Register(8), stride=2]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(5), popcount_register=Register(4), update_register=Register(8), offset=1, stride=2]
   )",
                   /*cols_used=*/1);
 }
@@ -759,8 +759,8 @@ TEST_F(DataframeBytecodeTest, PlanQuery_DistinctTwoNonNullCols) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    CopyToRowLayout<Int32, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<String, NonNull>: [col=1, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int32, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(6), null_bv_register=Register(7), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     Distinct: [buffer_register=Register(3), total_row_stride=8, indices_register=Register(2)]
   )";
 
@@ -784,12 +784,12 @@ TEST_F(DataframeBytecodeTest, LimitOffsetPlacement) {
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-    LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
+    LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
     LimitOffsetIndices: [offset_value=2, limit_value=10, update_register=Register(3)]
-    AllocateIndices: [size=0, dest_slab_register=Register(4), dest_span_register=Register(5)]
-    StrideCopy: [source_register=Register(3), update_register=Register(5), stride=2]
-    PrefixPopcount: [col=1, dest_register=Register(6)]
-    StrideTranslateAndCopySparseNullIndices: [col=1, popcount_register=Register(6), update_register=Register(5), offset=1, stride=2]
+    AllocateIndices: [size=0, dest_slab_register=Register(5), dest_span_register=Register(6)]
+    StrideCopy: [source_register=Register(3), update_register=Register(6), stride=2]
+    PrefixPopcount: [null_bv_register=Register(8), dest_register=Register(7)]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(8), popcount_register=Register(7), update_register=Register(6), offset=1, stride=2]
   )",
                   /*cols_used=*/2);
 }
@@ -807,7 +807,7 @@ TEST_F(DataframeBytecodeTest, PlanQuery_MinOptimizationApplied) {
     InitRange: [size=0, dest_register=Register(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
-    FindMinMaxIndex<Uint32, MinOp>: [col=0, update_register=Register(2)]
+    FindMinMaxIndex<Uint32, MinOp>: [storage_register=Register(3), update_register=Register(2)]
   )";
 
   RunBytecodeTest(cols, filters, distinct_specs, sort_specs, limit_spec,
@@ -841,8 +841,8 @@ TEST_F(DataframeBytecodeTest, SortOptimizationNotApplied_MultipleSpecs) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    CopyToRowLayout<Uint32, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<Int32, NonNull>: [col=1, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Uint32, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int32, NonNull>: [storage_register=Register(6), null_bv_register=Register(7), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=8, indices_register=Register(2)]
   )",
                   /*cols_used=*/3);  // 0b11
@@ -872,12 +872,12 @@ TEST_F(DataframeBytecodeTest, SortOptimizationNotApplied_NullableColumn) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    PrefixPopcount: [col=0, dest_register=Register(4)]
-    CopyToRowLayout<Uint32, SparseNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=5, invert_copied_bits=0, popcount_register=Register(4), rank_map_register=Register(4294967295)]
+    PrefixPopcount: [null_bv_register=Register(5), dest_register=Register(4)]
+    CopyToRowLayout<Uint32, SparseNull>: [storage_register=Register(6), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=5, invert_copied_bits=0, popcount_register=Register(4), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=5, indices_register=Register(2)]
-    AllocateIndices: [size=0, dest_slab_register=Register(5), dest_span_register=Register(6)]
-    StrideCopy: [source_register=Register(2), update_register=Register(6), stride=2]
-    StrideTranslateAndCopySparseNullIndices: [col=0, popcount_register=Register(4), update_register=Register(6), offset=1, stride=2]
+    AllocateIndices: [size=0, dest_slab_register=Register(7), dest_span_register=Register(8)]
+    StrideCopy: [source_register=Register(2), update_register=Register(8), stride=2]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(5), popcount_register=Register(4), update_register=Register(8), offset=1, stride=2]
   )",
                   /*cols_used=*/1);
 }
@@ -892,7 +892,7 @@ TEST_F(DataframeBytecodeTest, SortOptimizationNotApplied_UnsortedColumn) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    CopyToRowLayout<Uint32, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Uint32, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=4, indices_register=Register(2)]
   )",
                   /*cols_used=*/1);
@@ -916,13 +916,13 @@ TEST_F(DataframeBytecodeTest, PlanQuery_MinOptimizationNotAppliedNullable) {
     AllocateIndices: [size=0, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(3)]
-    PrefixPopcount: [col=0, dest_register=Register(4)]
-    CopyToRowLayout<Uint32, SparseNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=5, invert_copied_bits=0, popcount_register=Register(4), rank_map_register=Register(4294967295)]
+    PrefixPopcount: [null_bv_register=Register(5), dest_register=Register(4)]
+    CopyToRowLayout<Uint32, SparseNull>: [storage_register=Register(6), null_bv_register=Register(5), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=5, invert_copied_bits=0, popcount_register=Register(4), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=5, indices_register=Register(2)]
     LimitOffsetIndices: [offset_value=0, limit_value=1, update_register=Register(2)]
-    AllocateIndices: [size=0, dest_slab_register=Register(5), dest_span_register=Register(6)]
-    StrideCopy: [source_register=Register(2), update_register=Register(6), stride=2]
-    StrideTranslateAndCopySparseNullIndices: [col=0, popcount_register=Register(4), update_register=Register(6), offset=1, stride=2]
+    AllocateIndices: [size=0, dest_slab_register=Register(7), dest_span_register=Register(8)]
+    StrideCopy: [source_register=Register(2), update_register=Register(8), stride=2]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(5), popcount_register=Register(4), update_register=Register(8), offset=1, stride=2]
   )";
   RunBytecodeTest(cols, filters, distinct_specs, sort_specs, limit_spec,
                   expected_bytecode, /*cols_used=*/1);
@@ -945,11 +945,10 @@ TEST_F(DataframeBytecodeTest, PlanQuery_SingleColIndex_EqFilter_NonNullInt) {
   std::vector<FilterSpec> filters = {{0, 0, Eq{}, std::nullopt}};
   std::string expected_bytecode = R"(
     InitRange: [size=100, dest_register=Register(0)]
-    IndexPermutationVectorToSpan: [index=0, write_register=Register(1)]
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(2), op=NonNullOp(0)]
-    IndexedFilterEq<Uint32, NonNull>: [col=0, filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
-    AllocateIndices: [size=100, dest_slab_register=Register(4), dest_span_register=Register(5)]
-    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(5)]
+    IndexedFilterEq<Uint32, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
+    AllocateIndices: [size=100, dest_slab_register=Register(6), dest_span_register=Register(7)]
+    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(7)]
   )";
   RunBytecodeTest(df, filters, {}, {}, {}, expected_bytecode,
                   /*cols_used=*/1);
@@ -976,15 +975,14 @@ TEST_F(DataframeBytecodeTest,
   std::vector<FilterSpec> filters = {{0, 0, Eq{}, std::nullopt}};
   std::string expected_bytecode = R"(
     InitRange: [size=4, dest_register=Register(0)]
-    IndexPermutationVectorToSpan: [index=0, write_register=Register(1)]
     CastFilterValue<String>: [fval_handle=FilterValue(0), write_register=Register(2), op=NonNullOp(0)]
-    PrefixPopcount: [col=0, dest_register=Register(3)]
-    IndexedFilterEq<String, SparseNull>: [col=0, filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
-    AllocateIndices: [size=4, dest_slab_register=Register(4), dest_span_register=Register(5)]
-    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(5)]
-    AllocateIndices: [size=8, dest_slab_register=Register(6), dest_span_register=Register(7)]
-    StrideCopy: [source_register=Register(5), update_register=Register(7), stride=2]
-    StrideTranslateAndCopySparseNullIndices: [col=0, popcount_register=Register(3), update_register=Register(7), offset=1, stride=2]
+    PrefixPopcount: [null_bv_register=Register(4), dest_register=Register(3)]
+    IndexedFilterEq<String, SparseNull>: [storage_register=Register(5), null_bv_register=Register(4), filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
+    AllocateIndices: [size=4, dest_slab_register=Register(6), dest_span_register=Register(7)]
+    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(7)]
+    AllocateIndices: [size=8, dest_slab_register=Register(8), dest_span_register=Register(9)]
+    StrideCopy: [source_register=Register(7), update_register=Register(9), stride=2]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(4), popcount_register=Register(3), update_register=Register(9), offset=1, stride=2]
   )";
   RunBytecodeTest(df, filters, {}, {}, {}, expected_bytecode);
 }
@@ -1006,14 +1004,13 @@ TEST_F(DataframeBytecodeTest, PlanQuery_SingleColIndex_EqFilter_DenseNullInt) {
   std::vector<FilterSpec> filters = {{0, 0, Eq{}, std::nullopt}};
   std::string expected_bytecode = R"(
     InitRange: [size=4, dest_register=Register(0)]
-    IndexPermutationVectorToSpan: [index=0, write_register=Register(1)]
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(2), op=NonNullOp(0)]
-    IndexedFilterEq<Uint32, DenseNull>: [col=0, filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
-    AllocateIndices: [size=4, dest_slab_register=Register(4), dest_span_register=Register(5)]
-    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(5)]
-    AllocateIndices: [size=8, dest_slab_register=Register(6), dest_span_register=Register(7)]
-    StrideCopy: [source_register=Register(5), update_register=Register(7), stride=2]
-    StrideCopyDenseNullIndices: [col=0, update_register=Register(7), offset=1, stride=2]
+    IndexedFilterEq<Uint32, DenseNull>: [storage_register=Register(4), null_bv_register=Register(5), filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
+    AllocateIndices: [size=4, dest_slab_register=Register(6), dest_span_register=Register(7)]
+    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(7)]
+    AllocateIndices: [size=8, dest_slab_register=Register(8), dest_span_register=Register(9)]
+    StrideCopy: [source_register=Register(7), update_register=Register(9), stride=2]
+    StrideCopyDenseNullIndices: [null_bv_register=Register(5), update_register=Register(9), offset=1, stride=2]
   )";
   RunBytecodeTest(df, filters, {}, {}, {}, expected_bytecode);
 }
@@ -1042,13 +1039,12 @@ TEST_F(DataframeBytecodeTest, PlanQuery_MultiColIndex_PrefixEqFilters) {
   };
   std::string expected_bytecode = R"(
     InitRange: [size=4, dest_register=Register(0)]
-    IndexPermutationVectorToSpan: [index=0, write_register=Register(1)]
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(2), op=NonNullOp(0)]
-    IndexedFilterEq<Uint32, NonNull>: [col=0, filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
-    CastFilterValue<Uint32>: [fval_handle=FilterValue(1), write_register=Register(4), op=NonNullOp(0)]
-    IndexedFilterEq<Uint32, NonNull>: [col=1, filter_value_reg=Register(4), popcount_register=Register(5), update_register=Register(1)]
-    AllocateIndices: [size=4, dest_slab_register=Register(6), dest_span_register=Register(7)]
-    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(7)]
+    IndexedFilterEq<Uint32, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), filter_value_reg=Register(2), popcount_register=Register(3), update_register=Register(1)]
+    CastFilterValue<Uint32>: [fval_handle=FilterValue(1), write_register=Register(6), op=NonNullOp(0)]
+    IndexedFilterEq<Uint32, NonNull>: [storage_register=Register(8), null_bv_register=Register(9), filter_value_reg=Register(6), popcount_register=Register(7), update_register=Register(1)]
+    AllocateIndices: [size=4, dest_slab_register=Register(10), dest_span_register=Register(11)]
+    CopySpanIntersectingRange: [source_register=Register(1), source_range_register=Register(0), update_register=Register(11)]
   )";
   RunBytecodeTest(df, filters, {}, {}, {}, expected_bytecode);
 }
@@ -1065,7 +1061,7 @@ TEST_F(DataframeBytecodeTest, PlanQuery_LinearFilterEq_NonNullUint32) {
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-    LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
+    LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
   )",
                   /*cols_used=*/1);
 }
@@ -1078,7 +1074,7 @@ TEST_F(DataframeBytecodeTest, PlanQuery_LinearFilterEq_NonNullString) {
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<String>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
-    LinearFilterEq<String>: [col=0, filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
+    LinearFilterEq<String>: [storage_register=Register(4), filter_value_reg=Register(1), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(3)]
   )",
                   /*cols_used=*/1);
 }
@@ -1101,10 +1097,10 @@ TEST_F(DataframeBytecodeTest,
   RunBytecodeTest(cols, filters, {}, {}, {}, R"(
     InitRange: [size=0, dest_register=Register(0)]
     CastFilterValue<Id>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(4)]
-    SortedFilter<Id, UpperBound>: [col=0, val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
-    CastFilterValue<Uint32>: [fval_handle=FilterValue(1), write_register=Register(2), op=NonNullOp(0)]
-    AllocateIndices: [size=0, dest_slab_register=Register(3), dest_span_register=Register(4)]
-    LinearFilterEq<Uint32>: [col=1, filter_value_reg=Register(2), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(4)]
+    SortedFilter<Id, UpperBound>: [storage_register=Register(2), val_register=Register(1), update_register=Register(0), write_result_to=BoundModifier(1)]
+    CastFilterValue<Uint32>: [fval_handle=FilterValue(1), write_register=Register(3), op=NonNullOp(0)]
+    AllocateIndices: [size=0, dest_slab_register=Register(4), dest_span_register=Register(5)]
+    LinearFilterEq<Uint32>: [storage_register=Register(6), filter_value_reg=Register(3), popcount_register=Register(4294967295), source_register=Register(0), update_register=Register(5)]
   )",
                   /*cols_used=*/3);  // 0b11
 }
@@ -1119,7 +1115,7 @@ TEST_F(DataframeBytecodeTest, PlanQuery_NoLinearFilterEq_IfNotEqOperator) {
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(4)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
     Iota: [source_register=Register(0), update_register=Register(3)]
-    NonStringFilter<Uint32, Gt>: [col=0, val_register=Register(1), source_register=Register(3), update_register=Register(3)]
+    NonStringFilter<Uint32, Gt>: [storage_register=Register(4), val_register=Register(1), source_register=Register(3), update_register=Register(3)]
   )",
                   /*cols_used=*/1);
 }
@@ -1135,14 +1131,14 @@ TEST_F(DataframeBytecodeTest, PlanQuery_NoLinearFilterEq_IfNullableColumn) {
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(1), op=NonNullOp(0)]
     AllocateIndices: [size=0, dest_slab_register=Register(2), dest_span_register=Register(3)]
     Iota: [source_register=Register(0), update_register=Register(3)]
-    NullFilter<IsNotNull>: [col=0, update_register=Register(3)]
-    AllocateIndices: [size=0, dest_slab_register=Register(4), dest_span_register=Register(5)]
-    PrefixPopcount: [col=0, dest_register=Register(6)]
-    TranslateSparseNullIndices: [col=0, popcount_register=Register(6), source_register=Register(3), update_register=Register(5)]
-    NonStringFilter<Uint32, Eq>: [col=0, val_register=Register(1), source_register=Register(5), update_register=Register(3)]
-    AllocateIndices: [size=0, dest_slab_register=Register(7), dest_span_register=Register(8)]
-    StrideCopy: [source_register=Register(3), update_register=Register(8), stride=2]
-    StrideTranslateAndCopySparseNullIndices: [col=0, popcount_register=Register(6), update_register=Register(8), offset=1, stride=2]
+    NullFilter<IsNotNull>: [null_bv_register=Register(4), update_register=Register(3)]
+    AllocateIndices: [size=0, dest_slab_register=Register(5), dest_span_register=Register(6)]
+    PrefixPopcount: [null_bv_register=Register(4), dest_register=Register(7)]
+    TranslateSparseNullIndices: [null_bv_register=Register(4), popcount_register=Register(7), source_register=Register(3), update_register=Register(6)]
+    NonStringFilter<Uint32, Eq>: [storage_register=Register(8), val_register=Register(1), source_register=Register(6), update_register=Register(3)]
+    AllocateIndices: [size=0, dest_slab_register=Register(9), dest_span_register=Register(10)]
+    StrideCopy: [source_register=Register(3), update_register=Register(10), stride=2]
+    StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(4), popcount_register=Register(7), update_register=Register(10), offset=1, stride=2]
   )",
                   /*cols_used=*/1);
 }

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -42,13 +42,38 @@
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/interpreter/interpreter_types.h"
+#include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/range.h"
 #include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
+#include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core::dataframe {
 
-// Namespace alias for the bytecode interpreter.
+// Specification for initializing a register before bytecode execution.
+// The plan contains abstract references (column indices, index IDs), and
+// the cursor converts these to concrete pointers based on the kind.
+struct RegisterInit {
+  struct NullBitvector {};
+  struct IndexVector {};
+  struct SmallValueEqBitvector {};
+  struct SmallValueEqPopcount {};
+
+  using Type = TypeSet<Id,
+                       Uint32,
+                       Int32,
+                       Int64,
+                       Double,
+                       String,
+                       NullBitvector,
+                       IndexVector,
+                       SmallValueEqBitvector,
+                       SmallValueEqPopcount>;
+  uint32_t dest_register;
+  uint16_t source_index;  // col_index or index_id depending on kind
+  Type kind;
+};
+static_assert(std::is_trivially_copyable_v<RegisterInit>);
 
 // A QueryPlan encapsulates all the information needed to execute a query,
 // including the bytecode instructions and interpreter configuration.
@@ -59,7 +84,7 @@ struct QueryPlanImpl {
     double estimated_cost = 0;
 
     // Register holding the final filtered indices.
-    interpreter::reg::ReadHandle<Span<uint32_t>> output_register;
+    interpreter::ReadHandle<Span<uint32_t>> output_register;
 
     // The maximum number of rows it's possible for this query plan to return.
     uint32_t max_row_count = 0;
@@ -86,7 +111,9 @@ struct QueryPlanImpl {
     size_t size = sizeof(params) + sizeof(size_t) +
                   (bytecode.size() * sizeof(interpreter::Bytecode)) +
                   sizeof(size_t) +
-                  (col_to_output_offset.size() * sizeof(uint32_t));
+                  (col_to_output_offset.size() * sizeof(uint32_t)) +
+                  sizeof(size_t) +
+                  (register_inits.size() * sizeof(RegisterInit));
     std::string res(size, '\0');
     char* p = res.data();
     {
@@ -113,6 +140,16 @@ struct QueryPlanImpl {
       memcpy(p, col_to_output_offset.data(), columns_size * sizeof(uint32_t));
       p += columns_size * sizeof(uint32_t);
     }
+    {
+      size_t register_inits_size = register_inits.size();
+      memcpy(p, &register_inits_size, sizeof(register_inits_size));
+      p += sizeof(register_inits_size);
+    }
+    {
+      memcpy(p, register_inits.data(),
+             register_inits.size() * sizeof(RegisterInit));
+      p += register_inits.size() * sizeof(RegisterInit);
+    }
     PERFETTO_CHECK(p == res.data() + res.size());
     return base::Base64Encode(base::StringView(res));
   }
@@ -127,6 +164,7 @@ struct QueryPlanImpl {
     const char* p = raw_data->data();
     size_t bytecode_size;
     size_t columns_size;
+    size_t register_inits_size;
     {
       memcpy(&res.params, p, sizeof(res.params));
       p += sizeof(res.params);
@@ -155,6 +193,19 @@ struct QueryPlanImpl {
              columns_size * sizeof(uint32_t));
       p += columns_size * sizeof(uint32_t);
     }
+    {
+      memcpy(&register_inits_size, p, sizeof(register_inits_size));
+      p += sizeof(register_inits_size);
+    }
+    {
+      for (size_t i = 0; i < register_inits_size; ++i) {
+        alignas(RegisterInit) char buf[sizeof(RegisterInit)];
+        memcpy(buf, p, sizeof(RegisterInit));
+        p += sizeof(RegisterInit);
+        res.register_inits.emplace_back(
+            *reinterpret_cast<const RegisterInit*>(buf));
+      }
+    }
     PERFETTO_CHECK(p == raw_data->data() + raw_data->size());
     return res;
   }
@@ -162,6 +213,10 @@ struct QueryPlanImpl {
   ExecutionParams params;
   interpreter::BytecodeVector bytecode;
   base::SmallVector<uint32_t, 24> col_to_output_offset;
+
+  // Register initialization specifications.
+  // The cursor processes these to set up registers before bytecode execution.
+  base::SmallVector<RegisterInit, 16> register_inits;
 };
 
 // Builder class for creating query plans.
@@ -194,8 +249,8 @@ class QueryPlanBuilder {
 
  private:
   // Represents register types for holding indices.
-  using IndicesReg = std::variant<interpreter::reg::RwHandle<Range>,
-                                  interpreter::reg::RwHandle<Span<uint32_t>>>;
+  using IndicesReg = std::variant<interpreter::RwHandle<Range>,
+                                  interpreter::RwHandle<Span<uint32_t>>>;
 
   // Indicates that the bytecode does not change the estimated or maximum number
   // of rows.
@@ -232,14 +287,20 @@ class QueryPlanBuilder {
 
   // State information for a column during query planning.
   struct ColumnState {
-    std::optional<interpreter::reg::RwHandle<Slab<uint32_t>>> prefix_popcount;
+    std::optional<interpreter::RwHandle<Slab<uint32_t>>> prefix_popcount;
+    std::optional<interpreter::RwHandle<interpreter::StoragePtr>>
+        storage_register;
+    std::optional<interpreter::ReadHandle<const BitVector*>> null_bv_register;
+    std::optional<interpreter::ReadHandle<const BitVector*>>
+        small_value_eq_bv_register;
+    std::optional<interpreter::ReadHandle<Span<uint32_t>>>
+        small_value_eq_popcount_register;
   };
 
   // Constructs a builder for the given number of rows and columns.
-  QueryPlanBuilder(
-      uint32_t row_count,
-      const std::vector<std::shared_ptr<Column>>& columns,
-      const std::vector<Index>& indexes);
+  QueryPlanBuilder(uint32_t row_count,
+                   const std::vector<std::shared_ptr<Column>>& columns,
+                   const std::vector<Index>& indexes);
 
   // Adds filter operations to the query plan based on filter specifications.
   // Optimizes the order of filters for efficiency.
@@ -271,14 +332,14 @@ class QueryPlanBuilder {
       const FilterSpec& c,
       const interpreter::NonStringType& type,
       const interpreter::NonStringOp& op,
-      const interpreter::reg::ReadHandle<interpreter::CastFilterValueResult>&
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>&
           result);
 
   // Processes string filter constraints.
   base::Status StringConstraint(
       const FilterSpec& c,
       const interpreter::StringOp& op,
-      const interpreter::reg::ReadHandle<interpreter::CastFilterValueResult>&
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>&
           result);
 
   // Processes null filter constraints.
@@ -300,7 +361,7 @@ class QueryPlanBuilder {
   // in the given column. The indices are pruned in-place, and the
   // `indices_register` is updated to contain only non-null indices.
   void PruneNullIndices(uint32_t col,
-                        interpreter::reg::RwHandle<Span<uint32_t>> indices);
+                        interpreter::RwHandle<Span<uint32_t>> indices);
 
   // Given a list of table indices pointing to *only* non-null rows,
   // if necessary, translates them to the storage indices for the given column.
@@ -311,13 +372,13 @@ class QueryPlanBuilder {
   //
   // Returns a register handle to the translated indices (either
   // `indices_register` or the scratch register).
-  interpreter::reg::RwHandle<Span<uint32_t>> TranslateNonNullIndices(
+  interpreter::RwHandle<Span<uint32_t>> TranslateNonNullIndices(
       uint32_t col,
-      interpreter::reg::RwHandle<Span<uint32_t>> indices_register,
+      interpreter::RwHandle<Span<uint32_t>> indices_register,
       bool in_place);
 
   // Ensures indices are stored in a Slab, converting from Range if necessary.
-  PERFETTO_NO_INLINE interpreter::reg::RwHandle<Span<uint32_t>>
+  PERFETTO_NO_INLINE interpreter::RwHandle<Span<uint32_t>>
   EnsureIndicesAreInSlab();
 
   // Adds a new bytecode instruction of type T to the plan.
@@ -343,15 +404,39 @@ class QueryPlanBuilder {
   void SetGuaranteedToBeEmpty();
 
   // Returns the prefix popcount register for the given column.
-  interpreter::reg::ReadHandle<Slab<uint32_t>> PrefixPopcountRegisterFor(
+  interpreter::ReadHandle<Slab<uint32_t>> PrefixPopcountRegisterFor(
       uint32_t col);
 
-  interpreter::reg::ReadHandle<interpreter::CastFilterValueResult>
-  CastFilterValue(FilterSpec& c,
-                  const StorageType& ct,
-                  interpreter::NonNullOp non_null_op);
+  // Allocates a register for column data pointer and adds RegisterInit entry.
+  // Returns a HandleBase that can be assigned to typed data_register fields.
+  interpreter::RwHandle<interpreter::StoragePtr> StorageRegisterFor(
+      uint32_t col,
+      StorageType storage_type);
 
-  interpreter::reg::RwHandle<Span<uint32_t>> GetOrCreateScratchSpanRegister(
+  // Helper template to create or retrieve a register from ColumnState.
+  template <typename Handle, typename InitType, typename StateField>
+  Handle GetOrCreateInitRegister(uint32_t col,
+                                 StateField ColumnState::* field,
+                                 InitType init_type);
+
+  // Returns the null bitvector register for the given column.
+  interpreter::ReadHandle<const BitVector*> NullBitvectorRegisterFor(
+      uint32_t col);
+
+  // Returns the SmallValueEq bitvector register for the given column.
+  interpreter::ReadHandle<const BitVector*> SmallValueEqBvRegisterFor(
+      uint32_t col);
+
+  // Returns the SmallValueEq popcount register for the given column.
+  interpreter::ReadHandle<Span<uint32_t>> SmallValueEqPopcountRegisterFor(
+      uint32_t col);
+
+  interpreter::ReadHandle<interpreter::CastFilterValueResult> CastFilterValue(
+      FilterSpec& c,
+      const StorageType& ct,
+      interpreter::NonNullOp non_null_op);
+
+  interpreter::RwHandle<Span<uint32_t>> GetOrCreateScratchSpanRegister(
       uint32_t size);
 
   // Parameters for conversion to row layout.
@@ -369,18 +454,17 @@ class QueryPlanBuilder {
   uint16_t CalculateRowLayoutStride(
       const std::vector<RowLayoutParams>& row_layout_params);
 
-  interpreter::reg::RwHandle<Slab<uint8_t>> CopyToRowLayout(
+  interpreter::RwHandle<Slab<uint8_t>> CopyToRowLayout(
       uint16_t row_stride,
-      interpreter::reg::RwHandle<Span<uint32_t>> indices,
-      interpreter::reg::ReadHandle<interpreter::reg::StringIdToRankMap>
-          rank_map,
+      interpreter::RwHandle<Span<uint32_t>> indices,
+      interpreter::ReadHandle<interpreter::StringIdToRankMap> rank_map,
       const std::vector<RowLayoutParams>& row_layout_params);
 
   void MaybeReleaseScratchSpanRegister();
 
   void AddLinearFilterEqBytecode(
       const FilterSpec&,
-      const interpreter::reg::ReadHandle<interpreter::CastFilterValueResult>&,
+      const interpreter::ReadHandle<interpreter::CastFilterValueResult>&,
       const interpreter::NonIdStorageType&);
 
   bool CanUseMinMaxOptimization(const std::vector<SortSpec>&, const LimitSpec&);
@@ -406,8 +490,8 @@ class QueryPlanBuilder {
   // the scratch indices in both Span and Slab forms.
   struct ScratchIndices {
     uint32_t size;
-    interpreter::reg::RwHandle<Slab<uint32_t>> slab;
-    interpreter::reg::RwHandle<Span<uint32_t>> span;
+    interpreter::RwHandle<Slab<uint32_t>> slab;
+    interpreter::RwHandle<Span<uint32_t>> span;
     bool in_use = false;
   };
   std::optional<ScratchIndices> scratch_indices_;

--- a/src/trace_processor/core/interpreter/BUILD.gn
+++ b/src/trace_processor/core/interpreter/BUILD.gn
@@ -35,7 +35,6 @@ source_set("interpreter") {
     "../../util:glob",
     "../../util:regex",
     "../common",
-    "../dataframe:types",
     "../util",
   ]
 }
@@ -49,7 +48,7 @@ source_set("bytecode_interpreter_test_utils") {
     "../../../base",
     "../../containers",
     "../common",
-    "../dataframe:specs",
+    "../dataframe",
     "../util",
   ]
 }
@@ -65,7 +64,8 @@ perfetto_unittest_source_set("unittests") {
     "../../../base",
     "../../containers",
     "../../util:regex",
-    "../dataframe:specs",
+    "../common",
+    "../dataframe",
     "../util",
   ]
 }
@@ -81,6 +81,8 @@ if (enable_perfetto_benchmarks) {
       "../../../../gn:default_deps",
       "../../../base",
       "../../containers",
+      "../common",
+      "../dataframe",
       "../util",
     ]
   }

--- a/src/trace_processor/core/interpreter/bytecode_core.h
+++ b/src/trace_processor/core/interpreter/bytecode_core.h
@@ -31,10 +31,10 @@ namespace perfetto::trace_processor::core::interpreter {
 // code and fixed-size buffer for arguments.
 struct Bytecode {
   uint32_t option = 0;                    // Opcode determining instruction type
-  std::array<uint8_t, 32> args_buffer{};  // Storage for instruction arguments
+  std::array<uint8_t, 36> args_buffer{};  // Storage for instruction arguments
 };
 static_assert(std::is_trivially_copyable_v<Bytecode>);
-static_assert(sizeof(Bytecode) <= 36);
+static_assert(sizeof(Bytecode) <= 40);
 
 // Indicates that the bytecode has a fixed cost.
 struct FixedCost {

--- a/src/trace_processor/core/interpreter/bytecode_instructions.h
+++ b/src/trace_processor/core/interpreter/bytecode_instructions.h
@@ -18,18 +18,20 @@
 #define SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_INSTRUCTIONS_H_
 
 #include <cstdint>
-#include <string>
 #include <variant>
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/variant.h"
 #include "perfetto/public/compiler.h"
+#include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/common/null_types.h"
 #include "src/trace_processor/core/common/op_types.h"
 #include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_instruction_macros.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/interpreter/interpreter_types.h"
+#include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/range.h"
 #include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
@@ -48,7 +50,7 @@ struct InitRange : Bytecode {
 
   PERFETTO_DATAFRAME_BYTECODE_IMPL_2(uint32_t,
                                      size,
-                                     reg::WriteHandle<Range>,
+                                     WriteHandle<Range>,
                                      dest_register);
 };
 
@@ -61,9 +63,9 @@ struct AllocateIndices : Bytecode {
 
   PERFETTO_DATAFRAME_BYTECODE_IMPL_3(uint32_t,
                                      size,
-                                     reg::WriteHandle<Slab<uint32_t>>,
+                                     WriteHandle<Slab<uint32_t>>,
                                      dest_slab_register,
-                                     reg::WriteHandle<Span<uint32_t>>,
+                                     WriteHandle<Span<uint32_t>>,
                                      dest_span_register);
 };
 
@@ -74,9 +76,9 @@ struct Iota : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(reg::ReadHandle<Range>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(ReadHandle<Range>,
                                      source_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 
@@ -89,7 +91,7 @@ struct CastFilterValueBase : TemplatedBytecode1<StorageType> {
 
   PERFETTO_DATAFRAME_BYTECODE_IMPL_3(FilterValueHandle,
                                      fval_handle,
-                                     reg::WriteHandle<CastFilterValueResult>,
+                                     WriteHandle<CastFilterValueResult>,
                                      write_register,
                                      NonNullOp,
                                      op);
@@ -106,13 +108,12 @@ struct CastFilterValueListBase : TemplatedBytecode1<StorageType> {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = FixedCost{1000};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(
-      FilterValueHandle,
-      fval_handle,
-      reg::WriteHandle<CastFilterValueListResult>,
-      write_register,
-      NonNullOp,
-      op);
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(FilterValueHandle,
+                                     fval_handle,
+                                     WriteHandle<CastFilterValueListResult>,
+                                     write_register,
+                                     NonNullOp,
+                                     op);
 };
 template <typename T>
 struct CastFilterValueList : CastFilterValueListBase {
@@ -131,19 +132,15 @@ struct SortedFilterBase
     }
     return LogPerRowCost{10};
   }
-
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<CastFilterValueResult>,
                                      val_register,
-                                     reg::RwHandle<Range>,
+                                     RwHandle<Range>,
                                      update_register,
                                      BoundModifier,
                                      write_result_to);
 };
-
-// Specialized filter for sorted data with specific value type and range
-// operation.
 template <typename T, typename RangeOp>
 struct SortedFilter : SortedFilterBase {
   static_assert(TS1::Contains<T>());
@@ -158,11 +155,11 @@ struct Uint32SetIdSortedEq : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = FixedCost{100};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<CastFilterValueResult>,
                                      val_register,
-                                     reg::RwHandle<Range>,
+                                     RwHandle<Range>,
                                      update_register);
 };
 
@@ -174,11 +171,13 @@ struct SpecializedStorageSmallValueEq : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = FixedCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(ReadHandle<const BitVector*>,
+                                     small_value_bv_register,
+                                     ReadHandle<Span<uint32_t>>,
+                                     small_value_popcount_register,
+                                     ReadHandle<CastFilterValueResult>,
                                      val_register,
-                                     reg::RwHandle<Range>,
+                                     RwHandle<Range>,
                                      update_register);
 };
 
@@ -188,20 +187,19 @@ struct NonStringFilterBase : TemplatedBytecode2<NonStringType, NonStringOp> {
   // is plucked from thin air and has no real foundation. Fix this by creating
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{5};
-
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<CastFilterValueResult>,
                                      val_register,
-                                     reg::ReadHandle<Span<uint32_t>>,
+                                     ReadHandle<Span<uint32_t>>,
                                      source_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
-template <typename T, typename NonStringOp>
+template <typename T, typename Op>
 struct NonStringFilter : NonStringFilterBase {
   static_assert(TS1::Contains<T>());
-  static_assert(TS2::Contains<NonStringOp>());
+  static_assert(TS2::Contains<Op>());
 };
 
 // Filter operations on string columns.
@@ -211,13 +209,13 @@ struct StringFilterBase : TemplatedBytecode1<StringOp> {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{15};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<CastFilterValueResult>,
                                      val_register,
-                                     reg::ReadHandle<Span<uint32_t>>,
+                                     ReadHandle<Span<uint32_t>>,
                                      source_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 template <typename Op>
@@ -232,9 +230,9 @@ struct StrideCopy : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{15};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(reg::ReadHandle<Span<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(ReadHandle<Span<uint32_t>>,
                                      source_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register,
                                      uint32_t,
                                      stride);
@@ -254,9 +252,9 @@ struct PrefixPopcount : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{20};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(uint32_t,
-                                     col,
-                                     reg::WriteHandle<Slab<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(ReadHandle<const BitVector*>,
+                                     null_bv_register,
+                                     WriteHandle<Slab<uint32_t>>,
                                      dest_register);
 };
 
@@ -276,13 +274,13 @@ struct TranslateSparseNullIndices : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
-                                     col,
-                                     reg::ReadHandle<Slab<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(ReadHandle<const BitVector*>,
+                                     null_bv_register,
+                                     ReadHandle<Slab<uint32_t>>,
                                      popcount_register,
-                                     reg::ReadHandle<Span<uint32_t>>,
+                                     ReadHandle<Span<uint32_t>>,
                                      source_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 
@@ -293,9 +291,9 @@ struct NullFilterBase : TemplatedBytecode1<NullOp> {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{5};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(uint32_t,
-                                     col,
-                                     reg::RwHandle<Span<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(ReadHandle<const BitVector*>,
+                                     null_bv_register,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 
@@ -323,11 +321,11 @@ struct StrideTranslateAndCopySparseNullIndices : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_5(uint32_t,
-                                     col,
-                                     reg::ReadHandle<Slab<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_5(ReadHandle<const BitVector*>,
+                                     null_bv_register,
+                                     ReadHandle<Slab<uint32_t>>,
                                      popcount_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register,
                                      uint32_t,
                                      offset,
@@ -351,9 +349,9 @@ struct StrideCopyDenseNullIndices : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{5};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
-                                     col,
-                                     reg::RwHandle<Span<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(ReadHandle<const BitVector*>,
+                                     null_bv_register,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register,
                                      uint32_t,
                                      offset,
@@ -367,7 +365,7 @@ struct AllocateRowLayoutBuffer : Bytecode {
 
   PERFETTO_DATAFRAME_BYTECODE_IMPL_2(uint32_t,
                                      buffer_size,
-                                     reg::WriteHandle<Slab<uint8_t>>,
+                                     WriteHandle<Slab<uint8_t>>,
                                      dest_buffer_register);
 };
 
@@ -379,11 +377,13 @@ struct CopyToRowLayoutBase
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{5};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_8(uint32_t,
-                                     col,
-                                     reg::ReadHandle<Span<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_9(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<const BitVector*>,
+                                     null_bv_register,
+                                     ReadHandle<Span<uint32_t>>,
                                      source_indices_register,
-                                     reg::RwHandle<Slab<uint8_t>>,
+                                     RwHandle<Slab<uint8_t>>,
                                      dest_buffer_register,
                                      uint16_t,
                                      row_layout_offset,
@@ -391,9 +391,9 @@ struct CopyToRowLayoutBase
                                      row_layout_stride,
                                      uint32_t,
                                      invert_copied_bits,
-                                     reg::ReadHandle<Slab<uint32_t>>,
+                                     ReadHandle<Slab<uint32_t>>,
                                      popcount_register,
-                                     reg::ReadHandle<reg::StringIdToRankMap>,
+                                     ReadHandle<StringIdToRankMap>,
                                      rank_map_register);
 };
 template <typename T, typename Nullability>
@@ -410,11 +410,11 @@ struct Distinct : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{7};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(reg::ReadHandle<Slab<uint8_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(ReadHandle<Slab<uint8_t>>,
                                      buffer_register,
                                      uint32_t,
                                      total_row_stride,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      indices_register);
 };
 
@@ -432,7 +432,7 @@ struct LimitOffsetIndices : Bytecode {
                                      offset_value,
                                      uint32_t,
                                      limit_value,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 
@@ -443,9 +443,9 @@ struct FindMinMaxIndexBase : TemplatedBytecode2<StorageType, MinMaxOp> {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{2};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(uint32_t,
-                                     col,
-                                     reg::RwHandle<Span<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 template <typename T, typename Op>
@@ -454,23 +454,9 @@ struct FindMinMaxIndex : FindMinMaxIndexBase {
   static_assert(TS2::Contains<Op>());
 };
 
-// Given an index, creates a span of indices that point to the permutation
-// vector of the index.
-struct IndexPermutationVectorToSpan : Bytecode {
-  // TODO(lalitm): while the cost type is legitimate, the cost estimate inside
-  // is plucked from thin air and has no real foundation. Fix this by creating
-  // benchmarks and backing it up with actual data.
-  static constexpr Cost kCost = FixedCost{5};
-
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(uint32_t,
-                                     index,
-                                     reg::WriteHandle<Span<uint32_t>>,
-                                     write_register);
-};
-
-// Filters a column which is sorted by the given index with `update_register`
-// containing the span of permutation vector to consider. The span is updated
-// to only contain the indices which match the filter.
+// Filters a column which is sorted by the given index. `source_register`
+// contains the span of permutation vector to consider (read-only).
+// `dest_register` receives the filtered result (write-only).
 struct IndexedFilterEqBase
     : TemplatedBytecode2<NonIdStorageType, SparseNullCollapsedNullability> {
   // TODO(lalitm): while the cost type is legitimate, the cost estimate inside
@@ -478,14 +464,18 @@ struct IndexedFilterEqBase
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LogPerRowCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_6(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<const BitVector*>,
+                                     null_bv_register,
+                                     ReadHandle<CastFilterValueResult>,
                                      filter_value_reg,
-                                     reg::ReadHandle<Slab<uint32_t>>,
+                                     ReadHandle<Slab<uint32_t>>,
                                      popcount_register,
-                                     reg::RwHandle<Span<uint32_t>>,
-                                     update_register);
+                                     ReadHandle<Span<uint32_t>>,
+                                     source_register,
+                                     RwHandle<Span<uint32_t>>,
+                                     dest_register);
 };
 template <typename T, typename N>
 struct IndexedFilterEq : IndexedFilterEqBase {
@@ -502,11 +492,11 @@ struct CopySpanIntersectingRange : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{5};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(reg::ReadHandle<Span<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(ReadHandle<Span<uint32_t>>,
                                      source_register,
-                                     reg::ReadHandle<Range>,
+                                     ReadHandle<Range>,
                                      source_range_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 
@@ -517,7 +507,7 @@ struct InitRankMap : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = FixedCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_1(reg::WriteHandle<reg::StringIdToRankMap>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_1(WriteHandle<StringIdToRankMap>,
                                      dest_register);
 };
 
@@ -529,11 +519,11 @@ struct CollectIdIntoRankMap : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(uint32_t,
-                                     col,
-                                     reg::ReadHandle<Span<uint32_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<Span<uint32_t>>,
                                      source_register,
-                                     reg::RwHandle<reg::StringIdToRankMap>,
+                                     RwHandle<StringIdToRankMap>,
                                      rank_map_register);
 };
 
@@ -546,7 +536,7 @@ struct FinalizeRanksInMap : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LogLinearPerRowCost{20};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_1(reg::RwHandle<reg::StringIdToRankMap>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_1(RwHandle<StringIdToRankMap>,
                                      update_register);
 };
 
@@ -557,11 +547,11 @@ struct SortRowLayout : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LogLinearPerRowCost{10};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(reg::ReadHandle<Slab<uint8_t>>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_3(ReadHandle<Slab<uint8_t>>,
                                      buffer_register,
                                      uint32_t,
                                      total_row_stride,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      indices_register);
 };
 
@@ -574,16 +564,15 @@ struct LinearFilterEqBase : TemplatedBytecode1<NonIdStorageType> {
   // is plucked from thin air and has no real foundation. Fix this by creating
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{7};
-
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_5(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_5(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<CastFilterValueResult>,
                                      filter_value_reg,
-                                     reg::ReadHandle<Slab<uint32_t>>,
+                                     ReadHandle<Slab<uint32_t>>,
                                      popcount_register,
-                                     reg::ReadHandle<Range>,
+                                     ReadHandle<Range>,
                                      source_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 template <typename T>
@@ -597,14 +586,13 @@ struct InBase : TemplatedBytecode1<StorageType> {
   // is plucked from thin air and has no real foundation. Fix this by creating
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{10};
-
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(uint32_t,
-                                     col,
-                                     reg::ReadHandle<CastFilterValueListResult>,
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_4(ReadHandle<StoragePtr>,
+                                     storage_register,
+                                     ReadHandle<CastFilterValueListResult>,
                                      value_list_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      source_register,
-                                     reg::RwHandle<Span<uint32_t>>,
+                                     RwHandle<Span<uint32_t>>,
                                      update_register);
 };
 template <typename T>
@@ -619,8 +607,7 @@ struct Reverse : Bytecode {
   // benchmarks and backing it up with actual data.
   static constexpr Cost kCost = LinearPerRowCost{2};
 
-  PERFETTO_DATAFRAME_BYTECODE_IMPL_1(reg::RwHandle<Span<uint32_t>>,
-                                     update_register);
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_1(RwHandle<Span<uint32_t>>, update_register);
 };
 
 // Bytecode ops that require FilterValueFetcher access.
@@ -746,7 +733,6 @@ struct Reverse : Bytecode {
   X(FindMinMaxIndex<Double, MaxOp>)                    \
   X(FindMinMaxIndex<String, MinOp>)                    \
   X(FindMinMaxIndex<String, MaxOp>)                    \
-  X(IndexPermutationVectorToSpan)                      \
   X(IndexedFilterEq<Uint32, NonNull>)                  \
   X(IndexedFilterEq<Uint32, SparseNull>)               \
   X(IndexedFilterEq<Uint32, DenseNull>)                \

--- a/src/trace_processor/core/interpreter/bytecode_interpreter.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter.h
@@ -20,15 +20,14 @@
 #include <cstdint>
 #include <cstring>
 #include <type_traits>
+#include <utility>
 
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/common/value_fetcher.h"
-#include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_state.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
-#include "src/trace_processor/core/interpreter/interpreter_types.h"
 
 namespace perfetto::trace_processor::core::interpreter {
 
@@ -51,12 +50,8 @@ class Interpreter {
 
   void Initialize(const BytecodeVector& bytecode,
                   uint32_t num_registers,
-                  uint32_t column_count,
-                  const Column* const* columns,
-                  const dataframe::Index* indexes,
                   const StringPool* string_pool) {
-    state_.Initialize(bytecode, num_registers, column_count, columns, indexes,
-                      string_pool);
+    state_.Initialize(bytecode, num_registers, string_pool);
   }
 
   // Not movable because it's a very large object and the move cost would be
@@ -72,17 +67,19 @@ class Interpreter {
   // Returns the value of the specified register if it contains the expected
   // type. Returns nullptr if the register holds a different type or is empty.
   template <typename T>
-  PERFETTO_ALWAYS_INLINE const T* GetRegisterValue(reg::ReadHandle<T> reg) {
+  PERFETTO_ALWAYS_INLINE const T* GetRegisterValue(ReadHandle<T> reg) {
     return state_.MaybeReadFromRegister(reg);
   }
 
-  // Sets the value of the specified register for testing purposes.
+  // Sets the value of the specified register.
   //
-  // Makes it easier to test certain bytecode instructions which depend on
-  // the preexisting value of a register.
+  // For setting input values before execution or for testing purposes.
   template <typename T>
-  void SetRegisterValueForTesting(reg::WriteHandle<T> reg, T value) {
+  void SetRegisterValue(WriteHandle<T> reg, T value) {
     state_.WriteToRegister(reg, std::move(value));
+  }
+  PERFETTO_ALWAYS_INLINE void SetRegisterValue(HandleBase r, RegValue value) {
+    state_.WriteToRegister(r, std::move(value));
   }
 
  private:

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_benchmark.cc
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_benchmark.cc
@@ -17,20 +17,27 @@
 #include <benchmark/benchmark.h>
 #include <cstdint>
 #include <random>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "perfetto/ext/base/string_view.h"
 #include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/duplicate_types.h"
+#include "src/trace_processor/core/common/sort_types.h"
+#include "src/trace_processor/core/common/storage_types.h"
+#include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_impl.h"  // IWYU pragma: keep
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_test_utils.h"
+#include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/slab.h"
 
 namespace perfetto::trace_processor::core::interpreter {
 namespace {
 
-static void BM_BytecodeInterpreter_LinearFilterEqUint32(
-    benchmark::State& state) {
+void BM_BytecodeInterpreter_LinearFilterEqUint32(benchmark::State& state) {
   constexpr uint32_t kTableSize = 1024 * 1024;
 
   // Setup column
@@ -38,23 +45,34 @@ static void BM_BytecodeInterpreter_LinearFilterEqUint32(
   for (uint32_t i = 0; i < kTableSize; ++i) {
     col_data_vec.push_back(i % 256);
   }
-  Column col{Storage{std::move(col_data_vec)}, NullStorage::NonNull{},
-             Unsorted{}, HasDuplicates{}};
-  Column* col_ptr = &col;
+  dataframe::Column col{dataframe::Storage{std::move(col_data_vec)},
+                        dataframe::NullStorage::NonNull{}, Unsorted{},
+                        HasDuplicates{}};
 
   // Setup interpreter
+  // Register layout:
+  // R0: CastFilterValueResult (filter value)
+  // R1: Range (source range)
+  // R2: Span<uint32_t> (output indices)
+  // R3: Slab<uint32_t> (backing storage for output)
+  // R4: StoragePtr (column data pointer)
+  // R5: Slab<uint32_t> (dummy popcount for NonNull)
   std::string bytecode_str = R"(
     CastFilterValue<Uint32>: [fval_handle=FilterValue(0), write_register=Register(0), op=Op(0)]
     InitRange: [size=1048576, dest_register=Register(1)]
     AllocateIndices: [size=1048576, dest_slab_register=Register(3), dest_span_register=Register(2)]
-    LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(0), source_register=Register(1), update_register=Register(2)]
+    LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(5), source_register=Register(1), update_register=Register(2)]
   )";
 
   StringPool spool;
-  std::vector<dataframe::Index> indexes;
   Interpreter<Fetcher> interpreter;
-  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 4, 1, &col_ptr,
-                         indexes.data(), &spool);
+  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 6, &spool);
+
+  // Set up storage pointer in register
+  StoragePtr storage_ptr{col.storage.unchecked_data<Uint32>(), Uint32{}};
+  interpreter.SetRegisterValue(WriteHandle<StoragePtr>(4), storage_ptr);
+  interpreter.SetRegisterValue(WriteHandle<Slab<uint32_t>>(5),
+                               Slab<uint32_t>::Alloc(0));
 
   Fetcher fetcher;
   fetcher.value.push_back(int64_t(123));
@@ -66,8 +84,7 @@ static void BM_BytecodeInterpreter_LinearFilterEqUint32(
 }
 BENCHMARK(BM_BytecodeInterpreter_LinearFilterEqUint32);
 
-static void BM_BytecodeInterpreter_LinearFilterEqString(
-    benchmark::State& state) {
+void BM_BytecodeInterpreter_LinearFilterEqString(benchmark::State& state) {
   constexpr uint32_t kTableSize = 1024 * 1024;
 
   // Setup column
@@ -81,22 +98,33 @@ static void BM_BytecodeInterpreter_LinearFilterEqString(
     col_data_vec.push_back(
         spool.InternString(base::StringView(string_values[i % 256])));
   }
-  Column col{Storage{std::move(col_data_vec)}, NullStorage::NonNull{},
-             Unsorted{}, HasDuplicates{}};
-  Column* col_ptr = &col;
+  dataframe::Column col{dataframe::Storage{std::move(col_data_vec)},
+                        dataframe::NullStorage::NonNull{}, Unsorted{},
+                        HasDuplicates{}};
 
   // Setup interpreter
+  // Register layout:
+  // R0: CastFilterValueResult (filter value)
+  // R1: Range (source range)
+  // R2: Span<uint32_t> (output indices)
+  // R3: Slab<uint32_t> (backing storage for output)
+  // R4: StoragePtr (column data pointer)
+  // R5: Slab<uint32_t> (dummy popcount for NonNull)
   std::string bytecode_str = R"(
     CastFilterValue<String>: [fval_handle=FilterValue(0), write_register=Register(0), op=Op(0)]
     InitRange: [size=1048576, dest_register=Register(1)]
     AllocateIndices: [size=1048576, dest_slab_register=Register(3), dest_span_register=Register(2)]
-    LinearFilterEq<String>: [col=0, filter_value_reg=Register(0), source_register=Register(1), update_register=Register(2)]
+    LinearFilterEq<String>: [storage_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(5), source_register=Register(1), update_register=Register(2)]
   )";
 
-  std::vector<dataframe::Index> indexes;
   Interpreter<Fetcher> interpreter;
-  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 4, 1, &col_ptr,
-                         indexes.data(), &spool);
+  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 6, &spool);
+
+  // Set up storage pointer in register
+  StoragePtr storage_ptr{col.storage.unchecked_data<String>(), String{}};
+  interpreter.SetRegisterValue(WriteHandle<StoragePtr>(4), storage_ptr);
+  interpreter.SetRegisterValue(WriteHandle<Slab<uint32_t>>(5),
+                               Slab<uint32_t>::Alloc(0));
 
   Fetcher fetcher;
   fetcher.value.push_back("string_123");
@@ -119,25 +147,33 @@ static void BM_BytecodeInterpreter_SortUint32(benchmark::State& state) {
   for (uint32_t i = 0; i < kTableSize; ++i) {
     col_data_vec.push_back(static_cast<uint32_t>(rnd()));
   }
-  Column col{Storage{std::move(col_data_vec)}, NullStorage::NonNull{},
-             Unsorted{}, HasDuplicates{}};
-  Column* col_ptr = &col;
+  dataframe::Column col{dataframe::Storage{std::move(col_data_vec)},
+                        dataframe::NullStorage::NonNull{}, Unsorted{},
+                        HasDuplicates{}};
 
   // Setup interpreter
+  // Register layout:
+  // R0: Range (source range)
+  // R1: Slab<uint32_t> (backing storage for indices)
+  // R2: Span<uint32_t> (indices)
+  // R3: Slab<uint8_t> (row layout buffer)
+  // R4: StoragePtr (column data pointer)
   std::string bytecode_str = R"(
     InitRange: [size=1048576, dest_register=Register(0)]
     AllocateIndices: [size=1048576, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=4194304, dest_buffer_register=Register(3)]
-    CopyToRowLayout<Uint32, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Uint32, NonNull>: [storage_register=Register(4), null_bv_register=Register(4294967295), source_indices_register=Register(2), dest_buffer_register=Register(3), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(3), total_row_stride=4, indices_register=Register(2)]
   )";
 
   StringPool spool;
-  std::vector<dataframe::Index> indexes;
   Interpreter<Fetcher> interpreter;
-  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 4, 1, &col_ptr,
-                         indexes.data(), &spool);
+  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, &spool);
+
+  // Set up storage pointer in register
+  StoragePtr storage_ptr{col.storage.unchecked_data<Uint32>(), Uint32{}};
+  interpreter.SetRegisterValue(WriteHandle<StoragePtr>(4), storage_ptr);
 
   Fetcher fetcher;
   for (auto _ : state) {
@@ -162,27 +198,36 @@ static void BM_BytecodeInterpreter_SortString(benchmark::State& state) {
     }
     col_data_vec.push_back(spool.InternString(base::StringView(key)));
   }
-  Column col{Storage{std::move(col_data_vec)}, NullStorage::NonNull{},
-             Unsorted{}, HasDuplicates{}};
-  Column* col_ptr = &col;
+  dataframe::Column col{dataframe::Storage{std::move(col_data_vec)},
+                        dataframe::NullStorage::NonNull{}, Unsorted{},
+                        HasDuplicates{}};
 
   // Setup interpreter
+  // Register layout:
+  // R0: Range (source range)
+  // R1: Slab<uint32_t> (backing storage for indices)
+  // R2: Span<uint32_t> (indices)
+  // R3: StringIdToRankMap (rank map)
+  // R4: Slab<uint8_t> (row layout buffer)
+  // R5: StoragePtr (column data pointer)
   std::string bytecode_str = R"(
     InitRange: [size=1048576, dest_register=Register(0)]
     AllocateIndices: [size=1048576, dest_slab_register=Register(1), dest_span_register=Register(2)]
     Iota: [source_register=Register(0), update_register=Register(2)]
     InitRankMap: [dest_register=Register(3)]
-    CollectIdIntoRankMap: [col=0, source_register=Register(2), rank_map_register=Register(3)]
+    CollectIdIntoRankMap: [storage_register=Register(5), source_register=Register(2), rank_map_register=Register(3)]
     FinalizeRanksInMap: [update_register=Register(3)]
     AllocateRowLayoutBuffer: [buffer_size=4194304, dest_buffer_register=Register(4)]
-    CopyToRowLayout<String, NonNull>: [col=0, source_indices_register=Register(2), dest_buffer_register=Register(4), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(3)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(5), null_bv_register=Register(4294967295), source_indices_register=Register(2), dest_buffer_register=Register(4), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(3)]
     SortRowLayout: [buffer_register=Register(4), total_row_stride=4, indices_register=Register(2)]
   )";
 
-  std::vector<dataframe::Index> indexes;
   Interpreter<Fetcher> interpreter;
-  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 5, 1, &col_ptr,
-                         indexes.data(), &spool);
+  interpreter.Initialize(ParseBytecodeToVec(bytecode_str), 6, &spool);
+
+  // Set up storage pointer in register
+  StoragePtr storage_ptr{col.storage.unchecked_data<String>(), String{}};
+  interpreter.SetRegisterValue(WriteHandle<StoragePtr>(5), storage_ptr);
 
   Fetcher fetcher;
   for (auto _ : state) {

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
@@ -21,14 +21,14 @@
 #include <cstring>
 
 #include <limits>
+#include <utility>
 
 #include "perfetto/ext/base/small_vector.h"
+#include "perfetto/ext/base/variant.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/containers/string_pool.h"
-#include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
-#include "src/trace_processor/core/interpreter/interpreter_types.h"
 
 namespace perfetto::trace_processor::core::interpreter {
 
@@ -37,13 +37,7 @@ struct InterpreterState {
   // The sequence of bytecode instructions to execute
   BytecodeVector bytecode;
   // Register file holding intermediate values
-  base::SmallVector<reg::Value, 16> registers;
-  // Pointer to the columns being processed
-  const Column* const* columns;
-  // Cached storage data pointers for each column
-  base::SmallVector<Storage::DataPointer, 16> column_storage_data_ptrs;
-  // Pointer to the indexes
-  const dataframe::Index* indexes;
+  base::SmallVector<RegValue, 16> registers;
   // Pointer to the string pool (for string operations)
   const StringPool* string_pool;
 
@@ -53,42 +47,32 @@ struct InterpreterState {
 
   void Initialize(const BytecodeVector& bytecode_,
                   uint32_t num_registers,
-                  uint32_t column_count,
-                  const Column* const* columns_,
-                  const dataframe::Index* indexes_,
                   const StringPool* string_pool_) {
     bytecode = bytecode_;
     registers.clear();
     for (uint32_t i = 0; i < num_registers; ++i) {
       registers.emplace_back();
     }
-    columns = columns_;
-    column_storage_data_ptrs.clear();
-    for (uint32_t i = 0; i < column_count; ++i) {
-      column_storage_data_ptrs.emplace_back(columns_[i]->storage.data());
-    }
-    indexes = indexes_;
     string_pool = string_pool_;
   }
 
   // Access a register for reading/writing with type safety through the
   // handle.
   template <typename T>
-  PERFETTO_ALWAYS_INLINE T& ReadFromRegister(reg::RwHandle<T> r) {
+  PERFETTO_ALWAYS_INLINE T& ReadFromRegister(RwHandle<T> r) {
     return base::unchecked_get<T>(registers[r.index]);
   }
 
   // Access a register for reading only with type safety through the handle.
   template <typename T>
-  PERFETTO_ALWAYS_INLINE const T& ReadFromRegister(reg::ReadHandle<T> r) const {
+  PERFETTO_ALWAYS_INLINE const T& ReadFromRegister(ReadHandle<T> r) const {
     return base::unchecked_get<T>(registers[r.index]);
   }
 
   // Conditionally access a register if it contains the expected type.
   // Returns nullptr if the register holds a different type.
   template <typename T>
-  PERFETTO_ALWAYS_INLINE const T* MaybeReadFromRegister(
-      reg::ReadHandle<T> reg) {
+  PERFETTO_ALWAYS_INLINE const T* MaybeReadFromRegister(ReadHandle<T> reg) {
     if (reg.index != std::numeric_limits<uint32_t>::max() &&
         std::holds_alternative<T>(registers[reg.index])) {
       return &base::unchecked_get<T>(registers[reg.index]);
@@ -99,7 +83,7 @@ struct InterpreterState {
   // Conditionally access a register if it contains the expected type.
   // Returns nullptr if the register holds a different type.
   template <typename T>
-  PERFETTO_ALWAYS_INLINE T* MaybeReadFromRegister(reg::WriteHandle<T> reg) {
+  PERFETTO_ALWAYS_INLINE T* MaybeReadFromRegister(WriteHandle<T> reg) {
     if (reg.index != std::numeric_limits<uint32_t>::max() &&
         std::holds_alternative<T>(registers[reg.index])) {
       return &base::unchecked_get<T>(registers[reg.index]);
@@ -107,18 +91,20 @@ struct InterpreterState {
     return nullptr;
   }
 
+  template <typename T>
+  PERFETTO_ALWAYS_INLINE const auto* ReadStorageFromRegister(
+      ReadHandle<StoragePtr> reg) {
+    return static_cast<const typename T::cpp_type*>(ReadFromRegister(reg).ptr);
+  }
+
   // Writes a value to the specified register, handling type safety through
   // the handle.
   template <typename T>
-  PERFETTO_ALWAYS_INLINE void WriteToRegister(reg::WriteHandle<T> r, T value) {
+  PERFETTO_ALWAYS_INLINE void WriteToRegister(WriteHandle<T> r, T value) {
     registers[r.index] = std::move(value);
   }
-
-  const Column& GetColumn(uint32_t idx) const { return *columns[idx]; }
-
-  template <typename T>
-  const auto* GetColumnData(uint32_t idx) const {
-    return Storage::CastDataPtr<T>(column_storage_data_ptrs[idx]);
+  PERFETTO_ALWAYS_INLINE void WriteToRegister(HandleBase r, RegValue value) {
+    registers[r.index] = std::move(value);
   }
 };
 

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_test_utils.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_test_utils.h
@@ -38,7 +38,9 @@
 #include "src/trace_processor/core/common/op_types.h"
 #include "src/trace_processor/core/common/sort_types.h"
 #include "src/trace_processor/core/common/value_fetcher.h"
+#include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
+#include "src/trace_processor/core/interpreter/bytecode_instruction_macros.h"
 #include "src/trace_processor/core/interpreter/bytecode_instructions.h"
 #include "src/trace_processor/core/interpreter/interpreter_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
@@ -194,12 +196,14 @@ inline Bytecode ParseBytecode(const std::string& bytecode_str) {
       PERFETTO_DATAFRAME_BYTECODE_LIST(PERFETTO_DATAFRAME_BYTECODE_AS_STRING)};
 
 #define PERFETTO_DATAFRAME_BYTECODE_OFFSETS(...) __VA_ARGS__::kOffsets,
-  static constexpr std::array<std::array<uint32_t, 9>, kNumBytecodeCount>
+  static constexpr std::array<std::array<uint32_t, kMaxBytecodeArgs + 1>,
+                              kNumBytecodeCount>
       offsets{PERFETTO_DATAFRAME_BYTECODE_LIST(
           PERFETTO_DATAFRAME_BYTECODE_OFFSETS)};
 
 #define PERFETTO_DATAFRAME_BYTECODE_NAMES(...) __VA_ARGS__::kNames,
-  static constexpr std::array<std::array<const char*, 8>, kNumBytecodeCount>
+  static constexpr std::array<std::array<const char*, kMaxBytecodeArgs>,
+                              kNumBytecodeCount>
       names{
           PERFETTO_DATAFRAME_BYTECODE_LIST(PERFETTO_DATAFRAME_BYTECODE_NAMES)};
 
@@ -261,29 +265,32 @@ inline Bytecode ParseBytecode(const std::string& bytecode_str) {
 }
 
 template <typename T, typename U>
-inline Column CreateNonNullColumn(std::initializer_list<U> data,
-                                  SortState sort_state,
-                                  DuplicateState duplicate_state) {
+inline dataframe::Column CreateNonNullColumn(std::initializer_list<U> data,
+                                             SortState sort_state,
+                                             DuplicateState duplicate_state) {
   core::FlexVector<T> vec;
   for (const U& val : data) {
     vec.push_back(val);
   }
-  return Column{Storage{std::move(vec)}, NullStorage::NonNull{}, sort_state,
-                duplicate_state};
+  return dataframe::Column{dataframe::Storage{std::move(vec)},
+                           dataframe::NullStorage::NonNull{}, sort_state,
+                           duplicate_state};
 }
 
 template <typename U>
-inline Column CreateNonNullStringColumn(std::initializer_list<U> data,
-                                        SortState sort_state,
-                                        DuplicateState duplicate_state,
-                                        StringPool* pool) {
+inline dataframe::Column CreateNonNullStringColumn(
+    std::initializer_list<U> data,
+    SortState sort_state,
+    DuplicateState duplicate_state,
+    StringPool* pool) {
   PERFETTO_CHECK(pool);
   core::FlexVector<StringPool::Id> vec;
   for (const auto& str_like : data) {
     vec.push_back(pool->InternString(str_like));
   }
-  return Column{Storage{std::move(vec)}, NullStorage::NonNull{}, sort_state,
-                duplicate_state};
+  return dataframe::Column{dataframe::Storage{std::move(vec)},
+                           dataframe::NullStorage::NonNull{}, sort_state,
+                           duplicate_state};
 }
 
 template <typename T>
@@ -297,7 +304,7 @@ inline FlexVector<T> CreateFlexVectorForTesting(
 }
 
 template <typename T>
-inline Column CreateSparseNullableColumn(
+inline dataframe::Column CreateSparseNullableColumn(
     const std::vector<std::optional<T>>& data_with_nulls,
     SortState sort_state,
     DuplicateState duplicate_state) {
@@ -310,12 +317,13 @@ inline Column CreateSparseNullableColumn(
       bv.set(i);
     }
   }
-  return Column{Storage{std::move(data_vec)},
-                NullStorage{NullStorage::SparseNull{std::move(bv), {}}},
-                sort_state, duplicate_state};
+  return dataframe::Column{
+      dataframe::Storage{std::move(data_vec)},
+      dataframe::NullStorage::SparseNull{std::move(bv), {}}, sort_state,
+      duplicate_state};
 }
 
-inline Column CreateSparseNullableStringColumn(
+inline dataframe::Column CreateSparseNullableStringColumn(
     const std::vector<std::optional<const char*>>& data_with_nulls,
     StringPool* pool,
     SortState sort_state,
@@ -329,13 +337,14 @@ inline Column CreateSparseNullableStringColumn(
       bv.set(i);
     }
   }
-  return Column{Storage{std::move(data_vec)},
-                NullStorage{NullStorage::SparseNull{std::move(bv), {}}},
-                sort_state, duplicate_state};
+  return dataframe::Column{
+      dataframe::Storage{std::move(data_vec)},
+      dataframe::NullStorage::SparseNull{std::move(bv), {}}, sort_state,
+      duplicate_state};
 }
 
 template <typename T>
-inline Column CreateDenseNullableColumn(
+inline dataframe::Column CreateDenseNullableColumn(
     const std::vector<std::optional<T>>& data_with_nulls,
     SortState sort_state,
     DuplicateState duplicate_state) {
@@ -351,12 +360,12 @@ inline Column CreateDenseNullableColumn(
       data_vec[i] = T{};  // Default construct T for null storage slot
     }
   }
-  return Column{Storage{std::move(data_vec)},
-                NullStorage{NullStorage::DenseNull{std::move(bv)}}, sort_state,
-                duplicate_state};
+  return dataframe::Column{dataframe::Storage{std::move(data_vec)},
+                           dataframe::NullStorage::DenseNull{std::move(bv)},
+                           sort_state, duplicate_state};
 }
 
-inline Column CreateDenseNullableStringColumn(
+inline dataframe::Column CreateDenseNullableStringColumn(
     const std::vector<std::optional<const char*>>& data_with_nulls,
     StringPool* pool,
     SortState sort_state,
@@ -373,9 +382,9 @@ inline Column CreateDenseNullableStringColumn(
       data_vec[i] = StringPool::Id::Null();
     }
   }
-  return Column{Storage{std::move(data_vec)},
-                NullStorage{NullStorage::DenseNull{std::move(bv)}}, sort_state,
-                duplicate_state};
+  return dataframe::Column{dataframe::Storage{std::move(data_vec)},
+                           dataframe::NullStorage::DenseNull{std::move(bv)},
+                           sort_state, duplicate_state};
 }
 
 PERFETTO_NO_INLINE BytecodeVector inline ParseBytecodeToVec(

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_unittest.cc
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_unittest.cc
@@ -32,11 +32,14 @@
 #include <vector>
 
 #include "perfetto/base/logging.h"
-#include "perfetto/ext/base/flat_hash_map.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/variant.h"
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/duplicate_types.h"
+#include "src/trace_processor/core/common/op_types.h"
+#include "src/trace_processor/core/common/sort_types.h"
+#include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
@@ -46,7 +49,9 @@
 #include "src/trace_processor/core/interpreter/interpreter_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/flex_vector.h"
+#include "src/trace_processor/core/util/range.h"
 #include "src/trace_processor/core/util/slab.h"
+#include "src/trace_processor/core/util/span.h"
 #include "src/trace_processor/util/regex.h"
 #include "test/gtest_and_gmock.h"
 
@@ -83,36 +88,45 @@ class BytecodeInterpreterTest : public testing::Test {
     // Hardcode the register count to 128 for testing.
     static constexpr uint32_t kNumRegisters = 128;
     interpreter_ = std::make_unique<Interpreter<Fetcher>>();
-    interpreter_->Initialize(bytecode, kNumRegisters,
-                             static_cast<uint32_t>(column_ptrs_.size()),
-                             column_ptrs_.data(), indexes_.data(), &spool_);
+    interpreter_->Initialize(bytecode, kNumRegisters, &spool_);
   }
 
   template <typename T>
   const T& GetRegister(uint32_t reg_idx) {
-    const auto* r = interpreter_->GetRegisterValue(reg::ReadHandle<T>(reg_idx));
+    const auto* r = interpreter_->GetRegisterValue(ReadHandle<T>(reg_idx));
     PERFETTO_CHECK(r);
     return *r;
   }
 
-  void AddColumn(Column column) {
-    columns_vec_.emplace_back(std::make_unique<Column>(std::move(column)));
+  void AddColumn(dataframe::Column column) {
+    columns_vec_.emplace_back(
+        std::make_unique<dataframe::Column>(std::move(column)));
     column_ptrs_.emplace_back(columns_vec_.back().get());
+  }
+
+  // Returns StoragePtr for a column, to pass to SetRegistersAndExecute.
+  template <typename T>
+  StoragePtr GetStoragePtr(uint32_t col_idx) {
+    return StoragePtr{column_ptrs_[col_idx]->storage.unchecked_data<T>(), T{}};
+  }
+
+  // Returns null bitvector pointer for a column.
+  const BitVector* GetNullBv(uint32_t col_idx) {
+    return column_ptrs_[col_idx]->null_storage.MaybeGetNullBitVector();
   }
 
   template <typename... Ts, uint32_t... Is>
   void SetRegisterValuesForTesting(Interpreter<Fetcher>* interpreter,
                                    std::integer_sequence<uint32_t, Is...>,
                                    Ts... values) {
-    (interpreter->SetRegisterValueForTesting(reg::WriteHandle<Ts>(Is),
-                                             std::move(values)),
+    (interpreter->SetRegisterValue(WriteHandle<Ts>(Is), std::move(values)),
      ...);
   }
 
   Fetcher fetcher_;
   StringPool spool_;
-  std::vector<std::unique_ptr<Column>> columns_vec_;
-  std::vector<Column*> column_ptrs_;
+  std::vector<std::unique_ptr<dataframe::Column>> columns_vec_;
+  std::vector<dataframe::Column*> column_ptrs_;
   std::vector<dataframe::Index> indexes_;
   std::unique_ptr<Interpreter<Fetcher>> interpreter_;
 };
@@ -508,7 +522,8 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(BytecodeInterpreterTest, SortedFilterIdEq) {
   std::string bytecode =
-      "SortedFilter<Id, EqualRange>: [col=0, val_register=Register(0), "
+      "SortedFilter<Id, EqualRange>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(0)]";
   {
     // Test case 1: Value exists in range
@@ -537,7 +552,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterIdEq) {
 
 TEST_F(BytecodeInterpreterTest, SortedFilter_LowerBound_BeginBound_Normal) {
   std::string bytecode =
-      "SortedFilter<Id, LowerBound>: [col=0, val_register=Register(0), "
+      "SortedFilter<Id, LowerBound>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(1)]";
   SetRegistersAndExecute(
       bytecode, CastFilterValueResult::Valid(CastFilterValueResult::Id{5}),
@@ -550,7 +566,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilter_LowerBound_BeginBound_Normal) {
 
 TEST_F(BytecodeInterpreterTest, SortedFilter_LowerBound_EndBound_EmptiesRange) {
   std::string bytecode =
-      "SortedFilter<Id, LowerBound>: [col=0, val_register=Register(0), "
+      "SortedFilter<Id, LowerBound>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(2)]";
   SetRegistersAndExecute(
       bytecode, CastFilterValueResult::Valid(CastFilterValueResult::Id{2}),
@@ -564,7 +581,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilter_LowerBound_EndBound_EmptiesRange) {
 TEST_F(BytecodeInterpreterTest,
        SortedFilter_UpperBound_BeginBound_EmptiesRange) {
   std::string bytecode =
-      "SortedFilter<Id, UpperBound>: [col=0, val_register=Register(0), "
+      "SortedFilter<Id, UpperBound>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(1)]";
   SetRegistersAndExecute(
       bytecode, CastFilterValueResult::Valid(CastFilterValueResult::Id{15}),
@@ -577,7 +595,8 @@ TEST_F(BytecodeInterpreterTest,
 
 TEST_F(BytecodeInterpreterTest, SortedFilter_UpperBound_EndBound_Normal) {
   std::string bytecode =
-      "SortedFilter<Id, UpperBound>: [col=0, val_register=Register(0), "
+      "SortedFilter<Id, UpperBound>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(2)]";
   SetRegistersAndExecute(
       bytecode, CastFilterValueResult::Valid(CastFilterValueResult::Id{5}),
@@ -590,7 +609,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilter_UpperBound_EndBound_Normal) {
 
 TEST_F(BytecodeInterpreterTest, SortedFilter_UpperBound_EndBound_Redundant) {
   std::string bytecode =
-      "SortedFilter<Id, UpperBound>: [col=0, val_register=Register(0), "
+      "SortedFilter<Id, UpperBound>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(2)]";
   SetRegistersAndExecute(
       bytecode, CastFilterValueResult::Valid(CastFilterValueResult::Id{12}),
@@ -603,17 +623,19 @@ TEST_F(BytecodeInterpreterTest, SortedFilter_UpperBound_EndBound_Redundant) {
 
 TEST_F(BytecodeInterpreterTest, SortedFilterUint32Eq) {
   std::string bytecode =
-      "SortedFilter<Uint32, EqualRange>: [col=0, val_register=Register(0), "
+      "SortedFilter<Uint32, EqualRange>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(0)]";
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Sorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Sorted{},
+                              HasDuplicates{}});
   {
     // Test case 1: Value exists in range
     SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
-                           Range{3u, 8u});
+                           Range{3u, 8u}, GetStoragePtr<Uint32>(0));
     const auto& result = GetRegister<Range>(1);
     EXPECT_EQ(result.b, 3u);
     EXPECT_EQ(result.e, 5u);
@@ -621,34 +643,36 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32Eq) {
   {
     // Test case 2: Value exists not range
     SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(4u),
-                           Range{3u, 8u});
+                           Range{3u, 8u}, GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Range>(1), IsEmpty());
   }
   {
     // Test case 3: Invalid cast result (NoneMatch)
     SetRegistersAndExecute(bytecode, CastFilterValueResult::NoneMatch(),
-                           Range{0, 8u});
+                           Range{0, 8u}, GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Range>(1), IsEmpty());
   }
 }
 
 TEST_F(BytecodeInterpreterTest, SortedFilterUint32LowerBound) {
   std::string bytecode =
-      "SortedFilter<Uint32, LowerBound>: [col=0, val_register=Register(0), "
+      "SortedFilter<Uint32, LowerBound>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(2)]";
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  AddColumn(Column{Storage{std::move(values)},
-                   NullStorage{NullStorage::NonNull{}}, Sorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{
+      dataframe::Storage{std::move(values)},
+      dataframe::NullStorage{dataframe::NullStorage::NonNull{}}, Sorted{},
+      HasDuplicates{}});
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
-                         Range{3u, 8u});
+                         Range{3u, 8u}, GetStoragePtr<Uint32>(0));
   EXPECT_THAT(GetRegister<Range>(1), IsEmpty());
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
-                         Range{1u, 8u});
+                         Range{1u, 8u}, GetStoragePtr<Uint32>(0));
   auto result = GetRegister<Range>(1);
   EXPECT_EQ(result.b, 1u);
   EXPECT_EQ(result.e, 2u);
@@ -656,16 +680,18 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32LowerBound) {
 
 TEST_F(BytecodeInterpreterTest, SortedFilterUint32UpperBound) {
   std::string bytecode =
-      "SortedFilter<Uint32, UpperBound>: [col=0, val_register=Register(0), "
+      "SortedFilter<Uint32, UpperBound>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(1)]";
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({0u, 4u, 5u, 5u, 5u, 6u, 10u, 10u});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Sorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Sorted{},
+                              HasDuplicates{}});
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
-                         Range{3u, 7u});
+                         Range{3u, 7u}, GetStoragePtr<Uint32>(0));
   auto result = GetRegister<Range>(1);
   EXPECT_EQ(result.b, 5u);
   EXPECT_EQ(result.e, 7u);
@@ -673,7 +699,8 @@ TEST_F(BytecodeInterpreterTest, SortedFilterUint32UpperBound) {
 
 TEST_F(BytecodeInterpreterTest, FilterIdEq) {
   std::string bytecode =
-      "NonStringFilter<Id, Eq>: [col=0, val_register=Register(0), "
+      "NonStringFilter<Id, Eq>: [storage_register=Register(3), "
+      "val_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]";
 
   std::vector<uint32_t> indices_spec = {12, 44, 10, 4, 5, 2, 3};
@@ -697,28 +724,30 @@ TEST_F(BytecodeInterpreterTest, FilterIdEq) {
     // Test case 3: Invalid cast result (NoneMatch)
     std::vector<uint32_t> indices = indices_spec;
     SetRegistersAndExecute(bytecode, CastFilterValueResult::NoneMatch(),
-                           CastFilterValueResult::NoneMatch(), GetSpan(indices),
-                           GetSpan(indices));
+                           GetSpan(indices), GetSpan(indices));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(2), IsEmpty());
   }
 }
 
 TEST_F(BytecodeInterpreterTest, FilterUint32Eq) {
   std::string bytecode =
-      "NonStringFilter<Uint32, Eq>: [col=0, val_register=Register(0), "
+      "NonStringFilter<Uint32, Eq>: [storage_register=Register(3), "
+      "val_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]";
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({4u, 49u, 392u, 4u, 49u, 4u, 391u});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Unsorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Unsorted{},
+                              HasDuplicates{}});
 
   std::vector<uint32_t> indices_spec = {3, 3, 4, 5, 0, 6, 0};
   {
     // Test case 1: Value exists
     std::vector<uint32_t> indices = indices_spec;
     SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(4u),
-                           GetSpan(indices), GetSpan(indices));
+                           GetSpan(indices), GetSpan(indices),
+                           GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(2),
                 ElementsAre(3u, 3u, 5u, 0u, 0u));
   }
@@ -726,14 +755,16 @@ TEST_F(BytecodeInterpreterTest, FilterUint32Eq) {
     // Test case 2: Value does not exist
     std::vector<uint32_t> indices = indices_spec;
     SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
-                           GetSpan(indices), GetSpan(indices));
+                           GetSpan(indices), GetSpan(indices),
+                           GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(2), IsEmpty());
   }
   {
     // Test case 3: Invalid cast result (NoneMatch)
     std::vector<uint32_t> indices = indices_spec;
     SetRegistersAndExecute(bytecode, CastFilterValueResult::NoneMatch(),
-                           GetSpan(indices), GetSpan(indices));
+                           GetSpan(indices), GetSpan(indices),
+                           GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(2), IsEmpty());
   }
 }
@@ -760,16 +791,18 @@ TEST_F(BytecodeInterpreterTest, SortedFilterString) {
   // Sorted string data: ["apple", "banana", "banana", "cherry", "date"]
   auto values = CreateFlexVectorForTesting<StringPool::Id>(
       {apple_id, banana_id, banana_id, cherry_id, date_id});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Sorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Sorted{},
+                              HasDuplicates{}});
 
   // --- Sub-test for EqualRange (Eq) ---
   {
     std::string bytecode_str =
-        "SortedFilter<String, EqualRange>: [col=0, val_register=Register(0), "
+        "SortedFilter<String, EqualRange>: [storage_register=Register(2), "
+        "val_register=Register(0), "
         "update_register=Register(1), write_result_to=BoundModifier(0)]";
     SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid("banana"),
-                           Range{0, 5});
+                           Range{0, 5}, GetStoragePtr<String>(0));
     const auto& result_range = GetRegister<Range>(1);
     EXPECT_EQ(result_range.b, 1u) << "EqualRange begin";
     EXPECT_EQ(result_range.e, 3u) << "EqualRange end";
@@ -778,10 +811,11 @@ TEST_F(BytecodeInterpreterTest, SortedFilterString) {
   {
     // BoundModifier(1) == BeginBound (for Ge)
     std::string bytecode_str =
-        "SortedFilter<String, LowerBound>: [col=0, val_register=Register(0), "
+        "SortedFilter<String, LowerBound>: [storage_register=Register(2), "
+        "val_register=Register(0), "
         "update_register=Register(1), write_result_to=BoundModifier(1)]";
     SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid("banana"),
-                           Range{0, 5});
+                           Range{0, 5}, GetStoragePtr<String>(0));
     const auto& result_range = GetRegister<Range>(1);
     EXPECT_EQ(result_range.b, 1u) << "LowerBound(Ge) begin";
     EXPECT_EQ(result_range.e, 5u) << "LowerBound(Ge) end";
@@ -790,10 +824,11 @@ TEST_F(BytecodeInterpreterTest, SortedFilterString) {
   {
     // BoundModifier(2) == EndBound (for Le)
     std::string bytecode_str =
-        "SortedFilter<String, UpperBound>: [col=0, val_register=Register(0), "
+        "SortedFilter<String, UpperBound>: [storage_register=Register(2), "
+        "val_register=Register(0), "
         "update_register=Register(1), write_result_to=BoundModifier(2)]";
     SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid("banana"),
-                           Range{0, 5});
+                           Range{0, 5}, GetStoragePtr<String>(0));
     const auto& result_range = GetRegister<Range>(1);
     EXPECT_EQ(result_range.b, 0u) << "UpperBound(Le) begin";
     EXPECT_EQ(result_range.e, 3u) << "UpperBound(Le) end";
@@ -813,8 +848,9 @@ TEST_F(BytecodeInterpreterTest, StringFilter) {
   // Index:    0        1      2      3        4       5        6
   auto values = CreateFlexVectorForTesting<StringPool::Id>(
       {cherry_id, apple_id, empty_id, banana_id, apple_id, date_id, durian_id});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Unsorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Unsorted{},
+                              HasDuplicates{}});
 
   // Initial indices {0, 1, 2, 3, 4, 5, 6} pointing to the data
   const std::vector<uint32_t> source_indices = {0, 1, 2, 3, 4, 5, 6};
@@ -827,15 +863,16 @@ TEST_F(BytecodeInterpreterTest, StringFilter) {
         // Construct the bytecode string for the specific operation
         std::string bytecode_str =
             base::StackString<1024>(
-                "StringFilter<%s>: [col=0, val_register=Register(0), "
+                "StringFilter<%s>: [storage_register=Register(3), "
+                "val_register=Register(0), "
                 "source_register=Register(1), update_register=Register(2)]",
                 op_name.c_str())
                 .ToStdString();
 
         std::vector<uint32_t> res = source_indices;
-        SetRegistersAndExecute(bytecode_str,
-                               CastFilterValueResult::Valid(filter_value),
-                               GetSpan(res), GetSpan(res));
+        SetRegistersAndExecute(
+            bytecode_str, CastFilterValueResult::Valid(filter_value),
+            GetSpan(res), GetSpan(res), GetStoragePtr<String>(0));
         EXPECT_THAT(GetRegister<Span<uint32_t>>(2),
                     ElementsAreArray(expected_indices))
             << test_label;
@@ -872,18 +909,20 @@ TEST_F(BytecodeInterpreterTest, StringFilterNeStringNotInPool) {
 
   auto values = CreateFlexVectorForTesting<StringPool::Id>(
       {apple_id, banana_id, apple_id, banana_id});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Unsorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Unsorted{},
+                              HasDuplicates{}});
 
   // Use separate source and update buffers to properly test memcpy behavior.
   std::vector<uint32_t> source_indices = {0, 1, 2, 3};
   std::vector<uint32_t> update_buffer(4, 0);
 
   SetRegistersAndExecute(
-      "StringFilter<Ne>: [col=0, val_register=Register(0), "
+      "StringFilter<Ne>: [storage_register=Register(3), "
+      "val_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]",
       CastFilterValueResult::Valid("nonexistent"), GetSpan(source_indices),
-      GetSpan(update_buffer));
+      GetSpan(update_buffer), GetStoragePtr<String>(0));
 
   // All 4 indices should be returned since "nonexistent" != any string
   EXPECT_THAT(GetRegister<Span<uint32_t>>(2), ElementsAre(0, 1, 2, 3));
@@ -907,18 +946,19 @@ TEST_F(BytecodeInterpreterTest, NullFilter) {
 
   // Create a dummy column with a DenseNull overlay using the BitVector
   // (SparseNull would work identically for this specific test)
-  AddColumn(Column{
-      Storage{Storage::Uint32{}},  // Storage type doesn't matter for NullFilter
-      NullStorage{NullStorage::DenseNull{std::move(bv)}}, Unsorted{},
-      HasDuplicates{}});
+  AddColumn(dataframe::Column{
+      dataframe::Storage{dataframe::Storage::Uint32{}},
+      dataframe::NullStorage{dataframe::NullStorage::DenseNull{std::move(bv)}},
+      Unsorted{}, HasDuplicates{}});
 
   std::vector<uint32_t> indices(kNumIndices);
   std::iota(indices.begin(), indices.end(), 0);
   {
     std::vector<uint32_t> res = indices;
     SetRegistersAndExecute(
-        "NullFilter<IsNull>: [col=0, update_register=Register(0)]",
-        GetSpan(res));
+        "NullFilter<IsNull>: [null_bv_register=Register(1), "
+        "update_register=Register(0)]",
+        GetSpan(res), GetNullBv(0));
 
     // Expected output: indices where the bit was *not* set (even indices)
     std::vector<uint32_t> expected_isnull;
@@ -931,8 +971,9 @@ TEST_F(BytecodeInterpreterTest, NullFilter) {
   {
     std::vector<uint32_t> res = indices;
     SetRegistersAndExecute(
-        "NullFilter<IsNotNull>: [col=0, update_register=Register(0)]",
-        GetSpan(res));
+        "NullFilter<IsNotNull>: [null_bv_register=Register(1), "
+        "update_register=Register(0)]",
+        GetSpan(res), GetNullBv(0));
 
     // Expected output: indices where the bit *was* set (odd indices)
     std::vector<uint32_t> expected_isnotnull;
@@ -963,10 +1004,16 @@ TEST_F(BytecodeInterpreterTest, PrefixPopcount) {
   bv.set(160);  // Word 2
   bv.set(200);  // Word 3
 
-  AddColumn(Column{Storage{Storage::Uint32{}},  // Storage type doesn't matter
-                   NullStorage{NullStorage::SparseNull{std::move(bv), {}}},
-                   Unsorted{}, HasDuplicates{}});
-  SetRegistersAndExecute("PrefixPopcount: [col=0, dest_register=Register(0)]");
+  AddColumn(dataframe::Column{
+      dataframe::Storage{
+          dataframe::Storage::Uint32{}},  // Storage type doesn't matter
+      dataframe::NullStorage{
+          dataframe::NullStorage::SparseNull{std::move(bv), {}}},
+      Unsorted{}, HasDuplicates{}});
+  SetRegistersAndExecute(
+      "PrefixPopcount: [null_bv_register=Register(1), "
+      "dest_register=Register(0)]",
+      Empty{}, GetNullBv(0));
 
   const auto& result_slab = GetRegister<Slab<uint32_t>>(0);
 
@@ -1012,9 +1059,12 @@ TEST_F(BytecodeInterpreterTest, TranslateSparseNullIndices) {
   bv.set(160);  // Word 2
   bv.set(200);  // Word 3
 
-  AddColumn(Column{Storage{Storage::Uint32{}},  // Storage type doesn't matter
-                   NullStorage{NullStorage::SparseNull{std::move(bv), {}}},
-                   Unsorted{}, HasDuplicates{}});
+  AddColumn(dataframe::Column{
+      dataframe::Storage{
+          dataframe::Storage::Uint32{}},  // Storage type doesn't matter
+      dataframe::NullStorage{
+          dataframe::NullStorage::SparseNull{std::move(bv), {}}},
+      Unsorted{}, HasDuplicates{}});
 
   // Precomputed PrefixPopcount Slab (from previous test)
   auto popcount_slab = Slab<uint32_t>::Alloc(4);
@@ -1026,10 +1076,11 @@ TEST_F(BytecodeInterpreterTest, TranslateSparseNullIndices) {
   std::vector<uint32_t> source_indices = {5, 40, 70, 150, 200};
   std::vector<uint32_t> translated_indices(source_indices.size());
   SetRegistersAndExecute(
-      "TranslateSparseNullIndices: [col=0, popcount_register=Register(0), "
+      "TranslateSparseNullIndices: [null_bv_register=Register(3), "
+      "popcount_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]",
       std::move(popcount_slab), GetSpan(source_indices),
-      GetSpan(translated_indices));
+      GetSpan(translated_indices), GetNullBv(0));
 
   // Verify the translated indices in Register 2
   // Index 5 -> Storage 0 (Popcnt[0] + 0)
@@ -1068,9 +1119,12 @@ TEST_F(BytecodeInterpreterTest, StrideTranslateAndCopySparseNullIndices) {
   popcount_slab[3] = 9;
 
   // Create a dummy column with the BitVector (SparseNull overlay)
-  AddColumn(Column{Storage{Storage::Uint32{}},  // Storage type doesn't matter
-                   NullStorage{NullStorage::SparseNull{std::move(bv), {}}},
-                   Unsorted{}, HasDuplicates{}});
+  AddColumn(dataframe::Column{
+      dataframe::Storage{
+          dataframe::Storage::Uint32{}},  // Storage type doesn't matter
+      dataframe::NullStorage{
+          dataframe::NullStorage::SparseNull{std::move(bv), {}}},
+      Unsorted{}, HasDuplicates{}});
 
   // Input/Output buffer setup: Stride = 3, Offset for this column = 1
   // We pre-populate offset 0 with the original indices to simulate the state
@@ -1085,11 +1139,11 @@ TEST_F(BytecodeInterpreterTest, StrideTranslateAndCopySparseNullIndices) {
   }
 
   SetRegistersAndExecute(
-      "StrideTranslateAndCopySparseNullIndices: [col=0, "
+      "StrideTranslateAndCopySparseNullIndices: [null_bv_register=Register(2), "
       "popcount_register=Register(0), "
       "update_register=Register(1), offset=" +
           std::to_string(kOffset) + ", stride=" + std::to_string(kStride) + "]",
-      std::move(popcount_slab), GetSpan(buffer));
+      std::move(popcount_slab), GetSpan(buffer), GetNullBv(0));
 
   // Verify the contents of the buffer at the specified offset
   // Original Index | Is Set (Not Null) | Storage Index | Expected @ Offset 1
@@ -1137,9 +1191,11 @@ TEST_F(BytecodeInterpreterTest, StrideCopyDenseNullIndices) {
   bv.set(200);  // Word 3
 
   // Create a dummy column with the BitVector (DenseNull overlay)
-  AddColumn(Column{Storage{Storage::Uint32{}},  // Storage type doesn't matter
-                   NullStorage{NullStorage::DenseNull{std::move(bv)}},
-                   Unsorted{}, HasDuplicates{}});
+  AddColumn(dataframe::Column{
+      dataframe::Storage{
+          dataframe::Storage::Uint32{}},  // Storage type doesn't matter
+      dataframe::NullStorage{dataframe::NullStorage::DenseNull{std::move(bv)}},
+      Unsorted{}, HasDuplicates{}});
 
   // Input/Output buffer setup: Stride = 2, Offset for this column = 1
   // Pre-populate offset 0 with the original indices.
@@ -1153,10 +1209,11 @@ TEST_F(BytecodeInterpreterTest, StrideCopyDenseNullIndices) {
   }
 
   SetRegistersAndExecute(
-      "StrideCopyDenseNullIndices: [col=0, update_register=Register(0), "
+      "StrideCopyDenseNullIndices: [null_bv_register=Register(1), "
+      "update_register=Register(0), "
       "offset=" +
           std::to_string(kOffset) + ", stride=" + std::to_string(kStride) + "]",
-      GetSpan(buffer));
+      GetSpan(buffer), GetNullBv(0));
 
   // Verify the contents of the buffer at the specified offset
   // Original Index | Is Set (Not Null) | Expected @ Offset 1
@@ -1191,8 +1248,10 @@ TEST_F(BytecodeInterpreterTest, StrideCopyDenseNullIndices) {
 TEST_F(BytecodeInterpreterTest, NonStringFilterInPlace) {
   // Column data: {5, 10, 5, 15, 10, 20}
   auto values = CreateFlexVectorForTesting<uint32_t>({5, 10, 5, 15, 10, 20});
-  AddColumn(Column{std::move(values), NullStorage{NullStorage::NonNull{}},
-                   Unsorted{}, HasDuplicates{}});
+  AddColumn(dataframe::Column{
+      std::move(values),
+      dataframe::NullStorage{dataframe::NullStorage::NonNull{}}, Unsorted{},
+      HasDuplicates{}});
 
   // Source indices (imagine these are translated storage indices for data
   // lookup).
@@ -1205,10 +1264,11 @@ TEST_F(BytecodeInterpreterTest, NonStringFilterInPlace) {
                                           104};  // Initial values
 
   SetRegistersAndExecute(
-      "NonStringFilter<Uint32, Eq>: [col=0, val_register=Register(0), "
+      "NonStringFilter<Uint32, Eq>: [storage_register=Register(3), "
+      "val_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]",
       CastFilterValueResult::Valid(10u), GetSpan(source_indices),
-      GetSpan(update_indices));
+      GetSpan(update_indices), GetStoragePtr<Uint32>(0));
 
   // Verify the update register (Register 2) - it should be filtered in-place.
   // Iteration | Src Idx | Data | Update Idx | Compares? | Action
@@ -1228,18 +1288,21 @@ TEST_F(BytecodeInterpreterTest, Uint32SetIdSortedEq) {
   // 7  7  10
   auto values = CreateFlexVectorForTesting<uint32_t>(
       {0u, 0u, 0u, 3u, 3u, 5u, 5u, 7u, 7u, 7u, 10u});
-  AddColumn(Column{std::move(values), NullStorage{NullStorage::NonNull{}},
-                   SetIdSorted{}, HasDuplicates{}});
+  AddColumn(dataframe::Column{
+      std::move(values),
+      dataframe::NullStorage{dataframe::NullStorage::NonNull{}}, SetIdSorted{},
+      HasDuplicates{}});
 
   std::string bytecode =
-      "Uint32SetIdSortedEq: [col=0, val_register=Register(0), "
+      "Uint32SetIdSortedEq: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1)]";
 
   auto RunSubTest = [&](const std::string& label, Range initial_range,
                         uint32_t filter_val, Range expected_range) {
     SCOPED_TRACE("Sub-test: " + label);
     SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(filter_val),
-                           initial_range);
+                           initial_range, GetStoragePtr<Uint32>(0));
     const auto& result = GetRegister<Range>(1);
     EXPECT_EQ(result.b, expected_range.b) << "Range begin mismatch";
     EXPECT_EQ(result.e, expected_range.e) << "Range end mismatch";
@@ -1305,15 +1368,23 @@ TEST_F(BytecodeInterpreterTest, Distinct_TwoNonNullCols_SimpleDuplicates) {
   AddColumn(CreateNonNullStringColumn<const char*>(
       {"A", "B", "A", "C", "B"}, Unsorted{}, HasDuplicates{}, &spool_));
 
+  // Register layout:
+  // 0: indices span, 1: unused, 2: buffer
+  // 3: storage col0, 4: null_bv col0 (nullptr for NonNull)
+  // 5: storage col1, 6: null_bv col1 (nullptr for NonNull)
   std::string bytecode_sequence = R"(
     AllocateRowLayoutBuffer: [buffer_size=40, dest_buffer_register=Register(2)]
-    CopyToRowLayout<Int32, NonNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<String, NonNull>: [col=1, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int32, NonNull>: [storage_register=Register(3), null_bv_register=Register(4), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(5), null_bv_register=Register(6), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     Distinct: [buffer_register=Register(2), total_row_stride=8, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices = {0, 1, 2, 3, 4};
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  // Registers: 0=indices, 1=unused, 2=unused (buffer allocated by bytecode),
+  // 3=storage0, 4=null_bv0, 5=storage1, 6=null_bv1
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         GetStoragePtr<Int32>(0), GetNullBv(0),
+                         GetStoragePtr<String>(1), GetNullBv(1));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 1, 3));
 }
 
@@ -1327,16 +1398,22 @@ TEST_F(BytecodeInterpreterTest,
       {std::nullopt, "B", "A", std::nullopt, std::nullopt, "B", std::nullopt},
       &spool_, Unsorted{}, HasDuplicates{}));
 
+  // Register layout:
+  // 0: indices span, 1: unused, 2: buffer
+  // 3: storage col0, 4: null_bv col0
+  // 5: storage col1, 6: null_bv col1
   std::string bytecode_sequence = R"(
     AllocateRowLayoutBuffer: [buffer_size=70, dest_buffer_register=Register(2)]
-    CopyToRowLayout<Int32, DenseNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<String, DenseNull>: [col=1, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=5, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int32, DenseNull>: [storage_register=Register(3), null_bv_register=Register(4), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<String, DenseNull>: [storage_register=Register(5), null_bv_register=Register(6), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=5, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     Distinct: [buffer_register=Register(2), total_row_stride=10, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices(num_rows);
   std::iota(indices.begin(), indices.end(), 0);
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         GetStoragePtr<Int32>(0), GetNullBv(0),
+                         GetStoragePtr<String>(1), GetNullBv(1));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0),
               testing::UnorderedElementsAre(0, 1, 2, 3));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), SizeIs(4));
@@ -1352,18 +1429,27 @@ TEST_F(BytecodeInterpreterTest,
       {std::nullopt, "B", "A", std::nullopt, std::nullopt, "B", std::nullopt},
       &spool_, Unsorted{}, HasDuplicates{}));
 
+  // Register layout:
+  // 0: indices span, 1: unused, 2: buffer
+  // 3: popcount col0, 4: popcount col1
+  // 5: storage col0, 6: null_bv col0
+  // 7: storage col1, 8: null_bv col1
   std::string bytecode_sequence = R"(
     AllocateRowLayoutBuffer: [buffer_size=70, dest_buffer_register=Register(2)]
-    PrefixPopcount: [col=0, dest_register=Register(3)]
-    PrefixPopcount: [col=1, dest_register=Register(4)]
-    CopyToRowLayout<Int32, SparseNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(3), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<String, SparseNull>: [col=1, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=5, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(4), rank_map_register=Register(4294967295)]
+    PrefixPopcount: [null_bv_register=Register(6), dest_register=Register(3)]
+    PrefixPopcount: [null_bv_register=Register(8), dest_register=Register(4)]
+    CopyToRowLayout<Int32, SparseNull>: [storage_register=Register(5), null_bv_register=Register(6), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(3), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<String, SparseNull>: [storage_register=Register(7), null_bv_register=Register(8), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=5, row_layout_stride=10, invert_copied_bits=0, popcount_register=Register(4), rank_map_register=Register(4294967295)]
     Distinct: [buffer_register=Register(2), total_row_stride=10, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices(num_rows);
   std::iota(indices.begin(), indices.end(), 0);
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  // Registers: 0=indices, 1=unused, 2=buffer, 3=popcount0, 4=popcount1,
+  // 5=storage0, 6=null_bv0, 7=storage1, 8=null_bv1
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         Empty{}, Empty{}, GetStoragePtr<Int32>(0),
+                         GetNullBv(0), GetStoragePtr<String>(1), GetNullBv(1));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0),
               testing::UnorderedElementsAre(0, 1, 2, 3));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), SizeIs(4));
@@ -1375,15 +1461,21 @@ TEST_F(BytecodeInterpreterTest, Distinct_TwoNonNullCols_InputAlreadyDistinct) {
   AddColumn(CreateNonNullStringColumn<const char*>({"A", "B", "C"}, Unsorted{},
                                                    HasDuplicates{}, &spool_));
 
+  // Register layout:
+  // 0: indices span, 1: unused, 2: buffer
+  // 3: storage col0, 4: null_bv col0 (nullptr for NonNull)
+  // 5: storage col1, 6: null_bv col1 (nullptr for NonNull)
   std::string bytecode_sequence = R"(
     AllocateRowLayoutBuffer: [buffer_size=24, dest_buffer_register=Register(2)]
-    CopyToRowLayout<Int32, NonNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<String, NonNull>: [col=1, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int32, NonNull>: [storage_register=Register(3), null_bv_register=Register(4), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(5), null_bv_register=Register(6), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     Distinct: [buffer_register=Register(2), total_row_stride=8, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices = {0, 1, 2};
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         GetStoragePtr<Int32>(0), GetNullBv(0),
+                         GetStoragePtr<String>(1), GetNullBv(1));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 1, 2));
 }
 
@@ -1393,15 +1485,21 @@ TEST_F(BytecodeInterpreterTest, Distinct_EmptyInput) {
   AddColumn(CreateNonNullStringColumn<const char*>({}, Unsorted{},
                                                    HasDuplicates{}, &spool_));
 
+  // Register layout:
+  // 0: indices span, 1: unused, 2: buffer
+  // 3: storage col0, 4: null_bv col0 (nullptr for NonNull)
+  // 5: storage col1, 6: null_bv col1 (nullptr for NonNull)
   std::string bytecode_sequence = R"(
     AllocateRowLayoutBuffer: [buffer_size=0, dest_buffer_register=Register(2)]
-    CopyToRowLayout<Int32, NonNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<String, NonNull>: [col=1, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int32, NonNull>: [storage_register=Register(3), null_bv_register=Register(4), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(5), null_bv_register=Register(6), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=4, row_layout_stride=8, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     Distinct: [buffer_register=Register(2), total_row_stride=8, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices = {};
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         GetStoragePtr<Int32>(0), GetNullBv(0),
+                         GetStoragePtr<String>(1), GetNullBv(1));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), IsEmpty());
 }
 
@@ -1409,14 +1507,18 @@ TEST_F(BytecodeInterpreterTest, Distinct_OneNonNullCol_SimpleDuplicates) {
   AddColumn(CreateNonNullColumn<int32_t, int32_t>({10, 20, 10, 30, 20},
                                                   Unsorted{}, HasDuplicates{}));
 
+  // Register layout:
+  // 0: indices span, 1: unused, 2: buffer
+  // 3: storage col0, 4: null_bv col0 (nullptr for NonNull)
   std::string bytecode_sequence = R"(
     AllocateRowLayoutBuffer: [buffer_size=20, dest_buffer_register=Register(2)]
-    CopyToRowLayout<Int32, NonNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int32, NonNull>: [storage_register=Register(3), null_bv_register=Register(4), source_indices_register=Register(0), dest_buffer_register=Register(2), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     Distinct: [buffer_register=Register(2), total_row_stride=4, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices = {0, 1, 2, 3, 4};
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         GetStoragePtr<Int32>(0), GetNullBv(0));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 1, 3));
 }
 
@@ -1469,8 +1571,10 @@ TEST_F(BytecodeInterpreterTest, FindMinMaxIndexUint32) {
   {
     std::vector<uint32_t> indices = initial_indices;
     std::string bytecode =
-        "FindMinMaxIndex<Uint32, MinOp>: [col=0, update_register=Register(0)]";
-    SetRegistersAndExecute(bytecode, GetSpan(indices));
+        "FindMinMaxIndex<Uint32, MinOp>: [storage_register=Register(1), "
+        "update_register=Register(0)]";
+    SetRegistersAndExecute(bytecode, GetSpan(indices),
+                           GetStoragePtr<Uint32>(0));
     // Expected result: Span containing only index 1 (where value 10u is)
     EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1u));
   }
@@ -1478,8 +1582,10 @@ TEST_F(BytecodeInterpreterTest, FindMinMaxIndexUint32) {
     // Use a fresh copy for testing MaxOp
     std::vector<uint32_t> indices = initial_indices;
     std::string bytecode =
-        "FindMinMaxIndex<Uint32, MaxOp>: [col=0, update_register=Register(0)]";
-    SetRegistersAndExecute(bytecode, GetSpan(indices));
+        "FindMinMaxIndex<Uint32, MaxOp>: [storage_register=Register(1), "
+        "update_register=Register(0)]";
+    SetRegistersAndExecute(bytecode, GetSpan(indices),
+                           GetStoragePtr<Uint32>(0));
     // Expected result: Span containing only index 0 (where value 50u is)
     EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0u));
   }
@@ -1494,39 +1600,21 @@ TEST_F(BytecodeInterpreterTest, FindMinMaxIndexString) {
   {
     std::vector<uint32_t> indices = initial_indices;
     std::string bytecode =
-        "FindMinMaxIndex<String, MinOp>: [col=0, update_register=Register(0)]";
-    SetRegistersAndExecute(bytecode, GetSpan(indices));
+        "FindMinMaxIndex<String, MinOp>: [storage_register=Register(1), "
+        "update_register=Register(0)]";
+    SetRegistersAndExecute(bytecode, GetSpan(indices),
+                           GetStoragePtr<String>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1u));
   }
   {
     std::vector<uint32_t> indices = initial_indices;
     std::string bytecode =
-        "FindMinMaxIndex<String, MaxOp>: [col=0, update_register=Register(0)]";
-    SetRegistersAndExecute(bytecode, GetSpan(indices));
+        "FindMinMaxIndex<String, MaxOp>: [storage_register=Register(1), "
+        "update_register=Register(0)]";
+    SetRegistersAndExecute(bytecode, GetSpan(indices),
+                           GetStoragePtr<String>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(3u));
   }
-}
-
-TEST_F(BytecodeInterpreterTest, IndexPermutationVectorToSpan) {
-  std::vector<uint32_t> p_vec = {2, 0, 4, 1, 3};
-  auto shared_p_vec = std::make_shared<std::vector<uint32_t>>(p_vec);
-  indexes_.emplace_back(std::vector<uint32_t>{0}, shared_p_vec);
-
-  std::string bytecode_str =
-      "IndexPermutationVectorToSpan: [index=0, write_register=Register(0)]";
-  SetRegistersAndExecute(bytecode_str);
-  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), testing::ElementsAreArray(p_vec));
-}
-
-TEST_F(BytecodeInterpreterTest, IndexPermutationVectorToSpan_Empty) {
-  std::vector<uint32_t> p_vec = {};
-  auto shared_p_vec = std::make_shared<std::vector<uint32_t>>(p_vec);
-  indexes_.emplace_back(std::vector<uint32_t>{0}, shared_p_vec);
-
-  std::string bytecode_str =
-      "IndexPermutationVectorToSpan: [index=0, write_register=Register(0)]";
-  SetRegistersAndExecute(bytecode_str);
-  EXPECT_THAT(GetRegister<Span<uint32_t>>(0), IsEmpty());
 }
 
 TEST_F(BytecodeInterpreterTest, IndexedFilterEq_Uint32_NonNull_ValueExists) {
@@ -1537,11 +1625,14 @@ TEST_F(BytecodeInterpreterTest, IndexedFilterEq_Uint32_NonNull_ValueExists) {
   indexes_.emplace_back(std::vector<uint32_t>{0},
                         std::make_shared<std::vector<uint32_t>>(p_vec));
 
+  // Register layout:
+  // 0: filter value, 1: popcount, 2: update (result), 3: storage, 4: null_bv
   std::string bytecode_str = R"(
-    IndexedFilterEq<Uint32, NonNull>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
+    IndexedFilterEq<Uint32, NonNull>: [storage_register=Register(3), null_bv_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
   )";
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid(20u),
-                         Slab<uint32_t>::Alloc(0), GetSpan(p_vec));
+                         Slab<uint32_t>::Alloc(0), GetSpan(p_vec),
+                         GetStoragePtr<Uint32>(0), GetNullBv(0));
 
   EXPECT_THAT(GetRegister<Span<uint32_t>>(2), testing::ElementsAre(1, 4, 2));
 }
@@ -1553,11 +1644,14 @@ TEST_F(BytecodeInterpreterTest, IndexedFilterEq_Uint32_NonNull_ValueNotExists) {
   indexes_.emplace_back(std::vector<uint32_t>{0},
                         std::make_shared<std::vector<uint32_t>>(p_vec));
 
+  // Register layout:
+  // 0: filter value, 1: popcount, 2: update (result), 3: storage, 4: null_bv
   std::string bytecode_str = R"(
-    IndexedFilterEq<Uint32, NonNull>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
+    IndexedFilterEq<Uint32, NonNull>: [storage_register=Register(3), null_bv_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
   )";
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid(25u),
-                         Slab<uint32_t>::Alloc(0), GetSpan(p_vec));
+                         Slab<uint32_t>::Alloc(0), GetSpan(p_vec),
+                         GetStoragePtr<Uint32>(0), GetNullBv(0));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(2), IsEmpty());
 }
 
@@ -1571,12 +1665,16 @@ TEST_F(BytecodeInterpreterTest, IndexedFilterEq_String_SparseNull_ValueExists) {
   indexes_.emplace_back(std::vector<uint32_t>{0},
                         std::make_shared<std::vector<uint32_t>>(p_vec));
 
+  // Register layout:
+  // 0: filter value, 1: popcount result, 2: update (result), 3: storage, 4:
+  // null_bv
   std::string bytecode_str = R"(
-    PrefixPopcount: [col=0, dest_register=Register(1)]
-    IndexedFilterEq<String, SparseNull>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
+    PrefixPopcount: [null_bv_register=Register(4), dest_register=Register(1)]
+    IndexedFilterEq<String, SparseNull>: [storage_register=Register(3), null_bv_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
   )";
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid("apple"),
-                         reg::Empty(), GetSpan(p_vec));
+                         Empty{}, GetSpan(p_vec), GetStoragePtr<String>(0),
+                         GetNullBv(0));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(2), testing::ElementsAre(0, 3));
 }
 
@@ -1590,12 +1688,16 @@ TEST_F(BytecodeInterpreterTest,
   indexes_.emplace_back(std::vector<uint32_t>{0},
                         std::make_shared<std::vector<uint32_t>>(p_vec));
 
+  // Register layout:
+  // 0: filter value, 1: popcount result, 2: update (result), 3: storage, 4:
+  // null_bv
   std::string bytecode_str = R"(
-    PrefixPopcount: [col=0, dest_register=Register(1)]
-    IndexedFilterEq<String, SparseNull>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
+    PrefixPopcount: [null_bv_register=Register(4), dest_register=Register(1)]
+    IndexedFilterEq<String, SparseNull>: [storage_register=Register(3), null_bv_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), update_register=Register(2)]
   )";
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid("bird"),
-                         reg::Empty(), GetSpan(p_vec));
+                         Empty{}, GetSpan(p_vec), GetStoragePtr<String>(0),
+                         GetNullBv(0));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(2), IsEmpty());
 }
 
@@ -1627,8 +1729,11 @@ TEST_F(BytecodeInterpreterTest, LinearFilterEq_Uint32_NonNull_ValueExists) {
   AddColumn(CreateNonNullColumn<uint32_t, uint32_t>(
       {10u, 20u, 20u, 30u, 20u, 40u}, Unsorted{}, HasDuplicates{}));
 
+  // Register layout:
+  // 0: filter value, 1: popcount, 2: source range, 3: update (result), 4:
+  // storage
   std::string bytecode_str = R"(
-    LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
+    LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
   )";
   // Initial range covers all elements.
   Range source_range{0, 6};
@@ -1638,7 +1743,7 @@ TEST_F(BytecodeInterpreterTest, LinearFilterEq_Uint32_NonNull_ValueExists) {
   SetRegistersAndExecute(
       bytecode_str, CastFilterValueResult::Valid(20u),
       Slab<uint32_t>::Alloc(0),  // Dummy popcount for NonNull
-      source_range, GetSpan(update_data));
+      source_range, GetSpan(update_data), GetStoragePtr<Uint32>(0));
 
   // Expected indices where data[i] == 20u: 1, 2, 4
   EXPECT_THAT(GetRegister<Span<uint32_t>>(3), ElementsAre(1u, 2u, 4u));
@@ -1648,15 +1753,19 @@ TEST_F(BytecodeInterpreterTest, LinearFilterEq_Uint32_NonNull_ValueNotExists) {
   AddColumn(CreateNonNullColumn<uint32_t, uint32_t>({10u, 20u, 30u}, Unsorted{},
                                                     HasDuplicates{}));
 
+  // Register layout:
+  // 0: filter value, 1: popcount, 2: source range, 3: update (result), 4:
+  // storage
   std::string bytecode_str = R"(
-    LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
+    LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
   )";
   Range source_range{0, 3};
   std::vector<uint32_t> update_data(3);
 
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid(25u),
                          Slab<uint32_t>::Alloc(0),  // Dummy popcount
-                         source_range, GetSpan(update_data));
+                         source_range, GetSpan(update_data),
+                         GetStoragePtr<Uint32>(0));
 
   EXPECT_THAT(GetRegister<Span<uint32_t>>(3), IsEmpty());
 }
@@ -1666,15 +1775,19 @@ TEST_F(BytecodeInterpreterTest, LinearFilterEq_String_NonNull_ValueExists) {
       {"apple", "banana", "apple", "cherry"}, Unsorted{}, HasDuplicates{},
       &spool_));
 
+  // Register layout:
+  // 0: filter value, 1: popcount, 2: source range, 3: update (result), 4:
+  // storage
   std::string bytecode_str = R"(
-    LinearFilterEq<String>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
+    LinearFilterEq<String>: [storage_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
   )";
   Range source_range{0, 4};
   std::vector<uint32_t> update_data(4);
 
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::Valid("apple"),
                          Slab<uint32_t>::Alloc(0),  // Dummy popcount
-                         source_range, GetSpan(update_data));
+                         source_range, GetSpan(update_data),
+                         GetStoragePtr<String>(0));
 
   // Expected indices where data[i] == "apple": 0, 2
   EXPECT_THAT(GetRegister<Span<uint32_t>>(3), ElementsAre(0u, 2u));
@@ -1683,8 +1796,11 @@ TEST_F(BytecodeInterpreterTest, LinearFilterEq_String_NonNull_ValueExists) {
 TEST_F(BytecodeInterpreterTest, LinearFilterEq_HandleInvalidCast_NoneMatch) {
   AddColumn(CreateNonNullColumn<uint32_t, uint32_t>({10u, 20u, 30u}, Unsorted{},
                                                     HasDuplicates{}));
+  // Register layout:
+  // 0: filter value, 1: popcount, 2: source range, 3: update (result), 4:
+  // storage
   std::string bytecode_str = R"(
-    LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
+    LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
   )";
   Range source_range{0, 3};
   std::vector<uint32_t> update_data(3);
@@ -1693,7 +1809,7 @@ TEST_F(BytecodeInterpreterTest, LinearFilterEq_HandleInvalidCast_NoneMatch) {
   // (user version) correctly handles an empty effective range.
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::NoneMatch(),
                          Slab<uint32_t>::Alloc(0), source_range,
-                         GetSpan(update_data));
+                         GetSpan(update_data), GetStoragePtr<Uint32>(0));
 
   // HandleInvalidCastFilterValueResult should make the source_range empty,
   // then the iota in the user's corrected LinearFilterEq will copy 0 elements.
@@ -1703,15 +1819,18 @@ TEST_F(BytecodeInterpreterTest, LinearFilterEq_HandleInvalidCast_NoneMatch) {
 TEST_F(BytecodeInterpreterTest, LinearFilterEq_HandleInvalidCast_AllMatch) {
   AddColumn(CreateNonNullColumn<uint32_t, uint32_t>({10u, 20u, 30u}, Unsorted{},
                                                     HasDuplicates{}));
+  // Register layout:
+  // 0: filter value, 1: popcount, 2: source range, 3: update (result), 4:
+  // storage
   std::string bytecode_str = R"(
-    LinearFilterEq<Uint32>: [col=0, filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
+    LinearFilterEq<Uint32>: [storage_register=Register(4), filter_value_reg=Register(0), popcount_register=Register(1), source_register=Register(2), update_register=Register(3)]
   )";
   Range source_range{0, 3};
   std::vector<uint32_t> update_data(3);
 
   SetRegistersAndExecute(bytecode_str, CastFilterValueResult::AllMatch(),
                          Slab<uint32_t>::Alloc(0), source_range,
-                         GetSpan(update_data));
+                         GetSpan(update_data), GetStoragePtr<Uint32>(0));
   // HandleInvalidCastFilterValueResult returns early, source_range is not
   // modified. The iota in LinearFilterEq (user corrected version) copies all
   // original indices from the range.
@@ -1725,14 +1844,17 @@ TEST_F(BytecodeInterpreterTest, CollectIdIntoRankMap) {
 
   std::vector<uint32_t> data = {0, 1};
 
+  // Register layout:
+  // 0: source span, 1: rank map, 2: storage
   std::string bytecode_str = R"(
     InitRankMap: [dest_register=Register(1)]
-    CollectIdIntoRankMap: [col=0, source_register=Register(0), rank_map_register=Register(1)]
+    CollectIdIntoRankMap: [storage_register=Register(2), source_register=Register(0), rank_map_register=Register(1)]
   )";
-  SetRegistersAndExecute(
-      bytecode_str, Span<uint32_t>(data.data(), data.data() + data.size()));
+  SetRegistersAndExecute(bytecode_str,
+                         Span<uint32_t>(data.data(), data.data() + data.size()),
+                         Empty{}, GetStoragePtr<String>(0));
 
-  const auto& rank_map = *GetRegister<reg::StringIdToRankMap>(1);
+  const auto& rank_map = *GetRegister<StringIdToRankMap>(1);
   EXPECT_EQ(rank_map.size(), 2u);
   EXPECT_THAT(rank_map.Find(*spool_.GetId("apple")), Pointee(0u));
   EXPECT_THAT(rank_map.Find(*spool_.GetId("banana")), Pointee(0u));
@@ -1752,7 +1874,7 @@ TEST_F(BytecodeInterpreterTest, FinalizeRanksInMap_Simple) {
       "FinalizeRanksInMap: [update_register=Register(0)]";
   SetRegistersAndExecute(bytecode_str, std::move(map));
 
-  const auto& rank_map = *GetRegister<reg::StringIdToRankMap>(0);
+  const auto& rank_map = *GetRegister<StringIdToRankMap>(0);
   EXPECT_EQ(rank_map.size(), 3u);
   EXPECT_THAT(rank_map.Find(apple_id), Pointee(0u));
   EXPECT_THAT(rank_map.Find(banana_id), Pointee(1u));
@@ -1770,16 +1892,21 @@ TEST_F(BytecodeInterpreterTest, Sort_SingleUint32Column_Ascending) {
   // 1. AllocateRowLayoutBuffer (stride = sizeof(uint32_t) = 4, size = 4*4 = 16)
   // 2. CopyToRowLayout<Uint32, NonNull> (invert_copied_bits = 0 for asc)
   // 3. SortRowLayout
+  //
+  // Register layout:
+  // 0: indices span, 1: buffer
+  // 2: storage col0, 3: null_bv col0 (nullptr for NonNull)
   std::string bytecode_sequence = R"(
     AllocateRowLayoutBuffer: [buffer_size=16, dest_buffer_register=Register(1)]
-    CopyToRowLayout<Uint32, NonNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Uint32, NonNull>: [storage_register=Register(2), null_bv_register=Register(3), source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(1), total_row_stride=4, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices(num_rows);
   std::iota(indices.begin(), indices.end(), 0);  // {0, 1, 2, 3}
 
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{},
+                         GetStoragePtr<Uint32>(0), GetNullBv(0));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1, 3, 0, 2));
 }
 
@@ -1800,19 +1927,24 @@ TEST_F(BytecodeInterpreterTest,
   // 3*4 = 12)
   // 5. CopyToRowLayout<String, NonNull> (invert_copied_bits = 1 for desc)
   // 6. SortRowLayout
+  //
+  // Register layout:
+  // 0: indices span, 1: buffer, 2: rank map
+  // 3: storage col0, 4: null_bv col0 (nullptr for NonNull)
   std::string bytecode_sequence = R"(
     InitRankMap: [dest_register=Register(2)]
-    CollectIdIntoRankMap: [col=0, source_register=Register(0), rank_map_register=Register(2)]
+    CollectIdIntoRankMap: [storage_register=Register(3), source_register=Register(0), rank_map_register=Register(2)]
     FinalizeRanksInMap: [update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=12, dest_buffer_register=Register(1)]
-    CopyToRowLayout<String, NonNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(2)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(3), null_bv_register=Register(4), source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=0, row_layout_stride=4, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(2)]
     SortRowLayout: [buffer_register=Register(1), total_row_stride=4, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices(num_rows);
   std::iota(indices.begin(), indices.end(), 0);  // {0, 1, 2}
 
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         GetStoragePtr<String>(0), GetNullBv(0));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(0, 2, 1));
 }
 
@@ -1849,31 +1981,44 @@ TEST_F(BytecodeInterpreterTest,
   // Col 2 (Int32 SparseNull): 1 (null flag) + sizeof(int32_t) (4) = 5
   // Total row stride = 8 + 4 + 5 = 17
   // Buffer size = num_rows * total_row_stride = 4 * 17 = 68
+  //
+  // Register layout:
+  // 0: indices span, 1: buffer, 2: rank map, 3: popcount col2
+  // 4: storage col0, 5: null_bv col0 (nullptr for NonNull)
+  // 6: storage col1, 7: null_bv col1 (nullptr for NonNull)
+  // 8: storage col2, 9: null_bv col2
 
   std::string bytecode_sequence = R"(
-    PrefixPopcount: [col=2, dest_register=Register(3)]
+    PrefixPopcount: [null_bv_register=Register(9), dest_register=Register(3)]
     InitRankMap: [dest_register=Register(2)]
-    CollectIdIntoRankMap: [col=1, source_register=Register(0), rank_map_register=Register(2)]
+    CollectIdIntoRankMap: [storage_register=Register(6), source_register=Register(0), rank_map_register=Register(2)]
     FinalizeRanksInMap: [update_register=Register(2)]
     AllocateRowLayoutBuffer: [buffer_size=68, dest_buffer_register=Register(1)]
-    CopyToRowLayout<Int64, NonNull>: [col=0, source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=0, row_layout_stride=17, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
-    CopyToRowLayout<String, NonNull>: [col=1, source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=8, row_layout_stride=17, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(2)]
-    CopyToRowLayout<Int32, SparseNull>: [col=2, source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=12, row_layout_stride=17, invert_copied_bits=0, popcount_register=Register(3), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<Int64, NonNull>: [storage_register=Register(4), null_bv_register=Register(5), source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=0, row_layout_stride=17, invert_copied_bits=1, popcount_register=Register(4294967295), rank_map_register=Register(4294967295)]
+    CopyToRowLayout<String, NonNull>: [storage_register=Register(6), null_bv_register=Register(7), source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=8, row_layout_stride=17, invert_copied_bits=0, popcount_register=Register(4294967295), rank_map_register=Register(2)]
+    CopyToRowLayout<Int32, SparseNull>: [storage_register=Register(8), null_bv_register=Register(9), source_indices_register=Register(0), dest_buffer_register=Register(1), row_layout_offset=12, row_layout_stride=17, invert_copied_bits=0, popcount_register=Register(3), rank_map_register=Register(4294967295)]
     SortRowLayout: [buffer_register=Register(1), total_row_stride=17, indices_register=Register(0)]
   )";
 
   std::vector<uint32_t> indices(num_rows);
   std::iota(indices.begin(), indices.end(), 0);  // {0, 1, 2, 3}
 
-  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices));
+  // Registers: 0=indices, 1=buffer, 2=rankmap, 3=popcount
+  // 4=storage0, 5=null0, 6=storage1, 7=null1, 8=storage2, 9=null2
+  SetRegistersAndExecute(bytecode_sequence, GetSpan(indices), Empty{}, Empty{},
+                         Empty{},  // Register 3: popcount (written by bytecode)
+                         GetStoragePtr<Int64>(0), GetNullBv(0),
+                         GetStoragePtr<String>(1), GetNullBv(1),
+                         GetStoragePtr<Int32>(2), GetNullBv(2));
   EXPECT_THAT(GetRegister<Span<uint32_t>>(0), ElementsAre(1, 3, 2, 0));
 }
 
 TEST_F(BytecodeInterpreterTest, InId) {
-  AddColumn(Column{Storage::Id{}, NullStorage::NonNull{}, Unsorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{dataframe::Storage::Id{},
+                              dataframe::NullStorage::NonNull{}, Unsorted{},
+                              HasDuplicates{}});
   std::string bytecode =
-      "In<Id>: [col=0, value_list_register=Register(0), "
+      "In<Id>: [storage_register=Register(3), value_list_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]";
 
   std::vector<uint32_t> indices_spec = {12, 44, 10, 4, 5, 2, 3};
@@ -1915,13 +2060,15 @@ TEST_F(BytecodeInterpreterTest, InId) {
 
 TEST_F(BytecodeInterpreterTest, InUint32) {
   std::string bytecode =
-      "In<Uint32>: [col=0, value_list_register=Register(0), "
+      "In<Uint32>: [storage_register=Register(3), "
+      "value_list_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]";
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({4u, 49u, 392u, 4u, 49u, 4u, 391u});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Unsorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Unsorted{},
+                              HasDuplicates{}});
 
   std::vector<uint32_t> indices_spec = {3, 3, 4, 5, 0, 6, 0};
   {
@@ -1933,7 +2080,7 @@ TEST_F(BytecodeInterpreterTest, InUint32) {
     value_list.value_list = CreateFlexVectorForTesting<uint32_t>({4u, 391u});
 
     SetRegistersAndExecute(bytecode, std::move(value_list), GetSpan(indices),
-                           GetSpan(indices));
+                           GetSpan(indices), GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(2), ElementsAre(3, 3, 5, 0, 6, 0));
   }
   {
@@ -1943,17 +2090,18 @@ TEST_F(BytecodeInterpreterTest, InUint32) {
     value_list.validity = CastFilterValueResult::kValid;
     value_list.value_list = CreateFlexVectorForTesting<uint32_t>({100u, 200u});
     SetRegistersAndExecute(bytecode, std::move(value_list), GetSpan(indices),
-                           GetSpan(indices));
+                           GetSpan(indices), GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(2), IsEmpty());
   }
 }
 
 TEST_F(BytecodeInterpreterTest, InIdBitVectorSparse) {
-  AddColumn(Column{Storage::Id{1000}, NullStorage::NonNull{}, Unsorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{dataframe::Storage::Id{1000},
+                              dataframe::NullStorage::NonNull{}, Unsorted{},
+                              HasDuplicates{}});
 
   std::string bytecode =
-      "In<Id>: [col=0, value_list_register=Register(0), "
+      "In<Id>: [storage_register=Register(3), value_list_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]";
 
   std::vector<uint32_t> indices_spec = {12, 44, 10, 4, 5, 2, 3, 500};
@@ -1974,13 +2122,15 @@ TEST_F(BytecodeInterpreterTest, InIdBitVectorSparse) {
 
 TEST_F(BytecodeInterpreterTest, InUint32BitVector) {
   std::string bytecode =
-      "In<Uint32>: [col=0, value_list_register=Register(0), "
+      "In<Uint32>: [storage_register=Register(3), "
+      "value_list_register=Register(0), "
       "source_register=Register(1), update_register=Register(2)]";
 
   auto values =
       CreateFlexVectorForTesting<uint32_t>({4u, 49u, 392u, 4u, 49u, 4u, 391u});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Unsorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Unsorted{},
+                              HasDuplicates{}});
 
   std::vector<uint32_t> indices_spec = {3, 3, 4, 5, 0, 6, 0};
   {
@@ -1992,7 +2142,7 @@ TEST_F(BytecodeInterpreterTest, InUint32BitVector) {
     value_list.value_list = CreateFlexVectorForTesting<uint32_t>({4u, 30u});
 
     SetRegistersAndExecute(bytecode, std::move(value_list), GetSpan(indices),
-                           GetSpan(indices));
+                           GetSpan(indices), GetStoragePtr<Uint32>(0));
     EXPECT_THAT(GetRegister<Span<uint32_t>>(2), ElementsAre(3, 3, 5, 0, 0));
   }
 }
@@ -2038,17 +2188,19 @@ TEST_F(BytecodeInterpreterTest, CastFilterValueList_String) {
 
 TEST_F(BytecodeInterpreterTest, SortedFilterUint32Eq_ManyDuplicates) {
   std::string bytecode =
-      "SortedFilter<Uint32, EqualRange>: [col=0, val_register=Register(0), "
+      "SortedFilter<Uint32, EqualRange>: [storage_register=Register(2), "
+      "val_register=Register(0), "
       "update_register=Register(1), write_result_to=BoundModifier(0)]";
 
   auto values = CreateFlexVectorForTesting<uint32_t>(
       {0u, 4u, 5u, 5u, 5u, 5u, 5u, 5u, 5u, 5u, 5u,  5u, 5u,
        5u, 5u, 5u, 5u, 5u, 5u, 5u, 5u, 5u, 6u, 10u, 10u});
-  AddColumn(Column{std::move(values), NullStorage::NonNull{}, Sorted{},
-                   HasDuplicates{}});
+  AddColumn(dataframe::Column{std::move(values),
+                              dataframe::NullStorage::NonNull{}, Sorted{},
+                              HasDuplicates{}});
 
   SetRegistersAndExecute(bytecode, CastFilterValueResult::Valid(5u),
-                         Range{0u, 25u});
+                         Range{0u, 25u}, GetStoragePtr<Uint32>(0));
   const auto& result = GetRegister<Range>(1);
   EXPECT_EQ(result.b, 2u);
   EXPECT_EQ(result.e, 22u);

--- a/src/trace_processor/core/interpreter/bytecode_registers.h
+++ b/src/trace_processor/core/interpreter/bytecode_registers.h
@@ -17,6 +17,7 @@
 #ifndef SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_REGISTERS_H_
 #define SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_REGISTERS_H_
 
+#include <sys/types.h>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -25,12 +26,14 @@
 #include "perfetto/base/build_config.h"
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/interpreter/interpreter_types.h"
+#include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/range.h"
 #include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
 
-namespace perfetto::trace_processor::core::interpreter::reg {
+namespace perfetto::trace_processor::core::interpreter {
 
 // Register system for the bytecode interpreter.
 // Provides typed handles for accessing virtual registers with appropriate
@@ -95,16 +98,25 @@ struct Empty {};
 using StringIdToRankMap =
     std::unique_ptr<base::FlatHashMap<StringPool::Id, uint32_t>>;
 
-// Values that can be stored in a register.
-using Value = std::variant<Empty,
-                           Range,
-                           Slab<uint32_t>,
-                           Span<uint32_t>,
-                           CastFilterValueResult,
-                           CastFilterValueListResult,
-                           Slab<uint8_t>,
-                           StringIdToRankMap>;
+// Pointer to storage data along with its type.
+struct StoragePtr {
+  const void* ptr;
+  StorageType type;
+};
 
-}  // namespace perfetto::trace_processor::core::interpreter::reg
+// Values that can be stored in a register.
+using RegValue = std::variant<Empty,
+                              Range,
+                              Slab<uint32_t>,
+                              Span<uint32_t>,
+                              CastFilterValueResult,
+                              CastFilterValueListResult,
+                              Slab<uint8_t>,
+                              StringIdToRankMap,
+                              StoragePtr,
+                              const BitVector*,
+                              Span<const uint32_t>>;
+
+}  // namespace perfetto::trace_processor::core::interpreter
 
 #endif  // SRC_TRACE_PROCESSOR_CORE_INTERPRETER_BYTECODE_REGISTERS_H_

--- a/src/trace_processor/core/interpreter/bytecode_to_string.cc
+++ b/src/trace_processor/core/interpreter/bytecode_to_string.cc
@@ -35,7 +35,7 @@ base::StackString<32> ArgToString(uint32_t value) {
   return base::StackString<32>("%u", value);
 }
 
-base::StackString<64> ArgToString(const reg::HandleBase& value) {
+base::StackString<64> ArgToString(const HandleBase& value) {
   return base::StackString<64>("Register(%u)", value.index);
 }
 

--- a/src/trace_processor/core/interpreter/bytecode_to_string.h
+++ b/src/trace_processor/core/interpreter/bytecode_to_string.h
@@ -33,7 +33,7 @@ struct Bytecode;
 
 // String conversion utilities for bytecode arguments.
 base::StackString<32> ArgToString(uint32_t value);
-base::StackString<64> ArgToString(const reg::HandleBase& value);
+base::StackString<64> ArgToString(const HandleBase& value);
 base::StackString<64> ArgToString(NonNullOp value);
 base::StackString<64> ArgToString(FilterValueHandle value);
 base::StackString<64> ArgToString(BoundModifier bound);

--- a/src/trace_processor/core/interpreter/interpreter_types.h
+++ b/src/trace_processor/core/interpreter/interpreter_types.h
@@ -26,24 +26,10 @@
 #include "src/trace_processor/core/common/null_types.h"
 #include "src/trace_processor/core/common/op_types.h"
 #include "src/trace_processor/core/common/storage_types.h"
-#include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/util/flex_vector.h"
 #include "src/trace_processor/core/util/type_set.h"
 
 namespace perfetto::trace_processor::core::interpreter {
-
-// TODO(lalitm): The interpreter currently depends on dataframe types (Column,
-// Storage, NullStorage, etc.). This coupling should be removed to make the
-// interpreter truly generic and reusable for other data structures like trees,
-// graphs, and intervals.
-
-// Import types from dataframe that interpreter currently depends on.
-using dataframe::Column;
-using dataframe::IdDataTag;
-using dataframe::Index;
-using dataframe::NullStorage;
-using dataframe::SpecializedStorage;
-using dataframe::Storage;
 
 // Type categories for column content and operations.
 // These define which operations can be applied to which content types.
@@ -129,11 +115,6 @@ using NonIdStorageType = TypeSet<Uint32, Int32, Int64, Double, String>;
 // TypeSet which collapses all of the sparse nullability types into a single
 // type.
 using SparseNullCollapsedNullability = TypeSet<NonNull, SparseNull, DenseNull>;
-
-// TypeSet of all possible sparse nullability states.
-using SparseNullTypes = TypeSet<SparseNull,
-                                SparseNullWithPopcountAlways,
-                                SparseNullWithPopcountUntilFinalization>;
 
 // Handle for referring to a filter value during query execution.
 struct FilterValueHandle {

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -239,7 +239,7 @@ source_set("args_utils") {
     "../../../include/perfetto/base",
     "../../../include/perfetto/ext/base",
     "../containers",
-    "../core/dataframe:specs",
+    "../core/dataframe",
     "../storage",
     "../tables",
     "../types",


### PR DESCRIPTION
This CL finally achieves to goal over the last few CLs of making the
interpreter decoupled from the dataframe. This is necessary to allow for
graphs/trees support to be added to the interpreter.
