### PR TITLE
de: Multiple metrics in metrics node

### DIFF
--- a/ui/src/assets/explore_page/node_info/metrics.md
+++ b/ui/src/assets/explore_page/node_info/metrics.md
@@ -1,38 +1,44 @@
 # Metrics
 
-**Purpose:** Define trace-based metrics from your query results. This node packages your data into a `TraceMetricV2TemplateSpec` proto (metric bundle) that can be exported and used in trace analysis pipelines. The selected value column becomes the metric value, and all other columns become dimensions.
+**Purpose:** Define trace-based metrics from your query results. This node packages your data into a `TraceMetricV2TemplateSpec` proto that can be exported and used in trace analysis pipelines. Each value column becomes a separate metric, and all remaining columns become dimensions.
 
 **How to use:**
 
 1. **Connect an input:** This node requires a source of data (e.g., from a Table Source or after filtering/aggregating data)
 
-2. **Set Metric ID Prefix:** Give your metric a unique identifier prefix (e.g., `cpu_metrics`, `memory_usage`). The metric will be named `<prefix>_<column_name>`.
+2. **Set Metric ID Prefix:** Give your metric a unique identifier prefix (e.g., `cpu_metrics`, `memory_usage`). Each metric is named `<prefix>_<column_name>`.
 
-3. **Select a Value Column:** Choose a numeric column (int, double, etc.) that contains the metric value you want to track. Then configure:
-   - **Unit:** Select the appropriate unit for the metric values (Count, Time, Bytes, Percentage, etc.). Use "Custom" for units not in the predefined list.
-   - **Polarity:** Indicate whether higher or lower values are "better"
-     - Higher is Better: e.g., throughput, cache hit rate
-     - Lower is Better: e.g., latency, error count
-     - Not Applicable: for metrics where direction doesn't apply
+3. **Drag columns to Values:** The panel shows two lists — **Dimensions** on the left and **Values** on the right.
+   - Drag any numeric column (int, double, etc.) from Dimensions to Values to make it a metric value.
+   - Drag a value column back to Dimensions (or click ✕) to remove it.
+   - Use the "Add value column" dropdown at the bottom of the Values panel as an alternative to drag-and-drop.
 
-4. **Configure Dimension Uniqueness:** Specify whether dimension combinations are unique
-   - Unique: Each combination of dimension values appears at most once
-   - Not Unique: The same dimension combination may appear multiple times
+4. **Configure each Value column:** For each value column in the Values panel, set:
+   - **Unit:** The appropriate unit (Count, Time, Bytes, Percentage, etc.). Use "Custom" to enter a custom unit string.
+   - **Polarity:** Whether higher or lower values are "better":
+     - *Higher is Better:* e.g., throughput, cache hit rate
+     - *Lower is Better:* e.g., latency, error count
+     - *Not Applicable:* when direction doesn't matter
+
+5. **Configure Dimension Uniqueness:** Specify whether dimension combinations are unique:
+   - *Unique:* Each combination of dimension values appears at most once
+   - *Not Unique:* The same dimension combination may appear multiple times
 
 **Dimensions:**
-All columns in your input **except** the value column automatically become dimensions. Use a Modify Columns node before this one to control which columns are included as dimensions.
+All columns **not** in the Values list automatically become dimensions. Use a Modify Columns node before this one to control which columns are present.
 
 **Export:**
-Click the "Export" button to generate a textproto representation of your metric template specification. This can be saved and used in trace analysis pipelines.
+Click the "Export" button to generate a textproto representation of your metric template specification. A preview table shows the metric values as they would appear in an actual trace. When there are multiple value columns, each has its own tab in the preview.
 
 **Example workflow:**
 1. Start with a Table Source (e.g., `slice` table)
-2. Add Aggregation to compute `SUM(dur)` grouped by `process_name`
-3. Add Metrics node:
+2. Add Aggregation to compute `SUM(dur)` and `COUNT(*)` grouped by `process_name`
+3. Add a Metrics node:
    - Metric ID Prefix: `slice_stats`
-   - Value column: `sum_dur` with Unit: Time (nanoseconds), Polarity: Not Applicable
+   - Drag `sum_dur` to Values → Unit: Time (nanoseconds), Polarity: Lower is Better
+   - Drag `count` to Values → Unit: Count, Polarity: Not Applicable
 4. Export the metric spec
 
-This creates a metric `slice_stats_sum_dur` with `process_name` as a dimension.
+This creates two metrics — `slice_stats_sum_dur` and `slice_stats_count` — both with `process_name` as a dimension.
 
 **Output:** The node passes through input columns unchanged. The metric template specification is generated separately via the Export button.

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -361,6 +361,8 @@ function getNodeHue(node: QueryNode): number {
       return 14; // Deep Orange (#ffccbc)
     case NodeType.kCreateSlices:
       return 100; // Green (#c8e6c9)
+    case NodeType.kMetrics:
+      return 280; // Violet (#e1bee7)
     default:
       return 65; // Lime (#f0f4c3)
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/metrics_enum_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/metrics_enum_utils.ts
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import protos from '../../../../protos';
+
+export interface EnumOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Converts an UPPER_SNAKE_CASE enum key to a human-readable label.
+ * E.g., "TIME_NANOS" -> "Time nanos", "HIGHER_IS_BETTER" -> "Higher is better"
+ */
+export function enumKeyToLabel(key: string): string {
+  return key
+    .toLowerCase()
+    .split('_')
+    .map((word, i) =>
+      i === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word,
+    )
+    .join(' ');
+}
+
+/**
+ * Extracts enum options from a protobuf enum object.
+ * Filters out UNSPECIFIED values and converts keys to human-readable labels.
+ */
+export function getEnumOptions(
+  enumObj: Record<string, string | number>,
+  excludePatterns: string[] = ['UNSPECIFIED'],
+): EnumOption[] {
+  const options: EnumOption[] = [];
+  for (const key of Object.keys(enumObj)) {
+    // Skip numeric reverse mappings and excluded patterns
+    if (typeof enumObj[key] !== 'number') continue;
+    if (excludePatterns.some((pattern) => key.includes(pattern))) continue;
+    // Skip legacy values
+    if (key.includes('LEGACY')) continue;
+
+    options.push({
+      value: key,
+      label: enumKeyToLabel(key),
+    });
+  }
+  return options;
+}
+
+/**
+ * Returns metric unit options from the proto enum, plus a CUSTOM option.
+ */
+export function getMetricUnitOptions(): EnumOption[] {
+  const options = getEnumOptions(protos.TraceMetricV2Spec.MetricUnit);
+  // Add custom unit option at the end
+  options.push({value: 'CUSTOM', label: 'Custom unit...'});
+  return options;
+}
+
+/**
+ * Returns polarity options from the proto enum.
+ */
+export function getPolarityOptions(): EnumOption[] {
+  return getEnumOptions(protos.TraceMetricV2Spec.MetricPolarity);
+}
+
+/**
+ * Returns dimension uniqueness options from the proto enum.
+ */
+export function getDimensionUniquenessOptions(): EnumOption[] {
+  return getEnumOptions(protos.TraceMetricV2Spec.DimensionUniqueness);
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/metrics_export_modal.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/metrics_export_modal.ts
@@ -1,0 +1,297 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import protos from '../../../../protos';
+import {showModal} from '../../../../widgets/modal';
+import {CodeSnippet} from '../../../../widgets/code_snippet';
+import {traceSummarySpecToText} from '../../../../base/proto_utils_wasm';
+import {Spinner} from '../../../../widgets/spinner';
+import {DataGrid} from '../../../../components/widgets/datagrid/datagrid';
+import {SchemaRegistry} from '../../../../components/widgets/datagrid/datagrid_schema';
+import {Row} from '../../../../trace_processor/query_result';
+import {Tabs} from '../../../../widgets/tabs';
+import {Engine} from '../../../../trace_processor/engine';
+import {
+  getStructuredQueries,
+  buildEmbeddedQueryTree,
+} from '../query_builder_utils';
+import {ValueColumnConfig} from './metrics_node';
+import {QueryNode} from '../../query_node';
+
+// Helper to extract dimension value as string.
+function getDimensionValue(
+  dim: protos.TraceMetricV2Bundle.Row.IDimension,
+): string {
+  if (dim.stringValue !== undefined && dim.stringValue !== null) {
+    return dim.stringValue;
+  }
+  if (dim.int64Value !== undefined && dim.int64Value !== null) {
+    return String(dim.int64Value);
+  }
+  if (dim.doubleValue !== undefined && dim.doubleValue !== null) {
+    return String(dim.doubleValue);
+  }
+  if (dim.boolValue !== undefined && dim.boolValue !== null) {
+    return String(dim.boolValue);
+  }
+  return 'NULL';
+}
+
+// Helper to extract metric value as number or null.
+function getMetricValue(
+  val: protos.TraceMetricV2Bundle.Row.IValue,
+): number | null {
+  if (val.doubleValue !== undefined && val.doubleValue !== null) {
+    return val.doubleValue;
+  }
+  return null;
+}
+
+export interface MetricResult {
+  schema: SchemaRegistry;
+  rows: Row[];
+  metricId: string;
+}
+
+/**
+ * Parse a specific value column's data from a TraceSummary proto bundle.
+ * The bundle contains one row per dimension combination, and each row has
+ * one value per value column (in the same order as valueColumnSpecs).
+ */
+export function parseMetricBundleForValue(
+  data: Uint8Array,
+  metricIdPrefix: string,
+  dimensionNames: string[],
+  valueColumnNames: string[],
+  valueIndex: number,
+): MetricResult | undefined {
+  const summary = protos.TraceSummary.decode(data);
+  const bundle = summary.metricBundles[0];
+  if (bundle === undefined) return undefined;
+
+  const valueColumn = valueColumnNames[valueIndex];
+  if (valueColumn === undefined) return undefined;
+  const metricId = `${metricIdPrefix}_${valueColumn}`;
+
+  // Build schema columns: dimensions (text) + this value (quantitative).
+  const schemaColumns: Record<
+    string,
+    {title: string; columnType: 'text' | 'quantitative'}
+  > = {};
+  for (const dim of dimensionNames) {
+    schemaColumns[dim] = {title: dim, columnType: 'text'};
+  }
+  schemaColumns[valueColumn] = {
+    title: valueColumn,
+    columnType: 'quantitative',
+  };
+
+  const schema: SchemaRegistry = {[metricId]: schemaColumns};
+
+  // Convert rows to DataGrid format.
+  const rows: Row[] = [];
+  for (const row of bundle.row ?? []) {
+    const rowData: Row = {};
+    for (let i = 0; i < dimensionNames.length; i++) {
+      const dimValue = row.dimension?.[i];
+      rowData[dimensionNames[i]] = dimValue
+        ? getDimensionValue(dimValue)
+        : null;
+    }
+    // Extract the value at the specific index for this value column.
+    const val = row.values?.[valueIndex];
+    rowData[valueColumn] = val ? getMetricValue(val) : null;
+    rows.push(rowData);
+  }
+
+  return {schema, rows, metricId};
+}
+
+type ResultState =
+  | {kind: 'loading'}
+  | {kind: 'error'; message: string}
+  | {kind: 'data'; result: MetricResult};
+
+export interface ShowExportModalArgs {
+  templateSpec: protos.TraceMetricV2TemplateSpec;
+  primaryInput: QueryNode | undefined;
+  metricIdPrefix: string;
+  dimensions: string[];
+  valueColumns: ValueColumnConfig[];
+  engine: Engine | undefined;
+}
+
+export async function showMetricsExportModal(
+  args: ShowExportModalArgs,
+): Promise<void> {
+  const {templateSpec, primaryInput, metricIdPrefix, dimensions, valueColumns} =
+    args;
+
+  // Build a self-contained query tree for the template.
+  if (primaryInput !== undefined) {
+    const allQueries = getStructuredQueries(primaryInput);
+    if (!(allQueries instanceof Error)) {
+      const embedded = buildEmbeddedQueryTree(allQueries);
+      if (embedded !== undefined) {
+        templateSpec.query = embedded;
+      }
+    }
+  }
+
+  const summarySpec = new protos.TraceSummarySpec();
+  summarySpec.metricTemplateSpec = [templateSpec];
+
+  const textproto = await traceSummarySpecToText(summarySpec);
+
+  // Per-value-column result state, updated asynchronously.
+  const resultStates = new Map<string, ResultState>();
+  for (const vc of valueColumns) {
+    resultStates.set(vc.column, {kind: 'loading'});
+  }
+  // `activeTab` is a plain `let` captured by the `content` closure passed to
+  // showModal. This is intentional: Mithril re-calls `content()` on every
+  // redraw, so reassigning `activeTab` here (not a stale closure) correctly
+  // reflects the new active tab in the next render cycle.
+  let activeTab = valueColumns[0]?.column;
+
+  const valueColumnNames = valueColumns.map((vc) => vc.column);
+
+  const renderResultForValue = (columnName: string): m.Children => {
+    const state = resultStates.get(columnName);
+    if (state === undefined) return null;
+    switch (state.kind) {
+      case 'loading':
+        return m(Spinner);
+      case 'error':
+        return m('span.pf-metrics-error', state.message);
+      case 'data':
+        return m(DataGrid, {
+          data: state.result.rows,
+          schema: state.result.schema,
+          rootSchema: state.result.metricId,
+        });
+    }
+  };
+
+  showModal({
+    title: 'Export Metric',
+    className: 'pf-metrics-export-modal',
+    content: () =>
+      m(
+        'div',
+        m(CodeSnippet, {
+          text: textproto,
+          language: 'textproto',
+          downloadFileName: `${metricIdPrefix || 'metric'}_spec.pbtxt`,
+        }),
+        m(
+          '.pf-metrics-result-box',
+          valueColumns.length === 1
+            ? [
+                m('.pf-metrics-result-header', valueColumns[0].column),
+                m(
+                  '.pf-metrics-result-content',
+                  renderResultForValue(valueColumns[0].column),
+                ),
+              ]
+            : m(Tabs, {
+                activeTabKey: activeTab,
+                onTabChange: (key: string) => {
+                  activeTab = key;
+                },
+                tabs: valueColumns.map((vc) => ({
+                  key: vc.column,
+                  title: vc.column,
+                  content: m(
+                    '.pf-metrics-result-content',
+                    renderResultForValue(vc.column),
+                  ),
+                })),
+              }),
+        ),
+      ),
+    buttons: [{text: 'Close'}],
+  });
+
+  const engine = args.engine;
+  if (engine === undefined) {
+    for (const vc of valueColumns) {
+      resultStates.set(vc.column, {
+        kind: 'error',
+        message: 'No trace engine available. Please load a trace first.',
+      });
+    }
+    m.redraw();
+    return;
+  }
+
+  const TIMEOUT_MS = 30_000;
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(
+      () => reject(new Error('Timed out waiting for trace processor')),
+      TIMEOUT_MS,
+    ),
+  );
+  // Note: Promise.race does not cancel the losing promise. If summarizeTrace
+  // completes after the timeout fires, its result is silently ignored because
+  // resultStates is already in the error state and the modal may be closed.
+  Promise.race([
+    engine.summarizeTrace([summarySpec], undefined, undefined, 'proto'),
+    timeout,
+  ]).then(
+    (result) => {
+      if (result.error) {
+        for (const vc of valueColumns) {
+          resultStates.set(vc.column, {kind: 'error', message: result.error});
+        }
+      } else if (result.protoSummary) {
+        for (let i = 0; i < valueColumns.length; i++) {
+          const parsed = parseMetricBundleForValue(
+            result.protoSummary,
+            metricIdPrefix,
+            dimensions,
+            valueColumnNames,
+            i,
+          );
+          if (parsed !== undefined && parsed.rows.length > 0) {
+            resultStates.set(valueColumns[i].column, {
+              kind: 'data',
+              result: parsed,
+            });
+          } else {
+            resultStates.set(valueColumns[i].column, {
+              kind: 'error',
+              message: 'No metric data found',
+            });
+          }
+        }
+      } else {
+        for (const vc of valueColumns) {
+          resultStates.set(vc.column, {
+            kind: 'error',
+            message: 'No results returned',
+          });
+        }
+      }
+      m.redraw();
+    },
+    (err) => {
+      for (const vc of valueColumns) {
+        resultStates.set(vc.column, {kind: 'error', message: String(err)});
+      }
+      m.redraw();
+    },
+  );
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/metrics_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/metrics_node_unittest.ts
@@ -16,7 +16,9 @@ import {
   MetricsNode,
   MetricsNodeState,
   MetricsSerializedState,
+  ValueColumnConfig,
 } from './metrics_node';
+import {parseMetricBundleForValue} from './metrics_export_modal';
 import {NodeType} from '../../query_node';
 import {
   createMockNode,
@@ -25,7 +27,33 @@ import {
   expectValidationError,
   createMockNodeWithStructuredQuery,
 } from '../testing/test_utils';
+import {isColumnDef} from '../../../../components/widgets/datagrid/datagrid_schema';
 import protos from '../../../../protos';
+
+// Helper to build a minimal valid state with one value column.
+function makeState(
+  overrides: Partial<MetricsNodeState> = {},
+): MetricsNodeState {
+  return {
+    metricIdPrefix: 'test_metric',
+    valueColumns: [
+      {column: 'value', unit: 'COUNT', polarity: 'NOT_APPLICABLE'},
+    ],
+    dimensionUniqueness: 'NOT_UNIQUE',
+    availableColumns: [],
+    ...overrides,
+  };
+}
+
+// Helper to build a single ValueColumnConfig.
+function makeValueCol(
+  column: string,
+  unit = 'COUNT',
+  polarity = 'NOT_APPLICABLE',
+  customUnit?: string,
+): ValueColumnConfig {
+  return {column, unit, polarity, customUnit};
+}
 
 describe('MetricsNode', () => {
   describe('constructor', () => {
@@ -33,9 +61,7 @@ describe('MetricsNode', () => {
       const node = new MetricsNode({} as MetricsNodeState);
 
       expect(node.state.metricIdPrefix).toBe('');
-      expect(node.state.valueColumn).toBeUndefined();
-      expect(node.state.unit).toBe('COUNT');
-      expect(node.state.polarity).toBe('NOT_APPLICABLE');
+      expect(node.state.valueColumns).toEqual([]);
       expect(node.state.dimensionUniqueness).toBe('NOT_UNIQUE');
       expect(node.state.availableColumns).toEqual([]);
     });
@@ -59,20 +85,35 @@ describe('MetricsNode', () => {
     });
 
     it('should preserve provided state values', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'my_metric',
-        valueColumn: 'value1',
-        unit: 'BYTES',
-        polarity: 'HIGHER_IS_BETTER',
-        dimensionUniqueness: 'UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'my_metric',
+          valueColumns: [makeValueCol('value1', 'BYTES', 'HIGHER_IS_BETTER')],
+          dimensionUniqueness: 'UNIQUE',
+        }),
+      );
 
       expect(node.state.metricIdPrefix).toBe('my_metric');
-      expect(node.state.valueColumn).toBe('value1');
-      expect(node.state.unit).toBe('BYTES');
-      expect(node.state.polarity).toBe('HIGHER_IS_BETTER');
+      expect(node.state.valueColumns).toHaveLength(1);
+      expect(node.state.valueColumns[0].column).toBe('value1');
+      expect(node.state.valueColumns[0].unit).toBe('BYTES');
+      expect(node.state.valueColumns[0].polarity).toBe('HIGHER_IS_BETTER');
       expect(node.state.dimensionUniqueness).toBe('UNIQUE');
+    });
+
+    it('should preserve multiple value columns', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('cpu_time', 'TIME_NANOS', 'LOWER_IS_BETTER'),
+            makeValueCol('mem_bytes', 'BYTES', 'LOWER_IS_BETTER'),
+          ],
+        }),
+      );
+
+      expect(node.state.valueColumns).toHaveLength(2);
+      expect(node.state.valueColumns[0].column).toBe('cpu_time');
+      expect(node.state.valueColumns[1].column).toBe('mem_bytes');
     });
   });
 
@@ -99,49 +140,59 @@ describe('MetricsNode', () => {
   });
 
   describe('getDimensions', () => {
-    it('should return all columns when no value column is set', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: undefined,
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string'),
-        ],
-      });
+    it('should return all columns when no value columns are set', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [],
+          availableColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string'),
+          ],
+        }),
+      );
 
       expect(node.getDimensions()).toEqual(['id', 'name']);
     });
 
-    it('should return all columns except value column as dimensions', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value1',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string'),
-          createColumnInfo('value1', 'double'),
-          createColumnInfo('category', 'string'),
-        ],
-      });
+    it('should return all columns except value columns as dimensions', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('value1')],
+          availableColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string'),
+            createColumnInfo('value1', 'double'),
+            createColumnInfo('category', 'string'),
+          ],
+        }),
+      );
 
       expect(node.getDimensions()).toEqual(['id', 'name', 'category']);
     });
 
-    it('should return empty array when the only column is the value column', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [createColumnInfo('value', 'double')],
-      });
+    it('should exclude multiple value columns from dimensions', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('cpu'), makeValueCol('mem')],
+          availableColumns: [
+            createColumnInfo('process', 'string'),
+            createColumnInfo('cpu', 'double'),
+            createColumnInfo('mem', 'double'),
+            createColumnInfo('pid', 'int'),
+          ],
+        }),
+      );
+
+      expect(node.getDimensions()).toEqual(['process', 'pid']);
+    });
+
+    it('should return empty array when all columns are value columns', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('value')],
+          availableColumns: [createColumnInfo('value', 'double')],
+        }),
+      );
 
       expect(node.getDimensions()).toEqual([]);
     });
@@ -149,14 +200,7 @@ describe('MetricsNode', () => {
 
   describe('validate', () => {
     it('should fail validation when no primary input', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState());
 
       expectValidationError(node, 'No input node connected');
     });
@@ -164,14 +208,7 @@ describe('MetricsNode', () => {
     it('should fail validation when primary input is invalid', () => {
       const inputNode = createMockNode({validate: () => false});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState());
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'Previous node is invalid');
@@ -181,14 +218,7 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: '',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState({metricIdPrefix: ''}));
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'Metric ID prefix is required');
@@ -198,48 +228,29 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: '   ',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState({metricIdPrefix: '   '}));
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'Metric ID prefix is required');
     });
 
-    it('should fail validation when no value column set', () => {
+    it('should fail validation when no value columns set', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: undefined,
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState({valueColumns: []}));
       connectNodes(inputNode, node);
 
-      expectValidationError(node, 'A value column is required');
+      expectValidationError(node, 'At least one value column is required');
     });
 
     it('should fail validation when value column not found in input', () => {
       const inputCols = [createColumnInfo('other', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'missing_column',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({valueColumns: [makeValueCol('missing_column')]}),
+      );
       connectNodes(inputNode, node);
 
       expectValidationError(node, "Value column 'missing_column' not found");
@@ -249,14 +260,9 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('name', 'string')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'name',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({valueColumns: [makeValueCol('name')]}),
+      );
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'must be numeric');
@@ -266,21 +272,40 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'CUSTOM',
-        customUnit: '',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('value', 'CUSTOM', 'NOT_APPLICABLE', '')],
+        }),
+      );
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'Custom unit is required');
     });
 
-    it('should pass validation with valid configuration', () => {
+    it('should fail validation when second value column has custom unit problem', () => {
+      const inputCols = [
+        createColumnInfo('cpu', 'double'),
+        createColumnInfo('mem', 'double'),
+      ];
+      const inputNode = createMockNode({columns: inputCols});
+
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('cpu', 'COUNT', 'NOT_APPLICABLE'),
+            makeValueCol('mem', 'CUSTOM', 'NOT_APPLICABLE', ''), // missing custom unit
+          ],
+        }),
+      );
+      connectNodes(inputNode, node);
+
+      expectValidationError(
+        node,
+        "Custom unit is required for value column 'mem'",
+      );
+    });
+
+    it('should pass validation with valid single value column', () => {
       const inputCols = [
         createColumnInfo('id', 'int'),
         createColumnInfo('value', 'double'),
@@ -288,14 +313,30 @@ describe('MetricsNode', () => {
       ];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({valueColumns: [makeValueCol('value')]}),
+      );
+      connectNodes(inputNode, node);
+
+      expect(node.validate()).toBe(true);
+    });
+
+    it('should pass validation with multiple value columns', () => {
+      const inputCols = [
+        createColumnInfo('cpu', 'double'),
+        createColumnInfo('mem', 'int'),
+        createColumnInfo('name', 'string'),
+      ];
+      const inputNode = createMockNode({columns: inputCols});
+
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('cpu', 'TIME_NANOS', 'LOWER_IS_BETTER'),
+            makeValueCol('mem', 'BYTES', 'LOWER_IS_BETTER'),
+          ],
+        }),
+      );
       connectNodes(inputNode, node);
 
       expect(node.validate()).toBe(true);
@@ -305,29 +346,20 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'CUSTOM',
-        customUnit: 'widgets',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('value', 'CUSTOM', 'NOT_APPLICABLE', 'widgets'),
+          ],
+        }),
+      );
       connectNodes(inputNode, node);
 
       expect(node.validate()).toBe(true);
     });
 
     it('should clear previous validation errors on success', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState());
 
       // First validation should fail (no input)
       expect(node.validate()).toBe(false);
@@ -365,78 +397,85 @@ describe('MetricsNode', () => {
       ]);
     });
 
-    it('should clear value column if it no longer exists', () => {
+    it('should remove value column entry if the column no longer exists', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'old_value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({valueColumns: [makeValueCol('old_value')]}),
+      );
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
-      expect(node.state.valueColumn).toBeUndefined();
+      // 'old_value' is gone, so it should be removed from valueColumns
+      expect(node.state.valueColumns).toHaveLength(0);
     });
 
-    it('should clear value column if it becomes non-numeric', () => {
+    it('should remove value column entry if it becomes non-numeric', () => {
       const inputCols = [createColumnInfo('value', 'string')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({valueColumns: [makeValueCol('value')]}),
+      );
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
-      expect(node.state.valueColumn).toBeUndefined();
+      // 'value' is now string, so it should be removed
+      expect(node.state.valueColumns).toHaveLength(0);
     });
 
     it('should preserve value column if it still exists and is numeric', () => {
       const inputCols = [createColumnInfo('value', 'double')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({valueColumns: [makeValueCol('value')]}),
+      );
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
-      expect(node.state.valueColumn).toBe('value');
+      expect(node.state.valueColumns).toHaveLength(1);
+      expect(node.state.valueColumns[0].column).toBe('value');
+    });
+
+    it('should selectively remove only stale value columns from multi-value', () => {
+      const inputCols = [
+        createColumnInfo('cpu', 'double'),
+        createColumnInfo('name', 'string'), // was numeric, now string
+      ];
+      const inputNode = createMockNode({columns: inputCols});
+
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('cpu'),
+            makeValueCol('stale_col'), // no longer exists
+          ],
+        }),
+      );
+      connectNodes(inputNode, node);
+
+      node.onPrevNodesUpdated();
+
+      expect(node.state.valueColumns).toHaveLength(1);
+      expect(node.state.valueColumns[0].column).toBe('cpu');
     });
 
     it('should do nothing when no primary input', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({valueColumns: [makeValueCol('value')]}),
+      );
 
       // Should not throw
       node.onPrevNodesUpdated();
 
       // State should remain unchanged
-      expect(node.state.valueColumn).toBe('value');
+      expect(node.state.valueColumns).toHaveLength(1);
+      expect(node.state.valueColumns[0].column).toBe('value');
     });
   });
 
@@ -454,14 +493,7 @@ describe('MetricsNode', () => {
         getStructuredQuery: () => undefined,
       });
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState());
       connectNodes(inputNode, node);
 
       expect(node.getStructuredQuery()).toBeUndefined();
@@ -471,14 +503,7 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState());
       connectNodes(inputNode, node);
 
       const sq = node.getStructuredQuery();
@@ -500,14 +525,12 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'my_metric_prefix',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'my_metric_prefix',
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -516,7 +539,7 @@ describe('MetricsNode', () => {
       expect(spec?.idPrefix).toBe('my_metric_prefix');
     });
 
-    it('should compute dimensions as all columns except value column', () => {
+    it('should compute dimensions as all columns except value columns', () => {
       const inputCols = [
         createColumnInfo('value1', 'double'),
         createColumnInfo('dim1', 'string'),
@@ -524,14 +547,12 @@ describe('MetricsNode', () => {
       ];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value1',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('value1')],
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -539,18 +560,37 @@ describe('MetricsNode', () => {
       expect(spec?.dimensions).toEqual(['dim1', 'dim2']);
     });
 
-    it('should include value column spec', () => {
+    it('should compute dimensions excluding all value columns', () => {
+      const inputCols = [
+        createColumnInfo('cpu', 'double'),
+        createColumnInfo('mem', 'double'),
+        createColumnInfo('proc', 'string'),
+      ];
+      const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
+
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('cpu'), makeValueCol('mem')],
+          availableColumns: inputCols,
+        }),
+      );
+      connectNodes(inputNode, node);
+
+      const spec = node.getMetricTemplateSpec();
+
+      expect(spec?.dimensions).toEqual(['proc']);
+    });
+
+    it('should include single value column spec', () => {
       const inputCols = [createColumnInfo('value', 'double')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('value')],
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -562,18 +602,44 @@ describe('MetricsNode', () => {
       );
     });
 
+    it('should include multiple value column specs', () => {
+      const inputCols = [
+        createColumnInfo('cpu', 'double'),
+        createColumnInfo('mem', 'int'),
+      ];
+      const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
+
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('cpu', 'TIME_NANOS', 'LOWER_IS_BETTER'),
+            makeValueCol('mem', 'BYTES', 'LOWER_IS_BETTER'),
+          ],
+          availableColumns: inputCols,
+        }),
+      );
+      connectNodes(inputNode, node);
+
+      const spec = node.getMetricTemplateSpec();
+
+      expect(spec?.valueColumnSpecs?.length).toBe(2);
+      expect(spec?.valueColumnSpecs?.[0].name).toBe('cpu');
+      expect(spec?.valueColumnSpecs?.[0].unit).toBe(
+        protos.TraceMetricV2Spec.MetricUnit.TIME_NANOS,
+      );
+      expect(spec?.valueColumnSpecs?.[1].name).toBe('mem');
+      expect(spec?.valueColumnSpecs?.[1].unit).toBe(
+        protos.TraceMetricV2Spec.MetricUnit.BYTES,
+      );
+    });
+
     it('should set dimension uniqueness to UNIQUE', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({dimensionUniqueness: 'UNIQUE', availableColumns: inputCols}),
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -587,14 +653,12 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          dimensionUniqueness: 'NOT_UNIQUE',
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -608,15 +672,14 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'CUSTOM',
-        customUnit: 'my_custom_unit',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('value', 'CUSTOM', 'NOT_APPLICABLE', 'my_custom_unit'),
+          ],
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -628,14 +691,12 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'LOWER_IS_BETTER',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('value', 'COUNT', 'LOWER_IS_BETTER')],
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -649,14 +710,7 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(makeState({availableColumns: inputCols}));
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -667,38 +721,48 @@ describe('MetricsNode', () => {
   });
 
   describe('serializeState', () => {
-    it('should serialize all state properties', () => {
+    it('should serialize all state properties including valueColumns array', () => {
       const inputNode = createMockNode({columns: []});
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'my_metric',
-        valueColumn: 'value1',
-        unit: 'BYTES',
-        polarity: 'HIGHER_IS_BETTER',
-        dimensionUniqueness: 'UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'my_metric',
+          valueColumns: [makeValueCol('value1', 'BYTES', 'HIGHER_IS_BETTER')],
+          dimensionUniqueness: 'UNIQUE',
+        }),
+      );
       connectNodes(inputNode, node);
 
       const serialized = node.serializeState();
 
       expect(serialized.metricIdPrefix).toBe('my_metric');
-      expect(serialized.valueColumn).toBe('value1');
-      expect(serialized.unit).toBe('BYTES');
-      expect(serialized.polarity).toBe('HIGHER_IS_BETTER');
+      expect(serialized.valueColumns).toHaveLength(1);
+      expect(serialized.valueColumns?.[0].column).toBe('value1');
+      expect(serialized.valueColumns?.[0].unit).toBe('BYTES');
+      expect(serialized.valueColumns?.[0].polarity).toBe('HIGHER_IS_BETTER');
       expect(serialized.dimensionUniqueness).toBe('UNIQUE');
       expect(serialized.primaryInputId).toBe(inputNode.nodeId);
     });
 
+    it('should serialize multiple value columns', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [
+            makeValueCol('cpu', 'TIME_NANOS', 'LOWER_IS_BETTER'),
+            makeValueCol('mem', 'BYTES', 'LOWER_IS_BETTER'),
+          ],
+        }),
+      );
+
+      const serialized = node.serializeState();
+
+      expect(serialized.valueColumns).toHaveLength(2);
+      expect(serialized.valueColumns?.[0].column).toBe('cpu');
+      expect(serialized.valueColumns?.[1].column).toBe('mem');
+    });
+
     it('should handle missing primary input', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState());
 
       const serialized = node.serializeState();
 
@@ -707,45 +771,102 @@ describe('MetricsNode', () => {
   });
 
   describe('deserializeState', () => {
-    it('should deserialize all state properties', () => {
+    it('should deserialize new-format valueColumns array', () => {
       const serialized: MetricsSerializedState = {
         metricIdPrefix: 'restored_metric',
-        valueColumn: 'value1',
-        unit: 'MEGABYTES',
-        polarity: 'LOWER_IS_BETTER',
+        valueColumns: [
+          {column: 'value1', unit: 'MEGABYTES', polarity: 'LOWER_IS_BETTER'},
+        ],
         dimensionUniqueness: 'UNIQUE',
       };
 
       const state = MetricsNode.deserializeState(serialized);
 
       expect(state.metricIdPrefix).toBe('restored_metric');
-      expect(state.valueColumn).toBe('value1');
-      expect(state.unit).toBe('MEGABYTES');
-      expect(state.polarity).toBe('LOWER_IS_BETTER');
+      expect(state.valueColumns).toHaveLength(1);
+      expect(state.valueColumns[0].column).toBe('value1');
+      expect(state.valueColumns[0].unit).toBe('MEGABYTES');
+      expect(state.valueColumns[0].polarity).toBe('LOWER_IS_BETTER');
       expect(state.dimensionUniqueness).toBe('UNIQUE');
       expect(state.availableColumns).toEqual([]);
+    });
+
+    it('should deserialize multiple value columns', () => {
+      const serialized: MetricsSerializedState = {
+        metricIdPrefix: 'multi',
+        valueColumns: [
+          {column: 'cpu', unit: 'TIME_NANOS', polarity: 'LOWER_IS_BETTER'},
+          {column: 'mem', unit: 'BYTES', polarity: 'LOWER_IS_BETTER'},
+        ],
+        dimensionUniqueness: 'NOT_UNIQUE',
+      };
+
+      const state = MetricsNode.deserializeState(serialized);
+
+      expect(state.valueColumns).toHaveLength(2);
+      expect(state.valueColumns[0].column).toBe('cpu');
+      expect(state.valueColumns[1].column).toBe('mem');
     });
 
     it('should provide defaults for missing properties', () => {
       const state = MetricsNode.deserializeState({} as MetricsSerializedState);
 
       expect(state.metricIdPrefix).toBe('');
-      expect(state.valueColumn).toBeUndefined();
-      expect(state.unit).toBe('COUNT');
-      expect(state.polarity).toBe('NOT_APPLICABLE');
+      expect(state.valueColumns).toEqual([]);
       expect(state.dimensionUniqueness).toBe('NOT_UNIQUE');
     });
 
-    it('should migrate from old multi-value format', () => {
-      // Old format had values array
+    it('should migrate from old single-value format (valueColumn field)', () => {
+      const oldFormat = {
+        metricIdPrefix: 'old_metric',
+        valueColumn: 'value1',
+        unit: 'BYTES',
+        customUnit: undefined,
+        polarity: 'HIGHER_IS_BETTER',
+        dimensionUniqueness: 'NOT_UNIQUE',
+      } as unknown as MetricsSerializedState;
+
+      const state = MetricsNode.deserializeState(oldFormat);
+
+      expect(state.metricIdPrefix).toBe('old_metric');
+      expect(state.valueColumns).toHaveLength(1);
+      expect(state.valueColumns[0].column).toBe('value1');
+      expect(state.valueColumns[0].unit).toBe('BYTES');
+      expect(state.valueColumns[0].polarity).toBe('HIGHER_IS_BETTER');
+    });
+
+    it('should migrate from old single-value format with custom unit', () => {
+      const oldFormat = {
+        metricIdPrefix: 'test',
+        valueColumn: 'value',
+        unit: 'CUSTOM',
+        customUnit: 'widgets',
+        polarity: 'NOT_APPLICABLE',
+        dimensionUniqueness: 'NOT_UNIQUE',
+      } as unknown as MetricsSerializedState;
+
+      const state = MetricsNode.deserializeState(oldFormat);
+
+      expect(state.valueColumns).toHaveLength(1);
+      expect(state.valueColumns[0].unit).toBe('CUSTOM');
+      expect(state.valueColumns[0].customUnit).toBe('widgets');
+    });
+
+    it('should migrate from old multi-value values[] array format', () => {
       const oldFormat = {
         metricIdPrefix: 'old_metric',
         values: [
           {
-            column: 'old_value',
+            column: 'cpu',
+            unit: 'TIME_NANOS',
+            customUnit: undefined,
+            polarity: 'LOWER_IS_BETTER',
+          },
+          {
+            column: 'mem',
             unit: 'BYTES',
-            customUnit: 'old_custom',
-            polarity: 'HIGHER_IS_BETTER',
+            customUnit: undefined,
+            polarity: 'LOWER_IS_BETTER',
           },
         ],
         dimensionUniqueness: 'UNIQUE',
@@ -754,18 +875,17 @@ describe('MetricsNode', () => {
       const state = MetricsNode.deserializeState(oldFormat);
 
       expect(state.metricIdPrefix).toBe('old_metric');
-      expect(state.valueColumn).toBe('old_value');
-      expect(state.unit).toBe('BYTES');
-      expect(state.customUnit).toBe('old_custom');
-      expect(state.polarity).toBe('HIGHER_IS_BETTER');
+      expect(state.valueColumns).toHaveLength(2);
+      expect(state.valueColumns[0].column).toBe('cpu');
+      expect(state.valueColumns[1].column).toBe('mem');
     });
 
     it('should migrate from old metricId field', () => {
       const oldFormat = {
         metricId: 'legacy_metric',
-        valueColumn: 'val',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
+        valueColumns: [
+          {column: 'val', unit: 'COUNT', polarity: 'NOT_APPLICABLE'},
+        ],
         dimensionUniqueness: 'NOT_UNIQUE',
       } as unknown as MetricsSerializedState;
 
@@ -777,40 +897,63 @@ describe('MetricsNode', () => {
 
   describe('clone', () => {
     it('should create a new node with same state', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value1',
-        unit: 'BYTES',
-        polarity: 'HIGHER_IS_BETTER',
-        dimensionUniqueness: 'UNIQUE',
-        availableColumns: [createColumnInfo('value1', 'int')],
-      });
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'test',
+          valueColumns: [makeValueCol('value1', 'BYTES', 'HIGHER_IS_BETTER')],
+          dimensionUniqueness: 'UNIQUE',
+          availableColumns: [createColumnInfo('value1', 'int')],
+        }),
+      );
 
       const cloned = node.clone() as MetricsNode;
 
       expect(cloned).toBeInstanceOf(MetricsNode);
       expect(cloned.nodeId).not.toBe(node.nodeId);
       expect(cloned.state.metricIdPrefix).toBe('test');
-      expect(cloned.state.valueColumn).toBe('value1');
-      expect(cloned.state.unit).toBe('BYTES');
+      expect(cloned.state.valueColumns).toHaveLength(1);
+      expect(cloned.state.valueColumns[0].column).toBe('value1');
+      expect(cloned.state.valueColumns[0].unit).toBe('BYTES');
       expect(cloned.state.dimensionUniqueness).toBe('UNIQUE');
+    });
+
+    it('should deep-copy valueColumns array so mutation does not affect original', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('cpu'), makeValueCol('mem')],
+        }),
+      );
+
+      const cloned = node.clone() as MetricsNode;
+
+      // Mutate clone
+      cloned.state.valueColumns[0].unit = 'BYTES';
+      cloned.state.valueColumns.push(makeValueCol('extra'));
+
+      // Original should be unaffected
+      expect(node.state.valueColumns[0].unit).toBe('COUNT');
+      expect(node.state.valueColumns).toHaveLength(2);
     });
 
     it('should preserve onchange callback', () => {
       const onchange = jest.fn();
       const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
+        ...makeState(),
         onchange,
       });
 
       const cloned = node.clone() as MetricsNode;
 
       expect(cloned.state.onchange).toBe(onchange);
+    });
+
+    it('should not copy issues to the clone', () => {
+      const node = new MetricsNode({} as MetricsNodeState);
+      node.validate(); // Triggers issues creation
+
+      const cloned = node.clone() as MetricsNode;
+
+      expect(cloned.state.issues).toBeUndefined();
     });
   });
 
@@ -832,86 +975,64 @@ describe('MetricsNode', () => {
     });
 
     it('should show invalid state when metric ID prefix is empty', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: '',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState({metricIdPrefix: ''}));
 
       const details = node.nodeDetails();
 
-      // Content should be defined and show invalid state
       expect(details.content).toBeDefined();
     });
 
     it('should show metric ID prefix when configured', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'my_metric',
-        valueColumn: undefined,
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(
+        makeState({metricIdPrefix: 'my_metric', valueColumns: []}),
+      );
 
       const details = node.nodeDetails();
 
       expect(details.content).toBeDefined();
     });
 
-    it('should show value column', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'my_metric',
-        valueColumn: 'value1',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+    it('should show value columns', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('cpu'), makeValueCol('mem')],
+        }),
+      );
 
       const details = node.nodeDetails();
 
       expect(details.content).toBeDefined();
     });
 
-    it('should show computed dimensions', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'my_metric',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [
-          createColumnInfo('value', 'double'),
-          createColumnInfo('dim1', 'string'),
-          createColumnInfo('dim2', 'int'),
-        ],
-      });
+    it('should compute getDimensions correctly excluding value columns', () => {
+      const node = new MetricsNode(
+        makeState({
+          valueColumns: [makeValueCol('value')],
+          availableColumns: [
+            createColumnInfo('value', 'double'),
+            createColumnInfo('dim1', 'string'),
+            createColumnInfo('dim2', 'int'),
+          ],
+        }),
+      );
 
       const details = node.nodeDetails();
 
       expect(details.content).toBeDefined();
-      // Dimensions should be computed as ['dim1', 'dim2']
       expect(node.getDimensions()).toEqual(['dim1', 'dim2']);
     });
   });
 
   describe('nodeSpecificModify', () => {
     it('should return sections for configuration', () => {
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [
-          createColumnInfo('value', 'int'),
-          createColumnInfo('name', 'string'),
-        ],
-      });
+      const node = new MetricsNode(
+        makeState({
+          availableColumns: [
+            createColumnInfo('value', 'int'),
+            createColumnInfo('name', 'string'),
+          ],
+        }),
+      );
 
       const modify = node.nodeSpecificModify();
 
@@ -925,7 +1046,7 @@ describe('MetricsNode', () => {
   });
 
   describe('integration tests', () => {
-    it('should work end-to-end with complete configuration', () => {
+    it('should work end-to-end with single value column', () => {
       const inputCols = [
         createColumnInfo('id', 'int'),
         createColumnInfo('ts', 'timestamp'),
@@ -935,24 +1056,22 @@ describe('MetricsNode', () => {
       ];
       const inputNode = createMockNodeWithStructuredQuery('source', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'process_metrics',
-        valueColumn: 'cpu_time',
-        unit: 'TIME_NANOS',
-        polarity: 'LOWER_IS_BETTER',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'process_metrics',
+          valueColumns: [
+            makeValueCol('cpu_time', 'TIME_NANOS', 'LOWER_IS_BETTER'),
+          ],
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
-      // Should validate
       expect(node.validate()).toBe(true);
 
-      // Should generate structured query
       const sq = node.getStructuredQuery();
       expect(sq).toBeDefined();
 
-      // Should generate metric template spec
       const spec = node.getMetricTemplateSpec();
       expect(spec).toBeDefined();
       expect(spec?.idPrefix).toBe('process_metrics');
@@ -961,13 +1080,39 @@ describe('MetricsNode', () => {
       expect(spec?.valueColumnSpecs?.[0].unit).toBe(
         protos.TraceMetricV2Spec.MetricUnit.TIME_NANOS,
       );
-      // Dimensions should be all columns except value
       expect(spec?.dimensions).toEqual([
         'id',
         'ts',
         'process_name',
         'thread_name',
       ]);
+    });
+
+    it('should work end-to-end with multiple value columns', () => {
+      const inputCols = [
+        createColumnInfo('cpu_time', 'double'),
+        createColumnInfo('mem_bytes', 'int'),
+        createColumnInfo('process_name', 'string'),
+      ];
+      const inputNode = createMockNodeWithStructuredQuery('source', inputCols);
+
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'multi_metrics',
+          valueColumns: [
+            makeValueCol('cpu_time', 'TIME_NANOS', 'LOWER_IS_BETTER'),
+            makeValueCol('mem_bytes', 'BYTES', 'LOWER_IS_BETTER'),
+          ],
+          availableColumns: inputCols,
+        }),
+      );
+      connectNodes(inputNode, node);
+
+      expect(node.validate()).toBe(true);
+
+      const spec = node.getMetricTemplateSpec();
+      expect(spec?.valueColumnSpecs?.length).toBe(2);
+      expect(spec?.dimensions).toEqual(['process_name']);
     });
 
     it('should handle serialization round-trip', () => {
@@ -977,36 +1122,59 @@ describe('MetricsNode', () => {
       ];
       const inputNode = createMockNodeWithStructuredQuery('source', inputCols);
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'original_metric',
-        valueColumn: 'value1',
-        unit: 'PERCENTAGE',
-        polarity: 'HIGHER_IS_BETTER',
-        dimensionUniqueness: 'UNIQUE',
-        availableColumns: inputCols,
-      });
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'original_metric',
+          valueColumns: [
+            makeValueCol('value1', 'PERCENTAGE', 'HIGHER_IS_BETTER'),
+          ],
+          dimensionUniqueness: 'UNIQUE',
+          availableColumns: inputCols,
+        }),
+      );
       connectNodes(inputNode, node);
 
-      // Serialize
       const serialized = node.serializeState();
 
-      // Deserialize
       const restoredState = MetricsNode.deserializeState(
         serialized as MetricsSerializedState,
       );
 
-      // Create new node
       const restoredNode = new MetricsNode(restoredState);
 
-      // Should have same configuration
       expect(restoredNode.state.metricIdPrefix).toBe('original_metric');
-      expect(restoredNode.state.valueColumn).toBe('value1');
-      expect(restoredNode.state.unit).toBe('PERCENTAGE');
-      expect(restoredNode.state.polarity).toBe('HIGHER_IS_BETTER');
+      expect(restoredNode.state.valueColumns).toHaveLength(1);
+      expect(restoredNode.state.valueColumns[0].column).toBe('value1');
+      expect(restoredNode.state.valueColumns[0].unit).toBe('PERCENTAGE');
+      expect(restoredNode.state.valueColumns[0].polarity).toBe(
+        'HIGHER_IS_BETTER',
+      );
       expect(restoredNode.state.dimensionUniqueness).toBe('UNIQUE');
     });
 
-    it('should preserve value column after deserialization and reconnection', () => {
+    it('should handle multi-value serialization round-trip', () => {
+      const node = new MetricsNode(
+        makeState({
+          metricIdPrefix: 'multi',
+          valueColumns: [
+            makeValueCol('cpu', 'TIME_NANOS', 'LOWER_IS_BETTER'),
+            makeValueCol('mem', 'BYTES', 'LOWER_IS_BETTER'),
+            makeValueCol('score', 'CUSTOM', 'HIGHER_IS_BETTER', 'pts'),
+          ],
+        }),
+      );
+
+      const serialized = node.serializeState();
+      const restored = MetricsNode.deserializeState(
+        serialized as MetricsSerializedState,
+      );
+      const restoredNode = new MetricsNode(restored);
+
+      expect(restoredNode.state.valueColumns).toHaveLength(3);
+      expect(restoredNode.state.valueColumns[2].customUnit).toBe('pts');
+    });
+
+    it('should preserve value columns after deserialization and reconnection', () => {
       const inputCols = [
         createColumnInfo('id', 'int'),
         createColumnInfo('metric_value', 'double'),
@@ -1014,48 +1182,30 @@ describe('MetricsNode', () => {
       ];
       const inputNode = createMockNodeWithStructuredQuery('source', inputCols);
 
-      // Simulate deserialization: create node with value but empty availableColumns
       const deserializedState = MetricsNode.deserializeState({
         metricIdPrefix: 'my_metric',
-        valueColumn: 'metric_value',
-        unit: 'BYTES',
-        polarity: 'LOWER_IS_BETTER',
+        valueColumns: [
+          {column: 'metric_value', unit: 'BYTES', polarity: 'LOWER_IS_BETTER'},
+        ],
         dimensionUniqueness: 'NOT_UNIQUE',
       });
 
-      // availableColumns should be empty after deserialization
       expect(deserializedState.availableColumns).toEqual([]);
 
       const restoredNode = new MetricsNode(deserializedState);
+      expect(restoredNode.state.valueColumns).toHaveLength(1);
 
-      // Value should be preserved even with empty availableColumns
-      expect(restoredNode.state.valueColumn).toBe('metric_value');
-
-      // Connect to input (simulates third pass of deserialization)
       connectNodes(inputNode, restoredNode);
-
-      // Call onPrevNodesUpdated (simulates fourth pass of deserialization)
       restoredNode.onPrevNodesUpdated();
 
-      // availableColumns should now be populated
       expect(restoredNode.state.availableColumns.length).toBe(3);
-      expect(restoredNode.state.availableColumns.map((c) => c.name)).toEqual([
-        'id',
-        'metric_value',
-        'category',
-      ]);
-
-      // Value should STILL be preserved (not cleared)
-      expect(restoredNode.state.valueColumn).toBe('metric_value');
-
-      // Dimensions should be computed as all columns except value
+      expect(restoredNode.state.valueColumns).toHaveLength(1);
+      expect(restoredNode.state.valueColumns[0].column).toBe('metric_value');
       expect(restoredNode.getDimensions()).toEqual(['id', 'category']);
-
-      // Node should validate successfully
       expect(restoredNode.validate()).toBe(true);
     });
 
-    it('should clear value column if it no longer exists after reconnection', () => {
+    it('should clear stale value columns if they no longer exist after reconnection', () => {
       const inputCols = [
         createColumnInfo('id', 'int'),
         createColumnInfo('different_value', 'double'),
@@ -1064,9 +1214,13 @@ describe('MetricsNode', () => {
 
       const deserializedState = MetricsNode.deserializeState({
         metricIdPrefix: 'my_metric',
-        valueColumn: 'old_value_column',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
+        valueColumns: [
+          {
+            column: 'old_value_column',
+            unit: 'COUNT',
+            polarity: 'NOT_APPLICABLE',
+          },
+        ],
         dimensionUniqueness: 'NOT_UNIQUE',
       });
 
@@ -1074,22 +1228,21 @@ describe('MetricsNode', () => {
       connectNodes(inputNode, restoredNode);
       restoredNode.onPrevNodesUpdated();
 
-      // Value column should be cleared because 'old_value_column' doesn't exist
-      expect(restoredNode.state.valueColumn).toBeUndefined();
+      expect(restoredNode.state.valueColumns).toHaveLength(0);
     });
 
-    it('should clear value column if it becomes non-numeric after reconnection', () => {
+    it('should clear value columns that become non-numeric after reconnection', () => {
       const inputCols = [
         createColumnInfo('id', 'int'),
-        createColumnInfo('metric_value', 'string'), // Same name but now string type
+        createColumnInfo('metric_value', 'string'), // was numeric, now string
       ];
       const inputNode = createMockNodeWithStructuredQuery('source', inputCols);
 
       const deserializedState = MetricsNode.deserializeState({
         metricIdPrefix: 'my_metric',
-        valueColumn: 'metric_value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
+        valueColumns: [
+          {column: 'metric_value', unit: 'COUNT', polarity: 'NOT_APPLICABLE'},
+        ],
         dimensionUniqueness: 'NOT_UNIQUE',
       });
 
@@ -1097,8 +1250,7 @@ describe('MetricsNode', () => {
       connectNodes(inputNode, restoredNode);
       restoredNode.onPrevNodesUpdated();
 
-      // Value column should be cleared because 'metric_value' is not numeric
-      expect(restoredNode.state.valueColumn).toBeUndefined();
+      expect(restoredNode.state.valueColumns).toHaveLength(0);
     });
 
     it('should include primaryInputId in serialized state', () => {
@@ -1107,22 +1259,166 @@ describe('MetricsNode', () => {
         'input-123',
         inputCols,
       );
-      // Override the nodeId for testing
       (inputNode as {nodeId: string}).nodeId = 'input-123';
 
-      const node = new MetricsNode({
-        metricIdPrefix: 'test',
-        valueColumn: 'value',
-        unit: 'COUNT',
-        polarity: 'NOT_APPLICABLE',
-        dimensionUniqueness: 'NOT_UNIQUE',
-        availableColumns: [],
-      });
+      const node = new MetricsNode(makeState());
       connectNodes(inputNode, node);
 
       const serialized = node.serializeState();
 
       expect(serialized.primaryInputId).toBe('input-123');
     });
+  });
+});
+
+describe('parseMetricBundleForValue', () => {
+  // Build a TraceSummary proto with one bundle.
+  // _dimensionNames and _valueColumnNames are passed for call-site readability
+  // but the proto structure doesn't embed column names (those come from
+  // the calling code's dimension/valueColumnNames arguments).
+  function buildTestProto(
+    rows: Array<{dims: string[]; values: number[]}>,
+  ): Uint8Array {
+    const bundle = protos.TraceMetricV2Bundle.create({
+      row: rows.map((r) => ({
+        dimension: r.dims.map((d) =>
+          protos.TraceMetricV2Bundle.Row.Dimension.create({stringValue: d}),
+        ),
+        values: r.values.map((v) =>
+          protos.TraceMetricV2Bundle.Row.Value.create({doubleValue: v}),
+        ),
+      })),
+    });
+    const summary = protos.TraceSummary.create({metricBundles: [bundle]});
+    return protos.TraceSummary.encode(summary).finish();
+  }
+
+  it('should return undefined when bundle is missing', () => {
+    const summary = protos.TraceSummary.create({metricBundles: []});
+    const data = protos.TraceSummary.encode(summary).finish();
+
+    const result = parseMetricBundleForValue(
+      data,
+      'prefix',
+      ['dim'],
+      ['val'],
+      0,
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when valueIndex is out of range', () => {
+    const data = buildTestProto([{dims: ['a'], values: [1]}]);
+
+    const result = parseMetricBundleForValue(
+      data,
+      'prefix',
+      ['dim'],
+      ['val'],
+      1, // out of range
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should parse the first value column correctly', () => {
+    const data = buildTestProto([
+      {dims: ['chrome'], values: [100, 200]},
+      {dims: ['android'], values: [150, 250]},
+    ]);
+
+    const result = parseMetricBundleForValue(
+      data,
+      'my_metric',
+      ['process'],
+      ['cpu', 'mem'],
+      0, // cpu
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.metricId).toBe('my_metric_cpu');
+    expect(result?.rows).toHaveLength(2);
+    expect(result?.rows[0]['process']).toBe('chrome');
+    expect(result?.rows[0]['cpu']).toBe(100);
+    // Should NOT include 'mem' column
+    expect('mem' in (result?.rows[0] ?? {})).toBe(false);
+  });
+
+  it('should parse the second value column correctly', () => {
+    const data = buildTestProto([
+      {dims: ['chrome'], values: [100, 200]},
+      {dims: ['android'], values: [150, 250]},
+    ]);
+
+    const result = parseMetricBundleForValue(
+      data,
+      'my_metric',
+      ['process'],
+      ['cpu', 'mem'],
+      1, // mem
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.metricId).toBe('my_metric_mem');
+    expect(result?.rows[0]['mem']).toBe(200);
+    expect(result?.rows[1]['mem']).toBe(250);
+    expect('cpu' in (result?.rows[0] ?? {})).toBe(false);
+  });
+
+  it('should build schema with dimension columns as text and value as quantitative', () => {
+    const data = buildTestProto([{dims: ['chrome', 'main'], values: [42]}]);
+
+    const result = parseMetricBundleForValue(
+      data,
+      'prefix',
+      ['process', 'thread'],
+      ['cpu'],
+      0,
+    );
+
+    expect(result).toBeDefined();
+    if (result !== undefined) {
+      const schema = result.schema[result.metricId];
+      const processEntry = schema['process'];
+      const threadEntry = schema['thread'];
+      const cpuEntry = schema['cpu'];
+      // Schema values for leaf columns are ColumnDef objects with columnType.
+      expect(
+        isColumnDef(processEntry) ? processEntry.columnType : undefined,
+      ).toBe('text');
+      expect(
+        isColumnDef(threadEntry) ? threadEntry.columnType : undefined,
+      ).toBe('text');
+      expect(isColumnDef(cpuEntry) ? cpuEntry.columnType : undefined).toBe(
+        'quantitative',
+      );
+    }
+  });
+
+  it('should handle rows with null values', () => {
+    const bundle = protos.TraceMetricV2Bundle.create({
+      row: [
+        {
+          dimension: [
+            protos.TraceMetricV2Bundle.Row.Dimension.create({stringValue: 'a'}),
+          ],
+          values: [], // no values - simulates null
+        },
+      ],
+    });
+    const summary = protos.TraceSummary.create({metricBundles: [bundle]});
+    const data = protos.TraceSummary.encode(summary).finish();
+
+    const result = parseMetricBundleForValue(
+      data,
+      'prefix',
+      ['dim'],
+      ['val'],
+      0,
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.rows[0]['val']).toBeNull();
   });
 });

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -798,3 +798,165 @@
   justify-content: center;
   padding: 24px;
 }
+
+// Tabs inside the result box take full height.
+.pf-metrics-result-content > .pf-tabs {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .pf-tabs__content {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+
+    .pf-data-grid {
+      height: 100%;
+    }
+  }
+}
+
+// ─── Two-column drag-and-drop layout (Dimensions | Values) ──────────────────
+
+.pf-metrics-v2-columns-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  min-height: 200px;
+}
+
+.pf-metrics-v2-column-panel {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--pf-color-border);
+  border-radius: 6px;
+  overflow: hidden;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+
+  &.pf-drop-active {
+    border-color: var(--pf-color-primary);
+    background-color: color-mix(
+      in srgb,
+      var(--pf-color-primary) 8%,
+      transparent
+    );
+  }
+
+  &.pf-drop-rejected {
+    border-color: var(--md-sys-color-error);
+    background-color: color-mix(
+      in srgb,
+      var(--md-sys-color-error) 8%,
+      transparent
+    );
+  }
+}
+
+.pf-metrics-v2-column-panel__header {
+  padding: 6px 10px;
+  font-size: var(--pf-font-size-s);
+  font-weight: 600;
+  background: var(--pf-color-background-secondary);
+  border-bottom: 1px solid var(--pf-color-border);
+  user-select: none;
+}
+
+.pf-metrics-v2-column-panel__list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.pf-metrics-v2-empty-hint {
+  padding: 12px;
+  color: var(--pf-color-text-secondary);
+  font-size: var(--pf-font-size-s);
+  text-align: center;
+  font-style: italic;
+}
+
+// Individual column item row (shared between dimensions and values)
+.pf-metrics-v2-column-item {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 8px;
+  cursor: grab;
+  user-select: none;
+  border-bottom: 1px solid var(--pf-color-border);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &[draggable="true"]:hover {
+    background: var(--pf-color-background-secondary);
+  }
+}
+
+.pf-metrics-v2-value-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 28px;
+}
+
+.pf-metrics-v2-drag-handle {
+  color: var(--pf-color-text-secondary);
+  font-size: 14px;
+  cursor: grab;
+  flex-shrink: 0;
+}
+
+.pf-metrics-v2-col-name {
+  flex: 1;
+  font-family: var(--pf-font-monospace);
+  font-size: var(--pf-font-size-s);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pf-metrics-v2-col-type {
+  font-size: var(--pf-font-size-xs);
+  color: var(--pf-color-text-secondary);
+  font-style: italic;
+  flex-shrink: 0;
+}
+
+// Value item: config row (unit + polarity selects)
+.pf-metrics-v2-value-config {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 0 4px 18px; // Indent to align under column name
+
+  > .pf-outlined-field {
+    flex: 1;
+    min-width: 100px;
+  }
+}
+
+// "Add value column" dropdown at the bottom of the values panel
+.pf-metrics-v2-add-value {
+  padding: 4px 8px;
+  border-top: 1px dashed var(--pf-color-border);
+
+  > .pf-outlined-field {
+    width: 100%;
+  }
+}
+
+// Dimensions item: inline layout (handle + name + type + optional arrow btn)
+.pf-metrics-v2-columns-layout .pf-metrics-v2-column-panel:first-child {
+  .pf-metrics-v2-column-item {
+    flex-direction: row;
+    align-items: center;
+    gap: 4px;
+  }
+}


### PR DESCRIPTION
Previously the Metrics node in the Data Explorer supported only a single
numeric value column. This change extends it to support any number of
value columns simultaneously, each becoming a separate metric in the
exported `TraceMetricV2TemplateSpec`.

Changes:
- Replace the single value-column dropdown with a two-panel drag-and-drop
  layout (Dimensions | Values); numeric columns can be dragged between
  panels or added via a dropdown
- Per-column unit and polarity config, revealed by an expand toggle on
  each value item
- Export modal shows a tab per value column in the result preview
- Deserializer migrates the old single-value (`valueColumn`) and
  intermediate multi-value (`values[]`) serialized formats
- Extract enum utilities to `metrics_enum_utils.ts` and export modal
  logic to `metrics_export_modal.ts`
- Full unit test coverage for multi-value behavior and
  `parseMetricBundleForValue`

<img width="940" height="424" alt="image" src="https://github.com/user-attachments/assets/44a92501-2aa2-4250-b847-b671f52ef907" />
