### PR TITLE
ui: Add more charts

### DIFF
--- a/ui/src/components/widgets/charts/boxplot.ts
+++ b/ui/src/components/widgets/charts/boxplot.ts
@@ -1,0 +1,197 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {EChartsCoreOption} from 'echarts/core';
+import {formatNumber} from './chart_utils';
+import {EChartView} from './echart_view';
+import {
+  buildAxisOption,
+  buildGridOption,
+  buildTooltipOption,
+} from './chart_option_builder';
+import {getChartThemeColors} from './chart_theme';
+
+/**
+ * A single box in a boxplot chart.
+ */
+export interface BoxplotItem {
+  /** Label for this box (category name) */
+  readonly label: string;
+  /** Minimum value (lower whisker) */
+  readonly min: number;
+  /** First quartile (Q1 / 25th percentile) */
+  readonly q1: number;
+  /** Median (Q2 / 50th percentile) */
+  readonly median: number;
+  /** Third quartile (Q3 / 75th percentile) */
+  readonly q3: number;
+  /** Maximum value (upper whisker) */
+  readonly max: number;
+}
+
+/**
+ * Data provided to a BoxplotChart.
+ */
+export interface BoxplotData {
+  readonly items: readonly BoxplotItem[];
+}
+
+export interface BoxplotAttrs {
+  /**
+   * Boxplot data to display, or undefined if loading.
+   * When undefined, a loading spinner is shown.
+   */
+  readonly data: BoxplotData | undefined;
+
+  /**
+   * Height of the chart in pixels. Defaults to 200.
+   */
+  readonly height?: number;
+
+  /**
+   * Label for the category axis.
+   */
+  readonly categoryLabel?: string;
+
+  /**
+   * Label for the value axis.
+   */
+  readonly valueLabel?: string;
+
+  /**
+   * Orientation: 'vertical' (categories on X) or 'horizontal' (categories on Y).
+   * Defaults to 'vertical'.
+   */
+  readonly orientation?: 'vertical' | 'horizontal';
+
+  /**
+   * Fill parent container. Defaults to false.
+   */
+  readonly fillParent?: boolean;
+
+  /**
+   * Custom class name for the container.
+   */
+  readonly className?: string;
+
+  /**
+   * Format function for value axis tick values.
+   */
+  readonly formatValue?: (value: number) => string;
+}
+
+export class BoxplotChart implements m.ClassComponent<BoxplotAttrs> {
+  view({attrs}: m.CVnode<BoxplotAttrs>) {
+    const {data, height, fillParent, className} = attrs;
+
+    const isEmpty = data !== undefined && data.items.length === 0;
+    const option =
+      data !== undefined && !isEmpty
+        ? buildBoxplotOption(attrs, data)
+        : undefined;
+
+    return m(EChartView, {
+      option,
+      height,
+      fillParent,
+      className,
+      empty: isEmpty,
+    });
+  }
+}
+
+function buildBoxplotOption(
+  attrs: BoxplotAttrs,
+  data: BoxplotData,
+): EChartsCoreOption {
+  const {
+    categoryLabel,
+    valueLabel,
+    orientation = 'vertical',
+    formatValue,
+  } = attrs;
+  const fmtVal = formatValue ?? formatNumber;
+  const horizontal = orientation === 'horizontal';
+  const theme = getChartThemeColors();
+
+  const categories = data.items.map((item) => item.label);
+  // ECharts boxplot series data format: [min, Q1, median, Q3, max].
+  // In tooltip params.value, ECharts prepends the x-axis index, so the
+  // actual values are at indices 1-5.
+  const boxData = data.items.map((item) => [
+    item.min,
+    item.q1,
+    item.median,
+    item.q3,
+    item.max,
+  ]);
+
+  const categoryAxis = buildAxisOption(
+    {
+      type: 'category',
+      data: categories,
+      name: categoryLabel,
+      labelOverflow: 'truncate',
+      labelWidth: 80,
+    },
+    !horizontal,
+  );
+
+  const valueAxis = buildAxisOption(
+    {
+      type: 'value',
+      name: valueLabel,
+      formatter:
+        formatValue !== undefined
+          ? (v: number | string) => fmtVal(v as number)
+          : undefined,
+      scale: true,
+    },
+    horizontal,
+  );
+
+  const option: Record<string, unknown> = {
+    animation: false,
+    color: [...theme.chartColors],
+    grid: buildGridOption({
+      bottom: horizontal ? 25 : categoryLabel ? 40 : 25,
+    }),
+    xAxis: horizontal ? valueAxis : categoryAxis,
+    yAxis: horizontal ? categoryAxis : valueAxis,
+    tooltip: buildTooltipOption({
+      trigger: 'item' as const,
+      formatter: (params: {name?: string; value?: number[]}) => {
+        const v = params.value;
+        if (v === undefined) return '';
+        return [
+          `<b>${params.name ?? ''}</b>`,
+          `Max: ${fmtVal(v[5] ?? v[4])}`,
+          `Q3: ${fmtVal(v[4] ?? v[3])}`,
+          `Median: ${fmtVal(v[3] ?? v[2])}`,
+          `Q1: ${fmtVal(v[2] ?? v[1])}`,
+          `Min: ${fmtVal(v[1] ?? v[0])}`,
+        ].join('<br>');
+      },
+    }),
+    series: [
+      {
+        type: 'boxplot',
+        data: boxData,
+      },
+    ],
+  };
+
+  return option as EChartsCoreOption;
+}

--- a/ui/src/components/widgets/charts/boxplot_loader.ts
+++ b/ui/src/components/widgets/charts/boxplot_loader.ts
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  QuerySlot,
+  SerialTaskQueue,
+  type QueryResult,
+} from '../../../base/query_slot';
+import {Engine} from '../../../trace_processor/engine';
+import {NUM, STR} from '../../../trace_processor/query_result';
+import {BoxplotData} from './boxplot';
+import {validateColumnName} from './chart_utils';
+
+/**
+ * Configuration for boxplot loaders.
+ */
+export interface BoxplotLoaderConfig {
+  /**
+   * Maximum number of categories to show.
+   * Categories are ordered by median value descending.
+   */
+  readonly limit?: number;
+}
+
+/**
+ * Configuration for SQLBoxplotLoader.
+ */
+export interface SQLBoxplotLoaderOpts {
+  /** The trace processor engine to run queries against. */
+  readonly engine: Engine;
+
+  /** SQL query that provides the data. */
+  readonly query: string;
+
+  /** Column name containing the category/grouping values. */
+  readonly categoryColumn: string;
+
+  /** Column name containing the numeric values to compute stats over. */
+  readonly valueColumn: string;
+}
+
+/**
+ * SQL-based boxplot loader.
+ *
+ * Computes quartile statistics (min, Q1, median, Q3, max) per category
+ * using ROW_NUMBER and conditional aggregation to approximate percentiles
+ * in SQLite (which lacks native PERCENTILE_CONT).
+ */
+export class SQLBoxplotLoader {
+  private readonly engine: Engine;
+  private readonly query: string;
+  private readonly categoryColumn: string;
+  private readonly valueColumn: string;
+  private readonly taskQueue = new SerialTaskQueue();
+  private readonly querySlot = new QuerySlot<BoxplotData>(this.taskQueue);
+
+  constructor(opts: SQLBoxplotLoaderOpts) {
+    validateColumnName(opts.categoryColumn);
+    validateColumnName(opts.valueColumn);
+    this.engine = opts.engine;
+    this.query = opts.query;
+    this.categoryColumn = opts.categoryColumn;
+    this.valueColumn = opts.valueColumn;
+  }
+
+  use(config: BoxplotLoaderConfig): QueryResult<BoxplotData> {
+    const limit = config.limit ?? 20;
+    const cat = this.categoryColumn;
+    const val = this.valueColumn;
+
+    const sql = `
+WITH _src AS (
+  SELECT
+    CAST(${cat} AS TEXT) AS _cat,
+    CAST(${val} AS REAL) AS _val
+  FROM (${this.query})
+  WHERE ${val} IS NOT NULL
+),
+_stats AS (
+  SELECT
+    _cat,
+    MIN(_val) AS _min,
+    MAX(_val) AS _max,
+    COUNT(*) AS _cnt
+  FROM _src
+  GROUP BY _cat
+),
+_ranked AS (
+  SELECT
+    s._cat,
+    s._val,
+    ROW_NUMBER() OVER (PARTITION BY s._cat ORDER BY s._val) AS _rn,
+    st._cnt
+  FROM _src s
+  JOIN _stats st ON s._cat = st._cat
+),
+_quartiles AS (
+  SELECT
+    _cat,
+    MAX(CASE WHEN _rn = MAX(1, CAST((_cnt + 1) * 0.25 AS INT)) THEN _val END) AS _q1,
+    MAX(CASE WHEN _rn = MAX(1, CAST((_cnt + 1) * 0.50 AS INT)) THEN _val END) AS _median,
+    MAX(CASE WHEN _rn = MAX(1, CAST((_cnt + 1) * 0.75 AS INT)) THEN _val END) AS _q3
+  FROM _ranked
+  GROUP BY _cat
+)
+SELECT
+  s._cat,
+  s._min,
+  q._q1,
+  q._median,
+  q._q3,
+  s._max
+FROM _stats s
+JOIN _quartiles q ON s._cat = q._cat
+ORDER BY q._median DESC
+LIMIT ${limit}`.trim();
+
+    return this.querySlot.use({
+      key: {sql},
+      retainOn: ['sql'],
+      queryFn: async () => {
+        const queryResult = await this.engine.query(sql);
+        const items = [];
+
+        const iter = queryResult.iter({
+          _cat: STR,
+          _min: NUM,
+          _q1: NUM,
+          _median: NUM,
+          _q3: NUM,
+          _max: NUM,
+        });
+
+        for (; iter.valid(); iter.next()) {
+          items.push({
+            label: iter._cat,
+            min: iter._min,
+            q1: iter._q1,
+            median: iter._median,
+            q3: iter._q3,
+            max: iter._max,
+          });
+        }
+
+        return {items};
+      },
+    });
+  }
+
+  dispose(): void {
+    this.querySlot.dispose();
+  }
+}

--- a/ui/src/components/widgets/charts/cdf_loader.ts
+++ b/ui/src/components/widgets/charts/cdf_loader.ts
@@ -1,0 +1,145 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Engine} from '../../../trace_processor/engine';
+import {NUM, STR, QueryResult} from '../../../trace_processor/query_result';
+import {LineChartData} from './line_chart';
+import {createChartLoader, ChartLoader, rangeFilters} from './chart_sql_source';
+import type {QueryResult as SlotResult} from '../../../base/query_slot';
+
+/**
+ * Configuration for CDF loaders.
+ */
+export interface CdfLoaderConfig {
+  /**
+   * Range filter to apply to the data (e.g., from brush selection).
+   * Only values within [min, max] are included.
+   */
+  readonly filter?: {
+    readonly min: number;
+    readonly max: number;
+  };
+
+  /**
+   * Maximum number of points to return. When the dataset is larger,
+   * results are capped via SQL LIMIT. Defaults to 500.
+   */
+  readonly maxPoints?: number;
+}
+
+/**
+ * Configuration for SQLCdfLoader.
+ */
+export interface SQLCdfLoaderOpts {
+  /** The trace processor engine to run queries against. */
+  readonly engine: Engine;
+
+  /** SQL query that provides the data. */
+  readonly query: string;
+
+  /** Column name containing the values to compute CDF over. */
+  readonly valueColumn: string;
+
+  /** Optional series/breakdown column name. */
+  readonly seriesColumn?: string;
+}
+
+/**
+ * SQL-based CDF (Cumulative Distribution Function) loader.
+ *
+ * Fetches sorted values from SQL and computes cumulative percentages
+ * in JS. The result is a LineChartData that can be rendered directly
+ * with the LineChart widget.
+ *
+ * Each point has x = value, y = cumulative percentage (0-100).
+ */
+export class SQLCdfLoader {
+  private readonly loader: ChartLoader<CdfLoaderConfig, LineChartData>;
+
+  constructor(opts: SQLCdfLoaderOpts) {
+    const valCol = opts.valueColumn;
+    const seriesCol = opts.seriesColumn;
+
+    const schema: Record<string, 'real' | 'text'> = {
+      [valCol]: 'real',
+    };
+    if (seriesCol !== undefined) {
+      schema[seriesCol] = 'text';
+    }
+
+    this.loader = createChartLoader({
+      engine: opts.engine,
+      query: opts.query,
+      schema,
+      buildQueryConfig: (config) => ({
+        type: 'points',
+        columns: [{column: valCol, alias: '_x', cast: 'real' as const}],
+        breakdown: seriesCol,
+        filters: rangeFilters(valCol, config.filter),
+        orderBy: [{column: '_x', direction: 'asc'}],
+        maxPointsPerSeries: config.maxPoints ?? 500,
+      }),
+      parseResult: (queryResult: QueryResult) => {
+        return parseCdfResult(queryResult, seriesCol !== undefined);
+      },
+    });
+  }
+
+  use(config: CdfLoaderConfig): SlotResult<LineChartData> {
+    return this.loader.use(config);
+  }
+
+  dispose(): void {
+    this.loader.dispose();
+  }
+}
+
+function parseCdfResult(
+  queryResult: QueryResult,
+  hasSeries: boolean,
+): LineChartData {
+  const seriesMap = new Map<string, number[]>();
+
+  if (hasSeries) {
+    const iter = queryResult.iter({_x: NUM, _series: STR});
+    for (; iter.valid(); iter.next()) {
+      const name = iter._series;
+      let values = seriesMap.get(name);
+      if (values === undefined) {
+        values = [];
+        seriesMap.set(name, values);
+      }
+      values.push(iter._x);
+    }
+  } else {
+    const values: number[] = [];
+    seriesMap.set('CDF', values);
+    const iter = queryResult.iter({_x: NUM});
+    for (; iter.valid(); iter.next()) {
+      values.push(iter._x);
+    }
+  }
+
+  const series = Array.from(seriesMap.entries()).map(([name, values]) => {
+    // Values are already sorted (ORDER BY in SQL)
+    const n = values.length;
+    const points = values.map((x, i) => ({
+      x,
+      y: ((i + 1) / n) * 100,
+    }));
+    return {name, points};
+  });
+
+  return {series};
+}

--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -31,6 +31,8 @@ import m from 'mithril';
 import * as echarts from 'echarts/core';
 import {
   BarChart as EBarChart,
+  BoxplotChart as EBoxplotChart,
+  HeatmapChart as EHeatmapChart,
   LineChart as ELineChart,
   PieChart as EPieChart,
   ScatterChart as EScatterChart,
@@ -43,6 +45,7 @@ import {
   DataZoomComponent,
   BrushComponent,
   ToolboxComponent,
+  VisualMapComponent,
 } from 'echarts/components';
 import {CanvasRenderer} from 'echarts/renderers';
 import type {EChartsType} from 'echarts/core';
@@ -63,6 +66,8 @@ function ensureEChartsSetup(): void {
   echartsInitialized = true;
   echarts.use([
     EBarChart,
+    EBoxplotChart,
+    EHeatmapChart,
     ELineChart,
     EPieChart,
     EScatterChart,
@@ -73,6 +78,7 @@ function ensureEChartsSetup(): void {
     DataZoomComponent,
     BrushComponent,
     ToolboxComponent,
+    VisualMapComponent,
     CanvasRenderer,
   ]);
 }

--- a/ui/src/components/widgets/charts/heatmap.ts
+++ b/ui/src/components/widgets/charts/heatmap.ts
@@ -1,0 +1,190 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {EChartsCoreOption} from 'echarts/core';
+import {formatNumber} from './chart_utils';
+import {EChartView} from './echart_view';
+import {
+  buildAxisOption,
+  buildGridOption,
+  buildTooltipOption,
+} from './chart_option_builder';
+import {getChartThemeColors} from './chart_theme';
+
+/**
+ * Data provided to a HeatmapChart.
+ * The grid is defined by xLabels, yLabels, and a values matrix.
+ */
+export interface HeatmapData {
+  /** Labels for the X axis (columns). */
+  readonly xLabels: readonly string[];
+  /** Labels for the Y axis (rows). */
+  readonly yLabels: readonly string[];
+  /**
+   * Values as [xIndex, yIndex, value] triples.
+   * Missing entries are treated as 0.
+   */
+  readonly values: ReadonlyArray<readonly [number, number, number]>;
+  /** Minimum value in the dataset (for color scale). */
+  readonly min: number;
+  /** Maximum value in the dataset (for color scale). */
+  readonly max: number;
+}
+
+export interface HeatmapAttrs {
+  /**
+   * Heatmap data to display, or undefined if loading.
+   * When undefined, a loading spinner is shown.
+   */
+  readonly data: HeatmapData | undefined;
+
+  /**
+   * Height of the chart in pixels. Defaults to 300.
+   */
+  readonly height?: number;
+
+  /**
+   * Label for the X axis.
+   */
+  readonly xAxisLabel?: string;
+
+  /**
+   * Label for the Y axis.
+   */
+  readonly yAxisLabel?: string;
+
+  /**
+   * Fill parent container. Defaults to false.
+   */
+  readonly fillParent?: boolean;
+
+  /**
+   * Custom class name for the container.
+   */
+  readonly className?: string;
+
+  /**
+   * Format function for cell values.
+   */
+  readonly formatValue?: (value: number) => string;
+}
+
+export class HeatmapChart implements m.ClassComponent<HeatmapAttrs> {
+  view({attrs}: m.CVnode<HeatmapAttrs>) {
+    const {data, height = 300, fillParent, className} = attrs;
+
+    const isEmpty =
+      data !== undefined &&
+      (data.values.length === 0 ||
+        data.xLabels.length === 0 ||
+        data.yLabels.length === 0);
+    const option =
+      data !== undefined && !isEmpty
+        ? buildHeatmapOption(attrs, data)
+        : undefined;
+
+    return m(EChartView, {
+      option,
+      height,
+      fillParent,
+      className,
+      empty: isEmpty,
+    });
+  }
+}
+
+function buildHeatmapOption(
+  attrs: HeatmapAttrs,
+  data: HeatmapData,
+): EChartsCoreOption {
+  const {xAxisLabel, yAxisLabel, formatValue} = attrs;
+  const fmtVal = formatValue ?? formatNumber;
+  const theme = getChartThemeColors();
+
+  const option: Record<string, unknown> = {
+    animation: false,
+    grid: buildGridOption({
+      top: 10,
+      right: 80,
+      bottom: xAxisLabel ? 40 : 25,
+    }),
+    xAxis: {
+      ...buildAxisOption(
+        {
+          type: 'category',
+          data: [...data.xLabels],
+          name: xAxisLabel,
+          labelOverflow: 'truncate',
+          labelWidth: 60,
+        },
+        true,
+      ),
+      splitArea: {show: true},
+    },
+    yAxis: {
+      ...buildAxisOption(
+        {
+          type: 'category',
+          data: [...data.yLabels],
+          name: yAxisLabel,
+          labelOverflow: 'truncate',
+          labelWidth: 80,
+        },
+        false,
+      ),
+      splitArea: {show: true},
+    },
+    tooltip: buildTooltipOption({
+      trigger: 'item',
+      formatter: (params: {
+        value?: [number, number, number];
+        name?: string;
+      }) => {
+        const v = params.value;
+        if (v === undefined) return '';
+        const xLabel = data.xLabels[v[0]] ?? '';
+        const yLabel = data.yLabels[v[1]] ?? '';
+        return [`${xLabel} / ${yLabel}`, `Value: ${fmtVal(v[2])}`].join('<br>');
+      },
+    }),
+    visualMap: {
+      min: data.min,
+      max: data.max,
+      calculable: true,
+      orient: 'vertical',
+      right: 0,
+      top: 'center',
+      textStyle: {color: theme.textColor, fontSize: 10},
+      inRange: {
+        color: [theme.chartColors[0] + '22', theme.chartColors[0]],
+      },
+    },
+    series: [
+      {
+        type: 'heatmap',
+        data: [...data.values],
+        label: {show: false},
+        emphasis: {
+          itemStyle: {
+            shadowBlur: 10,
+            shadowColor: 'rgba(0, 0, 0, 0.5)',
+          },
+        },
+      },
+    ],
+  };
+
+  return option as EChartsCoreOption;
+}

--- a/ui/src/components/widgets/charts/heatmap_loader.ts
+++ b/ui/src/components/widgets/charts/heatmap_loader.ts
@@ -1,0 +1,184 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  QuerySlot,
+  SerialTaskQueue,
+  type QueryResult,
+} from '../../../base/query_slot';
+import {Engine} from '../../../trace_processor/engine';
+import {
+  NUM,
+  STR,
+  QueryResult as TPQueryResult,
+} from '../../../trace_processor/query_result';
+import {AggregateFunction} from '../datagrid/model';
+import {sqlAggregateExpr} from '../datagrid/sql_utils';
+import {HeatmapData} from './heatmap';
+import {validateColumnName} from './chart_utils';
+
+/**
+ * Configuration for heatmap loaders.
+ */
+export interface HeatmapLoaderConfig {
+  /** Aggregation function for cell values. Defaults to 'SUM'. */
+  readonly aggregation?: AggregateFunction;
+
+  /** Maximum number of X-axis categories. */
+  readonly xLimit?: number;
+
+  /** Maximum number of Y-axis categories. */
+  readonly yLimit?: number;
+}
+
+/**
+ * Configuration for SQLHeatmapLoader.
+ */
+export interface SQLHeatmapLoaderOpts {
+  /** The trace processor engine to run queries against. */
+  readonly engine: Engine;
+
+  /** SQL query that provides the data. */
+  readonly query: string;
+
+  /** Column name for the X axis (columns of the heatmap). */
+  readonly xColumn: string;
+
+  /** Column name for the Y axis (rows of the heatmap). */
+  readonly yColumn: string;
+
+  /** Column name containing the numeric values to aggregate. */
+  readonly valueColumn: string;
+}
+
+/**
+ * SQL-based heatmap loader.
+ *
+ * Groups data by two categorical dimensions (x, y) and aggregates a
+ * numeric value, producing a grid suitable for the HeatmapChart widget.
+ */
+export class SQLHeatmapLoader {
+  private readonly engine: Engine;
+  private readonly query: string;
+  private readonly xColumn: string;
+  private readonly yColumn: string;
+  private readonly valueColumn: string;
+  private readonly taskQueue = new SerialTaskQueue();
+  private readonly querySlot = new QuerySlot<HeatmapData>(this.taskQueue);
+
+  constructor(opts: SQLHeatmapLoaderOpts) {
+    validateColumnName(opts.xColumn);
+    validateColumnName(opts.yColumn);
+    validateColumnName(opts.valueColumn);
+    this.engine = opts.engine;
+    this.query = opts.query;
+    this.xColumn = opts.xColumn;
+    this.yColumn = opts.yColumn;
+    this.valueColumn = opts.valueColumn;
+  }
+
+  use(config: HeatmapLoaderConfig): QueryResult<HeatmapData> {
+    const agg = config.aggregation ?? 'SUM';
+    const xLimit = config.xLimit ?? 20;
+    const yLimit = config.yLimit ?? 20;
+    const aggExpr = sqlAggregateExpr(agg, this.valueColumn);
+
+    const sql = `
+WITH _src AS (
+  SELECT
+    CAST(${this.xColumn} AS TEXT) AS _x,
+    CAST(${this.yColumn} AS TEXT) AS _y,
+    ${aggExpr} AS _val
+  FROM (${this.query})
+  WHERE ${this.valueColumn} IS NOT NULL
+  GROUP BY _x, _y
+),
+_top_x AS (
+  SELECT _x, SUM(_val) AS _total
+  FROM _src
+  GROUP BY _x
+  ORDER BY _total DESC
+  LIMIT ${xLimit}
+),
+_top_y AS (
+  SELECT _y, SUM(_val) AS _total
+  FROM _src
+  GROUP BY _y
+  ORDER BY _total DESC
+  LIMIT ${yLimit}
+)
+SELECT _x, _y, _val
+FROM _src
+WHERE _x IN (SELECT _x FROM _top_x)
+  AND _y IN (SELECT _y FROM _top_y)
+ORDER BY _x, _y`.trim();
+
+    return this.querySlot.use({
+      key: {sql},
+      retainOn: ['sql'],
+      queryFn: async () => {
+        const queryResult = await this.engine.query(sql);
+        return parseHeatmapResult(queryResult);
+      },
+    });
+  }
+
+  dispose(): void {
+    this.querySlot.dispose();
+  }
+}
+
+function parseHeatmapResult(queryResult: TPQueryResult): HeatmapData {
+  const xSet = new Map<string, number>();
+  const ySet = new Map<string, number>();
+  const rawValues: Array<{x: string; y: string; val: number}> = [];
+
+  const iter = queryResult.iter({
+    _x: STR,
+    _y: STR,
+    _val: NUM,
+  });
+
+  for (; iter.valid(); iter.next()) {
+    rawValues.push({x: iter._x, y: iter._y, val: iter._val});
+    if (!xSet.has(iter._x)) {
+      xSet.set(iter._x, xSet.size);
+    }
+    if (!ySet.has(iter._y)) {
+      ySet.set(iter._y, ySet.size);
+    }
+  }
+
+  const xLabels = Array.from(xSet.keys());
+  const yLabels = Array.from(ySet.keys());
+
+  let min = Infinity;
+  let max = -Infinity;
+  const values: Array<readonly [number, number, number]> = rawValues.map(
+    ({x, y, val}) => {
+      min = Math.min(min, val);
+      max = Math.max(max, val);
+      const xIdx = xSet.get(x) ?? 0;
+      const yIdx = ySet.get(y) ?? 0;
+      return [xIdx, yIdx, val] as const;
+    },
+  );
+
+  if (min === Infinity) {
+    min = 0;
+    max = 0;
+  }
+
+  return {xLabels, yLabels, values, min, max};
+}


### PR DESCRIPTION
Extends the chart library with three new chart types
- CDF (Cumulative Distribution Function)
- Boxplot
- Heatmap 
each with a corresponding SQL-backed loader. Also improves `createChartLoader` to retain stale data
while new queries are in-flight, preventing loading spinner flashes during brush/filter changes.