### PR TITLE
tp: Intervals Create uses kDense dataframe

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/create_intervals.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/create_intervals.cc
@@ -69,7 +69,7 @@ struct IntervalCreate : public sqlite::Function<IntervalCreate> {
     dataframe::AdhocDataframeBuilder builder(
         col_names, GetUserData(ctx)->pool,
         dataframe::AdhocDataframeBuilder::Options{
-            col_types, dataframe::NullabilityType::kSparseNullWithPopcount});
+            col_types, dataframe::NullabilityType::kDenseNull});
 
     if (!starts || !ends || starts->timestamps.empty() ||
         ends->timestamps.empty()) {


### PR DESCRIPTION
By mistake merged before resolving the comment on https://github.com/google/perfetto/pull/4988. Fix.