### PR TITLE
Protect VMADDR_FLAG_TO_HOST usage for backward compatibility

### DIFF
--- a/src/base/unix_socket.cc
+++ b/src/base/unix_socket.cc
@@ -240,11 +240,13 @@ SockaddrAny MakeSockAddr(SockFamily family, const std::string& socket_name) {
       addr.svm_cid = *base::StringToUInt32(parts[0]);
       addr.svm_port = *base::StringToUInt32(parts[1]);
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+#if defined(VMADDR_FLAG_TO_HOST)
       if (IsVirtualized()) {
         // VM-to-VM VSOCK communication requires messages to be
         // routed through the host.
         addr.svm_flags = VMADDR_FLAG_TO_HOST;
       }
+#endif
 #endif
       SockaddrAny res(&addr, sizeof(addr));
       return res;


### PR DESCRIPTION
Some Qualcomm targets using the Perfetto SDK fail to build after the recent change that introduced addr.svm_flags = VMADDR_FLAG_TO_HOST. Older devices ship Linux UAPI headers that do not define 'svm_flags' in sockaddr_vm, nor the VMADDR_FLAG_TO_HOST macro, resulting in errors:

    error: no member named 'svm_flags' in 'sockaddr_vm'
    error: use of undeclared identifier 'VMADDR_FLAG_TO_HOST'

The macro was added upstream in Dec 2020 (Linux 5.11). Any environment pinned to pre‑5.11 headers hits this issue.

To retain portability, the assignment is now guarded with:

    #if defined(VMADDR_FLAG_TO_HOST)
      if (IsVirtualized()) {
        addr.svm_flags = VMADDR_FLAG_TO_HOST;
      }
    #endif

Reference: Perfetto change introducing VMADDR_FLAG_TO_HOST usage: b453c10f669a6bd80b1208e14b5f483cb1324302
("Set VMADDR_FLAG_TO_HOST when doing VM-to-VM VSOCK in QNX")

Fixes build failures on older LE/Android targets.

Welcome to Perfetto!
Make sure your PR has a bug/issue attached or has at least
a clear description of the problem you are trying to fix.

For more details please see
https://perfetto.dev/docs/contributing/getting-started
