### PR TITLE
tp: rearchitect error/warning/OK logging of symbolization and enrichment

### DIFF
--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -1369,23 +1369,8 @@ base::Status LoadTrace(TraceProcessor* trace_processor,
       !sym_config.find_symbol_paths.empty()) {
     if (is_proto_trace) {
       trace_processor->Flush();
-      auto sym_result =
-          profiling::SymbolizeDatabase(trace_processor, sym_config);
-      if (sym_result.error == profiling::SymbolizerError::kOk) {
-        if (!sym_result.mappings_without_build_id.empty()) {
-          std::vector<std::string> mapping_strs;
-          mapping_strs.reserve(sym_result.mappings_without_build_id.size());
-          for (const auto& [name, count] :
-               sym_result.mappings_without_build_id) {
-            mapping_strs.push_back(name + " (" + std::to_string(count) +
-                                   " frames)");
-          }
-          PERFETTO_ELOG(
-              "Some frames could not be symbolized because their "
-              "mapping has an empty build ID. Mappings: %s",
-              base::Join(mapping_strs, ", ").c_str());
-        }
-      }
+      auto sym_result = profiling::SymbolizeDatabaseAndLog(
+          trace_processor, sym_config, /*verbose=*/false);
       if (sym_result.error == profiling::SymbolizerError::kOk &&
           !sym_result.symbols.empty()) {
         std::unique_ptr<uint8_t[]> buf(new uint8_t[sym_result.symbols.size()]);

--- a/src/trace_processor/util/symbolizer/breakpad_parser.cc
+++ b/src/trace_processor/util/symbolizer/breakpad_parser.cc
@@ -67,7 +67,6 @@ BreakpadParser::BreakpadParser(const std::string& file_path)
 bool BreakpadParser::ParseFile() {
   std::optional<std::string> file_contents = GetFileContents(file_path_);
   if (!file_contents) {
-    PERFETTO_ELOG("Could not get file contents of %s.", file_path_.c_str());
     return false;
   }
 

--- a/src/trace_processor/util/symbolizer/breakpad_symbolizer.cc
+++ b/src/trace_processor/util/symbolizer/breakpad_symbolizer.cc
@@ -25,6 +25,7 @@
 
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
+#include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "src/trace_processor/util/symbolizer/breakpad_parser.h"
 #include "src/trace_processor/util/symbolizer/symbolizer.h"
@@ -36,21 +37,18 @@ namespace {
 // Returns the file path for a breakpad symbol file with the given |build_id|.
 std::string MakeFilePath(const std::string& build_id,
                          const std::string& symbol_dir_path) {
-  // The directory of the symbol file is stored in an environment variable.
   constexpr char kBreakpadSuffix[] = ".breakpad";
-  std::string file_path;
-  // Append file name to symbol directory path using |build_id| and
-  // |kBreakpadSuffix|.
-  file_path.append(symbol_dir_path);
-// TODO: Add a path utility for perfetto to use here.
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-  file_path.append("\\");
+  constexpr char kPathSep = '\\';
 #else
-  file_path.append("/");
+  constexpr char kPathSep = '/';
 #endif
+  std::string file_path = symbol_dir_path;
+  if (!file_path.empty() && file_path.back() != kPathSep) {
+    file_path += kPathSep;
+  }
   file_path.append(build_id);
   file_path.append(kBreakpadSuffix);
-
   return file_path;
 }
 
@@ -59,15 +57,14 @@ std::string MakeFilePath(const std::string& build_id,
 BreakpadSymbolizer::BreakpadSymbolizer(const std::string& symbol_dir_path)
     : symbol_dir_path_(symbol_dir_path) {}
 
-std::vector<std::vector<SymbolizedFrame>> BreakpadSymbolizer::Symbolize(
+SymbolizeResult BreakpadSymbolizer::Symbolize(
     const Environment&,
     const std::string&,
     const std::string& build_id,
     uint64_t,
     const std::vector<uint64_t>& address) {
-  std::vector<std::vector<SymbolizedFrame>> result;
-  size_t num_symbolized_frames = 0;
-  result.reserve(address.size());
+  SymbolizeResult result;
+  result.frames.reserve(address.size());
   std::string file_path;
   std::string raw_build_id = base::ToHex(build_id.c_str(), build_id.length());
 
@@ -79,13 +76,20 @@ std::vector<std::vector<SymbolizedFrame>> BreakpadSymbolizer::Symbolize(
     file_path = file_path_for_testing_;
   }
 
-  BreakpadParser parser(file_path);
-  if (!parser.ParseFile()) {
-    PERFETTO_ELOG("Failed to parse file %s.", file_path.c_str());
-    PERFETTO_PLOG("Symbolized %zu of %zu frames.", num_symbolized_frames,
-                  address.size());
+  // Check if file exists first to distinguish file-not-found from parse errors.
+  if (!base::FileExists(file_path)) {
+    result.attempts.push_back({file_path, SymbolPathError::kFileNotFound});
     return result;
   }
+
+  BreakpadParser parser(file_path);
+  if (!parser.ParseFile()) {
+    result.attempts.push_back({file_path, SymbolPathError::kParseError});
+    return result;
+  }
+
+  // Record the successful lookup.
+  result.attempts.push_back({file_path, SymbolPathError::kOk});
 
   // Add each address's function name to the |result| vector in the same order.
   for (uint64_t addr : address) {
@@ -103,12 +107,9 @@ std::vector<std::vector<SymbolizedFrame>> BreakpadSymbolizer::Symbolize(
       }
 
       frame.function_name = *opt_func_name;
-      num_symbolized_frames++;
     }
-    result.push_back({std::move(frame)});
+    result.frames.push_back({std::move(frame)});
   }
-  PERFETTO_PLOG("Symbolized %zu of %zu frames on symbol file %s.",
-                num_symbolized_frames, address.size(), file_path.c_str());
   return result;
 }
 

--- a/src/trace_processor/util/symbolizer/breakpad_symbolizer.h
+++ b/src/trace_processor/util/symbolizer/breakpad_symbolizer.h
@@ -39,12 +39,11 @@ class BreakpadSymbolizer : public Symbolizer {
   BreakpadSymbolizer(BreakpadSymbolizer&& other) = default;
   BreakpadSymbolizer& operator=(BreakpadSymbolizer&& other) = default;
 
-  std::vector<std::vector<SymbolizedFrame>> Symbolize(
-      const Environment&,
-      const std::string&,
-      const std::string& build_id,
-      uint64_t,
-      const std::vector<uint64_t>& address) override;
+  SymbolizeResult Symbolize(const Environment&,
+                            const std::string&,
+                            const std::string& build_id,
+                            uint64_t,
+                            const std::vector<uint64_t>& address) override;
 
   void SetBreakpadFileForTesting(const std::string& path) {
     file_path_for_testing_ = path;

--- a/src/trace_processor/util/symbolizer/local_symbolizer.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer.cc
@@ -276,7 +276,6 @@ std::optional<BinaryInfo> GetBinaryInfo(const char* fname, size_t size) {
   }
   base::ScopedMmap map = base::ReadMmapFilePart(fname, size);
   if (!map.IsValid()) {
-    PERFETTO_PLOG("Failed to mmap %s", fname);
     return std::nullopt;
   }
   char* mem = static_cast<char*>(map.data());
@@ -318,10 +317,13 @@ void ProcessBinaryFile(const char* fname,
   char magic[EI_MAG3 + 1];
   // Scope file access. On windows OpenFile opens an exclusive lock.
   // This lock needs to be released before mapping the file.
+  // Check if file exists first to avoid noisy errors for speculative paths.
+  if (!base::FileExists(fname)) {
+    return;
+  }
   {
     base::ScopedFile fd(base::OpenFile(fname, O_RDONLY));
     if (!fd) {
-      PERFETTO_PLOG("Failed to open %s", fname);
       return;
     }
     auto rd = base::Read(*fd, &magic, sizeof(magic));
@@ -572,7 +574,6 @@ std::optional<FoundBinary> IsCorrectFile(
   // Openfile opens the file with an exclusive lock on windows.
   std::optional<uint64_t> file_size = base::GetFileSize(symbol_file);
   if (!file_size.has_value()) {
-    PERFETTO_PLOG("Failed to get file size %s", symbol_file.c_str());
     return std::nullopt;
   }
 
@@ -595,17 +596,40 @@ std::optional<FoundBinary> IsCorrectFile(
                      binary_info->type};
 }
 
-std::optional<FoundBinary> FindBinaryInRoot(const std::string& root_str,
-                                            const std::string& abspath,
-                                            const std::string& build_id) {
+// Try a path and record the attempt.
+// Returns true if the binary was found.
+bool TryPath(const std::string& path,
+             const std::string& build_id,
+             std::optional<FoundBinary>& out_binary,
+             std::vector<BinaryPathAttempt>& attempts) {
+  if (!base::FileExists(path)) {
+    attempts.push_back({path, BinaryPathError::kFileNotFound});
+    return false;
+  }
+  std::optional<FoundBinary> found = IsCorrectFile(path, build_id);
+  if (found) {
+    out_binary = std::move(found);
+    attempts.push_back({path, BinaryPathError::kOk});
+    return true;
+  }
+  attempts.push_back({path, BinaryPathError::kBuildIdMismatch});
+  return false;
+}
+
+std::optional<FoundBinary> FindBinaryInRoot(
+    const std::string& root_str,
+    const std::string& abspath,
+    const std::string& build_id,
+    std::vector<BinaryPathAttempt>& attempts) {
   constexpr char kApkPrefix[] = "base.apk!";
 
   std::string filename;
   std::string dirname;
 
   for (base::StringSplitter sp(abspath, '/'); sp.Next();) {
-    if (!dirname.empty())
+    if (!dirname.empty()) {
       dirname += "/";
+    }
     dirname += filename;
     filename = sp.cur_token();
   }
@@ -631,30 +655,31 @@ std::optional<FoundBinary> FindBinaryInRoot(const std::string& root_str,
   // * $ROOT/.build-id/ab/cd1234.debug
 
   std::optional<FoundBinary> result;
+  std::string symbol_file;
 
-  std::string symbol_file = root_str + "/" + dirname + "/" + filename;
-  result = IsCorrectFile(symbol_file, build_id);
-  if (result)
+  symbol_file = root_str + "/" + dirname + "/" + filename;
+  if (TryPath(symbol_file, build_id, result, attempts)) {
     return result;
+  }
 
   if (base::StartsWith(filename, kApkPrefix)) {
     symbol_file = root_str + "/" + dirname + "/" +
                   filename.substr(sizeof(kApkPrefix) - 1);
-    result = IsCorrectFile(symbol_file, build_id);
-    if (result)
+    if (TryPath(symbol_file, build_id, result, attempts)) {
       return result;
+    }
   }
 
   symbol_file = root_str + "/" + filename;
-  result = IsCorrectFile(symbol_file, build_id);
-  if (result)
+  if (TryPath(symbol_file, build_id, result, attempts)) {
     return result;
+  }
 
   if (base::StartsWith(filename, kApkPrefix)) {
     symbol_file = root_str + "/" + filename.substr(sizeof(kApkPrefix) - 1);
-    result = IsCorrectFile(symbol_file, build_id);
-    if (result)
+    if (TryPath(symbol_file, build_id, result, attempts)) {
       return result;
+    }
   }
 
   std::string hex_build_id = base::ToHex(build_id.c_str(), build_id.size());
@@ -662,39 +687,59 @@ std::optional<FoundBinary> FindBinaryInRoot(const std::string& root_str,
   if (!split_hex_build_id.empty()) {
     symbol_file =
         root_str + "/" + ".build-id" + "/" + split_hex_build_id + ".debug";
-    result = IsCorrectFile(symbol_file, build_id);
-    if (result)
+    if (TryPath(symbol_file, build_id, result, attempts)) {
       return result;
+    }
   }
 
   return std::nullopt;
 }
 
-std::optional<FoundBinary> FindKernelBinary(const std::string& os_release) {
+std::optional<FoundBinary> FindKernelBinary(
+    const std::string& os_release,
+    std::vector<BinaryPathAttempt>& attempts) {
   using SS = base::StackString<512>;
   const char* rel = os_release.c_str();
-  auto find_kernel = [](base::StackString<512> path) {
-    return IsCorrectFile(path.ToStdString(), std::nullopt);
+
+  // Helper to try a kernel path and record the attempt.
+  auto try_kernel_path =
+      [&](base::StackString<512> path_ss) -> std::optional<FoundBinary> {
+    std::string path = path_ss.ToStdString();
+    if (!base::FileExists(path)) {
+      attempts.push_back({path, BinaryPathError::kFileNotFound});
+      return std::nullopt;
+    }
+    std::optional<FoundBinary> found = IsCorrectFile(path, std::nullopt);
+    if (found) {
+      attempts.push_back({path, BinaryPathError::kOk});
+      return found;
+    }
+    // File exists but isn't a valid binary.
+    attempts.push_back({path, BinaryPathError::kBuildIdMismatch});
+    return std::nullopt;
   };
+
   // This list comes from the perf symbolization code [1]: it's an incomplete
   // list (it doesn't include pre-symbolized kernels or reading /proc/kallsyms)
   // but works if you just install e.g. the symbol packages for the kernel.
   //
   // [1]
   // https://elixir.bootlin.com/linux/v6.12.2/source/tools/perf/util/symbol.c#L2294
-  if (auto b = find_kernel(SS("/boot/vmlinux-%s", rel))) {
+  if (auto b = try_kernel_path(SS("/boot/vmlinux-%s", rel))) {
     return b;
   }
-  if (auto b = find_kernel(SS("/usr/lib/debug/boot/vmlinux-%s", rel))) {
+  if (auto b = try_kernel_path(SS("/usr/lib/debug/boot/vmlinux-%s", rel))) {
     return b;
   }
-  if (auto b = find_kernel(SS("/lib/modules/%s/build/vmlinux", rel))) {
+  if (auto b = try_kernel_path(SS("/lib/modules/%s/build/vmlinux", rel))) {
     return b;
   }
-  if (auto b = find_kernel(SS("/usr/lib/debug/lib/modules/%s/vmlinux", rel))) {
+  if (auto b =
+          try_kernel_path(SS("/usr/lib/debug/lib/modules/%s/vmlinux", rel))) {
     return b;
   }
-  if (auto b = find_kernel(SS("/usr/lib/debug/boot/vmlinux-%s.debug", rel))) {
+  if (auto b =
+          try_kernel_path(SS("/usr/lib/debug/boot/vmlinux-%s.debug", rel))) {
     return b;
   }
   return std::nullopt;
@@ -774,16 +819,15 @@ LocalBinaryIndexer::LocalBinaryIndexer(
     : buildid_to_file_(
           BuildIdIndex(std::move(directories), std::move(individual_files))) {}
 
-std::optional<FoundBinary> LocalBinaryIndexer::FindBinary(
-    const std::string& abspath,
-    const std::string& build_id) {
+BinaryLookupResult LocalBinaryIndexer::FindBinary(const std::string& abspath,
+                                                  const std::string& build_id) {
   auto it = buildid_to_file_.find(build_id);
   if (it != buildid_to_file_.end()) {
-    return it->second;
+    // Success - record the successful path lookup.
+    return {it->second, {{it->second.file_name, BinaryPathError::kOk}}};
   }
-  PERFETTO_ELOG("Could not find Build ID: %s (file %s).",
-                base::ToHex(build_id).c_str(), abspath.c_str());
-  return std::nullopt;
+  // Build ID not in index - report as file not found for the mapping path.
+  return {{}, {{abspath, BinaryPathError::kFileNotFound}}};
 }
 
 LocalBinaryIndexer::~LocalBinaryIndexer() = default;
@@ -791,30 +835,31 @@ LocalBinaryIndexer::~LocalBinaryIndexer() = default;
 LocalBinaryFinder::LocalBinaryFinder(std::vector<std::string> roots)
     : roots_(std::move(roots)) {}
 
-std::optional<FoundBinary> LocalBinaryFinder::FindBinary(
-    const std::string& abspath,
-    const std::string& build_id) {
-  auto p = cache_.emplace(abspath, std::nullopt);
+BinaryLookupResult LocalBinaryFinder::FindBinary(const std::string& abspath,
+                                                 const std::string& build_id) {
+  auto p = cache_.emplace(abspath, BinaryLookupResult{});
   if (!p.second)
     return p.first->second;
 
-  std::optional<FoundBinary>& cache_entry = p.first->second;
+  BinaryLookupResult& result = p.first->second;
 
   // Try the absolute path first.
   if (base::StartsWith(abspath, "/")) {
-    cache_entry = IsCorrectFile(abspath, build_id);
-    if (cache_entry)
-      return cache_entry;
+    if (TryPath(abspath, build_id, result.binary, result.attempts)) {
+      return result;
+    }
   }
 
+  // Try each root directory.
   for (const std::string& root_str : roots_) {
-    cache_entry = FindBinaryInRoot(root_str, abspath, build_id);
-    if (cache_entry)
-      return cache_entry;
+    std::optional<FoundBinary> found =
+        FindBinaryInRoot(root_str, abspath, build_id, result.attempts);
+    if (found) {
+      result.binary = std::move(found);
+      return result;
+    }
   }
-  PERFETTO_ELOG("Could not find %s (Build ID: %s).", abspath.c_str(),
-                base::ToHex(build_id).c_str());
-  return cache_entry;
+  return result;
 }
 
 LocalBinaryFinder::~LocalBinaryFinder() = default;
@@ -850,7 +895,31 @@ std::vector<SymbolizedFrame> LLVMSymbolizerProcess::Symbolize(
   return result;
 }
 
-std::vector<std::vector<SymbolizedFrame>> LocalSymbolizer::Symbolize(
+namespace {
+SymbolPathError ToSymbolPathError(BinaryPathError error) {
+  switch (error) {
+    case BinaryPathError::kOk:
+      return SymbolPathError::kOk;
+    case BinaryPathError::kFileNotFound:
+      return SymbolPathError::kFileNotFound;
+    case BinaryPathError::kBuildIdMismatch:
+      return SymbolPathError::kBuildIdMismatch;
+  }
+  PERFETTO_FATAL("Unknown BinaryPathError");
+}
+
+std::vector<SymbolPathAttempt> ToSymbolPathAttempts(
+    const std::vector<BinaryPathAttempt>& attempts) {
+  std::vector<SymbolPathAttempt> result;
+  result.reserve(attempts.size());
+  for (const auto& attempt : attempts) {
+    result.push_back({attempt.path, ToSymbolPathError(attempt.error)});
+  }
+  return result;
+}
+}  // namespace
+
+SymbolizeResult LocalSymbolizer::Symbolize(
     const Environment& env,
     const std::string& mapping_name,
     const std::string& build_id,
@@ -858,15 +927,20 @@ std::vector<std::vector<SymbolizedFrame>> LocalSymbolizer::Symbolize(
     const std::vector<uint64_t>& addresses) {
   bool is_kernel = base::StartsWith(mapping_name, "[kernel.kallsyms]");
   std::optional<FoundBinary> binary;
+  std::vector<BinaryPathAttempt> binary_attempts;
   if (is_kernel) {
     if (env.os_release) {
-      binary = FindKernelBinary(*env.os_release);
+      binary = FindKernelBinary(*env.os_release, binary_attempts);
     }
   } else {
-    binary = finder_->FindBinary(mapping_name, build_id);
+    BinaryLookupResult lookup = finder_->FindBinary(mapping_name, build_id);
+    binary = std::move(lookup.binary);
+    binary_attempts = std::move(lookup.attempts);
   }
+  std::vector<SymbolPathAttempt> attempts =
+      ToSymbolPathAttempts(binary_attempts);
   if (!binary) {
-    return {};
+    return {{}, std::move(attempts)};
   }
   uint64_t binary_load_bias = binary->p_vaddr - binary->p_offset;
   uint64_t addr_correction = 0;
@@ -889,14 +963,14 @@ std::vector<std::vector<SymbolizedFrame>> LocalSymbolizer::Symbolize(
     // Whereas with libunwindstack, `p_offset` should always be greater than
     // zero.
     addr_correction = (binary->p_vaddr - binary->p_offset) - load_bias;
-    PERFETTO_LOG("Correcting load bias by %" PRIu64 " for %s", addr_correction,
-                 mapping_name.c_str());
+    PERFETTO_DLOG("Correcting load bias by %" PRIu64 " for %s", addr_correction,
+                  mapping_name.c_str());
   }
-  std::vector<std::vector<SymbolizedFrame>> result;
-  result.reserve(addresses.size());
+  SymbolizeResult result;
+  result.frames.reserve(addresses.size());
   for (uint64_t address : addresses) {
-    result.emplace_back(llvm_symbolizer_.Symbolize(binary->file_name,
-                                                   address + addr_correction));
+    result.frames.emplace_back(llvm_symbolizer_.Symbolize(
+        binary->file_name, address + addr_correction));
   }
   return result;
 }

--- a/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
+++ b/src/trace_processor/util/symbolizer/local_symbolizer_unittest.cc
@@ -116,21 +116,19 @@ TEST(LocalBinaryIndexerTest, NOMSAN_SimpleTree) {
 
   LocalBinaryIndexer indexer({tmp.path() + "/dir1", tmp.path() + "/dir2"}, {});
 
-  std::optional<FoundBinary> bin1 =
-      indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
+  BinaryLookupResult result1 = indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
+  ASSERT_TRUE(result1.ok());
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-  EXPECT_EQ(bin1.value().file_name, tmp.path() + "/dir1\\elf1");
+  EXPECT_EQ(result1.binary->file_name, tmp.path() + "/dir1\\elf1");
 #else
-  EXPECT_EQ(bin1.value().file_name, tmp.path() + "/dir1/elf1");
+  EXPECT_EQ(result1.binary->file_name, tmp.path() + "/dir1/elf1");
 #endif
-  std::optional<FoundBinary> bin2 =
-      indexer.FindBinary("", "BBBBBBBBBBBBBBBBBBBB");
-  ASSERT_TRUE(bin2.has_value());
+  BinaryLookupResult result2 = indexer.FindBinary("", "BBBBBBBBBBBBBBBBBBBB");
+  ASSERT_TRUE(result2.ok());
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
-  EXPECT_EQ(bin2.value().file_name, tmp.path() + "/dir2\\elf1");
+  EXPECT_EQ(result2.binary->file_name, tmp.path() + "/dir2\\elf1");
 #else
-  EXPECT_EQ(bin2.value().file_name, tmp.path() + "/dir2/elf1");
+  EXPECT_EQ(result2.binary->file_name, tmp.path() + "/dir2/elf1");
 #endif
 }
 
@@ -163,20 +161,17 @@ TEST(LocalBinaryIndexerTest, NOMSAN_Symlinks) {
 
   LocalBinaryIndexer indexer({tmp.AbsolutePath("sym")}, {});
 
-  std::optional<FoundBinary> bin1 =
-      indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
-  EXPECT_EQ(bin1.value().file_name, tmp.AbsolutePath("sym/elf1"));
+  BinaryLookupResult result1 = indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
+  ASSERT_TRUE(result1.ok());
+  EXPECT_EQ(result1.binary->file_name, tmp.AbsolutePath("sym/elf1"));
 
-  std::optional<FoundBinary> bin2 =
-      indexer.FindBinary("", "BBBBBBBBBBBBBBBBBBBB");
-  ASSERT_TRUE(bin2.has_value());
-  EXPECT_EQ(bin2.value().file_name, tmp.AbsolutePath("sym/dir1/elf2"));
+  BinaryLookupResult result2 = indexer.FindBinary("", "BBBBBBBBBBBBBBBBBBBB");
+  ASSERT_TRUE(result2.ok());
+  EXPECT_EQ(result2.binary->file_name, tmp.AbsolutePath("sym/dir1/elf2"));
 
-  std::optional<FoundBinary> bin3 =
-      indexer.FindBinary("", "CCCCCCCCCCCCCCCCCCCC");
-  ASSERT_TRUE(bin3.has_value());
-  EXPECT_EQ(bin3.value().file_name, tmp.AbsolutePath("sym/dir1/elf3"));
+  BinaryLookupResult result3 = indexer.FindBinary("", "CCCCCCCCCCCCCCCCCCCC");
+  ASSERT_TRUE(result3.ok());
+  EXPECT_EQ(result3.binary->file_name, tmp.AbsolutePath("sym/dir1/elf3"));
 }
 
 #if defined(MEMORY_SANITIZER)
@@ -197,10 +192,9 @@ TEST(LocalBinaryIndexerTest, NOMSAN_RecursiveSymlinks) {
 
   LocalBinaryIndexer indexer({tmp.AbsolutePath("main")}, {});
 
-  std::optional<FoundBinary> bin1 =
-      indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
-  EXPECT_EQ(bin1.value().file_name, tmp.AbsolutePath("main/elf1"));
+  BinaryLookupResult result1 = indexer.FindBinary("", "AAAAAAAAAAAAAAAAAAAA");
+  ASSERT_TRUE(result1.ok());
+  EXPECT_EQ(result1.binary->file_name, tmp.AbsolutePath("main/elf1"));
 }
 
 #endif  // PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) ||
@@ -215,10 +209,10 @@ TEST(LocalBinaryFinderTest, AbsolutePath) {
 
   LocalBinaryFinder finder({tmp.path() + "/root"});
 
-  std::optional<FoundBinary> bin1 =
+  BinaryLookupResult result =
       finder.FindBinary("/dir/elf1.so", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
-  EXPECT_EQ(bin1.value().file_name, tmp.path() + "/root/dir/elf1.so");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/dir/elf1.so");
 }
 
 TEST(LocalBinaryFinderTest, AbsolutePathWithoutBaseApk) {
@@ -229,10 +223,10 @@ TEST(LocalBinaryFinderTest, AbsolutePathWithoutBaseApk) {
 
   LocalBinaryFinder finder({tmp.path() + "/root"});
 
-  std::optional<FoundBinary> bin1 =
+  BinaryLookupResult result =
       finder.FindBinary("/dir/base.apk!elf1.so", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
-  EXPECT_EQ(bin1.value().file_name, tmp.path() + "/root/dir/elf1.so");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/dir/elf1.so");
 }
 
 TEST(LocalBinaryFinderTest, OnlyFilename) {
@@ -242,10 +236,10 @@ TEST(LocalBinaryFinderTest, OnlyFilename) {
 
   LocalBinaryFinder finder({tmp.path() + "/root"});
 
-  std::optional<FoundBinary> bin1 =
+  BinaryLookupResult result =
       finder.FindBinary("/ignored_dir/elf1.so", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
-  EXPECT_EQ(bin1.value().file_name, tmp.path() + "/root/elf1.so");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/elf1.so");
 }
 
 TEST(LocalBinaryFinderTest, OnlyFilenameWithoutBaseApk) {
@@ -255,10 +249,10 @@ TEST(LocalBinaryFinderTest, OnlyFilenameWithoutBaseApk) {
 
   LocalBinaryFinder finder({tmp.path() + "/root"});
 
-  std::optional<FoundBinary> bin1 = finder.FindBinary(
-      "/ignored_dir/base.apk!elf1.so", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
-  EXPECT_EQ(bin1.value().file_name, tmp.path() + "/root/elf1.so");
+  BinaryLookupResult result = finder.FindBinary("/ignored_dir/base.apk!elf1.so",
+                                                "AAAAAAAAAAAAAAAAAAAA");
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.binary->file_name, tmp.path() + "/root/elf1.so");
 }
 
 TEST(LocalBinaryFinderTest, BuildIdSubdir) {
@@ -271,11 +265,11 @@ TEST(LocalBinaryFinderTest, BuildIdSubdir) {
 
   LocalBinaryFinder finder({tmp.path() + "/root"});
 
-  std::optional<FoundBinary> bin1 =
+  BinaryLookupResult result =
       finder.FindBinary("/ignored_dir/ignored_name.so", "AAAAAAAAAAAAAAAAAAAA");
-  ASSERT_TRUE(bin1.has_value());
+  ASSERT_TRUE(result.ok());
   EXPECT_EQ(
-      bin1.value().file_name,
+      result.binary->file_name,
       tmp.path() +
           "/root/.build-id/41/41414141414141414141414141414141414141.debug");
 }

--- a/src/trace_processor/util/symbolizer/symbolize_database.cc
+++ b/src/trace_processor/util/symbolizer/symbolize_database.cc
@@ -18,10 +18,12 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -42,6 +44,12 @@
 #include "protos/perfetto/trace/profiling/profile_common.pbzero.h"
 #include "protos/perfetto/trace/trace.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
+
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN) &&  \
+    !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM) && \
+    !PERFETTO_BUILDFLAG(PERFETTO_CHROMIUM_BUILD)
+#include <unistd.h>  // For isatty()
+#endif
 
 namespace perfetto::profiling {
 
@@ -157,40 +165,229 @@ std::unique_ptr<Symbolizer> CreateFindSymbolizer(
   return MaybeLocalSymbolizer(config.find_symbol_paths, {}, "find");
 }
 
-std::string SymbolizeDatabaseWithSymbolizer(trace_processor::TraceProcessor* tp,
-                                            Symbolizer* symbolizer) {
+struct SymbolizationOutput {
+  std::string symbols_proto;
+  std::vector<SuccessfulMapping> successful_mappings;
+  std::vector<FailedMapping> failed_mappings;
+};
+
+SymbolizationOutput SymbolizeDatabaseWithSymbolizer(
+    trace_processor::TraceProcessor* tp,
+    Symbolizer* symbolizer) {
   PERFETTO_CHECK(symbolizer);
   auto unsymbolized = GetUnsymbolizedFrames(tp);
   Symbolizer::Environment env = {GetOsRelease(tp)};
 
-  std::string symbols_proto;
+  SymbolizationOutput output;
   for (const auto& [unsymbolized_mapping, rel_pcs] : unsymbolized) {
-    auto res = symbolizer->Symbolize(env, unsymbolized_mapping.name,
-                                     unsymbolized_mapping.build_id,
-                                     unsymbolized_mapping.load_bias, rel_pcs);
-    if (res.empty()) {
+    uint32_t frame_count = static_cast<uint32_t>(rel_pcs.size());
+    SymbolizeResult res = symbolizer->Symbolize(
+        env, unsymbolized_mapping.name, unsymbolized_mapping.build_id,
+        unsymbolized_mapping.load_bias, rel_pcs);
+    if (res.frames.empty()) {
+      // Record the failed mapping with all attempted paths.
+      if (!res.attempts.empty()) {
+        output.failed_mappings.push_back(
+            {unsymbolized_mapping.name, unsymbolized_mapping.build_id,
+             std::move(res.attempts), frame_count});
+      }
       continue;
     }
+
+    // Find the successful path from attempts (the one with kOk).
+    std::string symbol_path;
+    for (const auto& attempt : res.attempts) {
+      if (attempt.error == SymbolPathError::kOk) {
+        symbol_path = attempt.path;
+        break;
+      }
+    }
+    output.successful_mappings.push_back({unsymbolized_mapping.name,
+                                          unsymbolized_mapping.build_id,
+                                          symbol_path, frame_count});
 
     protozero::HeapBuffered<perfetto::protos::pbzero::Trace> trace;
     auto* packet = trace->add_packet();
     auto* module_symbols = packet->set_module_symbols();
     module_symbols->set_path(unsymbolized_mapping.name);
     module_symbols->set_build_id(unsymbolized_mapping.build_id);
-    PERFETTO_DCHECK(res.size() == rel_pcs.size());
-    for (size_t i = 0; i < res.size(); ++i) {
+    PERFETTO_DCHECK(res.frames.size() == rel_pcs.size());
+    for (size_t i = 0; i < res.frames.size(); ++i) {
       auto* address_symbols = module_symbols->add_address_symbols();
       address_symbols->set_address(rel_pcs[i]);
-      for (const SymbolizedFrame& frame : res[i]) {
+      for (const SymbolizedFrame& frame : res.frames[i]) {
         auto* line = address_symbols->add_lines();
         line->set_function_name(frame.function_name);
         line->set_source_file_name(frame.file_name);
         line->set_line_number(frame.line);
       }
     }
-    symbols_proto += trace.SerializeAsString();
+    output.symbols_proto += trace.SerializeAsString();
   }
-  return symbols_proto;
+  return output;
+}
+
+// ANSI color codes for terminal output.
+const char kReset[] = "\x1b[0m";
+const char kRed[] = "\x1b[31m";
+const char kYellow[] = "\x1b[33m";
+const char kCyan[] = "\x1b[36m";
+
+// Helper to wrap text in color codes if colorize is true.
+std::string Colorize(bool colorize,
+                     const char* color,
+                     const std::string& text) {
+  if (!colorize) {
+    return text;
+  }
+  return std::string(color) + text + kReset;
+}
+
+const char* SymbolPathErrorToString(SymbolPathError error) {
+  switch (error) {
+    case SymbolPathError::kOk:
+      return "ok";
+    case SymbolPathError::kFileNotFound:
+      return "file not found";
+    case SymbolPathError::kBuildIdMismatch:
+      return "build ID mismatch";
+    case SymbolPathError::kParseError:
+      return "failed to parse";
+  }
+  return "unknown";
+}
+
+std::string Plural(size_t count, const char* singular, const char* plural) {
+  return std::to_string(count) + " " + (count == 1 ? singular : plural);
+}
+
+// Formats a hint with optional coloring.
+std::string FormatHint(bool colorize, const std::string& text) {
+  return Colorize(colorize, kCyan, "hint: " + text);
+}
+
+// Hint text for symbol path issues.
+std::string SymbolPathHint(bool colorize) {
+  return FormatHint(
+             colorize,
+             "use --symbol-paths to specify symbol files or directories") +
+         "\n";
+}
+
+// Hint text for missing build IDs.
+std::string MissingBuildIdHint(bool colorize) {
+  return FormatHint(colorize,
+                    "rebuild binaries with build IDs (linker flag "
+                    "-Wl,--build-id) and re-record the trace") +
+         "\n";
+}
+
+// Formats kernel debug symbol installation hint.
+void FormatKernelHint(bool colorize, std::string* out, const char* indent) {
+  *out += indent;
+  *out +=
+      FormatHint(colorize, "install kernel debug symbols (vmlinux):") + "\n";
+  *out += indent;
+  *out +=
+      "  Linux (Debian/Ubuntu): sudo apt install "
+      "linux-image-$(uname -r)-dbgsym\n";
+  *out += indent;
+  *out += "  Linux (Fedora): sudo dnf debuginfo-install kernel\n";
+  *out += indent;
+  *out += "  Android: obtain vmlinux from your kernel build tree\n";
+}
+
+void FormatSuccessfulMappings(const std::vector<SuccessfulMapping>& mappings,
+                              std::string* out) {
+  uint32_t frame_count = 0;
+  for (const auto& mapping : mappings) {
+    frame_count += mapping.frame_count;
+  }
+  if (frame_count == 0) {
+    return;
+  }
+  *out += "\n  Symbolized " + Plural(frame_count, "frame", "frames") +
+          " from " + Plural(mappings.size(), "mapping", "mappings") + ":\n";
+  for (const auto& mapping : mappings) {
+    *out += "    " + mapping.mapping_name + " (" +
+            Plural(mapping.frame_count, "frame", "frames") + ")";
+    if (!mapping.symbol_path.empty()) {
+      *out += " -> " + mapping.symbol_path;
+    }
+    *out += "\n";
+  }
+}
+
+bool IsKernelMapping(const std::string& name) {
+  return base::StartsWith(name, "[kernel.kallsyms]");
+}
+
+void FormatFailedMappings(bool colorize,
+                          const std::vector<FailedMapping>& mappings,
+                          std::string* out) {
+  uint32_t frame_count = 0;
+  for (const auto& mapping : mappings) {
+    frame_count += mapping.frame_count;
+  }
+  if (frame_count == 0) {
+    return;
+  }
+  *out += "\n  No matching symbols in searched paths for " +
+          Plural(mappings.size(), "mapping", "mappings") + " (" +
+          Plural(frame_count, "frame", "frames") + "):\n";
+  for (const auto& mapping : mappings) {
+    bool is_kernel = IsKernelMapping(mapping.mapping_name);
+    *out += "    " + mapping.mapping_name + " (" +
+            Plural(mapping.frame_count, "frame", "frames") + ")\n";
+    if (!is_kernel) {
+      *out += "      build ID: " + base::ToHex(mapping.build_id) + "\n";
+    }
+    if (!mapping.attempts.empty()) {
+      *out += "      paths searched:\n";
+      for (const auto& attempt : mapping.attempts) {
+        *out += "        " + attempt.path;
+        if (attempt.error != SymbolPathError::kOk) {
+          *out +=
+              " " +
+              Colorize(colorize, kRed,
+                       "(" +
+                           std::string(SymbolPathErrorToString(attempt.error)) +
+                           ")");
+        }
+        *out += "\n";
+      }
+    } else {
+      *out += "      no paths were configured to search\n";
+    }
+    if (is_kernel) {
+      FormatKernelHint(colorize, out, "      ");
+    } else {
+      *out += "      ";
+      *out += SymbolPathHint(colorize);
+    }
+  }
+}
+
+void FormatSkippedMappings(
+    bool colorize,
+    const std::vector<std::pair<std::string, uint32_t>>& mappings,
+    std::string* out) {
+  uint32_t frame_count = 0;
+  for (const auto& [name, count] : mappings) {
+    frame_count += count;
+  }
+  if (frame_count == 0) {
+    return;
+  }
+  *out += "\n  No build IDs in trace for " +
+          Plural(mappings.size(), "mapping", "mappings") + " (" +
+          Plural(frame_count, "frame", "frames") +
+          "), symbol lookup requires build IDs:\n";
+  for (const auto& [name, count] : mappings) {
+    *out += "    " + name + " (" + Plural(count, "frame", "frames") + ")\n";
+  }
+  *out += "  ";
+  *out += MissingBuildIdHint(colorize);
 }
 
 }  // namespace
@@ -211,20 +408,54 @@ SymbolizerResult SymbolizeDatabase(trace_processor::TraceProcessor* tp,
     return result;
   }
 
+  // Track successful and failed mappings by (mapping_name, build_id).
+  std::set<std::pair<std::string, std::string>> successful_mapping_keys;
+  std::map<std::pair<std::string, std::string>, size_t> failed_mapping_index;
+
+  auto collect_output = [&result, &successful_mapping_keys,
+                         &failed_mapping_index](SymbolizationOutput output) {
+    result.symbols += output.symbols_proto;
+    for (auto& success : output.successful_mappings) {
+      auto key = std::make_pair(success.mapping_name, success.build_id);
+      successful_mapping_keys.insert(key);
+      result.successful_mappings.push_back(std::move(success));
+    }
+    // Merge failed mappings - skip if already successful, merge attempts if
+    // already failed.
+    for (auto& failed : output.failed_mappings) {
+      auto key = std::make_pair(failed.mapping_name, failed.build_id);
+      // Skip if this mapping was already successfully symbolized.
+      if (successful_mapping_keys.count(key)) {
+        continue;
+      }
+      auto it = failed_mapping_index.find(key);
+      if (it != failed_mapping_index.end()) {
+        // Merge attempts into existing entry.
+        FailedMapping& existing = result.failed_mappings[it->second];
+        for (auto& attempt : failed.attempts) {
+          existing.attempts.push_back(std::move(attempt));
+        }
+      } else {
+        failed_mapping_index[key] = result.failed_mappings.size();
+        result.failed_mappings.push_back(std::move(failed));
+      }
+    }
+  };
+
   // Run "index" mode symbolizer if paths are provided.
   if (auto symbolizer = CreateIndexSymbolizer(config); symbolizer) {
-    result.symbols += SymbolizeDatabaseWithSymbolizer(tp, symbolizer.get());
+    collect_output(SymbolizeDatabaseWithSymbolizer(tp, symbolizer.get()));
   }
 
   // Run "find" mode symbolizer if paths are provided.
   if (auto symbolizer = CreateFindSymbolizer(config); symbolizer) {
-    result.symbols += SymbolizeDatabaseWithSymbolizer(tp, symbolizer.get());
+    collect_output(SymbolizeDatabaseWithSymbolizer(tp, symbolizer.get()));
   }
 
   // Run breakpad symbolizers for each breakpad path.
   for (const std::string& breakpad_path : config.breakpad_paths) {
     BreakpadSymbolizer symbolizer(breakpad_path);
-    result.symbols += SymbolizeDatabaseWithSymbolizer(tp, &symbolizer);
+    collect_output(SymbolizeDatabaseWithSymbolizer(tp, &symbolizer));
   }
 
   result.error = SymbolizerError::kOk;
@@ -242,6 +473,98 @@ std::vector<std::string> GetPerfettoBinaryPath() {
     return base::SplitString(root, delimiter);
   }
   return {};
+}
+
+std::string FormatSymbolizationSummary(const SymbolizerResult& result,
+                                       bool verbose,
+                                       bool colorize) {
+  std::string summary;
+
+  size_t failed_count = result.failed_mappings.size();
+  size_t skipped_count = result.mappings_without_build_id.size();
+
+  // Count total frames.
+  uint32_t failed_frames = 0;
+  for (const auto& mapping : result.failed_mappings) {
+    failed_frames += mapping.frame_count;
+  }
+  uint32_t skipped_frames = 0;
+  for (const auto& [name, count] : result.mappings_without_build_id) {
+    skipped_frames += count;
+  }
+  uint32_t unsymbolized_frames = failed_frames + skipped_frames;
+
+  // If everything succeeded, don't log anything.
+  if (failed_count == 0 && skipped_count == 0) {
+    return summary;
+  }
+
+  // Header showing the problem.
+  summary += Colorize(colorize, kYellow,
+                      Plural(unsymbolized_frames, "frame", "frames") +
+                          " could not be symbolized") +
+             " and will appear as \"unknown\".\n";
+
+  if (!verbose) {
+    // Non-verbose: show breakdown summary with hints nested under each.
+    if (failed_frames > 0) {
+      summary += "  - " + Plural(failed_frames, "frame", "frames") + " from " +
+                 Plural(failed_count, "mapping", "mappings") +
+                 ": no matching symbols in searched paths\n";
+
+      // Add hints nested under "no matching symbols".
+      bool has_kernel_failure = false;
+      bool has_non_kernel_failure = false;
+      for (const auto& mapping : result.failed_mappings) {
+        if (IsKernelMapping(mapping.mapping_name)) {
+          has_kernel_failure = true;
+        } else {
+          has_non_kernel_failure = true;
+        }
+      }
+      if (has_non_kernel_failure) {
+        summary += "    ";
+        summary += SymbolPathHint(colorize);
+      }
+      if (has_kernel_failure) {
+        FormatKernelHint(colorize, &summary, "    ");
+      }
+    }
+    if (skipped_frames > 0) {
+      summary += "  - " + Plural(skipped_frames, "frame", "frames") + " from " +
+                 Plural(skipped_count, "mapping", "mappings") +
+                 ": no build IDs in trace, symbol lookup requires build IDs\n";
+      summary += "    ";
+      summary += MissingBuildIdHint(colorize);
+    }
+
+    summary += "Use --verbose to see the full details.\n";
+    return summary;
+  }
+
+  // Verbose output - show everything.
+  FormatSuccessfulMappings(result.successful_mappings, &summary);
+  FormatFailedMappings(colorize, result.failed_mappings, &summary);
+  FormatSkippedMappings(colorize, result.mappings_without_build_id, &summary);
+
+  return summary;
+}
+
+SymbolizerResult SymbolizeDatabaseAndLog(trace_processor::TraceProcessor* tp,
+                                         const SymbolizerConfig& config,
+                                         bool verbose) {
+  SymbolizerResult result = SymbolizeDatabase(tp, config);
+  bool colorize = false;
+#if !PERFETTO_BUILDFLAG(PERFETTO_OS_WIN) &&  \
+    !PERFETTO_BUILDFLAG(PERFETTO_OS_WASM) && \
+    !PERFETTO_BUILDFLAG(PERFETTO_CHROMIUM_BUILD)
+  colorize = isatty(STDERR_FILENO);
+#endif
+  std::string summary = FormatSymbolizationSummary(result, verbose, colorize);
+  if (!summary.empty()) {
+    fprintf(stderr, "%s", summary.c_str());
+  }
+  return result;
 }
 
 }  // namespace perfetto::profiling

--- a/src/trace_processor/util/trace_enrichment/trace_enrichment.h
+++ b/src/trace_processor/util/trace_enrichment/trace_enrichment.h
@@ -52,6 +52,13 @@ struct EnrichmentConfig {
   // PERFETTO_PROGUARD_MAP is always respected.
   bool no_auto_proguard_maps = false;
 
+  // If true, output verbose details (all paths tried, etc.).
+  // If false, output a concise summary with hint to use --verbose for failures.
+  bool verbose = false;
+
+  // If true, include ANSI color codes in the output.
+  bool colorize = false;
+
   // Environment values for path discovery.
   // Must be provided by caller; if empty, related paths are not discovered.
   std::string android_product_out;

--- a/src/traceconv/main.cc
+++ b/src/traceconv/main.cc
@@ -110,6 +110,7 @@ CONVERSION MODES AND THEIR SUPPORTED OPTIONS:
    --symbol-paths PATH1,PATH2,...     Additional paths to search for symbols
                                       (beyond automatic discovery)
    --no-auto-symbol-paths             Disable automatic symbol path discovery
+   --verbose                          Print more detailed output
 
  binary                               Converts text proto to binary format
    (no additional options)
@@ -160,6 +161,7 @@ int Main(int argc, char** argv) {
   bool profile_no_annotations = false;
   std::vector<std::string> symbol_paths;
   bool no_auto_symbol_paths = false;
+  bool verbose = false;
   std::string output_dir;
   for (int i = 1; i < argc; i++) {
     if (strcmp(argv[i], "-v") == 0 || strcmp(argv[i], "--version") == 0) {
@@ -202,6 +204,8 @@ int Main(int argc, char** argv) {
       symbol_paths = base::SplitString(argv[i], ",");
     } else if (strcmp(argv[i], "--no-auto-symbol-paths") == 0) {
       no_auto_symbol_paths = true;
+    } else if (strcmp(argv[i], "--verbose") == 0) {
+      verbose = true;
     } else if (i < argc && strcmp(argv[i], "--output-dir") == 0) {
       i++;
       if (i >= argc) {
@@ -316,21 +320,22 @@ int Main(int argc, char** argv) {
       return Usage(argv[0]);
     }
     return TraceToProfile(input_stream, pid, timestamps,
-                          !profile_no_annotations, output_dir, profile_type);
+                          !profile_no_annotations, output_dir, profile_type,
+                          verbose);
   }
 
   if (format == "java_heap_profile") {
     // legacy alias for "profile --java-heap"
     return TraceToProfile(input_stream, pid, timestamps,
                           !profile_no_annotations, output_dir,
-                          ConversionMode::kJavaHeapProfile);
+                          ConversionMode::kJavaHeapProfile, verbose);
   }
 
   if (format == "hprof")
     return TraceToHprof(input_stream, output_stream, pid, timestamps);
 
   if (format == "symbolize")
-    return SymbolizeProfile(input_stream, output_stream);
+    return SymbolizeProfile(input_stream, output_stream, verbose);
 
   if (format == "deobfuscate")
     return DeobfuscateProfile(input_stream, output_stream);
@@ -372,6 +377,7 @@ int Main(int argc, char** argv) {
     BundleContext context;
     context.symbol_paths = symbol_paths;
     context.no_auto_symbol_paths = no_auto_symbol_paths;
+    context.verbose = verbose;
     if (const char* val = getenv("ANDROID_PRODUCT_OUT")) {
       context.android_product_out = val;
     }

--- a/src/traceconv/symbolize_profile.cc
+++ b/src/traceconv/symbolize_profile.cc
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "perfetto/base/logging.h"
-#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/trace_processor/trace_processor.h"
 #include "src/trace_processor/util/symbolizer/symbolize_database.h"
 #include "src/traceconv/utils.h"
@@ -32,7 +31,7 @@ namespace trace_to_text {
 
 // Ingest profile, and emit a symbolization table for each sequence. This can
 // be prepended to the profile to attach the symbol information.
-int SymbolizeProfile(std::istream* input, std::ostream* output) {
+int SymbolizeProfile(std::istream* input, std::ostream* output, bool verbose) {
   profiling::SymbolizerConfig sym_config;
 
   const char* breakpad_dir = getenv("BREAKPAD_SYMBOL_DIR");
@@ -66,20 +65,10 @@ int SymbolizeProfile(std::istream* input, std::ostream* output) {
     PERFETTO_FATAL("%s", status.c_message());
   }
 
-  auto result = profiling::SymbolizeDatabase(tp.get(), sym_config);
+  auto result =
+      profiling::SymbolizeDatabaseAndLog(tp.get(), sym_config, verbose);
   if (result.error != profiling::SymbolizerError::kOk) {
     PERFETTO_FATAL("Symbolization failed: %s", result.error_details.c_str());
-  }
-  if (!result.mappings_without_build_id.empty()) {
-    std::vector<std::string> mapping_strs;
-    mapping_strs.reserve(result.mappings_without_build_id.size());
-    for (const auto& [name, count] : result.mappings_without_build_id) {
-      mapping_strs.push_back(name + " (" + std::to_string(count) + " frames)");
-    }
-    PERFETTO_ELOG(
-        "Some frames could not be symbolized because their "
-        "mapping has an empty build ID. Mappings: %s",
-        base::Join(mapping_strs, ", ").c_str());
   }
   *output << result.symbols;
 

--- a/src/traceconv/symbolize_profile.h
+++ b/src/traceconv/symbolize_profile.h
@@ -22,7 +22,7 @@
 namespace perfetto {
 namespace trace_to_text {
 
-int SymbolizeProfile(std::istream* input, std::ostream* output);
+int SymbolizeProfile(std::istream* input, std::ostream* output, bool verbose);
 
 }  // namespace trace_to_text
 }  // namespace perfetto

--- a/src/traceconv/trace_to_bundle.h
+++ b/src/traceconv/trace_to_bundle.h
@@ -39,6 +39,9 @@ struct BundleContext {
   // If true, disables automatic symbol path discovery
   bool no_auto_symbol_paths = false;
 
+  // If true, output verbose details (all paths tried, etc.)
+  bool verbose = false;
+
   // Value of ANDROID_PRODUCT_OUT for AOSP builds symbol discovery
   std::string android_product_out;
 

--- a/src/traceconv/trace_to_pprof_integrationtest.cc
+++ b/src/traceconv/trace_to_pprof_integrationtest.cc
@@ -46,7 +46,8 @@ pprof::PprofProfileReader ConvertTraceToPprof(
   trace_to_text::TraceToProfile(&file_istream, /*pid=*/0,
                                 /*timestamps=*/{},
                                 /*annotate_frames=*/false, out_dirname,
-                                /*conversion_mode=*/std::nullopt);
+                                /*conversion_mode=*/std::nullopt,
+                                /*verbose=*/false);
   std::vector<std::string> filenames;
   base::ListFilesRecursive(out_dirname, filenames);
   // assumption: all test inputs contain exactly one profile
@@ -136,7 +137,8 @@ TEST_F(TraceToPprofTest, OutputDirectory) {
   trace_to_text::TraceToProfile(&file_istream, /*pid=*/0,
                                 /*timestamps=*/{},
                                 /*annotate_frames=*/false, output_dir,
-                                ConversionMode::kJavaHeapProfile);
+                                ConversionMode::kJavaHeapProfile,
+                                /*verbose=*/false);
 
   // Check files exist
   std::vector<std::string> filenames;

--- a/src/traceconv/trace_to_profile.h
+++ b/src/traceconv/trace_to_profile.h
@@ -34,7 +34,8 @@ int TraceToProfile(std::istream* input,
                    const std::vector<uint64_t>& timestamps,
                    bool annotate_frames,
                    const std::string& output_dir,
-                   std::optional<ConversionMode> conversion_mode);
+                   std::optional<ConversionMode> conversion_mode,
+                   bool verbose);
 
 }  // namespace trace_to_text
 }  // namespace perfetto


### PR DESCRIPTION
This CL totally overhauls how enrichment and symbolization log messages
about issues which happened during their process. Until this CL, we just
spewed out error messages which were incredibly cryptic to callers on
the assumption that they would be knowledgable enough to figure things
out.

However, with the "bundle" subcommand, this is no longer the case. We
expect that callers won't necessarily be knowledable and will expect
things to "just work". So for this reason, we need to give them much
better error messages and actually explain how to do things.

So for this reason, overhaul how logging works to give a "summary
report" at the end rather than constantly printing messages during. This
allows us to nicely consolodiate and format the infomration. Moreorver,
we can also add a "verbose" mode printing even more information. We can
also give hints of how this works.

Here's an example of normal mode when something goes wrong:
```
Symbolization: 17514 frames could not be symbolized and will appear as "unknown".
  - 16107 frames from 7 mappings: no matching symbols in searched paths
    hint: use --symbol-paths to specify symbol files or directories
    hint: install kernel debug symbols (vmlinux):
      Linux (Debian/Ubuntu): sudo apt install linux-image-$(uname -r)-dbgsym
      Linux (Fedora): sudo dnf debuginfo-install kernel
      Android: obtain vmlinux from your kernel build tree
  - 1407 frames from 5 mappings: no build IDs in trace, symbol lookup requires build IDs
    hint: rebuild binaries with build IDs (linker flag -Wl,--build-id) and re-record the trace
Use --verbose to see the full details.
```

Same with --verbose:
```
Symbolization: 17514 frames could not be symbolized and will appear as "unknown".

  No matching symbols in searched paths for 7 mappings (16107 frames):
    /apex/com.android.runtime/bin/linker64 (10 frames)
      build ID: fa0d2a01d5f25b5f8b0b4da06b97bc14
      paths searched:
        /apex/com.android.runtime/bin/linker64 (file not found)
        /usr/lib/debug/fa0d2a01d5f25b5f8b0b4da06b97bc14.breakpad (file not found)
        /usr/local/google/home/lalitm/.debug/fa0d2a01d5f25b5f8b0b4da06b97bc14.breakpad (file not found)
      hint: use --symbol-paths to specify symbol files or directories
    /apex/com.android.runtime/lib64/bionic/libc.so (135 frames)
      build ID: 8d65ea529c21c79c019713e50adb6675
      paths searched:
        /apex/com.android.runtime/lib64/bionic/libc.so (file not found)
        /usr/lib/debug/8d65ea529c21c79c019713e50adb6675.breakpad (file not found)
        /usr/local/google/home/lalitm/.debug/8d65ea529c21c79c019713e50adb6675.breakpad (file not found)
      hint: use --symbol-paths to specify symbol files or directories
    /apex/com.android.runtime/lib64/bionic/libm.so (3 frames)
      build ID: e9531fc429cc3d713807b4deac7d9f31
      paths searched:
        /apex/com.android.runtime/lib64/bionic/libm.so (file not found)
        /usr/lib/debug/e9531fc429cc3d713807b4deac7d9f31.breakpad (file not found)
        /usr/local/google/home/lalitm/.debug/e9531fc429cc3d713807b4deac7d9f31.breakpad (file not found)
      hint: use --symbol-paths to specify symbol files or directories
    /data/app/~~dH_L5IkOvbUwOwGrTCoGHg==/com.chrome.canary-VXxHA5UfpEivbxwTEQShDA==/lib/arm64/libchrome.so (15034 frames)
      build ID: 6020f5e513a734b2b978e35005f2b783dca3baec
      paths searched:
        /data/app/~~dH_L5IkOvbUwOwGrTCoGHg==/com.chrome.canary-VXxHA5UfpEivbxwTEQShDA==/lib/arm64/libchrome.so (file not found)
        /usr/lib/debug/6020f5e513a734b2b978e35005f2b783dca3baec.breakpad (file not found)
        /usr/local/google/home/lalitm/.debug/6020f5e513a734b2b978e35005f2b783dca3baec.breakpad (file not found)
      hint: use --symbol-paths to specify symbol files or directories
    /system/lib64/libcutils.so (2 frames)
      build ID: 19c947ed846ad8f330274f60fd8e8ea3
      paths searched:
        /system/lib64/libcutils.so (file not found)
        /usr/lib/debug/19c947ed846ad8f330274f60fd8e8ea3.breakpad (file not found)
        /usr/local/google/home/lalitm/.debug/19c947ed846ad8f330274f60fd8e8ea3.breakpad (file not found)
      hint: use --symbol-paths to specify symbol files or directories
    [kernel.kallsyms]_stext (912 frames)
      paths searched:
        /boot/vmlinux-6.6.102-android15-8-g6eb5b2a8c46b-ab14739656-4k (file not found)
        /usr/lib/debug/boot/vmlinux-6.6.102-android15-8-g6eb5b2a8c46b-ab14739656-4k (file not found)
        /lib/modules/6.6.102-android15-8-g6eb5b2a8c46b-ab14739656-4k/build/vmlinux (file not found)
        /usr/lib/debug/lib/modules/6.6.102-android15-8-g6eb5b2a8c46b-ab14739656-4k/vmlinux (file not found)
        /usr/lib/debug/boot/vmlinux-6.6.102-android15-8-g6eb5b2a8c46b-ab14739656-4k.debug (file not found)
        /usr/lib/debug/.breakpad (file not found)
        /usr/local/google/home/lalitm/.debug/.breakpad (file not found)
      hint: install kernel debug symbols (vmlinux):
        Linux (Debian/Ubuntu): sudo apt install linux-image-$(uname -r)-dbgsym
        Linux (Fedora): sudo dnf debuginfo-install kernel
        Android: obtain vmlinux from your kernel build tree
    [vdso] (11 frames)
      build ID: 7c522842cf63b4ab7a58730bf6d55d3032125839
      paths searched:
        [vdso] (file not found)
        /usr/lib/debug/7c522842cf63b4ab7a58730bf6d55d3032125839.breakpad (file not found)
        /usr/local/google/home/lalitm/.debug/7c522842cf63b4ab7a58730bf6d55d3032125839.breakpad (file not found)
      hint: use --symbol-paths to specify symbol files or directories

  No build IDs in trace for 5 mappings (1407 frames), symbol lookup requires build IDs:
    [empty mapping name] (1369 frames)
    /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (1 frame)
    [fips140] (32 frames)
    [pixel_metrics] (2 frames)
    [smra] (3 frames)
  hint: rebuild binaries with build IDs (linker flag -Wl,--build-id) and re-record the trace
```
