### PR TITLE
de: Serialization covered in node registry

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/history_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/history_manager_unittest.ts
@@ -23,6 +23,9 @@ import {PerfettoSqlType} from '../../trace_processor/perfetto_sql_type';
 import {addConnection, removeConnection} from './query_builder/graph_utils';
 import {UIFilter} from './query_builder/operations/filter';
 import {ColumnInfo} from './query_builder/column_info';
+import {registerCoreNodes} from './query_builder/core_nodes';
+
+registerCoreNodes();
 
 describe('HistoryManager', () => {
   let trace: Trace;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler.ts
@@ -13,99 +13,17 @@
 // limitations under the License.
 
 import {ExplorePageState} from './explore_page';
-import {
-  QueryNode,
-  NodeType,
-  singleNodeOperation,
-  ensureCounterAbove,
-} from './query_node';
+import {QueryNode, NodeType, ensureCounterAbove} from './query_node';
 import {getAllNodes as getAllNodesUtil} from './query_builder/graph_utils';
-import {
-  TableSourceNode,
-  TableSourceSerializedState,
-} from './query_builder/nodes/sources/table_source';
-import {
-  SlicesSourceNode,
-  SlicesSourceSerializedState,
-} from './query_builder/nodes/sources/slices_source';
-import {
-  SqlSourceNode,
-  SqlSourceSerializedState,
-} from './query_builder/nodes/sources/sql_source';
-import {
-  TimeRangeSourceNode,
-  TimeRangeSourceSerializedState,
-} from './query_builder/nodes/sources/timerange_source';
-import {
-  AggregationNode,
-  AggregationSerializedState,
-} from './query_builder/nodes/aggregation_node';
-import {
-  ModifyColumnsNode,
-  ModifyColumnsSerializedState,
-} from './query_builder/nodes/modify_columns_node';
-import {
-  IntervalIntersectNode,
-  IntervalIntersectSerializedState,
-} from './query_builder/nodes/interval_intersect_node';
 import {Trace} from '../../public/trace';
 import {SqlModules} from '../../plugins/dev.perfetto.SqlModules/sql_modules';
-import {
-  AddColumnsNode,
-  AddColumnsNodeState,
-} from './query_builder/nodes/add_columns_node';
-import {
-  LimitAndOffsetNode,
-  LimitAndOffsetNodeState,
-} from './query_builder/nodes/limit_and_offset_node';
-import {SortNode, SortNodeState} from './query_builder/nodes/sort_node';
-import {FilterNode, FilterNodeState} from './query_builder/nodes/filter_node';
-import {JoinNode, JoinSerializedState} from './query_builder/nodes/join_node';
-import {
-  CreateSlicesNode,
-  CreateSlicesSerializedState,
-} from './query_builder/nodes/create_slices_node';
-import {
-  UnionNode,
-  UnionSerializedState,
-} from './query_builder/nodes/union_node';
-import {
-  FilterDuringNode,
-  FilterDuringNodeState,
-} from './query_builder/nodes/filter_during_node';
-import {
-  CounterToIntervalsNode,
-  CounterToIntervalsNodeState,
-} from './query_builder/nodes/counter_to_intervals_node';
-import {
-  FilterInNode,
-  FilterInNodeState,
-} from './query_builder/nodes/filter_in_node';
-
-type SerializedNodeState =
-  | TableSourceSerializedState
-  | SlicesSourceSerializedState
-  | SqlSourceSerializedState
-  | TimeRangeSourceSerializedState
-  | AggregationSerializedState
-  | ModifyColumnsSerializedState
-  | IntervalIntersectSerializedState
-  | AddColumnsNodeState
-  | LimitAndOffsetNodeState
-  | SortNodeState
-  | FilterNodeState
-  | JoinSerializedState
-  | CreateSlicesSerializedState
-  | UnionSerializedState
-  | FilterDuringNodeState
-  | CounterToIntervalsNodeState
-  | FilterInNodeState;
+import {nodeRegistry} from './query_builder/node_registry';
 
 // Interfaces for the serialized JSON structure
 export interface SerializedNode {
   nodeId: string;
   type: NodeType;
-  state: SerializedNodeState; // This will hold the serializable state of the node
+  state: object;
   nextNodes: string[];
   // Input node IDs (for multi-source nodes like Union, Merge, IntervalIntersect)
   inputNodeIds?: string[];
@@ -132,19 +50,12 @@ function serializeNode(node: QueryNode): SerializedNode {
     throw new Error(`Node type ${node.type} is not serializable.`);
   }
 
-  const state = node.serializeState() as SerializedNodeState;
-
-  const serialized: SerializedNode = {
+  return {
     nodeId: node.nodeId,
     type: node.type,
-    state: state,
+    state: node.serializeState(),
     nextNodes: node.nextNodes.map((n: QueryNode) => n.nodeId),
   };
-
-  // Connection information is stored in nextNodes and node-specific serializedState
-  // Each node's serializeState() method handles its own input connections
-
-  return serialized;
 }
 
 interface LabelData {
@@ -280,111 +191,11 @@ function createNodeInstance(
   trace: Trace,
   sqlModules: SqlModules,
 ): QueryNode {
-  const {state} = serializedNode;
-  switch (serializedNode.type) {
-    case NodeType.kTable:
-      return new TableSourceNode(
-        TableSourceNode.deserializeState(
-          trace,
-          sqlModules,
-          state as TableSourceSerializedState,
-        ),
-      );
-    case NodeType.kSimpleSlices:
-      return new SlicesSourceNode({trace, sqlModules});
-    case NodeType.kSqlSource:
-      return new SqlSourceNode({
-        ...(state as SqlSourceSerializedState),
-        trace,
-      });
-    case NodeType.kTimeRangeSource:
-      return new TimeRangeSourceNode(
-        TimeRangeSourceNode.deserializeState(
-          trace,
-          state as TimeRangeSourceSerializedState,
-        ),
-      );
-    case NodeType.kAggregation:
-      return new AggregationNode({
-        ...AggregationNode.deserializeState(
-          state as AggregationSerializedState,
-        ),
-        sqlModules,
-      });
-    case NodeType.kModifyColumns:
-      return new ModifyColumnsNode(
-        ModifyColumnsNode.deserializeState(
-          sqlModules,
-          state as ModifyColumnsSerializedState,
-        ),
-      );
-    case NodeType.kAddColumns:
-      return new AddColumnsNode(
-        AddColumnsNode.deserializeState(
-          sqlModules,
-          state as AddColumnsNodeState,
-        ),
-      );
-    case NodeType.kLimitAndOffset:
-      return new LimitAndOffsetNode({
-        ...LimitAndOffsetNode.deserializeState(
-          state as LimitAndOffsetNodeState,
-        ),
-        sqlModules,
-      });
-    case NodeType.kSort:
-      return new SortNode({
-        ...SortNode.deserializeState(state as SortNodeState),
-        sqlModules,
-      });
-    case NodeType.kFilter:
-      return new FilterNode({
-        ...FilterNode.deserializeState(state as FilterNodeState),
-        sqlModules,
-      });
-    case NodeType.kIntervalIntersect:
-      return new IntervalIntersectNode({
-        ...IntervalIntersectNode.deserializeState(
-          state as IntervalIntersectSerializedState,
-        ),
-        sqlModules,
-      });
-    case NodeType.kJoin:
-      return new JoinNode({
-        ...JoinNode.deserializeState(state as JoinSerializedState),
-        sqlModules,
-      });
-    case NodeType.kCreateSlices:
-      return new CreateSlicesNode({
-        ...CreateSlicesNode.deserializeState(
-          state as CreateSlicesSerializedState,
-        ),
-        sqlModules,
-      });
-    case NodeType.kUnion:
-      return new UnionNode({
-        ...UnionNode.deserializeState(state as UnionSerializedState),
-        sqlModules,
-      });
-    case NodeType.kFilterDuring:
-      return new FilterDuringNode({
-        ...FilterDuringNode.deserializeState(state as FilterDuringNodeState),
-        sqlModules,
-      });
-    case NodeType.kCounterToIntervals:
-      return new CounterToIntervalsNode({
-        ...CounterToIntervalsNode.deserializeState(
-          state as CounterToIntervalsNodeState,
-        ),
-        sqlModules,
-      });
-    case NodeType.kFilterIn:
-      return new FilterInNode(
-        FilterInNode.deserializeState(state as FilterInNodeState),
-      );
-    default:
-      throw new Error(`Unknown node type: ${serializedNode.type}`);
+  const descriptor = nodeRegistry.getByNodeType(serializedNode.type);
+  if (!descriptor) {
+    throw new Error(`Unknown node type: ${serializedNode.type}`);
   }
+  return descriptor.deserialize(serializedNode.state, trace, sqlModules);
 }
 
 export function deserializeState(
@@ -448,16 +259,26 @@ export function deserializeState(
     });
   }
 
-  // Third pass: set backward connections using serialized state
-  // For single-input operations, we use primaryInputId from state rather than inferring
-  // from nextNodes. This is important for nodes like AddColumnsNode that have both
-  // primaryInput AND secondaryInputs.
+  // Third pass: set backward connections using the node registry
   for (const serializedNode of serializedGraph.nodes) {
-    const node = nodes.get(serializedNode.nodeId)!;
-    const serializedState = serializedNode.state as {primaryInputId?: string};
+    const node = nodes.get(serializedNode.nodeId);
+    if (!node) {
+      throw new Error(
+        `Graph is corrupted. Node "${serializedNode.nodeId}" not found.`,
+      );
+    }
+    const descriptor = nodeRegistry.getByNodeType(serializedNode.type);
+    if (!descriptor) {
+      throw new Error(`Unknown node type: ${serializedNode.type}`);
+    }
 
-    // Set primaryInput for single-input operations using the serialized primaryInputId
-    if (singleNodeOperation(node.type)) {
+    // Restore primary input for nodes that have one
+    const hasPrimary =
+      descriptor.hasPrimaryInput ?? descriptor.type === 'modification';
+    if (hasPrimary) {
+      const serializedState = serializedNode.state as {
+        primaryInputId?: string;
+      };
       if (serializedState.primaryInputId) {
         const inputNode = nodes.get(serializedState.primaryInputId);
         if (inputNode) {
@@ -466,170 +287,22 @@ export function deserializeState(
       }
     }
 
-    // Node-specific connection deserialization for multi-input operations
-    if (serializedNode.type === NodeType.kIntervalIntersect) {
-      const intervalNode = node as IntervalIntersectNode;
-      const serializedState =
-        serializedNode.state as IntervalIntersectSerializedState;
-      const deserializedConnections =
-        IntervalIntersectNode.deserializeConnections(nodes, serializedState);
-      intervalNode.secondaryInputs.connections.clear();
-      for (let i = 0; i < deserializedConnections.inputNodes.length; i++) {
-        intervalNode.secondaryInputs.connections.set(
-          i,
-          deserializedConnections.inputNodes[i],
-        );
-      }
-    }
-    if (serializedNode.type === NodeType.kJoin) {
-      const joinNode = node as JoinNode;
-      const deserializedConnections = JoinNode.deserializeConnections(
-        nodes,
-        serializedNode.state as JoinSerializedState,
-      );
-      if (deserializedConnections.leftNode) {
-        joinNode.secondaryInputs.connections.set(
-          0,
-          deserializedConnections.leftNode,
-        );
-      }
-      if (deserializedConnections.rightNode) {
-        joinNode.secondaryInputs.connections.set(
-          1,
-          deserializedConnections.rightNode,
-        );
-      }
-    }
-    if (serializedNode.type === NodeType.kCreateSlices) {
-      const createSlicesNode = node as CreateSlicesNode;
-      const deserializedConnections = CreateSlicesNode.deserializeConnections(
-        nodes,
-        serializedNode.state as CreateSlicesSerializedState,
-      );
-      if (deserializedConnections.startsNode) {
-        createSlicesNode.secondaryInputs.connections.set(
-          0,
-          deserializedConnections.startsNode,
-        );
-      }
-      if (deserializedConnections.endsNode) {
-        createSlicesNode.secondaryInputs.connections.set(
-          1,
-          deserializedConnections.endsNode,
-        );
-      }
-    }
-    if (serializedNode.type === NodeType.kUnion) {
-      const unionNode = node as UnionNode;
-      const serializedState = serializedNode.state as UnionSerializedState;
-      const deserializedConnections = UnionNode.deserializeConnections(
-        nodes,
-        serializedState,
-      );
-      unionNode.secondaryInputs.connections.clear();
-      for (let i = 0; i < deserializedConnections.inputNodes.length; i++) {
-        unionNode.secondaryInputs.connections.set(
-          i,
-          deserializedConnections.inputNodes[i],
-        );
-      }
-    }
-    if (serializedNode.type === NodeType.kAddColumns) {
-      const addColumnsNode = node as AddColumnsNode;
-      const serializedState = serializedNode.state as {
-        secondaryInputNodeId?: string;
-      };
-      if (serializedState.secondaryInputNodeId) {
-        const secondaryInputNode = nodes.get(
-          serializedState.secondaryInputNodeId,
-        );
-        if (secondaryInputNode) {
-          addColumnsNode.secondaryInputs.connections.set(0, secondaryInputNode);
-        }
-      }
-    }
-    if (serializedNode.type === NodeType.kFilterDuring) {
-      const filterDuringNode = node as FilterDuringNode;
-      const serializedState = serializedNode.state as {
-        secondaryInputNodeIds?: string[];
-      };
-      const deserializedConnections = FilterDuringNode.deserializeConnections(
-        nodes,
-        serializedState,
-      );
-      filterDuringNode.secondaryInputs.connections.clear();
-      for (
-        let i = 0;
-        i < deserializedConnections.secondaryInputNodes.length;
-        i++
-      ) {
-        filterDuringNode.secondaryInputs.connections.set(
-          i,
-          deserializedConnections.secondaryInputNodes[i],
-        );
-      }
-    }
-    if (serializedNode.type === NodeType.kFilterIn) {
-      const filterInNode = node as FilterInNode;
-      const serializedState = serializedNode.state as {
-        secondaryInputNodeIds?: string[];
-      };
-      const deserializedConnections = FilterInNode.deserializeConnections(
-        nodes,
-        serializedState,
-      );
-      filterInNode.secondaryInputs.connections.clear();
-      for (
-        let i = 0;
-        i < deserializedConnections.secondaryInputNodes.length;
-        i++
-      ) {
-        filterInNode.secondaryInputs.connections.set(
-          i,
-          deserializedConnections.secondaryInputNodes[i],
-        );
-      }
-    }
-    if (serializedNode.type === NodeType.kSqlSource) {
-      const sqlSourceNode = node as SqlSourceNode;
-      const serializedState = serializedNode.state as SqlSourceSerializedState;
-      const deserializedConnections = SqlSourceNode.deserializeConnections(
-        nodes,
-        serializedState,
-      );
-      sqlSourceNode.secondaryInputs.connections.clear();
-      for (let i = 0; i < deserializedConnections.inputNodes.length; i++) {
-        sqlSourceNode.secondaryInputs.connections.set(
-          i,
-          deserializedConnections.inputNodes[i],
-        );
-      }
-    }
+    // Node-specific connection deserialization
+    descriptor.deserializeConnections?.(node, serializedNode.state, nodes);
   }
 
-  // Third pass: resolve columns
-  for (const node of nodes.values()) {
-    if (node.type === NodeType.kAggregation) {
-      (node as AggregationNode).resolveColumns();
-    }
-    if (node.type === NodeType.kModifyColumns) {
-      (node as ModifyColumnsNode).resolveColumns();
-    }
+  // Fourth pass: post-deserialization (resolve internal references, then
+  // update derived state). Two phases ensure that all nodes are resolved
+  // before any derived state is computed.
+  const descriptors = [...nodes.values()].map((node) => ({
+    node,
+    descriptor: nodeRegistry.getByNodeType(node.type),
+  }));
+  for (const {node, descriptor} of descriptors) {
+    descriptor?.postDeserialize?.(node);
   }
-
-  // Fourth pass: call onPrevNodesUpdated on specific node types that need it
-  // JoinNode needs special handling because:
-  // 1. Its constructor calls updateColumnArrays() which needs connected nodes
-  // 2. During deserialization, connections don't exist yet (restored above in third pass)
-  // 3. So updateColumnArrays() runs with no connections, creating empty arrays
-  // 4. We need to call it again now that connections are restored
-  // We DON'T call this on all nodes because some nodes (like AddColumnsNode) have
-  // onPrevNodesUpdated() implementations that can reset/modify state inappropriately
-  // during deserialization (e.g., clearing selectedColumns).
-  for (const node of nodes.values()) {
-    if (node.type === NodeType.kJoin) {
-      (node as JoinNode).onPrevNodesUpdated();
-    }
+  for (const {node, descriptor} of descriptors) {
+    descriptor?.postDeserializeLate?.(node);
   }
 
   const rootNodes = serializedGraph.rootNodeIds.map((id) => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/json_handler_unittest.ts
@@ -38,6 +38,9 @@ import {ColumnInfo} from './query_builder/column_info';
 import {FilterDuringNode} from './query_builder/nodes/filter_during_node';
 import {TimeRangeSourceNode} from './query_builder/nodes/sources/timerange_source';
 import {Time} from '../../base/time';
+import {registerCoreNodes} from './query_builder/core_nodes';
+
+registerCoreNodes();
 
 describe('JSON serialization/deserialization', () => {
   let trace: Trace;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/multi_node_operations_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/multi_node_operations_unittest.ts
@@ -20,6 +20,9 @@ import {TableSourceNode} from './query_builder/nodes/sources/table_source';
 import {FilterNode} from './query_builder/nodes/filter_node';
 import {PerfettoSqlType} from '../../trace_processor/perfetto_sql_type';
 import {addConnection, getAllNodes} from './query_builder/graph_utils';
+import {registerCoreNodes} from './query_builder/core_nodes';
+
+registerCoreNodes();
 
 describe('Multi-node operations', () => {
   let trace: Trace;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -8,7 +8,7 @@
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY, either express or implied.
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
@@ -18,16 +18,27 @@ import {
   modalForTableSelection,
   TableSourceNode,
   TableSourceState,
+  TableSourceSerializedState,
 } from './nodes/sources/table_source';
-import {SqlSourceNode, SqlSourceState} from './nodes/sources/sql_source';
+import {
+  SqlSourceNode,
+  SqlSourceState,
+  SqlSourceSerializedState,
+} from './nodes/sources/sql_source';
 import {
   TimeRangeSourceNode,
   TimeRangeSourceState,
+  TimeRangeSourceSerializedState,
 } from './nodes/sources/timerange_source';
-import {AggregationNode, AggregationNodeState} from './nodes/aggregation_node';
+import {
+  AggregationNode,
+  AggregationNodeState,
+  AggregationSerializedState,
+} from './nodes/aggregation_node';
 import {
   ModifyColumnsNode,
   ModifyColumnsState,
+  ModifyColumnsSerializedState,
 } from './nodes/modify_columns_node';
 import {AddColumnsNode, AddColumnsNodeState} from './nodes/add_columns_node';
 import {
@@ -38,15 +49,21 @@ import {FilterInNode, FilterInNodeState} from './nodes/filter_in_node';
 import {
   IntervalIntersectNode,
   IntervalIntersectNodeState,
+  IntervalIntersectSerializedState,
 } from './nodes/interval_intersect_node';
-import {JoinNode, JoinNodeState} from './nodes/join_node';
+import {JoinNode, JoinNodeState, JoinSerializedState} from './nodes/join_node';
 import {
   CreateSlicesNode,
   CreateSlicesNodeState,
+  CreateSlicesSerializedState,
 } from './nodes/create_slices_node';
 import {SortNode, SortNodeState} from './nodes/sort_node';
 import {FilterNode, FilterNodeState} from './nodes/filter_node';
-import {UnionNode, UnionNodeState} from './nodes/union_node';
+import {
+  UnionNode,
+  UnionNodeState,
+  UnionSerializedState,
+} from './nodes/union_node';
 import {
   LimitAndOffsetNode,
   LimitAndOffsetNodeState,
@@ -56,6 +73,7 @@ import {
   CounterToIntervalsNodeState,
 } from './nodes/counter_to_intervals_node';
 import {Icons} from '../../../base/semantic_icons';
+import {NodeType} from '../query_node';
 
 export function registerCoreNodes() {
   nodeRegistry.register('slice', {
@@ -65,7 +83,10 @@ export function registerCoreNodes() {
     hotkey: 'l',
     type: 'source',
     showOnLandingPage: true,
+    nodeType: NodeType.kSimpleSlices,
     factory: (state) => new SlicesSourceNode(state),
+    deserialize: (_state, trace, sqlModules) =>
+      new SlicesSourceNode({trace, sqlModules}),
   });
 
   nodeRegistry.register('table', {
@@ -75,6 +96,7 @@ export function registerCoreNodes() {
     hotkey: 't',
     type: 'source',
     showOnLandingPage: true,
+    nodeType: NodeType.kTable,
     preCreate: async ({sqlModules}) => {
       const selections = await modalForTableSelection(sqlModules);
       if (selections && selections.length > 0) {
@@ -86,6 +108,14 @@ export function registerCoreNodes() {
       return null;
     },
     factory: (state) => new TableSourceNode(state as TableSourceState),
+    deserialize: (state, trace, sqlModules) =>
+      new TableSourceNode(
+        TableSourceNode.deserializeState(
+          trace,
+          sqlModules,
+          state as TableSourceSerializedState,
+        ),
+      ),
   });
 
   nodeRegistry.register('sql', {
@@ -96,7 +126,24 @@ export function registerCoreNodes() {
     hotkey: 'q',
     type: 'source',
     showOnLandingPage: true,
+    nodeType: NodeType.kSqlSource,
     factory: (state) => new SqlSourceNode(state as SqlSourceState),
+    deserialize: (state, trace) =>
+      new SqlSourceNode({
+        ...(state as SqlSourceSerializedState),
+        trace,
+      }),
+    deserializeConnections: (node, state, allNodes) => {
+      const sqlSourceNode = node as SqlSourceNode;
+      const conns = SqlSourceNode.deserializeConnections(
+        allNodes,
+        state as SqlSourceSerializedState,
+      );
+      sqlSourceNode.secondaryInputs.connections.clear();
+      for (let i = 0; i < conns.inputNodes.length; i++) {
+        sqlSourceNode.secondaryInputs.connections.set(i, conns.inputNodes[i]);
+      }
+    },
   });
 
   nodeRegistry.register('timerange', {
@@ -106,6 +153,7 @@ export function registerCoreNodes() {
     icon: 'schedule',
     type: 'source',
     showOnLandingPage: false, // Available in menus but not on landing page
+    nodeType: NodeType.kTimeRangeSource,
     factory: (state) => {
       // If start/end are already set, this is being restored from serialization
       // or created programmatically - use those values
@@ -145,6 +193,13 @@ export function registerCoreNodes() {
       };
       return new TimeRangeSourceNode(fullState);
     },
+    deserialize: (state, trace) =>
+      new TimeRangeSourceNode(
+        TimeRangeSourceNode.deserializeState(
+          trace,
+          state as TimeRangeSourceSerializedState,
+        ),
+      ),
   });
 
   nodeRegistry.register('add_columns', {
@@ -153,6 +208,7 @@ export function registerCoreNodes() {
       'Add columns from another node via LEFT JOIN. Connect a node to the left-side port.',
     icon: 'add_box',
     type: 'modification',
+    nodeType: NodeType.kAddColumns,
     factory: (state) => {
       const fullState: AddColumnsNodeState = {
         ...state,
@@ -162,6 +218,23 @@ export function registerCoreNodes() {
       };
       return new AddColumnsNode(fullState);
     },
+    deserialize: (state, _trace, sqlModules) =>
+      new AddColumnsNode(
+        AddColumnsNode.deserializeState(
+          sqlModules,
+          state as AddColumnsNodeState,
+        ),
+      ),
+    deserializeConnections: (node, state, allNodes) => {
+      const addColumnsNode = node as AddColumnsNode;
+      const s = state as {secondaryInputNodeId?: string};
+      if (s.secondaryInputNodeId) {
+        const secondaryInputNode = allNodes.get(s.secondaryInputNodeId);
+        if (secondaryInputNode) {
+          addColumnsNode.secondaryInputs.connections.set(0, secondaryInputNode);
+        }
+      }
+    },
   });
 
   nodeRegistry.register('modify_columns', {
@@ -169,7 +242,16 @@ export function registerCoreNodes() {
     description: 'Select, rename, and add new columns to the data.',
     icon: 'edit',
     type: 'modification',
+    nodeType: NodeType.kModifyColumns,
     factory: (state) => new ModifyColumnsNode(state as ModifyColumnsState),
+    deserialize: (state, _trace, sqlModules) =>
+      new ModifyColumnsNode(
+        ModifyColumnsNode.deserializeState(
+          sqlModules,
+          state as ModifyColumnsSerializedState,
+        ),
+      ),
+    postDeserialize: (node) => (node as ModifyColumnsNode).resolveColumns(),
   });
 
   nodeRegistry.register('aggregation', {
@@ -177,7 +259,16 @@ export function registerCoreNodes() {
     description: 'Group and aggregate data from the source node.',
     icon: 'functions',
     type: 'modification',
+    nodeType: NodeType.kAggregation,
     factory: (state) => new AggregationNode(state as AggregationNodeState),
+    deserialize: (state, _trace, sqlModules) =>
+      new AggregationNode({
+        ...AggregationNode.deserializeState(
+          state as AggregationSerializedState,
+        ),
+        sqlModules,
+      }),
+    postDeserialize: (node) => (node as AggregationNode).resolveColumns(),
   });
 
   nodeRegistry.register('filter_node', {
@@ -185,7 +276,13 @@ export function registerCoreNodes() {
     description: 'Filter rows based on column values.',
     icon: Icons.Filter,
     type: 'modification',
+    nodeType: NodeType.kFilter,
     factory: (state) => new FilterNode(state as FilterNodeState),
+    deserialize: (state, _trace, sqlModules) =>
+      new FilterNode({
+        ...FilterNode.deserializeState(state as FilterNodeState),
+        sqlModules,
+      }),
   });
 
   nodeRegistry.register('filter_during', {
@@ -195,8 +292,31 @@ export function registerCoreNodes() {
     icon: Icons.Filter,
     type: 'multisource',
     category: 'Time',
+    nodeType: NodeType.kFilterDuring,
+    // Override: multisource nodes default to no primary input, but
+    // FilterDuring has both a primary input and secondary inputs.
+    hasPrimaryInput: true,
     factory: (state) => {
       return new FilterDuringNode(state as FilterDuringNodeState);
+    },
+    deserialize: (state, _trace, sqlModules) =>
+      new FilterDuringNode({
+        ...FilterDuringNode.deserializeState(state as FilterDuringNodeState),
+        sqlModules,
+      }),
+    deserializeConnections: (node, state, allNodes) => {
+      const filterDuringNode = node as FilterDuringNode;
+      const conns = FilterDuringNode.deserializeConnections(
+        allNodes,
+        state as {secondaryInputNodeIds?: string[]},
+      );
+      filterDuringNode.secondaryInputs.connections.clear();
+      for (let i = 0; i < conns.secondaryInputNodes.length; i++) {
+        filterDuringNode.secondaryInputs.connections.set(
+          i,
+          conns.secondaryInputNodes[i],
+        );
+      }
     },
   });
 
@@ -207,8 +327,30 @@ export function registerCoreNodes() {
     icon: Icons.Filter,
     type: 'multisource',
     category: 'Filtering',
+    nodeType: NodeType.kFilterIn,
+    // Override: multisource nodes default to no primary input, but
+    // FilterIn has both a primary input and secondary inputs.
+    hasPrimaryInput: true,
     factory: (state) => {
       return new FilterInNode(state as FilterInNodeState);
+    },
+    deserialize: (state) =>
+      new FilterInNode(
+        FilterInNode.deserializeState(state as FilterInNodeState),
+      ),
+    deserializeConnections: (node, state, allNodes) => {
+      const filterInNode = node as FilterInNode;
+      const conns = FilterInNode.deserializeConnections(
+        allNodes,
+        state as {secondaryInputNodeIds?: string[]},
+      );
+      filterInNode.secondaryInputs.connections.clear();
+      for (let i = 0; i < conns.secondaryInputNodes.length; i++) {
+        filterInNode.secondaryInputs.connections.set(
+          i,
+          conns.secondaryInputNodes[i],
+        );
+      }
     },
   });
 
@@ -218,8 +360,16 @@ export function registerCoreNodes() {
       'Convert counter data (with ts but no dur) to interval data (with ts and dur).',
     icon: 'show_chart',
     type: 'modification',
+    nodeType: NodeType.kCounterToIntervals,
     factory: (state) =>
       new CounterToIntervalsNode(state as CounterToIntervalsNodeState),
+    deserialize: (state, _trace, sqlModules) =>
+      new CounterToIntervalsNode({
+        ...CounterToIntervalsNode.deserializeState(
+          state as CounterToIntervalsNodeState,
+        ),
+        sqlModules,
+      }),
   });
 
   nodeRegistry.register('interval_intersect', {
@@ -228,6 +378,7 @@ export function registerCoreNodes() {
     icon: 'timeline',
     type: 'multisource',
     category: 'Time',
+    nodeType: NodeType.kIntervalIntersect,
     factory: (state, context) => {
       if (!context) {
         throw new Error(
@@ -240,6 +391,24 @@ export function registerCoreNodes() {
       };
       return new IntervalIntersectNode(fullState);
     },
+    deserialize: (state, _trace, sqlModules) =>
+      new IntervalIntersectNode({
+        ...IntervalIntersectNode.deserializeState(
+          state as IntervalIntersectSerializedState,
+        ),
+        sqlModules,
+      }),
+    deserializeConnections: (node, state, allNodes) => {
+      const intervalNode = node as IntervalIntersectNode;
+      const conns = IntervalIntersectNode.deserializeConnections(
+        allNodes,
+        state as IntervalIntersectSerializedState,
+      );
+      intervalNode.secondaryInputs.connections.clear();
+      for (let i = 0; i < conns.inputNodes.length; i++) {
+        intervalNode.secondaryInputs.connections.set(i, conns.inputNodes[i]);
+      }
+    },
   });
 
   nodeRegistry.register('join', {
@@ -248,6 +417,7 @@ export function registerCoreNodes() {
       'Join two tables using equality columns or custom SQL condition.',
     icon: 'merge',
     type: 'multisource',
+    nodeType: NodeType.kJoin,
     factory: (state) => {
       const fullState: JoinNodeState = {
         ...state,
@@ -263,6 +433,25 @@ export function registerCoreNodes() {
       };
       return new JoinNode(fullState);
     },
+    deserialize: (state, _trace, sqlModules) =>
+      new JoinNode({
+        ...JoinNode.deserializeState(state as JoinSerializedState),
+        sqlModules,
+      }),
+    deserializeConnections: (node, state, allNodes) => {
+      const joinNode = node as JoinNode;
+      const conns = JoinNode.deserializeConnections(
+        allNodes,
+        state as JoinSerializedState,
+      );
+      if (conns.leftNode) {
+        joinNode.secondaryInputs.connections.set(0, conns.leftNode);
+      }
+      if (conns.rightNode) {
+        joinNode.secondaryInputs.connections.set(1, conns.rightNode);
+      }
+    },
+    postDeserializeLate: (node) => (node as JoinNode).onPrevNodesUpdated(),
   });
 
   nodeRegistry.register('create_slices', {
@@ -272,6 +461,7 @@ export function registerCoreNodes() {
     icon: 'add_circle',
     type: 'multisource',
     category: 'Time',
+    nodeType: NodeType.kCreateSlices,
     factory: (state) => {
       const fullState: CreateSlicesNodeState = {
         ...state,
@@ -280,6 +470,26 @@ export function registerCoreNodes() {
       };
       return new CreateSlicesNode(fullState);
     },
+    deserialize: (state, _trace, sqlModules) =>
+      new CreateSlicesNode({
+        ...CreateSlicesNode.deserializeState(
+          state as CreateSlicesSerializedState,
+        ),
+        sqlModules,
+      }),
+    deserializeConnections: (node, state, allNodes) => {
+      const createSlicesNode = node as CreateSlicesNode;
+      const conns = CreateSlicesNode.deserializeConnections(
+        allNodes,
+        state as CreateSlicesSerializedState,
+      );
+      if (conns.startsNode) {
+        createSlicesNode.secondaryInputs.connections.set(0, conns.startsNode);
+      }
+      if (conns.endsNode) {
+        createSlicesNode.secondaryInputs.connections.set(1, conns.endsNode);
+      }
+    },
   });
 
   nodeRegistry.register('sort_node', {
@@ -287,7 +497,13 @@ export function registerCoreNodes() {
     description: 'Sort rows by one or more columns.',
     icon: 'sort',
     type: 'modification',
+    nodeType: NodeType.kSort,
     factory: (state) => new SortNode(state as SortNodeState),
+    deserialize: (state, _trace, sqlModules) =>
+      new SortNode({
+        ...SortNode.deserializeState(state as SortNodeState),
+        sqlModules,
+      }),
   });
 
   nodeRegistry.register('union_node', {
@@ -295,6 +511,7 @@ export function registerCoreNodes() {
     description: 'Combine rows from multiple sources.',
     icon: 'merge_type',
     type: 'multisource',
+    nodeType: NodeType.kUnion,
     factory: (state) => {
       const fullState: UnionNodeState = {
         ...state,
@@ -305,6 +522,22 @@ export function registerCoreNodes() {
       node.onPrevNodesUpdated();
       return node;
     },
+    deserialize: (state, _trace, sqlModules) =>
+      new UnionNode({
+        ...UnionNode.deserializeState(state as UnionSerializedState),
+        sqlModules,
+      }),
+    deserializeConnections: (node, state, allNodes) => {
+      const unionNode = node as UnionNode;
+      const conns = UnionNode.deserializeConnections(
+        allNodes,
+        state as UnionSerializedState,
+      );
+      unionNode.secondaryInputs.connections.clear();
+      for (let i = 0; i < conns.inputNodes.length; i++) {
+        unionNode.secondaryInputs.connections.set(i, conns.inputNodes[i]);
+      }
+    },
   });
 
   nodeRegistry.register('limit_and_offset_node', {
@@ -312,7 +545,15 @@ export function registerCoreNodes() {
     description: 'Limit the number of rows returned and optionally skip rows.',
     icon: Icons.Filter,
     type: 'modification',
+    nodeType: NodeType.kLimitAndOffset,
     factory: (state) =>
       new LimitAndOffsetNode(state as LimitAndOffsetNodeState),
+    deserialize: (state, _trace, sqlModules) =>
+      new LimitAndOffsetNode({
+        ...LimitAndOffsetNode.deserializeState(
+          state as LimitAndOffsetNodeState,
+        ),
+        sqlModules,
+      }),
   });
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry_unittest.ts
@@ -34,10 +34,17 @@ describe('NodeRegistry', () => {
     } as QueryNode;
   }
 
+  // Default required fields for test descriptors (nodeType, deserialize).
+  const defaults = {
+    nodeType: NodeType.kTable,
+    deserialize: () => createMockNode('mock'),
+  };
+
   describe('register', () => {
     it('should register a node descriptor', () => {
       const registry = new NodeRegistry();
       const descriptor: NodeDescriptor = {
+        ...defaults,
         name: 'Test Node',
         description: 'A test node',
         icon: 'test-icon',
@@ -54,6 +61,7 @@ describe('NodeRegistry', () => {
     it('should allow registering multiple nodes', () => {
       const registry = new NodeRegistry();
       const descriptor1: NodeDescriptor = {
+        ...defaults,
         name: 'Node 1',
         description: 'First node',
         icon: 'icon1',
@@ -61,6 +69,7 @@ describe('NodeRegistry', () => {
         factory: (_state: QueryNodeState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
+        ...defaults,
         name: 'Node 2',
         description: 'Second node',
         icon: 'icon2',
@@ -78,6 +87,7 @@ describe('NodeRegistry', () => {
     it('should overwrite existing registration with same id', () => {
       const registry = new NodeRegistry();
       const descriptor1: NodeDescriptor = {
+        ...defaults,
         name: 'Node 1',
         description: 'First node',
         icon: 'icon1',
@@ -85,6 +95,7 @@ describe('NodeRegistry', () => {
         factory: (_state: QueryNodeState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
+        ...defaults,
         name: 'Node 1 Updated',
         description: 'Updated node',
         icon: 'icon1-updated',
@@ -104,6 +115,7 @@ describe('NodeRegistry', () => {
       const registry = new NodeRegistry();
       const preCreate = async (_context: PreCreateContext) => ({});
       const descriptor: NodeDescriptor = {
+        ...defaults,
         name: 'Advanced Node',
         description: 'Node with optional fields',
         icon: 'advanced-icon',
@@ -133,6 +145,7 @@ describe('NodeRegistry', () => {
     it('should return registered descriptor', () => {
       const registry = new NodeRegistry();
       const descriptor: NodeDescriptor = {
+        ...defaults,
         name: 'Test Node',
         description: 'A test node',
         icon: 'test-icon',
@@ -150,6 +163,7 @@ describe('NodeRegistry', () => {
     it('should handle special characters in id', () => {
       const registry = new NodeRegistry();
       const descriptor: NodeDescriptor = {
+        ...defaults,
         name: 'Special Node',
         description: 'Node with special id',
         icon: 'special-icon',
@@ -176,6 +190,7 @@ describe('NodeRegistry', () => {
     it('should return all registered nodes', () => {
       const registry = new NodeRegistry();
       const descriptor1: NodeDescriptor = {
+        ...defaults,
         name: 'Node 1',
         description: 'First node',
         icon: 'icon1',
@@ -183,6 +198,7 @@ describe('NodeRegistry', () => {
         factory: (_state: QueryNodeState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
+        ...defaults,
         name: 'Node 2',
         description: 'Second node',
         icon: 'icon2',
@@ -190,6 +206,7 @@ describe('NodeRegistry', () => {
         factory: (_state: QueryNodeState) => createMockNode('node2'),
       };
       const descriptor3: NodeDescriptor = {
+        ...defaults,
         name: 'Node 3',
         description: 'Third node',
         icon: 'icon3',
@@ -212,6 +229,7 @@ describe('NodeRegistry', () => {
     it('should return tuples of [id, descriptor]', () => {
       const registry = new NodeRegistry();
       const descriptor: NodeDescriptor = {
+        ...defaults,
         name: 'Test Node',
         description: 'A test node',
         icon: 'test-icon',
@@ -231,6 +249,7 @@ describe('NodeRegistry', () => {
     it('should reflect updates when node is re-registered', () => {
       const registry = new NodeRegistry();
       const descriptor1: NodeDescriptor = {
+        ...defaults,
         name: 'Node 1',
         description: 'First node',
         icon: 'icon1',
@@ -238,6 +257,7 @@ describe('NodeRegistry', () => {
         factory: (_state: QueryNodeState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
+        ...defaults,
         name: 'Node 1 Updated',
         description: 'Updated node',
         icon: 'icon1-updated',
@@ -266,6 +286,7 @@ describe('NodeRegistry', () => {
 
       // Register first node
       const descriptor1: NodeDescriptor = {
+        ...defaults,
         name: 'Source Node',
         description: 'A source node',
         icon: 'source-icon',
@@ -278,6 +299,7 @@ describe('NodeRegistry', () => {
 
       // Register second node
       const descriptor2: NodeDescriptor = {
+        ...defaults,
         name: 'Modify Node',
         description: 'A modification node',
         icon: 'modify-icon',
@@ -290,6 +312,7 @@ describe('NodeRegistry', () => {
 
       // Update first node
       const descriptor1Updated: NodeDescriptor = {
+        ...defaults,
         name: 'Source Node Updated',
         description: 'Updated source node',
         icon: 'source-icon-updated',


### PR DESCRIPTION
## Summary

Move serialization/deserialization logic from the centralized `json_handler.ts`
switch statements into the node registry, co-locating each node type's
serialization behavior with its registration descriptor in `core_nodes.ts`.

## Changes

- Added `nodeType`, `deserialize`, `deserializeConnections`, `postDeserialize`,
  `postDeserializeLate`, and `hasPrimaryInput` fields to `NodeDescriptor`
- Added `byNodeType` reverse lookup map to `NodeRegistry`
- Moved all node-specific deserialization, connection restoration, and
  post-deserialization logic from `json_handler.ts` into each node's registration
  in `core_nodes.ts`
- Removed the large `SerializedNodeState` union type and all per-node imports
  from `json_handler.ts` (~340 lines removed)
- Fixed license header typo in `core_nodes.ts`