### PR TITLE
tp: make BytecodeBuilder scratch slot allocation dynamic

### DIFF
--- a/src/trace_processor/core/dataframe/dataframe_transformer.cc
+++ b/src/trace_processor/core/dataframe/dataframe_transformer.cc
@@ -42,10 +42,6 @@ namespace perfetto::trace_processor::core::dataframe {
 namespace {
 namespace i = interpreter;
 
-// Scratch slot used for filter bytecode within DataframeTransformer.
-// Starts at 20 to avoid collision with TreeTransformer::ScratchSlot (0-9).
-constexpr uint32_t kDtFilterBytecodeSlot = 20;
-
 }  // namespace
 
 DataframeTransformer::DataframeTransformer(i::BytecodeBuilder& builder,
@@ -82,8 +78,7 @@ base::StatusOr<i::RwHandle<BitVector>> DataframeTransformer::Filter(
   auto bv_reg = builder_.AllocateRegister<BitVector>();
   if (auto* range_ptr =
           std::get_if<i::RwHandle<Range>>(&filter_result.indices)) {
-    auto filter_scratch =
-        builder_.AllocateScratch(kDtFilterBytecodeSlot, max_row_count_);
+    auto filter_scratch = builder_.AllocateScratch(max_row_count_);
     {
       using Iota = i::Iota;
       auto& op = builder_.AddOpcode<Iota>(i::Index<Iota>());
@@ -97,7 +92,7 @@ base::StatusOr<i::RwHandle<BitVector>> DataframeTransformer::Filter(
       op.arg<SpanToBv::bitvector_size>() = max_row_count_;
       op.arg<SpanToBv::dest_register>() = bv_reg;
     }
-    builder_.ReleaseScratch(kDtFilterBytecodeSlot);
+    builder_.ReleaseScratch(filter_scratch);
   } else {
     auto span = std::get<i::RwHandle<Span<uint32_t>>>(filter_result.indices);
     auto& op = builder_.AddOpcode<i::IndexSpanToBitvector>(

--- a/src/trace_processor/core/dataframe/query_plan.cc
+++ b/src/trace_processor/core/dataframe/query_plan.cc
@@ -1291,7 +1291,7 @@ i::ReadHandle<i::CastFilterValueResult> QueryPlanBuilder::CastFilterValue(
 
 i::RwHandle<Span<uint32_t>> QueryPlanBuilder::GetOrCreateScratchSpanRegister(
     uint32_t size) {
-  auto scratch = builder_.GetOrCreateScratchRegisters(size);
+  auto scratch = builder_.GetOrCreateScratch(size);
   {
     using B = i::AllocateIndices;
     auto& bc = AddOpcode<B>(UnchangedRowCount{});
@@ -1299,12 +1299,15 @@ i::RwHandle<Span<uint32_t>> QueryPlanBuilder::GetOrCreateScratchSpanRegister(
     bc.arg<B::dest_slab_register>() = scratch.slab;
     bc.arg<B::dest_span_register>() = scratch.span;
   }
-  builder_.MarkScratchInUse();
+  active_scratch_ = scratch;
   return scratch.span;
 }
 
 void QueryPlanBuilder::MaybeReleaseScratchSpanRegister() {
-  builder_.ReleaseScratch();
+  if (active_scratch_) {
+    builder_.ReleaseScratch(*active_scratch_);
+    active_scratch_.reset();
+  }
 }
 
 uint16_t QueryPlanBuilder::CalculateRowLayoutStride(

--- a/src/trace_processor/core/dataframe/query_plan.h
+++ b/src/trace_processor/core/dataframe/query_plan.h
@@ -523,6 +523,9 @@ class QueryPlanBuilder {
 
   // Cache for column/index registers across Filter() calls.
   RegisterCache& cache_;
+
+  // Currently active scratch registers (if any).
+  std::optional<interpreter::BytecodeBuilder::ScratchRegisters> active_scratch_;
 };
 
 }  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/interpreter/bytecode_builder.cc
+++ b/src/trace_processor/core/interpreter/bytecode_builder.cc
@@ -17,6 +17,7 @@
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
 
 #include <cstdint>
+#include <limits>
 
 #include "perfetto/base/logging.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
@@ -26,50 +27,53 @@
 
 namespace perfetto::trace_processor::core::interpreter {
 
-BytecodeBuilder::ScratchRegisters BytecodeBuilder::GetOrCreateScratchRegisters(
-    uint32_t slot_id,
+BytecodeBuilder::ScratchSlot* BytecodeBuilder::FindBestFitFreeSlot(
     uint32_t size) {
-  if (slot_id >= scratch_slots_.size()) {
-    scratch_slots_.resize(slot_id + 1);
+  ScratchSlot* best = nullptr;
+  uint32_t best_size = std::numeric_limits<uint32_t>::max();
+  for (auto& slot : scratch_slots_) {
+    if (!slot.in_use && slot.size >= size && slot.size < best_size) {
+      best = &slot;
+      best_size = slot.size;
+    }
   }
-  auto& slot = scratch_slots_[slot_id];
-  if (slot.has_value()) {
-    PERFETTO_CHECK(size <= slot->size);
-    PERFETTO_CHECK(!slot->in_use);
-    return ScratchRegisters{slot->slab, slot->span};
+  return best;
+}
+
+BytecodeBuilder::ScratchRegisters BytecodeBuilder::GetOrCreateScratch(
+    uint32_t size) {
+  if (auto* slot = FindBestFitFreeSlot(size)) {
+    slot->in_use = true;
+    return {slot->slab, slot->span};
   }
   auto slab = AllocateRegister<Slab<uint32_t>>();
   auto span = AllocateRegister<Span<uint32_t>>();
-  slot = ScratchIndices{size, slab, span, false};
-  return ScratchRegisters{slab, span};
+  scratch_slots_.push_back({size, slab, span, true});
+  return {slab, span};
 }
 
 BytecodeBuilder::ScratchRegisters BytecodeBuilder::AllocateScratch(
-    uint32_t slot_id,
     uint32_t size) {
-  auto regs = GetOrCreateScratchRegisters(slot_id, size);
+  auto regs = GetOrCreateScratch(size);
 
   auto& alloc = AddOpcode<AllocateIndices>(Index<AllocateIndices>());
   alloc.arg<AllocateIndices::size>() = size;
   alloc.arg<AllocateIndices::dest_slab_register>() = regs.slab;
   alloc.arg<AllocateIndices::dest_span_register>() = regs.span;
 
-  // GetOrCreateScratchRegisters guarantees the slot exists
-  scratch_slots_[slot_id]->in_use = true;
-
   return regs;
 }
 
-void BytecodeBuilder::MarkScratchInUse(uint32_t slot_id) {
-  PERFETTO_CHECK(slot_id < scratch_slots_.size() &&
-                 scratch_slots_[slot_id].has_value());
-  scratch_slots_[slot_id]->in_use = true;
-}
-
-void BytecodeBuilder::ReleaseScratch(uint32_t slot_id) {
-  if (slot_id < scratch_slots_.size() && scratch_slots_[slot_id].has_value()) {
-    scratch_slots_[slot_id]->in_use = false;
+void BytecodeBuilder::ReleaseScratch(ScratchRegisters scratch) {
+  for (auto& slot : scratch_slots_) {
+    if (slot.slab.index == scratch.slab.index &&
+        slot.span.index == scratch.span.index) {
+      PERFETTO_DCHECK(slot.in_use);
+      slot.in_use = false;
+      return;
+    }
   }
+  PERFETTO_DFATAL("ReleaseScratch: no matching slot found");
 }
 
 Bytecode& BytecodeBuilder::AddRawOpcode(uint32_t option) {

--- a/src/trace_processor/core/interpreter/bytecode_builder.h
+++ b/src/trace_processor/core/interpreter/bytecode_builder.h
@@ -55,55 +55,28 @@ class BytecodeBuilder {
 
   // === Scratch register management ===
   //
-  // These methods manage scratch register state for operations that need
-  // temporary storage. The caller is responsible for emitting the actual
-  // AllocateIndices opcode (this allows different cost tracking strategies).
-  //
-  // Multiple named scratch slots are supported via slot_id parameter.
-  // The default slot (used by single-argument methods) is slot 0.
+  // Scratch slots provide reusable temporary storage. The allocator
+  // dynamically finds the best-fit free slot (smallest slot with capacity
+  // >= requested size), or creates a new one if none is available.
 
-  // Result from GetOrCreateScratchRegisters.
+  // Result from AllocateScratch / GetOrCreateScratch.
   struct ScratchRegisters {
     RwHandle<Slab<uint32_t>> slab;
     RwHandle<Span<uint32_t>> span;
   };
 
-  // Gets or creates scratch registers of the given size in the specified slot.
-  // Multiple slots can coexist with different slot_ids.
-  // Does NOT emit AllocateIndices - caller must emit it separately.
-  ScratchRegisters GetOrCreateScratchRegisters(uint32_t slot_id, uint32_t size);
+  // Finds a free scratch slot with capacity >= |size| (best-fit) or creates
+  // a new one. Emits AllocateIndices bytecode and marks the slot in-use.
+  ScratchRegisters AllocateScratch(uint32_t size);
 
-  // Gets or creates scratch registers in the default slot (slot 0).
-  ScratchRegisters GetOrCreateScratchRegisters(uint32_t size) {
-    return GetOrCreateScratchRegisters(0, size);
-  }
+  // Finds a free scratch slot with capacity >= |size| (best-fit) or creates
+  // a new one. Does NOT emit AllocateIndices — caller must emit it.
+  // Marks the slot in-use.
+  ScratchRegisters GetOrCreateScratch(uint32_t size);
 
-  // Allocates scratch in the specified slot and emits AllocateIndices bytecode.
-  // This is the preferred method - combines register allocation + bytecode
-  // emission.
-  ScratchRegisters AllocateScratch(uint32_t slot_id, uint32_t size);
-
-  // Marks the specified scratch slot as being in use.
-  void MarkScratchInUse(uint32_t slot_id);
-
-  // Marks the default scratch slot (slot 0) as being in use.
-  void MarkScratchInUse() { MarkScratchInUse(0); }
-
-  // Releases the specified scratch slot so it can be reused.
-  void ReleaseScratch(uint32_t slot_id);
-
-  // Releases the default scratch slot (slot 0).
-  void ReleaseScratch() { ReleaseScratch(0); }
-
-  // Returns true if the specified scratch slot is currently in use.
-  bool IsScratchInUse(uint32_t slot_id) const {
-    return slot_id < scratch_slots_.size() &&
-           scratch_slots_[slot_id].has_value() &&
-           scratch_slots_[slot_id]->in_use;
-  }
-
-  // Returns true if the default scratch slot (slot 0) is currently in use.
-  bool IsScratchInUse() const { return IsScratchInUse(0); }
+  // Releases a scratch slot so it can be reused by future AllocateScratch
+  // calls. Identified by matching slab/span registers.
+  void ReleaseScratch(ScratchRegisters scratch);
 
   // === Opcode emission ===
 
@@ -126,18 +99,22 @@ class BytecodeBuilder {
 
  private:
   // Scratch indices state.
-  struct ScratchIndices {
+  struct ScratchSlot {
     uint32_t size;
     RwHandle<Slab<uint32_t>> slab;
     RwHandle<Span<uint32_t>> span;
     bool in_use = false;
   };
 
+  // Finds the best-fit free slot (smallest with capacity >= size), or
+  // returns nullptr if none exists.
+  ScratchSlot* FindBestFitFreeSlot(uint32_t size);
+
   BytecodeVector bytecode_;
   uint32_t register_count_ = 0;
 
-  // Scratch management - multiple slots indexed by slot_id
-  std::vector<std::optional<ScratchIndices>> scratch_slots_;
+  // Scratch management - dynamically allocated slots.
+  std::vector<ScratchSlot> scratch_slots_;
 };
 
 }  // namespace perfetto::trace_processor::core::interpreter

--- a/src/trace_processor/core/tree/tree_transformer.cc
+++ b/src/trace_processor/core/tree/tree_transformer.cc
@@ -274,8 +274,8 @@ void TreeTransformer::InitializeTreeStructure(uint32_t row_count) {
   dt_.emplace(*builder_, df_);
 
   // Allocate persistent scratch for parent and original_rows spans.
-  auto parent_scratch = builder_->AllocateScratch(kParentSlot, row_count);
-  auto orig_scratch = builder_->AllocateScratch(kOriginalRowsSlot, row_count);
+  auto parent_scratch = builder_->AllocateScratch(row_count);
+  auto orig_scratch = builder_->AllocateScratch(row_count);
 
   parent_span_ = parent_scratch.span;
   original_rows_span_ = orig_scratch.span;
@@ -293,12 +293,12 @@ void TreeTransformer::InitializeTreeStructure(uint32_t row_count) {
   // Allocate all scratch buffers once for reuse across FilterTree() calls.
   // This avoids emitting AllocateIndices bytecode for each filter operation.
   filter_scratch_ = FilterScratch{
-      builder_->AllocateScratch(kFilterScratch1Slot, row_count * 2),
-      builder_->AllocateScratch(kFilterScratch2Slot, row_count),
-      builder_->AllocateScratch(kP2CScratchSlot, row_count),
-      builder_->AllocateScratch(kP2COffsetsSlot, row_count + 1),
-      builder_->AllocateScratch(kP2CChildrenSlot, row_count),
-      builder_->AllocateScratch(kP2CRootsSlot, row_count),
+      builder_->AllocateScratch(row_count * 2),
+      builder_->AllocateScratch(row_count),
+      builder_->AllocateScratch(row_count),
+      builder_->AllocateScratch(row_count + 1),
+      builder_->AllocateScratch(row_count),
+      builder_->AllocateScratch(row_count),
   };
 }
 

--- a/src/trace_processor/core/tree/tree_transformer.h
+++ b/src/trace_processor/core/tree/tree_transformer.h
@@ -85,18 +85,6 @@ class TreeTransformer {
   base::StatusOr<dataframe::Dataframe> ToDataframe() &&;
 
  private:
-  // Scratch slot IDs for tree operations (following QueryPlanBuilder pattern).
-  enum ScratchSlot : uint32_t {
-    kParentSlot = 0,
-    kOriginalRowsSlot = 1,
-    kFilterScratch1Slot = 2,
-    kFilterScratch2Slot = 3,
-    kP2COffsetsSlot = 4,
-    kP2CChildrenSlot = 5,
-    kP2CRootsSlot = 6,
-    kP2CScratchSlot = 7,
-  };
-
   // Initializes tree structure on first FilterTree call.
   // Allocates persistent parent/original_rows spans, all scratch buffers,
   // and emits MakeChildToParentTreeStructure bytecode.


### PR DESCRIPTION
Replace manually-assigned scratch slot IDs with automatic best-fit
allocation. AllocateScratch(size) now finds the smallest free slot
with sufficient capacity, or creates a new one. This removes the
need for callers to coordinate slot IDs across classes.
