### PR TITLE
de: Share summarizer properly

### DIFF
--- a/src/trace_processor/trace_summary/summarizer.cc
+++ b/src/trace_processor/trace_summary/summarizer.cc
@@ -42,6 +42,8 @@ Summarizer::~Summarizer() = default;
 
 namespace summary {
 
+uint32_t SummarizerImpl::next_table_id_ = 0;
+
 namespace {
 
 using perfetto_sql::generator::StructuredQueryGenerator;

--- a/src/trace_processor/trace_summary/summarizer.h
+++ b/src/trace_processor/trace_summary/summarizer.h
@@ -118,7 +118,9 @@ class SummarizerImpl : public Summarizer {
   base::FlatHashMap<std::string, QueryState> query_states_;
   base::FlatHashMap<std::string, bool>
       included_modules_;  // Track included modules.
-  uint32_t next_table_id_ = 0;
+  // Static so that table names are globally unique across all summarizer
+  // instances (multiple Data Explorer tabs share the same TP).
+  static uint32_t next_table_id_;
 };
 
 }  // namespace summary


### PR DESCRIPTION
Fix materialized table name collisions when using multiple Data Explorer tabs.

Each DE tab creates its own `SummarizerImpl` instance, but all instances share
the same TraceProcessor SQL engine. The `next_table_id_` counter was per-instance
(starting at 0), so two tabs would both try to `CREATE PERFETTO TABLE _exp_mat_1`,
causing a "table already exists" error. Making the counter static ensures globally
unique table names across all summarizer instances.
