### PR TITLE
ui: Return all names when using the datagrid eq filter

### DIFF
--- a/ui/src/components/widgets/datagrid/sql_data_source.ts
+++ b/ui/src/components/widgets/datagrid/sql_data_source.ts
@@ -169,7 +169,6 @@ export class SQLDataSource implements DataSource {
           FROM ${baseTable} AS ${baseAlias}
           ${joinClauses}
           ORDER BY 1
-          LIMIT 1000
         `;
 
         const result = await this.engine.query(query);


### PR DESCRIPTION
Used to limit 1000, remove this to return all
