### PR TITLE
de: Change behaviour when adding to node with undocked child

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/node_crud_operations.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/node_crud_operations.ts
@@ -24,9 +24,9 @@ import {
   insertNodeBetween,
   getInputNodeAtPort,
   getAllInputNodes,
+  isNodeUndocked,
   findDockedChildren,
-  calculateUndockLayouts,
-  getEffectiveLayout,
+  applyUndockLayouts,
   addConnection,
   removeConnection,
   notifyNextNodes,
@@ -134,13 +134,43 @@ export async function addOperationNode(
     deps.initializedNodes.add(newNode.nodeId);
 
     if (singleNodeOperation(newNode.type)) {
-      // For single-input operations: insert between the target and its children
-      insertNodeBetween(parentNode, newNode, addConnection, removeConnection);
+      // Check if parent has any undocked (detached) children.
+      // If so, the new node should also be undocked rather than inserted
+      // between the parent and its children.
+      const hasUndockedChildren = parentNode.nextNodes.some((child) =>
+        isNodeUndocked(child, state.nodeLayouts),
+      );
 
-      deps.onStateUpdate((currentState) => ({
-        ...currentState,
-        selectedNodes: new Set([newNode.nodeId]),
-      }));
+      if (hasUndockedChildren) {
+        // Capture docked children before modifying connections — they need
+        // to be undocked since docking only works with a single child.
+        const dockedChildren = findDockedChildren(
+          parentNode,
+          state.nodeLayouts,
+        );
+
+        addConnection(parentNode, newNode);
+
+        deps.onStateUpdate((currentState) => ({
+          ...currentState,
+          // Undock docked children and position the new node, staggered
+          // after them so nothing overlaps.
+          nodeLayouts: applyUndockLayouts(
+            parentNode,
+            [...dockedChildren, newNode],
+            currentState.nodeLayouts,
+          ),
+          selectedNodes: new Set([newNode.nodeId]),
+        }));
+      } else {
+        // No undocked children: insert between the target and its children
+        insertNodeBetween(parentNode, newNode, addConnection, removeConnection);
+
+        deps.onStateUpdate((currentState) => ({
+          ...currentState,
+          selectedNodes: new Set([newNode.nodeId]),
+        }));
+      }
     } else {
       // For multi-source nodes: just connect and add to root nodes
       // Don't insert in-between - the node combines multiple sources
@@ -150,34 +180,16 @@ export async function addOperationNode(
 
       addConnection(parentNode, newNode);
 
-      deps.onStateUpdate((currentState) => {
-        const updatedLayouts = new Map(currentState.nodeLayouts);
-
-        // Undock existing docked children by giving them layouts.
-        // Use getEffectiveLayout to handle the case where the parent node is
-        // itself docked (no direct layout) - we walk up the chain to find
-        // the first ancestor with a layout.
-        const effectiveLayout = getEffectiveLayout(
+      deps.onStateUpdate((currentState) => ({
+        ...currentState,
+        rootNodes: [...currentState.rootNodes, newNode],
+        nodeLayouts: applyUndockLayouts(
           parentNode,
+          dockedChildren,
           currentState.nodeLayouts,
-        );
-        if (effectiveLayout !== undefined && dockedChildren.length > 0) {
-          const undockLayouts = calculateUndockLayouts(
-            dockedChildren,
-            effectiveLayout,
-          );
-          for (const [nodeId, layout] of undockLayouts) {
-            updatedLayouts.set(nodeId, layout);
-          }
-        }
-
-        return {
-          ...currentState,
-          rootNodes: [...currentState.rootNodes, newNode],
-          nodeLayouts: updatedLayouts,
-          selectedNodes: new Set([newNode.nodeId]),
-        };
-      });
+        ),
+        selectedNodes: new Set([newNode.nodeId]),
+      }));
     }
 
     return newNode;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph_utils.ts
@@ -305,6 +305,18 @@ export function getAllInputNodes(node: QueryNode): QueryNode[] {
 // ============================================================================
 
 /**
+ * Returns true if a node is undocked (has an explicit layout position).
+ * Undocked nodes are rendered as separate graph nodes rather than inline
+ * with their parent's chain.
+ */
+export function isNodeUndocked(
+  node: QueryNode,
+  nodeLayouts: ReadonlyMap<string, {x: number; y: number}>,
+): boolean {
+  return nodeLayouts.has(node.nodeId);
+}
+
+/**
  * Finds children of a node that are currently docked (rendered inline with parent).
  *
  * A child is considered docked if:
@@ -386,6 +398,45 @@ export function calculateUndockLayouts(
   }
 
   return layouts;
+}
+
+/**
+ * Computes updated layout positions that undock the given children from a
+ * parent node.  Merges the new positions into `existingLayouts` and returns
+ * the updated map.
+ *
+ * This is the shared logic used whenever we need to convert docked children
+ * into undocked ones (e.g. when adding a new sibling node or a multi-source
+ * node).
+ *
+ * @param parentNode      The parent whose children are being undocked.
+ * @param childrenToUndock Nodes that need explicit layout positions.
+ * @param existingLayouts  Current layout map (will be shallow-copied).
+ * @returns A new Map with the undock positions merged in, or the original map
+ *          if no positions could be computed (parent has no effective layout).
+ */
+export function applyUndockLayouts(
+  parentNode: QueryNode,
+  childrenToUndock: QueryNode[],
+  existingLayouts: ReadonlyMap<string, {x: number; y: number}>,
+): Map<string, {x: number; y: number}> {
+  const updatedLayouts = new Map(existingLayouts);
+  if (childrenToUndock.length === 0) {
+    return updatedLayouts;
+  }
+
+  const effectiveLayout = getEffectiveLayout(parentNode, existingLayouts);
+  if (effectiveLayout !== undefined) {
+    const undockLayouts = calculateUndockLayouts(
+      childrenToUndock,
+      effectiveLayout,
+    );
+    for (const [nodeId, layout] of undockLayouts) {
+      updatedLayouts.set(nodeId, layout);
+    }
+  }
+
+  return updatedLayouts;
 }
 
 // ============================================================================


### PR DESCRIPTION
When adding a single-input operation to a node that already has undocked
children, the new node is now also undocked and positioned alongside them
instead of being inserted between the parent and its children. This prevents
the confusing situation where a new node would "absorb" all existing children
of a parent that already has a branching layout.