### PR TITLE
de: Split explore_page.ts

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations.ts
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {QueryNode} from './query_node';
+import {getAllNodes, addConnection} from './query_builder/graph_utils';
+
+// Clipboard entry stores a cloned node with its relative position for paste.
+export interface ClipboardEntry {
+  node: QueryNode;
+  relativeX: number; // Position relative to the first node (only used if not docked)
+  relativeY: number;
+  isDocked: boolean; // True if node was docked (no explicit layout position)
+}
+
+// Clipboard connection stores connections between clipboard nodes (by index).
+export interface ClipboardConnection {
+  fromIndex: number;
+  toIndex: number;
+  portIndex?: number;
+}
+
+export interface ClipboardResult {
+  clipboardNodes: ClipboardEntry[];
+  clipboardConnections: ClipboardConnection[];
+}
+
+// The subset of state needed for copy operations.
+interface CopyableState {
+  readonly rootNodes: QueryNode[];
+  readonly selectedNodes: ReadonlySet<string>;
+  readonly nodeLayouts: Map<string, {x: number; y: number}>;
+}
+
+// The subset of state needed for paste operations.
+interface PastableState {
+  readonly rootNodes: QueryNode[];
+  readonly nodeLayouts: Map<string, {x: number; y: number}>;
+  readonly clipboardNodes?: ClipboardEntry[];
+  readonly clipboardConnections?: ClipboardConnection[];
+}
+
+// Copies the currently selected nodes and their internal connections to a
+// clipboard result. Returns undefined if no nodes are selected.
+export function copySelectedNodes(
+  state: CopyableState,
+): ClipboardResult | undefined {
+  const selectedNodeIds = state.selectedNodes;
+
+  if (selectedNodeIds.size === 0) {
+    return undefined;
+  }
+
+  const allNodes = getAllNodes(state.rootNodes);
+  const selectedNodes = allNodes.filter((n) => selectedNodeIds.has(n.nodeId));
+
+  if (selectedNodes.length === 0) {
+    return undefined;
+  }
+
+  // Get positions for relative layout calculation
+  const positions = selectedNodes.map((node) => {
+    const layout = state.nodeLayouts.get(node.nodeId);
+    return {
+      node,
+      x: layout?.x ?? 0,
+      y: layout?.y ?? 0,
+    };
+  });
+
+  // Find the top-left corner as reference point
+  const minX = Math.min(...positions.map((p) => p.x));
+  const minY = Math.min(...positions.map((p) => p.y));
+
+  // Create clipboard entries with cloned nodes and relative positions
+  // Track whether each node is docked (no explicit layout) or undocked
+  const nodeIdToIndex = new Map<string, number>();
+  const clipboardNodes: ClipboardEntry[] = positions.map((p, index) => {
+    nodeIdToIndex.set(p.node.nodeId, index);
+    const hasLayout = state.nodeLayouts.has(p.node.nodeId);
+    return {
+      node: p.node.clone(),
+      relativeX: p.x - minX,
+      relativeY: p.y - minY,
+      isDocked: !hasLayout,
+    };
+  });
+
+  // Capture connections between selected nodes
+  const clipboardConnections: ClipboardConnection[] = [];
+  for (const node of selectedNodes) {
+    const toIndex = nodeIdToIndex.get(node.nodeId);
+    if (toIndex === undefined) continue;
+
+    // Check primaryInput
+    if (node.primaryInput && selectedNodeIds.has(node.primaryInput.nodeId)) {
+      const fromIndex = nodeIdToIndex.get(node.primaryInput.nodeId);
+      if (fromIndex !== undefined) {
+        clipboardConnections.push({fromIndex, toIndex});
+      }
+    }
+
+    // Check secondaryInputs
+    if (node.secondaryInputs) {
+      for (const [portIndex, inputNode] of node.secondaryInputs.connections) {
+        if (selectedNodeIds.has(inputNode.nodeId)) {
+          const fromIndex = nodeIdToIndex.get(inputNode.nodeId);
+          if (fromIndex !== undefined) {
+            clipboardConnections.push({fromIndex, toIndex, portIndex});
+          }
+        }
+      }
+    }
+  }
+
+  return {clipboardNodes, clipboardConnections};
+}
+
+// Pastes clipboard nodes into the state. Returns the updated state fields
+// with new nodes added, or undefined if clipboard is empty.
+export function pasteClipboardNodes(state: PastableState):
+  | {
+      rootNodes: QueryNode[];
+      selectedNodes: Set<string>;
+      nodeLayouts: Map<string, {x: number; y: number}>;
+    }
+  | undefined {
+  if (state.clipboardNodes === undefined || state.clipboardNodes.length === 0) {
+    return undefined;
+  }
+
+  // Clone nodes again for this paste operation (allows multiple pastes)
+  const newNodes = state.clipboardNodes.map((entry) => entry.node.clone());
+
+  // Calculate paste offset (place slightly offset from original)
+  const pasteOffsetX = 50;
+  const pasteOffsetY = 50;
+
+  // Update layouts for new nodes - only add layouts for undocked nodes
+  // Docked nodes will remain docked (attached to their parent)
+  const updatedLayouts = new Map(state.nodeLayouts);
+  state.clipboardNodes.forEach((entry, index) => {
+    if (!entry.isDocked) {
+      updatedLayouts.set(newNodes[index].nodeId, {
+        x: entry.relativeX + pasteOffsetX,
+        y: entry.relativeY + pasteOffsetY,
+      });
+    }
+  });
+
+  // Restore connections between pasted nodes
+  if (state.clipboardConnections) {
+    for (const conn of state.clipboardConnections) {
+      const fromNode = newNodes[conn.fromIndex] as QueryNode | undefined;
+      const toNode = newNodes[conn.toIndex] as QueryNode | undefined;
+      if (fromNode !== undefined && toNode !== undefined) {
+        addConnection(fromNode, toNode, conn.portIndex);
+      }
+    }
+  }
+
+  return {
+    rootNodes: [...state.rootNodes, ...newNodes],
+    selectedNodes: new Set(newNodes.map((n) => n.nodeId)),
+    nodeLayouts: updatedLayouts,
+  };
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations_unittest.ts
@@ -1,0 +1,354 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {NodeType} from './query_node';
+import {
+  copySelectedNodes,
+  pasteClipboardNodes,
+  ClipboardEntry,
+  ClipboardConnection,
+} from './clipboard_operations';
+import {createMockNode, connectNodes} from './query_builder/testing/test_utils';
+import {TableSourceNode} from './query_builder/nodes/sources/table_source';
+import {Trace} from '../../public/trace';
+import {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
+
+describe('clipboard_operations', () => {
+  describe('copySelectedNodes', () => {
+    it('should return undefined when no nodes are selected', () => {
+      const node = createMockNode({nodeId: 'n1'});
+      const result = copySelectedNodes({
+        rootNodes: [node],
+        selectedNodes: new Set(),
+        nodeLayouts: new Map(),
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when selected IDs do not match any nodes', () => {
+      const node = createMockNode({nodeId: 'n1'});
+      const result = copySelectedNodes({
+        rootNodes: [node],
+        selectedNodes: new Set(['nonexistent']),
+        nodeLayouts: new Map(),
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should copy a single selected node with relative position (0,0)', () => {
+      const node = createMockNode({nodeId: 'n1'});
+      const result = copySelectedNodes({
+        rootNodes: [node],
+        selectedNodes: new Set(['n1']),
+        nodeLayouts: new Map([['n1', {x: 100, y: 200}]]),
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.clipboardNodes).toHaveLength(1);
+      expect(result?.clipboardNodes[0].relativeX).toBe(0);
+      expect(result?.clipboardNodes[0].relativeY).toBe(0);
+      expect(result?.clipboardNodes[0].isDocked).toBe(false);
+    });
+
+    it('should compute relative positions for multiple nodes', () => {
+      const node1 = createMockNode({nodeId: 'n1'});
+      const node2 = createMockNode({nodeId: 'n2'});
+      const result = copySelectedNodes({
+        rootNodes: [node1, node2],
+        selectedNodes: new Set(['n1', 'n2']),
+        nodeLayouts: new Map([
+          ['n1', {x: 50, y: 100}],
+          ['n2', {x: 250, y: 300}],
+        ]),
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.clipboardNodes).toHaveLength(2);
+      // First node is at origin (min x/y)
+      expect(result?.clipboardNodes[0].relativeX).toBe(0);
+      expect(result?.clipboardNodes[0].relativeY).toBe(0);
+      // Second node is offset
+      expect(result?.clipboardNodes[1].relativeX).toBe(200);
+      expect(result?.clipboardNodes[1].relativeY).toBe(200);
+    });
+
+    it('should mark nodes without layout as docked', () => {
+      const node1 = createMockNode({nodeId: 'n1'});
+      const node2 = createMockNode({nodeId: 'n2'});
+      const result = copySelectedNodes({
+        rootNodes: [node1, node2],
+        selectedNodes: new Set(['n1', 'n2']),
+        nodeLayouts: new Map([['n1', {x: 100, y: 100}]]),
+        // n2 has no layout → docked
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.clipboardNodes[0].isDocked).toBe(false);
+      expect(result?.clipboardNodes[1].isDocked).toBe(true);
+    });
+
+    it('should clone nodes for the clipboard', () => {
+      const node = createMockNode({nodeId: 'n1'});
+      const result = copySelectedNodes({
+        rootNodes: [node],
+        selectedNodes: new Set(['n1']),
+        nodeLayouts: new Map([['n1', {x: 0, y: 0}]]),
+      });
+
+      expect(result).toBeDefined();
+      // Cloned node should not be the same object reference
+      expect(result?.clipboardNodes[0].node).not.toBe(node);
+    });
+
+    it('should capture primaryInput connections between selected nodes', () => {
+      const parent = createMockNode({nodeId: 'p', type: NodeType.kTable});
+      const child = createMockNode({nodeId: 'c', type: NodeType.kFilter});
+      connectNodes(parent, child);
+
+      const result = copySelectedNodes({
+        rootNodes: [parent],
+        selectedNodes: new Set(['p', 'c']),
+        nodeLayouts: new Map([
+          ['p', {x: 0, y: 0}],
+          ['c', {x: 0, y: 100}],
+        ]),
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.clipboardConnections).toHaveLength(1);
+      expect(result?.clipboardConnections[0].fromIndex).toBe(0);
+      expect(result?.clipboardConnections[0].toIndex).toBe(1);
+      expect(result?.clipboardConnections[0].portIndex).toBeUndefined();
+    });
+
+    it('should not capture connections to nodes outside the selection', () => {
+      const parent = createMockNode({nodeId: 'p', type: NodeType.kTable});
+      const child = createMockNode({nodeId: 'c', type: NodeType.kFilter});
+      connectNodes(parent, child);
+
+      // Only select the child, not the parent
+      const result = copySelectedNodes({
+        rootNodes: [parent],
+        selectedNodes: new Set(['c']),
+        nodeLayouts: new Map([['c', {x: 0, y: 100}]]),
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.clipboardConnections).toHaveLength(0);
+    });
+
+    it('should capture secondaryInput connections between selected nodes', () => {
+      const source = createMockNode({nodeId: 's', type: NodeType.kTable});
+      const multi = createMockNode({nodeId: 'm', type: NodeType.kJoin});
+      multi.secondaryInputs = {
+        connections: new Map([[0, source]]),
+        min: 2,
+        max: 2,
+        portNames: ['Left', 'Right'],
+      };
+      source.nextNodes = [multi];
+
+      const result = copySelectedNodes({
+        rootNodes: [source, multi],
+        selectedNodes: new Set(['s', 'm']),
+        nodeLayouts: new Map([
+          ['s', {x: 0, y: 0}],
+          ['m', {x: 100, y: 0}],
+        ]),
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.clipboardConnections).toHaveLength(1);
+      expect(result?.clipboardConnections[0].portIndex).toBe(0);
+    });
+  });
+
+  describe('pasteClipboardNodes', () => {
+    it('should return undefined when clipboard is empty', () => {
+      const result = pasteClipboardNodes({
+        rootNodes: [],
+        nodeLayouts: new Map(),
+        clipboardNodes: undefined,
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when clipboard has zero entries', () => {
+      const result = pasteClipboardNodes({
+        rootNodes: [],
+        nodeLayouts: new Map(),
+        clipboardNodes: [],
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('should append cloned nodes to rootNodes', () => {
+      const existing = createMockNode({nodeId: 'existing'});
+      const clipNode = createMockNode({nodeId: 'clip'});
+      const clipboardNodes: ClipboardEntry[] = [
+        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
+      ];
+
+      const result = pasteClipboardNodes({
+        rootNodes: [existing],
+        nodeLayouts: new Map(),
+        clipboardNodes,
+      });
+
+      expect(result).toBeDefined();
+      // Original node + pasted node
+      expect(result?.rootNodes).toHaveLength(2);
+      expect(result?.rootNodes[0]).toBe(existing);
+      // Pasted node is cloned (not the same reference)
+      expect(result?.rootNodes[1]).not.toBe(clipNode);
+    });
+
+    it('should select only the newly pasted nodes', () => {
+      const clipNode = createMockNode({nodeId: 'clip'});
+      const clipboardNodes: ClipboardEntry[] = [
+        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
+      ];
+
+      const result = pasteClipboardNodes({
+        rootNodes: [],
+        nodeLayouts: new Map(),
+        clipboardNodes,
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.selectedNodes.size).toBe(1);
+      // The selected ID should be the NEW (cloned) node's ID, not the clipboard node
+      const pastedNodeId = result?.rootNodes[0].nodeId;
+      expect(result?.selectedNodes.has(pastedNodeId ?? '')).toBe(true);
+    });
+
+    it('should add layout positions for undocked nodes with offset', () => {
+      const clipNode = createMockNode({nodeId: 'clip'});
+      const clipboardNodes: ClipboardEntry[] = [
+        {node: clipNode, relativeX: 100, relativeY: 200, isDocked: false},
+      ];
+
+      const result = pasteClipboardNodes({
+        rootNodes: [],
+        nodeLayouts: new Map(),
+        clipboardNodes,
+      });
+
+      expect(result).toBeDefined();
+      const pastedNodeId = result?.rootNodes[0].nodeId ?? '';
+      const layout = result?.nodeLayouts.get(pastedNodeId);
+      expect(layout).toBeDefined();
+      // relativeX + pasteOffsetX (50), relativeY + pasteOffsetY (50)
+      expect(layout?.x).toBe(150);
+      expect(layout?.y).toBe(250);
+    });
+
+    it('should not add layout for docked nodes', () => {
+      const clipNode = createMockNode({nodeId: 'clip'});
+      const clipboardNodes: ClipboardEntry[] = [
+        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: true},
+      ];
+
+      const result = pasteClipboardNodes({
+        rootNodes: [],
+        nodeLayouts: new Map(),
+        clipboardNodes,
+      });
+
+      expect(result).toBeDefined();
+      const pastedNodeId = result?.rootNodes[0].nodeId ?? '';
+      expect(result?.nodeLayouts.has(pastedNodeId)).toBe(false);
+    });
+
+    it('should allow multiple pastes from the same clipboard', () => {
+      // Use real TableSourceNode since its clone() generates new IDs
+      const mockTrace = {traceInfo: {traceTitle: 'test'}} as Trace;
+      const mockSqlModules = {
+        listTables: () => [],
+        getTable: () => undefined,
+      } as unknown as SqlModules;
+      const realNode = new TableSourceNode({
+        trace: mockTrace,
+        sqlModules: mockSqlModules,
+      });
+
+      const clipboardNodes: ClipboardEntry[] = [
+        {node: realNode, relativeX: 0, relativeY: 0, isDocked: false},
+      ];
+
+      const result1 = pasteClipboardNodes({
+        rootNodes: [],
+        nodeLayouts: new Map(),
+        clipboardNodes,
+      });
+
+      const result2 = pasteClipboardNodes({
+        rootNodes: result1?.rootNodes ?? [],
+        nodeLayouts: result1?.nodeLayouts ?? new Map(),
+        clipboardNodes,
+      });
+
+      expect(result2).toBeDefined();
+      expect(result2?.rootNodes).toHaveLength(2);
+      // The two pasted nodes should have different IDs
+      expect(result2?.rootNodes[0].nodeId).not.toBe(
+        result2?.rootNodes[1].nodeId,
+      );
+    });
+
+    it('should restore connections between pasted nodes', () => {
+      const parent = createMockNode({nodeId: 'p', type: NodeType.kTable});
+      const child = createMockNode({nodeId: 'c', type: NodeType.kFilter});
+      const clipboardNodes: ClipboardEntry[] = [
+        {node: parent, relativeX: 0, relativeY: 0, isDocked: false},
+        {node: child, relativeX: 0, relativeY: 100, isDocked: false},
+      ];
+      const clipboardConnections: ClipboardConnection[] = [
+        {fromIndex: 0, toIndex: 1},
+      ];
+
+      const result = pasteClipboardNodes({
+        rootNodes: [],
+        nodeLayouts: new Map(),
+        clipboardNodes,
+        clipboardConnections,
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.rootNodes).toHaveLength(2);
+      const pastedParent = result?.rootNodes[0];
+      const pastedChild = result?.rootNodes[1];
+      // addConnection should have connected them
+      expect(pastedParent?.nextNodes).toContain(pastedChild);
+    });
+
+    it('should preserve existing nodeLayouts on paste', () => {
+      const existing = createMockNode({nodeId: 'existing'});
+      const clipNode = createMockNode({nodeId: 'clip'});
+      const existingLayouts = new Map([['existing', {x: 500, y: 600}]]);
+      const clipboardNodes: ClipboardEntry[] = [
+        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
+      ];
+
+      const result = pasteClipboardNodes({
+        rootNodes: [existing],
+        nodeLayouts: existingLayouts,
+        clipboardNodes,
+      });
+
+      expect(result).toBeDefined();
+      expect(result?.nodeLayouts.get('existing')).toEqual({x: 500, y: 600});
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/datagrid_node_creation.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/datagrid_node_creation.ts
@@ -1,0 +1,318 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Trace} from '../../public/trace';
+import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
+import type {NodeActionHandlers} from './node_actions';
+import {createNodeActions} from './node_actions';
+import {QueryNode, NodeType} from './query_node';
+import {UIFilter} from './query_builder/operations/filter';
+import {FilterNode} from './query_builder/nodes/filter_node';
+import {AddColumnsNode} from './query_builder/nodes/add_columns_node';
+import {Column} from '../../components/widgets/datagrid/model';
+import {nodeRegistry} from './query_builder/node_registry';
+import {
+  insertNodeBetween,
+  addConnection,
+  removeConnection,
+} from './query_builder/graph_utils';
+import {ExplorePageState} from './explore_page';
+
+// Dependencies needed by datagrid-triggered node creation operations.
+export interface DatagridNodeCreationDeps {
+  readonly trace: Trace;
+  readonly sqlModules: SqlModules;
+  readonly onStateUpdate: (
+    update:
+      | ExplorePageState
+      | ((currentState: ExplorePageState) => ExplorePageState),
+  ) => void;
+  readonly initializedNodes: Set<string>;
+  readonly nodeActionHandlers: NodeActionHandlers;
+}
+
+// Sets filters on a node and optionally sets the filter operator.
+function setFiltersOnNode(
+  node: QueryNode,
+  filters: UIFilter[],
+  filterOperator?: 'AND' | 'OR',
+): void {
+  node.state.filters = filters;
+  if (filterOperator) {
+    node.state.filterOperator = filterOperator;
+  }
+}
+
+// Parses a column field to extract joinid information.
+// Returns undefined if the field is not a joinid column reference.
+export function parseJoinidColumnField(
+  field: string,
+  sourceNode: QueryNode,
+):
+  | {
+      joinidColumnName: string;
+      targetColumnName: string;
+      targetTable: string;
+      targetJoinColumn: string;
+    }
+  | undefined {
+  // Parse the field to extract joinid column name and target column
+  // Expected format: "joinidColumnName.targetColumnName"
+  const dotIndex = field.indexOf('.');
+  if (dotIndex === -1) {
+    return undefined;
+  }
+
+  const joinidColumnName = field.substring(0, dotIndex);
+  const targetColumnName = field.substring(dotIndex + 1);
+
+  // Find the joinid column in the source node's finalCols
+  const joinidColumnInfo = sourceNode.finalCols.find(
+    (col) => col.name === joinidColumnName,
+  );
+
+  if (
+    joinidColumnInfo === undefined ||
+    joinidColumnInfo.column.type?.kind !== 'joinid'
+  ) {
+    return undefined;
+  }
+
+  return {
+    joinidColumnName,
+    targetColumnName,
+    targetTable: joinidColumnInfo.column.type.source.table,
+    targetJoinColumn: joinidColumnInfo.column.type.source.column,
+  };
+}
+
+// Finds an AddColumnsNode that matches the given join configuration.
+// Checks both the source node itself and its immediate child.
+export function findMatchingAddColumnsNode(
+  sourceNode: QueryNode,
+  joinidColumnName: string,
+  targetJoinColumn: string,
+): AddColumnsNode | undefined {
+  // Check if the source node is already an AddColumnsNode with the same join
+  if (sourceNode.type === NodeType.kAddColumns) {
+    const addColumnsNode = sourceNode as AddColumnsNode;
+    if (
+      addColumnsNode.state.leftColumn === joinidColumnName &&
+      addColumnsNode.state.rightColumn === targetJoinColumn
+    ) {
+      return addColumnsNode;
+    }
+  }
+
+  // Check if the source node has exactly one child that's an AddColumnsNode with same join
+  if (
+    sourceNode.nextNodes.length === 1 &&
+    sourceNode.nextNodes[0].type === NodeType.kAddColumns
+  ) {
+    const existingAddColumnsNode = sourceNode.nextNodes[0] as AddColumnsNode;
+    if (
+      existingAddColumnsNode.state.leftColumn === joinidColumnName &&
+      existingAddColumnsNode.state.rightColumn === targetJoinColumn
+    ) {
+      return existingAddColumnsNode;
+    }
+  }
+
+  return undefined;
+}
+
+export async function addFilter(
+  deps: DatagridNodeCreationDeps,
+  sourceNode: QueryNode,
+  filter: UIFilter | UIFilter[],
+  filterOperator?: 'AND' | 'OR',
+): Promise<void> {
+  // Normalize to array for uniform handling (single filter → [filter])
+  const filters: UIFilter[] = Array.isArray(filter) ? filter : [filter];
+
+  // If the source node is already a FilterNode, just add the filter(s) to it
+  if (sourceNode.type === NodeType.kFilter) {
+    setFiltersOnNode(
+      sourceNode,
+      [...(sourceNode.state.filters ?? []), ...filters] as UIFilter[],
+      filterOperator,
+    );
+    deps.onStateUpdate((currentState) => ({...currentState}));
+    return;
+  }
+
+  // If the source node has exactly one child and it's a FilterNode, add to that
+  if (
+    sourceNode.nextNodes.length === 1 &&
+    sourceNode.nextNodes[0].type === NodeType.kFilter
+  ) {
+    const existingFilterNode = sourceNode.nextNodes[0];
+    setFiltersOnNode(
+      existingFilterNode,
+      [...(existingFilterNode.state.filters ?? []), ...filters] as UIFilter[],
+      filterOperator,
+    );
+    deps.onStateUpdate((currentState) => ({
+      ...currentState,
+      selectedNodes: new Set([existingFilterNode.nodeId]),
+    }));
+    return;
+  }
+
+  // Otherwise, create a new FilterNode after the source node
+  // Create it with filters already configured to avoid multiple undo points
+  const newFilterNode = new FilterNode({
+    filters,
+    filterOperator,
+    sqlModules: deps.sqlModules,
+  });
+
+  // Mark as initialized
+  deps.initializedNodes.add(newFilterNode.nodeId);
+
+  // Insert between source node and its children
+  insertNodeBetween(sourceNode, newFilterNode, addConnection, removeConnection);
+
+  // Single state update records the entire operation (node + filters)
+  deps.onStateUpdate((currentState) => ({
+    ...currentState,
+    selectedNodes: new Set([newFilterNode.nodeId]),
+  }));
+}
+
+// Handles adding a column from a joinid table by creating an AddColumnsNode.
+// The column field is expected to be in the format "joinidColumn.targetColumnName"
+// where joinidColumn is a column with joinid type in the source node.
+export function addColumnFromJoinid(
+  deps: DatagridNodeCreationDeps,
+  state: ExplorePageState,
+  sourceNode: QueryNode,
+  column: Column,
+): void {
+  const parsed = parseJoinidColumnField(column.field, sourceNode);
+  if (parsed === undefined) {
+    // Not a joinid column reference - nothing to do
+    return;
+  }
+
+  const {joinidColumnName, targetColumnName, targetTable, targetJoinColumn} =
+    parsed;
+
+  // Check if this column name already exists in the source node's schema
+  const existingColumnNames = new Set(
+    sourceNode.finalCols.map((col) => col.name),
+  );
+  if (existingColumnNames.has(targetColumnName)) {
+    console.warn(
+      `Cannot add column: "${targetColumnName}" already exists in the schema`,
+    );
+    return;
+  }
+
+  // Try to find an existing AddColumnsNode with the same join configuration
+  const existingNode = findMatchingAddColumnsNode(
+    sourceNode,
+    joinidColumnName,
+    targetJoinColumn,
+  );
+
+  if (existingNode !== undefined) {
+    // Check if the column is already added
+    if (existingNode.state.selectedColumns?.includes(targetColumnName)) {
+      console.warn(`Cannot add column: "${targetColumnName}" is already added`);
+      return;
+    }
+
+    // Add the column to the existing AddColumnsNode
+    existingNode.state.selectedColumns = [
+      ...(existingNode.state.selectedColumns ?? []),
+      targetColumnName,
+    ];
+    existingNode.state.onchange?.();
+    if (existingNode !== sourceNode) {
+      deps.onStateUpdate((currentState) => ({
+        ...currentState,
+        selectedNodes: new Set([existingNode.nodeId]),
+      }));
+    }
+    return;
+  }
+
+  // Create a new AddColumnsNode with the join configuration
+  // Note: selectedColumns is set after connecting the table node because
+  // onPrevNodesUpdated() resets selectedColumns when rightNode is not connected
+  const newAddColumnsNode = new AddColumnsNode({
+    leftColumn: joinidColumnName,
+    rightColumn: targetJoinColumn,
+    isGuidedConnection: true,
+    sqlModules: deps.sqlModules,
+    trace: deps.trace,
+  });
+
+  // Set actions now that the node is created
+  newAddColumnsNode.state.actions = createNodeActions(
+    newAddColumnsNode,
+    deps.nodeActionHandlers,
+  );
+
+  // Mark as initialized
+  deps.initializedNodes.add(newAddColumnsNode.nodeId);
+
+  // Insert between source node and its children
+  insertNodeBetween(
+    sourceNode,
+    newAddColumnsNode,
+    addConnection,
+    removeConnection,
+  );
+
+  // Now create and connect the table source node
+  const descriptor = nodeRegistry.get('table');
+  if (descriptor === undefined) {
+    console.warn("Cannot add table: 'table' node type not found in registry");
+    return;
+  }
+
+  const sqlTable = deps.sqlModules
+    .listTables()
+    .find((t) => t.name === targetTable);
+  if (sqlTable === undefined) {
+    console.warn(`Table ${targetTable} not found in SQL modules`);
+    return;
+  }
+
+  // Create the table node with the specific table
+  const tableNode = descriptor.factory(
+    {
+      sqlTable,
+      sqlModules: deps.sqlModules,
+      trace: deps.trace,
+    },
+    {allNodes: state.rootNodes},
+  );
+
+  // Connect table node to AddColumnsNode's secondary input (port 0)
+  addConnection(tableNode, newAddColumnsNode, 0);
+
+  // Now that rightNode is connected, set the selected column
+  // (must be done after connection because onPrevNodesUpdated resets it otherwise)
+  newAddColumnsNode.state.selectedColumns = [targetColumnName];
+
+  // Update state with both new nodes
+  deps.onStateUpdate((currentState) => ({
+    ...currentState,
+    rootNodes: [...currentState.rootNodes, tableNode],
+    selectedNodes: new Set([newAddColumnsNode.nodeId]),
+  }));
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/datagrid_node_creation_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/datagrid_node_creation_unittest.ts
@@ -1,0 +1,337 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {NodeType, QueryNode} from './query_node';
+import {
+  parseJoinidColumnField,
+  findMatchingAddColumnsNode,
+  addFilter,
+  DatagridNodeCreationDeps,
+} from './datagrid_node_creation';
+import {ExplorePageState} from './explore_page';
+import {FilterNode} from './query_builder/nodes/filter_node';
+import {AddColumnsNode} from './query_builder/nodes/add_columns_node';
+import {
+  createMockNode,
+  createColumnInfo,
+  connectNodes,
+} from './query_builder/testing/test_utils';
+import {ColumnInfo} from './query_builder/column_info';
+import {Trace} from '../../public/trace';
+import {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
+import {UIFilter} from './query_builder/operations/filter';
+
+describe('datagrid_node_creation', () => {
+  // Helper to create a joinid column for testing
+  function createJoinidColumn(
+    name: string,
+    targetTable: string,
+    targetColumn: string,
+  ): ColumnInfo {
+    return {
+      name,
+      type: 'JOINID',
+      checked: true,
+      column: {
+        name,
+        type: {
+          kind: 'joinid',
+          source: {table: targetTable, column: targetColumn},
+        },
+      },
+    };
+  }
+
+  describe('parseJoinidColumnField', () => {
+    it('should return undefined for a field without a dot', () => {
+      const node = createMockNode({
+        nodeId: 'n1',
+        columns: [createColumnInfo('name', 'string')],
+      });
+      const result = parseJoinidColumnField('name', node);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when the column is not a joinid type', () => {
+      const node = createMockNode({
+        nodeId: 'n1',
+        columns: [createColumnInfo('parent_id', 'int')],
+      });
+      const result = parseJoinidColumnField('parent_id.name', node);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when the joinid column does not exist', () => {
+      const node = createMockNode({
+        nodeId: 'n1',
+        columns: [createColumnInfo('id', 'int')],
+      });
+      const result = parseJoinidColumnField('nonexistent.name', node);
+      expect(result).toBeUndefined();
+    });
+
+    it('should parse a valid joinid column field', () => {
+      const node = createMockNode({
+        nodeId: 'n1',
+        columns: [
+          createColumnInfo('id', 'int'),
+          createJoinidColumn('track_id', 'track', 'id'),
+        ],
+      });
+
+      const result = parseJoinidColumnField('track_id.name', node);
+
+      expect(result).toBeDefined();
+      expect(result?.joinidColumnName).toBe('track_id');
+      expect(result?.targetColumnName).toBe('name');
+      expect(result?.targetTable).toBe('track');
+      expect(result?.targetJoinColumn).toBe('id');
+    });
+
+    it('should handle fields with multiple dots (first dot is the separator)', () => {
+      const node = createMockNode({
+        nodeId: 'n1',
+        columns: [createJoinidColumn('ref', 'other_table', 'pk')],
+      });
+
+      const result = parseJoinidColumnField('ref.some.dotted.name', node);
+
+      expect(result).toBeDefined();
+      expect(result?.joinidColumnName).toBe('ref');
+      expect(result?.targetColumnName).toBe('some.dotted.name');
+    });
+  });
+
+  describe('findMatchingAddColumnsNode', () => {
+    let mockTrace: Trace;
+    let mockSqlModules: SqlModules;
+
+    beforeEach(() => {
+      mockTrace = {
+        traceInfo: {traceTitle: 'test'},
+      } as Trace;
+      mockSqlModules = {
+        listTables: () => [],
+        getTable: () => undefined,
+        listModules: () => [],
+        listTablesNames: () => [],
+        getModuleForTable: () => undefined,
+      } as unknown as SqlModules;
+    });
+
+    it('should return undefined when source node is not an AddColumnsNode', () => {
+      const node = createMockNode({nodeId: 'n1', type: NodeType.kTable});
+      const result = findMatchingAddColumnsNode(node, 'track_id', 'id');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return the source node when it is an AddColumnsNode with matching join', () => {
+      const addColumnsNode = new AddColumnsNode({
+        leftColumn: 'track_id',
+        rightColumn: 'id',
+        sqlModules: mockSqlModules,
+        trace: mockTrace,
+      });
+
+      const result = findMatchingAddColumnsNode(
+        addColumnsNode,
+        'track_id',
+        'id',
+      );
+      expect(result).toBe(addColumnsNode);
+    });
+
+    it('should return undefined when source AddColumnsNode has different join columns', () => {
+      const addColumnsNode = new AddColumnsNode({
+        leftColumn: 'other_column',
+        rightColumn: 'pk',
+        sqlModules: mockSqlModules,
+        trace: mockTrace,
+      });
+
+      const result = findMatchingAddColumnsNode(
+        addColumnsNode,
+        'track_id',
+        'id',
+      );
+      expect(result).toBeUndefined();
+    });
+
+    it('should find matching AddColumnsNode in immediate child', () => {
+      const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
+      const addColumnsChild = new AddColumnsNode({
+        leftColumn: 'track_id',
+        rightColumn: 'id',
+        sqlModules: mockSqlModules,
+        trace: mockTrace,
+      });
+
+      parent.nextNodes = [addColumnsChild as QueryNode];
+
+      const result = findMatchingAddColumnsNode(parent, 'track_id', 'id');
+      expect(result).toBe(addColumnsChild);
+    });
+
+    it('should return undefined when child AddColumnsNode has different join', () => {
+      const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
+      const addColumnsChild = new AddColumnsNode({
+        leftColumn: 'other',
+        rightColumn: 'pk',
+        sqlModules: mockSqlModules,
+        trace: mockTrace,
+      });
+
+      parent.nextNodes = [addColumnsChild as QueryNode];
+
+      const result = findMatchingAddColumnsNode(parent, 'track_id', 'id');
+      expect(result).toBeUndefined();
+    });
+
+    it('should not check children when parent has multiple children', () => {
+      const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
+      const child1 = new AddColumnsNode({
+        leftColumn: 'track_id',
+        rightColumn: 'id',
+        sqlModules: mockSqlModules,
+        trace: mockTrace,
+      });
+      const child2 = createMockNode({nodeId: 'c2', type: NodeType.kFilter});
+
+      parent.nextNodes = [child1 as QueryNode, child2];
+
+      // Should not find it because parent has more than 1 child
+      const result = findMatchingAddColumnsNode(parent, 'track_id', 'id');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('addFilter', () => {
+    let deps: DatagridNodeCreationDeps;
+    let stateUpdates: Array<
+      ExplorePageState | ((s: ExplorePageState) => ExplorePageState)
+    >;
+
+    beforeEach(() => {
+      stateUpdates = [];
+      deps = {
+        trace: {traceInfo: {traceTitle: 'test'}} as Trace,
+        sqlModules: {
+          listTables: () => [],
+          getTable: () => undefined,
+        } as unknown as SqlModules,
+        onStateUpdate: (update) => {
+          stateUpdates.push(update);
+        },
+        initializedNodes: new Set<string>(),
+        nodeActionHandlers: {
+          onAddAndConnectTable: () => {},
+          onInsertNodeAtPort: () => {},
+        },
+      };
+    });
+
+    function createTestFilter(column: string, value: string): UIFilter {
+      return {
+        column,
+        op: '=',
+        value,
+      };
+    }
+
+    it('should add filters to a FilterNode source directly', async () => {
+      const filterNode = new FilterNode({filters: []});
+      const newFilter = createTestFilter('name', 'alice');
+
+      await addFilter(deps, filterNode, newFilter);
+
+      expect(filterNode.state.filters).toHaveLength(1);
+      expect(stateUpdates).toHaveLength(1);
+    });
+
+    it('should add multiple filters at once to a FilterNode source', async () => {
+      const filterNode = new FilterNode({filters: []});
+      const filters = [
+        createTestFilter('name', 'alice'),
+        createTestFilter('name', 'bob'),
+      ];
+
+      await addFilter(deps, filterNode, filters);
+
+      expect(filterNode.state.filters).toHaveLength(2);
+    });
+
+    it('should set filter operator on a FilterNode source', async () => {
+      const filterNode = new FilterNode({filters: []});
+      const newFilter = createTestFilter('name', 'alice');
+
+      await addFilter(deps, filterNode, newFilter, 'OR');
+
+      expect(filterNode.state.filterOperator).toBe('OR');
+    });
+
+    it('should add filters to child FilterNode when source has one', async () => {
+      const source = createMockNode({nodeId: 'src', type: NodeType.kTable});
+      const existingFilter = new FilterNode({filters: []});
+      connectNodes(source, existingFilter as QueryNode);
+
+      const newFilter = createTestFilter('name', 'alice');
+      await addFilter(deps, source, newFilter);
+
+      expect(existingFilter.state.filters).toHaveLength(1);
+      // Should select the existing filter node
+      expect(stateUpdates).toHaveLength(1);
+    });
+
+    it('should create a new FilterNode when source has no filter child', async () => {
+      const source = createMockNode({nodeId: 'src', type: NodeType.kTable});
+      const newFilter = createTestFilter('name', 'alice');
+
+      await addFilter(deps, source, newFilter);
+
+      // A new node should have been inserted
+      expect(source.nextNodes).toHaveLength(1);
+      expect(source.nextNodes[0].type).toBe(NodeType.kFilter);
+      expect(deps.initializedNodes.size).toBe(1);
+      expect(stateUpdates).toHaveLength(1);
+    });
+
+    it('should create a new FilterNode with pre-set filter operator', async () => {
+      const source = createMockNode({nodeId: 'src', type: NodeType.kTable});
+      const newFilter = createTestFilter('name', 'alice');
+
+      await addFilter(deps, source, newFilter, 'OR');
+
+      const createdFilter = source.nextNodes[0] as FilterNode;
+      expect(createdFilter.state.filterOperator).toBe('OR');
+    });
+
+    it('should not create new FilterNode when source has non-filter child', async () => {
+      const source = createMockNode({nodeId: 'src', type: NodeType.kTable});
+      const sortChild = createMockNode({
+        nodeId: 'sort',
+        type: NodeType.kSort,
+      });
+      connectNodes(source, sortChild);
+
+      const newFilter = createTestFilter('name', 'alice');
+      await addFilter(deps, source, newFilter);
+
+      // New filter node should be inserted between source and sort
+      expect(source.nextNodes).toHaveLength(1);
+      expect(source.nextNodes[0].type).toBe(NodeType.kFilter);
+      // Sort should now be downstream of the new filter
+      expect(source.nextNodes[0].nextNodes).toContain(sortChild);
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -14,67 +14,49 @@
 
 import m from 'mithril';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
-import {assetSrc} from '../../base/assets';
-import {showModal} from '../../widgets/modal';
 
 import {Builder} from './query_builder/builder';
-import {
-  QueryNode,
-  QueryNodeState,
-  NodeType,
-  NodeActions,
-  singleNodeOperation,
-} from './query_node';
-import {UIFilter} from './query_builder/operations/filter';
-import {FilterNode} from './query_builder/nodes/filter_node';
-import {AddColumnsNode} from './query_builder/nodes/add_columns_node';
-import {SlicesSourceNode} from './query_builder/nodes/sources/slices_source';
-import {Column} from '../../components/widgets/datagrid/model';
+import {QueryNode} from './query_node';
+import {ensureAllNodeActions} from './node_actions';
 import {Trace} from '../../public/trace';
 
-import {exportStateAsJson, deserializeState} from './json_handler';
+import {
+  confirmAndFinalizeCurrentGraph,
+  exportGraph,
+  importGraph,
+  loadGraphFromJson,
+  loadGraphFromPath,
+  initializeHighImportanceTables,
+  createExploreGraph,
+  GraphIODeps,
+} from './graph_io';
 import {registerCoreNodes} from './query_builder/core_nodes';
-import {nodeRegistry, PreCreateState} from './query_builder/node_registry';
+import {nodeRegistry} from './query_builder/node_registry';
 import {QueryExecutionService} from './query_builder/query_execution_service';
 import {CleanupManager} from './query_builder/cleanup_manager';
 import {HistoryManager} from './history_manager';
 import {getPrimarySelectedNode} from './selection_utils';
+import {getAllNodes} from './query_builder/graph_utils';
 import {
-  getAllNodes,
-  insertNodeBetween,
-  getInputNodeAtPort,
-  getAllInputNodes,
-  findDockedChildren,
-  calculateUndockLayouts,
-  getEffectiveLayout,
-  addConnection,
-  removeConnection,
-  notifyNextNodes,
-  captureAllChildConnections,
-} from './query_builder/graph_utils';
-import {
-  showStateOverwriteWarning,
-  showExportWarning,
-} from './query_builder/widgets';
-import {recentGraphsStorage} from './recent_graphs';
+  cleanupExistingNodes,
+  addOperationNode,
+  addSourceNode,
+  addAndConnectTable,
+  insertNodeAtPort,
+  clearAllNodes,
+  duplicateNode,
+  deleteNode,
+  deleteSelectedNodes,
+  removeNodeConnection,
+} from './node_crud_operations';
+import type {NodeCrudDeps} from './node_crud_operations';
+import {addFilter, addColumnFromJoinid} from './datagrid_node_creation';
 import {showDataExplorerHelp} from './data_explorer_help_modal';
 
+import type {ClipboardEntry, ClipboardConnection} from './clipboard_operations';
+import {copySelectedNodes, pasteClipboardNodes} from './clipboard_operations';
+
 registerCoreNodes();
-
-// Clipboard entry stores a cloned node with its relative position for paste
-interface ClipboardEntry {
-  node: QueryNode;
-  relativeX: number; // Position relative to the first node (only used if not docked)
-  relativeY: number;
-  isDocked: boolean; // True if node was docked (no explicit layout position)
-}
-
-// Clipboard connection stores connections between clipboard nodes (by index)
-interface ClipboardConnection {
-  fromIndex: number;
-  toIndex: number;
-  portIndex?: number;
-}
 
 export interface ExplorePageState {
   rootNodes: QueryNode[];
@@ -115,22 +97,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
   private initializedNodes = new Set<string>();
   private executeFn?: () => Promise<void>;
 
-  /**
-   * Shows confirmation dialog if there are unsaved changes, and finalizes
-   * the current graph before loading a new one. Returns true if the user
-   * confirmed (or there was nothing to confirm), false if cancelled.
-   */
-  private async confirmAndFinalizeCurrentGraph(
-    state: ExplorePageState,
-  ): Promise<boolean> {
-    if (state.rootNodes.length > 0 || state.labels.length > 0) {
-      const confirmed = await showStateOverwriteWarning();
-      if (!confirmed) return false;
-      recentGraphsStorage.finalizeCurrentGraph();
-    }
-    return true;
-  }
-
   private selectNode(attrs: ExplorePageAttrs, node: QueryNode) {
     attrs.onStateUpdate((currentState) => ({
       ...currentState,
@@ -167,1452 +133,30 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     }));
   }
 
-  private createNodeActions(
-    attrs: ExplorePageAttrs,
-    node: QueryNode,
-  ): NodeActions {
-    return {
-      onAddAndConnectTable: (tableName: string, portIndex: number) => {
-        this.handleAddAndConnectTable(attrs, tableName, node, portIndex);
-      },
-      onInsertModifyColumnsNode: (portIndex: number) => {
-        this.handleInsertModifyColumnsNode(attrs, node, portIndex);
-      },
-      onInsertCounterToIntervalsNode: (portIndex: number) => {
-        this.handleInsertCounterToIntervalsNode(attrs, node, portIndex);
-      },
-    };
-  }
-
-  private ensureNodeActions(attrs: ExplorePageAttrs, node: QueryNode) {
-    // Skip if already initialized
-    if (this.initializedNodes.has(node.nodeId)) {
-      return;
-    }
-
-    // Initialize actions if not present
-    if (!node.state.actions) {
-      node.state.actions = this.createNodeActions(attrs, node);
-    }
-
-    // Mark as initialized
-    this.initializedNodes.add(node.nodeId);
-  }
-
-  async handleAddOperationNode(
-    attrs: ExplorePageAttrs,
-    node: QueryNode,
-    derivedNodeId: string,
-  ): Promise<QueryNode | undefined> {
-    const {state, onStateUpdate} = attrs;
-    const descriptor = nodeRegistry.get(derivedNodeId);
-    if (descriptor) {
-      let initialState: PreCreateState | PreCreateState[] | null = {};
-      if (descriptor.preCreate) {
-        const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-        if (!sqlModules) {
-          console.warn('Cannot add operation node: SQL modules not loaded yet');
-          return;
-        }
-        initialState = await descriptor.preCreate({sqlModules});
-      }
-
-      if (initialState === null) {
-        return;
-      }
-
-      // For operation nodes, we only support single node creation
-      // (multi-select only makes sense for source nodes)
-      if (Array.isArray(initialState)) {
-        console.warn(
-          'Operation nodes do not support multi-node creation from preCreate',
-        );
-        return;
-      }
-
-      const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-      if (!sqlModules) {
-        console.warn('Cannot add operation node: SQL modules not loaded yet');
-        return;
-      }
-
-      // Use a wrapper object to hold the node reference (allows mutation without 'let')
-      const nodeRef: {current?: QueryNode} = {};
-
-      const nodeState: QueryNodeState = {
-        ...(initialState as Partial<QueryNodeState>),
-        sqlModules,
-        trace: attrs.trace,
-        // Provide actions for nodes that need to interact with the graph
-        // We use a closure pattern because the node doesn't exist yet
-        actions: {
-          onAddAndConnectTable: (tableName: string, portIndex: number) => {
-            if (nodeRef.current !== undefined) {
-              this.handleAddAndConnectTable(
-                attrs,
-                tableName,
-                nodeRef.current,
-                portIndex,
-              );
-            }
-          },
-          onInsertModifyColumnsNode: (portIndex: number) => {
-            if (nodeRef.current !== undefined) {
-              this.handleInsertModifyColumnsNode(
-                attrs,
-                nodeRef.current,
-                portIndex,
-              );
-            }
-          },
-          onInsertCounterToIntervalsNode: (portIndex: number) => {
-            if (nodeRef.current !== undefined) {
-              this.handleInsertCounterToIntervalsNode(
-                attrs,
-                nodeRef.current,
-                portIndex,
-              );
-            }
-          },
-        },
-      };
-
-      const newNode = descriptor.factory(nodeState, {
-        allNodes: state.rootNodes,
-      });
-
-      // Set the reference so the callback can use it
-      nodeRef.current = newNode;
-
-      // Mark this node as initialized
-      this.initializedNodes.add(newNode.nodeId);
-
-      if (singleNodeOperation(newNode.type)) {
-        // For single-input operations: insert between the target and its children
-        insertNodeBetween(node, newNode, addConnection, removeConnection);
-
-        onStateUpdate((currentState) => ({
-          ...currentState,
-          selectedNodes: new Set([newNode.nodeId]),
-        }));
-      } else {
-        // For multi-source nodes: just connect and add to root nodes
-        // Don't insert in-between - the node combines multiple sources
-
-        // Undock docked children before adding (docking requires exactly one child)
-        const dockedChildren = findDockedChildren(node, state.nodeLayouts);
-
-        addConnection(node, newNode);
-
-        onStateUpdate((currentState) => {
-          const updatedLayouts = new Map(currentState.nodeLayouts);
-
-          // Undock existing docked children by giving them layouts.
-          // Use getEffectiveLayout to handle the case where the parent node is
-          // itself docked (no direct layout) - we walk up the chain to find
-          // the first ancestor with a layout.
-          const effectiveLayout = getEffectiveLayout(
-            node,
-            currentState.nodeLayouts,
-          );
-          if (effectiveLayout !== undefined && dockedChildren.length > 0) {
-            const undockLayouts = calculateUndockLayouts(
-              dockedChildren,
-              effectiveLayout,
-            );
-            for (const [nodeId, layout] of undockLayouts) {
-              updatedLayouts.set(nodeId, layout);
-            }
-          }
-
-          return {
-            ...currentState,
-            rootNodes: [...currentState.rootNodes, newNode],
-            nodeLayouts: updatedLayouts,
-            selectedNodes: new Set([newNode.nodeId]),
-          };
-        });
-      }
-
-      return newNode;
-    }
-
-    console.warn(
-      `Cannot add operation node: unknown type '${derivedNodeId}' for source node ${node.nodeId}`,
-    );
-    return undefined;
-  }
-
-  private async handleAddSourceNode(attrs: ExplorePageAttrs, id: string) {
-    const descriptor = nodeRegistry.get(id);
-    if (!descriptor) {
-      console.warn(`Cannot add source node: unknown node type '${id}'`);
-      return;
-    }
-
-    let initialState: PreCreateState | PreCreateState[] | null = {};
-
-    if (descriptor.preCreate) {
-      const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-      if (!sqlModules) {
-        console.warn('Cannot add source node: SQL modules not loaded yet');
-        return;
-      }
-      initialState = await descriptor.preCreate({sqlModules});
-    }
-
-    // User cancelled the preCreate dialog
-    if (initialState === null) {
-      return;
-    }
-
-    // Handle both single node and multi-node creation
-    const statesToCreate = Array.isArray(initialState)
-      ? initialState
-      : [initialState];
-
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-    const newNodes: QueryNode[] = [];
-    for (const state of statesToCreate) {
-      try {
-        const newNode = descriptor.factory(
-          {
-            ...state,
-            trace: attrs.trace,
-            sqlModules,
-          } as QueryNodeState,
-          {allNodes: attrs.state.rootNodes},
-        );
-        newNodes.push(newNode);
-      } catch (error) {
-        console.error('Failed to create node:', error);
-        // Continue creating other nodes even if one fails
-      }
-    }
-
-    // If no nodes were successfully created, return early
-    // (errors were already logged in the try-catch above)
-    if (newNodes.length === 0) {
-      console.warn('No nodes were created from the preCreate result');
-      return;
-    }
-
-    const lastNode = newNodes[newNodes.length - 1];
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      rootNodes: [...currentState.rootNodes, ...newNodes],
-      selectedNodes: new Set([lastNode.nodeId]),
-    }));
-  }
-
-  private async createExploreGraph(attrs: ExplorePageAttrs) {
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-    if (!sqlModules) return;
-
-    const newNodes: QueryNode[] = [];
-
-    // Create slices source node
-    const slicesNode = new SlicesSourceNode({sqlModules, trace: attrs.trace});
-    newNodes.push(slicesNode);
-
-    // Get high-frequency tables with data
-    const tableDescriptor = nodeRegistry.get('table');
-    if (tableDescriptor) {
-      const highFreqTables = sqlModules
-        .listTables()
-        .filter((table) => table.importance === 'high');
-
-      for (const sqlTable of highFreqTables) {
-        try {
-          // Check if the module is disabled (no data available)
-          const module = sqlModules.getModuleForTable(sqlTable.name);
-          if (module && sqlModules.isModuleDisabled(module.includeKey)) {
-            continue; // Skip tables from disabled modules
-          }
-
-          const tableNode = tableDescriptor.factory(
-            {
-              sqlTable,
-              sqlModules,
-              trace: attrs.trace,
-            },
-            {allNodes: attrs.state.rootNodes},
-          );
-          newNodes.push(tableNode);
-        } catch (error) {
-          console.error(
-            `Failed to create table node for ${sqlTable.name}:`,
-            error,
-          );
-        }
-      }
-    }
-
-    // Add all nodes to root nodes with grid layout
-    if (newNodes.length > 0) {
-      // Calculate grid dimensions (as square as possible)
-      const totalNodes = newNodes.length;
-      const cols = Math.ceil(Math.sqrt(totalNodes));
-
-      // Create layout map with grid positions
-      const newNodeLayouts = new Map();
-      const NODE_WIDTH = 300;
-      const NODE_HEIGHT = 200;
-      const GRID_PADDING_X = 10;
-      const GRID_PADDING_Y = 10;
-      const START_X = 50;
-      const START_Y = 50;
-
-      newNodes.forEach((node, index) => {
-        const col = index % cols;
-        const row = Math.floor(index / cols);
-        newNodeLayouts.set(node.nodeId, {
-          x: START_X + col * (NODE_WIDTH + GRID_PADDING_X),
-          y: START_Y + row * (NODE_HEIGHT + GRID_PADDING_Y),
-        });
-      });
-
-      // Atomically update state with new nodes and incremented loadGeneration
+  private handleCopy(attrs: ExplorePageAttrs): void {
+    const result = copySelectedNodes(attrs.state);
+    if (result !== undefined) {
       attrs.onStateUpdate((currentState) => ({
         ...currentState,
-        rootNodes: newNodes, // Replace all nodes
-        nodeLayouts: newNodeLayouts,
-        selectedNodes: new Set([newNodes[0].nodeId]),
-        labels: [], // Clear labels
-        loadGeneration: (currentState.loadGeneration ?? 0) + 1,
+        ...result,
       }));
     }
-  }
-
-  private async autoInitializeHighImportanceTables(attrs: ExplorePageAttrs) {
-    attrs.setHasAutoInitialized(true);
-
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-    if (!sqlModules) {
-      console.warn('Cannot auto-initialize tables: SQL modules not loaded yet');
-      return;
-    }
-
-    try {
-      // Load the base page state from JSON
-      const response = await fetch(
-        assetSrc('assets/explore_page/base-page.json'),
-      );
-      if (!response.ok) {
-        console.warn(
-          'Failed to load base page state, falling back to empty state',
-        );
-        return;
-      }
-      const json = await response.text();
-      const newState = deserializeState(json, attrs.trace, sqlModules);
-      // Atomically update state with incremented loadGeneration
-      attrs.onStateUpdate((currentState) => ({
-        ...newState,
-        loadGeneration: (currentState.loadGeneration ?? 0) + 1,
-      }));
-    } catch (error) {
-      console.error('Failed to load base page state:', error);
-      // Silently fail - leave the page empty if JSON can't be loaded
-    }
-  }
-
-  private async handleAddAndConnectTable(
-    attrs: ExplorePageAttrs,
-    tableName: string,
-    targetNode: QueryNode,
-    portIndex: number,
-  ) {
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-    if (!sqlModules) {
-      console.warn('Cannot add table: SQL modules not loaded yet');
-      return;
-    }
-
-    // Get the table descriptor
-    const descriptor = nodeRegistry.get('table');
-    if (!descriptor) {
-      console.warn("Cannot add table: 'table' node type not found in registry");
-      return;
-    }
-
-    // Find the table in SQL modules
-    const sqlTable = sqlModules.listTables().find((t) => t.name === tableName);
-    if (!sqlTable) {
-      console.warn(`Table ${tableName} not found in SQL modules`);
-      return;
-    }
-
-    // Create the table node with the specific table (bypass the modal)
-    const newNode = descriptor.factory(
-      {
-        sqlTable,
-        sqlModules,
-        trace: attrs.trace,
-      },
-      {allNodes: attrs.state.rootNodes},
-    );
-
-    // Add connection from the new table node to the target node
-    addConnection(newNode, targetNode, portIndex);
-
-    // Add the new node to root nodes
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      rootNodes: [...currentState.rootNodes, newNode],
-    }));
-  }
-
-  private async handleInsertModifyColumnsNode(
-    attrs: ExplorePageAttrs,
-    targetNode: QueryNode,
-    portIndex: number,
-  ) {
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-    if (!sqlModules) {
-      console.warn('Cannot insert modify columns node: SQL modules not loaded');
-      return;
-    }
-
-    // Get the ModifyColumns descriptor
-    const descriptor = nodeRegistry.get('modify_columns');
-    if (!descriptor) {
-      console.warn(
-        "Cannot insert modify columns node: 'modify_columns' node type not found in registry",
-      );
-      return;
-    }
-
-    // Get the current input node at the specified port
-    const inputNode = getInputNodeAtPort(targetNode, portIndex);
-
-    if (!inputNode) {
-      console.warn(`No input node found at port ${portIndex}`);
-      return;
-    }
-
-    // Create the ModifyColumns node
-    const newNode = descriptor.factory(
-      {
-        sqlModules,
-        trace: attrs.trace,
-      },
-      {allNodes: attrs.state.rootNodes},
-    );
-
-    // Remove the old connection from inputNode to targetNode
-    removeConnection(inputNode, targetNode);
-
-    // Add connection from inputNode to ModifyColumns node (sets primaryInput)
-    addConnection(inputNode, newNode);
-
-    // Add connection from ModifyColumns node to targetNode at the same port
-    addConnection(newNode, targetNode, portIndex);
-
-    // Add the new node to root nodes (so it appears in the graph)
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      rootNodes: [...currentState.rootNodes, newNode],
-      selectedNodes: new Set([newNode.nodeId]),
-    }));
-  }
-
-  private async handleInsertCounterToIntervalsNode(
-    attrs: ExplorePageAttrs,
-    targetNode: QueryNode,
-    portIndex: number,
-  ) {
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-    if (!sqlModules) {
-      console.warn(
-        'Cannot insert counter to intervals node: SQL modules not loaded',
-      );
-      return;
-    }
-
-    // Get the CounterToIntervals descriptor
-    const descriptor = nodeRegistry.get('counter_to_intervals');
-    if (!descriptor) {
-      console.warn(
-        "Cannot insert counter to intervals node: 'counter_to_intervals' node type not found in registry",
-      );
-      return;
-    }
-
-    // Get the current input node at the specified port
-    const inputNode = getInputNodeAtPort(targetNode, portIndex);
-
-    if (!inputNode) {
-      console.warn(`No input node found at port ${portIndex}`);
-      return;
-    }
-
-    // Create the CounterToIntervals node
-    const newNode = descriptor.factory(
-      {
-        sqlModules,
-        trace: attrs.trace,
-      },
-      {allNodes: attrs.state.rootNodes},
-    );
-
-    // Remove the old connection from inputNode to targetNode
-    removeConnection(inputNode, targetNode);
-
-    // Add connection from inputNode to CounterToIntervals node (sets primaryInput)
-    addConnection(inputNode, newNode);
-
-    // Add connection from CounterToIntervals node to targetNode at the same port
-    addConnection(newNode, targetNode, portIndex);
-
-    // Add the new node to root nodes (so it appears in the graph)
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      rootNodes: [...currentState.rootNodes, newNode],
-      selectedNodes: new Set([newNode.nodeId]),
-    }));
-  }
-
-  /**
-   * Cleans up all existing nodes (drops materialized tables) and clears
-   * the initialized nodes set. Used when replacing the entire graph state.
-   */
-  private async cleanupExistingNodes(rootNodes: QueryNode[]) {
-    if (this.cleanupManager !== undefined) {
-      const allNodes = getAllNodes(rootNodes);
-      await this.cleanupManager.cleanupNodes(allNodes);
-    }
-    this.initializedNodes.clear();
-  }
-
-  async handleClearAllNodes(attrs: ExplorePageAttrs) {
-    await this.cleanupExistingNodes(attrs.state.rootNodes);
-
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      rootNodes: [],
-      selectedNodes: new Set(),
-      nodeLayouts: new Map(),
-      labels: [],
-    }));
-  }
-
-  handleDuplicateNode(attrs: ExplorePageAttrs, node: QueryNode) {
-    const {onStateUpdate} = attrs;
-    onStateUpdate((currentState) => ({
-      ...currentState,
-      rootNodes: [...currentState.rootNodes, node.clone()],
-    }));
-  }
-
-  private handleCopy(attrs: ExplorePageAttrs): void {
-    const {state} = attrs;
-    const selectedNodeIds = state.selectedNodes;
-
-    if (selectedNodeIds.size === 0) {
-      return;
-    }
-
-    const allNodes = getAllNodes(state.rootNodes);
-    const selectedNodes = allNodes.filter((n) => selectedNodeIds.has(n.nodeId));
-
-    if (selectedNodes.length === 0) {
-      return;
-    }
-
-    // Get positions for relative layout calculation
-    const positions = selectedNodes.map((node) => {
-      const layout = state.nodeLayouts.get(node.nodeId);
-      return {
-        node,
-        x: layout?.x ?? 0,
-        y: layout?.y ?? 0,
-      };
-    });
-
-    // Find the top-left corner as reference point
-    const minX = Math.min(...positions.map((p) => p.x));
-    const minY = Math.min(...positions.map((p) => p.y));
-
-    // Create clipboard entries with cloned nodes and relative positions
-    // Track whether each node is docked (no explicit layout) or undocked
-    const nodeIdToIndex = new Map<string, number>();
-    const clipboardNodes: ClipboardEntry[] = positions.map((p, index) => {
-      nodeIdToIndex.set(p.node.nodeId, index);
-      const hasLayout = state.nodeLayouts.has(p.node.nodeId);
-      return {
-        node: p.node.clone(),
-        relativeX: p.x - minX,
-        relativeY: p.y - minY,
-        isDocked: !hasLayout,
-      };
-    });
-
-    // Capture connections between selected nodes
-    const clipboardConnections: ClipboardConnection[] = [];
-    for (const node of selectedNodes) {
-      const toIndex = nodeIdToIndex.get(node.nodeId);
-      if (toIndex === undefined) continue;
-
-      // Check primaryInput
-      if (node.primaryInput && selectedNodeIds.has(node.primaryInput.nodeId)) {
-        const fromIndex = nodeIdToIndex.get(node.primaryInput.nodeId);
-        if (fromIndex !== undefined) {
-          clipboardConnections.push({fromIndex, toIndex});
-        }
-      }
-
-      // Check secondaryInputs
-      if (node.secondaryInputs) {
-        for (const [portIndex, inputNode] of node.secondaryInputs.connections) {
-          if (selectedNodeIds.has(inputNode.nodeId)) {
-            const fromIndex = nodeIdToIndex.get(inputNode.nodeId);
-            if (fromIndex !== undefined) {
-              clipboardConnections.push({fromIndex, toIndex, portIndex});
-            }
-          }
-        }
-      }
-    }
-
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      clipboardNodes,
-      clipboardConnections,
-    }));
   }
 
   private handlePaste(attrs: ExplorePageAttrs): void {
-    const {state, onStateUpdate} = attrs;
-    if (
-      state.clipboardNodes === undefined ||
-      state.clipboardNodes.length === 0
-    ) {
-      return;
-    }
-
-    onStateUpdate((currentState) => {
-      if (
-        currentState.clipboardNodes === undefined ||
-        currentState.clipboardNodes.length === 0
-      ) {
-        return currentState;
-      }
-
-      // Clone nodes again for this paste operation (allows multiple pastes)
-      const newNodes = currentState.clipboardNodes.map((entry) =>
-        entry.node.clone(),
-      );
-
-      // Calculate paste offset (place slightly offset from original)
-      const pasteOffsetX = 50;
-      const pasteOffsetY = 50;
-
-      // Update layouts for new nodes - only add layouts for undocked nodes
-      // Docked nodes will remain docked (attached to their parent)
-      const updatedLayouts = new Map(currentState.nodeLayouts);
-      currentState.clipboardNodes.forEach((entry, index) => {
-        if (!entry.isDocked) {
-          updatedLayouts.set(newNodes[index].nodeId, {
-            x: entry.relativeX + pasteOffsetX,
-            y: entry.relativeY + pasteOffsetY,
-          });
-        }
-      });
-
-      // Restore connections between pasted nodes
-      if (currentState.clipboardConnections) {
-        for (const conn of currentState.clipboardConnections) {
-          const fromNode = newNodes[conn.fromIndex] as QueryNode | undefined;
-          const toNode = newNodes[conn.toIndex] as QueryNode | undefined;
-          if (fromNode !== undefined && toNode !== undefined) {
-            addConnection(fromNode, toNode, conn.portIndex);
-          }
-        }
-      }
-
-      // Select all newly pasted nodes
-      const newSelectedNodes = new Set(newNodes.map((n) => n.nodeId));
-
-      return {
-        ...currentState,
-        rootNodes: [...currentState.rootNodes, ...newNodes],
-        selectedNodes: newSelectedNodes,
-        nodeLayouts: updatedLayouts,
-      };
+    attrs.onStateUpdate((currentState) => {
+      const result = pasteClipboardNodes(currentState);
+      if (result === undefined) return currentState;
+      return {...currentState, ...result};
     });
   }
 
-  /**
-   * Helper to set filters on a node and optionally set the filter operator.
-   * Reduces duplication across multiple filter-setting locations.
-   */
-  private setFiltersOnNode(
-    node: QueryNode,
-    filters: UIFilter[],
-    filterOperator?: 'AND' | 'OR',
-  ): void {
-    node.state.filters = filters;
-    if (filterOperator) {
-      node.state.filterOperator = filterOperator;
-    }
-  }
-
-  async handleFilterAdd(
+  private handleKeyDown(
+    event: KeyboardEvent,
     attrs: ExplorePageAttrs,
-    sourceNode: QueryNode,
-    filter: UIFilter | UIFilter[],
-    filterOperator?: 'AND' | 'OR',
+    nodeCrudDeps: NodeCrudDeps,
+    graphIODeps: GraphIODeps,
   ) {
-    // Normalize to array for uniform handling (single filter → [filter])
-    const filters: UIFilter[] = Array.isArray(filter) ? filter : [filter];
-
-    // If the source node is already a FilterNode, just add the filter(s) to it
-    if (sourceNode.type === NodeType.kFilter) {
-      this.setFiltersOnNode(
-        sourceNode,
-        [...(sourceNode.state.filters ?? []), ...filters] as UIFilter[],
-        filterOperator,
-      );
-      attrs.onStateUpdate((currentState) => ({...currentState}));
-      return;
-    }
-
-    // If the source node has exactly one child and it's a FilterNode, add to that
-    if (
-      sourceNode.nextNodes.length === 1 &&
-      sourceNode.nextNodes[0].type === NodeType.kFilter
-    ) {
-      const existingFilterNode = sourceNode.nextNodes[0];
-      this.setFiltersOnNode(
-        existingFilterNode,
-        [...(existingFilterNode.state.filters ?? []), ...filters] as UIFilter[],
-        filterOperator,
-      );
-      attrs.onStateUpdate((currentState) => ({
-        ...currentState,
-        selectedNodes: new Set([existingFilterNode.nodeId]),
-      }));
-      return;
-    }
-
-    // Otherwise, create a new FilterNode after the source node
-    // Create it with filters already configured to avoid multiple undo points
-    const newFilterNode = new FilterNode({
-      filters,
-      filterOperator,
-      sqlModules: attrs.sqlModulesPlugin.getSqlModules(),
-    });
-
-    // Mark as initialized
-    this.initializedNodes.add(newFilterNode.nodeId);
-
-    // Insert between source node and its children
-    insertNodeBetween(
-      sourceNode,
-      newFilterNode,
-      addConnection,
-      removeConnection,
-    );
-
-    // Single state update records the entire operation (node + filters)
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      selectedNodes: new Set([newFilterNode.nodeId]),
-    }));
-  }
-
-  /**
-   * Parses a column field to extract joinid information.
-   * Returns undefined if the field is not a joinid column reference.
-   */
-  private parseJoinidColumnField(
-    field: string,
-    sourceNode: QueryNode,
-  ):
-    | {
-        joinidColumnName: string;
-        targetColumnName: string;
-        targetTable: string;
-        targetJoinColumn: string;
-      }
-    | undefined {
-    // Parse the field to extract joinid column name and target column
-    // Expected format: "joinidColumnName.targetColumnName"
-    const dotIndex = field.indexOf('.');
-    if (dotIndex === -1) {
-      return undefined;
-    }
-
-    const joinidColumnName = field.substring(0, dotIndex);
-    const targetColumnName = field.substring(dotIndex + 1);
-
-    // Find the joinid column in the source node's finalCols
-    const joinidColumnInfo = sourceNode.finalCols.find(
-      (col) => col.name === joinidColumnName,
-    );
-
-    if (
-      joinidColumnInfo === undefined ||
-      joinidColumnInfo.column.type?.kind !== 'joinid'
-    ) {
-      return undefined;
-    }
-
-    return {
-      joinidColumnName,
-      targetColumnName,
-      targetTable: joinidColumnInfo.column.type.source.table,
-      targetJoinColumn: joinidColumnInfo.column.type.source.column,
-    };
-  }
-
-  /**
-   * Finds an AddColumnsNode that matches the given join configuration.
-   * Checks both the source node itself and its immediate child.
-   */
-  private findMatchingAddColumnsNode(
-    sourceNode: QueryNode,
-    joinidColumnName: string,
-    targetJoinColumn: string,
-  ): AddColumnsNode | undefined {
-    // Check if the source node is already an AddColumnsNode with the same join
-    if (sourceNode.type === NodeType.kAddColumns) {
-      const addColumnsNode = sourceNode as AddColumnsNode;
-      if (
-        addColumnsNode.state.leftColumn === joinidColumnName &&
-        addColumnsNode.state.rightColumn === targetJoinColumn
-      ) {
-        return addColumnsNode;
-      }
-    }
-
-    // Check if the source node has exactly one child that's an AddColumnsNode with same join
-    if (
-      sourceNode.nextNodes.length === 1 &&
-      sourceNode.nextNodes[0].type === NodeType.kAddColumns
-    ) {
-      const existingAddColumnsNode = sourceNode.nextNodes[0] as AddColumnsNode;
-      if (
-        existingAddColumnsNode.state.leftColumn === joinidColumnName &&
-        existingAddColumnsNode.state.rightColumn === targetJoinColumn
-      ) {
-        return existingAddColumnsNode;
-      }
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Handles adding a column from a joinid table by creating an AddColumnsNode.
-   * The column field is expected to be in the format "joinidColumn.targetColumnName"
-   * where joinidColumn is a column with joinid type in the source node.
-   */
-  handleColumnAdd(
-    attrs: ExplorePageAttrs,
-    sourceNode: QueryNode,
-    column: Column,
-  ) {
-    const parsed = this.parseJoinidColumnField(column.field, sourceNode);
-    if (parsed === undefined) {
-      // Not a joinid column reference - nothing to do
-      return;
-    }
-
-    const {joinidColumnName, targetColumnName, targetTable, targetJoinColumn} =
-      parsed;
-
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
-    if (sqlModules === undefined) {
-      console.warn('Cannot add column: SQL modules not loaded yet');
-      return;
-    }
-
-    // Check if this column name already exists in the source node's schema
-    const existingColumnNames = new Set(
-      sourceNode.finalCols.map((col) => col.name),
-    );
-    if (existingColumnNames.has(targetColumnName)) {
-      console.warn(
-        `Cannot add column: "${targetColumnName}" already exists in the schema`,
-      );
-      return;
-    }
-
-    // Try to find an existing AddColumnsNode with the same join configuration
-    const existingNode = this.findMatchingAddColumnsNode(
-      sourceNode,
-      joinidColumnName,
-      targetJoinColumn,
-    );
-
-    if (existingNode !== undefined) {
-      // Check if the column is already added
-      if (existingNode.state.selectedColumns?.includes(targetColumnName)) {
-        console.warn(
-          `Cannot add column: "${targetColumnName}" is already added`,
-        );
-        return;
-      }
-
-      // Add the column to the existing AddColumnsNode
-      existingNode.state.selectedColumns = [
-        ...(existingNode.state.selectedColumns ?? []),
-        targetColumnName,
-      ];
-      existingNode.state.onchange?.();
-      if (existingNode !== sourceNode) {
-        attrs.onStateUpdate((currentState) => ({
-          ...currentState,
-          selectedNodes: new Set([existingNode.nodeId]),
-        }));
-      }
-      return;
-    }
-
-    // Create a new AddColumnsNode with the join configuration
-    // Note: selectedColumns is set after connecting the table node because
-    // onPrevNodesUpdated() resets selectedColumns when rightNode is not connected
-    const newAddColumnsNode = new AddColumnsNode({
-      leftColumn: joinidColumnName,
-      rightColumn: targetJoinColumn,
-      isGuidedConnection: true,
-      sqlModules,
-      trace: attrs.trace,
-    });
-
-    // Set actions now that the node is created
-    newAddColumnsNode.state.actions = this.createNodeActions(
-      attrs,
-      newAddColumnsNode,
-    );
-
-    // Mark as initialized
-    this.initializedNodes.add(newAddColumnsNode.nodeId);
-
-    // Insert between source node and its children
-    insertNodeBetween(
-      sourceNode,
-      newAddColumnsNode,
-      addConnection,
-      removeConnection,
-    );
-
-    // Now create and connect the table source node
-    const descriptor = nodeRegistry.get('table');
-    if (descriptor === undefined) {
-      console.warn("Cannot add table: 'table' node type not found in registry");
-      return;
-    }
-
-    const sqlTable = sqlModules
-      .listTables()
-      .find((t) => t.name === targetTable);
-    if (sqlTable === undefined) {
-      console.warn(`Table ${targetTable} not found in SQL modules`);
-      return;
-    }
-
-    // Create the table node with the specific table
-    const tableNode = descriptor.factory(
-      {
-        sqlTable,
-        sqlModules,
-        trace: attrs.trace,
-      },
-      {allNodes: attrs.state.rootNodes},
-    );
-
-    // Connect table node to AddColumnsNode's secondary input (port 0)
-    addConnection(tableNode, newAddColumnsNode, 0);
-
-    // Now that rightNode is connected, set the selected column
-    // (must be done after connection because onPrevNodesUpdated resets it otherwise)
-    newAddColumnsNode.state.selectedColumns = [targetColumnName];
-
-    // Update state with both new nodes
-    attrs.onStateUpdate((currentState) => ({
-      ...currentState,
-      rootNodes: [...currentState.rootNodes, tableNode],
-      selectedNodes: new Set([newAddColumnsNode.nodeId]),
-    }));
-  }
-
-  /**
-   * Gets the primary input parent of a node.
-   * Returns undefined for:
-   * - Source nodes (no inputs)
-   * - Multi-source nodes (Union, Join, IntervalIntersect - they only have secondary inputs)
-   */
-  private getPrimaryParent(node: QueryNode): QueryNode | undefined {
-    if ('primaryInput' in node) {
-      return node.primaryInput;
-    }
-    return undefined;
-  }
-
-  /**
-   * Disconnects a node from all its parents and children.
-   */
-  private disconnectNodeFromGraph(node: QueryNode): void {
-    // Disconnect from all parents (both primary and secondary)
-    const allParents = getAllInputNodes(node);
-    for (const parent of allParents) {
-      removeConnection(parent, node);
-    }
-
-    // Disconnect from all children
-    const children = [...node.nextNodes];
-    for (const child of children) {
-      removeConnection(node, child);
-    }
-  }
-
-  async handleDeleteNode(attrs: ExplorePageAttrs, node: QueryNode) {
-    const {state, onStateUpdate} = attrs;
-
-    // STEP 1: Clean up resources (SQL tables, JS subscriptions, etc.)
-    if (this.cleanupManager !== undefined) {
-      try {
-        await this.cleanupManager.cleanupNode(node);
-      } catch (error) {
-        // Log error but continue with deletion
-        console.error('Failed to cleanup node resources:', error);
-      }
-    }
-
-    // STEP 2: Capture graph structure BEFORE modification
-    // We need to capture this info before removeConnection() clears the references
-    const primaryParent = this.getPrimaryParent(node);
-    const childConnections = captureAllChildConnections(node);
-    const allInputs = getAllInputNodes(node); // Capture ALL parents (primary + secondary)
-
-    // STEP 3: Remove the node from the graph
-    this.disconnectNodeFromGraph(node);
-
-    // STEP 4: Reconnect primary parent to children (if exists)
-    // This bypasses the deleted node, maintaining data flow for PRIMARY connections only.
-    //
-    // IMPORTANT RULES:
-    // 1. Only reconnect if deleted node fed child's PRIMARY input (portIndex === undefined)
-    // 2. Secondary connections are specific to the deleted node - DROP them, don't reconnect
-    // 3. Skip reconnection if parent is already connected to avoid duplicates
-    // 4. Transfer deleted node's layout to docked children so they can render at same position
-    const reconnectedChildren: QueryNode[] = [];
-    const updatedNodeLayouts = new Map(state.nodeLayouts);
-    const deletedNodeLayout = state.nodeLayouts.get(node.nodeId);
-
-    if (primaryParent !== undefined) {
-      let layoutOffsetCount = 0;
-      for (const {child, portIndex} of childConnections) {
-        // If deleted node fed child's secondary input, DROP the connection
-        // Secondary inputs are specific to the deleted node (e.g., intervals for FilterDuring)
-        if (portIndex !== undefined) {
-          continue; // Don't reconnect secondary connections
-        }
-
-        // Check if parent is already connected to this child
-        if (primaryParent.nextNodes.includes(child)) {
-          continue; // Already connected - don't create duplicates
-        }
-
-        // Reconnect: maintain primary data flow (A → B → C becomes A → C)
-        addConnection(primaryParent, child, portIndex);
-        reconnectedChildren.push(child);
-
-        // If child was docked (no layout) and deleted node had a layout,
-        // transfer the layout to the child so it renders at the same position
-        // For multiple children, offset their positions to avoid overlapping
-        const childHasNoLayout = !state.nodeLayouts.has(child.nodeId);
-        if (childHasNoLayout && deletedNodeLayout !== undefined) {
-          const offsetX = layoutOffsetCount * 30; // Offset each child by 30px
-          const offsetY = layoutOffsetCount * 30;
-          updatedNodeLayouts.set(child.nodeId, {
-            x: deletedNodeLayout.x + offsetX,
-            y: deletedNodeLayout.y + offsetY,
-          });
-          layoutOffsetCount++;
-        }
-      }
-    }
-
-    // STEP 4b: Check if reconnected children can actually be rendered
-    // A child becomes "unrenderable" if:
-    // - It was reconnected to a parent
-    // - It has no layout (was docked to deleted node)
-    // - Parent has multiple children (can't render as docked anymore)
-    const unrenderableChildren: QueryNode[] = [];
-    if (primaryParent !== undefined && reconnectedChildren.length > 0) {
-      const parentHasMultipleChildren = primaryParent.nextNodes.length > 1;
-      for (const child of reconnectedChildren) {
-        // Check the UPDATED layouts, not the old state
-        const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
-        // If child has no layout and parent has multiple children,
-        // the child can't be rendered (not as docked, not as root)
-        if (childHasNoLayout && parentHasMultipleChildren) {
-          unrenderableChildren.push(child);
-        }
-      }
-    }
-
-    // STEP 5: Update root nodes list
-    // Use a Set to prevent duplicate root nodes
-    const newRootNodesSet = new Set(state.rootNodes.filter((n) => n !== node));
-
-    // Add orphaned children to root nodes so they remain visible
-    // Children are orphaned ONLY if:
-    // 1. There was no primary parent to reconnect them to, AND
-    // 2. They were connected via PRIMARY input (not secondary)
-    // Children connected via secondary input still have their own primary parent!
-    if (primaryParent === undefined && childConnections.length > 0) {
-      // Only children connected via primary input are truly orphaned
-      const orphanedChildren = childConnections
-        .filter((c) => c.portIndex === undefined) // Primary input only
-        .map((c) => c.child);
-
-      for (const child of orphanedChildren) {
-        newRootNodesSet.add(child);
-      }
-
-      // Transfer deleted node's layout to orphaned children so they appear at same position
-      // For multiple children, offset their positions to avoid overlapping
-      if (deletedNodeLayout !== undefined) {
-        let layoutOffsetCount = 0;
-        for (const child of orphanedChildren) {
-          const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
-          if (childHasNoLayout) {
-            const offsetX = layoutOffsetCount * 30; // Offset each child by 30px
-            const offsetY = layoutOffsetCount * 30;
-            updatedNodeLayouts.set(child.nodeId, {
-              x: deletedNodeLayout.x + offsetX,
-              y: deletedNodeLayout.y + offsetY,
-            });
-            layoutOffsetCount++;
-          }
-        }
-      }
-    }
-
-    // Add unrenderable children to root nodes so they become visible
-    // These are children that were reconnected but can't be rendered as docked
-    for (const child of unrenderableChildren) {
-      newRootNodesSet.add(child);
-    }
-
-    // STEP 5b: Promote orphaned input providers to root nodes
-    // Simple rule: If a node was NOT a root node, and we deleted the node that
-    // consumed it, then it should become a root node.
-    const orphanedInputs: QueryNode[] = [];
-    for (const inputNode of allInputs) {
-      // Check if this input node becomes orphaned:
-      // 1. It was NOT originally a root node
-      // 2. After deletion, it has no consumers (nextNodes is empty)
-      const wasNotRoot = !state.rootNodes.includes(inputNode);
-      const hasNoConsumers = inputNode.nextNodes.length === 0;
-
-      if (wasNotRoot && hasNoConsumers) {
-        orphanedInputs.push(inputNode);
-      }
-    }
-
-    for (const inputNode of orphanedInputs) {
-      newRootNodesSet.add(inputNode);
-    }
-
-    const newRootNodes = Array.from(newRootNodesSet);
-
-    // STEP 5c: Remove the deleted node's layout from the map
-    // Now that we've transferred the layout to children/orphans, clean it up
-    updatedNodeLayouts.delete(node.nodeId);
-
-    // STEP 6: Trigger validation on affected children
-    // Children need to re-validate because their inputs have changed
-    // (either reconnected to a different parent or lost their parent entirely)
-    for (const {child} of childConnections) {
-      child.onPrevNodesUpdated?.();
-    }
-
-    // Also notify orphaned input providers that their consumers changed
-    for (const inputNode of orphanedInputs) {
-      notifyNextNodes(inputNode);
-    }
-
-    // STEP 7: Commit state changes
-    onStateUpdate((currentState) => {
-      // Update selection based on current state (not stale state)
-      // This is important for multi-node deletion where state changes between deletions
-      const newSelectedNodes = new Set(currentState.selectedNodes);
-      newSelectedNodes.delete(node.nodeId);
-
-      return {
-        ...currentState,
-        rootNodes: newRootNodes,
-        selectedNodes: newSelectedNodes,
-        nodeLayouts: updatedNodeLayouts,
-      };
-    });
-  }
-
-  /**
-   * Delete all currently selected nodes.
-   * Batches all deletions into a single state update to create one undo point.
-   */
-  async handleDeleteSelectedNodes(attrs: ExplorePageAttrs): Promise<void> {
-    const {state, onStateUpdate} = attrs;
-    const selectedNodeIds = new Set(state.selectedNodes);
-
-    if (selectedNodeIds.size === 0) {
-      return;
-    }
-
-    // Get all nodes to delete
-    const allNodes = getAllNodes(state.rootNodes);
-    const nodesToDelete = allNodes.filter((n) => selectedNodeIds.has(n.nodeId));
-
-    if (nodesToDelete.length === 0) {
-      return;
-    }
-
-    // STEP 1: Clean up resources for all nodes (async operations)
-    if (this.cleanupManager !== undefined) {
-      for (const node of nodesToDelete) {
-        try {
-          await this.cleanupManager.cleanupNode(node);
-        } catch (error) {
-          console.error('Failed to cleanup node resources:', error);
-        }
-      }
-    }
-
-    // STEP 2: Capture graph info and perform all deletions in a single state update
-    onStateUpdate((currentState) => {
-      const nodesToDeleteSet = new Set(nodesToDelete);
-      const updatedNodeLayouts = new Map(currentState.nodeLayouts);
-      const newRootNodesSet = new Set(currentState.rootNodes);
-      const affectedChildren: QueryNode[] = [];
-      const orphanedInputs: QueryNode[] = [];
-
-      // Process each node deletion
-      for (const node of nodesToDelete) {
-        // Capture info before disconnection
-        const primaryParent = this.getPrimaryParent(node);
-        const childConnections = captureAllChildConnections(node);
-        const allInputs = getAllInputNodes(node);
-
-        // Disconnect from graph
-        this.disconnectNodeFromGraph(node);
-
-        // Remove from root nodes
-        newRootNodesSet.delete(node);
-
-        // Remove layout
-        const deletedNodeLayout = updatedNodeLayouts.get(node.nodeId);
-        updatedNodeLayouts.delete(node.nodeId);
-
-        // Reconnect primary parent to children (if parent is not also being deleted)
-        if (
-          primaryParent !== undefined &&
-          !nodesToDeleteSet.has(primaryParent)
-        ) {
-          let layoutOffsetCount = 0;
-          for (const {child, portIndex} of childConnections) {
-            // Skip if child is also being deleted
-            if (nodesToDeleteSet.has(child)) {
-              continue;
-            }
-
-            // Only reconnect primary connections
-            if (portIndex === undefined) {
-              if (!primaryParent.nextNodes.includes(child)) {
-                addConnection(primaryParent, child, portIndex);
-                affectedChildren.push(child);
-
-                // Transfer layout if child was docked
-                const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
-                if (childHasNoLayout && deletedNodeLayout !== undefined) {
-                  const offsetX = layoutOffsetCount * 30;
-                  const offsetY = layoutOffsetCount * 30;
-                  updatedNodeLayouts.set(child.nodeId, {
-                    x: deletedNodeLayout.x + offsetX,
-                    y: deletedNodeLayout.y + offsetY,
-                  });
-                  layoutOffsetCount++;
-                }
-              }
-            }
-          }
-        }
-
-        // Handle orphaned children (no parent or parent was deleted)
-        if (
-          primaryParent === undefined ||
-          nodesToDeleteSet.has(primaryParent)
-        ) {
-          let layoutOffsetCount = 0;
-          for (const {child, portIndex} of childConnections) {
-            // Skip if child is also being deleted
-            if (nodesToDeleteSet.has(child)) {
-              continue;
-            }
-
-            // Only orphan primary connections
-            if (portIndex === undefined) {
-              newRootNodesSet.add(child);
-              affectedChildren.push(child);
-
-              // Transfer layout
-              const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
-              if (childHasNoLayout && deletedNodeLayout !== undefined) {
-                const offsetX = layoutOffsetCount * 30;
-                const offsetY = layoutOffsetCount * 30;
-                updatedNodeLayouts.set(child.nodeId, {
-                  x: deletedNodeLayout.x + offsetX,
-                  y: deletedNodeLayout.y + offsetY,
-                });
-                layoutOffsetCount++;
-              }
-            }
-          }
-        }
-
-        // Handle orphaned input providers
-        for (const inputNode of allInputs) {
-          // Skip if input is also being deleted
-          if (nodesToDeleteSet.has(inputNode)) {
-            continue;
-          }
-
-          const wasNotRoot = !currentState.rootNodes.includes(inputNode);
-          const hasNoConsumers = inputNode.nextNodes.length === 0;
-
-          if (wasNotRoot && hasNoConsumers) {
-            newRootNodesSet.add(inputNode);
-            orphanedInputs.push(inputNode);
-          }
-        }
-      }
-
-      // Trigger validation on affected nodes
-      for (const child of affectedChildren) {
-        child.onPrevNodesUpdated?.();
-      }
-      for (const inputNode of orphanedInputs) {
-        notifyNextNodes(inputNode);
-      }
-
-      // Clear selection
-      return {
-        ...currentState,
-        rootNodes: Array.from(newRootNodesSet),
-        selectedNodes: new Set<string>(),
-        nodeLayouts: updatedNodeLayouts,
-      };
-    });
-  }
-
-  handleConnectionRemove(
-    attrs: ExplorePageAttrs,
-    fromNode: QueryNode,
-    toNode: QueryNode,
-    isSecondaryInput: boolean,
-  ) {
-    const {state, onStateUpdate} = attrs;
-
-    // NOTE: The basic connection removal is already handled by graph.ts
-    // This callback handles higher-level logic like reconnection and state updates
-
-    // Only reconnect fromNode to toNode's children when removing a PRIMARY input.
-    // When removing a SECONDARY input, we should NOT reconnect - the secondary
-    // input node is just an auxiliary input (like intervals for FilterDuring)
-    // and should not be connected to the children of the node it was feeding into.
-    const shouldReconnect =
-      !isSecondaryInput &&
-      fromNode.nextNodes.length === 0 &&
-      toNode.nextNodes.length > 0;
-
-    if (shouldReconnect) {
-      // Reconnect fromNode to all of toNode's children (bypass toNode)
-      for (const child of toNode.nextNodes) {
-        addConnection(fromNode, child);
-      }
-    }
-
-    // Handle state updates based on node type
-    if ('primaryInput' in toNode && toNode.primaryInput === undefined) {
-      // toNode is a ModificationNode that's now orphaned
-      // Add it to rootNodes so it remains visible (but invalid)
-      const newRootNodes = state.rootNodes.includes(toNode)
-        ? state.rootNodes
-        : [...state.rootNodes, toNode];
-
-      onStateUpdate((currentState) => ({
-        ...currentState,
-        rootNodes: newRootNodes,
-      }));
-    } else if ('secondaryInputs' in toNode) {
-      // toNode is a MultiSourceNode - just trigger a state update
-      onStateUpdate((currentState) => ({...currentState}));
-    }
-  }
-
-  async handleExport(state: ExplorePageState, trace: Trace) {
-    const confirmed = await showExportWarning();
-    if (!confirmed) return;
-    exportStateAsJson(state, trace);
-  }
-
-  /**
-   * Common method to load state from a JSON string.
-   * Handles cleanup of existing nodes and state update.
-   */
-  private async loadStateFromJson(attrs: ExplorePageAttrs, json: string) {
-    const {trace, sqlModulesPlugin, state, onStateUpdate} = attrs;
-    const sqlModules = sqlModulesPlugin.getSqlModules();
-    if (!sqlModules) {
-      console.warn('Cannot load state from JSON: SQL modules not loaded yet');
-      return;
-    }
-
-    await this.cleanupExistingNodes(state.rootNodes);
-
-    const newState = deserializeState(json, trace, sqlModules);
-    // Atomically update state with incremented loadGeneration
-    // This ensures the Graph component sees the generation change in a single render
-    onStateUpdate((currentState) => ({
-      ...newState,
-      loadGeneration: (currentState.loadGeneration ?? 0) + 1,
-    }));
-  }
-
-  async handleImport(attrs: ExplorePageAttrs) {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.json';
-    input.onchange = async (event) => {
-      const files = (event.target as HTMLInputElement).files;
-      if (files && files.length > 0) {
-        const file = files[0];
-
-        // Show warning modal and finalize current graph before loading
-        if (!(await this.confirmAndFinalizeCurrentGraph(attrs.state))) return;
-
-        const reader = new FileReader();
-        reader.onload = async (e) => {
-          const json = e.target?.result as string;
-          if (!json) {
-            console.error('The selected file is empty or could not be read.');
-            return;
-          }
-          await this.loadStateFromJson(attrs, json);
-        };
-        reader.readAsText(file);
-      }
-    };
-    input.click();
-  }
-
-  private handleKeyDown(event: KeyboardEvent, attrs: ExplorePageAttrs) {
     const {state} = attrs;
 
     // Do not interfere with text inputs
@@ -1663,7 +207,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     // Handle delete key - delete all selected nodes
     if (event.key === 'Delete' || event.key === 'Backspace') {
       if (state.selectedNodes.size > 0) {
-        this.handleDeleteSelectedNodes(attrs);
+        deleteSelectedNodes(nodeCrudDeps, attrs.state);
         event.preventDefault();
       }
       return;
@@ -1704,7 +248,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
         descriptor.hotkey &&
         event.key.toLowerCase() === descriptor.hotkey.toLowerCase()
       ) {
-        this.handleAddSourceNode(attrs, id);
+        addSourceNode(nodeCrudDeps, attrs.state, id);
         event.preventDefault(); // Prevent default browser actions for this key
         return;
       }
@@ -1713,46 +257,11 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     // Handle other shortcuts
     switch (event.key) {
       case 'i':
-        this.handleImport(attrs);
+        importGraph(graphIODeps, attrs.state);
         break;
       case 'e':
-        this.handleExport(attrs.state, attrs.trace);
+        exportGraph(attrs.state, attrs.trace);
         break;
-    }
-  }
-
-  /**
-   * Centralized method to load JSON from a URL path.
-   * Handles confirmation, fetching, and error handling.
-   */
-  private async loadJsonFromPath(
-    attrs: ExplorePageAttrs,
-    jsonPath: string,
-    errorTitle: string = 'Failed to Load',
-  ): Promise<void> {
-    // Show warning modal and finalize current graph before loading
-    if (!(await this.confirmAndFinalizeCurrentGraph(attrs.state))) return;
-
-    try {
-      const response = await fetch(assetSrc(jsonPath));
-      if (!response.ok) {
-        throw new Error(
-          `Failed to load: ${response.status} ${response.statusText}`,
-        );
-      }
-      const json = await response.text();
-      await this.loadStateFromJson(attrs, json);
-    } catch (error) {
-      console.error(`Failed to load from ${jsonPath}:`, error);
-      showModal({
-        title: errorTitle,
-        content: () =>
-          m(
-            'div',
-            `An error occurred while loading: ${error instanceof Error ? error.message : String(error)}`,
-          ),
-        buttons: [],
-      });
     }
   }
 
@@ -1823,13 +332,6 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       onStateUpdate: wrappedOnStateUpdate,
     };
 
-    // Ensure all nodes have actions initialized (e.g., nodes from imported state)
-    // This is efficient - only processes nodes not yet initialized
-    const allNodes = getAllNodes(state.rootNodes);
-    for (const node of allNodes) {
-      this.ensureNodeActions(wrappedAttrs, node);
-    }
-
     // Initialize services if not already done
     if (this.queryExecutionService === undefined) {
       this.queryExecutionService = new QueryExecutionService(
@@ -1838,16 +340,80 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       this.cleanupManager = new CleanupManager(this.queryExecutionService);
     }
 
+    // Construct deps objects once per render cycle.
+    // nodeActionHandlers closures reference nodeCrudDeps lazily — they are
+    // only invoked on user interaction, well after the const is initialized.
+    const nodeCrudDeps: NodeCrudDeps = {
+      trace: attrs.trace,
+      sqlModules,
+      onStateUpdate: wrappedOnStateUpdate,
+      cleanupManager: this.cleanupManager,
+      initializedNodes: this.initializedNodes,
+      nodeActionHandlers: {
+        onAddAndConnectTable: (
+          tableName: string,
+          node: QueryNode,
+          portIndex: number,
+        ) => {
+          addAndConnectTable(
+            nodeCrudDeps,
+            wrappedAttrs.state,
+            tableName,
+            node,
+            portIndex,
+          );
+        },
+        onInsertNodeAtPort: (
+          node: QueryNode,
+          portIndex: number,
+          descriptorKey: string,
+        ) => {
+          insertNodeAtPort(
+            nodeCrudDeps,
+            wrappedAttrs.state,
+            node,
+            portIndex,
+            descriptorKey,
+          );
+        },
+      },
+    };
+
+    const graphIODeps: GraphIODeps = {
+      trace: attrs.trace,
+      sqlModules,
+      onStateUpdate: wrappedOnStateUpdate,
+      cleanupExistingNodes: (rootNodes) =>
+        cleanupExistingNodes(
+          this.cleanupManager,
+          this.initializedNodes,
+          rootNodes,
+        ),
+    };
+
+    // Ensure all nodes have actions initialized (e.g., nodes from imported state)
+    // This is efficient - only processes nodes not yet initialized
+    const allNodes = getAllNodes(state.rootNodes);
+    ensureAllNodeActions(
+      allNodes,
+      this.initializedNodes,
+      nodeCrudDeps.nodeActionHandlers,
+    );
+
     // Auto-initialize high-importance tables on first render when state is empty
     // Never load base JSON if we've already initialized in this session (even after clearing nodes)
     if (state.rootNodes.length === 0 && !attrs.hasAutoInitialized) {
-      void this.autoInitializeHighImportanceTables(wrappedAttrs);
+      void initializeHighImportanceTables(
+        graphIODeps,
+        attrs.setHasAutoInitialized,
+      );
     }
 
     return m(
       '.pf-explore-page',
       {
-        onkeydown: (e: KeyboardEvent) => this.handleKeyDown(e, wrappedAttrs),
+        onkeydown: (e: KeyboardEvent) =>
+          this.handleKeyDown(e, wrappedAttrs, nodeCrudDeps, graphIODeps),
         oncreate: (vnode) => {
           (vnode.dom as HTMLElement).focus();
         },
@@ -1893,72 +459,62 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
             sidebarWidth: width,
           }));
         },
-        onNodeSelected: (node) => {
-          if (node) this.selectNode(wrappedAttrs, node);
-        },
-        onNodeAddToSelection: (node) => {
-          this.addNodeToSelection(wrappedAttrs, node);
-        },
-        onNodeRemoveFromSelection: (nodeId) => {
-          this.removeNodeFromSelection(wrappedAttrs, nodeId);
-        },
-        onDeselect: () => this.deselectNode(wrappedAttrs),
-        onNodeLayoutChange: (nodeId, layout) => {
-          wrappedAttrs.onStateUpdate((currentState) => {
-            const newNodeLayouts = new Map(currentState.nodeLayouts);
-            newNodeLayouts.set(nodeId, layout);
-            return {
+        graphCallbacks: {
+          onNodeSelected: (node) => {
+            this.selectNode(wrappedAttrs, node);
+          },
+          onNodeAddToSelection: (node) => {
+            this.addNodeToSelection(wrappedAttrs, node);
+          },
+          onNodeRemoveFromSelection: (nodeId) => {
+            this.removeNodeFromSelection(wrappedAttrs, nodeId);
+          },
+          onDeselect: () => this.deselectNode(wrappedAttrs),
+          onNodeLayoutChange: (nodeId, layout) => {
+            wrappedAttrs.onStateUpdate((currentState) => {
+              const newNodeLayouts = new Map(currentState.nodeLayouts);
+              newNodeLayouts.set(nodeId, layout);
+              return {
+                ...currentState,
+                nodeLayouts: newNodeLayouts,
+              };
+            });
+          },
+          onLabelsChange: (labels) => {
+            wrappedAttrs.onStateUpdate((currentState) => ({
               ...currentState,
-              nodeLayouts: newNodeLayouts,
-            };
-          });
+              labels,
+            }));
+          },
+          onAddSourceNode: (id) => {
+            addSourceNode(nodeCrudDeps, wrappedAttrs.state, id);
+          },
+          onAddOperationNode: (id, node) => {
+            addOperationNode(nodeCrudDeps, wrappedAttrs.state, node, id);
+          },
+          onClearAllNodes: () =>
+            clearAllNodes(nodeCrudDeps, wrappedAttrs.state),
+          onDuplicateNode: (node) => {
+            duplicateNode(wrappedAttrs.onStateUpdate, node);
+          },
+          onDeleteNode: (node) => {
+            deleteNode(nodeCrudDeps, wrappedAttrs.state, node);
+          },
+          onConnectionRemove: (fromNode, toNode, isSecondaryInput) => {
+            removeNodeConnection(
+              wrappedAttrs.state,
+              wrappedAttrs.onStateUpdate,
+              fromNode,
+              toNode,
+              isSecondaryInput,
+            );
+          },
+          onImport: () => importGraph(graphIODeps, state),
+          onExport: () => exportGraph(state, trace),
         },
-        onLabelsChange: (labels) => {
-          wrappedAttrs.onStateUpdate((currentState) => ({
-            ...currentState,
-            labels,
-          }));
-        },
-        onAddSourceNode: (id) => {
-          this.handleAddSourceNode(wrappedAttrs, id);
-        },
-        onAddOperationNode: (id, node) => {
-          this.handleAddOperationNode(wrappedAttrs, node, id);
-        },
-        onClearAllNodes: () => this.handleClearAllNodes(wrappedAttrs),
-        onDuplicateNode: () => {
-          const selectedNode = getPrimarySelectedNode(
-            state.selectedNodes,
-            state.rootNodes,
-          );
-          if (selectedNode) {
-            this.handleDuplicateNode(wrappedAttrs, selectedNode);
-          }
-        },
-        onDeleteNode: () => {
-          const selectedNode = getPrimarySelectedNode(
-            state.selectedNodes,
-            state.rootNodes,
-          );
-          if (selectedNode) {
-            this.handleDeleteNode(wrappedAttrs, selectedNode);
-          }
-        },
-        onConnectionRemove: (fromNode, toNode, isSecondaryInput) => {
-          this.handleConnectionRemove(
-            wrappedAttrs,
-            fromNode,
-            toNode,
-            isSecondaryInput,
-          );
-        },
-        onImport: () => this.handleImport(wrappedAttrs),
-        onExport: () => this.handleExport(state, trace),
         onLoadEmptyTemplate: async () => {
-          // Show warning modal and finalize current graph before clearing
-          if (!(await this.confirmAndFinalizeCurrentGraph(state))) return;
+          if (!(await confirmAndFinalizeCurrentGraph(state))) return;
 
-          // Clear all nodes for empty graph and increment loadGeneration
           wrappedAttrs.onStateUpdate((currentState) => {
             return {
               ...currentState,
@@ -1971,23 +527,20 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
           });
         },
         onLoadExampleByPath: (jsonPath: string) =>
-          this.loadJsonFromPath(wrappedAttrs, jsonPath, 'Failed to Load'),
+          loadGraphFromPath(graphIODeps, state, jsonPath, 'Failed to Load'),
         onLoadExploreTemplate: async () => {
-          // Show warning modal and finalize current graph before loading
-          if (!(await this.confirmAndFinalizeCurrentGraph(state))) return;
-
-          await this.createExploreGraph(wrappedAttrs);
+          if (!(await confirmAndFinalizeCurrentGraph(state))) return;
+          await createExploreGraph(graphIODeps);
         },
         onLoadRecentGraph: async (json: string) => {
-          // Show warning modal and finalize current graph before loading
-          if (!(await this.confirmAndFinalizeCurrentGraph(state))) return;
-          await this.loadStateFromJson(wrappedAttrs, json);
+          if (!(await confirmAndFinalizeCurrentGraph(state))) return;
+          await loadGraphFromJson(graphIODeps, state.rootNodes, json);
         },
         onFilterAdd: (node, filter, filterOperator) => {
-          this.handleFilterAdd(wrappedAttrs, node, filter, filterOperator);
+          addFilter(nodeCrudDeps, node, filter, filterOperator);
         },
         onColumnAdd: (node, column) => {
-          this.handleColumnAdd(wrappedAttrs, node, column);
+          addColumnFromJoinid(nodeCrudDeps, wrappedAttrs.state, node, column);
         },
         onNodeStateChange: () => {
           // Trigger a state update when node properties change (e.g., selecting group by columns)

--- a/ui/src/plugins/dev.perfetto.ExplorePage/graph_io.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/graph_io.ts
@@ -1,0 +1,237 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {assetSrc} from '../../base/assets';
+import {showModal} from '../../widgets/modal';
+import {Trace} from '../../public/trace';
+import {QueryNode} from './query_node';
+import {exportStateAsJson, deserializeState} from './json_handler';
+import {nodeRegistry} from './query_builder/node_registry';
+import {SlicesSourceNode} from './query_builder/nodes/sources/slices_source';
+import {
+  showStateOverwriteWarning,
+  showExportWarning,
+} from './query_builder/widgets';
+import {recentGraphsStorage} from './recent_graphs';
+import {ExplorePageState} from './explore_page';
+import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
+
+// Dependencies needed by graph I/O operations.
+export interface GraphIODeps {
+  readonly trace: Trace;
+  readonly sqlModules: SqlModules;
+  readonly onStateUpdate: (
+    update:
+      | ExplorePageState
+      | ((currentState: ExplorePageState) => ExplorePageState),
+  ) => void;
+  readonly cleanupExistingNodes: (rootNodes: QueryNode[]) => Promise<void>;
+}
+
+// Shows confirmation dialog if there are unsaved changes, and finalizes
+// the current graph before loading a new one. Returns true if the user
+// confirmed (or there was nothing to confirm), false if cancelled.
+export async function confirmAndFinalizeCurrentGraph(
+  state: ExplorePageState,
+): Promise<boolean> {
+  if (state.rootNodes.length > 0 || state.labels.length > 0) {
+    const confirmed = await showStateOverwriteWarning();
+    if (!confirmed) return false;
+    recentGraphsStorage.finalizeCurrentGraph();
+  }
+  return true;
+}
+
+export async function exportGraph(
+  state: ExplorePageState,
+  trace: Trace,
+): Promise<void> {
+  const confirmed = await showExportWarning();
+  if (!confirmed) return;
+  exportStateAsJson(state, trace);
+}
+
+// Common method to load state from a JSON string.
+// Handles cleanup of existing nodes and state update.
+export async function loadGraphFromJson(
+  deps: GraphIODeps,
+  currentRootNodes: QueryNode[],
+  json: string,
+): Promise<void> {
+  await deps.cleanupExistingNodes(currentRootNodes);
+
+  const newState = deserializeState(json, deps.trace, deps.sqlModules);
+  deps.onStateUpdate((currentState) => ({
+    ...newState,
+    loadGeneration: (currentState.loadGeneration ?? 0) + 1,
+  }));
+}
+
+export async function importGraph(
+  deps: GraphIODeps,
+  state: ExplorePageState,
+): Promise<void> {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = '.json';
+  input.onchange = async (event) => {
+    const files = (event.target as HTMLInputElement).files;
+    if (files && files.length > 0) {
+      const file = files[0];
+
+      if (!(await confirmAndFinalizeCurrentGraph(state))) return;
+
+      const reader = new FileReader();
+      reader.onload = async (e) => {
+        const json = e.target?.result as string;
+        if (!json) {
+          console.error('The selected file is empty or could not be read.');
+          return;
+        }
+        await loadGraphFromJson(deps, state.rootNodes, json);
+      };
+      reader.readAsText(file);
+    }
+  };
+  input.click();
+}
+
+// Centralized method to load JSON from a URL path.
+// Handles confirmation, fetching, and error handling.
+export async function loadGraphFromPath(
+  deps: GraphIODeps,
+  state: ExplorePageState,
+  jsonPath: string,
+  errorTitle: string = 'Failed to Load',
+): Promise<void> {
+  if (!(await confirmAndFinalizeCurrentGraph(state))) return;
+
+  try {
+    const response = await fetch(assetSrc(jsonPath));
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load: ${response.status} ${response.statusText}`,
+      );
+    }
+    const json = await response.text();
+    await loadGraphFromJson(deps, state.rootNodes, json);
+  } catch (error) {
+    console.error(`Failed to load from ${jsonPath}:`, error);
+    showModal({
+      title: errorTitle,
+      content: () =>
+        m(
+          'div',
+          `An error occurred while loading: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      buttons: [],
+    });
+  }
+}
+
+export async function initializeHighImportanceTables(
+  deps: GraphIODeps,
+  setHasAutoInitialized: (value: boolean) => void,
+): Promise<void> {
+  setHasAutoInitialized(true);
+
+  try {
+    const response = await fetch(
+      assetSrc('assets/explore_page/base-page.json'),
+    );
+    if (!response.ok) {
+      console.warn(
+        'Failed to load base page state, falling back to empty state',
+      );
+      return;
+    }
+    const json = await response.text();
+    const newState = deserializeState(json, deps.trace, deps.sqlModules);
+    deps.onStateUpdate((currentState) => ({
+      ...newState,
+      loadGeneration: (currentState.loadGeneration ?? 0) + 1,
+    }));
+  } catch (error) {
+    console.error('Failed to load base page state:', error);
+  }
+}
+
+export async function createExploreGraph(deps: GraphIODeps): Promise<void> {
+  const {sqlModules, trace} = deps;
+  const newNodes: QueryNode[] = [];
+
+  // Create slices source node
+  const slicesNode = new SlicesSourceNode({sqlModules, trace});
+  newNodes.push(slicesNode);
+
+  // Get high-frequency tables with data
+  const tableDescriptor = nodeRegistry.get('table');
+  if (tableDescriptor) {
+    const highFreqTables = sqlModules
+      .listTables()
+      .filter((table) => table.importance === 'high');
+
+    for (const sqlTable of highFreqTables) {
+      try {
+        const module = sqlModules.getModuleForTable(sqlTable.name);
+        if (module && sqlModules.isModuleDisabled(module.includeKey)) {
+          continue;
+        }
+
+        const tableNode = tableDescriptor.factory(
+          {sqlTable, sqlModules, trace},
+          {allNodes: newNodes},
+        );
+        newNodes.push(tableNode);
+      } catch (error) {
+        console.error(
+          `Failed to create table node for ${sqlTable.name}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  if (newNodes.length > 0) {
+    const totalNodes = newNodes.length;
+    const cols = Math.ceil(Math.sqrt(totalNodes));
+
+    const newNodeLayouts = new Map<string, {x: number; y: number}>();
+    const NODE_WIDTH = 300;
+    const NODE_HEIGHT = 200;
+    const GRID_PADDING_X = 10;
+    const GRID_PADDING_Y = 10;
+    const START_X = 50;
+    const START_Y = 50;
+
+    newNodes.forEach((node, index) => {
+      const col = index % cols;
+      const row = Math.floor(index / cols);
+      newNodeLayouts.set(node.nodeId, {
+        x: START_X + col * (NODE_WIDTH + GRID_PADDING_X),
+        y: START_Y + row * (NODE_HEIGHT + GRID_PADDING_Y),
+      });
+    });
+
+    deps.onStateUpdate((currentState) => ({
+      ...currentState,
+      rootNodes: newNodes,
+      nodeLayouts: newNodeLayouts,
+      selectedNodes: new Set([newNodes[0].nodeId]),
+      labels: [],
+      loadGeneration: (currentState.loadGeneration ?? 0) + 1,
+    }));
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/node_actions.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/node_actions.ts
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {QueryNode, NodeActions} from './query_node';
+
+// Handler functions that NodeActions delegates to.
+export interface NodeActionHandlers {
+  onAddAndConnectTable: (
+    tableName: string,
+    node: QueryNode,
+    portIndex: number,
+  ) => void;
+  onInsertNodeAtPort: (
+    node: QueryNode,
+    portIndex: number,
+    descriptorKey: string,
+  ) => void;
+}
+
+// Creates NodeActions for a node, delegating to the given handlers.
+export function createNodeActions(
+  node: QueryNode,
+  handlers: NodeActionHandlers,
+): NodeActions {
+  return {
+    onAddAndConnectTable: (tableName: string, portIndex: number) => {
+      handlers.onAddAndConnectTable(tableName, node, portIndex);
+    },
+    onInsertModifyColumnsNode: (portIndex: number) => {
+      handlers.onInsertNodeAtPort(node, portIndex, 'modify_columns');
+    },
+    onInsertCounterToIntervalsNode: (portIndex: number) => {
+      handlers.onInsertNodeAtPort(node, portIndex, 'counter_to_intervals');
+    },
+  };
+}
+
+// Creates NodeActions using a deferred node reference. Used when the node
+// hasn't been created yet (e.g., in handleAddOperationNode).
+export function createDeferredNodeActions(
+  nodeRef: {current?: QueryNode},
+  handlers: NodeActionHandlers,
+): NodeActions {
+  return {
+    onAddAndConnectTable: (tableName: string, portIndex: number) => {
+      if (nodeRef.current !== undefined) {
+        handlers.onAddAndConnectTable(tableName, nodeRef.current, portIndex);
+      }
+    },
+    onInsertModifyColumnsNode: (portIndex: number) => {
+      if (nodeRef.current !== undefined) {
+        handlers.onInsertNodeAtPort(
+          nodeRef.current,
+          portIndex,
+          'modify_columns',
+        );
+      }
+    },
+    onInsertCounterToIntervalsNode: (portIndex: number) => {
+      if (nodeRef.current !== undefined) {
+        handlers.onInsertNodeAtPort(
+          nodeRef.current,
+          portIndex,
+          'counter_to_intervals',
+        );
+      }
+    },
+  };
+}
+
+// Ensures all nodes have their actions initialized. Skips nodes that have
+// already been initialized (tracked by initializedNodes set).
+export function ensureAllNodeActions(
+  nodes: QueryNode[],
+  initializedNodes: Set<string>,
+  handlers: NodeActionHandlers,
+): void {
+  for (const node of nodes) {
+    if (initializedNodes.has(node.nodeId)) {
+      continue;
+    }
+    if (!node.state.actions) {
+      node.state.actions = createNodeActions(node, handlers);
+    }
+    initializedNodes.add(node.nodeId);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/node_actions_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/node_actions_unittest.ts
@@ -1,0 +1,212 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {QueryNode} from './query_node';
+import {
+  NodeActionHandlers,
+  createNodeActions,
+  createDeferredNodeActions,
+  ensureAllNodeActions,
+} from './node_actions';
+import {createMockNode} from './query_builder/testing/test_utils';
+
+describe('node_actions', () => {
+  let handlers: NodeActionHandlers;
+  let addAndConnectTableCalls: Array<{
+    tableName: string;
+    node: QueryNode;
+    portIndex: number;
+  }>;
+  let insertNodeAtPortCalls: Array<{
+    node: QueryNode;
+    portIndex: number;
+    descriptorKey: string;
+  }>;
+
+  beforeEach(() => {
+    addAndConnectTableCalls = [];
+    insertNodeAtPortCalls = [];
+    handlers = {
+      onAddAndConnectTable: (tableName, node, portIndex) => {
+        addAndConnectTableCalls.push({tableName, node, portIndex});
+      },
+      onInsertNodeAtPort: (node, portIndex, descriptorKey) => {
+        insertNodeAtPortCalls.push({node, portIndex, descriptorKey});
+      },
+    };
+  });
+
+  describe('createNodeActions', () => {
+    it('should delegate onAddAndConnectTable to handler with node', () => {
+      const node = createMockNode({nodeId: 'test-node'});
+      const actions = createNodeActions(node, handlers);
+
+      actions.onAddAndConnectTable?.('my_table', 2);
+
+      expect(addAndConnectTableCalls).toHaveLength(1);
+      expect(addAndConnectTableCalls[0].tableName).toBe('my_table');
+      expect(addAndConnectTableCalls[0].node).toBe(node);
+      expect(addAndConnectTableCalls[0].portIndex).toBe(2);
+    });
+
+    it('should delegate onInsertModifyColumnsNode with correct descriptor key', () => {
+      const node = createMockNode({nodeId: 'test-node'});
+      const actions = createNodeActions(node, handlers);
+
+      actions.onInsertModifyColumnsNode?.(1);
+
+      expect(insertNodeAtPortCalls).toHaveLength(1);
+      expect(insertNodeAtPortCalls[0].node).toBe(node);
+      expect(insertNodeAtPortCalls[0].portIndex).toBe(1);
+      expect(insertNodeAtPortCalls[0].descriptorKey).toBe('modify_columns');
+    });
+
+    it('should delegate onInsertCounterToIntervalsNode with correct descriptor key', () => {
+      const node = createMockNode({nodeId: 'test-node'});
+      const actions = createNodeActions(node, handlers);
+
+      actions.onInsertCounterToIntervalsNode?.(3);
+
+      expect(insertNodeAtPortCalls).toHaveLength(1);
+      expect(insertNodeAtPortCalls[0].node).toBe(node);
+      expect(insertNodeAtPortCalls[0].portIndex).toBe(3);
+      expect(insertNodeAtPortCalls[0].descriptorKey).toBe(
+        'counter_to_intervals',
+      );
+    });
+  });
+
+  describe('createDeferredNodeActions', () => {
+    it('should not call handler when nodeRef is empty', () => {
+      const nodeRef: {current?: QueryNode} = {};
+      const actions = createDeferredNodeActions(nodeRef, handlers);
+
+      actions.onAddAndConnectTable?.('my_table', 0);
+      actions.onInsertModifyColumnsNode?.(0);
+      actions.onInsertCounterToIntervalsNode?.(0);
+
+      expect(addAndConnectTableCalls).toHaveLength(0);
+      expect(insertNodeAtPortCalls).toHaveLength(0);
+    });
+
+    it('should delegate to handler once nodeRef is set', () => {
+      const nodeRef: {current?: QueryNode} = {};
+      const actions = createDeferredNodeActions(nodeRef, handlers);
+
+      // Set the node reference after creating actions
+      const node = createMockNode({nodeId: 'deferred-node'});
+      nodeRef.current = node;
+
+      actions.onAddAndConnectTable?.('table_a', 1);
+
+      expect(addAndConnectTableCalls).toHaveLength(1);
+      expect(addAndConnectTableCalls[0].node).toBe(node);
+      expect(addAndConnectTableCalls[0].tableName).toBe('table_a');
+      expect(addAndConnectTableCalls[0].portIndex).toBe(1);
+    });
+
+    it('should delegate onInsertModifyColumnsNode once nodeRef is set', () => {
+      const nodeRef: {current?: QueryNode} = {};
+      const actions = createDeferredNodeActions(nodeRef, handlers);
+
+      const node = createMockNode({nodeId: 'deferred-node'});
+      nodeRef.current = node;
+
+      actions.onInsertModifyColumnsNode?.(5);
+
+      expect(insertNodeAtPortCalls).toHaveLength(1);
+      expect(insertNodeAtPortCalls[0].node).toBe(node);
+      expect(insertNodeAtPortCalls[0].descriptorKey).toBe('modify_columns');
+    });
+
+    it('should delegate onInsertCounterToIntervalsNode once nodeRef is set', () => {
+      const nodeRef: {current?: QueryNode} = {};
+      const actions = createDeferredNodeActions(nodeRef, handlers);
+
+      const node = createMockNode({nodeId: 'deferred-node'});
+      nodeRef.current = node;
+
+      actions.onInsertCounterToIntervalsNode?.(7);
+
+      expect(insertNodeAtPortCalls).toHaveLength(1);
+      expect(insertNodeAtPortCalls[0].node).toBe(node);
+      expect(insertNodeAtPortCalls[0].descriptorKey).toBe(
+        'counter_to_intervals',
+      );
+    });
+  });
+
+  describe('ensureAllNodeActions', () => {
+    it('should assign actions to nodes that have none', () => {
+      const node1 = createMockNode({nodeId: 'n1'});
+      const node2 = createMockNode({nodeId: 'n2'});
+      const initializedNodes = new Set<string>();
+
+      ensureAllNodeActions([node1, node2], initializedNodes, handlers);
+
+      expect(node1.state.actions).toBeDefined();
+      expect(node2.state.actions).toBeDefined();
+      expect(initializedNodes.has('n1')).toBe(true);
+      expect(initializedNodes.has('n2')).toBe(true);
+    });
+
+    it('should skip nodes already in initializedNodes set', () => {
+      const node = createMockNode({nodeId: 'n1'});
+      const initializedNodes = new Set<string>(['n1']);
+
+      ensureAllNodeActions([node], initializedNodes, handlers);
+
+      // Actions should not be set because the node was already tracked
+      expect(node.state.actions).toBeUndefined();
+    });
+
+    it('should preserve existing actions on nodes', () => {
+      const existingActions = {
+        onAddAndConnectTable: () => {},
+      };
+      const node = createMockNode({
+        nodeId: 'n1',
+        state: {actions: existingActions},
+      });
+      const initializedNodes = new Set<string>();
+
+      ensureAllNodeActions([node], initializedNodes, handlers);
+
+      // Existing actions should be preserved (not overwritten)
+      expect(node.state.actions).toBe(existingActions);
+      // But node should still be marked as initialized
+      expect(initializedNodes.has('n1')).toBe(true);
+    });
+
+    it('should handle empty node array', () => {
+      const initializedNodes = new Set<string>();
+      ensureAllNodeActions([], initializedNodes, handlers);
+      expect(initializedNodes.size).toBe(0);
+    });
+
+    it('should create working actions that delegate to handlers', () => {
+      const node = createMockNode({nodeId: 'n1'});
+      const initializedNodes = new Set<string>();
+
+      ensureAllNodeActions([node], initializedNodes, handlers);
+
+      // The created actions should actually work
+      node.state.actions?.onAddAndConnectTable?.('test_table', 0);
+
+      expect(addAndConnectTableCalls).toHaveLength(1);
+      expect(addAndConnectTableCalls[0].tableName).toBe('test_table');
+      expect(addAndConnectTableCalls[0].node).toBe(node);
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/node_crud_operations.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/node_crud_operations.ts
@@ -1,0 +1,748 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Trace} from '../../public/trace';
+import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
+import type {CleanupManager} from './query_builder/cleanup_manager';
+import type {NodeActionHandlers} from './node_actions';
+import {createDeferredNodeActions} from './node_actions';
+import {QueryNode, QueryNodeState, singleNodeOperation} from './query_node';
+import {nodeRegistry, type PreCreateState} from './query_builder/node_registry';
+import {
+  getAllNodes,
+  insertNodeBetween,
+  getInputNodeAtPort,
+  getAllInputNodes,
+  findDockedChildren,
+  calculateUndockLayouts,
+  getEffectiveLayout,
+  addConnection,
+  removeConnection,
+  notifyNextNodes,
+  captureAllChildConnections,
+} from './query_builder/graph_utils';
+import {ExplorePageState} from './explore_page';
+
+// Dependencies needed by node CRUD operations.
+export interface NodeCrudDeps {
+  readonly trace: Trace;
+  readonly sqlModules: SqlModules;
+  readonly onStateUpdate: (
+    update:
+      | ExplorePageState
+      | ((currentState: ExplorePageState) => ExplorePageState),
+  ) => void;
+  readonly cleanupManager?: CleanupManager;
+  readonly initializedNodes: Set<string>;
+  readonly nodeActionHandlers: NodeActionHandlers;
+}
+
+// Gets the primary input parent of a node.
+// Returns undefined for source nodes and multi-source nodes.
+function getPrimaryParent(node: QueryNode): QueryNode | undefined {
+  if ('primaryInput' in node) {
+    return node.primaryInput;
+  }
+  return undefined;
+}
+
+// Disconnects a node from all its parents and children.
+function disconnectNodeFromGraph(node: QueryNode): void {
+  const allParents = getAllInputNodes(node);
+  for (const parent of allParents) {
+    removeConnection(parent, node);
+  }
+  const children = [...node.nextNodes];
+  for (const child of children) {
+    removeConnection(node, child);
+  }
+}
+
+// Cleans up all existing nodes (drops materialized tables) and clears
+// the initialized nodes set. Used when replacing the entire graph state.
+export async function cleanupExistingNodes(
+  cleanupManager: CleanupManager | undefined,
+  initializedNodes: Set<string>,
+  rootNodes: QueryNode[],
+): Promise<void> {
+  if (cleanupManager !== undefined) {
+    const allNodes = getAllNodes(rootNodes);
+    await cleanupManager.cleanupNodes(allNodes);
+  }
+  initializedNodes.clear();
+}
+
+export async function addOperationNode(
+  deps: NodeCrudDeps,
+  state: ExplorePageState,
+  parentNode: QueryNode,
+  derivedNodeId: string,
+): Promise<QueryNode | undefined> {
+  const descriptor = nodeRegistry.get(derivedNodeId);
+  if (descriptor) {
+    let initialState: PreCreateState | PreCreateState[] | null = {};
+    if (descriptor.preCreate) {
+      initialState = await descriptor.preCreate({
+        sqlModules: deps.sqlModules,
+      });
+    }
+
+    if (initialState === null) {
+      return;
+    }
+
+    // For operation nodes, we only support single node creation
+    // (multi-select only makes sense for source nodes)
+    if (Array.isArray(initialState)) {
+      console.warn(
+        'Operation nodes do not support multi-node creation from preCreate',
+      );
+      return;
+    }
+
+    // Use a wrapper object to hold the node reference (allows mutation without 'let')
+    const nodeRef: {current?: QueryNode} = {};
+
+    const nodeState: QueryNodeState = {
+      ...(initialState as Partial<QueryNodeState>),
+      sqlModules: deps.sqlModules,
+      trace: deps.trace,
+      // Provide actions for nodes that need to interact with the graph
+      // We use a deferred pattern because the node doesn't exist yet
+      actions: createDeferredNodeActions(nodeRef, deps.nodeActionHandlers),
+    };
+
+    const newNode = descriptor.factory(nodeState, {
+      allNodes: state.rootNodes,
+    });
+
+    // Set the reference so the callback can use it
+    nodeRef.current = newNode;
+
+    // Mark this node as initialized
+    deps.initializedNodes.add(newNode.nodeId);
+
+    if (singleNodeOperation(newNode.type)) {
+      // For single-input operations: insert between the target and its children
+      insertNodeBetween(parentNode, newNode, addConnection, removeConnection);
+
+      deps.onStateUpdate((currentState) => ({
+        ...currentState,
+        selectedNodes: new Set([newNode.nodeId]),
+      }));
+    } else {
+      // For multi-source nodes: just connect and add to root nodes
+      // Don't insert in-between - the node combines multiple sources
+
+      // Undock docked children before adding (docking requires exactly one child)
+      const dockedChildren = findDockedChildren(parentNode, state.nodeLayouts);
+
+      addConnection(parentNode, newNode);
+
+      deps.onStateUpdate((currentState) => {
+        const updatedLayouts = new Map(currentState.nodeLayouts);
+
+        // Undock existing docked children by giving them layouts.
+        // Use getEffectiveLayout to handle the case where the parent node is
+        // itself docked (no direct layout) - we walk up the chain to find
+        // the first ancestor with a layout.
+        const effectiveLayout = getEffectiveLayout(
+          parentNode,
+          currentState.nodeLayouts,
+        );
+        if (effectiveLayout !== undefined && dockedChildren.length > 0) {
+          const undockLayouts = calculateUndockLayouts(
+            dockedChildren,
+            effectiveLayout,
+          );
+          for (const [nodeId, layout] of undockLayouts) {
+            updatedLayouts.set(nodeId, layout);
+          }
+        }
+
+        return {
+          ...currentState,
+          rootNodes: [...currentState.rootNodes, newNode],
+          nodeLayouts: updatedLayouts,
+          selectedNodes: new Set([newNode.nodeId]),
+        };
+      });
+    }
+
+    return newNode;
+  }
+
+  console.warn(
+    `Cannot add operation node: unknown type '${derivedNodeId}' for source node ${parentNode.nodeId}`,
+  );
+  return undefined;
+}
+
+export async function addSourceNode(
+  deps: NodeCrudDeps,
+  state: ExplorePageState,
+  id: string,
+): Promise<void> {
+  const descriptor = nodeRegistry.get(id);
+  if (!descriptor) {
+    console.warn(`Cannot add source node: unknown node type '${id}'`);
+    return;
+  }
+
+  let initialState: PreCreateState | PreCreateState[] | null = {};
+
+  if (descriptor.preCreate) {
+    initialState = await descriptor.preCreate({sqlModules: deps.sqlModules});
+  }
+
+  // User cancelled the preCreate dialog
+  if (initialState === null) {
+    return;
+  }
+
+  // Handle both single node and multi-node creation
+  const statesToCreate = Array.isArray(initialState)
+    ? initialState
+    : [initialState];
+
+  const newNodes: QueryNode[] = [];
+  for (const stateItem of statesToCreate) {
+    try {
+      const newNode = descriptor.factory(
+        {
+          ...stateItem,
+          trace: deps.trace,
+          sqlModules: deps.sqlModules,
+        } as QueryNodeState,
+        {allNodes: state.rootNodes},
+      );
+      newNodes.push(newNode);
+    } catch (error) {
+      console.error('Failed to create node:', error);
+      // Continue creating other nodes even if one fails
+    }
+  }
+
+  // If no nodes were successfully created, return early
+  // (errors were already logged in the try-catch above)
+  if (newNodes.length === 0) {
+    console.warn('No nodes were created from the preCreate result');
+    return;
+  }
+
+  const lastNode = newNodes[newNodes.length - 1];
+  deps.onStateUpdate((currentState) => ({
+    ...currentState,
+    rootNodes: [...currentState.rootNodes, ...newNodes],
+    selectedNodes: new Set([lastNode.nodeId]),
+  }));
+}
+
+export async function addAndConnectTable(
+  deps: NodeCrudDeps,
+  state: ExplorePageState,
+  tableName: string,
+  targetNode: QueryNode,
+  portIndex: number,
+): Promise<void> {
+  // Get the table descriptor
+  const descriptor = nodeRegistry.get('table');
+  if (!descriptor) {
+    console.warn("Cannot add table: 'table' node type not found in registry");
+    return;
+  }
+
+  // Find the table in SQL modules
+  const sqlTable = deps.sqlModules
+    .listTables()
+    .find((t) => t.name === tableName);
+  if (!sqlTable) {
+    console.warn(`Table ${tableName} not found in SQL modules`);
+    return;
+  }
+
+  // Create the table node with the specific table (bypass the modal)
+  const newNode = descriptor.factory(
+    {
+      sqlTable,
+      sqlModules: deps.sqlModules,
+      trace: deps.trace,
+    },
+    {allNodes: state.rootNodes},
+  );
+
+  // Add connection from the new table node to the target node
+  addConnection(newNode, targetNode, portIndex);
+
+  // Add the new node to root nodes
+  deps.onStateUpdate((currentState) => ({
+    ...currentState,
+    rootNodes: [...currentState.rootNodes, newNode],
+  }));
+}
+
+export async function insertNodeAtPort(
+  deps: NodeCrudDeps,
+  state: ExplorePageState,
+  targetNode: QueryNode,
+  portIndex: number,
+  descriptorKey: string,
+): Promise<void> {
+  const descriptor = nodeRegistry.get(descriptorKey);
+  if (!descriptor) {
+    console.warn(
+      `Cannot insert ${descriptorKey} node: '${descriptorKey}' not found in registry`,
+    );
+    return;
+  }
+
+  const inputNode = getInputNodeAtPort(targetNode, portIndex);
+  if (!inputNode) {
+    console.warn(`No input node found at port ${portIndex}`);
+    return;
+  }
+
+  const newNode = descriptor.factory(
+    {
+      sqlModules: deps.sqlModules,
+      trace: deps.trace,
+    },
+    {allNodes: state.rootNodes},
+  );
+
+  removeConnection(inputNode, targetNode);
+  addConnection(inputNode, newNode);
+  addConnection(newNode, targetNode, portIndex);
+
+  deps.onStateUpdate((currentState) => ({
+    ...currentState,
+    rootNodes: [...currentState.rootNodes, newNode],
+    selectedNodes: new Set([newNode.nodeId]),
+  }));
+}
+
+export async function deleteNode(
+  deps: NodeCrudDeps,
+  state: ExplorePageState,
+  node: QueryNode,
+): Promise<void> {
+  // STEP 1: Clean up resources (SQL tables, JS subscriptions, etc.)
+  if (deps.cleanupManager !== undefined) {
+    try {
+      await deps.cleanupManager.cleanupNode(node);
+    } catch (error) {
+      // Log error but continue with deletion
+      console.error('Failed to cleanup node resources:', error);
+    }
+  }
+
+  // STEP 2: Capture graph structure BEFORE modification
+  // We need to capture this info before removeConnection() clears the references
+  const primaryParent = getPrimaryParent(node);
+  const childConnections = captureAllChildConnections(node);
+  const allInputs = getAllInputNodes(node); // Capture ALL parents (primary + secondary)
+
+  // STEP 3: Remove the node from the graph
+  disconnectNodeFromGraph(node);
+
+  // STEP 4: Reconnect primary parent to children (if exists)
+  // This bypasses the deleted node, maintaining data flow for PRIMARY connections only.
+  //
+  // IMPORTANT RULES:
+  // 1. Only reconnect if deleted node fed child's PRIMARY input (portIndex === undefined)
+  // 2. Secondary connections are specific to the deleted node - DROP them, don't reconnect
+  // 3. Skip reconnection if parent is already connected to avoid duplicates
+  // 4. Transfer deleted node's layout to docked children so they can render at same position
+  const reconnectedChildren: QueryNode[] = [];
+  const updatedNodeLayouts = new Map(state.nodeLayouts);
+  const deletedNodeLayout = state.nodeLayouts.get(node.nodeId);
+
+  if (primaryParent !== undefined) {
+    let layoutOffsetCount = 0;
+    for (const {child, portIndex} of childConnections) {
+      // If deleted node fed child's secondary input, DROP the connection
+      // Secondary inputs are specific to the deleted node (e.g., intervals for FilterDuring)
+      if (portIndex !== undefined) {
+        continue; // Don't reconnect secondary connections
+      }
+
+      // Check if parent is already connected to this child
+      if (primaryParent.nextNodes.includes(child)) {
+        continue; // Already connected - don't create duplicates
+      }
+
+      // Reconnect: maintain primary data flow (A → B → C becomes A → C)
+      addConnection(primaryParent, child, portIndex);
+      reconnectedChildren.push(child);
+
+      // If child was docked (no layout) and deleted node had a layout,
+      // transfer the layout to the child so it renders at the same position
+      // For multiple children, offset their positions to avoid overlapping
+      const childHasNoLayout = !state.nodeLayouts.has(child.nodeId);
+      if (childHasNoLayout && deletedNodeLayout !== undefined) {
+        const offsetX = layoutOffsetCount * 30; // Offset each child by 30px
+        const offsetY = layoutOffsetCount * 30;
+        updatedNodeLayouts.set(child.nodeId, {
+          x: deletedNodeLayout.x + offsetX,
+          y: deletedNodeLayout.y + offsetY,
+        });
+        layoutOffsetCount++;
+      }
+    }
+  }
+
+  // STEP 4b: Check if reconnected children can actually be rendered
+  // A child becomes "unrenderable" if:
+  // - It was reconnected to a parent
+  // - It has no layout (was docked to deleted node)
+  // - Parent has multiple children (can't render as docked anymore)
+  const unrenderableChildren: QueryNode[] = [];
+  if (primaryParent !== undefined && reconnectedChildren.length > 0) {
+    const parentHasMultipleChildren = primaryParent.nextNodes.length > 1;
+    for (const child of reconnectedChildren) {
+      // Check the UPDATED layouts, not the old state
+      const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
+      // If child has no layout and parent has multiple children,
+      // the child can't be rendered (not as docked, not as root)
+      if (childHasNoLayout && parentHasMultipleChildren) {
+        unrenderableChildren.push(child);
+      }
+    }
+  }
+
+  // STEP 5: Update root nodes list
+  // Use a Set to prevent duplicate root nodes
+  const newRootNodesSet = new Set(state.rootNodes.filter((n) => n !== node));
+
+  // Add orphaned children to root nodes so they remain visible
+  // Children are orphaned ONLY if:
+  // 1. There was no primary parent to reconnect them to, AND
+  // 2. They were connected via PRIMARY input (not secondary)
+  // Children connected via secondary input still have their own primary parent!
+  if (primaryParent === undefined && childConnections.length > 0) {
+    // Only children connected via primary input are truly orphaned
+    const orphanedChildren = childConnections
+      .filter((c) => c.portIndex === undefined) // Primary input only
+      .map((c) => c.child);
+
+    for (const child of orphanedChildren) {
+      newRootNodesSet.add(child);
+    }
+
+    // Transfer deleted node's layout to orphaned children so they appear at same position
+    // For multiple children, offset their positions to avoid overlapping
+    if (deletedNodeLayout !== undefined) {
+      let layoutOffsetCount = 0;
+      for (const child of orphanedChildren) {
+        const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
+        if (childHasNoLayout) {
+          const offsetX = layoutOffsetCount * 30; // Offset each child by 30px
+          const offsetY = layoutOffsetCount * 30;
+          updatedNodeLayouts.set(child.nodeId, {
+            x: deletedNodeLayout.x + offsetX,
+            y: deletedNodeLayout.y + offsetY,
+          });
+          layoutOffsetCount++;
+        }
+      }
+    }
+  }
+
+  // Add unrenderable children to root nodes so they become visible
+  // These are children that were reconnected but can't be rendered as docked
+  for (const child of unrenderableChildren) {
+    newRootNodesSet.add(child);
+  }
+
+  // STEP 5b: Promote orphaned input providers to root nodes
+  // Simple rule: If a node was NOT a root node, and we deleted the node that
+  // consumed it, then it should become a root node.
+  const orphanedInputs: QueryNode[] = [];
+  for (const inputNode of allInputs) {
+    // Check if this input node becomes orphaned:
+    // 1. It was NOT originally a root node
+    // 2. After deletion, it has no consumers (nextNodes is empty)
+    const wasNotRoot = !state.rootNodes.includes(inputNode);
+    const hasNoConsumers = inputNode.nextNodes.length === 0;
+
+    if (wasNotRoot && hasNoConsumers) {
+      orphanedInputs.push(inputNode);
+    }
+  }
+
+  for (const inputNode of orphanedInputs) {
+    newRootNodesSet.add(inputNode);
+  }
+
+  const newRootNodes = Array.from(newRootNodesSet);
+
+  // STEP 5c: Remove the deleted node's layout from the map
+  // Now that we've transferred the layout to children/orphans, clean it up
+  updatedNodeLayouts.delete(node.nodeId);
+
+  // STEP 6: Trigger validation on affected children
+  // Children need to re-validate because their inputs have changed
+  // (either reconnected to a different parent or lost their parent entirely)
+  for (const {child} of childConnections) {
+    child.onPrevNodesUpdated?.();
+  }
+
+  // Also notify orphaned input providers that their consumers changed
+  for (const inputNode of orphanedInputs) {
+    notifyNextNodes(inputNode);
+  }
+
+  // STEP 7: Commit state changes
+  deps.onStateUpdate((currentState) => {
+    // Update selection based on current state (not stale state)
+    // This is important for multi-node deletion where state changes between deletions
+    const newSelectedNodes = new Set(currentState.selectedNodes);
+    newSelectedNodes.delete(node.nodeId);
+
+    return {
+      ...currentState,
+      rootNodes: newRootNodes,
+      selectedNodes: newSelectedNodes,
+      nodeLayouts: updatedNodeLayouts,
+    };
+  });
+}
+
+// Delete all currently selected nodes.
+// Batches all deletions into a single state update to create one undo point.
+export async function deleteSelectedNodes(
+  deps: NodeCrudDeps,
+  state: ExplorePageState,
+): Promise<void> {
+  const selectedNodeIds = new Set(state.selectedNodes);
+
+  if (selectedNodeIds.size === 0) {
+    return;
+  }
+
+  // Get all nodes to delete
+  const allNodes = getAllNodes(state.rootNodes);
+  const nodesToDelete = allNodes.filter((n) => selectedNodeIds.has(n.nodeId));
+
+  if (nodesToDelete.length === 0) {
+    return;
+  }
+
+  // STEP 1: Clean up resources for all nodes (async operations)
+  if (deps.cleanupManager !== undefined) {
+    for (const node of nodesToDelete) {
+      try {
+        await deps.cleanupManager.cleanupNode(node);
+      } catch (error) {
+        console.error('Failed to cleanup node resources:', error);
+      }
+    }
+  }
+
+  // STEP 2: Capture graph info and perform all deletions in a single state update
+  deps.onStateUpdate((currentState) => {
+    const nodesToDeleteSet = new Set(nodesToDelete);
+    const updatedNodeLayouts = new Map(currentState.nodeLayouts);
+    const newRootNodesSet = new Set(currentState.rootNodes);
+    const affectedChildren: QueryNode[] = [];
+    const orphanedInputs: QueryNode[] = [];
+
+    // Process each node deletion
+    for (const node of nodesToDelete) {
+      // Capture info before disconnection
+      const primaryParent = getPrimaryParent(node);
+      const childConnections = captureAllChildConnections(node);
+      const allInputs = getAllInputNodes(node);
+
+      // Disconnect from graph
+      disconnectNodeFromGraph(node);
+
+      // Remove from root nodes
+      newRootNodesSet.delete(node);
+
+      // Remove layout
+      const deletedNodeLayout = updatedNodeLayouts.get(node.nodeId);
+      updatedNodeLayouts.delete(node.nodeId);
+
+      // Reconnect primary parent to children (if parent is not also being deleted)
+      if (primaryParent !== undefined && !nodesToDeleteSet.has(primaryParent)) {
+        let layoutOffsetCount = 0;
+        for (const {child, portIndex} of childConnections) {
+          // Skip if child is also being deleted
+          if (nodesToDeleteSet.has(child)) {
+            continue;
+          }
+
+          // Only reconnect primary connections
+          if (portIndex === undefined) {
+            if (!primaryParent.nextNodes.includes(child)) {
+              addConnection(primaryParent, child, portIndex);
+              affectedChildren.push(child);
+
+              // Transfer layout if child was docked
+              const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
+              if (childHasNoLayout && deletedNodeLayout !== undefined) {
+                const offsetX = layoutOffsetCount * 30;
+                const offsetY = layoutOffsetCount * 30;
+                updatedNodeLayouts.set(child.nodeId, {
+                  x: deletedNodeLayout.x + offsetX,
+                  y: deletedNodeLayout.y + offsetY,
+                });
+                layoutOffsetCount++;
+              }
+            }
+          }
+        }
+      }
+
+      // Handle orphaned children (no parent or parent was deleted)
+      if (primaryParent === undefined || nodesToDeleteSet.has(primaryParent)) {
+        let layoutOffsetCount = 0;
+        for (const {child, portIndex} of childConnections) {
+          // Skip if child is also being deleted
+          if (nodesToDeleteSet.has(child)) {
+            continue;
+          }
+
+          // Only orphan primary connections
+          if (portIndex === undefined) {
+            newRootNodesSet.add(child);
+            affectedChildren.push(child);
+
+            // Transfer layout
+            const childHasNoLayout = !updatedNodeLayouts.has(child.nodeId);
+            if (childHasNoLayout && deletedNodeLayout !== undefined) {
+              const offsetX = layoutOffsetCount * 30;
+              const offsetY = layoutOffsetCount * 30;
+              updatedNodeLayouts.set(child.nodeId, {
+                x: deletedNodeLayout.x + offsetX,
+                y: deletedNodeLayout.y + offsetY,
+              });
+              layoutOffsetCount++;
+            }
+          }
+        }
+      }
+
+      // Handle orphaned input providers
+      for (const inputNode of allInputs) {
+        // Skip if input is also being deleted
+        if (nodesToDeleteSet.has(inputNode)) {
+          continue;
+        }
+
+        const wasNotRoot = !currentState.rootNodes.includes(inputNode);
+        const hasNoConsumers = inputNode.nextNodes.length === 0;
+
+        if (wasNotRoot && hasNoConsumers) {
+          newRootNodesSet.add(inputNode);
+          orphanedInputs.push(inputNode);
+        }
+      }
+    }
+
+    // Trigger validation on affected nodes
+    for (const child of affectedChildren) {
+      child.onPrevNodesUpdated?.();
+    }
+    for (const inputNode of orphanedInputs) {
+      notifyNextNodes(inputNode);
+    }
+
+    // Clear selection
+    return {
+      ...currentState,
+      rootNodes: Array.from(newRootNodesSet),
+      selectedNodes: new Set<string>(),
+      nodeLayouts: updatedNodeLayouts,
+    };
+  });
+}
+
+export async function clearAllNodes(
+  deps: NodeCrudDeps,
+  state: ExplorePageState,
+): Promise<void> {
+  await cleanupExistingNodes(
+    deps.cleanupManager,
+    deps.initializedNodes,
+    state.rootNodes,
+  );
+
+  deps.onStateUpdate((currentState) => ({
+    ...currentState,
+    rootNodes: [],
+    selectedNodes: new Set(),
+    nodeLayouts: new Map(),
+    labels: [],
+  }));
+}
+
+export function duplicateNode(
+  onStateUpdate: (
+    update: (currentState: ExplorePageState) => ExplorePageState,
+  ) => void,
+  node: QueryNode,
+): void {
+  onStateUpdate((currentState) => ({
+    ...currentState,
+    rootNodes: [...currentState.rootNodes, node.clone()],
+  }));
+}
+
+export function removeNodeConnection(
+  state: ExplorePageState,
+  onStateUpdate: (
+    update: (currentState: ExplorePageState) => ExplorePageState,
+  ) => void,
+  fromNode: QueryNode,
+  toNode: QueryNode,
+  isSecondaryInput: boolean,
+): void {
+  // NOTE: The basic connection removal is already handled by graph.ts
+  // This callback handles higher-level logic like reconnection and state updates
+
+  // Only reconnect fromNode to toNode's children when removing a PRIMARY input.
+  // When removing a SECONDARY input, we should NOT reconnect - the secondary
+  // input node is just an auxiliary input (like intervals for FilterDuring)
+  // and should not be connected to the children of the node it was feeding into.
+  const shouldReconnect =
+    !isSecondaryInput &&
+    fromNode.nextNodes.length === 0 &&
+    toNode.nextNodes.length > 0;
+
+  if (shouldReconnect) {
+    // Reconnect fromNode to all of toNode's children (bypass toNode)
+    for (const child of toNode.nextNodes) {
+      addConnection(fromNode, child);
+    }
+  }
+
+  // Handle state updates based on node type
+  if ('primaryInput' in toNode && toNode.primaryInput === undefined) {
+    // toNode is a ModificationNode that's now orphaned
+    // Add it to rootNodes so it remains visible (but invalid)
+    const newRootNodes = state.rootNodes.includes(toNode)
+      ? state.rootNodes
+      : [...state.rootNodes, toNode];
+
+    onStateUpdate((currentState) => ({
+      ...currentState,
+      rootNodes: newRootNodes,
+    }));
+  } else if ('secondaryInputs' in toNode) {
+    // toNode is a MultiSourceNode - just trigger a state update
+    onStateUpdate((currentState) => ({...currentState}));
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -95,12 +95,9 @@ function shouldShowTopPort(node: QueryNode): boolean {
 // GRAPH ATTRIBUTES INTERFACE
 // ========================================
 
-export interface GraphAttrs {
-  readonly rootNodes: QueryNode[];
-  readonly selectedNodes: ReadonlySet<string>;
-  readonly nodeLayouts: LayoutMap;
-  readonly labels: ReadonlyArray<TextLabelData>;
-  readonly loadGeneration?: number;
+// Callbacks shared between BuilderAttrs and GraphAttrs.
+// Builder forwards these to Graph without transformation.
+export interface GraphCallbacks {
   readonly onNodeSelected: (node: QueryNode) => void;
   readonly onNodeAddToSelection: (node: QueryNode) => void;
   readonly onNodeRemoveFromSelection: (nodeId: string) => void;
@@ -119,6 +116,14 @@ export interface GraphAttrs {
   ) => void;
   readonly onImport: () => void;
   readonly onExport: () => void;
+}
+
+export interface GraphAttrs extends GraphCallbacks {
+  readonly rootNodes: QueryNode[];
+  readonly selectedNodes: ReadonlySet<string>;
+  readonly nodeLayouts: LayoutMap;
+  readonly labels: ReadonlyArray<TextLabelData>;
+  readonly loadGeneration?: number;
 }
 
 // ========================================


### PR DESCRIPTION
Decomposes the monolithic `explore_page.ts` (~1600 lines) into focused pure-function
modules with explicit dependency injection, improving testability, readability, and
separation of concerns. The file is reduced to ~560 lines while retaining its
orchestration role.

## Changes

- **`clipboard_operations.ts`** — Extract `copySelectedNodes()` and `pasteClipboardNodes()`
  as pure functions operating on minimal state interfaces (`CopyableState`, `PastableState`)
- **`datagrid_node_creation.ts`** — Extract datagrid-triggered node creation (`addFilter`,
  `addColumnFromJoinid`, `parseJoinidColumnField`, `findMatchingAddColumnsNode`)
- **`node_crud_operations.ts`** — Extract node add/delete/duplicate/connect/disconnect
  operations with a `NodeCrudDeps` interface
- **`graph_io.ts`** — Extract import/export, JSON loading, template initialization, and
  explore graph creation with a `GraphIODeps` interface
- **`node_actions.ts`** — Extract `NodeActions` wiring into `createNodeActions()`,
  `createDeferredNodeActions()`, and `ensureAllNodeActions()`; unify
  `handleInsertModifyColumnsNode`/`handleInsertCounterToIntervalsNode` into a single
  generic `insertNodeAtPort()` function
- **`GraphCallbacks` interface** — Group 14 graph callbacks in `graph.ts`, passed as a
  single `graphCallbacks` field through `BuilderAttrs`, eliminating manual forwarding
- Add comprehensive unit tests for `clipboard_operations`, `datagrid_node_creation`,
  and `node_actions`
- Update architecture design doc to reflect the new modular structure
