### PR TITLE
Fix: Isolate clock tracking for multi-trace TAR loading

### DIFF
--- a/src/trace_processor/forwarding_trace_parser.cc
+++ b/src/trace_processor/forwarding_trace_parser.cc
@@ -128,7 +128,11 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
   // TODO(b/334978369) Make sure kProtoTraceType and kSystraceTraceType are
   // parsed first so that we do not get issues with
   // SetPidZeroIsUpidZeroIdleProcess()
-  trace_context_ = input_context_->ForkContextForTrace(file_id_, 0);
+  // Use file_id as the machine ID to ensure each trace file in a multi-trace
+  // session gets its own clock tracker. This prevents timestamp offsets when
+  // loading multiple traces from a TAR container.
+  trace_context_ =
+      input_context_->ForkContextForTrace(file_id_, file_id_.value);
   if (trace_type_ == kProtoTraceType || trace_type_ == kSystraceTraceType) {
     trace_context_->process_tracker->SetPidZeroIsUpidZeroIdleProcess();
   }


### PR DESCRIPTION
When multiple trace files are loaded from a TAR container, they were sharing the same clock tracker (machine_id=0), causing timestamp synchronization issues. Events from subsequent traces would appear offset by the duration of previous traces.

Fix: Use unique machine IDs (based on file_id) for each trace file to ensure each gets its own isolated clock tracker context.

Before:
<img width="2509" height="1411" alt="image" src="https://github.com/user-attachments/assets/d7170e92-ce78-4729-b5c9-1c533a3cd7b3" />

After:
<img width="2509" height="1411" alt="image" src="https://github.com/user-attachments/assets/88628b40-831a-4d58-a9bc-943696736044" />
