### PR TITLE
sdk: add emitDebugCallStack for local debugging

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -306,6 +306,9 @@ public final class PerfettoTrace {
    * or low-frequency diagnostic events. Do not use in production hot paths.
    */
   public static void emitExpensiveDebugCallStack(Category category, String eventName) {
+    if (!category.isEnabled()) {
+        return;
+    }
     final long FIELD_TRACK_EVENT_CALLSTACK = 55L;
     final long FIELD_CALLSTACK_FRAMES = 1L;
     final long FIELD_FRAME_FUNCTION_NAME = 1L;


### PR DESCRIPTION
Adds a utility to capture and emit Java stack traces to Perfetto. Note: This is expensive (Thread.getStackTrace()) and intended for debugging only. Do not use in production hot paths.

Test: Manual