### PR TITLE
Add MD file to notify about SDK move

### DIFF
--- a/sdk/MOVED_TO_GITHUB_RELEASES_ARTIFACTS.md
+++ b/sdk/MOVED_TO_GITHUB_RELEASES_ARTIFACTS.md
@@ -1,0 +1,6 @@
+The amalgamated tracing SDK is no longer available in the Git release branches.
+It moved to a .zip archive (perfetto-c-sdk-src.zip and perfetto-cpp-sdk-src.zip)  in the GitHub release pages:
+
+https://github.com/google/perfetto/releases/latest
+
+See also /docs/instrumentation/tracing-sdk.md


### PR DESCRIPTION
This is to reduce the surprise factor for next releases
and tell people where the SDK moved.