### PR TITLE
stdlib: memory_breakdown better anomaly detection

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/memory_breakdown.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/memory_breakdown.sql
@@ -51,16 +51,6 @@ WITH
     FROM counter AS c
     JOIN mem_process_counter_tracks AS t
       ON c.track_id = t.id
-    WHERE
-      c.ts BETWEEN (
-        SELECT
-          start_ts
-        FROM trace_limits
-      ) AND (
-        SELECT
-          end_ts
-        FROM trace_limits
-      )
   ),
   mem_intervals AS (
     SELECT
@@ -102,6 +92,15 @@ WITH
         SELECT
           track_id
         FROM denied_tracks
+      )
+      AND i.ts BETWEEN (
+        SELECT
+          start_ts
+        FROM trace_limits
+      ) AND (
+        SELECT
+          end_ts
+        FROM trace_limits
       )
   )
 SELECT


### PR DESCRIPTION
In this change:
- we first deny tracks with large swings in memory
- we then filter out counter values outside of trace_limits

The old version worked exactly the other way around, which could potentially allow tracks with large changes.

Example on the same trace (16GB device): 
OLD:
<img width="1848" height="656" alt="image" src="https://github.com/user-attachments/assets/146e4a55-d112-4286-899e-f5bc410672eb" />

NEW:
<img width="1996" height="856" alt="image" src="https://github.com/user-attachments/assets/5365b478-cda7-4ace-b072-c108791d229a" />

