### PR TITLE
Consider doFrames when extending frame timeline

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
@@ -65,7 +65,12 @@ SELECT
   cuj_name,
   -- Earliest of (Next Frame Start, Next doFrame Start).
   -- Fallback to original ts_end only if both are NULL.
-  coalesce(min(next_do_slice_after_frame, next_frame_start), original_ts_end) AS ts_end
+  coalesce(
+    min(next_do_slice_after_frame, next_frame_start),
+    next_do_slice_after_frame,
+    next_frame_start,
+    original_ts_end
+  ) AS ts_end
 FROM _frames_with_extension_options
 ORDER BY
   frame_id;

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.out
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.out
@@ -38,10 +38,10 @@ android_blocking_calls_cuj_per_frame_metric {
     }
     blocking_calls {
       name: "animation"
-      max_dur_per_frame_ms: 1
-      max_dur_per_frame_ns: 1000000
-      mean_dur_per_frame_ms: 0
-      mean_dur_per_frame_ns: 500000
+      max_dur_per_frame_ms: 11
+      max_dur_per_frame_ns: 11000000
+      mean_dur_per_frame_ms: 5
+      mean_dur_per_frame_ns: 5500000
       max_cnt_per_frame: 1
       mean_cnt_per_frame: 0.5
     }


### PR DESCRIPTION
For blocking calls per frame duration metrics
we extend the frame timeline to cover cases
where blocking calls starting within a certain frame extend beyond it.

- Problem:

Until now frames were extended till the next available frame in the actual frametine. This however can be problematic when UI thread gets vsync updates and makes blocking calls for a period of time where no draws actually happen.
This means the next actual frame might be much later. This leads to skewed metrics that collect blocking calls way into the future after a specific frame had already ended.

- Solution:

A better approach could be to consider both the next actual frame and the next Choreographer#doFrame slice, picking the earliest option. This updated definition of extended frame should make the metric more meaningful and stable.

Test: tools/diff_test_trace_processor.py --name-filter ".\*android.\*" out/android/trace_processor_shell