### PR TITLE
Changed severity to error

### DIFF
--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -508,7 +508,7 @@ namespace perfetto::trace_processor::stats {
                                           kSingle,  kInfo,     kAnalysis,      \
       "Failed to decode ProtoLog message."),                                   \
   F(winscope_protolog_view_config_collision,                                   \
-                                          kSingle,  kInfo,     kAnalysis,      \
+                                          kSingle,  kError,    kAnalysis,      \
       "Got a viewer config collision!"),                                       \
   F(winscope_protolog_param_mismatch,                                          \
                                           kSingle,  kInfo,     kAnalysis,      \


### PR DESCRIPTION
Bug: b/363786060
This is a small change in winscope_protolog_view_config_collision severity from info to error to match the task description "trace process error".