### PR TITLE
perfetto: heap_profile: fix traceconv profile path parsing

### DIFF
--- a/python/tools/heap_profile.py
+++ b/python/tools/heap_profile.py
@@ -208,7 +208,8 @@ def process_trace(trace_file, profile_target, traceconv_binary, args,
 
   conversion_args = [traceconv_binary, 'profile'] + (
       ['--no-annotations'] if args.no_annotations else []) + [trace_file]
-  traceconv_output = subprocess.check_output(conversion_args)
+  traceconv_output = subprocess.check_output(
+      conversion_args, stderr=subprocess.STDOUT)
   profile_path = None
   for word in traceconv_output.decode('utf-8').split():
     if 'heap_profile-' in word:

--- a/tools/heap_profile
+++ b/tools/heap_profile
@@ -474,7 +474,8 @@ def process_trace(trace_file, profile_target, traceconv_binary, args,
 
   conversion_args = [traceconv_binary, 'profile'] + (
       ['--no-annotations'] if args.no_annotations else []) + [trace_file]
-  traceconv_output = subprocess.check_output(conversion_args)
+  traceconv_output = subprocess.check_output(
+      conversion_args, stderr=subprocess.STDOUT)
   profile_path = None
   for word in traceconv_output.decode('utf-8').split():
     if 'heap_profile-' in word:


### PR DESCRIPTION
traceconv writes its output (including the "Wrote profiles to <path>"
line) to stderr, not stdout. subprocess.check_output() only captures
stdout by default, so the profile path was never found and the script
always reported "No profiles generated" even when profiles existed.

Fix by passing stderr=subprocess.STDOUT so both streams are captured.
