### PR TITLE
tp: extract RegisterCache from BytecodeBuilder

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2084,6 +2084,7 @@ perfetto_filegroup(
         "src/trace_processor/core/dataframe/dataframe.h",
         "src/trace_processor/core/dataframe/query_plan.cc",
         "src/trace_processor/core/dataframe/query_plan.h",
+        "src/trace_processor/core/dataframe/register_cache.h",
         "src/trace_processor/core/dataframe/runtime_dataframe_builder.h",
         "src/trace_processor/core/dataframe/specs.h",
         "src/trace_processor/core/dataframe/typed_cursor.cc",

--- a/src/trace_processor/core/dataframe/BUILD.gn
+++ b/src/trace_processor/core/dataframe/BUILD.gn
@@ -24,6 +24,7 @@ source_set("dataframe") {
     "dataframe.h",
     "query_plan.cc",
     "query_plan.h",
+    "register_cache.h",
     "runtime_dataframe_builder.h",
     "specs.h",
     "typed_cursor.cc",

--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -36,6 +36,7 @@
 #include "perfetto/public/compiler.h"
 #include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/dataframe/register_cache.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
@@ -55,19 +56,6 @@ namespace perfetto::trace_processor::core::dataframe {
 namespace {
 
 namespace i = interpreter;
-
-// Register type identifiers for scope cache key encoding.
-// Used with BytecodeBuilder::GetOrAllocateCachedRegister(scope_id, reg_type,
-// col_or_index) to cache column/index-specific registers.
-enum RegType : uint32_t {
-  kStorageReg = 0,
-  kNullBvReg = 1,
-  kPrefixPopcountReg = 2,
-  kSmallValueEqBvReg = 3,
-  kSmallValueEqPopcountReg = 4,
-  kIndexReg = 5,
-  kRegTypeCount = 6,
-};
 
 // TypeSet of all possible sparse nullability states.
 using SparseNullTypes = TypeSet<SparseNull,
@@ -223,7 +211,7 @@ std::optional<BestIndex> GetBestIndexForFilterSpecs(
 
 QueryPlanBuilder::QueryPlanBuilder(
     i::BytecodeBuilder& builder,
-    uint32_t scope_id,
+    RegisterCache& cache,
     IndicesReg indices,
     uint32_t row_count,
     const std::vector<std::shared_ptr<Column>>& columns,
@@ -232,7 +220,7 @@ QueryPlanBuilder::QueryPlanBuilder(
       indexes_(indexes),
       indices_reg_(indices),
       builder_(builder),
-      scope_id_(scope_id) {
+      cache_(cache) {
   // Setup the maximum and estimated row counts.
   plan_.params.max_row_count = row_count;
   plan_.params.estimated_row_count = row_count;
@@ -248,7 +236,7 @@ base::StatusOr<QueryPlanImpl> QueryPlanBuilder::Build(
     const LimitSpec& limit_spec,
     uint64_t cols_used) {
   i::BytecodeBuilder bytecode_builder;
-  uint32_t scope_id = bytecode_builder.CreateCacheScope();
+  RegisterCache cache(&bytecode_builder);
 
   // Initialize with a range covering all rows.
   i::RwHandle<Range> range = bytecode_builder.AllocateRegister<Range>();
@@ -259,8 +247,8 @@ base::StatusOr<QueryPlanImpl> QueryPlanBuilder::Build(
     ir.arg<B::dest_register>() = range;
   }
 
-  QueryPlanBuilder builder(bytecode_builder, scope_id, range, row_count,
-                           columns, indexes);
+  QueryPlanBuilder builder(bytecode_builder, cache, range, row_count, columns,
+                           indexes);
   RETURN_IF_ERROR(builder.Filter(specs));
   builder.Distinct(distinct);
   if (builder.CanUseMinMaxOptimization(sort_specs, limit_spec)) {
@@ -342,11 +330,11 @@ i::RegValue QueryPlanImpl::GetRegisterInitValue(const RegisterInit& init,
 
 base::StatusOr<FilterResult> QueryPlanBuilder::Filter(
     i::BytecodeBuilder& builder,
-    uint32_t scope_id,
     IndicesReg input_indices,
     const Dataframe& df,
+    RegisterCache& cache,
     std::vector<FilterSpec>& specs) {
-  QueryPlanBuilder plan_builder(builder, scope_id, input_indices, df.row_count_,
+  QueryPlanBuilder plan_builder(builder, cache, input_indices, df.row_count_,
                                 df.columns_, df.indexes_);
   RETURN_IF_ERROR(plan_builder.Filter(specs));
   return FilterResult{plan_builder.indices_reg_,
@@ -1187,8 +1175,8 @@ void QueryPlanBuilder::SetGuaranteedToBeEmpty() {
 
 i::ReadHandle<Slab<uint32_t>> QueryPlanBuilder::PrefixPopcountRegisterFor(
     uint32_t col) {
-  auto [reg, inserted] = builder_.GetOrAllocateCachedRegister<Slab<uint32_t>>(
-      scope_id_, kPrefixPopcountReg, col);
+  auto [reg, inserted] = cache_.GetOrAllocate<Slab<uint32_t>>(
+      columns_[col].get(), kPrefixPopcountReg);
   if (inserted) {
     using B = i::PrefixPopcount;
     auto& bc = AddOpcode<B>(UnchangedRowCount{});
@@ -1201,8 +1189,8 @@ i::ReadHandle<Slab<uint32_t>> QueryPlanBuilder::PrefixPopcountRegisterFor(
 i::RwHandle<i::StoragePtr> QueryPlanBuilder::StorageRegisterFor(
     uint32_t col,
     StorageType type) {
-  auto [reg, inserted] = builder_.GetOrAllocateCachedRegister<i::StoragePtr>(
-      scope_id_, kStorageReg, col);
+  auto [reg, inserted] =
+      cache_.GetOrAllocate<i::StoragePtr>(columns_[col].get(), kStorageReg);
   if (inserted) {
     plan_.register_inits.emplace_back(
         RegisterInit{reg.index, type.Upcast<RegisterInit::Type>(),
@@ -1213,8 +1201,8 @@ i::RwHandle<i::StoragePtr> QueryPlanBuilder::StorageRegisterFor(
 
 i::ReadHandle<const BitVector*> QueryPlanBuilder::NullBitvectorRegisterFor(
     uint32_t col) {
-  auto [reg, inserted] = builder_.GetOrAllocateCachedRegister<const BitVector*>(
-      scope_id_, kNullBvReg, col);
+  auto [reg, inserted] =
+      cache_.GetOrAllocate<const BitVector*>(columns_[col].get(), kNullBvReg);
   if (inserted) {
     plan_.register_inits.emplace_back(RegisterInit{
         reg.index, RegisterInit::NullBitvector{}, static_cast<uint16_t>(col)});
@@ -1224,8 +1212,8 @@ i::ReadHandle<const BitVector*> QueryPlanBuilder::NullBitvectorRegisterFor(
 
 i::ReadHandle<const BitVector*> QueryPlanBuilder::SmallValueEqBvRegisterFor(
     uint32_t col) {
-  auto [reg, inserted] = builder_.GetOrAllocateCachedRegister<const BitVector*>(
-      scope_id_, kSmallValueEqBvReg, col);
+  auto [reg, inserted] = cache_.GetOrAllocate<const BitVector*>(
+      columns_[col].get(), kSmallValueEqBvReg);
   if (inserted) {
     plan_.register_inits.emplace_back(
         RegisterInit{reg.index, RegisterInit::SmallValueEqBitvector{},
@@ -1236,9 +1224,8 @@ i::ReadHandle<const BitVector*> QueryPlanBuilder::SmallValueEqBvRegisterFor(
 
 i::ReadHandle<Span<const uint32_t>>
 QueryPlanBuilder::SmallValueEqPopcountRegisterFor(uint32_t col) {
-  auto [reg, inserted] =
-      builder_.GetOrAllocateCachedRegister<Span<const uint32_t>>(
-          scope_id_, kSmallValueEqPopcountReg, col);
+  auto [reg, inserted] = cache_.GetOrAllocate<Span<const uint32_t>>(
+      columns_[col].get(), kSmallValueEqPopcountReg);
   if (inserted) {
     plan_.register_inits.emplace_back(
         RegisterInit{reg.index, RegisterInit::SmallValueEqPopcount{},
@@ -1248,8 +1235,8 @@ QueryPlanBuilder::SmallValueEqPopcountRegisterFor(uint32_t col) {
 }
 
 i::RwHandle<Span<uint32_t>> QueryPlanBuilder::IndexRegisterFor(uint32_t pos) {
-  auto [reg, inserted] = builder_.GetOrAllocateCachedRegister<Span<uint32_t>>(
-      scope_id_, kIndexReg, pos);
+  auto [reg, inserted] =
+      cache_.GetOrAllocate<Span<uint32_t>>(&indexes_[pos], kIndexReg);
   if (inserted) {
     plan_.register_inits.emplace_back(RegisterInit{
         reg.index, RegisterInit::IndexVector{}, static_cast<uint16_t>(pos)});

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -35,6 +35,7 @@
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/ext/base/string_view.h"
 #include "perfetto/public/compiler.h"
+#include "src/trace_processor/core/dataframe/register_cache.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/dataframe/types.h"
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
@@ -267,9 +268,9 @@ class QueryPlanBuilder {
   //
   // Parameters:
   //   builder: The BytecodeBuilder to emit bytecode into
-  //   scope_id: Caller-managed cache scope for column register caching
   //   input_indices: Input indices to filter
   //   df: The dataframe to filter
+  //   cache: RegisterCache for column register caching
   //   specs: Filter specifications (may be reordered)
   //
   // Returns a FilterResult containing:
@@ -278,9 +279,9 @@ class QueryPlanBuilder {
   // Cost tracking is done internally and discarded at end of call.
   static base::StatusOr<FilterResult> Filter(
       interpreter::BytecodeBuilder& builder,
-      uint32_t scope_id,
       IndicesReg input_indices,
       const Dataframe& df,
+      RegisterCache& cache,
       std::vector<FilterSpec>& specs);
 
  private:
@@ -318,9 +319,9 @@ class QueryPlanBuilder {
                                         LimitOffsetRowCount>;
 
   // Constructs a builder for the given indices and columns.
-  // scope_id is used for caching column/index registers in the BytecodeBuilder.
+  // cache is used for caching column/index registers.
   QueryPlanBuilder(interpreter::BytecodeBuilder& builder,
-                   uint32_t scope_id,
+                   RegisterCache& cache,
                    IndicesReg indices,
                    uint32_t row_count,
                    const std::vector<std::shared_ptr<Column>>& columns,
@@ -508,8 +509,8 @@ class QueryPlanBuilder {
   // and scratch management.
   interpreter::BytecodeBuilder& builder_;
 
-  // Scope ID for caching column/index registers across Filter() calls.
-  uint32_t scope_id_;
+  // Cache for column/index registers across Filter() calls.
+  RegisterCache& cache_;
 };
 
 }  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/dataframe/register_cache.h
+++ b/src/trace_processor/core/dataframe/register_cache.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_DATAFRAME_REGISTER_CACHE_H_
+#define SRC_TRACE_PROCESSOR_CORE_DATAFRAME_REGISTER_CACHE_H_
+
+#include <cstdint>
+#include <utility>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/core/interpreter/bytecode_builder.h"
+#include "src/trace_processor/core/interpreter/bytecode_registers.h"
+
+namespace perfetto::trace_processor::core::dataframe {
+
+// Register type identifiers for cache key encoding.
+enum RegType : uint32_t {
+  kStorageReg = 0,
+  kNullBvReg = 1,
+  kPrefixPopcountReg = 2,
+  kSmallValueEqBvReg = 3,
+  kSmallValueEqPopcountReg = 4,
+  kIndexReg = 5,
+  kRegTypeCount = 6,
+};
+
+// Cache for register handles, keyed by data source pointer (e.g. Column*,
+// Index*) and register type.
+//
+// Used by QueryPlanBuilder for deduplication and by DataframeTransformer for
+// tracking registers across operations.
+//
+// Using pointers as keys provides natural scoping: when Column objects change
+// (e.g. after gather creates new Column instances), the new pointers miss the
+// cache and fresh registers are allocated.
+class RegisterCache {
+ public:
+  RegisterCache() = default;
+  explicit RegisterCache(interpreter::BytecodeBuilder* builder)
+      : builder_(builder) {}
+
+  // Gets a register from cache, or allocates a new one.
+  // |key| is typically Column* or Index*.
+  // |reg_type| distinguishes different register kinds for the same key.
+  // Returns the register and whether it was newly allocated.
+  template <typename T>
+  std::pair<interpreter::RwHandle<T>, bool> GetOrAllocate(const void* key,
+                                                          RegType reg_type) {
+    uintptr_t cache_key = MakeKey(key, reg_type);
+    auto* it = cache_.Find(cache_key);
+    if (it) {
+      return {interpreter::RwHandle<T>{it->index}, false};
+    }
+    auto reg = builder_->AllocateRegister<T>();
+    cache_[cache_key] = interpreter::HandleBase{reg.index};
+    return {reg, true};
+  }
+
+  // Sets a register in the cache for the given key and type.
+  void Set(const void* key, RegType reg_type, interpreter::HandleBase handle) {
+    cache_[MakeKey(key, reg_type)] = handle;
+  }
+
+ private:
+  // Combines pointer and reg_type into a single key. Since Column/Index
+  // objects are much larger than kRegTypeCount, adding reg_type to the
+  // pointer address produces unique keys without collision.
+  static uintptr_t MakeKey(const void* ptr, uint32_t reg_type) {
+    return reinterpret_cast<uintptr_t>(ptr) + reg_type;
+  }
+
+  interpreter::BytecodeBuilder* builder_ = nullptr;
+  base::FlatHashMap<uintptr_t, interpreter::HandleBase> cache_;
+};
+
+}  // namespace perfetto::trace_processor::core::dataframe
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_DATAFRAME_REGISTER_CACHE_H_

--- a/src/trace_processor/core/interpreter/bytecode_builder.cc
+++ b/src/trace_processor/core/interpreter/bytecode_builder.cc
@@ -26,17 +26,6 @@
 
 namespace perfetto::trace_processor::core::interpreter {
 
-uint32_t BytecodeBuilder::CreateCacheScope() {
-  auto scope_id = static_cast<uint32_t>(scope_caches_.size());
-  scope_caches_.emplace_back();
-  return scope_id;
-}
-
-void BytecodeBuilder::ClearCacheScope(uint32_t scope_id) {
-  PERFETTO_CHECK(scope_id < scope_caches_.size());
-  scope_caches_[scope_id].Clear();
-}
-
 BytecodeBuilder::ScratchRegisters BytecodeBuilder::GetOrCreateScratchRegisters(
     uint32_t slot_id,
     uint32_t size) {

--- a/src/trace_processor/core/interpreter/bytecode_builder.h
+++ b/src/trace_processor/core/interpreter/bytecode_builder.h
@@ -21,7 +21,6 @@
 #include <optional>
 #include <vector>
 
-#include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/util/slab.h"
@@ -33,8 +32,6 @@ namespace perfetto::trace_processor::core::interpreter {
 //
 // This class provides generic bytecode building capabilities. It handles:
 // - Register allocation
-// - Scope-based register caching (generic mechanism for callers to cache
-//   registers within a scope)
 // - Scratch register management
 // - Raw opcode emission
 //
@@ -55,43 +52,6 @@ class BytecodeBuilder {
 
   // Returns the total number of registers allocated.
   uint32_t register_count() const { return register_count_; }
-
-  // === Scope-based register caching ===
-
-  // Creates a new cache scope and returns its ID.
-  // Scopes allow callers to cache registers and retrieve them later by
-  // (reg_type, index) pairs.
-  uint32_t CreateCacheScope();
-
-  // Result from GetOrAllocateCachedRegister.
-  template <typename T>
-  struct CachedRegister {
-    RwHandle<T> reg;
-    bool inserted;  // True if newly allocated, false if found in cache
-  };
-
-  // Gets a register from the scope cache, or allocates a new one if not found.
-  // The allocated register is automatically added to the cache.
-  // Returns the register and whether it was newly inserted.
-  template <typename T>
-  CachedRegister<T> GetOrAllocateCachedRegister(uint32_t scope_id,
-                                                uint32_t reg_type,
-                                                uint32_t index) {
-    if (scope_id >= scope_caches_.size()) {
-      scope_caches_.resize(scope_id + 1);
-    }
-    uint64_t key = CacheKey(reg_type, index);
-    auto* it = scope_caches_[scope_id].Find(key);
-    if (it) {
-      return {RwHandle<T>{it->index}, false};
-    }
-    auto reg = AllocateRegister<T>();
-    scope_caches_[scope_id][key] = HandleBase{reg.index};
-    return {reg, true};
-  }
-
-  // Clears all cached registers for a scope.
-  void ClearCacheScope(uint32_t scope_id);
 
   // === Scratch register management ===
   //
@@ -173,16 +133,8 @@ class BytecodeBuilder {
     bool in_use = false;
   };
 
-  // Combines reg_type and index into a single cache key.
-  static constexpr uint64_t CacheKey(uint32_t reg_type, uint32_t index) {
-    return (static_cast<uint64_t>(reg_type) << 32) | index;
-  }
-
   BytecodeVector bytecode_;
   uint32_t register_count_ = 0;
-
-  // Scope-based cache: scope_id -> (reg_type, index) -> register handle
-  std::vector<base::FlatHashMap<uint64_t, HandleBase>> scope_caches_;
 
   // Scratch management - multiple slots indexed by slot_id
   std::vector<std::optional<ScratchIndices>> scratch_slots_;

--- a/src/trace_processor/core/tree/tree_transformer.cc
+++ b/src/trace_processor/core/tree/tree_transformer.cc
@@ -175,7 +175,7 @@ struct TreeValueFetcher : core::ValueFetcher {
 // =============================================================================
 
 TreeTransformer::TreeTransformer(dataframe::Dataframe df, StringPool* pool)
-    : df_(std::move(df)), pool_(pool), scope_id_(builder_.CreateCacheScope()) {}
+    : df_(std::move(df)), pool_(pool), cache_(&builder_) {}
 
 // =============================================================================
 // Public methods
@@ -331,8 +331,8 @@ TreeTransformer::BuildFilterBitvector(
   // Generate filter bytecode using QueryPlanBuilder::Filter.
   ASSIGN_OR_RETURN(auto filter_result,
                    dataframe::QueryPlanBuilder::Filter(
-                       builder_, scope_id_,
-                       interpreter::RwHandle<Range>(range_reg), df_, specs));
+                       builder_, interpreter::RwHandle<Range>(range_reg), df_,
+                       cache_, specs));
 
   // Capture register init specs for later initialization in ToDataframe().
   for (const auto& init : filter_result.register_inits) {

--- a/src/trace_processor/core/tree/tree_transformer.h
+++ b/src/trace_processor/core/tree/tree_transformer.h
@@ -28,6 +28,7 @@
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
 #include "src/trace_processor/core/dataframe/query_plan.h"
+#include "src/trace_processor/core/dataframe/register_cache.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
@@ -54,7 +55,7 @@ namespace perfetto::trace_processor::core::tree {
 //
 // Architecture follows QueryPlanBuilder patterns:
 // - Uses builder_.GetOrCreateScratchRegisters() for scratch management
-// - Uses scope-based register caching via builder_.CreateCacheScope()
+// - Uses RegisterCache for column register caching
 // - Single unified code path (no lazy initialization)
 class TreeTransformer {
  public:
@@ -123,8 +124,8 @@ class TreeTransformer {
   // Bytecode builder for accumulating tree operations.
   interpreter::BytecodeBuilder builder_;
 
-  // Scope ID for register caching (follows QueryPlanBuilder pattern).
-  uint32_t scope_id_;
+  // Cache for column register deduplication.
+  dataframe::RegisterCache cache_;
 
   // Parent and original_rows span registers (set on first FilterTree call).
   interpreter::RwHandle<Span<uint32_t>> parent_span_;


### PR DESCRIPTION
Extract scope-based register caching from BytecodeBuilder into a
standalone RegisterCache class in the dataframe layer. The new class
uses pointer-keyed caching (Column*/Index* + RegType) instead of
scope-based (scope_id, reg_type, index) caching, which provides
natural cache invalidation when Column objects change.

This is a pure refactor with no behavior change.
