### PR TITLE
de: Preserving modify columns data

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/modify_columns_node.ts
@@ -416,8 +416,18 @@ export class ModifyColumnsNode implements QueryNode {
   }
 
   clone(): QueryNode {
+    // Deep copy selectedColumns preserving exact state (including aliases)
+    // Do NOT use newColumnInfoList here - that transforms columns for downstream
+    // propagation (applying aliases as new names), but cloning needs exact copy.
+    const clonedColumns: ColumnInfo[] = this.state.selectedColumns.map(
+      (col) => ({
+        ...col,
+        column: {...col.column},
+      }),
+    );
+
     const stateCopy: ModifyColumnsState = {
-      selectedColumns: newColumnInfoList(this.state.selectedColumns),
+      selectedColumns: clonedColumns,
       filters: this.state.filters?.map((f) => ({...f})),
       filterOperator: this.state.filterOperator,
       onchange: this.state.onchange,


### PR DESCRIPTION
Fixes a bug in `ModifyColumnsNode.clone()` where column aliases and other state properties were being lost during cloning. The issue was that `newColumnInfoList()` was being used for cloning, but that function transforms columns for downstream propagation (applying aliases as new names), rather than creating an exact copy of the internal state.                                                                                                           
                        
     