### PR TITLE
ui: AndroidAnr expand process on missing main thread

### DIFF
--- a/ui/src/plugins/com.android.AndroidAnr/index.ts
+++ b/ui/src/plugins/com.android.AndroidAnr/index.ts
@@ -248,8 +248,8 @@ export default class AndroidAnr implements PerfettoPlugin {
     ts: bigint,
     dur: bigint,
   ) {
-    const startTime = Time.fromRaw(ts);
-    const endTime = Time.fromRaw(ts + dur);
+    const startTime = Time.fromRaw(BigInt(ts));
+    const endTime = Time.fromRaw(BigInt(ts + dur));
 
     ctx.scrollTo({
       track: {


### PR DESCRIPTION
This change treats the case when an app that ANRed doesn't have a main thread track associated with it (really common).
In this case, we will scroll to the process group of the ANRing app, expand it and select the ANR region. If the main thread track exists, this track is selected.

