### PR TITLE
tp: Add subcommand infrastructure and classic CLI integration tests

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16737,6 +16737,22 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/shell:subcommand
+filegroup {
+    name: "perfetto_src_trace_processor_shell_subcommand",
+    srcs: [
+        "src/trace_processor/shell/subcommand.cc",
+    ],
+}
+
+// GN: //src/trace_processor/shell:unittests
+filegroup {
+    name: "perfetto_src_trace_processor_shell_unittests",
+    srcs: [
+        "src/trace_processor/shell/find_subcommand_unittest.cc",
+    ],
+}
+
 // GN: //src/trace_processor/sorter:sorter
 filegroup {
     name: "perfetto_src_trace_processor_sorter_sorter",
@@ -19505,6 +19521,8 @@ cc_test {
         ":perfetto_src_trace_processor_perfetto_sql_tokenizer_unittests",
         ":perfetto_src_trace_processor_rpc_rpc",
         ":perfetto_src_trace_processor_rpc_unittests",
+        ":perfetto_src_trace_processor_shell_subcommand",
+        ":perfetto_src_trace_processor_shell_unittests",
         ":perfetto_src_trace_processor_sorter_sorter",
         ":perfetto_src_trace_processor_sorter_unittests",
         ":perfetto_src_trace_processor_sqlite_bindings_bindings",

--- a/gn/perfetto_unittests.gni
+++ b/gn/perfetto_unittests.gni
@@ -95,6 +95,7 @@ if (enable_perfetto_trace_processor) {
   if (enable_perfetto_trace_processor_sqlite) {
     _trace_processor_unittests_targets += [
       "src/trace_processor/metrics:unittests",
+      "src/trace_processor/shell:unittests",
       "src/trace_processor/trace_summary:unittests",
     ]
   }

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../gn/perfetto.gni")
+
+source_set("subcommand") {
+  sources = [
+    "subcommand.cc",
+    "subcommand.h",
+  ]
+  deps = [ "../../../gn:default_deps" ]
+}
+
+source_set("unittests") {
+  testonly = true
+  sources = [ "find_subcommand_unittest.cc" ]
+  deps = [
+    ":subcommand",
+    "../../../gn:default_deps",
+    "../../../gn:gtest_and_gmock",
+  ]
+}

--- a/src/trace_processor/shell/find_subcommand_unittest.cc
+++ b/src/trace_processor/shell/find_subcommand_unittest.cc
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/subcommand.h"
+#include "test/gtest_and_gmock.h"
+
+namespace perfetto::trace_processor::shell {
+namespace {
+
+// A minimal Subcommand implementation for testing.
+class FakeSubcommand : public Subcommand {
+ public:
+  explicit FakeSubcommand(const char* n) : name_(n) {}
+  const char* name() const override { return name_; }
+  const char* description() const override { return ""; }
+  int Run(int, char**) override { return 0; }
+  void PrintUsage(const char*) override {}
+
+ private:
+  const char* name_;
+};
+
+// Helper to build an argv array from an initializer list. The returned
+// vector owns the strings; the second vector contains the char* pointers.
+struct ArgvHolder {
+  std::vector<std::string> strings;
+  std::vector<char*> ptrs;
+
+  static ArgvHolder Make(std::initializer_list<const char*> args) {
+    ArgvHolder h;
+    for (const char* a : args) {
+      h.strings.emplace_back(a);
+    }
+    for (auto& s : h.strings) {
+      h.ptrs.push_back(s.data());
+    }
+    return h;
+  }
+
+  int argc() const { return static_cast<int>(ptrs.size()); }
+  char** argv() { return ptrs.data(); }
+};
+
+TEST(FindSubcommandTest, EmptyArgvReturnsNull) {
+  FakeSubcommand query("query");
+  std::vector<Subcommand*> subs = {&query};
+
+  auto args = ArgvHolder::Make({"tp_shell"});
+  auto result = FindSubcommandInArgs(args.argc(), args.argv(), subs, {});
+  EXPECT_EQ(result.subcommand, nullptr);
+}
+
+TEST(FindSubcommandTest, OnlyFlagsReturnsNull) {
+  FakeSubcommand query("query");
+  std::vector<Subcommand*> subs = {&query};
+
+  auto args = ArgvHolder::Make({"tp_shell", "-v", "--full-sort"});
+  auto result = FindSubcommandInArgs(args.argc(), args.argv(), subs, {});
+  EXPECT_EQ(result.subcommand, nullptr);
+}
+
+TEST(FindSubcommandTest, UnknownPositionalReturnsNull) {
+  FakeSubcommand query("query");
+  std::vector<Subcommand*> subs = {&query};
+
+  auto args = ArgvHolder::Make({"tp_shell", "trace.pb"});
+  auto result = FindSubcommandInArgs(args.argc(), args.argv(), subs, {});
+  EXPECT_EQ(result.subcommand, nullptr);
+}
+
+TEST(FindSubcommandTest, KnownSubcommandReturnsPtr) {
+  FakeSubcommand query("query");
+  FakeSubcommand serve("serve");
+  std::vector<Subcommand*> subs = {&query, &serve};
+
+  auto args = ArgvHolder::Make({"tp_shell", "query", "-c", "SELECT 1"});
+  auto result = FindSubcommandInArgs(args.argc(), args.argv(), subs, {});
+  EXPECT_EQ(result.subcommand, &query);
+  EXPECT_EQ(result.argv_index, 1);
+}
+
+TEST(FindSubcommandTest, FlagWithArgSkipsValue) {
+  FakeSubcommand query("query");
+  std::vector<Subcommand*> subs = {&query};
+
+  // --dev-flag takes an argument "x=y", so "query" at index 3 should be found.
+  auto args =
+      ArgvHolder::Make({"tp_shell", "--dev-flag", "x=y", "query", "trace.pb"});
+  auto result =
+      FindSubcommandInArgs(args.argc(), args.argv(), subs, {"--dev-flag"});
+  EXPECT_EQ(result.subcommand, &query);
+  EXPECT_EQ(result.argv_index, 3);
+}
+
+TEST(FindSubcommandTest, SubcommandAfterFlags) {
+  FakeSubcommand query("query");
+  std::vector<Subcommand*> subs = {&query};
+
+  auto args =
+      ArgvHolder::Make({"tp_shell", "--dev", "query", "-c", "sql", "trace.pb"});
+  auto result = FindSubcommandInArgs(args.argc(), args.argv(), subs, {});
+  EXPECT_EQ(result.subcommand, &query);
+  EXPECT_EQ(result.argv_index, 2);
+}
+
+}  // namespace
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/subcommand.cc
+++ b/src/trace_processor/shell/subcommand.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/subcommand.h"
+
+#include <cstring>
+
+namespace perfetto::trace_processor::shell {
+
+Subcommand::~Subcommand() = default;
+
+FindSubcommandResult FindSubcommandInArgs(
+    int argc,
+    char** argv,
+    const std::vector<Subcommand*>& subcommands,
+    const std::vector<std::string>& flags_with_arg) {
+  for (int i = 1; i < argc; ++i) {
+    const char* arg = argv[i];
+
+    // Skip flags.
+    if (arg[0] == '-') {
+      // Check if this flag consumes the next argument.
+      for (const auto& f : flags_with_arg) {
+        if (f == arg) {
+          ++i;  // Skip the flag's argument.
+          break;
+        }
+      }
+      continue;
+    }
+
+    // Positional argument: check if it matches a subcommand.
+    for (auto* sc : subcommands) {
+      if (strcmp(sc->name(), arg) == 0) {
+        return {sc, i};
+      }
+    }
+
+    // Unknown positional argument (likely a trace file) — stop searching.
+    break;
+  }
+  return {};
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/subcommand.h
+++ b/src/trace_processor/shell/subcommand.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_SUBCOMMAND_H_
+
+#include <string>
+#include <vector>
+
+namespace perfetto::trace_processor::shell {
+
+// Base class for all subcommands (query, export, serve, etc.).
+class Subcommand {
+ public:
+  virtual ~Subcommand();
+
+  // The name of the subcommand as it appears on the command line
+  // (e.g. "query", "export").
+  virtual const char* name() const = 0;
+
+  // A short one-line description shown in help output.
+  virtual const char* description() const = 0;
+
+  // Runs the subcommand. |argc| and |argv| point to the subcommand's own
+  // argument vector (i.e. argv[0] is the subcommand name).
+  // Returns 0 on success, non-zero on failure.
+  virtual int Run(int argc, char** argv) = 0;
+
+  // Prints subcommand-specific usage to stderr.
+  virtual void PrintUsage(const char* argv0) = 0;
+};
+
+// Result of FindSubcommandInArgs(). If |subcommand| is non-null, a subcommand
+// was found. |argv_index| is the index of the subcommand name in the original
+// argv.
+struct FindSubcommandResult {
+  Subcommand* subcommand = nullptr;
+  int argv_index = -1;
+};
+
+// Searches |argv[1..argc-1]| for the first positional argument that matches
+// a registered subcommand name. Skips flags (arguments starting with '-') and
+// their required arguments (for flags that take a value).
+//
+// |subcommands| is the list of registered subcommands to match against.
+// |flags_with_arg| is a list of flags that consume the next argv element as
+// their argument (e.g. "--dev-flag" takes a value).
+FindSubcommandResult FindSubcommandInArgs(
+    int argc,
+    char** argv,
+    const std::vector<Subcommand*>& subcommands,
+    const std::vector<std::string>& flags_with_arg);
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_SUBCOMMAND_H_

--- a/test/trace_processor_shell_integrationtest.cc
+++ b/test/trace_processor_shell_integrationtest.cc
@@ -16,7 +16,9 @@
 
 #include <string_view>
 
+#include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/subprocess.h"
+#include "perfetto/ext/base/temp_file.h"
 #include "perfetto/ext/base/utils.h"
 #include "protos/perfetto/trace_processor/trace_processor.gen.h"
 #include "test/gtest_and_gmock.h"
@@ -31,6 +33,7 @@ using CellsBatch = protos::gen::QueryResult::CellsBatch;
 
 using testing::AllOf;
 using testing::ElementsAre;
+using testing::HasSubstr;
 using testing::IsEmpty;
 using testing::Property;
 using testing::SizeIs;
@@ -39,6 +42,158 @@ const std::string_view kSimpleSystrace = R"(# tracer
 surfaceflinger-598   (  598) [004] .... 10852.771242: tracing_mark_write: B|598|some event
 surfaceflinger-598   (  598) [004] .... 10852.771245: tracing_mark_write: E|598
 )";
+
+std::string ShellPath() {
+  return base::GetCurExecutableDir() + "/trace_processor_shell";
+}
+
+// Writes kSimpleSystrace to a temp file and returns the TempFile object.
+base::TempFile WriteSimpleSystrace() {
+  auto f = base::TempFile::Create();
+  base::WriteAll(f.fd(), kSimpleSystrace.data(),
+                 static_cast<size_t>(kSimpleSystrace.size()));
+  return f;
+}
+
+// Writes arbitrary content to a temp file and returns the TempFile object.
+base::TempFile WriteTempFile(const std::string& content) {
+  auto f = base::TempFile::Create();
+  base::WriteAll(f.fd(), content.data(), content.size());
+  return f;
+}
+
+struct SubprocessResult {
+  int exit_code;
+  std::string out;
+};
+
+// Runs trace_processor_shell with the given args. stdout and stderr are both
+// captured into `out`.
+SubprocessResult RunShell(std::initializer_list<std::string> extra_args) {
+  base::Subprocess p;
+  p.args.exec_cmd.push_back(ShellPath());
+  for (const auto& a : extra_args) {
+    p.args.exec_cmd.push_back(a);
+  }
+  p.args.stdin_mode = base::Subprocess::InputMode::kDevNull;
+  p.args.stdout_mode = base::Subprocess::OutputMode::kBuffer;
+  p.args.stderr_mode = base::Subprocess::OutputMode::kBuffer;
+  p.Start();
+  PERFETTO_CHECK(p.Wait(kDefaultTestTimeoutMs));
+  return {p.returncode(), std::move(p.output())};
+}
+
+// ---------------------------------------------------------------------------
+// Classic CLI backcompat tests
+// ---------------------------------------------------------------------------
+
+TEST(TraceProcessorShellIntegrationTest, ClassicVersion) {
+  auto result = RunShell({"-v"});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("Trace Processor RPC API version"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicHelp) {
+  auto result = RunShell({"-h"});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("Interactive trace processor shell"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicUnknownFlag) {
+  auto result = RunShell({"--nonexistent"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicQueryString) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"-Q", "SELECT 1 AS x", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("x"));
+  EXPECT_THAT(result.out, HasSubstr("1"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicQueryFile) {
+  auto trace = WriteSimpleSystrace();
+  auto query = WriteTempFile("SELECT 42 AS val;");
+  auto result = RunShell({"-q", query.path(), trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("val"));
+  EXPECT_THAT(result.out, HasSubstr("42"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicQueryStringNoTrace) {
+  auto result = RunShell({"-Q", "SELECT 1"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicQueryFileBadPath) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"-q", "/nonexistent.sql", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicFullSort) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"--full-sort", "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicNoFtraceRaw) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"--no-ftrace-raw", "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicCropTrackEvents) {
+  auto trace = WriteSimpleSystrace();
+  auto result =
+      RunShell({"--crop-track-events", "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicAnalyzeProtoContent) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell(
+      {"--analyze-trace-proto-content", "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicExport) {
+  auto trace = WriteSimpleSystrace();
+  auto out_db = base::TempFile::Create();
+  auto result = RunShell({"-e", out_db.path(), trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_TRUE(base::FileExists(out_db.path()));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicSummary) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"--summary", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicDev) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"--dev", "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicExtraChecks) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"--extra-checks", "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicSummaryAndMetricsConflict) {
+  auto trace = WriteSimpleSystrace();
+  auto result =
+      RunShell({"--summary", "--run-metrics", "android_cpu", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Existing RPC test
+// ---------------------------------------------------------------------------
 
 TEST(TraceProcessorShellIntegrationTest, StdioSimpleRequestResponse) {
   TraceProcessorRpcStream req;


### PR DESCRIPTION
Part of RFC 0018 (subcommand CLI for trace_processor_shell).

Add comprehensive integration tests covering the entire classic CLI
surface (version, help, query, export, parsing flags, dev flags, and
mutual exclusion checks) to lock down backcompat before introducing
subcommands. Also add the Subcommand base class and FindSubcommandInArgs
function with unit tests as the foundation for subcommand dispatch.
