### PR TITLE
tracing_proto_extesions: change schema, add root

### DIFF
--- a/protos/perfetto/trace/track_event/track_event_extensions.json
+++ b/protos/perfetto/trace/track_event/track_event_extensions.json
@@ -1,41 +1,45 @@
 {
-  "scope": "perfetto.protos.TrackEvent",
-  "range": [1000, 9999],
-  "allocations": [
+  "extensions": [
     {
-      "name": "chromium",
-      "range": [1000, 1999],
-      "contact": "tracing@chromium.org",
-      "description": "Chrome browser and chromium-based projects",
-      "comment": ["The source of truth lives in chromium. A copy exists in ",
-                  "the Perfetto GitHub repo under ",
-                  "protos/third_party/chromium/chrome_track_event.proto ",
-                  "and is kept up-to-date via a Skia autoroller."
-                ],
+      "scope": "perfetto.protos.TrackEvent",
+      "range": [1000, 9999],
+      "allocations": [
+        {
+          "name": "chromium",
+          "range": [1000, 1999],
+          "contact": "tracing@chromium.org",
+          "description": "Chrome browser and chromium-based projects",
+          "comment": ["The source of truth lives in chromium. A copy exists in ",
+                      "the Perfetto GitHub repo under ",
+                      "protos/third_party/chromium/chrome_track_event.proto ",
+                      "and is kept up-to-date via a Skia autoroller."
+                    ],
 
-      "repo": "https://chromium.googlesource.com/chromium/src",
-      "proto": "base/tracing/protos/chrome_track_event.proto"
-    },
-    {
-      "name": "android_system",
-      "range": [2000, 2999],
-      "contact": "perfetto-dev@googlegroups.com",
-      "comment": ["TODO(primiano): moved these into the Android tree and ",
-                  "create sub-registries there."],
-      "description": "Android OS platform (System image)",
-      "proto": "protos/perfetto/trace/android/android_track_event.proto"
-    },
-    {
-      "name": "unallocated",
-      "comment": ["The next allocation goes here. Shrink and take from here."],
-      "range": [3000, 8999]
-    },
-    {
-      "name": "perfetto_tests",
-      "range": [9000, 9999],
-      "contact": "perfetto-dev@googlegroups.com",
-      "description": "Reserved for Perfetto unit and integration tests",
-      "proto": "protos/perfetto/trace/test_extensions.proto"
+          "repo": "https://chromium.googlesource.com/chromium/src",
+          "proto": "base/tracing/protos/chrome_track_event.proto"
+        },
+        {
+          "name": "android_system",
+          "range": [2000, 2999],
+          "contact": "perfetto-dev@googlegroups.com",
+          "comment": ["TODO(primiano): move these into the Android tree and ",
+                      "create sub-registries there."],
+          "description": "Android OS platform (System image)",
+          "proto": "protos/perfetto/trace/android/android_track_event.proto"
+        },
+        {
+          "name": "unallocated",
+          "comment": ["The next allocation goes here. Shrink and take from here."],
+          "range": [3000, 8999]
+        },
+        {
+          "name": "perfetto_tests",
+          "range": [9000, 9999],
+          "contact": "perfetto-dev@googlegroups.com",
+          "description": "Reserved for Perfetto unit and integration tests",
+          "proto": "protos/perfetto/trace/test_extensions.proto"
+        }
+      ]
     }
   ]
 }

--- a/src/tools/tracing_proto_extensions.cc
+++ b/src/tools/tracing_proto_extensions.cc
@@ -43,11 +43,12 @@
 
 namespace perfetto {
 namespace gen_proto_extensions {
-namespace {
 
 namespace pbzero = protos::pbzero;
 using trace_processor::json::FieldResult;
 using trace_processor::json::SimpleJsonParser;
+
+namespace {
 
 // Sorts ranges by start and checks for validity (start <= end, no internal
 // overlaps).
@@ -259,52 +260,13 @@ base::Status ValidateFieldNumbers(
   return base::OkStatus();
 }
 
-// Recursively collects all proto files from the registry tree.
-struct ProtoEntry {
-  std::string proto_path;
-  std::string scope;
-  std::vector<Range> ranges;
-};
-
-base::Status CollectProtos(const std::string& json_path,
-                           const std::string& root_dir,
-                           std::vector<ProtoEntry>* out) {
-  std::string contents;
-  if (!base::ReadFile(json_path, &contents)) {
-    return base::ErrStatus("Failed to read '%s'", json_path.c_str());
-  }
-
-  ASSIGN_OR_RETURN(auto reg, ParseRegistry(contents, json_path));
-  RETURN_IF_ERROR(ValidateRegistry(reg));
-
-  for (const auto& alloc : reg.allocations) {
-    if (!alloc.proto.empty() && alloc.repo.empty()) {
-      // Local proto leaf.
-      out->push_back({root_dir + "/" + alloc.proto, reg.scope, alloc.ranges});
-    } else if (!alloc.registry.empty() && alloc.repo.empty()) {
-      // Local sub-registry.
-      std::string sub_path = root_dir + "/" + alloc.registry;
-      RETURN_IF_ERROR(CollectProtos(sub_path, root_dir, out));
-    }
-    // Remote entries (repo is set) are skipped.
-  }
-  return base::OkStatus();
-}
-
-}  // namespace
-
-base::StatusOr<Registry> ParseRegistry(const std::string& json_contents,
-                                       const std::string& source_path) {
+// Parses a single registry object from the current parser position.
+// The parser should be positioned at a JSON object with
+// scope/range/allocations.
+base::StatusOr<Registry> ParseRegistryObject(SimpleJsonParser& parser,
+                                             const std::string& source_path) {
   Registry reg;
   reg.source_path = source_path;
-
-  SimpleJsonParser parser(json_contents);
-  {
-    auto status = parser.Parse();
-    if (!status.ok())
-      return base::ErrStatus("Failed to parse JSON in '%s': %s",
-                             source_path.c_str(), status.message().c_str());
-  }
 
   bool has_range = false;
   bool has_ranges = false;
@@ -462,6 +424,46 @@ base::StatusOr<Registry> ParseRegistry(const std::string& json_contents,
   return std::move(reg);
 }
 
+}  // namespace
+
+base::StatusOr<std::vector<Registry>> ParseRegistryFile(
+    const std::string& json_contents,
+    const std::string& source_path) {
+  SimpleJsonParser parser(json_contents);
+  {
+    auto status = parser.Parse();
+    if (!status.ok())
+      return base::ErrStatus("Failed to parse JSON in '%s': %s",
+                             source_path.c_str(), status.message().c_str());
+  }
+
+  std::vector<Registry> extensions;
+  RETURN_IF_ERROR(parser.ForEachField([&](std::string_view key) -> FieldResult {
+    if (key == "extensions") {
+      if (!parser.IsArray())
+        return base::ErrStatus("'extensions' must be an array in '%s'",
+                               source_path.c_str());
+      RETURN_IF_ERROR(parser.ForEachArrayElement([&]() -> base::Status {
+        if (!parser.IsObject())
+          return base::ErrStatus(
+              "Each entry in 'extensions' must be an object in '%s'",
+              source_path.c_str());
+        ASSIGN_OR_RETURN(auto reg, ParseRegistryObject(parser, source_path));
+        extensions.push_back(std::move(reg));
+        return base::OkStatus();
+      }));
+      return FieldResult::Handled{};
+    }
+    if (key == "comment")
+      return FieldResult::Skip{};
+    return base::ErrStatus("Unknown field '%.*s' in '%s'",
+                           static_cast<int>(key.size()), key.data(),
+                           source_path.c_str());
+  }));
+
+  return extensions;
+}
+
 base::Status ValidateRegistry(const Registry& reg) {
   // Currently only TrackEvent extensions are supported. In the future, this
   // field could be used to disambiguate TracePacket extensions.
@@ -554,13 +556,62 @@ base::Status ValidateRegistry(const Registry& reg) {
   return base::OkStatus();
 }
 
+namespace {
+
+// Recursively collects all proto files from the registry tree.
+struct ProtoEntry {
+  std::string proto_path;
+  std::string scope;
+  std::vector<Range> ranges;
+};
+
+// Walks allocations from an already-parsed registry. For sub-registries,
+// reads and parses them using the flat (non-wrapped) format.
+base::Status CollectProtosFromRegistry(const Registry& reg,
+                                       const std::string& root_dir,
+                                       std::vector<ProtoEntry>* out) {
+  for (const auto& alloc : reg.allocations) {
+    if (!alloc.proto.empty() && alloc.repo.empty()) {
+      // Local proto leaf.
+      out->push_back({root_dir + "/" + alloc.proto, reg.scope, alloc.ranges});
+    } else if (!alloc.registry.empty() && alloc.repo.empty()) {
+      // Local sub-registry (same {"extensions": [...]} format).
+      std::string sub_path = root_dir + "/" + alloc.registry;
+      std::string contents;
+      if (!base::ReadFile(sub_path, &contents)) {
+        return base::ErrStatus("Failed to read '%s'", sub_path.c_str());
+      }
+      ASSIGN_OR_RETURN(auto sub_regs, ParseRegistryFile(contents, sub_path));
+      for (const auto& sub_reg : sub_regs) {
+        RETURN_IF_ERROR(ValidateRegistry(sub_reg));
+        RETURN_IF_ERROR(CollectProtosFromRegistry(sub_reg, root_dir, out));
+      }
+    }
+    // Remote entries (repo is set) are skipped.
+  }
+  return base::OkStatus();
+}
+
+}  // namespace
+
 base::StatusOr<std::vector<uint8_t>> GenerateExtensionDescriptors(
     const std::string& root_json_path,
     const std::vector<std::string>& proto_paths,
     const std::string& root_dir) {
-  // 1. Recursively collect all local proto entries from the JSON hierarchy.
+  // 1. Read and parse the root registry file (uses the "extensions" wrapper).
+  std::string root_contents;
+  if (!base::ReadFile(root_json_path, &root_contents)) {
+    return base::ErrStatus("Failed to read '%s'", root_json_path.c_str());
+  }
+  ASSIGN_OR_RETURN(auto extensions,
+                   ParseRegistryFile(root_contents, root_json_path));
+
+  // 2. Recursively collect all local proto entries from each registry.
   std::vector<ProtoEntry> entries;
-  RETURN_IF_ERROR(CollectProtos(root_json_path, root_dir, &entries));
+  for (const auto& reg : extensions) {
+    RETURN_IF_ERROR(ValidateRegistry(reg));
+    RETURN_IF_ERROR(CollectProtosFromRegistry(reg, root_dir, &entries));
+  }
 
   if (entries.empty()) {
     PERFETTO_ILOG("No local proto files found in registry.");

--- a/src/tools/tracing_proto_extensions.h
+++ b/src/tools/tracing_proto_extensions.h
@@ -55,9 +55,11 @@ struct Registry {
   std::string source_path;
 };
 
-// Parses a track_event_extensions.json file from its contents.
-base::StatusOr<Registry> ParseRegistry(const std::string& json_contents,
-                                       const std::string& source_path);
+// Parses a track_event_extensions.json file with the {"extensions": [...]}
+// format. Returns one Registry per entry in the array.
+base::StatusOr<std::vector<Registry>> ParseRegistryFile(
+    const std::string& json_contents,
+    const std::string& source_path);
 
 // Validates a registry: checks that allocations tile the ranges exactly
 // (no gaps or overlaps) and that constraints on proto/registry fields are met.

--- a/src/tools/tracing_proto_extensions_unittest.cc
+++ b/src/tools/tracing_proto_extensions_unittest.cc
@@ -25,29 +25,34 @@ namespace perfetto {
 namespace gen_proto_extensions {
 namespace {
 
-TEST(GenProtoExtensionsTest, ParseRegistryBasic) {
+TEST(GenProtoExtensionsTest, ParseRegistryFileBasic) {
   const char kJson[] = R"({
-    "scope": "perfetto.protos.TrackEvent",
-    "range": [1000, 2000],
-    "allocations": [
+    "extensions": [
       {
-        "name": "project_a",
-        "range": [1000, 1499],
-        "contact": "foo@example.com",
-        "description": "Project A",
-        "proto": "path/to/a.proto"
-      },
-      {
-        "name": "unallocated",
-        "range": [1500, 2000]
+        "scope": "perfetto.protos.TrackEvent",
+        "range": [1000, 2000],
+        "allocations": [
+          {
+            "name": "project_a",
+            "range": [1000, 1499],
+            "contact": "foo@example.com",
+            "description": "Project A",
+            "proto": "path/to/a.proto"
+          },
+          {
+            "name": "unallocated",
+            "range": [1500, 2000]
+          }
+        ]
       }
     ]
   })";
 
-  auto result = ParseRegistry(kJson, "test.json");
+  auto result = ParseRegistryFile(kJson, "test.json");
   ASSERT_TRUE(result.ok()) << result.status().message();
 
-  const Registry& reg = *result;
+  ASSERT_EQ(result->size(), 1u);
+  const Registry& reg = (*result)[0];
   EXPECT_EQ(reg.scope, "perfetto.protos.TrackEvent");
   ASSERT_EQ(reg.ranges.size(), 1u);
   EXPECT_EQ(reg.ranges[0], Range(1000, 2000));
@@ -64,32 +69,194 @@ TEST(GenProtoExtensionsTest, ParseRegistryBasic) {
   EXPECT_EQ(reg.allocations[1].ranges[0], Range(1500, 2000));
 }
 
-TEST(GenProtoExtensionsTest, ParseRegistryWithSubRegistry) {
+TEST(GenProtoExtensionsTest, ParseRegistryFileWithSubRegistry) {
   const char kJson[] = R"({
-    "range": [1000, 2000],
-    "allocations": [
+    "extensions": [
       {
-        "name": "project_a",
-        "range": [1000, 1499],
-        "registry": "path/to/sub.json"
-      },
-      {
-        "name": "project_b",
-        "range": [1500, 1999],
-        "repo": "https://example.com/repo",
-        "proto": "some/path.proto"
-      },
-      {
-        "name": "unallocated",
-        "range": [2000, 2000]
+        "range": [1000, 2000],
+        "allocations": [
+          {
+            "name": "project_a",
+            "range": [1000, 1499],
+            "registry": "path/to/sub.json"
+          },
+          {
+            "name": "project_b",
+            "range": [1500, 1999],
+            "repo": "https://example.com/repo",
+            "proto": "some/path.proto"
+          },
+          {
+            "name": "unallocated",
+            "range": [2000, 2000]
+          }
+        ]
       }
     ]
   })";
 
-  auto result = ParseRegistry(kJson, "test.json");
+  auto result = ParseRegistryFile(kJson, "test.json");
   ASSERT_TRUE(result.ok()) << result.status().message();
-  EXPECT_EQ(result->allocations[0].registry, "path/to/sub.json");
-  EXPECT_EQ(result->allocations[1].repo, "https://example.com/repo");
+  ASSERT_EQ(result->size(), 1u);
+  EXPECT_EQ((*result)[0].allocations[0].registry, "path/to/sub.json");
+  EXPECT_EQ((*result)[0].allocations[1].repo, "https://example.com/repo");
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileMultipleExtensions) {
+  const char kJson[] = R"({
+    "extensions": [
+      {
+        "scope": "perfetto.protos.TrackEvent",
+        "range": [1000, 1999],
+        "allocations": [
+          {"name": "a", "range": [1000, 1999], "proto": "a.proto"}
+        ]
+      },
+      {
+        "scope": "perfetto.protos.TrackEvent",
+        "range": [2000, 2999],
+        "allocations": [
+          {"name": "b", "range": [2000, 2999], "proto": "b.proto"}
+        ]
+      }
+    ]
+  })";
+
+  auto result = ParseRegistryFile(kJson, "test.json");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_EQ(result->size(), 2u);
+  EXPECT_EQ((*result)[0].scope, "perfetto.protos.TrackEvent");
+  EXPECT_EQ((*result)[1].scope, "perfetto.protos.TrackEvent");
+  EXPECT_EQ((*result)[0].allocations[0].name, "a");
+  EXPECT_EQ((*result)[1].allocations[0].name, "b");
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileWithComment) {
+  const char kJson[] = R"({
+    "comment": ["Top-level comment"],
+    "extensions": [
+      {
+        "scope": "perfetto.protos.TrackEvent",
+        "range": [100, 199],
+        "allocations": [
+          {"name": "a", "range": [100, 199], "proto": "a.proto"}
+        ]
+      }
+    ]
+  })";
+
+  auto result = ParseRegistryFile(kJson, "test.json");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+  ASSERT_EQ(result->size(), 1u);
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileUnknownField) {
+  const char kJson[] = R"({
+    "extensions": [],
+    "unknown_field": 42
+  })";
+  auto result = ParseRegistryFile(kJson, "test.json");
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), testing::HasSubstr("Unknown field"));
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileInvalidJson) {
+  auto result = ParseRegistryFile("{invalid", "test.json");
+  EXPECT_FALSE(result.ok());
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileWithRanges) {
+  const char kJson[] = R"({
+    "extensions": [
+      {
+        "ranges": [[1000, 1499], [2000, 2999]],
+        "allocations": [
+          {
+            "name": "project_a",
+            "range": [1000, 1499],
+            "proto": "a.proto"
+          },
+          {
+            "name": "project_b",
+            "range": [2000, 2999],
+            "proto": "b.proto"
+          }
+        ]
+      }
+    ]
+  })";
+
+  auto result = ParseRegistryFile(kJson, "test.json");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  ASSERT_EQ(result->size(), 1u);
+  ASSERT_EQ((*result)[0].ranges.size(), 2u);
+  EXPECT_EQ((*result)[0].ranges[0], Range(1000, 1499));
+  EXPECT_EQ((*result)[0].ranges[1], Range(2000, 2999));
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileAllocWithRanges) {
+  const char kJson[] = R"({
+    "extensions": [
+      {
+        "range": [1000, 2999],
+        "allocations": [
+          {
+            "name": "project_a",
+            "ranges": [[1000, 1499], [2000, 2499]],
+            "proto": "a.proto"
+          },
+          {
+            "name": "unallocated",
+            "ranges": [[1500, 1999], [2500, 2999]]
+          }
+        ]
+      }
+    ]
+  })";
+
+  auto result = ParseRegistryFile(kJson, "test.json");
+  ASSERT_TRUE(result.ok()) << result.status().message();
+
+  ASSERT_EQ(result->size(), 1u);
+  ASSERT_EQ((*result)[0].allocations[0].ranges.size(), 2u);
+  EXPECT_EQ((*result)[0].allocations[0].ranges[0], Range(1000, 1499));
+  EXPECT_EQ((*result)[0].allocations[0].ranges[1], Range(2000, 2499));
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileRangeAndRangesMutuallyExclusive) {
+  const char kJson[] = R"({
+    "extensions": [
+      {
+        "range": [1000, 2000],
+        "ranges": [[1000, 1500], [1501, 2000]],
+        "allocations": []
+      }
+    ]
+  })";
+
+  auto result = ParseRegistryFile(kJson, "test.json");
+  EXPECT_FALSE(result.ok());
+  EXPECT_THAT(result.status().message(), testing::HasSubstr("both"));
+}
+
+TEST(GenProtoExtensionsTest, ParseRegistryFileMissingRange) {
+  const char kJson[] = R"({
+    "extensions": [
+      {
+        "allocations": [
+          {"name": "a", "range": [1, 10], "proto": "a.proto"}
+        ]
+      }
+    ]
+  })";
+  auto result = ParseRegistryFile(kJson, "test.json");
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(result->size(), 1u);
+  // ranges will be empty (no range specified in the entry).
+  // ValidateRegistry should catch this.
+  auto status = ValidateRegistry((*result)[0]);
+  EXPECT_FALSE(status.ok());
 }
 
 TEST(GenProtoExtensionsTest, ValidateRegistryValid) {
@@ -169,25 +336,6 @@ TEST(GenProtoExtensionsTest, ValidateRegistryUnallocatedWithProto) {
   EXPECT_THAT(status.message(), testing::HasSubstr("Unallocated"));
 }
 
-TEST(GenProtoExtensionsTest, ParseRegistryInvalidJson) {
-  auto result = ParseRegistry("{invalid", "test.json");
-  EXPECT_FALSE(result.ok());
-}
-
-TEST(GenProtoExtensionsTest, ParseRegistryMissingRange) {
-  const char kJson[] = R"({
-    "allocations": [
-      {"name": "a", "range": [1, 10], "proto": "a.proto"}
-    ]
-  })";
-  auto result = ParseRegistry(kJson, "test.json");
-  ASSERT_TRUE(result.ok());
-  // ranges will be empty (no top-level range specified).
-  // ValidateRegistry should catch this.
-  auto status = ValidateRegistry(*result);
-  EXPECT_FALSE(status.ok());
-}
-
 TEST(GenProtoExtensionsTest, ValidateRegistryRemoteEntrySkipsProtoCheck) {
   Registry reg;
   reg.source_path = "test.json";
@@ -199,67 +347,6 @@ TEST(GenProtoExtensionsTest, ValidateRegistryRemoteEntrySkipsProtoCheck) {
   reg.allocations.push_back({"unallocated", {{200, 299}}, "", "", "", "", ""});
 
   EXPECT_TRUE(ValidateRegistry(reg).ok());
-}
-
-TEST(GenProtoExtensionsTest, ParseRegistryWithRanges) {
-  const char kJson[] = R"({
-    "ranges": [[1000, 1499], [2000, 2999]],
-    "allocations": [
-      {
-        "name": "project_a",
-        "range": [1000, 1499],
-        "proto": "a.proto"
-      },
-      {
-        "name": "project_b",
-        "range": [2000, 2999],
-        "proto": "b.proto"
-      }
-    ]
-  })";
-
-  auto result = ParseRegistry(kJson, "test.json");
-  ASSERT_TRUE(result.ok()) << result.status().message();
-
-  ASSERT_EQ(result->ranges.size(), 2u);
-  EXPECT_EQ(result->ranges[0], Range(1000, 1499));
-  EXPECT_EQ(result->ranges[1], Range(2000, 2999));
-}
-
-TEST(GenProtoExtensionsTest, ParseRegistryAllocWithRanges) {
-  const char kJson[] = R"({
-    "range": [1000, 2999],
-    "allocations": [
-      {
-        "name": "project_a",
-        "ranges": [[1000, 1499], [2000, 2499]],
-        "proto": "a.proto"
-      },
-      {
-        "name": "unallocated",
-        "ranges": [[1500, 1999], [2500, 2999]]
-      }
-    ]
-  })";
-
-  auto result = ParseRegistry(kJson, "test.json");
-  ASSERT_TRUE(result.ok()) << result.status().message();
-
-  ASSERT_EQ(result->allocations[0].ranges.size(), 2u);
-  EXPECT_EQ(result->allocations[0].ranges[0], Range(1000, 1499));
-  EXPECT_EQ(result->allocations[0].ranges[1], Range(2000, 2499));
-}
-
-TEST(GenProtoExtensionsTest, ParseRegistryRangeAndRangesMutuallyExclusive) {
-  const char kJson[] = R"({
-    "range": [1000, 2000],
-    "ranges": [[1000, 1500], [1501, 2000]],
-    "allocations": []
-  })";
-
-  auto result = ParseRegistry(kJson, "test.json");
-  EXPECT_FALSE(result.ok());
-  EXPECT_THAT(result.status().message(), testing::HasSubstr("both"));
 }
 
 TEST(GenProtoExtensionsTest, ValidateRegistryScatteredRangesValid) {
@@ -302,26 +389,6 @@ TEST(GenProtoExtensionsTest, ValidateRegistryScatteredRangesOverlap) {
   EXPECT_THAT(status.message(), testing::HasSubstr("overlap"));
 }
 
-TEST(GenProtoExtensionsTest, ParseRegistryWithComment) {
-  const char kJson[] = R"({
-    "comment": ["This is a comment", "Another line"],
-    "range": [100, 199],
-    "allocations": [
-      {
-        "name": "a",
-        "comment": ["Allocation comment"],
-        "range": [100, 199],
-        "proto": "a.proto"
-      }
-    ]
-  })";
-
-  auto result = ParseRegistry(kJson, "test.json");
-  ASSERT_TRUE(result.ok()) << result.status().message();
-  ASSERT_EQ(result->ranges.size(), 1u);
-  EXPECT_EQ(result->ranges[0], Range(100, 199));
-}
-
 TEST(GenProtoExtensionsTest, ValidateRegistryMissingScope) {
   Registry reg;
   reg.source_path = "test.json";
@@ -361,13 +428,17 @@ TEST(GenProtoExtensionsTest, GenerateExtensionDescriptorsNoExtend) {
     }
   )");
   tmp.AddFile("registry.json", R"({
-    "scope": "perfetto.protos.TrackEvent",
-    "range": [9900, 9999],
-    "allocations": [
+    "extensions": [
       {
-        "name": "test",
+        "scope": "perfetto.protos.TrackEvent",
         "range": [9900, 9999],
-        "proto": "protos/perfetto/trace/track_event/no_extend.proto"
+        "allocations": [
+          {
+            "name": "test",
+            "range": [9900, 9999],
+            "proto": "protos/perfetto/trace/track_event/no_extend.proto"
+          }
+        ]
       }
     ]
   })");


### PR DESCRIPTION
I just realized that the format I introduced in #4833
is not future proof. The problem is specifically
extending both TrackEvent and TracePacket.
This PR adds an "extension" root, so we can define in
the same json two objects, one for each message to extend.