### PR TITLE
ui: fix SliceMipmapOperator::Create memory access out of bounds

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/operators/slice_mipmap_operator.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/operators/slice_mipmap_operator.cc
@@ -108,8 +108,12 @@ int SliceMipmapOperator::Create(sqlite3* db,
     }
     int64_t ts = sqlite3_column_int64(res->stmt.sqlite_stmt(), 1);
     int64_t dur = sqlite3_column_int64(res->stmt.sqlite_stmt(), 2);
-    auto depth =
-        static_cast<uint32_t>(sqlite3_column_int64(res->stmt.sqlite_stmt(), 3));
+    int64_t column = sqlite3_column_int64(res->stmt.sqlite_stmt(), 3);
+    if (column < 0) {
+      continue;
+    }
+    auto depth = static_cast<uint32_t>(column);
+
     if (PERFETTO_UNLIKELY(depth >= state->by_depth.size())) {
       state->by_depth.resize(depth + 1);
     }


### PR DESCRIPTION
* if sqlite3_column_int64 return -1，static_cast uint32 to 0xffffffff
*0xffffffff + 1 = 0, causing by_depth to be resized to 0.

test: The local run-dev-server does not crash when loading the same perfetto trace.
fix: https://github.com/google/perfetto/issues/4713