### PR TITLE
tp: Normalize StringPool::Id::Null() handling in dataframe

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -14319,6 +14319,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_core_dataframe_unittests",
     srcs: [
+        "src/trace_processor/core/dataframe/adhoc_dataframe_builder_unittest.cc",
         "src/trace_processor/core/dataframe/dataframe_unittest.cc",
         "src/trace_processor/core/dataframe/runtime_dataframe_builder_unittest.cc",
     ],

--- a/python/generators/trace_processor_table/serialize.py
+++ b/python/generators/trace_processor_table/serialize.py
@@ -58,9 +58,9 @@ class ColumnSerializer:
     if self.is_optional and self.is_id_type and not self.is_no_transform_id:
       return f'row.{self.name} ? std::make_optional(row.{self.name}->value) : std::nullopt'
     if self.is_optional and self.is_string:
-      return f'row.{self.name} && row.{self.name} != StringPool::Id::Null() ? std::make_optional(*row.{self.name}) : std::nullopt'
+      return f'row.{self.name}'
     if self.is_string:
-      return f'row.{self.name} != StringPool::Id::Null() ? std::make_optional(row.{self.name}) : std::nullopt'
+      return f'std::make_optional(row.{self.name})'
     if self.is_id_type and not self.is_no_transform_id:
       return f'row.{self.name}.value'
     return f'row.{self.name}'
@@ -85,15 +85,14 @@ class ColumnSerializer:
       return f'''
       {self.cpp_type_with_optionality} {self.name}() const {{
         {dcheck}
-        auto res = cursor_.GetCellUnchecked<ColumnIndex::{self.name}>(kSpec);
-        return res && res != StringPool::Id::Null() ? std::make_optional({self.cpp_type_non_optional}{{*res}}) : std::nullopt;
+        return cursor_.GetCellUnchecked<ColumnIndex::{self.name}>(kSpec);
       }}'''
     if self.is_string:
       return f'''
       {self.cpp_type_with_optionality} {self.name}() const {{
         {dcheck}
         auto res = cursor_.GetCellUnchecked<ColumnIndex::{self.name}>(kSpec);
-        return res && res != StringPool::Id::Null() ? *res : StringPool::Id::Null();
+        return res ? *res : StringPool::Id::Null();
       }}'''
     if self.is_id_type:
       return f'''
@@ -125,15 +124,13 @@ class ColumnSerializer:
       return f'''
       void set_{self.name}({self.cpp_type_with_optionality} res) {{
         {dcheck}
-        auto res_value = res && res != StringPool::Id::Null() ? std::make_optional(*res) : std::nullopt;
-        cursor_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, res_value);
+        cursor_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, res);
     }}'''
     if self.is_string:
       return f'''
       void set_{self.name}({self.cpp_type_with_optionality} res) {{
         {dcheck}
-        auto res_value = res != StringPool::Id::Null() ? std::make_optional(res) : std::nullopt;
-        cursor_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, res_value);
+        cursor_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, std::make_optional(res));
     }}'''
     if self.is_id_type and not self.is_no_transform_id:
       return f'''
@@ -165,15 +162,14 @@ class ColumnSerializer:
       return f'''
       {self.cpp_type_with_optionality} {self.name}() const {{
         {dcheck}
-        auto res = table_->dataframe_.template GetCellUnchecked<ColumnIndex::{self.name}>(kSpec, row_);
-        return res && res != StringPool::Id::Null() ? std::make_optional({self.cpp_type_non_optional}{{*res}}) : std::nullopt;
+        return table_->dataframe_.template GetCellUnchecked<ColumnIndex::{self.name}>(kSpec, row_);
       }}'''
     if self.is_string:
       return f'''
       {self.cpp_type_with_optionality} {self.name}() const {{
         {dcheck}
         auto res = table_->dataframe_.template GetCellUnchecked<ColumnIndex::{self.name}>(kSpec, row_);
-        return res && res != StringPool::Id::Null() ? {self.cpp_type_non_optional}{{*res}} : StringPool::Id::Null();
+        return res ? *res : StringPool::Id::Null();
       }}'''
     if self.is_id_type:
       return f'''
@@ -205,15 +201,13 @@ class ColumnSerializer:
       return f'''
       void set_{self.name}({self.cpp_type_with_optionality} res) {{
         {dcheck}
-        auto res_value = res && res != StringPool::Id::Null() ? std::make_optional(*res) : std::nullopt;
-        table_->dataframe_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, row_, res_value);
+        table_->dataframe_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, row_, res);
     }}'''
     if self.is_string:
       return f'''
       void set_{self.name}({self.cpp_type_with_optionality} res) {{
         {dcheck}
-        auto res_value = res != StringPool::Id::Null() ? std::make_optional(res) : std::nullopt;
-        table_->dataframe_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, row_, res_value);
+        table_->dataframe_.SetCellUnchecked<ColumnIndex::{self.name}>(kSpec, row_, std::make_optional(res));
     }}'''
     if self.is_id_type and not self.is_no_transform_id:
       return f'''

--- a/src/trace_processor/core/dataframe/BUILD.gn
+++ b/src/trace_processor/core/dataframe/BUILD.gn
@@ -45,6 +45,7 @@ source_set("dataframe") {
 perfetto_unittest_source_set("unittests") {
   testonly = true
   sources = [
+    "adhoc_dataframe_builder_unittest.cc",
     "dataframe_test_utils.h",
     "dataframe_unittest.cc",
     "runtime_dataframe_builder_unittest.cc",

--- a/src/trace_processor/core/dataframe/adhoc_dataframe_builder.h
+++ b/src/trace_processor/core/dataframe/adhoc_dataframe_builder.h
@@ -160,9 +160,14 @@ class AdhocDataframeBuilder {
                                           uint32_t count = 1) {
     return PushNonNullInternal(col, value, count);
   }
+  // See kStringNullLegacy in dataframe.h.
   PERFETTO_ALWAYS_INLINE bool PushNonNull(uint32_t col,
                                           StringPool::Id value,
                                           uint32_t count = 1) {
+    if (PERFETTO_UNLIKELY(value.is_null())) {
+      PushNull(col, count);
+      return true;
+    }
     return PushNonNullInternal(col, value, count);
   }
 
@@ -185,9 +190,11 @@ class AdhocDataframeBuilder {
                                                    uint32_t count = 1) {
     PushNonNullUncheckedInternal(col, value, count);
   }
+  // See kStringNullLegacy in dataframe.h.
   PERFETTO_ALWAYS_INLINE void PushNonNullUnchecked(uint32_t col,
                                                    StringPool::Id value,
                                                    uint32_t count = 1) {
+    PERFETTO_DCHECK(!value.is_null());
     PushNonNullUncheckedInternal(col, value, count);
   }
 

--- a/src/trace_processor/core/dataframe/adhoc_dataframe_builder_unittest.cc
+++ b/src/trace_processor/core/dataframe/adhoc_dataframe_builder_unittest.cc
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
+
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "perfetto/ext/base/status_or.h"
+#include "src/base/test/status_matchers.h"
+#include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/dataframe/specs.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::core::dataframe {
+
+inline void PrintTo(const ColumnSpec& spec, std::ostream* os) {
+  *os << "\n  ColumnSpec{\n"
+      << "    type: " << spec.type.ToString() << ",\n"
+      << "    nullability: " << spec.nullability.ToString() << ",\n"
+      << "    sort_state: " << spec.sort_state.ToString() << ",\n"
+      << "    duplicate_state: " << spec.duplicate_state.ToString() << "\n"
+      << "  }";
+}
+
+inline bool operator==(const ColumnSpec& lhs, const ColumnSpec& rhs) {
+  return lhs.type == rhs.type && lhs.nullability == rhs.nullability &&
+         lhs.sort_state == rhs.sort_state &&
+         lhs.duplicate_state == rhs.duplicate_state;
+}
+
+namespace {
+
+using testing::ElementsAre;
+
+class AdhocDataframeBuilderTest : public ::testing::Test {
+ protected:
+  StringPool pool_;
+};
+
+TEST_F(AdhocDataframeBuilderTest, StringColumnWithNullId) {
+  AdhocDataframeBuilder builder({"str_col"}, &pool_);
+
+  builder.PushNonNull(0, pool_.InternString("hello"));
+  builder.PushNonNull(0, StringPool::Id::Null());
+  builder.PushNonNull(0, pool_.InternString("world"));
+
+  base::StatusOr<Dataframe> df_status = std::move(builder).Build();
+  ASSERT_OK(df_status.status());
+  Dataframe df = std::move(df_status.value());
+
+  auto spec = df.CreateSpec();
+  ASSERT_THAT(spec.column_names, ElementsAre("str_col", "_auto_id"));
+  ASSERT_THAT(
+      spec.column_specs,
+      ElementsAre(
+          ColumnSpec{String{}, SparseNull{}, Unsorted{}, HasDuplicates{}},
+          ColumnSpec{Id{}, NonNull{}, IdSorted{}, NoDuplicates{}}));
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/dataframe/dataframe_unittest.cc
+++ b/src/trace_processor/core/dataframe/dataframe_unittest.cc
@@ -38,7 +38,6 @@
 #include "src/trace_processor/core/dataframe/typed_cursor.h"
 #include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_to_string.h"
-#include "src/trace_processor/core/interpreter/interpreter_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/util/regex.h"
 #include "test/gtest_and_gmock.h"


### PR DESCRIPTION
For legacy reasons, trace processor has two ways to represent null
strings: std::nullopt and StringPool::Id::Null(). This change
normalizes the handling throughout the dataframe code:

- Insert/Set paths: StringPool::Id::Null() is silently converted to
  a true null for nullable columns. For NonNull columns, passing
  StringPool::Id::Null() triggers a DCHECK.
- Get paths: DCHECKs that values read from storage are never
  StringPool::Id::Null() (since we convert them on write).

This ensures internal consistency while maintaining compatibility
with existing code that uses StringPool::Id::Null() to represent nulls.

Also adds a unittest for AdhocDataframeBuilder to verify the behavior.
