### PR TITLE
de: Fix too many updates for the query node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -315,6 +315,9 @@ export class SqlSourceNode implements QueryNode {
       m(SqlEditor, {
         sql: this.state.sql ?? '',
         onUpdate: (text: string) => {
+          if (this.state.sql === text) {
+            return;
+          }
           this.state.sql = text;
           // Clear columns when SQL changes to prevent stale column usage
           this.finalCols = [];


### PR DESCRIPTION
We were clearing the columns on each update (such as moving the node around), add a check for whether there was any real change. 

@ivan-chong, thanks for finding the fix!