### PR TITLE
ui: BinderViz null aidl name fix

### DIFF
--- a/ui/src/plugins/com.android.AndroidBinderViz/index.ts
+++ b/ui/src/plugins/com.android.AndroidBinderViz/index.ts
@@ -62,7 +62,7 @@ export default class implements PerfettoPlugin {
         tableName: 'android_binder_txns',
       },
       slice: {
-        columns: ['aidl_name'],
+        columns: ['IFNULL(aidl_name, "unknown aidl")'],
         tableName: 'android_binder_txns',
         tsCol: `${oppositePerspective}_ts`,
         durCol: `${oppositePerspective}_dur`,


### PR DESCRIPTION
This change addresses the issue with android_binder_txns slices that have aidl_name NULL.
The issue was the comparison aidl_name = NULL which is always false, so there would be no slices to show. We fixed this by replacing NULL with `unknown aidl`.

