### PR TITLE
tp: add tree PropagateDown feature with SQL bindings

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16292,6 +16292,7 @@ filegroup {
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_conversion.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_filter.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.cc",
     ],
 }
 
@@ -16629,6 +16630,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/std/traceinfo/metadata_for_primary_scope.sql",
         "src/trace_processor/perfetto_sql/stdlib/std/traceinfo/trace.sql",
         "src/trace_processor/perfetto_sql/stdlib/std/trees/filter.sql",
+        "src/trace_processor/perfetto_sql/stdlib/std/trees/propagate_down.sql",
         "src/trace_processor/perfetto_sql/stdlib/std/trees/table_conversion.sql",
         "src/trace_processor/perfetto_sql/stdlib/time/conversion.sql",
         "src/trace_processor/perfetto_sql/stdlib/traced/stats.sql",

--- a/BUILD
+++ b/BUILD
@@ -3258,6 +3258,8 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_filter.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.h",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.h",
     ],
 )
 
@@ -3875,6 +3877,7 @@ perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_std_trees_trees",
     srcs = [
         "src/trace_processor/perfetto_sql/stdlib/std/trees/filter.sql",
+        "src/trace_processor/perfetto_sql/stdlib/std/trees/propagate_down.sql",
         "src/trace_processor/perfetto_sql/stdlib/std/trees/table_conversion.sql",
     ],
 )

--- a/src/trace_processor/core/dataframe/dataframe_transformer.cc
+++ b/src/trace_processor/core/dataframe/dataframe_transformer.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -33,8 +34,10 @@
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
 #include "src/trace_processor/core/interpreter/bytecode_instructions.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/interpreter/interpreter_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/range.h"
+#include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
 
 namespace perfetto::trace_processor::core::dataframe {
@@ -52,14 +55,53 @@ DataframeTransformer::DataframeTransformer(i::BytecodeBuilder& builder,
   indexes_ = df.indexes_;
 }
 
+// static
+std::shared_ptr<Column> DataframeTransformer::MakeColumn(
+    StorageType type,
+    Nullability nullability) {
+  NullStorage null_storage(NullStorage::NonNull{});
+  if (!nullability.Is<NonNull>()) {
+    null_storage =
+        NullStorage(NullStorage::DenseNull{BitVector::CreateWithSize(0)});
+  }
+  if (type.Is<Int32>()) {
+    return std::make_shared<Column>(Column{Storage(Storage::Int32{}),
+                                           std::move(null_storage), Unsorted{},
+                                           DuplicateState(HasDuplicates{})});
+  }
+  if (type.Is<Int64>()) {
+    return std::make_shared<Column>(Column{Storage(Storage::Int64{}),
+                                           std::move(null_storage), Unsorted{},
+                                           DuplicateState(HasDuplicates{})});
+  }
+  if (type.Is<Double>()) {
+    return std::make_shared<Column>(Column{Storage(Storage::Double{}),
+                                           std::move(null_storage), Unsorted{},
+                                           DuplicateState(HasDuplicates{})});
+  }
+  if (type.Is<String>()) {
+    return std::make_shared<Column>(Column{Storage(Storage::String{}),
+                                           std::move(null_storage), Unsorted{},
+                                           DuplicateState(HasDuplicates{})});
+  }
+  return std::make_shared<Column>(Column{Storage(Storage::Uint32{}),
+                                         std::move(null_storage), Unsorted{},
+                                         DuplicateState(HasDuplicates{})});
+}
+
 base::StatusOr<i::RwHandle<BitVector>> DataframeTransformer::Filter(
     std::vector<FilterSpec>& specs) {
   // Build input indices.
   auto range_reg = builder_.AllocateRegister<Range>();
-  {
+  if (!gathered_) {
     using B = i::InitRange;
     auto& op = builder_.AddOpcode<B>(i::Index<B>());
     op.arg<B::size>() = max_row_count_;
+    op.arg<B::dest_register>() = range_reg;
+  } else {
+    using B = i::InitRangeFromSpan;
+    auto& op = builder_.AddOpcode<B>(i::Index<B>());
+    op.arg<B::source_span_register>() = row_count_span_;
     op.arg<B::dest_register>() = range_reg;
   }
 
@@ -122,6 +164,22 @@ StorageType DataframeTransformer::GetStorageType(uint32_t col_idx) const {
   return columns_[col_idx]->storage.type();
 }
 
+Nullability DataframeTransformer::GetNullability(uint32_t col_idx) const {
+  return columns_[col_idx]->null_storage.nullability();
+}
+
+i::ReadHandle<const BitVector*> DataframeTransformer::NullBitvectorRegisterFor(
+    uint32_t col_idx) {
+  auto [reg, inserted] = cache_.GetOrAllocate<const BitVector*>(
+      columns_[col_idx].get(), kNullBvReg);
+  if (inserted) {
+    register_inits_.emplace_back(RegisterInit{reg.index,
+                                              RegisterInit::NullBitvector{},
+                                              static_cast<uint16_t>(col_idx)});
+  }
+  return reg;
+}
+
 std::optional<uint32_t> DataframeTransformer::FindColumn(
     const std::string& name) const {
   for (uint32_t i = 0; i < column_names_.size(); ++i) {
@@ -130,6 +188,85 @@ std::optional<uint32_t> DataframeTransformer::FindColumn(
     }
   }
   return std::nullopt;
+}
+
+uint32_t DataframeTransformer::AddColumn(
+    const std::string& name,
+    StorageType type,
+    Nullability nullability,
+    i::RwHandle<i::StoragePtr> storage_reg) {
+  auto col_idx = static_cast<uint32_t>(columns_.size());
+  auto col = MakeColumn(type, nullability);
+  cache_.Set(col.get(), kStorageReg, i::HandleBase{storage_reg.index});
+  columns_.push_back(std::move(col));
+  column_names_.push_back(name);
+  return col_idx;
+}
+
+void DataframeTransformer::GatherAllColumns(
+    i::ReadHandle<Span<uint32_t>> indices) {
+  row_count_span_ = indices;
+
+  gather_state_.resize(columns_.size());
+  for (uint32_t col = 0; col < columns_.size(); ++col) {
+    StorageType type = columns_[col]->storage.type();
+
+    if (type.Is<Id>()) {
+      continue;
+    }
+
+    auto non_id = type.TryDowncast<i::NonIdStorageType>();
+    if (!non_id) {
+      continue;
+    }
+
+    // Allocate gather state registers.
+    auto slab_reg = builder_.AllocateRegister<Slab<uint8_t>>();
+    auto null_bv_reg = builder_.AllocateRegister<BitVector>();
+    auto null_bv_ptr_reg = builder_.AllocateRegister<const BitVector*>();
+    auto dest_storage_reg = builder_.AllocateRegister<i::StoragePtr>();
+
+    // Get source storage register (allocate + RegisterInit if needed).
+    auto source_storage_handle = StorageRegisterFor(col);
+
+    // Get null bitvector register (allocate + RegisterInit if needed).
+    auto [null_reg, null_inserted] =
+        cache_.GetOrAllocate<const BitVector*>(columns_[col].get(), kNullBvReg);
+    if (null_inserted) {
+      register_inits_.emplace_back(RegisterInit{null_reg.index,
+                                                RegisterInit::NullBitvector{},
+                                                static_cast<uint16_t>(col)});
+    }
+
+    Nullability nullability = columns_[col]->null_storage.nullability();
+
+    // Emit GatherColumn bytecode.
+    using GC = i::GatherColumnBase;
+    auto& op = builder_.AddOpcode<GC>(i::Index<i::GatherColumn>(*non_id));
+    op.arg<GC::source_storage_register>() = source_storage_handle;
+    op.arg<GC::indices_register>() = indices;
+    op.arg<GC::source_null_bv_register>() = null_reg;
+    op.arg<GC::source_nullability>() = nullability.index();
+    op.arg<GC::dest_slab_register>() = slab_reg;
+    op.arg<GC::dest_null_bv_register>() = null_bv_reg;
+    op.arg<GC::dest_null_bv_ptr_register>() = null_bv_ptr_reg;
+    op.arg<GC::dest_storage_register>() = dest_storage_reg;
+
+    gather_state_[col] =
+        GatherState{slab_reg, null_bv_reg, null_bv_ptr_reg, dest_storage_reg};
+
+    // Replace column with new object (new pointer = natural cache miss).
+    columns_[col] = MakeColumn(type, nullability);
+
+    // Pre-populate cache with new Column* -> new gathered registers.
+    cache_.Set(columns_[col].get(), kStorageReg,
+               i::HandleBase{dest_storage_reg.index});
+    cache_.Set(columns_[col].get(), kNullBvReg,
+               i::HandleBase{null_bv_ptr_reg.index});
+  }
+
+  gathered_ = true;
+  indexes_.clear();
 }
 
 }  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/dataframe/dataframe_transformer.h
+++ b/src/trace_processor/core/dataframe/dataframe_transformer.h
@@ -33,6 +33,8 @@
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/slab.h"
+#include "src/trace_processor/core/util/span.h"
 
 namespace perfetto::trace_processor::core::dataframe {
 
@@ -52,7 +54,9 @@ class DataframeTransformer {
 
   // Emit filter bytecodes against current column state.
   // Specs must already have value_index set by the caller.
-  // Filters with InitRange(row_count).
+  // On first call, filters with InitRange(row_count).
+  // On subsequent calls (after GatherAllColumns), filters with
+  // InitRangeFromSpan.
   base::StatusOr<interpreter::RwHandle<BitVector>> Filter(
       std::vector<FilterSpec>& specs);
 
@@ -64,8 +68,28 @@ class DataframeTransformer {
   // Get column storage type by index.
   StorageType GetStorageType(uint32_t col_idx) const;
 
+  // Get column nullability by index.
+  Nullability GetNullability(uint32_t col_idx) const;
+
+  // Get null bitvector register for column. If the column's null bv register
+  // has not been allocated yet, allocates one and emits a RegisterInit.
+  interpreter::ReadHandle<const BitVector*> NullBitvectorRegisterFor(
+      uint32_t col_idx);
+
   // Find column index by name.
   std::optional<uint32_t> FindColumn(const std::string& name) const;
+
+  // Add a virtual column backed by a pre-allocated register.
+  // Returns the new column index.
+  uint32_t AddColumn(
+      const std::string& name,
+      StorageType type,
+      Nullability nullability,
+      interpreter::RwHandle<interpreter::StoragePtr> storage_reg);
+
+  // Gather ALL columns at the given indices after a compaction (FilterTree).
+  // Emits GatherColumn bytecodes that create new storage from surviving rows.
+  void GatherAllColumns(interpreter::ReadHandle<Span<uint32_t>> indices);
 
   // Upper-bound row count (for scratch buffer allocation).
   uint32_t max_row_count() const { return max_row_count_; }
@@ -77,6 +101,10 @@ class DataframeTransformer {
   }
 
  private:
+  // Creates a Column with empty storage of the given type and nullability.
+  static std::shared_ptr<Column> MakeColumn(StorageType type,
+                                            Nullability nullability);
+
   interpreter::BytecodeBuilder& builder_;
 
   std::vector<std::shared_ptr<Column>> columns_;
@@ -86,9 +114,19 @@ class DataframeTransformer {
   // Pointer-keyed register cache for deduplication.
   RegisterCache cache_;
 
+  bool gathered_ = false;
+  interpreter::ReadHandle<Span<uint32_t>> row_count_span_;
   uint32_t max_row_count_;
 
   base::SmallVector<RegisterInit, 16> register_inits_;
+
+  struct GatherState {
+    interpreter::RwHandle<Slab<uint8_t>> slab_reg;
+    interpreter::RwHandle<BitVector> null_bv_reg;
+    interpreter::RwHandle<const BitVector*> null_bv_ptr_reg;
+    interpreter::RwHandle<interpreter::StoragePtr> storage_reg;
+  };
+  std::vector<GatherState> gather_state_;
 };
 
 }  // namespace perfetto::trace_processor::core::dataframe

--- a/src/trace_processor/core/interpreter/bytecode_instructions.h
+++ b/src/trace_processor/core/interpreter/bytecode_instructions.h
@@ -721,6 +721,105 @@ struct FilterTree : Bytecode {
                                      scratch2_register);
 };
 
+// Copies column storage data into a Slab<uint8_t> and creates a mutable
+// StoragePtr pointing to the copy. Used by PropagateDown which needs to
+// modify column data without mutating the original dataframe.
+// Handles all nullability types:
+//   - NonNull: plain memcpy
+//   - DenseNull: memcpy data + copy null bitvector
+//   - SparseNull: densify data (expand via popcount), create dense null bv
+struct CopyStorageToSlab : Bytecode {
+  static constexpr Cost kCost = LinearPerRowCost{5};
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_7(ReadHandle<StoragePtr>,
+                                     source_storage_register,
+                                     ReadHandle<Span<uint32_t>>,
+                                     row_count_span_register,
+                                     ReadHandle<const BitVector*>,
+                                     source_null_bv_register,
+                                     uint32_t,
+                                     source_nullability,
+                                     RwHandle<Slab<uint8_t>>,
+                                     dest_slab_register,
+                                     RwHandle<StoragePtr>,
+                                     dest_storage_register,
+                                     RwHandle<BitVector>,
+                                     dest_null_bv_register);
+};
+
+// Propagates values down a tree from roots to children using BFS.
+// For each child, the update value is combined with the parent's value using
+// the specified combine operation (passed as a runtime PropagateOp tag).
+// Handles nullable columns: if source_nullability != NonNull, uses
+// null_bv_register to track which rows are null. During BFS:
+//   - null parent + non-null child: child keeps its value
+//   - non-null parent + null child: child = parent, becomes non-null
+//   - both non-null: apply combine op
+//   - both null: stay null
+struct PropagateDownBase : TemplatedBytecode1<NonIdStorageType> {
+  static constexpr Cost kCost = LinearPerRowCost{10};
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_8(ReadHandle<Span<uint32_t>>,
+                                     offsets_register,
+                                     ReadHandle<Span<uint32_t>>,
+                                     children_register,
+                                     ReadHandle<Span<uint32_t>>,
+                                     roots_register,
+                                     RwHandle<StoragePtr>,
+                                     update_storage_register,
+                                     RwHandle<Span<uint32_t>>,
+                                     scratch_register,
+                                     uint32_t,
+                                     combine_op,
+                                     RwHandle<BitVector>,
+                                     null_bv_register,
+                                     uint32_t,
+                                     source_nullability);
+};
+template <typename T>
+struct PropagateDown : PropagateDownBase {
+  static_assert(TS1::Contains<T>());
+};
+
+// Creates Range{0, span.size()} for dynamic row count after compaction.
+// Used after FilterTree + GatherAllColumns to track the new row count.
+struct InitRangeFromSpan : Bytecode {
+  static constexpr Cost kCost = FixedCost{1};
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_2(ReadHandle<Span<uint32_t>>,
+                                     source_span_register,
+                                     WriteHandle<Range>,
+                                     dest_register);
+};
+
+// Gathers column data at specified indices, handling all nullability types.
+// Reads data from source StoragePtr using the given indices, writes gathered
+// data into dest_slab, and writes a new StoragePtr to dest_storage_register.
+// Also handles null bitvector gathering:
+//   - NonNull: no bitvector work
+//   - DenseNull: gather bitvector bits at indices
+//   - SparseNull: translate through popcount, gather data, expand to dense
+struct GatherColumnBase : TemplatedBytecode1<NonIdStorageType> {
+  static constexpr Cost kCost = LinearPerRowCost{5};
+  PERFETTO_DATAFRAME_BYTECODE_IMPL_8(ReadHandle<StoragePtr>,
+                                     source_storage_register,
+                                     ReadHandle<Span<uint32_t>>,
+                                     indices_register,
+                                     ReadHandle<const BitVector*>,
+                                     source_null_bv_register,
+                                     uint32_t,
+                                     source_nullability,
+                                     RwHandle<Slab<uint8_t>>,
+                                     dest_slab_register,
+                                     RwHandle<BitVector>,
+                                     dest_null_bv_register,
+                                     RwHandle<const BitVector*>,
+                                     dest_null_bv_ptr_register,
+                                     WriteHandle<StoragePtr>,
+                                     dest_storage_register);
+};
+template <typename T>
+struct GatherColumn : GatherColumnBase {
+  static_assert(TS1::Contains<T>());
+};
+
 // Bytecode ops that require FilterValueFetcher access.
 #define PERFETTO_DATAFRAME_BYTECODE_FVF_LIST(X) \
   X(CastFilterValue<Id>)                        \
@@ -874,7 +973,19 @@ struct FilterTree : Bytecode {
   X(MakeChildToParentTreeStructure)                    \
   X(MakeParentToChildTreeStructure)                    \
   X(IndexSpanToBitvector)                              \
-  X(FilterTree)
+  X(FilterTree)                                        \
+  X(CopyStorageToSlab)                                 \
+  X(PropagateDown<Uint32>)                             \
+  X(PropagateDown<Int32>)                              \
+  X(PropagateDown<Int64>)                              \
+  X(PropagateDown<Double>)                             \
+  X(PropagateDown<String>)                             \
+  X(InitRangeFromSpan)                                 \
+  X(GatherColumn<Uint32>)                              \
+  X(GatherColumn<Int32>)                               \
+  X(GatherColumn<Int64>)                               \
+  X(GatherColumn<Double>)                              \
+  X(GatherColumn<String>)
 
 // Combined list of all bytecode instruction types.
 #define PERFETTO_DATAFRAME_BYTECODE_LIST(X) \

--- a/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
+++ b/src/trace_processor/core/interpreter/bytecode_interpreter_impl.h
@@ -1830,6 +1830,310 @@ inline PERFETTO_ALWAYS_INLINE void FilterTree(InterpreterState& state,
   original_rows_span.e = original_rows_span.b + new_count;
 }
 
+// Copies column storage into a Slab<uint8_t> and creates a mutable StoragePtr.
+// Handles all nullability types: NonNull (plain copy), DenseNull (copy data +
+// bitvector), SparseNull (densify data via popcount + create dense bitvector).
+inline PERFETTO_ALWAYS_INLINE void CopyStorageToSlab(
+    InterpreterState& state,
+    const struct CopyStorageToSlab& bc) {
+  using B = struct CopyStorageToSlab;
+
+  const StoragePtr& src =
+      state.ReadFromRegister(bc.arg<B::source_storage_register>());
+  const Span<uint32_t>& row_count_span =
+      state.ReadFromRegister(bc.arg<B::row_count_span_register>());
+  const BitVector* source_null_bv =
+      state.ReadFromRegister(bc.arg<B::source_null_bv_register>());
+  uint32_t nullability_index = bc.arg<B::source_nullability>();
+  auto row_count = static_cast<uint32_t>(row_count_span.size());
+
+  // Compute byte size based on storage type.
+  static constexpr uint32_t kElementSizes[] = {
+      0,                      // Id (should not be used)
+      sizeof(uint32_t),       // Uint32
+      sizeof(int32_t),        // Int32
+      sizeof(int64_t),        // Int64
+      sizeof(double),         // Double
+      sizeof(StringPool::Id)  // String
+  };
+  uint32_t elem_size = kElementSizes[src.type.index()];
+  uint32_t byte_count = row_count * elem_size;
+
+  constexpr uint32_t kNonNullIdx = Nullability::GetTypeIndex<NonNull>();
+  constexpr uint32_t kDenseNullIdx = Nullability::GetTypeIndex<DenseNull>();
+
+  auto slab = Slab<uint8_t>::Alloc(byte_count);
+  if (nullability_index == kNonNullIdx || !source_null_bv) {
+    // NonNull: plain copy.
+    memcpy(slab.data(), src.ptr, byte_count);
+  } else if (nullability_index == kDenseNullIdx) {
+    // DenseNull: data is already dense, copy data and bitvector.
+    memcpy(slab.data(), src.ptr, byte_count);
+    BitVector bv_copy = source_null_bv->Copy();
+    state.WriteToRegister(bc.arg<B::dest_null_bv_register>(),
+                          std::move(bv_copy));
+  } else {
+    // SparseNull: data is compacted. Densify by expanding via popcount.
+    // Zero-fill first so null slots have deterministic values.
+    memset(slab.data(), 0, byte_count);
+    Slab<uint32_t> prefix_pop = source_null_bv->PrefixPopcount();
+    BitVector dense_bv = BitVector::CreateWithSize(row_count, false);
+    for (uint32_t i = 0; i < row_count; ++i) {
+      if (source_null_bv->is_set(i)) {
+        uint32_t word_idx = i / 64u;
+        uint32_t storage_idx =
+            prefix_pop[word_idx] +
+            static_cast<uint32_t>(
+                source_null_bv->count_set_bits_until_in_word(i));
+        memcpy(slab.data() + i * elem_size,
+               static_cast<const uint8_t*>(src.ptr) + storage_idx * elem_size,
+               elem_size);
+        dense_bv.set(i);
+      }
+    }
+    state.WriteToRegister(bc.arg<B::dest_null_bv_register>(),
+                          std::move(dense_bv));
+  }
+
+  void* mutable_ptr = slab.data();
+  state.WriteToRegister(bc.arg<B::dest_slab_register>(), std::move(slab));
+  state.WriteToRegister(bc.arg<B::dest_storage_register>(),
+                        StoragePtr{mutable_ptr, mutable_ptr, src.type});
+}
+
+// Propagates values down a tree from roots to children using BFS.
+// The combine operation is a runtime tag (CombineOp index) stored in the
+// bytecode. The switch hoists outside the BFS loop via a lambda, so each
+// case instantiates its own optimized loop with zero branches in the hot path.
+//
+// Null handling (when source_nullability != NonNull):
+//   - null parent + non-null child: child keeps its value
+//   - non-null parent + null child: child = parent, becomes non-null
+//   - both non-null: apply combine op
+//   - both null: stay null
+template <typename T>
+inline PERFETTO_ALWAYS_INLINE void PropagateDown(
+    InterpreterState& state,
+    const struct PropagateDown<T>& bc) {
+  using B = PropagateDownBase;
+
+  const Span<uint32_t>& offsets =
+      state.ReadFromRegister(bc.template arg<B::offsets_register>());
+  const Span<uint32_t>& children =
+      state.ReadFromRegister(bc.template arg<B::children_register>());
+  const Span<uint32_t>& roots =
+      state.ReadFromRegister(bc.template arg<B::roots_register>());
+  auto* data = state.ReadMutableStorageFromRegister<T>(
+      bc.template arg<B::update_storage_register>());
+  Span<uint32_t>& scratch =
+      state.ReadFromRegister(bc.template arg<B::scratch_register>());
+  uint32_t op = bc.template arg<B::combine_op>();
+  uint32_t nullability_index = bc.template arg<B::source_nullability>();
+
+  constexpr uint32_t kNonNullIdx = Nullability::GetTypeIndex<NonNull>();
+  bool has_nulls = nullability_index != kNonNullIdx;
+
+  // Get mutable pointer to the null bitvector (may be unused if non-null).
+  BitVector* null_bv = nullptr;
+  if (has_nulls) {
+    null_bv = state.MaybeReadFromRegister(
+        WriteHandle<BitVector>(bc.template arg<B::null_bv_register>()));
+  }
+
+  // BFS helper: seeds queue with roots, then traverses applying |apply|.
+  auto bfs = [&](auto apply) {
+    uint32_t* queue = scratch.b;
+    uint32_t queue_end = 0;
+    for (const uint32_t* it = roots.b; it != roots.e; ++it) {
+      queue[queue_end++] = *it;
+    }
+    for (uint32_t qi = 0; qi < queue_end; ++qi) {
+      uint32_t parent = queue[qi];
+      uint32_t cs = offsets.b[parent];
+      uint32_t ce = offsets.b[parent + 1];
+      for (uint32_t ci = cs; ci < ce; ++ci) {
+        uint32_t child = children.b[ci];
+        apply(data, parent, child);
+        queue[queue_end++] = child;
+      }
+    }
+  };
+
+  // Wraps a non-null combine lambda to add null handling.
+  auto with_nulls = [&](auto combine) {
+    return [&, combine](auto* d, uint32_t p, uint32_t c) {
+      bool p_null = !null_bv->is_set(p);
+      bool c_null = !null_bv->is_set(c);
+      if (p_null) {
+        // Null parent: child keeps its value (no-op).
+        return;
+      }
+      if (c_null) {
+        // Non-null parent + null child: child = parent, becomes non-null.
+        d[c] = d[p];
+        null_bv->set(c);
+        return;
+      }
+      // Both non-null: apply combine op.
+      combine(d, p, c);
+    };
+  };
+
+  if constexpr (std::is_same_v<typename T::cpp_type, StringPool::Id>) {
+    auto min_fn = [&](auto* d, uint32_t p, uint32_t c) {
+      if (state.string_pool->Get(d[p]) < state.string_pool->Get(d[c])) {
+        d[c] = d[p];
+      }
+    };
+    auto max_fn = [&](auto* d, uint32_t p, uint32_t c) {
+      if (state.string_pool->Get(d[p]) > state.string_pool->Get(d[c])) {
+        d[c] = d[p];
+      }
+    };
+    auto first_fn = [](auto* d, uint32_t p, uint32_t c) { d[c] = d[p]; };
+    switch (op) {
+      case CombineOp::GetTypeIndex<MinOp>():
+        has_nulls ? bfs(with_nulls(min_fn)) : bfs(min_fn);
+        break;
+      case CombineOp::GetTypeIndex<MaxOp>():
+        has_nulls ? bfs(with_nulls(max_fn)) : bfs(max_fn);
+        break;
+      case CombineOp::GetTypeIndex<FirstOp>():
+        has_nulls ? bfs(with_nulls(first_fn)) : bfs(first_fn);
+        break;
+      case CombineOp::GetTypeIndex<LastOp>():
+        break;  // No-op: keep child's value.
+      default:
+        PERFETTO_DCHECK(false);
+        break;
+    }
+  } else {
+    auto sum_fn = [](auto* d, uint32_t p, uint32_t c) { d[c] += d[p]; };
+    auto min_fn = [](auto* d, uint32_t p, uint32_t c) {
+      d[c] = std::min(d[p], d[c]);
+    };
+    auto max_fn = [](auto* d, uint32_t p, uint32_t c) {
+      d[c] = std::max(d[p], d[c]);
+    };
+    auto first_fn = [](auto* d, uint32_t p, uint32_t c) { d[c] = d[p]; };
+    switch (op) {
+      case CombineOp::GetTypeIndex<SumOp>():
+        has_nulls ? bfs(with_nulls(sum_fn)) : bfs(sum_fn);
+        break;
+      case CombineOp::GetTypeIndex<MinOp>():
+        has_nulls ? bfs(with_nulls(min_fn)) : bfs(min_fn);
+        break;
+      case CombineOp::GetTypeIndex<MaxOp>():
+        has_nulls ? bfs(with_nulls(max_fn)) : bfs(max_fn);
+        break;
+      case CombineOp::GetTypeIndex<FirstOp>():
+        has_nulls ? bfs(with_nulls(first_fn)) : bfs(first_fn);
+        break;
+      case CombineOp::GetTypeIndex<LastOp>():
+        break;  // No-op: keep child's value.
+      default:
+        PERFETTO_DCHECK(false);
+        break;
+    }
+  }
+}
+
+inline PERFETTO_ALWAYS_INLINE void InitRangeFromSpan(
+    InterpreterState& state,
+    const struct InitRangeFromSpan& bc) {
+  using B = struct InitRangeFromSpan;
+  const auto& span = state.ReadFromRegister(bc.arg<B::source_span_register>());
+  state.WriteToRegister(bc.arg<B::dest_register>(),
+                        Range{0, static_cast<uint32_t>(span.size())});
+}
+
+template <typename T>
+inline PERFETTO_ALWAYS_INLINE void GatherColumn(
+    InterpreterState& state,
+    const struct GatherColumn<T>& bc) {
+  using B = GatherColumnBase;
+  using CppType = typename T::cpp_type;
+
+  const StoragePtr& storage =
+      state.ReadFromRegister(bc.template arg<B::source_storage_register>());
+  const Span<uint32_t>& indices =
+      state.ReadFromRegister(bc.template arg<B::indices_register>());
+  const BitVector* source_null_bv =
+      state.ReadFromRegister(bc.template arg<B::source_null_bv_register>());
+  uint32_t nullability_index = bc.template arg<B::source_nullability>();
+
+  auto new_count = static_cast<uint32_t>(indices.size());
+  uint32_t byte_count = new_count * sizeof(CppType);
+
+  // Allocate destination slab.
+  auto slab = Slab<uint8_t>::Alloc(byte_count);
+  auto* dest = reinterpret_cast<CppType*>(slab.data());
+  const auto* src = static_cast<const CppType*>(storage.ptr);
+
+  // Nullability enum indices match Nullability TypeSet order.
+  // 0 = NonNull, 1..3 = SparseNull variants, 4 = DenseNull
+  constexpr uint32_t kNonNullIdx = Nullability::GetTypeIndex<NonNull>();
+  constexpr uint32_t kDenseNullIdx = Nullability::GetTypeIndex<DenseNull>();
+
+  if (nullability_index == kNonNullIdx || !source_null_bv) {
+    // NonNull: just gather data.
+    for (uint32_t i = 0; i < new_count; ++i) {
+      dest[i] = src[indices.b[i]];
+    }
+    // No null bitvector needed.
+    state.WriteToRegister(bc.template arg<B::dest_null_bv_ptr_register>(),
+                          static_cast<const BitVector*>(nullptr));
+  } else if (nullability_index == kDenseNullIdx) {
+    // DenseNull: gather data and gather bitvector bits.
+    for (uint32_t i = 0; i < new_count; ++i) {
+      dest[i] = src[indices.b[i]];
+    }
+    // Gather null bitvector bits.
+    BitVector gathered_bv = BitVector::CreateWithSize(new_count, false);
+    for (uint32_t i = 0; i < new_count; ++i) {
+      if (source_null_bv->is_set(indices.b[i])) {
+        gathered_bv.set(i);
+      }
+    }
+    state.WriteToRegister(bc.template arg<B::dest_null_bv_register>(),
+                          std::move(gathered_bv));
+    BitVector* bv_ptr = state.MaybeReadFromRegister(
+        WriteHandle<BitVector>(bc.template arg<B::dest_null_bv_register>()));
+    state.WriteToRegister(bc.template arg<B::dest_null_bv_ptr_register>(),
+                          static_cast<const BitVector*>(bv_ptr));
+  } else {
+    // SparseNull: translate indices through popcount, gather data,
+    // expand bitvector to dense.
+    Slab<uint32_t> prefix_pop = source_null_bv->PrefixPopcount();
+    BitVector gathered_bv = BitVector::CreateWithSize(new_count, false);
+    for (uint32_t i = 0; i < new_count; ++i) {
+      uint32_t table_idx = indices.b[i];
+      if (source_null_bv->is_set(table_idx)) {
+        uint32_t word_idx = table_idx / 64u;
+        uint32_t storage_idx =
+            prefix_pop[word_idx] +
+            static_cast<uint32_t>(
+                source_null_bv->count_set_bits_until_in_word(table_idx));
+        dest[i] = src[storage_idx];
+        gathered_bv.set(i);
+      }
+    }
+    state.WriteToRegister(bc.template arg<B::dest_null_bv_register>(),
+                          std::move(gathered_bv));
+    BitVector* bv_ptr = state.MaybeReadFromRegister(
+        WriteHandle<BitVector>(bc.template arg<B::dest_null_bv_register>()));
+    state.WriteToRegister(bc.template arg<B::dest_null_bv_ptr_register>(),
+                          static_cast<const BitVector*>(bv_ptr));
+  }
+
+  // Write gathered data to a NEW StoragePtr register (not in-place).
+  void* gathered_ptr = slab.data();
+  state.WriteToRegister(bc.template arg<B::dest_slab_register>(),
+                        std::move(slab));
+  state.WriteToRegister(bc.template arg<B::dest_storage_register>(),
+                        StoragePtr{gathered_ptr, gathered_ptr, T{}});
+}
+
 }  // namespace ops
 
 // Macros for generating case statements that dispatch to ops:: free functions.

--- a/src/trace_processor/core/interpreter/interpreter_types.h
+++ b/src/trace_processor/core/interpreter/interpreter_types.h
@@ -109,6 +109,18 @@ struct MaxOp {};
 // TypeSet combining Min and Max operations.
 using MinMaxOp = TypeSet<MinOp, MaxOp>;
 
+// Type tag for summing values during propagation.
+struct SumOp {};
+
+// Type tag for taking the first (parent) value during propagation.
+struct FirstOp {};
+
+// Type tag for keeping the last (child) value during propagation.
+struct LastOp {};
+
+// TypeSet of combine operations for numeric propagation.
+using CombineOp = TypeSet<SumOp, MinOp, MaxOp, FirstOp, LastOp>;
+
 // TypeSet containing all the non-id storage types.
 using NonIdStorageType = TypeSet<Uint32, Int32, Int64, Double, String>;
 

--- a/src/trace_processor/core/tree/tree_transformer.cc
+++ b/src/trace_processor/core/tree/tree_transformer.cc
@@ -16,11 +16,12 @@
 
 #include "src/trace_processor/core/tree/tree_transformer.h"
 
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "perfetto/base/status.h"
@@ -45,6 +46,7 @@
 #include "src/trace_processor/core/interpreter/bytecode_interpreter.h"
 #include "src/trace_processor/core/interpreter/bytecode_interpreter_impl.h"  // IWYU pragma: keep
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/interpreter/interpreter_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
 #include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
@@ -175,9 +177,7 @@ struct TreeValueFetcher : core::ValueFetcher {
 // =============================================================================
 
 TreeTransformer::TreeTransformer(dataframe::Dataframe df, StringPool* pool)
-    : df_(std::move(df)),
-      pool_(pool),
-      builder_(std::make_unique<interpreter::BytecodeBuilder>()) {}
+    : df_(std::move(df)), pool_(pool) {}
 
 // =============================================================================
 // Public methods
@@ -206,12 +206,96 @@ base::Status TreeTransformer::FilterTree(
   // Rebuild P2C from current C2P if stale.
   EnsureParentToChildStructure();
 
-  // Build filter bitvector from specs using DataframeTransformer.
+  // Build filter bitvector from specs.
   ASSIGN_OR_RETURN(auto keep_bv, dt_->Filter(specs));
 
   // Emit the tree filter operation (updates C2P, invalidates P2C).
   EmitFilterTreeBytecode(keep_bv);
   p2c_stale_ = true;
+
+  // Gather all columns at the surviving row positions.
+  dt_->GatherAllColumns(original_rows_span_);
+
+  // Re-emit propagation for any previously propagated columns,
+  // since their source data was just re-gathered.
+  if (!propagated_columns_.empty()) {
+    EnsureParentToChildStructure();
+    for (auto& pc : propagated_columns_) {
+      auto result =
+          EmitPropagateDownBytecode(pc.source_col_idx, pc.storage_type,
+                                    pc.nullability, pc.combine_op_tag, n);
+      pc.storage_reg = result.mutable_reg;
+      pc.slab_reg = result.slab_reg;
+      pc.null_bv_reg = result.null_bv_reg;
+    }
+  }
+
+  return base::OkStatus();
+}
+
+base::Status TreeTransformer::PropagateDown(const std::string& col_name,
+                                            const std::string& combine_op,
+                                            const std::string& output_name) {
+  uint32_t n = df_.row_count();
+  if (n == 0) {
+    return base::OkStatus();
+  }
+
+  // Initialize tree structure if this is the first tree operation.
+  if (!filter_scratch_.has_value()) {
+    InitializeTreeStructure(n);
+  }
+
+  // Rebuild P2C from current C2P if stale.
+  EnsureParentToChildStructure();
+
+  // Find the source column by name.
+  auto col_idx = dt_->FindColumn(col_name);
+  if (!col_idx) {
+    return base::ErrStatus("PropagateDown: unknown column '%s'",
+                           col_name.c_str());
+  }
+
+  dataframe::StorageType storage_type = dt_->GetStorageType(*col_idx);
+  if (storage_type.Is<Id>()) {
+    return base::ErrStatus("PropagateDown: cannot propagate Id columns");
+  }
+
+  // Parse the combine operation.
+  uint32_t op_tag;
+  if (combine_op == "sum") {
+    if (storage_type.Is<String>()) {
+      return base::ErrStatus("PropagateDown: 'sum' not supported for strings");
+    }
+    op_tag = interpreter::CombineOp(interpreter::SumOp{}).index();
+  } else if (combine_op == "min") {
+    op_tag = interpreter::CombineOp(interpreter::MinOp{}).index();
+  } else if (combine_op == "max") {
+    op_tag = interpreter::CombineOp(interpreter::MaxOp{}).index();
+  } else if (combine_op == "first") {
+    op_tag = interpreter::CombineOp(interpreter::FirstOp{}).index();
+  } else if (combine_op == "last") {
+    op_tag = interpreter::CombineOp(interpreter::LastOp{}).index();
+  } else {
+    return base::ErrStatus("PropagateDown: unknown combine op '%s'",
+                           combine_op.c_str());
+  }
+
+  // Emit CopyStorageToSlab + PropagateDown bytecodes.
+  Nullability nullability = dt_->GetNullability(*col_idx);
+  auto result =
+      EmitPropagateDownBytecode(*col_idx, storage_type, nullability, op_tag, n);
+
+  // Add the output column. Use DenseNull if source is nullable (propagation
+  // densifies sparse nulls), NonNull if source is non-null.
+  Nullability out_null = nullability.Is<NonNull>() ? Nullability(NonNull{})
+                                                   : Nullability(DenseNull{});
+  dt_->AddColumn(output_name, storage_type, out_null, result.mutable_reg);
+
+  // Track for re-propagation after future FilterTree calls.
+  propagated_columns_.push_back(PropagatedColumn{
+      output_name, *col_idx, op_tag, storage_type, nullability,
+      result.mutable_reg, result.slab_reg, result.null_bv_reg});
 
   return base::OkStatus();
 }
@@ -234,7 +318,8 @@ base::StatusOr<dataframe::Dataframe> TreeTransformer::ToDataframe() && {
   interp.Initialize(builder_->bytecode(), builder_->register_count(), pool_);
   interp.SetRegisterValue(
       interpreter::WriteHandle<StoragePtr>(parent_storage_reg_.index),
-      StoragePtr{normalized_parent.begin(), nullptr, StorageType(Uint32{})});
+      StoragePtr{normalized_parent.begin(), nullptr,
+                 dataframe::StorageType(Uint32{})});
 
   for (const auto& init : dt_->register_inits()) {
     auto val = dataframe::QueryPlanImpl::GetRegisterInitValue(init, df_);
@@ -258,9 +343,82 @@ base::StatusOr<dataframe::Dataframe> TreeTransformer::ToDataframe() && {
   auto final_count = static_cast<uint32_t>(parent_span->size());
   ASSIGN_OR_RETURN(auto tree_cols,
                    BuildTreeColumns(parent_span->b, final_count, pool_));
-  return dataframe::Dataframe::HorizontalConcat(
-      std::move(tree_cols),
-      std::move(df_).SelectRows(original_rows_span->b, final_count));
+
+  auto filtered_df =
+      std::move(df_).SelectRows(original_rows_span->b, final_count);
+
+  // If no propagated columns, just return tree + filtered df.
+  if (propagated_columns_.empty()) {
+    return dataframe::Dataframe::HorizontalConcat(std::move(tree_cols),
+                                                  std::move(filtered_df));
+  }
+
+  // Build propagated columns dataframe.
+  std::vector<std::string> prop_col_names;
+  for (const auto& pc : propagated_columns_) {
+    prop_col_names.push_back(pc.name);
+  }
+  dataframe::AdhocDataframeBuilder prop_builder(
+      prop_col_names, pool_,
+      dataframe::AdhocDataframeBuilder::Options{
+          {}, dataframe::NullabilityType::kDenseNull});
+
+  // Pre-fetch storage pointers and null bitvectors for each propagated column.
+  struct ResolvedColumn {
+    const void* data;
+    const BitVector* null_bv;
+  };
+  std::vector<ResolvedColumn> resolved(propagated_columns_.size());
+  for (uint32_t ci = 0; ci < propagated_columns_.size(); ++ci) {
+    const auto& pc = propagated_columns_[ci];
+    const StoragePtr* sp = interp.GetRegisterValue(
+        interpreter::ReadHandle<StoragePtr>(pc.storage_reg.index));
+    resolved[ci].data = (sp && sp->ptr) ? sp->ptr : nullptr;
+    if (!pc.nullability.Is<NonNull>()) {
+      resolved[ci].null_bv = interp.GetRegisterValue(
+          interpreter::ReadHandle<BitVector>(pc.null_bv_reg.index));
+    } else {
+      resolved[ci].null_bv = nullptr;
+    }
+  }
+
+  for (uint32_t row = 0; row < final_count; ++row) {
+    for (uint32_t ci = 0; ci < propagated_columns_.size(); ++ci) {
+      const auto& pc = propagated_columns_[ci];
+      const auto& rc = resolved[ci];
+      if (!rc.data) {
+        prop_builder.PushNull(ci);
+        continue;
+      }
+      // Check null bitvector if column is nullable.
+      if (rc.null_bv && !rc.null_bv->is_set(row)) {
+        prop_builder.PushNull(ci);
+        continue;
+      }
+      if (pc.storage_type.Is<Uint32>()) {
+        prop_builder.PushNonNull(ci,
+                                 static_cast<const uint32_t*>(rc.data)[row]);
+      } else if (pc.storage_type.Is<Int32>()) {
+        prop_builder.PushNonNull(
+            ci, int64_t{static_cast<const int32_t*>(rc.data)[row]});
+      } else if (pc.storage_type.Is<Int64>()) {
+        prop_builder.PushNonNull(ci, static_cast<const int64_t*>(rc.data)[row]);
+      } else if (pc.storage_type.Is<Double>()) {
+        prop_builder.PushNonNull(ci, static_cast<const double*>(rc.data)[row]);
+      } else if (pc.storage_type.Is<String>()) {
+        prop_builder.PushNonNull(
+            ci, static_cast<const StringPool::Id*>(rc.data)[row]);
+      }
+    }
+  }
+  ASSIGN_OR_RETURN(auto prop_df, std::move(prop_builder).Build());
+
+  // Concat: tree_cols + filtered_df + propagated_cols
+  ASSIGN_OR_RETURN(auto base_df,
+                   dataframe::Dataframe::HorizontalConcat(
+                       std::move(tree_cols), std::move(filtered_df)));
+  return dataframe::Dataframe::HorizontalConcat(std::move(base_df),
+                                                std::move(prop_df));
 }
 
 // =============================================================================
@@ -270,7 +428,7 @@ base::StatusOr<dataframe::Dataframe> TreeTransformer::ToDataframe() && {
 void TreeTransformer::InitializeTreeStructure(uint32_t row_count) {
   using MakeC2P = interpreter::MakeChildToParentTreeStructure;
 
-  // Create DataframeTransformer for filter/column operations.
+  // Create the DataframeTransformer from the current df.
   dt_.emplace(*builder_, df_);
 
   // Allocate persistent scratch for parent and original_rows spans.
@@ -315,6 +473,54 @@ void TreeTransformer::EnsureParentToChildStructure() {
   op.arg<MakeP2C::children_register>() = filter_scratch_->p2c_children.span;
   op.arg<MakeP2C::roots_register>() = filter_scratch_->p2c_roots.span;
   p2c_stale_ = false;
+}
+
+TreeTransformer::PropagateResult TreeTransformer::EmitPropagateDownBytecode(
+    uint32_t col_idx,
+    dataframe::StorageType storage_type,
+    Nullability nullability,
+    uint32_t combine_op_tag,
+    uint32_t max_rows) {
+  auto source_reg = dt_->StorageRegisterFor(col_idx);
+  auto null_bv_src = dt_->NullBitvectorRegisterFor(col_idx);
+
+  auto copy_slab_reg = builder_->AllocateRegister<Slab<uint8_t>>();
+  auto mutable_reg = interpreter::RwHandle<interpreter::StoragePtr>(
+      builder_->AllocateRegister<interpreter::StoragePtr>());
+  auto null_bv_reg = builder_->AllocateRegister<BitVector>();
+
+  // Emit CopyStorageToSlab (handles all nullability types).
+  {
+    using CopySlab = interpreter::CopyStorageToSlab;
+    auto& op = builder_->AddOpcode<CopySlab>(interpreter::Index<CopySlab>());
+    op.arg<CopySlab::source_storage_register>() = source_reg;
+    op.arg<CopySlab::row_count_span_register>() = original_rows_span_;
+    op.arg<CopySlab::source_null_bv_register>() = null_bv_src;
+    op.arg<CopySlab::source_nullability>() = nullability.index();
+    op.arg<CopySlab::dest_slab_register>() = copy_slab_reg;
+    op.arg<CopySlab::dest_storage_register>() = mutable_reg;
+    op.arg<CopySlab::dest_null_bv_register>() = null_bv_reg;
+  }
+
+  // Allocate scratch for BFS queue.
+  auto pd_scratch = builder_->AllocateScratch(max_rows);
+
+  // Emit PropagateDown bytecode (null-aware when nullable).
+  auto type_for_dispatch =
+      *storage_type.TryDowncast<interpreter::NonIdStorageType>();
+  using PD = interpreter::PropagateDownBase;
+  auto& op = builder_->AddOpcode<PD>(
+      interpreter::Index<interpreter::PropagateDown>(type_for_dispatch));
+  op.arg<PD::offsets_register>() = filter_scratch_->p2c_offsets.span;
+  op.arg<PD::children_register>() = filter_scratch_->p2c_children.span;
+  op.arg<PD::roots_register>() = filter_scratch_->p2c_roots.span;
+  op.arg<PD::update_storage_register>() = mutable_reg;
+  op.arg<PD::scratch_register>() = pd_scratch.span;
+  op.arg<PD::combine_op>() = combine_op_tag;
+  op.arg<PD::null_bv_register>() = null_bv_reg;
+  op.arg<PD::source_nullability>() = nullability.index();
+
+  return {mutable_reg, copy_slab_reg, null_bv_reg};
 }
 
 void TreeTransformer::EmitFilterTreeBytecode(

--- a/src/trace_processor/core/tree/tree_transformer.h
+++ b/src/trace_processor/core/tree/tree_transformer.h
@@ -20,18 +20,23 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "perfetto/base/status.h"
 #include "perfetto/ext/base/status_or.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "src/trace_processor/containers/string_pool.h"
+#include "src/trace_processor/core/common/null_types.h"
+#include "src/trace_processor/core/common/storage_types.h"
 #include "src/trace_processor/core/dataframe/dataframe.h"
 #include "src/trace_processor/core/dataframe/dataframe_transformer.h"
 #include "src/trace_processor/core/dataframe/specs.h"
 #include "src/trace_processor/core/interpreter/bytecode_builder.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
+#include "src/trace_processor/core/interpreter/interpreter_types.h"
 #include "src/trace_processor/core/util/bit_vector.h"
+#include "src/trace_processor/core/util/slab.h"
 #include "src/trace_processor/core/util/span.h"
 
 namespace perfetto::trace_processor::core::tree {
@@ -45,17 +50,19 @@ namespace perfetto::trace_processor::core::tree {
 //
 // Operations can be chained:
 //   auto status = TreeTransformer(df, pool)
-//       .FilterTree(filter_specs);  // Emits bytecode immediately
+//       .FilterTree(filter_specs, values);
+//   RETURN_IF_ERROR(status);
+//   status = transformer.PropagateDown("col", "sum", "out_col");
 //   RETURN_IF_ERROR(status);
 //   auto result = std::move(transformer).ToDataframe();
 //
 // All operations emit bytecode immediately. ToDataframe() executes the
 // accumulated bytecode and uses SelectRows to create the final dataframe.
 //
-// Architecture follows QueryPlanBuilder patterns:
-// - Uses builder_.GetOrCreateScratchRegisters() for scratch management
-// - Uses RegisterCache for column register caching
-// - Single unified code path (no lazy initialization)
+// Uses a DataframeTransformer for low-level column/register plumbing
+// (filtering, gathering, register allocation). TreeTransformer orchestrates
+// the tree-specific bytecode (C2P/P2C structure, FilterTree, PropagateDown)
+// and interpreter execution.
 class TreeTransformer {
  public:
   explicit TreeTransformer(dataframe::Dataframe df, StringPool* pool);
@@ -74,6 +81,11 @@ class TreeTransformer {
   base::Status FilterTree(std::vector<dataframe::FilterSpec> specs,
                           std::vector<SqlValue> values);
 
+  // Propagates values down the tree from roots to leaves using BFS.
+  base::Status PropagateDown(const std::string& col_name,
+                             const std::string& combine_op,
+                             const std::string& output_name);
+
   // Returns the underlying dataframe (for accessing column metadata).
   const dataframe::Dataframe& df() const { return df_; }
 
@@ -85,7 +97,7 @@ class TreeTransformer {
   base::StatusOr<dataframe::Dataframe> ToDataframe() &&;
 
  private:
-  // Initializes tree structure on first FilterTree call.
+  // Initializes tree structure on first FilterTree/PropagateDown call.
   // Allocates persistent parent/original_rows spans, all scratch buffers,
   // and emits MakeChildToParentTreeStructure bytecode.
   void InitializeTreeStructure(uint32_t row_count);
@@ -99,16 +111,29 @@ class TreeTransformer {
   // Uses pre-allocated scratch buffers stored as member variables.
   void EmitFilterTreeBytecode(interpreter::RwHandle<BitVector> keep_bv);
 
+  // Emits CopyStorageToSlab + PropagateDown bytecodes for a single column.
+  // Returns the mutable storage register, slab register, and null bv register.
+  struct PropagateResult {
+    interpreter::RwHandle<interpreter::StoragePtr> mutable_reg;
+    interpreter::RwHandle<Slab<uint8_t>> slab_reg;
+    interpreter::RwHandle<BitVector> null_bv_reg;
+  };
+  PropagateResult EmitPropagateDownBytecode(uint32_t col_idx,
+                                            dataframe::StorageType storage_type,
+                                            Nullability nullability,
+                                            uint32_t combine_op_tag,
+                                            uint32_t max_rows);
+
   dataframe::Dataframe df_;
   StringPool* pool_;
 
-  // Bytecode builder for accumulating tree operations.
-  // Stored as unique_ptr so its address remains stable when referenced
-  // by DataframeTransformer.
-  std::unique_ptr<interpreter::BytecodeBuilder> builder_;
+  // Heap-allocated so its address is stable across moves of TreeTransformer.
+  // DataframeTransformer holds a reference to this, so it must not relocate.
+  std::unique_ptr<interpreter::BytecodeBuilder> builder_ =
+      std::make_unique<interpreter::BytecodeBuilder>();
 
-  // DataframeTransformer for filter/column operations.
-  // Created on first FilterTree call via InitializeTreeStructure().
+  // Low-level column/register plumbing. Lazily initialized on first
+  // tree operation (when we know df has rows).
   std::optional<dataframe::DataframeTransformer> dt_;
 
   // Parent and original_rows span registers (set on first FilterTree call).
@@ -117,9 +142,6 @@ class TreeTransformer {
 
   // Register holding the normalized parent_id storage (set at execution time).
   interpreter::ReadHandle<interpreter::StoragePtr> parent_storage_reg_;
-
-  // Filter values for bytecode execution.
-  std::vector<SqlValue> filter_values_;
 
   // Alias for scratch register type.
   using Scratch = interpreter::BytecodeBuilder::ScratchRegisters;
@@ -142,6 +164,22 @@ class TreeTransformer {
   // rebuilding. Operations that modify C2P (like FilterTree) set this to true.
   // EnsureParentToChildStructure() checks this and rebuilds P2C if needed.
   bool p2c_stale_ = true;
+
+  // Propagated column tracking for re-propagation after FilterTree.
+  struct PropagatedColumn {
+    std::string name;
+    uint32_t source_col_idx;
+    uint32_t combine_op_tag;
+    StorageType storage_type;
+    Nullability nullability;
+    interpreter::RwHandle<interpreter::StoragePtr> storage_reg;
+    interpreter::RwHandle<Slab<uint8_t>> slab_reg;
+    interpreter::RwHandle<BitVector> null_bv_reg;
+  };
+  std::vector<PropagatedColumn> propagated_columns_;
+
+  // Accumulated filter values across all FilterTree() calls.
+  std::vector<SqlValue> filter_values_;
 };
 
 }  // namespace perfetto::trace_processor::core::tree

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/trees/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/trees/BUILD.gn
@@ -20,6 +20,8 @@ source_set("trees") {
     "tree_filter.h",
     "tree_functions.cc",
     "tree_functions.h",
+    "tree_propagate_down.cc",
+    "tree_propagate_down.h",
   ]
   deps = [
     "../../../../../../gn:default_deps",

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.cc
@@ -22,6 +22,7 @@
 #include "src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.h"
 #include "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_conversion.h"
 #include "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_filter.h"
+#include "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.h"
 
 namespace perfetto::trace_processor {
 
@@ -32,6 +33,7 @@ base::Status RegisterTreeFunctions(PerfettoSqlEngine& engine,
   RETURN_IF_ERROR(engine.RegisterFunction<TreeConstraint>(nullptr));
   RETURN_IF_ERROR(engine.RegisterFunction<TreeWhereAnd>(nullptr));
   RETURN_IF_ERROR(engine.RegisterFunction<TreeFilter>(nullptr));
+  RETURN_IF_ERROR(engine.RegisterFunction<TreePropagateDown>(nullptr));
   return base::OkStatus();
 }
 

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.cc
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "perfetto/ext/base/string_utils.h"
+#include "src/trace_processor/core/tree/tree_transformer.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_result.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_type.h"
+#include "src/trace_processor/sqlite/bindings/sqlite_value.h"
+#include "src/trace_processor/sqlite/sqlite_utils.h"
+
+namespace perfetto::trace_processor {
+
+void TreePropagateDown::Step(sqlite3_context* ctx,
+                             int argc,
+                             sqlite3_value** argv) {
+  if (argc != 4) {
+    return sqlite::result::Error(
+        ctx,
+        "tree_propagate_down: expected 4 arguments "
+        "(tree_ptr, column_name, combine_op, output_name)");
+  }
+
+  // Extract tree pointer.
+  auto* tree_ptr =
+      sqlite::value::Pointer<sqlite::utils::MovePointer<tree::TreeTransformer>>(
+          argv[0], "TREE_TRANSFORMER");
+  if (!tree_ptr) {
+    return sqlite::result::Error(ctx,
+                                 "tree_propagate_down: expected "
+                                 "TREE_TRANSFORMER");
+  }
+  if (tree_ptr->taken()) {
+    return sqlite::result::Error(
+        ctx, "tree_propagate_down: tree has already been consumed");
+  }
+
+  // Extract column name.
+  if (sqlite::value::Type(argv[1]) != sqlite::Type::kText) {
+    return sqlite::result::Error(
+        ctx, "tree_propagate_down: column_name must be a string");
+  }
+  std::string column_name = sqlite::value::Text(argv[1]);
+
+  // Extract combine operation.
+  if (sqlite::value::Type(argv[2]) != sqlite::Type::kText) {
+    return sqlite::result::Error(
+        ctx, "tree_propagate_down: combine_op must be a string");
+  }
+  std::string combine_op = sqlite::value::Text(argv[2]);
+
+  // Extract output name.
+  if (sqlite::value::Type(argv[3]) != sqlite::Type::kText) {
+    return sqlite::result::Error(
+        ctx, "tree_propagate_down: output_name must be a string");
+  }
+  std::string output_name = sqlite::value::Text(argv[3]);
+
+  // Take ownership of the transformer.
+  auto transformer = tree_ptr->Take();
+
+  auto status = transformer.PropagateDown(column_name, combine_op, output_name);
+  SQLITE_RETURN_IF_ERROR(ctx, status);
+
+  // Return the modified transformer wrapped in a new MovePointer.
+  return sqlite::result::UniquePointer(
+      ctx,
+      std::make_unique<sqlite::utils::MovePointer<tree::TreeTransformer>>(
+          std::move(transformer)),
+      "TREE_TRANSFORMER");
+}
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.h
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate_down.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_PERFETTO_SQL_INTRINSICS_FUNCTIONS_TREES_TREE_PROPAGATE_DOWN_H_
+#define SRC_TRACE_PROCESSOR_PERFETTO_SQL_INTRINSICS_FUNCTIONS_TREES_TREE_PROPAGATE_DOWN_H_
+
+#include "src/trace_processor/sqlite/bindings/sqlite_function.h"
+
+namespace perfetto::trace_processor {
+
+// Scalar function that propagates values down a tree from roots to leaves.
+// Args: tree_ptr (TREE_TRANSFORMER), column_name (STRING),
+//       combine_op (STRING), output_name (STRING)
+// combine_op is one of: 'sum', 'min', 'max', 'first', 'last'
+struct TreePropagateDown : public sqlite::Function<TreePropagateDown> {
+  static constexpr char kName[] = "__intrinsic_tree_propagate_down";
+  static constexpr int kArgCount = 4;
+
+  static void Step(sqlite3_context* ctx, int argc, sqlite3_value** argv);
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_PERFETTO_SQL_INTRINSICS_FUNCTIONS_TREES_TREE_PROPAGATE_DOWN_H_

--- a/src/trace_processor/perfetto_sql/stdlib/std/trees/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/std/trees/BUILD.gn
@@ -17,6 +17,7 @@ import("../../../../../../gn/perfetto_sql.gni")
 perfetto_sql_source_set("trees") {
   sources = [
     "filter.sql",
+    "propagate_down.sql",
     "table_conversion.sql",
   ]
 }

--- a/src/trace_processor/perfetto_sql/stdlib/std/trees/propagate_down.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/std/trees/propagate_down.sql
@@ -1,0 +1,55 @@
+--
+-- Copyright 2026 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- sqlformat file off
+
+-- Propagates values down a tree from roots to leaves using BFS.
+--
+-- For each child node, combines the parent's value with the child's value
+-- using the specified combine operation. This is useful for computing
+-- cumulative values like depth, cumulative sums, or inherited properties.
+--
+-- Combine operations:
+--   'sum':   child += parent (e.g., compute depth with initial values of 1)
+--   'min':   child = min(parent, child)
+--   'max':   child = max(parent, child)
+--   'first': child = parent (parent's value propagates down, overwriting child)
+--   'last':  no-op (child keeps its own value)
+--
+-- Example usage:
+-- ```
+-- SELECT * FROM _tree_to_table!(
+--   _tree_propagate_down(
+--     _tree_from_table!((SELECT id, parent_id, value FROM my_tree), (value)),
+--     'value',
+--     'sum',
+--     'cumulative_value'
+--   ),
+--   (cumulative_value)
+-- );
+-- ```
+CREATE PERFETTO FUNCTION _tree_propagate_down(
+    -- A TREE pointer from _tree_from_table or another tree operation.
+    tree_ptr ANY,
+    -- Name of the column to propagate values for.
+    column_name STRING,
+    -- Combine operation: 'sum', 'min', 'max', 'first', or 'last'.
+    combine_op STRING,
+    -- Name of the output column containing propagated values.
+    output_name STRING
+)
+-- Returns a TREE pointer with propagated values
+RETURNS ANY
+DELEGATES TO __intrinsic_tree_propagate_down;

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -175,6 +175,7 @@ from diff_tests.stdlib.timestamps.tests import Timestamps
 from diff_tests.stdlib.traced.stats import TracedStats
 from diff_tests.stdlib.trees.table_conversion_tests import TreeRoundtrip
 from diff_tests.stdlib.trees.tree_filter_tests import TreeFilter
+from diff_tests.stdlib.trees.tree_propagate_down_tests import TreePropagateDown
 from diff_tests.stdlib.viz.tests import Viz
 from diff_tests.stdlib.wattson.tests import WattsonStdlib
 from diff_tests.syntax.filtering_tests import PerfettoFiltering
@@ -318,6 +319,7 @@ def fetch_all_diff_tests(
       GraphScanTests,
       TreeRoundtrip,
       TreeFilter,
+      TreePropagateDown,
       ExportTests,
       Frames,
       GraphSearchTests,

--- a/test/trace_processor/diff_tests/stdlib/trees/tree_propagate_down_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/trees/tree_propagate_down_tests.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import DataPath
+from python.generators.diff_tests.testing import Csv
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class TreePropagateDown(TestSuite):
+  """Tests for tree propagate_down operation."""
+
+  def test_sum(self):
+    """Sum propagation: child += parent."""
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE std.trees.table_conversion;
+          INCLUDE PERFETTO MODULE std.trees.propagate_down;
+
+          CREATE PERFETTO TABLE input_tree AS
+          SELECT 1 AS id, NULL AS parent_id, 10 AS value
+          UNION ALL SELECT 2, 1, 5
+          UNION ALL SELECT 3, 1, 3
+          UNION ALL SELECT 4, 2, 2;
+
+          SELECT _tree_id, id, value, cumulative
+          FROM _tree_to_table!(
+            _tree_propagate_down(
+              _tree_from_table!((SELECT * FROM input_tree), (value)),
+              'value',
+              'sum',
+              'cumulative'
+            ),
+            (value, cumulative)
+          )
+          ORDER BY id;
+        """,
+        out=Csv("""
+        "_tree_id","id","value","cumulative"
+        0,1,10,10
+        1,2,5,15
+        2,3,3,13
+        3,4,2,17
+        """))
+
+  def test_min(self):
+    """Min propagation: child = min(parent, child)."""
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE std.trees.table_conversion;
+          INCLUDE PERFETTO MODULE std.trees.propagate_down;
+
+          CREATE PERFETTO TABLE input_tree AS
+          SELECT 1 AS id, NULL AS parent_id, 5 AS value
+          UNION ALL SELECT 2, 1, 3
+          UNION ALL SELECT 3, 1, 8
+          UNION ALL SELECT 4, 2, 1;
+
+          SELECT _tree_id, id, value, result
+          FROM _tree_to_table!(
+            _tree_propagate_down(
+              _tree_from_table!((SELECT * FROM input_tree), (value)),
+              'value',
+              'min',
+              'result'
+            ),
+            (value, result)
+          )
+          ORDER BY id;
+        """,
+        out=Csv("""
+        "_tree_id","id","value","result"
+        0,1,5,5
+        1,2,3,3
+        2,3,8,5
+        3,4,1,1
+        """))
+
+  def test_max(self):
+    """Max propagation: child = max(parent, child)."""
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE std.trees.table_conversion;
+          INCLUDE PERFETTO MODULE std.trees.propagate_down;
+
+          CREATE PERFETTO TABLE input_tree AS
+          SELECT 1 AS id, NULL AS parent_id, 5 AS value
+          UNION ALL SELECT 2, 1, 3
+          UNION ALL SELECT 3, 1, 8
+          UNION ALL SELECT 4, 2, 10;
+
+          SELECT _tree_id, id, value, result
+          FROM _tree_to_table!(
+            _tree_propagate_down(
+              _tree_from_table!((SELECT * FROM input_tree), (value)),
+              'value',
+              'max',
+              'result'
+            ),
+            (value, result)
+          )
+          ORDER BY id;
+        """,
+        out=Csv("""
+        "_tree_id","id","value","result"
+        0,1,5,5
+        1,2,3,5
+        2,3,8,8
+        3,4,10,10
+        """))
+
+  def test_first(self):
+    """First propagation: child = parent (parent overwrites)."""
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE std.trees.table_conversion;
+          INCLUDE PERFETTO MODULE std.trees.propagate_down;
+
+          CREATE PERFETTO TABLE input_tree AS
+          SELECT 1 AS id, NULL AS parent_id, 100 AS value
+          UNION ALL SELECT 2, 1, 200
+          UNION ALL SELECT 3, 2, 300
+          UNION ALL SELECT 4, 1, 400;
+
+          SELECT _tree_id, id, value, result
+          FROM _tree_to_table!(
+            _tree_propagate_down(
+              _tree_from_table!((SELECT * FROM input_tree), (value)),
+              'value',
+              'first',
+              'result'
+            ),
+            (value, result)
+          )
+          ORDER BY id;
+        """,
+        out=Csv("""
+        "_tree_id","id","value","result"
+        0,1,100,100
+        1,2,200,100
+        2,3,300,100
+        3,4,400,100
+        """))
+
+  def test_last(self):
+    """Last propagation: child keeps its own value."""
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE std.trees.table_conversion;
+          INCLUDE PERFETTO MODULE std.trees.propagate_down;
+
+          CREATE PERFETTO TABLE input_tree AS
+          SELECT 1 AS id, NULL AS parent_id, 100 AS value
+          UNION ALL SELECT 2, 1, 200
+          UNION ALL SELECT 3, 2, 300
+          UNION ALL SELECT 4, 1, 400;
+
+          SELECT _tree_id, id, value, result
+          FROM _tree_to_table!(
+            _tree_propagate_down(
+              _tree_from_table!((SELECT * FROM input_tree), (value)),
+              'value',
+              'last',
+              'result'
+            ),
+            (value, result)
+          )
+          ORDER BY id;
+        """,
+        out=Csv("""
+        "_tree_id","id","value","result"
+        0,1,100,100
+        1,2,200,200
+        2,3,300,300
+        3,4,400,400
+        """))


### PR DESCRIPTION
Add PropagateDown operation to TreeTransformer which performs a BFS
traversal from root to children, combining parent and child values
using configurable operations (sum, min, max, first, last). Includes
null-aware propagation, new bytecodes (CopyStorageToSlab,
PropagateDown, InitRangeFromSpan, GatherColumn), and PerfettoSQL
function _tree_propagate_down.
