### PR TITLE
github: Append UI build links to PR comments instead of replacing

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -78,7 +78,12 @@ jobs:
             if (uiBuildUrl && context.issue.number) {
               // Unique marker to identify our comment
               const marker = "<!-- perfetto-ui-build-comment -->";
-              const body = `${marker}\n### 🎨 Perfetto UI Build\n\n✅ UI build is ready: ${uiBuildUrl}`;
+              const header = `${marker}\n### 🎨 Perfetto UI Builds\n`;
+
+              // Get commit info for the new entry
+              const commitSha = context.sha.substring(0, 7);
+              const commitDate = new Date().toISOString().split('T')[0];
+              const newEntry = `- **${commitSha}** (${commitDate}): ${uiBuildUrl}`;
 
               // Get existing comments
               const { data: comments } = await github.rest.issues.listComments({
@@ -90,8 +95,10 @@ jobs:
               // Find the bot's previous comment
               const botComment = comments.find(c => c.body.includes(marker));
 
-              // Update existing or create new
+              let body;
               if (botComment) {
+                // Append new entry to existing comment
+                body = botComment.body + '\n' + newEntry;
                 await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -99,6 +106,8 @@ jobs:
                   body: body
                 });
               } else {
+                // Create new comment with header and first entry
+                body = header + '\n' + newEntry;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,


### PR DESCRIPTION
Previously, the GitHub action would replace the entire PR comment body with just the latest UI build link. This made it difficult to track build history across multiple commits.

Now the action appends each new build as a list entry with the commit SHA and date, preserving the history of all builds for the PR.

Format: - **{commit_sha}** ({date}): {build_url}