### PR TITLE
tp: Fix PerfettoUI failing to load single logcat file with clock_sync_failure_unknown_source_clock error

### DIFF
--- a/src/trace_processor/forwarding_trace_parser.cc
+++ b/src/trace_processor/forwarding_trace_parser.cc
@@ -167,7 +167,8 @@ base::Status ForwardingTraceParser::Init(const TraceBlobView& blob) {
              trace_type_ == kInstrumentsXmlTraceType) {
     trace_context_->clock_tracker->SetGlobalClock(
         ClockId::TraceFile(trace_context_->trace_id().value));
-  } else if (trace_type_ == kAndroidDumpstateTraceType) {
+  } else if (trace_type_ == kAndroidDumpstateTraceType ||
+             trace_type_ == kAndroidLogcatTraceType) {
     trace_context_->clock_tracker->SetGlobalClock(
         ClockId::Machine(protos::pbzero::BUILTIN_CLOCK_REALTIME));
   }


### PR DESCRIPTION
tp: Fix PerfettoUI failing to load single logcat file with clock_sync_failure_unknown_source_clock error (https://github.com/google/perfetto/issues/4914)

Description:
When loading a single logcat.txt file in PerfettoUI, the loading fails with error: clock_sync_failure_unknown_source_clock .

Problely Cause:
ForwardingTraceParser does not call SetGlobalClock for kAndroidLogcatTraceType , which is required for proper clock synchronization. Similar trace types like kAndroidDumpstateTraceType already handle this correctly.

Proposed Fix:
Add SetGlobalClock(BUILTIN_CLOCK_REALTIME) call for kAndroidLogcatTraceType in forwarding_trace_parser.cc .

I've tested this fix locally and confirmed it resolves the issue.
