### PR TITLE
ui: Move trace.timeline out the hotpath

### DIFF
--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -982,11 +982,13 @@ export abstract class BaseSliceTrack<
   // onUpdatedSlices() this gives them a chance to call the highlighting without
   // having to reimplement it.
   protected highlightHoveredAndSameTitle(slices: Slice[]) {
+    const highlightedSliceId = this.trace.timeline.highlightedSliceId;
+    const hoveredTitle = this.hoveredSlice?.title;
     for (const slice of slices) {
       const isHovering =
-        this.trace.timeline.highlightedSliceId === slice.id ||
-        (this.hoveredSlice && this.hoveredSlice.title === slice.title);
-      slice.isHighlighted = !!isHovering;
+        highlightedSliceId === slice.id ||
+        (hoveredTitle && hoveredTitle === slice.title);
+      slice.isHighlighted = Boolean(isHovering);
     }
   }
 

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
@@ -471,6 +471,8 @@ export class GroupSummaryTrack implements TrackRenderer {
     const pxPerNs = timescale.durationToPx(1n);
     const baseOffsetPx = timescale.timeToPx(data.start);
 
+    const timeline = this.trace.timeline;
+
     for (let i = 0; i < data.ends.length; i++) {
       // Use pre-computed relative timestamps for fast pixel conversion
       const rectStart = Math.floor(data.startRelNs[i] * pxPerNs + baseOffsetPx);
@@ -491,9 +493,9 @@ export class GroupSummaryTrack implements TrackRenderer {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const pid = (threadInfo ? threadInfo.pid : -1) || -1;
 
-        const isHovering = this.trace.timeline.hoveredUtid !== undefined;
-        const isThreadHovered = this.trace.timeline.hoveredUtid === utid;
-        const isProcessHovered = this.trace.timeline.hoveredPid === pid;
+        const isHovering = timeline.hoveredUtid !== undefined;
+        const isThreadHovered = timeline.hoveredUtid === utid;
+        const isProcessHovered = timeline.hoveredPid === pid;
 
         if (isHovering && !isThreadHovered) {
           if (!isProcessHovered) {

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
@@ -336,6 +336,8 @@ export class CpuSliceTrack implements TrackRenderer {
     const [, rawEndIdx] = searchSegment(data.startQs, endTime);
     const endIdx = rawEndIdx === -1 ? data.startQs.length : rawEndIdx;
 
+    const timeline = this.trace.timeline;
+
     for (let i = startIdx; i < endIdx; i++) {
       const utid = data.utids[i];
 
@@ -357,9 +359,9 @@ export class CpuSliceTrack implements TrackRenderer {
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       const pid = threadInfo && threadInfo.pid ? threadInfo.pid : -1;
 
-      const isHovering = this.trace.timeline.hoveredUtid !== undefined;
-      const isThreadHovered = this.trace.timeline.hoveredUtid === utid;
-      const isProcessHovered = this.trace.timeline.hoveredPid === pid;
+      const isHovering = timeline.hoveredUtid !== undefined;
+      const isThreadHovered = timeline.hoveredUtid === utid;
+      const isProcessHovered = timeline.hoveredPid === pid;
       const colorScheme = data.colorSchemes[i];
       let color: Color;
       let textColor: Color;


### PR DESCRIPTION
Parent PR: https://github.com/google/perfetto/pull/4628

Calling trace.timeline creates a proxy which should not be called on the hot-path. It probably shouldn't, but a simpler fix is to just cache it outside the slice render loop. 

## Testing
Average canvas render time before: **28ms**
After: **21ms**

## Test setup
- Macbook Pro 16 M1
- Android example trace
- Expand ftrace group, collpase cpu freq group, dismiss details panel - looks like this:
<img width="2056" height="1164" alt="image" src="https://github.com/user-attachments/assets/a1c256b5-40eb-4be8-9834-13f17267279e" />