### PR TITLE
LUCI: update windows SDK path

### DIFF
--- a/infra/luci/recipe_modules/windows_sdk/api.py
+++ b/infra/luci/recipe_modules/windows_sdk/api.py
@@ -70,7 +70,7 @@ class WindowsSDKApi(recipe_api.RecipeApi):
     env = {}
     env_prefixes = {}
 
-    # Load .../win_sdk/bin/SetEnv.${arch}.json to extract the required
+    # Load .../Windows Kits/10/bin/SetEnv.${arch}.json to extract the required
     # environment. It contains a dict that looks like this:
     # {
     #   "env": {
@@ -83,10 +83,13 @@ class WindowsSDKApi(recipe_api.RecipeApi):
     filename = 'SetEnv.%s.json' % {32: 'x86', 64: 'x64'}[self.m.platform.bits]
     step_result = self.m.json.read(
         'read %s' % filename,
-        sdk_dir / 'win_sdk' / 'bin' / filename,
+        sdk_dir / 'Windows Kits' / '10' / 'bin' / filename,
         step_test_data=lambda: self.m.json.test_api.output({
             'env': {
-                'PATH': [['..', '..', 'win_sdk', 'bin', 'x64']],
+                'PATH': [[
+                    '..', '..', 'Windows Kits', '10', 'bin', '10.0.19041.0',
+                    'x64'
+                ]],
                 'VSINSTALLDIR': [['..', '..\\']],
             },
         }))

--- a/infra/luci/recipe_modules/windows_sdk/examples/full.expected/win.json
+++ b/infra/luci/recipe_modules/windows_sdk/examples/full.expected/win.json
@@ -33,7 +33,7 @@
       "python3",
       "-u",
       "RECIPE_MODULE[recipe_engine::json]\\resources\\read.py",
-      "[CACHE]\\windows_sdk\\win_sdk\\bin\\SetEnv.x64.json",
+      "[CACHE]\\windows_sdk\\Windows Kits\\10\\bin\\SetEnv.x64.json",
       "/path/to/tmp/json"
     ],
     "name": "read SetEnv.x64.json",
@@ -44,8 +44,10 @@
       "@@@STEP_LOG_LINE@json.output@      [@@@",
       "@@@STEP_LOG_LINE@json.output@        \"..\",@@@",
       "@@@STEP_LOG_LINE@json.output@        \"..\",@@@",
-      "@@@STEP_LOG_LINE@json.output@        \"win_sdk\",@@@",
+      "@@@STEP_LOG_LINE@json.output@        \"Windows Kits\",@@@",
+      "@@@STEP_LOG_LINE@json.output@        \"10\",@@@",
       "@@@STEP_LOG_LINE@json.output@        \"bin\",@@@",
+      "@@@STEP_LOG_LINE@json.output@        \"10.0.19041.0\",@@@",
       "@@@STEP_LOG_LINE@json.output@        \"x64\"@@@",
       "@@@STEP_LOG_LINE@json.output@      ]@@@",
       "@@@STEP_LOG_LINE@json.output@    ],@@@",
@@ -71,7 +73,7 @@
     },
     "env_prefixes": {
       "PATH": [
-        "[CACHE]\\windows_sdk\\win_sdk\\bin\\x64"
+        "[CACHE]\\windows_sdk\\Windows Kits\\10\\bin\\10.0.19041.0\\x64"
       ]
     },
     "name": "gn"
@@ -87,7 +89,7 @@
     },
     "env_prefixes": {
       "PATH": [
-        "[CACHE]\\windows_sdk\\win_sdk\\bin\\x64"
+        "[CACHE]\\windows_sdk\\Windows Kits\\10\\bin\\10.0.19041.0\\x64"
       ]
     },
     "name": "ninja"

--- a/infra/luci/recipes/perfetto.expected/ci_win.json
+++ b/infra/luci/recipes/perfetto.expected/ci_win.json
@@ -204,7 +204,7 @@
       "python3",
       "-u",
       "RECIPE_MODULE[recipe_engine::json]\\resources\\read.py",
-      "[CACHE]\\windows_sdk\\win_sdk\\bin\\SetEnv.x64.json",
+      "[CACHE]\\windows_sdk\\Windows Kits\\10\\bin\\SetEnv.x64.json",
       "/path/to/tmp/json"
     ],
     "cwd": "[CACHE]\\builder\\perfetto",
@@ -228,8 +228,10 @@
       "@@@STEP_LOG_LINE@json.output@      [@@@",
       "@@@STEP_LOG_LINE@json.output@        \"..\",@@@",
       "@@@STEP_LOG_LINE@json.output@        \"..\",@@@",
-      "@@@STEP_LOG_LINE@json.output@        \"win_sdk\",@@@",
+      "@@@STEP_LOG_LINE@json.output@        \"Windows Kits\",@@@",
+      "@@@STEP_LOG_LINE@json.output@        \"10\",@@@",
       "@@@STEP_LOG_LINE@json.output@        \"bin\",@@@",
+      "@@@STEP_LOG_LINE@json.output@        \"10.0.19041.0\",@@@",
       "@@@STEP_LOG_LINE@json.output@        \"x64\"@@@",
       "@@@STEP_LOG_LINE@json.output@      ]@@@",
       "@@@STEP_LOG_LINE@json.output@    ],@@@",
@@ -258,7 +260,7 @@
     },
     "env_prefixes": {
       "PATH": [
-        "[CACHE]\\windows_sdk\\win_sdk\\bin\\x64"
+        "[CACHE]\\windows_sdk\\Windows Kits\\10\\bin\\10.0.19041.0\\x64"
       ]
     },
     "luci_context": {
@@ -288,7 +290,7 @@
     },
     "env_prefixes": {
       "PATH": [
-        "[CACHE]\\windows_sdk\\win_sdk\\bin\\x64"
+        "[CACHE]\\windows_sdk\\Windows Kits\\10\\bin\\10.0.19041.0\\x64"
       ]
     },
     "luci_context": {
@@ -322,7 +324,7 @@
     },
     "env_prefixes": {
       "PATH": [
-        "[CACHE]\\windows_sdk\\win_sdk\\bin\\x64"
+        "[CACHE]\\windows_sdk\\Windows Kits\\10\\bin\\10.0.19041.0\\x64"
       ]
     },
     "luci_context": {


### PR DESCRIPTION
The previous PR (#4953) updated the CIPD package for MSVC
but that is not enoguh. The path have changed as well.
Update the windows recipe to refer to the newer paths.