### PR TITLE
de: Fix filter during slowness

### DIFF
--- a/src/trace_processor/trace_summary/summarizer.cc
+++ b/src/trace_processor/trace_summary/summarizer.cc
@@ -638,39 +638,49 @@ base::Status SummarizerImpl::Query(const std::string& query_id,
 
   // Lazy materialization: materialize if needed.
   if (state->needs_materialization) {
-    // Prepare the generator ONCE (adds all queries, executes
-    // modules/preambles).
-    StructuredQueryGenerator generator;
-    std::vector<std::vector<uint8_t>> table_source_protos;
-    auto prepare_status = PrepareGenerator(generator, table_source_protos);
-    if (!prepare_status.ok()) {
-      state->error = prepare_status.message();
-      return prepare_status;
-    }
-
-    // Materialize dependencies first.
+    // Materialize dependencies and target in topological order. Each step
+    // gets a fresh generator so that already-materialized deps appear as
+    // table-sources rather than being re-evaluated inline. This ensures each
+    // piece of SQL is executed exactly once, even in cold-start scenarios
+    // where no deps are pre-materialized.
     auto deps = CollectDependencies(query_id);
     for (const auto& dep_id : deps) {
-      if (dep_id == query_id) {
-        continue;  // Handle the target query last.
-      }
       QueryState* dep_state = query_states_.Find(dep_id);
-      if (dep_state && dep_state->needs_materialization) {
-        auto status = MaterializeQuery(dep_id, *dep_state, generator);
-        if (!status.ok()) {
-          // Dependency failed - propagate error.
-          state->error =
-              "Dependency '" + dep_id + "' failed: " + status.message();
-          state->needs_materialization = false;
-        }
+      if (!dep_state || !dep_state->needs_materialization) {
+        continue;
       }
-    }
 
-    // Now materialize the target query (if dependencies succeeded).
-    if (!state->error) {
-      auto status = MaterializeQuery(query_id, *state, generator);
+      // Fresh generator: reflects all deps materialized so far.
+      // NOTE: |gen_protos| owns the backing memory for table-source protos
+      // added to |gen| — both must stay alive through MaterializeQuery().
+      StructuredQueryGenerator gen;
+      std::vector<std::vector<uint8_t>> gen_protos;
+      auto prepare_status = PrepareGenerator(gen, gen_protos);
+      if (!prepare_status.ok()) {
+        state->error = prepare_status.message();
+        return prepare_status;
+      }
+
+      bool is_target = (dep_id == query_id);
+      // CollectDependencies returns deps in topological order with query_id
+      // always last, so is_target should only be true for the final element.
+      if (is_target && dep_id != deps.back()) {
+        return base::ErrStatus(
+            "Internal error: target query '%s' is not last in dependency order",
+            query_id.c_str());
+      }
+      auto status = MaterializeQuery(dep_id, *dep_state, gen);
       if (!status.ok()) {
-        return status;
+        if (is_target) {
+          return status;
+        }
+        // Dependency failed - propagate error to target and stop.
+        // Note: the failed dep retains needs_materialization=true so a
+        // direct Query() on it will retry (in case of transient errors).
+        state->error =
+            "Dependency '" + dep_id + "' failed: " + status.message();
+        state->needs_materialization = false;
+        break;
       }
     }
   }

--- a/src/trace_processor/trace_summary/summarizer.h
+++ b/src/trace_processor/trace_summary/summarizer.h
@@ -101,8 +101,13 @@ class SummarizerImpl : public Summarizer {
   // Collects all dependencies for a query (in materialization order).
   std::vector<std::string> CollectDependencies(const std::string& query_id);
 
-  // Prepares the generator for materialization (adds queries, executes modules
-  // and preambles). Called once per Query() invocation.
+  // Prepares a StructuredQueryGenerator for materialization. The generator
+  // translates structured query protos into executable SQL. For queries whose
+  // results are already materialized, it substitutes a table-source reference
+  // (e.g. SELECT * FROM _exp_mat_X) so the SQL is not re-evaluated.
+  //
+  // Called once per dependency during Query() — each call creates a fresh
+  // generator that reflects the deps materialized so far.
   base::Status PrepareGenerator(
       perfetto_sql::generator::StructuredQueryGenerator& generator,
       std::vector<std::vector<uint8_t>>& table_source_protos);

--- a/src/trace_processor/trace_summary/summarizer_unittest.cc
+++ b/src/trace_processor/trace_summary/summarizer_unittest.cc
@@ -621,5 +621,57 @@ TEST_F(SummarizerTest, NestedEmbeddedQueryDependencyPropagation) {
   EXPECT_EQ(info_c2.row_count, 1);
 }
 
+// Tests that when query B depends on A via inner_query_id and neither is
+// pre-materialized, querying B directly (without first querying A) generates
+// SQL that references A's materialized table (_exp_mat_X) rather than inlining
+// A's SQL. This prevents expensive deps from being re-evaluated (e.g.
+// interval_merge_overlapping! evaluating android_startups twice).
+TEST_F(SummarizerTest, FreshDepUsesTableSourceInTargetSQL) {
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec_proto;
+
+  // Query A: expensive SQL (simulated).
+  {
+    auto* query = spec_proto->add_query();
+    query->set_id("A");
+    auto* sql_source = query->set_sql();
+    sql_source->set_sql("SELECT 1 as value UNION ALL SELECT 2 as value");
+    sql_source->add_column_names("value");
+  }
+
+  // Query B: depends on A via inner_query_id.
+  {
+    auto* query = spec_proto->add_query();
+    query->set_id("B");
+    query->set_inner_query_id("A");
+    auto* filter = query->add_filters();
+    filter->set_column_name("value");
+    filter->set_op(
+        protos::pbzero::PerfettoSqlStructuredQuery::Filter::GREATER_THAN);
+    filter->add_int64_rhs(0);
+  }
+
+  auto spec_data = spec_proto.SerializeAsArray();
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  // Query B WITHOUT first querying A (i.e. A is not pre-materialized).
+  SummarizerQueryResult info_b;
+  ASSERT_OK(summarizer_->Query("B", &info_b));
+  ASSERT_TRUE(info_b.exists);
+  EXPECT_EQ(info_b.row_count, 2);  // Both rows pass value > 0.
+
+  // B's execution SQL must reference A's materialized table (_exp_mat_X)
+  // rather than inlining A's SQL. This is the key invariant: the fix creates
+  // a fresh generator for the target that sees A as a table-source.
+  EXPECT_THAT(info_b.sql, HasSubstr("_exp_mat_"));
+
+  // Verify A was materialized as a side-effect of querying B.
+  SummarizerQueryResult info_a;
+  ASSERT_OK(summarizer_->Query("A", &info_a));
+  ASSERT_TRUE(info_a.exists);
+  EXPECT_EQ(info_a.row_count, 2);
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::summary


### PR DESCRIPTION
Fix cold-start materialization to avoid re-evaluating expensive dependency SQL.
When a query and its dependencies are both unmaterialized, the old code used a
single shared generator — so deps were inlined into the target's SQL rather than
being referenced as materialized tables. This caused expensive queries (e.g.
`interval_merge_overlapping!`) to be evaluated multiple times.

The fix creates a fresh `StructuredQueryGenerator` for each step in topological
order, so each newly-materialized dep appears as a table-source
(`_exp_mat_X`) in subsequent steps.