### PR TITLE
Add support for FWTP slice traces to Perfetto UI

### DIFF
--- a/src/trace_processor/importers/ftrace/ftrace_parser.h
+++ b/src/trace_processor/importers/ftrace/ftrace_parser.h
@@ -348,6 +348,7 @@ class FtraceParser {
   void ParseMaliGpuPowerState(int64_t ts, protozero::ConstBytes blob);
   void ParseDmabufRssStat(int64_t ts, uint32_t pid, protozero::ConstBytes blob);
   void ParseFwtpPerfettoCounter(protozero::ConstBytes blob);
+  void ParseFwtpPerfettoSlice(int64_t ts, protozero::ConstBytes blob);
   void ParseF2fsWriteCheckpoint(int64_t ts,
                                 uint32_t pid,
                                 protozero::ConstBytes blob);

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_tracks.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_tracks.ts
@@ -361,4 +361,9 @@ export const SLICE_TRACK_SCHEMAS: ReadonlyArray<SliceTrackTypeSchema> = [
     topLevelGroup: 'IO',
     group: 'F2FS Write Checkpoint',
   },
+  {
+    type: 'pixel_fwtp_slices',
+    topLevelGroup: 'HARDWARE',
+    group: 'Pixel Firmware',
+  },
 ];


### PR DESCRIPTION
Bug: 469451931
Test: Verified Pixel firmware slice events in Perfetto UI.
