### PR TITLE
de: Fix the broken permalinks

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
@@ -290,6 +290,17 @@ export default class implements PerfettoPlugin {
     // SQL modules are ready, mark load as attempted regardless of outcome
     this.hasAttemptedStateLoad = true;
 
+    this.loadStateFromSources(trace, sqlModules);
+
+    // Sync loaded state to the permalink store so that "Share trace" includes
+    // the Data Explorer state even if the user hasn't modified anything.
+    // Without this, state loaded from localStorage or recent graphs would
+    // never be written to the permalink store, causing permalinks to lose
+    // the Data Explorer state.
+    this.saveToPermalinkStore();
+  }
+
+  private loadStateFromSources(trace: Trace, sqlModules: SqlModules): void {
     // Priority 1: Check permalink store
     const permalinkState = this.permalinkStore?.state;
     if (permalinkState) {


### PR DESCRIPTION
Bug: When the Data Explorer loaded state from localStorage (the most common case) or recent graphs, it never wrote that state to the permalink store. So when "Share trace" created a permalink, serializeAppState() read an empty {version: 2} from the store — the Data Explorer state was completely lost from the permalink.

Fix: Extracted the state loading logic into a separate loadStateFromSources() method, and added a saveToPermalinkStore() call in tryLoadState() that always runs after state is loaded (regardless of which source it came from). This ensures the permalink store is populated immediately, so "Share trace" will include the Data Explorer state.