### PR TITLE
tp: add TraceProcessorShellMain

### DIFF
--- a/include/perfetto/ext/trace_processor/trace_processor_shell.h
+++ b/include/perfetto/ext/trace_processor/trace_processor_shell.h
@@ -89,6 +89,8 @@ class TraceProcessorShell_PlatformInterface {
       std::function<void(size_t)> progress_callback) = 0;
 };
 
+int PERFETTO_EXPORT_COMPONENT TraceProcessorShellMain(int argc, char** argv);
+
 }  // namespace perfetto::trace_processor
 
 #endif  // INCLUDE_PERFETTO_EXT_TRACE_PROCESSOR_TRACE_PROCESSOR_SHELL_H_

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -2358,4 +2358,14 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
 TraceProcessorShell_PlatformInterface::
     ~TraceProcessorShell_PlatformInterface() = default;
 
+int PERFETTO_EXPORT_ENTRYPOINT TraceProcessorShellMain(int argc, char** argv) {
+  auto shell = TraceProcessorShell::CreateWithDefaultPlatform();
+  auto status = shell->Run(argc, argv);
+  if (!status.ok()) {
+    fprintf(stderr, "%s\n", status.c_message());
+    return 1;
+  }
+  return 0;
+}
+
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/trace_processor_shell_main.cc
+++ b/src/trace_processor/trace_processor_shell_main.cc
@@ -20,12 +20,5 @@
 #include "perfetto/ext/trace_processor/trace_processor_shell.h"
 
 int main(int argc, char** argv) {
-  auto shell = perfetto::trace_processor::TraceProcessorShell::
-      CreateWithDefaultPlatform();
-  auto status = shell->Run(argc, argv);
-  if (!status.ok()) {
-    fprintf(stderr, "%s\n", status.c_message());
-    return 1;
-  }
-  return 0;
+  return perfetto::trace_processor::TraceProcessorShellMain(argc, argv);
 }


### PR DESCRIPTION
Small wrapper around TraceProcessorShell class that provides a library interface that matches the traced service interfaces.

This makes bundling into a single binary like tracebox easier and more consistent.