### PR TITLE
ui: add pid to slice name in AndroidAnr plugin

### DIFF
--- a/ui/src/plugins/com.android.AndroidAnr/index.ts
+++ b/ui/src/plugins/com.android.AndroidAnr/index.ts
@@ -99,7 +99,7 @@ export default class AndroidAnr implements PerfettoPlugin {
             SELECT
               ts - coalesce(anr_dur_ms, default_anr_dur_ms, 0) * 1000000 AS ts,
               coalesce(anr_dur_ms, default_anr_dur_ms, 0) * 1000000 AS dur,
-              process_name || ' ' || pid || ': ' || anr_type AS name
+              process_name || ' ' || pid || ' : ' || anr_type AS name
             FROM android_anrs
           `,
         }),


### PR DESCRIPTION
This change adds pid to the slice name of an ANR besides the process_name and anr_type

Additional: add default dur value when there's no expired timer event and the anr type is unkwown.
