### PR TITLE
tp: decouple QueryPlanBuilder::Filter from Dataframe

### DIFF
--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -331,14 +331,26 @@ i::RegValue QueryPlanImpl::GetRegisterInitValue(const RegisterInit& init,
 base::StatusOr<FilterResult> QueryPlanBuilder::Filter(
     i::BytecodeBuilder& builder,
     IndicesReg input_indices,
-    const Dataframe& df,
+    uint32_t row_count,
+    const std::vector<std::shared_ptr<Column>>& columns,
+    const std::vector<Index>& indexes,
     RegisterCache& cache,
     std::vector<FilterSpec>& specs) {
-  QueryPlanBuilder plan_builder(builder, cache, input_indices, df.row_count_,
-                                df.columns_, df.indexes_);
+  QueryPlanBuilder plan_builder(builder, cache, input_indices, row_count,
+                                columns, indexes);
   RETURN_IF_ERROR(plan_builder.Filter(specs));
   return FilterResult{plan_builder.indices_reg_,
                       std::move(plan_builder.plan_.register_inits)};
+}
+
+base::StatusOr<FilterResult> QueryPlanBuilder::Filter(
+    i::BytecodeBuilder& builder,
+    IndicesReg input_indices,
+    const Dataframe& df,
+    RegisterCache& cache,
+    std::vector<FilterSpec>& specs) {
+  return Filter(builder, input_indices, df.row_count_, df.columns_, df.indexes_,
+                cache, specs);
 }
 
 base::Status QueryPlanBuilder::Filter(std::vector<FilterSpec>& specs) {

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -269,7 +269,9 @@ class QueryPlanBuilder {
   // Parameters:
   //   builder: The BytecodeBuilder to emit bytecode into
   //   input_indices: Input indices to filter
-  //   df: The dataframe to filter
+  //   row_count: Number of rows in the data
+  //   columns: Column definitions
+  //   indexes: Index definitions
   //   cache: RegisterCache for column register caching
   //   specs: Filter specifications (may be reordered)
   //
@@ -277,6 +279,16 @@ class QueryPlanBuilder {
   //   - The filtered indices register
   //   - RegisterInit specs needed to initialize storage registers
   // Cost tracking is done internally and discarded at end of call.
+  static base::StatusOr<FilterResult> Filter(
+      interpreter::BytecodeBuilder& builder,
+      IndicesReg input_indices,
+      uint32_t row_count,
+      const std::vector<std::shared_ptr<Column>>& columns,
+      const std::vector<Index>& indexes,
+      RegisterCache& cache,
+      std::vector<FilterSpec>& specs);
+
+  // Convenience overload that extracts parameters from a Dataframe.
   static base::StatusOr<FilterResult> Filter(
       interpreter::BytecodeBuilder& builder,
       IndicesReg input_indices,


### PR DESCRIPTION
Add a decoupled Filter() overload that takes row_count, columns, and
indexes directly instead of requiring a Dataframe reference. This
allows callers that manage their own column state (like the upcoming
DataframeTransformer) to use Filter() without a Dataframe.

The existing Dataframe-based overload is kept as a convenience wrapper.
