### PR TITLE
Update gpu_frequency unit from MHz to kHz

### DIFF
--- a/src/trace_processor/importers/common/tracks_common.h
+++ b/src/trace_processor/importers/common/tracks_common.h
@@ -162,7 +162,7 @@ inline constexpr auto kCpuMinFrequencyLimitBlueprint = tracks::CounterBlueprint(
 
 inline constexpr auto kGpuFrequencyBlueprint = tracks::CounterBlueprint(
     "gpu_frequency",
-    tracks::StaticUnitBlueprint("MHz"),
+    tracks::StaticUnitBlueprint("kHz"),
     tracks::DimensionBlueprints(kGpuDimensionBlueprint),
     tracks::StaticNameBlueprint("gpufreq"));
 


### PR DESCRIPTION
The counter values reported by Android devices are already in kHz (e.g., Pixel reports values like 750,000 and 302,000 to mean that many kHz). But, Trace Processor currently reports the unit as MHz.

```
select name,unit from counters where name = "gpufreq" limit 1;
```

Before:
```
name    unit
gpufreq MHz
```
After:
```
name    unit
gpufreq kHz
```


Perfetto Web UI doesn't show the unit for GPU Frequency, so this change doesn't have any impact on it.