### PR TITLE
de: Improve Query node inputs to show dolar sign

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -181,7 +181,7 @@ export class SqlSourceNode implements QueryNode {
       connections: new Map(),
       min: 0,
       max: 'unbounded',
-      portNames: (portIndex: number) => `input_${portIndex}`,
+      portNames: (portIndex: number) => `$input_${portIndex}`,
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source_unittest.ts
@@ -62,7 +62,7 @@ describe('SqlSourceNode', () => {
       expect(node.secondaryInputs.connections.size).toBe(0);
     });
 
-    it('should have port names following input_N pattern', () => {
+    it('should have port names following $input_N pattern', () => {
       const node = new SqlSourceNode({
         sql: '',
         trace: mockTrace,
@@ -71,9 +71,9 @@ describe('SqlSourceNode', () => {
       const portNames = node.secondaryInputs.portNames;
       expect(typeof portNames).toBe('function');
       if (typeof portNames === 'function') {
-        expect(portNames(0)).toBe('input_0');
-        expect(portNames(1)).toBe('input_1');
-        expect(portNames(5)).toBe('input_5');
+        expect(portNames(0)).toBe('$input_0');
+        expect(portNames(1)).toBe('$input_1');
+        expect(portNames(5)).toBe('$input_5');
       }
     });
   });


### PR DESCRIPTION
Inputs in Query node should be starting with $ for better UX - seeing it might make it more obvious to the users that they can refer to the inputs this way.