### PR TITLE
Add custom tokenizing on fwtp_perfetto_slice ftrace events

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
+++ b/src/trace_processor/importers/ftrace/ftrace_tokenizer.h
@@ -90,6 +90,10 @@ class FtraceTokenizer {
       uint32_t cpu,
       TraceBlobView event,
       RefPtr<PacketSequenceStateGeneration> state);
+  void TokenizeFtraceFwtpPerfettoSlice(
+      uint32_t cpu,
+      TraceBlobView event,
+      RefPtr<PacketSequenceStateGeneration> state);
   std::optional<protozero::Field> GetFtraceEventField(
       uint32_t event_id,
       const TraceBlobView& event);


### PR DESCRIPTION
The fwtp_perfetto_slice ftrace events have the correct timestamp embedded in them.

Bug: 469451931
Test: Verified Perfetto captures correct timestamp with
 fwtp_perfetto_slice traces.