### PR TITLE
ui: OomAdjScoreViz plugin rename the bucket tracks

### DIFF
--- a/ui/src/plugins/com.android.OomAdjScoreViz/index.ts
+++ b/ui/src/plugins/com.android.OomAdjScoreViz/index.ts
@@ -113,7 +113,7 @@ export default class OomAdjScoreViz implements PerfettoPlugin {
 
     const concurrencyNode = new TrackNode({
       uri: concurrencyUri,
-      name: `OOM Score ${bucket}: Concurrent Processes`,
+      name: `${bucket} processes count`,
       removable: true,
     });
 


### PR DESCRIPTION
This change renames the bucket tracks to a `${bucket} processes count` in OomAdjScoreViz plugin