### PR TITLE
Remove references to `descendant_slice_by_stack` and `ascestor_slice_by_stack` from PerfettoSQL's "Getting Started" guide

### DIFF
--- a/docs/analysis/perfetto-sql-getting-started.md
+++ b/docs/analysis/perfetto-sql-getting-started.md
@@ -363,33 +363,6 @@ FROM
   ancestor_slice(interesting_slices.id) AS ancestor ON ancestor.depth = 0
 ```
 
-#### Ancestor slice by stack
-
-ancestor_slice_by_stack is a custom operator table that takes a
-[slice table's stack_id column](/docs/analysis/sql-tables.autogen#slice) and
-finds all slice ids with that stack_id, then, for each id it computes all the
-ancestor slices similarly to
-[ancestor_slice](/docs/analysis/trace-processor#ancestor-slice).
-
-The returned format is the same as the
-[slice table](/docs/analysis/sql-tables.autogen#slice)
-
-For example, the following finds the top level slice of all slices with the
-given name.
-
-```sql
-CREATE VIEW interesting_stack_ids AS
-SELECT stack_id
-FROM slice WHERE name LIKE "%interesting slice name%";
-
-SELECT
-  *
-FROM
-  interesting_stack_ids LEFT JOIN
-  ancestor_slice_by_stack(interesting_stack_ids.stack_id) AS ancestor
-  ON ancestor.depth = 0
-```
-
 #### Descendant slice
 
 descendant_slice is a custom operator table that takes a
@@ -417,33 +390,6 @@ SELECT
     FROM descendant_slice(interesting_slice.id)
   )
 FROM interesting_slices
-```
-
-#### Descendant slice by stack
-
-descendant_slice_by_stack is a custom operator table that takes a
-[slice table's stack_id column](/docs/analysis/sql-tables.autogen#slice) and
-finds all slice ids with that stack_id, then, for each id it computes all the
-descendant slices similarly to
-[descendant_slice](/docs/analysis/trace-processor#descendant-slice).
-
-The returned format is the same as the
-[slice table](/docs/analysis/sql-tables.autogen#slice)
-
-For example, the following finds the next level descendant of all slices with
-the given name.
-
-```sql
-CREATE VIEW interesting_stacks AS
-SELECT stack_id, depth
-FROM slice WHERE name LIKE "%interesting slice name%";
-
-SELECT
-  *
-FROM
-  interesting_stacks LEFT JOIN
-  descendant_slice_by_stack(interesting_stacks.stack_id) AS descendant
-  ON descendant.depth = interesting_stacks.depth + 1
 ```
 
 #### Connected/Following/Preceding flows


### PR DESCRIPTION
For newcomers to Perfetto, when they read the [PerfettoSQL's getting started guide](https://perfetto.dev/docs/analysis/perfetto-sql-getting-started#operator-tables) it's very easy to get confused because you have the following:

 1. Ancestor slice
 2. **Ancestor slice by stack**
 3. Descendant slice
 4. **Descendant slice by stack**

These "by stack" variants not only confuse beginners (it certainly confused me!), but operate on a `stack_id` column of the slice table [which appears to no longer exist](https://perfetto.dev/docs/analysis/perfetto-sql-backcompat#removal-of-code-stack_id-code-and-code-parent_stack_id-code-columns-from-slice-table). This PR aims to improve this part of the documentation by removing  references to these two variants from this beginner-facing guide.