### PR TITLE
ui: Fix resizable details panel

### DIFF
--- a/ui/src/assets/widgets/drawer_panel.scss
+++ b/ui/src/assets/widgets/drawer_panel.scss
@@ -45,12 +45,18 @@
     padding-inline: 3px; // Leave some space for the drop shadow
     display: flex;
     overflow: hidden;
-    flex: 1; // Expand to fill remaining space.
 
     // Align tabs to the bottom of the handle & overlap the drawer border so
     // that the active tab looks like it is part of the drawer.
     align-self: flex-end;
     margin-bottom: -1px;
+    cursor: default; // Tabs container itself is not clickable
+  }
+
+  &__spacer {
+    flex: 1;
+    align-self: stretch;
+    min-width: 30px; // Leave some room for the user to grab the handle even if there are many tabs
   }
 
   &__tab {

--- a/ui/src/widgets/drawer_panel.ts
+++ b/ui/src/widgets/drawer_panel.ts
@@ -233,6 +233,7 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
         [
           leftHandleContent,
           m('.pf-drawer-panel__tabs', tabsUI),
+          m('.pf-drawer-panel__spacer'),
           this.renderTabResizeButtons(visibility, onVisibilityChange),
         ],
       ),
@@ -301,6 +302,14 @@ export class DrawerPanel implements m.ClassComponent<DrawerPanelAttrs> {
   }
 
   private onPointerDown(e: PointerEvent, attrs: DrawerPanelAttrs) {
+    // Only start drag if the handle itself or the spacer is targeted
+    const target = e.target as HTMLElement;
+    const isHandle = target === e.currentTarget;
+    const isSpacer = target.classList.contains('pf-drawer-panel__spacer');
+    if (!isHandle && !isSpacer) {
+      return;
+    }
+
     this.handleElement = e.currentTarget as HTMLElement;
     this.handleElement.setPointerCapture(e.pointerId);
     this.dragStartY = e.clientY;


### PR DESCRIPTION
Capture pointer events to stop resizing the panel from scrolling the timeline