### PR TITLE
ui: Add flag to load track data in the background

### DIFF
--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -38,6 +38,7 @@ import {checkerboardExcept} from '../checkerboard';
 import {CacheKey} from './timeline_cache';
 import {valueIfAllEqual} from '../../base/array_utils';
 import {deferChunkedTask} from '../../base/chunked_task';
+import {CHUNKED_TASK_BACKGROUND_PRIORITY} from './feature_flags';
 import {HSLColor} from '../../base/color';
 
 function roundAway(n: number): number {
@@ -1149,7 +1150,10 @@ export abstract class BaseCounterTrack implements TrackRenderer {
       );
     `);
 
-    const task = await deferChunkedTask();
+    const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
+      ? 'background'
+      : undefined;
+    const task = await deferChunkedTask({priority});
 
     const it = queryRes.iter({
       ts: LONG,

--- a/ui/src/components/tracks/base_slice_track.ts
+++ b/ui/src/components/tracks/base_slice_track.ts
@@ -40,6 +40,7 @@ import {checkerboardExcept} from '../checkerboard';
 import {UNEXPECTED_PINK} from '../colorizer';
 import {BUCKETS_PER_PIXEL, CacheKey} from './timeline_cache';
 import {deferChunkedTask} from '../../base/chunked_task';
+import {CHUNKED_TASK_BACKGROUND_PRIORITY} from './feature_flags';
 
 // The common class that underpins all tracks drawing slices.
 
@@ -751,7 +752,10 @@ export abstract class BaseSliceTrack<
       CROSS JOIN (${this.getSqlSource()}) s using (id)
     `);
 
-    const task = await deferChunkedTask();
+    const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
+      ? 'background'
+      : undefined;
+    const task = await deferChunkedTask({priority});
 
     const it = queryRes.iter(this.rowSpec);
 

--- a/ui/src/components/tracks/feature_flags.ts
+++ b/ui/src/components/tracks/feature_flags.ts
@@ -1,0 +1,24 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {featureFlags} from '../../core/feature_flags';
+
+export const CHUNKED_TASK_BACKGROUND_PRIORITY = featureFlags.register({
+  id: 'trackBackgroundDataLoading',
+  name: 'Load track data in the background',
+  description: `When enabled, track data is loaded using background priority
+    tasks. This can help keep the UI responsive during heavy data loading
+    but may increase the time it takes for tracks to appear.`,
+  defaultValue: false,
+});

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -22,6 +22,7 @@ import {colorForCpu} from '../../components/colorizer';
 import m from 'mithril';
 import {TrackData} from '../../components/tracks/track_data';
 import {TimelineFetcher} from '../../components/tracks/track_helper';
+import {CHUNKED_TASK_BACKGROUND_PRIORITY} from '../../components/tracks/feature_flags';
 import {checkerboardExcept} from '../../components/checkerboard';
 import {TrackRenderer} from '../../public/track';
 import {LONG, NUM} from '../../trace_processor/query_result';
@@ -246,7 +247,10 @@ export class CpuFreqTrack implements TrackRenderer {
       );
     `);
 
-    const task = await deferChunkedTask();
+    const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
+      ? 'background'
+      : undefined;
+    const task = await deferChunkedTask({priority});
 
     const freqRows = freqResult.numRows();
     const idleRows = idleResult.numRows();

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
@@ -22,6 +22,7 @@ import {colorForThread, colorForTid} from '../../components/colorizer';
 import {ColorScheme} from '../../base/color_scheme';
 import {TrackData} from '../../components/tracks/track_data';
 import {TimelineFetcher} from '../../components/tracks/track_helper';
+import {CHUNKED_TASK_BACKGROUND_PRIORITY} from '../../components/tracks/feature_flags';
 import {checkerboardExcept} from '../../components/checkerboard';
 import {TrackRenderer} from '../../public/track';
 import {LONG, NUM, QueryResult} from '../../trace_processor/query_result';
@@ -321,7 +322,10 @@ export class GroupSummaryTrack implements TrackRenderer {
 
     const queryRes = await this.queryData(start, end, resolution);
 
-    const task = await deferChunkedTask();
+    const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
+      ? 'background'
+      : undefined;
+    const task = await deferChunkedTask({priority});
 
     const numRows = queryRes.numRows();
     const slices: Data = {

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_track.ts
@@ -25,6 +25,7 @@ import m from 'mithril';
 import {colorForThread} from '../../components/colorizer';
 import {TrackData} from '../../components/tracks/track_data';
 import {TimelineFetcher} from '../../components/tracks/track_helper';
+import {CHUNKED_TASK_BACKGROUND_PRIORITY} from '../../components/tracks/feature_flags';
 import {checkerboardExcept} from '../../components/checkerboard';
 import {Point2D} from '../../base/geom';
 import {HighPrecisionTime} from '../../base/high_precision_time';
@@ -195,7 +196,10 @@ export class CpuSliceTrack implements TrackRenderer {
       cross join sched s using (id)
     `);
 
-    const task = await deferChunkedTask();
+    const priority = CHUNKED_TASK_BACKGROUND_PRIORITY.get()
+      ? 'background'
+      : undefined;
+    const task = await deferChunkedTask({priority});
 
     const numRows = queryRes.numRows();
     const slices: Data = {


### PR DESCRIPTION
Adds an experimental flag which, when enabled, makes tracks load data in a **background** priority task rather than the default user-visible. This makes sure that rendering and RAFs take precedence over data loading, keeping the UI responsive at the expense of longer loading times.