### PR TITLE
Centralize specifications of Chrome Scroll Jank plugin's main tracks

### DIFF
--- a/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_track.ts
@@ -19,17 +19,14 @@ import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
 import {getColorForSlice} from '../../components/colorizer';
+import {EVENT_LATENCY_TRACK} from './tracks';
 
 export const JANKY_LATENCY_NAME = 'Janky EventLatency';
 
-export function createEventLatencyTrack(
-  trace: Trace,
-  uri: string,
-  baseTable: string,
-) {
+export function createEventLatencyTrack(trace: Trace) {
   return SliceTrack.create({
     trace,
-    uri,
+    uri: EVENT_LATENCY_TRACK.uri,
     dataset: new SourceDataset({
       schema: {
         id: NUM,
@@ -38,7 +35,7 @@ export function createEventLatencyTrack(
         name: STR,
         depth: NUM,
       },
-      src: baseTable,
+      src: EVENT_LATENCY_TRACK.tableName,
     }),
     colorizer: (row) => {
       return row.name === JANKY_LATENCY_NAME

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/index.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {uuidv4Sql} from '../../base/uuid';
 import {generateSqlWithInternalLayout} from '../../components/sql_utils/layout';
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
@@ -35,6 +34,11 @@ import {escapeQuery} from '../../trace_processor/query_utils';
 import {ThreadSliceDetailsPanel} from '../../components/details/thread_slice_details_tab';
 import {createScrollTimelineV4Track} from './scroll_timeline_v4_track';
 import {createScrollTimelineV4Model} from './scroll_timeline_v4_model';
+import {
+  EVENT_LATENCY_TRACK,
+  SCROLL_TIMELINE_TRACK,
+  SCROLL_TIMELINE_V4_TRACK,
+} from './tracks';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'org.chromium.ChromeScrollJank';
@@ -96,10 +100,7 @@ export default class implements PerfettoPlugin {
         AND is_presented`,
     });
 
-    // Table name must be unique - it cannot include '-' characters or begin
-    // with a numeric value.
-    const baseTable = `table_${uuidv4Sql()}_janky_event_latencies_v3`;
-    const tableDefSql = `CREATE TABLE ${baseTable} AS
+    const tableDefSql = `CREATE TABLE ${EVENT_LATENCY_TRACK.tableName} AS
         WITH
         event_latencies AS MATERIALIZED (
           ${subTableSql}
@@ -175,15 +176,15 @@ export default class implements PerfettoPlugin {
     );
     await ctx.engine.query(tableDefSql);
 
-    const uri = 'org.chromium.ChromeScrollJank#eventLatency';
-    const title = 'Chrome Scroll Input Latencies';
-
     ctx.tracks.registerTrack({
-      uri,
-      renderer: createEventLatencyTrack(ctx, uri, baseTable),
+      uri: EVENT_LATENCY_TRACK.uri,
+      renderer: createEventLatencyTrack(ctx),
     });
 
-    const track = new TrackNode({uri, name: title});
+    const track = new TrackNode({
+      uri: EVENT_LATENCY_TRACK.uri,
+      name: EVENT_LATENCY_TRACK.name,
+    });
     group.addChildInOrder(track);
   }
 
@@ -211,19 +212,17 @@ export default class implements PerfettoPlugin {
     ctx: Trace,
     group: TrackNode,
   ): Promise<void> {
-    const uri = 'org.chromium.ChromeScrollJank#scrollTimeline';
-    const title = 'Chrome Scroll Timeline';
-
-    const tableName =
-      'scrolltimelinetrack_org_chromium_ChromeScrollJank_scrollTimeline';
-    const model = await createScrollTimelineModel(ctx.engine, tableName, uri);
+    await createScrollTimelineModel(ctx.engine);
 
     ctx.tracks.registerTrack({
-      uri,
-      renderer: createScrollTimelineTrack(ctx, model),
+      uri: SCROLL_TIMELINE_TRACK.uri,
+      renderer: createScrollTimelineTrack(ctx),
     });
 
-    const track = new TrackNode({uri, name: title});
+    const track = new TrackNode({
+      uri: SCROLL_TIMELINE_TRACK.uri,
+      name: SCROLL_TIMELINE_TRACK.name,
+    });
     group.addChildInOrder(track);
   }
 
@@ -231,18 +230,17 @@ export default class implements PerfettoPlugin {
     ctx: Trace,
     group: TrackNode,
   ): Promise<void> {
-    const uri = 'org.chromium.ChromeScrollJank#scrollTimelineV4';
-    const title = 'Chrome Scroll Timeline v4';
-
-    const tableName = 'org_chromium_ChromeScrollJank_scroll_timeline_v4';
-    const model = await createScrollTimelineV4Model(ctx.engine, tableName, uri);
+    await createScrollTimelineV4Model(ctx.engine);
 
     ctx.tracks.registerTrack({
-      uri,
-      renderer: createScrollTimelineV4Track(ctx, model),
+      uri: SCROLL_TIMELINE_V4_TRACK.uri,
+      renderer: createScrollTimelineV4Track(ctx),
     });
 
-    const track = new TrackNode({uri, name: title});
+    const track = new TrackNode({
+      uri: SCROLL_TIMELINE_V4_TRACK.uri,
+      name: SCROLL_TIMELINE_V4_TRACK.name,
+    });
     group.addChildInOrder(track);
   }
 

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_details_panel.ts
@@ -26,23 +26,13 @@ import {Timestamp} from '../../components/widgets/timestamp';
 import {DurationWidget} from '../../components/widgets/duration';
 import {fromSqlBool, renderSqlRef} from './utils';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
-import {ColumnDefinition} from '../../components/widgets/sql/table/table_description';
-import {ScrollTimelineModel} from './scroll_timeline_model';
-import {PerfettoSqlTypes} from '../../trace_processor/perfetto_sql_type';
-
-const SCROLL_TIMELINE_TABLE_COLUMNS: ColumnDefinition[] = [
-  {column: 'id', type: {kind: 'id', source: {table: 'slice', column: 'id'}}},
-  {column: 'scroll_update_id', type: PerfettoSqlTypes.INT},
-  {column: 'ts', type: PerfettoSqlTypes.TIMESTAMP},
-  {column: 'dur', type: PerfettoSqlTypes.DURATION},
-  {column: 'name', type: PerfettoSqlTypes.STRING},
-  {column: 'classification', type: PerfettoSqlTypes.STRING},
-];
+import {SCROLL_TIMELINE_TRACK} from './tracks';
+import {SCROLL_TIMELINE_TABLE_DEFINITION} from './scroll_timeline_model';
 
 export class ScrollTimelineDetailsPanel implements TrackEventDetailsPanel {
   // Information about the scroll update *slice*, which was emitted by
   // ScrollTimelineTrack.
-  // Source: this.tableName[id=this.id]
+  // Source: SCROLL_TIMELINE_TRACK.tableName[id=this.id]
   private sliceData?: {
     name: string;
     ts: time;
@@ -65,7 +55,6 @@ export class ScrollTimelineDetailsPanel implements TrackEventDetailsPanel {
 
   constructor(
     private readonly trace: Trace,
-    private readonly model: ScrollTimelineModel,
     // ID of the slice in tableName.
     private readonly id: number,
   ) {}
@@ -83,7 +72,7 @@ export class ScrollTimelineDetailsPanel implements TrackEventDetailsPanel {
         ts,
         dur,
         scroll_update_id
-      FROM ${this.model.tableName}
+      FROM ${SCROLL_TIMELINE_TRACK.tableName}
       WHERE id = ${this.id}`);
     const row = queryResult.firstRow({
       name: STR,
@@ -179,11 +168,8 @@ export class ScrollTimelineDetailsPanel implements TrackEventDetailsPanel {
           left: 'SQL ID',
           right: renderSqlRef({
             trace: this.trace,
-            tableName: this.model.tableName,
-            tableDefinition: {
-              name: this.model.tableName,
-              columns: SCROLL_TIMELINE_TABLE_COLUMNS,
-            },
+            tableName: SCROLL_TIMELINE_TRACK.tableName,
+            tableDefinition: SCROLL_TIMELINE_TABLE_DEFINITION,
             id: this.id,
           }),
         }),

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_track.ts
@@ -19,12 +19,10 @@ import {JANK_COLOR} from './jank_colors';
 import {getColorForSlice, makeColorScheme} from '../../components/colorizer';
 import {HSLColor} from '../../base/color';
 import {ScrollTimelineDetailsPanel} from './scroll_timeline_details_panel';
-import {
-  ScrollTimelineModel,
-  ScrollUpdateClassification,
-} from './scroll_timeline_model';
+import {ScrollUpdateClassification} from './scroll_timeline_model';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
+import {SCROLL_TIMELINE_TRACK} from './tracks';
 
 const INDIGO = makeColorScheme(new HSLColor([231, 48, 48]));
 const GRAY = makeColorScheme(new HSLColor([0, 0, 62]));
@@ -50,15 +48,12 @@ function toColorScheme(
   }
 }
 
-export function createScrollTimelineTrack(
-  trace: Trace,
-  model: ScrollTimelineModel,
-) {
+export function createScrollTimelineTrack(trace: Trace) {
   return SliceTrack.create({
     trace,
-    uri: model.trackUri,
+    uri: SCROLL_TIMELINE_TRACK.uri,
     dataset: new SourceDataset({
-      src: model.tableName,
+      src: SCROLL_TIMELINE_TRACK.tableName,
       schema: {
         id: NUM,
         ts: LONG,
@@ -71,8 +66,6 @@ export function createScrollTimelineTrack(
     colorizer: (row) => {
       return toColorScheme(row.classification) ?? getColorForSlice(row.name);
     },
-    detailsPanel: (row) => {
-      return new ScrollTimelineDetailsPanel(trace, model, row.id);
-    },
+    detailsPanel: (row) => new ScrollTimelineDetailsPanel(trace, row.id),
   });
 }

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_v4_track.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_v4_track.ts
@@ -20,10 +20,8 @@ import {getColorForSlice, makeColorScheme} from '../../components/colorizer';
 import {HSLColor} from '../../base/color';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {SourceDataset} from '../../trace_processor/dataset';
-import {
-  ScrollFrameClassification,
-  ScrollTimelineV4Model,
-} from './scroll_timeline_v4_model';
+import {ScrollFrameClassification} from './scroll_timeline_v4_model';
+import {SCROLL_TIMELINE_V4_TRACK} from './tracks';
 
 const INDIGO = makeColorScheme(new HSLColor([231, 48, 48]));
 const GOLD = makeColorScheme(new HSLColor([48, 95, 55]));
@@ -52,15 +50,12 @@ function toColorScheme(
   }
 }
 
-export function createScrollTimelineV4Track(
-  trace: Trace,
-  model: ScrollTimelineV4Model,
-) {
+export function createScrollTimelineV4Track(trace: Trace) {
   return SliceTrack.create({
     trace,
-    uri: model.trackUri,
+    uri: SCROLL_TIMELINE_V4_TRACK.uri,
     dataset: new SourceDataset({
-      src: model.tableName,
+      src: SCROLL_TIMELINE_V4_TRACK.tableName,
       schema: {
         id: NUM,
         ts: LONG,

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/tracks.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/tracks.ts
@@ -1,0 +1,99 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+type TrackSpec = {
+  tableName: string;
+  uri: string;
+  name: string;
+};
+
+/**
+ * The EventLatency track.
+ *
+ * The track contains information about scroll updates and their stages, which
+ * can be visualized by {@link event_latency_track#createEventLatencyTrack} and
+ * whose details can be inspected in
+ * {@link event_latency_details_panel#EventLatencySliceDetailsPanel}.
+ *
+ * The undeflying table is created by
+ * {@link index#default.addEventLatencyTrack}.
+ *
+ * EventLatency slices on the track are marked as janky/non-janky based on the
+ * Perfetto scroll_jank_v3 metric. See the `chrome_janky_event_latencies_v3`
+ * table for more details.
+ */
+export const EVENT_LATENCY_TRACK: TrackSpec = {
+  tableName: `org_chromium_ChromeScrollJank_event_latency`,
+  uri: 'org.chromium.ChromeScrollJank#eventLatency',
+  name: 'Chrome Scroll Input Latencies',
+};
+
+/**
+ * The scroll timeline track.
+ *
+ * The timeline and the underlying table contain information about scroll
+ * updates and their stages, which can be visualized by
+ * {@link scroll_timeline_track#createScrollTimelineTrack} and whose details can
+ * be inspected in
+ * {@link scroll_timeline_details_panel#ScrollTimelineDetailsPanel}.
+ *
+ * The underlying table is created by
+ * {@link scroll_timeline_model#createScrollTimelineModel}. See
+ * {@link scroll_timeline_model#SCROLL_TIMELINE_TABLE_DEFINITION} for more
+ * information about the table's contents.
+ *
+ * Scroll updates on the scroll timeline are marked as janky/non-janky based on
+ * Chrome's v3.1 scroll jank metric
+ * ('Event.ScrollJank.DelayedFramesPercentage.FixedWindow'). See
+ * https://source.chromium.org/chromium/chromium/src/+/main:cc/metrics/scroll_jank_dropped_frame_tracker.h
+ * for more details.
+ *
+ * In general, there's a 1:1 mapping between scroll updates on this track and
+ * EventLatency slices on {@link EVENT_LATENCY_TRACK}.
+ */
+export const SCROLL_TIMELINE_TRACK: TrackSpec = {
+  tableName: 'org_chromium_ChromeScrollJank_scroll_timeline',
+  uri: 'org.chromium.ChromeScrollJank#scrollTimeline',
+  name: 'Chrome Scroll Timeline',
+};
+
+/**
+ * The scroll timeline track according to Chrome's scroll jank v4 metric.
+ *
+ * The timeline and the underlying table contain information about frames which
+ * contain one or more scroll updates and relevant events within the frames,
+ * which can be visualized by
+ * {@link scroll_timeline_v4_track#createScrollTimelineV4Track}.
+ *
+ * The underlying table is created by
+ * {@link scroll_timeline_v4_model#createScrollTimelineV4Model}. See
+ * {@link scroll_timeline_v4_model#SCROLL_TIMELINE_V4_TABLE_DEFINITION} for more
+ * information about the table's contents.
+ *
+ * Frames on the scroll timeline v4 are marked as janky/non-janky based on
+ * Chrome's v4 scroll jank metric
+ * ('Event.ScrollJank.DelayedFramesPercentage4.FixedWindow'). See
+ * https://docs.google.com/document/d/1AaBvTIf8i-c-WTKkjaL4vyhQMkSdynxo3XEiwpofdeA
+ * and scroll_jank_v4*.{h,cc} source files in
+ * https://source.chromium.org/chromium/chromium/src/+/main:cc/metrics/ for more
+ * details.
+ *
+ * In general, there's a 1:N mapping (N >= 1) between frames on this track and
+ * scroll updates on {@link SCROLL_TIMELINE_TRACK}.
+ */
+export const SCROLL_TIMELINE_V4_TRACK: TrackSpec = {
+  tableName: 'org_chromium_ChromeScrollJank_scroll_timeline_v4',
+  uri: 'org.chromium.ChromeScrollJank#scrollTimelineV4',
+  name: 'Chrome Scroll Timeline v4',
+};


### PR DESCRIPTION
This commit centralizes the specifications of the 'Chrome Scroll Input Latencies', 'Chrome Scroll Timeline' and  'Chrome Scroll Timeline v4' tracks in a single file (tracks.ts). This makes the code easier to understand and will allow us to add links between slices on the tracks in the future.

Issue: #4658