### PR TITLE
ui: Fix query results tab not updating properly

### DIFF
--- a/ui/src/components/query_table/query_table.ts
+++ b/ui/src/components/query_table/query_table.ts
@@ -293,12 +293,13 @@ export class QueryResultsTable
     return m(DataGrid, {
       schema,
       rootSchema: 'data',
-      initialColumns: resp.columns.map((col) => ({id: col, field: col})),
-      // If filters are defined by no onFilterChanged handler, the grid operates
-      // in filter read only mode.
-      enablePivotControls: false, // In-memory datasource does not support pivoting
+      // Fixed columns - ensures that any changes to the query response are
+      // reflected in the table immediately.
+      // TODO(stevegolton): Support column manipulation but sync with results on
+      // the query page.
+      columns: resp.columns.map((col) => ({id: col, field: col})),
+      enablePivotControls: false, // In-memory datasource doesn't support pivot
       fillHeight: true,
-      filters: [],
       data: dataSource,
       onReady: (api) => {
         this.dataGridApi = api;


### PR DESCRIPTION
This patch fixes a bug where running a new query on the query page then switching back to the timeline would not actually update the columns in the query results tab on the timeline. The first set of columns this tab sees is what it sticks with forever, despite query results changing underneath it.

Testing:
1. Run a query in the query page.
2. Switch to the timeline page.
3. Switch back to the query page and modify the query a different query with a different set of columns.
4. Switch back to the timeline page, confirm the query tab has the right set of columns.

Because this patch involves basically disabling mutable columns, this blocks the user from modifying columns at all in the query tab view - this includes adding, removing, or reordering columns but also sorting. The datagrid component currently doesn't hide these controls when despite the fact that they do nothing, so this patch also fixes this so the controls are no longer visible.

While in the area:
- Remove fixed filters from query results tab, there's no reason not to allow filters
- In DataGrid if filters are immutable (controlled but no onFiltersX callback passed, like above), don't show any of the filter controls.