### PR TITLE
github: Add hour/min to the UI build comments

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -87,7 +87,8 @@ jobs:
 
               // Get commit info for the new entry
               const commitSha = context.sha.substring(0, 7);
-              const commitDate = new Date().toISOString().split('T')[0];
+              const d = new Date();
+              const commitDate = d.toISOString().replace('T', ' ').substring(0, 16) + ' UTC';
               const newEntry = `- **${commitSha}** (${commitDate}): ${uiBuildUrl}`;
 
               // Get existing comments


### PR DESCRIPTION
Change the UI build comments from `YYYY-MM-DD` to `YYYY-MM-DD HH:MM UTC`
