### PR TITLE
de: Add export node category

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/core_nodes.ts
@@ -577,7 +577,8 @@ export function registerCoreNodes() {
     description:
       'Define a trace-based metric with value column and dimensions.',
     icon: 'analytics',
-    type: 'modification',
+    type: 'export',
+    hasPrimaryInput: true,
     nodeType: NodeType.kMetrics,
     allowedChildren: ['trace_summary'],
     factory: (state) => new MetricsNode(state as MetricsNodeState),
@@ -610,7 +611,7 @@ export function registerCoreNodes() {
     description:
       'Bundle multiple metrics into a single trace summary specification.',
     icon: 'summarize',
-    type: 'multisource',
+    type: 'export',
     nodeType: NodeType.kTraceSummary,
     allowedChildren: [],
     factory: (state) => new TraceSummaryNode(state as TraceSummaryNodeState),
@@ -650,8 +651,9 @@ export function registerCoreNodes() {
     'counter_to_intervals',
     'sort_node',
     'limit_and_offset_node',
-    'metrics',
     'visualisation',
+    // Export nodes
+    'metrics',
     // Multisource nodes
     'filter_during',
     'filter_in',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/graph.ts
@@ -221,32 +221,36 @@ function buildAddMenuItems(
     return [];
   }
 
+  const addCb = (id: string) => onAddOperationNode(id, targetNode);
   const multisourceItems = buildMenuItems(
     'multisource',
-    (id) => onAddOperationNode(id, targetNode),
+    addCb,
     allowedChildren,
   );
   const modificationItems = buildMenuItems(
     'modification',
-    (id) => onAddOperationNode(id, targetNode),
+    addCb,
     allowedChildren,
   );
+  const exportItems = buildMenuItems('export', addCb, allowedChildren);
 
-  if (modificationItems.length === 0 && multisourceItems.length === 0) {
+  const sections: {title: string; items: m.Children[]}[] = [
+    {title: 'Modification nodes', items: modificationItems},
+    {title: 'Operations', items: multisourceItems},
+    {title: 'Export', items: exportItems},
+  ].filter((s) => s.items.length > 0);
+
+  if (sections.length === 0) {
     return [];
   }
 
   const menuItems: m.Children[] = [];
-  if (modificationItems.length > 0) {
-    menuItems.push(m(MenuTitle, {label: 'Modification nodes'}));
-    menuItems.push(...modificationItems);
-  }
-  if (modificationItems.length > 0 && multisourceItems.length > 0) {
-    menuItems.push(m(MenuDivider));
-  }
-  if (multisourceItems.length > 0) {
-    menuItems.push(m(MenuTitle, {label: 'Operations'}));
-    menuItems.push(...multisourceItems);
+  for (let i = 0; i < sections.length; i++) {
+    if (i > 0) {
+      menuItems.push(m(MenuDivider));
+    }
+    menuItems.push(m(MenuTitle, {label: sections[i].title}));
+    menuItems.push(...sections[i].items);
   }
   return menuItems;
 }
@@ -742,32 +746,29 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
   }
 
   private renderControls(attrs: GraphAttrs) {
-    const sourceMenuItems = buildMenuItems('source', attrs.onAddSourceNode);
+    const cb = attrs.onAddSourceNode;
+    const sections: {title: string; items: m.Children[]}[] = [
+      {title: 'Sources', items: buildMenuItems('source', cb)},
+      {title: 'Operations', items: buildMenuItems('multisource', cb)},
+      {title: 'Modification nodes', items: buildMenuItems('modification', cb)},
+      {title: 'Export', items: buildMenuItems('export', cb)},
+    ].filter((s) => s.items.length > 0);
 
-    const modificationMenuItems = buildMenuItems(
-      'modification',
-      attrs.onAddSourceNode,
-    );
-
-    const operationMenuItems = buildMenuItems(
-      'multisource',
-      attrs.onAddSourceNode,
-    );
-
-    const addNodeMenuItems = [
-      m(MenuTitle, {label: 'Sources'}),
-      ...sourceMenuItems,
-      m(MenuDivider),
-      m(MenuTitle, {label: 'Operations'}),
-      ...operationMenuItems,
-      m(MenuTitle, {label: 'Modification nodes'}),
-      ...modificationMenuItems,
-      m(MenuDivider),
+    const addNodeMenuItems: m.Children[] = [];
+    for (let i = 0; i < sections.length; i++) {
+      if (i > 0) {
+        addNodeMenuItems.push(m(MenuDivider));
+      }
+      addNodeMenuItems.push(m(MenuTitle, {label: sections[i].title}));
+      addNodeMenuItems.push(...sections[i].items);
+    }
+    addNodeMenuItems.push(m(MenuDivider));
+    addNodeMenuItems.push(
       m(MenuItem, {
         label: 'Label',
         onclick: () => this.addLabel(attrs),
       }),
-    ];
+    );
 
     const moreMenuItems = [
       m(MenuItem, {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/menu_utils.ts
@@ -25,7 +25,7 @@ import {Keycap} from '../../../../widgets/hotkey_glyphs';
  * @returns Array of Mithril children representing the menu items
  */
 export function buildMenuItems(
-  nodeType: 'source' | 'multisource' | 'modification',
+  nodeType: 'source' | 'multisource' | 'modification' | 'export',
   onAddNode: (id: string) => void,
   allowedIds?: ReadonlyArray<string>,
 ): m.Children[] {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/graph/node_box.ts
@@ -48,33 +48,36 @@ export function renderAddButton(attrs: NodeBoxAttrs): m.Child {
     return null;
   }
 
+  const addCb = (id: string) => onAddOperationNode(id, node);
   const multisourceMenuItems = buildMenuItems(
     'multisource',
-    (id) => onAddOperationNode(id, node),
+    addCb,
     allowedChildren,
   );
-
   const modificationMenuItems = buildMenuItems(
     'modification',
-    (id) => onAddOperationNode(id, node),
+    addCb,
     allowedChildren,
   );
+  const exportMenuItems = buildMenuItems('export', addCb, allowedChildren);
 
-  if (modificationMenuItems.length === 0 && multisourceMenuItems.length === 0) {
+  const sections: {title: string; items: m.Children[]}[] = [
+    {title: 'Modification nodes', items: modificationMenuItems},
+    {title: 'Operations', items: multisourceMenuItems},
+    {title: 'Export', items: exportMenuItems},
+  ].filter((s) => s.items.length > 0);
+
+  if (sections.length === 0) {
     return null;
   }
 
   const menuItems: m.Children[] = [];
-  if (modificationMenuItems.length > 0) {
-    menuItems.push(m(MenuTitle, {label: 'Modification nodes'}));
-    menuItems.push(...modificationMenuItems);
-  }
-  if (modificationMenuItems.length > 0 && multisourceMenuItems.length > 0) {
-    menuItems.push(m(MenuDivider));
-  }
-  if (multisourceMenuItems.length > 0) {
-    menuItems.push(m(MenuTitle, {label: 'Operations'}));
-    menuItems.push(...multisourceMenuItems);
+  for (let i = 0; i < sections.length; i++) {
+    if (i > 0) {
+      menuItems.push(m(MenuDivider));
+    }
+    menuItems.push(m(MenuTitle, {label: sections[i].title}));
+    menuItems.push(...sections[i].items);
   }
 
   return m(

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_registry.ts
@@ -43,8 +43,8 @@ export interface NodeDescriptor {
   // The keyboard shortcut for this node.
   hotkey?: string;
 
-  // Whether this node is a source, modification or a multi-source node.
-  type: 'source' | 'modification' | 'multisource';
+  // Whether this node is a source, modification, multi-source, or export node.
+  type: 'source' | 'modification' | 'multisource' | 'export';
 
   // Optional category for grouping related nodes in the UI.
   // Nodes with the same category will be shown in a submenu.


### PR DESCRIPTION
Some nodes are of a completely different type than another. For now it's only metrics and trace summary - they should be in an Export Category, as they are here purely to have an "export" button somewhere and get the result used somewhere else.