### PR TITLE
ui: add embedder API for sidebar branding badges

### DIFF
--- a/ui/src/assets/sidebar.scss
+++ b/ui/src/assets/sidebar.scss
@@ -52,6 +52,25 @@
       height: 36px;
       margin-top: 4px;
     }
+    .pf-sidebar__branding-badge {
+      display: flex;
+      align-items: center;
+      position: absolute;
+      font-size: var(--pf-font-size-xs);
+      line-height: 1;
+      font-family: var(--pf-font);
+      top: 7px;
+      right: 48px;
+      z-index: 10;
+      i.pf-icon {
+        font-size: var(--pf-font-size-xs);
+        margin-right: 2px;
+      }
+      .pf-sidebar__branding-badge-img {
+        height: 10px;
+        margin-right: 2px;
+      }
+    }
     &::before {
       z-index: 10;
     }
@@ -64,6 +83,12 @@
       font-family: var(--pf-font);
       top: 7px;
       right: 48px;
+    }
+    &:has(.pf-sidebar__branding-badge) {
+      &.pf-sidebar__channel--canary::before,
+      &.pf-sidebar__channel--autopush::before {
+        top: 18px;
+      }
     }
     &.pf-sidebar__channel--canary::before {
       content: "CANARY";

--- a/ui/src/core/embedder/default_embedder.ts
+++ b/ui/src/core/embedder/default_embedder.ts
@@ -18,4 +18,5 @@ import {Embedder} from './embedder';
 export class DefaultEmbedder implements Embedder {
   readonly analyticsId = undefined;
   readonly extensionServer = undefined;
+  readonly brandingBadge = undefined;
 }

--- a/ui/src/core/embedder/embedder.ts
+++ b/ui/src/core/embedder/embedder.ts
@@ -21,6 +21,28 @@ export interface EmbedderExtensionServer {
 }
 
 /**
+ * Configuration for a branding badge displayed in the sidebar header.
+ *
+ * Example: To add a text-only branding badge, set in your embedder:
+ *   readonly brandingBadge = {text: 'BRAND', color: '#e07020'};
+ */
+export interface BrandingBadge {
+  /** The text to display, e.g. "BRAND". */
+  readonly text: string;
+  /** CSS color for the text, e.g. "#e07020". */
+  readonly color?: string;
+  /** Optional Material icon name to display before the text. */
+  readonly icon?: string;
+  /**
+   * Optional inline image data URI to display before the text (e.g.
+   * `data:image/svg+xml;base64,...`). Takes precedence over `icon` when
+   * both are specified. Only data URIs are supported; external URLs are not
+   * allowed.
+   */
+  readonly image?: string;
+}
+
+/**
  * Interface for embedder-specific behavior. Different implementations allow
  * the UI to adapt to the environment it's running in (e.g. ui.perfetto.dev
  * vs a third-party embedding).
@@ -33,4 +55,8 @@ export interface Embedder {
   // Returns the default extension server that should be added on startup if
   // not already configured by the user. Undefined means no default.
   readonly extensionServer: EmbedderExtensionServer | undefined;
+
+  // Returns the branding badge to display in the sidebar header, or undefined
+  // if no custom branding should be shown.
+  readonly brandingBadge: BrandingBadge | undefined;
 }

--- a/ui/src/core/embedder/perfetto_ui_embedder.ts
+++ b/ui/src/core/embedder/perfetto_ui_embedder.ts
@@ -21,4 +21,5 @@ export class PerfettoUiEmbedder implements Embedder {
     url: 'https://perfetto-gae-internal.googleplex.com/',
     authType: 'https_sso' as const,
   };
+  readonly brandingBadge = undefined;
 }

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -386,6 +386,21 @@ export class Sidebar implements m.ClassComponent {
       m(
         `header.pf-sidebar__channel--${getCurrentChannel()}`,
         m(`img[src=${assetSrc('assets/brand.png')}].pf-sidebar__brand`),
+        app.embedder.brandingBadge &&
+          m(
+            'span.pf-sidebar__branding-badge',
+            {style: {color: app.embedder.brandingBadge.color}},
+            app.embedder.brandingBadge.image
+              ? m('img.pf-sidebar__branding-badge-img', {
+                  src: app.embedder.brandingBadge.image,
+                })
+              : app.embedder.brandingBadge.icon &&
+                  m(Icon, {
+                    icon: app.embedder.brandingBadge.icon,
+                    className: 'pf-sidebar__branding-badge-icon',
+                  }),
+            app.embedder.brandingBadge.text,
+          ),
         m(Button, {
           icon: 'menu',
           className: 'pf-sidebar-button',


### PR DESCRIPTION
Add a BrandingBadge interface to the Embedder API that allows embedders to
display custom branding (text, icon, or inline image) in the sidebar header
next to the Perfetto logo.

The badge is rendered above the existing channel indicator (CANARY/AUTOPUSH),
which shifts down automatically via CSS :has() only when a badge is present.

The API supports three visual modes:
- Text only (e.g. {text: 'INTERNAL', color: '#0668E1'})
- Material icon + text (e.g. {icon: 'star', text: 'BRAND'})
- Inline data URI image + text (e.g. {image: 'data:image/svg+xml,...'})

Both DefaultEmbedder and PerfettoUiEmbedder set brandingBadge to undefined
(no branding). A fork wanting custom branding would either modify
default_embedder.ts directly or create a custom embedder class.