### PR TITLE
ui: Fix ui/run-all-tests

### DIFF
--- a/ui/run-all-tests
+++ b/ui/run-all-tests
@@ -17,4 +17,4 @@ UI_DIR="$(cd -P ${BASH_SOURCE[0]%/*}; pwd)"
 
 $UI_DIR/node $UI_DIR/build.js --only-wasm-memory64 "$@"  # Build just once.
 $UI_DIR/node $UI_DIR/build.js --no-build --run-unittests "$@"
-$UI_DIR/node $UI_DIR/build.js --no-build --run-integrationtests "$@"
+$UI_DIR/run-integrationtests --no-build "$@"


### PR DESCRIPTION
Use the standalone ui/run-integrationtests helper instead of the no longer supported "build.js --run-integrationtests".