### PR TITLE
Enable Windows support for libperfetto_c in Android

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1033,6 +1033,16 @@ cc_library {
                 "perfetto_flags_c_lib",
             ],
         },
+        windows: {
+            enabled: true,
+            cflags: [
+                "-Wno-shift-count-overflow",
+                "-Wno-unknown-pragmas",
+            ],
+            host_ldlibs: [
+                "-lws2_32",
+            ],
+        },
     },
 }
 

--- a/include/perfetto/ext/base/sys_types.h
+++ b/include/perfetto/ext/base/sys_types.h
@@ -27,6 +27,13 @@
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
 
+#ifdef __MINGW32__
+
+using uid_t = int;
+using gid_t = int;
+
+#else
+
 #if !PERFETTO_BUILDFLAG(PERFETTO_COMPILER_GCC)
 // MinGW has these. clang-cl and MSVC, which use just the Windows SDK, don't.
 using uid_t = int;
@@ -39,6 +46,8 @@ using ssize_t = int64_t;
 #else
 using ssize_t = long;
 #endif  // _WIN64
+
+#endif  // __MINGW32__
 
 #endif  // OS_WIN
 

--- a/tools/gen_android_bp
+++ b/tools/gen_android_bp
@@ -333,6 +333,14 @@ additional_args = {
         ('min_sdk_version', '30'),
         ('export_include_dirs', {'include'}),
         ('cflags', {'-DPERFETTO_SHLIB_SDK_IMPLEMENTATION'}),
+        ('windows', {
+            'enabled': True,
+            'cflags': [
+                '-Wno-shift-count-overflow',
+                '-Wno-unknown-pragmas',
+            ],
+            'host_ldlibs': ['-lws2_32'],
+        }),
     ],
     'perfetto_trace_protos': [
         ('apex_available', {
@@ -570,16 +578,20 @@ class Target(object):
     self.static_libs = set()
     self.whole_static_libs = set()
     self.cflags = set()
+    self.host_ldlibs = set()
+    self.enabled = None
     self.dist = dict()
     self.strip = dict()
     self.stl = None
 
   def to_string(self, output):
     nested_out = []
+    self._output_field(nested_out, 'enabled')
     self._output_field(nested_out, 'shared_libs')
     self._output_field(nested_out, 'static_libs')
     self._output_field(nested_out, 'whole_static_libs')
     self._output_field(nested_out, 'cflags')
+    self._output_field(nested_out, 'host_ldlibs')
     self._output_field(nested_out, 'stl')
     self._output_field(nested_out, 'dist')
     self._output_field(nested_out, 'strip')
@@ -629,6 +641,7 @@ class Module(object):
     self.tool_files: Optional[List[str]] = None
     self.android = Target('android')
     self.host = Target('host')
+    self.windows = Target('windows')
     self.musl = Target('musl')
     self.lto: Optional[bool] = None
     self.stl = None
@@ -709,6 +722,7 @@ class Module(object):
     target_out = []
     self._output_field(target_out, 'android')
     self._output_field(target_out, 'host')
+    self._output_field(target_out, 'windows')
     self._output_field(target_out, 'musl')
     if target_out:
       output.append('    target: {')


### PR DESCRIPTION
Add support for the 'windows' target to tools/gen_android_bp and update Android.bp to include Windows-specific flags and libraries. This allows building Perfetto components for Windows using the Android build system.

Also:
- Refactor src/base/ctrl_c_handler.cc to use a named trampoline function for the console control handler on Windows, which is more robust than a lambda.
- Update include/perfetto/ext/base/sys_types.h to correctly define POSIX-style types (uid_t, gid_t, pid_t, ssize_t) when building on Windows, providing compatibility for both MinGW and MSVC/clang-cl.
