### PR TITLE
Chrome: Remove totalDuration from WebContentInteraction

### DIFF
--- a/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/web_content_interaction_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeCriticalUserInteractions/web_content_interaction_details_panel.ts
@@ -44,7 +44,6 @@ interface Data {
   ts: time;
   dur: duration;
   interactionType: string;
-  totalDurationMs: duration;
   upid: Upid;
 }
 
@@ -62,7 +61,6 @@ export class WebContentInteractionPanel implements TrackEventDetailsPanel {
         ts,
         dur,
         interaction_type AS interactionType,
-        total_duration_ms AS totalDurationMs,
         renderer_upid AS upid
       FROM chrome_web_content_interactions
       WHERE id = ${this.id};
@@ -72,7 +70,6 @@ export class WebContentInteractionPanel implements TrackEventDetailsPanel {
       ts: LONG,
       dur: LONG,
       interactionType: STR,
-      totalDurationMs: LONG,
       upid: NUM,
     });
 
@@ -80,7 +77,6 @@ export class WebContentInteractionPanel implements TrackEventDetailsPanel {
       ts: Time.fromRaw(iter.ts),
       dur: iter.ts,
       interactionType: iter.interactionType,
-      totalDurationMs: iter.totalDurationMs,
       upid: asUpid(iter.upid),
     };
   }
@@ -119,13 +115,6 @@ export class WebContentInteractionPanel implements TrackEventDetailsPanel {
                 }),
               }),
               m(TreeNode, {left: 'Renderer Upid', right: this.data.upid}),
-              m(TreeNode, {
-                left: 'Total duration of all events',
-                right: m(DurationWidget, {
-                  trace: this.trace,
-                  dur: this.data.totalDurationMs,
-                }),
-              }),
               m(TreeNode, {
                 left: 'SQL ID',
                 right: m(SqlRef, {


### PR DESCRIPTION
I am [working on a Chromium patch](https://chromium-review.googlesource.com/c/chromium/src/+/7555792) to remove the `totalDuration` value from Event Timing trace events.  As part of that cleanup, there seems to be a single Perfetto UI feature that depends on that data.

Before ripping it out, it was suggested to remove the usage for it, and this is an attempt at that patch.

(FYI: I don't typically contribute to Perfetto UI and I am fixing this "blind", though this patch seems low risk I think?)

---

Subsequently I would like to change two more perfetto related files:
- src/trace_processor/perfetto_sql/stdlib/chrome/web_content_interactions.sql
- protos/third_party/chromium/chrome_track_event.proto

Both of these appear inside both Chromium and Perfetto, and I see there is a process to ROLL chromium files into Perfetto repo, but also vice versa.

I *think* those two should be landed as Chromium changes and sync into Perfetto repo, but if anyone suggests otherwise, I can land those changes here first.

Cheers!
