### PR TITLE
tp: signifcantly improve performance of mipmap operators

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -2836,6 +2836,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_clock",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
+        ":perfetto_src_trace_processor_util_galloping_search",
         ":perfetto_src_trace_processor_util_glob",
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
@@ -16281,6 +16282,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_clock",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
+        ":perfetto_src_trace_processor_util_galloping_search",
         ":perfetto_src_trace_processor_util_glob",
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
@@ -16575,6 +16577,11 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/util:galloping_search
+filegroup {
+    name: "perfetto_src_trace_processor_util_galloping_search",
+}
+
 // GN: //src/trace_processor/util:glob
 filegroup {
     name: "perfetto_src_trace_processor_util_glob",
@@ -16736,6 +16743,7 @@ filegroup {
     srcs: [
         "src/trace_processor/util/bump_allocator_unittest.cc",
         "src/trace_processor/util/debug_annotation_parser_unittest.cc",
+        "src/trace_processor/util/galloping_search_unittest.cc",
         "src/trace_processor/util/glob_unittest.cc",
         "src/trace_processor/util/gzip_utils_unittest.cc",
         "src/trace_processor/util/json_parser_unittest.cc",
@@ -18616,6 +18624,7 @@ cc_test {
         ":perfetto_src_trace_processor_util_clock",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
+        ":perfetto_src_trace_processor_util_galloping_search",
         ":perfetto_src_trace_processor_util_glob",
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
@@ -19474,6 +19483,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_util_clock",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
+        ":perfetto_src_trace_processor_util_galloping_search",
         ":perfetto_src_trace_processor_util_glob",
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",
@@ -19984,6 +19994,7 @@ cc_binary_host {
         ":perfetto_src_trace_processor_util_clock",
         ":perfetto_src_trace_processor_util_descriptors",
         ":perfetto_src_trace_processor_util_elf_elf",
+        ":perfetto_src_trace_processor_util_galloping_search",
         ":perfetto_src_trace_processor_util_glob",
         ":perfetto_src_trace_processor_util_gzip",
         ":perfetto_src_trace_processor_util_interned_message_view",

--- a/BUILD
+++ b/BUILD
@@ -429,6 +429,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_clock",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",
+        ":src_trace_processor_util_galloping_search",
         ":src_trace_processor_util_glob",
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",
@@ -640,6 +641,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_clock",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",
+        ":src_trace_processor_util_galloping_search",
         ":src_trace_processor_util_glob",
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",
@@ -4198,6 +4200,14 @@ perfetto_filegroup(
     srcs = [
         "src/trace_processor/util/descriptors.cc",
         "src/trace_processor/util/descriptors.h",
+    ],
+)
+
+# GN target: //src/trace_processor/util:galloping_search
+perfetto_filegroup(
+    name = "src_trace_processor_util_galloping_search",
+    srcs = [
+        "src/trace_processor/util/galloping_search.h",
     ],
 )
 
@@ -8222,6 +8232,7 @@ perfetto_cc_library(
         ":src_trace_processor_util_clock",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",
+        ":src_trace_processor_util_galloping_search",
         ":src_trace_processor_util_glob",
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",
@@ -8460,6 +8471,7 @@ perfetto_cc_binary(
         ":src_trace_processor_util_clock",
         ":src_trace_processor_util_descriptors",
         ":src_trace_processor_util_elf_elf",
+        ":src_trace_processor_util_galloping_search",
         ":src_trace_processor_util_glob",
         ":src_trace_processor_util_gzip",
         ":src_trace_processor_util_interned_message_view",

--- a/src/trace_processor/perfetto_sql/intrinsics/operators/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/BUILD.gn
@@ -36,6 +36,7 @@ source_set("operators") {
     "../../../../base",
     "../../../containers",
     "../../../sqlite",
+    "../../../util:galloping_search",
     "../../engine",
   ]
   if (enable_perfetto_etm_importer) {

--- a/src/trace_processor/perfetto_sql/intrinsics/operators/counter_mipmap_operator.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/counter_mipmap_operator.h
@@ -82,6 +82,8 @@ struct CounterMipmapOperator : sqlite::Module<CounterMipmapOperator> {
       int64_t last_ts;
     };
     std::vector<Result> counters;
+    std::vector<int64_t> queries;
+    std::vector<uint32_t> positions;
     uint32_t index;
   };
 

--- a/src/trace_processor/perfetto_sql/intrinsics/operators/slice_mipmap_operator.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/slice_mipmap_operator.h
@@ -86,6 +86,8 @@ struct SliceMipmapOperator : sqlite::Module<SliceMipmapOperator> {
       uint32_t depth;
     };
     std::vector<Result> results;
+    std::vector<int64_t> queries;
+    std::vector<uint32_t> positions;
     uint32_t index = 0;
   };
 

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -197,6 +197,11 @@ source_set("zip_reader") {
   }
 }
 
+source_set("galloping_search") {
+  sources = [ "galloping_search.h" ]
+  deps = [ "../../../gn:default_deps" ]
+}
+
 source_set("glob") {
   sources = [
     "glob.cc",
@@ -419,6 +424,7 @@ source_set("unittests") {
   sources = [
     "bump_allocator_unittest.cc",
     "debug_annotation_parser_unittest.cc",
+    "galloping_search_unittest.cc",
     "glob_unittest.cc",
     "json_parser_unittest.cc",
     "json_serializer_unittest.cc",
@@ -444,6 +450,7 @@ source_set("unittests") {
   deps = [
     ":bump_allocator",
     ":descriptors",
+    ":galloping_search",
     ":glob",
     ":gzip",
     ":json_parser",

--- a/src/trace_processor/util/galloping_search.h
+++ b/src/trace_processor/util/galloping_search.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_UTIL_GALLOPING_SEARCH_H_
+#define SRC_TRACE_PROCESSOR_UTIL_GALLOPING_SEARCH_H_
+
+#include <cstdint>
+
+namespace perfetto::trace_processor {
+
+// Galloping (exponential) search optimized for sorted queries.
+//
+// When searching for multiple keys that are themselves sorted, galloping search
+// exploits locality: each search starts from where the previous one ended,
+// using exponential probing to quickly find the new range, then binary search
+// within that range.
+//
+// Performance: O(log d) per query where d is the distance between consecutive
+// keys. Much faster than repeated std::lower_bound for sorted query batches.
+class GallopingSearch {
+ public:
+  GallopingSearch(const int64_t* data, uint32_t size) : data_(data), n_(size) {}
+
+  // Keys MUST be sorted in ascending order for this to work correctly.
+  // Results[i] will contain the lower_bound position for keys[i].
+  void BatchedLowerBound(const int64_t* keys,
+                         uint32_t num_keys,
+                         uint32_t* results) const {
+    if (n_ == 0) {
+      for (uint32_t i = 0; i < num_keys; ++i) {
+        results[i] = 0;
+      }
+      return;
+    }
+    uint32_t pos = LowerBound(0, n_, keys[0]);
+    results[0] = pos;
+    for (uint32_t i = 1; i < num_keys; ++i) {
+      pos = GallopForward(pos, keys[i]);
+      results[i] = pos;
+    }
+  }
+
+ private:
+  static constexpr uint32_t kLinearScanThreshold = 16;
+
+  uint32_t GallopForward(uint32_t pos, int64_t key) const {
+    if (pos >= n_ || data_[pos] >= key) {
+      return pos;
+    }
+    // Start at cache-line granularity (16 elements = 2 cache lines of int64_t)
+    // since nearby elements are already paged in when we access data[pos].
+    uint32_t step = kLinearScanThreshold;
+    uint32_t prev = pos;
+    while (pos + step < n_ && data_[pos + step] < key) {
+      prev = pos + step;
+      step *= 2;
+    }
+    uint32_t lo = prev + 1;
+    uint32_t hi = (pos + step + 1 > n_) ? n_ : pos + step + 1;
+    return LowerBound(lo, hi, key);
+  }
+
+  uint32_t LowerBound(uint32_t lo, uint32_t hi, int64_t key) const {
+    // Binary search until range is small enough for linear scan.
+    while (hi - lo > kLinearScanThreshold) {
+      uint32_t mid = lo + (hi - lo) / 2;
+      if (data_[mid] < key) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    // Linear scan for small ranges.
+    while (lo < hi && data_[lo] < key) {
+      ++lo;
+    }
+    return lo;
+  }
+
+  const int64_t* data_ = nullptr;
+  uint32_t n_ = 0;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_UTIL_GALLOPING_SEARCH_H_

--- a/src/trace_processor/util/galloping_search_unittest.cc
+++ b/src/trace_processor/util/galloping_search_unittest.cc
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/galloping_search.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor {
+namespace {
+
+std::vector<uint32_t> ExpectedLowerBounds(const std::vector<int64_t>& data,
+                                          const std::vector<int64_t>& keys) {
+  std::vector<uint32_t> expected;
+  expected.reserve(keys.size());
+  for (int64_t key : keys) {
+    auto it = std::lower_bound(data.begin(), data.end(), key);
+    expected.push_back(static_cast<uint32_t>(it - data.begin()));
+  }
+  return expected;
+}
+
+std::vector<int64_t> GenerateUniformKeys(int64_t start,
+                                         int64_t step,
+                                         size_t count) {
+  std::vector<int64_t> keys;
+  keys.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    keys.push_back(start + static_cast<int64_t>(i) * step);
+  }
+  return keys;
+}
+
+std::vector<int64_t> GenerateSortedRandomKeys(int64_t min_val,
+                                              int64_t max_val,
+                                              size_t count,
+                                              uint32_t seed = 42) {
+  std::vector<int64_t> keys;
+  keys.reserve(count);
+  std::mt19937 rng(seed);
+  std::uniform_int_distribution<int64_t> dist(min_val, max_val);
+  for (size_t i = 0; i < count; ++i) {
+    keys.push_back(dist(rng));
+  }
+  std::sort(keys.begin(), keys.end());
+  return keys;
+}
+
+TEST(GallopingSearchTest, Empty) {
+  std::vector<int64_t> data;
+  GallopingSearch searcher(data.data(), static_cast<uint32_t>(data.size()));
+
+  std::vector<int64_t> keys = {0, 100};
+  std::vector<uint32_t> results(keys.size());
+  searcher.BatchedLowerBound(keys.data(), static_cast<uint32_t>(keys.size()),
+                             results.data());
+  EXPECT_EQ(results[0], 0u);
+  EXPECT_EQ(results[1], 0u);
+}
+
+TEST(GallopingSearchTest, SingleElement) {
+  std::vector<int64_t> data = {50};
+  GallopingSearch searcher(data.data(), static_cast<uint32_t>(data.size()));
+
+  std::vector<int64_t> keys = {0, 50, 100};
+  std::vector<uint32_t> results(keys.size());
+  searcher.BatchedLowerBound(keys.data(), static_cast<uint32_t>(keys.size()),
+                             results.data());
+
+  auto expected = ExpectedLowerBounds(data, keys);
+  EXPECT_EQ(results, expected);
+}
+
+TEST(GallopingSearchTest, DenseQueries) {
+  std::vector<int64_t> data;
+  for (int64_t i = 0; i < 1000; ++i) {
+    data.push_back(i * 10);
+  }
+  GallopingSearch searcher(data.data(), static_cast<uint32_t>(data.size()));
+
+  auto keys = GenerateUniformKeys(0, 5, 200);
+  std::vector<uint32_t> results(keys.size());
+  searcher.BatchedLowerBound(keys.data(), static_cast<uint32_t>(keys.size()),
+                             results.data());
+
+  auto expected = ExpectedLowerBounds(data, keys);
+  EXPECT_EQ(results, expected);
+}
+
+TEST(GallopingSearchTest, SparseQueries) {
+  std::vector<int64_t> data;
+  for (int64_t i = 0; i < 10000; ++i) {
+    data.push_back(i * 10);
+  }
+  GallopingSearch searcher(data.data(), static_cast<uint32_t>(data.size()));
+
+  auto keys = GenerateUniformKeys(0, 1000, 100);
+  std::vector<uint32_t> results(keys.size());
+  searcher.BatchedLowerBound(keys.data(), static_cast<uint32_t>(keys.size()),
+                             results.data());
+
+  auto expected = ExpectedLowerBounds(data, keys);
+  EXPECT_EQ(results, expected);
+}
+
+TEST(GallopingSearchTest, RandomSortedKeys) {
+  std::vector<int64_t> data;
+  for (int64_t i = 0; i < 5000; ++i) {
+    data.push_back(i * 10);
+  }
+  GallopingSearch searcher(data.data(), static_cast<uint32_t>(data.size()));
+
+  auto keys = GenerateSortedRandomKeys(data.front(), data.back(), 500);
+  std::vector<uint32_t> results(keys.size());
+  searcher.BatchedLowerBound(keys.data(), static_cast<uint32_t>(keys.size()),
+                             results.data());
+
+  auto expected = ExpectedLowerBounds(data, keys);
+  EXPECT_EQ(results, expected);
+}
+
+TEST(GallopingSearchTest, KeysBeyondData) {
+  std::vector<int64_t> data = {10, 20, 30, 40, 50};
+  GallopingSearch searcher(data.data(), static_cast<uint32_t>(data.size()));
+
+  std::vector<int64_t> keys = {0, 5, 25, 35, 60, 100};
+  std::vector<uint32_t> results(keys.size());
+  searcher.BatchedLowerBound(keys.data(), static_cast<uint32_t>(keys.size()),
+                             results.data());
+
+  auto expected = ExpectedLowerBounds(data, keys);
+  EXPECT_EQ(results, expected);
+}
+
+TEST(GallopingSearchTest, DuplicateKeys) {
+  std::vector<int64_t> data = {10, 20, 20, 20, 30, 40};
+  GallopingSearch searcher(data.data(), static_cast<uint32_t>(data.size()));
+
+  std::vector<int64_t> keys = {15, 20, 25};
+  std::vector<uint32_t> results(keys.size());
+  searcher.BatchedLowerBound(keys.data(), static_cast<uint32_t>(keys.size()),
+                             results.data());
+
+  auto expected = ExpectedLowerBounds(data, keys);
+  EXPECT_EQ(results, expected);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor


### PR DESCRIPTION
Use galloping search instead of repeated lower_bounds to signifcantly speed up
performance.
