### PR TITLE
ui: Reduce ResizeHandle hitbox size

### DIFF
--- a/ui/src/assets/widgets/resize_handle.scss
+++ b/ui/src/assets/widgets/resize_handle.scss
@@ -15,7 +15,7 @@
 // Hitbox: 5px total clickable area (via ::before extending beyond visible area)
 // Accent: 3px visible hover area
 // Border: 1px visible line when not hovering
-$hitbox: 3px; // Extra clickable area on each side
+$hitbox: 2px; // Extra clickable area on each side
 $accent: 1px;
 $thickness: 1px;
 


### PR DESCRIPTION
Reduce the total width of ResizeHandle's hitbox from 7 to 5px (e.g. 2px either side of the 1px border).

This makes it easier to interact with other elements that happens to be very close to the handle, including clicking events on the timeline that are close to the track shell.

For example:
<img width="226" height="141" alt="image" src="https://github.com/user-attachments/assets/9c66d4b9-2c2f-4dfb-ab4c-f50033a893ec" />

Note: We should do something to improve accessibility when there are instant events at the very start of the trace like this, but this patch at least makes it possible to select them.
