### PR TITLE
de: Fix args extracting

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -400,6 +400,18 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       nodeCrudDeps.nodeActionHandlers,
     );
 
+    // Provide getTableNameForNode callback so nodes can query materialized
+    // tables from the execution service (e.g., for fetching arg keys).
+    const executionService = this.queryExecutionService;
+    if (executionService !== undefined) {
+      for (const node of allNodes) {
+        if (node.state.getTableNameForNode === undefined) {
+          node.state.getTableNameForNode = (nodeId: string) =>
+            executionService.getTableName(nodeId);
+        }
+      }
+    }
+
     // Auto-initialize high-importance tables on first render when state is empty
     // Never load base JSON if we've already initialized in this session (even after clearing nodes)
     if (state.rootNodes.length === 0 && !attrs.hasAutoInitialized) {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
@@ -22,7 +22,6 @@ import {nodeRegistry} from './query_builder/node_registry';
 import {QueryNodeState} from './query_node';
 import {deserializeState, serializeState} from './json_handler';
 import {recentGraphsStorage} from './recent_graphs';
-import {resetAnalyzeNodeSummarizer} from './query_builder/query_builder_utils';
 
 const STORE_VERSION = 1;
 
@@ -191,9 +190,6 @@ export default class implements PerfettoPlugin {
   }
 
   async onTraceLoad(trace: Trace): Promise<void> {
-    // Reset module-level state from previous traces to prevent stale IDs.
-    resetAnalyzeNodeSummarizer();
-
     trace.pages.registerPage({
       route: '/explore',
       render: () => {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -227,9 +227,10 @@ export function registerCoreNodes() {
       };
       return new AddColumnsNode(fullState);
     },
-    deserialize: (state, _trace, sqlModules) =>
+    deserialize: (state, trace, sqlModules) =>
       new AddColumnsNode(
         AddColumnsNode.deserializeState(
+          trace,
           sqlModules,
           state as AddColumnsNodeState,
         ),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_node.ts
@@ -19,7 +19,6 @@ import {
   SecondaryInputSpec,
 } from '../../query_node';
 import {getSecondaryInput} from '../graph_utils';
-import {analyzeNode, isAQuery} from '../query_builder_utils';
 import {
   ColumnInfo,
   columnInfoFromName,
@@ -44,6 +43,7 @@ import {setValidationError} from '../node_issues';
 import {EmptyState} from '../../../../widgets/empty_state';
 import {Callout} from '../../../../widgets/callout';
 import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
+import {Trace} from '../../../../public/trace';
 import {Form, FormSection} from '../../../../widgets/form';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
 import {NodeDetailsMessage, ColumnName} from '../node_styling_widgets';
@@ -235,6 +235,11 @@ export class AddColumnsNode implements QueryNode {
       return undefined; // Empty names are handled by isComputedColumnValid
     }
 
+    // Reject names that aren't valid SQL identifiers (alphanumeric + underscore)
+    if (/[^a-zA-Z0-9_]/.test(trimmedName)) {
+      return 'Column name can only contain letters, numbers, and underscores';
+    }
+
     // Check against source columns (use alias if present, otherwise column name)
     for (const c of this.sourceCols) {
       const effectiveName = c.alias ?? c.column.name;
@@ -316,21 +321,27 @@ export class AddColumnsNode implements QueryNode {
     );
   }
 
-  // Fetch available arg keys for the given arg_set_id column
+  // Fetch available arg keys for the given arg_set_id column.
+  // Uses the primary input's materialized table from the execution service
+  // to avoid creating a competing summarizer (which would conflict with
+  // the main QueryExecutionService's materialized tables).
   async fetchAvailableArgKeys(argSetIdCol: ColumnInfo): Promise<string[]> {
     const trace = this.state.trace;
     if (!trace) return [];
 
-    // We need to analyze the current node to get the SQL query
-    // that includes the arg_set_id column
-    const query = await analyzeNode(this, trace.engine);
-    if (!isAQuery(query)) return [];
+    const primaryInput = this.primaryInput;
+    if (!primaryInput) return [];
 
-    // Query for distinct arg keys using the current data
+    // Get the materialized table name for the primary input node
+    const tableName = await this.state.getTableNameForNode?.(
+      primaryInput.nodeId,
+    );
+    if (!tableName) return [];
+
     const argColName = argSetIdCol.column.name;
     const sql = `
       SELECT DISTINCT args.flat_key as key
-      FROM (${query.sql}) data
+      FROM ${tableName} data
       JOIN args ON args.arg_set_id = data.${argColName}
       ORDER BY key
     `;
@@ -343,7 +354,8 @@ export class AddColumnsNode implements QueryNode {
         keys.push(it.key);
       }
       return keys;
-    } catch {
+    } catch (e) {
+      console.warn('fetchAvailableArgKeys: query failed', e);
       return [];
     }
   }
@@ -885,7 +897,7 @@ export class AddColumnsNode implements QueryNode {
                     // Auto-generate column name from key (replace special chars)
                     if (selectedKey && !columnName) {
                       columnName = selectedKey
-                        .replace(/[.\[\]]/g, '_')
+                        .replace(/[^a-zA-Z0-9_]/g, '_')
                         .replace(/_+/g, '_')
                         .replace(/^_|_$/g, '');
                     }
@@ -901,7 +913,7 @@ export class AddColumnsNode implements QueryNode {
                       // Auto-generate column name from key (replace special chars)
                       if (selectedKey && !columnName) {
                         columnName = selectedKey
-                          .replace(/[.\[\]]/g, '_')
+                          .replace(/[^a-zA-Z0-9_]/g, '_')
                           .replace(/_+/g, '_')
                           .replace(/^_|_$/g, '');
                       }
@@ -1734,11 +1746,13 @@ export class AddColumnsNode implements QueryNode {
   }
 
   static deserializeState(
+    trace: Trace,
     sqlModules: SqlModules,
     serializedState: AddColumnsNodeState,
   ): AddColumnsNodeState {
     return {
       ...serializedState,
+      trace,
       sqlModules,
       suggestionSelections:
         (serializedState.suggestionSelections as unknown as Record<

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/query_builder_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/query_builder_utils.ts
@@ -14,9 +14,7 @@
 
 import protos from '../../../protos';
 import {QueryResponse} from '../../../components/query_table/queries';
-import {Engine} from '../../../trace_processor/engine';
 import {stringifyJsonWithBigints} from '../../../base/json_utils';
-import {uuidv4Sql} from '../../../base/uuid';
 import {Query, QueryNode} from '../query_node';
 import {SqlSourceNode} from './nodes/sources/sql_source';
 
@@ -159,91 +157,6 @@ export function hashNodeQuery(node: QueryNode): string | Error {
   // Protobuf objects have stable field ordering, making this deterministic.
   // Uses bigint-safe stringify to handle bigint values correctly.
   return stringifyJsonWithBigints(sq);
-}
-
-// Server-generated summarizer ID for analyzeNode operations.
-// This is module-level state that persists across the session.
-// Call resetAnalyzeNodeSummarizer() when loading a new trace to clear stale state.
-let analyzeNodeSummarizerId: string | undefined = undefined;
-
-/**
- * Resets the analyzeNode summarizer ID. Must be called when loading a new trace
- * to ensure stale summarizer IDs from previous traces are not reused.
- */
-export function resetAnalyzeNodeSummarizer(): void {
-  analyzeNodeSummarizerId = undefined;
-}
-
-// Analyzes a node's query via sync + fetch, returns generated SQL.
-export async function analyzeNode(
-  node: QueryNode,
-  engine: Engine,
-): Promise<Query | Error> {
-  const structuredQueries = getStructuredQueries(node);
-  if (structuredQueries instanceof Error) {
-    return structuredQueries;
-  }
-
-  if (structuredQueries.length === 0) {
-    return new Error('No structured queries to analyze');
-  }
-
-  // Build a TraceSummarySpec containing all the queries
-  const spec = new protos.TraceSummarySpec();
-  spec.query = structuredQueries;
-
-  // Use the node's ID as the query ID. The node's ID is set as the query's id
-  // field when the node builds its structured query.
-  const queryId = node.nodeId;
-
-  // Create the summarizer if it doesn't exist yet
-  if (analyzeNodeSummarizerId === undefined) {
-    const newId = `analyze_summarizer_${uuidv4Sql()}`;
-    const createRes = await engine.createSummarizer(newId);
-    if (
-      createRes.error !== undefined &&
-      createRes.error !== null &&
-      createRes.error !== ''
-    ) {
-      return new Error(createRes.error);
-    }
-    analyzeNodeSummarizerId = newId;
-  }
-
-  // Update the spec with our queries
-  const updateRes = await engine.updateSummarizerSpec(
-    analyzeNodeSummarizerId,
-    spec,
-  );
-  if (
-    updateRes.error !== undefined &&
-    updateRes.error !== null &&
-    updateRes.error !== ''
-  ) {
-    return new Error(updateRes.error);
-  }
-
-  // Query the summarizer for this node (materializes on demand)
-  const res = await engine.querySummarizer(analyzeNodeSummarizerId, queryId);
-  if (!res.exists) {
-    return new Error(
-      `Query '${queryId}' does not exist after updateSummarizerSpec`,
-    );
-  }
-  if (res.error !== undefined && res.error !== null && res.error !== '') {
-    return new Error(res.error);
-  }
-  if (res.sql === null || res.sql === undefined || res.sql === '') {
-    return new Error(
-      `analyzeNode: engine returned no SQL for node ${node.nodeId}`,
-    );
-  }
-
-  return {
-    sql: res.sql,
-    textproto: res.textproto ?? '',
-    standaloneSql: res.standaloneSql ?? '',
-  };
 }
 
 // Type guard for valid Query object.

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -133,6 +133,10 @@ export interface QueryNodeState {
   // Actions that can be performed on the parent graph
   actions?: NodeActions;
 
+  // Returns the materialized table name for a given node ID.
+  // Set by the parent component using the QueryExecutionService.
+  getTableNameForNode?: (nodeId: string) => Promise<string | undefined>;
+
   // Caching
   hasOperationChanged?: boolean;
 


### PR DESCRIPTION
Fix arg key fetching in AddColumnsNode to use the parent component's
materialized tables from QueryExecutionService, instead of creating a
competing summarizer via `analyzeNode`. This resolves conflicts between
the node-level summarizer and the main execution service's materialized
tables, and eliminates module-level mutable state that required manual
resets across trace loads.
