### PR TITLE
ui: Add MultiSelect options validation

### DIFF
--- a/ui/src/widgets/multiselect.ts
+++ b/ui/src/widgets/multiselect.ts
@@ -255,7 +255,7 @@ export class PopupMultiSelect
     const {options, showNumSelected, label} = attrs;
 
     if (showNumSelected) {
-      const numSelected = options.filter(({checked}) => checked).length;;
+      const numSelected = options.filter(({checked}) => checked).length;
       return `${label} (${numSelected} selected)`;
     } else {
       return label;


### PR DESCRIPTION
Providing duplicate ids in the MultiSelectAttrs options can lead to very unexpected side effects and late UI corruption.
This adds a minimal validation step with an explicit warning to speed up debugging.