### PR TITLE
tp: Fix HPROF importer for ahat parity

### DIFF
--- a/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
@@ -18,6 +18,36 @@
 #include <cinttypes>
 
 namespace perfetto::trace_processor::art_hprof {
+namespace {
+
+// Root type precedence ranking. Lower rank = higher priority.
+// Matches proto heap graph's kRootTypePrecedence:
+//   STICKY_CLASS (0) > JNI_GLOBAL (1) > JNI_LOCAL (2) > everything else (3)
+size_t RankRootType(HprofHeapRootTag tag) {
+  switch (tag) {
+    case HprofHeapRootTag::kStickyClass:
+      return 0;
+    case HprofHeapRootTag::kJniGlobal:
+      return 1;
+    case HprofHeapRootTag::kJniLocal:
+      return 2;
+    case HprofHeapRootTag::kJavaFrame:
+    case HprofHeapRootTag::kNativeStack:
+    case HprofHeapRootTag::kThreadBlock:
+    case HprofHeapRootTag::kMonitorUsed:
+    case HprofHeapRootTag::kThreadObj:
+    case HprofHeapRootTag::kInternedString:
+    case HprofHeapRootTag::kFinalizing:
+    case HprofHeapRootTag::kDebugger:
+    case HprofHeapRootTag::kVmInternal:
+    case HprofHeapRootTag::kJniMonitor:
+    case HprofHeapRootTag::kUnknown:
+      return 3;
+  }
+  return 3;
+}
+
+}  // namespace
 
 constexpr std::array<std::pair<const char*, FieldType>, 8> kPrimitiveArrayTypes{
     {
@@ -68,11 +98,11 @@ HeapGraph HeapGraphBuilder::BuildGraph() {
   }
 
   for (auto it = classes_.GetIterator(); it; ++it) {
-    graph.AddClass(it.value());
+    graph.AddClass(std::move(it.value()));
   }
 
   for (auto it = objects_.GetIterator(); it; ++it) {
-    graph.AddObject(it.value());
+    graph.AddObject(std::move(it.value()));
   }
 
   return graph;
@@ -324,7 +354,18 @@ bool HeapGraphBuilder::ParseRootRecord(HprofHeapRootTag tag) {
   }
 
   stats_.root_count++;
-  roots_[object_id] = tag;
+
+  // Root type precedence: only upgrade to a higher-priority root type.
+  // Matches proto heap graph's kRootTypePrecedence logic: STICKY_CLASS >
+  // JNI_GLOBAL > JNI_LOCAL > everything else (including VM_INTERNAL).
+  auto* existing = roots_.Find(object_id);
+  if (existing) {
+    if (RankRootType(tag) < RankRootType(*existing)) {
+      *existing = tag;
+    }
+  } else {
+    roots_[object_id] = tag;
+  }
   return true;
 }
 

--- a/src/trace_processor/importers/art_hprof/art_heap_graph_builder.h
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_builder.h
@@ -41,6 +41,10 @@ constexpr size_t kHprofHeaderLength = 20;           // Header size in bytes
 
 constexpr const char* kJavaLangString = "java.lang.String";
 constexpr const char* kSunMiscCleaner = "sun.misc.Cleaner";
+constexpr const char* kNativeAllocationRegistryCleanerThunk =
+    "libcore.util.NativeAllocationRegistry$CleanerThunk";
+constexpr const char* kNativeAllocationRegistry =
+    "libcore.util.NativeAllocationRegistry";
 
 class ByteIterator {
  public:
@@ -105,29 +109,18 @@ class HeapGraphResolver {
                     base::FlatHashMap<uint64_t, HprofHeapRootTag>& roots,
                     DebugStats& stats);
 
-  // Build the complete object graph with references and field values
   void ResolveGraph();
 
  private:
-  // Extract data for all objects
   void ExtractAllObjectData();
-
-  // Mark objects reachable from roots
   void MarkReachableObjects();
-
-  // Extract references from array elements
   void ExtractArrayElementReferences(Object& obj);
-
-  // Helper methods for data extraction
   bool ExtractObjectReferences(Object& obj, const ClassDefinition& cls);
   void ExtractFieldValues(Object& obj, const ClassDefinition& cls);
   void ExtractPrimitiveArrayValues(Object& obj);
   std::optional<std::string> DecodeJavaString(const Object& string_obj) const;
-
-  // Utility methods
-  std::vector<Field> GetClassHierarchyFields(uint64_t class_id) const;
-
-  // Calculate native memory sizes for objects
+  const std::vector<Field>& GetClassHierarchyFields(uint64_t class_id);
+  void ComputeSelfSizes();
   void CalculateNativeSizes();
 
   // Data references (not owned)
@@ -137,6 +130,9 @@ class HeapGraphResolver {
   base::FlatHashMap<uint64_t, HprofHeapRootTag>& roots_;
   base::FlatHashMap<uint64_t, ClassDefinition>& classes_;
   DebugStats& stats_;
+
+  // Cache for class hierarchy fields (avoids repeated hierarchy walks)
+  base::FlatHashMap<uint64_t, std::vector<Field>> field_cache_;
 };
 
 // Main parser class that builds a heap graph from HPROF data
@@ -244,7 +240,6 @@ class HeapGraphBuilder {
   TraceProcessorContext* context_;
 };
 
-// Helper method
 inline size_t GetFieldTypeSize(FieldType type, size_t id_size) {
   switch (type) {
     case FieldType::kObject:

--- a/src/trace_processor/importers/art_hprof/art_heap_graph_resolver.cc
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_resolver.cc
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+#include <deque>
+
 #include "perfetto/ext/base/flat_hash_map.h"
 #include "src/trace_processor/importers/art_hprof/art_heap_graph_builder.h"
 
-#include <unordered_set>
 namespace perfetto::trace_processor::art_hprof {
 
 template <typename T>
@@ -77,31 +78,37 @@ HeapGraphResolver::HeapGraphResolver(
       stats_(stats) {}
 
 void HeapGraphResolver::ResolveGraph() {
-  // Extract field values and references for all objects
   ExtractAllObjectData();
-
-  // Mark reachability from roots
   MarkReachableObjects();
-
-  // Set native_size for native objects. See:
+  ComputeSelfSizes();
   CalculateNativeSizes();
 }
 
 void HeapGraphResolver::ExtractAllObjectData() {
+  // Identify classes whose instances need field extraction (for native size
+  // calculation and string decoding). All other instances only need references.
+  base::FlatHashMap<uint64_t, bool> needs_field_extraction;
+  for (auto it = classes_.GetIterator(); it; ++it) {
+    const auto& name = it.value().GetName();
+    if (name == "libcore.util.NativeAllocationRegistry" ||
+        name == kJavaLangString) {
+      needs_field_extraction[it.key()] = true;
+    }
+  }
+
   for (auto it = objects_.GetIterator(); it; ++it) {
     auto& obj = it.value();
-    // Extract data based on object type
     if (obj.GetObjectType() == ObjectType::kInstance ||
         obj.GetObjectType() == ObjectType::kClass) {
       auto cls = classes_.Find(obj.GetClassId());
       if (cls) {
         ExtractObjectReferences(obj, *cls);
-        ExtractFieldValues(obj, *cls);
+        if (needs_field_extraction.Find(obj.GetClassId())) {
+          ExtractFieldValues(obj, *cls);
+        }
       }
     } else if (obj.GetObjectType() == ObjectType::kObjectArray) {
       ExtractArrayElementReferences(obj);
-    } else if (obj.GetObjectType() == ObjectType::kPrimitiveArray) {
-      ExtractPrimitiveArrayValues(obj);
     }
 
     uint64_t obj_id = obj.GetId();
@@ -114,39 +121,70 @@ void HeapGraphResolver::ExtractAllObjectData() {
 }
 
 void HeapGraphResolver::MarkReachableObjects() {
-  std::unordered_set<uint64_t> visited;
-  std::vector<uint64_t> processing_stack;
+  // BFS from roots to mark reachability and compute shortest-path
+  // root_distance. Skips "referent" fields from weak/phantom/finalizer
+  // reference types to match ahat's retained=SOFT behavior (soft referent
+  // edges are followed).
 
-  // Add all root objects to the stack
-  for (auto it = objects_.GetIterator(); it; ++it) {
-    auto id = it.key();
-    auto& obj = it.value();
-    if (obj.IsRoot()) {
-      processing_stack.push_back(id);
-      obj.SetReachable();
+  // Pre-compute which class IDs are reference types by walking the hierarchy.
+  base::FlatHashMap<uint64_t, bool> ref_type_classes;
+  {
+    base::FlatHashMap<uint64_t, bool> base_refs;
+    for (auto it = classes_.GetIterator(); it; ++it) {
+      const auto& name = it.value().GetName();
+      if (name == "java.lang.ref.WeakReference" ||
+          name == "java.lang.ref.PhantomReference" ||
+          name == "java.lang.ref.FinalizerReference") {
+        base_refs[it.key()] = true;
+      }
+    }
+    for (auto it = classes_.GetIterator(); it; ++it) {
+      uint64_t current = it.key();
+      for (int depth = 0; depth < 100 && current != 0; ++depth) {
+        if (base_refs.Find(current)) {
+          ref_type_classes[it.key()] = true;
+          break;
+        }
+        auto* cls = classes_.Find(current);
+        if (!cls)
+          break;
+        current = cls->GetSuperClassId();
+      }
     }
   }
 
-  // Process reachability
-  while (!processing_stack.empty()) {
-    uint64_t current_id = processing_stack.back();
-    processing_stack.pop_back();
+  std::deque<uint64_t> queue;
 
-    // Skip if already visited
-    if (!visited.insert(current_id).second)
+  for (auto it = objects_.GetIterator(); it; ++it) {
+    auto& obj = it.value();
+    if (obj.IsRoot()) {
+      queue.push_back(it.key());
+      obj.SetReachable();
+      obj.SetRootDistance(0);
+    }
+  }
+
+  while (!queue.empty()) {
+    uint64_t current_id = queue.front();
+    queue.pop_front();
+
+    auto* obj = objects_.Find(current_id);
+    if (!obj) {
       continue;
+    }
 
-    auto& obj = objects_[current_id];
-
-    // Add reference targets to stack and mark them as reachable
-    for (const auto& ref : obj.GetReferences()) {
-      auto it = objects_.Find(ref.target_id);
-      if (it && !it->IsReachable()) {
-        // Mark target as reachable
-        it->SetReachable();
-
-        // Add to processing stack
-        processing_stack.push_back(ref.target_id);
+    bool skip_referent = ref_type_classes.Find(obj->GetClassId()) != nullptr;
+    int32_t next_distance = obj->GetRootDistance() + 1;
+    for (const auto& ref : obj->GetReferences()) {
+      if (skip_referent &&
+          ref.field_name == "java.lang.ref.Reference.referent") {
+        continue;
+      }
+      auto* target = objects_.Find(ref.target_id);
+      if (target && !target->IsReachable()) {
+        target->SetReachable();
+        target->SetRootDistance(next_distance);
+        queue.push_back(ref.target_id);
       }
     }
   }
@@ -154,13 +192,14 @@ void HeapGraphResolver::MarkReachableObjects() {
 
 void HeapGraphResolver::ExtractArrayElementReferences(Object& obj) {
   const auto& elements = obj.GetArrayElements();
+  char buf[24];
   for (size_t i = 0; i < elements.size(); ++i) {
     uint64_t element_id = elements[i];
     if (element_id != 0) {
-      std::string ref_name = "[" + std::to_string(i) + "]";
       auto owned_obj = objects_.Find(element_id);
       if (owned_obj) {
-        obj.AddReference(ref_name, owned_obj->GetClassId(), element_id);
+        snprintf(buf, sizeof(buf), "[%zu]", i);
+        obj.AddReference(buf, owned_obj->GetClassId(), element_id);
         stats_.reference_count++;
       }
     }
@@ -169,13 +208,14 @@ void HeapGraphResolver::ExtractArrayElementReferences(Object& obj) {
 
 bool HeapGraphResolver::ExtractObjectReferences(Object& obj,
                                                 const ClassDefinition& cls) {
-  // Handle static fields of class objects. Now that we have all objects and
-  // classes available
+  // Resolve pending static field references, qualifying names as
+  // "ClassName.fieldName" to match the proto heap graph format.
   for (const auto& ref : obj.GetPendingReferences()) {
     if (!ref.field_class_id) {
       auto it = objects_.Find(ref.target_id);
       if (it) {
-        obj.AddReference(ref.field_name, it->GetClassId(), ref.target_id);
+        std::string qualified = cls.GetName() + "." + ref.field_name;
+        obj.AddReference(qualified, it->GetClassId(), ref.target_id);
         stats_.reference_count++;
       }
     }
@@ -186,7 +226,7 @@ bool HeapGraphResolver::ExtractObjectReferences(Object& obj,
     return true;
   }
 
-  std::vector<Field> fields = GetClassHierarchyFields(cls.GetId());
+  const auto& fields = GetClassHierarchyFields(cls.GetId());
   size_t offset = 0;
 
   for (const auto& field : fields) {
@@ -195,9 +235,7 @@ bool HeapGraphResolver::ExtractObjectReferences(Object& obj,
     }
 
     if (field.GetType() == FieldType::kObject) {
-      // Make sure we have enough data to read the ID
       if (offset + header_.GetIdSize() <= data.size()) {
-        // Use the helper function consistently for all ID extractions
         uint64_t target_id = ReadBigEndian<uint64_t>(context_, data, offset,
                                                      header_.GetIdSize());
         offset += header_.GetIdSize();
@@ -217,7 +255,7 @@ bool HeapGraphResolver::ExtractObjectReferences(Object& obj,
         break;
       }
     } else {
-      offset += field.GetSize();
+      offset += GetFieldTypeSize(field.GetType(), header_.GetIdSize());
     }
   }
 
@@ -231,22 +269,15 @@ void HeapGraphResolver::ExtractFieldValues(Object& obj,
     return;
   }
 
-  // Get all fields for the class hierarchy
-  std::vector<Field> fields = GetClassHierarchyFields(cls.GetId());
-
-  // Parse the raw data to extract field values
+  const auto& fields = GetClassHierarchyFields(cls.GetId());
+  const auto& data = obj.GetRawData();
   size_t offset = 0;
   for (const auto& field_def : fields) {
-    // Skip if we've run out of data
-    if (offset >= obj.GetRawData().size()) {
+    if (offset >= data.size()) {
       break;
     }
 
-    // Create a field with the same name and type
     Field field(field_def.GetName(), field_def.GetType());
-
-    // Extract the value based on type
-    const auto& data = obj.GetRawData();
     switch (field_def.GetType()) {
       case FieldType::kBoolean: {
         bool value = data[offset] != 0;
@@ -297,7 +328,6 @@ void HeapGraphResolver::ExtractFieldValues(Object& obj,
         break;
       }
       case FieldType::kObject: {
-        // Object IDs are based on the ID size
         uint64_t id = ReadBigEndian<uint64_t>(context_, data, offset,
                                               header_.GetIdSize());
         field.SetValue(id);
@@ -306,11 +336,6 @@ void HeapGraphResolver::ExtractFieldValues(Object& obj,
       }
     }
 
-    if (auto str = DecodeJavaString(obj)) {
-      field.SetDecodedString(*str);
-    }
-
-    // Add the field with its value to the object
     obj.AddField(std::move(field));
   }
 }
@@ -325,15 +350,12 @@ void HeapGraphResolver::ExtractPrimitiveArrayValues(Object& obj) {
   const auto& data = obj.GetRawData();
   size_t element_size = GetFieldTypeSize(element_type, header_.GetIdSize());
 
-  // Skip if the data is invalid
   if (element_size == 0 || data.size() % element_size != 0) {
     return;
   }
 
-  // Calculate the number of elements
   size_t element_count = data.size() / element_size;
 
-  // Parse the array based on its element type
   switch (element_type) {
     case FieldType::kBoolean: {
       std::vector<bool> values;
@@ -345,7 +367,6 @@ void HeapGraphResolver::ExtractPrimitiveArrayValues(Object& obj) {
       break;
     }
     case FieldType::kByte: {
-      // For byte arrays, we can directly use the raw data
       std::vector<uint8_t> values(data.begin(), data.end());
       obj.SetArrayData(std::move(values));
       break;
@@ -393,14 +414,12 @@ void HeapGraphResolver::ExtractPrimitiveArrayValues(Object& obj) {
       break;
     }
     case FieldType::kObject:
-      // Object arrays should be handled by HandleObjectArrayDumpRecord
       break;
   }
 }
 
 std::optional<std::string> HeapGraphResolver::DecodeJavaString(
     const Object& string_obj) const {
-  // 1. Verify it's a java.lang.String object
   auto cls = classes_.Find(string_obj.GetClassId());
   if (!cls || cls->GetName() != kJavaLangString)
     return std::nullopt;
@@ -408,26 +427,21 @@ std::optional<std::string> HeapGraphResolver::DecodeJavaString(
   uint64_t value_array_id = 0;
   std::optional<int32_t> offset_opt;
   std::optional<int32_t> count_opt;
-  std::optional<uint8_t> coder_opt;
 
-  // 2. Extract fields: value, offset, count, coder
   for (const Field& f : string_obj.GetFields()) {
-    if (f.GetName() == "value") {
+    if (f.GetName() == "java.lang.String.value") {
       if (auto v = f.GetValue<uint64_t>())
         value_array_id = *v;
-    } else if (f.GetName() == "offset") {
+    } else if (f.GetName() == "java.lang.String.offset") {
       offset_opt = f.GetValue<int32_t>();
-    } else if (f.GetName() == "count") {
+    } else if (f.GetName() == "java.lang.String.count") {
       count_opt = f.GetValue<int32_t>();
-    } else if (f.GetName() == "coder") {
-      coder_opt = f.GetValue<uint8_t>();
     }
   }
 
   if (value_array_id == 0)
     return std::nullopt;
 
-  // 3. Get the backing array
   auto array = objects_.Find(value_array_id);
   if (!array)
     return std::nullopt;
@@ -440,7 +454,6 @@ std::optional<std::string> HeapGraphResolver::DecodeJavaString(
       static_cast<size_t>(offset + count) > array_len)
     return std::nullopt;
 
-  // 4. Decode string
   std::string result;
   result.reserve(static_cast<size_t>(count));
 
@@ -475,6 +488,81 @@ std::optional<std::string> HeapGraphResolver::DecodeJavaString(
   return std::nullopt;
 }
 
+const std::vector<Field>& HeapGraphResolver::GetClassHierarchyFields(
+    uint64_t class_id) {
+  auto* cached = field_cache_.Find(class_id);
+  if (cached) {
+    return *cached;
+  }
+
+  // HPROF instance data is laid out derived-class-first: the most-derived
+  // class's fields come first, then its superclass fields, etc.
+  // Field names are qualified as "ClassName.fieldName" to match the proto
+  // heap graph format and allow MarkReachableObjects to recognize
+  // "java.lang.ref.Reference.referent".
+  std::vector<Field> result;
+  uint64_t current_class_id = class_id;
+  while (current_class_id != 0) {
+    auto cls = classes_.Find(current_class_id);
+    if (!cls) {
+      break;
+    }
+    for (const auto& f : cls->GetInstanceFields()) {
+      result.emplace_back(cls->GetName() + "." + f.GetName(), f.GetType());
+    }
+    current_class_id = cls->GetSuperClassId();
+  }
+
+  field_cache_[class_id] = std::move(result);
+  return *field_cache_.Find(class_id);
+}
+
+void HeapGraphResolver::ComputeSelfSizes() {
+  // Match ahat's self_size computation:
+  //   Instances: CLASS_DUMP.instanceSize (not INSTANCE_DUMP.data_length).
+  //   Class objects: java.lang.Class.instanceSize + staticFieldsSize.
+  //   Arrays: CLASS_DUMP.instanceSize (header) + element_count * element_size.
+  std::optional<uint32_t> java_lang_class_size;
+  for (auto it = classes_.GetIterator(); it; ++it) {
+    if (it.value().GetName() == "java.lang.Class") {
+      java_lang_class_size = it.value().GetInstanceSize();
+      break;
+    }
+  }
+
+  for (auto it = objects_.GetIterator(); it; ++it) {
+    auto& obj = it.value();
+    if (obj.GetObjectType() == ObjectType::kClass) {
+      // java.lang.Class.instanceSize + sum of static field sizes.
+      size_t size = java_lang_class_size.value_or(0);
+      for (const auto& field : obj.GetFields()) {
+        size += GetFieldTypeSize(field.GetType(), header_.GetIdSize());
+      }
+      obj.SetSelfSizeOverride(size);
+    } else if (obj.GetObjectType() == ObjectType::kInstance) {
+      auto* cls = classes_.Find(obj.GetClassId());
+      if (cls) {
+        obj.SetSelfSizeOverride(cls->GetInstanceSize());
+      }
+    } else if (obj.GetObjectType() == ObjectType::kObjectArray) {
+      auto* cls = classes_.Find(obj.GetClassId());
+      if (cls) {
+        size_t header = cls->GetInstanceSize();
+        size_t data = obj.GetArrayElements().size() * header_.GetIdSize();
+        obj.SetSelfSizeOverride(header + data);
+      }
+    } else if (obj.GetObjectType() == ObjectType::kPrimitiveArray) {
+      auto* cls = classes_.Find(obj.GetClassId());
+      if (cls) {
+        size_t header = cls->GetInstanceSize();
+        size_t data = obj.GetRawData().size();
+        obj.SetSelfSizeOverride(header + data);
+      }
+    }
+  }
+}
+
+// Attribute native_size to objects via the Cleaner→CleanerThunk→Registry chain:
 //
 //             +-------------------------------+  .referent   +--------+
 //             |       sun.misc.Cleaner        | -----------> | Object |
@@ -493,69 +581,32 @@ std::optional<std::string> HeapGraphResolver::DecodeJavaString(
 // |                       .size                        |
 // +----------------------------------------------------+
 //
-// `.size` should be attributed as the native size of Object
-// See: perfetto/src/trace_processor/importers/proto/heap_graph_tracker.cc
-std::vector<Field> HeapGraphResolver::GetClassHierarchyFields(
-    uint64_t class_id) const {
-  std::vector<Field> result;
-
-  // Follow class hierarchy to collect all fields
-  uint64_t current_class_id = class_id;
-  while (current_class_id != 0) {
-    auto cls = classes_.Find(current_class_id);
-    if (!cls) {
-      break;
-    }
-
-    const auto& fields = cls->GetInstanceFields();
-
-    // Add fields from this class
-    result.insert(result.end(), fields.begin(), fields.end());
-
-    // Move up to superclass
-    current_class_id = cls->GetSuperClassId();
-  }
-
-  return result;
-}
-
+// Registry.size is attributed as the native_size of Object.
+// Matches ahat's AhatClassInstance.asRegisteredNativeAllocation().
 void HeapGraphResolver::CalculateNativeSizes() {
   std::vector<std::pair<uint64_t, uint64_t>>
       cleaners;  // (referent_id, thunk_id)
 
   // Find sun.misc.Cleaner objects
   for (auto it = objects_.GetIterator(); it; ++it) {
-    auto obj_id = it.key();
     auto& obj = it.value();
     auto cls = classes_.Find(obj.GetClassId());
-    if (!cls) {
-      continue;
-    }
-
-    if (cls->GetName() != kSunMiscCleaner) {
+    if (!cls || cls->GetName() != kSunMiscCleaner) {
       continue;
     }
 
     std::optional<uint64_t> referent_id;
     std::optional<uint64_t> thunk_id;
-    std::optional<uint64_t> next_id;
 
     for (const auto& ref : obj.GetReferences()) {
-      if (ref.field_name == "referent") {
+      if (ref.field_name == "java.lang.ref.Reference.referent") {
         referent_id = ref.target_id;
-      } else if (ref.field_name == "thunk") {
+      } else if (ref.field_name == "sun.misc.Cleaner.thunk") {
         thunk_id = ref.target_id;
-      } else if (ref.field_name == "next") {
-        next_id = ref.target_id;
       }
     }
 
     if (!referent_id || !thunk_id) {
-      continue;
-    }
-
-    // Skip cleaned Cleaner objects
-    if (next_id && *next_id == obj_id) {
       continue;
     }
 
@@ -569,9 +620,17 @@ void HeapGraphResolver::CalculateNativeSizes() {
       continue;
     }
 
+    // Verify thunk is a CleanerThunk (matches ahat check)
+    auto thunk_cls = classes_.Find(thunk->GetClassId());
+    if (!thunk_cls ||
+        thunk_cls->GetName() != kNativeAllocationRegistryCleanerThunk) {
+      continue;
+    }
+
     std::optional<uint64_t> registry_id;
     for (const auto& ref : thunk->GetReferences()) {
-      if (ref.field_name == "this$0") {
+      if (ref.field_name ==
+          "libcore.util.NativeAllocationRegistry$CleanerThunk.this$0") {
         registry_id = ref.target_id;
         break;
       }
@@ -586,7 +645,14 @@ void HeapGraphResolver::CalculateNativeSizes() {
       continue;
     }
 
-    auto size_field = registry->FindField("size");
+    // Verify registry is a NativeAllocationRegistry (matches ahat check)
+    auto registry_cls = classes_.Find(registry->GetClassId());
+    if (!registry_cls || registry_cls->GetName() != kNativeAllocationRegistry) {
+      continue;
+    }
+
+    auto size_field =
+        registry->FindField("libcore.util.NativeAllocationRegistry.size");
     if (!size_field) {
       continue;
     }

--- a/src/trace_processor/importers/art_hprof/art_hprof_model.h
+++ b/src/trace_processor/importers/art_hprof/art_hprof_model.h
@@ -73,25 +73,6 @@ class Field {
     return !std::holds_alternative<std::monostate>(value_);
   }
 
-  size_t GetSize() const {
-    switch (type_) {
-      case FieldType::kBoolean:
-      case FieldType::kByte:
-        return 1;
-      case FieldType::kChar:
-      case FieldType::kShort:
-        return 2;
-      case FieldType::kFloat:
-      case FieldType::kInt:
-      case FieldType::kObject:
-        return 4;
-      case FieldType::kDouble:
-      case FieldType::kLong:
-        return 8;
-    }
-    return 0;
-  }
-
   // Template setter for all supported types
   template <typename T>
   void SetValue(T value) {
@@ -218,6 +199,9 @@ class Object {
   bool IsReachable() const { return is_reachable_; }
   std::optional<HprofHeapRootTag> GetRootType() const { return root_type_; }
 
+  void SetRootDistance(int32_t d) { root_distance_ = d; }
+  int32_t GetRootDistance() const { return root_distance_; }
+
   void SetRawData(std::vector<uint8_t> data) { raw_data_ = std::move(data); }
 
   const std::vector<uint8_t>& GetRawData() const { return raw_data_; }
@@ -253,33 +237,6 @@ class Object {
 
   FieldType GetArrayElementType() const { return array_element_type_; }
 
-  // Size calculation with id size parameter to avoid assumptions
-  size_t GetSize(uint32_t id_size = sizeof(uint64_t)) const {
-    // For instances and primitive arrays, use raw data size
-    if (type_ == ObjectType::kInstance ||
-        (type_ == ObjectType::kPrimitiveArray && !raw_data_.empty())) {
-      return raw_data_.size();
-    }
-
-    // For object arrays, use element count * id size
-    if (type_ == ObjectType::kObjectArray) {
-      return array_elements_.size() * id_size;
-    }
-
-    // For class objects, calculate size based on static fields
-    if (type_ == ObjectType::kClass) {
-      size_t size = 0;
-      for (const auto& field : fields_) {
-        size += field.GetSize();
-      }
-      // Use a minimum size if there are no static fields
-      return size > 0 ? size : 8;
-    }
-
-    // Default size for other objects
-    return 0;
-  }
-
   void AddField(Field field) { fields_.push_back(std::move(field)); }
 
   const std::vector<Field>& GetFields() const { return fields_; }
@@ -296,6 +253,11 @@ class Object {
   int64_t GetNativeSize() const { return native_size_; }
 
   void AddNativeSize(int64_t size) { native_size_ += size; }
+
+  void SetSelfSizeOverride(size_t size) { self_size_override_ = size; }
+  std::optional<size_t> GetSelfSizeOverride() const {
+    return self_size_override_;
+  }
 
   template <typename T>
   void SetArrayData(std::vector<T> data) {
@@ -333,6 +295,7 @@ class Object {
   ObjectType type_ = ObjectType::kInstance;
   bool is_root_ = false;
   bool is_reachable_ = false;
+  int32_t root_distance_ = -1;
   std::optional<HprofHeapRootTag> root_type_;
   std::string heap_type_;
 
@@ -344,6 +307,7 @@ class Object {
   FieldType array_element_type_ = FieldType::kObject;
 
   int64_t native_size_ = 0;
+  std::optional<size_t> self_size_override_;
 
   // Field values
   std::vector<Field> fields_;

--- a/src/trace_processor/importers/art_hprof/art_hprof_parser.cc
+++ b/src/trace_processor/importers/art_hprof/art_hprof_parser.cc
@@ -78,13 +78,10 @@ base::Status ArtHprofParser::OnPushDataToSorter() {
     return base::OkStatus();
   }
 
-  // Process classes first to establish type information
+  int64_t ts = static_cast<int64_t>(graph.GetTimestamp());
+
   PopulateClasses(graph);
-
-  // Process objects next
-  PopulateObjects(graph, static_cast<int64_t>(graph.GetTimestamp()), upid);
-
-  // Finally process references
+  PopulateObjects(graph, ts, upid);
   PopulateReferences(graph);
 
   class_map_.Clear();
@@ -96,7 +93,6 @@ base::Status ArtHprofParser::OnPushDataToSorter() {
   return base::OkStatus();
 }
 
-// Helper methods for map lookups
 tables::HeapGraphClassTable::Id* ArtHprofParser::FindClassId(
     uint64_t class_id) const {
   return class_map_.Find(class_id);
@@ -245,22 +241,19 @@ void ArtHprofParser::TraceBlobViewIterator::Shrink() {
 void ArtHprofParser::PopulateClasses(const HeapGraph& graph) {
   auto& class_table = *context_->storage->mutable_heap_graph_class_table();
 
-  // Process each class from the heap graph
   for (auto it = graph.GetClasses().GetIterator(); it; ++it) {
     auto class_id = it.key();
     auto& class_def = it.value();
 
-    // Intern strings for class metadata
     StringId name_id = InternClassName(class_def.GetName());
     StringId kind_id = context_->storage->InternString(kUnknownClassKind);
 
-    // Create and insert the class row
     tables::HeapGraphClassTable::Row class_row;
     class_row.name = name_id;
     class_row.deobfuscated_name = std::nullopt;
     class_row.location = std::nullopt;
-    class_row.superclass_id = std::nullopt;  // Will update in second pass
-    class_row.classloader_id = 0;            // Default
+    class_row.superclass_id = std::nullopt;
+    class_row.classloader_id = 0;
     class_row.kind = kind_id;
 
     tables::HeapGraphClassTable::Id table_id = class_table.Insert(class_row).id;
@@ -268,7 +261,6 @@ void ArtHprofParser::PopulateClasses(const HeapGraph& graph) {
     class_name_map_[class_id] = class_def.GetName();
   }
 
-  // Update superclass relationships
   for (auto it = graph.GetClasses().GetIterator(); it; ++it) {
     auto class_id = it.key();
     auto& class_def = it.value();
@@ -284,36 +276,79 @@ void ArtHprofParser::PopulateClasses(const HeapGraph& graph) {
     }
   }
 
-  // Process class objects
-  for (auto it = graph.GetObjects().GetIterator(); it; ++it) {
-    auto obj_id = it.key();
-    auto& obj = it.value();
-
-    if (obj.GetObjectType() == ObjectType::kClass) {
-      auto* class_name_it = class_name_map_.Find(obj.GetClassId());
-      if (!class_name_it) {
-        context_->storage->IncrementStats(stats::hprof_class_errors);
-        continue;
+  // Classify reference types so MarkReachableObjects can skip their
+  // "referent" field during BFS.
+  {
+    // Find base reference type class IDs
+    base::FlatHashMap<uint64_t, const char*> base_ref_kinds;
+    for (auto it = graph.GetClasses().GetIterator(); it; ++it) {
+      const auto& name = it.value().GetName();
+      if (name == "java.lang.ref.WeakReference") {
+        base_ref_kinds[it.key()] = "KIND_WEAK_REFERENCE";
+      } else if (name == "java.lang.ref.SoftReference") {
+        base_ref_kinds[it.key()] = "KIND_SOFT_REFERENCE";
+      } else if (name == "java.lang.ref.PhantomReference") {
+        base_ref_kinds[it.key()] = "KIND_PHANTOM_REFERENCE";
+      } else if (name == "java.lang.ref.FinalizerReference") {
+        base_ref_kinds[it.key()] = "KIND_FINALIZER_REFERENCE";
       }
-
-      // Intern strings for class metadata
-      StringId name_id =
-          InternClassName("java.lang.Class<" + *class_name_it + ">");
-      StringId kind_id = context_->storage->InternString(kUnknownClassKind);
-
-      // Create and insert the class row
-      tables::HeapGraphClassTable::Row class_row;
-      class_row.name = name_id;
-      class_row.deobfuscated_name = std::nullopt;
-      class_row.location = std::nullopt;
-      class_row.superclass_id = std::nullopt;
-      class_row.classloader_id = 0;
-      class_row.kind = kind_id;
-
-      tables::HeapGraphClassTable::Id table_id =
-          class_table.Insert(class_row).id;
-      class_object_map_[obj_id] = table_id;
     }
+
+    if (base_ref_kinds.size() > 0) {
+      for (auto it = graph.GetClasses().GetIterator(); it; ++it) {
+        uint64_t current = it.key();
+        const char* kind_name = nullptr;
+        for (int depth = 0; depth < 100 && current != 0; ++depth) {
+          auto* kind = base_ref_kinds.Find(current);
+          if (kind) {
+            kind_name = *kind;
+            break;
+          }
+          auto* cls = graph.GetClasses().Find(current);
+          if (!cls)
+            break;
+          current = cls->GetSuperClassId();
+        }
+        if (kind_name) {
+          auto* table_id = FindClassId(it.key());
+          if (table_id) {
+            StringId kind_id = context_->storage->InternString(kind_name);
+            class_table.FindById(*table_id)->set_kind(kind_id);
+          }
+        }
+      }
+    }
+  }
+
+  // Process class objects. Class objects share IDs with their ClassDefinition
+  // entries, so iterate classes instead of scanning all objects.
+  for (auto it = graph.GetClasses().GetIterator(); it; ++it) {
+    auto class_id = it.key();
+    auto* obj = graph.GetObjects().Find(class_id);
+    if (!obj || obj->GetObjectType() != ObjectType::kClass) {
+      continue;
+    }
+
+    auto* class_name_it = class_name_map_.Find(obj->GetClassId());
+    if (!class_name_it) {
+      context_->storage->IncrementStats(stats::hprof_class_errors);
+      continue;
+    }
+
+    StringId name_id =
+        InternClassName("java.lang.Class<" + *class_name_it + ">");
+    StringId kind_id = context_->storage->InternString(kUnknownClassKind);
+
+    tables::HeapGraphClassTable::Row class_row;
+    class_row.name = name_id;
+    class_row.deobfuscated_name = std::nullopt;
+    class_row.location = std::nullopt;
+    class_row.superclass_id = std::nullopt;
+    class_row.classloader_id = 0;
+    class_row.kind = kind_id;
+
+    tables::HeapGraphClassTable::Id table_id = class_table.Insert(class_row).id;
+    class_object_map_[class_id] = table_id;
   }
 }
 
@@ -322,7 +357,6 @@ void ArtHprofParser::PopulateObjects(const HeapGraph& graph,
                                      UniquePid upid) {
   auto& object_table = *context_->storage->mutable_heap_graph_object_table();
 
-  // Create fallback unknown class if needed
   tables::HeapGraphClassTable::Id unknown_class_id;
 
   for (auto it = graph.GetObjects().GetIterator(); it; ++it) {
@@ -338,7 +372,6 @@ void ArtHprofParser::PopulateObjects(const HeapGraph& graph,
         continue;
       }
     } else {
-      // Resolve object's type
       type_id = FindClassId(obj.GetClassId());
       if (!type_id && obj.GetObjectType() != ObjectType::kPrimitiveArray) {
         context_->storage->IncrementStats(stats::hprof_class_errors);
@@ -346,23 +379,20 @@ void ArtHprofParser::PopulateObjects(const HeapGraph& graph,
       }
     }
 
-    // Create object row
     tables::HeapGraphObjectTable::Row object_row;
     object_row.upid = upid;
     object_row.graph_sample_ts = ts;
-    object_row.self_size = static_cast<int64_t>(obj.GetSize());
+    object_row.self_size =
+        static_cast<int64_t>(obj.GetSelfSizeOverride().value_or(0));
     object_row.native_size = obj.GetNativeSize();
     object_row.reference_set_id = std::nullopt;
     object_row.reachable = obj.IsReachable();
     object_row.type_id = type_id ? *type_id : unknown_class_id;
 
-    // Handle heap type
     StringId heap_type_id = context_->storage->InternString(obj.GetHeapType());
     object_row.heap_type = heap_type_id;
 
-    // Handle root type
     if (obj.IsRoot() && obj.GetRootType().has_value()) {
-      // Convert root type enum to string
       std::string root_type_str =
           HeapGraph::GetRootTypeName(obj.GetRootType().value());
       StringId root_type_id = context_->storage->InternString(
@@ -370,9 +400,8 @@ void ArtHprofParser::PopulateObjects(const HeapGraph& graph,
       object_row.root_type = root_type_id;
     }
 
-    object_row.root_distance = -1;  // Ignored
+    object_row.root_distance = obj.GetRootDistance();
 
-    // Insert object and store mapping
     tables::HeapGraphObjectTable::Id table_id =
         object_table.Insert(object_row).id;
     object_map_[obj_id] = table_id;
@@ -383,103 +412,53 @@ void ArtHprofParser::PopulateReferences(const HeapGraph& graph) {
   auto& object_table = *context_->storage->mutable_heap_graph_object_table();
   auto& reference_table =
       *context_->storage->mutable_heap_graph_reference_table();
-  auto& class_table = *context_->storage->mutable_heap_graph_class_table();
 
-  // Group references by owner for efficient reference_set_id assignment
-  base::FlatHashMap<uint64_t, std::vector<Reference>> refs_by_owner;
+  StringId unknown_type_id = context_->storage->InternString("unknown");
 
-  // Step 1: Collect all references
   for (auto it = graph.GetObjects().GetIterator(); it; ++it) {
     auto obj_id = it.key();
     auto& obj = it.value();
 
     const auto& refs = obj.GetReferences();
-    if (!refs.empty()) {
-      refs_by_owner[obj_id].insert(refs_by_owner[obj_id].end(), refs.begin(),
-                                   refs.end());
-    }
-  }
-
-  // Step 2: Validate we have reference owners in our object map
-  size_t missing_owners = 0;
-  for (auto it = refs_by_owner.GetIterator(); it; ++it) {
-    auto owner_id = it.key();
-    if (!FindObjectId(owner_id)) {
-      missing_owners++;
-    }
-  }
-
-  if (missing_owners > 0) {
-    context_->storage->IncrementStats(stats::hprof_reference_errors);
-  }
-
-  // Step 3: Build class map for type resolution
-  base::FlatHashMap<uint64_t, tables::HeapGraphClassTable::Id> field_class_map;
-  for (auto it = graph.GetClasses().GetIterator(); it; ++it) {
-    auto class_id = it.key();
-    auto& class_def = it.value();
-    StringId name_id = InternClassName(class_def.GetName());
-
-    // Find the class ID in the table
-    for (uint32_t i = 0; i < class_table.row_count(); i++) {
-      if (class_table[i].name() == name_id) {
-        field_class_map[class_id] = tables::HeapGraphClassTable::Id(i);
-        break;
-      }
-    }
-  }
-
-  // Step 4: Process references and create reference sets
-  uint32_t next_reference_set_id = 1;
-
-  for (auto it = refs_by_owner.GetIterator(); it; ++it) {
-    auto owner_id = it.key();
-    auto& refs = it.value();
-    // Skip if no references
     if (refs.empty()) {
       continue;
     }
 
-    // Get owner's table ID
-    auto* owner_id_opt = FindObjectId(owner_id);
-    if (!owner_id_opt) {
+    auto* owner_table_id = FindObjectId(obj_id);
+    if (!owner_table_id) {
       continue;
     }
 
-    // Create reference set for owner
-    uint32_t reference_set_id = next_reference_set_id++;
-    object_table.FindById(*owner_id_opt)
+    // reference_set_id = row index of first reference for this object,
+    // matching the proto importer's convention.
+    uint32_t reference_set_id =
+        static_cast<uint32_t>(reference_table.row_count());
+    object_table.FindById(*owner_table_id)
         ->set_reference_set_id(reference_set_id);
 
-    // Process all references from this owner
     for (const auto& ref : refs) {
-      // Get owned object's table ID if it exists
       tables::HeapGraphObjectTable::Id* owned_table_id = nullptr;
       if (ref.target_id != 0) {
         owned_table_id = FindObjectId(ref.target_id);
-        if (!owned_table_id) {
-          context_->storage->IncrementStats(stats::hprof_reference_errors);
+      }
+
+      StringId field_name_id = context_->storage->InternString(ref.field_name);
+
+      StringId field_type_id = unknown_type_id;
+      if (ref.field_class_id.has_value() && *ref.field_class_id != 0) {
+        auto* cls_table_id = FindClassId(*ref.field_class_id);
+        if (cls_table_id) {
+          auto class_ref = context_->storage->heap_graph_class_table().FindById(
+              *cls_table_id);
+          if (class_ref) {
+            field_type_id = class_ref->name();
+          }
         }
       }
 
-      // Get the field name
-      StringId field_name_id = context_->storage->InternString(ref.field_name);
-
-      // Resolve field type from class ID
-      StringId field_type_id;
-      auto* cls = field_class_map.Find(*ref.field_class_id);
-      if (cls) {
-        // Get class name from class table
-        field_type_id = class_table[cls->value].name();
-      } else {
-        context_->storage->IncrementStats(stats::hprof_class_errors);
-        continue;
-      }
-
-      // Create reference record
       tables::HeapGraphReferenceTable::Row reference_row;
       reference_row.reference_set_id = reference_set_id;
-      reference_row.owner_id = *owner_id_opt;
+      reference_row.owner_id = *owner_table_id;
       reference_row.owned_id =
           owned_table_id
               ? std::optional<tables::HeapGraphObjectTable::Id>(*owned_table_id)
@@ -491,4 +470,5 @@ void ArtHprofParser::PopulateReferences(const HeapGraph& graph) {
     }
   }
 }
+
 }  // namespace perfetto::trace_processor::art_hprof

--- a/src/trace_processor/importers/art_hprof/art_hprof_parser.h
+++ b/src/trace_processor/importers/art_hprof/art_hprof_parser.h
@@ -53,7 +53,6 @@ class ArtHprofParser : public ChunkedTraceReader {
   void PopulateObjects(const HeapGraph& graph, int64_t ts, UniquePid upid);
   void PopulateReferences(const HeapGraph& graph);
 
-  // Helper methods
   tables::HeapGraphClassTable::Id* FindClassId(uint64_t class_id) const;
   tables::HeapGraphObjectTable::Id* FindObjectId(uint64_t obj_id) const;
   tables::HeapGraphClassTable::Id* FindClassObjectId(uint64_t obj_id) const;
@@ -86,16 +85,14 @@ class ArtHprofParser : public ChunkedTraceReader {
 
   TraceProcessorContext* const context_;
 
-  // Parser components
   std::unique_ptr<ByteIterator> byte_iterator_;
   std::unique_ptr<HeapGraphBuilder> parser_;
 
-  // Maps moved to instance variables
+  // HPROF ID → table row ID mappings, used during PopulateObjects/References.
   base::FlatHashMap<uint64_t, tables::HeapGraphClassTable::Id> class_map_;
   base::FlatHashMap<uint64_t, tables::HeapGraphClassTable::Id>
       class_object_map_;
   base::FlatHashMap<uint64_t, tables::HeapGraphObjectTable::Id> object_map_;
-  // For class objects that are denoted with "java.lang.Class<"
   base::FlatHashMap<uint64_t, std::string> class_name_map_;
 };
 }  // namespace perfetto::trace_processor::art_hprof

--- a/test/trace_processor/diff_tests/parser/art_hprof/tests.py
+++ b/test/trace_processor/diff_tests/parser/art_hprof/tests.py
@@ -83,16 +83,32 @@ class ArtHprofParser(TestSuite):
         """,
         out=Csv('''
           "graph_sample_ts","self_size","native_size","reachable","heap_type","root_type","root_distance"
-          1740172787560,1000000,0,1,"app","[NULL]",-1
-          1740172787560,16384,0,1,"app","[NULL]",-1
-          1740172787560,8192,0,1,"app","[NULL]",-1
-          1740172787560,6576,0,1,"app","[NULL]",-1
-          1740172787560,2800,0,1,"app","[NULL]",-1
-          1740172787560,2388,0,1,"app","STICKY_CLASS",-1
-          1740172787560,2048,0,1,"app","[NULL]",-1
-          1740172787560,2048,0,1,"app","[NULL]",-1
-          1740172787560,2048,0,1,"app","[NULL]",-1
-          1740172787560,2048,0,1,"app","[NULL]",-1
+          1740172787560,1000012,0,1,"app","[NULL]",2
+          1740172787560,16396,0,1,"app","[NULL]",2
+          1740172787560,8204,0,1,"app","[NULL]",4
+          1740172787560,3300,0,1,"app","[NULL]",1
+          1740172787560,2388,0,1,"app","STICKY_CLASS",0
+          1740172787560,1444,0,1,"app","STICKY_CLASS",0
+          1740172787560,1412,0,1,"app","[NULL]",1
+          1740172787560,1264,0,1,"app","[NULL]",1
+          1740172787560,1248,0,1,"app","[NULL]",1
+          1740172787560,1248,0,1,"app","[NULL]",1
+        '''))
+
+  def test_art_hprof_reference_type_kinds(self):
+    return DiffTestBlueprint(
+        trace=DataPath('test-dump.hprof'),
+        query="""
+          SELECT kind, count(*) AS cnt FROM heap_graph_class
+          WHERE kind != '[unknown class kind]'
+          GROUP BY kind ORDER BY kind
+        """,
+        out=Csv('''
+          "kind","cnt"
+          "KIND_FINALIZER_REFERENCE",1
+          "KIND_PHANTOM_REFERENCE",4
+          "KIND_SOFT_REFERENCE",2
+          "KIND_WEAK_REFERENCE",9
         '''))
 
   def test_art_hprof_reference_count_smoke(self):
@@ -121,14 +137,14 @@ class ArtHprofParser(TestSuite):
         """,
         out=Csv('''
           "field_name","field_type_name","name","name"
-          "$VALUES","java.io.File$PathStatus[]","java.lang.Class<java.io.File$PathStatus>","java.io.File$PathStatus[]"
-          "$VALUES","libcore.io.IoTracker$Mode[]","java.lang.Class<libcore.io.IoTracker$Mode>","libcore.io.IoTracker$Mode[]"
-          "$VALUES","libcore.reflect.AnnotationMember$DefaultValues[]","java.lang.Class<libcore.reflect.AnnotationMember$DefaultValues>","libcore.reflect.AnnotationMember$DefaultValues[]"
-          "$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<DumpedStuff>","dalvik.system.PathClassLoader"
-          "$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<Main>","dalvik.system.PathClassLoader"
-          "$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<SuperDumpedStuff>","dalvik.system.PathClassLoader"
-          "$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<a.a>","dalvik.system.PathClassLoader"
-          "$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<a.b>","dalvik.system.PathClassLoader"
-          "$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<a.c>","dalvik.system.PathClassLoader"
-          "$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<a>","dalvik.system.PathClassLoader"
+          "DumpedStuff.$class$classLoader","dalvik.system.PathClassLoader","java.lang.Class<DumpedStuff>","dalvik.system.PathClassLoader"
+          "DumpedStuff.$class$dexCache","java.lang.DexCache","java.lang.Class<DumpedStuff>","java.lang.DexCache"
+          "DumpedStuff.$class$ifTable","java.lang.Object[]","java.lang.Class<DumpedStuff>","java.lang.Object[]"
+          "DumpedStuff.$class$shadow$_klass_","java.lang.Class","java.lang.Class<DumpedStuff>","java.lang.Class<java.lang.Class>"
+          "DumpedStuff.$class$superClass","SuperDumpedStuff","java.lang.Class<DumpedStuff>","java.lang.Class<SuperDumpedStuff>"
+          "DumpedStuff.$classOverhead","byte[]","java.lang.Class<DumpedStuff>","byte[]"
+          "DumpedStuff.A","java.lang.ref.WeakReference","DumpedStuff","java.lang.ref.WeakReference"
+          "DumpedStuff.B","java.lang.ref.WeakReference","DumpedStuff","java.lang.ref.WeakReference"
+          "DumpedStuff.C","java.lang.ref.SoftReference","DumpedStuff","java.lang.ref.SoftReference"
+          "DumpedStuff.D","java.lang.Object[]","DumpedStuff","java.lang.Object[]"
         '''))


### PR DESCRIPTION
Match ahat's computation of self_size, native_size, reachability,
root_type, and qualified field names so that the raw table output
is identical to ahat for the same .hprof file.

 - Fixed reference_set_id to match the row index of the first reference.
 - Classified reference types (Weak, Soft, Phantom, Finalizer) to
   correctly skip "referent" fields during reachability analysis,
   matching ahat's behavior.
 - Implement root type precedence and shortest-path root distance
   calculation to align with proto heap graph expectations.
