### PR TITLE
Add Proto for ProcState events

### DIFF
--- a/include/perfetto/public/protos/trace/android/android_track_event.pzc.h
+++ b/include/perfetto/public/protos/trace/android/android_track_event.pzc.h
@@ -311,6 +311,18 @@ PERFETTO_PB_FIELD(perfetto_protos_AndroidJobSchedulerJob,
                   job_state_flags,
                   20);
 
+PERFETTO_PB_MSG(perfetto_protos_AndroidProcState);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidProcState,
+                  STRING,
+                  const char*,
+                  proc_state,
+                  1);
+PERFETTO_PB_FIELD(perfetto_protos_AndroidProcState,
+                  VARINT,
+                  int32_t,
+                  count_of_processes,
+                  2);
+
 PERFETTO_PB_MSG(perfetto_protos_AndroidMessageQueue);
 PERFETTO_PB_FIELD(perfetto_protos_AndroidMessageQueue,
                   STRING,
@@ -375,4 +387,10 @@ PERFETTO_PB_EXTENSION_FIELD(perfetto_protos_AndroidTrackEvent,
                             perfetto_protos_AndroidSurfaceFlingerWorkload,
                             surfaceflinger_workload,
                             2007);
+PERFETTO_PB_EXTENSION_FIELD(perfetto_protos_AndroidTrackEvent,
+                            perfetto_protos_TrackEvent,
+                            MSG,
+                            perfetto_protos_AndroidProcState,
+                            proc_state,
+                            2008);
 #endif  // INCLUDE_PERFETTO_PUBLIC_PROTOS_TRACE_ANDROID_ANDROID_TRACK_EVENT_PZC_H_

--- a/protos/perfetto/trace/android/android_track_event.proto
+++ b/protos/perfetto/trace/android/android_track_event.proto
@@ -33,6 +33,14 @@ message AndroidMessageQueue {
   optional uint64 message_delay_ms = 4;
 }
 
+// Information about ProcState of process in the system
+message ProcState {
+  // Name of the Process State.
+  optional string proc_state = 1;
+  // Count of processes in the proc_state
+  optional int32 count_of_processes = 2;
+}
+
 message AndroidJobSchedulerJob {
   // Job id.
   optional int32 job_id = 1;


### PR DESCRIPTION
This change introduces a new proto message, AndroidProcState, for perfetto tracing of process state.

This will help understand memory usage.
