### PR TITLE
Render heap profile snapshots separately

### DIFF
--- a/ui/src/plugins/dev.perfetto.HeapProfile/common.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/common.ts
@@ -30,6 +30,10 @@ export interface ProfileDescriptor {
   heapName?: string;
 }
 
+export function isProfileDescriptor(type: string): boolean {
+  return type === 'java_heap_graph' || type.startsWith('heap_profile:');
+}
+
 export function profileDescriptor(type: string): ProfileDescriptor {
   if (type === 'java_heap_graph') {
     return {

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {materialColorScheme} from '../../components/colorizer';
 import {Time} from '../../base/time';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
@@ -37,6 +38,7 @@ export function createHeapProfileTrack(
       src: tableName,
       schema: {
         ts: LONG,
+        dur: LONG,
         type: STR,
         id: NUM,
       },
@@ -44,6 +46,7 @@ export function createHeapProfileTrack(
     }),
     detailsPanel: (row) => {
       const ts = Time.fromRaw(row.ts);
+      const tsEnd = Time.fromRaw(row.ts + row.dur);
       const descriptor = profileDescriptor(row.type);
       return new HeapProfileFlamegraphDetailsPanel(
         trace,
@@ -51,10 +54,14 @@ export function createHeapProfileTrack(
         upid,
         descriptor,
         ts,
+        tsEnd,
         detailsPanelState,
         onDetailsPanelStateChange,
       );
     },
     tooltip: (slice) => slice.row.type,
+    colorizer: (slice) => {
+      return materialColorScheme(slice.ts.toString());
+    },
   });
 }

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -27,13 +27,28 @@ import {FLAMEGRAPH_STATE_SCHEMA} from '../../widgets/flamegraph';
 import {Store} from '../../base/store';
 import {z} from 'zod';
 import {assertExists} from '../../base/assert';
-import {profileDescriptor} from './common';
+import {
+  isProfileDescriptor,
+  ProfileDescriptor,
+  profileDescriptor,
+  ProfileType,
+} from './common';
+import {
+  AreaSelection,
+  areaSelectionsEqual,
+  AreaSelectionTab,
+} from '../../public/selection';
+import {HeapProfileFlamegraphDetailsPanel} from './heap_profile_details_panel';
 
 const EVENT_TABLE_NAME = 'heap_profile_events';
 
-const HEAP_PROFILE_PLUGIN_STATE_SCHEMA = z.object({
-  detailsPanelFlamegraphState: FLAMEGRAPH_STATE_SCHEMA.optional(),
-});
+const HEAP_PROFILE_PLUGIN_STATE_SCHEMA = z.record(
+  z.enum(ProfileType),
+  z.object({
+    trackFlamegraphState: FLAMEGRAPH_STATE_SCHEMA.optional(),
+    areaSelectionFlamegraphState: FLAMEGRAPH_STATE_SCHEMA.optional(),
+  }),
+);
 
 type HeapProfilePluginState = z.infer<typeof HEAP_PROFILE_PLUGIN_STATE_SCHEMA>;
 
@@ -50,7 +65,14 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
 
   private migrateHeapProfilePluginState(init: unknown): HeapProfilePluginState {
     const result = HEAP_PROFILE_PLUGIN_STATE_SCHEMA.safeParse(init);
-    return result.data ?? {};
+    return (
+      result.data ?? {
+        [ProfileType.NATIVE_HEAP_PROFILE]: {},
+        [ProfileType.GENERIC_HEAP_PROFILE]: {},
+        [ProfileType.JAVA_HEAP_SAMPLES]: {},
+        [ProfileType.JAVA_HEAP_GRAPH]: {},
+      }
+    );
   }
 
   async onTraceLoad(trace: Trace): Promise<void> {
@@ -58,10 +80,23 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
       this.migrateHeapProfilePluginState(init),
     );
     await this.createHeapProfileTable(trace);
-    await this.addProcessTracks(trace);
+    const heapTypes = await this.getHeapTypes(trace);
+    await this.addProcessTracks(trace, heapTypes);
+
+    // For applicable heap types, register an area selection
+    for (const heapType of heapTypes) {
+      const descriptor = profileDescriptor(heapType);
+      if (descriptor.type === ProfileType.JAVA_HEAP_GRAPH) {
+        // There's no area selection for java heap dumps.
+        continue;
+      }
+      trace.selection.registerAreaSelectionTab(
+        this.heapProfileSelectionHandler(trace, descriptor),
+      );
+    }
 
     trace.onTraceReady.addListener(async () => {
-      await this.selectFirstHeapProfile(trace);
+      await this.selectHeapProfile(trace);
     });
   }
 
@@ -70,6 +105,24 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
       engine: trace.engine,
       name: EVENT_TABLE_NAME,
       as: `
+        WITH heap_profile_points AS (
+          SELECT
+            MIN(id) as id,
+            ts,
+            upid,
+            heap_name
+          FROM heap_profile_allocation
+          GROUP BY ts, upid, heap_name
+        ), heap_profile_slices AS (
+          SELECT
+            id,
+            upid,
+            heap_name,
+            LAG(ts, 1, trace_start()) OVER (PARTITION BY upid, heap_name ORDER BY ts) + 1 AS ts,
+            ts AS ts_end
+          FROM heap_profile_points
+        )
+
         SELECT
           MIN(id) as id,
           graph_sample_ts AS ts,
@@ -83,23 +136,18 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
         UNION ALL
 
         SELECT
-          MIN(id) as id,
+          id,
           ts,
           upid,
-          0 AS dur,
+          ts_end - ts AS dur,
           0 AS depth,
           'heap_profile:' || heap_name AS type
-        FROM heap_profile_allocation
-        GROUP BY ts, upid, heap_name
+        FROM heap_profile_slices
       `,
     });
   }
 
-  private async addProcessTracks(trace: Trace) {
-    const trackGroupsPlugin = trace.plugins.getPlugin(
-      ProcessThreadGroupsPlugin,
-    );
-    const incomplete = await this.getIncomplete(trace);
+  private async getHeapTypes(trace: Trace): Promise<string[]> {
     const heapTypesResult = await trace.engine.query(`
       SELECT DISTINCT type
       FROM ${EVENT_TABLE_NAME}
@@ -108,6 +156,14 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
     for (const it = heapTypesResult.iter({type: STR}); it.valid(); it.next()) {
       heapTypes.push(it.type);
     }
+    return heapTypes;
+  }
+
+  private async addProcessTracks(trace: Trace, heapTypes: readonly string[]) {
+    const trackGroupsPlugin = trace.plugins.getPlugin(
+      ProcessThreadGroupsPlugin,
+    );
+    const incomplete = await this.getIncomplete(trace);
 
     let typeIdx = 0;
     for (const heapType of heapTypes) {
@@ -140,11 +196,12 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
 
         const store = assertExists(this.store);
         const uri = trackUri(upid, heapType);
-
+        const descriptor = profileDescriptor(heapType);
         const track: Track = {
           uri,
           tags: {
-            upid,
+            upid: upid,
+            kinds: [heapType],
           },
           renderer: createHeapProfileTrack(
             trace,
@@ -152,21 +209,20 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
             viewName,
             upid,
             incomplete,
-            store.state.detailsPanelFlamegraphState,
+            store.state[descriptor.type].trackFlamegraphState,
             (state) => {
               store.edit((draft) => {
-                draft.detailsPanelFlamegraphState = state;
+                draft[descriptor.type].trackFlamegraphState = state;
               });
             },
           ),
         };
-
         trace.tracks.registerTrack(track);
-        this.trackMap.set(uri, track);
 
+        this.trackMap.set(uri, track);
         const trackNode = new TrackNode({
           uri,
-          name: profileDescriptor(heapType).label,
+          name: descriptor.label,
           sortOrder: -30,
         });
         group.addChildInOrder(trackNode);
@@ -184,23 +240,96 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
     return incomplete;
   }
 
-  private async selectFirstHeapProfile(ctx: Trace) {
+  private async selectHeapProfile(ctx: Trace) {
     const result = await ctx.engine.query(`
         SELECT
           id,
           upid,
           type
         FROM ${EVENT_TABLE_NAME}
-        ORDER BY ts
+        ORDER BY type, ts
         LIMIT 1
       `);
 
     const iter = result.maybeFirstRow({id: NUM, upid: NUM, type: STR});
     if (!iter) return;
 
-    const track = this.trackMap.get(trackUri(iter.upid, iter.type));
+    const uri = trackUri(iter.upid, iter.type);
+    const track = this.trackMap.get(uri);
     if (!track) return;
 
-    ctx.selection.selectTrackEvent(track.uri, iter.id);
+    if (profileDescriptor(iter.type).type === ProfileType.JAVA_HEAP_GRAPH) {
+      ctx.selection.selectTrackEvent(track.uri, iter.id);
+    } else {
+      ctx.selection.selectArea({
+        start: ctx.traceInfo.start,
+        end: ctx.traceInfo.end,
+        trackUris: [uri],
+      });
+    }
   }
+
+  private heapProfileSelectionHandler(
+    trace: Trace,
+    descriptor: ProfileDescriptor,
+  ): AreaSelectionTab {
+    let previousSelection: AreaSelection | undefined;
+    let flamegraphPanel: HeapProfileFlamegraphDetailsPanel | undefined;
+    return {
+      id: `heap_profiler_flamegraph_selection_${descriptor.heapName}`,
+      name: `${descriptor.label} flamegraph`,
+      render: (selection: AreaSelection) => {
+        const store = assertExists(this.store);
+        const selectionChanged =
+          previousSelection === undefined ||
+          !areaSelectionsEqual(previousSelection, selection);
+        previousSelection = selection;
+        if (!selectionChanged) {
+          return {isLoading: false, content: flamegraphPanel?.render()};
+        }
+        const upids = matchingTracks(selection, descriptor.type).map(
+          (track) => track.tags!.upid,
+        );
+        // For the time being support selecting exactly one process.
+        flamegraphPanel =
+          upids.length !== 1
+            ? undefined
+            : new HeapProfileFlamegraphDetailsPanel(
+                trace,
+                false,
+                upids[0]!,
+                descriptor,
+                selection.start,
+                selection.end,
+                store.state[descriptor.type].areaSelectionFlamegraphState,
+                (state) => {
+                  store.edit((draft) => {
+                    draft[descriptor.type].areaSelectionFlamegraphState = state;
+                  });
+                },
+              );
+        return {
+          isLoading: false,
+          content: flamegraphPanel?.render(),
+        };
+      },
+    };
+  }
+}
+
+function matchingTracks(
+  selection: AreaSelection,
+  profileType: ProfileType,
+): Track[] {
+  return selection.tracks.filter((track) => {
+    for (const kind of track.tags?.kinds || []) {
+      if (
+        isProfileDescriptor(kind) &&
+        profileDescriptor(kind).type === profileType
+      ) {
+        return true;
+      }
+    }
+    return false;
+  });
 }


### PR DESCRIPTION
Instead of representing each snapshot of the continuous dump mode as an instant event spanning the entirety of the trace until the event, represent each span of time as a slice of its own, thus enabling better correlation of the allocations to other events in the trace.

Changes:
- Add duration to the tracks to show spans of time
- Use an Area selection to enable multi-select. Selection of any part of the slice effectively includes the snapshot spanning the slice.
- Exclude negative allocation data points (which represent frees to allocations happening in previous slices)
- Fix bug with the state management (state being reused across profile types would crash due to mismatching flame graph configs)

Bug: 485167541
