### PR TITLE
ui: Add android monitor lock contention plugin

### DIFF
--- a/ui/src/plugins/com.android.AndroidLockContention/OWNERS
+++ b/ui/src/plugins/com.android.AndroidLockContention/OWNERS
@@ -1,0 +1,2 @@
+ivankc@google.com
+gignat@google.com

--- a/ui/src/plugins/com.android.AndroidLockContention/android_lock_contention_event_source.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/android_lock_contention_event_source.ts
@@ -1,0 +1,280 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {QueryResult, QuerySlot, SerialTaskQueue} from '../../base/query_slot';
+import {duration, Duration, time, Time} from '../../base/time';
+import {getTrackUriForTrackId} from '../../components/related_events/utils';
+import {Trace} from '../../public/trace';
+import {
+  LONG,
+  LONG_NULL,
+  NUM,
+  NUM_NULL,
+  STR,
+  STR_NULL,
+} from '../../trace_processor/query_result';
+
+export interface ContentionState {
+  state: string;
+  dur: duration;
+  count: number;
+}
+
+export interface ContentionBlockedFunction {
+  func: string;
+  dur: duration;
+  count: number;
+}
+
+export interface ContentionWaiter {
+  threadName: string;
+  tid: number | null;
+  eventId: number;
+}
+
+export interface LockContentionDetails {
+  id: number;
+  ts: time;
+  dur: duration | null;
+  monotonicDur: duration | null;
+  waiterCount: number;
+
+  lockName: string;
+
+  blockedThreadName: string;
+  blockedThreadTid: number | null;
+  isBlockedThreadMain: boolean;
+  blockedMethod: string;
+  blockedSrc: string;
+
+  blockingThreadName: string;
+  blockingThreadTid: number | null;
+  isBlockingThreadMain: boolean;
+  blockingMethod: string;
+  blockingSrc: string;
+
+  parentId: number | null; // ID of the contention blocking THIS one, if nested
+
+  blockingTrackUri: string | undefined;
+
+  binderReplyId: number | null;
+  blockingBinderTxnId: number | null;
+  waiters: ContentionWaiter[];
+
+  threadStates: ContentionState[];
+  blockedFunctions: ContentionBlockedFunction[];
+}
+
+export class AndroidLockContentionEventSource {
+  private readonly queue = new SerialTaskQueue();
+  private readonly dataSlot = new QuerySlot<LockContentionDetails | null>(
+    this.queue,
+  );
+
+  constructor(private readonly trace: Trace) {}
+
+  use(eventId: number): QueryResult<LockContentionDetails | null> {
+    return this.dataSlot.use({
+      key: eventId,
+      queryFn: async () => this.fetchDetails(eventId),
+    });
+  }
+
+  private async fetchDetails(
+    eventId: number,
+  ): Promise<LockContentionDetails | null> {
+    const mainQuery = await this.trace.engine.query(`
+      SELECT 
+        id, 
+        ts, 
+        dur, 
+        monotonic_dur, 
+        waiter_count,
+        lock_name,
+        
+        blocked_thread_name,
+        blocked_thread_tid,
+        is_blocked_thread_main,
+        short_blocked_method,
+        blocked_src,
+        
+        blocking_thread_name,
+        blocking_thread_tid,
+        is_blocking_thread_main,
+        short_blocking_method,
+        blocking_src,
+        blocking_utid,
+        
+        parent_id,
+        (SELECT id FROM thread_track WHERE utid = blocking_utid) as blocking_track_id,
+        binder_reply_id
+      FROM android_monitor_contention_chain
+      WHERE id = ${eventId}
+    `);
+
+    if (mainQuery.numRows() === 0) return null;
+
+    const row = mainQuery.firstRow({
+      id: NUM,
+      ts: LONG,
+      dur: LONG_NULL,
+      monotonic_dur: LONG_NULL,
+      waiter_count: NUM_NULL,
+      lock_name: STR_NULL,
+
+      blocked_thread_name: STR_NULL,
+      blocked_thread_tid: NUM_NULL,
+      is_blocked_thread_main: NUM_NULL,
+      short_blocked_method: STR_NULL,
+      blocked_src: STR_NULL,
+
+      blocking_thread_name: STR_NULL,
+      blocking_thread_tid: NUM_NULL,
+      is_blocking_thread_main: NUM_NULL,
+      short_blocking_method: STR_NULL,
+      blocking_src: STR_NULL,
+      blocking_utid: NUM_NULL,
+
+      parent_id: NUM_NULL,
+      blocking_track_id: NUM_NULL,
+      binder_reply_id: NUM_NULL,
+    });
+
+    let blockingTrackUri: string | undefined;
+    if (row.blocking_track_id !== null) {
+      blockingTrackUri = getTrackUriForTrackId(
+        this.trace,
+        row.blocking_track_id,
+      );
+    }
+
+    const blockedFunctions: ContentionBlockedFunction[] = [];
+    const bfQuery = await this.trace.engine.query(`
+      SELECT blocked_function, blocked_function_dur, blocked_function_count
+      FROM android_monitor_contention_chain_blocked_functions_by_txn
+      WHERE id = ${eventId}
+      ORDER BY blocked_function_dur DESC
+    `);
+    const bfIt = bfQuery.iter({
+      blocked_function: STR,
+      blocked_function_dur: LONG,
+      blocked_function_count: NUM,
+    });
+    while (bfIt.valid()) {
+      blockedFunctions.push({
+        func: bfIt.blocked_function,
+        dur: Duration.fromRaw(bfIt.blocked_function_dur),
+        count: bfIt.blocked_function_count,
+      });
+      bfIt.next();
+    }
+
+    let blockingBinderTxnId: number | null = null;
+    if (row.blocking_track_id !== null) {
+      const binderQuery = await this.trace.engine.query(`
+        SELECT id 
+        FROM slice 
+        WHERE track_id = ${row.blocking_track_id} 
+          AND name = 'binder transaction' 
+          AND ts < ${row.ts + (row.dur ?? 0n)} 
+          AND (ts + dur) > ${row.ts}
+        LIMIT 1
+      `);
+      if (binderQuery.numRows() > 0) {
+        blockingBinderTxnId = binderQuery.firstRow({id: NUM}).id;
+      }
+    }
+
+    const waiters: ContentionWaiter[] = [];
+    const waitersQuery = await this.trace.engine.query(`
+      SELECT 
+        blocked_thread_name,
+        blocked_thread_tid,
+        id 
+      FROM android_monitor_contention_chain
+      WHERE blocking_utid = ${row.blocking_utid}
+        AND short_blocking_method = '${row.short_blocking_method || ''}'
+        AND ts < ${row.ts + (row.dur ?? 0n)} 
+        AND (ts + dur) > ${row.ts}
+        AND id != ${eventId}
+      ORDER BY ts ASC
+    `);
+    const waitersIt = waitersQuery.iter({
+      blocked_thread_name: STR_NULL,
+      blocked_thread_tid: NUM_NULL,
+      id: NUM,
+    });
+    while (waitersIt.valid()) {
+      waiters.push({
+        threadName: waitersIt.blocked_thread_name || 'Unknown Thread',
+        tid: waitersIt.blocked_thread_tid,
+        eventId: waitersIt.id,
+      });
+      waitersIt.next();
+    }
+
+    const threadStates: ContentionState[] = [];
+    const tsQuery = await this.trace.engine.query(`
+      SELECT thread_state, thread_state_dur, thread_state_count
+      FROM android_monitor_contention_chain_thread_state_by_txn
+      WHERE id = ${eventId}
+      ORDER BY thread_state_dur DESC
+    `);
+    const tsIt = tsQuery.iter({
+      thread_state: STR,
+      thread_state_dur: LONG,
+      thread_state_count: NUM,
+    });
+    while (tsIt.valid()) {
+      threadStates.push({
+        state: tsIt.thread_state,
+        dur: Duration.fromRaw(tsIt.thread_state_dur),
+        count: tsIt.thread_state_count,
+      });
+      tsIt.next();
+    }
+
+    return {
+      id: row.id,
+      ts: Time.fromRaw(row.ts),
+      dur: row.dur !== null ? Duration.fromRaw(row.dur) : null,
+      monotonicDur:
+        row.monotonic_dur !== null ? Duration.fromRaw(row.monotonic_dur) : null,
+      waiterCount: row.waiter_count ?? 0,
+      lockName: row.lock_name || 'Unknown Lock',
+
+      blockedThreadName: row.blocked_thread_name || 'Unknown Thread',
+      blockedThreadTid: row.blocked_thread_tid,
+      isBlockedThreadMain: row.is_blocked_thread_main === 1,
+      blockedMethod: row.short_blocked_method || 'Unknown Method',
+      blockedSrc: row.blocked_src || 'Unknown Source',
+
+      blockingThreadName: row.blocking_thread_name || 'Unknown Thread',
+      blockingThreadTid: row.blocking_thread_tid,
+      isBlockingThreadMain: row.is_blocking_thread_main === 1,
+      blockingMethod: row.short_blocking_method || 'Unknown Method',
+      blockingSrc: row.blocking_src || 'Unknown Source',
+
+      parentId: row.parent_id,
+      blockingTrackUri,
+
+      binderReplyId: row.binder_reply_id,
+      blockingBinderTxnId,
+      waiters,
+
+      threadStates,
+      blockedFunctions,
+    };
+  }
+}

--- a/ui/src/plugins/com.android.AndroidLockContention/index.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/index.ts
@@ -1,0 +1,282 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+
+import {QueryResult} from '../../base/query_slot';
+import {addDebugSliceTrack} from '../../components/tracks/debug_tracks';
+import {PerfettoPlugin} from '../../public/plugin';
+import {Selection} from '../../public/selection';
+import {Trace} from '../../public/trace';
+import {NUM_NULL} from '../../trace_processor/query_result';
+
+import {
+  AndroidLockContentionEventSource,
+  LockContentionDetails,
+} from './android_lock_contention_event_source';
+import {AndroidLockContentionTab} from './tab';
+
+export default class AndroidLockContentionPlugin implements PerfettoPlugin {
+  static readonly id = 'com.android.AndroidLockContention';
+  static readonly description =
+    'Visualise lock contention events in the trace. Activate by running the command ' +
+    "'Android Lock Contention: Go Forward' or using Ctrl+]. You can then navigate " +
+    'between contention events using Ctrl+] and Ctrl+[';
+
+  private nav = new LockContentionNavigation();
+  private activeContentionId?: number;
+
+  /**
+   * Navigates to the source of a monitor contention.
+   * Jumps to the parent slice in the chain if available, otherwise
+   * shifts focus to the track of the blocking thread.
+   */
+  private async contextualJump(trace: Trace) {
+    const selection = trace.selection.selection;
+    if (selection.kind !== 'track_event') return;
+
+    const queryRes = await trace.engine.query(`
+      SELECT 
+        parent_id,
+        (SELECT id FROM thread_track WHERE utid = blocking_utid) as track_id
+      FROM android_monitor_contention_chain
+      WHERE id = ${selection.eventId}
+    `);
+
+    if (queryRes.numRows() === 0) return;
+
+    const row = queryRes.firstRow({parent_id: NUM_NULL, track_id: NUM_NULL});
+
+    if (row.parent_id !== null) {
+      this.nav.push(selection);
+      trace.selection.selectSqlEvent('slice', row.parent_id, {
+        scrollToSelection: true,
+        switchToCurrentSelectionTab: false,
+      });
+      this.nav.push({
+        kind: 'track_event',
+        trackUri: 'unknown',
+        eventId: row.parent_id,
+      } as Selection);
+    } else if (row.track_id !== null) {
+      const track = trace.tracks.findTrack((t) =>
+        t.tags?.trackIds?.includes(row.track_id as number),
+      );
+      const trackUri = track?.uri || '/slice_' + row.track_id;
+      this.nav.push(selection);
+      trace.selection.selectTrack(trackUri, {
+        scrollToSelection: true,
+        switchToCurrentSelectionTab: false,
+      });
+      this.nav.push({kind: 'track', trackUri} as Selection);
+    }
+  }
+
+  private useDetailsState(
+    trace: Trace,
+    source: AndroidLockContentionEventSource,
+  ): QueryResult<LockContentionDetails | null> {
+    const selection = trace.selection.selection;
+
+    if (this.nav.has(selection) && this.activeContentionId !== undefined) {
+      return source.use(this.activeContentionId);
+    }
+
+    if (selection.kind !== 'track_event') {
+      return {data: null, isPending: false, isFresh: true};
+    }
+
+    this.activeContentionId = selection.eventId;
+    return source.use(selection.eventId);
+  }
+
+  async onTraceLoad(trace: Trace): Promise<void> {
+    await trace.engine.query(
+      'INCLUDE PERFETTO MODULE android.monitor_contention;',
+    );
+
+    const source = new AndroidLockContentionEventSource(trace);
+
+    trace.tabs.registerTab({
+      uri: 'com.android.AndroidLockContentionTab',
+      isEphemeral: false,
+      content: {
+        getTitle: () => 'Lock Contention Analysis',
+        render: () => {
+          const {data: row, isPending} = this.useDetailsState(trace, source);
+          const goToSlice = (id: number) => {
+            this.nav.push(trace.selection.selection);
+            trace.selection.selectSqlEvent('slice', id, {
+              scrollToSelection: true,
+              switchToCurrentSelectionTab: false,
+            });
+            this.nav.push({
+              kind: 'track_event',
+              trackUri: 'unknown',
+              eventId: id,
+            } as Selection);
+          };
+          const goToTrack = (uri: string) => {
+            this.nav.push(trace.selection.selection);
+            trace.selection.selectTrack(uri, {
+              scrollToSelection: true,
+              switchToCurrentSelectionTab: false,
+            });
+            this.nav.push({kind: 'track', trackUri: uri} as Selection);
+          };
+          return m(AndroidLockContentionTab, {
+            trace,
+            row: row ?? null,
+            isPending,
+            goToSlice,
+            goToTrack,
+          });
+        },
+      },
+    });
+
+    trace.commands.registerCommand({
+      id: 'com.android.AndroidLockContention:GoBack',
+      name: 'Android Lock Contention: Go Back',
+      defaultHotkey: 'Ctrl+[',
+      callback: () => {
+        trace.tabs.showTab('com.android.AndroidLockContentionTab');
+        this.nav.goBack(trace);
+      },
+    });
+
+    trace.commands.registerCommand({
+      id: 'com.android.AndroidLockContention:GoForward',
+      name: 'Android Lock Contention: Go Forward',
+      defaultHotkey: 'Ctrl+]',
+      callback: async () => {
+        trace.tabs.showTab('com.android.AndroidLockContentionTab');
+        if (this.nav.canGoForward()) {
+          this.nav.goForward(trace);
+        } else {
+          await this.contextualJump(trace);
+        }
+      },
+    });
+
+    // Visualise "big" locks on a debug track
+    trace.commands.registerCommand({
+      id: 'com.android.visualiseHeldLocks',
+      name: 'Lock Contention: Visualise held locks',
+      callback: async () => {
+        await addDebugSliceTrack({
+          trace: trace,
+          data: {
+            sqlSource: `
+                    WITH lock_held_slices AS (
+                    SELECT ts, dur, lock_name, utid
+                    FROM interval_merge_overlapping_partitioned!((
+                        SELECT ts, dur, name AS lock_name, utid
+                        FROM thread_slice
+                        WHERE dur > 0 AND thread_slice.name GLOB '*_lock_held'
+                    ), (lock_name, utid))
+                    )
+                    SELECT
+                    row_number() OVER () AS id,
+                    name AS thread_name,
+                    lock_name,
+                    utid,
+                    ts,
+                    MIN(LEAD(ts) OVER(PARTITION BY lock_name ORDER BY ts), ts + dur) - ts AS dur
+                    FROM lock_held_slices
+                    JOIN thread USING (utid)
+                `,
+          },
+          title: 'Held Lock',
+          columns: {
+            name: 'thread_name',
+          },
+          pivotOn: 'lock_name',
+        });
+      },
+    });
+  }
+}
+
+class LockContentionNavigation {
+  private stack: Selection[] = [];
+  private index = -1;
+
+  push(selection: Selection) {
+    if (this.index >= 0 && selectionsEqual(this.stack[this.index], selection)) {
+      return;
+    }
+    this.stack.splice(this.index + 1);
+    this.stack.push(selection);
+    this.index++;
+  }
+
+  goBack(trace: Trace) {
+    if (this.index > 0) {
+      this.index--;
+      this.restore(trace, this.stack[this.index]);
+    }
+  }
+
+  goForward(trace: Trace) {
+    if (this.index < this.stack.length - 1) {
+      this.index++;
+      this.restore(trace, this.stack[this.index]);
+    }
+  }
+
+  canGoForward(): boolean {
+    return this.index < this.stack.length - 1;
+  }
+
+  private restore(trace: Trace, selection: Selection) {
+    if (selection.kind === 'track_event') {
+      if (selection.trackUri === 'unknown' || selection.trackUri === '') {
+        trace.selection.selectSqlEvent('slice', selection.eventId, {
+          scrollToSelection: true,
+          switchToCurrentSelectionTab: false,
+        });
+      } else {
+        trace.selection.selectTrackEvent(
+          selection.trackUri,
+          selection.eventId,
+          {
+            scrollToSelection: true,
+            switchToCurrentSelectionTab: false,
+          },
+        );
+      }
+    } else if (selection.kind === 'track') {
+      trace.selection.selectTrack(selection.trackUri, {
+        scrollToSelection: true,
+        switchToCurrentSelectionTab: false,
+      });
+    }
+  }
+
+  has(selection: Selection) {
+    return this.stack.some((s) => selectionsEqual(s, selection));
+  }
+}
+
+function selectionsEqual(a: Selection, b: Selection): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === 'track_event' && b.kind === 'track_event') {
+    return a.eventId === b.eventId;
+  }
+  if (a.kind === 'track' && b.kind === 'track') {
+    return a.trackUri === b.trackUri;
+  }
+  return false;
+}

--- a/ui/src/plugins/com.android.AndroidLockContention/tab.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/tab.ts
@@ -1,0 +1,328 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+
+import {Icons} from '../../base/semantic_icons';
+import {DurationWidget} from '../../components/widgets/duration';
+import {Trace} from '../../public/trace';
+import {Anchor} from '../../widgets/anchor';
+import {Callout} from '../../widgets/callout';
+import {Intent} from '../../widgets/common';
+import {DetailsShell} from '../../widgets/details_shell';
+import {EmptyState} from '../../widgets/empty_state';
+import {Grid, GridCell, GridColumn, GridHeaderCell} from '../../widgets/grid';
+import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
+import {Section} from '../../widgets/section';
+import {Spinner} from '../../widgets/spinner';
+import {Tree, TreeNode} from '../../widgets/tree';
+
+import {LockContentionDetails} from './android_lock_contention_event_source';
+
+export interface AndroidLockContentionTabAttrs {
+  trace: Trace;
+  row: LockContentionDetails | null;
+  isPending: boolean;
+  goToSlice: (id: number) => void;
+  goToTrack: (uri: string) => void;
+}
+
+export class AndroidLockContentionTab
+  implements m.ClassComponent<AndroidLockContentionTabAttrs>
+{
+  view({attrs}: m.Vnode<AndroidLockContentionTabAttrs>): m.Children {
+    const {row, isPending} = attrs;
+
+    if (isPending) {
+      return m(
+        DetailsShell,
+        {title: 'Android Lock Contention'},
+        m(
+          'div',
+          {
+            style: {
+              display: 'flex',
+              justifyContent: 'center',
+              padding: '20px',
+            },
+          },
+          m(Spinner, {}),
+        ),
+      );
+    }
+
+    if (!row) {
+      return m(
+        DetailsShell,
+        {title: 'Android Lock Contention'},
+        m(EmptyState, {
+          title: 'No monitor contention slice selected',
+          description: 'Select a monitor contention slice to see details.',
+          icon: Icons.Android,
+        }),
+      );
+    }
+
+    return m(
+      DetailsShell,
+      {
+        title: 'Android Lock Contention',
+        description: row.lockName,
+      },
+      this.renderContent(attrs, row),
+    );
+  }
+
+  private renderContent(
+    attrs: AndroidLockContentionTabAttrs,
+    row: LockContentionDetails,
+  ): m.Children {
+    const trace = attrs.trace;
+    return [
+      row.parentId !== null &&
+        m(
+          Callout,
+          {
+            intent: Intent.Warning,
+            icon: 'warning',
+          },
+          m('strong', 'Nested Contention Warning: '),
+          'The thread holding this lock is currently blocked by another lock! ',
+          m(
+            Anchor,
+            {
+              icon: Icons.GoTo,
+              onclick: () => attrs.goToSlice(row.parentId!),
+            },
+            'Go to Root Cause',
+          ),
+        ),
+
+      m(
+        GridLayout,
+        m(
+          GridLayoutColumn,
+          m(
+            Section,
+            {title: 'Blocked Thread (Victim)'},
+            row.binderReplyId !== null &&
+              m(
+                Callout,
+                {
+                  intent: Intent.Primary,
+                  icon: 'info',
+                  style: {marginBottom: '8px'},
+                },
+                m('strong', 'Binder IPC (Inbound): '),
+                'This thread is blocked while handling an incoming Binder transaction. ',
+                m(
+                  Anchor,
+                  {
+                    icon: Icons.GoTo,
+                    onclick: () => attrs.goToSlice(row.binderReplyId!),
+                  },
+                  'View Transaction',
+                ),
+              ),
+            m(
+              Tree,
+              {},
+              m(TreeNode, {
+                left: 'Thread',
+                right: m(
+                  'span',
+                  `${row.blockedThreadName} [${row.blockedThreadTid ?? '-'}] `,
+                  m(Anchor, {
+                    icon: Icons.GoTo,
+                    onclick: () => attrs.goToSlice(row.id),
+                    title: 'Go to blocked thread slice',
+                  }),
+                ),
+              }),
+              m(TreeNode, {
+                left: 'Main Thread',
+                right: row.isBlockedThreadMain ? 'Yes' : 'No',
+              }),
+              m(TreeNode, {left: 'Method', right: row.blockedMethod}),
+              m(TreeNode, {left: 'Location', right: row.blockedSrc}),
+            ),
+          ),
+        ),
+        m(
+          GridLayoutColumn,
+          m(
+            Section,
+            {title: 'Contention Details'},
+            m(
+              Tree,
+              {},
+              m(TreeNode, {left: 'Lock', right: row.lockName}),
+              m(TreeNode, {
+                left: 'Duration',
+                right:
+                  row.dur !== null
+                    ? m(DurationWidget, {dur: row.dur, trace: trace})
+                    : '-',
+              }),
+              row.waiters.length === 0
+                ? m(TreeNode, {
+                    left: 'Other Waiters',
+                    right: row.waiterCount.toString(),
+                  })
+                : m(
+                    TreeNode,
+                    {
+                      left: 'Other Waiters',
+                      summary: row.waiterCount.toString(),
+                    },
+                    row.waiters.map((w) =>
+                      m(TreeNode, {
+                        left: 'Thread',
+                        right: m(
+                          'span',
+                          `${w.threadName} [${w.tid ?? '-'}] `,
+                          m(Anchor, {
+                            icon: Icons.GoTo,
+                            onclick: () => attrs.goToSlice(w.eventId),
+                            title: 'Go to contention slice for this waiter',
+                          }),
+                        ),
+                      }),
+                    ),
+                  ),
+              m(TreeNode, {
+                left: 'Monotonic Duration',
+                right:
+                  row.monotonicDur !== null
+                    ? m(DurationWidget, {dur: row.monotonicDur, trace})
+                    : '-',
+              }),
+            ),
+          ),
+        ),
+        m(
+          GridLayoutColumn,
+          m(
+            Section,
+            {title: 'Blocking Thread (Culprit)'},
+            row.blockingBinderTxnId !== null &&
+              m(
+                Callout,
+                {
+                  intent: Intent.Primary,
+                  icon: 'info',
+                  style: {marginBottom: '8px'},
+                },
+                m('strong', 'Binder IPC (Outbound): '),
+                'The blocking thread is currently delayed waiting for an outbound Binder transaction to return. ',
+                m(
+                  Anchor,
+                  {
+                    icon: Icons.GoTo,
+                    onclick: () => attrs.goToSlice(row.blockingBinderTxnId!),
+                  },
+                  'View Transaction',
+                ),
+              ),
+            m(
+              Tree,
+              {},
+              m(TreeNode, {
+                left: 'Thread',
+                right: m(
+                  'span',
+                  `${row.blockingThreadName} [${row.blockingThreadTid ?? '-'}] `,
+                  row.blockingTrackUri &&
+                    m(Anchor, {
+                      icon: Icons.GoTo,
+                      onclick: () => attrs.goToTrack(row.blockingTrackUri!),
+                      title: 'Go to blocking thread track',
+                    }),
+                ),
+              }),
+              m(TreeNode, {
+                left: 'Main Thread',
+                right: row.isBlockingThreadMain ? 'Yes' : 'No',
+              }),
+              m(TreeNode, {left: 'Method', right: row.blockingMethod}),
+              m(TreeNode, {left: 'Location', right: row.blockingSrc}),
+            ),
+          ),
+        ),
+      ),
+      m(
+        GridLayout,
+        m(
+          GridLayoutColumn,
+          m(
+            Section,
+            {title: 'Blocking Thread States'},
+            this.renderStatesTable(trace, row),
+          ),
+        ),
+        row.blockedFunctions.length > 0 &&
+          m(
+            GridLayoutColumn,
+            m(
+              Section,
+              {title: 'Kernel Functions (if blocked)'},
+              this.renderFunctionsTable(trace, row),
+            ),
+          ),
+      ),
+    ];
+  }
+
+  private renderFunctionsTable(
+    trace: Trace,
+    row: LockContentionDetails,
+  ): m.Children {
+    const columns: GridColumn[] = [
+      {key: 'func', header: m(GridHeaderCell, {}, 'Kernel Function')},
+      {key: 'dur', header: m(GridHeaderCell, {}, 'Duration')},
+      {key: 'count', header: m(GridHeaderCell, {}, 'Count')},
+    ];
+    return m(Grid, {
+      columns,
+      rowData: row.blockedFunctions.map((f) => [
+        m(GridCell, {}, f.func),
+        m(GridCell, {}, m(DurationWidget, {dur: f.dur, trace})),
+        m(GridCell, {}, f.count),
+      ]),
+    });
+  }
+
+  private renderStatesTable(
+    trace: Trace,
+    row: LockContentionDetails,
+  ): m.Children {
+    if (row.threadStates.length === 0) {
+      return m('div', 'No CPU state data available for blocking thread.');
+    }
+
+    const columns: GridColumn[] = [
+      {key: 'state', header: m(GridHeaderCell, {}, 'Thread State')},
+      {key: 'dur', header: m(GridHeaderCell, {}, 'Duration')},
+      {key: 'count', header: m(GridHeaderCell, {}, 'Count')},
+    ];
+    return m(Grid, {
+      columns,
+      rowData: row.threadStates.map((s) => [
+        m(GridCell, {}, s.state),
+        m(GridCell, {}, m(DurationWidget, {dur: s.dur, trace})),
+        m(GridCell, {}, s.count),
+      ]),
+    });
+  }
+}


### PR DESCRIPTION
# Android Lock Contention Plugin

This PR introduces the `com.android.AndroidLockContention` plugin, which allows navigation between events contending for a lock, and presents data about the events in a tabular format.

### Features

-   **Analysis Tab:** Displays detailed information about selected lock contention events:
    -   **Blocked Thread (Victim):** Thread name, TID, main thread status, method, and source location.
    -   **Contention Details:** Lock name, duration, monotonic duration, and a list of other waiters.
    -   **Blocking Thread (Culprit):** Thread name, TID, main thread status, method, and source location.
    -   **Blocking Thread States:** Table summarizing CPU states.
    -   **Kernel Functions:** Table summarizing time spent in kernel functions (if applicable).
    -   **Binder IPC Support:** Visualizes inbound/outbound Binder transactions related to the contention.
    -   **Nested Contention Support:** Displays a warning if the thread holding the lock is also blocked by another lock, with a shortcut to navigate to the root cause.
-   **Navigation History:** Supports navigating backward and forward through inspected contention events with shortcuts.

### Usage

1.  Run the command **"Android Lock Contention: Go Forward"** (or use shortcut `Ctrl+]`) to start navigating.
2.  Navigate backward using shortcut `Ctrl+[`.
3.  Inspect details in the **"Lock Contention Analysis"** tab.

Bug: 289343169