### PR TITLE
heapprofd: add PERFETTO_HEAPPROFD_BLOCKING_EXIT env variable

### DIFF
--- a/docs/data-sources/native-heap-profiler.md
+++ b/docs/data-sources/native-heap-profiler.md
@@ -504,6 +504,11 @@ these can be missed. To avoid this from happening, set the enironment variable
 be blocked until heapprofd initializes fully but means every allocation will
 be correctly tracked.
 
+Similarly, short-lived processes may exit before heapprofd finishes reading and
+unwinding all pending stacks. Set `PERFETTO_HEAPPROFD_BLOCKING_EXIT=1` to
+register an atexit handler that waits for heapprofd to drain the shared ring
+buffer before the process exits.
+
 ## Known Issues
 
 ### {#known-issues-android13} Android 13

--- a/docs/getting-started/memory-profiling.md
+++ b/docs/getting-started/memory-profiling.md
@@ -189,6 +189,7 @@ Open another terminal (or tab), start the process you want to profile,
 preloading the heapprofd's .so. Example:
 ```bash
 PERFETTO_HEAPPROFD_BLOCKING_INIT=1 \
+PERFETTO_HEAPPROFD_BLOCKING_EXIT=1 \
 LD_PRELOAD=out/lnx/libheapprofd_glibc_preload.so \
 trace_processor_shell /dev/null
 
@@ -202,6 +203,11 @@ these can be missed. To avoid this from happening, set the enironment variable
 `PERFETTO_HEAPPROFD_BLOCKING_INIT=1`; on the first malloc, your program will
 be blocked until heapprofd initializes fully but means every allocation will
 be correctly tracked.
+
+Similarly, short-lived processes may exit before heapprofd finishes reading and
+unwinding all pending stacks. Set `PERFETTO_HEAPPROFD_BLOCKING_EXIT=1` to
+register an atexit handler that waits for heapprofd to drain the shared ring
+buffer before the process exits.
 
 At this point:
 

--- a/src/profiling/memory/client.h
+++ b/src/profiling/memory/client.h
@@ -114,6 +114,7 @@ class Client {
     return client_config_.adaptive_sampling_max_sampling_interval_bytes;
   }
   uint64_t write_avail() { return shmem_.write_avail(); }
+  size_t read_avail() { return shmem_.read_avail(); }
 
   bool IsConnected();
 

--- a/src/profiling/memory/client_api.cc
+++ b/src/profiling/memory/client_api.cc
@@ -32,6 +32,7 @@
 
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
+#include "perfetto/base/time.h"
 #include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/unix_socket.h"
 #include "perfetto/ext/base/utils.h"
@@ -278,6 +279,30 @@ void AtForkChild() {
   // allocate, which should be the case for all implementations as the
   // constructor has to be noexcept.
   new (g_client_arr) std::shared_ptr<perfetto::profiling::Client>();
+}
+
+// Atexit handler that waits for heapprofd to finish reading and unwinding all
+// pending stacks from the shared ring buffer. Without this, short-lived
+// processes can exit before heapprofd finishes unwinding, causing
+// ERROR MEMORY_INVALID in the resulting trace.
+void AtExitDrain() {
+  std::shared_ptr<perfetto::profiling::Client> client;
+  {
+    ScopedSpinlock s(&g_client_lock, ScopedSpinlock::Mode::Try);
+    if (PERFETTO_UNLIKELY(!s.locked()))
+      return;
+    client = *GetClientLocked();
+  }
+  if (!client)
+    return;
+
+  constexpr uint32_t kTimeoutUs = 10000 * 1000;
+  constexpr uint32_t kSleepUs = 10 * 1000;
+  uint32_t elapsed_us = 0;
+  while (client->read_avail() > 0 && elapsed_us < kTimeoutUs) {
+    perfetto::base::SleepMicroseconds(kSleepUs);
+    elapsed_us += kSleepUs;
+  }
 }
 
 }  // namespace
@@ -585,4 +610,13 @@ __attribute__((visibility("default"))) bool AHeapProfile_initSession(
   }
 
   return true;
+}
+
+bool AHeapProfile_initSessionWithBlockingExit(void* (*malloc_fn)(size_t),
+                                              void (*free_fn)(void*)) {
+  static std::atomic<bool> registered{false};
+  if (!registered.exchange(true)) {
+    atexit(AtExitDrain);
+  }
+  return AHeapProfile_initSession(malloc_fn, free_fn);
 }

--- a/src/profiling/memory/client_api_factory_standalone.cc
+++ b/src/profiling/memory/client_api_factory_standalone.cc
@@ -50,6 +50,7 @@ namespace profiling {
 namespace {
 
 base::UnixSocketRaw* g_client_sock;
+bool g_blocking_exit = false;
 
 bool MonitorFdOnce() {
   char buf[1];
@@ -62,7 +63,11 @@ bool MonitorFdOnce() {
     PERFETTO_PLOG("Receive failed.");
     return true;
   }
-  AHeapProfile_initSession(malloc, free);
+  if (g_blocking_exit) {
+    AHeapProfile_initSessionWithBlockingExit(malloc, free);
+  } else {
+    AHeapProfile_initSession(malloc, free);
+  }
   return true;
 }
 
@@ -109,6 +114,9 @@ void StartHeapprofdIfStatic() {
       PERFETTO_PLOG("waitpid");
 
     *g_client_sock = std::move(cli_sock);
+
+    const char* e = getenv("PERFETTO_HEAPPROFD_BLOCKING_EXIT");
+    g_blocking_exit = e && e[0] == '1';
 
     const char* w = getenv("PERFETTO_HEAPPROFD_BLOCKING_INIT");
     if (w && w[0] == '1') {

--- a/src/profiling/memory/heap_profile_internal.h
+++ b/src/profiling/memory/heap_profile_internal.h
@@ -39,6 +39,13 @@ extern "C" {
 bool AHeapProfile_initSession(void* _Nullable (*_Nonnull malloc_fn)(size_t),
                               void (*_Nonnull free_fn)(void* _Nullable));
 
+// Like AHeapProfile_initSession, but also registers an atexit handler that
+// waits for heapprofd to drain pending stacks before the process exits.
+// Not part of the public ABI; only used by the standalone client.
+bool AHeapProfile_initSessionWithBlockingExit(
+    void* _Nullable (*_Nonnull malloc_fn)(size_t),
+    void (*_Nonnull free_fn)(void* _Nullable));
+
 #ifdef __cplusplus
 }
 #endif

--- a/tools/measure_tp_performance.py
+++ b/tools/measure_tp_performance.py
@@ -93,7 +93,8 @@ def heap_profile_run(args, dump_at_max: bool):
   env = {
       'LD_PRELOAD': os.path.join(args.out, 'libheapprofd_glibc_preload.so'),
       'TRACE_PROCESSOR_NO_MMAP': '1',
-      'PERFETTO_HEAPPROFD_BLOCKING_INIT': '1'
+      'PERFETTO_HEAPPROFD_BLOCKING_INIT': '1',
+      'PERFETTO_HEAPPROFD_BLOCKING_EXIT': '1'
   }
   (tp, fail, _) = run_tp_until_ingestion(args, env)
 


### PR DESCRIPTION
Short-lived processes can exit before heapprofd finishes reading and
unwinding all pending stacks from the shared ring buffer, causing
ERROR MEMORY_INVALID in the resulting trace.

Add a new PERFETTO_HEAPPROFD_BLOCKING_EXIT=1 environment variable
that registers an atexit handler to wait (up to 10s) for heapprofd
to drain the ring buffer before the process exits. This is independent
of PERFETTO_HEAPPROFD_BLOCKING_INIT which controls blocking on first
malloc for initialization.

Fixes: https://github.com/google/perfetto/issues/4801