### PR TITLE
de: Fix rendering of metrics node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -82,6 +82,7 @@ export function singleNodeOperation(type: NodeType): boolean {
     case NodeType.kSort:
     case NodeType.kFilter:
     case NodeType.kCounterToIntervals:
+    case NodeType.kMetrics:
     case NodeType.kVisualisation:
       return true;
     default:


### PR DESCRIPTION
By mistake we removed the kMetrics enum and replaced it with kVisualisation. This change made metrics node be treated as a multisource node