### PR TITLE
sdtlib: add new tracks to memory_breakdown module

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/memory_breakdown.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/memory_breakdown.sql
@@ -21,26 +21,46 @@ INCLUDE PERFETTO MODULE counters.intervals;
 -- Create a table containing intervals of memory counters values, adjusted to process lifetime.
 CREATE PERFETTO TABLE _memory_breakdown_mem_intervals_raw AS
 WITH
-  -- We deny tracks that have large swings in value
-  -- This can happen because of rss_stat accounting issue: see b/418231246 for details.
+  sched_bounds AS (
+    SELECT
+      min(ts) AS min_ts,
+      max(ts + dur) AS max_ts
+    FROM sched
+  ),
+  trace_limits AS (
+    SELECT
+      coalesce(sb.min_ts, trace_start()) AS start_ts,
+      coalesce(sb.max_ts, trace_end()) AS end_ts
+    FROM sched_bounds AS sb
+  ),
   mem_process_counter_tracks AS (
     SELECT
       id,
-      name,
+      iif(name = 'Heap size (KB)', 'mem.heap', name) AS name,
       upid
     FROM process_counter_track
     WHERE
-      name IN ('mem.rss.anon', 'mem.swap', 'mem.rss.file')
+      name IN ('mem.rss.anon', 'mem.swap', 'mem.rss.file', 'mem.rss.shmem', 'Heap size (KB)', 'mem.dmabuf_rss', 'mem.locked', 'GPU Memory')
   ),
   mem_counters AS (
     SELECT
       c.id,
       c.ts,
       c.track_id,
-      c.value
+      iif(name = 'mem.heap', cast_int!(c.value) * 1024, cast_int!(c.value)) AS value
     FROM counter AS c
     JOIN mem_process_counter_tracks AS t
       ON c.track_id = t.id
+    WHERE
+      c.ts BETWEEN (
+        SELECT
+          start_ts
+        FROM trace_limits
+      ) AND (
+        SELECT
+          end_ts
+        FROM trace_limits
+      )
   ),
   mem_intervals AS (
     SELECT
@@ -51,6 +71,8 @@ WITH
       delta_value
     FROM counter_leading_intervals!(mem_counters)
   ),
+  -- We deny tracks that have large swings in value
+  -- This can happen because of rss_stat accounting issue: see b/418231246 for details.
   denied_tracks AS (
     SELECT DISTINCT
       track_id
@@ -68,6 +90,7 @@ WITH
       p.start_ts,
       p.end_ts,
       t.name AS track_name,
+      i.track_id,
       i.value
     FROM mem_intervals AS i
     JOIN mem_process_counter_tracks AS t
@@ -86,6 +109,7 @@ SELECT
   min(raw_end_ts, coalesce(end_ts, raw_end_ts)) - max(ts, coalesce(start_ts, ts)) AS dur,
   upid,
   track_name,
+  track_id,
   value
 FROM mem_intervals_with_process_lifetime
 -- Only keep rows where the clipping resulted in a positive duration.
@@ -97,46 +121,69 @@ WHERE
 -- Create a table containing intervals of OOM adjustment scores.
 -- This table will be used as the right side of a span join.
 CREATE PERFETTO TABLE _memory_breakdown_oom_intervals_prepared AS
+WITH
+  process_mem_track_ids AS (
+    SELECT
+      track_id,
+      upid
+    FROM _memory_breakdown_mem_intervals_raw
+    GROUP BY
+      track_id,
+      upid
+  )
 SELECT
-  ts,
-  dur,
-  upid,
-  bucket
-FROM android_oom_adj_intervals
+  t.track_id,
+  o.ts,
+  o.dur,
+  o.bucket
+FROM android_oom_adj_intervals AS o
+JOIN process_mem_track_ids AS t
+  USING (upid)
 WHERE
-  dur > 0;
+  o.dur > 0;
 
--- Create a virtual table that joins memory counter intervals with OOM
--- adjustment score intervals.
 CREATE VIRTUAL TABLE _memory_breakdown_mem_oom_span_join USING SPAN_LEFT_JOIN (
-  _memory_breakdown_mem_intervals_raw PARTITIONED upid,
-  _memory_breakdown_oom_intervals_prepared PARTITIONED upid
+  _memory_breakdown_mem_intervals_raw PARTITIONED track_id,
+  _memory_breakdown_oom_intervals_prepared PARTITIONED track_id
 );
 
 -- Create a table containing memory counter intervals with OOM buckets.
 CREATE PERFETTO TABLE _memory_breakdown_mem_with_buckets AS
 WITH
   -- Get the baseline values for RSS anon and swap from the zygote process.
+  zygote_upid AS (
+    SELECT
+      upid
+    FROM process
+    -- TODO: improve zygote process detection
+    WHERE
+      name IN ('zygote', 'zygote64', 'webview_zygote')
+  ),
+  zygote_tracks AS (
+    SELECT
+      iif(t.name = 'Heap size (KB)', 'mem.heap', t.name) AS track_name,
+      t.id AS track_id
+    FROM process_counter_track AS t
+    JOIN zygote_upid AS z
+      USING (upid)
+    WHERE
+      t.name IN ('mem.rss.anon', 'mem.swap', 'mem.rss.file', 'Heap size (KB)')
+  ),
   zygote_baseline AS (
     SELECT
       max(CASE WHEN track_name = 'mem.rss.anon' THEN avg_val END) AS rss_anon_base,
       max(CASE WHEN track_name = 'mem.swap' THEN avg_val END) AS swap_base,
-      max(CASE WHEN track_name = 'mem.rss.file' THEN avg_val END) AS rss_file_base
+      max(CASE WHEN track_name = 'mem.rss.file' THEN avg_val END) AS rss_file_base,
+      max(CASE WHEN track_name = 'mem.heap' THEN avg_val END) AS heap_base
     FROM (
       SELECT
-        t.name AS track_name,
-        avg(c.value) AS avg_val
+        z.track_name,
+        avg(iif(z.track_name = 'mem.heap', cast_int!(c.value) * 1024, cast_int!(c.value))) AS avg_val
       FROM counter AS c
-      JOIN process_counter_track AS t
-        ON c.track_id = t.id
-      JOIN process AS p
-        USING (upid)
-      WHERE
-        -- TODO: improve zygote process detection
-        p.name IN ('zygote', 'zygote64', 'webview_zygote')
-        AND t.name IN ('mem.rss.anon', 'mem.swap', 'mem.rss.file')
+      JOIN zygote_tracks AS z
+        USING (track_id)
       GROUP BY
-        t.name
+        z.track_name
     )
   ),
   mem_with_zygote_baseline AS (
@@ -149,6 +196,8 @@ WITH
         THEN b.swap_base
         WHEN track_name = 'mem.rss.file'
         THEN b.rss_file_base
+        WHEN track_name = 'mem.heap'
+        THEN b.heap_base
         ELSE 0
       END AS zygote_baseline_value
     FROM _memory_breakdown_mem_oom_span_join AS s
@@ -159,17 +208,17 @@ SELECT
   ts,
   dur,
   track_name,
-  app.name AS process_name,
+  p.name AS process_name,
   upid,
   pid,
   coalesce(bucket, 'unknown') AS bucket,
   CASE
-    WHEN app.upid IS NOT NULL
+    WHEN NOT p.upid IS NULL AND NOT p.name IN ('zygote', 'zygote64', 'webview_zygote')
     THEN max(0, cast_int!(value) - cast_int!(IFNULL(zygote_baseline_value, 0)))
     ELSE cast_int!(value)
   END AS zygote_adjusted_value
 FROM mem_with_zygote_baseline
-LEFT JOIN process AS app
+LEFT JOIN process AS p
   USING (upid)
 WHERE
   dur > 0;


### PR DESCRIPTION
This change adds new memory counter tracks to the memory_breakdown module: mem.heap ('Heap size (KB)'), mem.rss.shmem, mem.dmabuf_rss, mem.locked and 'GPU Memory'.

For each process mem.heap is adjusted with the zygote's mem.heap value.

Additional:
- filtered counters to be within trace limits (sched_bounds or trace_bounds)
- fixed bug with span_left_join and overlapping intervals
- slightly improved performance of memory_breakdown.sql
