### PR TITLE
stdlib: add upid to android_input_events

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/input.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/input.sql
@@ -24,6 +24,7 @@ SELECT
   str_split(str_split(slice.name, '=', 1), ',', 0) AS event_channel,
   thread.tid,
   thread.name AS thread_name,
+  process.upid,
   process.pid,
   process.name AS process_name,
   slice.ts,
@@ -48,6 +49,7 @@ SELECT
   str_split(str_split(slice.name, '=', 1), ',', 0) AS event_channel,
   thread.tid,
   thread.name AS thread_name,
+  process.upid,
   process.pid,
   process.name AS process_name,
   slice.ts,
@@ -202,6 +204,8 @@ CREATE PERFETTO TABLE android_input_events (
   tid LONG,
   -- Name of thread receiving the input event.
   thread_name STRING,
+  -- Upid of process receiving the input event.
+  upid JOINID(process.upid),
   -- Pid of process receiving the input event.
   pid LONG,
   -- Name of process receiving the input event.
@@ -284,6 +288,7 @@ SELECT
   frame.present_time - frame.read_time AS end_to_end_latency_dur,
   finish.tid AS tid,
   finish.thread_name AS thread_name,
+  finish.upid AS upid,
   finish.pid AS pid,
   finish.process_name AS process_name,
   dispatch.event_type,

--- a/test/trace_processor/diff_tests/stdlib/android/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/tests.py
@@ -1308,6 +1308,7 @@ class AndroidStdlib(TestSuite):
         dispatch_latency_dur,
         tid,
         thread_name,
+        upid,
         pid,
         process_name,
         event_type,
@@ -1322,17 +1323,17 @@ class AndroidStdlib(TestSuite):
         LIMIT 10
       """,
         out=Csv("""
-        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","tid","thread_name","pid","process_name","event_type","event_seq","event_channel","dispatch_ts","dispatch_dur","receive_ts","receive_dur"
-        377149054,77503,377032734,7493,"ndroid.systemui",7493,"com.android.systemui","0x3","0x1","4325794 NotificationShade (server)",578307771330,1292,578684804064,1412
-        1684318,772908,48433,7493,"ndroid.systemui",7493,"com.android.systemui","0x1","0x2","a0526ca NavigationBar0 (server)",581956322279,1299,581956370712,1806
-        22069988,12614508,804831,7493,"ndroid.systemui",7493,"com.android.systemui","0x1","0x3","4325794 NotificationShade (server)",581956391308,1212,581957196139,1362
-        1603522,645723,75328,7964,"droid.launcher3",7964,"com.android.launcher3","0x1","0x4","[Gesture Monitor] swipe-up (server)",581956445376,1232,581956520704,1708
-        1583707,644313,208973,7310,"android.ui",7288,"system_server","0x1","0x5","PointerEventDispatcher0 (server)",581956495788,1208,581956704761,1281
-        22622740,22582066,25729,7493,"ndroid.systemui",7493,"com.android.systemui","0x1","0x6","4325794 NotificationShade (server)",582019627670,1230,582019653399,1607
-        20228399,20116160,95263,7964,"droid.launcher3",7964,"com.android.launcher3","0x1","0x7","[Gesture Monitor] swipe-up (server)",582019685639,1309,582019780902,1942
-        459763,287436,27342,7310,"android.ui",7288,"system_server","0x1","0x8","PointerEventDispatcher0 (server)",582019737156,1192,582019764498,1664
-        9848456,9806401,22714,7493,"ndroid.systemui",7493,"com.android.systemui","0x1","0x9","4325794 NotificationShade (server)",582051061377,1227,582051084091,1596
-        5533919,5487703,25013,7964,"droid.launcher3",7964,"com.android.launcher3","0x1","0xa","[Gesture Monitor] swipe-up (server)",582051112236,1258,582051137249,1771
+        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","tid","thread_name","upid","pid","process_name","event_type","event_seq","event_channel","dispatch_ts","dispatch_dur","receive_ts","receive_dur"
+        377149054,77503,377032734,7493,"ndroid.systemui",399,7493,"com.android.systemui","0x3","0x1","4325794 NotificationShade (server)",578307771330,1292,578684804064,1412
+        1684318,772908,48433,7493,"ndroid.systemui",399,7493,"com.android.systemui","0x1","0x2","a0526ca NavigationBar0 (server)",581956322279,1299,581956370712,1806
+        22069988,12614508,804831,7493,"ndroid.systemui",399,7493,"com.android.systemui","0x1","0x3","4325794 NotificationShade (server)",581956391308,1212,581957196139,1362
+        1603522,645723,75328,7964,"droid.launcher3",418,7964,"com.android.launcher3","0x1","0x4","[Gesture Monitor] swipe-up (server)",581956445376,1232,581956520704,1708
+        1583707,644313,208973,7310,"android.ui",395,7288,"system_server","0x1","0x5","PointerEventDispatcher0 (server)",581956495788,1208,581956704761,1281
+        22622740,22582066,25729,7493,"ndroid.systemui",399,7493,"com.android.systemui","0x1","0x6","4325794 NotificationShade (server)",582019627670,1230,582019653399,1607
+        20228399,20116160,95263,7964,"droid.launcher3",418,7964,"com.android.launcher3","0x1","0x7","[Gesture Monitor] swipe-up (server)",582019685639,1309,582019780902,1942
+        459763,287436,27342,7310,"android.ui",395,7288,"system_server","0x1","0x8","PointerEventDispatcher0 (server)",582019737156,1192,582019764498,1664
+        9848456,9806401,22714,7493,"ndroid.systemui",399,7493,"com.android.systemui","0x1","0x9","4325794 NotificationShade (server)",582051061377,1227,582051084091,1596
+        5533919,5487703,25013,7964,"droid.launcher3",418,7964,"com.android.launcher3","0x1","0xa","[Gesture Monitor] swipe-up (server)",582051112236,1258,582051137249,1771
       """))
 
   def test_input_events_end_to_end_latency(self):
@@ -1347,6 +1348,7 @@ class AndroidStdlib(TestSuite):
         end_to_end_latency_dur,
         tid,
         thread_name,
+        upid,
         pid,
         process_name,
         event_type
@@ -1355,9 +1357,9 @@ class AndroidStdlib(TestSuite):
         ORDER BY dispatch_ts
       """,
         out=Csv("""
-        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","end_to_end_latency_dur","tid","thread_name","pid","process_name","event_type"
-        3422992,2937418,363000,51007097,4816,"ndroid.settings",4816,"com.android.settings","MOTION"
-        2139405,1956366,81387,50642855,4816,"ndroid.settings",4816,"com.android.settings","MOTION"
+        "total_latency_dur","handling_latency_dur","dispatch_latency_dur","end_to_end_latency_dur","tid","thread_name","upid","pid","process_name","event_type"
+        3422992,2937418,363000,51007097,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION"
+        2139405,1956366,81387,50642855,4816,"ndroid.settings",344,4816,"com.android.settings","MOTION"
       """))
 
   def test_job_scheduler_events(self):


### PR DESCRIPTION
This change adds upid of the process receiving the input event, in the table android_input_events.

Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter '.*input_events.*'

