### PR TITLE
heapprofd: expose a reallocarray hook

### DIFF
--- a/src/profiling/memory/malloc_interceptor_bionic_hooks.cc
+++ b/src/profiling/memory/malloc_interceptor_bionic_hooks.cc
@@ -52,6 +52,7 @@ void heapprofd_free(void* pointer);
 void* heapprofd_aligned_alloc(size_t alignment, size_t size);
 void* heapprofd_memalign(size_t alignment, size_t bytes);
 void* heapprofd_realloc(void* pointer, size_t bytes);
+void* heapprofd_reallocarray(void* pointer, size_t nmemb, size_t size);
 void* heapprofd_calloc(size_t nmemb, size_t bytes);
 struct mallinfo heapprofd_mallinfo();
 int heapprofd_mallopt(int param, int value);
@@ -168,6 +169,11 @@ void heapprofd_free(void* pointer) {
 void* heapprofd_realloc(void* pointer, size_t size) {
   return perfetto::profiling::wrap_realloc(g_heap_id, GetDispatch()->realloc,
                                            pointer, size);
+}
+
+void* heapprofd_reallocarray(void* pointer, size_t nmemb, size_t size) {
+  return perfetto::profiling::wrap_reallocarray(
+      g_heap_id, GetDispatch()->reallocarray, pointer, nmemb, size);
 }
 
 void heapprofd_dump_heap(const char*) {}

--- a/src/profiling/memory/wrap_allocators.cc
+++ b/src/profiling/memory/wrap_allocators.cc
@@ -126,11 +126,15 @@ void* wrap_reallocarray(uint32_t heap_id,
                         void* pointer,
                         size_t nmemb,
                         size_t size) {
+  size_t alloc_size = 0;
+  if (__builtin_mul_overflow(nmemb, size, &alloc_size))
+    return fn(pointer, nmemb, size);
+
   if (pointer)
     AHeapProfile_reportFree(heap_id, reinterpret_cast<uint64_t>(pointer));
   void* addr = fn(pointer, nmemb, size);
   AHeapProfile_reportAllocation(heap_id, reinterpret_cast<uint64_t>(addr),
-                                nmemb * size);
+                                alloc_size);
   return addr;
 }
 


### PR DESCRIPTION
Allow bionic to find a `heapprofd_reallocarray`. Additionally, short-circuit
the overflow case as it is defined to cause a clean error.

Bug: 489692215