### PR TITLE
wasm: TxtToPb for TraceSummary

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1574,6 +1574,7 @@ cc_binary {
         "perfetto_src_base_version_gen_h",
         "perfetto_src_perfetto_cmd_protos_cpp_gen_headers",
         "perfetto_src_proto_utils_gen_cc_config_descriptor",
+        "perfetto_src_proto_utils_gen_cc_trace_summary_descriptor",
     ],
     defaults: [
         "perfetto_defaults",

--- a/BUILD
+++ b/BUILD
@@ -323,6 +323,7 @@ perfetto_cc_binary(
         ":src_base_base",
         ":src_base_version",
         ":src_proto_utils_gen_cc_config_descriptor",
+        ":src_proto_utils_gen_cc_trace_summary_descriptor",
     ] + PERFETTO_CONFIG.deps.protobuf_full,
 )
 
@@ -1824,6 +1825,17 @@ perfetto_cc_proto_descriptor(
     ],
     outs = [
         "src/proto_utils/config.descriptor.h",
+    ],
+)
+
+# GN target: //src/proto_utils:gen_cc_trace_summary_descriptor
+perfetto_cc_proto_descriptor(
+    name = "src_proto_utils_gen_cc_trace_summary_descriptor",
+    deps = [
+        ":protos_perfetto_trace_summary_descriptor",
+    ],
+    outs = [
+        "src/proto_utils/trace_summary.descriptor.h",
     ],
 )
 
@@ -8491,6 +8503,7 @@ perfetto_cc_binary(
         ":src_base_version",
         ":src_perfetto_cmd_protos_cpp",
         ":src_proto_utils_gen_cc_config_descriptor",
+        ":src_proto_utils_gen_cc_trace_summary_descriptor",
     ],
 )
 

--- a/src/proto_utils/BUILD.gn
+++ b/src/proto_utils/BUILD.gn
@@ -20,6 +20,7 @@ import("../../gn/wasm.gni")
 source_set("txt_to_pb") {
   deps = [
     ":gen_cc_config_descriptor",
+    ":gen_cc_trace_summary_descriptor",
     "../../gn:default_deps",
     "../base",
     "../protozero",

--- a/src/proto_utils/txt_to_pb.cc
+++ b/src/proto_utils/txt_to_pb.cc
@@ -21,12 +21,15 @@
 #include <vector>
 
 #include "perfetto/ext/base/status_or.h"
-#include "src/protozero/text_to_proto/text_to_proto.h"
 #include "src/proto_utils/config.descriptor.h"
+#include "src/proto_utils/trace_summary.descriptor.h"
+#include "src/protozero/text_to_proto/text_to_proto.h"
 
 namespace perfetto {
 namespace {
 constexpr char kConfigProtoName[] = ".perfetto.protos.TraceConfig";
+constexpr char kTraceSummarySpecProtoName[] =
+    ".perfetto.protos.TraceSummarySpec";
 
 }  // namespace
 
@@ -36,6 +39,14 @@ base::StatusOr<std::vector<uint8_t>> TraceConfigTxtToPb(
   return protozero::TextToProto(kConfigDescriptor.data(),
                                 kConfigDescriptor.size(), kConfigProtoName,
                                 file_name, input);
+}
+
+base::StatusOr<std::vector<uint8_t>> TraceSummarySpecTxtToPb(
+    const std::string& input,
+    const std::string& file_name) {
+  return protozero::TextToProto(kTraceSummaryDescriptor.data(),
+                                kTraceSummaryDescriptor.size(),
+                                kTraceSummarySpecProtoName, file_name, input);
 }
 
 }  // namespace perfetto

--- a/src/proto_utils/txt_to_pb.h
+++ b/src/proto_utils/txt_to_pb.h
@@ -30,6 +30,10 @@ base::StatusOr<std::vector<uint8_t>> TraceConfigTxtToPb(
     const std::string& input,
     const std::string& file_name = "-");
 
+base::StatusOr<std::vector<uint8_t>> TraceSummarySpecTxtToPb(
+    const std::string& input,
+    const std::string& file_name = "-");
+
 }  // namespace perfetto
 
 #endif  // SRC_PROTO_UTILS_TXT_TO_PB_H_

--- a/src/proto_utils/txt_to_pb_unittest.cc
+++ b/src/proto_utils/txt_to_pb_unittest.cc
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 
+#include "src/proto_utils/pb_to_txt.h"
 #include "test/gtest_and_gmock.h"
 
 #include "protos/perfetto/config/data_source_config.gen.h"
@@ -540,6 +541,70 @@ TEST(TxtToPbTest, UnknownNested) {
 // TEST(TxtToPbTest, UnterminatedString) {
 // TEST(TxtToPbTest, NumberIsEof)
 // TEST(TxtToPbTest, OneOf)
+
+TEST(TxtToPbTest, TraceSummarySpecMetricSpec) {
+  // metric_spec is defined in TraceSummarySpec in file.proto (field 1).
+  auto output = TraceSummarySpecTxtToPb(R"(
+metric_spec {
+  id: "my_metric"
+  value: "dur_ns"
+}
+  )");
+  ASSERT_TRUE(output.ok()) << output.status().message();
+  ASSERT_FALSE(output->empty());
+
+  // Verify round-trip by converting back to text.
+  std::string txt = TraceSummarySpecPbToTxt(output->data(), output->size());
+  EXPECT_THAT(txt, HasSubstr("id: \"my_metric\""));
+  EXPECT_THAT(txt, HasSubstr("value: \"dur_ns\""));
+}
+
+TEST(TxtToPbTest, TraceSummarySpecMetricTemplateSpec) {
+  auto output = TraceSummarySpecTxtToPb(R"(
+metric_template_spec {
+  id_prefix: "cpu_metric"
+  dimensions: "cpu"
+  value_columns: "dur"
+  value_columns: "count"
+}
+  )");
+  ASSERT_TRUE(output.ok()) << output.status().message();
+  ASSERT_FALSE(output->empty());
+
+  // Verify round-trip by converting back to text.
+  std::string txt = TraceSummarySpecPbToTxt(output->data(), output->size());
+  EXPECT_THAT(txt, HasSubstr("id_prefix: \"cpu_metric\""));
+  EXPECT_THAT(txt, HasSubstr("dimensions: \"cpu\""));
+  EXPECT_THAT(txt, HasSubstr("value_columns: \"dur\""));
+  EXPECT_THAT(txt, HasSubstr("value_columns: \"count\""));
+}
+
+TEST(TxtToPbTest, TraceSummarySpecWithQuery) {
+  auto output = TraceSummarySpecTxtToPb(R"(
+query {
+  id: "test_query"
+  sql {
+    sql: "SELECT * FROM slice"
+  }
+}
+  )");
+  ASSERT_TRUE(output.ok()) << output.status().message();
+  ASSERT_FALSE(output->empty());
+
+  // Verify round-trip by converting back to text.
+  std::string txt = TraceSummarySpecPbToTxt(output->data(), output->size());
+  EXPECT_THAT(txt, HasSubstr("id: \"test_query\""));
+  EXPECT_THAT(txt, HasSubstr("sql: \"SELECT * FROM slice\""));
+}
+
+TEST(TxtToPbTest, TraceSummarySpecUnknownField) {
+  auto res = TraceSummarySpecTxtToPb(R"(
+    not_a_field: 123
+  )");
+  EXPECT_FALSE(res.ok());
+  EXPECT_THAT(res.status().message(),
+              HasSubstr("No field named \"not_a_field\""));
+}
 
 }  // namespace
 }  // namespace perfetto

--- a/src/proto_utils/wasm.cc
+++ b/src/proto_utils/wasm.cc
@@ -29,6 +29,36 @@ namespace {
 // The buffer used to exchange input and output arguments. We assume 16MB
 // is enough to handle trace configs and proto specs.
 char wasm_buf[16 * 1024 * 1024];
+
+// Helper: converts proto bytes in wasm_buf to text using the given converter,
+// writes result back to wasm_buf, returns the text size.
+uint32_t pb_to_txt(std::string (*converter)(const void*, size_t),
+                   uint32_t size) {
+  std::string txt = converter(wasm_buf, size);
+  size_t wsize = perfetto::base::SprintfTrunc(wasm_buf, sizeof(wasm_buf), "%s",
+                                              txt.c_str());
+  return static_cast<uint32_t>(wsize);
+}
+
+// Helper: converts a pbtxt string in wasm_buf to proto-encoded bytes using the
+// given converter. Because this can fail (the C++ function returns a StatusOr)
+// we write a success/failure marker in the first byte.
+using TxtToPbFn =
+    perfetto::base::StatusOr<std::vector<uint8_t>> (*)(const std::string&,
+                                                       const std::string&);
+uint32_t txt_to_pb(TxtToPbFn converter, uint32_t size) {
+  auto res = converter(std::string(wasm_buf, size), "-");
+  if (!res.ok()) {
+    wasm_buf[0] = 0;
+    size_t wsize = perfetto::base::SprintfTrunc(
+        &wasm_buf[1], sizeof(wasm_buf) - 1, "%s", res.status().c_message());
+    return static_cast<uint32_t>(wsize);
+  }
+  const size_t resp_size = std::min(res->size(), sizeof(wasm_buf) - 1);
+  wasm_buf[0] = 1;
+  memcpy(&wasm_buf[1], res->data(), resp_size);
+  return static_cast<uint32_t>(resp_size);
+}
 }  // namespace
 
 extern "C" {
@@ -45,43 +75,24 @@ uint32_t proto_utils_buf_size() {
   return static_cast<uint32_t>(sizeof(wasm_buf));
 }
 
-// Helper: converts proto bytes in wasm_buf to text using the given converter,
-// writes result back to wasm_buf, returns the text size.
-uint32_t pb_to_txt(std::string (*converter)(const void*, size_t),
-                   uint32_t size) {
-  std::string txt = converter(wasm_buf, size);
-  size_t wsize = perfetto::base::SprintfTrunc(wasm_buf, sizeof(wasm_buf), "%s",
-                                              txt.c_str());
-  return static_cast<uint32_t>(wsize);
-}
-
 uint32_t EMSCRIPTEN_KEEPALIVE trace_config_pb_to_txt(uint32_t size);
 uint32_t trace_config_pb_to_txt(uint32_t size) {
   return pb_to_txt(perfetto::TraceConfigPbToTxt, size);
 }
 
-// Like the above, but converts a pbtxt into proto-encoded bytes.
-// Because this can fail (the C++ function returns a StatusOr) we write
-// a success/failure in the first byte to tell the difference.
 uint32_t EMSCRIPTEN_KEEPALIVE trace_config_txt_to_pb(uint32_t size);
-
 uint32_t trace_config_txt_to_pb(uint32_t size) {
-  auto res = perfetto::TraceConfigTxtToPb(std::string(wasm_buf, size));
-  if (!res.ok()) {
-    wasm_buf[0] = 0;
-    size_t wsize = perfetto::base::SprintfTrunc(
-        &wasm_buf[1], sizeof(wasm_buf) - 1, "%s", res.status().c_message());
-    return static_cast<uint32_t>(wsize);
-  }
-  const size_t resp_size = std::min(res->size(), sizeof(wasm_buf) - 1);
-  wasm_buf[0] = 1;
-  memcpy(&wasm_buf[1], res->data(), resp_size);
-  return static_cast<uint32_t>(resp_size);
+  return txt_to_pb(perfetto::TraceConfigTxtToPb, size);
 }
 
 uint32_t EMSCRIPTEN_KEEPALIVE trace_summary_spec_to_text(uint32_t size);
 uint32_t trace_summary_spec_to_text(uint32_t size) {
   return pb_to_txt(perfetto::TraceSummarySpecPbToTxt, size);
+}
+
+uint32_t EMSCRIPTEN_KEEPALIVE trace_summary_spec_txt_to_pb(uint32_t size);
+uint32_t trace_summary_spec_txt_to_pb(uint32_t size) {
+  return txt_to_pb(perfetto::TraceSummarySpecTxtToPb, size);
 }
 
 }  // extern "C"

--- a/ui/src/base/proto_utils_wasm.ts
+++ b/ui/src/base/proto_utils_wasm.ts
@@ -66,31 +66,38 @@ export async function traceConfigToTxt(
   return pbToText(config, protos.TraceConfig.encode, 'trace_config_pb_to_txt');
 }
 
-/** Convert a pbtxt (text-proto) text to a proto-encoded TraceConfig. */
-export async function traceConfigToPb(
-  configTxt: string,
+/**
+ * Generic helper: sends a text proto string to WASM for conversion to binary
+ * proto format. Mirrors pbToText but in the opposite direction.
+ */
+async function textToPb(
+  input: string,
+  ccallName: string,
 ): Promise<Result<Uint8Array>> {
   const wasm = await initWasmOnce();
 
-  const configUtf8 = utf8Encode(configTxt);
-  if (configUtf8.length > wasm.buf.length) {
+  const inputUtf8 = utf8Encode(input);
+  if (inputUtf8.length > wasm.buf.length) {
     return errResult(
-      `Config text too large: ${configUtf8.length} bytes exceeds buffer size ${wasm.buf.length}`,
+      `Text too large: ${inputUtf8.length} bytes exceeds buffer size ${wasm.buf.length}`,
     );
   }
-  wasm.buf.set(configUtf8);
+  wasm.buf.set(inputUtf8);
 
   const resSize =
-    wasm.module.ccall(
-      'trace_config_txt_to_pb',
-      'number',
-      ['number'],
-      [configUtf8.length],
-    ) >>> 0;
+    wasm.module.ccall(ccallName, 'number', ['number'], [inputUtf8.length]) >>>
+    0;
 
   const success = wasm.buf.at(0) === 1;
   const payload = wasm.buf.slice(1, 1 + resSize);
   return success ? okResult(payload) : errResult(utf8Decode(payload));
+}
+
+/** Convert a pbtxt (text-proto) text to a proto-encoded TraceConfig. */
+export async function traceConfigToPb(
+  configTxt: string,
+): Promise<Result<Uint8Array>> {
+  return textToPb(configTxt, 'trace_config_txt_to_pb');
 }
 
 /**
@@ -104,6 +111,15 @@ export async function traceSummarySpecToText(
     protos.TraceSummarySpec.encode,
     'trace_summary_spec_to_text',
   );
+}
+
+/**
+ * Convert a text proto (pbtxt) string to a proto-encoded TraceSummarySpec.
+ */
+export async function traceSummarySpecToPb(
+  specTxt: string,
+): Promise<Result<Uint8Array>> {
+  return textToPb(specTxt, 'trace_summary_spec_txt_to_pb');
 }
 
 async function initWasmOnce(): Promise<WasmModule> {
@@ -122,8 +138,7 @@ async function initWasmOnce(): Promise<WasmModule> {
       wasmBinary,
     } as WasmModuleGen.ModuleArgs);
     await deferredRuntimeInitialized;
-    const bufAddr =
-      instance.ccall('proto_utils_buf', 'number', [], []) >>> 0;
+    const bufAddr = instance.ccall('proto_utils_buf', 'number', [], []) >>> 0;
     const bufSize =
       instance.ccall('proto_utils_buf_size', 'number', [], []) >>> 0;
     moduleInstance = {


### PR DESCRIPTION
Add TxtToPb (text-proto to binary) conversion support for TraceSummarySpec, mirroring the existing PbToTxt direction. This completes the round-trip conversion capability for TraceSummarySpec across C++, WASM, and TypeScript and is required for future "load from text-proto" functionality in Data Explorer.
