### PR TITLE
traced: load gzipped descriptors from /etc on Android

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -19827,7 +19827,6 @@ cc_test {
         "bionic_libc_platform_headers",
     ],
     data: [
-        "protos/perfetto/trace/track_event/track_event_extensions.json",
         "src/profiling/memory/test/data/**/*",
         "src/traced/probes/filesystem/testdata/**/*",
         "src/traced/probes/ftrace/test/data/**/*",

--- a/include/perfetto/ext/tracing/core/tracing_service.h
+++ b/include/perfetto/ext/tracing/core/tracing_service.h
@@ -315,6 +315,20 @@ struct PERFETTO_EXPORT_COMPONENT TracingServiceInitOpts {
 
   // Whether the relay endpoint is enabled on producer transport(s).
   bool enable_relay_endpoint = false;
+
+  // An (optional) list of proto extension descriptors to dump into each trace
+  // recorded. This is to support injecting protos that are known by the
+  // embedder (e.g. the Android vendor image) but not by the upstream perfetto.
+  // See RFC-0017.
+  struct ProtoExtensionDescriptor {
+    std::string name;
+    const uint8_t* start = nullptr;
+    size_t size = 0;
+    bool gzipped = false;
+  };
+  // The caller owns the pointed memory (typically a mmaped file or a .rodata
+  // section) and must guarantee that it is indefinitely lived.
+  std::vector<ProtoExtensionDescriptor> extension_descriptors;
 };
 
 // The API for the Relay port of the Service. Subclassed by the

--- a/protos/perfetto/trace/extension_descriptor.proto
+++ b/protos/perfetto/trace/extension_descriptor.proto
@@ -25,5 +25,16 @@ import "protos/perfetto/common/descriptor.proto";
 //
 // See docs/design-docs/extensions.md for more details.
 message ExtensionDescriptor {
-  optional FileDescriptorSet extension_set = 1;
+  oneof descriptor {
+    FileDescriptorSet extension_set = 1;
+
+    // Same as extension_set, but gzip-compressed. This is used by the tracing
+    // service on Android to emit pre-compressed descriptor files from
+    // /etc/tracing_descriptors.gz without decompressing them first.
+    bytes extension_set_gzip = 2;
+  }
+
+  // Optional, for debugging only. The file name or path of the descriptor
+  // source. Can be omitted without affecting functionality.
+  optional string file_name = 3;
 }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -8539,7 +8539,18 @@ message OneofOptions {
 //
 // See docs/design-docs/extensions.md for more details.
 message ExtensionDescriptor {
-  optional FileDescriptorSet extension_set = 1;
+  oneof descriptor {
+    FileDescriptorSet extension_set = 1;
+
+    // Same as extension_set, but gzip-compressed. This is used by the tracing
+    // service on Android to emit pre-compressed descriptor files from
+    // /etc/tracing_descriptors.gz without decompressing them first.
+    bytes extension_set_gzip = 2;
+  }
+
+  // Optional, for debugging only. The file name or path of the descriptor
+  // source. Can be omitted without affecting functionality.
+  optional string file_name = 3;
 }
 
 // End of protos/perfetto/trace/extension_descriptor.proto

--- a/protos/perfetto/trace/track_event/track_event_extensions.json
+++ b/protos/perfetto/trace/track_event/track_event_extensions.json
@@ -1,6 +1,6 @@
 {
   "scope": "perfetto.protos.TrackEvent",
-  "range": [1000, 9999],
+  "range": [1000, 10000],
   "allocations": [
     {
       "name": "chromium",
@@ -17,8 +17,19 @@
       "proto": "base/tracing/protos/chrome_track_event.proto"
     },
     {
+      "name": "meepl",
+      "range": [2000, 2000],
+      "contact": "jannewger@google.com",
+      "comment": ["TODO(primiano): Cannot find the definition of the ",
+                  "extension proto anywhere. Contacted the owner on the ",
+                  "original bug on 2026-02-17."],
+      "description": "b/301227627",
+      "repo": "unknown",
+      "proto": "unknown"
+    },
+    {
       "name": "android_system",
-      "range": [2000, 2999],
+      "range": [2001, 2999],
       "contact": "perfetto-dev@googlegroups.com",
       "comment": ["TODO(primiano): moved these into the Android tree and ",
                   "create sub-registries there."],
@@ -27,12 +38,11 @@
     },
     {
       "name": "unallocated",
-      "comment": ["The next allocation goes here. Shrink and take from here."],
-      "range": [3000, 8999]
+      "range": [3000, 9899]
     },
     {
       "name": "perfetto_tests",
-      "range": [9000, 9999],
+      "range": [9900, 10000],
       "contact": "perfetto-dev@googlegroups.com",
       "description": "Reserved for Perfetto unit and integration tests",
       "proto": "protos/perfetto/trace/test_extensions.proto"

--- a/src/tools/tracing_proto_extensions_unittest.cc
+++ b/src/tools/tracing_proto_extensions_unittest.cc
@@ -18,7 +18,6 @@
 
 #include "perfetto/base/status.h"
 #include "src/base/test/tmp_dir_tree.h"
-#include "src/base/test/utils.h"
 #include "test/gtest_and_gmock.h"
 
 namespace perfetto {
@@ -382,9 +381,9 @@ TEST(GenProtoExtensionsTest, GenerateExtensionDescriptorsNoExtend) {
 TEST(GenProtoExtensionsTest, GenerateExtensionDescriptorsWithTestProto) {
   // This test uses the real test_extensions.proto from the repo.
   // It requires proto include paths to work.
-  std::string proto_path = base::GetTestDataPath(
-      "protos/perfetto/trace/track_event/track_event_extensions.json");
-  auto result = GenerateExtensionDescriptors(proto_path, {"."}, ".");
+  auto result = GenerateExtensionDescriptors(
+      "protos/perfetto/trace/track_event/track_event_extensions.json", {"."},
+      ".");
   // This should succeed for local protos (test_extensions.proto and
   // android_track_event.proto). Remote entries (chromium) are skipped.
   ASSERT_TRUE(result.ok()) << result.status().message();

--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -57,6 +57,7 @@
 #include "src/trace_processor/types/trace_processor_context.h"
 #include "src/trace_processor/types/variadic.h"
 #include "src/trace_processor/util/descriptors.h"
+#include "src/trace_processor/util/gzip_utils.h"
 
 #include "protos/perfetto/common/builtin_clock.pbzero.h"
 #include "protos/perfetto/common/trace_stats.pbzero.h"
@@ -195,9 +196,29 @@ base::Status ProtoTraceReader::ParseExtensionDescriptor(ConstBytes descriptor) {
   protos::pbzero::ExtensionDescriptor::Decoder decoder(descriptor.data,
                                                        descriptor.size);
 
-  auto extension = decoder.extension_set();
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+  std::vector<uint8_t> decompressed;
+  if (decoder.has_extension_set()) {
+    auto extension = decoder.extension_set();
+    data = extension.data;
+    size = extension.size;
+  } else if (decoder.has_extension_set_gzip()) {
+    auto gzipped = decoder.extension_set_gzip();
+    decompressed =
+        util::GzipDecompressor::DecompressFully(gzipped.data, gzipped.size);
+    if (decompressed.empty()) {
+      return base::ErrStatus(
+          "Failed to decompress gzipped extension descriptor");
+    }
+    data = decompressed.data();
+    size = decompressed.size();
+  } else {
+    return base::OkStatus();
+  }
+
   return context_->descriptor_pool_->AddFromFileDescriptorSet(
-      extension.data, extension.size,
+      data, size,
       /*skip_prefixes*/ {},
       /*merge_existing_messages=*/true);
 }

--- a/src/traced/service/service.cc
+++ b/src/traced/service/service.cc
@@ -22,6 +22,7 @@
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/getopt.h"
 #include "perfetto/ext/base/lock_free_task_runner.h"
+#include "perfetto/ext/base/scoped_mmap.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/unix_socket.h"
 #include "perfetto/ext/base/utils.h"
@@ -136,6 +137,23 @@ int PERFETTO_EXPORT_ENTRYPOINT ServiceMain(int argc, char** argv) {
 #if PERFETTO_BUILDFLAG(PERFETTO_ZLIB)
   init_opts.compressor_fn = &ZlibCompressFn;
 #endif
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+  // See /rfcs/0017-out-of-tree-protos.md .
+  std::vector<base::ScopedMmap> extension_descriptor_mmaps;
+  for (const char* path :
+       {"/etc/tracing_descriptors.gz", "/vendor/etc/tracing_descriptors.gz"}) {
+    auto mm = base::ReadMmapWholeFile(path);
+    if (!mm.IsValid())
+      continue;
+    PERFETTO_DLOG("Loaded extension descriptor: %s (%zu bytes)", path,
+                  mm.length());
+    init_opts.extension_descriptors.push_back(
+        {path, reinterpret_cast_cast<const uint8_t*>(mm.data()), mm.length(),
+         /*gzipped=*/true});
+    extension_descriptor_mmaps.push_back(std::move(mm));
+  }
+#endif
+
   std::string relay_producer_socket;
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
   relay_producer_socket = base::GetAndroidProp("traced.relay_producer_port");

--- a/src/tracing/service/tracing_service_impl.h
+++ b/src/tracing/service/tracing_service_impl.h
@@ -271,6 +271,7 @@ class TracingServiceImpl : public TracingService {
   void MaybeEmitReceivedTriggers(TracingSession*, std::vector<TracePacket>*);
   void MaybeEmitRemoteClockSync(TracingSession*, std::vector<TracePacket>*);
   void MaybeEmitProtoVmInstances(TracingSession*, std::vector<TracePacket>*);
+  void EmitExtensionDescriptors(TracingSession*, std::vector<TracePacket>*);
   void MaybeNotifyAllDataSourcesStarted(TracingSession*);
   void OnFlushTimeout(TracingSessionID, FlushRequestID, FlushFlags);
   void OnDisableTracingTimeout(TracingSessionID);

--- a/tools/test_data.txt
+++ b/tools/test_data.txt
@@ -3,7 +3,6 @@
 # The trailing /. at the end of a directory is to avoid creating a nesting
 # directory when pushing a 2nd-time. adb push has a slightly different behavior
 # than `cp` on directoriesm, trailing slash is not enough.
-protos/perfetto/trace/track_event/track_event_extensions.json
 src/profiling/memory/test/data/.
 src/traced/probes/filesystem/testdata/.
 src/traced/probes/ftrace/test/data/.


### PR DESCRIPTION
Support out-of-tree protos, see RFC-0017 on
https://github.com/google/perfetto/discussions/4783
Also add parsing in TraceProcessor


```
Stack:
├─ #4833 (oot_protos)
  ├─ **[This PR] (traced_descr)**
```