### PR TITLE
de: Add Trace Summary node

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -406,51 +406,52 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
             icon: 'info',
             title: `${attrs.selectedNodes.size} nodes selected`,
           })
-        : selectedNode
-          ? m(DataExplorer, {
-              trace: this.trace,
-              query: this.query,
-              node: selectedNode,
-              response: this.response,
-              dataSource: this.dataSource,
-              sqlModules: attrs.sqlModules,
-              queryExecutionService: this.queryExecutionService,
-              isQueryRunning: this.isQueryRunning,
-              isAnalyzing: this.isAnalyzing,
-              isStale: this.queryExecutionService.isNodeStale(
-                selectedNode.nodeId,
-              ),
-              onchange: () => {
-                attrs.onNodeStateChange?.();
-              },
-              onFilterAdd: (filter, filterOperator) => {
-                attrs.onFilterAdd(selectedNode, filter, filterOperator);
-              },
-              onColumnAdd: attrs.onColumnAdd
-                ? (column) => attrs.onColumnAdd?.(selectedNode, column)
-                : undefined,
-              isFullScreen:
-                this.drawerVisibility === DrawerPanelVisibility.FULLSCREEN,
-              onFullScreenToggle: () => {
-                if (
-                  this.drawerVisibility === DrawerPanelVisibility.FULLSCREEN
-                ) {
-                  this.drawerVisibility = DrawerPanelVisibility.VISIBLE;
-                } else {
-                  this.drawerVisibility = DrawerPanelVisibility.FULLSCREEN;
-                }
-              },
-              onExecute: async () => {
-                await this.executeSelectedNode();
-              },
-              onExportToTimeline: async () => {
-                await this.exportToTimeline(selectedNode);
-              },
-            })
-          : m(DataExplorerEmptyState, {
-              icon: 'info',
-              title: 'Select a node to see the data',
-            }),
+        : selectedNode?.customDataExplorer?.() ??
+          (selectedNode
+            ? m(DataExplorer, {
+                trace: this.trace,
+                query: this.query,
+                node: selectedNode,
+                response: this.response,
+                dataSource: this.dataSource,
+                sqlModules: attrs.sqlModules,
+                queryExecutionService: this.queryExecutionService,
+                isQueryRunning: this.isQueryRunning,
+                isAnalyzing: this.isAnalyzing,
+                isStale: this.queryExecutionService.isNodeStale(
+                  selectedNode.nodeId,
+                ),
+                onchange: () => {
+                  attrs.onNodeStateChange?.();
+                },
+                onFilterAdd: (filter, filterOperator) => {
+                  attrs.onFilterAdd(selectedNode, filter, filterOperator);
+                },
+                onColumnAdd: attrs.onColumnAdd
+                  ? (column) => attrs.onColumnAdd?.(selectedNode, column)
+                  : undefined,
+                isFullScreen:
+                  this.drawerVisibility === DrawerPanelVisibility.FULLSCREEN,
+                onFullScreenToggle: () => {
+                  if (
+                    this.drawerVisibility === DrawerPanelVisibility.FULLSCREEN
+                  ) {
+                    this.drawerVisibility = DrawerPanelVisibility.VISIBLE;
+                  } else {
+                    this.drawerVisibility = DrawerPanelVisibility.FULLSCREEN;
+                  }
+                },
+                onExecute: async () => {
+                  await this.executeSelectedNode();
+                },
+                onExportToTimeline: async () => {
+                  await this.exportToTimeline(selectedNode);
+                },
+              })
+            : m(DataExplorerEmptyState, {
+                icon: 'info',
+                title: 'Select a node to see the data',
+              })),
       mainContent: [
         m(
           '.pf-qb-node-graph',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -78,6 +78,11 @@ import {
   MetricsSerializedState,
 } from './nodes/metrics_node';
 import {
+  TraceSummaryNode,
+  TraceSummaryNodeState,
+  TraceSummarySerializedState,
+} from './nodes/trace_summary_node';
+import {
   VisualisationNode,
   VisualisationNodeState,
 } from './nodes/visualisation_node';
@@ -574,7 +579,7 @@ export function registerCoreNodes() {
     icon: 'analytics',
     type: 'modification',
     nodeType: NodeType.kMetrics,
-    allowedChildren: [],
+    allowedChildren: ['trace_summary'],
     factory: (state) => new MetricsNode(state as MetricsNodeState),
     deserialize: (state, trace, sqlModules) =>
       new MetricsNode({
@@ -598,6 +603,38 @@ export function registerCoreNodes() {
         ...VisualisationNode.deserializeState(state as VisualisationNodeState),
         sqlModules,
       }),
+  });
+
+  nodeRegistry.register('trace_summary', {
+    name: 'Trace Summary',
+    description:
+      'Bundle multiple metrics into a single trace summary specification.',
+    icon: 'summarize',
+    type: 'multisource',
+    nodeType: NodeType.kTraceSummary,
+    allowedChildren: [],
+    factory: (state) => new TraceSummaryNode(state as TraceSummaryNodeState),
+    deserialize: (state, trace) =>
+      new TraceSummaryNode({
+        ...TraceSummaryNode.deserializeState(
+          state as TraceSummarySerializedState,
+        ),
+        trace,
+      }),
+    deserializeConnections: (node, state, allNodes) => {
+      const traceSummaryNode = node as TraceSummaryNode;
+      const conns = TraceSummaryNode.deserializeConnections(
+        allNodes,
+        state as {secondaryInputNodeIds?: string[]},
+      );
+      traceSummaryNode.secondaryInputs.connections.clear();
+      for (let i = 0; i < conns.secondaryInputNodes.length; i++) {
+        traceSummaryNode.secondaryInputs.connections.set(
+          i,
+          conns.secondaryInputNodes[i],
+        );
+      }
+    },
   });
 
   // Set the default allowed children for all nodes.

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -100,6 +100,15 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
 
     const sq = node.getStructuredQuery();
     if (sq === undefined) {
+      // Some nodes (e.g. TraceSummary) intentionally don't produce a
+      // structured query. If the node validates, treat it as a no-op.
+      if (node.validate()) {
+        this.currentQuery = undefined;
+        this.prevSqString = undefined;
+        attrs.onQueryAnalyzed(undefined);
+        attrs.onAnalysisStateChange?.(false);
+        return;
+      }
       // Report error instead of silently returning
       const error = new Error(
         'Cannot generate structured query. This usually means:\n' +
@@ -183,6 +192,7 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
         label: btn.label,
         icon: btn.icon,
         compact: btn.compact,
+        disabled: btn.disabled,
       };
       result.push(m(Button, attrs as ButtonAttrs));
     }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer_types.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer_types.ts
@@ -19,6 +19,7 @@ interface CommonButtonAttrs {
   onclick: () => void;
   variant?: ButtonVariant;
   compact?: boolean;
+  disabled?: boolean;
 }
 
 interface IconButton extends CommonButtonAttrs {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_data_explorer.ts
@@ -1,0 +1,424 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import protos from '../../../../protos';
+import {TraceSummaryNode} from './trace_summary_node';
+import {Trace} from '../../../../public/trace';
+import {DetailsShell} from '../../../../widgets/details_shell';
+import {Button, ButtonVariant} from '../../../../widgets/button';
+import {Spinner} from '../../../../widgets/spinner';
+import {Switch} from '../../../../widgets/switch';
+import {Intent} from '../../../../widgets/common';
+import {DataGrid} from '../../../../components/widgets/datagrid/datagrid';
+import {SchemaRegistry} from '../../../../components/widgets/datagrid/datagrid_schema';
+import {Row} from '../../../../trace_processor/query_result';
+import {Tabs} from '../../../../widgets/tabs';
+import {
+  getStructuredQueries,
+  buildEmbeddedQueryTree,
+} from '../query_builder_utils';
+import {DataExplorerEmptyState} from '../widgets';
+
+// ============================================================================
+// Proto parsing helpers
+// ============================================================================
+
+function parseDimensionValue(
+  dim: protos.TraceMetricV2Bundle.Row.IDimension,
+): string {
+  if (dim.stringValue !== undefined && dim.stringValue !== null) {
+    return dim.stringValue;
+  }
+  if (dim.int64Value !== undefined && dim.int64Value !== null) {
+    return String(dim.int64Value);
+  }
+  if (dim.doubleValue !== undefined && dim.doubleValue !== null) {
+    return String(dim.doubleValue);
+  }
+  if (dim.boolValue !== undefined && dim.boolValue !== null) {
+    return String(dim.boolValue);
+  }
+  return 'NULL';
+}
+
+function parseValueNumber(
+  val: protos.TraceMetricV2Bundle.Row.IValue,
+): number | null {
+  if (val.doubleValue !== undefined && val.doubleValue !== null) {
+    return val.doubleValue;
+  }
+  return null;
+}
+
+function extractDimensionNames(
+  spec: protos.ITraceMetricV2Spec | null | undefined,
+): string[] {
+  if (!spec) return [];
+  if (spec.dimensionsSpecs && spec.dimensionsSpecs.length > 0) {
+    return spec.dimensionsSpecs
+      .map((ds) => ds.name)
+      .filter((name): name is string => name !== null && name !== undefined);
+  }
+  return spec.dimensions ?? [];
+}
+
+interface MetricBundleResult {
+  metricId: string;
+  schema: SchemaRegistry;
+  rows: Row[];
+}
+
+function parseTraceSummaryProto(data: Uint8Array): MetricBundleResult[] {
+  const summary = protos.TraceSummary.decode(data);
+  const results: MetricBundleResult[] = [];
+
+  for (const bundle of summary.metricBundles) {
+    const specs = bundle.specs ?? [];
+    const firstSpec = specs[0];
+    const dimensionNames = extractDimensionNames(firstSpec);
+
+    // Collect (metricId, valueName, valueIndex) tuples — one per metric tab.
+    const metrics: {metricId: string; valueName: string; valueIndex: number}[] =
+      [];
+    if (specs.length === 0) {
+      metrics.push({
+        metricId: bundle.bundleId ?? 'unknown',
+        valueName: 'value',
+        valueIndex: 0,
+      });
+    } else {
+      for (let i = 0; i < specs.length; i++) {
+        const spec = specs[i];
+        metrics.push({
+          metricId: spec.id ?? `${bundle.bundleId ?? 'unknown'}_${i}`,
+          valueName: spec.value ?? 'value',
+          valueIndex: i,
+        });
+      }
+    }
+
+    // Build one MetricBundleResult per metric (each gets its own tab).
+    for (const {metricId, valueName, valueIndex} of metrics) {
+      const schemaColumns: Record<
+        string,
+        {title: string; columnType: 'text' | 'quantitative'}
+      > = {};
+      for (const dimName of dimensionNames) {
+        schemaColumns[dimName] = {title: dimName, columnType: 'text'};
+      }
+      schemaColumns[valueName] = {
+        title: valueName,
+        columnType: 'quantitative',
+      };
+
+      const schema: SchemaRegistry = {[metricId]: schemaColumns};
+
+      const rows: Row[] = [];
+      for (const row of bundle.row ?? []) {
+        const rowData: Row = {};
+        for (let i = 0; i < dimensionNames.length; i++) {
+          const dimValue = row.dimension?.[i];
+          rowData[dimensionNames[i]] =
+            dimValue !== undefined && dimValue !== null
+              ? parseDimensionValue(dimValue)
+              : null;
+        }
+        const val = row.values?.[valueIndex];
+        rowData[valueName] =
+          val !== undefined && val !== null ? parseValueNumber(val) : null;
+        rows.push(rowData);
+      }
+
+      results.push({metricId, schema, rows});
+    }
+  }
+
+  return results;
+}
+
+// ============================================================================
+// Execution state
+// ============================================================================
+
+type ExecutionState =
+  | {kind: 'idle'}
+  | {kind: 'loading'}
+  | {kind: 'error'; message: string}
+  | {kind: 'done'; bundles: MetricBundleResult[]; durationMs: number};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export interface TraceSummaryDataExplorerAttrs {
+  readonly node: TraceSummaryNode;
+  readonly trace: Trace;
+  readonly onchange?: () => void;
+}
+
+export class TraceSummaryDataExplorer
+  implements m.ClassComponent<TraceSummaryDataExplorerAttrs>
+{
+  private executionState: ExecutionState = {kind: 'idle'};
+  private activeTab?: string;
+  private prevSpecHash?: string;
+
+  view({attrs}: m.CVnode<TraceSummaryDataExplorerAttrs>) {
+    const {node} = attrs;
+    const autoExecute = node.state.autoExecute ?? true;
+
+    // Auto-execute when spec changes.
+    if (autoExecute && node.validate()) {
+      const specHash = this.computeSpecHash(node);
+      if (specHash !== this.prevSpecHash) {
+        this.prevSpecHash = specHash;
+        this.execute(attrs);
+      }
+    }
+
+    return m(
+      DetailsShell,
+      {
+        title: 'Query data',
+        buttons: this.renderMenu(attrs),
+        fillHeight: true,
+      },
+      this.renderContent(attrs),
+    );
+  }
+
+  private computeSpecHash(node: TraceSummaryNode): string {
+    const metricsNodes = node.getAllMetricsNodes();
+    const parts = metricsNodes.map((mn) => {
+      const values = mn.state.valueColumns
+        .map((v) => `${v.column}/${v.unit}/${v.customUnit ?? ''}/${v.polarity}`)
+        .join(',');
+      const dims = mn.getDimensions().join(',');
+      return `${mn.nodeId}:${mn.state.metricIdPrefix}:${mn.state.dimensionUniqueness}:${dims}:${values}`;
+    });
+    return parts.join('|');
+  }
+
+  private renderMenu(attrs: TraceSummaryDataExplorerAttrs): m.Children {
+    const autoExecute = attrs.node.state.autoExecute ?? true;
+    const isLoading = this.executionState.kind === 'loading';
+    const isStale = this.prevSpecHash !== this.computeSpecHash(attrs.node);
+
+    const runButton =
+      !autoExecute &&
+      (isStale || this.executionState.kind === 'idle') &&
+      m(Button, {
+        label: 'Run Query',
+        icon: 'play_arrow',
+        intent: Intent.Primary,
+        variant: ButtonVariant.Filled,
+        disabled: !attrs.node.validate() || isLoading,
+        onclick: () => {
+          this.prevSpecHash = this.computeSpecHash(attrs.node);
+          this.execute(attrs);
+        },
+      });
+
+    const statusIndicator = isLoading ? m(Spinner) : null;
+
+    const autoExecuteSwitch = m(Switch, {
+      label: 'Auto Execute',
+      checked: autoExecute,
+      onchange: (e: Event) => {
+        const target = e.target as HTMLInputElement;
+        attrs.node.state.autoExecute = target.checked;
+        attrs.onchange?.();
+        if (target.checked && attrs.node.validate()) {
+          this.prevSpecHash = this.computeSpecHash(attrs.node);
+          this.execute(attrs);
+        }
+      },
+    });
+
+    const separator = () =>
+      m('span.pf-query-stats-separator', {'aria-hidden': 'true'}, '\u2022');
+
+    const queryStats =
+      this.executionState.kind === 'done'
+        ? m('.pf-query-stats', [
+            m(
+              'span',
+              `${this.executionState.bundles.reduce((n, b) => n + b.rows.length, 0).toLocaleString()} rows`,
+            ),
+            separator(),
+            m('span', `${this.executionState.durationMs.toFixed(1)}ms`),
+          ])
+        : null;
+
+    const items = [
+      runButton,
+      statusIndicator,
+      queryStats,
+      autoExecuteSwitch,
+    ].filter((item) => item !== null && item !== false);
+
+    const menuItems: m.Children = [];
+    for (let i = 0; i < items.length; i++) {
+      menuItems.push(items[i]);
+      if (i < items.length - 1) {
+        menuItems.push(separator());
+      }
+    }
+
+    return menuItems;
+  }
+
+  private renderContent(attrs: TraceSummaryDataExplorerAttrs): m.Children {
+    if (!attrs.node.validate()) {
+      return m(DataExplorerEmptyState, {
+        icon: 'warning',
+        title:
+          attrs.node.state.issues?.queryError?.message ??
+          'Node validation failed',
+      });
+    }
+
+    switch (this.executionState.kind) {
+      case 'idle':
+        return m(DataExplorerEmptyState, {
+          icon: 'play_arrow',
+          title: 'Click Run or enable Auto Execute',
+        });
+      case 'loading':
+        return m('.pf-trace-summary-loading', m(Spinner));
+      case 'error':
+        return m(DataExplorerEmptyState, {
+          icon: 'error',
+          title: this.executionState.message,
+        });
+      case 'done': {
+        const {bundles} = this.executionState;
+        if (bundles.length === 0) {
+          return m(DataExplorerEmptyState, {
+            icon: 'info',
+            title: 'No metric data returned',
+          });
+        }
+        if (bundles.length === 1) {
+          const bundle = bundles[0];
+          return m(DataGrid, {
+            data: bundle.rows,
+            schema: bundle.schema,
+            rootSchema: bundle.metricId,
+            fillHeight: true,
+          });
+        }
+        return m(Tabs, {
+          activeTabKey: this.activeTab,
+          onTabChange: (key: string) => {
+            this.activeTab = key;
+          },
+          tabs: bundles.map((bundle) => ({
+            key: bundle.metricId,
+            title: bundle.metricId,
+            content: m(DataGrid, {
+              data: bundle.rows,
+              schema: bundle.schema,
+              rootSchema: bundle.metricId,
+              fillHeight: true,
+            }),
+          })),
+        });
+      }
+    }
+  }
+
+  private async execute(attrs: TraceSummaryDataExplorerAttrs): Promise<void> {
+    const {node} = attrs;
+    if (!node.validate()) return;
+
+    // Guard against concurrent executions (e.g. re-renders during loading).
+    if (this.executionState.kind === 'loading') return;
+
+    const engine = node.state.trace?.engine;
+    if (engine === undefined) {
+      this.executionState = {
+        kind: 'error',
+        message: 'No trace loaded. Please load a trace first.',
+      };
+      m.redraw();
+      return;
+    }
+
+    this.executionState = {kind: 'loading'};
+    m.redraw();
+
+    const startTime = performance.now();
+
+    try {
+      const metricsNodes = node.getAllMetricsNodes();
+      const templateSpecs: protos.TraceMetricV2TemplateSpec[] = [];
+
+      for (const metricsNode of metricsNodes) {
+        const templateSpec = metricsNode.getMetricTemplateSpec();
+        if (templateSpec === undefined) continue;
+
+        // Build self-contained embedded query trees for summarizeTrace.
+        if (metricsNode.primaryInput !== undefined) {
+          const allQueries = getStructuredQueries(metricsNode.primaryInput);
+          if (!(allQueries instanceof Error)) {
+            const embedded = buildEmbeddedQueryTree(allQueries);
+            if (embedded !== undefined) {
+              templateSpec.query = embedded;
+            }
+          }
+        }
+        templateSpecs.push(templateSpec);
+      }
+
+      if (templateSpecs.length === 0) {
+        this.executionState = {
+          kind: 'error',
+          message: 'No valid metrics to execute',
+        };
+        m.redraw();
+        return;
+      }
+
+      const summarySpec = new protos.TraceSummarySpec();
+      summarySpec.metricTemplateSpec = templateSpecs;
+
+      const result = await engine.summarizeTrace(
+        [summarySpec],
+        undefined,
+        undefined,
+        'proto',
+      );
+
+      const durationMs = performance.now() - startTime;
+
+      if (result.error) {
+        this.executionState = {kind: 'error', message: result.error};
+      } else if (result.protoSummary) {
+        const bundles = parseTraceSummaryProto(result.protoSummary);
+        this.executionState = {kind: 'done', bundles, durationMs};
+        if (bundles.length > 0) {
+          this.activeTab ??= bundles[0].metricId;
+        }
+      } else {
+        this.executionState = {kind: 'error', message: 'No results returned'};
+      }
+    } catch (e) {
+      this.executionState = {kind: 'error', message: String(e)};
+    }
+
+    m.redraw();
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_node.ts
@@ -1,0 +1,385 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import protos from '../../../../protos';
+import {
+  QueryNode,
+  QueryNodeState,
+  nextNodeId,
+  NodeType,
+  SecondaryInputSpec,
+} from '../../query_node';
+import {ColumnInfo} from '../column_info';
+import {NodeIssues} from '../node_issues';
+import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
+import {loadNodeDoc} from '../node_doc_loader';
+import {
+  ColumnName,
+  NodeDetailsMessage,
+  NodeTitle,
+} from '../node_styling_widgets';
+import {MetricsNode} from './metrics_node';
+import {TraceSummaryDataExplorer} from './trace_summary_data_explorer';
+import {Accordion} from '../../../../widgets/accordion';
+import {enumKeyToLabel} from './metrics_enum_utils';
+import {showModal} from '../../../../widgets/modal';
+import {CodeSnippet} from '../../../../widgets/code_snippet';
+import {traceSummarySpecToText} from '../../../../base/proto_utils_wasm';
+import {
+  getStructuredQueries,
+  buildEmbeddedQueryTree,
+} from '../query_builder_utils';
+
+export interface TraceSummarySerializedState {
+  secondaryInputNodeIds?: string[];
+}
+
+export interface TraceSummaryNodeState extends QueryNodeState {}
+
+export class TraceSummaryNode implements QueryNode {
+  readonly nodeId: string;
+  readonly type = NodeType.kTraceSummary;
+  nextNodes: QueryNode[];
+  readonly state: TraceSummaryNodeState;
+  secondaryInputs: SecondaryInputSpec;
+
+  get finalCols(): ColumnInfo[] {
+    return [];
+  }
+
+  constructor(state: TraceSummaryNodeState) {
+    this.nodeId = nextNodeId();
+    this.state = {...state};
+    this.nextNodes = [];
+    this.secondaryInputs = {
+      connections: new Map(),
+      min: 1,
+      max: 'unbounded',
+      portNames: (idx) => `Metric node ${idx + 1}`,
+    };
+  }
+
+  /**
+   * Returns all connected Metrics nodes from secondary inputs, sorted by port.
+   */
+  getAllMetricsNodes(): MetricsNode[] {
+    const nodes: MetricsNode[] = [];
+    for (const [, node] of [...this.secondaryInputs.connections.entries()].sort(
+      ([a], [b]) => a - b,
+    )) {
+      if (node.type === NodeType.kMetrics) {
+        nodes.push(node as MetricsNode);
+      }
+    }
+    return nodes;
+  }
+
+  validate(): boolean {
+    if (this.state.issues) {
+      this.state.issues.clear();
+    }
+
+    // Validate all inputs are Metrics nodes.
+    for (const [, node] of this.secondaryInputs.connections) {
+      if (node.type !== NodeType.kMetrics) {
+        this.setValidationError('All inputs must be Metrics nodes');
+        return false;
+      }
+    }
+
+    // Validate at least one Metrics node is connected.
+    const metricsNodes = this.getAllMetricsNodes();
+    if (metricsNodes.length === 0) {
+      this.setValidationError('At least one Metrics node is required');
+      return false;
+    }
+
+    // Validate metric ID prefixes are unique.
+    const seenPrefixes = new Set<string>();
+    for (const metricsNode of metricsNodes) {
+      const prefix = metricsNode.state.metricIdPrefix;
+      if (prefix && seenPrefixes.has(prefix)) {
+        this.setValidationError(
+          `Duplicate metric ID prefix '${prefix}'. Each metric must have a unique prefix.`,
+        );
+        return false;
+      }
+      if (prefix) {
+        seenPrefixes.add(prefix);
+      }
+    }
+
+    for (const metricsNode of metricsNodes) {
+      if (!metricsNode.validate()) {
+        this.setValidationError(
+          `Metrics node '${metricsNode.state.metricIdPrefix || '(unnamed)'}' is invalid`,
+        );
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private setValidationError(message: string): void {
+    if (!this.state.issues) {
+      this.state.issues = new NodeIssues();
+    }
+    this.state.issues.queryError = new Error(message);
+  }
+
+  getTitle(): string {
+    return 'Trace Summary';
+  }
+
+  nodeDetails(): NodeDetailsAttrs {
+    const details: m.Child[] = [NodeTitle(this.getTitle())];
+
+    const metricsNodes = this.getAllMetricsNodes();
+    if (metricsNodes.length === 0) {
+      details.push(NodeDetailsMessage('No metrics connected'));
+      return {
+        content: m('.pf-trace-summary-node-details', details),
+      };
+    }
+
+    details.push(
+      m(
+        'div',
+        `${metricsNodes.length} metric${metricsNodes.length !== 1 ? 's' : ''}: `,
+        metricsNodes.map((mn, i) => [
+          ColumnName(mn.state.metricIdPrefix || '(unnamed)'),
+          i < metricsNodes.length - 1 ? ', ' : '',
+        ]),
+      ),
+    );
+
+    return {
+      content: m('.pf-trace-summary-node-details', details),
+    };
+  }
+
+  nodeSpecificModify(): NodeModifyAttrs {
+    const metricsNodes = this.getAllMetricsNodes();
+
+    const sections: NodeModifyAttrs['sections'] = [];
+
+    if (metricsNodes.length === 0) {
+      sections.push({
+        content: m(
+          '.pf-trace-summary-empty',
+          'Connect Metrics nodes to build a trace summary.',
+        ),
+      });
+    } else {
+      sections.push({
+        content: m(Accordion, {
+          items: metricsNodes.map((mn) => ({
+            id: mn.nodeId,
+            header: this.renderMetricHeader(mn),
+            content: this.renderMetricContent(mn),
+          })),
+        }),
+      });
+    }
+
+    const canExport = this.validate() && this.state.trace?.engine !== undefined;
+
+    return {
+      info: 'Bundle multiple metrics into a single trace summary. Connect Metrics nodes as inputs to include them in the summary.',
+      sections,
+      bottomRightButtons: [
+        {
+          label: 'Export',
+          icon: 'download',
+          onclick: () => this.showExportModal(),
+          disabled: !canExport,
+        },
+      ],
+    };
+  }
+
+  private renderMetricHeader(mn: MetricsNode): m.Children {
+    const prefix = mn.state.metricIdPrefix || '(unnamed)';
+    const valueCount = mn.state.valueColumns.length;
+    return m('.pf-trace-summary-metric-header', [
+      ColumnName(prefix),
+      m(
+        'span.pf-trace-summary-metric-badge',
+        `${valueCount} value${valueCount !== 1 ? 's' : ''}`,
+      ),
+    ]);
+  }
+
+  private renderMetricContent(mn: MetricsNode): m.Children {
+    const dimensions = mn.getDimensions();
+    const source = mn.primaryInput?.getTitle() ?? '(no source)';
+
+    return m('.pf-trace-summary-metric-detail', [
+      m('.pf-trace-summary-detail-row', [
+        m('span.pf-trace-summary-detail-label', 'Source'),
+        m('span', source),
+      ]),
+      m('.pf-trace-summary-detail-row', [
+        m('span.pf-trace-summary-detail-label', 'Dimensions'),
+        dimensions.length > 0
+          ? m(
+              'span',
+              dimensions.map((d, i) => [
+                ColumnName(d),
+                i < dimensions.length - 1 ? ', ' : '',
+              ]),
+            )
+          : m('span.pf-trace-summary-detail-none', 'none'),
+      ]),
+      m('.pf-trace-summary-detail-row', [
+        m('span.pf-trace-summary-detail-label', 'Values'),
+      ]),
+      ...mn.state.valueColumns.map((vc) =>
+        m('.pf-trace-summary-value-item', [
+          ColumnName(vc.column),
+          m(
+            'span.pf-trace-summary-value-meta',
+            `Unit: ${enumKeyToLabel(vc.unit)}`,
+          ),
+          m(
+            'span.pf-trace-summary-value-meta',
+            `Polarity: ${enumKeyToLabel(vc.polarity)}`,
+          ),
+        ]),
+      ),
+    ]);
+  }
+
+  private async showExportModal(): Promise<void> {
+    const spec = this.getTraceSummarySpec();
+    if (spec === undefined) return;
+
+    // Embed query trees for self-contained export.
+    for (const templateSpec of spec.metricTemplateSpec) {
+      const metricsNode = this.getAllMetricsNodes().find(
+        (mn) => mn.state.metricIdPrefix === templateSpec.idPrefix,
+      );
+      if (metricsNode?.primaryInput !== undefined) {
+        const allQueries = getStructuredQueries(metricsNode.primaryInput);
+        if (!(allQueries instanceof Error)) {
+          const embedded = buildEmbeddedQueryTree(allQueries);
+          if (embedded !== undefined) {
+            templateSpec.query = embedded;
+          }
+        }
+      }
+    }
+
+    const textproto = await traceSummarySpecToText(spec);
+
+    showModal({
+      title: 'Export Trace Summary',
+      className: 'pf-trace-summary-export-modal',
+      content: () =>
+        m(
+          'div',
+          m(CodeSnippet, {
+            text: textproto,
+            language: 'textproto',
+            downloadFileName: 'trace_summary_spec.pbtxt',
+          }),
+        ),
+      buttons: [{text: 'Close'}],
+    });
+  }
+
+  nodeInfo(): m.Children {
+    return loadNodeDoc('trace_summary');
+  }
+
+  clone(): QueryNode {
+    return new TraceSummaryNode({
+      onchange: this.state.onchange,
+    });
+  }
+
+  getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
+    return undefined;
+  }
+
+  customDataExplorer(): m.Children {
+    const trace = this.state.trace;
+    if (trace === undefined) return undefined;
+    return m(TraceSummaryDataExplorer, {
+      node: this,
+      trace,
+      onchange: () => this.state.onchange?.(),
+    });
+  }
+
+  /**
+   * Builds a TraceSummarySpec from all connected Metrics nodes.
+   */
+  getTraceSummarySpec(): protos.TraceSummarySpec | undefined {
+    if (!this.validate()) return undefined;
+
+    const metricsNodes = this.getAllMetricsNodes();
+    const templateSpecs: protos.TraceMetricV2TemplateSpec[] = [];
+
+    for (const metricsNode of metricsNodes) {
+      const templateSpec = metricsNode.getMetricTemplateSpec();
+      if (templateSpec !== undefined) {
+        templateSpecs.push(templateSpec);
+      }
+    }
+
+    if (templateSpecs.length === 0) return undefined;
+
+    const spec = new protos.TraceSummarySpec();
+    spec.metricTemplateSpec = templateSpecs;
+    return spec;
+  }
+
+  serializeState(): TraceSummarySerializedState {
+    const secondaryInputNodeIds: string[] = [];
+    for (const [, node] of [...this.secondaryInputs.connections.entries()].sort(
+      ([a], [b]) => a - b,
+    )) {
+      secondaryInputNodeIds.push(node.nodeId);
+    }
+    return {
+      secondaryInputNodeIds:
+        secondaryInputNodeIds.length > 0 ? secondaryInputNodeIds : undefined,
+    };
+  }
+
+  static deserializeState(
+    _state: TraceSummarySerializedState,
+  ): TraceSummaryNodeState {
+    return {};
+  }
+
+  static deserializeConnections(
+    allNodes: Map<string, QueryNode>,
+    state: {secondaryInputNodeIds?: string[]},
+  ): {secondaryInputNodes: QueryNode[]} {
+    const secondaryInputNodes: QueryNode[] = [];
+    if (state.secondaryInputNodeIds) {
+      for (const id of state.secondaryInputNodeIds) {
+        const node = allNodes.get(id);
+        if (node !== undefined) {
+          secondaryInputNodes.push(node);
+        }
+      }
+    }
+    return {secondaryInputNodes};
+  }
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_node_unittest.ts
@@ -1,0 +1,294 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {TraceSummaryNode} from './trace_summary_node';
+import {MetricsNode, MetricsNodeState} from './metrics_node';
+import {NodeType} from '../../query_node';
+import {
+  createMockNode,
+  createColumnInfo,
+  connectNodes,
+  connectSecondary,
+  expectValidationError,
+  expectValidationSuccess,
+  createMockNodeWithStructuredQuery,
+} from '../testing/test_utils';
+
+function makeMetricsNode(
+  overrides: Partial<MetricsNodeState> = {},
+): MetricsNode {
+  const state: MetricsNodeState = {
+    metricIdPrefix: 'test_metric',
+    valueColumns: [
+      {column: 'value', unit: 'COUNT', polarity: 'NOT_APPLICABLE'},
+    ],
+    dimensionUniqueness: 'NOT_UNIQUE',
+    availableColumns: [
+      createColumnInfo('name', 'string'),
+      createColumnInfo('value', 'int'),
+    ],
+    ...overrides,
+  };
+  return new MetricsNode(state);
+}
+
+function makeConnectedMetricsNode(prefix = 'test_metric'): {
+  source: ReturnType<typeof createMockNodeWithStructuredQuery>;
+  metrics: MetricsNode;
+} {
+  const source = createMockNodeWithStructuredQuery('source', [
+    createColumnInfo('name', 'string'),
+    createColumnInfo('value', 'int'),
+  ]);
+  const metrics = makeMetricsNode({metricIdPrefix: prefix});
+  connectNodes(source, metrics);
+  metrics.onPrevNodesUpdated();
+  return {source, metrics};
+}
+
+describe('TraceSummaryNode', () => {
+  describe('basic properties', () => {
+    test('type is kTraceSummary', () => {
+      const node = new TraceSummaryNode({});
+      expect(node.type).toBe(NodeType.kTraceSummary);
+    });
+
+    test('has unique nodeId', () => {
+      const node1 = new TraceSummaryNode({});
+      const node2 = new TraceSummaryNode({});
+      expect(node1.nodeId).not.toBe(node2.nodeId);
+    });
+
+    test('finalCols is always empty', () => {
+      const node = new TraceSummaryNode({});
+      expect(node.finalCols).toEqual([]);
+    });
+
+    test('getTitle returns Trace Summary', () => {
+      const node = new TraceSummaryNode({});
+      expect(node.getTitle()).toBe('Trace Summary');
+    });
+
+    test('nextNodes is empty', () => {
+      const node = new TraceSummaryNode({});
+      expect(node.nextNodes).toEqual([]);
+    });
+
+    test('getStructuredQuery returns undefined', () => {
+      const node = new TraceSummaryNode({});
+      expect(node.getStructuredQuery()).toBeUndefined();
+    });
+
+    test('secondaryInputs requires min 1', () => {
+      const node = new TraceSummaryNode({});
+      expect(node.secondaryInputs.min).toBe(1);
+      expect(node.secondaryInputs.max).toBe('unbounded');
+    });
+  });
+
+  describe('validation', () => {
+    test('fails with no inputs', () => {
+      const node = new TraceSummaryNode({});
+      expectValidationError(node, 'At least one Metrics node is required');
+    });
+
+    test('fails when input is not a Metrics node', () => {
+      const nonMetrics = createMockNode({nodeId: 'non-metrics'});
+      const node = new TraceSummaryNode({});
+      connectSecondary(nonMetrics, node, 0);
+      expectValidationError(node, 'All inputs must be Metrics nodes');
+    });
+
+    test('fails when one of multiple inputs is not a Metrics node', () => {
+      const {metrics} = makeConnectedMetricsNode();
+      const nonMetrics = createMockNode({nodeId: 'non-metrics'});
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics, node, 0);
+      connectSecondary(nonMetrics, node, 1);
+      expectValidationError(node, 'All inputs must be Metrics nodes');
+    });
+
+    test('fails when connected Metrics node is invalid', () => {
+      const metrics = makeMetricsNode({
+        metricIdPrefix: '',
+        valueColumns: [],
+      });
+      const source = createMockNodeWithStructuredQuery('source', [
+        createColumnInfo('name', 'string'),
+        createColumnInfo('value', 'int'),
+      ]);
+      connectNodes(source, metrics);
+      metrics.onPrevNodesUpdated();
+
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics, node, 0);
+
+      expect(node.validate()).toBe(false);
+    });
+
+    test('succeeds with one valid Metrics node', () => {
+      const {metrics} = makeConnectedMetricsNode();
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics, node, 0);
+      expectValidationSuccess(node);
+    });
+
+    test('succeeds with multiple Metrics nodes', () => {
+      const {metrics: metrics1} = makeConnectedMetricsNode('metric_a');
+      const {metrics: metrics2} = makeConnectedMetricsNode('metric_b');
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics1, node, 0);
+      connectSecondary(metrics2, node, 1);
+      expectValidationSuccess(node);
+    });
+  });
+
+  describe('getTraceSummarySpec', () => {
+    test('returns undefined when invalid', () => {
+      const node = new TraceSummaryNode({});
+      expect(node.getTraceSummarySpec()).toBeUndefined();
+    });
+
+    test('bundles single Metrics node', () => {
+      const {metrics} = makeConnectedMetricsNode('my_metric');
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics, node, 0);
+
+      const spec = node.getTraceSummarySpec();
+      expect(spec).toBeDefined();
+      expect(spec?.metricTemplateSpec).toHaveLength(1);
+      expect(spec?.metricTemplateSpec?.[0].idPrefix).toBe('my_metric');
+    });
+
+    test('bundles multiple Metrics nodes', () => {
+      const {metrics: metrics1} = makeConnectedMetricsNode('cpu_metric');
+      const {metrics: metrics2} = makeConnectedMetricsNode('mem_metric');
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics1, node, 0);
+      connectSecondary(metrics2, node, 1);
+
+      const spec = node.getTraceSummarySpec();
+      expect(spec).toBeDefined();
+      expect(spec?.metricTemplateSpec).toHaveLength(2);
+      const prefixes = spec?.metricTemplateSpec?.map((s) => s.idPrefix);
+      expect(prefixes).toContain('cpu_metric');
+      expect(prefixes).toContain('mem_metric');
+    });
+
+    test('preserves port order in the spec', () => {
+      const {metrics: metrics1} = makeConnectedMetricsNode('first_metric');
+      const {metrics: metrics2} = makeConnectedMetricsNode('second_metric');
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics1, node, 0);
+      connectSecondary(metrics2, node, 1);
+
+      const spec = node.getTraceSummarySpec();
+      expect(spec?.metricTemplateSpec?.[0].idPrefix).toBe('first_metric');
+      expect(spec?.metricTemplateSpec?.[1].idPrefix).toBe('second_metric');
+    });
+  });
+
+  describe('serialization', () => {
+    test('serializes secondary input node IDs', () => {
+      const {metrics: metrics1} = makeConnectedMetricsNode('m1');
+      const {metrics: metrics2} = makeConnectedMetricsNode('m2');
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics1, node, 0);
+      connectSecondary(metrics2, node, 1);
+
+      const serialized = node.serializeState();
+      expect(serialized.secondaryInputNodeIds).toEqual([
+        metrics1.nodeId,
+        metrics2.nodeId,
+      ]);
+    });
+
+    test('omits secondaryInputNodeIds when no inputs', () => {
+      const node = new TraceSummaryNode({});
+      const serialized = node.serializeState();
+      expect(serialized.secondaryInputNodeIds).toBeUndefined();
+    });
+
+    test('deserializeState returns empty state', () => {
+      const state = TraceSummaryNode.deserializeState({});
+      expect(state).toEqual({});
+    });
+
+    test('deserializeConnections restores secondary inputs', () => {
+      const metrics1 = makeMetricsNode({metricIdPrefix: 'm1'});
+      const metrics2 = makeMetricsNode({metricIdPrefix: 'm2'});
+      const allNodes = new Map<string, ReturnType<typeof createMockNode>>([
+        [metrics1.nodeId, metrics1],
+        [metrics2.nodeId, metrics2],
+      ]);
+
+      const result = TraceSummaryNode.deserializeConnections(allNodes, {
+        secondaryInputNodeIds: [metrics1.nodeId, metrics2.nodeId],
+      });
+
+      expect(result.secondaryInputNodes).toHaveLength(2);
+    });
+
+    test('deserializeConnections handles missing nodes', () => {
+      const allNodes = new Map();
+      const result = TraceSummaryNode.deserializeConnections(allNodes, {
+        secondaryInputNodeIds: ['nonexistent'],
+      });
+      expect(result.secondaryInputNodes).toHaveLength(0);
+    });
+
+    test('deserializeConnections handles undefined IDs', () => {
+      const allNodes = new Map();
+      const result = TraceSummaryNode.deserializeConnections(allNodes, {});
+      expect(result.secondaryInputNodes).toHaveLength(0);
+    });
+  });
+
+  describe('clone', () => {
+    test('creates a new node with different ID', () => {
+      const node = new TraceSummaryNode({});
+      const cloned = node.clone();
+      expect(cloned.nodeId).not.toBe(node.nodeId);
+      expect(cloned.type).toBe(NodeType.kTraceSummary);
+    });
+  });
+
+  describe('nodeDetails', () => {
+    test('shows message when no metrics connected', () => {
+      const node = new TraceSummaryNode({});
+      const details = node.nodeDetails();
+      expect(details.content).toBeDefined();
+    });
+
+    test('shows connected metrics count', () => {
+      const {metrics: metrics1} = makeConnectedMetricsNode('cpu');
+      const {metrics: metrics2} = makeConnectedMetricsNode('mem');
+      const node = new TraceSummaryNode({});
+      connectSecondary(metrics1, node, 0);
+      connectSecondary(metrics2, node, 1);
+
+      const details = node.nodeDetails();
+      expect(details.content).toBeDefined();
+    });
+  });
+
+  describe('nodeSpecificModify', () => {
+    test('returns NodeModifyAttrs with info', () => {
+      const node = new TraceSummaryNode({});
+      const result = node.nodeSpecificModify();
+      expect(result).toHaveProperty('info');
+      expect(result).toHaveProperty('sections');
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.scss
@@ -960,3 +960,58 @@
     gap: 4px;
   }
 }
+
+// ============================================================================
+// Trace Summary node modify view
+// ============================================================================
+
+.pf-trace-summary-metric-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.pf-trace-summary-metric-badge {
+  font-size: 11px;
+  color: var(--md-sys-color-outline);
+}
+
+.pf-trace-summary-metric-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 0;
+}
+
+.pf-trace-summary-detail-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.pf-trace-summary-detail-label {
+  font-weight: 500;
+  font-size: 11px;
+  color: var(--md-sys-color-outline);
+  min-width: 70px;
+  text-transform: uppercase;
+}
+
+.pf-trace-summary-detail-none {
+  color: var(--md-sys-color-outline);
+  font-style: italic;
+}
+
+.pf-trace-summary-value-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-left: 78px;
+}
+
+.pf-trace-summary-value-meta {
+  font-size: 11px;
+  color: var(--md-sys-color-outline);
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -69,6 +69,7 @@ export enum NodeType {
   // Deprecated (kept for backward compatibility)
   kMerge = kJoin,
   kMetrics = 'metrics',
+  kTraceSummary = 'trace_summary',
 }
 
 export function singleNodeOperation(type: NodeType): boolean {
@@ -179,6 +180,10 @@ export interface QueryNode {
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined;
   serializeState(): object;
   onPrevNodesUpdated?(): void;
+
+  // Optional custom data explorer for the bottom drawer panel.
+  // If provided, Builder renders this instead of the standard DataExplorer.
+  customDataExplorer?(): m.Children;
 }
 
 export interface Query {


### PR DESCRIPTION
Trace Summary node can only be a child of Metrics node - it takes multiple metrics and creates Trace Summary out of them. It has a custom data explorer that shows only metrics results (proto converted to data grid)