### PR TITLE
tp: fix behaviour when multiple userlists are seen in trace

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15762,6 +15762,7 @@ filegroup {
         "src/trace_processor/importers/proto/track_event_sequence_state.cc",
         "src/trace_processor/importers/proto/track_event_tokenizer.cc",
         "src/trace_processor/importers/proto/track_event_tracker.cc",
+        "src/trace_processor/importers/proto/user_tracker.cc",
     ],
 }
 

--- a/BUILD
+++ b/BUILD
@@ -2872,6 +2872,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/track_event_tokenizer.h",
         "src/trace_processor/importers/proto/track_event_tracker.cc",
         "src/trace_processor/importers/proto/track_event_tracker.h",
+        "src/trace_processor/importers/proto/user_tracker.cc",
+        "src/trace_processor/importers/proto/user_tracker.h",
     ],
 )
 

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -70,6 +70,8 @@ source_set("minimal") {
     "track_event_tokenizer.h",
     "track_event_tracker.cc",
     "track_event_tracker.h",
+    "user_tracker.cc",
+    "user_tracker.h",
   ]
   public_deps = [ ":proto_importer_module" ]
   deps = [

--- a/src/trace_processor/importers/proto/user_tracker.cc
+++ b/src/trace_processor/importers/proto/user_tracker.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/user_tracker.h"
+
+#include <cstdint>
+
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/android_tables_py.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor {
+
+UserTracker::UserTracker(TraceProcessorContext* context) : context_(context) {}
+
+void UserTracker::AddOrUpdateUser(int64_t android_user_id, StringId user_type) {
+  auto* it = user_rows_.Find(android_user_id);
+  if (it) {
+    auto row = context_->storage->mutable_user_list_table()->FindById(*it);
+    row->set_type(user_type);
+    return;
+  }
+  auto id = context_->storage->mutable_user_list_table()->Insert(
+      {user_type, android_user_id});
+  user_rows_.Insert(android_user_id, id.id);
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/user_tracker.h
+++ b/src/trace_processor/importers/proto/user_tracker.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_USER_TRACKER_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_USER_TRACKER_H_
+
+#include <cstdint>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/storage/trace_storage.h"
+#include "src/trace_processor/tables/android_tables_py.h"
+
+namespace perfetto::trace_processor {
+
+class TraceProcessorContext;
+
+class UserTracker {
+ public:
+  explicit UserTracker(TraceProcessorContext*);
+
+  void AddOrUpdateUser(int64_t android_user_id, StringId user_type);
+
+ private:
+  TraceProcessorContext* const context_;
+  base::FlatHashMap<int64_t, tables::AndroidUserListTable::Id> user_rows_;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_USER_TRACKER_H_

--- a/src/trace_processor/tables/android_tables.py
+++ b/src/trace_processor/tables/android_tables.py
@@ -345,7 +345,7 @@ ANDROID_USER_LIST_TABLE = Table(
     class_name='AndroidUserListTable',
     sql_name='__intrinsic_android_user_list',
     columns=[
-        C('type', CppString()),
+        C('type', CppString(), cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE),
         C('android_user_id', CppInt64()),
     ],
     tabledoc=TableDoc(

--- a/src/trace_processor/trace_processor_context.cc
+++ b/src/trace_processor/trace_processor_context.cc
@@ -49,6 +49,7 @@
 #include "src/trace_processor/importers/proto/blob_packet_writer.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/importers/proto/proto_trace_reader.h"
+#include "src/trace_processor/importers/proto/user_tracker.h"
 #include "src/trace_processor/storage/trace_storage.h"
 #include "src/trace_processor/trace_reader_registry.h"
 #include "src/trace_processor/types/trace_processor_context_ptr.h"
@@ -95,6 +96,7 @@ void InitPerMachineState(TraceProcessorContext* context, uint32_t machine_id) {
       std::make_unique<ClockSynchronizerListenerImpl>(context));
   context->mapping_tracker = Ptr<MappingTracker>::MakeRoot(context);
   context->cpu_tracker = Ptr<CpuTracker>::MakeRoot(context);
+  context->user_tracker = Ptr<UserTracker>::MakeRoot(context);
 }
 
 void CopyPerMachineState(const TraceProcessorContext* source,
@@ -105,6 +107,7 @@ void CopyPerMachineState(const TraceProcessorContext* source,
   dest->primary_clock_sync = source->primary_clock_sync.Fork();
   dest->mapping_tracker = source->mapping_tracker.Fork();
   dest->cpu_tracker = source->cpu_tracker.Fork();
+  dest->user_tracker = source->user_tracker.Fork();
 }
 
 void InitPerTraceState(TraceProcessorContext* context, TraceId trace_id) {

--- a/src/trace_processor/types/trace_processor_context.h
+++ b/src/trace_processor/types/trace_processor_context.h
@@ -35,6 +35,7 @@ class ClockConverter;
 class ClockSynchronizer;
 class ClockTracker;
 class CpuTracker;
+class UserTracker;
 class DescriptorPool;
 class EventTracker;
 class FileIoTracker;
@@ -193,6 +194,7 @@ class TraceProcessorContext {
   PerMachinePtr<MappingTracker> mapping_tracker;
   PerMachinePtr<MachineTracker> machine_tracker;
   PerMachinePtr<CpuTracker> cpu_tracker;
+  PerMachinePtr<UserTracker> user_tracker;
 
   // Per-Machine, Per-Trace State
   // ==========================

--- a/test/trace_processor/diff_tests/parser/android/tests.py
+++ b/test/trace_processor/diff_tests/parser/android/tests.py
@@ -208,6 +208,38 @@ class AndroidParser(TestSuite):
       0
       """))
 
+  def test_android_user_list_dedup(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          trusted_pid: 1
+          user_list {
+            users {
+              type: "android.os.usertype.full.SECONDARY"
+              uid: 10
+            }
+          }
+        }
+        packet {
+          trusted_pid: 2
+          user_list {
+            users {
+              type: "android.os.usertype.full.SECONDARY"
+              uid: 10
+            }
+          }
+        }
+        """),
+        query="""
+        INCLUDE PERFETTO MODULE android.user_list;
+        SELECT android_user_id, type FROM android_user_list
+        ORDER BY android_user_id;
+        """,
+        out=Csv("""
+        "android_user_id","type"
+        10,"android.os.usertype.full.SECONDARY"
+        """))
+
   # Tests when counter_tack.machine_id is not null.
   def test_android_system_property_counter_machine_id(self):
     return DiffTestBlueprint(


### PR DESCRIPTION
This CL protects against bad behaviour when multiple user list protos
are seen in a trace. Update it so that android_user_id is treated as
globally unique for a given machine as, in practice, it cannot change.
