### PR TITLE
ui: Separate assert* from logging

### DIFF
--- a/ui/src/base/array_buffer_builder.ts
+++ b/ui/src/base/array_buffer_builder.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {length as utf8Len, write as utf8Write} from '@protobufjs/utf8';
-import {assertTrue} from '../base/logging';
+import {assertTrue} from '../base/assert';
 import {isString} from '../base/object_utils';
 
 // A token that can be appended to an `ArrayBufferBuilder`.

--- a/ui/src/base/assert.ts
+++ b/ui/src/base/assert.ts
@@ -1,0 +1,77 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Assertion utilities for runtime validation and TypeScript type narrowing.
+//
+// These functions provide fail-fast semantics: if an assertion fails, an
+// exception is thrown immediately. This makes bugs easier to catch and debug
+// by surfacing issues at the point of failure rather than propagating invalid
+// state.
+//
+// In addition to runtime checks, these assertions help TypeScript narrow types.
+// For example, after calling assertExists(x), TypeScript knows x is non-null.
+
+export function assertExists<A>(
+  value: A | null | undefined,
+  optMsg?: string,
+): A {
+  if (value === null || value === undefined) {
+    throw new Error(optMsg ?? 'Value is null or undefined');
+  }
+  return value;
+}
+
+// assertExists trips over NULLs, but in many contexts NULL is a valid SQL value
+// we have to work with.
+export function assertDefined<T>(value: T | undefined, optMsg?: string): T {
+  if (value === undefined) {
+    throw new Error(optMsg ?? 'Value is undefined');
+  }
+  return value;
+}
+
+export function assertIsInstance<T>(
+  value: unknown,
+  clazz: Function,
+  optMsg?: string,
+): T {
+  assertTrue(
+    value instanceof clazz,
+    optMsg ?? `Value is not an instance of ${clazz.name}`,
+  );
+  return value as T;
+}
+
+export function assertTrue(value: boolean, optMsg?: string) {
+  if (!value) {
+    throw new Error(optMsg ?? 'Failed assertion');
+  }
+}
+
+export function assertFalse(value: boolean, optMsg?: string) {
+  assertTrue(!value, optMsg);
+}
+
+// This function serves two purposes.
+// 1) A runtime check - if we are ever called, we throw an exception.
+// This is useful for checking that code we suspect should never be reached is
+// actually never reached.
+// 2) A compile time check where typescript asserts that the value passed can be
+// cast to the "never" type.
+// This is useful for ensuring we exhaustively check union types.
+export function assertUnreachable(value: never, optMsg?: string): never {
+  throw new Error(
+    optMsg ?? `This code should not be reachable ${value as unknown}`,
+  );
+}

--- a/ui/src/base/bezier_arrow.ts
+++ b/ui/src/base/bezier_arrow.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {Point2D, Vector2D} from './geom';
-import {assertUnreachable} from './logging';
+import {assertUnreachable} from './assert';
 
 export type CardinalDirection = 'north' | 'south' | 'east' | 'west';
 

--- a/ui/src/base/high_precision_time.ts
+++ b/ui/src/base/high_precision_time.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertUnreachable} from './logging';
+import {assertUnreachable} from './assert';
 import {Time, time} from './time';
 
 export type RoundMode = 'round' | 'floor' | 'ceil';

--- a/ui/src/base/http_utils.ts
+++ b/ui/src/base/http_utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from './logging';
+import {assertTrue} from './assert';
 
 export function fetchWithTimeout(
   input: RequestInfo,

--- a/ui/src/base/logging.ts
+++ b/ui/src/base/logging.ts
@@ -29,57 +29,6 @@ export interface ErrorDetails {
 export type ErrorHandler = (err: ErrorDetails) => void;
 const errorHandlers: ErrorHandler[] = [];
 
-export function assertExists<A>(
-  value: A | null | undefined,
-  optMsg?: string,
-): A {
-  if (value === null || value === undefined) {
-    throw new Error(optMsg ?? "Value doesn't exist");
-  }
-  return value;
-}
-
-// assertExists trips over NULLs, but in many contexts NULL is a valid SQL value we have to work with.
-export function assertDefined<T>(value: T | undefined): T {
-  if (value === undefined) throw new Error('Value is undefined');
-  return value;
-}
-
-export function assertIsInstance<T>(
-  value: unknown,
-  clazz: Function,
-  optMsg?: string,
-): T {
-  assertTrue(
-    value instanceof clazz,
-    optMsg ?? `Value is not an instance of ${clazz.name}`,
-  );
-  return value as T;
-}
-
-export function assertTrue(value: boolean, optMsg?: string) {
-  if (!value) {
-    throw new Error(optMsg ?? 'Failed assertion');
-  }
-}
-
-export function assertFalse(value: boolean, optMsg?: string) {
-  assertTrue(!value, optMsg);
-}
-
-// This function serves two purposes.
-// 1) A runtime check - if we are ever called, we throw an exception.
-// This is useful for checking that code we suspect should never be reached is
-// actually never reached.
-// 2) A compile time check where typescript asserts that the value passed can be
-// cast to the "never" type.
-// This is useful for ensuring we exhaustively check union types.
-export function assertUnreachable(value: never, optMsg?: string): never {
-  throw new Error(
-    optMsg ?? `This code should not be reachable ${value as unknown}`,
-  );
-}
-
 export function addErrorHandler(handler: ErrorHandler) {
   if (!errorHandlers.includes(handler)) {
     errorHandlers.push(handler);

--- a/ui/src/base/object_utils.ts
+++ b/ui/src/base/object_utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists} from './logging';
+import {assertExists} from './assert';
 import {exists} from './utils';
 
 export type PathKey = string | number;

--- a/ui/src/base/resizable_array_buffer.ts
+++ b/ui/src/base/resizable_array_buffer.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from './logging';
+import {assertTrue} from './assert';
 
 /**
  * A dynamically resizable array buffer implementation for efficient

--- a/ui/src/base/shared_disposable.ts
+++ b/ui/src/base/shared_disposable.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertFalse} from './logging';
+import {assertFalse} from './assert';
 
 /**
  * Adds reference counting to an AsyncDisposable.

--- a/ui/src/base/string_utils.ts
+++ b/ui/src/base/string_utils.ts
@@ -17,7 +17,7 @@ import {
   encode as b64Encode,
   length as b64Len,
 } from '@protobufjs/base64';
-import {assertTrue} from './logging';
+import {assertTrue} from './assert';
 
 // Lazy initialize at first use.
 let textDecoder: TextDecoder | undefined = undefined;

--- a/ui/src/base/time.ts
+++ b/ui/src/base/time.ts
@@ -14,7 +14,7 @@
 
 import {BigintMath} from './bigint_math';
 import {Brand} from './brand';
-import {assertTrue} from './logging';
+import {assertTrue} from './assert';
 
 // The |time| type represents trace time in the same units and domain as trace
 // processor (i.e. typically boot time in nanoseconds, but most of the UI should

--- a/ui/src/base/touchscreen_handler.ts
+++ b/ui/src/base/touchscreen_handler.ts
@@ -14,7 +14,7 @@
 
 import {DisposableStack} from './disposable_stack';
 import {bindEventListener} from './dom_utils';
-import {assertTrue} from './logging';
+import {assertTrue} from './assert';
 
 export interface TouchArgs {
   clientX: number;

--- a/ui/src/components/details/thread_slice_details_tab.ts
+++ b/ui/src/components/details/thread_slice_details_tab.ts
@@ -34,7 +34,7 @@ import {
 import {asSliceSqlId} from '../sql_utils/core_types';
 import {DurationWidget} from '../widgets/duration';
 import {Grid, GridCell, GridHeaderCell} from '../../widgets/grid';
-import {assertIsInstance} from '../../base/logging';
+import {assertIsInstance} from '../../base/assert';
 import {Trace} from '../../public/trace';
 import {TrackEventDetailsPanel} from '../../public/details_panel';
 import {TrackEventSelection} from '../../public/selection';

--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {AsyncLimiter} from '../base/async_limiter';
 import {AsyncDisposableStack} from '../base/disposable_stack';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {uuidv4Sql} from '../base/uuid';
 import {Engine} from '../trace_processor/engine';
 import {

--- a/ui/src/components/sql_utils/sched.ts
+++ b/ui/src/components/sql_utils/sched.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from '../../base/logging';
+import {assertTrue} from '../../base/assert';
 import {duration, Time, time} from '../../base/time';
 import {Engine} from '../../trace_processor/engine';
 import {

--- a/ui/src/components/tracks/add_debug_track_menu.ts
+++ b/ui/src/components/tracks/add_debug_track_menu.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {findRef} from '../../base/dom_utils';
-import {assertUnreachable} from '../../base/logging';
+import {assertUnreachable} from '../../base/assert';
 import {Trace} from '../../public/trace';
 import {Form, FormLabel, FormSection} from '../../widgets/form';
 import {Select} from '../../widgets/select';

--- a/ui/src/components/tracks/base_counter_track.ts
+++ b/ui/src/components/tracks/base_counter_track.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import z from 'zod';
 import {searchSegment} from '../../base/binary_search';
 import {Point2D} from '../../base/geom';
-import {assertTrue, assertUnreachable} from '../../base/logging';
+import {assertTrue, assertUnreachable} from '../../base/assert';
 import {Monitor} from '../../base/monitor';
 import {duration, Time, time} from '../../base/time';
 import {TimeScale} from '../../base/time_scale';

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {ColorScheme} from '../../base/color_scheme';
 import {Point2D, Size2D, Transform2D, VerticalBounds} from '../../base/geom';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {Monitor} from '../../base/monitor';
 import {
   CancellationSignal,

--- a/ui/src/components/widgets/charts/chart_sql_source.ts
+++ b/ui/src/components/widgets/charts/chart_sql_source.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertUnreachable} from '../../../base/logging';
+import {assertUnreachable} from '../../../base/assert';
 import {
   QuerySlot,
   SerialTaskQueue,

--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -46,7 +46,7 @@ import {
 } from 'echarts/components';
 import {CanvasRenderer} from 'echarts/renderers';
 import type {EChartsType} from 'echarts/core';
-import {assertExists} from '../../../base/logging';
+import {assertExists} from '../../../base/assert';
 import {classNames} from '../../../base/classnames';
 import {SimpleResizeObserver} from '../../../base/resize_observer';
 import {Spinner} from '../../../widgets/spinner';

--- a/ui/src/components/widgets/charts/sql_bar_chart.ts
+++ b/ui/src/components/widgets/charts/sql_bar_chart.ts
@@ -27,7 +27,7 @@ import {Popup, PopupPosition} from '../../../widgets/popup';
 import {raf} from '../../../core/raf_scheduler';
 import {Button, ButtonBar} from '../../../widgets/button';
 import {AsyncLimiter} from '../../../base/async_limiter';
-import {assertDefined} from '../../../base/logging';
+import {assertDefined} from '../../../base/assert';
 import {uuidv4} from '../../../base/uuid';
 
 interface Data {

--- a/ui/src/components/widgets/datagrid/in_memory_data_source.ts
+++ b/ui/src/components/widgets/datagrid/in_memory_data_source.ts
@@ -14,7 +14,7 @@
 
 import {QueryResult} from '../../../base/query_slot';
 import {stringifyJsonWithBigints} from '../../../base/json_utils';
-import {assertUnreachable} from '../../../base/logging';
+import {assertUnreachable} from '../../../base/assert';
 import {Row, SqlValue} from '../../../trace_processor/query_result';
 import {
   DataSource,

--- a/ui/src/components/widgets/datagrid/sql_data_source.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertUnreachable} from '../../../base/logging';
+import {assertUnreachable} from '../../../base/assert';
 import {
   QueryResult,
   QuerySlot,

--- a/ui/src/components/widgets/datagrid/sql_utils.ts
+++ b/ui/src/components/widgets/datagrid/sql_utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertUnreachable} from '../../../base/logging';
+import {assertUnreachable} from '../../../base/assert';
 import {SqlValue} from '../../../trace_processor/query_result';
 import {AggregateFunction, Filter} from './model';
 

--- a/ui/src/components/widgets/query_history.ts
+++ b/ui/src/components/widgets/query_history.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {Icons} from '../../base/semantic_icons';
-import {assertTrue} from '../../base/logging';
+import {assertTrue} from '../../base/assert';
 import {z} from 'zod';
 import {Trace} from '../../public/trace';
 import {Button} from '../../widgets/button';

--- a/ui/src/components/widgets/sql/pivot_table/pivot_table_state.ts
+++ b/ui/src/components/widgets/sql/pivot_table/pivot_table_state.ts
@@ -22,7 +22,7 @@ import {SqlColumn, sqlColumnId, SqlExpression} from '../table/sql_column';
 import {TableColumn} from '../table/table_column';
 import {SqlTableDescription} from '../table/table_description';
 import {moveArrayItem} from '../../../../base/array_utils';
-import {assertExists} from '../../../../base/logging';
+import {assertExists} from '../../../../base/assert';
 import {SortDirection} from '../../../../base/comparison_utils';
 import {Aggregation, expandAggregations} from './aggregations';
 import {PivotTreeNode} from './pivot_tree_node';

--- a/ui/src/components/widgets/sql/pivot_table/pivot_tree_node.ts
+++ b/ui/src/components/widgets/sql/pivot_table/pivot_tree_node.ts
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  assertExists,
-  assertDefined,
-  assertTrue,
-} from '../../../../base/logging';
+import {assertExists, assertDefined, assertTrue} from '../../../../base/assert';
 import {Row, SqlValue} from '../../../../trace_processor/query_result';
 import {Filter, StandardFilters} from '../table/filters';
 import {TableColumn} from '../table/table_column';

--- a/ui/src/components/widgets/sql/table/state.ts
+++ b/ui/src/components/widgets/sql/table/state.ts
@@ -17,7 +17,7 @@ import {ColumnOrderClause, SqlColumn, sqlColumnId} from './sql_column';
 import {buildSqlQuery} from './query_builder';
 import {raf} from '../../../../core/raf_scheduler';
 import {SortDirection} from '../../../../base/comparison_utils';
-import {assertTrue} from '../../../../base/logging';
+import {assertTrue} from '../../../../base/assert';
 import {SqlTableDescription} from './table_description';
 import {Trace} from '../../../../public/trace';
 import {areFiltersEqual, Filter, Filters} from './filters';

--- a/ui/src/core/app_impl.ts
+++ b/ui/src/core/app_impl.ts
@@ -14,7 +14,7 @@
 
 import {AsyncLimiter} from '../base/async_limiter';
 import {defer} from '../base/deferred';
-import {assertExists, assertTrue} from '../base/logging';
+import {assertExists, assertTrue} from '../base/assert';
 import {ServiceWorkerController} from '../frontend/service_worker_controller';
 import {App} from '../public/app';
 import {SqlPackage} from '../public/extra_sql_packages';

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists, assertTrue} from '../base/logging';
+import {assertExists, assertTrue} from '../base/assert';
 import {time, Time, TimeSpan} from '../base/time';
 import {cacheTrace} from './cache_manager';
 import {

--- a/ui/src/core/page_manager.ts
+++ b/ui/src/core/page_manager.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertExists, assertTrue} from '../base/logging';
+import {assertExists, assertTrue} from '../base/assert';
 import {Registry} from '../base/registry';
 import {PageHandler, PageManager} from '../public/page';
 import {Analytics} from '../public/analytics';

--- a/ui/src/core/plugin_manager.ts
+++ b/ui/src/core/plugin_manager.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {Registry} from '../base/registry';
 import {PerfettoPlugin, PerfettoPluginStatic} from '../public/plugin';
 import {Trace} from '../public/trace';

--- a/ui/src/core/router.ts
+++ b/ui/src/core/router.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertTrue} from '../base/logging';
+import {assertTrue} from '../base/assert';
 import {RouteArgs, ROUTE_SCHEMA} from '../public/route_schema';
 
 export const ROUTE_PREFIX = '#!';

--- a/ui/src/core/selection_manager.ts
+++ b/ui/src/core/selection_manager.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue, assertUnreachable} from '../base/logging';
+import {assertTrue, assertUnreachable} from '../base/assert';
 import {
   Selection,
   Area,

--- a/ui/src/core/timeline.ts
+++ b/ui/src/core/timeline.ts
@@ -14,7 +14,7 @@
 
 import {HighPrecisionTimeSpan} from '../base/high_precision_time_span';
 import {HighPrecisionTime} from '../base/high_precision_time';
-import {assertUnreachable} from '../base/logging';
+import {assertUnreachable} from '../base/assert';
 import {Time, time, timezoneOffsetMap} from '../base/time';
 import {Setting} from '../public/settings';
 import {

--- a/ui/src/core/trace_stream.ts
+++ b/ui/src/core/trace_stream.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {defer, Deferred} from '../base/deferred';
-import {assertExists, assertTrue} from '../base/logging';
+import {assertExists, assertTrue} from '../base/assert';
 import {exists} from '../base/utils';
 import {TraceChunk, TraceStream} from '../public/stream';
 

--- a/ui/src/core/track_manager_unittest.ts
+++ b/ui/src/core/track_manager_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {Duration} from '../base/time';
 import {TimeScale} from '../base/time_scale';
 import {Track, TrackRenderContext} from '../public/track';

--- a/ui/src/core/workspace_manager.ts
+++ b/ui/src/core/workspace_manager.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from '../base/logging';
+import {assertTrue} from '../base/assert';
 import {Workspace, WorkspaceManager} from '../public/workspace';
 import {featureFlags} from './feature_flags';
 

--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -43,7 +43,7 @@ import {DurationPrecision, TimestampFormat} from '../../public/timeline';
 import {getTimeSpanOfSelectionOrVisibleWindow} from '../../public/utils';
 import {Workspace} from '../../public/workspace';
 import {showModal} from '../../widgets/modal';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {Setting} from '../../public/settings';
 import {toggleHelp} from '../../frontend/help_modal';
 

--- a/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
+++ b/ui/src/core_plugins/dev.perfetto.FlagsPage/plugins_page.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {classNames} from '../../base/classnames';
-import {assertUnreachable} from '../../base/logging';
+import {assertUnreachable} from '../../base/assert';
 import {exists} from '../../base/utils';
 import {AppImpl} from '../../core/app_impl';
 import {PluginWrapper} from '../../core/plugin_manager';

--- a/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller_unittest.ts
+++ b/ui/src/core_plugins/dev.perfetto.MultiTraceOpen/multi_trace_controller_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {MultiTraceController} from './multi_trace_controller';
 import {
   TraceFileAnalyzed,

--- a/ui/src/engine/wasm_bridge.ts
+++ b/ui/src/engine/wasm_bridge.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {defer} from '../base/deferred';
-import {assertExists, assertTrue} from '../base/logging';
+import {assertExists, assertTrue} from '../base/assert';
 
 // The 64-bit variant of TraceProcessor wasm is always built in all build
 // configurations and we can depend on it from typescript.

--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {AppImpl} from '../core/app_impl';
 import {HotkeyGlyphs, Keycap} from '../widgets/hotkey_glyphs';
 import {showModal} from '../widgets/modal';

--- a/ui/src/frontend/legacy_trace_viewer.ts
+++ b/ui/src/frontend/legacy_trace_viewer.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {inflate} from 'pako';
-import {assertTrue} from '../base/logging';
+import {assertTrue} from '../base/assert';
 import {isString} from '../base/object_utils';
 import {showModal} from '../widgets/modal';
 import {utf8Decode} from '../base/string_utils';

--- a/ui/src/frontend/note_editor.ts
+++ b/ui/src/frontend/note_editor.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertUnreachable} from '../base/logging';
+import {assertUnreachable} from '../base/assert';
 import {Icons} from '../base/semantic_icons';
 import {Timestamp} from '../components/widgets/timestamp';
 import {TraceImpl} from '../core/trace_impl';

--- a/ui/src/frontend/omnibox.ts
+++ b/ui/src/frontend/omnibox.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {classNames} from '../base/classnames';
 import {findRef} from '../base/dom_utils';
 import {FuzzyFinder, FuzzySegment} from '../base/fuzzy';
-import {assertExists, assertUnreachable} from '../base/logging';
+import {assertExists, assertUnreachable} from '../base/assert';
 import {isString} from '../base/object_utils';
 import {undoCommonChatAppReplacements} from '../base/string_utils';
 import {exists} from '../base/utils';

--- a/ui/src/frontend/rpc_http_dialog.ts
+++ b/ui/src/frontend/rpc_http_dialog.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import protos from '../protos';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {VERSION} from '../gen/perfetto_version';
 import {HttpRpcEngine} from '../trace_processor/http_rpc_engine';
 import {showModal} from '../widgets/modal';

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -44,7 +44,7 @@ import {exists, getOrCreate} from '../base/utils';
 import {classNames} from '../base/classnames';
 import {formatHotkey} from '../base/hotkeys';
 import {assetSrc} from '../base/assets';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {Icon} from '../widgets/icon';
 import {Button} from '../widgets/button';
 

--- a/ui/src/frontend/timeline_page/current_selection_tab.ts
+++ b/ui/src/frontend/timeline_page/current_selection_tab.ts
@@ -25,7 +25,7 @@ import {
   NoteSelection,
   TrackSelection,
 } from '../../public/selection';
-import {assertUnreachable} from '../../base/logging';
+import {assertUnreachable} from '../../base/assert';
 import {Button, ButtonBar} from '../../widgets/button';
 import {NoteEditor} from '../note_editor';
 import {Gate} from '../../base/mithril_utils';

--- a/ui/src/frontend/timeline_page/gridline_helper.ts
+++ b/ui/src/frontend/timeline_page/gridline_helper.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from '../../base/logging';
+import {assertTrue} from '../../base/assert';
 import {duration, time, Time, TimeSpan} from '../../base/time';
 
 const micros = 1000n;

--- a/ui/src/frontend/timeline_page/minimap.ts
+++ b/ui/src/frontend/timeline_page/minimap.ts
@@ -17,7 +17,7 @@ import {DisposableStack} from '../../base/disposable_stack';
 import {toHTMLElement} from '../../base/dom_utils';
 import {Rect2D, Size2D} from '../../base/geom';
 import {HighPrecisionTimeSpan} from '../../base/high_precision_time_span';
-import {assertExists, assertUnreachable} from '../../base/logging';
+import {assertExists, assertUnreachable} from '../../base/assert';
 import {Time, time, TimeSpan} from '../../base/time';
 import {TimeScale} from '../../base/time_scale';
 import {ZonedInteractionHandler} from '../../base/zoned_interaction_handler';

--- a/ui/src/frontend/timeline_page/notes_panel.ts
+++ b/ui/src/frontend/timeline_page/notes_panel.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {canvasClip} from '../../base/canvas_utils';
 import {currentTargetOffset} from '../../base/dom_utils';
 import {Size2D} from '../../base/geom';
-import {assertUnreachable} from '../../base/logging';
+import {assertUnreachable} from '../../base/assert';
 import {TimeScale} from '../../base/time_scale';
 import {randomColor} from '../../components/colorizer';
 import {raf} from '../../core/raf_scheduler';

--- a/ui/src/frontend/timeline_page/time_axis_panel.ts
+++ b/ui/src/frontend/timeline_page/time_axis_panel.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {canvasClip} from '../../base/canvas_utils';
 import {Size2D} from '../../base/geom';
-import {assertUnreachable} from '../../base/logging';
+import {assertUnreachable} from '../../base/assert';
 import {Time, time, formatDate} from '../../base/time';
 import {TimeScale} from '../../base/time_scale';
 import {TimestampFormat} from '../../public/timeline';

--- a/ui/src/frontend/timeline_page/time_selection_panel.ts
+++ b/ui/src/frontend/timeline_page/time_selection_panel.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {canvasClip} from '../../base/canvas_utils';
 import {Size2D} from '../../base/geom';
-import {assertUnreachable} from '../../base/logging';
+import {assertUnreachable} from '../../base/assert';
 import {time, Time} from '../../base/time';
 import {TimeScale} from '../../base/time_scale';
 import {formatDuration} from '../../components/time_utils';

--- a/ui/src/frontend/timeline_page/timeline_header.ts
+++ b/ui/src/frontend/timeline_page/timeline_header.ts
@@ -17,7 +17,7 @@ import {canvasSave} from '../../base/canvas_utils';
 import {DisposableStack} from '../../base/disposable_stack';
 import {toHTMLElement} from '../../base/dom_utils';
 import {Rect2D, Size2D} from '../../base/geom';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {TimeScale} from '../../base/time_scale';
 import {ZonedInteractionHandler} from '../../base/zoned_interaction_handler';
 import {TraceImpl} from '../../core/trace_impl';

--- a/ui/src/frontend/timeline_page/track_tree_view.ts
+++ b/ui/src/frontend/timeline_page/track_tree_view.ts
@@ -36,7 +36,7 @@ import {
 } from '../../base/geom';
 import {HighPrecisionTime} from '../../base/high_precision_time';
 import {HighPrecisionTimeSpan} from '../../base/high_precision_time_span';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {Time} from '../../base/time';
 import {TimeScale} from '../../base/time_scale';
 import {

--- a/ui/src/frontend/topbar.ts
+++ b/ui/src/frontend/topbar.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {classNames} from '../base/classnames';
-import {assertFalse} from '../base/logging';
+import {assertFalse} from '../base/assert';
 import {AppImpl} from '../core/app_impl';
 import {OmniboxMode} from '../core/omnibox_manager';
 import {Router} from '../core/router';

--- a/ui/src/plugins/com.android.DayExplorer/index.ts
+++ b/ui/src/plugins/com.android.DayExplorer/index.ts
@@ -30,7 +30,7 @@ import {
 import SupportPlugin from '../com.android.AndroidLongBatterySupport';
 import {Store} from '../../base/store';
 import {z} from 'zod';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 
 const DAY_EXPLORER_TRACK_KIND = 'day_explorer_counter_track';
 

--- a/ui/src/plugins/com.google.PerfettoMcp/uitools.ts
+++ b/ui/src/plugins/com.google.PerfettoMcp/uitools.ts
@@ -17,7 +17,7 @@ import {z} from 'zod';
 import {addQueryResultsTab} from '../../components/query_table/query_result_tab';
 import {Trace} from '../../public/trace';
 import {Time} from '../../base/time';
-import {assertTrue} from '../../base/logging';
+import {assertTrue} from '../../base/assert';
 
 export function registerUiTools(server: McpServer, ctxt: Trace) {
   server.tool(

--- a/ui/src/plugins/dev.perfetto.AggregateProfiles/index.ts
+++ b/ui/src/plugins/dev.perfetto.AggregateProfiles/index.ts
@@ -19,9 +19,12 @@ import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {NUM, STR} from '../../trace_processor/query_result';
 import {AggregateProfilesPage} from './aggregate_profiles_page';
-import {AggregateProfilesPageState, AGGREGATE_PROFILES_PAGE_STATE_SCHEMA} from './types';
+import {
+  AggregateProfilesPageState,
+  AGGREGATE_PROFILES_PAGE_STATE_SCHEMA,
+} from './types';
 import {Store} from '../../base/store';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.AggregateProfiles';

--- a/ui/src/plugins/dev.perfetto.AutoPinAndExpandTracks/index.ts
+++ b/ui/src/plugins/dev.perfetto.AutoPinAndExpandTracks/index.ts
@@ -18,7 +18,7 @@ import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Track} from '../../public/track';
 import {z} from 'zod';
-import {assertIsInstance} from '../../base/logging';
+import {assertIsInstance} from '../../base/assert';
 import {RouteArg, RouteArgs} from '../../public/route_schema';
 import {arrayEquals} from '../../base/array_utils';
 

--- a/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
+++ b/ui/src/plugins/dev.perfetto.CpuFreq/cpu_freq_track.ts
@@ -19,7 +19,7 @@ import {deferChunkedTask} from '../../base/chunked_task';
 import {Color} from '../../base/color';
 import {AsyncDisposableStack} from '../../base/disposable_stack';
 import {Point2D} from '../../base/geom';
-import {assertTrue} from '../../base/logging';
+import {assertTrue} from '../../base/assert';
 import {Monitor} from '../../base/monitor';
 import {
   CancellationSignal,

--- a/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.CpuProfile/index.ts
@@ -27,7 +27,7 @@ import {
   QueryFlamegraphWithMetrics,
 } from '../../components/query_flamegraph';
 import {Flamegraph, FLAMEGRAPH_STATE_SCHEMA} from '../../widgets/flamegraph';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {Store} from '../../base/store';
 import {z} from 'zod';
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/sources/sql_source.ts
@@ -34,7 +34,7 @@ import {ColumnInfo} from '../../column_info';
 import {setValidationError} from '../../node_issues';
 import {NodeDetailsAttrs} from '../../node_explorer_types';
 import {findRef, toHTMLElement} from '../../../../../base/dom_utils';
-import {assertExists} from '../../../../../base/logging';
+import {assertExists} from '../../../../../base/assert';
 import {ResizeHandle} from '../../../../../widgets/resize_handle';
 import {loadNodeDoc} from '../../node_doc_loader';
 import {NodeTitle} from '../../node_styling_widgets';

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
@@ -36,7 +36,7 @@ import {showModal} from '../../../widgets/modal';
 import {Editor} from '../../../widgets/editor';
 import {ResizeHandle} from '../../../widgets/resize_handle';
 import {findRef, toHTMLElement} from '../../../base/dom_utils';
-import {assertExists} from '../../../base/logging';
+import {assertExists} from '../../../base/assert';
 
 /**
  * Round action button with consistent styling for Explore Page.

--- a/ui/src/plugins/dev.perfetto.ExplorePage/recent_graphs.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/recent_graphs.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {z} from 'zod';
-import {assertTrue} from '../../base/logging';
+import {assertTrue} from '../../base/assert';
 import {Card, CardStack} from '../../widgets/card';
 import {Button} from '../../widgets/button';
 import {Icons} from '../../base/semantic_icons';

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -26,7 +26,7 @@ import {Track} from '../../public/track';
 import {FLAMEGRAPH_STATE_SCHEMA} from '../../widgets/flamegraph';
 import {Store} from '../../base/store';
 import {z} from 'zod';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {profileDescriptor} from './common';
 
 const EVENT_TABLE_NAME = 'heap_profile_events';

--- a/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.InstrumentsSamplesProfile/index.ts
@@ -21,7 +21,7 @@ import {
   NUM_NULL,
   STR_NULL,
 } from '../../trace_processor/query_result';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {getThreadUriPrefix} from '../../public/utils';
 import {TrackNode} from '../../public/workspace';
 import ProcessThreadGroupsPlugin from '../dev.perfetto.ProcessThreadGroups';

--- a/ui/src/plugins/dev.perfetto.KernelTrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.KernelTrackEvent/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';

--- a/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
+++ b/ui/src/plugins/dev.perfetto.LinuxPerf/index.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {
   QueryFlamegraph,
   QueryFlamegraphMetric,

--- a/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
+++ b/ui/src/plugins/dev.perfetto.MetricsPage/metrics_page.ts
@@ -18,7 +18,7 @@ import {Engine} from '../../trace_processor/engine';
 import {STR} from '../../trace_processor/query_result';
 import {Select} from '../../widgets/select';
 import {Spinner} from '../../widgets/spinner';
-import {assertExists, assertUnreachable} from '../../base/logging';
+import {assertExists, assertUnreachable} from '../../base/assert';
 import {Trace} from '../../public/trace';
 import {SegmentedButtons} from '../../widgets/segmented_buttons';
 import {Editor} from '../../widgets/editor';

--- a/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
+++ b/ui/src/plugins/dev.perfetto.ProcessSummary/group_summary_track.ts
@@ -20,7 +20,7 @@ import {Color} from '../../base/color';
 import {ColorScheme} from '../../base/color_scheme';
 import {AsyncDisposableStack} from '../../base/disposable_stack';
 import {Point2D} from '../../base/geom';
-import {assertExists, assertTrue} from '../../base/logging';
+import {assertExists, assertTrue} from '../../base/assert';
 import {Monitor} from '../../base/monitor';
 import {
   CancellationSignal,

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_msg.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/adb_msg.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from '../../../base/logging';
+import {assertTrue} from '../../../base/assert';
 import {isString} from '../../../base/object_utils';
 import {binaryEncode, utf8Decode, utf8Encode} from '../../../base/string_utils';
 

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_websocket_stream .ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/web_device_proxy/wdp_websocket_stream .ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import z from 'zod';
-import {assertExists, assertTrue} from '../../../../base/logging';
+import {assertExists, assertTrue} from '../../../../base/assert';
 import {ByteStream} from '../../interfaces/byte_stream';
 import {base64Decode} from '../../../../base/string_utils';
 

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_device.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_device.ts
@@ -19,7 +19,7 @@ import {adbCmdAndWait} from './adb_websocket_utils';
 import {AsyncWebsocket} from '../../websocket/async_websocket';
 import {ByteStream} from '../../interfaces/byte_stream';
 import {WdpWebSocketStream} from '../web_device_proxy/wdp_websocket_stream ';
-import {assertUnreachable} from '../../../../base/logging';
+import {assertUnreachable} from '../../../../base/assert';
 
 export type AdbWebsocketMode = 'WEBSOCKET_BRIDGE' | 'WEB_DEVICE_PROXY';
 /**

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_utils.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/websocket/adb_websocket_utils.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from '../../../../base/logging';
+import {assertTrue} from '../../../../base/assert';
 import {Result, okResult, errResult} from '../../../../base/result';
 import {AsyncWebsocket} from '../../websocket/async_websocket';
 import {prefixWithHexLen} from '../../websocket/websocket_utils';

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_key.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_key.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {BigInteger, RSAKey} from 'jsbn-rsa';
-import {assertExists, assertTrue} from '../../../../base/logging';
+import {assertExists, assertTrue} from '../../../../base/assert';
 import {
   base64Decode,
   base64Encode,

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_device.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/adb/webusb/adb_webusb_device.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {defer, Deferred} from '../../../../base/deferred';
-import {assertFalse, assertTrue} from '../../../../base/logging';
+import {assertFalse, assertTrue} from '../../../../base/assert';
 import {isString} from '../../../../base/object_utils';
 import {hexEncode, utf8Decode, utf8Encode} from '../../../../base/string_utils';
 import {exists} from '../../../../base/utils';

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_manager.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_manager.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import protos from '../../../protos';
-import {assertExists, assertFalse, assertTrue} from '../../../base/logging';
+import {assertExists, assertFalse, assertTrue} from '../../../base/assert';
 import {getOrCreate} from '../../../base/utils';
 import {ProbesSchema} from '../serialization_schema';
 import {TargetPlatformId} from '../interfaces/target_platform';

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_sharing.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/config/config_sharing.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {GcsUploader} from '../../../base/gcs_uploader';
-import {assertExists} from '../../../base/logging';
+import {assertExists} from '../../../base/assert';
 import {CopyableLink} from '../../../widgets/copyable_link';
 import {showModal} from '../../../widgets/modal';
 import {RecordSessionSchema} from '../serialization_schema';

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/config/trace_config_builder.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/config/trace_config_builder.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists, assertFalse} from '../../../base/logging';
+import {assertExists, assertFalse} from '../../../base/assert';
 import {getOrCreate} from '../../../base/utils';
 import protos from '../../../protos';
 

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/memory.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/memory.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertExists} from '../../../base/logging';
+import {assertExists} from '../../../base/assert';
 import {splitLinesNonEmpty} from '../../../base/string_utils';
 import protos from '../../../protos';
 import {

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/widgets/slider.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {ProbeSetting} from '../../config/config_interfaces';
-import {assertTrue} from '../../../../base/logging';
+import {assertTrue} from '../../../../base/assert';
 import {exists} from '../../../../base/utils';
 import {Icon} from '../../../../widgets/icon';
 

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/recording_manager.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/recording_manager.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import protos from '../../protos';
-import {assertFalse, assertTrue} from '../../base/logging';
+import {assertFalse, assertTrue} from '../../base/assert';
 import {errResult, okResult, Result} from '../../base/result';
 import {App} from '../../public/app';
 import {RecordSubpage} from './config/config_interfaces';

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/tracing_protocol/tracing_protocol.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/tracing_protocol/tracing_protocol.ts
@@ -19,7 +19,7 @@ import {ByteStream} from '../interfaces/byte_stream';
 import {ProtoRingBuffer} from '../../../trace_processor/proto_ring_buffer';
 import {defer} from '../../../base/deferred';
 import {exists} from '../../../base/utils';
-import {assertExists, assertFalse, assertTrue} from '../../../base/logging';
+import {assertExists, assertFalse, assertTrue} from '../../../base/assert';
 import {PacketAssembler} from './packet_assembler';
 import {ResizableArrayBuffer} from '../../../base/resizable_array_buffer';
 

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/websocket/async_websocket.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/websocket/async_websocket.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {defer, Deferred} from '../../../base/deferred';
-import {assertExists, assertTrue} from '../../../base/logging';
+import {assertExists, assertTrue} from '../../../base/assert';
 import {ResizableArrayBuffer} from '../../../base/resizable_array_buffer';
 import {utf8Decode, utf8Encode} from '../../../base/string_utils';
 

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/websocket/websocket_stream.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/websocket/websocket_stream.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from '../../../base/logging';
+import {assertTrue} from '../../../base/assert';
 import {ByteStream} from '../interfaces/byte_stream';
 
 export class WebSocketStream extends ByteStream {

--- a/ui/src/plugins/dev.perfetto.Thread/index.ts
+++ b/ui/src/plugins/dev.perfetto.Thread/index.ts
@@ -26,7 +26,7 @@ import {
   STR,
   STR_NULL,
 } from '../../trace_processor/query_result';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 
 async function listThreads(trace: Trace) {
   const query = `

--- a/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
+++ b/ui/src/plugins/dev.perfetto.TimelineSync/index.ts
@@ -17,7 +17,7 @@ import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Time, TimeSpan} from '../../base/time';
 import {redrawModal, showModal} from '../../widgets/modal';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {Button, ButtonBar, ButtonVariant} from '../../widgets/button';
 import {Intent} from '../../widgets/common';
 import {HighPrecisionTimeSpan} from '../../base/high_precision_time_span';

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/index.ts
@@ -14,7 +14,7 @@
 
 import {removeFalsyValues} from '../../base/array_utils';
 import {AsyncLimiter} from '../../base/async_limiter';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {Time} from '../../base/time';
 import {
   createAggregationTab,

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/pivot_table_tab.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/pivot_table_tab.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertExists} from '../../base/logging';
+import {assertExists} from '../../base/assert';
 import {Icons} from '../../base/semantic_icons';
 import {PivotTable} from '../../components/widgets/sql/pivot_table/pivot_table';
 import {PivotTableState} from '../../components/widgets/sql/pivot_table/pivot_table_state';

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/trace_processor_slice_track.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {BigintMath as BIMath} from '../../base/bigint_math';
-import {assertTrue} from '../../base/logging';
+import {assertTrue} from '../../base/assert';
 import {clamp} from '../../base/math_utils';
 import {exists} from '../../base/utils';
 import {getColorForSlice} from '../../components/colorizer';

--- a/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
+++ b/ui/src/plugins/dev.perfetto.TrackEvent/index.ts
@@ -24,7 +24,7 @@ import {
   STR_NULL,
 } from '../../trace_processor/query_result';
 import {TrackNode} from '../../public/workspace';
-import {assertExists, assertTrue} from '../../base/logging';
+import {assertExists, assertTrue} from '../../base/assert';
 import {COUNTER_TRACK_KIND, SLICE_TRACK_KIND} from '../../public/track_kinds';
 import {createTraceProcessorSliceTrack} from '../dev.perfetto.TraceProcessorTrack/trace_processor_slice_track';
 import {TraceProcessorCounterTrack} from '../dev.perfetto.TraceProcessorTrack/trace_processor_counter_track';

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/event_latency_details_panel.ts
@@ -52,7 +52,7 @@ import {Trace} from '../../public/trace';
 import {renderSliceArguments} from '../../components/details/slice_args';
 import {TrackEventRef} from '../../components/widgets/track_event_ref';
 import {SLICE_TABLE} from '../../components/widgets/sql/table_definitions';
-import {assertExists, assertTrue} from '../../base/logging';
+import {assertExists, assertTrue} from '../../base/assert';
 import {
   EVENT_LATENCY_TRACK,
   SCROLL_TIMELINE_TRACK,

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_details_panel.ts
@@ -19,7 +19,7 @@ import {LONG, NUM_NULL, STR} from '../../trace_processor/query_result';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
 import {Duration, duration, Time, time} from '../../base/time';
-import {assertExists, assertTrue} from '../../base/logging';
+import {assertExists, assertTrue} from '../../base/assert';
 import {Section} from '../../widgets/section';
 import {Tree, TreeNode} from '../../widgets/tree';
 import {Timestamp} from '../../components/widgets/timestamp';

--- a/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_v4_details_panel.ts
+++ b/ui/src/plugins/org.chromium.ChromeScrollJank/scroll_timeline_v4_details_panel.ts
@@ -18,7 +18,7 @@ import {Trace} from '../../public/trace';
 import {NUM, NUM_NULL, STR} from '../../trace_processor/query_result';
 import {DetailsShell} from '../../widgets/details_shell';
 import {GridLayout, GridLayoutColumn} from '../../widgets/grid_layout';
-import {assertExists, assertTrue} from '../../base/logging';
+import {assertExists, assertTrue} from '../../base/assert';
 import {Section} from '../../widgets/section';
 import {Tree, TreeNode} from '../../widgets/tree';
 import {

--- a/ui/src/public/workspace.ts
+++ b/ui/src/public/workspace.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue} from '../base/logging';
+import {assertTrue} from '../base/assert';
 import {errResult, okResult, Result} from '../base/result';
 
 export interface WorkspaceManager {

--- a/ui/src/test/aggregation.test.ts
+++ b/ui/src/test/aggregation.test.ts
@@ -14,7 +14,7 @@
 
 import {test, Page} from '@playwright/test';
 import {PerfettoTestHelper} from './perfetto_ui_test_helper';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 
 test.describe.configure({mode: 'serial'});
 

--- a/ui/src/test/perfetto_ui_test_helper.ts
+++ b/ui/src/test/perfetto_ui_test_helper.ts
@@ -21,7 +21,7 @@ import {
 import fs from 'fs';
 import path from 'path';
 import {IdleDetectorWindow} from '../frontend/idle_detector_interface';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {Size2D} from '../base/geom';
 import {AppImpl} from '../core/app_impl';
 

--- a/ui/src/test/wattson.test.ts
+++ b/ui/src/test/wattson.test.ts
@@ -14,7 +14,7 @@
 
 import {test, Page} from '@playwright/test';
 import {PerfettoTestHelper} from './perfetto_ui_test_helper';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 
 test.describe.configure({mode: 'serial'});
 

--- a/ui/src/trace_processor/dataset.ts
+++ b/ui/src/trace_processor/dataset.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertUnreachable} from '../base/logging';
+import {assertUnreachable} from '../base/assert';
 import {getOrCreate} from '../base/utils';
 import {checkExtends, NUM, SqlValue, unionTypes, UNKNOWN} from './query_result';
 import {sqlValueToSqliteString} from './sql_utils';

--- a/ui/src/trace_processor/engine.ts
+++ b/ui/src/trace_processor/engine.ts
@@ -14,7 +14,7 @@
 
 import protos from '../protos';
 import {defer, Deferred} from '../base/deferred';
-import {assertExists, assertTrue, assertUnreachable} from '../base/logging';
+import {assertExists, assertTrue, assertUnreachable} from '../base/assert';
 import {ProtoRingBuffer} from './proto_ring_buffer';
 import {
   createQueryResult,

--- a/ui/src/trace_processor/http_rpc_engine.ts
+++ b/ui/src/trace_processor/http_rpc_engine.ts
@@ -14,7 +14,8 @@
 
 import protos from '../protos';
 import {fetchWithTimeout} from '../base/http_utils';
-import {assertExists, reportError} from '../base/logging';
+import {reportError} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {EngineBase} from '../trace_processor/engine';
 
 const RPC_CONNECT_TIMEOUT_MS = 2000;

--- a/ui/src/trace_processor/proto_ring_buffer.ts
+++ b/ui/src/trace_processor/proto_ring_buffer.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertTrue, assertUnreachable} from '../base/logging';
+import {assertTrue, assertUnreachable} from '../base/assert';
 
 // This class is the TypeScript equivalent of the identically-named C++ class in
 // //protozero/proto_ring_buffer.h. See comments in that header for a detailed

--- a/ui/src/trace_processor/proto_ring_buffer_unittest.ts
+++ b/ui/src/trace_processor/proto_ring_buffer_unittest.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import protobuf from 'protobufjs/minimal';
-import {assertTrue} from '../base/logging';
+import {assertTrue} from '../base/assert';
 import {ProtoRingBuffer} from './proto_ring_buffer';
 
 let seed = 1;

--- a/ui/src/trace_processor/query_result.ts
+++ b/ui/src/trace_processor/query_result.ts
@@ -51,7 +51,7 @@
 import '../base/static_initializers';
 import protobuf from 'protobufjs/minimal';
 import {defer, Deferred} from '../base/deferred';
-import {assertExists, assertFalse, assertTrue} from '../base/logging';
+import {assertExists, assertFalse, assertTrue} from '../base/assert';
 import {utf8Decode} from '../base/string_utils';
 import {Duration, duration, Time, time} from '../base/time';
 

--- a/ui/src/trace_processor/wasm_engine_proxy.ts
+++ b/ui/src/trace_processor/wasm_engine_proxy.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {assetSrc} from '../base/assets';
-import {assertTrue} from '../base/logging';
+import {assertTrue} from '../base/assert';
 import {EngineBase} from '../trace_processor/engine';
 
 let idleWasmWorker: Worker | undefined = undefined;

--- a/ui/src/traceconv/index.ts
+++ b/ui/src/traceconv/index.ts
@@ -13,12 +13,8 @@
 // limitations under the License.
 
 import {defer} from '../base/deferred';
-import {
-  addErrorHandler,
-  assertExists,
-  ErrorDetails,
-  reportError,
-} from '../base/logging';
+import {addErrorHandler, ErrorDetails, reportError} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {time} from '../base/time';
 import traceconv from '../gen/traceconv';
 

--- a/ui/src/widgets/button.ts
+++ b/ui/src/widgets/button.ts
@@ -17,7 +17,7 @@ import {classNames} from '../base/classnames';
 import {HTMLAttrs, HTMLButtonAttrs, Intent, classForIntent} from './common';
 import {Icon} from './icon';
 import {Popup, PopupPosition} from './popup';
-import {assertUnreachable} from '../base/logging';
+import {assertUnreachable} from '../base/assert';
 import {isEmptyVnodes} from '../base/mithril_utils';
 import {Tooltip} from './tooltip';
 

--- a/ui/src/widgets/common.ts
+++ b/ui/src/widgets/common.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {assertUnreachable} from '../base/logging';
+import {assertUnreachable} from '../base/assert';
 
 // This file contains interfaces for attributes for various HTML elements.
 // They are typically used by widgets which pass attributes down to their

--- a/ui/src/widgets/drawer_panel.ts
+++ b/ui/src/widgets/drawer_panel.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertUnreachable} from '../base/logging';
+import {assertUnreachable} from '../base/assert';
 import {Gate, MithrilEvent} from '../base/mithril_utils';
 import {Button, ButtonBar} from './button';
 import {classNames} from '../base/classnames';

--- a/ui/src/widgets/editor.ts
+++ b/ui/src/widgets/editor.ts
@@ -20,7 +20,7 @@ import {basicSetup, EditorView} from 'codemirror';
 import {javascript} from '@codemirror/lang-javascript';
 import m from 'mithril';
 import {removeFalsyValues} from '../base/array_utils';
-import {assertUnreachable} from '../base/logging';
+import {assertUnreachable} from '../base/assert';
 import {perfettoSql} from '../base/perfetto_sql_lang/language';
 import {HTMLAttrs} from './common';
 import {classNames} from '../base/classnames';

--- a/ui/src/widgets/flamegraph.ts
+++ b/ui/src/widgets/flamegraph.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertExists, assertTrue} from '../base/logging';
+import {assertExists, assertTrue} from '../base/assert';
 import {Monitor} from '../base/monitor';
 import {Button, ButtonBar} from './button';
 import {Chip} from './chip';

--- a/ui/src/widgets/popup.ts
+++ b/ui/src/widgets/popup.ts
@@ -18,7 +18,7 @@ import m from 'mithril';
 import {MountOptions, Portal, PortalAttrs} from './portal';
 import {classNames} from '../base/classnames';
 import {findRef, isOrContains, toHTMLElement} from '../base/dom_utils';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {ExtendedModifiers} from './popper_utils';
 
 // Note: We could just use the Placement type from popper.js instead, which is a

--- a/ui/src/widgets/settings_shell.ts
+++ b/ui/src/widgets/settings_shell.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {classForIntent, HTMLAttrs, Intent} from './common';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {Card} from './card';
 import {classNames} from '../base/classnames';
 import {Anchor} from './anchor';

--- a/ui/src/widgets/tooltip.ts
+++ b/ui/src/widgets/tooltip.ts
@@ -17,7 +17,7 @@ import m from 'mithril';
 import {MountOptions, Portal, PortalAttrs} from './portal';
 import {classNames} from '../base/classnames';
 import {findRef, toHTMLElement} from '../base/dom_utils';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {PopupPosition} from './popup';
 import {ExtendedModifiers} from './popper_utils';
 

--- a/ui/src/widgets/virtual_overlay_canvas.ts
+++ b/ui/src/widgets/virtual_overlay_canvas.ts
@@ -33,7 +33,7 @@ import m from 'mithril';
 import {DisposableStack} from '../base/disposable_stack';
 import {findRef, toHTMLElement} from '../base/dom_utils';
 import {Rect2D, Size2D} from '../base/geom';
-import {assertExists} from '../base/logging';
+import {assertExists} from '../base/assert';
 import {VirtualCanvas} from '../base/virtual_canvas';
 import {WebGLRenderer} from '../base/gl/webgl_renderer';
 import {Canvas2DRenderer} from '../base/canvas2d_renderer';


### PR DESCRIPTION
Currently logging functions are in the same file as assert functions, but the two serve fundamentally different purposes.
- Assert statements are simple, pure assert-or-throw functions that can be used anywhere, including playwright scripts and unit tests.
- Logging function like addErrorHandler and reportError are stateful error handlers and reporters used by the root files of each bundle and include files like the perfetto version generated file and manage their own global state.

This PR moves the assert* functions into their own file `assert.ts` so that we can use them in various testing targets without pulling in all the logging stuff as well.
