### PR TITLE
Revert "ui: Use modern pointer events & pointer capture on drawer panel resize handle (#4852)

### DIFF
--- a/ui/src/assets/widgets/drawer_panel.scss
+++ b/ui/src/assets/widgets/drawer_panel.scss
@@ -38,7 +38,6 @@
     align-items: baseline;
     padding-inline: 2px;
     align-items: center;
-    touch-action: none;
   }
 
   &__tabs {

--- a/ui/src/widgets/drawer_panel.ts
+++ b/ui/src/widgets/drawer_panel.ts
@@ -13,12 +13,15 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {assertUnreachable} from '../base/assert';
-import {Gate, MithrilEvent} from '../base/mithril_utils';
+import {DisposableStack} from '../base/disposable_stack';
+import {toHTMLElement} from '../base/dom_utils';
+import {DragGestureHandler} from '../base/drag_gesture_handler';
+import {Gate} from '../base/mithril_utils';
 import {Button, ButtonBar} from './button';
 import {classNames} from '../base/classnames';
 import {HTMLAttrs} from './common';
 import {Icons} from '../base/semantic_icons';
+import {assertExists, assertUnreachable} from '../base/assert';
 
 export interface TabAttrs extends HTMLAttrs {
   // Is this tab currently active?
@@ -141,6 +144,8 @@ export interface DrawerPanelAttrs {
  * └───────────────────────────────────────────────────────────────────┘
  */
 export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
+  private readonly trash = new DisposableStack();
+
   // The actual height of the vdom node. It matches resizableHeight if VISIBLE,
   // 0 if COLLAPSED, fullscreenHeight if FULLSCREEN.
   private height = 0;
@@ -156,13 +161,6 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
 
   // Current active tab key (for uncontrolled mode).
   private internalActiveTab?: string;
-
-  // For pointer capture drag handling
-  private handleElement?: HTMLElement;
-  private dragStartY?: number;
-  private heightWhenDragStarted = 0;
-  private pendingPointerId?: number;
-  private resizeObserver?: ResizeObserver;
 
   constructor({attrs}: m.CVnode<DrawerPanelAttrs>) {
     this.resizableHeight = attrs.startingHeight ?? 100;
@@ -219,24 +217,11 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
         className,
       },
       m('.pf-drawer-panel__main', mainContent),
-      m(
-        '.pf-drawer-panel__handle',
-        {
-          oncontextmenu: (e: Event) => e.preventDefault(),
-          onpointerdown: (e: PointerEvent) => this.onPointerDown(e, attrs),
-          onpointermove: (e: MithrilEvent<PointerEvent>) =>
-            this.onPointerMove(e),
-          onpointerup: (e: PointerEvent) => this.onPointerUp(e),
-          onpointercancel: (e: PointerEvent) => this.onPointerCancel(e),
-          onpointercapturelost: (e: PointerEvent) =>
-            this.onPointerCaptureLost(e),
-        },
-        [
-          leftHandleContent,
-          m('.pf-drawer-panel__tabs', tabsUI),
-          this.renderTabResizeButtons(visibility, onVisibilityChange),
-        ],
-      ),
+      m('.pf-drawer-panel__handle', [
+        leftHandleContent,
+        m('.pf-drawer-panel__tabs', tabsUI),
+        this.renderTabResizeButtons(visibility, onVisibilityChange),
+      ]),
       m(
         '.pf-drawer-panel__drawer',
         {
@@ -277,71 +262,46 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
   }
 
   oncreate(vnode: m.VnodeDOM<DrawerPanelAttrs, this>) {
-    const parent = vnode.dom.parentElement;
-    if (parent) {
+    let dragStartY = 0;
+    let heightWhenDragStarted = 0;
+
+    const handle = toHTMLElement(
+      assertExists(vnode.dom.querySelector('.pf-drawer-panel__handle')),
+    );
+
+    this.trash.use(
+      new DragGestureHandler(
+        handle,
+        /* onDrag */ (_x, y) => {
+          const deltaYSinceDragStart = dragStartY - y;
+          this.resizableHeight = heightWhenDragStarted + deltaYSinceDragStart;
+          m.redraw();
+        },
+        /* onDragStarted */ (_x, y) => {
+          this.resizableHeight = this.height;
+          heightWhenDragStarted = this.height;
+          dragStartY = y;
+          this.updatePanelVisibility(
+            DrawerPanelVisibility.VISIBLE,
+            vnode.attrs.onVisibilityChange,
+          );
+        },
+        /* onDragFinished */ () => {},
+      ),
+    );
+
+    const parent = assertExists(vnode.dom.parentElement);
+    this.fullscreenHeight = parent.clientHeight;
+    const resizeObs = new ResizeObserver(() => {
       this.fullscreenHeight = parent.clientHeight;
-      this.resizeObserver = new ResizeObserver(() => {
-        this.fullscreenHeight = parent.clientHeight;
-        m.redraw();
-      });
-      this.resizeObserver.observe(parent);
-    }
+      m.redraw();
+    });
+    resizeObs.observe(parent);
+    this.trash.defer(() => resizeObs.disconnect());
   }
 
   onremove() {
-    this.resizeObserver?.disconnect();
-  }
-
-  private endDrag(pointerId: number) {
-    if (this.dragStartY !== undefined) {
-      this.dragStartY = undefined;
-      this.pendingPointerId = undefined;
-      if (this.handleElement?.hasPointerCapture(pointerId)) {
-        this.handleElement.releasePointerCapture(pointerId);
-      }
-    }
-  }
-
-  private onPointerDown(e: PointerEvent, attrs: DrawerPanelAttrs) {
-    this.handleElement = e.currentTarget as HTMLElement;
-    this.dragStartY = e.clientY;
-    this.resizableHeight = this.height;
-    this.heightWhenDragStarted = this.height;
-    // Defer setPointerCapture to the first pointermove. Capturing on
-    // pointerdown redirects pointerup (and the derived click event) to the
-    // handle element, which prevents onclick handlers on child elements (e.g.
-    // tabs) from firing.
-    this.pendingPointerId = e.pointerId;
-    this.updatePanelVisibility(
-      DrawerPanelVisibility.VISIBLE,
-      attrs.onVisibilityChange,
-    );
-    e.stopPropagation();
-  }
-
-  private onPointerMove(e: MithrilEvent<PointerEvent>) {
-    e.redraw = false;
-    if (this.dragStartY !== undefined) {
-      if (this.pendingPointerId !== undefined && this.handleElement) {
-        this.handleElement.setPointerCapture(this.pendingPointerId);
-        this.pendingPointerId = undefined;
-      }
-      const deltaY = this.dragStartY - e.clientY;
-      this.resizableHeight = this.heightWhenDragStarted + deltaY;
-      m.redraw();
-    }
-  }
-
-  private onPointerUp(e: PointerEvent) {
-    this.endDrag(e.pointerId);
-  }
-
-  private onPointerCancel(e: PointerEvent) {
-    this.endDrag(e.pointerId);
-  }
-
-  private onPointerCaptureLost(e: PointerEvent) {
-    this.endDrag(e.pointerId);
+    this.trash.dispose();
   }
 
   private renderTabResizeButtons(


### PR DESCRIPTION
Reverted because the change can result in the drag events becoming detached from the resize handle