### PR TITLE
perf: Allow raw perf events to specify dev by name

### DIFF
--- a/protos/perfetto/common/perf_events.proto
+++ b/protos/perfetto/common/perf_events.proto
@@ -160,10 +160,14 @@ message PerfEvents {
   // struct. Primarily for local use-cases, since the event availability and
   // encoding is hardware-specific.
   message RawEvent {
+    // Either |type| or |perf_device| can be set.
     optional uint32 type = 1;
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
+    // The name of a PMU under /sys/bus/event_source/devices
+    // (e.g. "armv8_pmuv3").
+    optional string perf_device = 5;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/protos/perfetto/common/perf_events.proto
+++ b/protos/perfetto/common/perf_events.proto
@@ -160,14 +160,17 @@ message PerfEvents {
   // struct. Primarily for local use-cases, since the event availability and
   // encoding is hardware-specific.
   message RawEvent {
-    // Either |type| or |perf_device| can be set.
+    // Either |type| or |pmu_name| can be set.
     optional uint32 type = 1;
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
-    // The name of a PMU under /sys/bus/event_source/devices
+    // The name of a dynamic PMU under /sys/bus/event_source/devices
     // (e.g. "armv8_pmuv3").
-    optional string perf_device = 5;
+    // If set, leave |type| unset.
+    // Android: the relevant sysfs paths are not allowlisted by default, so
+    // this option will require a rooted device with selinux disabled.
+    optional string pmu_name = 5;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -2279,10 +2279,14 @@ message PerfEvents {
   // struct. Primarily for local use-cases, since the event availability and
   // encoding is hardware-specific.
   message RawEvent {
+    // Either |type| or |perf_device| can be set.
     optional uint32 type = 1;
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
+    // The name of a PMU under /sys/bus/event_source/devices
+    // (e.g. "armv8_pmuv3").
+    optional string perf_device = 5;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -2279,14 +2279,17 @@ message PerfEvents {
   // struct. Primarily for local use-cases, since the event availability and
   // encoding is hardware-specific.
   message RawEvent {
-    // Either |type| or |perf_device| can be set.
+    // Either |type| or |pmu_name| can be set.
     optional uint32 type = 1;
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
-    // The name of a PMU under /sys/bus/event_source/devices
+    // The name of a dynamic PMU under /sys/bus/event_source/devices
     // (e.g. "armv8_pmuv3").
-    optional string perf_device = 5;
+    // If set, leave |type| unset.
+    // Android: the relevant sysfs paths are not allowlisted by default, so
+    // this option will require a rooted device with selinux disabled.
+    optional string pmu_name = 5;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -2279,10 +2279,14 @@ message PerfEvents {
   // struct. Primarily for local use-cases, since the event availability and
   // encoding is hardware-specific.
   message RawEvent {
+    // Either |type| or |perf_device| can be set.
     optional uint32 type = 1;
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
+    // The name of a PMU under /sys/bus/event_source/devices
+    // (e.g. "armv8_pmuv3").
+    optional string perf_device = 5;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -2279,14 +2279,17 @@ message PerfEvents {
   // struct. Primarily for local use-cases, since the event availability and
   // encoding is hardware-specific.
   message RawEvent {
-    // Either |type| or |perf_device| can be set.
+    // Either |type| or |pmu_name| can be set.
     optional uint32 type = 1;
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
-    // The name of a PMU under /sys/bus/event_source/devices
+    // The name of a dynamic PMU under /sys/bus/event_source/devices
     // (e.g. "armv8_pmuv3").
-    optional string perf_device = 5;
+    // If set, leave |type| unset.
+    // Android: the relevant sysfs paths are not allowlisted by default, so
+    // this option will require a rooted device with selinux disabled.
+    optional string pmu_name = 5;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/src/profiling/perf/event_config.cc
+++ b/src/profiling/perf/event_config.cc
@@ -22,14 +22,12 @@
 
 #include <cinttypes>
 #include <optional>
-#include <unordered_map>
 #include <vector>
 
 #include <unwindstack/Regs.h>
 
 #include "perfetto/base/flat_set.h"
 #include "perfetto/ext/base/file_utils.h"
-#include "perfetto/ext/base/no_destructor.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/utils.h"
 #include "protos/perfetto/common/perf_events.gen.h"
@@ -120,6 +118,8 @@ TargetFilter ParseTargetFilter(
 constexpr bool IsPowerOfTwo(size_t v) {
   return (v != 0 && ((v & (v - 1)) == 0));
 }
+
+std::optional<uint32_t> LookupPerfDeviceType(const std::string& perf_device);
 
 // returns |std::nullopt| if the input is invalid.
 std::optional<uint32_t> ChooseActualRingBufferPages(uint32_t config_value) {
@@ -306,14 +306,19 @@ std::optional<PerfCounter> MakePerfCounter(
                                      tracepoint_pb.filter(), *maybe_id);
     } else if (event_desc.has_raw_event()) {
       const auto& raw = event_desc.raw_event();
-      if (raw.has_perf_device() && !raw.perf_device().empty() &&
-          raw.has_type()) {
-        PERFETTO_ELOG("raw_event cannot specify both type and perf_device.");
+      if (raw.has_pmu_name() && !raw.pmu_name().empty() && raw.has_type()) {
+        PERFETTO_ELOG("raw_event cannot specify both type and pmu_name.");
         return std::nullopt;
       }
-      return PerfCounter::RawEvent(name, raw.has_type() ? raw.type() : 0u,
-                                   raw.config(), raw.config1(), raw.config2(),
-                                   raw.perf_device());
+      std::optional<uint32_t> raw_type =
+          raw.has_type() ? std::make_optional(raw.type())
+                         : LookupPerfDeviceType(raw.pmu_name());
+      if (!raw_type) {
+        PERFETTO_ELOG("Failed to resolve raw_event type.");
+        return std::nullopt;
+      }
+      return PerfCounter::RawEvent(name, *raw_type, raw.config(), raw.config1(),
+                                   raw.config2());
     } else {
       return PerfCounter::BuiltinCounter(
           name, protos::gen::PerfEvents::PerfEvents::SW_CPU_CLOCK,
@@ -340,6 +345,21 @@ bool IsSupportedUnwindMode(
     default:
       return false;
   }
+}
+
+std::optional<uint32_t> LookupPerfDeviceType(const std::string& perf_device) {
+  if (perf_device.empty())
+    return std::nullopt;
+  if (base::Contains(perf_device, '/') || base::StartsWith(perf_device, ".."))
+    return std::nullopt;
+
+  const std::string type_path =
+      "/sys/bus/event_source/devices/" + perf_device + "/type";
+  std::string buf;
+  if (!base::ReadFile(type_path, &buf))
+    return std::nullopt;
+
+  return base::StringToUInt32(base::TrimWhitespace(buf));
 }
 
 }  // namespace
@@ -382,49 +402,12 @@ PerfCounter PerfCounter::RawEvent(std::string name,
                                   uint32_t type,
                                   uint64_t config,
                                   uint64_t config1,
-                                  uint64_t config2,
-                                  std::string perf_device) {
+                                  uint64_t config2) {
   PerfCounter ret;
   ret.type = PerfCounter::Type::kRawEvent;
   ret.name = std::move(name);
 
   ret.attr_type = type;
-  if (!perf_device.empty()) {  // Lookup type from PMU device.
-    static const base::NoDestructor<std::unordered_map<std::string, uint32_t>>
-        perf_devices([]() {
-          std::unordered_map<std::string, uint32_t> devs;
-          const char* devices_path = "/sys/bus/event_source/devices";
-          base::ScopedDir perf_device_dir(opendir(devices_path));
-          if (!perf_device_dir)
-            return devs;
-
-          for (auto* ent = readdir(perf_device_dir.get()); ent;
-               ent = readdir(perf_device_dir.get())) {
-            if (ent->d_name[0] == '.')
-              continue;
-            const std::string dir_name =
-                std::string(devices_path) + "/" + ent->d_name;
-            std::string buf;
-            if (!base::ReadFile(dir_name + "/type", &buf))
-              continue;
-
-            std::optional<uint32_t> maybe_type =
-                base::StringToUInt32(base::TrimWhitespace(buf));
-            if (!maybe_type)
-              continue;
-            devs[ent->d_name] = *maybe_type;
-          }
-          return devs;
-        }());
-    const auto& devices = perf_devices.ref();
-    auto it = devices.find(perf_device);
-    if (it != devices.end()) {
-      ret.attr_type = it->second;
-    } else {
-      PERFETTO_ELOG("RawEvent config perf_device couldn't be found");
-    }
-  }
-
   ret.attr_config = config;
   ret.attr_config1 = config1;
   ret.attr_config2 = config2;

--- a/src/profiling/perf/event_config.h
+++ b/src/profiling/perf/event_config.h
@@ -105,7 +105,8 @@ struct PerfCounter {
                               uint32_t type,
                               uint64_t config,
                               uint64_t config1,
-                              uint64_t config2);
+                              uint64_t config2,
+                              std::string perf_device);
 };
 
 // Describes a single profiling configuration. Bridges the gap between the data

--- a/src/profiling/perf/event_config.h
+++ b/src/profiling/perf/event_config.h
@@ -105,8 +105,7 @@ struct PerfCounter {
                               uint32_t type,
                               uint64_t config,
                               uint64_t config1,
-                              uint64_t config2,
-                              std::string perf_device);
+                              uint64_t config2);
 };
 
 // Describes a single profiling configuration. Bridges the gap between the data

--- a/src/profiling/perf/event_config_unittest.cc
+++ b/src/profiling/perf/event_config_unittest.cc
@@ -494,6 +494,19 @@ TEST(EventConfigTest, GroupMultipleType) {
   EXPECT_TRUE(tracepoint.sample_type & PERF_SAMPLE_READ);
 }
 
+TEST(EventConfigTest, RawEventRejectsTypeAndPmu) {
+  protos::gen::PerfEventConfig cfg;
+  auto* follower = cfg.add_followers();
+  follower->set_name("raw");
+  auto* raw_event = follower->mutable_raw_event();
+  raw_event->set_type(8);
+  raw_event->set_config(8);
+  raw_event->set_perf_device("armv8_pmuv3");
+
+  std::optional<EventConfig> event_config = CreateEventConfig(cfg);
+  EXPECT_FALSE(event_config.has_value());
+}
+
 TEST(EventConfigTest, EventModifiers) {
   protos::gen::PerfEventConfig cfg;
   {


### PR DESCRIPTION
Add perf_device option to let raw_perf events derive type from /sys/bus/event_source/devices/<perf_device>/type

