### PR TITLE
Update pinning logic for Android Input Lifecycle

### DIFF
--- a/ui/src/plugins/com.android.AndroidInputLifecycle/tab.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/tab.ts
@@ -223,7 +223,7 @@ export class AndroidInputTab implements Tab {
           },
         );
 
-        // Check if this row matches the clicked vent
+        // Check if this row matches the clicked event
         const matchesClickedEvent = [
           it.id_reader,
           it.id_dispatch,


### PR DESCRIPTION
- Use the global workspace as the source of truth when pinning, ensuring that when new selections are focused, existing pinned tracks remain pinned.