### PR TITLE
ui: Add auth support and refactor extension servers

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/add_extension_server_modal.ts
@@ -18,29 +18,20 @@ import {Button} from '../../widgets/button';
 import {showModal} from '../../widgets/modal';
 import {TextInput} from '../../widgets/text_input';
 import {SegmentedButtons} from '../../widgets/segmented_buttons';
-import {FormLabel} from '../../widgets/form';
+import {Form, FormLabel, FormSection} from '../../widgets/form';
 import {MultiSelect, MultiSelectDiff} from '../../widgets/multiselect';
-import {ExtensionServer} from './types';
+import {ExtensionServer, UserInput} from './types';
 import {defer} from '../../base/deferred';
-import {resolveServerUrl} from './url_utils';
 import {loadManifest} from './extension_server';
-import {Stack} from '../../widgets/stack';
+import {normalizeHttpsUrl} from './url_utils';
+import {Icon} from '../../widgets/icon';
+import {Anchor} from '../../widgets/anchor';
+import {Popup} from '../../widgets/popup';
 import {EmptyState} from '../../widgets/empty_state';
-import {Section} from '../../widgets/section';
 import {debounce} from '../../base/rate_limiters';
 
-interface GithubUserInput {
-  type: 'github';
-  repo: string;
-  ref: string;
-}
-
-interface HttpsUserInput {
-  type: 'https';
-  url: string;
-}
-
-type UserInput = GithubUserInput | HttpsUserInput;
+type GithubUserInput = Extract<UserInput, {type: 'github'}>;
+type HttpsUserInput = Extract<UserInput, {type: 'https'}>;
 
 interface OkLoadedState {
   type: 'ok';
@@ -54,6 +45,9 @@ interface ErrorLoadedState {
 }
 
 type LoadedState = OkLoadedState | ErrorLoadedState;
+
+const PAT_HELP_URL =
+  'https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens';
 
 class AddExtensionServerModal {
   private readonly fetchLimiter = new AsyncLimiter();
@@ -72,82 +66,7 @@ class AddExtensionServerModal {
   view() {
     return m(
       '.pf-add-extension-server-modal',
-      m(
-        Section,
-        {title: 'Server'},
-        m(
-          Stack,
-          {gap: 'small'},
-          m(SegmentedButtons, {
-            options: [
-              {label: 'GitHub', icon: 'link'},
-              {label: 'HTTPS', icon: 'public'},
-            ],
-            selectedOption: this.userInput.type === 'github' ? 0 : 1,
-            onOptionSelected: (idx: number) => {
-              if (idx === 0 && this.userInput.type !== 'github') {
-                this.userInput = {type: 'github', repo: '', ref: 'main'};
-                this.scheduleManifestFetch();
-              } else if (idx === 1 && this.userInput.type !== 'https') {
-                this.userInput = {type: 'https', url: ''};
-                this.scheduleManifestFetch();
-              }
-            },
-          }),
-          this.userInput.type === 'github'
-            ? [
-                m(FormLabel, 'Repository'),
-                m(TextInput, {
-                  placeholder:
-                    'owner/repo (e.g., perfetto-dev/extension-server-test)',
-                  value: this.userInput.repo,
-                  onInput: (value: string) => {
-                    const github = assertGithub(this.userInput);
-                    github.repo = value;
-                    this.debouncedFetch();
-                  },
-                }),
-                m(FormLabel, 'Branch/Tag'),
-                m(TextInput, {
-                  placeholder: 'e.g., main',
-                  value: this.userInput.ref,
-                  onInput: (value: string) => {
-                    const github = assertGithub(this.userInput);
-                    github.ref = value;
-                    this.debouncedFetch();
-                  },
-                }),
-              ]
-            : [
-                m(FormLabel, 'URL'),
-                m(TextInput, {
-                  placeholder: 'https://example.com/path/to/extensions',
-                  value: this.userInput.url,
-                  onInput: (value: string) => {
-                    const https = assertHttps(this.userInput);
-                    https.url = value;
-                    this.debouncedFetch();
-                  },
-                }),
-              ],
-        ),
-      ),
-      m(
-        Section,
-        {
-          title: [
-            m('span', 'Modules'),
-            (this.loadedState?.type === 'ok' ||
-              this.loadedState?.type === 'error') &&
-              m(Button, {
-                icon: 'refresh',
-                compact: true,
-                onclick: () => this.scheduleManifestFetch(),
-              }),
-          ],
-        },
-        this.renderModuleSection(),
-      ),
+      m(Form, {}, this.renderServerSection(), this.renderModuleSection()),
     );
   }
 
@@ -162,11 +81,215 @@ class AddExtensionServerModal {
     if (this.loadedState?.type !== 'ok') {
       return undefined;
     }
+    const enabledModules = Array.from(this.loadedState.enabledModules);
+    if (this.userInput.type === 'github') {
+      return {
+        type: 'github',
+        repo: this.userInput.repo,
+        ref: this.userInput.ref,
+        path: this.userInput.path.trim() || '/',
+        enabledModules,
+        enabled: true,
+        auth: this.userInput.auth,
+      };
+    }
     return {
-      url: this.getUrl(),
-      enabledModules: Array.from(this.loadedState.enabledModules),
+      type: 'https',
+      url: normalizeHttpsUrl(this.userInput.url),
+      enabledModules,
       enabled: true,
+      auth: this.userInput.auth,
     };
+  }
+
+  private renderServerSection(): m.Children {
+    return m(
+      FormSection,
+      {label: 'Server'},
+      this.renderServerTypePicker(),
+      this.userInput.type === 'github'
+        ? this.renderGithubFields(this.userInput)
+        : this.renderHttpsFields(this.userInput),
+    );
+  }
+
+  private renderServerTypePicker(): m.Children {
+    return m(SegmentedButtons, {
+      options: [
+        {label: 'GitHub', icon: 'link'},
+        {label: 'HTTPS', icon: 'public'},
+      ],
+      selectedOption: this.userInput.type === 'github' ? 0 : 1,
+      onOptionSelected: (idx: number) => {
+        if (idx === 0 && this.userInput.type !== 'github') {
+          this.userInput = {
+            type: 'github',
+            repo: '',
+            ref: 'main',
+            path: '',
+            auth: {type: 'none'},
+          };
+          this.scheduleManifestFetch();
+        } else if (idx === 1 && this.userInput.type !== 'https') {
+          this.userInput = {type: 'https', url: '', auth: {type: 'none'}};
+          this.scheduleManifestFetch();
+        }
+      },
+    });
+  }
+
+  private renderGithubFields(input: GithubUserInput): m.Children {
+    return [
+      m(FormLabel, 'Repository'),
+      m(TextInput, {
+        placeholder: 'owner/repo (e.g., perfetto-dev/extension-server-test)',
+        value: input.repo,
+        onInput: (value: string) => {
+          input.repo = value;
+          this.debouncedFetch();
+        },
+      }),
+      m(FormLabel, 'Branch/Tag'),
+      m(TextInput, {
+        placeholder: 'e.g., main',
+        value: input.ref,
+        onInput: (value: string) => {
+          input.ref = value;
+          this.debouncedFetch();
+        },
+      }),
+      m(FormLabel, 'Path'),
+      m(TextInput, {
+        placeholder: '(default: /)',
+        value: input.path,
+        onInput: (value: string) => {
+          input.path = value;
+          this.debouncedFetch();
+        },
+      }),
+      this.renderGithubAuth(input),
+    ];
+  }
+
+  private renderGithubAuth(input: GithubUserInput): m.Children {
+    return [
+      m(FormLabel, [
+        'Authentication ',
+        m(
+          Popup,
+          {
+            trigger: m(Icon, {icon: 'help_outline'}),
+            closeOnOutsideClick: true,
+          },
+          m(
+            'span',
+            'A GitHub ',
+            m(
+              Anchor,
+              {href: PAT_HELP_URL, target: '_blank'},
+              'Personal Access Token',
+            ),
+            ' is required to access private repositories.',
+          ),
+        ),
+      ]),
+      m(SegmentedButtons, {
+        options: [{label: 'None'}, {label: 'PAT'}],
+        selectedOption: input.auth.type === 'github_pat' ? 1 : 0,
+        onOptionSelected: (idx: number) => {
+          input.auth =
+            idx === 1 ? {type: 'github_pat', pat: ''} : {type: 'none'};
+          this.debouncedFetch();
+        },
+      }),
+      input.auth.type === 'github_pat' &&
+        m(TextInput, {
+          placeholder: 'github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+          type: 'password',
+          value: input.auth.pat,
+          onInput: (value: string) => {
+            input.auth = {type: 'github_pat', pat: value};
+            this.debouncedFetch();
+          },
+        }),
+    ];
+  }
+
+  private renderHttpsFields(input: HttpsUserInput): m.Children {
+    return [
+      m(FormLabel, 'URL'),
+      m(TextInput, {
+        placeholder: 'https://example.com/path/to/extensions',
+        value: input.url,
+        onInput: (value: string) => {
+          input.url = value;
+          this.debouncedFetch();
+        },
+      }),
+    ];
+  }
+
+  private renderModuleSection(): m.Children {
+    const showRefresh =
+      this.loadedState?.type === 'ok' || this.loadedState?.type === 'error';
+    return m(
+      FormSection,
+      {label: 'Modules'},
+      showRefresh &&
+        m(
+          '.pf-add-extension-server-modal__refresh',
+          m(Button, {
+            icon: 'refresh',
+            compact: true,
+            onclick: () => this.scheduleManifestFetch(),
+          }),
+        ),
+      this.renderModuleContent(),
+    );
+  }
+
+  private renderModuleContent(): m.Children {
+    if (this.isEmptyInput()) {
+      return m(EmptyState, {
+        icon: 'extension',
+        title: 'Enter server details above to load available modules',
+      });
+    }
+    if (this.loadedState === undefined) {
+      return m(EmptyState, {
+        icon: 'hourglass_empty',
+        title: 'Fetching manifest...',
+      });
+    }
+    if (this.loadedState.type === 'error') {
+      return m(EmptyState, {
+        icon: 'error',
+        title: this.loadedState.error,
+      });
+    }
+    if (this.loadedState.availableModules.length === 0) {
+      return m(EmptyState, {
+        icon: 'inbox',
+        title: 'No modules available in this extension server',
+      });
+    }
+    const {enabledModules, availableModules} = this.loadedState;
+    return m(MultiSelect, {
+      options: availableModules.map((name) => ({
+        id: name,
+        name,
+        checked: enabledModules.has(name),
+      })),
+      onChange: (diffs: MultiSelectDiff[]) => {
+        for (const diff of diffs) {
+          if (diff.checked) {
+            enabledModules.add(diff.id);
+          } else {
+            enabledModules.delete(diff.id);
+          }
+        }
+      },
+    });
   }
 
   private scheduleManifestFetch(
@@ -193,9 +316,7 @@ class AddExtensionServerModal {
       }
     }
 
-    const url = this.getUrl();
-    const resolvedUrl = resolveServerUrl(url);
-    const manifestResult = await loadManifest(resolvedUrl);
+    const manifestResult = await loadManifest(this.userInput);
     if (!manifestResult.ok) {
       const location =
         this.userInput.type === 'github'
@@ -209,27 +330,17 @@ class AddExtensionServerModal {
         type: 'error',
         error: `Could not fetch manifest from ${location}. ${hint}`,
       };
-      console.warn(
-        `Error fetching manifest from ${resolvedUrl}: ${manifestResult.error}`,
-      );
+      console.warn(`Error fetching manifest: ${manifestResult.error}`);
       m.redraw();
       return;
     }
 
-    // Determine which modules to enable
     const manifest = manifestResult.value;
-    let enabledModules: Set<string>;
-    if (preserveEnabledModules) {
-      // When editing, preserve enabled modules that still exist in manifest
-      enabledModules = new Set(
-        preserveEnabledModules.filter((m) => manifest.modules.includes(m)),
-      );
-    } else {
-      // When creating new, default to 'default' module if available
-      enabledModules = new Set(
-        manifest.modules.includes('default') ? ['default'] : [],
-      );
-    }
+    const enabledModules = preserveEnabledModules
+      ? new Set(
+          preserveEnabledModules.filter((m) => manifest.modules.includes(m)),
+        )
+      : new Set(manifest.modules.includes('default') ? ['default'] : []);
 
     this.loadedState = {
       type: 'ok',
@@ -239,23 +350,10 @@ class AddExtensionServerModal {
     m.redraw();
   }
 
-  private getUrl() {
-    if (this.userInput.type === 'github') {
-      return `github://${this.userInput.repo}/${this.userInput.ref}`;
-    }
-    const url = this.userInput.url.trim();
-    // Auto-add https:// if no protocol specified
-    if (!url.includes('://')) {
-      return `https://${url}`;
-    }
-    return url;
-  }
-
   private validateHttpsUrl(): string | undefined {
     if (this.userInput.type !== 'https') return undefined;
     const url = this.userInput.url.trim();
     if (url === '') return undefined;
-    // Check for invalid protocol prefixes
     if (url.includes('://') && !url.startsWith('https://')) {
       return 'URL must use https:// protocol';
     }
@@ -264,68 +362,20 @@ class AddExtensionServerModal {
 
   private isEmptyInput(): boolean {
     if (this.userInput.type === 'github') {
-      // Both repo and ref are required
-      return (
-        this.userInput.repo.trim() === '' || this.userInput.ref.trim() === ''
-      );
-    } else {
-      return this.userInput.url.trim() === '';
+      if (
+        this.userInput.repo.trim() === '' ||
+        this.userInput.ref.trim() === ''
+      ) {
+        return true;
+      }
+      // PAT auth requires a non-empty token.
+      const auth = this.userInput.auth;
+      if (auth.type === 'github_pat' && !auth.pat.trim()) {
+        return true;
+      }
+      return false;
     }
-  }
-
-  private renderModuleSection(): m.Children {
-    // Empty input state
-    if (this.isEmptyInput()) {
-      return m(EmptyState, {
-        icon: 'extension',
-        title: 'Enter server details above to load available modules',
-      });
-    }
-
-    // Loading state
-    if (this.loadedState === undefined) {
-      return m(EmptyState, {
-        icon: 'hourglass_empty',
-        title: 'Fetching manifest...',
-      });
-    }
-
-    // Error state
-    if (this.loadedState.type === 'error') {
-      return m(EmptyState, {
-        icon: 'error',
-        title: this.loadedState.error,
-      });
-    }
-
-    // Success but no modules
-    if (this.loadedState.availableModules.length === 0) {
-      return m(EmptyState, {
-        icon: 'inbox',
-        title: 'No modules available in this extension server',
-      });
-    }
-
-    // Success with modules
-    return m(MultiSelect, {
-      options: this.loadedState.availableModules.map((moduleName) => ({
-        id: moduleName,
-        name: moduleName,
-        checked: assertOkLoadedState(this.loadedState).enabledModules.has(
-          moduleName,
-        ),
-      })),
-      onChange: (diffs: MultiSelectDiff[]) => {
-        const ok = assertOkLoadedState(this.loadedState);
-        for (const diff of diffs) {
-          if (diff.checked) {
-            ok.enabledModules.add(diff.id);
-          } else {
-            ok.enabledModules.delete(diff.id);
-          }
-        }
-      },
-    });
+    return this.userInput.url.trim() === '';
   }
 }
 
@@ -360,43 +410,22 @@ function createInitial(server?: ExtensionServer): UserInput {
       type: 'github',
       repo: '',
       ref: 'main',
+      path: '',
+      auth: {type: 'none'},
     };
   }
-  const githubMatch = server.url.match(/^github:\/\/([^/]+\/[^/]+)\/(.+)$/);
-  if (githubMatch) {
+  if (server.type === 'github') {
     return {
       type: 'github',
-      repo: githubMatch[1] ?? '',
-      ref: githubMatch[2] ?? 'main',
+      repo: server.repo,
+      ref: server.ref,
+      path: server.path === '/' ? '' : server.path,
+      auth: server.auth,
     };
   }
-  const httpsMatch = server.url.match(/^https?:\/\/(.+)$/);
-  if (httpsMatch) {
-    return {
-      type: 'https',
-      url: httpsMatch[1],
-    };
-  }
-  throw new Error(`Unsupported server URL: ${server.url}`);
-}
-
-function assertGithub(state: UserInput): GithubUserInput {
-  if (state.type !== 'github') {
-    throw new Error('State is not of type GithubState');
-  }
-  return state;
-}
-
-function assertHttps(state: UserInput): HttpsUserInput {
-  if (state.type !== 'https') {
-    throw new Error('State is not of type HttpsState');
-  }
-  return state;
-}
-
-function assertOkLoadedState(state: LoadedState | undefined): OkLoadedState {
-  if (state?.type !== 'ok') {
-    throw new Error('LoadedState is not of type OkLoadedState');
-  }
-  return state;
+  return {
+    type: 'https',
+    url: server.url.replace(/^https:\/\//, ''),
+    auth: server.auth,
+  };
 }

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/index.ts
@@ -45,6 +45,11 @@ export default class ExtensionServersPlugin implements PerfettoPlugin {
   }
 }
 
+function authLabel(server: ExtensionServer): string | undefined {
+  if (server.auth.type === 'github_pat') return ' | Auth: PAT';
+  return undefined;
+}
+
 export function renderExtensionServersSettings(
   setting: Setting<ExtensionServer[]>,
 ): m.Children {
@@ -113,11 +118,12 @@ export function renderExtensionServersSettings(
                   '.pf-extension-servers-settings__item-content',
                   m(
                     '.pf-extension-servers-settings__item-url',
-                    makeDisplayUrl(server.url),
+                    makeDisplayUrl(server),
                   ),
                   m(
                     '.pf-extension-servers-settings__item-info',
                     `${server.enabledModules.length} module${server.enabledModules.length === 1 ? '' : 's'}`,
+                    authLabel(server),
                     !server.enabled && ' (Disabled)',
                   ),
                 ),

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/styles.scss
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/styles.scss
@@ -74,43 +74,19 @@
 // Add/Edit Extension Server modal
 .pf-add-extension-server-modal {
   width: 350px;
-  height: 450px;
-  display: flex;
-  flex-direction: column;
+  min-height: 450px;
 
-  .pf-section {
-    margin-bottom: 12px;
+  // Last form section (Modules) fills remaining space
+  .pf-form__section:last-child {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
 
-    header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 8px 12px;
-      background: var(--pf-minimal-background);
-      border-bottom: 1px solid var(--pf-color-border-secondary);
-      font-size: var(--pf-font-size-s);
-      font-weight: 600;
-    }
-
-    article {
-      padding: 12px;
-    }
-
-    // Last section (Modules) fills remaining space
-    &:last-child {
-      flex: 1;
-      display: flex;
-      flex-direction: column;
-      min-height: 0;
-
-      article {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        overflow-y: auto;
-        min-height: 0;
-      }
-    }
+  &__refresh {
+    display: flex;
+    justify-content: flex-end;
   }
 
   .pf-empty-state {

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/types.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/types.ts
@@ -32,17 +32,60 @@ import {macroSchema} from '../../core/command_manager';
 //
 // =============================================================================
 
+// Auth schemas for each server type. These are discriminated unions so that
+// secret fields (like PAT) only exist in variants that need them.
+// Fields containing secrets should use .meta({secret: true}) so that any
+// future settings export feature can identify and strip them.
+const githubAuthSchema = z.discriminatedUnion('type', [
+  z.object({type: z.literal('none')}),
+  z.object({
+    type: z.literal('github_pat'),
+    pat: z.string().meta({secret: true}),
+  }),
+]);
+
+const httpsAuthSchema = z.discriminatedUnion('type', [
+  z.object({type: z.literal('none')}),
+]);
+
 // Extension server configuration (persisted via Settings).
-// Both installation-provided and user-added servers use this schema.
-export const extensionServerSchema = z.object({
-  url: z.string(),
-  enabledModules: z.array(z.string()),
-  enabled: z.boolean(),
-});
+// Discriminated union: GitHub servers store repo+ref, HTTPS servers store a URL.
+// Auth is constrained per server type via nested discriminated unions.
+export const extensionServerSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('github'),
+    repo: z.string(), // "owner/repo"
+    ref: z.string(), // branch or tag, e.g. "main"
+    path: z.string().default('/'), // subdirectory within the repo
+    enabledModules: z.array(z.string()),
+    enabled: z.boolean(),
+    auth: githubAuthSchema.default({type: 'none'}),
+  }),
+  z.object({
+    type: z.literal('https'),
+    url: z.string(),
+    enabledModules: z.array(z.string()),
+    enabled: z.boolean(),
+    auth: httpsAuthSchema.default({type: 'none'}),
+  }),
+]);
 
 // Array of extension servers.
 // This is the schema used for the Settings registration.
 export const extensionServersSchema = z.array(extensionServerSchema);
+
+// The minimal set of fields needed to fetch from an extension server.
+// ExtensionServer is structurally compatible with this (has extra fields like
+// enabledModules/enabled which are ignored).
+export type UserInput =
+  | {
+      type: 'github';
+      repo: string;
+      ref: string;
+      path: string;
+      auth: {type: 'none'} | {type: 'github_pat'; pat: string};
+    }
+  | {type: 'https'; url: string; auth: {type: 'none'}};
 
 // Manifest format from {base_url}/manifest
 // Provides server metadata, features, and available modules.

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/url_utils.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/url_utils.ts
@@ -12,45 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Resolves extension server URLs from shorthand aliases to canonical HTTPS URLs.
-//
-// Supports:
-// - github://owner/repo/ref -> https://raw.githubusercontent.com/owner/repo/ref
-// - https://... -> unchanged (already canonical)
-//
-// Note: http:// URLs are rejected. Use https:// instead.
-export function resolveServerUrl(input: string): string {
-  const trimmed = input.trim();
+import {UserInput} from './types';
 
-  // GitHub alias: github://owner/repo/ref
-  if (trimmed.startsWith('github://')) {
-    const path = trimmed.substring('github://'.length);
-    if (!path) {
-      throw new Error('Invalid GitHub URL: missing owner/repo/ref');
-    }
-    // Path format: owner/repo/ref
-    return `https://raw.githubusercontent.com/${path}`;
+// Converts a server location into a display-friendly string.
+export function makeDisplayUrl(server: UserInput): string {
+  if (server.type === 'github') {
+    const path = server.path !== '/' ? `:${server.path}` : '';
+    return `${server.repo}${path} @ ${server.ref}`;
   }
-
-  // HTTPS URLs pass through unchanged
-  if (trimmed.startsWith('https://')) {
-    return trimmed;
-  }
-
-  // HTTP URLs are rejected - browsers don't allow mixed-content fetch,
-  // and silently upgrading can hide bugs if server behaves differently.
-  if (trimmed.startsWith('http://')) {
-    throw new Error(
-      'Invalid server URL: http:// is not supported, use https:// instead',
-    );
-  }
-
-  // Unknown format
-  throw new Error('Invalid server URL: must start with https:// or github://');
+  return server.url.replace(/^https?:\/\//, '');
 }
 
-// Converts a canonical URL into a display-friendly format by removing
-// the protocol prefix.
-export function makeDisplayUrl(url: string) {
-  return url.replace(/^github:\/\//, '').replace(/^https?:\/\//, '');
+// Joins a base path (e.g. "/" or "/subdir") with a resource path, stripping
+// redundant slashes.
+export function joinPath(base: string, resource: string): string {
+  const trimmed = base.replace(/^\/+|\/+$/g, '');
+  return trimmed ? `${trimmed}/${resource}` : resource;
+}
+
+// Auto-add https:// if no protocol specified.
+export function normalizeHttpsUrl(input: string): string {
+  const url = input.trim();
+  if (!url.includes('://')) {
+    return `https://${url}`;
+  }
+  return url;
 }

--- a/ui/src/public/settings.ts
+++ b/ui/src/public/settings.ts
@@ -37,6 +37,12 @@ export interface SettingDescriptor<T> {
   readonly description: string;
   // The Zod schema used for validating the setting's value, and defining the
   // structure and type of this setting.
+  //
+  // Secret fields: If a schema field contains sensitive data (e.g. API tokens,
+  // passwords), annotate it with `.meta({secret: true})`. This allows any
+  // future settings export feature to identify and strip these fields
+  // automatically. Example:
+  //   z.object({ token: z.string().meta({secret: true}) })
   readonly schema: z.ZodType<T>;
   // The default value of the setting if the setting is absent from the
   // underlying storage.


### PR DESCRIPTION
- Add GitHub PAT auth for private repos
- Refactor server config from flat url-based schema to discriminated
  union (github vs https) with per-type auth
- Switch GitHub fetches to Contents API unconditionally
- Centralize URL utilities into url_utils.ts
- Use Form/FormSection widgets in add server modal
- Add tests for buildFetchRequest and buildAuthConfig