### PR TITLE
ui: gitignore .playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .gm-actuals
 .gradle
 .idea
+.playwright
 .project
 .recipe_deps/
 .roo*


### PR DESCRIPTION
[playwright-cli](https://github.com/microsoft/playwright-cli) creates configs in `.playwright` in your project root when configuring it, which don't need to be tracked. This patch adds `.playwright` to `.gitignore`.