### PR TITLE
tp: Allow inlining referenced queries to CTE

### DIFF
--- a/src/trace_processor/perfetto_sql/generator/structured_query_generator.h
+++ b/src/trace_processor/perfetto_sql/generator/structured_query_generator.h
@@ -53,13 +53,20 @@ class StructuredQueryGenerator {
   // `referenced_modules` have been included and all shared queries indicated
   // by `referenced_shared_queries` are available, either by tables or views or
   // as a common table expression (CTE).
-  base::StatusOr<std::string> Generate(const uint8_t* data, size_t size);
+  //
+  // If `inline_shared_queries` is true, shared queries will be inlined as CTEs
+  // in the generated SQL instead of being added to `referenced_queries()`.
+  // This makes the generated SQL self-contained.
+  base::StatusOr<std::string> Generate(const uint8_t* data,
+                                       size_t size,
+                                       bool inline_shared_queries = false);
 
   // Generates an SQL query for a query with the given id. The query should have
   // been added with `AddQuery`
   //
   // See `Generate` above for expectations of this function
-  base::StatusOr<std::string> GenerateById(const std::string& id);
+  base::StatusOr<std::string> GenerateById(const std::string& id,
+                                           bool inline_shared_queries = false);
 
   // Adds a query to the internal state to reference in all future calls to
   // `Generate*`. Returns the query's ID on success.

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -810,9 +810,11 @@ base::Status TraceProcessorImpl::AnalyzeStructuredQuery(
   const QueryBytes& target_query = *target_query_ptr;
 
   // Generate SQL for the target query (which can reference other queries via
-  // inner_query_id).
+  // inner_query_id). Use inline_shared_queries=true to include all referenced
+  // queries as CTEs, making the SQL self-contained.
   ASSIGN_OR_RETURN(output->sql,
-                   sqg.Generate(target_query.ptr, target_query.size));
+                   sqg.Generate(target_query.ptr, target_query.size,
+                                /*inline_shared_queries=*/true));
   output->textproto =
       perfetto::trace_processor::protozero_to_text::ProtozeroToText(
           metrics_descriptor_pool_,


### PR DESCRIPTION
When true, shared queries (referenced via inner_query_id) are included as CTEs in the generated SQL instead of being added to referenced_queries() for separate table creation.                                                                               
                                                                                                                                  
  - Summarize (default false): Creates separate tables for shared queries                                                         
  - AnalyzeStructuredQuery (true): Generates self-contained SQL with all dependencies as CTEs                                     
                                                                                                                                  
  This fixes the Explore Page issue where generated SQL referenced shared_sq_X tables that were never created.    