### PR TITLE
tp: Make primary key unique in stats_table

### DIFF
--- a/src/trace_processor/sqlite/stats_table.cc
+++ b/src/trace_processor/sqlite/stats_table.cc
@@ -41,7 +41,7 @@ int StatsModule::Connect(sqlite3* db,
       value BIGINT,
       description TEXT,
       key BIGINT HIDDEN,
-      PRIMARY KEY(name)
+      PRIMARY KEY(name, idx)
     ) WITHOUT ROWID
   )";
   if (int ret = sqlite3_declare_vtab(db, kSchema); ret != SQLITE_OK) {


### PR DESCRIPTION
We have certain stats name which are not unique by themselves including ftrace_cpu_bytes_begin, traced_buf_v2 stats. So to make the key unique use their index along with their name.
