### PR TITLE
tp: Provide transition timestamps in table for drawing pending and playing stages.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
+++ b/src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h
@@ -40,10 +40,12 @@ class ShellTransitionsTracker {
   void SetSendTime(int32_t transition_id, int64_t timestamp_ns);
   void SetDispatchTime(int32_t transition_id, int64_t timestamp_ns);
   void SetShellAbortTime(int32_t transition_id, int64_t timestamp_ns);
+  void SetWmAbortTime(int32_t transition_id, int64_t timestamp_ns);
   void SetFinishTime(int32_t transition_id, int64_t finish_time_ns);
+  void SetMergeTime(int32_t transition_id, int64_t merge_time_ns);
+  void SetCreateTime(int32_t transition_id, int64_t create_time_ns);
   void SetHandler(int32_t transition_id, int64_t handler);
   void SetFlags(int32_t transition_id, int32_t flags);
-  void SetStatus(int32_t transition_id, StringPool::Id status);
   void SetStartTransactionId(int32_t transition_id, uint64_t transaction_id);
   void SetFinishTransactionId(int32_t transition_id, uint64_t transaction_id);
 
@@ -59,6 +61,8 @@ class ShellTransitionsTracker {
 
   std::optional<tables::WindowManagerShellTransitionsTable::RowReference>
   GetRowReference(int32_t transition_id);
+
+  void SetStatusesAndDurations();
 
   TraceProcessorContext* context_;
   std::unordered_map<int32_t, TransitionInfo> transitions_infos_;

--- a/src/trace_processor/tables/winscope_tables.py
+++ b/src/trace_processor/tables/winscope_tables.py
@@ -617,6 +617,21 @@ WINDOW_MANAGER_SHELL_TRANSITIONS_TABLE = Table(
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
         ),
         C(
+            'wm_abort_time_ns',
+            CppOptional(CppInt64()),
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+        ),
+        C(
+            'merge_time_ns',
+            CppOptional(CppInt64()),
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+        ),
+        C(
+            'create_time_ns',
+            CppOptional(CppInt64()),
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+        ),
+        C(
             'handler',
             CppOptional(CppInt64()),
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
@@ -664,6 +679,12 @@ WINDOW_MANAGER_SHELL_TRANSITIONS_TABLE = Table(
                 'Transition finish time',
             'shell_abort_time_ns':
                 'Transition shell abort time',
+            'wm_abort_time_ns':
+                'Transition wm abort time',
+            'merge_time_ns':
+                'Transition merge time',
+            'create_time_ns':
+                'Transition create time',
             'handler':
                 'Handler id',
             'status':

--- a/test/trace_processor/diff_tests/parser/android/shell_transitions.textproto
+++ b/test/trace_processor/diff_tests/parser/android/shell_transitions.textproto
@@ -79,7 +79,7 @@ packet {
   trusted_uid: 1000
   trusted_packet_sequence_id: 5
   trusted_pid: 1305
-  shell_transition { id: 9 finish_time_ns: 77873935462 }
+  shell_transition { id: 9 wm_abort_time_ns: 77876414732 }
 }
 packet {
   trusted_uid: 1000
@@ -105,7 +105,7 @@ packet {
   trusted_uid: 10241
   trusted_packet_sequence_id: 6
   trusted_pid: 2528
-  shell_transition { id: 8 dispatch_time_ns: 77320527177 handler: 3 }
+  shell_transition { id: 8 handler: 3 }
 }
 packet {
   trusted_uid: 10241
@@ -125,7 +125,6 @@ packet {
   trusted_pid: 2528
   shell_transition {
     id: 11
-    dispatch_time_ns: 82536817137
     handler: 2
     targets { layer_id: 4 }
   }
@@ -140,5 +139,38 @@ packet {
     merge_time_ns: 82697060749
     merge_target: 11
     targets { window_id: 12 layer_id: 4 }
+    dispatch_time_ns: 77876454832
+    finish_time_ns: 82697061749
+  }
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 2
+  trusted_pid: 1305
+  shell_transition {
+    id: 13
+    create_time_ns: 82498127051
+    send_time_ns: 82535513845
+    wm_abort_time_ns: 82536819537
+  }
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 2
+  trusted_pid: 1305
+  shell_transition {
+    id: 14
+    create_time_ns: 82498127051
+    finish_time_ns: 82536819537
+  }
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 2
+  trusted_pid: 1305
+  shell_transition {
+    id: 15
+    send_time_ns: 82498127051
+    finish_time_ns: 82536819537
   }
 }

--- a/test/trace_processor/diff_tests/parser/android/tests_shell_transitions.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_shell_transitions.py
@@ -22,6 +22,15 @@ from python.generators.diff_tests.testing import TestSuite
 class ShellTransitions(TestSuite):
 
   def test_has_expected_transition_rows(self):
+    # 7: no status - dispatched but no finish time
+    # 8: merged - merge time present
+    # 9: no status - aborted then dispatched but no finish time
+    # 10: played - dispatched and finished
+    # 11: aborted - from shell side
+    # 12: merged - merge time and finish time present
+    # 13: aborted - from WM side
+    # 14: no status - created and finished without dispatch
+    # 15: no status - sent and finished without dispatch
     return DiffTestBlueprint(
         trace=Path('shell_transitions.textproto'),
         query="""
@@ -35,6 +44,9 @@ class ShellTransitions(TestSuite):
           duration_ns,
           finish_time_ns,
           shell_abort_time_ns,
+          wm_abort_time_ns,
+          merge_time_ns,
+          create_time_ns,
           handler,
           status,
           flags,
@@ -45,13 +57,16 @@ class ShellTransitions(TestSuite):
         ORDER BY id;
         """,
         out=Csv("""
-        "id","ts","transition_id","transition_type","send_time_ns","dispatch_time_ns","duration_ns","finish_time_ns","shell_abort_time_ns","handler","status","flags","start_transaction_id","finish_transaction_id"
-        0,76879063147,7,"[NULL]",76875395422,76879063147,"[NULL]","[NULL]","[NULL]",2,"[NULL]","[NULL]",5604932321952,5604932321954
-        1,77899001013,10,"[NULL]",77894307328,77899001013,727303101,78621610429,"[NULL]",4,"played","[NULL]",5604932322158,5604932322159
-        2,82536817137,11,"[NULL]",82535513345,82536817137,"[NULL]","[NULL]",82536817537,2,"aborted","[NULL]",5604932322346,5604932322347
-        3,77320527177,8,"[NULL]",77277756832,77320527177,"[NULL]","[NULL]","[NULL]",3,"merged","[NULL]",5604932322028,5604932322029
-        4,77876414832,9,"[NULL]",77843436723,77876414832,30498739,77873935462,"[NULL]",3,"played","[NULL]",5604932322137,5604932322138
-        5,0,12,1,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","merged","[NULL]","[NULL]","[NULL]"
+        "id","ts","transition_id","transition_type","send_time_ns","dispatch_time_ns","duration_ns","finish_time_ns","shell_abort_time_ns","wm_abort_time_ns","merge_time_ns","create_time_ns","handler","status","flags","start_transaction_id","finish_transaction_id"
+        0,76875395422,7,"[NULL]",76875395422,76879063147,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]",76799049027,2,"[NULL]","[NULL]",5604932321952,5604932321954
+        1,77894307328,10,"[NULL]",77894307328,77899001013,722609416,78621610429,"[NULL]","[NULL]","[NULL]",77854865352,4,"played","[NULL]",5604932322158,5604932322159
+        2,82535513345,11,"[NULL]",82535513345,"[NULL]","[NULL]","[NULL]",82536817537,"[NULL]","[NULL]",82498121051,2,"aborted","[NULL]",5604932322346,5604932322347
+        3,77277756832,8,"[NULL]",77277756832,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]",77278725500,76955664017,3,"merged","[NULL]",5604932322028,5604932322029
+        4,77843436723,9,"[NULL]",77843436723,77876414832,"[NULL]","[NULL]","[NULL]",77876414732,"[NULL]",77825423417,3,"[NULL]","[NULL]",5604932322137,5604932322138
+        5,77876454832,12,1,"[NULL]",77876454832,"[NULL]",82697061749,"[NULL]","[NULL]",82697060749,"[NULL]","[NULL]","merged","[NULL]","[NULL]","[NULL]"
+        6,82535513845,13,"[NULL]",82535513845,"[NULL]","[NULL]","[NULL]","[NULL]",82536819537,"[NULL]",82498127051,"[NULL]","aborted","[NULL]","[NULL]","[NULL]"
+        7,0,14,"[NULL]","[NULL]","[NULL]","[NULL]",82536819537,"[NULL]","[NULL]","[NULL]",82498127051,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]"
+        8,82498127051,15,"[NULL]",82498127051,"[NULL]","[NULL]",82536819537,"[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]","[NULL]"
         """))
 
   def test_has_expected_transition_args(self):
@@ -97,7 +112,7 @@ class ShellTransitions(TestSuite):
         """,
         out=Csv("""
         "COUNT(*)"
-        15
+        18
         """))
 
   def test_has_shell_handlers(self):

--- a/test/trace_processor/diff_tests/syntax/table_tests.py
+++ b/test/trace_processor/diff_tests/syntax/table_tests.py
@@ -622,7 +622,7 @@ class PerfettoTable(TestSuite):
         query="""
           SELECT key, int_value, real_value FROM __intrinsic_winscope_proto_to_args_with_defaults('__intrinsic_window_manager_shell_transition_protos') as tbl
           ORDER BY tbl.base64_proto_id, key
-          LIMIT 56
+          LIMIT 58
           """,
         out=Csv("""
           "key","int_value","real_value"
@@ -654,6 +654,7 @@ class PerfettoTable(TestSuite):
           "type",0,"[NULL]"
           "wm_abort_time_ns",0,"[NULL]"
           "create_time_ns",82498121051,"[NULL]"
+          "dispatch_time_ns",0,"[NULL]"
           "finish_time_ns",0,"[NULL]"
           "finish_transaction_id",5604932322347,"[NULL]"
           "flags",0,"[NULL]"
@@ -670,6 +671,7 @@ class PerfettoTable(TestSuite):
           "type",0,"[NULL]"
           "wm_abort_time_ns",0,"[NULL]"
           "create_time_ns",76955664017,"[NULL]"
+          "dispatch_time_ns",0,"[NULL]"
           "finish_time_ns",0,"[NULL]"
           "finish_transaction_id",5604932322029,"[NULL]"
           "flags",0,"[NULL]"


### PR DESCRIPTION
Less confusing UX in Winscope.

Prioritise send time over dispatch time for transition timestamp.
Set status and duration on flush after all proto packets have been processed for increased clarity.

Bug: 481316747
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="ShellTransition|PerfettoTable:winscope"
