### PR TITLE
stdlib: add lock name to android_monitor_contention

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/monitor_contention.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/monitor_contention.sql
@@ -137,7 +137,8 @@ WHERE
 GROUP BY
   slice.id;
 
--- Contains parsed monitor contention slices.
+-- Contains parsed Java monitor contention slices, detailing the blocking and blocked
+-- threads, methods involved, and the duration of the contention.
 CREATE PERFETTO TABLE android_monitor_contention (
   -- Name of the method holding the lock.
   blocking_method STRING,
@@ -192,8 +193,51 @@ CREATE PERFETTO TABLE android_monitor_contention (
   -- Tid of binder reply slice if lock contention was part of a binder txn.
   binder_reply_tid LONG,
   -- Pid of process experiencing lock contention.
-  pid LONG
+  pid LONG,
+  -- Extracted lock name from surrounding slices.
+  lock_name STRING
 ) AS
+WITH
+  all_slices_on_contention_tracks AS (
+    SELECT
+      s.id,
+      s.track_id,
+      s.ts,
+      s.name,
+      lag(s.name) OVER (PARTITION BY s.track_id ORDER BY s.ts) AS prev_name,
+      lead(s.name) OVER (PARTITION BY s.track_id ORDER BY s.ts) AS next_name
+    FROM slice AS s
+    WHERE
+      s.track_id IN (
+        SELECT DISTINCT
+          track_id
+        FROM slice
+        WHERE
+          id IN (
+            SELECT
+              *
+            FROM _valid_android_monitor_contention
+          )
+      )
+  ),
+  contention_lock_names AS (
+    SELECT
+      id,
+      CASE
+        WHEN prev_name GLOB '*_lock_acquire'
+        AND next_name GLOB '*_lock_held'
+        AND replace(prev_name, '_lock_acquire', '') = replace(next_name, '_lock_held', '')
+        THEN replace(prev_name, '_lock_acquire', '')
+        ELSE NULL
+      END AS lock_name
+    FROM all_slices_on_contention_tracks
+    WHERE
+      id IN (
+        SELECT
+          *
+        FROM _valid_android_monitor_contention
+      )
+  )
 SELECT
   android_extract_android_monitor_contention_blocking_method(slice.name) AS blocking_method,
   android_extract_android_monitor_contention_blocked_method(slice.name) AS blocked_method,
@@ -221,7 +265,8 @@ SELECT
   binder_reply.id AS binder_reply_id,
   binder_reply.ts AS binder_reply_ts,
   binder_reply_thread.tid AS binder_reply_tid,
-  process.pid
+  process.pid,
+  cln.lock_name
 FROM slice
 JOIN thread_track
   ON thread_track.id = slice.track_id
@@ -241,6 +286,8 @@ LEFT JOIN thread AS blocking_thread
   ON blocking_thread.tid = blocking_tid AND blocking_thread.upid = thread.upid
 JOIN _valid_android_monitor_contention
   ON _valid_android_monitor_contention.id = slice.id
+LEFT JOIN contention_lock_names AS cln
+  ON slice.id = cln.id
 WHERE
   slice.name GLOB 'monitor contention*'
   AND slice.dur != -1
@@ -361,7 +408,9 @@ CREATE PERFETTO TABLE android_monitor_contention_chain (
   -- Pid of process experiencing lock contention.
   pid LONG,
   -- Id of monitor contention slice blocked by this contention.
-  child_id LONG
+  child_id LONG,
+  -- Extracted lock name from surrounding slices.
+  lock_name STRING
 ) AS
 SELECT
   NULL AS parent_id,


### PR DESCRIPTION
This change adds lock name to android_ monitor_contention table: if a slice `monitor contention*` is surrounded by `${name}_lock_acquire` on left and `${name}_lock_held` on right, then we have contention on `${name}` lock (at the moment just for big locks: ams, proc, wms, pms).
