### PR TITLE
ui: Add ability to pivot on arg values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ Unreleased:
     * Remap OpenCommandPalette command hotkey to F1 on Firefox.
     * Ftrace plugin: now handles area selections and multi-machine traces.
     * Update node to v22.23.1.
+    * Allow pivoting on arg values in slice aggregation table.
   SDK:
     *
 

--- a/ui/src/components/aggregation.ts
+++ b/ui/src/components/aggregation.ts
@@ -12,32 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type m from 'mithril';
 import type {ColorScheme} from '../base/color_scheme';
-import type {Row, SqlValue} from '../trace_processor/query_result';
-import type {CellRenderResult} from './widgets/datagrid/datagrid_schema';
-
-export interface ColumnDef {
-  readonly columnId: string;
-  readonly title: string;
-  readonly formatHint?: string;
-  readonly sum?: boolean;
-  readonly sort?: 'ASC' | 'DESC';
-  // Custom renderer for this column's cells. If provided, this takes precedence
-  // over the formatHint-based renderer.
-  readonly cellRenderer?: (
-    value: SqlValue,
-    row: Row,
-  ) => m.Children | CellRenderResult;
-}
 
 export interface BarChartData {
   readonly title: string;
   readonly value: number;
   readonly color: ColorScheme;
-}
-
-export interface Sorting {
-  readonly column: string;
-  readonly direction: 'DESC' | 'ASC';
 }

--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -32,12 +32,11 @@ import {
 import type {Engine} from '../trace_processor/engine';
 import {EmptyState} from '../widgets/empty_state';
 import {Spinner} from '../widgets/spinner';
-import {shortUuid} from '../base/uuid';
 import {AggregationPanel} from './aggregation_panel';
 import type {Column, Filter, Pivot} from './widgets/datagrid/model';
 import {SQLDataSource} from './widgets/datagrid/sql_data_source';
 import {createSimpleSchema} from './widgets/datagrid/sql_schema';
-import type {BarChartData, ColumnDef} from './aggregation';
+import type {BarChartData} from './aggregation';
 import {
   createPerfettoTable,
   type DisposableSqlEntity,
@@ -45,6 +44,7 @@ import {
 import type {DataGridApi} from './widgets/datagrid/datagrid';
 import {ExportButton} from '../widgets/export_button';
 import {SerialTaskQueue} from '../base/query_slot';
+import type {ColumnSchema} from './widgets/datagrid/datagrid_schema';
 
 export interface AggregationData {
   readonly tableName: string;
@@ -63,9 +63,15 @@ export interface Aggregation {
   prepareData(engine: Engine): Promise<AggregationData>;
 }
 
-export type AggregatePivotModel = Pivot & {
-  readonly columns: ReadonlyArray<ColumnDef>;
-};
+/**
+ * Initial configuration for the DataGrid in an aggregation panel.
+ */
+export interface AggregatorGridConfig {
+  readonly schema: ColumnSchema;
+  readonly initialColumns?: readonly Column[];
+  readonly initialPivot?: Pivot;
+  readonly initialFilters?: readonly Filter[];
+}
 
 /**
  * State that can be controlled externally for a DataGrid.
@@ -100,9 +106,9 @@ export interface Aggregator {
   // Returns the name of this aggregation tag. Called every render cycle.
   getTabName(): string;
 
-  // Return the column definitions for this aggregation panel. Called every
+  // Return the grid configuration for this aggregation panel. Called every
   // render cycle.
-  getColumnDefinitions(): ColumnDef[] | AggregatePivotModel;
+  getGridConfig(): AggregatorGridConfig;
 
   // Optional controls to render in the top bar of the aggregation panel.
   renderTopbarControls?(): m.Children;
@@ -222,28 +228,12 @@ export function createAggregationTab(
   let dataGridApi: DataGridApi | undefined;
 
   function createInitialState(): DataGridModel {
-    const initialModel = aggregator.getColumnDefinitions();
-    if ('groupBy' in initialModel) {
-      return {
-        pivot: {
-          groupBy: initialModel.groupBy,
-          aggregates: initialModel.aggregates,
-        },
-        filters: [],
-      };
-    } else {
-      // Generate initial columns for flat mode
-      const columns: readonly Column[] = initialModel.map((c) => ({
-        id: shortUuid(),
-        field: c.columnId,
-        aggregate: c.sum ? 'SUM' : undefined,
-        sort: c.sort,
-      }));
-      return {
-        columns,
-        filters: [],
-      };
-    }
+    const config = aggregator.getGridConfig();
+    return {
+      columns: config.initialColumns,
+      pivot: config.initialPivot,
+      filters: config.initialFilters ?? [],
+    };
   }
 
   // DataGrid state managed by the adapter
@@ -324,7 +314,7 @@ export function createAggregationTab(
           controls: aggregator.renderTopbarControls?.(),
           key: aggregator.id,
           dataSource,
-          columns: aggregator.getColumnDefinitions(),
+          gridConfig: aggregator.getGridConfig(),
           barChartData: data?.barChartData,
           onReady: (api: DataGridApi) => {
             dataGridApi = api;

--- a/ui/src/components/aggregation_adapter.ts
+++ b/ui/src/components/aggregation_adapter.ts
@@ -35,7 +35,10 @@ import {Spinner} from '../widgets/spinner';
 import {AggregationPanel} from './aggregation_panel';
 import type {Column, Filter, Pivot} from './widgets/datagrid/model';
 import {SQLDataSource} from './widgets/datagrid/sql_data_source';
-import {createSimpleSchema} from './widgets/datagrid/sql_schema';
+import {
+  createSimpleSchema,
+  type SQLSchemaRegistry,
+} from './widgets/datagrid/sql_schema';
 import type {BarChartData} from './aggregation';
 import {
   createPerfettoTable,
@@ -71,6 +74,12 @@ export interface AggregatorGridConfig {
   readonly initialColumns?: readonly Column[];
   readonly initialPivot?: Pivot;
   readonly initialFilters?: readonly Filter[];
+  /**
+   * Optional override that produces the SQL schema used to resolve columns
+   * for the aggregation table. If undefined, a generic schema is created from
+   * the table name via `createSimpleSchema`.
+   */
+  readonly sqlConfig?: (data: AggregationData) => SQLSchemaRegistry;
 }
 
 /**
@@ -263,10 +272,13 @@ export function createAggregationTab(
           data = undefined;
           if (aggregation) {
             data = await aggregation?.prepareData(trace.engine);
+            const gridConfig = aggregator.getGridConfig();
             dataSource = new SQLDataSource({
               queue,
               engine: trace.engine,
-              sqlSchema: createSimpleSchema(data.tableName),
+              sqlSchema:
+                gridConfig.sqlConfig?.(data) ??
+                createSimpleSchema(data.tableName),
               rootSchemaName: 'query',
             });
           }

--- a/ui/src/components/aggregation_panel.ts
+++ b/ui/src/components/aggregation_panel.ts
@@ -17,17 +17,16 @@ import {Duration} from '../base/time';
 import type {SqlValue} from '../trace_processor/query_result';
 import {Box} from '../widgets/box';
 import {Stack, StackAuto, StackFixed} from '../widgets/stack';
-import type {BarChartData, ColumnDef} from './aggregation';
+import type {BarChartData} from './aggregation';
 import {
   DataGrid,
   renderCell,
   type DataGridApi,
 } from './widgets/datagrid/datagrid';
 import {defaultValueFormatter} from './widgets/datagrid/export_utils';
-import type {AggregatePivotModel, DataGridState} from './aggregation_adapter';
+import type {AggregatorGridConfig, DataGridState} from './aggregation_adapter';
 import type {
   CellRenderer,
-  ColumnSchema,
   ColumnType,
   SchemaRegistry,
 } from './widgets/datagrid/datagrid_schema';
@@ -37,7 +36,7 @@ import {Icons} from '../base/semantic_icons';
 
 export interface AggregationPanelAttrs {
   readonly dataSource: DataSource;
-  readonly columns: ReadonlyArray<ColumnDef> | AggregatePivotModel;
+  readonly gridConfig: AggregatorGridConfig;
   readonly barChartData?: ReadonlyArray<BarChartData>;
   readonly onReady?: (api: DataGridApi) => void;
   readonly dataGridState?: DataGridState;
@@ -51,7 +50,7 @@ export class AggregationPanel
   view({attrs}: m.CVnode<AggregationPanelAttrs>) {
     const {
       dataSource,
-      columns,
+      gridConfig,
       barChartData,
       onReady,
       dataGridState,
@@ -66,7 +65,7 @@ export class AggregationPanel
         this.renderTable(
           controls,
           dataSource,
-          columns,
+          gridConfig,
           onReady,
           dataGridState,
           onClearGridState,
@@ -78,27 +77,12 @@ export class AggregationPanel
   private renderTable(
     controls: m.Children | undefined,
     dataSource: DataSource,
-    model: ReadonlyArray<ColumnDef> | AggregatePivotModel,
+    gridConfig: AggregatorGridConfig,
     onReady?: (api: DataGridApi) => void,
     dataGridState?: DataGridState,
     onClearGridState?: () => void,
   ) {
-    // Get column definitions - either from pivot model or flat model
-    const columnDefs = 'groupBy' in model ? model.columns : model;
-
-    // Build schema from column definitions
-    const columnSchema: ColumnSchema = {};
-    for (const c of columnDefs) {
-      columnSchema[c.columnId] = {
-        title: c.title,
-        titleString: c.title,
-        columnType: filterTypeForColumnDef(c.formatHint),
-        cellRenderer:
-          c.cellRenderer ?? getCellRenderer(c.formatHint, c.columnId),
-        cellFormatter: getValueFormatter(c.formatHint),
-      };
-    }
-    const schema: SchemaRegistry = {data: columnSchema};
+    const schema: SchemaRegistry = {data: gridConfig.schema};
 
     return m(DataGrid, {
       fillHeight: true,
@@ -143,7 +127,7 @@ export class AggregationPanel
   }
 }
 
-function filterTypeForColumnDef(
+export function filterTypeForFormatHint(
   formatHint: string | undefined,
 ): ColumnType | undefined {
   switch (formatHint) {
@@ -161,7 +145,7 @@ function filterTypeForColumnDef(
   }
 }
 
-function getValueFormatter(
+export function getValueFormatter(
   formatHint: string | undefined,
 ): (value: SqlValue) => string {
   switch (formatHint) {
@@ -174,7 +158,7 @@ function getValueFormatter(
   }
 }
 
-function getCellRenderer(
+export function getCellRenderer(
   formatHint: string | undefined,
   columnName: string,
 ): CellRenderer {
@@ -190,7 +174,7 @@ function getCellRenderer(
   }
 }
 
-function formatDurationValue(value: SqlValue): string {
+export function formatDurationValue(value: SqlValue): string {
   if (typeof value === 'bigint') {
     return Duration.humanise(value);
   } else if (typeof value === 'number') {
@@ -200,7 +184,7 @@ function formatDurationValue(value: SqlValue): string {
   }
 }
 
-function formatPercentValue(value: SqlValue): string {
+export function formatPercentValue(value: SqlValue): string {
   if (typeof value === 'number') {
     return `${(value * 100).toFixed(2)}%`;
   } else {

--- a/ui/src/components/widgets/datagrid/sql_schema.ts
+++ b/ui/src/components/widgets/datagrid/sql_schema.ts
@@ -463,7 +463,21 @@ export function createSimpleSchema(
   return {
     [schemaName]: {
       table,
-      columns: {}, // Empty columns - all column access falls through to direct access
+      columns: {
+        args: {
+          expression: (alias, key) =>
+            `extract_arg(${alias}.arg_set_id, '${key}')`,
+          parameterized: true,
+          parameterKeysQuery: (baseTable, baseAlias) => `
+            SELECT DISTINCT args.key
+            FROM ${baseTable} AS ${baseAlias}
+            JOIN args ON args.arg_set_id = ${baseAlias}.arg_set_id
+            WHERE args.key IS NOT NULL
+            ORDER BY args.key
+            LIMIT 1000
+          `,
+        },
+      },
     },
   };
 }

--- a/ui/src/components/widgets/datagrid/sql_schema.ts
+++ b/ui/src/components/widgets/datagrid/sql_schema.ts
@@ -463,21 +463,7 @@ export function createSimpleSchema(
   return {
     [schemaName]: {
       table,
-      columns: {
-        args: {
-          expression: (alias, key) =>
-            `extract_arg(${alias}.arg_set_id, '${key}')`,
-          parameterized: true,
-          parameterKeysQuery: (baseTable, baseAlias) => `
-            SELECT DISTINCT args.key
-            FROM ${baseTable} AS ${baseAlias}
-            JOIN args ON args.arg_set_id = ${baseAlias}.arg_set_id
-            WHERE args.key IS NOT NULL
-            ORDER BY args.key
-            LIMIT 1000
-          `,
-        },
-      },
+      columns: {}, // Empty columns - all column access falls through to direct access
     },
   };
 }

--- a/ui/src/plugins/com.android.AndroidLog/log_selection_aggregator.ts
+++ b/ui/src/plugins/com.android.AndroidLog/log_selection_aggregator.ts
@@ -15,9 +15,9 @@
 import m from 'mithril';
 import {Icons} from '../../base/semantic_icons';
 import type {
-  AggregatePivotModel,
   Aggregation,
   Aggregator,
+  AggregatorGridConfig,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import type {Trace} from '../../public/trace';
@@ -75,19 +75,13 @@ export class AndroidLogSelectionAggregator implements Aggregator {
     return 'Android Logs';
   }
 
-  getColumnDefinitions(): AggregatePivotModel {
+  getGridConfig(): AggregatorGridConfig {
     return {
-      groupBy: [
-        {id: 'tag', field: 'tag'},
-        {id: 'prio', field: 'prio'},
-      ],
-      aggregates: [{id: 'count', function: 'COUNT'}],
-      columns: [
-        {
+      schema: {
+        id: {
           title: 'ID',
-          columnId: 'id',
-          formatHint: 'NUMERIC',
-          cellRenderer: (value) => {
+          columnType: 'identifier',
+          cellRenderer: (value: unknown) => {
             const id = typeof value === 'bigint' ? Number(value) : value;
             if (typeof id !== 'number') return String(value);
             return m(
@@ -104,15 +98,22 @@ export class AndroidLogSelectionAggregator implements Aggregator {
             );
           },
         },
-        {title: 'Timestamp', columnId: 'ts', formatHint: 'TIMESTAMP_NS'},
-        {title: 'Priority', columnId: 'prio', formatHint: 'NUMERIC'},
-        {title: 'Tag', columnId: 'tag', formatHint: 'STRING'},
-        {title: 'Message', columnId: 'msg', formatHint: 'STRING'},
-        {title: 'TID', columnId: 'tid', formatHint: 'NUMERIC'},
-        {title: 'Thread', columnId: 'thread_name', formatHint: 'STRING'},
-        {title: 'PID', columnId: 'pid', formatHint: 'NUMERIC'},
-        {title: 'Process', columnId: 'process_name', formatHint: 'STRING'},
-      ],
+        ts: {title: 'Timestamp', columnType: 'quantitative'},
+        prio: {title: 'Priority', columnType: 'quantitative'},
+        tag: {title: 'Tag', columnType: 'text'},
+        msg: {title: 'Message', columnType: 'text'},
+        tid: {title: 'TID', columnType: 'quantitative'},
+        thread_name: {title: 'Thread', columnType: 'text'},
+        pid: {title: 'PID', columnType: 'quantitative'},
+        process_name: {title: 'Process', columnType: 'text'},
+      },
+      initialPivot: {
+        groupBy: [
+          {id: 'tag', field: 'tag'},
+          {id: 'prio', field: 'prio'},
+        ],
+        aggregates: [{id: 'count', function: 'COUNT'}],
+      },
     };
   }
 }

--- a/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.EntityStateResidency/entity_state_residency_selection_aggregator.ts
@@ -13,11 +13,14 @@
 // limitations under the License.
 
 import {Duration} from '../../base/time';
-import type {ColumnDef} from '../../components/aggregation';
-import type {Aggregator} from '../../components/aggregation_adapter';
+import type {
+  Aggregator,
+  AggregatorGridConfig,
+} from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
 import type {Engine} from '../../trace_processor/engine';
+import {formatPercentValue} from '../../components/aggregation_panel';
 
 export class EntityStateResidencySelectionAggregator implements Aggregator {
   readonly id = 'entity_state_residency_aggregation';
@@ -76,35 +79,27 @@ export class EntityStateResidencySelectionAggregator implements Aggregator {
     };
   }
 
-  getColumnDefinitions(): ColumnDef[] {
-    return [
-      {
-        title: 'Entity',
-        columnId: 'entity_name',
-        sort: 'DESC',
+  getGridConfig(): AggregatorGridConfig {
+    return {
+      schema: {
+        entity_name: {title: 'Entity', columnType: 'text'},
+        state_name: {title: 'State', columnType: 'text'},
+        delta_value: {title: 'Time in state (ms)', columnType: 'quantitative'},
+        rate_percent: {
+          title: 'Time in state',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
+        },
+        count: {title: 'Sample Count', columnType: 'quantitative'},
       },
-      {
-        title: 'State',
-        columnId: 'state_name',
-      },
-      {
-        title: 'Time in state (ms)',
-        columnId: 'delta_value',
-        sum: true,
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Time in state',
-        formatHint: 'PERCENT',
-        columnId: 'rate_percent',
-        sum: true,
-      },
-      {
-        title: 'Sample Count',
-        columnId: 'count',
-        formatHint: 'NUMERIC',
-      },
-    ];
+      initialColumns: [
+        {id: 'entity_name', field: 'entity_name', sort: 'DESC'},
+        {id: 'state_name', field: 'state_name'},
+        {id: 'delta_value', field: 'delta_value', aggregate: 'SUM'},
+        {id: 'rate_percent', field: 'rate_percent', aggregate: 'SUM'},
+        {id: 'count', field: 'count'},
+      ],
+    };
   }
 
   getTabName() {

--- a/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Frames/frame_selection_aggregator.ts
@@ -13,15 +13,16 @@
 // limitations under the License.
 
 import {
-  type AggregatePivotModel,
   type Aggregation,
   type Aggregator,
+  type AggregatorGridConfig,
   createIITable,
   selectTracksAndGetDataset,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import type {Engine} from '../../trace_processor/engine';
 import {LONG, NUM, STR} from '../../trace_processor/query_result';
+import {formatDurationValue} from '../../components/aggregation_panel';
 
 export const ACTUAL_FRAMES_SLICE_TRACK_KIND = 'ActualFramesSliceTrack';
 
@@ -69,42 +70,25 @@ export class FrameSelectionAggregator implements Aggregator {
     return 'Frames';
   }
 
-  getColumnDefinitions(): AggregatePivotModel {
+  getGridConfig(): AggregatorGridConfig {
     return {
-      groupBy: [{id: 'jank_type', field: 'jank_type'}],
-      aggregates: [
-        {
-          id: 'count',
-          function: 'COUNT',
-          sort: 'DESC',
-        },
-        {
-          id: 'dur_min',
-          field: 'dur',
-          function: 'MIN',
-        },
-        {
-          id: 'dur_max',
-          field: 'dur',
-          function: 'MAX',
-        },
-        {
-          id: 'dur_avg',
-          field: 'dur',
-          function: 'AVG',
-        },
-      ],
-      columns: [
-        {
-          title: 'Jank Type',
-          columnId: 'jank_type',
-        },
-        {
+      schema: {
+        jank_type: {title: 'Jank Type', columnType: 'text'},
+        dur: {
           title: 'Duration',
-          formatHint: 'DURATION_NS',
-          columnId: 'dur',
+          columnType: 'quantitative',
+          cellRenderer: formatDurationValue,
         },
-      ],
+      },
+      initialPivot: {
+        groupBy: [{id: 'jank_type', field: 'jank_type'}],
+        aggregates: [
+          {id: 'count', function: 'COUNT', sort: 'DESC'},
+          {id: 'dur_min', field: 'dur', function: 'MIN'},
+          {id: 'dur_max', field: 'dur', function: 'MAX'},
+          {id: 'dur_avg', field: 'dur', function: 'AVG'},
+        ],
+      },
     };
   }
 }

--- a/ui/src/plugins/dev.perfetto.PowerRails/power_counter_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.PowerRails/power_counter_selection_aggregator.ts
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import {Duration} from '../../base/time';
-import type {ColumnDef} from '../../components/aggregation';
 import type {
   Aggregation,
   Aggregator,
+  AggregatorGridConfig,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
@@ -81,32 +81,21 @@ export class PowerCounterSelectionAggregator implements Aggregator {
     };
   }
 
-  getColumnDefinitions(): ColumnDef[] {
-    return [
-      {
-        title: 'Rail Name',
-        columnId: 'name',
-        sort: 'DESC',
+  getGridConfig(): AggregatorGridConfig {
+    return {
+      schema: {
+        name: {title: 'Rail Name', columnType: 'text'},
+        delta_value: {title: 'Delta energy (mJ)', columnType: 'quantitative'},
+        rate: {title: 'Avg Power (mW)', columnType: 'quantitative'},
+        count: {title: 'Sample Count', columnType: 'quantitative'},
       },
-      {
-        title: 'Delta energy (mJ)',
-        columnId: 'delta_value',
-        sum: true,
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Avg Power (mW)',
-        columnId: 'rate',
-        sum: true,
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Sample Count',
-        columnId: 'count',
-        sum: true,
-        formatHint: 'NUMERIC',
-      },
-    ];
+      initialColumns: [
+        {id: 'name', field: 'name', sort: 'DESC'},
+        {id: 'delta_value', field: 'delta_value', aggregate: 'SUM'},
+        {id: 'rate', field: 'rate', aggregate: 'SUM'},
+        {id: 'count', field: 'count', aggregate: 'SUM'},
+      ],
+    };
   }
 
   getTabName() {

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_by_process_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_by_process_selection_aggregator.ts
@@ -15,9 +15,9 @@
 import m from 'mithril';
 import {Icons} from '../../base/semantic_icons';
 import {
-  type AggregatePivotModel,
   type Aggregation,
   type Aggregator,
+  type AggregatorGridConfig,
   createIITable,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
@@ -38,6 +38,10 @@ import {
   UNKNOWN,
 } from '../../trace_processor/query_result';
 import {Anchor} from '../../widgets/anchor';
+import {
+  formatDurationValue,
+  formatPercentValue,
+} from '../../components/aggregation_panel';
 
 const CPU_SLICE_SPEC = {
   id: NUM,
@@ -127,24 +131,12 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
     return 'CPU by process';
   }
 
-  getColumnDefinitions(): AggregatePivotModel {
+  getGridConfig(): AggregatorGridConfig {
     return {
-      groupBy: [{id: 'process_name', field: 'process_name'}],
-      aggregates: [
-        {id: 'count', function: 'COUNT'},
-        {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
-        {
-          id: 'fraction_of_total_sum',
-          field: 'fraction_of_total',
-          function: 'SUM',
-        },
-        {id: 'dur_avg', field: 'dur', function: 'AVG'},
-      ],
-      columns: [
-        {
+      schema: {
+        id_with_lineage: {
           title: 'ID',
-          columnId: 'id_with_lineage',
-          formatHint: 'ID',
+          columnType: 'identifier',
           cellRenderer: (value: unknown) => {
             // Value is a JSON object {id, groupid, partition}
             if (typeof value !== 'string') {
@@ -179,31 +171,37 @@ export class CpuSliceByProcessSelectionAggregator implements Aggregator {
             );
           },
         },
-        {
-          title: 'PID',
-          columnId: 'pid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'Process Name',
-          columnId: 'process_name',
-        },
-        {
+        pid: {title: 'PID', columnType: 'identifier'},
+        process_name: {title: 'Process Name', columnType: 'text'},
+        dur: {
           title: 'CPU Time',
-          formatHint: 'DURATION_NS',
-          columnId: 'dur',
+          columnType: 'quantitative',
+          cellRenderer: formatDurationValue,
         },
-        {
+        fraction_of_total: {
           title: 'CPU Time %',
-          formatHint: 'PERCENT',
-          columnId: 'fraction_of_total',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
         },
-        {
+        fraction_of_selection: {
           title: 'CPU Time / Wall Time',
-          columnId: 'fraction_of_selection',
-          formatHint: 'PERCENT',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
         },
-      ],
+      },
+      initialPivot: {
+        groupBy: [{id: 'process_name', field: 'process_name'}],
+        aggregates: [
+          {id: 'count', function: 'COUNT'},
+          {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
+          {
+            id: 'fraction_of_total_sum',
+            field: 'fraction_of_total',
+            function: 'SUM',
+          },
+          {id: 'dur_avg', field: 'dur', function: 'AVG'},
+        ],
+      },
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/cpu_slice_selection_aggregator.ts
@@ -15,9 +15,9 @@
 import m from 'mithril';
 import {Icons} from '../../base/semantic_icons';
 import {
-  type AggregatePivotModel,
   type Aggregation,
   type Aggregator,
+  type AggregatorGridConfig,
   createIITable,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
@@ -38,6 +38,10 @@ import {
   UNKNOWN,
 } from '../../trace_processor/query_result';
 import {Anchor} from '../../widgets/anchor';
+import {
+  formatDurationValue,
+  formatPercentValue,
+} from '../../components/aggregation_panel';
 
 const CPU_SLICE_SPEC = {
   id: NUM,
@@ -133,27 +137,12 @@ export class CpuSliceSelectionAggregator implements Aggregator {
     return `CPU by thread`;
   }
 
-  getColumnDefinitions(): AggregatePivotModel {
+  getGridConfig(): AggregatorGridConfig {
     return {
-      groupBy: [
-        {id: 'process_name', field: 'process_name'},
-        {id: 'thread_name', field: 'thread_name'},
-      ],
-      aggregates: [
-        {id: 'count', function: 'COUNT'},
-        {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
-        {
-          id: 'fraction_of_total_sum',
-          field: 'fraction_of_total',
-          function: 'SUM',
-        },
-        {id: 'dur_avg', field: 'dur', function: 'AVG'},
-      ],
-      columns: [
-        {
+      schema: {
+        id_with_lineage: {
           title: 'ID',
-          columnId: 'id_with_lineage',
-          formatHint: 'ID',
+          columnType: 'identifier',
           cellRenderer: (value: unknown) => {
             // Value is a JSON object {id, groupid, partition}
             if (typeof value !== 'string') {
@@ -188,47 +177,43 @@ export class CpuSliceSelectionAggregator implements Aggregator {
             );
           },
         },
-        {
-          title: 'PID',
-          columnId: 'pid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'Process Name',
-          columnId: 'process_name',
-          formatHint: 'STRING',
-        },
-        {
-          title: 'TID',
-          columnId: 'tid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'Thread Name',
-          columnId: 'thread_name',
-          formatHint: 'STRING',
-        },
-        {
+        pid: {title: 'PID', columnType: 'identifier'},
+        process_name: {title: 'Process Name', columnType: 'text'},
+        tid: {title: 'TID', columnType: 'identifier'},
+        thread_name: {title: 'Thread Name', columnType: 'text'},
+        dur: {
           title: 'CPU Time',
-          formatHint: 'DURATION_NS',
-          columnId: 'dur',
+          columnType: 'quantitative',
+          cellRenderer: formatDurationValue,
         },
-        {
+        fraction_of_total: {
           title: 'CPU Time %',
-          columnId: 'fraction_of_total',
-          formatHint: 'PERCENT',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
         },
-        {
+        fraction_of_selection: {
           title: 'CPU Time / Wall Time',
-          columnId: 'fraction_of_selection',
-          formatHint: 'PERCENT',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
         },
-        {
-          title: 'CPU',
-          columnId: 'ucpu',
-          formatHint: 'NUMERIC',
-        },
-      ],
+        ucpu: {title: 'CPU', columnType: 'quantitative'},
+      },
+      initialPivot: {
+        groupBy: [
+          {id: 'process_name', field: 'process_name'},
+          {id: 'thread_name', field: 'thread_name'},
+        ],
+        aggregates: [
+          {id: 'count', function: 'COUNT'},
+          {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
+          {
+            id: 'fraction_of_total_sum',
+            field: 'fraction_of_total',
+            function: 'SUM',
+          },
+          {id: 'dur_avg', field: 'dur', function: 'AVG'},
+        ],
+      },
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_by_cpu_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_by_cpu_aggregator.ts
@@ -15,9 +15,9 @@
 import {Duration} from '../../base/time';
 import type {BarChartData} from '../../components/aggregation';
 import {
-  type AggregatePivotModel,
   type Aggregation,
   type Aggregator,
+  type AggregatorGridConfig,
   createIITable,
   selectTracksAndGetDataset,
 } from '../../components/aggregation_adapter';
@@ -32,6 +32,10 @@ import {
   STR_NULL,
 } from '../../trace_processor/query_result';
 import {colorForThreadState} from './common';
+import {
+  formatDurationValue,
+  formatPercentValue,
+} from '../../components/aggregation_panel';
 
 export class ThreadStateByCpuAggregator implements Aggregator {
   readonly id = 'thread_state_by_cpu_aggregation';
@@ -114,71 +118,48 @@ export class ThreadStateByCpuAggregator implements Aggregator {
     };
   }
 
-  getColumnDefinitions(): AggregatePivotModel {
+  getGridConfig(): AggregatorGridConfig {
     return {
-      groupBy: [
-        {id: 'thread_name', field: 'thread_name'},
-        {id: 'state', field: 'state'},
-        {id: 'ucpu', field: 'ucpu'},
-      ],
-      aggregates: [
-        {id: 'count', function: 'COUNT'},
-        {id: 'process_name', field: 'process_name', function: 'ANY'},
-        {id: 'pid', field: 'pid', function: 'ANY'},
-        {id: 'thread_name', field: 'thread_name', function: 'ANY'},
-        {id: 'tid', field: 'tid', function: 'ANY'},
-        {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
-        {
-          id: 'fraction_of_total_sum',
-          field: 'fraction_of_total',
-          function: 'SUM',
-        },
-        {id: 'dur_avg', field: 'dur', function: 'AVG'},
-      ],
-      columns: [
-        {
-          title: 'Process',
-          columnId: 'process_name',
-        },
-        {
-          title: 'PID',
-          columnId: 'pid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'Thread',
-          columnId: 'thread_name',
-        },
-        {
-          title: 'TID',
-          columnId: 'tid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'CPU',
-          columnId: 'ucpu',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'UTID',
-          columnId: 'utid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'State',
-          columnId: 'state',
-        },
-        {
+      schema: {
+        process_name: {title: 'Process', columnType: 'text'},
+        pid: {title: 'PID', columnType: 'identifier'},
+        thread_name: {title: 'Thread', columnType: 'text'},
+        tid: {title: 'TID', columnType: 'identifier'},
+        ucpu: {title: 'CPU', columnType: 'quantitative'},
+        utid: {title: 'UTID', columnType: 'identifier'},
+        state: {title: 'State', columnType: 'text'},
+        dur: {
           title: 'Wall duration',
-          formatHint: 'DURATION_NS',
-          columnId: 'dur',
+          columnType: 'quantitative',
+          cellRenderer: formatDurationValue,
         },
-        {
+        fraction_of_total: {
           title: 'Wall duration %',
-          formatHint: 'PERCENT',
-          columnId: 'fraction_of_total',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
         },
-      ],
+      },
+      initialPivot: {
+        groupBy: [
+          {id: 'thread_name', field: 'thread_name'},
+          {id: 'state', field: 'state'},
+          {id: 'ucpu', field: 'ucpu'},
+        ],
+        aggregates: [
+          {id: 'count', function: 'COUNT'},
+          {id: 'process_name_any', field: 'process_name', function: 'ANY'},
+          {id: 'pid_any', field: 'pid', function: 'ANY'},
+          {id: 'thread_name_any', field: 'thread_name', function: 'ANY'},
+          {id: 'tid_any', field: 'tid', function: 'ANY'},
+          {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
+          {
+            id: 'fraction_of_total_sum',
+            field: 'fraction_of_total',
+            function: 'SUM',
+          },
+          {id: 'dur_avg', field: 'dur', function: 'AVG'},
+        ],
+      },
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/thread_state_selection_aggregator.ts
@@ -17,9 +17,9 @@ import {Icons} from '../../base/semantic_icons';
 import {Duration} from '../../base/time';
 import type {BarChartData} from '../../components/aggregation';
 import {
-  type AggregatePivotModel,
   type Aggregation,
   type Aggregator,
+  type AggregatorGridConfig,
   createIITable,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
@@ -44,6 +44,10 @@ import {
 } from '../../trace_processor/query_result';
 import {Anchor} from '../../widgets/anchor';
 import {colorForThreadState} from './common';
+import {
+  formatDurationValue,
+  formatPercentValue,
+} from '../../components/aggregation_panel';
 
 const THREAD_STATE_SPEC = {
   id: NUM,
@@ -166,31 +170,12 @@ export class ThreadStateSelectionAggregator implements Aggregator {
     };
   }
 
-  getColumnDefinitions(): AggregatePivotModel {
+  getGridConfig(): AggregatorGridConfig {
     return {
-      groupBy: [
-        {id: 'thread_name', field: 'thread_name'},
-        {id: 'state', field: 'state'},
-      ],
-      aggregates: [
-        {id: 'count', function: 'COUNT'},
-        {id: 'process_name', field: 'process_name', function: 'ANY'},
-        {id: 'pid', field: 'pid', function: 'ANY'},
-        {id: 'thread_name', field: 'thread_name', function: 'ANY'},
-        {id: 'tid', field: 'tid', function: 'ANY'},
-        {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
-        {
-          id: 'fraction_of_total_sum',
-          field: 'fraction_of_total',
-          function: 'SUM',
-        },
-        {id: 'dur_avg', field: 'dur', function: 'AVG'},
-      ],
-      columns: [
-        {
+      schema: {
+        id_with_lineage: {
           title: 'ID',
-          columnId: 'id_with_lineage',
-          formatHint: 'ID',
+          columnType: 'identifier',
           cellRenderer: (value: unknown) => {
             // Value is a JSON object {id, groupid, partition}
             if (typeof value !== 'string') {
@@ -225,52 +210,45 @@ export class ThreadStateSelectionAggregator implements Aggregator {
             );
           },
         },
-        {title: 'Cluster Type', columnId: 'cluster_type', formatHint: 'STRING'},
-        {
-          title: 'Process',
-          columnId: 'process_name',
-          formatHint: 'STRING',
-        },
-        {
-          title: 'PID',
-          columnId: 'pid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'Thread',
-          columnId: 'thread_name',
-          formatHint: 'STRING',
-        },
-        {
-          title: 'TID',
-          columnId: 'tid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'CPU',
-          columnId: 'ucpu',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'UTID',
-          columnId: 'utid',
-          formatHint: 'NUMERIC',
-        },
-        {
-          title: 'State',
-          columnId: 'state',
-        },
-        {
+        cluster_type: {title: 'Cluster Type', columnType: 'text'},
+        process_name: {title: 'Process', columnType: 'text'},
+        pid: {title: 'PID', columnType: 'identifier'},
+        thread_name: {title: 'Thread', columnType: 'text'},
+        tid: {title: 'TID', columnType: 'identifier'},
+        ucpu: {title: 'CPU', columnType: 'quantitative'},
+        utid: {title: 'UTID', columnType: 'identifier'},
+        state: {title: 'State', columnType: 'text'},
+        dur: {
           title: 'Wall duration',
-          formatHint: 'DURATION_NS',
-          columnId: 'dur',
+          columnType: 'quantitative',
+          cellRenderer: formatDurationValue,
         },
-        {
+        fraction_of_total: {
           title: 'Wall duration %',
-          formatHint: 'PERCENT',
-          columnId: 'fraction_of_total',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
         },
-      ],
+      },
+      initialPivot: {
+        groupBy: [
+          {id: 'thread_name', field: 'thread_name'},
+          {id: 'state', field: 'state'},
+        ],
+        aggregates: [
+          {id: 'count', function: 'COUNT'},
+          {id: 'process_name_any', field: 'process_name', function: 'ANY'},
+          {id: 'pid_any', field: 'pid', function: 'ANY'},
+          {id: 'thread_name_any', field: 'thread_name', function: 'ANY'},
+          {id: 'tid_any', field: 'tid', function: 'ANY'},
+          {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
+          {
+            id: 'fraction_of_total_sum',
+            field: 'fraction_of_total',
+            function: 'SUM',
+          },
+          {id: 'dur_avg', field: 'dur', function: 'AVG'},
+        ],
+      },
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/counter_selection_aggregator.ts
@@ -1,22 +1,22 @@
 // Copyright (C) 2020 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the \"License\");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an \"AS IS\" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
 import {Duration} from '../../base/time';
-import type {ColumnDef} from '../../components/aggregation';
 import type {
   Aggregation,
   Aggregator,
+  AggregatorGridConfig,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import {COUNTER_TRACK_KIND} from '../../public/track_kinds';
@@ -129,55 +129,31 @@ export class CounterSelectionAggregator implements Aggregator {
     };
   }
 
-  getColumnDefinitions(): ColumnDef[] {
-    return [
-      {
-        title: 'Name',
-        columnId: 'name',
-        sort: 'DESC',
+  getGridConfig(): AggregatorGridConfig {
+    return {
+      schema: {
+        name: {title: 'Name', columnType: 'text'},
+        delta_value: {title: 'Delta value', columnType: 'quantitative'},
+        rate: {title: 'Rate /s', columnType: 'quantitative'},
+        avg_value: {title: 'Weighted avg value', columnType: 'quantitative'},
+        count: {title: 'Count', columnType: 'quantitative'},
+        first_value: {title: 'First value', columnType: 'quantitative'},
+        last_value: {title: 'Last value', columnType: 'quantitative'},
+        min_value: {title: 'Min value', columnType: 'quantitative'},
+        max_value: {title: 'Max value', columnType: 'quantitative'},
       },
-      {
-        title: 'Delta value',
-        columnId: 'delta_value',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Rate /s',
-        columnId: 'rate',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Weighted avg value',
-        columnId: 'avg_value',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Count',
-        columnId: 'count',
-        sum: true,
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'First value',
-        columnId: 'first_value',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Last value',
-        columnId: 'last_value',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Min value',
-        columnId: 'min_value',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'Max value',
-        columnId: 'max_value',
-        formatHint: 'NUMERIC',
-      },
-    ];
+      initialColumns: [
+        {id: 'name', field: 'name', sort: 'DESC'},
+        {id: 'delta_value', field: 'delta_value'},
+        {id: 'rate', field: 'rate'},
+        {id: 'avg_value', field: 'avg_value'},
+        {id: 'count', field: 'count', aggregate: 'SUM'},
+        {id: 'first_value', field: 'first_value'},
+        {id: 'last_value', field: 'last_value'},
+        {id: 'min_value', field: 'min_value'},
+        {id: 'max_value', field: 'max_value'},
+      ],
+    };
   }
 
   getTabName() {

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -40,6 +40,7 @@ import {
   UNKNOWN,
 } from '../../trace_processor/query_result';
 import {createPerfettoTable} from '../../trace_processor/sql_utils';
+import type {SQLSchemaRegistry} from '../../components/widgets/datagrid/sql_schema';
 import {Anchor} from '../../widgets/anchor';
 import {formatDurationValue} from '../../components/aggregation_panel';
 
@@ -343,6 +344,28 @@ export class SliceSelectionAggregator implements Aggregator {
           parameterized: true,
         },
       },
+      // The aggregation table always has an `arg_set_id` column, so we can
+      // expose a parameterized `args.*` column to the data grid.
+      sqlConfig: ({tableName}): SQLSchemaRegistry => ({
+        query: {
+          table: tableName,
+          columns: {
+            args: {
+              expression: (alias, key) =>
+                `extract_arg(${alias}.arg_set_id, '${key}')`,
+              parameterized: true,
+              parameterKeysQuery: (baseTable, baseAlias) => `
+                SELECT DISTINCT args.key
+                FROM ${baseTable} AS ${baseAlias}
+                JOIN args ON args.arg_set_id = ${baseAlias}.arg_set_id
+                WHERE args.key IS NOT NULL
+                ORDER BY args.key
+                LIMIT 1000
+              `,
+            },
+          },
+        },
+      }),
       initialPivot: {
         groupBy: [{id: 'name', field: 'name'}],
         aggregates: [

--- a/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
+++ b/ui/src/plugins/dev.perfetto.TraceProcessorTrack/slice_selection_aggregator.ts
@@ -1,13 +1,13 @@
 // Copyright (C) 2020 The Android Open Source Project
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
+// Licensed under the Apache License, Version 2.0 (the \"License\");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under the License is distributed on an \"AS IS\" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
@@ -16,9 +16,9 @@ import m from 'mithril';
 import {AsyncDisposableStack} from '../../base/disposable_stack';
 import {Icons} from '../../base/semantic_icons';
 import {
-  type AggregatePivotModel,
   type Aggregation,
   type Aggregator,
+  type AggregatorGridConfig,
   createIITable,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
@@ -41,6 +41,7 @@ import {
 } from '../../trace_processor/query_result';
 import {createPerfettoTable} from '../../trace_processor/sql_utils';
 import {Anchor} from '../../widgets/anchor';
+import {formatDurationValue} from '../../components/aggregation_panel';
 
 const SLICE_WITH_PARENT_SPEC = {
   id: NUM,
@@ -48,6 +49,7 @@ const SLICE_WITH_PARENT_SPEC = {
   ts: LONG,
   dur: LONG,
   parent_id: NUM_NULL,
+  arg_set_id: NUM_NULL,
 };
 
 const SLICELIKE_SPEC = {
@@ -55,6 +57,7 @@ const SLICELIKE_SPEC = {
   name: STR_NULL,
   ts: LONG,
   dur: LONG,
+  arg_set_id: NUM_NULL,
 };
 
 export class SliceSelectionAggregator implements Aggregator {
@@ -134,7 +137,8 @@ export class SliceSelectionAggregator implements Aggregator {
             json_object('id', id, 'groupid', __groupid, 'partition', __partition) as id_with_lineage,
             name,
             dur,
-            self_dur
+            self_dur,
+            arg_set_id
           FROM (${unionQueries.join(' UNION ALL ')})
         `);
 
@@ -206,6 +210,7 @@ export class SliceSelectionAggregator implements Aggregator {
           ts,
           dur,
           dur - COALESCE(child_dur, 0) AS self_dur,
+          arg_set_id,
           __groupid,
           __partition
         FROM ${iiTable.name}
@@ -265,6 +270,7 @@ export class SliceSelectionAggregator implements Aggregator {
           ts,
           dur,
           dur AS self_dur,
+          arg_set_id,
           __groupid,
           __partition
         FROM ${iiTable.name}
@@ -278,21 +284,13 @@ export class SliceSelectionAggregator implements Aggregator {
     return 'Slices';
   }
 
-  getColumnDefinitions(): AggregatePivotModel {
+  getGridConfig(): AggregatorGridConfig {
     return {
-      groupBy: [{id: 'name', field: 'name'}],
-      aggregates: [
-        {id: 'count', function: 'COUNT'},
-        {id: 'total_time_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
-        {id: 'self_time_sum', field: 'self_dur', function: 'SUM'},
-        {id: 'total_time_avg', field: 'dur', function: 'AVG'},
-      ],
-      columns: [
-        {
+      schema: {
+        id_with_lineage: {
           title: 'ID',
-          columnId: 'id_with_lineage',
-          formatHint: 'ID',
-          cellRenderer: (value: SqlValue) => {
+          columnType: 'identifier',
+          cellRenderer: (value: unknown) => {
             // Value is a JSON object {id, groupid, partition}
             if (typeof value !== 'string') {
               return String(value);
@@ -326,22 +324,34 @@ export class SliceSelectionAggregator implements Aggregator {
             );
           },
         },
-        {
+        name: {
           title: 'Name',
-          columnId: 'name',
-          formatHint: 'STRING',
+          columnType: 'text',
         },
-        {
+        dur: {
           title: 'Wall Duration',
-          formatHint: 'DURATION_NS',
-          columnId: 'dur',
+          columnType: 'quantitative',
+          cellRenderer: formatDurationValue,
         },
-        {
+        self_dur: {
           title: 'Self Duration',
-          formatHint: 'DURATION_NS',
-          columnId: 'self_dur',
+          columnType: 'quantitative',
+          cellRenderer: formatDurationValue,
         },
-      ],
+        args: {
+          title: 'Args',
+          parameterized: true,
+        },
+      },
+      initialPivot: {
+        groupBy: [{id: 'name', field: 'name'}],
+        aggregates: [
+          {id: 'count', function: 'COUNT'},
+          {id: 'dur_sum', field: 'dur', function: 'SUM', sort: 'DESC'},
+          {id: 'self_dur_sum', field: 'self_dur', function: 'SUM'},
+          {id: 'dur_avg', field: 'dur', function: 'AVG'},
+        ],
+      },
     };
   }
 

--- a/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/estimate_aggregator.ts
@@ -14,8 +14,10 @@
 
 import m from 'mithril';
 import {exists} from '../../base/utils';
-import type {ColumnDef} from '../../components/aggregation';
-import type {Aggregator} from '../../components/aggregation_adapter';
+import type {
+  Aggregator,
+  AggregatorGridConfig,
+} from '../../components/aggregation_adapter';
 import type {Area, AreaSelection} from '../../public/selection';
 import type {Engine} from '../../trace_processor/engine';
 import type {SqlValue} from '../../trace_processor/query_result';
@@ -109,10 +111,6 @@ export class WattsonEstimateSelectionAggregator implements Aggregator {
     );
   }
 
-  private powerUnits(): string {
-    return this.scaleNumericData ? 'µW' : 'mW';
-  }
-
   private renderMilliwatts(value: SqlValue): m.Children {
     if (this.scaleNumericData && typeof value === 'number') {
       return value * 1000;
@@ -120,26 +118,30 @@ export class WattsonEstimateSelectionAggregator implements Aggregator {
     return String(value);
   }
 
-  getColumnDefinitions(): ColumnDef[] {
-    return [
-      {
-        title: 'Name',
-        columnId: 'name',
-        sort: 'ASC',
+  getGridConfig(): AggregatorGridConfig {
+    const powerUnits = this.scaleNumericData ? 'µW' : 'mW';
+    const energyUnits = this.scaleNumericData ? 'µWs' : 'mWs';
+
+    return {
+      schema: {
+        name: {title: 'Name', columnType: 'text'},
+        power_mw: {
+          title: `Power (estimated ${powerUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        energy_mws: {
+          title: `Energy (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
       },
-      {
-        title: `Power (estimated ${this.powerUnits()})`,
-        columnId: 'power_mw',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: `Energy (estimated ${this.powerUnits()}s)`,
-        columnId: 'energy_mws',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-    ];
+      initialColumns: [
+        {id: 'name', field: 'name', sort: 'ASC'},
+        {id: 'power_mw', field: 'power_mw', aggregate: 'SUM'},
+        {id: 'energy_mws', field: 'energy_mws', aggregate: 'SUM'},
+      ],
+    };
   }
 
   getTabName() {

--- a/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
@@ -14,16 +14,17 @@
 
 import m from 'mithril';
 import {exists} from '../../base/utils';
-import type {ColumnDef} from '../../components/aggregation';
 import type {
   Aggregation,
   Aggregator,
+  AggregatorGridConfig,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import {CPU_SLICE_TRACK_KIND} from '../../public/track_kinds';
 import type {Engine} from '../../trace_processor/engine';
 import type {SqlValue} from '../../trace_processor/query_result';
 import {RadioGroup} from '../../widgets/radio_group';
+import {formatPercentValue} from '../../components/aggregation_panel';
 
 // Base class to share logic between CPU and GPU package aggregators
 abstract class WattsonBasePackageSelectionAggregator implements Aggregator {
@@ -89,57 +90,53 @@ abstract class WattsonBasePackageSelectionAggregator implements Aggregator {
     return String(value);
   }
 
-  getColumnDefinitions(): ColumnDef[] {
-    const cols: ColumnDef[] = [
-      {
-        title: 'Package Name',
-        columnId: 'package_name',
-      },
-      {
-        title: 'Android app UID',
-        columnId: 'uid',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: `Active power (estimated ${this.powerUnits()})`,
-        columnId: 'active_mw',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: `Active energy (estimated ${this.powerUnits()}s)`,
-        columnId: 'active_mws',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-        sort: 'DESC',
-      },
-    ];
+  getGridConfig(): AggregatorGridConfig {
+    const powerUnits = this.powerUnits();
+    const energyUnits = `${powerUnits}s`;
+    const idleCost = this.hasIdleCost();
 
-    if (this.hasIdleCost()) {
-      cols.push({
-        title: `Idle transitions overhead (estimated ${this.powerUnits()}s)`,
-        columnId: 'idle_cost_mws',
-        sum: false,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      });
-    }
-
-    cols.push(
-      {
-        title: `Total energy (estimated ${this.powerUnits()}s)`,
-        columnId: 'total_mws',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
+    return {
+      schema: {
+        package_name: {title: 'Package Name', columnType: 'text'},
+        uid: {title: 'Android app UID', columnType: 'identifier'},
+        active_mw: {
+          title: `Active power (estimated ${powerUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        active_mws: {
+          title: `Active energy (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        ...(idleCost && {
+          idle_cost_mws: {
+            title: `Idle transitions overhead (estimated ${energyUnits})`,
+            columnType: 'quantitative',
+            cellRenderer: (v: SqlValue) => this.renderMilliwatts(v),
+          },
+        }),
+        total_mws: {
+          title: `Total energy (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        percent_of_total_energy: {
+          title: '% of total energy',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
+        },
       },
-      {
-        title: '% of total energy',
-        formatHint: 'PERCENT',
-        columnId: 'percent_of_total_energy',
-        sum: false,
-      },
-    );
-
-    return cols;
+      initialColumns: [
+        {id: 'package_name', field: 'package_name'},
+        {id: 'uid', field: 'uid'},
+        {id: 'active_mw', field: 'active_mw', aggregate: 'SUM'},
+        {id: 'active_mws', field: 'active_mws', aggregate: 'SUM', sort: 'DESC'},
+        ...(idleCost ? [{id: 'idle_cost_mws', field: 'idle_cost_mws'}] : []),
+        {id: 'total_mws', field: 'total_mws', aggregate: 'SUM'},
+        {id: 'percent_of_total_energy', field: 'percent_of_total_energy'},
+      ],
+    };
   }
 
   // Default to true, GPU override to false

--- a/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/process_aggregator.ts
@@ -14,13 +14,16 @@
 
 import m from 'mithril';
 import {exists} from '../../base/utils';
-import type {ColumnDef} from '../../components/aggregation';
-import type {Aggregator} from '../../components/aggregation_adapter';
+import type {
+  Aggregator,
+  AggregatorGridConfig,
+} from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import {CPU_SLICE_TRACK_KIND} from '../../public/track_kinds';
 import type {Engine} from '../../trace_processor/engine';
 import type {SqlValue} from '../../trace_processor/query_result';
 import {RadioGroup} from '../../widgets/radio_group';
+import {formatPercentValue} from '../../components/aggregation_panel';
 
 export class WattsonProcessSelectionAggregator implements Aggregator {
   readonly id = 'wattson_plugin_process_aggregation';
@@ -85,10 +88,6 @@ export class WattsonProcessSelectionAggregator implements Aggregator {
     );
   }
 
-  private powerUnits(): string {
-    return this.scaleNumericData ? 'µW' : 'mW';
-  }
-
   private renderMilliwatts(value: SqlValue): m.Children {
     if (this.scaleNumericData && typeof value === 'number') {
       return value * 1000;
@@ -96,49 +95,50 @@ export class WattsonProcessSelectionAggregator implements Aggregator {
     return String(value);
   }
 
-  getColumnDefinitions(): ColumnDef[] {
-    return [
-      {
-        title: 'Process Name',
-        columnId: 'process_name',
+  getGridConfig(): AggregatorGridConfig {
+    const powerUnits = this.scaleNumericData ? 'µW' : 'mW';
+    const energyUnits = this.scaleNumericData ? 'µWs' : 'mWs';
+
+    return {
+      schema: {
+        process_name: {title: 'Process Name', columnType: 'text'},
+        pid: {title: 'PID', columnType: 'identifier'},
+        active_mw: {
+          title: `Active power (estimated ${powerUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        active_mws: {
+          title: `Active energy (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        idle_cost_mws: {
+          title: `Idle transitions overhead (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        total_mws: {
+          title: `Total energy (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        percent_of_total_energy: {
+          title: '% of total energy',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
+        },
       },
-      {
-        title: 'PID',
-        columnId: 'pid',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: `Active power (estimated ${this.powerUnits()})`,
-        columnId: 'active_mw',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: `Active energy (estimated ${this.powerUnits()}s)`,
-        columnId: 'active_mws',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-        sort: 'DESC',
-      },
-      {
-        title: `Idle transitions overhead (estimated ${this.powerUnits()}s)`,
-        columnId: 'idle_cost_mws',
-        sum: false,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: `Total energy (estimated ${this.powerUnits()}s)`,
-        columnId: 'total_mws',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: '% of total energy',
-        formatHint: 'PERCENT',
-        columnId: 'percent_of_total_energy',
-        sum: false,
-      },
-    ];
+      initialColumns: [
+        {id: 'process_name', field: 'process_name'},
+        {id: 'pid', field: 'pid'},
+        {id: 'active_mw', field: 'active_mw', aggregate: 'SUM'},
+        {id: 'active_mws', field: 'active_mws', aggregate: 'SUM', sort: 'DESC'},
+        {id: 'idle_cost_mws', field: 'idle_cost_mws'},
+        {id: 'total_mws', field: 'total_mws', aggregate: 'SUM'},
+        {id: 'percent_of_total_energy', field: 'percent_of_total_energy'},
+      ],
+    };
   }
 
   getTabName() {

--- a/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/thread_aggregator.ts
@@ -14,11 +14,11 @@
 
 import m from 'mithril';
 import {exists} from '../../base/utils';
-import type {ColumnDef} from '../../components/aggregation';
 import {addWattsonThreadTrack} from './wattson_thread_utils';
 import type {
   Aggregation,
   Aggregator,
+  AggregatorGridConfig,
 } from '../../components/aggregation_adapter';
 import type {AreaSelection} from '../../public/selection';
 import {Button, ButtonVariant} from '../../widgets/button';
@@ -29,6 +29,7 @@ import type {SqlValue} from '../../trace_processor/query_result';
 import {RadioGroup} from '../../widgets/radio_group';
 import type {Trace} from '../../public/trace';
 import {WATTSON_THREAD_TRACK_KIND} from './track_kinds';
+import {formatPercentValue} from '../../components/aggregation_panel';
 
 export class WattsonThreadSelectionAggregator implements Aggregator {
   readonly id = 'wattson_plugin_thread_aggregation';
@@ -143,10 +144,6 @@ export class WattsonThreadSelectionAggregator implements Aggregator {
     );
   }
 
-  private powerUnits(): string {
-    return this.scaleNumericData ? 'µW' : 'mW';
-  }
-
   private renderMilliwatts(value: SqlValue): m.Children {
     if (this.scaleNumericData && typeof value === 'number') {
       return value * 1000;
@@ -167,59 +164,57 @@ export class WattsonThreadSelectionAggregator implements Aggregator {
     });
   }
 
-  getColumnDefinitions(): ColumnDef[] {
-    return [
-      {
-        title: 'Track',
-        columnId: 'utid',
-        cellRenderer: this.renderShowButton.bind(this),
+  getGridConfig(): AggregatorGridConfig {
+    const powerUnits = this.scaleNumericData ? 'µW' : 'mW';
+    const energyUnits = this.scaleNumericData ? 'µWs' : 'mWs';
+
+    return {
+      schema: {
+        utid: {
+          title: 'Track',
+          cellRenderer: (v) => this.renderShowButton(v),
+        },
+        thread_name: {title: 'Thread Name', columnType: 'text'},
+        tid: {title: 'TID', columnType: 'identifier'},
+        pid: {title: 'PID', columnType: 'identifier'},
+        active_mw: {
+          title: `Active power (estimated ${powerUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        active_mws: {
+          title: `Active energy (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        idle_cost_mws: {
+          title: `Idle transitions overhead (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        total_mws: {
+          title: `Total energy (estimated ${energyUnits})`,
+          columnType: 'quantitative',
+          cellRenderer: (v) => this.renderMilliwatts(v),
+        },
+        percent_of_total_energy: {
+          title: '% of total energy',
+          columnType: 'quantitative',
+          cellRenderer: formatPercentValue,
+        },
       },
-      {
-        title: 'Thread Name',
-        columnId: 'thread_name',
-      },
-      {
-        title: 'TID',
-        columnId: 'tid',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: 'PID',
-        columnId: 'pid',
-        formatHint: 'NUMERIC',
-      },
-      {
-        title: `Active power (estimated ${this.powerUnits()})`,
-        columnId: 'active_mw',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: `Active energy (estimated ${this.powerUnits()}s)`,
-        columnId: 'active_mws',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-        sort: 'DESC',
-      },
-      {
-        title: `Idle transitions overhead (estimated ${this.powerUnits()}s)`,
-        columnId: 'idle_cost_mws',
-        sum: false,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: `Total energy (estimated ${this.powerUnits()}s)`,
-        columnId: 'total_mws',
-        sum: true,
-        cellRenderer: this.renderMilliwatts.bind(this),
-      },
-      {
-        title: '% of total energy',
-        formatHint: 'PERCENT',
-        columnId: 'percent_of_total_energy',
-        sum: false,
-      },
-    ];
+      initialColumns: [
+        {id: 'utid', field: 'utid'},
+        {id: 'thread_name', field: 'thread_name'},
+        {id: 'tid', field: 'tid'},
+        {id: 'pid', field: 'pid'},
+        {id: 'active_mw', field: 'active_mw', aggregate: 'SUM'},
+        {id: 'active_mws', field: 'active_mws', aggregate: 'SUM', sort: 'DESC'},
+        {id: 'idle_cost_mws', field: 'idle_cost_mws'},
+        {id: 'total_mws', field: 'total_mws', aggregate: 'SUM'},
+        {id: 'percent_of_total_energy', field: 'percent_of_total_energy'},
+      ],
+    };
   }
 
   getTabName() {


### PR DESCRIPTION
This patch allows users to add group by argument values in the slice selection aggregation view.

In order to get this working, we needed to provide much more configurability from the aggregators so this patch also reconfigures the output of the aggregators to be closer to that of the datagrid, giving them more control. All aggregators needed to be updated accordingly to fit the new interface.

The only aggregator which has actually changed is the slice selection aggregator, which adds `arg_set_id` to the underlying table, and adds a new parameterised `Args` column.

Testing: 

- Make an area selection over one or more slice tracks
- Wait for the table to load
- Click the triple dot dropdown in one of the group header cells -> click `Add group by`
- Select an argument (or fuzzy search) to add the column

Fixes: b/536858906

<img width="959" height="378" alt="image" src="https://github.com/user-attachments/assets/fb8252a0-5695-4dcb-824b-acc203322940" />

<img width="781" height="146" alt="image" src="https://github.com/user-attachments/assets/18fe506c-7a89-49cb-a7a4-f9b53c94d17f" />

