### PR TITLE
tp: Refactor AdhocDataframeBuilder to use Storage instead of DataVariant

### DIFF
--- a/src/trace_processor/core/common/storage_types.h
+++ b/src/trace_processor/core/common/storage_types.h
@@ -60,6 +60,32 @@ struct String {
 // TypeSet of all possible storage value types.
 using StorageType = core::TypeSet<Id, Uint32, Int32, Int64, Double, String>;
 
+// Maps a C++ type to its corresponding storage type tag.
+// E.g., TypeTagFor<int64_t>::type = Int64
+template <typename CppType>
+struct TypeTagFor;
+
+template <>
+struct TypeTagFor<uint32_t> {
+  using type = Uint32;
+};
+template <>
+struct TypeTagFor<int32_t> {
+  using type = Int32;
+};
+template <>
+struct TypeTagFor<int64_t> {
+  using type = Int64;
+};
+template <>
+struct TypeTagFor<double> {
+  using type = Double;
+};
+template <>
+struct TypeTagFor<StringPool::Id> {
+  using type = String;
+};
+
 }  // namespace perfetto::trace_processor::core
 
 #endif  // SRC_TRACE_PROCESSOR_CORE_COMMON_STORAGE_TYPES_H_

--- a/src/trace_processor/core/dataframe/adhoc_dataframe_builder.cc
+++ b/src/trace_processor/core/dataframe/adhoc_dataframe_builder.cc
@@ -45,30 +45,26 @@ namespace perfetto::trace_processor::core::dataframe {
 AdhocDataframeBuilder::AdhocDataframeBuilder(std::vector<std::string> names,
                                              StringPool* pool,
                                              const Options& options)
-    : string_pool_(pool),
-      did_declare_types_(!options.types.empty()),
-      nullability_type_(options.nullability_type) {
+    : string_pool_(pool), did_declare_types_(!options.types.empty()) {
   PERFETTO_DCHECK(options.types.empty() ||
                   options.types.size() == names.size());
   for (uint32_t i = 0; i < names.size(); ++i) {
-    if (options.types.empty()) {
-      column_states_.emplace_back();
-    } else {
+    ColumnState state;
+    state.nullability_type = options.nullability_type;
+    if (!options.types.empty()) {
       switch (options.types[i]) {
         case ColumnType::kInt64:
-          column_states_.emplace_back(
-              ColumnState{core::FlexVector<int64_t>(), {}});
+          state.storage = Storage{core::FlexVector<int64_t>()};
           break;
         case ColumnType::kDouble:
-          column_states_.emplace_back(
-              ColumnState{core::FlexVector<double>(), {}});
+          state.storage = Storage{core::FlexVector<double>()};
           break;
         case ColumnType::kString:
-          column_states_.emplace_back(
-              ColumnState{core::FlexVector<StringPool::Id>(), {}});
+          state.storage = Storage{core::FlexVector<StringPool::Id>()};
           break;
       }
     }
+    column_states_.emplace_back(std::move(state));
   }
   for (auto& name : names) {
     column_names_.emplace_back(std::move(name));
@@ -77,23 +73,17 @@ AdhocDataframeBuilder::AdhocDataframeBuilder(std::vector<std::string> names,
 
 void AdhocDataframeBuilder::AddPlaceholderValue(uint32_t col, uint32_t count) {
   auto& state = column_states_[col];
-  switch (state.data.index()) {
-    case base::variant_index<DataVariant, core::FlexVector<int64_t>>():
-      base::unchecked_get<core::FlexVector<int64_t>>(state.data)
-          .push_back_multiple(0, count);
-      break;
-    case base::variant_index<DataVariant, core::FlexVector<double>>():
-      base::unchecked_get<core::FlexVector<double>>(state.data)
-          .push_back_multiple(0.0, count);
-      break;
-    case base::variant_index<DataVariant, core::FlexVector<StringPool::Id>>():
-      base::unchecked_get<core::FlexVector<StringPool::Id>>(state.data)
-          .push_back_multiple(StringPool::Id::Null(), count);
-      break;
-    default:
-      // For std::nullopt_t, we don't need to push anything as the column
-      // type hasn't been determined yet.
-      break;
+  if (!state.storage) {
+    // Column type hasn't been determined yet - nothing to push.
+    return;
+  }
+  if (state.storage->type().Is<Int64>()) {
+    state.storage->unchecked_get<Int64>().push_back_multiple(0, count);
+  } else if (state.storage->type().Is<Double>()) {
+    state.storage->unchecked_get<Double>().push_back_multiple(0.0, count);
+  } else if (state.storage->type().Is<String>()) {
+    state.storage->unchecked_get<String>().push_back_multiple(
+        StringPool::Id::Null(), count);
   }
 }
 
@@ -104,103 +94,93 @@ base::StatusOr<Dataframe> AdhocDataframeBuilder::Build() && {
   for (uint32_t i = 0; i < column_names_.size(); ++i) {
     auto& state = column_states_[i];
     size_t non_null_row_count;
-    switch (state.data.index()) {
-      case base::variant_index<DataVariant, std::nullopt_t>():
-        non_null_row_count = 0;
-        columns.emplace_back(std::make_shared<Column>(Column{
-            Storage{core::FlexVector<uint32_t>()},
-            CreateNullStorageFromBitvector(std::move(state.null_overlay),
-                                           nullability_type_),
-            Unsorted{},
-            HasDuplicates{},
-        }));
-        break;
-      case base::variant_index<DataVariant, core::FlexVector<int64_t>>(): {
-        auto& data = base::unchecked_get<core::FlexVector<int64_t>>(state.data);
-        non_null_row_count = data.size();
-        duplicate_bit_vector_.clear();
+    if (!state.storage) {
+      non_null_row_count = 0;
+      columns.emplace_back(std::make_shared<Column>(Column{
+          Storage{core::FlexVector<uint32_t>()},
+          CreateNullStorageFromBitvector(std::move(state.null_overlay),
+                                         state.nullability_type),
+          Unsorted{},
+          HasDuplicates{},
+      }));
+    } else if (state.storage->type().Is<Int64>()) {
+      auto& data = state.storage->unchecked_get<Int64>();
+      non_null_row_count = data.size();
+      duplicate_bit_vector_.clear();
 
-        IntegerColumnSummary summary;
-        summary.is_id_sorted = data.empty() || data[0] == 0;
-        summary.is_setid_sorted = data.empty() || data[0] == 0;
-        summary.is_sorted = true;
-        summary.min = data.empty() ? 0 : data[0];
-        summary.max = data.empty() ? 0 : data[0];
+      IntegerColumnSummary summary;
+      summary.is_id_sorted = data.empty() || data[0] == 0;
+      summary.is_setid_sorted = data.empty() || data[0] == 0;
+      summary.is_sorted = true;
+      summary.min = data.empty() ? 0 : data[0];
+      summary.max = data.empty() ? 0 : data[0];
+      summary.has_duplicates =
+          data.empty() ? false : CheckDuplicate(data[0], data.size());
+      summary.is_nullable = state.null_overlay.has_value();
+      for (uint32_t j = 1; j < data.size(); ++j) {
+        summary.is_id_sorted = summary.is_id_sorted && (data[j] == j);
+        summary.is_setid_sorted =
+            summary.is_setid_sorted && (data[j] == data[j - 1] || data[j] == j);
+        summary.is_sorted = summary.is_sorted && data[j - 1] <= data[j];
+        summary.min = std::min(summary.min, data[j]);
+        summary.max = std::max(summary.max, data[j]);
         summary.has_duplicates =
-            data.empty() ? false : CheckDuplicate(data[0], data.size());
-        summary.is_nullable = state.null_overlay.has_value();
-        for (uint32_t j = 1; j < data.size(); ++j) {
-          summary.is_id_sorted = summary.is_id_sorted && (data[j] == j);
-          summary.is_setid_sorted = summary.is_setid_sorted &&
-                                    (data[j] == data[j - 1] || data[j] == j);
-          summary.is_sorted = summary.is_sorted && data[j - 1] <= data[j];
-          summary.min = std::min(summary.min, data[j]);
-          summary.max = std::max(summary.max, data[j]);
-          summary.has_duplicates =
-              summary.has_duplicates || CheckDuplicate(data[j], data.size());
-        }
-        auto integer = CreateIntegerStorage(std::move(data), summary);
-        SpecializedStorage specialized_storage =
-            GetSpecializedStorage(integer, summary);
-        columns.emplace_back(std::make_shared<Column>(Column{
-            std::move(integer),
-            CreateNullStorageFromBitvector(std::move(state.null_overlay),
-                                           nullability_type_),
-            GetIntegerSortStateFromProperties(summary),
-            summary.is_nullable || summary.has_duplicates
-                ? DuplicateState{HasDuplicates{}}
-                : DuplicateState{NoDuplicates{}},
-            std::move(specialized_storage),
-        }));
-        break;
+            summary.has_duplicates || CheckDuplicate(data[j], data.size());
       }
-      case base::variant_index<DataVariant, core::FlexVector<double>>(): {
-        auto& data = base::unchecked_get<core::FlexVector<double>>(state.data);
-        non_null_row_count = data.size();
+      auto integer = CreateIntegerStorage(std::move(data), summary);
+      SpecializedStorage specialized_storage =
+          GetSpecializedStorage(integer, summary);
+      columns.emplace_back(std::make_shared<Column>(Column{
+          std::move(integer),
+          CreateNullStorageFromBitvector(std::move(state.null_overlay),
+                                         state.nullability_type),
+          GetIntegerSortStateFromProperties(summary),
+          summary.is_nullable || summary.has_duplicates
+              ? DuplicateState{HasDuplicates{}}
+              : DuplicateState{NoDuplicates{}},
+          std::move(specialized_storage),
+      }));
+    } else if (state.storage->type().Is<Double>()) {
+      auto& data = state.storage->unchecked_get<Double>();
+      non_null_row_count = data.size();
 
-        bool is_nullable = state.null_overlay.has_value();
-        bool is_sorted = true;
-        for (uint32_t j = 1; j < data.size(); ++j) {
-          is_sorted = is_sorted && data[j - 1] <= data[j];
-        }
-        columns.emplace_back(std::make_shared<Column>(Column{
-            Storage{std::move(data)},
-            CreateNullStorageFromBitvector(std::move(state.null_overlay),
-                                           nullability_type_),
-            is_sorted && !is_nullable ? SortState{Sorted{}}
-                                      : SortState{Unsorted{}},
-            HasDuplicates{},
-        }));
-        break;
+      bool is_nullable = state.null_overlay.has_value();
+      bool is_sorted = true;
+      for (uint32_t j = 1; j < data.size(); ++j) {
+        is_sorted = is_sorted && data[j - 1] <= data[j];
       }
-      case base::variant_index<DataVariant,
-                               core::FlexVector<StringPool::Id>>(): {
-        auto& data =
-            base::unchecked_get<core::FlexVector<StringPool::Id>>(state.data);
-        non_null_row_count = data.size();
+      columns.emplace_back(std::make_shared<Column>(Column{
+          Storage{std::move(data)},
+          CreateNullStorageFromBitvector(std::move(state.null_overlay),
+                                         state.nullability_type),
+          is_sorted && !is_nullable ? SortState{Sorted{}}
+                                    : SortState{Unsorted{}},
+          HasDuplicates{},
+      }));
+    } else if (state.storage->type().Is<String>()) {
+      auto& data = state.storage->unchecked_get<String>();
+      non_null_row_count = data.size();
 
-        bool is_nullable = state.null_overlay.has_value();
-        bool is_sorted = true;
-        if (!data.empty()) {
-          NullTermStringView prev = string_pool_->Get(data[0]);
-          for (uint32_t j = 1; j < data.size(); ++j) {
-            NullTermStringView curr = string_pool_->Get(data[j]);
-            is_sorted = is_sorted && prev <= curr;
-            prev = curr;
-          }
+      bool is_nullable = state.null_overlay.has_value();
+      bool is_sorted = true;
+      if (!data.empty()) {
+        NullTermStringView prev = string_pool_->Get(data[0]);
+        for (uint32_t j = 1; j < data.size(); ++j) {
+          NullTermStringView curr = string_pool_->Get(data[j]);
+          is_sorted = is_sorted && prev <= curr;
+          prev = curr;
         }
-        columns.emplace_back(std::make_shared<Column>(Column{
-            Storage{std::move(data)},
-            CreateNullStorageFromBitvector(std::move(state.null_overlay),
-                                           nullability_type_),
-            is_sorted && !is_nullable ? SortState{Sorted{}}
-                                      : SortState{Unsorted{}},
-            HasDuplicates{},
-        }));
-        break;
       }
-      default:
-        PERFETTO_FATAL("Unexpected data variant in column %u", i);
+      columns.emplace_back(std::make_shared<Column>(Column{
+          Storage{std::move(data)},
+          CreateNullStorageFromBitvector(std::move(state.null_overlay),
+                                         state.nullability_type),
+          is_sorted && !is_nullable ? SortState{Sorted{}}
+                                    : SortState{Unsorted{}},
+          HasDuplicates{},
+      }));
+    } else {
+      PERFETTO_FATAL("Unexpected storage type in column %u", i);
     }
     uint64_t current_row_count =
         state.null_overlay ? state.null_overlay->size() : non_null_row_count;
@@ -329,45 +309,35 @@ SpecializedStorage::SmallValueEq AdhocDataframeBuilder::BuildSmallValueEq(
 }
 
 void AdhocDataframeBuilder::EnsureNullOverlayExists(ColumnState& state) {
-  uint64_t row_count;
-  switch (state.data.index()) {
-    case base::variant_index<DataVariant, std::nullopt_t>():
-      row_count = 0;
-      break;
-    case base::variant_index<DataVariant, core::FlexVector<int64_t>>():
-      row_count =
-          base::unchecked_get<core::FlexVector<int64_t>>(state.data).size();
-      break;
-    case base::variant_index<DataVariant, core::FlexVector<double>>():
-      row_count =
-          base::unchecked_get<core::FlexVector<double>>(state.data).size();
-      break;
-    case base::variant_index<DataVariant, core::FlexVector<StringPool::Id>>():
-      row_count =
-          base::unchecked_get<core::FlexVector<StringPool::Id>>(state.data)
-              .size();
-      break;
-    default:
-      PERFETTO_FATAL("Unexpected data type in column state.");
+  uint64_t row_count = 0;
+  if (state.storage) {
+    if (state.storage->type().Is<Int64>()) {
+      row_count = state.storage->unchecked_get<Int64>().size();
+    } else if (state.storage->type().Is<Double>()) {
+      row_count = state.storage->unchecked_get<Double>().size();
+    } else if (state.storage->type().Is<String>()) {
+      row_count = state.storage->unchecked_get<String>().size();
+    }
   }
   state.null_overlay =
       core::BitVector::CreateWithSize(static_cast<uint32_t>(row_count), true);
 }
 
-const char* AdhocDataframeBuilder::ToString(const DataVariant& data) {
-  static_assert(std::variant_size_v<DataVariant> == 4);
-  switch (data.index()) {
-    case base::variant_index<DataVariant, std::nullopt_t>():
-      return "NULL";
-    case base::variant_index<DataVariant, core::FlexVector<int64_t>>():
-      return "LONG";
-    case base::variant_index<DataVariant, core::FlexVector<double>>():
-      return "DOUBLE";
-    case base::variant_index<DataVariant, core::FlexVector<StringPool::Id>>():
-      return "STRING";
-    default:
-      PERFETTO_FATAL("Unexpected data type in column state.");
+const char* AdhocDataframeBuilder::ToString(
+    const std::optional<Storage>& storage) {
+  if (!storage) {
+    return "NULL";
   }
+  if (storage->type().Is<Int64>()) {
+    return "LONG";
+  }
+  if (storage->type().Is<Double>()) {
+    return "DOUBLE";
+  }
+  if (storage->type().Is<String>()) {
+    return "STRING";
+  }
+  PERFETTO_FATAL("Unexpected storage type.");
 }
 
 }  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/dataframe/adhoc_dataframe_builder.h
+++ b/src/trace_processor/core/dataframe/adhoc_dataframe_builder.h
@@ -205,7 +205,7 @@ class AdhocDataframeBuilder {
       EnsureNullOverlayExists(state);
     }
     state.null_overlay->push_back_multiple(false, count);
-    if (nullability_type_ == NullabilityType::kDenseNull) {
+    if (state.nullability_type == NullabilityType::kDenseNull) {
       // For dense null, we need to push placeholder values to the data storage
       // since DenseNull stores all values (with nulls marked by the bitvector).
       AddPlaceholderValue(col, count);
@@ -245,14 +245,10 @@ class AdhocDataframeBuilder {
   const base::Status& status() const { return current_status_; }
 
  private:
-  struct Null {};
-  using DataVariant = std::variant<std::nullopt_t,
-                                   core::FlexVector<int64_t>,
-                                   core::FlexVector<double>,
-                                   core::FlexVector<StringPool::Id>>;
   struct ColumnState {
-    DataVariant data = std::nullopt;
+    std::optional<Storage> storage;
     std::optional<core::BitVector> null_overlay;
+    NullabilityType nullability_type = NullabilityType::kSparseNull;
   };
   struct IntegerColumnSummary {
     bool is_id_sorted = true;
@@ -278,66 +274,55 @@ class AdhocDataframeBuilder {
   PERFETTO_ALWAYS_INLINE bool PushNonNullInternal(uint32_t col,
                                                   T value,
                                                   uint32_t count = 1) {
+    using FlexVec = core::FlexVector<T>;
+    using TypeTag = typename core::TypeTagFor<T>::type;
     auto& state = column_states_[col];
-    auto& data = state.data;
-    switch (data.index()) {
-      case base::variant_index<DataVariant, std::nullopt_t>(): {
-        data = core::FlexVector<T>();
-        auto& vec = base::unchecked_get<core::FlexVector<T>>(data);
-        vec.push_back_multiple(value, count);
-        break;
-      }
-      case base::variant_index<DataVariant, core::FlexVector<T>>(): {
-        auto& vec = base::unchecked_get<core::FlexVector<T>>(data);
-        vec.push_back_multiple(value, count);
-        break;
-      }
-      default: {
-        if constexpr (std::is_same_v<T, double>) {
-          if (std::holds_alternative<core::FlexVector<int64_t>>(data)) {
-            auto& vec = base::unchecked_get<core::FlexVector<int64_t>>(data);
-            auto res = core::FlexVector<double>::CreateWithSize(vec.size());
-            for (uint32_t i = 0; i < vec.size(); ++i) {
-              int64_t v = vec[i];
-              if (!IsPerfectlyRepresentableAsDouble(v)) {
-                current_status_ =
-                    base::ErrStatus("Unable to represent %" PRId64
-                                    " in column '%s' at row %u as a double.",
-                                    v, column_names_[col].c_str(), i);
-                return false;
-              }
-              res[i] = static_cast<double>(v);
-            }
-            res.push_back_multiple(value, count);
-            data = std::move(res);
-            break;
-          }
-        } else if constexpr (std::is_same_v<T, int64_t>) {
-          if (std::holds_alternative<core::FlexVector<double>>(data)) {
-            auto& vec = base::unchecked_get<core::FlexVector<double>>(data);
-            if (!IsPerfectlyRepresentableAsDouble(value)) {
-              current_status_ = base::ErrStatus(
-                  "Inserting a too-large integer (%" PRId64
-                  ") in column '%s' at row %" PRIu64
-                  ". Column currently holds doubles.",
-                  value, column_names_[col].c_str(), vec.size());
+    if (!state.storage) {
+      // No storage yet - create appropriate storage for this type.
+      state.storage = Storage{FlexVec{}};
+      state.storage->unchecked_get<TypeTag>().push_back_multiple(value, count);
+    } else if (state.storage->type().Is<TypeTag>()) {
+      // Same type - push directly.
+      state.storage->unchecked_get<TypeTag>().push_back_multiple(value, count);
+    } else {
+      // Type mismatch - try conversions or report error.
+      if constexpr (std::is_same_v<T, double>) {
+        if (state.storage->type().Is<Int64>()) {
+          auto& vec = state.storage->unchecked_get<Int64>();
+          auto res = Storage::Double::CreateWithSize(vec.size());
+          for (uint32_t i = 0; i < vec.size(); ++i) {
+            int64_t v = vec[i];
+            if (!IsPerfectlyRepresentableAsDouble(v)) {
+              current_status_ =
+                  base::ErrStatus("Unable to represent %" PRId64
+                                  " in column '%s' at row %u as a double.",
+                                  v, column_names_[col].c_str(), i);
               return false;
             }
-            vec.push_back_multiple(static_cast<double>(value), count);
-            break;
+            res[i] = static_cast<double>(v);
           }
-        }
-        if (did_declare_types_) {
-          current_status_ = base::ErrStatus(
-              "column '%s' declared as %s in the schema, but %s found",
-              column_names_[col].c_str(), ToString(data), ToString<T>());
+          res.push_back_multiple(value, count);
+          state.storage = Storage{std::move(res)};
         } else {
-          current_status_ = base::ErrStatus(
-              "column '%s' was inferred to be %s, but later received a value "
-              "of type %s",
-              column_names_[col].c_str(), ToString(data), ToString<T>());
+          return ReportTypeMismatch<T>(col);
         }
-        return false;
+      } else if constexpr (std::is_same_v<T, int64_t>) {
+        if (state.storage->type().Is<Double>()) {
+          auto& vec = state.storage->unchecked_get<Double>();
+          if (!IsPerfectlyRepresentableAsDouble(value)) {
+            current_status_ =
+                base::ErrStatus("Inserting a too-large integer (%" PRId64
+                                ") in column '%s' at row %" PRIu64
+                                ". Column currently holds doubles.",
+                                value, column_names_[col].c_str(), vec.size());
+            return false;
+          }
+          vec.push_back_multiple(static_cast<double>(value), count);
+        } else {
+          return ReportTypeMismatch<T>(col);
+        }
+      } else {
+        return ReportTypeMismatch<T>(col);
       }
     }
     if (PERFETTO_UNLIKELY(state.null_overlay)) {
@@ -350,13 +335,30 @@ class AdhocDataframeBuilder {
   PERFETTO_ALWAYS_INLINE void PushNonNullUncheckedInternal(uint32_t col,
                                                            T value,
                                                            uint32_t count) {
+    using TypeTag = typename core::TypeTagFor<T>::type;
     auto& state = column_states_[col];
-    PERFETTO_DCHECK(std::holds_alternative<core::FlexVector<T>>(state.data));
-    auto& data = base::unchecked_get<core::FlexVector<T>>(state.data);
-    data.push_back_multiple(value, count);
+    PERFETTO_DCHECK(state.storage && state.storage->type().Is<TypeTag>());
+    state.storage->unchecked_get<TypeTag>().push_back_multiple(value, count);
     if (PERFETTO_UNLIKELY(state.null_overlay)) {
       state.null_overlay->push_back_multiple(true, count);
     }
+  }
+
+  template <typename T>
+  bool ReportTypeMismatch(uint32_t col) {
+    if (did_declare_types_) {
+      current_status_ = base::ErrStatus(
+          "column '%s' declared as %s in the schema, but %s found",
+          column_names_[col].c_str(), ToString(column_states_[col].storage),
+          ToString<T>());
+    } else {
+      current_status_ = base::ErrStatus(
+          "column '%s' was inferred to be %s, but later received a value "
+          "of type %s",
+          column_names_[col].c_str(), ToString(column_states_[col].storage),
+          ToString<T>());
+    }
+    return false;
   }
 
   static Storage CreateIntegerStorage(core::FlexVector<int64_t> data,
@@ -419,7 +421,7 @@ class AdhocDataframeBuilder {
     return false;
   }
 
-  static const char* ToString(const DataVariant&);
+  static const char* ToString(const std::optional<Storage>&);
 
   template <typename T>
   static const char* ToString() {
@@ -438,7 +440,6 @@ class AdhocDataframeBuilder {
   std::vector<std::string> column_names_;
   std::vector<ColumnState> column_states_;
   bool did_declare_types_ = false;
-  NullabilityType nullability_type_ = NullabilityType::kSparseNull;
   base::Status current_status_ = base::OkStatus();
   core::BitVector duplicate_bit_vector_;
 };


### PR DESCRIPTION
Pure refactoring change, no behavior change.

Change ColumnState to use std::optional<Storage> instead of the
custom DataVariant type. This simplifies unnecessarily complex
code required when you use std::variant directly.

Key changes:
- Replace DataVariant with std::optional<Storage> in ColumnState
- Add per-column nullability_type to ColumnState
- Update all methods to work with new Storage-based structure
- Remove global nullability_type_ member variable
