### PR TITLE
tp: add BitVector::Copy() and StoragePtr::mutable_ptr

### DIFF
--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -268,30 +268,35 @@ i::RegValue QueryPlanImpl::GetRegisterInitValue(const RegisterInit& init,
     case RegisterInit::Type::GetTypeIndex<Id>():
       // Id columns don't have actual storage - the row index IS the value.
       // Return a nullptr StoragePtr which the interpreter knows to handle.
-      return i::StoragePtr{nullptr, Id{}};
+      return i::StoragePtr{nullptr, nullptr, Id{}};
     case RegisterInit::Type::GetTypeIndex<Uint32>():
       return i::StoragePtr{
           columns[init.source_index]->storage.unchecked_data<Uint32>(),
+          nullptr,
           Uint32{},
       };
     case RegisterInit::Type::GetTypeIndex<Int32>():
       return i::StoragePtr{
           columns[init.source_index]->storage.unchecked_data<Int32>(),
+          nullptr,
           Int32{},
       };
     case RegisterInit::Type::GetTypeIndex<Int64>():
       return i::StoragePtr{
           columns[init.source_index]->storage.unchecked_data<Int64>(),
+          nullptr,
           Int64{},
       };
     case RegisterInit::Type::GetTypeIndex<Double>():
       return i::StoragePtr{
           columns[init.source_index]->storage.unchecked_data<Double>(),
+          nullptr,
           Double{},
       };
     case RegisterInit::Type::GetTypeIndex<String>():
       return i::StoragePtr{
           columns[init.source_index]->storage.unchecked_data<String>(),
+          nullptr,
           String{},
       };
     case RegisterInit::Type::GetTypeIndex<RegisterInit::NullBitvector>():

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_state.h
@@ -101,6 +101,14 @@ struct InterpreterState {
     return static_cast<const typename T::cpp_type*>(ReadFromRegister(reg).ptr);
   }
 
+  template <typename T>
+  PERFETTO_ALWAYS_INLINE auto* ReadMutableStorageFromRegister(
+      RwHandle<StoragePtr> reg) {
+    auto& sp = ReadFromRegister(reg);
+    PERFETTO_DCHECK(sp.mutable_ptr);
+    return static_cast<typename T::cpp_type*>(sp.mutable_ptr);
+  }
+
   // Writes a value to the specified register, handling type safety through
   // the handle.
   template <typename T>

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_unittest.cc
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_unittest.cc
@@ -107,7 +107,8 @@ class BytecodeInterpreterTest : public testing::Test {
   // Returns StoragePtr for a column, to pass to SetRegistersAndExecute.
   template <typename T>
   StoragePtr GetStoragePtr(uint32_t col_idx) {
-    return StoragePtr{column_ptrs_[col_idx]->storage.unchecked_data<T>(), T{}};
+    return StoragePtr{column_ptrs_[col_idx]->storage.unchecked_data<T>(),
+                      nullptr, T{}};
   }
 
   // Returns null bitvector pointer for a column.

--- a/src/trace_processor/core/interpreter/bytecode_registers.h
+++ b/src/trace_processor/core/interpreter/bytecode_registers.h
@@ -100,6 +100,7 @@ using StringIdToRankMap =
 // Pointer to storage data along with its type.
 struct StoragePtr {
   const void* ptr;
+  void* mutable_ptr = nullptr;
   StorageType type;
 };
 

--- a/src/trace_processor/core/tree/tree_transformer.cc
+++ b/src/trace_processor/core/tree/tree_transformer.cc
@@ -234,7 +234,7 @@ base::StatusOr<dataframe::Dataframe> TreeTransformer::ToDataframe() && {
   interp.Initialize(builder_->bytecode(), builder_->register_count(), pool_);
   interp.SetRegisterValue(
       interpreter::WriteHandle<StoragePtr>(parent_storage_reg_.index),
-      StoragePtr{normalized_parent.begin(), StorageType(Uint32{})});
+      StoragePtr{normalized_parent.begin(), nullptr, StorageType(Uint32{})});
 
   for (const auto& init : dt_->register_inits()) {
     auto val = dataframe::QueryPlanImpl::GetRegisterInitValue(init, df_);

--- a/src/trace_processor/core/util/bit_vector.h
+++ b/src/trace_processor/core/util/bit_vector.h
@@ -254,6 +254,14 @@ struct BitVector {
   // still maintaining the invariants of the class.
   void shrink_to_fit() { words_.shrink_to_fit(); }
 
+  // Returns a deep copy of this bitvector.
+  BitVector Copy() const {
+    auto word_count = (size_ + 63ull) / 64ull;
+    auto words = FlexVector<uint64_t>::CreateWithSize(word_count);
+    memcpy(words.data(), words_.data(), word_count * sizeof(uint64_t));
+    return BitVector(std::move(words), size_);
+  }
+
   // Returns the number of bits in the vector.
   PERFETTO_ALWAYS_INLINE uint64_t size() const { return size_; }
 

--- a/src/trace_processor/core/util/bit_vector_unittest.cc
+++ b/src/trace_processor/core/util/bit_vector_unittest.cc
@@ -490,5 +490,33 @@ TEST(BitVectorTest, ResizeAcrossWordBoundary) {
   }
 }
 
+// Test Copy produces an independent deep copy
+TEST(BitVectorTest, Copy) {
+  auto bits = BitVector::CreateWithSize(200, false);
+  bits.set(0);
+  bits.set(63);
+  bits.set(64);
+  bits.set(127);
+  bits.set(199);
+
+  auto copy = bits.Copy();
+
+  // Copy should have the same size and bits.
+  EXPECT_EQ(copy.size(), 200u);
+  EXPECT_TRUE(copy.is_set(0));
+  EXPECT_TRUE(copy.is_set(63));
+  EXPECT_TRUE(copy.is_set(64));
+  EXPECT_TRUE(copy.is_set(127));
+  EXPECT_TRUE(copy.is_set(199));
+  EXPECT_FALSE(copy.is_set(1));
+  EXPECT_FALSE(copy.is_set(128));
+
+  // Mutating the copy should not affect the original.
+  copy.clear(0);
+  copy.set(1);
+  EXPECT_TRUE(bits.is_set(0));
+  EXPECT_FALSE(bits.is_set(1));
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::core


### PR DESCRIPTION
Add BitVector::Copy() for deep-copying bitvectors (needed for nullable
column propagation). Add mutable_ptr field to StoragePtr for in-place
mutation of copied column data. Add ReadMutableStorageFromRegister()
helper to InterpreterState.

These are infrastructure additions for the upcoming PropagateDown
feature.
