### PR TITLE
de: Add visualisation node

### DIFF
--- a/ui/src/assets/explore_page/node_info/visualisation.md
+++ b/ui/src/assets/explore_page/node_info/visualisation.md
@@ -1,0 +1,69 @@
+# Visualisation Node
+
+The Visualisation node allows you to visualize data from upstream nodes as interactive charts. Click on chart elements to create filters that flow to downstream nodes.
+
+## Chart Types
+
+The visualization system uses a registry-based architecture for extensibility. Currently supported chart types are:
+
+### Bar Chart
+Displays categorical data with bars. Each bar represents a unique value and its aggregated measure.
+
+- Best for: Categorical columns, discrete values
+- Supports: Aggregation functions (COUNT, SUM, AVG, MIN, MAX)
+- Click behavior: Adds an equality filter (`column = value`)
+
+### Histogram
+Displays the distribution of numeric data using binned ranges.
+
+- Best for: Numeric columns (integers, doubles, timestamps, durations)
+- Supports: Binning (automatic or custom bin count)
+- Click behavior: Adds a range filter (`column >= binStart AND column < binEnd`)
+
+## Adding New Chart Types
+
+The chart system uses a registry pattern for extensibility. To add a new chart type:
+
+1. **Update the type union**: Add your type to `ChartType` in `visualisation_node.ts`
+2. **Register the type**: Add an entry to `CHART_TYPES` in `chart_type_registry.ts` with:
+   - `type`: The string identifier
+   - `label`: Human-readable name for the UI
+   - `icon`: Material icon name
+   - `supportsAggregation`: Whether the chart can aggregate values
+   - `supportsBinning`: Whether the chart bins continuous values
+3. **Implement rendering**: Add rendering logic in `chart_view.ts`
+4. **Implement data loading**: Add data fetching in `chart_data_loader.ts`
+
+## Configuration
+
+1. **Chart Type**: Select the visualization type (Bar Chart, Histogram)
+2. **Column**: Choose which column to visualize
+3. **Aggregation** (Bar Chart): Select the aggregation function
+4. **Measure Column** (Bar Chart, non-COUNT): Select the column to aggregate
+5. **Orientation** (Bar Chart): Choose vertical or horizontal layout
+6. **Bin Count** (Histogram): Override the automatic bin calculation
+
+## Filtering
+
+- **Single click**: Replaces existing chart filters with the clicked element
+- **Brush selection**: Drag to select multiple elements
+- **Clear Filters**: Use the toolbar button to remove all chart filters
+
+## Current Limitations
+
+### Single Measure Per Chart
+
+Currently, each chart supports only a single measure:
+- Bar charts can show one aggregation at a time (e.g., COUNT OR SUM(duration), not both)
+- Histograms visualize a single numeric column's distribution
+
+Future work may extend this to support multiple measures (e.g., overlaying multiple metrics on the same chart). See the `ChartConfig` interface documentation in `visualisation_node.ts` for implementation guidance.
+
+## Tips
+
+- For large datasets, the bar chart shows the top 100 categories by count
+- Histogram bin count is automatically calculated using the Terrell-Scott rule if not specified
+- Chart filters are additive - each click adds filters that downstream nodes see
+- Toggle individual filters on/off in the node configuration panel
+- Drag chart headers to reorder charts
+- Use the resize handle to customize chart widths

--- a/ui/src/components/widgets/charts/chart_sql_source_unittest.ts
+++ b/ui/src/components/widgets/charts/chart_sql_source_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {buildChartQuery, ColumnSchema, QueryConfig} from './chart_sql_source';
+import {ChartSource, ColumnSchema, QueryConfig} from './chart_sql_source';
 
 const QUERY = 'SELECT name, dur, ts, cpu, size, category FROM slice';
 const SCHEMA: ColumnSchema = {
@@ -29,7 +29,7 @@ function normalizeWhitespace(sql: string): string {
 }
 
 function build(config: QueryConfig): string {
-  return buildChartQuery(QUERY, SCHEMA, config);
+  return new ChartSource({query: QUERY, schema: SCHEMA}).buildQuery(config);
 }
 
 // ---------------------------------------------------------------------------
@@ -38,19 +38,18 @@ function build(config: QueryConfig): string {
 
 test('validates column names in schema', () => {
   expect(() =>
-    buildChartQuery(
-      'SELECT * FROM t',
-      {'bad column': 'text'},
-      {
-        type: 'aggregated',
-        dimensions: [{column: 'bad column'}],
-        measures: [{column: 'bad column', aggregation: 'SUM'}],
-      },
-    ),
+    new ChartSource({
+      query: 'SELECT * FROM t',
+      schema: {'bad column': 'text'},
+    }).buildQuery({
+      type: 'aggregated',
+      dimensions: [{column: 'bad column'}],
+      measures: [{column: 'bad column', aggregation: 'SUM'}],
+    }),
   ).toThrow('Invalid SQL column name');
 });
 
-test('buildChartQuery throws for unknown column', () => {
+test('ChartSource throws for unknown column', () => {
   expect(() =>
     build({
       type: 'aggregated',

--- a/ui/src/components/widgets/charts/chart_utils.ts
+++ b/ui/src/components/widgets/charts/chart_utils.ts
@@ -15,6 +15,13 @@
 import {AggregateFunction} from '../datagrid/model';
 
 /**
+ * Aggregation functions available for charts.
+ * Extends the datagrid's AggregateFunction with COUNT, which is
+ * field-independent (counts rows rather than aggregating a column).
+ */
+export type ChartAggregation = AggregateFunction | 'COUNT';
+
+/**
  * Format a number for display on chart axes.
  */
 export function formatNumber(value: number): string {
@@ -34,8 +41,8 @@ export function formatNumber(value: number): string {
 /**
  * Whether an aggregation always produces integer results.
  */
-export function isIntegerAggregation(agg: AggregateFunction): boolean {
-  return agg === 'COUNT_DISTINCT';
+export function isIntegerAggregation(agg: ChartAggregation): boolean {
+  return agg === 'COUNT' || agg === 'COUNT_DISTINCT';
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/src/components/widgets/charts/datagrid_chart.ts
+++ b/ui/src/components/widgets/charts/datagrid_chart.ts
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Row} from '../../../trace_processor/query_result';
+import {DataGrid} from '../datagrid/datagrid';
+import {CellFormatter, SchemaRegistry} from '../datagrid/datagrid_schema';
+
+/**
+ * Data provided to a DatagridChart.
+ */
+export interface DatagridChartData {
+  /** Column names to display. */
+  readonly columns: readonly string[];
+  /** The rows to display. */
+  readonly rows: readonly Row[];
+}
+
+export interface DatagridChartAttrs {
+  /**
+   * Data to display, or undefined if loading.
+   */
+  readonly data: DatagridChartData | undefined;
+
+  /**
+   * Fill parent container height. Defaults to false.
+   */
+  readonly fillParent?: boolean;
+
+  /**
+   * Custom class name for the container.
+   */
+  readonly className?: string;
+
+  /**
+   * Custom cell formatters keyed by column name.
+   * Used to format timestamp/duration columns etc.
+   */
+  readonly cellFormatters?: Readonly<Record<string, CellFormatter>>;
+
+  /**
+   * Callback when a row is clicked. Called with the row data.
+   */
+  readonly onRowClick?: (row: Row) => void;
+}
+
+/**
+ * A chart widget that displays tabular data using the standard DataGrid.
+ * Wraps the existing DataGrid with a minimal schema derived from column names.
+ */
+export class DatagridChart implements m.ClassComponent<DatagridChartAttrs> {
+  view({attrs}: m.Vnode<DatagridChartAttrs>) {
+    const {data, fillParent, className, cellFormatters} = attrs;
+
+    if (data === undefined || data.rows.length === 0) {
+      return undefined;
+    }
+
+    const schema = buildSchemaFromColumns(data.columns, cellFormatters);
+
+    return m(DataGrid, {
+      schema,
+      rootSchema: 'root',
+      // DataGrid expects a mutable Row[] but our source is readonly Row[].
+      // The cast is safe because DataGrid only reads from the array.
+      data: data.rows as Row[],
+      fillHeight: fillParent,
+      className,
+      canAddColumns: false,
+      canRemoveColumns: false,
+    });
+  }
+}
+
+/**
+ * Build a minimal SchemaRegistry from column names.
+ * Each column becomes a simple leaf ColumnDef.
+ */
+function buildSchemaFromColumns(
+  columns: readonly string[],
+  cellFormatters?: Readonly<Record<string, CellFormatter>>,
+): SchemaRegistry {
+  const schema: SchemaRegistry = {
+    root: Object.fromEntries(
+      columns.map((col) => {
+        const formatter = cellFormatters?.[col];
+        return [
+          col,
+          {title: col, ...(formatter && {cellFormatter: formatter})},
+        ];
+      }),
+    ),
+  };
+  return schema;
+}

--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -239,7 +239,7 @@ export class EChartView implements m.ClassComponent<EChartViewAttrs> {
       this.resizeObs = undefined;
     }
     this.detachAllHandlers();
-    if (this.chart) {
+    if (this.chart !== undefined) {
       this.chart.dispose();
       this.chart = undefined;
     }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_column_formatters.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_column_formatters.ts
@@ -1,0 +1,89 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {CellFormatter} from '../../../../components/widgets/datagrid/datagrid_schema';
+import {Duration} from '../../../../base/time';
+import {
+  underlyingSqlType,
+  PerfettoSqlType,
+} from '../../../../trace_processor/perfetto_sql_type';
+import {VisualisationNode} from '../nodes/visualisation_node';
+
+/**
+ * Whether a column's underlying SQL type is INTEGER.
+ */
+export function isIntegerColumn(
+  node: VisualisationNode,
+  columnName: string,
+): boolean {
+  const columnInfo = node.sourceCols.find((col) => col.name === columnName);
+  const columnType = columnInfo?.column.type;
+  return (
+    columnType !== undefined && underlyingSqlType(columnType) === 'INTEGER'
+  );
+}
+
+/**
+ * Get the PerfettoSQL type kind for a column, if available.
+ */
+export function getColumnTypeKind(
+  node: VisualisationNode,
+  columnName: string,
+): PerfettoSqlType['kind'] | undefined {
+  const columnInfo = node.sourceCols.find((col) => col.name === columnName);
+  return columnInfo?.column.type?.kind;
+}
+
+/**
+ * Create a numeric formatter for timestamp/duration columns.
+ * Returns undefined if the column doesn't need special formatting.
+ */
+export function getNumericFormatter(
+  node: VisualisationNode,
+  columnName: string,
+): ((value: number) => string) | undefined {
+  const kind = getColumnTypeKind(node, columnName);
+  if (kind === 'timestamp' || kind === 'duration') {
+    return (value: number) => Duration.humanise(BigInt(Math.round(value)));
+  }
+  return undefined;
+}
+
+/**
+ * Build a map of CellFormatters for columns that need special formatting
+ * (e.g., timestamp/duration columns).
+ */
+export function buildCellFormatters(
+  node: VisualisationNode,
+  columns: readonly string[],
+): Record<string, CellFormatter> | undefined {
+  const formatters: Record<string, CellFormatter> = {};
+  let hasAny = false;
+  for (const col of columns) {
+    const kind = getColumnTypeKind(node, col);
+    if (kind === 'timestamp' || kind === 'duration') {
+      formatters[col] = (value) => {
+        if (typeof value === 'number') {
+          return Duration.humanise(BigInt(Math.round(value)));
+        }
+        if (typeof value === 'bigint') {
+          return Duration.humanise(value);
+        }
+        return String(value ?? '');
+      };
+      hasAny = true;
+    }
+  }
+  return hasAny ? formatters : undefined;
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_config_popup.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_config_popup.ts
@@ -1,0 +1,297 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {
+  VisualisationNode,
+  ChartConfig,
+  BarOrientation,
+} from '../nodes/visualisation_node';
+import {
+  CHART_TYPES,
+  getChartTypeDefinition,
+  isValidChartType,
+} from '../nodes/chart_type_registry';
+import {ChartAggregation} from '../../../../components/widgets/charts/chart_utils';
+import {Select} from '../../../../widgets/select';
+import {Form, FormLabel} from '../../../../widgets/form';
+
+export interface ChartConfigPopupContext {
+  readonly node: VisualisationNode;
+  readonly onFilterChange?: () => void;
+}
+
+/**
+ * Render the settings popup for a single chart.
+ *
+ * @param ctx - Node and filter-change callback.
+ * @param config - The chart configuration being edited.
+ * @param onBinCountDebounce - Called after bin count input so the caller can
+ *   schedule a debounced redraw without exposing timer state here.
+ */
+export function renderChartConfigPopup(
+  ctx: ChartConfigPopupContext,
+  config: ChartConfig,
+  onBinCountDebounce: () => void,
+): m.Child {
+  const def = getChartTypeDefinition(config.chartType);
+  const chartableColumns = ctx.node.getChartableColumns(config.chartType);
+  const allColumns = ctx.node.sourceCols;
+  const numericColumns = ctx.node.getChartableColumns('histogram');
+
+  // Bar shows measure column when aggregation is not COUNT.
+  const showMeasureColumn =
+    def?.supportsAggregation &&
+    config.aggregation !== undefined &&
+    config.aggregation !== 'COUNT';
+
+  const measureColumnLabel = 'Measure Column';
+
+  // Orientation only applies to bar charts.
+  const showOrientation = config.chartType === 'bar';
+
+  return m(
+    Form,
+    {
+      submitLabel:
+        ctx.node.state.chartConfigs.length > 1 ? 'Delete Chart' : undefined,
+      submitIcon: ctx.node.state.chartConfigs.length > 1 ? 'delete' : undefined,
+      onSubmit: () => {
+        ctx.node.removeChart(config.id);
+        ctx.onFilterChange?.();
+      },
+    },
+    [
+      // Chart type selector
+      m(FormLabel, [
+        m('span', 'Chart Type'),
+        m(
+          Select,
+          {
+            value: config.chartType,
+            onchange: (e: Event) => {
+              const target = e.target as HTMLSelectElement;
+              const newType = target.value;
+              if (!isValidChartType(newType)) return;
+              const newChartableColumns = ctx.node.getChartableColumns(newType);
+              const columnStillValid = newChartableColumns.some(
+                (c) => c.name === config.column,
+              );
+              ctx.node.updateChart(config.id, {
+                chartType: newType,
+                column: columnStillValid ? config.column : '',
+              });
+            },
+          },
+          CHART_TYPES.map((chartTypeDef) =>
+            m(
+              'option',
+              {
+                value: chartTypeDef.type,
+                disabled:
+                  chartTypeDef.requiresNumericDimension &&
+                  ctx.node.getChartableColumns(chartTypeDef.type).length === 0,
+              },
+              chartTypeDef.label,
+            ),
+          ),
+        ),
+      ]),
+      // Primary column selector
+      m(FormLabel, [
+        m('span', def?.primaryColumnLabel ?? 'Column'),
+        m(
+          Select,
+          {
+            value: config.column,
+            onchange: (e: Event) => {
+              const target = e.target as HTMLSelectElement;
+              ctx.node.updateChart(config.id, {column: target.value});
+            },
+          },
+          [
+            m('option', {value: '', disabled: true}, 'Select column...'),
+            ...chartableColumns.map((col) =>
+              m('option', {value: col.name}, col.name),
+            ),
+          ],
+        ),
+      ]),
+      // Y column — for line and scatter
+      def?.supportsYColumn &&
+        m(FormLabel, [
+          m('span', 'Y Column'),
+          m(
+            Select,
+            {
+              value: config.yColumn ?? '',
+              onchange: (e: Event) => {
+                const target = e.target as HTMLSelectElement;
+                ctx.node.updateChart(config.id, {yColumn: target.value});
+              },
+            },
+            [
+              m('option', {value: '', disabled: true}, 'Select column...'),
+              ...numericColumns.map((col) =>
+                m('option', {value: col.name}, col.name),
+              ),
+            ],
+          ),
+        ]),
+      // Aggregation — bar, pie, treemap
+      def?.supportsAggregation &&
+        m(FormLabel, [
+          m('span', 'Aggregation'),
+          m(
+            Select,
+            {
+              value: config.aggregation ?? 'COUNT',
+              onchange: (e: Event) => {
+                const target = e.target as HTMLSelectElement;
+                const agg = target.value as ChartAggregation;
+                ctx.node.updateChart(config.id, {aggregation: agg});
+              },
+            },
+            [
+              m('option', {value: 'COUNT'}, 'Count'),
+              m('option', {value: 'SUM'}, 'Sum'),
+              m('option', {value: 'AVG'}, 'Avg'),
+              m('option', {value: 'MIN'}, 'Min'),
+              m('option', {value: 'MAX'}, 'Max'),
+            ],
+          ),
+        ]),
+      // Measure / size column
+      showMeasureColumn &&
+        m(FormLabel, [
+          m('span', measureColumnLabel),
+          m(
+            Select,
+            {
+              value: config.measureColumn ?? '',
+              onchange: (e: Event) => {
+                const target = e.target as HTMLSelectElement;
+                ctx.node.updateChart(config.id, {
+                  measureColumn: target.value,
+                });
+              },
+            },
+            [
+              m(
+                'option',
+                {value: '', disabled: true},
+                `Select ${measureColumnLabel.toLowerCase()}...`,
+              ),
+              ...numericColumns.map((col) =>
+                m('option', {value: col.name}, col.name),
+              ),
+            ],
+          ),
+        ]),
+      // Group / series column
+      def?.supportsGroupColumn &&
+        m(FormLabel, [
+          m('span', 'Series Column'),
+          m(
+            Select,
+            {
+              value: config.groupColumn ?? '',
+              onchange: (e: Event) => {
+                const target = e.target as HTMLSelectElement;
+                ctx.node.updateChart(config.id, {
+                  groupColumn: target.value || undefined,
+                });
+              },
+            },
+            [
+              m('option', {value: ''}, '(none)'),
+              ...allColumns.map((col) =>
+                m('option', {value: col.name}, col.name),
+              ),
+            ],
+          ),
+        ]),
+      // Bubble size column — scatter only
+      def?.supportsSizeColumn &&
+        m(FormLabel, [
+          m('span', 'Size Column'),
+          m(
+            Select,
+            {
+              value: config.sizeColumn ?? '',
+              onchange: (e: Event) => {
+                const target = e.target as HTMLSelectElement;
+                ctx.node.updateChart(config.id, {
+                  sizeColumn: target.value || undefined,
+                });
+              },
+            },
+            [
+              m('option', {value: ''}, '(none)'),
+              ...numericColumns.map((col) =>
+                m('option', {value: col.name}, col.name),
+              ),
+            ],
+          ),
+        ]),
+      // Orientation — bar only
+      showOrientation &&
+        m(FormLabel, [
+          m('span', 'Orientation'),
+          m(
+            Select,
+            {
+              value: config.orientation ?? 'vertical',
+              onchange: (e: Event) => {
+                const target = e.target as HTMLSelectElement;
+                const orientation = target.value as BarOrientation;
+                ctx.node.updateChart(config.id, {orientation});
+              },
+            },
+            [
+              m('option', {value: 'vertical'}, 'Vertical'),
+              m('option', {value: 'horizontal'}, 'Horizontal'),
+            ],
+          ),
+        ]),
+      // Bin count — histogram only
+      def?.supportsBinning &&
+        m(FormLabel, [
+          m('span', 'Bin Count'),
+          m('input', {
+            type: 'number',
+            min: 1,
+            max: 100,
+            value: config.binCount ?? '',
+            placeholder: 'Auto',
+            oninput: (e: Event) => {
+              const target = e.target as HTMLInputElement;
+              const value = target.value.trim();
+
+              let binCount: number | undefined;
+              if (value === '') {
+                binCount = undefined;
+              } else {
+                const parsed = parseInt(value, 10);
+                binCount =
+                  !Number.isNaN(parsed) && parsed > 0 ? parsed : undefined;
+              }
+              ctx.node.updateChart(config.id, {binCount});
+              onBinCountDebounce();
+            },
+          }),
+        ]),
+    ],
+  );
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_data_loader.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_data_loader.ts
@@ -1,0 +1,61 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Engine} from '../../../../trace_processor/engine';
+import {SqlValue} from '../../../../trace_processor/query_result';
+
+/**
+ * Data grid row.
+ */
+export interface DataGridRow {
+  [key: string]: SqlValue;
+}
+
+/**
+ * Data grid result.
+ */
+export interface DataGridResult {
+  readonly columns: readonly string[];
+  readonly rows: readonly DataGridRow[];
+  readonly totalCount: number;
+}
+
+/**
+ * Load datagrid data — raw rows from the table with all columns.
+ *
+ * Note: tableName is interpolated directly into the SQL query. This is safe
+ * because it comes from trusted sources (materialized table names from the
+ * query execution service), not from user input.
+ */
+export async function loadDatagridData(
+  engine: Engine,
+  tableName: string,
+  limit: number = 100,
+): Promise<DataGridResult> {
+  const query = `SELECT * FROM ${tableName} LIMIT ${limit}`;
+  const result = await engine.query(query);
+
+  const columns = result.columns();
+  const rows: DataGridRow[] = [];
+
+  for (const it = result.iter({}); it.valid(); it.next()) {
+    const row: DataGridRow = {};
+    for (const col of columns) {
+      row[col] = it.get(col);
+    }
+    rows.push(row);
+  }
+
+  return {columns, rows, totalCount: rows.length};
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_renderers.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_renderers.ts
@@ -1,0 +1,163 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {VisualisationNode, ChartConfig} from '../nodes/visualisation_node';
+import {BarChart} from '../../../../components/widgets/charts/bar_chart';
+import {Histogram} from '../../../../components/widgets/charts/histogram';
+import {SQLBarChartLoader} from '../../../../components/widgets/charts/bar_chart_loader';
+import {SQLHistogramLoader} from '../../../../components/widgets/charts/histogram_loader';
+import {EmptyState} from '../../../../widgets/empty_state';
+import {SqlValue} from '../../../../trace_processor/query_result';
+import {isIntegerColumn, getNumericFormatter} from './chart_column_formatters';
+
+/**
+ * Per-chart loader state.
+ *
+ * The `key` encodes the loader's constructor params so we know when to dispose
+ * and recreate.
+ */
+export interface ChartLoaderEntry {
+  key: string;
+  barLoader?: SQLBarChartLoader;
+  histogramLoader?: SQLHistogramLoader;
+}
+
+/**
+ * Minimal context passed to chart render functions.
+ * Avoids passing the full ChartViewAttrs (which includes Trace and
+ * QueryExecutionService that renderers don't need).
+ */
+export interface ChartRenderContext {
+  readonly node: VisualisationNode;
+  readonly onFilterChange?: () => void;
+}
+
+export function renderBarChart(
+  ctx: ChartRenderContext,
+  config: ChartConfig,
+  entry: ChartLoaderEntry,
+): m.Child {
+  if (!entry.barLoader) {
+    return m(EmptyState, {icon: 'bar_chart', title: 'No data to display'});
+  }
+
+  const agg = config.aggregation ?? 'COUNT';
+  const {data} = entry.barLoader.use({aggregation: agg, limit: 100});
+
+  const measureLabel =
+    agg === 'COUNT'
+      ? 'Count'
+      : `${agg}(${config.measureColumn ?? config.column})`;
+
+  const dimFormatter = getNumericFormatter(ctx.node, config.column);
+  const formatDimension =
+    dimFormatter !== undefined
+      ? (v: string | number) => (typeof v === 'number' ? dimFormatter(v) : v)
+      : undefined;
+
+  const formatMeasure =
+    agg !== 'COUNT'
+      ? getNumericFormatter(ctx.node, config.measureColumn ?? config.column)
+      : undefined;
+
+  return m(BarChart, {
+    data,
+    height: 250,
+    dimensionLabel: config.column,
+    measureLabel,
+    orientation: config.orientation ?? 'vertical',
+    fillParent: true,
+    formatDimension,
+    formatMeasure,
+    onBrush: (labels) => handleBarBrush(ctx, config, labels),
+  });
+}
+
+export function renderHistogram(
+  ctx: ChartRenderContext,
+  config: ChartConfig,
+  entry: ChartLoaderEntry,
+): m.Child {
+  if (!entry.histogramLoader) {
+    return m(EmptyState, {icon: 'ssid_chart', title: 'No data to display'});
+  }
+
+  const isInteger = isIntegerColumn(ctx.node, config.column);
+  const {data} = entry.histogramLoader.use({
+    bucketCount: config.binCount,
+    integer: isInteger,
+  });
+
+  const formatXValue = getNumericFormatter(ctx.node, config.column);
+
+  return m(Histogram, {
+    data,
+    height: 250,
+    xAxisLabel: config.column,
+    integerDimension: isInteger,
+    fillParent: true,
+    formatXValue,
+    onBrush: (range) =>
+      handleHistogramBrush(ctx, config, range.start, range.end),
+  });
+}
+
+function handleBarBrush(
+  ctx: ChartRenderContext,
+  config: ChartConfig,
+  labels: Array<string | number>,
+): void {
+  if (labels.length === 0) return;
+
+  // Convert ECharts label strings back to SqlValues for filter construction.
+  // ECharts delivers labels as strings (after CAST(column AS TEXT) in SQL), so
+  // numeric-looking strings are converted back to numbers for accurate matching.
+  //
+  // TODO: If a formatDimension function is active (e.g. duration formatting),
+  // ECharts still provides the *original* (unformatted) string here, so the
+  // round-trip is correct. However, if the column stores numeric values that
+  // were stored as text (e.g. "1,234"), Number("1,234") = NaN and the filter
+  // will correctly fall back to the string. No known broken case at this time,
+  // but verify if adding new formatDimension types that change the numeric value.
+  const values: SqlValue[] = labels.map((label) => {
+    const str = String(label);
+    if (str === '(null)') return null;
+    // Try to convert numeric-looking strings back to numbers
+    const num = Number(str);
+    if (!isNaN(num) && str !== '') return num;
+    return str;
+  });
+
+  ctx.node.clearChartFiltersForColumn(config.column);
+  ctx.node.setBrushSelection(config.column, values);
+  ctx.onFilterChange?.();
+}
+
+function handleHistogramBrush(
+  ctx: ChartRenderContext,
+  config: ChartConfig,
+  start: number,
+  end: number,
+): void {
+  const isInteger = isIntegerColumn(ctx.node, config.column);
+
+  // For integer columns, use floor/ceil to capture all integer values
+  const filterStart = isInteger ? Math.floor(start) : start;
+  const filterEnd = isInteger ? Math.ceil(end) : end;
+
+  ctx.node.clearChartFiltersForColumn(config.column);
+  ctx.node.addRangeFilter(config.column, filterStart, filterEnd);
+  ctx.onFilterChange?.();
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/charts/chart_view.ts
@@ -1,0 +1,484 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Trace} from '../../../../public/trace';
+import {VisualisationNode, ChartConfig} from '../nodes/visualisation_node';
+import {SQLBarChartLoader} from '../../../../components/widgets/charts/bar_chart_loader';
+import {SQLHistogramLoader} from '../../../../components/widgets/charts/histogram_loader';
+import {
+  ChartLoaderEntry,
+  ChartRenderContext,
+  renderBarChart,
+  renderHistogram,
+} from './chart_renderers';
+import {renderChartConfigPopup} from './chart_config_popup';
+import {Button} from '../../../../widgets/button';
+import {classNames} from '../../../../base/classnames';
+import {Popup, PopupPosition} from '../../../../widgets/popup';
+import {Select} from '../../../../widgets/select';
+import {ResizeHandle} from '../../../../widgets/resize_handle';
+import {QueryExecutionService} from '../query_execution_service';
+import {EmptyState} from '../../../../widgets/empty_state';
+import {Card} from '../../../../widgets/card';
+import {AddItemPlaceholder} from '../widgets';
+
+export interface ChartViewAttrs {
+  trace: Trace;
+  node: VisualisationNode;
+  queryExecutionService: QueryExecutionService;
+  onFilterChange?: () => void;
+}
+
+interface ChartViewState {
+  loaders: Map<string, ChartLoaderEntry>;
+  containerWidth: number;
+  editingChartId?: string;
+  draggingChartId?: string;
+  dragOverChartId?: string;
+  tableName?: string;
+}
+
+export class ChartView implements m.ClassComponent<ChartViewAttrs> {
+  private state: ChartViewState = {
+    loaders: new Map(),
+    containerWidth: 600,
+  };
+
+  private resizeObserver?: ResizeObserver;
+  private binCountDebounceTimeout?: ReturnType<typeof setTimeout>;
+  private isResolvingTableName = false;
+
+  oncreate({dom, attrs}: m.VnodeDOM<ChartViewAttrs>) {
+    const container = dom as HTMLElement;
+    this.resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const {width} = entry.contentRect;
+        if (width !== this.state.containerWidth) {
+          this.state.containerWidth = width;
+          m.redraw();
+        }
+      }
+    });
+    this.resizeObserver.observe(container);
+    this.resolveTableName(attrs);
+  }
+
+  onremove() {
+    this.resizeObserver?.disconnect();
+    if (this.binCountDebounceTimeout !== undefined) {
+      clearTimeout(this.binCountDebounceTimeout);
+    }
+    for (const entry of this.state.loaders.values()) {
+      entry.barLoader?.dispose();
+      entry.histogramLoader?.dispose();
+    }
+    this.state.loaders.clear();
+  }
+
+  onupdate({attrs}: m.VnodeDOM<ChartViewAttrs>) {
+    this.resolveTableName(attrs);
+  }
+
+  /**
+   * Resolve the materialized table name from the query execution service.
+   * When the table name changes, loaders are recreated on the next view().
+   *
+   * The `isResolvingTableName` flag prevents concurrent resolutions. If an
+   * `onupdate` fires while a resolution is in flight the call is a no-op, but
+   * the completion of the current resolution always calls `m.redraw()` when the
+   * table name changes, which triggers another `onupdate` → another resolution.
+   * The state is therefore eventually consistent within one render cycle.
+   */
+  private async resolveTableName(attrs: ChartViewAttrs): Promise<void> {
+    if (this.isResolvingTableName) return;
+    this.isResolvingTableName = true;
+    try {
+      const tableName = await attrs.queryExecutionService.getTableName(
+        attrs.node.nodeId,
+      );
+      if (tableName !== undefined && tableName !== this.state.tableName) {
+        this.state.tableName = tableName;
+        m.redraw();
+      }
+    } finally {
+      this.isResolvingTableName = false;
+    }
+  }
+
+  /**
+   * Get or create a loader for the given chart config.
+   * Disposes and recreates the loader when the config changes.
+   */
+  private ensureLoader(
+    attrs: ChartViewAttrs,
+    config: ChartConfig,
+  ): ChartLoaderEntry {
+    const tableName = this.state.tableName;
+
+    // No table or no column — return empty entry.
+    const needsColumn = config.column === '';
+    if (tableName === undefined || needsColumn) {
+      let entry = this.state.loaders.get(config.id);
+      if (!entry) {
+        entry = {key: ''};
+        this.state.loaders.set(config.id, entry);
+      }
+      return entry;
+    }
+
+    // Key encodes fields that affect loader behaviour for the currently
+    // implemented chart types (bar, histogram).  When line/scatter/treemap are
+    // added, extend this to include yColumn, groupColumn and sizeColumn.
+    const key = [
+      tableName,
+      config.chartType,
+      config.column,
+      config.measureColumn ?? '',
+    ].join('|');
+    const existing = this.state.loaders.get(config.id);
+
+    if (existing && existing.key === key) return existing;
+
+    // Dispose old loaders before creating new ones.
+    if (existing) {
+      existing.barLoader?.dispose();
+      existing.histogramLoader?.dispose();
+    }
+
+    const entry: ChartLoaderEntry = {key};
+    this.state.loaders.set(config.id, entry);
+
+    const engine = attrs.trace.engine;
+
+    if (config.chartType === 'bar') {
+      entry.barLoader = new SQLBarChartLoader({
+        engine,
+        query: `SELECT * FROM ${tableName}`,
+        dimensionColumn: config.column,
+        measureColumn: config.measureColumn ?? config.column,
+      });
+    } else if (config.chartType === 'histogram') {
+      // Histograms only need the value column — avoid scanning every column.
+      entry.histogramLoader = new SQLHistogramLoader({
+        engine,
+        query: `SELECT ${config.column} FROM ${tableName}`,
+        valueColumn: config.column,
+      });
+    }
+
+    return entry;
+  }
+
+  view({attrs}: m.CVnode<ChartViewAttrs>) {
+    const configs = attrs.node.state.chartConfigs;
+    const filters = attrs.node.state.chartFilters ?? [];
+    const hasFilters = filters.some((f) => f.enabled !== false);
+
+    if (configs.length === 0) {
+      return m(
+        '.pf-chart-view',
+        m(
+          EmptyState,
+          {
+            icon: 'bar_chart',
+            title: 'No charts configured',
+            fillHeight: true,
+          },
+          m(Button, {
+            label: 'Add first chart',
+            icon: 'add',
+            onclick: () => {
+              attrs.node.addChart();
+              attrs.onFilterChange?.();
+            },
+          }),
+        ),
+      );
+    }
+
+    const toolbar = m('.pf-chart-view__toolbar', [
+      m(
+        '.pf-chart-view__title',
+        configs.length === 1 ? 'Chart' : `${configs.length} Charts`,
+      ),
+      hasFilters &&
+        m(Button, {
+          label: 'Clear All Filters',
+          icon: 'filter_list_off',
+          compact: true,
+          onclick: () => {
+            attrs.node.clearChartFilters();
+            attrs.onFilterChange?.();
+          },
+        }),
+    ]);
+
+    const gridClass = this.getGridClass(configs.length);
+
+    return m('.pf-chart-view', [
+      toolbar,
+      m(`.pf-chart-view__charts.${gridClass}`, [
+        ...configs.map((config) => this.renderSingleChart(attrs, config)),
+        m(AddItemPlaceholder, {
+          key: 'add-chart',
+          label: 'Add Chart',
+          icon: 'add',
+          onclick: () => {
+            attrs.node.addChart();
+            attrs.onFilterChange?.();
+          },
+        }),
+      ]),
+    ]);
+  }
+
+  private getGridClass(chartCount: number): string {
+    if (chartCount === 1) return 'pf-chart-grid--1';
+    if (chartCount === 2) return 'pf-chart-grid--2';
+    if (chartCount <= 4) return 'pf-chart-grid--2x2'; // 3 or 4 → 2×2 grid
+    return 'pf-chart-grid--3'; // 5+ → 3-column grid
+  }
+
+  private getDefaultChartLabel(config: ChartConfig): string {
+    if (config.chartType === 'histogram') return `Histogram: ${config.column}`;
+    // bar
+    const agg = config.aggregation ?? 'COUNT';
+    if (agg === 'COUNT') return `Count by ${config.column}`;
+    return `${agg}(${config.measureColumn ?? config.column}) by ${config.column}`;
+  }
+
+  private getDefaultChartWidth(chartCount: number): number {
+    // 40px = left + right padding of the chart view container
+    const containerWidth = this.state.containerWidth - 40;
+    if (chartCount === 1) {
+      // 32px = card padding (left + right)
+      return Math.max(300, containerWidth - 32);
+    }
+    // 20px = gap between two charts; 32px = card padding per chart
+    return Math.max(250, (containerWidth - 20) / 2 - 32);
+  }
+
+  private renderSingleChart(
+    attrs: ChartViewAttrs,
+    config: ChartConfig,
+  ): m.Child {
+    const ctx: ChartRenderContext = {
+      node: attrs.node,
+      onFilterChange: attrs.onFilterChange,
+    };
+
+    const entry = this.ensureLoader(attrs, config);
+
+    const needsColumn = config.column === '';
+
+    let chartContent: m.Child;
+
+    if (needsColumn) {
+      const chartableColumns = attrs.node.getChartableColumns(config.chartType);
+      chartContent = m('.pf-chart-view__column-picker', [
+        m(EmptyState, {icon: 'ssid_chart', title: 'Select a column'}),
+        m(
+          Select,
+          {
+            value: '',
+            onchange: (e: Event) => {
+              const target = e.target as HTMLSelectElement;
+              attrs.node.updateChart(config.id, {column: target.value});
+            },
+          },
+          [
+            m('option', {value: '', disabled: true}, 'Select column...'),
+            ...chartableColumns.map((col) =>
+              m('option', {value: col.name}, col.name),
+            ),
+          ],
+        ),
+      ]);
+    } else if (config.chartType === 'bar') {
+      chartContent = renderBarChart(ctx, config, entry);
+    } else {
+      chartContent = renderHistogram(ctx, config, entry);
+    }
+
+    const isEditing = this.state.editingChartId === config.id;
+    const headerLabel = config.name ?? this.getDefaultChartLabel(config);
+
+    const headerTextContent = isEditing
+      ? m('input.pf-chart-view__single-header-input', {
+          type: 'text',
+          value: config.name ?? '',
+          placeholder: this.getDefaultChartLabel(config),
+          oncreate: (vnode: m.VnodeDOM) => {
+            const input = vnode.dom as HTMLInputElement;
+            input.focus();
+            input.select();
+          },
+          onblur: (e: Event) => {
+            const target = e.target as HTMLInputElement;
+            const name = target.value.trim() || undefined;
+            attrs.node.updateChart(config.id, {name});
+            this.state.editingChartId = undefined;
+          },
+          onkeydown: (e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === 'Escape') {
+              this.state.editingChartId = undefined;
+              (e.target as HTMLInputElement).blur();
+            }
+          },
+          oninput: (e: Event) => {
+            const target = e.target as HTMLInputElement;
+            // Don't trim while typing — let the user type spaces.
+            const name = target.value || undefined;
+            attrs.node.updateChart(config.id, {name});
+          },
+        })
+      : m(
+          '.pf-chart-view__single-header-text',
+          {
+            onclick: () => {
+              this.state.editingChartId = config.id;
+            },
+            title: 'Click to rename',
+          },
+          headerLabel,
+        );
+
+    const editButton = m(
+      Popup,
+      {
+        trigger: m(Button, {
+          icon: 'settings',
+          title: 'Edit chart settings',
+          compact: true,
+        }),
+        position: PopupPosition.BottomEnd,
+        className: 'pf-chart-config-popup',
+      },
+      renderChartConfigPopup(ctx, config, () => {
+        if (this.binCountDebounceTimeout !== undefined) {
+          clearTimeout(this.binCountDebounceTimeout);
+        }
+        this.binCountDebounceTimeout = setTimeout(() => m.redraw(), 400);
+      }),
+    );
+
+    const duplicateButton = m(Button, {
+      icon: 'content_copy',
+      title: 'Duplicate chart',
+      compact: true,
+      onclick: (e: MouseEvent) => {
+        e.stopPropagation();
+        attrs.node.duplicateChart(config.id);
+        attrs.onFilterChange?.();
+      },
+    });
+
+    const deleteButton = m(Button, {
+      icon: 'close',
+      title: 'Delete chart',
+      compact: true,
+      onclick: (e: MouseEvent) => {
+        e.stopPropagation();
+        attrs.node.removeChart(config.id);
+        attrs.onFilterChange?.();
+      },
+    });
+
+    const isDragging = this.state.draggingChartId === config.id;
+    const isDragOver = this.state.dragOverChartId === config.id;
+    const hasCustomWidth = config.widthPx !== undefined;
+
+    const resizeHandle = m(ResizeHandle, {
+      direction: 'horizontal',
+      onResize: (deltaPx: number) => {
+        const currentWidth =
+          config.widthPx ??
+          this.getDefaultChartWidth(attrs.node.state.chartConfigs.length);
+        const newWidth = Math.max(200, currentWidth + deltaPx);
+        attrs.node.updateChart(config.id, {widthPx: newWidth});
+      },
+    });
+
+    return m(
+      Card,
+      {
+        key: config.id,
+        style: hasCustomWidth
+          ? `--pf-chart-width: ${config.widthPx}px`
+          : undefined,
+        className: classNames(
+          'pf-chart-view__single',
+          hasCustomWidth && 'pf-chart-view__single--custom-width',
+          isDragging && 'pf-chart-view__single--dragging',
+          isDragOver && 'pf-chart-view__single--drag-over',
+        ),
+        ondragover: (e: DragEvent) => {
+          e.preventDefault();
+          if (
+            this.state.draggingChartId &&
+            this.state.draggingChartId !== config.id
+          ) {
+            this.state.dragOverChartId = config.id;
+          }
+        },
+        ondragleave: () => {
+          if (this.state.dragOverChartId === config.id) {
+            this.state.dragOverChartId = undefined;
+          }
+        },
+        ondrop: (e: DragEvent) => {
+          e.preventDefault();
+          if (
+            this.state.draggingChartId &&
+            this.state.draggingChartId !== config.id
+          ) {
+            attrs.node.reorderChart(this.state.draggingChartId, config.id);
+            attrs.onFilterChange?.();
+          }
+          this.state.draggingChartId = undefined;
+          this.state.dragOverChartId = undefined;
+        },
+      },
+      [
+        m(
+          '.pf-chart-view__single-header.pf-chart-view__single-header--draggable',
+          {
+            draggable: true,
+            ondragstart: (e: DragEvent) => {
+              this.state.draggingChartId = config.id;
+              if (e.dataTransfer) {
+                e.dataTransfer.effectAllowed = 'move';
+              }
+            },
+            ondragend: () => {
+              this.state.draggingChartId = undefined;
+              this.state.dragOverChartId = undefined;
+            },
+          },
+          [
+            headerTextContent,
+            m('.pf-chart-view__single-actions', [
+              editButton,
+              duplicateButton,
+              deleteButton,
+            ]),
+          ],
+        ),
+        m('.pf-chart-view__single-content', chartContent),
+        resizeHandle,
+      ],
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -77,6 +77,10 @@ import {
   MetricsNodeState,
   MetricsSerializedState,
 } from './nodes/metrics_node';
+import {
+  VisualisationNode,
+  VisualisationNodeState,
+} from './nodes/visualisation_node';
 import {Icons} from '../../../base/semantic_icons';
 import {NodeType} from '../query_node';
 
@@ -580,6 +584,21 @@ export function registerCoreNodes() {
     postDeserializeLate: (node) => (node as MetricsNode).onPrevNodesUpdated(),
   });
 
+  nodeRegistry.register('visualisation', {
+    name: 'Visualisation',
+    description:
+      'Visualize data with bar charts or histograms. Click to filter.',
+    icon: 'bar_chart',
+    type: 'modification',
+    nodeType: NodeType.kVisualisation,
+    factory: (state) => new VisualisationNode(state as VisualisationNodeState),
+    deserialize: (state, _trace, sqlModules) =>
+      new VisualisationNode({
+        ...VisualisationNode.deserializeState(state as VisualisationNodeState),
+        sqlModules,
+      }),
+  });
+
   // Set the default allowed children for all nodes.
   // This is the full set of modification + multisource nodes, matching the
   // current behavior. Individual node registrations can override this by
@@ -594,6 +613,7 @@ export function registerCoreNodes() {
     'sort_node',
     'limit_and_offset_node',
     'metrics',
+    'visualisation',
     // Multisource nodes
     'filter_during',
     'filter_in',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -363,6 +363,8 @@ function getNodeHue(node: QueryNode): number {
       return 100; // Green (#c8e6c9)
     case NodeType.kMetrics:
       return 280; // Violet (#e1bee7)
+    case NodeType.kVisualisation:
+      return 30; // Orange (#ffe0b2)
     default:
       return 65; // Lime (#f0f4c3)
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/chart_type_registry.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/chart_type_registry.ts
@@ -1,0 +1,136 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {ChartType} from './visualisation_node';
+
+/**
+ * Definition of a chart type, including metadata and capabilities.
+ *
+ * This registry pattern allows for extensible chart types. To add a new chart
+ * type:
+ * 1. Add the new type to the ChartType union in visualisation_node.ts
+ * 2. Add a new entry to CHART_TYPES below
+ * 3. Implement the rendering logic in chart_view.ts
+ * 4. Implement the data loading logic in chart_data_loader.ts
+ */
+export interface ChartTypeDefinition {
+  /** The chart type identifier (must match ChartType union) */
+  readonly type: ChartType;
+
+  /** Human-readable label for the chart type */
+  readonly label: string;
+
+  /** Material icon name for the chart type */
+  readonly icon: string;
+
+  /**
+   * Whether this chart type supports aggregation functions (COUNT, SUM, etc.)
+   * When true, the chart can show aggregated values per category.
+   * Example: Bar chart showing SUM(duration) by thread_name
+   */
+  readonly supportsAggregation: boolean;
+
+  /**
+   * Whether this chart type supports binning of continuous values.
+   * When true, the chart groups values into bins/buckets.
+   * Example: Histogram showing distribution of durations in 10 bins
+   */
+  readonly supportsBinning: boolean;
+
+  /**
+   * Whether the primary column must be numeric.
+   * When true, the column picker is filtered to quantitative types.
+   * Example: Histogram, line chart, scatter plot all require numeric X.
+   */
+  readonly requiresNumericDimension: boolean;
+
+  /** Label shown for the primary column picker in the config popup. */
+  readonly primaryColumnLabel: string;
+
+  /**
+   * Whether the chart requires a second numeric column (Y axis).
+   * When true, a Y column picker is shown in the config popup.
+   * Example: Line chart (Y values), scatter plot (Y values).
+   */
+  readonly supportsYColumn: boolean;
+
+  /**
+   * Whether the chart supports an optional grouping/series column (any type).
+   * When true, a group column picker is shown in the config popup.
+   * Example: Line chart series grouping, treemap parent grouping.
+   */
+  readonly supportsGroupColumn: boolean;
+
+  /**
+   * Whether the chart supports an optional numeric size column.
+   * When true, a size column picker is shown in the config popup.
+   * Example: Scatter plot bubble size.
+   */
+  readonly supportsSizeColumn: boolean;
+}
+
+/**
+ * Registry of all supported chart types.
+ *
+ * This array defines all available chart types and their capabilities.
+ * The order here determines the order in UI dropdowns.
+ */
+export const CHART_TYPES: readonly ChartTypeDefinition[] = [
+  {
+    type: 'bar',
+    label: 'Bar Chart',
+    icon: 'bar_chart',
+    supportsAggregation: true,
+    supportsBinning: false,
+    requiresNumericDimension: false,
+    primaryColumnLabel: 'Dimension',
+    supportsYColumn: false,
+    supportsGroupColumn: false,
+    supportsSizeColumn: false,
+  },
+  {
+    type: 'histogram',
+    label: 'Histogram',
+    icon: 'ssid_chart',
+    supportsAggregation: false,
+    supportsBinning: true,
+    requiresNumericDimension: true,
+    primaryColumnLabel: 'Column',
+    supportsYColumn: false,
+    supportsGroupColumn: false,
+    supportsSizeColumn: false,
+  },
+] as const;
+
+/**
+ * Get the definition for a specific chart type.
+ *
+ * @param type The chart type to look up
+ * @returns The chart type definition, or undefined if not found
+ */
+export function getChartTypeDefinition(
+  type: ChartType,
+): ChartTypeDefinition | undefined {
+  return CHART_TYPES.find((d) => d.type === type);
+}
+
+/**
+ * Check if a given string is a valid chart type.
+ *
+ * @param type String to validate
+ * @returns True if the string is a valid ChartType
+ */
+export function isValidChartType(type: string): type is ChartType {
+  return CHART_TYPES.some((d) => d.type === type);
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/visualisation_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/visualisation_node.ts
@@ -1,0 +1,832 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {
+  QueryNode,
+  QueryNodeState,
+  nextNodeId,
+  NodeType,
+} from '../../query_node';
+import {ColumnInfo} from '../column_info';
+import protos from '../../../../protos';
+import {isQuantitativeType} from '../../../../trace_processor/perfetto_sql_type';
+import {SqlValue} from '../../../../trace_processor/query_result';
+import {ChartAggregation} from '../../../../components/widgets/charts/chart_utils';
+import {
+  UIFilter,
+  createAutoGroupedFiltersProto,
+  formatFilterSummary,
+  formatFilterValue,
+  isFilterDefinitionValid,
+  parseFilterValue,
+} from '../operations/filter';
+import {Chip} from '../../../../widgets/chip';
+import {StructuredQueryBuilder} from '../structured_query_builder';
+import {NodeIssues} from '../node_issues';
+import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
+import {NodeDetailsMessage, NodeTitle} from '../node_styling_widgets';
+import {loadNodeDoc} from '../node_doc_loader';
+import {AddItemPlaceholder} from '../widgets';
+import {Button} from '../../../../widgets/button';
+import {Icon} from '../../../../widgets/icon';
+import {Card} from '../../../../widgets/card';
+import {classNames} from '../../../../base/classnames';
+
+/**
+ * Chart type options.
+ */
+export type ChartType = 'bar' | 'histogram';
+
+/**
+ * Bar chart orientation options.
+ */
+export type BarOrientation = 'horizontal' | 'vertical';
+
+/**
+ * Configuration for a single chart within a visualisation node.
+ *
+ * ## Current Single-Measure Limitation
+ *
+ * The current implementation supports a single measure per chart. This means:
+ * - Bar charts can only show one aggregation at a time (e.g., COUNT or SUM(duration))
+ * - Histograms visualize a single numeric column's distribution
+ *
+ * ## Future Multi-Measure Support
+ *
+ * To extend this to support multiple measures (e.g., overlay multiple metrics):
+ *
+ * 1. Replace `measureColumn` and `aggregation` with an array:
+ *    ```typescript
+ *    measures?: Array<{
+ *      column: string;
+ *      aggregation: ChartAggregation;
+ *      color?: string;
+ *    }>;
+ *    ```
+ *
+ * 2. Update chart_data_loader.ts to fetch multiple aggregations in one query
+ *
+ * 3. Update bar_chart.ts to render multiple bars per category (grouped/stacked)
+ *
+ * 4. Update the chart config UI to allow adding/removing measures
+ *
+ * The registry pattern in chart_type_registry.ts can help determine which chart
+ * types support multiple measures via a new `supportsMultipleMeasures` flag.
+ */
+export interface ChartConfig {
+  /** Unique identifier for this chart */
+  readonly id: string;
+  /** Custom display name for this chart (optional, defaults to column name) */
+  name?: string;
+  /** Column to visualize (dimension for bar charts, value for histograms) */
+  column: string;
+  /** Type of chart - see chart_type_registry.ts for available types */
+  chartType: ChartType;
+  /** Number of bins for histogram (optional, auto-calculated if not set) */
+  binCount?: number;
+  /** Bar chart orientation (default: horizontal) */
+  orientation?: BarOrientation;
+  /** Custom width in pixels (optional, uses flex layout if not set) */
+  widthPx?: number;
+  /**
+   * Aggregation function for bar/pie/treemap charts (default: COUNT).
+   * Currently only a single aggregation is supported per chart.
+   * See the interface docs above for multi-measure extension plans.
+   */
+  aggregation?: ChartAggregation;
+  /**
+   * Measure/size column for non-count aggregations (bar, pie) or always for
+   * treemap. Currently only a single measure column is supported.
+   */
+  measureColumn?: string;
+  /**
+   * Y-axis column for line and scatter charts (numeric).
+   * Required for those chart types.
+   */
+  yColumn?: string;
+  /**
+   * Optional grouping column: series grouping for line/scatter,
+   * parent grouping for treemap.
+   */
+  groupColumn?: string;
+  /**
+   * Optional bubble-size column for scatter charts (numeric).
+   */
+  sizeColumn?: string;
+}
+
+/**
+ * Generate a unique ID for a new chart.
+ */
+export function generateChartId(): string {
+  return `chart-${crypto.randomUUID()}`;
+}
+
+export interface VisualisationNodeState extends QueryNodeState {
+  /** Array of chart configurations - multiple charts per node */
+  chartConfigs: ChartConfig[];
+  /** Shared filters applied to all charts */
+  chartFilters?: Partial<UIFilter>[];
+}
+
+export class VisualisationNode implements QueryNode {
+  readonly nodeId: string;
+  readonly type = NodeType.kVisualisation;
+  primaryInput?: QueryNode;
+  secondaryInputs?: undefined;
+  nextNodes: QueryNode[];
+  readonly state: VisualisationNodeState;
+
+  // UI-only state for tracking collapsed charts (not persisted)
+  private collapsedCharts: Set<string> = new Set();
+  // UI-only state for tracking which chart title is being edited
+  private editingChartId?: string;
+
+  constructor(state: Partial<VisualisationNodeState>) {
+    this.nodeId = nextNodeId();
+    this.state = {
+      ...state,
+      chartConfigs: state.chartConfigs ?? [],
+      chartFilters: state.chartFilters ?? [],
+    };
+    this.nextNodes = [];
+  }
+
+  get sourceCols(): ColumnInfo[] {
+    return this.primaryInput?.finalCols ?? [];
+  }
+
+  get finalCols(): ColumnInfo[] {
+    // Visualisation node doesn't change the schema - it's a visualization/filter node
+    return this.sourceCols;
+  }
+
+  /**
+   * Get columns suitable for the primary column of a given chart type.
+   * Histogram, line, and scatter require numeric columns for their primary
+   * axis; all other types accept any column.
+   */
+  getChartableColumns(chartType: ChartType): ColumnInfo[] {
+    if (chartType === 'histogram') {
+      return this.sourceCols.filter((col) => {
+        const type = col.column.type;
+        return type !== undefined && isQuantitativeType(type);
+      });
+    }
+    return this.sourceCols;
+  }
+
+  /**
+   * Check if a filter is valid for this node.
+   */
+  private isFilterValid(filter: Partial<UIFilter>): filter is UIFilter {
+    if (!isFilterDefinitionValid(filter)) {
+      return false;
+    }
+    const columnExists = this.sourceCols.some(
+      (col) => col.name === filter.column,
+    );
+    return columnExists;
+  }
+
+  getTitle(): string {
+    return 'Visualisation';
+  }
+
+  /** Number of charts that have a column selected. */
+  private configuredChartCount(): number {
+    return this.state.chartConfigs.filter((c) => c.column).length;
+  }
+
+  private setValidationError(message: string): void {
+    if (!this.state.issues) {
+      this.state.issues = new NodeIssues();
+    }
+    this.state.issues.queryError = new Error(message);
+  }
+
+  nodeDetails(): NodeDetailsAttrs {
+    this.validate();
+
+    const validFilters =
+      this.state.chartFilters?.filter((f) => this.isFilterValid(f)) ?? [];
+
+    const configuredCount = this.configuredChartCount();
+    if (configuredCount === 0) {
+      return {
+        content: [
+          NodeTitle(this.getTitle()),
+          NodeDetailsMessage('No charts configured'),
+        ],
+      };
+    }
+
+    if (validFilters.length === 0) {
+      return {
+        content: [
+          NodeTitle(this.getTitle()),
+          m(
+            '.pf-visualisation-node-details',
+            `${configuredCount} chart${configuredCount !== 1 ? 's' : ''}`,
+          ),
+        ],
+      };
+    }
+
+    return {
+      content: [
+        NodeTitle(this.getTitle()),
+        m('.pf-visualisation-node-details', [
+          m(
+            '.pf-visualisation-node-details__config',
+            `${configuredCount} chart${configuredCount !== 1 ? 's' : ''}`,
+          ),
+          formatFilterSummary(validFilters),
+        ]),
+      ],
+    };
+  }
+
+  nodeSpecificModify(): NodeModifyAttrs {
+    this.validate();
+
+    // Build sections
+    const sections: NodeModifyAttrs['sections'] = [];
+
+    // Chart cards container
+    const chartCards = this.state.chartConfigs.map((config, index) => {
+      const chartTypeIcon =
+        config.chartType === 'bar' ? 'bar_chart' : 'ssid_chart';
+      const chartTypeLabel = config.chartType === 'bar' ? 'Bar' : 'Histogram';
+      const columnLabel = config.column || 'Not configured';
+
+      // Filters matching this chart's column
+      const chartFilters = (this.state.chartFilters?.filter(
+        (f) => this.isFilterValid(f) && f.column === config.column,
+      ) ?? []) as UIFilter[];
+      const hasFilters = chartFilters.length > 0;
+
+      // Collapse by default when no filters
+      const isCollapsed = hasFilters
+        ? this.collapsedCharts.has(config.id)
+        : true;
+
+      return m(
+        Card,
+        {
+          key: config.id,
+          className: classNames(
+            'pf-chart-card',
+            isCollapsed && 'pf-chart-card--collapsed',
+          ),
+        },
+        [
+          // Card header (always visible)
+          m('.pf-chart-card__header', [
+            // Toggle button (only when there are filters to show)
+            hasFilters
+              ? m(
+                  '.pf-chart-card__toggle',
+                  {
+                    onclick: () => {
+                      this.toggleChartCollapsed(config.id);
+                    },
+                  },
+                  m(Icon, {
+                    icon: isCollapsed ? 'chevron_right' : 'expand_more',
+                  }),
+                )
+              : m('.pf-chart-card__toggle'),
+            // Chart info
+            m('.pf-chart-card__info', [
+              m(Icon, {icon: chartTypeIcon}),
+              this.editingChartId === config.id
+                ? m('input.pf-chart-card__title-input', {
+                    type: 'text',
+                    value: config.name ?? '',
+                    placeholder: config.column
+                      ? `${chartTypeLabel}: ${columnLabel}`
+                      : `Chart ${index + 1}`,
+                    oncreate: (vnode: m.VnodeDOM) => {
+                      const input = vnode.dom as HTMLInputElement;
+                      input.focus();
+                      input.select();
+                    },
+                    onblur: (e: Event) => {
+                      // Trim the value when user finishes editing
+                      const target = e.target as HTMLInputElement;
+                      const name = target.value.trim() || undefined;
+                      this.updateChart(config.id, {name});
+                      this.editingChartId = undefined;
+                    },
+                    onkeydown: (e: KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === 'Escape') {
+                        e.stopPropagation();
+                        this.editingChartId = undefined;
+                        (e.target as HTMLInputElement).blur();
+                      }
+                    },
+                    oninput: (e: Event) => {
+                      const target = e.target as HTMLInputElement;
+                      // Don't trim while typing - let the user type spaces!
+                      const name = target.value || undefined;
+                      this.updateChart(config.id, {name});
+                    },
+                    onclick: (e: Event) => {
+                      e.stopPropagation();
+                    },
+                  })
+                : m(
+                    '.pf-chart-card__title',
+                    {
+                      onclick: (e: Event) => {
+                        e.stopPropagation();
+                        this.editingChartId = config.id;
+                      },
+                      title: 'Click to rename',
+                    },
+                    config.name ??
+                      (config.column
+                        ? `${chartTypeLabel}: ${columnLabel}`
+                        : `Chart ${index + 1}`),
+                  ),
+            ]),
+            // Actions
+            m('.pf-chart-card__actions', [
+              hasFilters &&
+                m(
+                  '.pf-chart-card__filter-count',
+                  {title: `${chartFilters.length} active filter(s)`},
+                  [
+                    `${chartFilters.length}`,
+                    m(
+                      '.pf-chart-card__filter-count-close',
+                      {
+                        onclick: (e: Event) => {
+                          e.stopPropagation();
+                          this.clearChartFiltersForColumn(config.column);
+                          this.state.onchange?.();
+                        },
+                        title: 'Clear filters for this chart',
+                      },
+                      '\u00d7',
+                    ),
+                  ],
+                ),
+              // Remove button (only show if more than one chart)
+              this.state.chartConfigs.length > 1 &&
+                m(Button, {
+                  icon: 'close',
+                  compact: true,
+                  title: 'Remove chart',
+                  onclick: (e: Event) => {
+                    e.stopPropagation();
+                    this.removeChart(config.id);
+                  },
+                }),
+            ]),
+          ]),
+          // Card body — individual filter chips
+          !isCollapsed &&
+            hasFilters &&
+            m('.pf-chart-card__body', [
+              m(
+                '.pf-chart-card__filter-label',
+                `Filters on `,
+                m('strong', config.column),
+              ),
+              m(
+                '.pf-chart-card__filters',
+                chartFilters.map((filter, i) =>
+                  m(Chip, {
+                    key: `filter-${i}`,
+                    label: formatFilterValue(filter),
+                    compact: true,
+                    rounded: true,
+                    removable: true,
+                    onRemove: () => {
+                      // Find the index in the full filters array
+                      const fullIndex =
+                        this.state.chartFilters?.indexOf(filter) ?? -1;
+                      if (fullIndex >= 0) {
+                        this.removeChartFilter(fullIndex);
+                      }
+                    },
+                    removeButtonTitle: 'Remove filter',
+                  }),
+                ),
+              ),
+            ]),
+        ],
+      );
+    });
+
+    // Charts section with add button and cards
+    sections.push({
+      title: 'Charts',
+      content: m('.pf-chart-cards-container', [
+        ...chartCards,
+        m(AddItemPlaceholder, {
+          key: 'add-chart',
+          label: 'Add Chart',
+          icon: 'add',
+          onclick: () => {
+            this.addChart();
+          },
+        }),
+      ]),
+    });
+
+    const info =
+      'Visualize your data with charts. Click on chart elements to add filters that affect all charts.';
+
+    return {
+      info,
+      sections,
+    };
+  }
+
+  /**
+   * Toggle the collapsed state of a chart card.
+   */
+  private toggleChartCollapsed(chartId: string): void {
+    if (this.collapsedCharts.has(chartId)) {
+      this.collapsedCharts.delete(chartId);
+    } else {
+      this.collapsedCharts.add(chartId);
+    }
+    // No explicit m.redraw() needed — this is always called from an onclick
+    // handler, which triggers Mithril's automatic redraw.
+  }
+
+  /**
+   * Add a new chart configuration with a sensible default column.
+   * Prefers string/categorical columns for bar charts, and avoids
+   * columns already used by other charts when possible.
+   */
+  addChart(): void {
+    // Get columns already used by existing charts
+    const usedColumns = new Set(
+      this.state.chartConfigs.map((c) => c.column).filter(Boolean),
+    );
+
+    // Find a good default column:
+    // 1. Prefer unused columns
+    // 2. Prefer non-numeric columns (better for bar charts)
+    // 3. Fall back to first available column
+    const availableCols = this.sourceCols;
+    const unusedCols = availableCols.filter((c) => !usedColumns.has(c.name));
+    const colsToCheck = unusedCols.length > 0 ? unusedCols : availableCols;
+
+    // Prefer string/categorical columns for bar charts
+    const stringCol = colsToCheck.find(
+      (c) => c.column.type === undefined || !isQuantitativeType(c.column.type),
+    );
+    const defaultColumn = stringCol?.name ?? colsToCheck[0]?.name ?? '';
+
+    const newChart: ChartConfig = {
+      id: generateChartId(),
+      column: defaultColumn,
+      chartType: 'bar',
+    };
+    this.state.chartConfigs.push(newChart);
+    this.state.onchange?.();
+  }
+
+  /**
+   * Update a chart configuration by ID.
+   */
+  updateChart(
+    chartId: string,
+    updates: Partial<Omit<ChartConfig, 'id'>>,
+  ): void {
+    const chartIndex = this.state.chartConfigs.findIndex(
+      (c) => c.id === chartId,
+    );
+    if (chartIndex === -1) return;
+
+    const config = this.state.chartConfigs[chartIndex];
+    this.state.chartConfigs[chartIndex] = {
+      ...config,
+      ...updates,
+    };
+    this.state.onchange?.();
+  }
+
+  /**
+   * Remove a chart configuration by ID.
+   */
+  removeChart(chartId: string): void {
+    this.state.chartConfigs = this.state.chartConfigs.filter(
+      (c) => c.id !== chartId,
+    );
+    this.state.onchange?.();
+  }
+
+  /**
+   * Duplicate a chart configuration by ID.
+   * Creates a copy with a new ID placed after the original.
+   */
+  duplicateChart(chartId: string): void {
+    const chartIndex = this.state.chartConfigs.findIndex(
+      (c) => c.id === chartId,
+    );
+    if (chartIndex === -1) return;
+
+    const original = this.state.chartConfigs[chartIndex];
+    const duplicate: ChartConfig = {
+      ...original,
+      id: generateChartId(),
+      name: original.name ? `${original.name} (copy)` : undefined,
+    };
+
+    // Insert after the original
+    this.state.chartConfigs.splice(chartIndex + 1, 0, duplicate);
+    this.state.onchange?.();
+  }
+
+  /**
+   * Reorder a chart by moving it before another chart.
+   * @param draggedId The ID of the chart being dragged
+   * @param targetId The ID of the chart to drop before
+   */
+  reorderChart(draggedId: string, targetId: string): void {
+    const configs = this.state.chartConfigs;
+    const draggedIndex = configs.findIndex((c) => c.id === draggedId);
+    const targetIndex = configs.findIndex((c) => c.id === targetId);
+
+    if (draggedIndex === -1 || targetIndex === -1) return;
+    if (draggedIndex === targetIndex) return;
+
+    // Remove the dragged item
+    const [draggedItem] = configs.splice(draggedIndex, 1);
+
+    // Calculate new target index (may have shifted after removal)
+    const newTargetIndex =
+      draggedIndex < targetIndex ? targetIndex - 1 : targetIndex;
+
+    // Insert at new position
+    configs.splice(newTargetIndex, 0, draggedItem);
+
+    this.state.onchange?.();
+  }
+
+  nodeInfo(): m.Children {
+    return loadNodeDoc('visualisation');
+  }
+
+  validate(): boolean {
+    if (this.state.issues) {
+      this.state.issues.clear();
+    }
+
+    if (this.primaryInput === undefined) {
+      this.setValidationError('No input node connected');
+      return false;
+    }
+
+    if (!this.primaryInput.validate()) {
+      this.setValidationError('Previous node is invalid');
+      return false;
+    }
+
+    if (this.sourceCols.length === 0) {
+      this.setValidationError(
+        'No columns available. Please connect a data source.',
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  clone(): QueryNode {
+    const stateCopy: Partial<VisualisationNodeState> = {
+      chartConfigs: this.state.chartConfigs.map((c) => ({...c})),
+      chartFilters: this.state.chartFilters?.map((f) => ({...f})),
+      onchange: this.state.onchange,
+    };
+    return new VisualisationNode(stateCopy);
+  }
+
+  getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
+    if (this.primaryInput === undefined) return undefined;
+
+    // Get valid filters
+    const validFilters =
+      this.state.chartFilters?.filter((f) => this.isFilterValid(f)) ?? [];
+
+    if (validFilters.length === 0) {
+      // No filters - return passthrough
+      return StructuredQueryBuilder.passthrough(this.primaryInput, this.nodeId);
+    }
+
+    const filtersProto = createAutoGroupedFiltersProto(
+      validFilters,
+      this.sourceCols,
+    );
+
+    if (filtersProto === undefined) {
+      return StructuredQueryBuilder.passthrough(this.primaryInput, this.nodeId);
+    }
+
+    return StructuredQueryBuilder.withFilter(
+      this.primaryInput,
+      filtersProto,
+      this.nodeId,
+    );
+  }
+
+  /**
+   * Add a filter from a chart click.
+   * This is called by the chart component when a user clicks on a bar/bin.
+   */
+  addChartFilter(filter: UIFilter): void {
+    if (!this.state.chartFilters) {
+      this.state.chartFilters = [];
+    }
+    this.state.chartFilters.push({...filter, enabled: true});
+    this.state.onchange?.();
+  }
+
+  /**
+   * Add a range filter (for histogram bins).
+   * Creates two filters: column >= min AND column < max
+   */
+  addRangeFilter(column: string, min: number, max: number): void {
+    if (!this.state.chartFilters) {
+      this.state.chartFilters = [];
+    }
+    // Add >= min filter
+    this.state.chartFilters.push({
+      column,
+      op: '>=',
+      value: min,
+      enabled: true,
+    });
+    // Add < max filter
+    this.state.chartFilters.push({
+      column,
+      op: '<',
+      value: max,
+      enabled: true,
+    });
+    this.state.onchange?.();
+  }
+
+  /**
+   * Clear all chart filters.
+   */
+  clearChartFilters(): void {
+    this.state.chartFilters = [];
+    this.state.onchange?.();
+  }
+
+  /**
+   * Clear chart filters for a specific column only.
+   * Keeps filters on other columns intact.
+   *
+   * Does NOT call `onchange`. Use this when immediately followed by a method
+   * that adds replacement filters and calls `onchange` (e.g. `setBrushSelection`,
+   * `addRangeFilter`). If clearing filters is the final operation, callers must
+   * call `this.state.onchange?.()` themselves — or use `clearChartFilters()`
+   * which handles it automatically.
+   */
+  clearChartFiltersForColumn(column: string): void {
+    if (!this.state.chartFilters) return;
+    this.state.chartFilters = this.state.chartFilters.filter(
+      (f) => f.column !== column,
+    );
+  }
+
+  /**
+   * Toggle the enabled state of a chart filter by index.
+   * Calls onchange to rebuild query so child nodes see filtered data.
+   */
+  toggleChartFilter(index: number): void {
+    if (!this.state.chartFilters || index >= this.state.chartFilters.length) {
+      return;
+    }
+    const filter = this.state.chartFilters[index];
+    this.state.chartFilters[index] = {
+      ...filter,
+      enabled: !(filter.enabled ?? true),
+    };
+    this.state.onchange?.();
+  }
+
+  /**
+   * Remove a chart filter by index.
+   * Calls onchange to rebuild query so child nodes see filtered data.
+   */
+  removeChartFilter(index: number): void {
+    if (!this.state.chartFilters || index >= this.state.chartFilters.length) {
+      return;
+    }
+    this.state.chartFilters = this.state.chartFilters.filter(
+      (_, i) => i !== index,
+    );
+    this.state.onchange?.();
+  }
+
+  /**
+   * Set brush selection filters (multiple values with OR logic).
+   * Used when user drags to select multiple bars in a bar chart.
+   * Note: Caller should call clearChartFiltersForColumn() first if needed.
+   */
+  setBrushSelection(column: string, values: SqlValue[]): void {
+    if (!this.state.chartFilters) {
+      this.state.chartFilters = [];
+    }
+    for (const value of values) {
+      if (value === null) {
+        this.state.chartFilters.push({
+          column,
+          op: 'is null',
+          enabled: true,
+        });
+      } else {
+        this.state.chartFilters.push({
+          column,
+          op: '=',
+          value,
+          enabled: true,
+        });
+      }
+    }
+
+    this.state.onchange?.();
+  }
+
+  serializeState(): object {
+    return {
+      primaryInputId: this.primaryInput?.nodeId,
+      chartConfigs: this.state.chartConfigs.map((c) => ({
+        id: c.id,
+        name: c.name,
+        column: c.column,
+        chartType: c.chartType,
+        binCount: c.binCount,
+        orientation: c.orientation,
+        widthPx: c.widthPx,
+        aggregation: c.aggregation,
+        measureColumn: c.measureColumn,
+        yColumn: c.yColumn,
+        groupColumn: c.groupColumn,
+        sizeColumn: c.sizeColumn,
+      })),
+      chartFilters: this.state.chartFilters?.map((f) => {
+        if ('value' in f) {
+          return {
+            column: f.column,
+            op: f.op,
+            value: f.value,
+            enabled: f.enabled,
+          };
+        } else {
+          return {
+            column: f.column,
+            op: f.op,
+            enabled: f.enabled,
+          };
+        }
+      }),
+    };
+  }
+
+  static deserializeState(
+    state: Partial<VisualisationNodeState>,
+  ): Partial<VisualisationNodeState> {
+    // Convert filter values from strings back to numbers when appropriate.
+    // JSON serialization converts BigInt to string, and we need numeric
+    // values for proper filtering (same logic as FilterNode).
+    const chartFilters = state.chartFilters?.map((f): Partial<UIFilter> => {
+      if ('value' in f && typeof f.value === 'string') {
+        if (!Array.isArray(f.value)) {
+          const parsed = parseFilterValue(f.value);
+          if (parsed !== undefined && parsed !== f.value) {
+            return {...f, value: parsed} as Partial<UIFilter>;
+          }
+        }
+      }
+      return {...f};
+    });
+    return {
+      ...state,
+      chartConfigs: state.chartConfigs?.map((c) => ({...c})) ?? [],
+      chartFilters,
+    };
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/operations/filter.scss
@@ -58,7 +58,7 @@
 // Enabled count indicator
 .pf-filter-enabled-count {
   font-size: 11px;
-  color: #9e9e9e;
+  color: var(--pf-color-text-muted);
   margin-bottom: 4px;
   margin-top: 4px;
 }
@@ -90,6 +90,21 @@
   }
 }
 
+// Filter summary for nodeDetails (simple text)
+.pf-filter-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--pf-font-size-s);
+  color: var(--pf-color-text-secondary);
+
+  &__line {
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+  }
+}
+
 // Filter container base
 .pf-filter-container {
   max-width: 250px;
@@ -101,7 +116,7 @@
 .pf-filter-and-header {
   margin-bottom: 8px;
   font-size: 11px;
-  color: #616161;
+  color: var(--pf-color-text-secondary);
   font-weight: 500;
   display: flex;
   align-items: center;
@@ -117,6 +132,46 @@
   font-size: var(--pf-font-size-xs);
   font-weight: 500;
   text-transform: uppercase;
+
+  &--small {
+    padding: 1px 4px;
+    font-size: 9px;
+  }
+}
+
+// Grouped filter container
+.pf-filter-container--grouped {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+// Individual filter group (one column)
+.pf-filter-group {
+  background-color: var(--pf-color-background-secondary);
+  border-radius: 6px;
+  padding: 6px 8px;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+  }
+
+  &__column {
+    font-size: var(--pf-font-size-s);
+    font-weight: 500;
+    color: var(--pf-color-text-secondary);
+  }
+}
+
+// AND connector between groups
+.pf-filter-group-connector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 0;
 }
 
 // OR group container for nodeDetails and nodeSpecificModify
@@ -124,12 +179,9 @@
   display: flex;
   gap: 8px;
   padding: 12px;
-  border: 2px solid var(--primary-color, #4a90e2);
+  border: 2px solid var(--pf-color-primary);
   border-radius: 8px;
-  background-color: var(
-    --primary-background-transparent,
-    rgba(74, 144, 226, 0.05)
-  );
+  background-color: color-mix(in srgb, var(--pf-color-primary) 5%, transparent);
   margin-top: 8px;
   margin-bottom: 8px;
 
@@ -141,7 +193,7 @@
 .pf-or-group-label {
   font-weight: bold;
   font-size: var(--pf-font-size-m);
-  color: var(--primary-color, #4a90e2);
+  color: var(--pf-color-primary);
   min-width: 30px;
   display: flex;
   align-items: center;
@@ -167,7 +219,7 @@
 
 // Filters container with separator
 .pf-filters-container {
-  border-top: 1px solid var(--stroke-color, #e0e0e0);
+  border-top: 1px solid var(--pf-color-border);
   padding-top: 12px;
   margin-top: 12px;
 }
@@ -194,11 +246,11 @@
 .pf-exp-filter-mode-help {
   margin-bottom: 16px;
   padding: 8px 12px;
-  background-color: rgba(74, 144, 226, 0.08);
-  border-left: 3px solid var(--primary-color, #4a90e2);
+  background-color: color-mix(in srgb, var(--pf-color-primary) 8%, transparent);
+  border-left: 3px solid var(--pf-color-primary);
   border-radius: 4px;
   font-size: 13px;
-  color: var(--text-primary, #333);
+  color: var(--pf-color-text);
   line-height: 1.4;
 }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -56,7 +56,6 @@ export enum NodeType {
   kSort = 'sort',
   kFilter = 'filter',
   kCounterToIntervals = 'counter_to_intervals',
-  kMetrics = 'metrics',
 
   // Multi node operations
   kIntervalIntersect = 'interval_intersect',
@@ -64,8 +63,12 @@ export enum NodeType {
   kJoin = 'join',
   kCreateSlices = 'create_slices',
 
+  // Visualization
+  kVisualisation = 'visualisation',
+
   // Deprecated (kept for backward compatibility)
   kMerge = kJoin,
+  kMetrics = 'metrics',
 }
 
 export function singleNodeOperation(type: NodeType): boolean {
@@ -79,7 +82,7 @@ export function singleNodeOperation(type: NodeType): boolean {
     case NodeType.kSort:
     case NodeType.kFilter:
     case NodeType.kCounterToIntervals:
-    case NodeType.kMetrics:
+    case NodeType.kVisualisation:
       return true;
     default:
       return false;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
@@ -154,3 +154,435 @@
     margin-top: 0.5rem;
   }
 }
+
+// Visualisation node details in node graph
+.pf-visualisation-node-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  &__config {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  &__type {
+    font-weight: 500;
+  }
+
+  &__column {
+    color: var(--pf-color-text-secondary);
+  }
+}
+
+// Chart view container (for DataExplorer integration)
+.pf-chart-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+    gap: 12px;
+    flex-shrink: 0;
+  }
+
+  &__title {
+    font-size: var(--pf-font-size-m);
+    font-weight: 500;
+    color: var(--pf-color-text);
+  }
+
+  &__charts {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    overflow: auto;
+    // Prevent flex lines from stretching to fill container height.
+    // Cards have fixed height and should not resize with the panel.
+    align-content: flex-start;
+  }
+
+  &__column-picker {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    width: 100%;
+    height: 100%;
+
+    select {
+      max-width: 250px;
+    }
+  }
+
+  // Single chart container (extends Card widget)
+  &__single {
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+    position: relative;
+    // Fixed height: header (~36px) + content (250px) + padding (8px top)
+    height: 294px;
+    flex-shrink: 0;
+    // Override Card padding
+    padding: 0;
+
+    // Resize handle positioned on right edge
+    > .pf-resize-handle {
+      position: absolute;
+      right: -3px;
+      top: 0;
+      bottom: 0;
+      height: auto;
+      background: transparent;
+
+      // Hide the default line - chart border is sufficient
+      &::after {
+        display: none;
+      }
+    }
+  }
+
+  &__single-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0;
+    font-size: var(--pf-font-size-s);
+    font-weight: 500;
+    color: var(--pf-color-text);
+    background: var(--pf-color-background-secondary);
+    border-bottom: 1px solid var(--pf-color-border);
+    flex-shrink: 0;
+  }
+
+  &__single-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding-right: 8px;
+  }
+
+  &__single-header-text {
+    flex: 1;
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: background 0.15s ease;
+
+    &:hover {
+      background: var(--pf-color-hover);
+    }
+  }
+
+  &__single-header-input {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    outline: none;
+    font-size: var(--pf-font-size-s);
+    font-weight: 500;
+    font-family: inherit;
+    background: var(--pf-color-background);
+    color: var(--pf-color-text);
+    box-sizing: border-box;
+  }
+
+  // Draggable header styling
+  &__single-header--draggable {
+    cursor: grab;
+
+    &:active {
+      cursor: grabbing;
+    }
+  }
+
+  &__single--dragging {
+    opacity: 0.5;
+  }
+
+  &__single--drag-over {
+    border-color: var(--pf-color-primary);
+    border-style: dashed;
+  }
+
+  &__single-content {
+    height: 250px; // Fixed height for chart container
+    flex: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 8px 0;
+    overflow: hidden;
+
+    // Datagrid fills the content area edge-to-edge with no padding.
+    &--datagrid {
+      padding: 0;
+      align-items: stretch;
+      justify-content: stretch;
+    }
+  }
+}
+
+// Chart grid layouts
+.pf-chart-grid {
+  &--1 {
+    .pf-chart-view__single {
+      flex: 1 1 100%;
+      min-width: 300px;
+    }
+  }
+
+  &--2 {
+    .pf-chart-view__single {
+      flex: 1 1 calc(50% - 8px);
+      min-width: 250px;
+    }
+  }
+
+  &--2x2 {
+    .pf-chart-view__single {
+      flex: 1 1 calc(50% - 8px);
+      min-width: 250px;
+    }
+  }
+
+  &--3 {
+    .pf-chart-view__single {
+      flex: 1 1 calc(33.333% - 11px);
+      min-width: 200px;
+    }
+  }
+}
+
+// Applied when the user resizes a chart via the resize handle.
+// Doubled class selector bumps specificity to (0,2,0) so it overrides
+// the .pf-chart-grid--X .pf-chart-view__single rules above.
+.pf-chart-view__single--custom-width.pf-chart-view__single--custom-width {
+  width: var(--pf-chart-width);
+  flex: none;
+}
+
+// Chart config popup - horizontal form layout
+.pf-chart-config-popup {
+  // Override form styles for horizontal layout
+  .pf-form {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 8px 16px;
+    align-items: center;
+    padding: 12px;
+    min-width: 280px;
+  }
+
+  // FormLabel uses display:contents so its children become grid items
+  .pf-form__label {
+    display: contents;
+    margin-bottom: 0;
+
+    // Label text (the span)
+    > span {
+      font-size: var(--pf-font-size-s);
+      color: var(--pf-color-text-secondary);
+      font-weight: 500;
+      white-space: nowrap;
+    }
+  }
+
+  // Inputs take full width of their column
+  .pf-select {
+    width: 100%;
+    min-width: 140px;
+    margin-bottom: 0;
+  }
+
+  input[type="number"] {
+    width: 100%;
+    min-width: 140px;
+    padding: 6px 8px;
+    border: 1px solid var(--pf-color-border);
+    border-radius: 4px;
+    font-size: var(--pf-font-size-s);
+    font-family: inherit;
+    background: var(--pf-color-background);
+    color: var(--pf-color-text);
+    box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+      border-color: var(--pf-color-primary);
+    }
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      opacity: 1;
+    }
+  }
+
+  // Button bar spans full width
+  .pf-form__button-bar {
+    grid-column: 1 / -1;
+    margin-top: 4px;
+    padding-top: 8px;
+    border-top: 1px solid var(--pf-color-border);
+  }
+}
+
+// Chart cards container in modify panel
+.pf-chart-cards-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+// Individual chart card (extends Card widget)
+.pf-chart-card {
+  overflow: hidden;
+  padding: 0;
+
+  &--collapsed {
+    .pf-chart-card__header {
+      border-bottom: none;
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--pf-color-background-secondary);
+    border-bottom: 1px solid var(--pf-color-border);
+    cursor: pointer;
+    user-select: none;
+
+    &:hover {
+      background: var(--pf-color-hover);
+    }
+  }
+
+  &__toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--pf-color-text-secondary);
+  }
+
+  &__info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+    color: var(--pf-color-text);
+
+    .pf-icon {
+      color: var(--pf-color-primary);
+      flex-shrink: 0;
+    }
+  }
+
+  &__title {
+    font-size: var(--pf-font-size-s);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: text;
+
+    &:hover {
+      color: var(--pf-color-primary);
+    }
+  }
+
+  &__title-input {
+    font-size: var(--pf-font-size-s);
+    font-weight: 500;
+    border: none;
+    background: transparent;
+    outline: none;
+    padding: 0;
+    margin: 0;
+    font-family: inherit;
+    color: var(--pf-color-text);
+    flex: 1;
+    min-width: 0;
+
+    &::placeholder {
+      color: var(--pf-color-text-muted);
+      font-style: italic;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  &__filter-count {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    height: 20px;
+    padding: 0 4px 0 8px;
+    border-radius: 10px;
+    background: var(--pf-color-primary);
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  &__filter-count-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    font-size: 12px;
+    cursor: pointer;
+    opacity: 0.7;
+
+    &:hover {
+      opacity: 1;
+      background: rgba(255, 255, 255, 0.3);
+    }
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  &__filter-label {
+    font-size: var(--pf-font-size-xs);
+    color: var(--pf-color-text-secondary);
+  }
+
+  &__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  &__empty-message {
+    color: var(--pf-color-text-muted);
+    font-size: var(--pf-font-size-s);
+    font-style: italic;
+    text-align: center;
+    padding: 16px 8px;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
@@ -18,8 +18,10 @@ import {
   BarChartData,
   aggregateBarChartData,
 } from '../../../components/widgets/charts/bar_chart';
-import {AggregateFunction} from '../../../components/widgets/datagrid/model';
-import {isIntegerAggregation} from '../../../components/widgets/charts/chart_utils';
+import {
+  ChartAggregation,
+  isIntegerAggregation,
+} from '../../../components/widgets/charts/chart_utils';
 import {
   SQLBarChartLoader,
   BarChartLoaderConfig,
@@ -630,7 +632,7 @@ function BarChartDemo(): m.Component<{
   logScale: boolean;
   enableBrush: boolean;
   horizontal: boolean;
-  aggregation: AggregateFunction;
+  aggregation: ChartAggregation;
   gridLines: string;
 }> {
   let brushedLabels: Array<string | number> | undefined;
@@ -653,8 +655,9 @@ function BarChartDemo(): m.Component<{
         };
       }
 
-      const measureLabels: Record<AggregateFunction, string> = {
+      const measureLabels: Record<ChartAggregation, string> = {
         ANY: 'Any Duration',
+        COUNT: 'Count',
         SUM: 'Total Duration',
         AVG: 'Avg Duration',
         MIN: 'Min Duration',
@@ -715,7 +718,7 @@ function SQLBarChartDemo(): m.Component<{
   enableBrush: boolean;
   logScale: boolean;
   horizontal: boolean;
-  aggregation: AggregateFunction;
+  aggregation: ChartAggregation;
   gridLines: string;
 }> {
   let loader: SQLBarChartLoader | undefined;
@@ -740,8 +743,9 @@ function SQLBarChartDemo(): m.Component<{
       };
       const {data, isPending} = loader.use(config);
 
-      const measureLabels: Record<AggregateFunction, string> = {
+      const measureLabels: Record<ChartAggregation, string> = {
         ANY: 'Any Duration',
+        COUNT: 'Count',
         SUM: 'Total Duration',
         AVG: 'Avg Duration',
         MIN: 'Min Duration',
@@ -968,7 +972,7 @@ function SQLPieChartDemo(): m.Component<{
   height: number;
   showLegend: boolean;
   donut: boolean;
-  aggregation: AggregateFunction;
+  aggregation: ChartAggregation;
   limit: number;
 }> {
   let loader: SQLPieChartLoader | undefined;


### PR DESCRIPTION
New node.
- In terms of SQ it is passthrough + filters created from charts brushing -> a filter node
- Only supports Histogram and Bar chart for now
- Shows charts at the dataExplorer tab at the bottom