### PR TITLE
de: Enable children set control

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -556,4 +556,29 @@ export function registerCoreNodes() {
         sqlModules,
       }),
   });
+
+  // Set the default allowed children for all nodes.
+  // This is the full set of modification + multisource nodes, matching the
+  // current behavior. Individual node registrations can override this by
+  // setting allowedChildren on their descriptor.
+  nodeRegistry.setDefaultAllowedChildren([
+    // Modification nodes
+    'add_columns',
+    'modify_columns',
+    'aggregation',
+    'filter_node',
+    'counter_to_intervals',
+    'sort_node',
+    'limit_and_offset_node',
+    // Multisource nodes
+    'filter_during',
+    'filter_in',
+    'interval_intersect',
+    'join',
+    'create_slices',
+    'union_node',
+  ]);
+
+  // Validate that all allowedChildren references point to registered nodes.
+  nodeRegistry.validateAllowedChildren();
 }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -56,6 +56,7 @@ import {createEditableTextLabels} from './text_label';
 import {QueryNode, singleNodeOperation, NodeType} from '../../query_node';
 import {NodeBox} from './node_box';
 import {buildMenuItems} from './menu_utils';
+import {nodeRegistry} from '../node_registry';
 import {
   getAllNodes,
   findNodeById,
@@ -210,20 +211,39 @@ function buildAddMenuItems(
   targetNode: QueryNode,
   onAddOperationNode: (id: string, node: QueryNode) => void,
 ): m.Children[] {
-  const multisourceItems = buildMenuItems('multisource', (id) =>
-    onAddOperationNode(id, targetNode),
+  const allowedChildren = nodeRegistry.getAllowedChildrenFor(targetNode.type);
+  if (allowedChildren.length === 0) {
+    return [];
+  }
+
+  const multisourceItems = buildMenuItems(
+    'multisource',
+    (id) => onAddOperationNode(id, targetNode),
+    allowedChildren,
   );
-  const modificationItems = buildMenuItems('modification', (id) =>
-    onAddOperationNode(id, targetNode),
+  const modificationItems = buildMenuItems(
+    'modification',
+    (id) => onAddOperationNode(id, targetNode),
+    allowedChildren,
   );
 
-  return [
-    m(MenuTitle, {label: 'Modification nodes'}),
-    ...modificationItems,
-    m(MenuDivider),
-    m(MenuTitle, {label: 'Operations'}),
-    ...multisourceItems,
-  ];
+  if (modificationItems.length === 0 && multisourceItems.length === 0) {
+    return [];
+  }
+
+  const menuItems: m.Children[] = [];
+  if (modificationItems.length > 0) {
+    menuItems.push(m(MenuTitle, {label: 'Modification nodes'}));
+    menuItems.push(...modificationItems);
+  }
+  if (modificationItems.length > 0 && multisourceItems.length > 0) {
+    menuItems.push(m(MenuDivider));
+  }
+  if (multisourceItems.length > 0) {
+    menuItems.push(m(MenuTitle, {label: 'Operations'}));
+    menuItems.push(...multisourceItems);
+  }
+  return menuItems;
 }
 
 // ========================================
@@ -383,17 +403,24 @@ function createNodeConfig(
   attrs: GraphAttrs,
 ): Omit<Node, 'x' | 'y'> {
   const canDockTop = shouldShowTopPort(qnode);
+  const addMenuItems = buildAddMenuItems(qnode, attrs.onAddOperationNode);
+  const outputs: NodePort[] =
+    addMenuItems.length > 0
+      ? [
+          {
+            content: 'Output',
+            direction: 'bottom',
+            contextMenuItems: addMenuItems,
+          },
+        ]
+      : nodeRegistry.getAllowedChildrenFor(qnode.type).length > 0
+        ? [{content: 'Output', direction: 'bottom'}]
+        : [];
 
   return {
     id: qnode.nodeId,
     inputs: getInputLabels(qnode),
-    outputs: [
-      {
-        content: 'Output',
-        direction: 'bottom',
-        contextMenuItems: buildAddMenuItems(qnode, attrs.onAddOperationNode),
-      },
-    ],
+    outputs,
     canDockBottom: true,
     canDockTop,
     hue: getNodeHue(qnode),
@@ -537,6 +564,10 @@ function handleConnect(conn: Connection, rootNodes: QueryNode[]): void {
     console.warn(
       `Cannot create connection: node not found (from: ${conn.fromNode}, to: ${conn.toNode})`,
     );
+    return;
+  }
+
+  if (!nodeRegistry.isConnectionAllowed(fromNode.type, toNode.type)) {
     return;
   }
 
@@ -971,6 +1002,17 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
               console.warn(
                 'Cannot dock: only single-node operations can be docked',
               );
+              m.redraw();
+              return;
+            }
+
+            // Check if the child node type is allowed as a child of the parent
+            if (
+              !nodeRegistry.isConnectionAllowed(
+                parentNode.type,
+                childQueryNode.type,
+              )
+            ) {
               m.redraw();
               return;
             }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
@@ -27,10 +27,15 @@ import {Keycap} from '../../../../widgets/hotkey_glyphs';
 export function buildMenuItems(
   nodeType: 'source' | 'multisource' | 'modification',
   onAddNode: (id: string) => void,
+  allowedIds?: ReadonlyArray<string>,
 ): m.Children[] {
   const nodes = nodeRegistry
     .list()
-    .filter(([_id, descriptor]) => descriptor.type === nodeType);
+    .filter(([_id, descriptor]) => descriptor.type === nodeType)
+    .filter(
+      ([id, _descriptor]) =>
+        allowedIds === undefined || allowedIds.includes(id),
+    );
 
   return buildCategorizedMenuItems(nodes, onAddNode);
 }


### PR DESCRIPTION
Each register node can only have some well defined nodes as children. Add support for it. This change is a noop, it will enable future changes, for nodes like Metrics node (the only child is the Summary node)