### PR TITLE
ui: do not expand User Interaction group  by default

### DIFF
--- a/ui/src/plugins/dev.perfetto.StandardGroups/index.ts
+++ b/ui/src/plugins/dev.perfetto.StandardGroups/index.ts
@@ -35,8 +35,7 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.StandardGroups';
 
   private readonly groups: Record<StandardGroup, TrackNode> = {
-    // Expand this group by default
-    USER_INTERACTION: makeGroupNode('User Interaction', false),
+    USER_INTERACTION: makeGroupNode('User Interaction'),
     THERMALS: makeGroupNode('Thermals'),
     POWER: makeGroupNode('Power'),
     CPU: makeGroupNode('CPU'),


### PR DESCRIPTION
This change removes the expand by default bahaviour of `User Interaction` group.