### PR TITLE
protovm: refactor serialization

### DIFF
--- a/src/protovm/rw_proto.h
+++ b/src/protovm/rw_proto.h
@@ -141,7 +141,7 @@ class RwProto {
   explicit RwProto(Allocator* allocator);
   ~RwProto();
   Cursor GetRoot();
-  std::string SerializeAsString() const;
+  void Serialize(protozero::Message*) const;
 
  private:
   void SerializeField(uint32_t field_id,

--- a/src/protovm/vm.h
+++ b/src/protovm/vm.h
@@ -105,7 +105,7 @@ class Vm {
      size_t memory_limit_bytes,
      protozero::ConstBytes initial_incremental_state = {nullptr, 0});
   StatusOr<void> ApplyPatch(protozero::ConstBytes packet);
-  std::string SerializeIncrementalState() const;
+  void SerializeIncrementalState(protozero::Message*) const;
   std::string SerializeProgram() const;
   std::unique_ptr<Vm> CloneReadOnly() const;
   uint64_t GetMemoryUsageBytes() const;
@@ -147,6 +147,8 @@ class Vm {
 
   // Constructor used only for cloning
   explicit Vm(std::string incremental_state);
+
+  std::string SerializeIncrementalStateAsString() const;
 
   std::string owned_program_;
   std::variant<ReadWriteState, ReadOnlyState> state_;

--- a/src/tracing/service/tracing_service_impl.cc
+++ b/src/tracing/service/tracing_service_impl.cc
@@ -4363,9 +4363,8 @@ void TracingServiceImpl::MaybeEmitProtoVmInstances(
       vm_instance->AppendString(
           protos::pbzero::TracePacket::ProtoVms::Instance::kProgramFieldNumber,
           vm.instance->SerializeProgram());
-      vm_instance->AppendString(
-          protos::pbzero::TracePacket::ProtoVms::Instance::kStateFieldNumber,
-          vm.instance->SerializeIncrementalState());
+      auto* state = vm_instance->set_state();
+      vm.instance->SerializeIncrementalState(state);
       vm_instance->set_memory_limit_kb(vm.memory_limit_kb);
       for (ProducerID producer_id : vm.producers) {
         vm_instance->add_producer_id(producer_id);


### PR DESCRIPTION
protovm: optimize the serialization API to reduce copies on the client side

Now Vm::SerializeIncrementalState(protozero::Message*) takes a protozero::Message
as an output parameter and the incremental state is written directly there, instead of first
creating an std::string which is then copied into the protozero::Message.