### PR TITLE
de: Fix preventing CTRL+C copy

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -286,14 +286,16 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
       return;
     }
 
-    // Handle copy/paste shortcuts - these work when nodes are selected
+    // Handle copy shortcut - text selection takes priority over node copy,
+    // so users can copy proto/SQL from the sidebar, error messages, etc.
     if ((event.ctrlKey || event.metaKey) && event.key === 'c') {
-      if (state.selectedNodes.size > 0) {
+      const textSelection = window.getSelection();
+      const hasTextSelected =
+        textSelection !== null && textSelection.toString().length > 0;
+      if (!hasTextSelected && state.selectedNodes.size > 0) {
         this.handleCopy(attrs);
         event.preventDefault();
       }
-      // When no nodes are selected, allow the default browser copy behavior
-      // so users can copy text from the sidebar, error messages, etc.
       return;
     }
 


### PR DESCRIPTION
CTRL+C will work on text selection, having priority over node selection - if the text is selected and node is selected, CTRL+C will cause text copy, not node copy.. Before all CTRL+C was saved only for node copy.