### PR TITLE
de: Move SqlModules plugin to DataExplorer from nodes

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -432,6 +432,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               node: selectedNode,
               response: this.response,
               dataSource: this.dataSource,
+              sqlModules: attrs.sqlModules,
               isQueryRunning: this.isQueryRunning,
               isAnalyzing: this.isAnalyzing,
               onchange: () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -80,7 +80,6 @@ export function registerCoreNodes() {
         // Return an array of states, one for each selected table
         return selections.map((selection) => ({
           sqlTable: selection.sqlTable,
-          sqlModules,
         }));
       }
       return null;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/data_explorer.ts
@@ -33,6 +33,7 @@ import {UIFilter, normalizeDataGridFilter} from './operations/filter';
 import {DataExplorerEmptyState} from './widgets';
 import {Trace} from '../../../public/trace';
 import {Timestamp} from '../../../components/widgets/timestamp';
+import {SqlModules} from '../../dev.perfetto.SqlModules/sql_modules';
 import {DurationWidget} from '../../../components/widgets/duration';
 import {Time, Duration} from '../../../base/time';
 import {ColumnInfo} from './column_info';
@@ -67,6 +68,7 @@ export interface DataExplorerAttrs {
   readonly query?: Query | Error;
   readonly response?: QueryResponse;
   readonly dataSource?: DataSource;
+  readonly sqlModules: SqlModules;
   readonly isQueryRunning: boolean;
   readonly isAnalyzing: boolean;
   readonly isFullScreen: boolean;
@@ -366,8 +368,8 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       const columnSchema: ColumnSchema = {};
       const schema: SchemaRegistry = {data: columnSchema};
 
-      // Get sqlModules from node state (if available)
-      const {sqlModules} = attrs.node.state;
+      // Get sqlModules from attrs (centralized, not from node state)
+      const {sqlModules} = attrs;
 
       // Capture columns for use in closures
       const responseColumns = attrs.response.columns;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/aggregation_node.ts
@@ -514,7 +514,6 @@ export class AggregationNode implements QueryNode {
       aggregations: this.state.aggregations.map((a) => ({...a})),
       onchange: this.state.onchange,
       issues: this.state.issues,
-      sqlModules: this.state.sqlModules,
     };
     return new AggregationNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/counter_to_intervals_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/counter_to_intervals_node.ts
@@ -167,7 +167,6 @@ export class CounterToIntervalsNode implements QueryNode {
   clone(): QueryNode {
     const stateCopy: CounterToIntervalsNodeState = {
       onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
     };
     return new CounterToIntervalsNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/create_slices_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/create_slices_node.ts
@@ -547,7 +547,6 @@ export class CreateSlicesNode implements QueryNode {
       endsTsColumn: this.state.endsTsColumn,
       startsDurColumn: this.state.startsDurColumn,
       endsDurColumn: this.state.endsDurColumn,
-      sqlModules: this.state.sqlModules,
     };
     return new CreateSlicesNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_during_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_during_node.ts
@@ -438,7 +438,6 @@ export class FilterDuringNode implements QueryNode {
       filters: this.state.filters?.map((f) => ({...f})),
       filterOperator: this.state.filterOperator,
       onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
     };
     return new FilterDuringNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/filter_node.ts
@@ -458,7 +458,6 @@ export class FilterNode implements QueryNode {
       filters: this.state.filters?.map((f) => ({...f})),
       filterOperator: this.state.filterOperator,
       onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
     };
     return new FilterNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/interval_intersect_node.ts
@@ -714,7 +714,6 @@ export class IntervalIntersectNode implements QueryNode {
         : undefined,
       tsDurSource: this.state.tsDurSource,
       onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
     };
     return new IntervalIntersectNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/join_node.ts
@@ -469,7 +469,6 @@ export class JoinNode implements QueryNode {
       rightColumns: this.state.rightColumns
         ? newColumnInfoList(this.state.rightColumns)
         : undefined,
-      sqlModules: this.state.sqlModules,
     };
     return new JoinNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/limit_and_offset_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/limit_and_offset_node.ts
@@ -155,7 +155,6 @@ export class LimitAndOffsetNode implements QueryNode {
       filters: this.state.filters?.map((f) => ({...f})),
       filterOperator: this.state.filterOperator,
       onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
     };
     return new LimitAndOffsetNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sort_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sort_node.ts
@@ -258,7 +258,6 @@ export class SortNode implements QueryNode {
       filters: this.state.filters?.map((f) => ({...f})),
       filterOperator: this.state.filterOperator,
       onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
     };
     return new SortNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/slices_source.ts
@@ -65,7 +65,6 @@ export class SlicesSourceNode implements QueryNode {
     const stateCopy: SlicesSourceState = {
       onchange: this.state.onchange,
       trace: this.state.trace,
-      sqlModules: this.state.sqlModules,
     };
     return new SlicesSourceNode(stateCopy);
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/table_source.ts
@@ -47,7 +47,6 @@ export interface TableSourceSerializedState {
 
 export interface TableSourceState extends QueryNodeState {
   readonly trace: Trace;
-  readonly sqlModules: SqlModules;
 
   sqlTable?: SqlTable;
   onchange?: () => void;
@@ -178,7 +177,6 @@ export class TableSourceNode implements QueryNode {
   clone(): QueryNode {
     const stateCopy: TableSourceState = {
       trace: this.state.trace,
-      sqlModules: this.state.sqlModules,
       sqlTable: this.state.sqlTable,
       onchange: this.state.onchange,
     };
@@ -269,7 +267,6 @@ export class TableSourceNode implements QueryNode {
     return {
       ...state,
       trace,
-      sqlModules,
       sqlTable,
     };
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
@@ -328,7 +328,6 @@ export class UnionNode implements QueryNode {
     const stateCopy: UnionNodeState = {
       inputNodes: [...this.state.inputNodes],
       selectedColumns: this.state.selectedColumns.map((c) => ({...c})),
-      sqlModules: this.state.sqlModules,
     };
     const clone = new UnionNode(stateCopy);
     clone.comment = this.comment;


### PR DESCRIPTION
This refactoring moves the `sqlModules` dependency from being stored in individual query node states to being passed through the `DataExplorer` component via attrs. This centralizes the `sqlModules` access pattern and removes duplicated state from numerous node implementations.             
                                    