### PR TITLE
de: Fix the 'query doesn't exist' bug on empty tables

### DIFF
--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -441,21 +441,19 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
         Summarizer* summarizer = summarizer_ptr->get();
         SummarizerQueryResult query_result;
         base::Status status = summarizer->Query(query_id, &query_result);
+        result->set_exists(query_result.exists);
         if (!status.ok()) {
           result->set_error(status.message());
-        } else {
-          result->set_exists(query_result.exists);
-          if (query_result.exists) {
-            result->set_table_name(query_result.table_name);
-            result->set_row_count(query_result.row_count);
-            for (const auto& col : query_result.columns) {
-              result->add_columns(col);
-            }
-            result->set_duration_ms(query_result.duration_ms);
-            result->set_sql(query_result.sql);
-            result->set_textproto(query_result.textproto);
-            result->set_standalone_sql(query_result.standalone_sql);
+        } else if (query_result.exists) {
+          result->set_table_name(query_result.table_name);
+          result->set_row_count(query_result.row_count);
+          for (const auto& col : query_result.columns) {
+            result->add_columns(col);
           }
+          result->set_duration_ms(query_result.duration_ms);
+          result->set_sql(query_result.sql);
+          result->set_textproto(query_result.textproto);
+          result->set_standalone_sql(query_result.standalone_sql);
         }
       }
       resp.Send(rpc_response_fn_);


### PR DESCRIPTION
Fix two bugs that caused module-based tables (e.g. `android_binder_txns`) to
show a generic "Query result not found" error in the Data Explorer instead of
working correctly.

## Changes
- **rpc.cc**: Always set `exists` in the query summarizer RPC response,
  regardless of whether materialization succeeded or failed. Previously
  `exists` was only set in the success branch, which caused the UI to show
  a generic "not found" error instead of the real error message.
- **structured_query_generator.cc**: Extract `referenced_modules` and
  `table.module_name` from the proto in `AddQuery()`, so that
  `ComputeReferencedModules()` returns the correct modules before
  `Generate()` is called. Without this, `PrepareGenerator()` never included
  any modules, causing "no such table" errors for all module-based tables.