### PR TITLE
de: Fix joins example

### DIFF
--- a/ui/src/assets/explore_page/examples/joins_learning.json
+++ b/ui/src/assets/explore_page/examples/joins_learning.json
@@ -250,13 +250,13 @@
         "primaryInputId": "1",
         "secondaryInputNodeId": "2",
         "selectedColumns": [
-          "name"
+          "is_main_thread"
         ],
         "leftColumn": "utid",
         "rightColumn": "id",
         "suggestionSelections": {
           "thread": [
-            "name"
+            "is_main_thread"
           ]
         },
         "expandedSuggestions": [],


### PR DESCRIPTION
In add columns node, we were adding name column, which was causing duplication with slices name. Now we add `is_main_thread`.