### PR TITLE
stdlib: _normalize_event_channel special case

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/input.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/input.sql
@@ -282,6 +282,9 @@ CREATE PERFETTO FUNCTION _normalize_event_channel(
 RETURNS STRING AS
 SELECT
   CASE
+    -- '[Gesture Monitor] swipe-up' -> '[Gesture Monitor] swipe-up'
+    WHEN $event_channel GLOB '[[]*] *'
+    THEN $event_channel
     -- 'ccf6448 PopupWindow:b20fb4d' -> 'PopupWindow'
     WHEN $event_channel GLOB '* *:*'
     THEN trim(substr(str_split($event_channel, ':', 0), instr($event_channel, ' ') + 1))


### PR DESCRIPTION
This change modifies the function _normalize_event_channel to treat this channel name `[Gesture Monitor] swipe-up`, which normalized should be the same. 
The old version returned `Monitor] swipe-up`.
