### PR TITLE
Migrate tools/test_data from `gsutil` to `gcloud storage`

### DIFF
--- a/tools/test_data
+++ b/tools/test_data
@@ -151,7 +151,10 @@ def cmd_upload(dir):
     assert (fs.actual_digest is not None)
     dst_name = '%s/%s-%s' % (args.bucket, os.path.basename(
         fs.path), fs.actual_digest)
-    cmd = ['gsutil', '-q', 'cp', '-n', '-a', 'public-read', fs.path, dst_name]
+    cmd = [
+        'gcloud', 'storage', '-q', 'cp', '-n', '-a', 'publicRead', fs.path,
+        dst_name
+    ]
     logging.debug(' '.join(cmd))
     subprocess.check_call(cmd)
     with open(fs.path + SUFFIX + '.swp', 'w') as f:


### PR DESCRIPTION
According to https://docs.cloud.google.com/storage/docs/gsutil, `gsutil` is not the recommended CLI for Cloud Storage.