### PR TITLE
add trace config option to preserve logcat buffers

### DIFF
--- a/protos/perfetto/config/android/android_log_config.proto
+++ b/protos/perfetto/config/android/android_log_config.proto
@@ -31,4 +31,11 @@ message AndroidLogConfig {
   // If non-empty ignores all log messages whose tag doesn't match one of the
   // specified values.
   repeated string filter_tags = 4;
+
+  // If true, includes the contents of the logcat buffers that were already
+  // present before the data source started. By default (false), only new
+  // log entries produced after the data source starts are recorded.
+  // Can be useful for boot traces or situations where logs from before
+  // traced started are important.
+  optional bool preserve_log_buffer = 5;
 }

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -704,6 +704,13 @@ message AndroidLogConfig {
   // If non-empty ignores all log messages whose tag doesn't match one of the
   // specified values.
   repeated string filter_tags = 4;
+
+  // If true, includes the contents of the logcat buffers that were already
+  // present before the data source started. By default (false), only new
+  // log entries produced after the data source starts are recorded.
+  // Can be useful for boot traces or situations where logs from before
+  // traced started are important.
+  optional bool preserve_log_buffer = 5;
 }
 
 // End of protos/perfetto/config/android/android_log_config.proto

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -704,6 +704,13 @@ message AndroidLogConfig {
   // If non-empty ignores all log messages whose tag doesn't match one of the
   // specified values.
   repeated string filter_tags = 4;
+
+  // If true, includes the contents of the logcat buffers that were already
+  // present before the data source started. By default (false), only new
+  // log entries produced after the data source starts are recorded.
+  // Can be useful for boot traces or situations where logs from before
+  // traced started are important.
+  optional bool preserve_log_buffer = 5;
 }
 
 // End of protos/perfetto/config/android/android_log_config.proto

--- a/src/traced/probes/android_log/android_log_data_source.cc
+++ b/src/traced/probes/android_log/android_log_data_source.cc
@@ -117,7 +117,13 @@ AndroidLogDataSource::AndroidLogDataSource(DataSourceConfig ds_config,
 
   // Build the command string that will be sent to the logdr socket on Start(),
   // which looks like "stream lids=1,2,3,4" (lids == log buffer id(s)).
-  mode_ = "stream tail=1 lids";
+  // If preserve_log_buffer is true, omit tail=1 to include existing buffered
+  // log entries. Otherwise, tail=1 means only new entries are recorded.
+  if (cfg.preserve_log_buffer()) {
+    mode_ = "stream lids";
+  } else {
+    mode_ = "stream tail=1 lids";
+  }
   for (auto it = log_ids.begin(); it != log_ids.end(); it++) {
     mode_ += it == log_ids.begin() ? "=" : ",";
     mode_ += std::to_string(*it);


### PR DESCRIPTION
Add and option to preserve logcat buffers, analogous to the existing
[preserve_ftrace](https://source.chromium.org/chromium/chromium/src/+/main:third_party/perfetto//protos/perfetto/config/ftrace/ftrace_config.proto;l=255) option.

keeping logcat from before the trace starts is useful in similar situations
where you would want to do this for ftrace, such as tracing the boot sequence.

## testing:
test_preserve_log_buffer.pbtx:
```
buffers: {
  size_kb: 32768
  fill_policy: DISCARD
}

data_sources: {
  config {
    name: "android.log"
    android_log_config {
      # Include all common log buffers
      log_ids: LID_DEFAULT
      log_ids: LID_SYSTEM
      log_ids: LID_EVENTS
      log_ids: LID_CRASH
      log_ids: LID_KERNEL

      preserve_log_buffer: true
    }
  }
}

data_sources: {
  config {
    name: "linux.ftrace"
    ftrace_config {
      ftrace_events: "sched/sched_switch"
      ftrace_events: "sched/sched_waking"
      ftrace_events: "sched/sched_wakeup"
    }
  }
}

duration_ms: 5000
```

```
./tools/record_android_trace --sideload-path ./out/android_release_arm64/tracebox -c test_preserve_log_buffer.pbtx
```


<img width="1590" height="836" alt="image" src="https://github.com/user-attachments/assets/4e611a28-ad18-44f4-a903-657675df32a9" />
