### PR TITLE
Minor fixes to tools/release/ scripts

### DIFF
--- a/tools/gen_amalgamated
+++ b/tools/gen_amalgamated
@@ -598,9 +598,8 @@ Example build command:
     library = self._get_nice_path(output_prefix, 'lib%s.so')
 
     if sys.platform.startswith('linux') and not system_buildtools:
-      llvm_script = os.path.join(gn_utils.repo_root(), 'gn', 'standalone',
-                                 'toolchain', 'linux_find_llvm.py')
-      cxx = subprocess.check_output([llvm_script]).splitlines()[2].decode()
+      cxx = os.path.join(gn_utils.repo_root(),
+                         'buildtools/linux64/clang/bin/clang++')
     else:
       cxx = 'clang++'
 

--- a/tools/release/roll-prebuilts
+++ b/tools/release/roll-prebuilts
@@ -35,7 +35,8 @@ from concurrent.futures import ThreadPoolExecutor
 
 GCS_URL = 'https://commondatastorage.googleapis.com/perfetto-luci-artifacts'
 
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROOT_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 MANIFESTS_DIR = os.path.join(ROOT_DIR, 'python/perfetto/prebuilts/manifests')
 
 UNIX_ARCHS = [
@@ -135,6 +136,12 @@ def update_manifest(git_revision, tool_name, archs):
   os.chmod(out_file, 0o755)
 
 
+def run_cmd(cmd):
+  print('Running ', cmd)
+  cmd_path = os.path.join(ROOT_DIR, cmd)
+  subprocess.check_call(cmd_path)
+
+
 def main():
   usage = '%s v20.0 | 0a1b2c3d\n\n' % __file__
   usage += 'To list available revisions run\n'
@@ -148,6 +155,9 @@ def main():
   for spec in MANIFESTS_TO_UPDATE:
     logging.info('Updating %s', spec['tool'])
     update_manifest(git_revision, spec['tool'], spec['archs'])
+
+  run_cmd('tools/gen_amalgamated_python_tools')
+  run_cmd('tools/format-sources')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fix gen_amalgmated to actually use the hermetic compiler
  unless the system_buildtools is used. find_llvm finds the
  NON-hermetic toolchain, and can fail if clang is not installed
  by default.
- Fix ROOT_DIR after roll-prebuilts was moved
- Also run gen_amalgamated + format-sources after rolling the
  prebuilds. The current script relies on the git upload-hook to
  find that issue and is just wasting time.