### PR TITLE
tp: fix kernel package hint and also document indexed dirs search

### DIFF
--- a/src/trace_processor/util/symbolizer/breakpad_symbolizer.cc
+++ b/src/trace_processor/util/symbolizer/breakpad_symbolizer.cc
@@ -65,6 +65,12 @@ SymbolizeResult BreakpadSymbolizer::Symbolize(
     const std::vector<uint64_t>& address) {
   SymbolizeResult result;
   result.frames.reserve(address.size());
+
+  // Skip lookup if build_id is empty (e.g., kernel symbols).
+  if (build_id.empty()) {
+    return result;
+  }
+
   std::string file_path;
   std::string raw_build_id = base::ToHex(build_id.c_str(), build_id.length());
 

--- a/src/trace_processor/util/symbolizer/local_symbolizer.h
+++ b/src/trace_processor/util/symbolizer/local_symbolizer.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -52,6 +53,9 @@ enum class BinaryPathError : uint8_t {
   kFileNotFound,
   // A file was found but had the wrong build ID.
   kBuildIdMismatch,
+  // A directory was indexed but didn't contain a binary with the requested
+  // build ID.
+  kBuildIdNotInIndex,
 };
 
 // Record of a single path attempt during binary lookup.
@@ -88,6 +92,8 @@ class LocalBinaryIndexer : public BinaryFinder {
   ~LocalBinaryIndexer() override;
 
  private:
+  std::vector<std::string> indexed_directories_;
+  std::set<std::string> symbol_files_;
   std::map<std::string, FoundBinary> buildid_to_file_;
 };
 

--- a/src/trace_processor/util/symbolizer/symbolize_database.cc
+++ b/src/trace_processor/util/symbolizer/symbolize_database.cc
@@ -253,6 +253,8 @@ const char* SymbolPathErrorToString(SymbolPathError error) {
       return "build ID mismatch";
     case SymbolPathError::kParseError:
       return "failed to parse";
+    case SymbolPathError::kBuildIdNotInIndex:
+      return "no matching build ID";
   }
   return "unknown";
 }
@@ -290,7 +292,7 @@ void FormatKernelHint(bool colorize, std::string* out, const char* indent) {
   *out += indent;
   *out +=
       "  Linux (Debian/Ubuntu): sudo apt install "
-      "linux-image-$(uname -r)-dbgsym\n";
+      "linux-image-$(uname -r)-dbg\n";
   *out += indent;
   *out += "  Linux (Fedora): sudo dnf debuginfo-install kernel\n";
   *out += indent;

--- a/src/trace_processor/util/symbolizer/symbolizer.h
+++ b/src/trace_processor/util/symbolizer/symbolizer.h
@@ -41,6 +41,9 @@ enum class SymbolPathError : uint8_t {
   kBuildIdMismatch,
   // The file exists but couldn't be parsed (e.g., invalid breakpad file).
   kParseError,
+  // A directory was indexed but didn't contain a binary with the requested
+  // build ID.
+  kBuildIdNotInIndex,
 };
 
 // Record of a single path attempt during symbolization.


### PR DESCRIPTION
When symbolizing, we were not correctly indicating which directories we
searched via build id indexing. Add that in.

Also fix the kernel package recommendation.
