### PR TITLE
tp: Make Summarizers truly independent

### DIFF
--- a/include/perfetto/trace_processor/trace_processor.h
+++ b/include/perfetto/trace_processor/trace_processor.h
@@ -249,8 +249,7 @@ class PERFETTO_EXPORT_COMPONENT TraceProcessor : public TraceProcessorStorage {
   // EXPERIMENTAL: Creates a new Summarizer instance for managing lazy
   // materialization of structured queries. On success, |out| is populated with
   // the new instance and ownership is transferred to the caller.
-  virtual base::Status CreateSummarizer(const std::string& id,
-                                        std::unique_ptr<Summarizer>* out) = 0;
+  virtual base::Status CreateSummarizer(std::unique_ptr<Summarizer>* out) = 0;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/rpc/rpc.cc
+++ b/src/trace_processor/rpc/rpc.cc
@@ -381,8 +381,7 @@ void Rpc::ParseRpcRequest(const uint8_t* data, size_t len) {
         result->set_error("Summarizer already exists: " + summarizer_id);
       } else {
         std::unique_ptr<Summarizer> summarizer;
-        base::Status status =
-            trace_processor_->CreateSummarizer(summarizer_id, &summarizer);
+        base::Status status = trace_processor_->CreateSummarizer(&summarizer);
         if (!status.ok()) {
           result->set_error(status.message());
         } else {

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -1464,20 +1464,7 @@ bool TraceProcessorImpl::IsRootMetricField(const std::string& metric_name) {
 // =================================================================
 
 base::Status TraceProcessorImpl::CreateSummarizer(
-    const std::string& id,
     std::unique_ptr<Summarizer>* out) {
-  // The id is embedded in SQL table names (e.g. "_exp_mat_{id}_{seq}"),
-  // so it must only contain characters valid in SQL identifiers.
-  if (id.empty() || !std::all_of(id.begin(), id.end(), [](char c) {
-        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') ||
-               (c >= 'A' && c <= 'Z') || c == '_';
-      })) {
-    return base::ErrStatus(
-        "Invalid summarizer id '%s': must be non-empty and contain only "
-        "alphanumeric characters or underscores",
-        id.c_str());
-  }
-
   // Lazily initialize the descriptor pool for textproto generation.
   auto opt_idx = metrics_descriptor_pool_.FindDescriptorIdx(
       ".perfetto.protos.TraceSummarySpec");
@@ -1486,8 +1473,12 @@ base::Status TraceProcessorImpl::CreateSummarizer(
         kTraceSummaryDescriptor.data(), kTraceSummaryDescriptor.size());
   }
 
+  // Auto-generate a unique id for table namespacing. The id is embedded in
+  // SQL table names (e.g. "_exp_mat_{id}_{seq}") to prevent collisions
+  // between multiple summarizer instances.
+  std::string id = std::to_string(next_summarizer_id_++);
   *out = std::make_unique<summary::SummarizerImpl>(
-      this, &metrics_descriptor_pool_, id);
+      this, &metrics_descriptor_pool_, std::move(id));
   return base::OkStatus();
 }
 

--- a/src/trace_processor/trace_processor_impl.h
+++ b/src/trace_processor/trace_processor_impl.h
@@ -135,8 +135,7 @@ class TraceProcessorImpl : public TraceProcessor,
   // |   Summarizer    |
   // ===================
 
-  base::Status CreateSummarizer(const std::string& id,
-                                std::unique_ptr<Summarizer>* out) override;
+  base::Status CreateSummarizer(std::unique_ptr<Summarizer>* out) override;
 
  private:
   // Needed for iterators to be able to access the context.
@@ -203,6 +202,9 @@ class TraceProcessorImpl : public TraceProcessor,
   // Tracks the sum of mutations across all tables used by
   // CacheBoundsAndBuildTable to avoid recomputing bounds when unchanged.
   uint64_t bounds_tables_mutations_ = 0;
+
+  // Auto-incrementing counter for generating unique summarizer ids.
+  uint32_t next_summarizer_id_ = 0;
 };
 
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/trace_summary/summarizer_unittest.cc
+++ b/src/trace_processor/trace_summary/summarizer_unittest.cc
@@ -31,7 +31,6 @@
 namespace perfetto::trace_processor::summary {
 namespace {
 
-using base::gtest_matchers::IsError;
 using ::testing::HasSubstr;
 // Import public types from parent namespace.
 using ::perfetto::trace_processor::Summarizer;
@@ -623,28 +622,14 @@ TEST_F(SummarizerTest, NestedEmbeddedQueryDependencyPropagation) {
   EXPECT_EQ(info_c2.row_count, 1);
 }
 
-TEST_F(SummarizerTest, CreateSummarizerRejectsInvalidId) {
-  // Ids are used in SQL table names, so only alphanumeric + underscore are
-  // allowed.
-  std::unique_ptr<Summarizer> summarizer;
-  EXPECT_THAT(tp_->CreateSummarizer("abc-def", &summarizer), IsError());
-  EXPECT_THAT(tp_->CreateSummarizer("", &summarizer), IsError());
-  EXPECT_THAT(tp_->CreateSummarizer("has spaces", &summarizer), IsError());
-  EXPECT_THAT(tp_->CreateSummarizer("semi;colon", &summarizer), IsError());
-
-  // Valid ids should be accepted, including digit-only ids.
-  EXPECT_OK(tp_->CreateSummarizer("valid_id_123", &summarizer));
-  EXPECT_OK(tp_->CreateSummarizer("ABCdef09_", &summarizer));
-  EXPECT_OK(tp_->CreateSummarizer("123", &summarizer));
-}
-
 TEST_F(SummarizerTest, MultipleSummarizersCoexist) {
-  // Two summarizers with different ids should be able to materialize the same
-  // query without table name collisions.
+  // Two summarizers created via the public API should be able to materialize
+  // the same query without table name collisions. The ids are auto-generated
+  // internally by TraceProcessor.
   std::unique_ptr<Summarizer> s1;
   std::unique_ptr<Summarizer> s2;
-  ASSERT_OK(tp_->CreateSummarizer("alpha", &s1));
-  ASSERT_OK(tp_->CreateSummarizer("beta", &s2));
+  ASSERT_OK(tp_->CreateSummarizer(&s1));
+  ASSERT_OK(tp_->CreateSummarizer(&s2));
 
   auto spec_data = CreateSpec({{"q", "SELECT 1 as value"}});
 
@@ -666,14 +651,13 @@ TEST_F(SummarizerTest, MultipleSummarizersCoexist) {
   ASSERT_OK(s2->Query("q", &info2));
   ASSERT_TRUE(info2.exists);
 
-  // Table names must differ (namespaced by summarizer id).
+  // Table names must differ (namespaced by auto-generated summarizer id).
   EXPECT_NE(info1.table_name, info2.table_name);
-  EXPECT_THAT(info1.table_name, HasSubstr("alpha"));
-  EXPECT_THAT(info2.table_name, HasSubstr("beta"));
 }
 
 TEST_F(SummarizerTest, TableNameContainsSummarizerId) {
   // Verify that the materialized table name includes the summarizer id.
+  // The test fixture creates a SummarizerImpl with id "test_id".
   auto spec_data = CreateSpec({{"q", "SELECT 1 as value"}});
 
   SummarizerUpdateSpecResult result;


### PR DESCRIPTION
Make summarizer instances truly independent by incorporating a unique id into materialized table names. Previously, multiple summarizers sharing the same TraceProcessor would generate colliding table names (e.g. `_exp_mat_0`),
causing CREATE TABLE failures. Each summarizer now produces namespaced tables like `_exp_mat_{id}_{seq}`.
