### PR TITLE
tp: add DataframeTransformer, refactor TreeTransformer

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15092,6 +15092,7 @@ filegroup {
     srcs: [
         "src/trace_processor/core/dataframe/adhoc_dataframe_builder.cc",
         "src/trace_processor/core/dataframe/dataframe.cc",
+        "src/trace_processor/core/dataframe/dataframe_transformer.cc",
         "src/trace_processor/core/dataframe/query_plan.cc",
         "src/trace_processor/core/dataframe/typed_cursor.cc",
     ],

--- a/BUILD
+++ b/BUILD
@@ -2082,6 +2082,8 @@ perfetto_filegroup(
         "src/trace_processor/core/dataframe/cursor_impl.h",
         "src/trace_processor/core/dataframe/dataframe.cc",
         "src/trace_processor/core/dataframe/dataframe.h",
+        "src/trace_processor/core/dataframe/dataframe_transformer.cc",
+        "src/trace_processor/core/dataframe/dataframe_transformer.h",
         "src/trace_processor/core/dataframe/query_plan.cc",
         "src/trace_processor/core/dataframe/query_plan.h",
         "src/trace_processor/core/dataframe/register_cache.h",

--- a/src/trace_processor/core/dataframe/BUILD.gn
+++ b/src/trace_processor/core/dataframe/BUILD.gn
@@ -22,6 +22,8 @@ source_set("dataframe") {
     "cursor_impl.h",
     "dataframe.cc",
     "dataframe.h",
+    "dataframe_transformer.cc",
+    "dataframe_transformer.h",
     "query_plan.cc",
     "query_plan.h",
     "register_cache.h",

--- a/src/trace_processor/core/dataframe/dataframe.h
+++ b/src/trace_processor/core/dataframe/dataframe.h
@@ -408,6 +408,7 @@ class Dataframe {
 
  private:
   friend class AdhocDataframeBuilder;
+  friend class DataframeTransformer;
   friend class TypedCursor;
   friend class QueryPlanBuilder;
   friend struct QueryPlanImpl;

--- a/src/trace_processor/core/dataframe/dataframe_transformer.cc
+++ b/src/trace_processor/core/dataframe/dataframe_transformer.cc
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/core/dataframe/dataframe_transformer.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/dataframe/query_plan.h"
+#include "src/trace_processor/core/dataframe/register_cache.h"
+#include "src/trace_processor/core/dataframe/specs.h"
+#include "src/trace_processor/core/dataframe/types.h"
+#include "src/trace_processor/core/interpreter/bytecode_builder.h"
+#include "src/trace_processor/core/interpreter/bytecode_instructions.h"
+#include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/range.h"
+#include "src/trace_processor/core/util/span.h"
+
+namespace perfetto::trace_processor::core::dataframe {
+
+namespace {
+namespace i = interpreter;
+
+// Scratch slot used for filter bytecode within DataframeTransformer.
+// Starts at 20 to avoid collision with TreeTransformer::ScratchSlot (0-9).
+constexpr uint32_t kDtFilterBytecodeSlot = 20;
+
+}  // namespace
+
+DataframeTransformer::DataframeTransformer(i::BytecodeBuilder& builder,
+                                           const Dataframe& df)
+    : builder_(builder), cache_(&builder), max_row_count_(df.row_count()) {
+  columns_ = df.columns_;
+  column_names_ = df.column_names();
+  indexes_ = df.indexes_;
+}
+
+base::StatusOr<i::RwHandle<BitVector>> DataframeTransformer::Filter(
+    std::vector<FilterSpec>& specs) {
+  // Build input indices.
+  auto range_reg = builder_.AllocateRegister<Range>();
+  {
+    using B = i::InitRange;
+    auto& op = builder_.AddOpcode<B>(i::Index<B>());
+    op.arg<B::size>() = max_row_count_;
+    op.arg<B::dest_register>() = range_reg;
+  }
+
+  // Call Filter with the register cache.
+  ASSIGN_OR_RETURN(auto filter_result,
+                   QueryPlanBuilder::Filter(
+                       builder_, i::RwHandle<Range>(range_reg), max_row_count_,
+                       columns_, indexes_, cache_, specs));
+
+  // Capture register init specs from newly allocated registers.
+  for (const auto& init : filter_result.register_inits) {
+    register_inits_.emplace_back(init);
+  }
+
+  // Convert filtered result to bitvector.
+  auto bv_reg = builder_.AllocateRegister<BitVector>();
+  if (auto* range_ptr =
+          std::get_if<i::RwHandle<Range>>(&filter_result.indices)) {
+    auto filter_scratch =
+        builder_.AllocateScratch(kDtFilterBytecodeSlot, max_row_count_);
+    {
+      using Iota = i::Iota;
+      auto& op = builder_.AddOpcode<Iota>(i::Index<Iota>());
+      op.arg<Iota::source_register>() = *range_ptr;
+      op.arg<Iota::update_register>() = filter_scratch.span;
+    }
+    {
+      using SpanToBv = i::IndexSpanToBitvector;
+      auto& op = builder_.AddOpcode<SpanToBv>(i::Index<SpanToBv>());
+      op.arg<SpanToBv::indices_register>() = filter_scratch.span;
+      op.arg<SpanToBv::bitvector_size>() = max_row_count_;
+      op.arg<SpanToBv::dest_register>() = bv_reg;
+    }
+    builder_.ReleaseScratch(kDtFilterBytecodeSlot);
+  } else {
+    auto span = std::get<i::RwHandle<Span<uint32_t>>>(filter_result.indices);
+    auto& op = builder_.AddOpcode<i::IndexSpanToBitvector>(
+        i::Index<i::IndexSpanToBitvector>());
+    op.arg<i::IndexSpanToBitvector::indices_register>() = span;
+    op.arg<i::IndexSpanToBitvector::bitvector_size>() = max_row_count_;
+    op.arg<i::IndexSpanToBitvector::dest_register>() = bv_reg;
+  }
+
+  return bv_reg;
+}
+
+i::ReadHandle<i::StoragePtr> DataframeTransformer::StorageRegisterFor(
+    uint32_t col_idx) {
+  auto [reg, inserted] =
+      cache_.GetOrAllocate<i::StoragePtr>(columns_[col_idx].get(), kStorageReg);
+  if (inserted) {
+    StorageType type = columns_[col_idx]->storage.type();
+    register_inits_.emplace_back(RegisterInit{reg.index,
+                                              type.Upcast<RegisterInit::Type>(),
+                                              static_cast<uint16_t>(col_idx)});
+  }
+  return reg;
+}
+
+StorageType DataframeTransformer::GetStorageType(uint32_t col_idx) const {
+  return columns_[col_idx]->storage.type();
+}
+
+std::optional<uint32_t> DataframeTransformer::FindColumn(
+    const std::string& name) const {
+  for (uint32_t i = 0; i < column_names_.size(); ++i) {
+    if (column_names_[i] == name) {
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/dataframe/dataframe_transformer.h
+++ b/src/trace_processor/core/dataframe/dataframe_transformer.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_DATAFRAME_DATAFRAME_TRANSFORMER_H_
+#define SRC_TRACE_PROCESSOR_CORE_DATAFRAME_DATAFRAME_TRANSFORMER_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "perfetto/ext/base/small_vector.h"
+#include "perfetto/ext/base/status_or.h"
+#include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/dataframe/query_plan.h"
+#include "src/trace_processor/core/dataframe/register_cache.h"
+#include "src/trace_processor/core/dataframe/specs.h"
+#include "src/trace_processor/core/dataframe/types.h"
+#include "src/trace_processor/core/interpreter/bytecode_builder.h"
+#include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/util/bit_vector.h"
+
+namespace perfetto::trace_processor::core::dataframe {
+
+// Persistent wrapper around stateless QueryPlanBuilder::Filter.
+//
+// Owns a mutable column set that evolves across chained operations. Handles
+// all column/index/register plumbing so callers (TreeTransformer) only deal
+// with column indices, names, and register handles.
+//
+// Uses a pointer-keyed RegisterCache for register deduplication. When Column
+// objects change (e.g. after gather creates new Column instances), the new
+// pointers naturally miss the cache and fresh registers are allocated.
+class DataframeTransformer {
+ public:
+  DataframeTransformer(interpreter::BytecodeBuilder& builder,
+                       const Dataframe& df);
+
+  // Emit filter bytecodes against current column state.
+  // Specs must already have value_index set by the caller.
+  // Filters with InitRange(row_count).
+  base::StatusOr<interpreter::RwHandle<BitVector>> Filter(
+      std::vector<FilterSpec>& specs);
+
+  // Get storage register for column. If the column's storage register has
+  // not been allocated yet, allocates one and emits a RegisterInit.
+  interpreter::ReadHandle<interpreter::StoragePtr> StorageRegisterFor(
+      uint32_t col_idx);
+
+  // Get column storage type by index.
+  StorageType GetStorageType(uint32_t col_idx) const;
+
+  // Find column index by name.
+  std::optional<uint32_t> FindColumn(const std::string& name) const;
+
+  // Upper-bound row count (for scratch buffer allocation).
+  uint32_t max_row_count() const { return max_row_count_; }
+
+  // Register initialization specs accumulated across all operations.
+  // Used by TreeTransformer::ToDataframe() to initialize the interpreter.
+  const base::SmallVector<RegisterInit, 16>& register_inits() const {
+    return register_inits_;
+  }
+
+ private:
+  interpreter::BytecodeBuilder& builder_;
+
+  std::vector<std::shared_ptr<Column>> columns_;
+  std::vector<std::string> column_names_;
+  std::vector<Index> indexes_;
+
+  // Pointer-keyed register cache for deduplication.
+  RegisterCache cache_;
+
+  uint32_t max_row_count_;
+
+  base::SmallVector<RegisterInit, 16> register_inits_;
+};
+
+}  // namespace perfetto::trace_processor::core::dataframe
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_DATAFRAME_DATAFRAME_TRANSFORMER_H_

--- a/src/trace_processor/core/tree/tree_transformer.cc
+++ b/src/trace_processor/core/tree/tree_transformer.cc
@@ -18,9 +18,9 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "perfetto/base/status.h"
@@ -37,6 +37,7 @@
 #include "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h"
 #include "src/trace_processor/core/dataframe/cursor.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
+#include "src/trace_processor/core/dataframe/dataframe_transformer.h"
 #include "src/trace_processor/core/dataframe/query_plan.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
@@ -45,7 +46,6 @@
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_impl.h"  // IWYU pragma: keep
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/util/bit_vector.h"
-#include "src/trace_processor/core/util/range.h"
 #include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
 
@@ -175,7 +175,9 @@ struct TreeValueFetcher : core::ValueFetcher {
 // =============================================================================
 
 TreeTransformer::TreeTransformer(dataframe::Dataframe df, StringPool* pool)
-    : df_(std::move(df)), pool_(pool), cache_(&builder_) {}
+    : df_(std::move(df)),
+      pool_(pool),
+      builder_(std::make_unique<interpreter::BytecodeBuilder>()) {}
 
 // =============================================================================
 // Public methods
@@ -204,8 +206,8 @@ base::Status TreeTransformer::FilterTree(
   // Rebuild P2C from current C2P if stale.
   EnsureParentToChildStructure();
 
-  // Build filter bitvector from specs.
-  ASSIGN_OR_RETURN(auto keep_bv, BuildFilterBitvector(n, specs));
+  // Build filter bitvector from specs using DataframeTransformer.
+  ASSIGN_OR_RETURN(auto keep_bv, dt_->Filter(specs));
 
   // Emit the tree filter operation (updates C2P, invalidates P2C).
   EmitFilterTreeBytecode(keep_bv);
@@ -229,12 +231,12 @@ base::StatusOr<dataframe::Dataframe> TreeTransformer::ToDataframe() && {
   }
 
   interpreter::Interpreter<TreeValueFetcher> interp;
-  interp.Initialize(builder_.bytecode(), builder_.register_count(), pool_);
+  interp.Initialize(builder_->bytecode(), builder_->register_count(), pool_);
   interp.SetRegisterValue(
       interpreter::WriteHandle<StoragePtr>(parent_storage_reg_.index),
       StoragePtr{normalized_parent.begin(), StorageType(Uint32{})});
 
-  for (const auto& init : register_inits_) {
+  for (const auto& init : dt_->register_inits()) {
     auto val = dataframe::QueryPlanImpl::GetRegisterInitValue(init, df_);
     interp.SetRegisterValue(interpreter::HandleBase{init.dest_register},
                             std::move(val));
@@ -268,18 +270,21 @@ base::StatusOr<dataframe::Dataframe> TreeTransformer::ToDataframe() && {
 void TreeTransformer::InitializeTreeStructure(uint32_t row_count) {
   using MakeC2P = interpreter::MakeChildToParentTreeStructure;
 
+  // Create DataframeTransformer for filter/column operations.
+  dt_.emplace(*builder_, df_);
+
   // Allocate persistent scratch for parent and original_rows spans.
-  auto parent_scratch = builder_.AllocateScratch(kParentSlot, row_count);
-  auto orig_scratch = builder_.AllocateScratch(kOriginalRowsSlot, row_count);
+  auto parent_scratch = builder_->AllocateScratch(kParentSlot, row_count);
+  auto orig_scratch = builder_->AllocateScratch(kOriginalRowsSlot, row_count);
 
   parent_span_ = parent_scratch.span;
   original_rows_span_ = orig_scratch.span;
 
   // Allocate register for parent storage pointer.
-  parent_storage_reg_ = builder_.AllocateRegister<interpreter::StoragePtr>();
+  parent_storage_reg_ = builder_->AllocateRegister<interpreter::StoragePtr>();
 
   // Emit bytecode to initialize child-to-parent structure from parent storage.
-  auto& op = builder_.AddOpcode<MakeC2P>(interpreter::Index<MakeC2P>());
+  auto& op = builder_->AddOpcode<MakeC2P>(interpreter::Index<MakeC2P>());
   op.arg<MakeC2P::parent_id_storage_register>() = parent_storage_reg_;
   op.arg<MakeC2P::row_count>() = row_count;
   op.arg<MakeC2P::parent_span_register>() = parent_span_;
@@ -288,12 +293,12 @@ void TreeTransformer::InitializeTreeStructure(uint32_t row_count) {
   // Allocate all scratch buffers once for reuse across FilterTree() calls.
   // This avoids emitting AllocateIndices bytecode for each filter operation.
   filter_scratch_ = FilterScratch{
-      builder_.AllocateScratch(kFilterScratch1Slot, row_count * 2),
-      builder_.AllocateScratch(kFilterScratch2Slot, row_count),
-      builder_.AllocateScratch(kP2CScratchSlot, row_count),
-      builder_.AllocateScratch(kP2COffsetsSlot, row_count + 1),
-      builder_.AllocateScratch(kP2CChildrenSlot, row_count),
-      builder_.AllocateScratch(kP2CRootsSlot, row_count),
+      builder_->AllocateScratch(kFilterScratch1Slot, row_count * 2),
+      builder_->AllocateScratch(kFilterScratch2Slot, row_count),
+      builder_->AllocateScratch(kP2CScratchSlot, row_count),
+      builder_->AllocateScratch(kP2COffsetsSlot, row_count + 1),
+      builder_->AllocateScratch(kP2CChildrenSlot, row_count),
+      builder_->AllocateScratch(kP2CRootsSlot, row_count),
   };
 }
 
@@ -303,7 +308,7 @@ void TreeTransformer::EnsureParentToChildStructure() {
   }
   using MakeP2C = interpreter::MakeParentToChildTreeStructure;
 
-  auto& op = builder_.AddOpcode<MakeP2C>(interpreter::Index<MakeP2C>());
+  auto& op = builder_->AddOpcode<MakeP2C>(interpreter::Index<MakeP2C>());
   op.arg<MakeP2C::parent_span_register>() = parent_span_;
   op.arg<MakeP2C::scratch_register>() = filter_scratch_->p2c_scratch.span;
   op.arg<MakeP2C::offsets_register>() = filter_scratch_->p2c_offsets.span;
@@ -312,70 +317,11 @@ void TreeTransformer::EnsureParentToChildStructure() {
   p2c_stale_ = false;
 }
 
-base::StatusOr<interpreter::RwHandle<BitVector>>
-TreeTransformer::BuildFilterBitvector(
-    uint32_t row_count,
-    std::vector<dataframe::FilterSpec>& specs) {
-  using InitRange = interpreter::InitRange;
-  using Iota = interpreter::Iota;
-  using SpanToBv = interpreter::IndexSpanToBitvector;
-
-  // Initialize range covering all rows.
-  auto range_reg = builder_.AllocateRegister<Range>();
-  {
-    auto& op = builder_.AddOpcode<InitRange>(interpreter::Index<InitRange>());
-    op.arg<InitRange::size>() = row_count;
-    op.arg<InitRange::dest_register>() = range_reg;
-  }
-
-  // Generate filter bytecode using QueryPlanBuilder::Filter.
-  ASSIGN_OR_RETURN(auto filter_result,
-                   dataframe::QueryPlanBuilder::Filter(
-                       builder_, interpreter::RwHandle<Range>(range_reg), df_,
-                       cache_, specs));
-
-  // Capture register init specs for later initialization in ToDataframe().
-  for (const auto& init : filter_result.register_inits) {
-    register_inits_.emplace_back(init);
-  }
-
-  // Convert filtered result to bitvector.
-  auto bv_reg = builder_.AllocateRegister<BitVector>();
-  if (auto* range_ptr =
-          std::get_if<interpreter::RwHandle<Range>>(&filter_result.indices)) {
-    // For Range, use Iota to expand to indices first, then convert to
-    // bitvector.
-    auto filter_scratch =
-        builder_.AllocateScratch(kFilterBytecodeSlot, row_count);
-    {
-      auto& op = builder_.AddOpcode<Iota>(interpreter::Index<Iota>());
-      op.arg<Iota::source_register>() = *range_ptr;
-      op.arg<Iota::update_register>() = filter_scratch.span;
-    }
-    {
-      auto& op = builder_.AddOpcode<SpanToBv>(interpreter::Index<SpanToBv>());
-      op.arg<SpanToBv::indices_register>() = filter_scratch.span;
-      op.arg<SpanToBv::bitvector_size>() = row_count;
-      op.arg<SpanToBv::dest_register>() = bv_reg;
-    }
-    builder_.ReleaseScratch(kFilterBytecodeSlot);
-  } else {
-    auto span =
-        std::get<interpreter::RwHandle<Span<uint32_t>>>(filter_result.indices);
-    auto& op = builder_.AddOpcode<SpanToBv>(interpreter::Index<SpanToBv>());
-    op.arg<SpanToBv::indices_register>() = span;
-    op.arg<SpanToBv::bitvector_size>() = row_count;
-    op.arg<SpanToBv::dest_register>() = bv_reg;
-  }
-
-  return bv_reg;
-}
-
 void TreeTransformer::EmitFilterTreeBytecode(
     interpreter::RwHandle<BitVector> keep_bv) {
   using Filter = interpreter::FilterTree;
 
-  auto& op = builder_.AddOpcode<Filter>(interpreter::Index<Filter>());
+  auto& op = builder_->AddOpcode<Filter>(interpreter::Index<Filter>());
   op.arg<Filter::offsets_register>() = filter_scratch_->p2c_offsets.span;
   op.arg<Filter::children_register>() = filter_scratch_->p2c_children.span;
   op.arg<Filter::roots_register>() = filter_scratch_->p2c_roots.span;

--- a/src/trace_processor/core/tree/tree_transformer.h
+++ b/src/trace_processor/core/tree/tree_transformer.h
@@ -18,17 +18,16 @@
 #define SRC_TRACE_PROCESSOR_CORE_TREE_TREE_TRANSFORMER_H_
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <vector>
 
 #include "perfetto/base/status.h"
-#include "perfetto/ext/base/small_vector.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
-#include "src/trace_processor/core/dataframe/query_plan.h"
-#include "src/trace_processor/core/dataframe/register_cache.h"
+#include "src/trace_processor/core/dataframe/dataframe_transformer.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
@@ -96,7 +95,6 @@ class TreeTransformer {
     kP2CChildrenSlot = 5,
     kP2CRootsSlot = 6,
     kP2CScratchSlot = 7,
-    kFilterBytecodeSlot = 8,
   };
 
   // Initializes tree structure on first FilterTree call.
@@ -109,11 +107,6 @@ class TreeTransformer {
   // Sets p2c_stale_ to false after emitting.
   void EnsureParentToChildStructure();
 
-  // Generates filter bytecode and converts result to a bitvector.
-  base::StatusOr<interpreter::RwHandle<BitVector>> BuildFilterBitvector(
-      uint32_t row_count,
-      std::vector<dataframe::FilterSpec>& specs);
-
   // Emits FilterTree bytecode with all required registers.
   // Uses pre-allocated scratch buffers stored as member variables.
   void EmitFilterTreeBytecode(interpreter::RwHandle<BitVector> keep_bv);
@@ -122,10 +115,13 @@ class TreeTransformer {
   StringPool* pool_;
 
   // Bytecode builder for accumulating tree operations.
-  interpreter::BytecodeBuilder builder_;
+  // Stored as unique_ptr so its address remains stable when referenced
+  // by DataframeTransformer.
+  std::unique_ptr<interpreter::BytecodeBuilder> builder_;
 
-  // Cache for column register deduplication.
-  dataframe::RegisterCache cache_;
+  // DataframeTransformer for filter/column operations.
+  // Created on first FilterTree call via InitializeTreeStructure().
+  std::optional<dataframe::DataframeTransformer> dt_;
 
   // Parent and original_rows span registers (set on first FilterTree call).
   interpreter::RwHandle<Span<uint32_t>> parent_span_;
@@ -136,10 +132,6 @@ class TreeTransformer {
 
   // Filter values for bytecode execution.
   std::vector<SqlValue> filter_values_;
-
-  // Register initialization specs collected from Filter() calls.
-  // Needed to initialize storage registers before bytecode execution.
-  base::SmallVector<dataframe::RegisterInit, 16> register_inits_;
 
   // Alias for scratch register type.
   using Scratch = interpreter::BytecodeBuilder::ScratchRegisters;


### PR DESCRIPTION
Add DataframeTransformer as a persistent wrapper around
QueryPlanBuilder::Filter. It owns a mutable column set with
pointer-keyed RegisterCache for register deduplication.

Refactor TreeTransformer to use DataframeTransformer for filter
operations instead of directly calling QueryPlanBuilder::Filter.
The BytecodeBuilder is now stored as unique_ptr for address stability.

This is a pure refactor with no behavior change.
