### PR TITLE
ui: Fix flaky integration tests

### DIFF
--- a/ui/src/test/perfetto_ui_test_helper.ts
+++ b/ui/src/test/perfetto_ui_test_helper.ts
@@ -69,7 +69,7 @@ export class PerfettoTestHelper {
       localStorage.setItem('dismissedPanningHint', 'true'),
     );
     const tracePath = this.getTestTracePath(traceName);
-    assertExists(file).setInputFiles(tracePath);
+    await assertExists(file).setInputFiles(tracePath);
     await this.waitForPerfettoIdle();
     await this.applyTestingStyles();
     await this.page.mouse.move(0, 0);


### PR DESCRIPTION
Await setInputFiles() in PTH which fixes a race between this and waitForPerfettoIdle(). It seems running with more workers was making this race more likely.

Fixes flakes like this:

```
 1) [chromium] › test/startup_commands_allowlist.test.ts:311:7 › dev.perfetto.CollapseTracksByRegex with path filtering 

    Error: page.evaluate: RegistryError: dev.perfetto.CollapseTracksByRegex has not been registered.
```
