### PR TITLE
tp: Split ClockSynchronizer into pure engine and ClockTracker wrapper

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17271,6 +17271,9 @@ filegroup {
 // GN: //src/trace_processor/util:clock
 filegroup {
     name: "perfetto_src_trace_processor_util_clock",
+    srcs: [
+        "src/trace_processor/util/clock_synchronizer.cc",
+    ],
 }
 
 // GN: //src/trace_processor/util/deobfuscation:deobfuscator

--- a/BUILD
+++ b/BUILD
@@ -4283,6 +4283,7 @@ perfetto_filegroup(
 perfetto_filegroup(
     name = "src_trace_processor_util_clock",
     srcs = [
+        "src/trace_processor/util/clock_synchronizer.cc",
         "src/trace_processor/util/clock_synchronizer.h",
     ],
 )

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -126,6 +126,7 @@ source_set("storage_minimal") {
   ]
   deps = [
     "../../gn:default_deps",
+    "../../protos/perfetto/common:zero",
     "../base",
     "../protozero",
     "containers",

--- a/src/trace_processor/importers/android_bugreport/android_log_unittest.cc
+++ b/src/trace_processor/importers/android_bugreport/android_log_unittest.cc
@@ -25,6 +25,7 @@
 #include "perfetto/base/time.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/trace/clock_snapshot.pbzero.h"
 #include "src/trace_processor/importers/android_bugreport/android_bugreport_reader.h"
 #include "src/trace_processor/importers/android_bugreport/android_log_event.h"
@@ -67,16 +68,16 @@ class AndroidLogReaderTest : public ::testing::Test {
     context_.storage = std::make_unique<TraceStorage>();
     context_.machine_tracker =
         std::make_unique<MachineTracker>(&context_, kDefaultMachineId);
-    std::unique_ptr<ClockSynchronizerListenerImpl> clock_tracker_listener =
-        std::make_unique<ClockSynchronizerListenerImpl>(&context_);
-    context_.clock_tracker =
-        std::make_unique<ClockTracker>(std::move(clock_tracker_listener));
     context_.global_metadata_tracker =
         std::make_unique<GlobalMetadataTracker>(context_.storage.get());
     context_.trace_state =
         TraceProcessorContextPtr<TraceProcessorContext::TraceState>::MakeRoot(
             TraceProcessorContext::TraceState{TraceId(0)});
     context_.metadata_tracker = std::make_unique<MetadataTracker>(&context_);
+    context_.trace_time_state = std::make_unique<TraceTimeState>(TraceTimeState{
+        ClockTracker::ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), false});
+    context_.clock_tracker = std::make_unique<ClockTracker>(
+        &context_, std::make_unique<ClockSynchronizerListenerImpl>(&context_));
     context_.clock_tracker->SetTraceTimeClock(
         ClockTracker::ClockId(protos::pbzero::ClockSnapshot::Clock::REALTIME));
     context_.sorter = std::make_unique<TraceSorter>(

--- a/src/trace_processor/importers/common/clock_tracker.h
+++ b/src/trace_processor/importers/common/clock_tracker.h
@@ -19,37 +19,125 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
+#include <vector>
+
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/public/compiler.h"
 #include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/util/clock_synchronizer.h"
 
 namespace perfetto::trace_processor {
 
 class ClockTrackerTest;
-class TraceProcessorContext;
 
-class ClockSynchronizerListenerImpl {
+class ClockSynchronizerListenerImpl;
+
+// ClockTracker wraps ClockSynchronizer (the pure conversion engine) and adds
+// trace-time semantics: which clock domain is the "trace time", applying
+// remote-machine offsets, and writing metadata.
+class ClockTracker {
  public:
-  using ClockId = ClockSynchronizerBase::ClockId;
+  // Re-export types for callers that use ClockTracker::ClockId etc.
+  using ClockId = ::perfetto::trace_processor::ClockId;
+  using ClockTimestamp = ::perfetto::trace_processor::ClockTimestamp;
+  using Clock = ::perfetto::trace_processor::Clock;
 
+  ClockTracker(TraceProcessorContext* context,
+               std::unique_ptr<ClockSynchronizerListenerImpl> listener);
+
+  // --- Hot-path APIs (inlined) ---
+
+  // Converts a timestamp to the trace time domain. On the first call, also
+  // "locks" the trace time clock, preventing it from being changed later.
+  PERFETTO_ALWAYS_INLINE std::optional<int64_t> ToTraceTime(
+      ClockId clock_id,
+      int64_t timestamp,
+      std::optional<size_t> byte_offset = std::nullopt) {
+    auto* state = context_->trace_time_state.get();
+    if (PERFETTO_UNLIKELY(!state->used_for_conversion)) {
+      OnFirstTraceTimeUse();
+    }
+    auto ts = sync_.Convert(clock_id, timestamp, state->clock_id, byte_offset);
+    return ts ? std::optional(ToHostTraceTime(*ts)) : ts;
+  }
+
+  // Converts a timestamp between two arbitrary clock domains.
+  PERFETTO_ALWAYS_INLINE std::optional<int64_t> Convert(
+      ClockId src,
+      int64_t ts,
+      ClockId target,
+      std::optional<size_t> byte_offset = {}) {
+    return sync_.Convert(src, ts, target, byte_offset);
+  }
+
+  static bool IsSequenceClock(uint32_t raw_clock_id) {
+    return ClockSynchronizer::IsSequenceClock(raw_clock_id);
+  }
+
+  static ClockId SequenceToGlobalClock(uint32_t tfi,
+                                       uint32_t seq,
+                                       uint32_t clk) {
+    return ClockSynchronizer::SequenceToGlobalClock(tfi, seq, clk);
+  }
+
+  // --- Slow-path public APIs ---
+
+  base::StatusOr<uint32_t> AddSnapshot(
+      const std::vector<ClockTimestamp>& clock_timestamps);
+
+  base::Status SetTraceTimeClock(ClockId clock_id);
+
+  std::optional<int64_t> ToTraceTimeFromSnapshot(
+      const std::vector<ClockTimestamp>& snapshot);
+
+  void SetRemoteClockOffset(ClockId clock_id, int64_t offset);
+  std::optional<int64_t> timezone_offset() const;
+  void set_timezone_offset(int64_t offset);
+
+  // --- Testing ---
+  void set_cache_lookups_disabled_for_testing(bool v);
+  const base::FlatHashMap<ClockId, int64_t>& remote_clock_offsets_for_testing();
+  uint32_t cache_hits_for_testing() const;
+
+ private:
+  friend class ClockTrackerTest;
+
+  PERFETTO_ALWAYS_INLINE int64_t ToHostTraceTime(int64_t timestamp) {
+    if (PERFETTO_LIKELY(context_->machine_id() ==
+                        MachineId(kDefaultMachineId))) {
+      return timestamp;
+    }
+    auto* state = context_->trace_time_state.get();
+    int64_t clock_offset = remote_clock_offsets_[state->clock_id];
+    return timestamp - clock_offset;
+  }
+
+  void OnFirstTraceTimeUse();
+
+  TraceProcessorContext* context_;
+  ClockSynchronizer sync_;
+  base::FlatHashMap<ClockId, int64_t> remote_clock_offsets_;
+  std::optional<int64_t> timezone_offset_;
+};
+
+class ClockSynchronizerListenerImpl : public ClockSynchronizerListener {
+ public:
   explicit ClockSynchronizerListenerImpl(TraceProcessorContext* context);
 
-  base::Status OnClockSyncCacheMiss();
+  base::Status OnClockSyncCacheMiss() override;
 
-  base::Status OnInvalidClockSnapshot();
+  base::Status OnInvalidClockSnapshot() override;
 
-  base::Status OnTraceTimeClockIdChanged(ClockId);
-
-  base::Status OnSetTraceTimeClock(ClockId);
-
-  void RecordConversionError(ClockSynchronizerBase::ErrorType,
+  void RecordConversionError(ClockSyncErrorType,
                              ClockId source_clock_id,
                              ClockId target_clock_id,
                              int64_t source_timestamp,
-                             std::optional<size_t>);
-
-  bool IsLocalHost();
+                             std::optional<size_t>) override;
 
  private:
   TraceProcessorContext* context_;
@@ -59,8 +147,6 @@ class ClockSynchronizerListenerImpl {
   StringId source_sequence_id_key_;
   StringId target_sequence_id_key_;
 };
-
-using ClockTracker = ClockSynchronizer<ClockSynchronizerListenerImpl>;
 
 }  // namespace perfetto::trace_processor
 

--- a/src/trace_processor/importers/common/clock_tracker_unittest.cc
+++ b/src/trace_processor/importers/common/clock_tracker_unittest.cc
@@ -53,8 +53,10 @@ class ClockTrackerTest : public ::testing::Test {
         new ImportLogsTracker(&context_, TraceId(1)));
     context_.machine_tracker =
         std::make_unique<MachineTracker>(&context_, kDefaultMachineId);
+    context_.trace_time_state = std::make_unique<TraceTimeState>(TraceTimeState{
+        ClockTracker::ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), false});
     ct_ = std::make_unique<ClockTracker>(
-        std::make_unique<ClockSynchronizerListenerImpl>(&context_));
+        &context_, std::make_unique<ClockSynchronizerListenerImpl>(&context_));
   }
   std::optional<int64_t> Convert(ClockTracker::ClockId src_clock_id,
                                  int64_t src_timestamp,

--- a/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
+++ b/src/trace_processor/importers/fuchsia/fuchsia_parser_unittest.cc
@@ -59,6 +59,7 @@
 #include "src/trace_processor/util/descriptors.h"
 #include "test/gtest_and_gmock.h"
 
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/trace/trace.pbzero.h"
 #include "protos/perfetto/trace/trace_packet.pbzero.h"
 #include "protos/perfetto/trace/track_event/thread_descriptor.pbzero.h"
@@ -200,8 +201,10 @@ class FuchsiaTraceParserTest : public ::testing::Test {
     context_.slice_tracker = std::make_unique<SliceTracker>(&context_);
     context_.slice_translation_table =
         std::make_unique<SliceTranslationTable>(storage_);
+    context_.trace_time_state = std::make_unique<TraceTimeState>(TraceTimeState{
+        ClockTracker::ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), false});
     context_.clock_tracker = std::make_unique<ClockTracker>(
-        std::make_unique<ClockSynchronizerListenerImpl>(&context_));
+        &context_, std::make_unique<ClockSynchronizerListenerImpl>(&context_));
     clock_ = context_.clock_tracker.get();
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
     context_.sorter = std::make_unique<TraceSorter>(

--- a/src/trace_processor/importers/proto/network_trace_module_unittest.cc
+++ b/src/trace_processor/importers/proto/network_trace_module_unittest.cc
@@ -27,6 +27,7 @@
 #include "perfetto/protozero/scattered_heap_buffer.h"
 #include "perfetto/trace_processor/trace_blob.h"
 #include "perfetto/trace_processor/trace_blob_view.h"
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/trace/android/network_trace.pbzero.h"
 #include "protos/perfetto/trace/trace.pbzero.h"
 #include "src/trace_processor/core/dataframe/specs.h"
@@ -52,6 +53,7 @@
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/tables/metadata_tables_py.h"
 #include "src/trace_processor/types/trace_processor_context.h"
+#include "src/trace_processor/types/trace_processor_context_ptr.h"
 #include "src/trace_processor/types/variadic.h"
 #include "src/trace_processor/util/args_utils.h"
 #include "src/trace_processor/util/descriptors.h"
@@ -78,8 +80,10 @@ class NetworkTraceModuleTest : public testing::Test {
     context_.metadata_tracker = std::make_unique<MetadataTracker>(&context_);
     context_.import_logs_tracker =
         std::make_unique<ImportLogsTracker>(&context_, TraceId(1));
+    context_.trace_time_state = std::make_unique<TraceTimeState>(TraceTimeState{
+        ClockTracker::ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), false});
     context_.clock_tracker = std::make_unique<ClockTracker>(
-        std::make_unique<ClockSynchronizerListenerImpl>(&context_));
+        &context_, std::make_unique<ClockSynchronizerListenerImpl>(&context_));
     context_.track_tracker = std::make_unique<TrackTracker>(&context_);
     context_.slice_tracker = std::make_unique<SliceTracker>(&context_);
     context_.global_args_tracker =

--- a/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl_unittest.cc
@@ -280,8 +280,10 @@ class ProtoTraceParserTest : public ::testing::Test {
     context_.slice_tracker = std::make_unique<SliceTracker>(&context_);
     context_.slice_translation_table =
         std::make_unique<SliceTranslationTable>(storage_);
+    context_.trace_time_state = std::make_unique<TraceTimeState>(TraceTimeState{
+        ClockTracker::ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME), false});
     context_.clock_tracker = std::make_unique<ClockTracker>(
-        std::make_unique<ClockSynchronizerListenerImpl>(&context_));
+        &context_, std::make_unique<ClockSynchronizerListenerImpl>(&context_));
     context_.flow_tracker = std::make_unique<FlowTracker>(&context_);
     context_.sorter = std::make_unique<TraceSorter>(
         &context_, TraceSorter::SortingMode::kFullSort);

--- a/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader_unittest.cc
@@ -63,7 +63,12 @@ class ProtoTraceReaderTest : public ::testing::Test {
         std::make_unique<GlobalArgsTracker>(host_context_.storage.get());
     host_context_.import_logs_tracker =
         std::make_unique<ImportLogsTracker>(&host_context_, TraceId(1));
+    host_context_.trace_time_state =
+        std::make_unique<TraceTimeState>(TraceTimeState{
+            ClockTracker::ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME),
+            false});
     host_context_.clock_tracker = std::make_unique<ClockTracker>(
+        &host_context_,
         std::make_unique<ClockSynchronizerListenerImpl>(&host_context_));
     host_context_.sorter = std::make_unique<TraceSorter>(
         &host_context_, TraceSorter::SortingMode::kDefault);

--- a/src/trace_processor/importers/systrace/BUILD.gn
+++ b/src/trace_processor/importers/systrace/BUILD.gn
@@ -51,6 +51,7 @@ source_set("full") {
     ":systrace_parser",
     "../..:storage_minimal",
     "../../../../gn:default_deps",
+    "../../../../protos/perfetto/common:zero",
     "../../containers",
     "../../sorter",
     "../../storage",

--- a/src/trace_processor/trace_processor_context.cc
+++ b/src/trace_processor/trace_processor_context.cc
@@ -52,6 +52,8 @@
 #include "src/trace_processor/trace_reader_registry.h"
 #include "src/trace_processor/types/trace_processor_context_ptr.h"
 
+#include "protos/perfetto/common/builtin_clock.pbzero.h"
+
 namespace perfetto::trace_processor {
 namespace {
 
@@ -85,10 +87,8 @@ void InitPerMachineState(TraceProcessorContext* context, uint32_t machine_id) {
   context->symbol_tracker = Ptr<SymbolTracker>::MakeRoot(context);
   context->machine_tracker = Ptr<MachineTracker>::MakeRoot(context, machine_id);
   context->process_tracker = Ptr<ProcessTracker>::MakeRoot(context);
-  std::unique_ptr<ClockSynchronizerListenerImpl> clock_tracker_listener =
-      std::make_unique<ClockSynchronizerListenerImpl>(context);
-  context->clock_tracker =
-      Ptr<ClockTracker>::MakeRoot(std::move(clock_tracker_listener));
+  context->clock_tracker = Ptr<ClockTracker>::MakeRoot(
+      context, std::make_unique<ClockSynchronizerListenerImpl>(context));
   context->mapping_tracker = Ptr<MappingTracker>::MakeRoot(context);
   context->cpu_tracker = Ptr<CpuTracker>::MakeRoot(context);
 }
@@ -157,6 +157,9 @@ void InitGlobalState(TraceProcessorContext* context, const Config& config) {
   context->forked_context_state =
       Ptr<TraceProcessorContext::ForkedContextState>::MakeRoot();
   context->clock_converter = Ptr<ClockConverter>::MakeRoot(context);
+  context->trace_time_state = Ptr<TraceTimeState>::MakeRoot(TraceTimeState{
+      ClockTracker::ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME),
+      /*used_for_conversion=*/false});
   context->track_group_idx_state =
       Ptr<TrackCompressorGroupIdxState>::MakeRoot();
   context->stack_profile_tracker = Ptr<StackProfileTracker>::MakeRoot(context);
@@ -183,6 +186,7 @@ void CopyGlobalState(const TraceProcessorContext* source,
   dest->descriptor_pool_ = source->descriptor_pool_.Fork();
   dest->forked_context_state = source->forked_context_state.Fork();
   dest->clock_converter = source->clock_converter.Fork();
+  dest->trace_time_state = source->trace_time_state.Fork();
   dest->track_group_idx_state = source->track_group_idx_state.Fork();
   dest->register_additional_proto_modules =
       source->register_additional_proto_modules;

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -30,11 +30,9 @@
 
 namespace perfetto::trace_processor {
 
-class ClockSynchronizerListenerImpl;
 class ArgsTranslationTable;
 class ClockConverter;
-template <typename T>
-class ClockSynchronizer;
+class ClockTracker;
 class CpuTracker;
 class DescriptorPool;
 class EventTracker;
@@ -62,11 +60,11 @@ class TraceStorage;
 class TrackCompressor;
 class TrackTracker;
 struct ProtoImporterModuleContext;
+struct TraceTimeState;
 struct TrackCompressorGroupIdxState;
 
 using MachineId = tables::MachineTable::Id;
 using TraceId = tables::TraceFileTable::Id;
-using ClockTracker = ClockSynchronizer<ClockSynchronizerListenerImpl>;
 
 class TraceProcessorContext {
  public:
@@ -144,6 +142,7 @@ class TraceProcessorContext {
   GlobalPtr<DescriptorPool> descriptor_pool_;
   GlobalPtr<ForkedContextState> forked_context_state;
   GlobalPtr<ClockConverter> clock_converter;
+  GlobalPtr<TraceTimeState> trace_time_state;
   GlobalPtr<TrackCompressorGroupIdxState> track_group_idx_state;
   GlobalPtr<StackProfileTracker> stack_profile_tracker;
   GlobalPtr<Destructible> deobfuscation_tracker;  // DeobfuscationTracker

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -76,7 +76,10 @@ source_set("blob") {
 }
 
 source_set("clock") {
-  sources = [ "clock_synchronizer.h" ]
+  sources = [
+    "clock_synchronizer.cc",
+    "clock_synchronizer.h",
+  ]
   deps = [
     "../../../gn:default_deps",
     "../../../include/perfetto/ext/base:base",

--- a/src/trace_processor/util/clock_synchronizer.cc
+++ b/src/trace_processor/util/clock_synchronizer.cc
@@ -1,0 +1,382 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/util/clock_synchronizer.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/murmur_hash.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/public/compiler.h"
+
+namespace perfetto::trace_processor {
+
+// --- ClockId ---
+
+std::string ClockId::ToString() const {
+  if (seq_id == 0 && trace_file_id == 0)
+    return std::to_string(clock_id);
+  return std::to_string(clock_id) + "(seq=" + std::to_string(seq_id) +
+         ",tf=" + std::to_string(trace_file_id) + ")";
+}
+
+// --- ClockSynchronizerListener ---
+
+ClockSynchronizerListener::~ClockSynchronizerListener() = default;
+
+// --- ClockSynchronizer ---
+
+ClockSynchronizer::ClockSynchronizer(
+    TraceTimeState* trace_time_state,
+    std::unique_ptr<ClockSynchronizerListener> clock_event_listener)
+    : trace_time_state_(trace_time_state),
+      clock_event_listener_(std::move(clock_event_listener)) {}
+
+base::StatusOr<uint32_t> ClockSynchronizer::AddSnapshot(
+    const std::vector<ClockTimestamp>& clock_timestamps) {
+  const auto snapshot_id = cur_snapshot_id_++;
+
+  // Clear the cache
+  cache_.fill({});
+
+  // Compute the fingerprint of the snapshot by hashing all clock ids. This is
+  // used by the clock pathfinding logic.
+  base::MurmurHashCombiner hasher;
+  for (const auto& clock_ts : clock_timestamps)
+    hasher.Combine(clock_ts.clock.id);
+  const auto snapshot_hash = static_cast<SnapshotHash>(hasher.digest());
+
+  // Add a new entry in each clock's snapshot vector.
+  for (const auto& clock_ts : clock_timestamps) {
+    ClockId clock_id = clock_ts.clock.id;
+    ClockDomain& domain = clocks_[clock_id];
+
+    if (domain.snapshots.empty()) {
+      if (clock_ts.clock.is_incremental &&
+          !IsConvertedSequenceClock(clock_id)) {
+        clock_event_listener_->OnInvalidClockSnapshot();
+        return base::ErrStatus(
+            "Clock sync error: the global clock with id=%s"
+            " cannot use incremental encoding; this is only "
+            "supported for sequence-scoped clocks.",
+            clock_id.ToString().c_str());
+      }
+      domain.unit_multiplier_ns = clock_ts.clock.unit_multiplier_ns;
+      domain.is_incremental = clock_ts.clock.is_incremental;
+    } else if (PERFETTO_UNLIKELY(domain.unit_multiplier_ns !=
+                                     clock_ts.clock.unit_multiplier_ns ||
+                                 domain.is_incremental !=
+                                     clock_ts.clock.is_incremental)) {
+      clock_event_listener_->OnInvalidClockSnapshot();
+      return base::ErrStatus(
+          "Clock sync error: the clock domain with id=%s"
+          " (unit=%" PRId64
+          ", incremental=%d), was previously registered with "
+          "different properties (unit=%" PRId64 ", incremental=%d).",
+          clock_id.ToString().c_str(), clock_ts.clock.unit_multiplier_ns,
+          clock_ts.clock.is_incremental, domain.unit_multiplier_ns,
+          domain.is_incremental);
+    }
+    if (PERFETTO_UNLIKELY(clock_id == trace_time_state_->clock_id &&
+                          domain.unit_multiplier_ns != 1)) {
+      clock_event_listener_->OnInvalidClockSnapshot();
+      return base::ErrStatus(
+          "Clock sync error: the trace clock (id=%s"
+          ") must always use nanoseconds as unit multiplier.",
+          clock_id.ToString().c_str());
+    }
+    const int64_t timestamp_ns = clock_ts.timestamp * domain.unit_multiplier_ns;
+    domain.last_timestamp_ns = timestamp_ns;
+
+    ClockSnapshots& vect = domain.snapshots[snapshot_hash];
+    if (!vect.snapshot_ids.empty() &&
+        PERFETTO_UNLIKELY(vect.snapshot_ids.back() == snapshot_id)) {
+      clock_event_listener_->OnInvalidClockSnapshot();
+      return base::ErrStatus(
+          "Clock sync error: duplicate clock domain with id=%s"
+          " at snapshot %" PRIu32 ".",
+          clock_id.ToString().c_str(), snapshot_id);
+    }
+
+    // Clock ids in the range [64, 128) are sequence-scoped and must be
+    // translated to global ids via SequenceToGlobalClock() before calling
+    // this function.
+    PERFETTO_DCHECK(!IsSequenceClock(clock_id.clock_id) ||
+                    clock_id.seq_id != 0);
+
+    // Snapshot IDs must be always monotonic.
+    PERFETTO_DCHECK(vect.snapshot_ids.empty() ||
+                    vect.snapshot_ids.back() < snapshot_id);
+
+    if (!vect.timestamps_ns.empty() &&
+        timestamp_ns < vect.timestamps_ns.back()) {
+      // Clock is not monotonic.
+
+      if (clock_id == trace_time_state_->clock_id) {
+        clock_event_listener_->OnInvalidClockSnapshot();
+        return base::ErrStatus(
+            "Clock sync error: the trace clock (id=%s"
+            ") is not monotonic at snapshot %" PRIu32 ". %" PRId64
+            " not >= %" PRId64 ".",
+            clock_id.ToString().c_str(), snapshot_id, timestamp_ns,
+            vect.timestamps_ns.back());
+      }
+
+      PERFETTO_DLOG("Detected non-monotonic clock with ID %s",
+                    clock_id.ToString().c_str());
+
+      // For the other clocks the best thing we can do is mark it as
+      // non-monotonic and refuse to use it as a source clock in the
+      // resolution graph. We can still use it as a target clock, but not
+      // viceversa. The concrete example is the CLOCK_REALTIME going 1h
+      // backwards during daylight saving. We can still answer the question
+      // "what was the REALTIME timestamp when BOOTTIME was X?" but we can't
+      // answer the opposite question because there can be two valid
+      // BOOTTIME(s) for the same REALTIME instant because of the 1:many
+      // relationship.
+      non_monotonic_clocks_.insert(clock_id);
+
+      // Erase all edges from the graph that start from this clock (but keep
+      // the ones that end on this clock).
+      PERFETTO_CHECK(clock_id.trace_file_id <
+                     std::numeric_limits<uint32_t>::max());
+      auto begin = graph_.lower_bound(ClockGraphEdge{clock_id, ClockId{}, 0});
+      ClockId upper = {clock_id.clock_id, clock_id.seq_id,
+                       clock_id.trace_file_id + 1};
+      auto end = graph_.lower_bound(ClockGraphEdge{upper, ClockId{}, 0});
+      graph_.erase(begin, end);
+    }
+    vect.snapshot_ids.emplace_back(snapshot_id);
+    vect.timestamps_ns.emplace_back(timestamp_ns);
+  }
+  // Create graph edges for all the possible tuples of clocks in this
+  // snapshot. If the snapshot contains clock a, b, c, d create edges [ab, ac,
+  // ad, bc, bd, cd] and the symmetrical ones [ba, ca, da, bc, db, dc]. This
+  // is to store the information: Clock A is syncable to Clock B via the
+  // snapshots of type (hash).
+  // Clocks that were previously marked as non-monotonic won't be added as
+  // valid sources.
+  for (auto it1 = clock_timestamps.begin(); it1 != clock_timestamps.end();
+       ++it1) {
+    auto it2 = it1;
+    ++it2;
+    for (; it2 != clock_timestamps.end(); ++it2) {
+      if (!non_monotonic_clocks_.count(it1->clock.id))
+        graph_.emplace(it1->clock.id, it2->clock.id, snapshot_hash);
+
+      if (!non_monotonic_clocks_.count(it2->clock.id))
+        graph_.emplace(it2->clock.id, it1->clock.id, snapshot_hash);
+    }
+  }
+
+  return snapshot_id;
+}
+
+std::optional<int64_t> ClockSynchronizer::ConvertSlowpath(
+    ClockId src_clock_id,
+    int64_t src_timestamp,
+    std::optional<int64_t> src_ts_ns,
+    ClockId target_clock_id,
+    std::optional<size_t> byte_offset) {
+  PERFETTO_DCHECK(!IsSequenceClock(src_clock_id.clock_id) ||
+                  src_clock_id.seq_id != 0);
+  PERFETTO_DCHECK(!IsSequenceClock(target_clock_id.clock_id) ||
+                  target_clock_id.seq_id != 0);
+  clock_event_listener_->OnClockSyncCacheMiss();
+
+  ClockPath path = FindPath(src_clock_id, target_clock_id);
+  if (!path.valid()) {
+    // Determine which clock(s) are unknown and record error
+    ClockSyncErrorType error;
+    if (clocks_.find(src_clock_id) == clocks_.end()) {
+      error = ClockSyncErrorType::kUnknownSourceClock;
+    } else if (clocks_.find(target_clock_id) == clocks_.end()) {
+      error = ClockSyncErrorType::kUnknownTargetClock;
+    } else {
+      error = ClockSyncErrorType::kNoPath;
+    }
+    clock_event_listener_->RecordConversionError(
+        error, src_clock_id, target_clock_id, src_timestamp, byte_offset);
+    return std::nullopt;
+  }
+
+  // Iterate trough the path found and translate timestamps onto the new clock
+  // domain on each step, until the target domain is reached.
+  ClockDomain* src_domain = GetClock(src_clock_id);
+  int64_t ns = src_ts_ns ? *src_ts_ns : src_domain->ToNs(src_timestamp);
+
+  // These will track the overall translation and valid range for the whole
+  // path.
+  int64_t total_translation_ns = 0;
+  int64_t path_min_ts_ns = std::numeric_limits<int64_t>::min();
+  int64_t path_max_ts_ns = std::numeric_limits<int64_t>::max();
+
+  for (uint32_t i = 0; i < path.len; ++i) {
+    const ClockGraphEdge edge = path.at(i);
+    ClockDomain* cur_clock = GetClock(std::get<0>(edge));
+    ClockDomain* next_clock = GetClock(std::get<1>(edge));
+    const SnapshotHash hash = std::get<2>(edge);
+
+    // Find the closest timestamp within the snapshots of the source clock.
+    const ClockSnapshots& cur_snap = cur_clock->GetSnapshot(hash);
+    const auto& ts_vec = cur_snap.timestamps_ns;
+    auto it = std::upper_bound(ts_vec.begin(), ts_vec.end(), ns);
+    if (it != ts_vec.begin())
+      --it;
+
+    // Now lookup the snapshot id that matches the closest timestamp.
+    size_t index = static_cast<size_t>(std::distance(ts_vec.begin(), it));
+    PERFETTO_DCHECK(index < ts_vec.size());
+    PERFETTO_DCHECK(cur_snap.snapshot_ids.size() == ts_vec.size());
+    uint32_t snapshot_id = cur_snap.snapshot_ids[index];
+
+    // And use that to retrieve the corresponding time in the next clock
+    // domain. The snapshot id must exist in the target clock domain. If it
+    // doesn't either the hash logic or the pathfinding logic are bugged. This
+    // can also happen if the checks in AddSnapshot fail and we skip part of
+    // the snapshot.
+    const ClockSnapshots& next_snap = next_clock->GetSnapshot(hash);
+
+    // Using std::lower_bound because snapshot_ids is sorted, so we can do
+    // a binary search. std::find would do a linear scan.
+    auto next_it = std::lower_bound(next_snap.snapshot_ids.begin(),
+                                    next_snap.snapshot_ids.end(), snapshot_id);
+    if (next_it == next_snap.snapshot_ids.end() || *next_it != snapshot_id) {
+      PERFETTO_DFATAL("Snapshot does not exist in clock domain.");
+      continue;
+    }
+    size_t next_index = static_cast<size_t>(
+        std::distance(next_snap.snapshot_ids.begin(), next_it));
+    PERFETTO_DCHECK(next_index < next_snap.snapshot_ids.size());
+    int64_t next_timestamp_ns = next_snap.timestamps_ns[next_index];
+
+    // The translated timestamp is the relative delta of the source timestamp
+    // from the closest snapshot found (ns - *it), plus the timestamp in
+    // the new clock domain for the same snapshot id.
+    const int64_t hop_translation_ns = next_timestamp_ns - *it;
+    ns += hop_translation_ns;
+
+    // Now, calculate the valid range for this specific hop and intersect it
+    // with the accumulated valid range for the whole path.
+    // The range for this hop needs to be translated back to the source
+    // clock's coordinate system.
+    const int64_t kInt64Min = std::numeric_limits<int64_t>::min();
+    const int64_t kInt64Max = std::numeric_limits<int64_t>::max();
+
+    int64_t hop_min_ts_ns = (it == ts_vec.begin()) ? kInt64Min : *it;
+    auto ubound = it + 1;
+    int64_t hop_max_ts_ns = (ubound == ts_vec.end()) ? kInt64Max : *ubound;
+
+    // Translate the hop's valid range back to the original source clock's
+    // domain. `total_translation_ns` is the translation from the *start* of
+    // the path to the *start* of the current hop.
+    int64_t hop_min_in_src_domain_ns =
+        (hop_min_ts_ns == kInt64Min) ? kInt64Min
+                                     : hop_min_ts_ns - total_translation_ns;
+    int64_t hop_max_in_src_domain_ns =
+        (hop_max_ts_ns == kInt64Max) ? kInt64Max
+                                     : hop_max_ts_ns - total_translation_ns;
+
+    // Intersect with the path's current valid range.
+    path_min_ts_ns = std::max(path_min_ts_ns, hop_min_in_src_domain_ns);
+    path_max_ts_ns = std::min(path_max_ts_ns, hop_max_in_src_domain_ns);
+
+    // Accumulate the translation.
+    total_translation_ns += hop_translation_ns;
+
+    // The last clock in the path must be the target clock.
+    PERFETTO_DCHECK(i < path.len - 1 || std::get<1>(edge) == target_clock_id);
+  }
+
+  // After the loop, we have the final converted timestamp `ns`, and the
+  // total translation and valid range for the entire path.
+  // We can now cache this result.
+  CachedClockPath cache_entry{};
+  cache_entry.src = src_clock_id;
+  cache_entry.target = target_clock_id;
+  cache_entry.src_domain = src_domain;
+  cache_entry.min_ts_ns = path_min_ts_ns;
+  cache_entry.max_ts_ns = path_max_ts_ns;
+  cache_entry.translation_ns = total_translation_ns;
+  cache_[rnd_() % cache_.size()] = cache_entry;
+
+  return ns;
+}
+
+ClockSynchronizer::ClockPath ClockSynchronizer::FindPath(ClockId src,
+                                                         ClockId target) {
+  PERFETTO_CHECK(src != target);
+
+  // If we've never heard of the clock before there is no hope:
+  if (clocks_.find(target) == clocks_.end()) {
+    return ClockPath();
+  }
+  if (clocks_.find(src) == clocks_.end()) {
+    return ClockPath();
+  }
+
+  // This is a classic breadth-first search. Each node in the queue holds also
+  // the full path to reach that node.
+  // We assume the graph is acyclic, if it isn't the ClockPath::kMaxLen will
+  // stop the search anyways.
+  queue_find_path_cache_.clear();
+  queue_find_path_cache_.emplace_back(src);
+
+  while (!queue_find_path_cache_.empty()) {
+    ClockPath cur_path = queue_find_path_cache_.front();
+    queue_find_path_cache_.pop_front();
+
+    const ClockId cur_clock_id = cur_path.last;
+    if (cur_path.len >= ClockPath::kMaxLen)
+      continue;
+
+    // Expore all the adjacent clocks.
+    // The lower_bound() below returns an iterator to the first edge that
+    // starts on |cur_clock_id|. The edges are sorted by (src, target, hash).
+    for (auto it =
+             graph_.lower_bound(ClockGraphEdge(cur_clock_id, ClockId{}, 0));
+         it != graph_.end() && std::get<0>(*it) == cur_clock_id; ++it) {
+      ClockId next_clock_id = std::get<1>(*it);
+      SnapshotHash hash = std::get<2>(*it);
+      if (next_clock_id == target)
+        return ClockPath(cur_path, next_clock_id, hash);
+      queue_find_path_cache_.emplace_back(
+          ClockPath(cur_path, next_clock_id, hash));
+    }
+  }
+  return ClockPath();  // invalid path.
+}
+
+ClockSynchronizer::ClockDomain* ClockSynchronizer::GetClock(ClockId clock_id) {
+  auto it = clocks_.find(clock_id);
+  PERFETTO_DCHECK(it != clocks_.end());
+  return &it->second;
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/util/clock_synchronizer.h
+++ b/src/trace_processor/util/clock_synchronizer.h
@@ -17,12 +17,9 @@
 #ifndef SRC_TRACE_PROCESSOR_UTIL_CLOCK_SYNCHRONIZER_H_
 #define SRC_TRACE_PROCESSOR_UTIL_CLOCK_SYNCHRONIZER_H_
 
-#include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -36,17 +33,10 @@
 #include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/circular_queue.h"
-#include "perfetto/ext/base/flat_hash_map.h"
-#include "perfetto/ext/base/murmur_hash.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/public/compiler.h"
 
-#include "protos/perfetto/common/builtin_clock.pbzero.h"
-
 namespace perfetto::trace_processor {
-
-class ClockTrackerTest;
-class TraceProcessorContext;
 
 // This class handles synchronization of timestamps across different clock
 // domains. This includes multi-hop conversions from two clocks A and D, e.g.
@@ -55,8 +45,8 @@ class TraceProcessorContext;
 // The API is fairly simple (but the inner operation is not):
 // - AddSnapshot(map<clock_id, timestamp>): pushes a set of clocks that have
 //   been snapshotted at the same time (within technical limits).
-// - ToTraceTime(src_clock_id, src_timestamp):
-//   converts a timestamp between clock domain and TraceTime.
+// - Convert(src_clock_id, src_timestamp, target_clock_id):
+//   converts a timestamp between two clock domains.
 //
 // Concepts:
 // - Snapshot hash:
@@ -122,87 +112,94 @@ class TraceProcessorContext;
 //   S2                        {t: 2000, id: 2}   |
 //   S3                                           {t:5000, id:3}
 
-// Base class for ClockSynchronizer containing non-templated types.
-// This allows listener implementations to reference these types without
-// depending on the template instantiation.
-class ClockSynchronizerBase {
- public:
-  // Represents a clock identifier with explicit fields for the raw clock ID,
-  // the sequence ID (for sequence-scoped clocks), and the trace file ID
-  // (to isolate sequence-scoped state across different trace files in a TAR).
-  // Non-sequence clocks have seq_id=0, trace_file_id=0.
-  struct ClockId {
-    uint32_t clock_id = 0;
-    uint32_t seq_id = 0;
-    uint32_t trace_file_id = 0;
+// Represents a clock identifier with explicit fields for the raw clock ID,
+// the sequence ID (for sequence-scoped clocks), and the trace file ID
+// (to isolate sequence-scoped state across different trace files in a TAR).
+// Non-sequence clocks have seq_id=0, trace_file_id=0.
+struct ClockId {
+  uint32_t clock_id = 0;
+  uint32_t seq_id = 0;
+  uint32_t trace_file_id = 0;
 
-    constexpr ClockId() = default;
-    constexpr explicit ClockId(uint32_t _clock_id) : ClockId(_clock_id, 0, 0) {}
-    constexpr ClockId(uint32_t cid, uint32_t sid, uint32_t tfi)
-        : clock_id(cid), seq_id(sid), trace_file_id(tfi) {}
+  constexpr ClockId() = default;
+  constexpr explicit ClockId(uint32_t _clock_id) : ClockId(_clock_id, 0, 0) {}
+  constexpr ClockId(uint32_t cid, uint32_t sid, uint32_t tfi)
+      : clock_id(cid), seq_id(sid), trace_file_id(tfi) {}
 
-    bool operator==(const ClockId& o) const {
-      return clock_id == o.clock_id && seq_id == o.seq_id &&
-             trace_file_id == o.trace_file_id;
-    }
-    bool operator!=(const ClockId& o) const { return !(*this == o); }
-    bool operator<(const ClockId& o) const {
-      return std::tie(clock_id, seq_id, trace_file_id) <
-             std::tie(o.clock_id, o.seq_id, o.trace_file_id);
-    }
+  bool operator==(const ClockId& o) const {
+    return clock_id == o.clock_id && seq_id == o.seq_id &&
+           trace_file_id == o.trace_file_id;
+  }
+  bool operator!=(const ClockId& o) const { return !(*this == o); }
+  bool operator<(const ClockId& o) const {
+    return std::tie(clock_id, seq_id, trace_file_id) <
+           std::tie(o.clock_id, o.seq_id, o.trace_file_id);
+  }
 
-    std::string ToString() const {
-      if (seq_id == 0 && trace_file_id == 0)
-        return std::to_string(clock_id);
-      return std::to_string(clock_id) + "(seq=" + std::to_string(seq_id) +
-             ",tf=" + std::to_string(trace_file_id) + ")";
-    }
+  std::string ToString() const;
 
-    friend base::MurmurHashCombiner PerfettoHashValue(
-        base::MurmurHashCombiner h,
-        const ClockId& c) {
-      return base::MurmurHashCombiner::Combine(std::move(h), c.clock_id,
-                                               c.seq_id, c.trace_file_id);
-    }
-  };
-
-  // Error type when clock conversion fails (used internally for listener)
-  enum class ErrorType {
-    kOk = 0,
-    kUnknownSourceClock,  // Source clock never seen in any snapshot
-    kUnknownTargetClock,  // Target clock never seen in any snapshot
-    kNoPath,              // No snapshot path connects source to target
-  };
+  template <typename H>
+  friend H PerfettoHashValue(H h, const ClockId& c) {
+    return H::Combine(std::move(h), c.clock_id, c.seq_id, c.trace_file_id);
+  }
 };
 
-template <typename TClockEventListener>
-class ClockSynchronizer : public ClockSynchronizerBase {
+// Clock description.
+struct Clock {
+  explicit Clock(ClockId clock_id) : id(clock_id) {}
+  Clock(ClockId clock_id, int64_t unit, bool incremental)
+      : id(clock_id), unit_multiplier_ns(unit), is_incremental(incremental) {}
+
+  ClockId id;
+  int64_t unit_multiplier_ns = 1;
+  bool is_incremental = false;
+};
+
+// Timestamp with clock.
+struct ClockTimestamp {
+  ClockTimestamp(ClockId id, int64_t ts) : clock(id), timestamp(ts) {}
+  ClockTimestamp(ClockId id, int64_t ts, int64_t unit, bool incremental)
+      : clock(id, unit, incremental), timestamp(ts) {}
+
+  Clock clock;
+  int64_t timestamp;
+};
+
+// Error type when clock conversion fails.
+enum class ClockSyncErrorType {
+  kOk = 0,
+  kUnknownSourceClock,  // Source clock never seen in any snapshot
+  kUnknownTargetClock,  // Target clock never seen in any snapshot
+  kNoPath,              // No snapshot path connects source to target
+};
+
+// Shared state for the trace time clock. Owned externally (e.g. by
+// TraceProcessorContext) and passed by pointer to ClockSynchronizer so
+// that AddSnapshot can validate against the current trace-time clock
+// without a virtual call.
+struct TraceTimeState {
+  ClockId clock_id;
+  bool used_for_conversion = false;
+};
+
+// Virtual interface for listening to clock synchronization events.
+// All methods are on slow paths, so virtual dispatch overhead is negligible.
+class ClockSynchronizerListener {
  public:
-  explicit ClockSynchronizer(
-      std::unique_ptr<TClockEventListener> clock_event_listener)
-      : trace_time_clock_id_(ClockId(protos::pbzero::BUILTIN_CLOCK_BOOTTIME)),
-        clock_event_listener_(std::move(clock_event_listener)) {}
+  virtual ~ClockSynchronizerListener();
+  virtual base::Status OnClockSyncCacheMiss() = 0;
+  virtual base::Status OnInvalidClockSnapshot() = 0;
+  virtual void RecordConversionError(ClockSyncErrorType,
+                                     ClockId,
+                                     ClockId,
+                                     int64_t,
+                                     std::optional<size_t>) = 0;
+};
 
-  // Clock description.
-  struct Clock {
-    explicit Clock(ClockId clock_id) : id(clock_id) {}
-    Clock(ClockId clock_id, int64_t unit, bool incremental)
-        : id(clock_id), unit_multiplier_ns(unit), is_incremental(incremental) {}
-
-    ClockId id;
-    int64_t unit_multiplier_ns = 1;
-    bool is_incremental = false;
-  };
-
-  // Timestamp with clock.
-  struct ClockTimestamp {
-    ClockTimestamp(ClockId id, int64_t ts) : clock(id), timestamp(ts) {}
-    ClockTimestamp(ClockId id, int64_t ts, int64_t unit, bool incremental)
-        : clock(id, unit, incremental), timestamp(ts) {}
-
-    Clock clock;
-    int64_t timestamp;
-  };
+class ClockSynchronizer {
+ public:
+  ClockSynchronizer(TraceTimeState* trace_time_state,
+                    std::unique_ptr<ClockSynchronizerListener> listener);
 
   // IDs in the range [64, 128) are reserved for sequence-scoped clock ids.
   // They can't be passed directly in ClockSynchronizer calls and must be
@@ -220,234 +217,46 @@ class ClockSynchronizer : public ClockSynchronizerBase {
     return ClockId{clock_id, seq_id, trace_file_id};
   }
 
-  // Converts a timestamp from an arbitrary clock domain to the trace time.
-  // On the first call, it also "locks" the trace time clock, preventing it
-  // from being changed later.
-  // If byte_offset is provided and conversion fails, records the error via
-  // the listener.
-  PERFETTO_ALWAYS_INLINE std::optional<int64_t> ToTraceTime(
-      ClockId clock_id,
-      int64_t timestamp,
-      std::optional<size_t> byte_offset = std::nullopt) {
-    if (PERFETTO_UNLIKELY(!trace_time_clock_id_used_for_conversion_)) {
-      clock_event_listener_->OnTraceTimeClockIdChanged(trace_time_clock_id_);
-    }
-    trace_time_clock_id_used_for_conversion_ = true;
-    if (clock_id == trace_time_clock_id_) {
-      return ToHostTraceTime(timestamp);
-    }
-    std::optional<int64_t> ts =
-        Convert(clock_id, timestamp, trace_time_clock_id_, byte_offset);
-    if (ts) {
-      return ToHostTraceTime(*ts);
-    }
-    return ts;
-  }
-
   // Appends a new snapshot for the given clock domains.
   // This is typically called by the code that reads the ClockSnapshot packet.
   // Returns the internal snapshot id of this set of clocks.
   base::StatusOr<uint32_t> AddSnapshot(
-      const std::vector<ClockTimestamp>& clock_timestamps) {
-    const auto snapshot_id = cur_snapshot_id_++;
+      const std::vector<ClockTimestamp>& clock_timestamps);
 
-    // Clear the cache
-    cache_.fill({});
-
-    // Compute the fingerprint of the snapshot by hashing all clock ids. This is
-    // used by the clock pathfinding logic.
-    base::MurmurHashCombiner hasher;
-    for (const auto& clock_ts : clock_timestamps)
-      hasher.Combine(clock_ts.clock.id);
-    const auto snapshot_hash = static_cast<SnapshotHash>(hasher.digest());
-
-    // Add a new entry in each clock's snapshot vector.
-    for (const auto& clock_ts : clock_timestamps) {
-      ClockId clock_id = clock_ts.clock.id;
-      ClockDomain& domain = clocks_[clock_id];
-
-      if (domain.snapshots.empty()) {
-        if (clock_ts.clock.is_incremental &&
-            !IsConvertedSequenceClock(clock_id)) {
-          clock_event_listener_->OnInvalidClockSnapshot();
-          return base::ErrStatus(
-              "Clock sync error: the global clock with id=%s"
-              " cannot use incremental encoding; this is only "
-              "supported for sequence-scoped clocks.",
-              clock_id.ToString().c_str());
+  // Converts a timestamp between two clock domains. Tries to use the cache
+  // first (only for single-path resolutions), then falls back on path finding
+  // as described in the header.
+  std::optional<int64_t> Convert(ClockId src_clock_id,
+                                 int64_t src_timestamp,
+                                 ClockId target_clock_id,
+                                 std::optional<size_t> byte_offset) {
+    if (PERFETTO_LIKELY(src_clock_id == target_clock_id)) {
+      return src_timestamp;
+    }
+    std::optional<int64_t> ns;
+    if (PERFETTO_LIKELY(!cache_lookups_disabled_for_testing_)) {
+      for (const auto& cached_clock_path : cache_) {
+        if (cached_clock_path.src != src_clock_id ||
+            cached_clock_path.target != target_clock_id) {
+          continue;
         }
-        domain.unit_multiplier_ns = clock_ts.clock.unit_multiplier_ns;
-        domain.is_incremental = clock_ts.clock.is_incremental;
-      } else if (PERFETTO_UNLIKELY(domain.unit_multiplier_ns !=
-                                       clock_ts.clock.unit_multiplier_ns ||
-                                   domain.is_incremental !=
-                                       clock_ts.clock.is_incremental)) {
-        clock_event_listener_->OnInvalidClockSnapshot();
-        return base::ErrStatus(
-            "Clock sync error: the clock domain with id=%s"
-            " (unit=%" PRId64
-            ", incremental=%d), was previously registered with "
-            "different properties (unit=%" PRId64 ", incremental=%d).",
-            clock_id.ToString().c_str(), clock_ts.clock.unit_multiplier_ns,
-            clock_ts.clock.is_incremental, domain.unit_multiplier_ns,
-            domain.is_incremental);
-      }
-      if (PERFETTO_UNLIKELY(clock_id == trace_time_clock_id_ &&
-                            domain.unit_multiplier_ns != 1)) {
-        // The trace time clock must always be in nanoseconds.
-        clock_event_listener_->OnInvalidClockSnapshot();
-        return base::ErrStatus(
-            "Clock sync error: the trace clock (id=%s"
-            ") must always use nanoseconds as unit multiplier.",
-            clock_id.ToString().c_str());
-      }
-      const int64_t timestamp_ns =
-          clock_ts.timestamp * domain.unit_multiplier_ns;
-      domain.last_timestamp_ns = timestamp_ns;
-
-      ClockSnapshots& vect = domain.snapshots[snapshot_hash];
-      if (!vect.snapshot_ids.empty() &&
-          PERFETTO_UNLIKELY(vect.snapshot_ids.back() == snapshot_id)) {
-        clock_event_listener_->OnInvalidClockSnapshot();
-        return base::ErrStatus(
-            "Clock sync error: duplicate clock domain with id=%s"
-            " at snapshot %" PRIu32 ".",
-            clock_id.ToString().c_str(), snapshot_id);
-      }
-
-      // Clock ids in the range [64, 128) are sequence-scoped and must be
-      // translated to global ids via SequenceToGlobalClock() before calling
-      // this function.
-      PERFETTO_DCHECK(!IsSequenceClock(clock_id.clock_id) ||
-                      clock_id.seq_id != 0);
-
-      // Snapshot IDs must be always monotonic.
-      PERFETTO_DCHECK(vect.snapshot_ids.empty() ||
-                      vect.snapshot_ids.back() < snapshot_id);
-
-      if (!vect.timestamps_ns.empty() &&
-          timestamp_ns < vect.timestamps_ns.back()) {
-        // Clock is not monotonic.
-
-        if (clock_id == trace_time_clock_id_) {
-          clock_event_listener_->OnInvalidClockSnapshot();
-          // The trace clock cannot be non-monotonic.
-          return base::ErrStatus(
-              "Clock sync error: the trace clock (id=%s"
-              ") is not monotonic at snapshot %" PRIu32 ". %" PRId64
-              " not >= %" PRId64 ".",
-              clock_id.ToString().c_str(), snapshot_id, timestamp_ns,
-              vect.timestamps_ns.back());
+        if (!ns) {
+          ns = cached_clock_path.src_domain->ToNs(src_timestamp);
         }
-
-        PERFETTO_DLOG("Detected non-monotonic clock with ID %s",
-                      clock_id.ToString().c_str());
-
-        // For the other clocks the best thing we can do is mark it as
-        // non-monotonic and refuse to use it as a source clock in the
-        // resolution graph. We can still use it as a target clock, but not
-        // viceversa. The concrete example is the CLOCK_REALTIME going 1h
-        // backwards during daylight saving. We can still answer the question
-        // "what was the REALTIME timestamp when BOOTTIME was X?" but we can't
-        // answer the opposite question because there can be two valid
-        // BOOTTIME(s) for the same REALTIME instant because of the 1:many
-        // relationship.
-        non_monotonic_clocks_.insert(clock_id);
-
-        // Erase all edges from the graph that start from this clock (but keep
-        // the ones that end on this clock).
-        PERFETTO_CHECK(clock_id.trace_file_id <
-                       std::numeric_limits<uint32_t>::max());
-        auto begin = graph_.lower_bound(ClockGraphEdge{clock_id, ClockId{}, 0});
-        ClockId upper = {clock_id.clock_id, clock_id.seq_id,
-                         clock_id.trace_file_id + 1};
-        auto end = graph_.lower_bound(ClockGraphEdge{upper, ClockId{}, 0});
-        graph_.erase(begin, end);
-      }
-      vect.snapshot_ids.emplace_back(snapshot_id);
-      vect.timestamps_ns.emplace_back(timestamp_ns);
-    }
-    // Create graph edges for all the possible tuples of clocks in this
-    // snapshot. If the snapshot contains clock a, b, c, d create edges [ab, ac,
-    // ad, bc, bd, cd] and the symmetrical ones [ba, ca, da, bc, db, dc]. This
-    // is to store the information: Clock A is syncable to Clock B via the
-    // snapshots of type (hash).
-    // Clocks that were previously marked as non-monotonic won't be added as
-    // valid sources.
-    for (auto it1 = clock_timestamps.begin(); it1 != clock_timestamps.end();
-         ++it1) {
-      auto it2 = it1;
-      ++it2;
-      for (; it2 != clock_timestamps.end(); ++it2) {
-        if (!non_monotonic_clocks_.count(it1->clock.id))
-          graph_.emplace(it1->clock.id, it2->clock.id, snapshot_hash);
-
-        if (!non_monotonic_clocks_.count(it2->clock.id))
-          graph_.emplace(it2->clock.id, it1->clock.id, snapshot_hash);
+        if (*ns >= cached_clock_path.min_ts_ns &&
+            *ns < cached_clock_path.max_ts_ns) {
+          cache_hits_for_testing_++;
+          return *ns + cached_clock_path.translation_ns;
+        }
       }
     }
-
-    return snapshot_id;
+    return ConvertSlowpath(src_clock_id, src_timestamp, ns, target_clock_id,
+                           byte_offset);
   }
-
-  // If trace clock and source clock are available in the snapshot will return
-  // the trace clock time in snapshot.
-  std::optional<int64_t> ToTraceTimeFromSnapshot(
-      const std::vector<ClockTimestamp>& snapshot) {
-    auto maybe_found_trace_time_clock = std::find_if(
-        snapshot.begin(), snapshot.end(),
-        [this](const ClockTimestamp& clock_timestamp) {
-          return clock_timestamp.clock.id == this->trace_time_clock_id_;
-        });
-
-    if (maybe_found_trace_time_clock == snapshot.end())
-      return std::nullopt;
-
-    return maybe_found_trace_time_clock->timestamp;
-  }
-
-  // Sets the offset for a given clock to convert timestamps from a remote
-  // machine to the host's trace time. This is typically called by the code
-  // that reads the RemoteClockSync packet. Typically only the offset of
-  // |trace_time_clock_id_| (which is CLOCK_BOOTTIME) is used.
-  void SetRemoteClockOffset(ClockId clock_id, int64_t offset) {
-    remote_clock_offsets_[clock_id] = offset;
-  }
-
-  // Sets the clock domain to be used as the trace time.
-  // Can be called multiple times with the same clock_id, but will log an error
-  // and do nothing if called with a different clock_id after a timestamp
-  // conversion has already occurred.
-  base::Status SetTraceTimeClock(ClockId clock_id) {
-    PERFETTO_DCHECK(!IsSequenceClock(clock_id.clock_id));
-    if (trace_time_clock_id_used_for_conversion_ &&
-        trace_time_clock_id_ != clock_id) {
-      return base::ErrStatus(
-          "Not updating trace time clock from %s to %s"
-          " because the old clock was already used for timestamp "
-          "conversion - ClockSnapshot too late in trace?",
-          trace_time_clock_id_.ToString().c_str(), clock_id.ToString().c_str());
-    }
-    trace_time_clock_id_ = clock_id;
-    clock_event_listener_->OnSetTraceTimeClock(clock_id);
-
-    return base::OkStatus();
-  }
-
-  // Returns the timezone offset in seconds from UTC, if one has been set.
-  std::optional<int64_t> timezone_offset() const { return timezone_offset_; }
-
-  // Sets the timezone offset in seconds from UTC.
-  void set_timezone_offset(int64_t offset) { timezone_offset_ = offset; }
 
   // For testing:
   void set_cache_lookups_disabled_for_testing(bool v) {
     cache_lookups_disabled_for_testing_ = v;
-  }
-
-  const base::FlatHashMap<ClockId, int64_t>&
-  remote_clock_offsets_for_testing() {
-    return remote_clock_offsets_;
   }
 
   uint32_t cache_hits_for_testing() const { return cache_hits_for_testing_; }
@@ -457,9 +266,6 @@ class ClockSynchronizer : public ClockSynchronizerBase {
 
   // 0th argument is the source clock, 1st argument is the target clock.
   using ClockGraphEdge = std::tuple<ClockId, ClockId, SnapshotHash>;
-
-  // TODO(b/273263113): Remove in the next stages.
-  friend class ClockTrackerTest;
 
   // A value-type object that carries the information about the path between
   // two clock domains. It's used by the BFS algorithm.
@@ -545,166 +351,11 @@ class ClockSynchronizer : public ClockSynchronizerBase {
   ClockSynchronizer(const ClockSynchronizer&) = delete;
   ClockSynchronizer& operator=(const ClockSynchronizer&) = delete;
 
-  std::optional<int64_t> ConvertSlowpath(
-      ClockId src_clock_id,
-      int64_t src_timestamp,
-      std::optional<int64_t> src_timestamp_ns,
-      ClockId target_clock_id,
-      std::optional<size_t> byte_offset) {
-    PERFETTO_DCHECK(!IsSequenceClock(src_clock_id.clock_id) ||
-                    src_clock_id.seq_id != 0);
-    PERFETTO_DCHECK(!IsSequenceClock(target_clock_id.clock_id) ||
-                    target_clock_id.seq_id != 0);
-    clock_event_listener_->OnClockSyncCacheMiss();
-
-    ClockPath path = FindPath(src_clock_id, target_clock_id);
-    if (!path.valid()) {
-      // Determine which clock(s) are unknown and record error
-      ErrorType error;
-      if (clocks_.find(src_clock_id) == clocks_.end()) {
-        error = ErrorType::kUnknownSourceClock;
-      } else if (clocks_.find(target_clock_id) == clocks_.end()) {
-        error = ErrorType::kUnknownTargetClock;
-      } else {
-        error = ErrorType::kNoPath;
-      }
-      clock_event_listener_->RecordConversionError(
-          error, src_clock_id, target_clock_id, src_timestamp, byte_offset);
-      return std::nullopt;
-    }
-
-    // Iterate trough the path found and translate timestamps onto the new clock
-    // domain on each step, until the target domain is reached.
-    ClockDomain* src_domain = GetClock(src_clock_id);
-    int64_t ns =
-        src_timestamp_ns ? *src_timestamp_ns : src_domain->ToNs(src_timestamp);
-
-    // These will track the overall translation and valid range for the whole
-    // path.
-    int64_t total_translation_ns = 0;
-    int64_t path_min_ts_ns = std::numeric_limits<int64_t>::min();
-    int64_t path_max_ts_ns = std::numeric_limits<int64_t>::max();
-
-    for (uint32_t i = 0; i < path.len; ++i) {
-      const ClockGraphEdge edge = path.at(i);
-      ClockDomain* cur_clock = GetClock(std::get<0>(edge));
-      ClockDomain* next_clock = GetClock(std::get<1>(edge));
-      const SnapshotHash hash = std::get<2>(edge);
-
-      // Find the closest timestamp within the snapshots of the source clock.
-      const ClockSnapshots& cur_snap = cur_clock->GetSnapshot(hash);
-      const auto& ts_vec = cur_snap.timestamps_ns;
-      auto it = std::upper_bound(ts_vec.begin(), ts_vec.end(), ns);
-      if (it != ts_vec.begin())
-        --it;
-
-      // Now lookup the snapshot id that matches the closest timestamp.
-      size_t index = static_cast<size_t>(std::distance(ts_vec.begin(), it));
-      PERFETTO_DCHECK(index < ts_vec.size());
-      PERFETTO_DCHECK(cur_snap.snapshot_ids.size() == ts_vec.size());
-      uint32_t snapshot_id = cur_snap.snapshot_ids[index];
-
-      // And use that to retrieve the corresponding time in the next clock
-      // domain. The snapshot id must exist in the target clock domain. If it
-      // doesn't either the hash logic or the pathfinding logic are bugged. This
-      // can also happen if the checks in AddSnapshot fail and we skip part of
-      // the snapshot.
-      const ClockSnapshots& next_snap = next_clock->GetSnapshot(hash);
-
-      // Using std::lower_bound because snapshot_ids is sorted, so we can do
-      // a binary search. std::find would do a linear scan.
-      auto next_it =
-          std::lower_bound(next_snap.snapshot_ids.begin(),
-                           next_snap.snapshot_ids.end(), snapshot_id);
-      if (next_it == next_snap.snapshot_ids.end() || *next_it != snapshot_id) {
-        PERFETTO_DFATAL("Snapshot does not exist in clock domain.");
-        continue;
-      }
-      size_t next_index = static_cast<size_t>(
-          std::distance(next_snap.snapshot_ids.begin(), next_it));
-      PERFETTO_DCHECK(next_index < next_snap.snapshot_ids.size());
-      int64_t next_timestamp_ns = next_snap.timestamps_ns[next_index];
-
-      // The translated timestamp is the relative delta of the source timestamp
-      // from the closest snapshot found (ns - *it), plus the timestamp in
-      // the new clock domain for the same snapshot id.
-      const int64_t hop_translation_ns = next_timestamp_ns - *it;
-      ns += hop_translation_ns;
-
-      // Now, calculate the valid range for this specific hop and intersect it
-      // with the accumulated valid range for the whole path.
-      // The range for this hop needs to be translated back to the source
-      // clock's coordinate system.
-      const int64_t kInt64Min = std::numeric_limits<int64_t>::min();
-      const int64_t kInt64Max = std::numeric_limits<int64_t>::max();
-
-      int64_t hop_min_ts_ns = (it == ts_vec.begin()) ? kInt64Min : *it;
-      auto ubound = it + 1;
-      int64_t hop_max_ts_ns = (ubound == ts_vec.end()) ? kInt64Max : *ubound;
-
-      // Translate the hop's valid range back to the original source clock's
-      // domain. `total_translation_ns` is the translation from the *start* of
-      // the path to the *start* of the current hop.
-      int64_t hop_min_in_src_domain_ns =
-          (hop_min_ts_ns == kInt64Min) ? kInt64Min
-                                       : hop_min_ts_ns - total_translation_ns;
-      int64_t hop_max_in_src_domain_ns =
-          (hop_max_ts_ns == kInt64Max) ? kInt64Max
-                                       : hop_max_ts_ns - total_translation_ns;
-
-      // Intersect with the path's current valid range.
-      path_min_ts_ns = std::max(path_min_ts_ns, hop_min_in_src_domain_ns);
-      path_max_ts_ns = std::min(path_max_ts_ns, hop_max_in_src_domain_ns);
-
-      // Accumulate the translation.
-      total_translation_ns += hop_translation_ns;
-
-      // The last clock in the path must be the target clock.
-      PERFETTO_DCHECK(i < path.len - 1 || std::get<1>(edge) == target_clock_id);
-    }
-
-    // After the loop, we have the final converted timestamp `ns`, and the
-    // total translation and valid range for the entire path.
-    // We can now cache this result.
-    CachedClockPath cache_entry{};
-    cache_entry.src = src_clock_id;
-    cache_entry.target = target_clock_id;
-    cache_entry.src_domain = src_domain;
-    cache_entry.min_ts_ns = path_min_ts_ns;
-    cache_entry.max_ts_ns = path_max_ts_ns;
-    cache_entry.translation_ns = total_translation_ns;
-    cache_[rnd_() % cache_.size()] = cache_entry;
-
-    return ns;
-  }
-
-  // Converts a timestamp between two clock domains. Tries to use the cache
-  // first (only for single-path resolutions), then falls back on path finding
-  // as described in the header.
-  std::optional<int64_t> Convert(ClockId src_clock_id,
-                                 int64_t src_timestamp,
-                                 ClockId target_clock_id,
-                                 std::optional<size_t> byte_offset) {
-    std::optional<int64_t> ns;
-    if (PERFETTO_LIKELY(!cache_lookups_disabled_for_testing_)) {
-      for (const auto& cached_clock_path : cache_) {
-        if (cached_clock_path.src != src_clock_id ||
-            cached_clock_path.target != target_clock_id) {
-          continue;
-        }
-        if (!ns) {
-          ns = cached_clock_path.src_domain->ToNs(src_timestamp);
-        }
-        if (*ns >= cached_clock_path.min_ts_ns &&
-            *ns < cached_clock_path.max_ts_ns) {
-          cache_hits_for_testing_++;
-          return *ns + cached_clock_path.translation_ns;
-        }
-      }
-    }
-    return ConvertSlowpath(src_clock_id, src_timestamp, ns, target_clock_id,
-                           byte_offset);
-  }
+  std::optional<int64_t> ConvertSlowpath(ClockId src_clock_id,
+                                         int64_t src_timestamp,
+                                         std::optional<int64_t> src_ts_ns,
+                                         ClockId target_clock_id,
+                                         std::optional<size_t> byte_offset);
 
   // Returns whether |global_clock_id| represents a sequence-scoped clock, i.e.
   // a ClockId returned by SequenceToGlobalClock().
@@ -714,72 +365,11 @@ class ClockSynchronizer : public ClockSynchronizerBase {
 
   // Finds the shortest clock resolution path in the graph that allows to
   // translate a timestamp from |src| to |target| clocks.
-  // The return value looks like the following: "If you want to convert a
-  // timestamp from clock C1 to C2 you need to first convert C1 -> C3 using the
-  // snapshot hash A, then convert C3 -> C2 via snapshot hash B".
-  ClockPath FindPath(ClockId src, ClockId target) {
-    PERFETTO_CHECK(src != target);
+  ClockPath FindPath(ClockId src, ClockId target);
 
-    // If we've never heard of the clock before there is no hope:
-    if (clocks_.find(target) == clocks_.end()) {
-      return ClockPath();
-    }
-    if (clocks_.find(src) == clocks_.end()) {
-      return ClockPath();
-    }
+  ClockDomain* GetClock(ClockId clock_id);
 
-    // This is a classic breadth-first search. Each node in the queue holds also
-    // the full path to reach that node.
-    // We assume the graph is acyclic, if it isn't the ClockPath::kMaxLen will
-    // stop the search anyways.
-    queue_find_path_cache_.clear();
-    queue_find_path_cache_.emplace_back(src);
-
-    while (!queue_find_path_cache_.empty()) {
-      ClockPath cur_path = queue_find_path_cache_.front();
-      queue_find_path_cache_.pop_front();
-
-      const ClockId cur_clock_id = cur_path.last;
-      if (cur_path.len >= ClockPath::kMaxLen)
-        continue;
-
-      // Expore all the adjacent clocks.
-      // The lower_bound() below returns an iterator to the first edge that
-      // starts on |cur_clock_id|. The edges are sorted by (src, target, hash).
-      for (auto it =
-               graph_.lower_bound(ClockGraphEdge(cur_clock_id, ClockId{}, 0));
-           it != graph_.end() && std::get<0>(*it) == cur_clock_id; ++it) {
-        ClockId next_clock_id = std::get<1>(*it);
-        SnapshotHash hash = std::get<2>(*it);
-        if (next_clock_id == target)
-          return ClockPath(cur_path, next_clock_id, hash);
-        queue_find_path_cache_.emplace_back(
-            ClockPath(cur_path, next_clock_id, hash));
-      }
-    }
-    return ClockPath();  // invalid path.
-  }
-
-  ClockDomain* GetClock(ClockId clock_id) {
-    auto it = clocks_.find(clock_id);
-    PERFETTO_DCHECK(it != clocks_.end());
-    return &it->second;
-  }
-
-  // Apply the clock offset to convert remote trace times to host trace time.
-  PERFETTO_ALWAYS_INLINE int64_t ToHostTraceTime(int64_t timestamp) {
-    if (PERFETTO_LIKELY(clock_event_listener_->IsLocalHost())) {
-      // No need to convert host timestamps.
-      return timestamp;
-    }
-
-    // Find the offset for |trace_time_clock_id_| and apply the offset, or
-    // default offset 0 if not offset is found for |trace_time_clock_id_|.
-    int64_t clock_offset = remote_clock_offsets_[trace_time_clock_id_];
-    return timestamp - clock_offset;
-  }
-
-  ClockId trace_time_clock_id_;
+  TraceTimeState* trace_time_state_;
   std::map<ClockId, ClockDomain> clocks_;
   std::set<ClockGraphEdge> graph_;
   std::set<ClockId> non_monotonic_clocks_;
@@ -788,10 +378,7 @@ class ClockSynchronizer : public ClockSynchronizerBase {
   uint32_t cache_hits_for_testing_ = 0;
   std::minstd_rand rnd_;  // For cache eviction.
   uint32_t cur_snapshot_id_ = 0;
-  bool trace_time_clock_id_used_for_conversion_ = false;
-  base::FlatHashMap<ClockId, int64_t> remote_clock_offsets_;
-  std::optional<int64_t> timezone_offset_;
-  std::unique_ptr<TClockEventListener> clock_event_listener_;
+  std::unique_ptr<ClockSynchronizerListener> clock_event_listener_;
 
   // A queue of paths to explore. Stored as a field to reduce allocations
   // on every call to FindPath().

--- a/src/trace_redaction/collect_clocks.h
+++ b/src/trace_redaction/collect_clocks.h
@@ -56,8 +56,7 @@ class CollectClocks : public CollectPrimitive {
       const protos::pbzero::TracePacket::Decoder& packet,
       Context* context) const;
 
-  mutable std::vector<RedactorClockSynchronizer::ClockTimestamp>
-      clock_snapshot_;
+  mutable std::vector<ClockTimestamp> clock_snapshot_;
 };
 
 }  // namespace perfetto::trace_redaction

--- a/src/trace_redaction/redactor_clock_converter.h
+++ b/src/trace_redaction/redactor_clock_converter.h
@@ -29,40 +29,26 @@
 
 namespace perfetto::trace_redaction {
 
-class RedactorClockSynchronizerListenerImpl {
+class RedactorClockSynchronizerListenerImpl
+    : public perfetto::trace_processor::ClockSynchronizerListener {
  public:
-  using Synchronizer = perfetto::trace_processor::ClockSynchronizer<
-      RedactorClockSynchronizerListenerImpl>;
-
   RedactorClockSynchronizerListenerImpl();
 
-  base::Status OnClockSyncCacheMiss();
+  base::Status OnClockSyncCacheMiss() override;
 
-  base::Status OnInvalidClockSnapshot();
+  base::Status OnInvalidClockSnapshot() override;
 
-  base::Status OnTraceTimeClockIdChanged(Synchronizer::ClockId);
-
-  base::Status OnSetTraceTimeClock(Synchronizer::ClockId);
-
-  void RecordConversionError(Synchronizer::ErrorType,
-                             Synchronizer::ClockId,
-                             Synchronizer::ClockId,
+  void RecordConversionError(trace_processor::ClockSyncErrorType,
+                             trace_processor::ClockId,
+                             trace_processor::ClockId,
                              int64_t,
-                             std::optional<size_t>);
-
-  // Always returns true as redactor only supports local host clock conversion.
-  bool IsLocalHost();
-
- private:
-  // Number of time that trace time has been updated.
-  uint32_t trace_time_updates_;
+                             std::optional<size_t>) override;
 };
 
-using RedactorClockSynchronizer = perfetto::trace_processor::ClockSynchronizer<
-    RedactorClockSynchronizerListenerImpl>;
+using RedactorClockSynchronizer = trace_processor::ClockSynchronizer;
 using SequenceId = uint32_t;
-using ClockId = RedactorClockSynchronizer::ClockId;
-using ClockTimestamp = RedactorClockSynchronizer::ClockTimestamp;
+using ClockId = trace_processor::ClockId;
+using ClockTimestamp = trace_processor::ClockTimestamp;
 
 // This class handles conversions between different clocks for trace redactor.
 //
@@ -137,6 +123,7 @@ class RedactorClockConverter {
   base::StatusOr<ClockId> GetGlobalDefaultDataSourceClock(
       const DataSourceType& clock_type) const;
 
+  perfetto::trace_processor::TraceTimeState trace_time_state_;
   mutable RedactorClockSynchronizer clock_synchronizer_;
   std::optional<ClockId> primary_trace_clock_;
   base::FlatHashMap<SequenceId, SequenceClocks> seq_to_default_clocks_;


### PR DESCRIPTION
Refactor ClockSynchronizer from a template class into a concrete class
with a virtual listener interface, and introduce ClockTracker as a
wrapper that adds trace-time semantics (trace-time clock selection,
remote-machine offsets, metadata writes).

This separates concerns: ClockSynchronizer is now a pure clock-domain
conversion engine (graph, snapshots, BFS pathfinding, cache), while
ClockTracker handles trace-processor-specific policy. TraceTimeState
is extracted as shared state owned by TraceProcessorContext.

Key changes:
- ClockId, Clock, ClockTimestamp, ClockSyncErrorType promoted to
  namespace-level types
- Template listener replaced with ClockSynchronizerListener virtual
  base class
- Method bodies moved from header to clock_synchronizer.cc
- Listener callbacks OnTraceTimeClockIdChanged, OnSetTraceTimeClock,
  IsLocalHost removed (logic inlined into ClockTracker)
