### PR TITLE
ui: Use relative timestamps to avoid expensive bigint conversions in the hotpath while retaining precision

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -134,6 +134,9 @@ interface CounterData {
   maxDisplayValues: Float64Array;
   lastDisplayValues: Float64Array;
   displayValueRange: [number, number];
+  // Relative timestamps for fast rendering (relative to dataStart)
+  dataStart: time;
+  timestampsRelNs: Float64Array;
 }
 
 // 0.5 Makes the horizontal lines sharp.
@@ -419,6 +422,8 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     maxDisplayValues: new Float64Array(0),
     lastDisplayValues: new Float64Array(0),
     displayValueRange: [0, 0],
+    dataStart: Time.ZERO,
+    timestampsRelNs: new Float64Array(0),
   };
 
   private limits?: CounterLimits;
@@ -680,6 +685,8 @@ export abstract class BaseCounterTrack implements TrackRenderer {
       maxDisplayValues: new Float64Array(0),
       lastDisplayValues: new Float64Array(0),
       displayValueRange: [0, 0],
+      dataStart: Time.ZERO,
+      timestampsRelNs: new Float64Array(0),
     };
     this.hover = undefined;
 
@@ -819,8 +826,12 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     ctx.fillStyle = `hsla(${hue}, 45%, 50%, 0.6)`;
     ctx.strokeStyle = `hsl(${hue}, 45%, 50%)`;
 
-    const calculateX = (ts: time) => {
-      return Math.floor(timescale.timeToPx(ts));
+    // Pre-compute conversion factors for fast timestamp-to-pixel conversion.
+    const pxPerNs = timescale.durationToPx(1n);
+    const baseOffsetPx = timescale.timeToPx(data.dataStart);
+
+    const calculateX = (relNs: number) => {
+      return Math.floor(relNs * pxPerNs + baseOffsetPx);
     };
     const calculateY = (value: number) => {
       return (
@@ -839,12 +850,10 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     }
 
     ctx.beginPath();
-    const timestamp = Time.fromRaw(timestamps[0]);
-    ctx.moveTo(Math.max(0, calculateX(timestamp)), zeroY);
+    ctx.moveTo(Math.max(0, calculateX(data.timestampsRelNs[0])), zeroY);
     let lastDrawnY = zeroY;
     for (let i = 0; i < timestamps.length; i++) {
-      const timestamp = Time.fromRaw(timestamps[i]);
-      const x = Math.max(0, calculateX(timestamp));
+      const x = Math.max(0, calculateX(data.timestampsRelNs[i]));
       const minY = calculateY(minValues[i]);
       const maxY = calculateY(maxValues[i]);
       const lastY = calculateY(lastValues[i]);
@@ -884,12 +893,14 @@ export abstract class BaseCounterTrack implements TrackRenderer {
       ctx.fillStyle = `hsl(${hue}, 45%, 75%)`;
       ctx.strokeStyle = `hsl(${hue}, 45%, 45%)`;
 
-      const rawXStart = calculateX(hover.ts);
+      // Convert hover timestamps to relative for calculateX
+      const hoverRelNs = Number(hover.ts - data.dataStart);
+      const rawXStart = calculateX(hoverRelNs);
       const xStart = Math.max(0, rawXStart);
       const xEnd =
         hover.tsEnd === undefined
           ? endPx
-          : Math.floor(timescale.timeToPx(hover.tsEnd));
+          : calculateX(Number(hover.tsEnd - data.dataStart));
       const y =
         MARGIN_TOP +
         effectiveHeight -
@@ -1127,18 +1138,22 @@ export abstract class BaseCounterTrack implements TrackRenderer {
     });
 
     const numRows = queryRes.numRows();
+    const dataStart = countersKey.start;
     const data: CounterData = {
       timestamps: new BigInt64Array(numRows),
       minDisplayValues: new Float64Array(numRows),
       maxDisplayValues: new Float64Array(numRows),
       lastDisplayValues: new Float64Array(numRows),
       displayValueRange: [0, 0],
+      dataStart,
+      timestampsRelNs: new Float64Array(numRows),
     };
 
     let min = 0;
     let max = 0;
     for (let row = 0; it.valid(); it.next(), row++) {
       data.timestamps[row] = Time.fromRaw(it.ts);
+      data.timestampsRelNs[row] = Number(it.ts - dataStart);
       data.minDisplayValues[row] = it.minDisplayValue;
       data.maxDisplayValues[row] = it.maxDisplayValue;
       data.lastDisplayValues[row] = it.lastDisplayValue;


### PR DESCRIPTION
Parent PR: https://github.com/google/perfetto/pull/4627

Cache slice start/end timestamps as floats offset from the start of the window. This means we can avoid doing expensive bigint conversions in the hotpath, only requiring much more efficient number math. Precision is retained for large timestamps as all the values are relative timestamps offset from the start of the loaded window, which is stored as a bigint.

## Testing
Average canvas render time before: **32ms**
After: **28ms**

## Test setup
- Macbook Pro 16 M1
- Android example trace
- Expand ftrace group, collpase cpu freq group, dismiss details panel - looks like this:
<img width="2056" height="1164" alt="image" src="https://github.com/user-attachments/assets/a1c256b5-40eb-4be8-9834-13f17267279e" />

