### PR TITLE
stdlib: _oom_adjuster_intervals fix counter.ts matching with 2 reasons

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/oom_adjuster.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/oom_adjuster.sql
@@ -149,7 +149,8 @@ JOIN process_counter_track AS track
 JOIN process
   USING (upid)
 LEFT JOIN reason
-  ON counter.ts BETWEEN oom_adj_ts AND coalesce(oom_adj_next_ts, trace_end())
+  ON counter.ts > reason.oom_adj_ts
+  AND counter.ts <= coalesce(reason.oom_adj_next_ts, trace_end())
 WHERE
   track.name = 'oom_score_adj';
 


### PR DESCRIPTION
The LEFT JOIN condition in _oom_adjuster_intervals within oom_adjuster.sql appears to cause issues: `ON counter.ts BETWEEN oom_adj_ts AND coalesce(oom_adj_next_ts, trace_end())`

Problem: When the oom_score value remains the same across consecutive 'updateOomAdj_' slices, a single counter.ts can fall within the time range of two oom_adj intervals. This is because BETWEEN is inclusive at both ends. Consequently, the counter event is matched with two 'updateOomAdj_', leading to overlapping intervals for the same process.


To prevent this double counting, tighten the join condition to associate the counter value only with the preceding 'updateOomAdj_' slice. This assumes a delay between the 'updateOomAdj_' slice and the actual oom_score counter update. `ON counter.ts > oom_adj_ts AND counter.ts <= coalesce(oom_adj_next_ts, trace_end())`

Edge Case:
In extremely rare cases, where the oom_score counter is changed at the exact start timestamp of 'updateOomAdj_' slice, we will have no matches.

Bug: b/486145766
