### PR TITLE
CI: update self-hosted runners

### DIFF
--- a/infra/ci/Makefile
+++ b/infra/ci/Makefile
@@ -42,6 +42,7 @@ build-sandbox: .deps/${BUILDER}-sandbox
 
 .PHONY: push
 push: build
+	echo "If push below fails run: gcloud auth configure-docker us-docker.pkg.dev"
 	${BUILDER} push ${WORKER_IMG}
 	${BUILDER} push ${SANDBOX_IMG}
 

--- a/infra/ci/sandbox/Dockerfile
+++ b/infra/ci/sandbox/Dockerfile
@@ -173,12 +173,10 @@ RUN set -ex; \
     chmod 755 ./*; \
     mkdir github-action-runner; \
     cd github-action-runner; \
-    # As of May 2024, a recent version. Please check for the latest.
-    # For example, on May 8 2025, 2.323.0 was a version.
     # You should update GHAR_VER to the latest from:
     # https://api.github.com/repos/actions/runner/releases/latest
     # Example: response.tag_name gives "v2.317.0", so GHAR_VER would be "2.317.0"
-    GHAR_VER=${GHAR_VER:-2.323.0}; \
+    GHAR_VER=${GHAR_VER:-2.331.0}; \
     GHAR_URL=https://github.com/actions/runner/releases/download/v${GHAR_VER}/actions-runner-linux-x64-${GHAR_VER}.tar.gz; \
     echo "Downloading GitHub Actions Runner version ${GHAR_VER} from ${GHAR_URL}"; \
     curl -L -o actions-runner.tar.gz $GHAR_URL; \


### PR DESCRIPTION
The runners are auto-updating as expected.
But somehow the fact that we start the older version
triggers GitHub into believing we are using old ones.

Context: thread [ACTION REQUIRED] Migrate Your GitHub Actions Self-Hosted Runners for google/perfetto