### PR TITLE
ui: Save recent graphs to local storage

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -56,6 +56,7 @@ import {
   showStateOverwriteWarning,
   showExportWarning,
 } from './query_builder/widgets';
+import {recentGraphsStorage} from './recent_graphs';
 
 registerCoreNodes();
 
@@ -112,6 +113,22 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
   private historyManager?: HistoryManager;
   private initializedNodes = new Set<string>();
   private executeFn?: () => Promise<void>;
+
+  /**
+   * Shows confirmation dialog if there are unsaved changes, and finalizes
+   * the current graph before loading a new one. Returns true if the user
+   * confirmed (or there was nothing to confirm), false if cancelled.
+   */
+  private async confirmAndFinalizeCurrentGraph(
+    state: ExplorePageState,
+  ): Promise<boolean> {
+    if (state.rootNodes.length > 0 || state.labels.length > 0) {
+      const confirmed = await showStateOverwriteWarning();
+      if (!confirmed) return false;
+      recentGraphsStorage.finalizeCurrentGraph();
+    }
+    return true;
+  }
 
   private selectNode(attrs: ExplorePageAttrs, node: QueryNode) {
     attrs.onStateUpdate((currentState) => ({
@@ -1576,11 +1593,8 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       if (files && files.length > 0) {
         const file = files[0];
 
-        // Show warning modal after file is selected (only if canvas has nodes or labels)
-        if (attrs.state.rootNodes.length > 0 || attrs.state.labels.length > 0) {
-          const confirmed = await showStateOverwriteWarning();
-          if (!confirmed) return;
-        }
+        // Show warning modal and finalize current graph before loading
+        if (!(await this.confirmAndFinalizeCurrentGraph(attrs.state))) return;
 
         const reader = new FileReader();
         reader.onload = async (e) => {
@@ -1708,11 +1722,8 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     jsonPath: string,
     errorTitle: string = 'Failed to Load',
   ): Promise<void> {
-    // Show warning modal before loading (only if canvas has nodes or labels)
-    if (attrs.state.rootNodes.length > 0 || attrs.state.labels.length > 0) {
-      const confirmed = await showStateOverwriteWarning();
-      if (!confirmed) return;
-    }
+    // Show warning modal and finalize current graph before loading
+    if (!(await this.confirmAndFinalizeCurrentGraph(attrs.state))) return;
 
     try {
       const response = await fetch(assetSrc(jsonPath));
@@ -1936,11 +1947,8 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         onImport: () => this.handleImport(wrappedAttrs),
         onExport: () => this.handleExport(state, trace),
         onLoadEmptyTemplate: async () => {
-          // Show warning modal before clearing (only if canvas has nodes or labels)
-          if (state.rootNodes.length > 0 || state.labels.length > 0) {
-            const confirmed = await showStateOverwriteWarning();
-            if (!confirmed) return;
-          }
+          // Show warning modal and finalize current graph before clearing
+          if (!(await this.confirmAndFinalizeCurrentGraph(state))) return;
 
           // Clear all nodes for empty graph and increment loadGeneration
           wrappedAttrs.onStateUpdate((currentState) => {
@@ -1957,13 +1965,15 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         onLoadExampleByPath: (jsonPath: string) =>
           this.loadJsonFromPath(wrappedAttrs, jsonPath, 'Failed to Load'),
         onLoadExploreTemplate: async () => {
-          // Show warning modal before loading (only if canvas has nodes or labels)
-          if (state.rootNodes.length > 0 || state.labels.length > 0) {
-            const confirmed = await showStateOverwriteWarning();
-            if (!confirmed) return;
-          }
+          // Show warning modal and finalize current graph before loading
+          if (!(await this.confirmAndFinalizeCurrentGraph(state))) return;
 
           await this.createExploreGraph(wrappedAttrs);
+        },
+        onLoadRecentGraph: async (json: string) => {
+          // Show warning modal and finalize current graph before loading
+          if (!(await this.confirmAndFinalizeCurrentGraph(state))) return;
+          await this.loadStateFromJson(wrappedAttrs, json);
         },
         onFilterAdd: (node, filter, filterOperator) => {
           this.handleFilterAdd(wrappedAttrs, node, filter, filterOperator);

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.scss
@@ -229,6 +229,59 @@
   max-width: 510px;
 }
 
+.pf-recent-graphs-section {
+  margin-bottom: 24px;
+  width: 100%;
+  max-width: 510px;
+  text-align: center;
+}
+
+.pf-recent-graphs-scroll-container {
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.pf-recent-graphs-empty {
+  color: var(--pf-color-text-muted);
+  font-size: var(--pf-font-size-m);
+  font-style: italic;
+}
+
+.pf-recent-graph-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  text-align: left;
+
+  > div:not(.pf-recent-graph-card__actions) {
+    flex: 1;
+    min-width: 0;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: var(--pf-font-size-m);
+    font-weight: 500;
+  }
+
+  p {
+    margin: 0;
+    font-size: var(--pf-font-size-s);
+    color: var(--pf-color-text-muted);
+  }
+
+  .pf-recent-graph-card__actions {
+    display: flex;
+    visibility: hidden;
+    flex-shrink: 0;
+  }
+
+  &:hover .pf-recent-graph-card__actions,
+  &:focus-within .pf-recent-graph-card__actions {
+    visibility: visible;
+  }
+}
+
 .pf-starting-section-title {
   font-size: 16px;
   font-weight: 500;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -205,6 +205,7 @@ export interface BuilderAttrs {
   readonly onLoadEmptyTemplate?: () => void;
   readonly onLoadExampleByPath?: (jsonPath: string) => void;
   readonly onLoadExploreTemplate?: () => void;
+  readonly onLoadRecentGraph?: (json: string) => void;
 
   // Node state change callback
   readonly onNodeStateChange?: () => void;
@@ -410,6 +411,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
               onLoadExampleByPath: attrs.onLoadExampleByPath,
               onLoadExploreTemplate: attrs.onLoadExploreTemplate,
               onLoadEmptyTemplate: attrs.onLoadEmptyTemplate,
+              onLoadRecentGraph: attrs.onLoadRecentGraph,
             }),
           );
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/navigation_sidepanel.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/navigation_sidepanel.ts
@@ -17,6 +17,7 @@ import {Card} from '../../../widgets/card';
 import {Icon} from '../../../widgets/icon';
 import {QueryNode} from '../query_node';
 import {EXAMPLE_GRAPHS} from '../example_graphs';
+import {RecentGraphsSection} from '../recent_graphs';
 
 // Helper function for keyboard-accessible card interactions
 function createKeyboardHandler(callback: () => void) {
@@ -64,6 +65,7 @@ export interface NavigationSidePanelAttrs {
   readonly onLoadExampleByPath?: (jsonPath: string) => void;
   readonly onLoadExploreTemplate?: () => void;
   readonly onLoadEmptyTemplate?: () => void;
+  readonly onLoadRecentGraph?: (json: string) => void;
 }
 
 export class NavigationSidePanel
@@ -153,6 +155,15 @@ export class NavigationSidePanel
           }),
         );
         results.push(m('.pf-solution-cards', ...solutionCards));
+      }
+
+      // Recent graphs section
+      if (attrs.onLoadRecentGraph !== undefined) {
+        results.push(
+          m(RecentGraphsSection, {
+            onLoadGraph: attrs.onLoadRecentGraph,
+          }),
+        );
       }
     }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/recent_graphs.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/recent_graphs.ts
@@ -1,0 +1,457 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {z} from 'zod';
+import {assertTrue} from '../../base/logging';
+import {Card, CardStack} from '../../widgets/card';
+import {Button} from '../../widgets/button';
+import {Icons} from '../../base/semantic_icons';
+import {ExplorePageState} from './explore_page';
+import {serializeState} from './json_handler';
+import {getAllNodes} from './query_builder/graph_utils';
+
+const RECENT_GRAPHS_KEY = 'recentExploreGraphs';
+
+// Schema for a single recent graph entry
+const RECENT_GRAPH_ENTRY_SCHEMA = z.object({
+  name: z.string(),
+  json: z.string(),
+  timestamp: z.number(),
+  nodeCount: z.number().optional(),
+  labelCount: z.number().optional(),
+  starred: z.boolean().default(false),
+});
+
+export type RecentGraphEntry = z.infer<typeof RECENT_GRAPH_ENTRY_SCHEMA>;
+
+const RECENT_GRAPHS_SCHEMA = z.array(RECENT_GRAPH_ENTRY_SCHEMA);
+
+export type RecentGraphs = z.infer<typeof RECENT_GRAPHS_SCHEMA>;
+
+/**
+ * Storage class for recent explore graphs.
+ * Stores serialized graph states in localStorage.
+ *
+ * The data array uses index 0 as a "working slot" for the current graph being
+ * edited. When the user switches to a different graph (via import, example, or
+ * clear), the current graph is "finalized" - it gets a proper name and becomes
+ * a historical entry at index 1+. A new empty placeholder is then inserted at
+ * index 0 for the next graph.
+ *
+ * Historical graphs (index 1+) are displayed in the Recent Graphs section.
+ * The working slot (index 0) is never displayed to the user.
+ */
+export class RecentGraphsStorage {
+  private _data: RecentGraphs;
+  maxItems = 10;
+
+  constructor() {
+    this._data = this.load();
+  }
+
+  /**
+   * Returns the recent graphs data. Historical graphs start at index 1.
+   * Index 0 is the current working graph (not displayed in UI).
+   */
+  get data(): RecentGraphs {
+    return this._data;
+  }
+
+  /**
+   * Sets the data directly. Used for testing.
+   */
+  set data(value: RecentGraphs) {
+    this._data = value;
+  }
+
+  /**
+   * Saves the current graph state. This updates the working slot (index 0),
+   * or creates it if the list is empty.
+   * Called on every state change to persist the current work.
+   */
+  saveCurrentState(state: ExplorePageState): void {
+    // Don't save empty graphs
+    if (state.rootNodes.length === 0) {
+      return;
+    }
+
+    const json = serializeState(state);
+    const timestamp = Date.now();
+    const nodeCount = getAllNodes(state.rootNodes).length;
+    const labelCount = state.labels.length;
+
+    if (this._data.length === 0) {
+      // No entries yet - create the working slot
+      this._data.unshift({
+        name: this.generateName(),
+        json,
+        timestamp,
+        nodeCount,
+        labelCount,
+        starred: false,
+      });
+    } else {
+      // Update the working slot in place
+      this._data[0].json = json;
+      this._data[0].timestamp = timestamp;
+      this._data[0].nodeCount = nodeCount;
+      this._data[0].labelCount = labelCount;
+    }
+    this.save();
+  }
+
+  /**
+   * Finalizes the current graph and prepares for a new one.
+   * Called when the user switches to a different graph (New graph, tutorial, etc.).
+   * The working slot (index 0) becomes a historical entry (moved to index 1+).
+   */
+  finalizeCurrentGraph(): void {
+    const hasWorkingGraph =
+      this._data.length > 0 && (this._data[0].nodeCount ?? 0) > 0;
+    if (!hasWorkingGraph) {
+      return;
+    }
+
+    // Give the current graph a proper name based on when it was finalized
+    this._data[0].name = this.generateName();
+
+    // Count unstarred items (excluding working slot which will become historical)
+    let lastUnstarredIndex = -1;
+    let unstarredCount = 0;
+    for (let i = 0; i < this._data.length; i++) {
+      if (!this._data[i].starred) {
+        unstarredCount++;
+        lastUnstarredIndex = i;
+      }
+    }
+
+    // If we're at max unstarred capacity, remove the oldest unstarred
+    // (but not the working slot at index 0)
+    if (unstarredCount >= this.maxItems && lastUnstarredIndex > 0) {
+      this._data.splice(lastUnstarredIndex, 1);
+    }
+
+    // Insert a new empty working slot at index 0
+    // This pushes the finalized graph to index 1
+    this._data.unshift({
+      name: 'Current',
+      json: '',
+      timestamp: Date.now(),
+      nodeCount: 0,
+      starred: false,
+    });
+
+    this.save();
+  }
+
+  /**
+   * Gets the most recent valid graph's JSON for restoring state on page load.
+   * Skips empty working slots and returns the first graph with actual content.
+   */
+  getCurrentJson(): string | undefined {
+    for (const entry of this._data) {
+      if (entry.json && (entry.nodeCount ?? 0) > 0) {
+        return entry.json;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Sets the starred status of a graph.
+   */
+  setStarred(index: number, starred: boolean): void {
+    assertTrue(index >= 0 && index < this._data.length);
+    this._data[index].starred = starred;
+    this.save();
+  }
+
+  /**
+   * Renames a graph.
+   */
+  rename(index: number, newName: string): void {
+    assertTrue(index >= 0 && index < this._data.length);
+    this._data[index].name = newName.trim() || this._data[index].name;
+    this.save();
+  }
+
+  /**
+   * Generates a unique name for a new graph based on timestamp.
+   */
+  generateName(): string {
+    const now = new Date();
+    const dateStr = now.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+    const timeStr = now.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    return `Graph ${dateStr} ${timeStr}`;
+  }
+
+  /**
+   * Gets a graph's JSON by index.
+   */
+  getJson(index: number): string | undefined {
+    if (index >= 0 && index < this._data.length) {
+      return this._data[index].json;
+    }
+    return undefined;
+  }
+
+  /**
+   * Removes a graph from the list by index.
+   */
+  remove(index: number): void {
+    assertTrue(index >= 0 && index < this._data.length);
+    this._data.splice(index, 1);
+    this.save();
+  }
+
+  /**
+   * Clears all stored data. Used when stored data is corrupted.
+   */
+  clear(): void {
+    this._data = [];
+    this.save();
+  }
+
+  private load(): RecentGraphs {
+    const value = window.localStorage.getItem(RECENT_GRAPHS_KEY);
+    if (value === null) {
+      return [];
+    }
+    try {
+      const res = RECENT_GRAPHS_SCHEMA.safeParse(JSON.parse(value));
+      return res.success ? res.data : [];
+    } catch {
+      // Invalid JSON in localStorage, return empty array
+      return [];
+    }
+  }
+
+  private save(): void {
+    try {
+      window.localStorage.setItem(
+        RECENT_GRAPHS_KEY,
+        JSON.stringify(this._data),
+      );
+    } catch (e) {
+      // Handle localStorage quota exceeded or other storage errors.
+      // Log the error but don't crash - recent graphs is a nice-to-have feature.
+      console.warn('Failed to save recent graphs to localStorage:', e);
+    }
+  }
+}
+
+// Singleton instance
+export const recentGraphsStorage = new RecentGraphsStorage();
+
+export interface RecentGraphsSectionAttrs {
+  readonly onLoadGraph: (json: string) => void;
+}
+
+interface RecentGraphCardAttrs {
+  readonly entry: RecentGraphEntry;
+  readonly index: number;
+  readonly onLoadGraph: (json: string) => void;
+}
+
+/**
+ * Component that renders a single recent graph card.
+ */
+class RecentGraphCard implements m.ClassComponent<RecentGraphCardAttrs> {
+  private isEditing = false;
+  private editName = '';
+
+  private startEditing(entry: RecentGraphEntry, e: Event): void {
+    e.stopPropagation();
+    this.isEditing = true;
+    this.editName = entry.name;
+  }
+
+  private finishEditing(index: number): void {
+    if (this.editName.trim()) {
+      recentGraphsStorage.rename(index, this.editName);
+    }
+    this.isEditing = false;
+  }
+
+  private cancelEditing(): void {
+    this.isEditing = false;
+  }
+
+  view({attrs}: m.CVnode<RecentGraphCardAttrs>): m.Children {
+    const {entry, index} = attrs;
+
+    if (this.isEditing) {
+      return m(
+        Card,
+        {
+          className: 'pf-recent-graph-card',
+          onclick: (e: Event) => e.stopPropagation(),
+        },
+        m(
+          'div',
+          m('input', {
+            type: 'text',
+            value: this.editName,
+            oninput: (e: Event) => {
+              this.editName = (e.target as HTMLInputElement).value;
+            },
+            onkeydown: (e: KeyboardEvent) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                this.finishEditing(index);
+              } else if (e.key === 'Escape') {
+                e.preventDefault();
+                this.cancelEditing();
+              }
+            },
+            oncreate: (vnode: m.VnodeDOM<unknown>) => {
+              (vnode.dom as HTMLInputElement).focus();
+              (vnode.dom as HTMLInputElement).select();
+            },
+          }),
+          m('p', `${entry.nodeCount ?? '?'} nodes`),
+        ),
+        m(
+          '.pf-recent-graph-card__actions',
+          m(Button, {
+            icon: 'check',
+            title: 'Save',
+            onclick: (e: Event) => {
+              e.stopPropagation();
+              this.finishEditing(index);
+            },
+          }),
+          m(Button, {
+            icon: 'close',
+            title: 'Cancel',
+            onclick: (e: Event) => {
+              e.stopPropagation();
+              this.cancelEditing();
+            },
+          }),
+        ),
+      );
+    }
+
+    const nodeCount = entry.nodeCount ?? 0;
+    const labelCount = entry.labelCount ?? 0;
+
+    return m(
+      Card,
+      {
+        interactive: true,
+        className: 'pf-recent-graph-card',
+        onclick: () => {
+          const json = recentGraphsStorage.getJson(index);
+          if (json !== undefined) {
+            attrs.onLoadGraph(json);
+          }
+        },
+      },
+      m(Button, {
+        icon: Icons.Star,
+        iconFilled: entry.starred,
+        title: entry.starred ? 'Unstar' : 'Star',
+        onclick: (e: Event) => {
+          e.stopPropagation();
+          recentGraphsStorage.setStarred(index, !entry.starred);
+        },
+      }),
+      m(
+        'div',
+        m('h3', entry.name),
+        m('p', `${nodeCount} nodes, ${labelCount} labels`),
+      ),
+      m(
+        '.pf-recent-graph-card__actions',
+        m(Button, {
+          icon: 'edit',
+          title: 'Rename',
+          onclick: (e: Event) => this.startEditing(entry, e),
+        }),
+        m(Button, {
+          icon: Icons.Delete,
+          title: 'Remove from recent',
+          onclick: (e: Event) => {
+            e.stopPropagation();
+            recentGraphsStorage.remove(index);
+          },
+        }),
+      ),
+    );
+  }
+}
+
+/**
+ * Component that renders the "Recent graphs" section in the sidebar.
+ * Shows historical graphs (not the current one at index 0).
+ * Starred graphs appear first, followed by unstarred graphs.
+ * Always shows the section header, even when empty.
+ */
+export class RecentGraphsSection
+  implements m.ClassComponent<RecentGraphsSectionAttrs>
+{
+  view({attrs}: m.CVnode<RecentGraphsSectionAttrs>): m.Children {
+    const recentGraphs = recentGraphsStorage.data;
+
+    // Separate starred and unstarred graphs while preserving indices
+    // Start from index 1 to skip the current graph (index 0)
+    const starred: Array<{entry: RecentGraphEntry; index: number}> = [];
+    const unstarred: Array<{entry: RecentGraphEntry; index: number}> = [];
+
+    for (let i = 1; i < recentGraphs.length; i++) {
+      const entry = recentGraphs[i];
+      // Skip empty placeholders (working slots with no content)
+      if ((entry.nodeCount ?? 0) === 0) continue;
+
+      if (entry.starred) {
+        starred.push({entry, index: i});
+      } else {
+        unstarred.push({entry, index: i});
+      }
+    }
+
+    // Render starred first, then unstarred
+    const allCards = [...starred, ...unstarred];
+
+    return m(
+      '.pf-recent-graphs-section',
+      m('h4.pf-starting-section-title', 'Recent graphs'),
+      allCards.length > 0
+        ? m(
+            '.pf-recent-graphs-scroll-container',
+            m(
+              CardStack,
+              allCards.map(({entry, index}) =>
+                m(RecentGraphCard, {
+                  key: index,
+                  entry,
+                  index,
+                  onLoadGraph: attrs.onLoadGraph,
+                }),
+              ),
+            ),
+          )
+        : m('.pf-recent-graphs-empty', 'No recent graphs'),
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/recent_graphs_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/recent_graphs_unittest.ts
@@ -1,0 +1,330 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {recentGraphsStorage, RecentGraphEntry} from './recent_graphs';
+
+describe('RecentGraphsStorage', () => {
+  beforeEach(() => {
+    // Clear localStorage before each test
+    window.localStorage.clear();
+    // Reset the storage instance
+    recentGraphsStorage.data = [];
+  });
+
+  // Helper to create a mock graph entry
+  function createEntry(
+    nodeCount: number,
+    options?: Partial<RecentGraphEntry>,
+  ): RecentGraphEntry {
+    return {
+      name: options?.name ?? `Graph ${nodeCount}`,
+      json: options?.json ?? `{"nodes": ${nodeCount}}`,
+      timestamp: options?.timestamp ?? Date.now(),
+      nodeCount,
+      labelCount: options?.labelCount ?? 0,
+      starred: options?.starred ?? false,
+    };
+  }
+
+  describe('data getter/setter', () => {
+    test('should start with empty data after clear', () => {
+      expect(recentGraphsStorage.data.length).toBe(0);
+    });
+
+    test('should allow setting data directly', () => {
+      recentGraphsStorage.data = [createEntry(3)];
+      expect(recentGraphsStorage.data.length).toBe(1);
+      expect(recentGraphsStorage.data[0].nodeCount).toBe(3);
+    });
+  });
+
+  describe('finalizeCurrentGraph', () => {
+    test('should do nothing when there is no working graph', () => {
+      recentGraphsStorage.finalizeCurrentGraph();
+      expect(recentGraphsStorage.data.length).toBe(0);
+    });
+
+    test('should do nothing when working graph has zero nodes', () => {
+      recentGraphsStorage.data = [createEntry(0)];
+      recentGraphsStorage.finalizeCurrentGraph();
+      // Should still be just one entry (unchanged)
+      expect(recentGraphsStorage.data.length).toBe(1);
+    });
+
+    test('should finalize current graph and create new working slot', () => {
+      recentGraphsStorage.data = [createEntry(3)];
+      expect(recentGraphsStorage.data.length).toBe(1);
+
+      recentGraphsStorage.finalizeCurrentGraph();
+
+      // Should now have 2 entries: new working slot at 0, finalized graph at 1
+      expect(recentGraphsStorage.data.length).toBe(2);
+      expect(recentGraphsStorage.data[0].nodeCount).toBe(0); // New empty working slot
+      expect(recentGraphsStorage.data[1].nodeCount).toBe(3); // Finalized graph
+    });
+
+    test('should enforce maxItems limit for unstarred graphs', () => {
+      const originalMaxItems = recentGraphsStorage.maxItems;
+      recentGraphsStorage.maxItems = 3;
+
+      // Set up 3 existing finalized graphs (index 0 is working slot)
+      recentGraphsStorage.data = [
+        createEntry(4), // Working slot with content
+        createEntry(3),
+        createEntry(2),
+        createEntry(1),
+      ];
+
+      // Finalize current - should remove oldest unstarred
+      recentGraphsStorage.finalizeCurrentGraph();
+
+      // Count unstarred items with content
+      const unstarredWithContent = recentGraphsStorage.data.filter(
+        (e) => !e.starred && (e.nodeCount ?? 0) > 0,
+      );
+
+      // Should have at most maxItems unstarred graphs with content
+      expect(unstarredWithContent.length).toBeLessThanOrEqual(3);
+
+      recentGraphsStorage.maxItems = originalMaxItems;
+    });
+
+    test('should not count starred graphs toward maxItems limit', () => {
+      const originalMaxItems = recentGraphsStorage.maxItems;
+      recentGraphsStorage.maxItems = 2;
+
+      // Set up data with one starred graph and working slot
+      recentGraphsStorage.data = [
+        createEntry(4), // Working slot with content
+        createEntry(3, {starred: true}), // Starred - should be preserved
+        createEntry(2),
+        createEntry(1),
+      ];
+
+      recentGraphsStorage.finalizeCurrentGraph();
+
+      // Count starred and unstarred with content
+      const starred = recentGraphsStorage.data.filter(
+        (e) => e.starred && (e.nodeCount ?? 0) > 0,
+      );
+      const unstarred = recentGraphsStorage.data.filter(
+        (e) => !e.starred && (e.nodeCount ?? 0) > 0,
+      );
+
+      // Should have 1 starred graph preserved
+      expect(starred.length).toBe(1);
+
+      // Should have at most maxItems unstarred graphs
+      expect(unstarred.length).toBeLessThanOrEqual(2);
+
+      recentGraphsStorage.maxItems = originalMaxItems;
+    });
+  });
+
+  describe('getCurrentJson', () => {
+    test('should return undefined when no graphs exist', () => {
+      expect(recentGraphsStorage.getCurrentJson()).toBeUndefined();
+    });
+
+    test('should return undefined when only empty working slot exists', () => {
+      recentGraphsStorage.data = [createEntry(0)];
+      expect(recentGraphsStorage.getCurrentJson()).toBeUndefined();
+    });
+
+    test('should return first graph with content', () => {
+      recentGraphsStorage.data = [createEntry(2, {json: '{"test": true}'})];
+
+      const json = recentGraphsStorage.getCurrentJson();
+      expect(json).toBe('{"test": true}');
+    });
+
+    test('should skip empty working slot and return finalized graph', () => {
+      recentGraphsStorage.data = [
+        createEntry(0), // Empty working slot
+        createEntry(3, {json: '{"finalized": true}'}),
+      ];
+
+      const json = recentGraphsStorage.getCurrentJson();
+      expect(json).toBe('{"finalized": true}');
+    });
+  });
+
+  describe('setStarred', () => {
+    test('should star a graph', () => {
+      recentGraphsStorage.data = [createEntry(2)];
+      recentGraphsStorage.setStarred(0, true);
+
+      expect(recentGraphsStorage.data[0].starred).toBe(true);
+    });
+
+    test('should unstar a graph', () => {
+      recentGraphsStorage.data = [createEntry(2, {starred: true})];
+      recentGraphsStorage.setStarred(0, false);
+
+      expect(recentGraphsStorage.data[0].starred).toBe(false);
+    });
+  });
+
+  describe('rename', () => {
+    test('should rename a graph', () => {
+      recentGraphsStorage.data = [createEntry(2)];
+      recentGraphsStorage.rename(0, 'My Custom Name');
+
+      expect(recentGraphsStorage.data[0].name).toBe('My Custom Name');
+    });
+
+    test('should trim whitespace from name', () => {
+      recentGraphsStorage.data = [createEntry(2)];
+      recentGraphsStorage.rename(0, '  Trimmed Name  ');
+
+      expect(recentGraphsStorage.data[0].name).toBe('Trimmed Name');
+    });
+
+    test('should keep original name if new name is empty', () => {
+      recentGraphsStorage.data = [createEntry(2, {name: 'Original'})];
+      recentGraphsStorage.rename(0, '   ');
+
+      expect(recentGraphsStorage.data[0].name).toBe('Original');
+    });
+  });
+
+  describe('getJson', () => {
+    test('should return undefined for invalid index', () => {
+      expect(recentGraphsStorage.getJson(-1)).toBeUndefined();
+      expect(recentGraphsStorage.getJson(0)).toBeUndefined();
+      expect(recentGraphsStorage.getJson(100)).toBeUndefined();
+    });
+
+    test('should return json for valid index', () => {
+      recentGraphsStorage.data = [createEntry(2, {json: '{"test": 123}'})];
+      const json = recentGraphsStorage.getJson(0);
+
+      expect(json).toBe('{"test": 123}');
+    });
+  });
+
+  describe('remove', () => {
+    test('should remove a graph from history', () => {
+      recentGraphsStorage.data = [
+        createEntry(0), // Working slot
+        createEntry(3),
+        createEntry(2),
+        createEntry(1),
+      ];
+
+      const initialLength = recentGraphsStorage.data.length;
+      recentGraphsStorage.remove(2); // Remove middle entry
+
+      expect(recentGraphsStorage.data.length).toBe(initialLength - 1);
+      expect(recentGraphsStorage.data[2].nodeCount).toBe(1); // Last entry moved up
+    });
+
+    test('should remove first entry', () => {
+      recentGraphsStorage.data = [createEntry(1), createEntry(2)];
+      recentGraphsStorage.remove(0);
+
+      expect(recentGraphsStorage.data.length).toBe(1);
+      expect(recentGraphsStorage.data[0].nodeCount).toBe(2);
+    });
+
+    test('should remove last entry', () => {
+      recentGraphsStorage.data = [createEntry(1), createEntry(2)];
+      recentGraphsStorage.remove(1);
+
+      expect(recentGraphsStorage.data.length).toBe(1);
+      expect(recentGraphsStorage.data[0].nodeCount).toBe(1);
+    });
+  });
+
+  describe('clear', () => {
+    test('should clear all data', () => {
+      recentGraphsStorage.data = [
+        createEntry(1),
+        createEntry(2),
+        createEntry(3),
+      ];
+      recentGraphsStorage.clear();
+
+      expect(recentGraphsStorage.data.length).toBe(0);
+    });
+  });
+
+  describe('generateName', () => {
+    test('should generate a name with date and time', () => {
+      const name = recentGraphsStorage.generateName();
+
+      // Should contain "Graph" and some date/time info
+      expect(name).toContain('Graph');
+      // Should match pattern like "Graph Jan 15 14:30"
+      expect(name).toMatch(/Graph \w+ \d+ \d{2}:\d{2}/);
+    });
+  });
+
+  describe('persistence', () => {
+    test('should persist graphs to localStorage', () => {
+      recentGraphsStorage.data = [createEntry(2)];
+      // Trigger save by calling a mutating method
+      recentGraphsStorage.setStarred(0, true);
+
+      const stored = window.localStorage.getItem('recentExploreGraphs');
+      expect(stored).not.toBeNull();
+
+      const parsed = JSON.parse(stored!);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].nodeCount).toBe(2);
+      expect(parsed[0].starred).toBe(true);
+    });
+
+    test('should persist renamed graph', () => {
+      recentGraphsStorage.data = [createEntry(2)];
+      recentGraphsStorage.rename(0, 'Custom Name');
+
+      const stored = window.localStorage.getItem('recentExploreGraphs');
+      const parsed = JSON.parse(stored!);
+      expect(parsed[0].name).toBe('Custom Name');
+    });
+
+    test('should persist removal', () => {
+      recentGraphsStorage.data = [createEntry(1), createEntry(2)];
+      recentGraphsStorage.remove(0);
+
+      const stored = window.localStorage.getItem('recentExploreGraphs');
+      const parsed = JSON.parse(stored!);
+      expect(parsed.length).toBe(1);
+      expect(parsed[0].nodeCount).toBe(2);
+    });
+  });
+
+  describe('historical graphs ordering', () => {
+    test('starred graphs should be identifiable in data', () => {
+      recentGraphsStorage.data = [
+        createEntry(0), // Working slot
+        createEntry(1, {starred: false}),
+        createEntry(2, {starred: true}),
+        createEntry(3, {starred: false}),
+      ];
+
+      const starred = recentGraphsStorage.data.filter(
+        (e, i) => i > 0 && e.starred,
+      );
+      const unstarred = recentGraphsStorage.data.filter(
+        (e, i) => i > 0 && !e.starred,
+      );
+
+      expect(starred.length).toBe(1);
+      expect(starred[0].nodeCount).toBe(2);
+      expect(unstarred.length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
Add a RecentGraphsStorage class that persists explore graphs to localStorage. Graphs are saved automatically on state changes and finalized when the user switches to a new graph (via import, example, or clear). The Recent Graphs section in the sidebar shows historical graphs with starring, rename, and delete capabilities.
