### PR TITLE
Remove cts tag from testing APKs for perfetto modules.

### DIFF
--- a/test/cts/producer/Android.bp
+++ b/test/cts/producer/Android.bp
@@ -25,7 +25,6 @@ android_test_helper_app {
     name: "CtsPerfettoProducerApp",
     // tag this module as a cts test artifact
     test_suites: [
-        "cts",
         "vts10",
         "general-tests",
     ],

--- a/test/cts/test_apps/Android.bp
+++ b/test/cts/test_apps/Android.bp
@@ -25,7 +25,6 @@ android_test_helper_app {
     name: "CtsPerfettoDebuggableApp",
     // tag this module as a cts test artifact
     test_suites: [
-        "cts",
         "vts10",
         "general-tests",
     ],
@@ -48,7 +47,6 @@ android_test_helper_app {
     name: "CtsPerfettoReleaseApp",
     // tag this module as a cts test artifact
     test_suites: [
-        "cts",
         "vts10",
         "general-tests",
     ],
@@ -71,7 +69,6 @@ android_test_helper_app {
     name: "CtsPerfettoProfileableApp",
     // tag this module as a cts test artifact
     test_suites: [
-        "cts",
         "vts10",
         "general-tests",
     ],
@@ -94,7 +91,6 @@ android_test_helper_app {
     name: "CtsPerfettoNonProfileableApp",
     // tag this module as a cts test artifact
     test_suites: [
-        "cts",
         "vts10",
         "general-tests",
     ],


### PR DESCRIPTION
Only the true modules should be tagged with cts in their test_suites
property. Dependencies like testing APKs do not require cts tagging.

Test: presubmit
Bug: 457307300
Change-Id: I939ba91a81acd847a22618231a143c01f75220ad
