### PR TITLE
de: Add tabs to Data Explorer

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations.ts
@@ -46,8 +46,6 @@ interface CopyableState {
 interface PastableState {
   readonly rootNodes: QueryNode[];
   readonly nodeLayouts: Map<string, {x: number; y: number}>;
-  readonly clipboardNodes?: ClipboardEntry[];
-  readonly clipboardConnections?: ClipboardConnection[];
 }
 
 // Copies the currently selected nodes and their internal connections to a
@@ -128,19 +126,22 @@ export function copySelectedNodes(
 
 // Pastes clipboard nodes into the state. Returns the updated state fields
 // with new nodes added, or undefined if clipboard is empty.
-export function pasteClipboardNodes(state: PastableState):
+export function pasteClipboardNodes(
+  state: PastableState,
+  clipboard: ClipboardResult | undefined,
+):
   | {
       rootNodes: QueryNode[];
       selectedNodes: Set<string>;
       nodeLayouts: Map<string, {x: number; y: number}>;
     }
   | undefined {
-  if (state.clipboardNodes === undefined || state.clipboardNodes.length === 0) {
+  if (clipboard === undefined || clipboard.clipboardNodes.length === 0) {
     return undefined;
   }
 
   // Clone nodes again for this paste operation (allows multiple pastes)
-  const newNodes = state.clipboardNodes.map((entry) => entry.node.clone());
+  const newNodes = clipboard.clipboardNodes.map((entry) => entry.node.clone());
 
   // Calculate paste offset (place slightly offset from original)
   const pasteOffsetX = 50;
@@ -149,7 +150,7 @@ export function pasteClipboardNodes(state: PastableState):
   // Update layouts for new nodes - only add layouts for undocked nodes
   // Docked nodes will remain docked (attached to their parent)
   const updatedLayouts = new Map(state.nodeLayouts);
-  state.clipboardNodes.forEach((entry, index) => {
+  clipboard.clipboardNodes.forEach((entry, index) => {
     if (!entry.isDocked) {
       updatedLayouts.set(newNodes[index].nodeId, {
         x: entry.relativeX + pasteOffsetX,
@@ -159,13 +160,11 @@ export function pasteClipboardNodes(state: PastableState):
   });
 
   // Restore connections between pasted nodes
-  if (state.clipboardConnections) {
-    for (const conn of state.clipboardConnections) {
-      const fromNode = newNodes[conn.fromIndex] as QueryNode | undefined;
-      const toNode = newNodes[conn.toIndex] as QueryNode | undefined;
-      if (fromNode !== undefined && toNode !== undefined) {
-        addConnection(fromNode, toNode, conn.portIndex);
-      }
+  for (const conn of clipboard.clipboardConnections) {
+    const fromNode = newNodes[conn.fromIndex] as QueryNode | undefined;
+    const toNode = newNodes[conn.toIndex] as QueryNode | undefined;
+    if (fromNode !== undefined && toNode !== undefined) {
+      addConnection(fromNode, toNode, conn.portIndex);
     }
   }
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/clipboard_operations_unittest.ts
@@ -175,36 +175,36 @@ describe('clipboard_operations', () => {
   });
 
   describe('pasteClipboardNodes', () => {
-    it('should return undefined when clipboard is empty', () => {
-      const result = pasteClipboardNodes({
-        rootNodes: [],
-        nodeLayouts: new Map(),
-        clipboardNodes: undefined,
-      });
+    it('should return undefined when clipboard is undefined', () => {
+      const result = pasteClipboardNodes(
+        {rootNodes: [], nodeLayouts: new Map()},
+        undefined,
+      );
       expect(result).toBeUndefined();
     });
 
     it('should return undefined when clipboard has zero entries', () => {
-      const result = pasteClipboardNodes({
-        rootNodes: [],
-        nodeLayouts: new Map(),
-        clipboardNodes: [],
-      });
+      const result = pasteClipboardNodes(
+        {rootNodes: [], nodeLayouts: new Map()},
+        {clipboardNodes: [], clipboardConnections: []},
+      );
       expect(result).toBeUndefined();
     });
 
     it('should append cloned nodes to rootNodes', () => {
       const existing = createMockNode({nodeId: 'existing'});
       const clipNode = createMockNode({nodeId: 'clip'});
-      const clipboardNodes: ClipboardEntry[] = [
-        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
-      ];
+      const clipboard = {
+        clipboardNodes: [
+          {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
+        ] as ClipboardEntry[],
+        clipboardConnections: [] as ClipboardConnection[],
+      };
 
-      const result = pasteClipboardNodes({
-        rootNodes: [existing],
-        nodeLayouts: new Map(),
-        clipboardNodes,
-      });
+      const result = pasteClipboardNodes(
+        {rootNodes: [existing], nodeLayouts: new Map()},
+        clipboard,
+      );
 
       expect(result).toBeDefined();
       // Original node + pasted node
@@ -216,15 +216,17 @@ describe('clipboard_operations', () => {
 
     it('should select only the newly pasted nodes', () => {
       const clipNode = createMockNode({nodeId: 'clip'});
-      const clipboardNodes: ClipboardEntry[] = [
-        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
-      ];
+      const clipboard = {
+        clipboardNodes: [
+          {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
+        ] as ClipboardEntry[],
+        clipboardConnections: [] as ClipboardConnection[],
+      };
 
-      const result = pasteClipboardNodes({
-        rootNodes: [],
-        nodeLayouts: new Map(),
-        clipboardNodes,
-      });
+      const result = pasteClipboardNodes(
+        {rootNodes: [], nodeLayouts: new Map()},
+        clipboard,
+      );
 
       expect(result).toBeDefined();
       expect(result?.selectedNodes.size).toBe(1);
@@ -235,15 +237,17 @@ describe('clipboard_operations', () => {
 
     it('should add layout positions for undocked nodes with offset', () => {
       const clipNode = createMockNode({nodeId: 'clip'});
-      const clipboardNodes: ClipboardEntry[] = [
-        {node: clipNode, relativeX: 100, relativeY: 200, isDocked: false},
-      ];
+      const clipboard = {
+        clipboardNodes: [
+          {node: clipNode, relativeX: 100, relativeY: 200, isDocked: false},
+        ] as ClipboardEntry[],
+        clipboardConnections: [] as ClipboardConnection[],
+      };
 
-      const result = pasteClipboardNodes({
-        rootNodes: [],
-        nodeLayouts: new Map(),
-        clipboardNodes,
-      });
+      const result = pasteClipboardNodes(
+        {rootNodes: [], nodeLayouts: new Map()},
+        clipboard,
+      );
 
       expect(result).toBeDefined();
       const pastedNodeId = result?.rootNodes[0].nodeId ?? '';
@@ -256,15 +260,17 @@ describe('clipboard_operations', () => {
 
     it('should not add layout for docked nodes', () => {
       const clipNode = createMockNode({nodeId: 'clip'});
-      const clipboardNodes: ClipboardEntry[] = [
-        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: true},
-      ];
+      const clipboard = {
+        clipboardNodes: [
+          {node: clipNode, relativeX: 0, relativeY: 0, isDocked: true},
+        ] as ClipboardEntry[],
+        clipboardConnections: [] as ClipboardConnection[],
+      };
 
-      const result = pasteClipboardNodes({
-        rootNodes: [],
-        nodeLayouts: new Map(),
-        clipboardNodes,
-      });
+      const result = pasteClipboardNodes(
+        {rootNodes: [], nodeLayouts: new Map()},
+        clipboard,
+      );
 
       expect(result).toBeDefined();
       const pastedNodeId = result?.rootNodes[0].nodeId ?? '';
@@ -283,21 +289,25 @@ describe('clipboard_operations', () => {
         sqlModules: mockSqlModules,
       });
 
-      const clipboardNodes: ClipboardEntry[] = [
-        {node: realNode, relativeX: 0, relativeY: 0, isDocked: false},
-      ];
+      const clipboard = {
+        clipboardNodes: [
+          {node: realNode, relativeX: 0, relativeY: 0, isDocked: false},
+        ] as ClipboardEntry[],
+        clipboardConnections: [] as ClipboardConnection[],
+      };
 
-      const result1 = pasteClipboardNodes({
-        rootNodes: [],
-        nodeLayouts: new Map(),
-        clipboardNodes,
-      });
+      const result1 = pasteClipboardNodes(
+        {rootNodes: [], nodeLayouts: new Map()},
+        clipboard,
+      );
 
-      const result2 = pasteClipboardNodes({
-        rootNodes: result1?.rootNodes ?? [],
-        nodeLayouts: result1?.nodeLayouts ?? new Map(),
-        clipboardNodes,
-      });
+      const result2 = pasteClipboardNodes(
+        {
+          rootNodes: result1?.rootNodes ?? [],
+          nodeLayouts: result1?.nodeLayouts ?? new Map(),
+        },
+        clipboard,
+      );
 
       expect(result2).toBeDefined();
       expect(result2?.rootNodes).toHaveLength(2);
@@ -310,20 +320,18 @@ describe('clipboard_operations', () => {
     it('should restore connections between pasted nodes', () => {
       const parent = createMockNode({nodeId: 'p', type: NodeType.kTable});
       const child = createMockNode({nodeId: 'c', type: NodeType.kFilter});
-      const clipboardNodes: ClipboardEntry[] = [
-        {node: parent, relativeX: 0, relativeY: 0, isDocked: false},
-        {node: child, relativeX: 0, relativeY: 100, isDocked: false},
-      ];
-      const clipboardConnections: ClipboardConnection[] = [
-        {fromIndex: 0, toIndex: 1},
-      ];
+      const clipboard = {
+        clipboardNodes: [
+          {node: parent, relativeX: 0, relativeY: 0, isDocked: false},
+          {node: child, relativeX: 0, relativeY: 100, isDocked: false},
+        ] as ClipboardEntry[],
+        clipboardConnections: [{fromIndex: 0, toIndex: 1}],
+      };
 
-      const result = pasteClipboardNodes({
-        rootNodes: [],
-        nodeLayouts: new Map(),
-        clipboardNodes,
-        clipboardConnections,
-      });
+      const result = pasteClipboardNodes(
+        {rootNodes: [], nodeLayouts: new Map()},
+        clipboard,
+      );
 
       expect(result).toBeDefined();
       expect(result?.rootNodes).toHaveLength(2);
@@ -337,15 +345,17 @@ describe('clipboard_operations', () => {
       const existing = createMockNode({nodeId: 'existing'});
       const clipNode = createMockNode({nodeId: 'clip'});
       const existingLayouts = new Map([['existing', {x: 500, y: 600}]]);
-      const clipboardNodes: ClipboardEntry[] = [
-        {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
-      ];
+      const clipboard = {
+        clipboardNodes: [
+          {node: clipNode, relativeX: 0, relativeY: 0, isDocked: false},
+        ] as ClipboardEntry[],
+        clipboardConnections: [] as ClipboardConnection[],
+      };
 
-      const result = pasteClipboardNodes({
-        rootNodes: [existing],
-        nodeLayouts: existingLayouts,
-        clipboardNodes,
-      });
+      const result = pasteClipboardNodes(
+        {rootNodes: [existing], nodeLayouts: existingLayouts},
+        clipboard,
+      );
 
       expect(result).toBeDefined();
       expect(result?.nodeLayouts.get('existing')).toEqual({x: 500, y: 600});

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -19,6 +19,10 @@ import {Builder} from './query_builder/builder';
 import {QueryNode} from './query_node';
 import {ensureAllNodeActions} from './node_actions';
 import {Trace} from '../../public/trace';
+import {Icon} from '../../widgets/icon';
+import {Icons} from '../../base/semantic_icons';
+import {getOrCreate} from '../../base/utils';
+import {Tabs, TabsTab} from '../../widgets/tabs';
 
 import {
   confirmAndFinalizeCurrentGraph,
@@ -26,7 +30,6 @@ import {
   importGraph,
   loadGraphFromJson,
   loadGraphFromPath,
-  initializeHighImportanceTables,
   createExploreGraph,
   GraphIODeps,
 } from './graph_io';
@@ -53,10 +56,17 @@ import type {NodeCrudDeps} from './node_crud_operations';
 import {addFilter, addColumnFromJoinid} from './datagrid_node_creation';
 import {showDataExplorerHelp} from './data_explorer_help_modal';
 
-import type {ClipboardEntry, ClipboardConnection} from './clipboard_operations';
 import {copySelectedNodes, pasteClipboardNodes} from './clipboard_operations';
+import type {ClipboardResult} from './clipboard_operations';
+import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 
 registerCoreNodes();
+
+export interface ExploreTab {
+  readonly id: string;
+  title: string;
+  state: ExplorePageState;
+}
 
 export interface ExplorePageState {
   rootNodes: QueryNode[];
@@ -72,30 +82,74 @@ export interface ExplorePageState {
   isExplorerCollapsed?: boolean;
   sidebarWidth?: number;
   loadGeneration?: number; // Incremented each time content is loaded
-  // Clipboard for multi-node copy/paste
-  clipboardNodes?: ClipboardEntry[];
-  clipboardConnections?: ClipboardConnection[];
 }
+
+type StateUpdateFn = (
+  update: ExplorePageState | ((current: ExplorePageState) => ExplorePageState),
+) => void;
 
 interface ExplorePageAttrs {
   readonly trace: Trace;
   readonly sqlModulesPlugin: SqlModulesPlugin;
+  // Active tab's state (convenience reference)
   readonly state: ExplorePageState;
-  readonly onStateUpdate: (
-    update:
-      | ExplorePageState
-      | ((currentState: ExplorePageState) => ExplorePageState),
+  // State updater for the active tab (used by keyboard handlers, etc.)
+  readonly onStateUpdate: StateUpdateFn;
+  // Factory that returns a per-tab state update function.
+  // Used in renderTabContent to create tab-scoped updaters that remain
+  // correct even if the active tab changes while async work is in flight.
+  readonly makeOnStateUpdate: (tabId: string) => StateUpdateFn;
+  // Multi-tab props
+  readonly tabs: ExploreTab[];
+  readonly activeTabId: string;
+  readonly onTabAdd: () => void;
+  readonly onTabClose: (tabId: string) => void;
+  readonly onTabChange: (tabId: string) => void;
+  readonly onTabRename: (tabId: string, newName: string) => void;
+  readonly onTabReorder: (
+    draggedId: string,
+    beforeId: string | undefined,
   ) => void;
-  readonly hasAutoInitialized: boolean;
-  readonly setHasAutoInitialized: (value: boolean) => void;
 }
 
+// Per-tab service instances that live for the lifetime of the tab.
+interface TabServices {
+  queryExecutionService: QueryExecutionService;
+  cleanupManager: CleanupManager;
+  historyManager?: HistoryManager;
+  initializedNodes: Set<string>;
+  executeFn?: () => Promise<void>;
+}
+
+const ADD_TAB_KEY = '__add_tab__';
+
 export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
-  private queryExecutionService?: QueryExecutionService;
-  private cleanupManager?: CleanupManager;
-  private historyManager?: HistoryManager;
-  private initializedNodes = new Set<string>();
-  private executeFn?: () => Promise<void>;
+  // Shared clipboard across all tabs (not persisted).
+  private clipboard?: ClipboardResult;
+
+  // Tab currently being renamed via inline editing (undefined = no rename).
+  private renamingTabId?: string;
+
+  // Per-tab services, keyed by tab ID.
+  private tabServices = new Map<string, TabServices>();
+
+  private getOrCreateServices(
+    tabId: string,
+    engine: Trace['engine'],
+  ): TabServices {
+    return getOrCreate(this.tabServices, tabId, () => {
+      const qes = new QueryExecutionService(engine);
+      return {
+        queryExecutionService: qes,
+        cleanupManager: new CleanupManager(qes),
+        initializedNodes: new Set<string>(),
+      };
+    });
+  }
+
+  private getActiveServices(activeTabId: string): TabServices | undefined {
+    return this.tabServices.get(activeTabId);
+  }
 
   private selectNode(attrs: ExplorePageAttrs, node: QueryNode) {
     attrs.onStateUpdate((currentState) => ({
@@ -133,19 +187,59 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     }));
   }
 
+  private renderInlineRenameInput(
+    attrs: ExplorePageAttrs,
+    tab: ExploreTab,
+  ): m.Children {
+    let inputEl: HTMLInputElement | undefined;
+
+    const commit = () => {
+      if (inputEl === undefined) return;
+      const newName = inputEl.value.trim();
+      if (newName) {
+        attrs.onTabRename(tab.id, newName);
+      }
+      this.renamingTabId = undefined;
+      m.redraw();
+    };
+
+    return m('input.pf-explore-page__tab-rename-input', {
+      value: tab.title,
+      oncreate: (vnode: m.VnodeDOM) => {
+        inputEl = vnode.dom as HTMLInputElement;
+        inputEl.focus();
+        inputEl.select();
+      },
+      onkeydown: (e: KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          commit();
+          e.preventDefault();
+        } else if (e.key === 'Escape') {
+          this.renamingTabId = undefined;
+          m.redraw();
+          e.preventDefault();
+        }
+        // Stop propagation so the graph doesn't handle these keys
+        e.stopPropagation();
+      },
+      onblur: () => commit(),
+      // Prevent clicks from propagating to the tab (which would switch tabs)
+      onclick: (e: Event) => e.stopPropagation(),
+    });
+  }
+
   private handleCopy(attrs: ExplorePageAttrs): void {
     const result = copySelectedNodes(attrs.state);
     if (result !== undefined) {
-      attrs.onStateUpdate((currentState) => ({
-        ...currentState,
-        ...result,
-      }));
+      this.clipboard = result;
     }
   }
 
   private handlePaste(attrs: ExplorePageAttrs): void {
+    if (this.clipboard === undefined) return;
+    const clipboard = this.clipboard;
     attrs.onStateUpdate((currentState) => {
-      const result = pasteClipboardNodes(currentState);
+      const result = pasteClipboardNodes(currentState, clipboard);
       if (result === undefined) return currentState;
       return {...currentState, ...result};
     });
@@ -174,14 +268,19 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       return;
     }
 
+    const activeServices = this.getActiveServices(attrs.activeTabId);
+
     // Handle Ctrl+Enter to execute selected node
     if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
       const selectedNode = getPrimarySelectedNode(
         state.selectedNodes,
         state.rootNodes,
       );
-      if (selectedNode !== undefined && this.executeFn !== undefined) {
-        void this.executeFn();
+      if (
+        selectedNode !== undefined &&
+        activeServices?.executeFn !== undefined
+      ) {
+        void activeServices.executeFn();
         event.preventDefault();
       }
       return;
@@ -257,98 +356,89 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     // Handle other shortcuts
     switch (event.key) {
       case 'i':
-        importGraph(graphIODeps, attrs.state);
+        importGraph(graphIODeps, state);
         break;
       case 'e':
-        exportGraph(attrs.state, attrs.trace);
+        exportGraph(state, attrs.trace);
         break;
     }
   }
 
   private handleUndo(attrs: ExplorePageAttrs) {
-    if (!this.historyManager) {
+    const historyManager = this.getActiveServices(
+      attrs.activeTabId,
+    )?.historyManager;
+    if (!historyManager) {
       console.warn('Cannot undo: history manager not initialized');
       return;
     }
 
-    const previousState = this.historyManager.undo();
+    const previousState = historyManager.undo();
     if (previousState) {
       attrs.onStateUpdate(previousState);
     }
   }
 
   private handleRedo(attrs: ExplorePageAttrs) {
-    if (!this.historyManager) {
+    const historyManager = this.getActiveServices(
+      attrs.activeTabId,
+    )?.historyManager;
+    if (!historyManager) {
       console.warn('Cannot redo: history manager not initialized');
       return;
     }
 
-    const nextState = this.historyManager.redo();
+    const nextState = historyManager.redo();
     if (nextState) {
       attrs.onStateUpdate(nextState);
     }
   }
 
-  view({attrs}: m.CVnode<ExplorePageAttrs>) {
-    const {trace, state} = attrs;
+  // Render the content for a single tab. This includes the Builder and all
+  // per-tab service setup (history, query execution, cleanup, etc.).
+  private renderTabContent(
+    attrs: ExplorePageAttrs,
+    tab: ExploreTab,
+    sqlModules: SqlModules,
+  ): m.Children {
+    const {trace} = attrs;
+    const {state} = tab;
+    const isActive = tab.id === attrs.activeTabId;
 
-    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
+    const services = this.getOrCreateServices(tab.id, trace.engine);
 
-    if (!sqlModules) {
-      return m(
-        '.pf-explore-page',
-        m(
-          '.pf-explore-page__header',
-          m('h1', 'Loading SQL Modules, please wait...'),
-        ),
-      );
+    // Initialize history manager for this tab if not already done
+    if (services.historyManager === undefined) {
+      services.historyManager = new HistoryManager(trace, sqlModules);
+      services.historyManager.pushState(state);
     }
 
-    // Initialize history manager if not already done
-    if (!this.historyManager) {
-      this.historyManager = new HistoryManager(trace, sqlModules);
-      // Push initial state
-      this.historyManager.pushState(state);
-    }
-
-    // Wrap onStateUpdate to track history
-    const wrappedOnStateUpdate = (
-      update:
-        | ExplorePageState
-        | ((currentState: ExplorePageState) => ExplorePageState),
-    ) => {
-      attrs.onStateUpdate((currentState) => {
+    // Create a per-tab state updater that wraps history tracking.
+    // Uses makeOnStateUpdate(tab.id) so the updater is always bound to THIS
+    // tab's state, even if the active tab changes while async work is in flight.
+    const tabOnStateUpdate = attrs.makeOnStateUpdate(tab.id);
+    const wrappedOnStateUpdate: StateUpdateFn = (update) => {
+      tabOnStateUpdate((currentState) => {
         const newState =
           typeof update === 'function' ? update(currentState) : update;
-        // Push state to history after update
-        this.historyManager?.pushState(newState);
+        services.historyManager?.pushState(newState);
         return newState;
       });
     };
 
-    // Create wrapped attrs to track history
     const wrappedAttrs = {
       ...attrs,
+      state,
       onStateUpdate: wrappedOnStateUpdate,
     };
 
-    // Initialize services if not already done
-    if (this.queryExecutionService === undefined) {
-      this.queryExecutionService = new QueryExecutionService(
-        attrs.trace.engine,
-      );
-      this.cleanupManager = new CleanupManager(this.queryExecutionService);
-    }
-
     // Construct deps objects once per render cycle.
-    // nodeActionHandlers closures reference nodeCrudDeps lazily — they are
-    // only invoked on user interaction, well after the const is initialized.
     const nodeCrudDeps: NodeCrudDeps = {
-      trace: attrs.trace,
+      trace,
       sqlModules,
       onStateUpdate: wrappedOnStateUpdate,
-      cleanupManager: this.cleanupManager,
-      initializedNodes: this.initializedNodes,
+      cleanupManager: services.cleanupManager,
+      initializedNodes: services.initializedNodes,
       nodeActionHandlers: {
         onAddAndConnectTable: (
           tableName: string,
@@ -380,191 +470,271 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
     };
 
     const graphIODeps: GraphIODeps = {
-      trace: attrs.trace,
+      trace,
       sqlModules,
       onStateUpdate: wrappedOnStateUpdate,
       cleanupExistingNodes: (rootNodes) =>
         cleanupExistingNodes(
-          this.cleanupManager,
-          this.initializedNodes,
+          services.cleanupManager,
+          services.initializedNodes,
           rootNodes,
         ),
     };
 
-    // Ensure all nodes have actions initialized (e.g., nodes from imported state)
-    // This is efficient - only processes nodes not yet initialized
-    const allNodes = getAllNodes(state.rootNodes);
-    ensureAllNodeActions(
-      allNodes,
-      this.initializedNodes,
-      nodeCrudDeps.nodeActionHandlers,
-    );
+    // Only do full node processing for the active tab to avoid unnecessary work
+    if (isActive) {
+      // Ensure all nodes have actions initialized
+      const allNodes = getAllNodes(state.rootNodes);
+      ensureAllNodeActions(
+        allNodes,
+        services.initializedNodes,
+        nodeCrudDeps.nodeActionHandlers,
+      );
 
-    // Provide getTableNameForNode callback so nodes can query materialized
-    // tables from the execution service (e.g., for fetching arg keys).
-    const executionService = this.queryExecutionService;
-    if (executionService !== undefined) {
+      // Provide getTableNameForNode callback
       for (const node of allNodes) {
         if (node.state.getTableNameForNode === undefined) {
           node.state.getTableNameForNode = (nodeId: string) =>
-            executionService.getTableName(nodeId);
+            services.queryExecutionService.getTableName(nodeId);
         }
       }
+
+      // Store deps for keyboard handler access
+      this.activeNodeCrudDeps = nodeCrudDeps;
+      this.activeGraphIODeps = graphIODeps;
     }
 
-    // Auto-initialize high-importance tables on first render when state is empty
-    // Never load base JSON if we've already initialized in this session (even after clearing nodes)
-    if (state.rootNodes.length === 0 && !attrs.hasAutoInitialized) {
-      void initializeHighImportanceTables(
-        graphIODeps,
-        attrs.setHasAutoInitialized,
+    return m(Builder, {
+      trace,
+      sqlModules,
+      queryExecutionService: services.queryExecutionService,
+      rootNodes: state.rootNodes,
+      selectedNodes: state.selectedNodes,
+      nodeLayouts: state.nodeLayouts,
+      labels: state.labels,
+      loadGeneration: state.loadGeneration,
+      isExplorerCollapsed: state.isExplorerCollapsed,
+      sidebarWidth: state.sidebarWidth,
+      onExecuteReady: (executeFn) => {
+        services.executeFn = executeFn;
+      },
+      onRootNodeCreated: (node) => {
+        wrappedOnStateUpdate((currentState) => ({
+          ...currentState,
+          rootNodes: [...currentState.rootNodes, node],
+          selectedNodes: new Set([node.nodeId]),
+        }));
+      },
+      onExplorerCollapsedChange: (collapsed) => {
+        wrappedOnStateUpdate((currentState) => ({
+          ...currentState,
+          isExplorerCollapsed: collapsed,
+        }));
+      },
+      onSidebarWidthChange: (width) => {
+        wrappedOnStateUpdate((currentState) => ({
+          ...currentState,
+          sidebarWidth: width,
+        }));
+      },
+      graphCallbacks: {
+        onNodeSelected: (node) => {
+          this.selectNode(wrappedAttrs, node);
+        },
+        onNodeAddToSelection: (node) => {
+          this.addNodeToSelection(wrappedAttrs, node);
+        },
+        onNodeRemoveFromSelection: (nodeId) => {
+          this.removeNodeFromSelection(wrappedAttrs, nodeId);
+        },
+        onDeselect: () => this.deselectNode(wrappedAttrs),
+        onNodeLayoutChange: (nodeId, layout) => {
+          wrappedOnStateUpdate((currentState) => {
+            const newNodeLayouts = new Map(currentState.nodeLayouts);
+            newNodeLayouts.set(nodeId, layout);
+            return {
+              ...currentState,
+              nodeLayouts: newNodeLayouts,
+            };
+          });
+        },
+        onLabelsChange: (labels) => {
+          wrappedOnStateUpdate((currentState) => ({
+            ...currentState,
+            labels,
+          }));
+        },
+        onAddSourceNode: (id) => {
+          addSourceNode(nodeCrudDeps, wrappedAttrs.state, id);
+        },
+        onAddOperationNode: (id, node) => {
+          addOperationNode(nodeCrudDeps, wrappedAttrs.state, node, id);
+        },
+        onClearAllNodes: () => clearAllNodes(nodeCrudDeps, wrappedAttrs.state),
+        onDuplicateNode: (node) => {
+          duplicateNode(wrappedOnStateUpdate, node);
+        },
+        onDeleteNode: (node) => {
+          deleteNode(nodeCrudDeps, wrappedAttrs.state, node);
+        },
+        onConnectionRemove: (fromNode, toNode, isSecondaryInput) => {
+          removeNodeConnection(
+            wrappedAttrs.state,
+            wrappedOnStateUpdate,
+            fromNode,
+            toNode,
+            isSecondaryInput,
+          );
+        },
+        onImport: () => importGraph(graphIODeps, state),
+        onExport: () => exportGraph(state, trace),
+      },
+      onLoadEmptyTemplate: async () => {
+        if (!(await confirmAndFinalizeCurrentGraph(state))) return;
+
+        wrappedOnStateUpdate((currentState) => {
+          return {
+            ...currentState,
+            rootNodes: [],
+            selectedNodes: new Set(),
+            nodeLayouts: new Map(),
+            labels: [],
+            loadGeneration: (currentState.loadGeneration ?? 0) + 1,
+          };
+        });
+      },
+      onLoadExampleByPath: (jsonPath: string) =>
+        loadGraphFromPath(graphIODeps, state, jsonPath, 'Failed to Load'),
+      onLoadExploreTemplate: async () => {
+        if (!(await confirmAndFinalizeCurrentGraph(state))) return;
+        await createExploreGraph(graphIODeps);
+      },
+      onLoadRecentGraph: async (json: string) => {
+        if (!(await confirmAndFinalizeCurrentGraph(state))) return;
+        await loadGraphFromJson(graphIODeps, state.rootNodes, json);
+      },
+      onFilterAdd: (node, filter, filterOperator) => {
+        addFilter(nodeCrudDeps, node, filter, filterOperator);
+      },
+      onColumnAdd: (node, column) => {
+        addColumnFromJoinid(nodeCrudDeps, wrappedAttrs.state, node, column);
+      },
+      onNodeStateChange: () => {
+        wrappedOnStateUpdate((currentState) => {
+          return {...currentState};
+        });
+      },
+      onUndo: () => this.handleUndo(attrs),
+      onRedo: () => this.handleRedo(attrs),
+      canUndo: services.historyManager?.canUndo() ?? false,
+      canRedo: services.historyManager?.canRedo() ?? false,
+    });
+  }
+
+  // Stored references for the active tab's deps, used by keyboard handler.
+  private activeNodeCrudDeps?: NodeCrudDeps;
+  private activeGraphIODeps?: GraphIODeps;
+
+  view({attrs}: m.CVnode<ExplorePageAttrs>) {
+    const {tabs, activeTabId} = attrs;
+
+    const sqlModules = attrs.sqlModulesPlugin.getSqlModules();
+
+    if (!sqlModules) {
+      return m(
+        '.pf-explore-page',
+        m(
+          '.pf-explore-page__header',
+          m('h1', 'Loading SQL Modules, please wait...'),
+        ),
       );
     }
+
+    // Build tab entries for the Tabs widget
+    const tabEntries: TabsTab[] = tabs.map((tab) => ({
+      key: tab.id,
+      title:
+        this.renamingTabId === tab.id
+          ? this.renderInlineRenameInput(attrs, tab)
+          : tab.title,
+      leftIcon: 'account_tree',
+      closeButton: tabs.length > 1,
+      content: this.renderTabContent(attrs, tab, sqlModules),
+    }));
+
+    // Add "+" button tab
+    tabEntries.push({
+      key: ADD_TAB_KEY,
+      title: m(Icon, {icon: Icons.Add}),
+      content: null,
+    });
 
     return m(
       '.pf-explore-page',
       {
-        onkeydown: (e: KeyboardEvent) =>
-          this.handleKeyDown(e, wrappedAttrs, nodeCrudDeps, graphIODeps),
+        onkeydown: (e: KeyboardEvent) => {
+          if (this.activeNodeCrudDeps && this.activeGraphIODeps) {
+            this.handleKeyDown(
+              e,
+              attrs,
+              this.activeNodeCrudDeps,
+              this.activeGraphIODeps,
+            );
+          }
+        },
         oncreate: (vnode) => {
           (vnode.dom as HTMLElement).focus();
         },
-        onremove: async () => {
-          // Clean up all materialized tables when component is destroyed
-          if (this.cleanupManager !== undefined) {
-            const allNodes = getAllNodes(state.rootNodes);
-            await this.cleanupManager.cleanupAll(allNodes);
-          }
+        onremove: () => {
+          // Clean up all materialized tables for all tabs in parallel
+          void Promise.all(
+            [...this.tabServices].map(([tabId, services]) => {
+              const tab = tabs.find((t) => t.id === tabId);
+              const rootNodes = tab ? getAllNodes(tab.state.rootNodes) : [];
+              return services.cleanupManager
+                .cleanupAll(rootNodes)
+                .catch((e) => console.warn(`Tab ${tabId} cleanup failed:`, e));
+            }),
+          ).finally(() => this.tabServices.clear());
         },
         tabindex: 0,
       },
-      m(Builder, {
-        trace,
-        sqlModules,
-        queryExecutionService: this.queryExecutionService,
-        rootNodes: state.rootNodes,
-        selectedNodes: state.selectedNodes,
-        nodeLayouts: state.nodeLayouts,
-        labels: state.labels,
-        loadGeneration: state.loadGeneration,
-        isExplorerCollapsed: state.isExplorerCollapsed,
-        sidebarWidth: state.sidebarWidth,
-        onExecuteReady: (executeFn) => {
-          this.executeFn = executeFn;
+      m(Tabs, {
+        className: 'pf-explore-page__tabs',
+        tabs: tabEntries,
+        activeTabKey: activeTabId,
+        reorderable: true,
+        onTabChange: (key) => {
+          if (key === ADD_TAB_KEY) {
+            attrs.onTabAdd();
+          } else {
+            attrs.onTabChange(key);
+          }
         },
-        onRootNodeCreated: (node) => {
-          wrappedAttrs.onStateUpdate((currentState) => ({
-            ...currentState,
-            rootNodes: [...currentState.rootNodes, node],
-            selectedNodes: new Set([node.nodeId]),
-          }));
+        onTabDblClick: (key) => {
+          if (key === ADD_TAB_KEY) return;
+          this.renamingTabId = key;
+          m.redraw();
         },
-        onExplorerCollapsedChange: (collapsed) => {
-          wrappedAttrs.onStateUpdate((currentState) => ({
-            ...currentState,
-            isExplorerCollapsed: collapsed,
-          }));
+        onTabClose: (key) => {
+          // Clean up services for the closed tab eagerly
+          const services = this.tabServices.get(key);
+          if (services) {
+            const tab = tabs.find((t) => t.id === key);
+            const rootNodes = tab ? getAllNodes(tab.state.rootNodes) : [];
+            void services.cleanupManager
+              .cleanupAll(rootNodes)
+              .catch((e) => console.warn(`Tab ${key} cleanup failed:`, e));
+            this.tabServices.delete(key);
+          }
+          attrs.onTabClose(key);
         },
-        onSidebarWidthChange: (width) => {
-          wrappedAttrs.onStateUpdate((currentState) => ({
-            ...currentState,
-            sidebarWidth: width,
-          }));
+        onTabReorder: (draggedKey, beforeKey) => {
+          if (draggedKey === ADD_TAB_KEY || beforeKey === ADD_TAB_KEY) {
+            return;
+          }
+          attrs.onTabReorder(draggedKey, beforeKey);
         },
-        graphCallbacks: {
-          onNodeSelected: (node) => {
-            this.selectNode(wrappedAttrs, node);
-          },
-          onNodeAddToSelection: (node) => {
-            this.addNodeToSelection(wrappedAttrs, node);
-          },
-          onNodeRemoveFromSelection: (nodeId) => {
-            this.removeNodeFromSelection(wrappedAttrs, nodeId);
-          },
-          onDeselect: () => this.deselectNode(wrappedAttrs),
-          onNodeLayoutChange: (nodeId, layout) => {
-            wrappedAttrs.onStateUpdate((currentState) => {
-              const newNodeLayouts = new Map(currentState.nodeLayouts);
-              newNodeLayouts.set(nodeId, layout);
-              return {
-                ...currentState,
-                nodeLayouts: newNodeLayouts,
-              };
-            });
-          },
-          onLabelsChange: (labels) => {
-            wrappedAttrs.onStateUpdate((currentState) => ({
-              ...currentState,
-              labels,
-            }));
-          },
-          onAddSourceNode: (id) => {
-            addSourceNode(nodeCrudDeps, wrappedAttrs.state, id);
-          },
-          onAddOperationNode: (id, node) => {
-            addOperationNode(nodeCrudDeps, wrappedAttrs.state, node, id);
-          },
-          onClearAllNodes: () =>
-            clearAllNodes(nodeCrudDeps, wrappedAttrs.state),
-          onDuplicateNode: (node) => {
-            duplicateNode(wrappedAttrs.onStateUpdate, node);
-          },
-          onDeleteNode: (node) => {
-            deleteNode(nodeCrudDeps, wrappedAttrs.state, node);
-          },
-          onConnectionRemove: (fromNode, toNode, isSecondaryInput) => {
-            removeNodeConnection(
-              wrappedAttrs.state,
-              wrappedAttrs.onStateUpdate,
-              fromNode,
-              toNode,
-              isSecondaryInput,
-            );
-          },
-          onImport: () => importGraph(graphIODeps, state),
-          onExport: () => exportGraph(state, trace),
-        },
-        onLoadEmptyTemplate: async () => {
-          if (!(await confirmAndFinalizeCurrentGraph(state))) return;
-
-          wrappedAttrs.onStateUpdate((currentState) => {
-            return {
-              ...currentState,
-              rootNodes: [],
-              selectedNodes: new Set(),
-              nodeLayouts: new Map(),
-              labels: [],
-              loadGeneration: (currentState.loadGeneration ?? 0) + 1,
-            };
-          });
-        },
-        onLoadExampleByPath: (jsonPath: string) =>
-          loadGraphFromPath(graphIODeps, state, jsonPath, 'Failed to Load'),
-        onLoadExploreTemplate: async () => {
-          if (!(await confirmAndFinalizeCurrentGraph(state))) return;
-          await createExploreGraph(graphIODeps);
-        },
-        onLoadRecentGraph: async (json: string) => {
-          if (!(await confirmAndFinalizeCurrentGraph(state))) return;
-          await loadGraphFromJson(graphIODeps, state.rootNodes, json);
-        },
-        onFilterAdd: (node, filter, filterOperator) => {
-          addFilter(nodeCrudDeps, node, filter, filterOperator);
-        },
-        onColumnAdd: (node, column) => {
-          addColumnFromJoinid(nodeCrudDeps, wrappedAttrs.state, node, column);
-        },
-        onNodeStateChange: () => {
-          // Trigger a state update when node properties change (e.g., selecting group by columns)
-          // This ensures these granular changes are captured in history
-          wrappedAttrs.onStateUpdate((currentState) => {
-            return {...currentState};
-          });
-        },
-        onUndo: () => this.handleUndo(attrs),
-        onRedo: () => this.handleRedo(attrs),
-        canUndo: this.historyManager?.canUndo() ?? false,
-        canRedo: this.historyManager?.canRedo() ?? false,
       }),
     );
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_tabs_storage.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_tabs_storage.ts
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {z} from 'zod';
+import {ExploreTab, ExplorePageState} from './explore_page';
+import {serializeState} from './json_handler';
+
+const EXPLORE_TABS_STORAGE_KEY = 'perfettoExploreTabs';
+
+const PERSISTED_EXPLORE_TAB_SCHEMA = z.object({
+  id: z.string(),
+  title: z.string(),
+  graphJson: z.string().optional(),
+});
+
+const PERSISTED_EXPLORE_TABS_STATE_SCHEMA = z.object({
+  tabs: z.array(PERSISTED_EXPLORE_TAB_SCHEMA).min(1),
+  activeTabId: z.string(),
+});
+
+export type PersistedExploreTabData = z.infer<
+  typeof PERSISTED_EXPLORE_TAB_SCHEMA
+>;
+
+export type PersistedExploreTabsState = z.infer<
+  typeof PERSISTED_EXPLORE_TABS_STATE_SCHEMA
+>;
+
+/**
+ * Storage class for explore tabs state.
+ * Persists tab layout (IDs, titles, serialized graphs) and active tab to
+ * localStorage so that the Data Explorer survives page reloads.
+ */
+class ExploreTabsStorage {
+  save(tabs: ExploreTab[], activeTabId: string): void {
+    const state: PersistedExploreTabsState = {
+      tabs: tabs.map((tab) => ({
+        id: tab.id,
+        title: tab.title,
+        graphJson:
+          tab.state.rootNodes.length > 0
+            ? serializeState(tab.state)
+            : undefined,
+      })),
+      activeTabId,
+    };
+    try {
+      window.localStorage.setItem(
+        EXPLORE_TABS_STORAGE_KEY,
+        JSON.stringify(state),
+      );
+    } catch (e) {
+      console.warn('Failed to save explore tabs to localStorage:', e);
+    }
+  }
+
+  load(): PersistedExploreTabsState | undefined {
+    const value = window.localStorage.getItem(EXPLORE_TABS_STORAGE_KEY);
+    if (value === null) {
+      return undefined;
+    }
+    try {
+      const res = PERSISTED_EXPLORE_TABS_STATE_SCHEMA.safeParse(
+        JSON.parse(value),
+      );
+      return res.success ? res.data : undefined;
+    } catch (e) {
+      console.debug('Failed to parse explore tabs from localStorage:', e);
+      return undefined;
+    }
+  }
+}
+
+// Singleton instance
+export const exploreTabsStorage = new ExploreTabsStorage();
+
+export function createNewTabName(tabs: ExploreTab[], prefix = 'Graph'): string {
+  const existingNames = new Set(tabs.map((t) => t.title));
+  let count = 1;
+  while (existingNames.has(`${prefix} ${count}`)) {
+    count++;
+  }
+  return `${prefix} ${count}`;
+}
+
+export function createEmptyState(): ExplorePageState {
+  return {
+    rootNodes: [],
+    selectedNodes: new Set(),
+    nodeLayouts: new Map(),
+    labels: [],
+  };
+}

--- a/ui/src/plugins/dev.perfetto.ExplorePage/graph_io.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/graph_io.ts
@@ -141,33 +141,6 @@ export async function loadGraphFromPath(
   }
 }
 
-export async function initializeHighImportanceTables(
-  deps: GraphIODeps,
-  setHasAutoInitialized: (value: boolean) => void,
-): Promise<void> {
-  setHasAutoInitialized(true);
-
-  try {
-    const response = await fetch(
-      assetSrc('assets/explore_page/base-page.json'),
-    );
-    if (!response.ok) {
-      console.warn(
-        'Failed to load base page state, falling back to empty state',
-      );
-      return;
-    }
-    const json = await response.text();
-    const newState = deserializeState(json, deps.trace, deps.sqlModules);
-    deps.onStateUpdate((currentState) => ({
-      ...newState,
-      loadGeneration: (currentState.loadGeneration ?? 0) + 1,
-    }));
-  } catch (error) {
-    console.error('Failed to load base page state:', error);
-  }
-}
-
 export async function createExploreGraph(deps: GraphIODeps): Promise<void> {
   const {sqlModules, trace} = deps;
   const newNodes: QueryNode[] = [];

--- a/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
@@ -16,114 +16,205 @@ import m from 'mithril';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {Store} from '../../base/store';
+import {shortUuid} from '../../base/uuid';
+import {getErrorMessage} from '../../base/errors';
+import {debounce} from '../../base/rate_limiters';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
-import {ExplorePage, ExplorePageState} from './explore_page';
+import {ExplorePage, ExplorePageState, ExploreTab} from './explore_page';
 import {nodeRegistry} from './query_builder/node_registry';
 import {QueryNodeState} from './query_node';
 import {deserializeState, serializeState} from './json_handler';
 import {recentGraphsStorage} from './recent_graphs';
+import {
+  exploreTabsStorage,
+  createNewTabName,
+  createEmptyState,
+} from './explore_tabs_storage';
+import type {PersistedExploreTabData} from './explore_tabs_storage';
+import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 
-const STORE_VERSION = 1;
+// --- Permalink persistence ---
+
+const STORE_VERSION = 2;
 
 interface ExplorePagePersistedState {
   version: number;
+  // Multi-tab format (version 2+)
+  tabs?: PersistedExploreTabData[];
+  activeTabId?: string;
+  // Old single-graph format (version 1) - kept for backward compat
   graphJson?: string;
 }
 
 function isValidPersistedState(
   init: unknown,
 ): init is ExplorePagePersistedState {
-  return (
-    typeof init === 'object' &&
-    init !== null &&
-    'version' in init &&
-    (init as {version: unknown}).version === STORE_VERSION
-  );
-}
-
-/**
- * Loads the Explore Page state from recent graphs storage.
- * Returns undefined if no state is found or if deserialization fails.
- */
-function loadStateFromRecentGraphs(trace: Trace): ExplorePageState | undefined {
-  try {
-    const json = recentGraphsStorage.getCurrentJson();
-    if (!json) {
-      return undefined;
-    }
-
-    const sqlModulesPlugin = trace.plugins.getPlugin(SqlModulesPlugin);
-    const sqlModules = sqlModulesPlugin.getSqlModules();
-    if (!sqlModules) {
-      // SQL modules not yet initialized - return undefined to retry later
-      return undefined;
-    }
-
-    return deserializeState(json, trace, sqlModules);
-  } catch (error) {
-    console.debug(
-      'Failed to load Explore Page state from recent graphs:',
-      error,
-    );
-    // Clear corrupted data to prevent repeated failures
-    recentGraphsStorage.clear();
-    return undefined;
+  if (typeof init !== 'object' || init === null || !('version' in init)) {
+    return false;
   }
+  const version = (init as {version: unknown}).version;
+  // Accept both v1 (old single-graph) and v2 (multi-tab)
+  return version === 1 || version === STORE_VERSION;
 }
+
+// --- Plugin ---
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.ExplorePage';
   static readonly dependencies = [SqlModulesPlugin];
 
-  // The following allows us to have persistent
-  // state/charts for the lifecycle of a single
-  // trace.
-  private state: ExplorePageState = {
-    rootNodes: [],
-    selectedNodes: new Set(),
-    nodeLayouts: new Map(),
-    labels: [],
-  };
+  // Multi-tab state
+  private tabs: ExploreTab[] = [];
+  private activeTabId = '';
 
   // Track whether we've successfully loaded state from local storage
   private hasAttemptedStateLoad = false;
 
-  // Track whether we've auto-initialized base JSON in this session
-  // This prevents reloading base JSON when clearing all nodes
-  private hasAutoInitialized = false;
-
   // Store for persisting state in permalinks
   private permalinkStore?: Store<ExplorePagePersistedState>;
 
-  onStateUpdate = (
-    update:
-      | ExplorePageState
-      | ((current: ExplorePageState) => ExplorePageState),
-  ) => {
-    if (typeof update === 'function') {
-      this.state = update(this.state);
-    } else {
-      this.state = update;
+  // Debounced saves to avoid expensive serialization on every state change
+  private debouncedSave = debounce(() => {
+    exploreTabsStorage.save(this.tabs, this.activeTabId);
+  }, 1000);
+
+  private debouncedPermalinkSave = debounce(() => {
+    this.saveToPermalinkStore();
+  }, 1000);
+
+  // Flush pending saves on page unload to avoid data loss
+  private readonly onBeforeUnload = () => {
+    try {
+      exploreTabsStorage.save(this.tabs, this.activeTabId);
+      this.saveToPermalinkStore();
+    } catch (e) {
+      console.warn('Failed to flush explore tabs on unload:', e);
     }
+  };
 
-    // Save current state to recent graphs (updates the first entry)
-    recentGraphsStorage.saveCurrentState(this.state);
+  // --- Tab helpers ---
 
-    // Save to permalink store for sharing (clear if graph is empty)
-    if (this.permalinkStore) {
-      const graphJson =
-        this.state.rootNodes.length > 0
-          ? serializeState(this.state)
-          : undefined;
-      this.permalinkStore.edit((draft) => {
-        draft.graphJson = graphJson;
-      });
+  private createNewTab(title?: string): ExploreTab {
+    return {
+      id: shortUuid(),
+      title: title ?? createNewTabName(this.tabs),
+      state: createEmptyState(),
+    };
+  }
+
+  private getActiveTab(): ExploreTab | undefined {
+    return this.tabs.find((t) => t.id === this.activeTabId);
+  }
+
+  private ensureAtLeastOneTab(): void {
+    if (this.tabs.length === 0) {
+      const tab = this.createNewTab();
+      this.tabs.push(tab);
+      this.activeTabId = tab.id;
     }
+  }
 
+  // --- Tab CRUD ---
+
+  private handleTabAdd = (): void => {
+    const newTab = this.createNewTab();
+    this.tabs.push(newTab);
+    this.activeTabId = newTab.id;
+    this.debouncedSave();
     m.redraw();
   };
 
-  // Mount the permalink store lazily on first page access.
+  private handleTabClose = (tabId: string): void => {
+    const index = this.tabs.findIndex((t) => t.id === tabId);
+    if (index === -1) return;
+
+    // Don't close the last tab
+    if (this.tabs.length === 1) return;
+
+    this.tabs.splice(index, 1);
+
+    // If we closed the active tab, switch to an adjacent one
+    if (this.activeTabId === tabId) {
+      const newIndex = Math.min(index, this.tabs.length - 1);
+      this.activeTabId = this.tabs[newIndex].id;
+    }
+
+    this.debouncedSave();
+    m.redraw();
+  };
+
+  private handleTabChange = (tabId: string): void => {
+    this.activeTabId = tabId;
+    this.debouncedSave();
+    m.redraw();
+  };
+
+  private handleTabRename = (tabId: string, newName: string): void => {
+    const tab = this.tabs.find((t) => t.id === tabId);
+    if (tab) {
+      tab.title = newName;
+      this.debouncedSave();
+      m.redraw();
+    }
+  };
+
+  private handleTabReorder = (
+    draggedTabId: string,
+    beforeTabId: string | undefined,
+  ): void => {
+    const draggedIndex = this.tabs.findIndex((t) => t.id === draggedTabId);
+    if (draggedIndex === -1) return;
+
+    const [draggedTab] = this.tabs.splice(draggedIndex, 1);
+
+    if (beforeTabId === undefined) {
+      this.tabs.push(draggedTab);
+    } else {
+      const beforeIndex = this.tabs.findIndex((t) => t.id === beforeTabId);
+      if (beforeIndex === -1) {
+        this.tabs.push(draggedTab);
+      } else {
+        this.tabs.splice(beforeIndex, 0, draggedTab);
+      }
+    }
+
+    this.debouncedSave();
+  };
+
+  // --- Per-tab state update ---
+
+  private makeOnStateUpdate(tabId: string) {
+    return (
+      update:
+        | ExplorePageState
+        | ((current: ExplorePageState) => ExplorePageState),
+    ) => {
+      const tab = this.tabs.find((t) => t.id === tabId);
+      if (!tab) return;
+
+      if (typeof update === 'function') {
+        tab.state = update(tab.state);
+      } else {
+        tab.state = update;
+      }
+
+      // Save active tab's state to recent graphs (updates the working slot)
+      if (tabId === this.activeTabId) {
+        recentGraphsStorage.saveCurrentState(tab.state);
+      }
+
+      // Save all tabs to permalink store (debounced)
+      this.debouncedPermalinkSave();
+
+      // Save all tabs to localStorage (debounced)
+      this.debouncedSave();
+
+      m.redraw();
+    };
+  }
+
+  // --- Permalink store ---
+
   private mountPermalinkStore(trace: Trace): void {
     if (this.permalinkStore) return;
 
@@ -138,12 +229,54 @@ export default class implements PerfettoPlugin {
     );
   }
 
-  // Try to load state from permalink store or recent graphs.
-  // Called lazily when the page renders.
+  private saveToPermalinkStore(): void {
+    if (!this.permalinkStore) return;
+
+    const tabsData: PersistedExploreTabData[] = this.tabs
+      .filter((tab) => tab.state.rootNodes.length > 0)
+      .map((tab) => ({
+        id: tab.id,
+        title: tab.title,
+        graphJson: serializeState(tab.state),
+      }));
+
+    this.permalinkStore.edit((draft) => {
+      draft.version = STORE_VERSION;
+      draft.tabs = tabsData.length > 0 ? tabsData : undefined;
+      draft.activeTabId = this.activeTabId;
+      // Clear deprecated single-graph field
+      draft.graphJson = undefined;
+    });
+  }
+
+  // --- State loading ---
+
+  /** Hydrate tabs from persisted tab data, returning the list of loaded tabs. */
+  private hydrateTabs(
+    tabsData: ReadonlyArray<{
+      id: string;
+      title: string;
+      graphJson?: string;
+    }>,
+    trace: Trace,
+    sqlModules: SqlModules,
+  ): ExploreTab[] {
+    return tabsData.map((tabData) => {
+      const state =
+        tabData.graphJson !== undefined
+          ? deserializeState(tabData.graphJson, trace, sqlModules)
+          : createEmptyState();
+      return {
+        id: tabData.id,
+        title: tabData.title,
+        state,
+      };
+    });
+  }
+
   private tryLoadState(trace: Trace): void {
     if (this.hasAttemptedStateLoad) return;
 
-    // Mount permalink store on first access
     this.mountPermalinkStore(trace);
 
     const sqlModulesPlugin = trace.plugins.getPlugin(SqlModulesPlugin);
@@ -156,58 +289,122 @@ export default class implements PerfettoPlugin {
     // SQL modules are ready, mark load as attempted regardless of outcome
     this.hasAttemptedStateLoad = true;
 
-    // First, check permalink store (for graphs restored from permalinks)
-    const permalinkJson = this.permalinkStore?.state.graphJson;
-    if (permalinkJson) {
+    // Priority 1: Check permalink store
+    const permalinkState = this.permalinkStore?.state;
+    if (permalinkState) {
+      // Try multi-tab format first (version 2+)
+      if (permalinkState.tabs !== undefined && permalinkState.tabs.length > 0) {
+        try {
+          this.tabs = this.hydrateTabs(permalinkState.tabs, trace, sqlModules);
+          this.activeTabId =
+            permalinkState.activeTabId !== undefined &&
+            this.tabs.some((t) => t.id === permalinkState.activeTabId)
+              ? permalinkState.activeTabId
+              : this.tabs[0].id;
+          return;
+        } catch (e) {
+          const msg = getErrorMessage(e);
+          console.warn('Failed to load Explore Page tabs from permalink:', msg);
+          this.tabs = [];
+          // Fall through to try other sources
+        }
+      }
+
+      // Try old single-graph format (version 1 backward compat)
+      if (permalinkState.graphJson !== undefined) {
+        try {
+          const state = deserializeState(
+            permalinkState.graphJson,
+            trace,
+            sqlModules,
+          );
+          const tab = this.createNewTab();
+          tab.state = state;
+          this.tabs.push(tab);
+          this.activeTabId = tab.id;
+          return;
+        } catch (e) {
+          const msg = getErrorMessage(e);
+          console.warn(
+            'Failed to load Explore Page state from permalink:',
+            msg,
+          );
+          // Fall through to try other sources
+        }
+      }
+    }
+
+    // Priority 2: Check new localStorage tabs key
+    const persistedTabs = exploreTabsStorage.load();
+    if (persistedTabs !== undefined) {
       try {
-        const permalinkState = deserializeState(
-          permalinkJson,
-          trace,
-          sqlModules,
-        );
-        this.state = permalinkState;
-        this.hasAutoInitialized = true;
+        this.tabs = this.hydrateTabs(persistedTabs.tabs, trace, sqlModules);
+        this.activeTabId = this.tabs.some(
+          (t) => t.id === persistedTabs.activeTabId,
+        )
+          ? persistedTabs.activeTabId
+          : this.tabs[0].id;
         return;
       } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.warn('Failed to load Explore Page state from permalink:', msg);
+        console.debug('Failed to load Explore Page tabs from localStorage:', e);
+        this.tabs = [];
         // Fall through to try recent graphs
       }
     }
 
-    // Fall back to recent graphs (local storage)
-    const savedState = loadStateFromRecentGraphs(trace);
-    if (savedState !== undefined) {
-      // Load saved state from recent graphs (preserves work across page refreshes)
-      this.state = savedState;
-      // Only mark as auto-initialized if the saved state has nodes
-      // This allows base JSON to load after a reload when state is empty,
-      // but prevents it from loading after manual "Clear all nodes" in the same session
-      if (savedState.rootNodes.length > 0) {
-        this.hasAutoInitialized = true;
+    // Priority 3: Backward compat - try old recentGraphsStorage
+    try {
+      const json = recentGraphsStorage.getCurrentJson();
+      if (json) {
+        const state = deserializeState(json, trace, sqlModules);
+        const tab = this.createNewTab();
+        tab.state = state;
+        this.tabs.push(tab);
+        this.activeTabId = tab.id;
+        return;
       }
+    } catch (e) {
+      console.debug('Failed to load Explore Page state from recent graphs:', e);
+      recentGraphsStorage.clear();
     }
+
+    // Priority 4: Create one empty default tab
+    this.ensureAtLeastOneTab();
   }
 
+  // --- Plugin lifecycle ---
+
   async onTraceLoad(trace: Trace): Promise<void> {
+    // Flush pending localStorage saves on page unload
+    window.addEventListener('beforeunload', this.onBeforeUnload);
+    trace.trash.defer(() => {
+      window.removeEventListener('beforeunload', this.onBeforeUnload);
+    });
+
     trace.pages.registerPage({
       route: '/explore',
       render: () => {
-        // Ensure SQL modules initialization is triggered (no-op if already started)
-        trace.plugins.getPlugin(SqlModulesPlugin).ensureInitialized();
-
-        // Try to load saved state lazily (waits for SQL modules to be ready)
+        // Try to load saved state lazily (waits for SQL modules to be ready).
         this.tryLoadState(trace);
+
+        const activeTab = this.getActiveTab();
+        if (!activeTab) {
+          return m('.pf-explore-page', 'Loading...');
+        }
 
         return m(ExplorePage, {
           trace,
-          state: this.state,
+          tabs: this.tabs,
+          activeTabId: this.activeTabId,
+          state: activeTab.state,
           sqlModulesPlugin: trace.plugins.getPlugin(SqlModulesPlugin),
-          onStateUpdate: this.onStateUpdate,
-          hasAutoInitialized: this.hasAutoInitialized,
-          setHasAutoInitialized: (value: boolean) => {
-            this.hasAutoInitialized = value;
-          },
+          onStateUpdate: this.makeOnStateUpdate(this.activeTabId),
+          makeOnStateUpdate: (tabId: string) => this.makeOnStateUpdate(tabId),
+          onTabAdd: this.handleTabAdd,
+          onTabClose: this.handleTabClose,
+          onTabChange: this.handleTabChange,
+          onTabRename: this.handleTabRename,
+          onTabReorder: this.handleTabReorder,
         });
       },
     });
@@ -254,8 +451,12 @@ export default class implements PerfettoPlugin {
           end,
         } as unknown as QueryNodeState);
 
-        // Add node to state and select it
-        this.onStateUpdate((currentState) => ({
+        // Ensure we have an active tab
+        this.ensureAtLeastOneTab();
+
+        // Add node to active tab's state
+        const onStateUpdate = this.makeOnStateUpdate(this.activeTabId);
+        onStateUpdate((currentState) => ({
           ...currentState,
           rootNodes: [...currentState.rootNodes, newNode],
           selectedNodes: new Set([newNode.nodeId]),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -654,6 +654,11 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
   private hasPerformedInitialLayout: boolean = false;
   private hasPerformedInitialRecenter: boolean = false;
   private recenterRequired: boolean = false;
+  // True while a recenter is pending. The graph is hidden (visibility:hidden)
+  // to prevent a flash of un-centered content.
+  private pendingRecenter: boolean = false;
+  // DOM reference for checking visibility (Gate may hide us with display:none).
+  private graphElement?: HTMLElement;
   private labels: Label[] = [];
   private labelTexts: Map<string, string> = new Map();
   private editingLabels: Set<string> = new Set();
@@ -665,8 +670,9 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
   }
 
   oncreate(vnode: m.VnodeDOM<GraphAttrs>) {
+    this.graphElement = vnode.dom as HTMLElement;
     // Focus the graph container so WSAD keyboard controls work immediately
-    (vnode.dom as HTMLElement).focus();
+    this.graphElement.focus();
   }
 
   onbeforeupdate(vnode: m.Vnode<GraphAttrs>, old: m.VnodeDOM<GraphAttrs>) {
@@ -874,6 +880,12 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
       this.recenterRequired = true;
     }
 
+    // Hide graph content while a recenter is pending to prevent a flash of
+    // un-centered nodes before autofit adjusts the viewport.
+    if (this.recenterRequired) {
+      this.pendingRecenter = true;
+    }
+
     return m(
       '.pf-exp-node-graph',
       {
@@ -923,13 +935,29 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
           selectedNodeIds: attrs.selectedNodes,
           hideControls: true,
           fillHeight: true,
+          // Hide the graph while a recenter is pending to avoid a flash of
+          // un-centered content.
+          style: this.pendingRecenter ? {visibility: 'hidden'} : undefined,
           onReady: (api: NodeGraphApi) => {
             this.nodeGraphApi = api;
 
-            // Check if recenter is required and execute it after render
             if (this.recenterRequired) {
-              this.nodeGraphApi.recenter();
+              // Check that our container is actually visible (non-zero size).
+              // When a tab is hidden via Gate (display:none) the canvas has
+              // 0×0 dimensions and autofit would produce bogus zoom/pan.
+              // Leave the flags in place so recenter fires the next time
+              // the tab becomes visible and onReady is called again.
+              const rect = this.graphElement?.getBoundingClientRect();
+              if (rect === undefined || rect.width === 0 || rect.height === 0) {
+                return; // Defer until canvas is visible
+              }
+
               this.recenterRequired = false;
+              api.recenter();
+              if (this.pendingRecenter) {
+                this.pendingRecenter = false;
+                m.redraw();
+              }
             }
           },
           multiselect: true,

--- a/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
@@ -18,11 +18,34 @@
 .pf-explore-page {
   height: 100%;
   position: relative;
-  overflow: auto;
+  overflow: hidden;
 
   &__header {
     display: flex;
     align-items: center;
+  }
+
+  &__tabs {
+    height: 100%;
+
+    // Override the default overflow:auto on tab content. The explore page
+    // manages its own layout (sidebar + canvas) and does not need container
+    // scrollbars, which can cause scroll jumps when switching tabs.
+    .pf-tabs__content {
+      overflow: hidden;
+    }
+  }
+
+  &__tab-rename-input {
+    border: none;
+    outline: none;
+    background: transparent;
+    font: inherit;
+    color: inherit;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+    min-width: 40px;
   }
 }
 

--- a/ui/src/widgets/nodegraph.ts
+++ b/ui/src/widgets/nodegraph.ts
@@ -53,6 +53,8 @@ import {Icon} from './icon';
 import {PopupMenu} from './menu';
 import {classNames} from '../base/classnames';
 import {Icons} from '../base/semantic_icons';
+import {assertExists} from '../base/assert';
+import {shortUuid} from '../base/uuid';
 
 // Default height estimate for labels (used for box selection calculations)
 const DEFAULT_LABEL_MIN_HEIGHT = 30;
@@ -365,6 +367,12 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
 
   let latestVnode: m.Vnode<NodeGraphAttrs> | null = null;
   let canvasElement: HTMLElement | null = null;
+
+  // Unique instance ID for SVG marker references. Multiple NodeGraph instances
+  // (e.g. in different tabs) each create <marker id="..."> elements. Without
+  // unique IDs, url(#arrowhead) resolves to the first matching marker in
+  // document order, which may be inside a hidden tab (display:none).
+  const instanceId = shortUuid();
 
   // Shared pan function used by both internal handlers and external API
   const panBy = (dx: number, dy: number) => {
@@ -819,8 +827,11 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
     // Cache all port positions at once for performance
     const portPositionCache = new Map<string, Position>();
 
-    // Query all ports in one go and cache their positions
-    const allPorts = document.querySelectorAll('.pf-port[data-port]');
+    // Query ports within this NodeGraph instance only (not globally).
+    // Using document.querySelectorAll would pick up ports from other
+    // NodeGraph instances (e.g. hidden tabs), causing incorrect positions.
+    const container = assertExists(canvasElement);
+    const allPorts = container.querySelectorAll('.pf-port[data-port]');
     allPorts.forEach((portElement) => {
       const portId = portElement.getAttribute('data-port');
       if (!portId) return;
@@ -983,7 +994,7 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
           m('path', {
             'd': pathData,
             'class': 'pf-connection',
-            'marker-end': 'url(#arrowhead)',
+            'marker-end': `url(#arrowhead-${instanceId})`,
             'style': {
               pointerEvents: 'none',
             },
@@ -1031,13 +1042,16 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
           toPortType,
           shortenLength,
         ),
-        'marker-end': 'url(#arrowhead)',
+        'marker-end': `url(#arrowhead-${instanceId})`,
       });
     }
 
-    // Render everything using mithril's render function
+    // Render everything using mithril's render function.
+    // Use instance-unique marker ID to avoid conflicts when multiple
+    // NodeGraph instances exist in the document (e.g. tabs).
+    const markerId = `arrowhead-${instanceId}`;
     m.render(svg, [
-      m('defs', [arrowheadMarker('arrowhead')]),
+      m('defs', [arrowheadMarker(markerId)]),
       m('g', connectionPaths),
       tempConnectionPath,
     ]);
@@ -1055,7 +1069,10 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
         ? `[data-node="${nodeId}"] .pf-port[data-port="${portType}-${portIndex}"]`
         : `[data-node="${nodeId}"] [data-port="${portType}-${portIndex}"] .pf-port`;
 
-    const portElement = document.querySelector(selector);
+    // Scope to this NodeGraph instance to avoid matching elements from other
+    // instances (e.g. hidden tabs with the same node IDs).
+    const scope = assertExists(canvasElement);
+    const portElement = scope.querySelector(selector);
 
     if (portElement) {
       const nodeElement = portElement.closest('.pf-node') as HTMLElement | null;
@@ -1171,7 +1188,8 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
   }
 
   function getNodeDimensions(nodeId: string): {width: number; height: number} {
-    const nodeElement = document.querySelector(`[data-node="${nodeId}"]`);
+    const scope = assertExists(canvasElement);
+    const nodeElement = scope.querySelector(`[data-node="${nodeId}"]`);
     if (nodeElement) {
       const rect = nodeElement.getBoundingClientRect();
       // Divide by zoom to get canvas content space dimensions
@@ -2002,7 +2020,12 @@ export function NodeGraph(): m.Component<NodeGraphAttrs> {
       document.addEventListener('pointerup', handleMouseUp);
       canvasElement.addEventListener('wheel', handleWheel, {passive: false});
 
-      const {connections, nodes, onConnectionRemove, onReady} = vnode.attrs;
+      const {
+        connections = [],
+        nodes = [],
+        onConnectionRemove,
+        onReady,
+      } = vnode.attrs;
 
       // Render connections after DOM is ready
       const svg = vnode.dom.querySelector('svg');

--- a/ui/src/widgets/tabs.ts
+++ b/ui/src/widgets/tabs.ts
@@ -43,6 +43,8 @@ export interface TabsAttrs {
   onTabChange?(key: string): void;
   // Called when a tab's close button is clicked.
   onTabClose?(key: string): void;
+  // Called when a tab is double-clicked (e.g. for renaming).
+  onTabDblClick?(key: string): void;
   // Whether tabs can be reordered via drag and drop.
   readonly reorderable?: boolean;
   // Called when tabs are reordered. Receives the key of the dragged tab and
@@ -57,6 +59,7 @@ interface TabHandleAttrs {
   readonly hasCloseButton?: boolean;
   readonly onClose?: () => void;
   readonly onclick?: () => void;
+  readonly ondblclick?: () => void;
   readonly leftIcon?: string | m.Children;
   readonly tabKey?: string;
   readonly reorderable?: boolean;
@@ -74,6 +77,7 @@ class TabHandle implements m.ClassComponent<TabHandleAttrs> {
       hasCloseButton,
       onClose,
       onclick,
+      ondblclick,
       leftIcon,
       tabKey,
       reorderable,
@@ -100,6 +104,7 @@ class TabHandle implements m.ClassComponent<TabHandleAttrs> {
       {
         className: classNames(active && 'pf-tabs__tab--active'),
         onclick,
+        ondblclick,
         onauxclick: () => onClose?.(),
         draggable: reorderable,
         ondragstart: reorderable
@@ -170,6 +175,7 @@ export class Tabs implements m.ClassComponent<TabsAttrs> {
       activeTabKey,
       onTabChange,
       onTabClose,
+      onTabDblClick,
       reorderable,
       onTabReorder,
       className,
@@ -225,6 +231,9 @@ export class Tabs implements m.ClassComponent<TabsAttrs> {
                   this.internalActiveTab = tab.key;
                   onTabChange?.(tab.key);
                 },
+                ondblclick: onTabDblClick
+                  ? () => onTabDblClick(tab.key)
+                  : undefined,
                 onClose: () => onTabClose?.(tab.key),
                 onDragStart: (key) => {
                   this.draggedKey = key;


### PR DESCRIPTION
Add multi-tab support to the Data Explorer, allowing users to work on multiple independent graph explorations simultaneously. Each tab maintains its own state (nodes, layout, history, materialization) and tabs persist across page reloads via localStorage and permalinks.

## Changes

- Refactored `ExplorePage` component to render multiple tabs using the existing
  `Tabs` widget, with per-tab services (query execution, cleanup, history)
- Added `explore_tabs_storage.ts` for persisting tab layout to localStorage
  using zod schema validation
- Updated plugin (`index.ts`) to manage an array of tabs instead of a single
  state, with debounced saves and backward compatibility for v1 single-graph
  permalinks and recentGraphsStorage
- Fixed SVG marker ID collisions in `nodegraph.ts` when multiple NodeGraph
  instances exist (e.g. across tabs) by using instance-unique IDs and scoped
  DOM queries
- Added `onTabDblClick` callback to the `Tabs` widget for tab renaming
- Registered a `beforeunload` handler to flush pending saves on page unload
