### PR TITLE
sdk: Accept a callstack in the track event sdk instead of dumping

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -304,7 +304,7 @@ public final class PerfettoTrace {
    * A stack can be captured with Thread.getStackTrace() but note that it is expensive
    * and should only be used for local debugging or low-frequency diagnostic events.
    */
-  public static void emitDebugCallStack(Category category, String eventName,
+  public static void emitExpensiveDebugCallStack(Category category, String eventName,
     StackTraceElement[] stackTrace) {
     if (!category.isEnabled() || stackTrace == null || stackTrace.length == 0) {
       return;


### PR DESCRIPTION
This allows callers to pass cached stacks. In this case, drop the 'expensive' from the name since the perfetto API is no longer responsible for dumping.

