### PR TITLE
presubmit: Don't silently fail on checks

### DIFF
--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -347,8 +347,8 @@ def CheckIncludeViolations(changed_files: List[str]) -> List[str]:
     run_command([sys.executable, tool], cwd=REPO_ROOT)
   except FileNotFoundError:
     return [f"Tool not found: {tool}"]
-  except subprocess.CalledProcessError:
-    return [f'{tool} failed.']
+  except subprocess.CalledProcessError as e:
+    return [f'{tool} failed:\n{e.stdout}']
   return []
 
 
@@ -422,8 +422,8 @@ def CheckProtoComments(changed_files: List[str]) -> List[str]:
     run_command([sys.executable, tool], cwd=REPO_ROOT)
   except FileNotFoundError:
     return [f"Tool not found: {tool}"]
-  except subprocess.CalledProcessError:
-    return [f'{tool} failed']
+  except subprocess.CalledProcessError as e:
+    return [f'{tool} failed:\n{e.stdout}']
   return []
 
 
@@ -694,8 +694,8 @@ def CheckSqlModules(changed_files: List[str]) -> List[str]:
         cwd=REPO_ROOT)
   except FileNotFoundError:
     return [f"Tool not found: {tool}"]
-  except subprocess.CalledProcessError:
-    return [f'{tool} failed']
+  except subprocess.CalledProcessError as e:
+    return [f'{tool} failed:\n{e.stdout}']
   return []
 
 
@@ -721,8 +721,8 @@ def CheckSqlMetrics(changed_files: List[str]) -> List[str]:
     run_command([sys.executable, tool], cwd=REPO_ROOT)
   except FileNotFoundError:
     return [f"Tool not found: {tool}"]
-  except subprocess.CalledProcessError:
-    return [f'{tool} failed']
+  except subprocess.CalledProcessError as e:
+    return [f'{tool} failed:\n{e.stdout}']
   return []
 
 


### PR DESCRIPTION
Presubmit runs a few helper scripts, such as tools/check_sql_modules.py. However, the failures of those scripts aren't printed, and for something like the check_sql_modules.py, there extra arguments needed to fully replicate what run_presubmit uses (e.g. --check-includes).

Print stdout of scripts on error so that it is  obvious what the issue is.

Signed-off-by: Samuel Wu [wusamuel@google.com](mailto:wusamuel@google.com)