### PR TITLE
tp: best-fit scratch registers + DataframeRegisterCache

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2082,6 +2082,7 @@ perfetto_filegroup(
         "src/trace_processor/core/dataframe/cursor_impl.h",
         "src/trace_processor/core/dataframe/dataframe.cc",
         "src/trace_processor/core/dataframe/dataframe.h",
+        "src/trace_processor/core/dataframe/dataframe_register_cache.h",
         "src/trace_processor/core/dataframe/query_plan.cc",
         "src/trace_processor/core/dataframe/query_plan.h",
         "src/trace_processor/core/dataframe/runtime_dataframe_builder.h",

--- a/src/trace_processor/core/dataframe/BUILD.gn
+++ b/src/trace_processor/core/dataframe/BUILD.gn
@@ -22,6 +22,7 @@ source_set("dataframe") {
     "cursor_impl.h",
     "dataframe.cc",
     "dataframe.h",
+    "dataframe_register_cache.h",
     "query_plan.cc",
     "query_plan.h",
     "runtime_dataframe_builder.h",

--- a/src/trace_processor/core/dataframe/dataframe_register_cache.h
+++ b/src/trace_processor/core/dataframe/dataframe_register_cache.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_CORE_DATAFRAME_DATAFRAME_REGISTER_CACHE_H_
+#define SRC_TRACE_PROCESSOR_CORE_DATAFRAME_DATAFRAME_REGISTER_CACHE_H_
+
+#include <cstdint>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "perfetto/ext/base/murmur_hash.h"
+#include "src/trace_processor/core/interpreter/bytecode_builder.h"
+#include "src/trace_processor/core/interpreter/bytecode_registers.h"
+
+namespace perfetto::trace_processor::core::dataframe {
+
+// A helper that wraps BytecodeBuilder's AllocateRegister with a cache keyed
+// by (reg_type, void* address). This allows callers to cache registers for
+// columns/indexes using their pointer identity as the key.
+class DataframeRegisterCache {
+ public:
+  explicit DataframeRegisterCache(interpreter::BytecodeBuilder& builder)
+      : builder_(builder) {}
+
+  template <typename T>
+  struct CachedRegister {
+    interpreter::RwHandle<T> reg;
+    bool inserted;
+  };
+
+  // Gets a register from the cache, or allocates a new one if not found.
+  // The key is formed from (reg_type, ptr). Returns the register and whether
+  // it was newly inserted.
+  template <typename T>
+  CachedRegister<T> GetOrAllocate(uint32_t reg_type, const void* ptr) {
+    CacheKey key{reg_type, ptr};
+    auto* it = cache_.Find(key);
+    if (it) {
+      return {interpreter::RwHandle<T>{it->index}, false};
+    }
+    auto reg = builder_.AllocateRegister<T>();
+    cache_[key] = interpreter::HandleBase{reg.index};
+    return {reg, true};
+  }
+
+  void Clear() { cache_.Clear(); }
+
+ private:
+  struct CacheKey {
+    uint32_t reg_type;
+    const void* ptr;
+
+    bool operator==(const CacheKey& o) const {
+      return reg_type == o.reg_type && ptr == o.ptr;
+    }
+
+    friend base::MurmurHashCombiner PerfettoHashValue(
+        base::MurmurHashCombiner h,
+        const CacheKey& k) {
+      return base::MurmurHashCombiner::Combine(
+          std::move(h), k.reg_type,
+          static_cast<uint64_t>(reinterpret_cast<uintptr_t>(k.ptr)));
+    }
+  };
+
+  base::FlatHashMapV2<CacheKey, interpreter::HandleBase> cache_;
+  interpreter::BytecodeBuilder& builder_;
+};
+
+}  // namespace perfetto::trace_processor::core::dataframe
+
+#endif  // SRC_TRACE_PROCESSOR_CORE_DATAFRAME_DATAFRAME_REGISTER_CACHE_H_

--- a/src/trace_processor/core/interpreter/bytecode_builder.h
+++ b/src/trace_processor/core/interpreter/bytecode_builder.h
@@ -21,7 +21,6 @@
 #include <optional>
 #include <vector>
 
-#include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/core/interpreter/bytecode_core.h"
 #include "src/trace_processor/core/interpreter/bytecode_registers.h"
 #include "src/trace_processor/core/util/slab.h"
@@ -33,9 +32,7 @@ namespace perfetto::trace_processor::core::interpreter {
 //
 // This class provides generic bytecode building capabilities. It handles:
 // - Register allocation
-// - Scope-based register caching (generic mechanism for callers to cache
-//   registers within a scope)
-// - Scratch register management
+// - Scratch register management (best-fit allocation)
 // - Raw opcode emission
 //
 // Higher-level builders (like QueryPlanBuilder for dataframes or
@@ -56,51 +53,13 @@ class BytecodeBuilder {
   // Returns the total number of registers allocated.
   uint32_t register_count() const { return register_count_; }
 
-  // === Scope-based register caching ===
-
-  // Creates a new cache scope and returns its ID.
-  // Scopes allow callers to cache registers and retrieve them later by
-  // (reg_type, index) pairs.
-  uint32_t CreateCacheScope();
-
-  // Result from GetOrAllocateCachedRegister.
-  template <typename T>
-  struct CachedRegister {
-    RwHandle<T> reg;
-    bool inserted;  // True if newly allocated, false if found in cache
-  };
-
-  // Gets a register from the scope cache, or allocates a new one if not found.
-  // The allocated register is automatically added to the cache.
-  // Returns the register and whether it was newly inserted.
-  template <typename T>
-  CachedRegister<T> GetOrAllocateCachedRegister(uint32_t scope_id,
-                                                uint32_t reg_type,
-                                                uint32_t index) {
-    if (scope_id >= scope_caches_.size()) {
-      scope_caches_.resize(scope_id + 1);
-    }
-    uint64_t key = CacheKey(reg_type, index);
-    auto* it = scope_caches_[scope_id].Find(key);
-    if (it) {
-      return {RwHandle<T>{it->index}, false};
-    }
-    auto reg = AllocateRegister<T>();
-    scope_caches_[scope_id][key] = HandleBase{reg.index};
-    return {reg, true};
-  }
-
-  // Clears all cached registers for a scope.
-  void ClearCacheScope(uint32_t scope_id);
-
   // === Scratch register management ===
   //
   // These methods manage scratch register state for operations that need
-  // temporary storage. The caller is responsible for emitting the actual
-  // AllocateIndices opcode (this allows different cost tracking strategies).
-  //
-  // Multiple named scratch slots are supported via slot_id parameter.
-  // The default slot (used by single-argument methods) is slot 0.
+  // temporary storage. Scratch slots are allocated using a best-fit strategy:
+  // when requesting scratch of a given size, the smallest existing free slot
+  // that can accommodate the request is reused. If no suitable slot exists,
+  // a new one is allocated.
 
   // Result from GetOrCreateScratchRegisters.
   struct ScratchRegisters {
@@ -108,42 +67,24 @@ class BytecodeBuilder {
     RwHandle<Span<uint32_t>> span;
   };
 
-  // Gets or creates scratch registers of the given size in the specified slot.
-  // Multiple slots can coexist with different slot_ids.
+  // Gets or creates scratch registers of the given size using best-fit.
+  // Finds the smallest free slot with size >= requested, or allocates new.
   // Does NOT emit AllocateIndices - caller must emit it separately.
-  ScratchRegisters GetOrCreateScratchRegisters(uint32_t slot_id, uint32_t size);
+  ScratchRegisters GetOrCreateScratchRegisters(uint32_t size);
 
-  // Gets or creates scratch registers in the default slot (slot 0).
-  ScratchRegisters GetOrCreateScratchRegisters(uint32_t size) {
-    return GetOrCreateScratchRegisters(0, size);
-  }
-
-  // Allocates scratch in the specified slot and emits AllocateIndices bytecode.
+  // Allocates scratch using best-fit and emits AllocateIndices bytecode.
   // This is the preferred method - combines register allocation + bytecode
   // emission.
-  ScratchRegisters AllocateScratch(uint32_t slot_id, uint32_t size);
+  ScratchRegisters AllocateScratch(uint32_t size);
 
-  // Marks the specified scratch slot as being in use.
-  void MarkScratchInUse(uint32_t slot_id);
+  // Marks the given scratch registers as being in use.
+  void MarkScratchInUse(ScratchRegisters regs);
 
-  // Marks the default scratch slot (slot 0) as being in use.
-  void MarkScratchInUse() { MarkScratchInUse(0); }
+  // Releases the given scratch registers so they can be reused.
+  void ReleaseScratch(ScratchRegisters regs);
 
-  // Releases the specified scratch slot so it can be reused.
-  void ReleaseScratch(uint32_t slot_id);
-
-  // Releases the default scratch slot (slot 0).
-  void ReleaseScratch() { ReleaseScratch(0); }
-
-  // Returns true if the specified scratch slot is currently in use.
-  bool IsScratchInUse(uint32_t slot_id) const {
-    return slot_id < scratch_slots_.size() &&
-           scratch_slots_[slot_id].has_value() &&
-           scratch_slots_[slot_id]->in_use;
-  }
-
-  // Returns true if the default scratch slot (slot 0) is currently in use.
-  bool IsScratchInUse() const { return IsScratchInUse(0); }
+  // Returns true if the given scratch registers are currently in use.
+  bool IsScratchInUse(ScratchRegisters regs) const;
 
   // === Opcode emission ===
 
@@ -173,19 +114,19 @@ class BytecodeBuilder {
     bool in_use = false;
   };
 
-  // Combines reg_type and index into a single cache key.
-  static constexpr uint64_t CacheKey(uint32_t reg_type, uint32_t index) {
-    return (static_cast<uint64_t>(reg_type) << 32) | index;
-  }
+  // Finds the index of the best-fit free slot for the given size.
+  // Returns nullopt if no suitable slot exists.
+  std::optional<uint32_t> FindBestFitSlot(uint32_t size) const;
+
+  // Finds the slot index matching the given slab register.
+  // Returns nullopt if not found.
+  std::optional<uint32_t> FindSlotByRegisters(ScratchRegisters regs) const;
 
   BytecodeVector bytecode_;
   uint32_t register_count_ = 0;
 
-  // Scope-based cache: scope_id -> (reg_type, index) -> register handle
-  std::vector<base::FlatHashMap<uint64_t, HandleBase>> scope_caches_;
-
-  // Scratch management - multiple slots indexed by slot_id
-  std::vector<std::optional<ScratchIndices>> scratch_slots_;
+  // Scratch management - slots indexed internally.
+  std::vector<ScratchIndices> scratch_slots_;
 };
 
 }  // namespace perfetto::trace_processor::core::interpreter


### PR DESCRIPTION
Replace the slot_id-based scratch register API with a best-fit
allocation strategy: when requesting scratch of a given size, the
smallest existing free slot that fits is reused. This removes the
need for callers to manually assign slot numbers.

Extract the scope-based register caching from BytecodeBuilder into
a new DataframeRegisterCache helper keyed by (reg_type, void*),
using column/index pointer identity as the key instead of abstract
numeric indices. This makes the caching more type-safe and removes
the CreateCacheScope/ClearCacheScope API.

In TreeTransformer, heap-allocate both the BytecodeBuilder and
DataframeRegisterCache via unique_ptr so the cache's internal
reference to the builder survives moves (TreeTransformer is moved
into MovePointer by tree_conversion/tree_filter).
