### PR TITLE
tp: Add JsonSerializer and SimpleJsonSerializer infrastructure

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -2834,6 +2834,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
         ":perfetto_src_trace_processor_util_json_parser",
+        ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_writer",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
@@ -16204,6 +16205,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
         ":perfetto_src_trace_processor_util_json_parser",
+        ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_writer",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
@@ -16519,6 +16521,11 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/util:json_serializer
+filegroup {
+    name: "perfetto_src_trace_processor_util_json_serializer",
+}
+
 // GN: //src/trace_processor/util:json_writer
 filegroup {
     name: "perfetto_src_trace_processor_util_json_writer",
@@ -16582,6 +16589,14 @@ filegroup {
     name: "perfetto_src_trace_processor_util_regex",
 }
 
+// GN: //src/trace_processor/util:simple_json_serializer
+filegroup {
+    name: "perfetto_src_trace_processor_util_simple_json_serializer",
+    srcs: [
+        "src/trace_processor/util/simple_json_serializer.cc",
+    ],
+}
+
 // GN: //src/trace_processor/util:sql_argument
 filegroup {
     name: "perfetto_src_trace_processor_util_sql_argument",
@@ -16628,12 +16643,14 @@ filegroup {
         "src/trace_processor/util/glob_unittest.cc",
         "src/trace_processor/util/gzip_utils_unittest.cc",
         "src/trace_processor/util/json_parser_unittest.cc",
+        "src/trace_processor/util/json_serializer_unittest.cc",
         "src/trace_processor/util/json_writer_unittest.cc",
         "src/trace_processor/util/proto_profiler_unittest.cc",
         "src/trace_processor/util/proto_to_args_parser_unittest.cc",
         "src/trace_processor/util/protozero_to_json_unittests.cc",
         "src/trace_processor/util/protozero_to_text_unittests.cc",
         "src/trace_processor/util/regex_unittest.cc",
+        "src/trace_processor/util/simple_json_serializer_unittest.cc",
         "src/trace_processor/util/sql_argument_unittest.cc",
         "src/trace_processor/util/streaming_line_reader_unittest.cc",
         "src/trace_processor/util/tar_writer_unittest.cc",
@@ -18499,6 +18516,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
         ":perfetto_src_trace_processor_util_json_parser",
+        ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_writer",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
@@ -18507,6 +18525,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_protozero_to_json",
         ":perfetto_src_trace_processor_util_protozero_to_text",
         ":perfetto_src_trace_processor_util_regex",
+        ":perfetto_src_trace_processor_util_simple_json_serializer",
         ":perfetto_src_trace_processor_util_sql_argument",
         ":perfetto_src_trace_processor_util_stdlib",
         ":perfetto_src_trace_processor_util_tar_writer",
@@ -19347,6 +19366,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
         ":perfetto_src_trace_processor_util_json_parser",
+        ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_writer",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",
@@ -19847,6 +19867,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
         ":perfetto_src_trace_processor_util_json_parser",
+        ":perfetto_src_trace_processor_util_json_serializer",
         ":perfetto_src_trace_processor_util_json_writer",
         ":perfetto_src_trace_processor_util_profile_builder",
         ":perfetto_src_trace_processor_util_profiler_util",

--- a/BUILD
+++ b/BUILD
@@ -430,6 +430,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",
         ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_writer",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",
@@ -635,6 +636,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",
         ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_writer",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",
@@ -4166,6 +4168,14 @@ perfetto_filegroup(
         "src/trace_processor/util/json_parser.h",
         "src/trace_processor/util/json_utils.cc",
         "src/trace_processor/util/json_utils.h",
+    ],
+)
+
+# GN target: //src/trace_processor/util:json_serializer
+perfetto_filegroup(
+    name = "src_trace_processor_util_json_serializer",
+    srcs = [
+        "src/trace_processor/util/json_serializer.h",
     ],
 )
 
@@ -8122,6 +8132,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",
         ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_writer",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",
@@ -8354,6 +8365,7 @@ perfetto_cc_binary(
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",
         ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_json_serializer",
         ":src_trace_processor_util_json_writer",
         ":src_trace_processor_util_profile_builder",
         ":src_trace_processor_util_profiler_util",

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -119,6 +119,7 @@ source_set("protozero_to_json") {
   ]
   deps = [
     ":descriptors",
+    ":json_serializer",
     "../../../gn:default_deps",
     "../../../protos/perfetto/common:zero",
     "../../../protos/perfetto/trace/track_event:zero",
@@ -264,6 +265,25 @@ source_set("json_parser") {
   }
 }
 
+source_set("json_serializer") {
+  sources = [ "json_serializer.h" ]
+  deps = [
+    "../../../gn:default_deps",
+    "../../../include/perfetto/ext/base",
+  ]
+}
+
+source_set("simple_json_serializer") {
+  sources = [
+    "simple_json_serializer.cc",
+    "simple_json_serializer.h",
+  ]
+  deps = [
+    ":json_serializer",
+    "../../../gn:default_deps",
+  ]
+}
+
 source_set("json_writer") {
   sources = [
     "json_writer.cc",
@@ -371,11 +391,13 @@ source_set("unittests") {
     "debug_annotation_parser_unittest.cc",
     "glob_unittest.cc",
     "json_parser_unittest.cc",
+    "json_serializer_unittest.cc",
     "json_writer_unittest.cc",
     "proto_profiler_unittest.cc",
     "proto_to_args_parser_unittest.cc",
     "protozero_to_json_unittests.cc",
     "protozero_to_text_unittests.cc",
+    "simple_json_serializer_unittest.cc",
     "sql_argument_unittest.cc",
     "streaming_line_reader_unittest.cc",
     "tar_writer_unittest.cc",
@@ -394,12 +416,14 @@ source_set("unittests") {
     ":glob",
     ":gzip",
     ":json_parser",
+    ":json_serializer",
     ":json_writer",
     ":proto_profiler",
     ":proto_to_args_parser",
     ":protozero_to_json",
     ":protozero_to_text",
     ":regex",
+    ":simple_json_serializer",
     ":sql_argument",
     ":tar_writer",
     ":trace_blob_view_reader",

--- a/src/trace_processor/util/json_serializer.h
+++ b/src/trace_processor/util/json_serializer.h
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_JSON_SERIALIZER_H_
+#define SRC_TRACE_PROCESSOR_UTIL_JSON_SERIALIZER_H_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include "perfetto/ext/base/dynamic_string_writer.h"
+#include "perfetto/ext/base/string_view.h"
+
+namespace perfetto::trace_processor::json {
+
+// Low-level JSON serializer with state tracking.
+// Handles comma insertion, nesting, and optional pretty-printing.
+//
+// For a higher-level callback-based API, see simple_json_serializer.h.
+//
+// Usage:
+//   JsonSerializer s;
+//   s.OpenObject();
+//   s.Key("name");
+//   s.StringValue("hello");
+//   s.Key("values");
+//   s.OpenArray();
+//   s.NumberValue(1);
+//   s.NumberValue(2);
+//   s.CloseArray();
+//   s.CloseObject();
+//   std::string json = s.ToString();
+class JsonSerializer {
+ public:
+  enum Flags {
+    kNone = 0,
+    kPretty = 1 << 0,
+  };
+
+  explicit JsonSerializer(int flags = kNone) : flags_(flags) {}
+
+  void OpenObject() {
+    if (is_array_scope()) {
+      if (!is_empty_scope()) {
+        writer_.AppendChar(',');
+      }
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    writer_.AppendChar('{');
+    stack_.push_back(Scope{ScopeContext::kObject});
+  }
+
+  void CloseObject() {
+    bool needs_newline = !is_empty_scope();
+    stack_.pop_back();
+    if (needs_newline) {
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    MarkScopeAsNonEmpty();
+    writer_.AppendChar('}');
+  }
+
+  void OpenArray() {
+    if (is_array_scope()) {
+      if (!is_empty_scope()) {
+        writer_.AppendChar(',');
+      }
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    writer_.AppendChar('[');
+    stack_.push_back(Scope{ScopeContext::kArray});
+  }
+
+  void CloseArray() {
+    bool needs_newline = !is_empty_scope();
+    stack_.pop_back();
+    if (needs_newline) {
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    writer_.AppendChar(']');
+    MarkScopeAsNonEmpty();
+  }
+
+  void Key(std::string_view key) {
+    if (is_object_scope() && !is_empty_scope()) {
+      writer_.AppendChar(',');
+    }
+    MaybeAppendNewline();
+    MaybeAppendIndent();
+    AppendEscapedString(key);
+    writer_.AppendChar(':');
+    MaybeAppendSpace();
+    MarkScopeAsNonEmpty();
+  }
+
+  template <typename T>
+  void NumberValue(T v) {
+    if (is_array_scope() && !is_empty_scope()) {
+      writer_.AppendChar(',');
+    }
+    if (is_array_scope()) {
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    if constexpr (std::is_floating_point_v<T>) {
+      writer_.AppendDouble(static_cast<double>(v));
+    } else if constexpr (std::is_signed_v<T>) {
+      writer_.AppendInt(static_cast<int64_t>(v));
+    } else {
+      writer_.AppendUnsignedInt(static_cast<uint64_t>(v));
+    }
+    MarkScopeAsNonEmpty();
+  }
+
+  void BoolValue(bool v) {
+    if (is_array_scope() && !is_empty_scope()) {
+      writer_.AppendChar(',');
+    }
+    if (is_array_scope()) {
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    writer_.AppendBool(v);
+    MarkScopeAsNonEmpty();
+  }
+
+  void FloatValue(float v) { DoubleValue(static_cast<double>(v)); }
+
+  void DoubleValue(double v) {
+    if (is_array_scope() && !is_empty_scope()) {
+      writer_.AppendChar(',');
+    }
+    if (is_array_scope()) {
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    // Handle special values that JSON doesn't support - output as strings
+    if (std::isnan(v)) {
+      writer_.AppendLiteral("\"NaN\"");
+    } else if (std::isinf(v)) {
+      if (v > 0) {
+        writer_.AppendLiteral("\"Infinity\"");
+      } else {
+        writer_.AppendLiteral("\"-Infinity\"");
+      }
+    } else {
+      writer_.AppendDouble(v);
+    }
+    MarkScopeAsNonEmpty();
+  }
+
+  void StringValue(std::string_view v) {
+    if (is_array_scope() && !is_empty_scope()) {
+      writer_.AppendChar(',');
+    }
+    if (is_array_scope()) {
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    AppendEscapedString(v);
+    MarkScopeAsNonEmpty();
+  }
+
+  void NullValue() {
+    if (is_array_scope() && !is_empty_scope()) {
+      writer_.AppendChar(',');
+    }
+    if (is_array_scope()) {
+      MaybeAppendNewline();
+      MaybeAppendIndent();
+    }
+    writer_.AppendLiteral("null");
+    MarkScopeAsNonEmpty();
+  }
+
+  std::string ToString() const {
+    auto sv = writer_.GetStringView();
+    return std::string(sv.data(), sv.size());
+  }
+
+  base::StringView GetStringView() const { return writer_.GetStringView(); }
+
+  // Clears internal state for reuse, preserving allocated memory.
+  void Clear() {
+    writer_.Clear();
+    stack_.clear();
+  }
+
+  bool is_empty_scope() const {
+    return !stack_.empty() && stack_.back().is_empty;
+  }
+
+  bool is_pretty() const { return flags_ & Flags::kPretty; }
+
+ private:
+  enum class ScopeContext {
+    kObject,
+    kArray,
+  };
+
+  struct Scope {
+    ScopeContext ctx;
+    bool is_empty = true;
+  };
+
+  bool is_object_scope() const {
+    return !stack_.empty() && stack_.back().ctx == ScopeContext::kObject;
+  }
+
+  bool is_array_scope() const {
+    return !stack_.empty() && stack_.back().ctx == ScopeContext::kArray;
+  }
+
+  void MarkScopeAsNonEmpty() {
+    if (!stack_.empty()) {
+      stack_.back().is_empty = false;
+    }
+  }
+
+  void MaybeAppendSpace() {
+    if (is_pretty()) {
+      writer_.AppendChar(' ');
+    }
+  }
+
+  void MaybeAppendIndent() {
+    if (is_pretty()) {
+      writer_.AppendChar(' ', stack_.size() * 2);
+    }
+  }
+
+  void MaybeAppendNewline() {
+    if (is_pretty()) {
+      writer_.AppendChar('\n');
+    }
+  }
+
+  // Escapes a string for JSON output and appends it directly to the writer.
+  // Includes the surrounding quotes and proper UTF-8 handling.
+  void AppendEscapedString(std::string_view raw) {
+    static const char hex_chars[] = "0123456789abcdef";
+    writer_.AppendChar('"');
+    for (size_t i = 0; i < raw.size(); ++i) {
+      char c = raw[i];
+      switch (c) {
+        case '"':
+        case '\\':
+          writer_.AppendChar('\\');
+          writer_.AppendChar(c);
+          break;
+        case '\n':
+          writer_.AppendLiteral("\\n");
+          break;
+        case '\b':
+          writer_.AppendLiteral("\\b");
+          break;
+        case '\f':
+          writer_.AppendLiteral("\\f");
+          break;
+        case '\r':
+          writer_.AppendLiteral("\\r");
+          break;
+        case '\t':
+          writer_.AppendLiteral("\\t");
+          break;
+        default:
+          // ASCII characters between 0x20 (space) and 0x7e (tilde) are
+          // inserted directly. All others are escaped.
+          if (c >= 0x20 && c <= 0x7e) {
+            writer_.AppendChar(c);
+          } else {
+            unsigned char uc = static_cast<unsigned char>(c);
+            uint32_t codepoint = 0;
+
+            // Compute the number of bytes in this UTF-8 sequence.
+            size_t extra = 1 + (uc >= 0xc0u) + (uc >= 0xe0u) + (uc >= 0xf0u);
+
+            // Consume up to |extra| bytes but don't read out of bounds.
+            size_t stop = std::min(raw.size(), i + extra);
+
+            // Extract bits from the first byte.
+            codepoint |= uc & (0xff >> (extra + 1));
+
+            // Extract remaining bits from continuation bytes.
+            for (size_t j = i + 1; j < stop; ++j) {
+              uc = static_cast<unsigned char>(raw[j]);
+              codepoint = (codepoint << 6) | (uc & 0x3f);
+            }
+
+            // Update i to account for consumed bytes.
+            i = stop - 1;
+
+            // JSON uses UTF-16 escapes. For BMP codepoints use \uXXXX.
+            // For supplementary codepoints use a surrogate pair.
+            if (codepoint <= 0xffff) {
+              writer_.AppendLiteral("\\u");
+              writer_.AppendChar(hex_chars[(codepoint >> 12) & 0xf]);
+              writer_.AppendChar(hex_chars[(codepoint >> 8) & 0xf]);
+              writer_.AppendChar(hex_chars[(codepoint >> 4) & 0xf]);
+              writer_.AppendChar(hex_chars[(codepoint >> 0) & 0xf]);
+            } else {
+              uint32_t high = ((codepoint - 0x10000) >> 10) + 0xD800;
+              uint32_t low = (codepoint & 0x3ff) + 0xDC00;
+              writer_.AppendLiteral("\\u");
+              writer_.AppendChar(hex_chars[(high >> 12) & 0xf]);
+              writer_.AppendChar(hex_chars[(high >> 8) & 0xf]);
+              writer_.AppendChar(hex_chars[(high >> 4) & 0xf]);
+              writer_.AppendChar(hex_chars[(high >> 0) & 0xf]);
+              writer_.AppendLiteral("\\u");
+              writer_.AppendChar(hex_chars[(low >> 12) & 0xf]);
+              writer_.AppendChar(hex_chars[(low >> 8) & 0xf]);
+              writer_.AppendChar(hex_chars[(low >> 4) & 0xf]);
+              writer_.AppendChar(hex_chars[(low >> 0) & 0xf]);
+            }
+          }
+          break;
+      }
+    }
+    writer_.AppendChar('"');
+  }
+
+  int flags_;
+  mutable base::DynamicStringWriter writer_;
+  std::vector<Scope> stack_;
+};
+
+}  // namespace perfetto::trace_processor::json
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_JSON_SERIALIZER_H_

--- a/src/trace_processor/util/json_serializer_unittest.cc
+++ b/src/trace_processor/util/json_serializer_unittest.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/json_serializer.h"
+
+#include <string>
+
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::json {
+namespace {
+
+// Tests pretty-printing - the only test needed for this feature
+TEST(JsonSerializerTest, PrettyPrint) {
+  JsonSerializer s(JsonSerializer::kPretty);
+  s.OpenObject();
+  s.Key("outer");
+  s.OpenObject();
+  s.Key("inner");
+  s.NumberValue(1);
+  s.CloseObject();
+  s.Key("array");
+  s.OpenArray();
+  s.NumberValue(2);
+  s.NumberValue(3);
+  s.CloseArray();
+  s.CloseObject();
+
+  std::string expected =
+      "{\n"
+      "  \"outer\": {\n"
+      "    \"inner\": 1\n"
+      "  },\n"
+      "  \"array\": [\n"
+      "    2,\n"
+      "    3\n"
+      "  ]\n"
+      "}";
+  EXPECT_EQ(s.ToString(), expected);
+}
+
+// Tests UTF-8 surrogate pair encoding (4-byte sequences)
+// This is the most complex case that could break
+TEST(JsonSerializerTest, Utf8SurrogatePair) {
+  JsonSerializer s;
+  // U+1D11E (musical G clef) = UTF-8: F0 9D 84 9E
+  // Should become surrogate pair: \uD834\uDD1E
+  s.StringValue("\xf0\x9d\x84\x9e");
+  EXPECT_EQ(s.ToString(), R"("\ud834\udd1e")");
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::json

--- a/src/trace_processor/util/simple_json_serializer.cc
+++ b/src/trace_processor/util/simple_json_serializer.cc
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/simple_json_serializer.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "src/trace_processor/util/json_serializer.h"
+
+namespace perfetto::trace_processor::json {
+
+// JsonDictSerializer implementation - delegates to JsonSerializer
+
+JsonDictSerializer::JsonDictSerializer(JsonSerializer& serializer)
+    : serializer_(serializer) {}
+
+void JsonDictSerializer::AddNull(std::string_view key) {
+  serializer_.Key(key);
+  serializer_.NullValue();
+}
+
+void JsonDictSerializer::AddBool(std::string_view key, bool value) {
+  serializer_.Key(key);
+  serializer_.BoolValue(value);
+}
+
+void JsonDictSerializer::AddInt(std::string_view key, int64_t value) {
+  serializer_.Key(key);
+  serializer_.NumberValue(value);
+}
+
+void JsonDictSerializer::AddUint(std::string_view key, uint64_t value) {
+  serializer_.Key(key);
+  serializer_.NumberValue(value);
+}
+
+void JsonDictSerializer::AddDouble(std::string_view key, double value) {
+  serializer_.Key(key);
+  serializer_.DoubleValue(value);
+}
+
+void JsonDictSerializer::AddString(std::string_view key,
+                                   std::string_view value) {
+  serializer_.Key(key);
+  serializer_.StringValue(value);
+}
+
+void JsonDictSerializer::AddDict(
+    std::string_view key,
+    std::function<void(JsonDictSerializer&)> dict_writer) {
+  serializer_.Key(key);
+  serializer_.OpenObject();
+  JsonDictSerializer nested(serializer_);
+  dict_writer(nested);
+  serializer_.CloseObject();
+}
+
+void JsonDictSerializer::AddArray(
+    std::string_view key,
+    std::function<void(JsonArraySerializer&)> array_writer) {
+  serializer_.Key(key);
+  serializer_.OpenArray();
+  JsonArraySerializer nested(serializer_);
+  array_writer(nested);
+  serializer_.CloseArray();
+}
+
+void JsonDictSerializer::Add(
+    std::string_view key,
+    std::function<void(JsonValueSerializer&&)> value_writer) {
+  serializer_.Key(key);
+  value_writer(JsonValueSerializer(serializer_));
+}
+
+// JsonArraySerializer implementation - delegates to JsonSerializer
+
+JsonArraySerializer::JsonArraySerializer(JsonSerializer& serializer)
+    : serializer_(serializer) {}
+
+void JsonArraySerializer::AppendNull() {
+  serializer_.NullValue();
+}
+
+void JsonArraySerializer::AppendBool(bool value) {
+  serializer_.BoolValue(value);
+}
+
+void JsonArraySerializer::AppendInt(int64_t value) {
+  serializer_.NumberValue(value);
+}
+
+void JsonArraySerializer::AppendUint(uint64_t value) {
+  serializer_.NumberValue(value);
+}
+
+void JsonArraySerializer::AppendDouble(double value) {
+  serializer_.DoubleValue(value);
+}
+
+void JsonArraySerializer::AppendString(std::string_view value) {
+  serializer_.StringValue(value);
+}
+
+void JsonArraySerializer::AppendDict(
+    std::function<void(JsonDictSerializer&)> dict_writer) {
+  serializer_.OpenObject();
+  JsonDictSerializer nested(serializer_);
+  dict_writer(nested);
+  serializer_.CloseObject();
+}
+
+void JsonArraySerializer::AppendArray(
+    std::function<void(JsonArraySerializer&)> array_writer) {
+  serializer_.OpenArray();
+  JsonArraySerializer nested(serializer_);
+  array_writer(nested);
+  serializer_.CloseArray();
+}
+
+void JsonArraySerializer::Append(
+    std::function<void(JsonValueSerializer&&)> value_writer) {
+  value_writer(JsonValueSerializer(serializer_));
+}
+
+// JsonValueSerializer implementation - delegates to JsonSerializer
+
+JsonValueSerializer::JsonValueSerializer(JsonSerializer& serializer)
+    : serializer_(serializer) {}
+
+void JsonValueSerializer::WriteNull() && {
+  serializer_.NullValue();
+}
+
+void JsonValueSerializer::WriteBool(bool value) && {
+  serializer_.BoolValue(value);
+}
+
+void JsonValueSerializer::WriteInt(int64_t value) && {
+  serializer_.NumberValue(value);
+}
+
+void JsonValueSerializer::WriteUint(uint64_t value) && {
+  serializer_.NumberValue(value);
+}
+
+void JsonValueSerializer::WriteDouble(double value) && {
+  serializer_.DoubleValue(value);
+}
+
+void JsonValueSerializer::WriteString(std::string_view value) && {
+  serializer_.StringValue(value);
+}
+
+void JsonValueSerializer::WriteDict(
+    std::function<void(JsonDictSerializer&)> dict_writer) && {
+  serializer_.OpenObject();
+  JsonDictSerializer nested(serializer_);
+  dict_writer(nested);
+  serializer_.CloseObject();
+}
+
+void JsonValueSerializer::WriteArray(
+    std::function<void(JsonArraySerializer&)> array_writer) && {
+  serializer_.OpenArray();
+  JsonArraySerializer nested(serializer_);
+  array_writer(nested);
+  serializer_.CloseArray();
+}
+
+// Main entry point
+
+std::string SerializeJson(
+    std::function<void(JsonValueSerializer&&)> value_writer) {
+  JsonSerializer serializer;
+  value_writer(JsonValueSerializer(serializer));
+  return serializer.ToString();
+}
+
+}  // namespace perfetto::trace_processor::json

--- a/src/trace_processor/util/simple_json_serializer.h
+++ b/src/trace_processor/util/simple_json_serializer.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_SIMPLE_JSON_SERIALIZER_H_
+#define SRC_TRACE_PROCESSOR_UTIL_SIMPLE_JSON_SERIALIZER_H_
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+
+#include "src/trace_processor/util/json_serializer.h"
+
+namespace perfetto::trace_processor::json {
+
+class JsonDictSerializer;
+class JsonArraySerializer;
+class JsonValueSerializer;
+
+// Main entry point for serializing JSON using a callback-based API.
+// This is a higher-level wrapper around JsonSerializer that provides
+// a more ergonomic callback-based interface.
+//
+// Usage:
+//   std::string json = SerializeJson([](JsonValueSerializer&& writer) {
+//     std::move(writer).WriteDict([](JsonDictSerializer& dict) {
+//       dict.AddString("hello", "world");
+//     });
+//   });
+std::string SerializeJson(
+    std::function<void(JsonValueSerializer&&)> value_writer);
+
+// Serializes a JSON dictionary.
+// Usage example:
+//   dict.AddString("key", "value");
+//   dict.AddDict("nested", [](JsonDictSerializer& nested) {
+//     nested.AddInt("count", 42);
+//   });
+class JsonDictSerializer {
+ public:
+  explicit JsonDictSerializer(JsonSerializer& serializer);
+  JsonDictSerializer(const JsonDictSerializer&) = delete;
+  JsonDictSerializer& operator=(const JsonDictSerializer&) = delete;
+
+  // Primitive values.
+  void AddNull(std::string_view key);
+  void AddBool(std::string_view key, bool value);
+  void AddInt(std::string_view key, int64_t value);
+  void AddUint(std::string_view key, uint64_t value);
+  void AddDouble(std::string_view key, double value);
+  void AddString(std::string_view key, std::string_view value);
+
+  // Writes a nested dictionary.
+  void AddDict(std::string_view key,
+               std::function<void(JsonDictSerializer&)> dict_writer);
+
+  // Writes a nested array.
+  void AddArray(std::string_view key,
+                std::function<void(JsonArraySerializer&)> array_writer);
+
+  // Writes a generic value.
+  void Add(std::string_view key,
+           std::function<void(JsonValueSerializer&&)> value_writer);
+
+ private:
+  JsonSerializer& serializer_;
+};
+
+// Serializes a JSON array.
+// Usage example:
+//   array.AppendString("item1");
+//   array.AppendDict([](JsonDictSerializer& dict) {
+//     dict.AddString("key", "value");
+//   });
+class JsonArraySerializer {
+ public:
+  explicit JsonArraySerializer(JsonSerializer& serializer);
+  JsonArraySerializer(const JsonArraySerializer&) = delete;
+  JsonArraySerializer& operator=(const JsonArraySerializer&) = delete;
+
+  // Primitive values.
+  void AppendNull();
+  void AppendBool(bool value);
+  void AppendInt(int64_t value);
+  void AppendUint(uint64_t value);
+  void AppendDouble(double value);
+  void AppendString(std::string_view value);
+
+  // Writes a nested dictionary.
+  void AppendDict(std::function<void(JsonDictSerializer&)> dict_writer);
+
+  // Writes a nested array.
+  void AppendArray(std::function<void(JsonArraySerializer&)> array_writer);
+
+  // Writes a generic value.
+  void Append(std::function<void(JsonValueSerializer&&)> value_writer);
+
+ private:
+  JsonSerializer& serializer_;
+};
+
+// Generic value serializer.
+// Usage example:
+//   [](JsonValueSerializer&& writer) {
+//     std::move(writer).WriteString("foo");
+//   });
+class JsonValueSerializer {
+ public:
+  explicit JsonValueSerializer(JsonSerializer& serializer);
+  JsonValueSerializer(const JsonValueSerializer&) = delete;
+  JsonValueSerializer& operator=(const JsonValueSerializer&) = delete;
+
+  void WriteNull() &&;
+  void WriteBool(bool value) &&;
+  void WriteInt(int64_t value) &&;
+  void WriteUint(uint64_t value) &&;
+  void WriteDouble(double value) &&;
+  void WriteString(std::string_view value) &&;
+  void WriteDict(std::function<void(JsonDictSerializer&)> dict_writer) &&;
+  void WriteArray(std::function<void(JsonArraySerializer&)> array_writer) &&;
+
+ private:
+  JsonSerializer& serializer_;
+};
+
+}  // namespace perfetto::trace_processor::json
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_SIMPLE_JSON_SERIALIZER_H_

--- a/src/trace_processor/util/simple_json_serializer_unittest.cc
+++ b/src/trace_processor/util/simple_json_serializer_unittest.cc
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/simple_json_serializer.h"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::json {
+namespace {
+
+// Comprehensive test covering all the APIs with nested structures
+TEST(SimpleJsonSerializerTest, Complex) {
+  std::string result = SerializeJson([](JsonValueSerializer&& writer) {
+    std::move(writer).WriteDict([](JsonDictSerializer& dict) {
+      dict.AddNull("null_val");
+      dict.AddBool("bool_val", true);
+      dict.AddInt("int_val", int64_t{-42});
+      dict.AddUint("uint_val", uint64_t{18446744073709551615ULL});
+      dict.AddDouble("double_val", 3.14);
+      dict.AddString("string_val", "hello");
+      dict.AddString("escaped", "a\"b\\c\nd");
+      dict.AddArray("items", [](JsonArraySerializer& arr) {
+        arr.AppendDict([](JsonDictSerializer& obj) {
+          obj.AddInt("id", int64_t{1});
+          obj.AddArray("tags", [](JsonArraySerializer& tags) {
+            tags.AppendString("x");
+            tags.AppendString("y");
+          });
+        });
+      });
+      dict.AddDict("nested", [](JsonDictSerializer& nested) {
+        nested.AddInt("inner", int64_t{99});
+      });
+    });
+  });
+
+  // Check key parts of the output
+  EXPECT_TRUE(result.find("\"null_val\":null") != std::string::npos);
+  EXPECT_TRUE(result.find("\"bool_val\":true") != std::string::npos);
+  EXPECT_TRUE(result.find("\"int_val\":-42") != std::string::npos);
+  EXPECT_TRUE(result.find("18446744073709551615") != std::string::npos);
+  EXPECT_TRUE(result.find("\"escaped\":\"a\\\"b\\\\c\\nd\"") !=
+              std::string::npos);
+  EXPECT_TRUE(result.find("\"tags\":[\"x\",\"y\"]") != std::string::npos);
+  EXPECT_TRUE(result.find("\"inner\":99") != std::string::npos);
+}
+
+// Tests special double handling - unique functionality
+TEST(SimpleJsonSerializerTest, SpecialDoubles) {
+  std::string result = SerializeJson([](JsonValueSerializer&& writer) {
+    std::move(writer).WriteDict([](JsonDictSerializer& dict) {
+      dict.AddDouble("nan", std::nan(""));
+      dict.AddDouble("inf", std::numeric_limits<double>::infinity());
+      dict.AddDouble("neg_inf", -std::numeric_limits<double>::infinity());
+    });
+  });
+
+  EXPECT_TRUE(result.find("\"nan\":\"NaN\"") != std::string::npos);
+  EXPECT_TRUE(result.find("\"inf\":\"Infinity\"") != std::string::npos);
+  EXPECT_TRUE(result.find("\"neg_inf\":\"-Infinity\"") != std::string::npos);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::json


### PR DESCRIPTION
Add new JSON serialization infrastructure to replace the jsoncpp dependency:

- JsonSerializer: Low-level, header-only JSON serializer with state tracking
  for comma insertion, nesting, and optional pretty-printing. Directly uses
  DynamicStringWriter for efficient string building.

- SimpleJsonSerializer: Higher-level callback-based API (JsonDictSerializer,
  JsonArraySerializer, JsonValueSerializer) wrapping JsonSerializer for a
  more ergonomic interface.

Migrate protozero_to_json.cc to use the new JsonSerializer directly.

The old json_writer.h/cc with JsonDictWriter/JsonArrayWriter/JsonValueWriter
is kept for now to maintain backward compatibility with existing consumers.
These will be migrated in follow-up CLs.
