### PR TITLE
ui: Make AndroidAnr plugin default

### DIFF
--- a/ui/src/core/default_plugins.ts
+++ b/ui/src/core/default_plugins.ts
@@ -21,6 +21,7 @@
 // - Not directly rely on any other plugins.
 // - Be approved by one of Perfetto UI owners.
 export const defaultPlugins = [
+  'com.android.AndroidAnr',
   'com.android.AndroidClientServer',
   'com.android.AndroidCujs',
   'com.android.AndroidDmabuf',


### PR DESCRIPTION
This change adds `com.android.AndroidAnr` plugin to the enable by default list.
