### PR TITLE
ui: Relax playwright screenshot tolerances

### DIFF
--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -15,7 +15,6 @@
 import {defineConfig} from '@playwright/test';
 import * as os from 'os';
 
-const isMac = os.platform() === 'darwin';
 const isCi = Boolean(process.env.CI);
 const outDir = process.env.OUT_DIR ?? '../out/ui';
 
@@ -40,9 +39,8 @@ export default defineConfig({
   expect: {
     timeout: 5000,
     toHaveScreenshot: {
-      // Rendering is not 100% identical on Mac. Be more tolerant.
-      // Otherwise, allow for small differences between rasterizers on different platforms.
-      maxDiffPixelRatio: isMac ? 0.05 : undefined,
+      // Allow for very small differences between rasterizers on different platforms.
+      maxDiffPixels: 1,
     },
   },
 


### PR DESCRIPTION
We are getting consistent flakes on the the CI where `scroll_timeline_v4_track` screenshot test was failing by 1px.

In theory, screenshots should be the same since we run playwright in a container, but in practice something is going wrong.

Ideally we should fix the environment or the tests to make these screenshots identical, but this PR offers a practical solution which is to simply allow configure playwright to allow for a 1px difference before failing the tests.

While in the area, remove the isMac relaxed tolerances as I think we have to accept that playwright tests can no longer be of any use on a mac.

