### PR TITLE
ui: Fix crash in slice track tooltips when no dur present in dataset

### DIFF
--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -855,13 +855,6 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
         if (task.shouldYield()) await task.yield();
       }
 
-      // Clone raw data out of the iterator
-      const row: Record<string, SqlValue> = {};
-      // eslint-disable-next-line guard-for-in
-      for (const k in dataset.schema) {
-        row[k] = it[k];
-      }
-
       const id = it.__id;
       const ts = it.__ts;
       const count = it.__count;
@@ -869,6 +862,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       const title = this.getTitle(it);
       const subtitle = this.getSubtitle(it);
       const colorScheme = this.getColor(it, title);
+      const row = this.extractKeys(it, dataset.schema);
 
       xs[i] = ts;
       ys[i] = depth;
@@ -878,7 +872,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
         subtitle,
         colorScheme,
         count,
-        row: row as T,
+        row,
       };
     }
 
@@ -966,13 +960,6 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
         if (task.shouldYield()) await task.yield();
       }
 
-      // Clone raw data out of the iterator
-      const row: Record<string, SqlValue> = {};
-      // eslint-disable-next-line guard-for-in
-      for (const k in dataset.schema) {
-        row[k] = it[k];
-      }
-
       const count = it.__count;
       const id = it.__id;
       const ts = it.__ts;
@@ -982,6 +969,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       const subtitle = this.getSubtitle(it);
       const colorScheme = this.getColor(it, title);
       const isIncomplete = it.__incomplete === 1;
+      const row = this.extractKeys(it, dataset.schema);
 
       xs[i] = ts;
       ys[i] = depth;
@@ -996,7 +984,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
         colorScheme,
         count,
         fillRatio: this.attrs.fillRatio?.(it) ?? 1,
-        row: row as T,
+        row,
       };
     }
 
@@ -1008,6 +996,18 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       slices,
       count,
     };
+  }
+
+  // Efficiently copy a sebset of keys from a raw value based on some template.
+  // Note: Only the template's keys are used, the values are ignored (hence the
+  // unknown value types).
+  private extractKeys(from: T, template: Record<keyof T, unknown>): T {
+    const result = {} as T;
+    // eslint-disable-next-line guard-for-in
+    for (const k in template) {
+      result[k] = from[k];
+    }
+    return result;
   }
 
   private async deferChunkedTask() {


### PR DESCRIPTION
On ToT, there is a type mismatch between what TS things the type of each raw row is and the actual type. Typescript thinks each row should have `ts, dur, depth, layer, id` fields but in reality each row only has what's specified in the dataset's schema used when the track was created. This mismatch was missed by TS due to a dodgy type assertion.

Some tracks that only contain instant events (such as stack trace tracks) simply don't define `dur` in their dataset. The problem is that tooltipRenderer assumes dur is of type `bigint | null`, and so doesn't handle the `undefined` case. Typescript didn't complain due to the aforementioned type mismatch above.

This fix is just to use the track's dataset schema as the type, and handle the situation where dur is undefined in the tooltip renderer. Thus, everywhere that assumes the full type has now been reverted to simply use the dataset type (T), and the tooltipRenderer has been changed to handle the case where dur === undefined.

While in the area, minimize the type assertion and extract into a separate little function to contain the unsafe code.

Fixes: https://b.corp.google.com/issues/483051607