### PR TITLE
tp: 'Materialize' as views where it's optimal

### DIFF
--- a/include/perfetto/trace_processor/summarizer.h
+++ b/include/perfetto/trace_processor/summarizer.h
@@ -47,6 +47,7 @@ struct PERFETTO_EXPORT_COMPONENT SummarizerUpdateSpecResult {
 struct PERFETTO_EXPORT_COMPONENT SummarizerQueryResult {
   bool exists = false;
   std::string table_name;
+  bool is_view = false;  // Whether created as VIEW (not TABLE).
   int64_t row_count = 0;
   std::vector<std::string> columns;
   double duration_ms = 0.0;
@@ -62,7 +63,7 @@ struct PERFETTO_EXPORT_COMPONENT SummarizerQueryResult {
 // - Change detection: Uses proto hash to detect changes.
 // - Dependency propagation: If A changes, dependents B->C->D re-materialize.
 // - Table substitution: Unchanged queries reference their materialized tables.
-// - Cleanup: All materialized tables are dropped when the Summarizer is
+// - Cleanup: All materialized tables/views are dropped when the Summarizer is
 //   destroyed.
 //
 // Obtain an instance via TraceProcessor::CreateSummarizer().

--- a/src/trace_processor/trace_summary/summarizer.cc
+++ b/src/trace_processor/trace_summary/summarizer.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "perfetto/base/logging.h"
 #include "perfetto/base/status.h"
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/flat_hash_map.h"
@@ -211,6 +212,19 @@ void ExtractInnerQueryIds(const uint8_t* data,
 
 }  // namespace
 
+// static
+bool SummarizerImpl::ShouldUseView(const uint8_t* data, size_t size) {
+  PerfettoSqlStructuredQuery::Decoder query(data, size);
+  if (query.has_group_by() || query.has_order_by()) {
+    return false;
+  }
+  // Simple pass-through source types where preserving index visibility is
+  // beneficial. All other source types (sql, embedded inner_query,
+  // interval_intersect, etc.) default to materialized TABLE.
+  return query.has_table() || query.has_simple_slices() ||
+         query.has_inner_query_id();
+}
+
 SummarizerImpl::SummarizerImpl(TraceProcessor* tp,
                                DescriptorPool* descriptor_pool,
                                std::string id)
@@ -277,6 +291,7 @@ base::Status SummarizerImpl::UpdateSpec(const uint8_t* spec_data,
     // table fail with "no such table" errors.
     if (existing && !existing->table_name.empty()) {
       state.old_table_name = existing->table_name;
+      state.old_is_view = existing->is_view;
     }
 
     query_states_[query_id] = std::move(state);
@@ -286,12 +301,9 @@ base::Status SummarizerImpl::UpdateSpec(const uint8_t* spec_data,
   std::vector<std::string> to_remove;
   for (auto state_it = query_states_.GetIterator(); state_it; ++state_it) {
     if (!new_query_ids.Find(state_it.key())) {
-      // Query was removed - drop its table.
+      // Query was removed - drop its table/view.
       if (!state_it.value().table_name.empty()) {
-        auto drop_it = tp_->ExecuteQuery("DROP TABLE IF EXISTS " +
-                                         state_it.value().table_name);
-        while (drop_it.Next()) {
-        }
+        DropTableOrView(state_it.value().table_name, state_it.value().is_view);
       }
       // Record the drop in the result.
       SummarizerUpdateSpecResult::QuerySyncInfo sync_info;
@@ -322,9 +334,10 @@ base::Status SummarizerImpl::UpdateSpec(const uint8_t* spec_data,
         if (dep && dep->needs_materialization) {
           // Dependency needs re-materialization, so does this query.
           state.needs_materialization = true;
-          // Defer dropping the old table until new materialization.
+          // Defer dropping the old table/view until new materialization.
           if (!state.table_name.empty()) {
             state.old_table_name = state.table_name;
+            state.old_is_view = state.is_view;
             state.table_name.clear();
           }
           changes_made = true;
@@ -493,25 +506,31 @@ base::Status SummarizerImpl::MaterializeQuery(
   // GenerateStandaloneSql(). This avoids O(N²) work during batch
   // materialization since each call would otherwise iterate all queries.
 
-  // Generate a new table name. Include the summarizer id so that multiple
-  // summarizer instances can coexist without table name collisions.
+  // Generate a new name. Include the summarizer id so that multiple
+  // summarizer instances can coexist without name collisions.
   std::string table_name =
-      "_exp_mat_" + id_ + "_" + std::to_string(next_table_id_++);
+      "_exp_mat_" + id_ + "_" + std::to_string(next_materialized_id_++);
 
-  // Track timing for materialization.
+  // Decide whether to create a VIEW (preserves source table indexes for
+  // downstream joins) or a TABLE (materializes data for caching).
+  bool use_view =
+      ShouldUseView(state.proto_data.data(), state.proto_data.size());
+
+  // Track timing. For tables, we measure only the CREATE TABLE AS SELECT
+  // (which executes the query and writes results). For views, CREATE VIEW is
+  // near-instant, so we measure the COUNT(*) query which forces execution.
   auto start_time = base::GetWallTimeNs();
 
-  // Materialize the query.
-  std::string create_sql =
-      "CREATE PERFETTO TABLE " + table_name + " AS " + query_sql;
+  // Create as VIEW or TABLE.
+  std::string create_sql;
+  if (use_view) {
+    create_sql = "CREATE PERFETTO VIEW " + table_name + " AS " + query_sql;
+  } else {
+    create_sql = "CREATE PERFETTO TABLE " + table_name + " AS " + query_sql;
+  }
   auto create_it = tp_->ExecuteQuery(create_sql);
   while (create_it.Next()) {
   }
-
-  auto end_time = base::GetWallTimeNs();
-  // GetWallTimeNs() returns nanoseconds; divide by 1e6 to convert to ms.
-  state.duration_ms =
-      static_cast<double>((end_time - start_time).count()) / 1e6;
 
   if (!create_it.Status().ok()) {
     state.error = create_it.Status().message();
@@ -519,7 +538,15 @@ base::Status SummarizerImpl::MaterializeQuery(
     return create_it.Status();
   }
 
-  // Get column information and row count from the materialized table.
+  // For tables, capture timing now (CREATE TABLE AS already executed the
+  // query). For views, we defer until after COUNT(*) which forces execution.
+  if (!use_view) {
+    auto end_time = base::GetWallTimeNs();
+    state.duration_ms =
+        static_cast<double>((end_time - start_time).count()) / 1e6;
+  }
+
+  // Get column information from the created table/view.
   auto schema_it =
       tp_->ExecuteQuery("SELECT * FROM " + table_name + " LIMIT 0");
   uint32_t col_count = schema_it.ColumnCount();
@@ -529,14 +556,32 @@ base::Status SummarizerImpl::MaterializeQuery(
   }
   while (schema_it.Next()) {
   }
+  if (!schema_it.Status().ok()) {
+    state.error = schema_it.Status().message();
+    state.needs_materialization = false;
+    return schema_it.Status();
+  }
 
-  // Get row count.
+  // Get row count. For views this executes the underlying query.
   auto count_it = tp_->ExecuteQuery("SELECT COUNT(*) FROM " + table_name);
   if (count_it.Next()) {
     state.row_count = count_it.Get(0).AsLong();
   }
+  if (!count_it.Status().ok()) {
+    state.error = count_it.Status().message();
+    state.needs_materialization = false;
+    return count_it.Status();
+  }
+
+  // For views, capture timing after COUNT(*) which forces query execution.
+  if (use_view) {
+    auto end_time = base::GetWallTimeNs();
+    state.duration_ms =
+        static_cast<double>((end_time - start_time).count()) / 1e6;
+  }
 
   state.table_name = table_name;
+  state.is_view = use_view;
   state.error = std::nullopt;
   state.needs_materialization = false;
   // Note: We intentionally keep proto_data after materialization.
@@ -544,17 +589,13 @@ base::Status SummarizerImpl::MaterializeQuery(
   // are materialized later in the same batch. The memory cost is acceptable
   // because the client re-sends the full spec on each sync anyway.
 
-  // Now that the new table is created, drop the old one if it exists.
+  // Now that the new table/view is created, drop the old one if it exists.
   // This deferred drop prevents race conditions where in-flight queries
   // against the old table would fail with "no such table" errors.
   if (!state.old_table_name.empty()) {
-    auto drop_it =
-        tp_->ExecuteQuery("DROP TABLE IF EXISTS " + state.old_table_name);
-    while (drop_it.Next()) {
-    }
-    // Drop errors are silently ignored - if the table is still locked by
-    // in-flight queries, it will be cleaned up later.
+    DropTableOrView(state.old_table_name, state.old_is_view);
     state.old_table_name.clear();
+    state.old_is_view = false;
   }
 
   return base::OkStatus();
@@ -616,23 +657,30 @@ void SummarizerImpl::GenerateStandaloneSql(QueryState& state) {
   state.standalone_sql = standalone_complete;
 }
 
+void SummarizerImpl::DropTableOrView(const std::string& name, bool is_view) {
+  std::string sql = is_view ? ("DROP VIEW IF EXISTS " + name)
+                            : ("DROP TABLE IF EXISTS " + name);
+  auto drop_it = tp_->ExecuteQuery(sql);
+  while (drop_it.Next()) {
+  }
+  // Drop failures are non-fatal: the table/view may still be referenced by
+  // in-flight queries. Log to aid debugging but don't propagate the error.
+  if (!drop_it.Status().ok()) {
+    PERFETTO_DLOG("Failed to drop %s '%s': %s", is_view ? "view" : "table",
+                  name.c_str(), drop_it.Status().c_message());
+  }
+}
+
 void SummarizerImpl::DropAll() {
   for (auto it = query_states_.GetIterator(); it; ++it) {
     if (!it.value().table_name.empty()) {
-      auto drop_it =
-          tp_->ExecuteQuery("DROP TABLE IF EXISTS " + it.value().table_name);
-      while (drop_it.Next()) {
-      }
-      // Ignore errors during drop.
+      DropTableOrView(it.value().table_name, it.value().is_view);
     }
-    // Also drop old tables that haven't been cleaned up yet (e.g., if
+    // Also drop old tables/views that haven't been cleaned up yet (e.g., if
     // UpdateSpec() marked a query for re-materialization but Query() was
     // never called to complete the swap).
     if (!it.value().old_table_name.empty()) {
-      auto drop_it = tp_->ExecuteQuery("DROP TABLE IF EXISTS " +
-                                       it.value().old_table_name);
-      while (drop_it.Next()) {
-      }
+      DropTableOrView(it.value().old_table_name, it.value().old_is_view);
     }
   }
   query_states_.Clear();
@@ -698,6 +746,7 @@ base::Status SummarizerImpl::Query(const std::string& query_id,
   GenerateStandaloneSql(*state);
 
   result->table_name = state->table_name;
+  result->is_view = state->is_view;
   result->row_count = state->row_count;
   result->columns = state->columns;
   result->duration_ms = state->duration_ms;

--- a/src/trace_processor/trace_summary/summarizer.h
+++ b/src/trace_processor/trace_summary/summarizer.h
@@ -45,8 +45,8 @@ namespace summary {
 // - Change detection: Uses proto hash to detect changes.
 // - Dependency propagation: If A changes, dependents B->C->D re-materialize.
 // - Table substitution: Unchanged queries reference their materialized tables.
-// - Cleanup: All materialized tables are dropped when the SummarizerImpl is
-//   destroyed.
+// - Cleanup: All materialized tables/views are dropped when the SummarizerImpl
+//   is destroyed.
 class SummarizerImpl : public Summarizer {
  public:
   SummarizerImpl(TraceProcessor* tp,
@@ -65,6 +65,11 @@ class SummarizerImpl : public Summarizer {
   base::Status Query(const std::string& query_id,
                      SummarizerQueryResult* result) override;
 
+  // Determines whether a query should be created as a VIEW instead of a
+  // materialized TABLE. Uses an allowlist of simple pass-through source types;
+  // unrecognized or complex sources default to TABLE (safe by default).
+  static bool ShouldUseView(const uint8_t* data, size_t size);
+
  private:
   struct QueryState {
     std::string table_name;
@@ -82,7 +87,10 @@ class SummarizerImpl : public Summarizer {
     // if any dependency changes, this query must also be re-materialized.
     std::vector<std::string> inner_query_ids;
     bool needs_materialization = true;  // True until successfully materialized.
-    std::string old_table_name;  // Old table to drop after new materialization.
+    bool is_view = false;  // Whether materialized as VIEW (not TABLE).
+    std::string
+        old_table_name;        // Old table/view to drop after new one created.
+    bool old_is_view = false;  // Whether old_table_name is a VIEW.
 
     // Analysis results (populated during materialization):
     std::string sql;  // Complete runnable SQL (includes + preambles + query).
@@ -109,7 +117,10 @@ class SummarizerImpl : public Summarizer {
       perfetto_sql::generator::StructuredQueryGenerator& generator,
       std::vector<std::vector<uint8_t>>& table_source_protos);
 
-  // Drops all materialized tables.
+  // Drops a table or view by name.
+  void DropTableOrView(const std::string& name, bool is_view);
+
+  // Drops all materialized tables and views.
   void DropAll();
 
   // Generates standalone SQL for a query (deferred from materialization).
@@ -121,7 +132,7 @@ class SummarizerImpl : public Summarizer {
   base::FlatHashMap<std::string, QueryState> query_states_;
   base::FlatHashMap<std::string, bool>
       included_modules_;  // Track included modules.
-  uint32_t next_table_id_ = 0;
+  uint32_t next_materialized_id_ = 0;
 };
 
 }  // namespace summary

--- a/src/trace_processor/trace_summary/summarizer_unittest.cc
+++ b/src/trace_processor/trace_summary/summarizer_unittest.cc
@@ -710,5 +710,411 @@ TEST_F(SummarizerTest, DestructorCleansUpOldTableName) {
       << "old_table_name should be dropped on destruction";
 }
 
+TEST_F(SummarizerTest, SimpleTableSourceCreatesView) {
+  // A query with a simple table source (no aggregation, no joins) should be
+  // created as a VIEW instead of a TABLE, preserving source table indexes.
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec;
+  {
+    auto* query = spec->add_query();
+    query->set_id("table_query");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+    table->add_column_names("dur");
+  }
+  auto spec_data = spec.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  SummarizerQueryResult info;
+  ASSERT_OK(summarizer_->Query("table_query", &info));
+  ASSERT_TRUE(info.exists);
+  EXPECT_FALSE(info.table_name.empty());
+  EXPECT_TRUE(info.is_view);
+}
+
+TEST_F(SummarizerTest, SqlSourceMaterializesAsTable) {
+  // A query with SQL source should always be materialized as a TABLE.
+  auto spec_data = CreateSpec({{"sql_query", "SELECT 42 as value"}});
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  SummarizerQueryResult info;
+  ASSERT_OK(summarizer_->Query("sql_query", &info));
+  ASSERT_TRUE(info.exists);
+  EXPECT_FALSE(info.table_name.empty());
+  EXPECT_FALSE(info.is_view);
+}
+
+TEST_F(SummarizerTest, TableSourceWithGroupByMaterializesAsTable) {
+  // A query with GROUP BY should always be materialized, even if source is
+  // a simple table.
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec;
+  {
+    auto* query = spec->add_query();
+    query->set_id("agg_query");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+    auto* group_by = query->set_group_by();
+    group_by->add_column_names("ts");
+  }
+  auto spec_data = spec.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  SummarizerQueryResult info;
+  ASSERT_OK(summarizer_->Query("agg_query", &info));
+  ASSERT_TRUE(info.exists);
+  EXPECT_FALSE(info.table_name.empty());
+  EXPECT_FALSE(info.is_view);
+}
+
+TEST_F(SummarizerTest, ViewQueryableWithPagination) {
+  // Verify that a view can be queried with LIMIT/OFFSET (as the UI does for
+  // DataGrid pagination).
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec;
+  {
+    auto* query = spec->add_query();
+    query->set_id("view_query");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+    table->add_column_names("dur");
+  }
+  auto spec_data = spec.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  SummarizerQueryResult info;
+  ASSERT_OK(summarizer_->Query("view_query", &info));
+  ASSERT_TRUE(info.exists);
+  EXPECT_TRUE(info.is_view);
+
+  // Query the view with LIMIT/OFFSET (simulates DataGrid pagination).
+  auto paginated = tp_->ExecuteQuery("SELECT * FROM " + info.table_name +
+                                     " LIMIT 10 OFFSET 0");
+  // Verify the query succeeds and returns columns.
+  EXPECT_GT(paginated.ColumnCount(), 0u);
+  while (paginated.Next()) {
+  }
+  EXPECT_TRUE(paginated.Status().ok());
+}
+
+TEST_F(SummarizerTest, ViewRematerializedOnChange) {
+  // Verify that a view is properly dropped and recreated when its source
+  // table changes.
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec1;
+  {
+    auto* query = spec1->add_query();
+    query->set_id("v");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+  }
+  auto spec_data1 = spec1.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result1;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data1.data(), spec_data1.size(), &result1));
+  SummarizerQueryResult info1;
+  ASSERT_OK(summarizer_->Query("v", &info1));
+  ASSERT_TRUE(info1.exists);
+  EXPECT_TRUE(info1.is_view);
+  std::string old_view = info1.table_name;
+
+  // Change the query (add a column).
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec2;
+  {
+    auto* query = spec2->add_query();
+    query->set_id("v");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+    table->add_column_names("dur");
+  }
+  auto spec_data2 = spec2.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result2;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data2.data(), spec_data2.size(), &result2));
+  SummarizerQueryResult info2;
+  ASSERT_OK(summarizer_->Query("v", &info2));
+  ASSERT_TRUE(info2.exists);
+
+  // Should have a new name.
+  EXPECT_NE(info2.table_name, old_view);
+
+  // Old view should be dropped.
+  auto check = tp_->ExecuteQuery("SELECT * FROM " + old_view + " LIMIT 0");
+  check.Next();
+  EXPECT_FALSE(check.Status().ok())
+      << "Old view should be dropped after rematerialization";
+}
+
+TEST_F(SummarizerTest, DestructorCleansUpViews) {
+  // Verify that destroying a summarizer cleans up views (not just tables).
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec;
+  {
+    auto* query = spec->add_query();
+    query->set_id("v");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+  }
+  auto spec_data = spec.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+  SummarizerQueryResult info;
+  ASSERT_OK(summarizer_->Query("v", &info));
+  ASSERT_TRUE(info.exists);
+  EXPECT_TRUE(info.is_view);
+  std::string view_name = info.table_name;
+
+  // Verify view exists before destruction.
+  {
+    auto check = tp_->ExecuteQuery("SELECT * FROM " + view_name + " LIMIT 0");
+    while (check.Next()) {
+    }
+    EXPECT_TRUE(check.Status().ok());
+  }
+
+  // Destroy the summarizer.
+  summarizer_.reset();
+
+  // View should be dropped.
+  auto check = tp_->ExecuteQuery("SELECT * FROM " + view_name + " LIMIT 0");
+  check.Next();
+  EXPECT_FALSE(check.Status().ok()) << "View should be dropped on destruction";
+}
+
+TEST_F(SummarizerTest, ChainedViewsQueryCorrectly) {
+  // Test a chain where B and C are views referencing A (a table).
+  // CreateChainedSpec builds: A = SQL source, B = inner_query_id("A") with
+  // a "value > 0" filter, C = inner_query_id("B") with no filter.
+  // Verify the whole chain produces correct results when C is queried.
+  auto spec_data =
+      CreateChainedSpec("SELECT 1 as value UNION ALL SELECT 2 as value");
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  // Query all three to verify types.
+  SummarizerQueryResult info_a;
+  ASSERT_OK(summarizer_->Query("A", &info_a));
+  ASSERT_TRUE(info_a.exists);
+  EXPECT_FALSE(info_a.is_view) << "A has SQL source, should be a table";
+
+  SummarizerQueryResult info_b;
+  ASSERT_OK(summarizer_->Query("B", &info_b));
+  ASSERT_TRUE(info_b.exists);
+  EXPECT_TRUE(info_b.is_view) << "B is inner_query_id, should be a view";
+
+  SummarizerQueryResult info_c;
+  ASSERT_OK(summarizer_->Query("C", &info_c));
+  ASSERT_TRUE(info_c.exists);
+  EXPECT_TRUE(info_c.is_view) << "C is inner_query_id, should be a view";
+
+  // B filters value > 0, so both rows (1 and 2) should pass through.
+  // C has no additional filter, so it should have the same rows as B.
+  EXPECT_EQ(info_c.row_count, 2);
+
+  // Verify C's view resolves to the correct values.
+  auto query_c = tp_->ExecuteQuery("SELECT value FROM " + info_c.table_name +
+                                   " ORDER BY value");
+  ASSERT_TRUE(query_c.Next());
+  EXPECT_EQ(query_c.Get(0).AsLong(), 1);
+  ASSERT_TRUE(query_c.Next());
+  EXPECT_EQ(query_c.Get(0).AsLong(), 2);
+  EXPECT_FALSE(query_c.Next());
+  ASSERT_OK(query_c.Status());
+}
+
+TEST_F(SummarizerTest, QuerySwitchesFromTableToView) {
+  // A query that initially has GROUP BY (→ table) then changes to not have
+  // GROUP BY (→ view). The old TABLE should be dropped even though the new
+  // one is a VIEW.
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec1;
+  {
+    auto* query = spec1->add_query();
+    query->set_id("q");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("ts");
+    auto* group_by = query->set_group_by();
+    group_by->add_column_names("ts");
+  }
+  auto spec_data1 = spec1.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result1;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data1.data(), spec_data1.size(), &result1));
+  SummarizerQueryResult info1;
+  ASSERT_OK(summarizer_->Query("q", &info1));
+  ASSERT_TRUE(info1.exists);
+  EXPECT_FALSE(info1.is_view) << "GROUP BY query should be a table";
+  std::string old_name = info1.table_name;
+
+  // Change to no GROUP BY (should become a view).
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec2;
+  {
+    auto* query = spec2->add_query();
+    query->set_id("q");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("ts");
+  }
+  auto spec_data2 = spec2.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result2;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data2.data(), spec_data2.size(), &result2));
+  SummarizerQueryResult info2;
+  ASSERT_OK(summarizer_->Query("q", &info2));
+  ASSERT_TRUE(info2.exists);
+  EXPECT_TRUE(info2.is_view) << "Without GROUP BY should be a view";
+  EXPECT_NE(info2.table_name, old_name);
+
+  // Old table should be dropped.
+  auto check = tp_->ExecuteQuery("SELECT * FROM " + old_name + " LIMIT 0");
+  check.Next();
+  EXPECT_FALSE(check.Status().ok())
+      << "Old TABLE should be dropped when query switches to VIEW";
+}
+
+TEST_F(SummarizerTest, InnerQueryIdSourceCreatesView) {
+  // An inner_query_id source (referencing another query) should create a view.
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec;
+  {
+    auto* base_query = spec->add_query();
+    base_query->set_id("base");
+    auto* sql_source = base_query->set_sql();
+    sql_source->set_sql("SELECT 1 as value");
+    sql_source->add_column_names("value");
+  }
+  {
+    auto* ref_query = spec->add_query();
+    ref_query->set_id("ref");
+    ref_query->set_inner_query_id("base");
+  }
+  auto spec_data = spec.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  SummarizerQueryResult base_info;
+  ASSERT_OK(summarizer_->Query("base", &base_info));
+  EXPECT_FALSE(base_info.is_view) << "SQL source should be a table";
+
+  SummarizerQueryResult ref_info;
+  ASSERT_OK(summarizer_->Query("ref", &ref_info));
+  ASSERT_TRUE(ref_info.exists);
+  EXPECT_FALSE(ref_info.table_name.empty());
+  EXPECT_TRUE(ref_info.is_view) << "inner_query_id source should be a view";
+}
+
+TEST_F(SummarizerTest, TableSourceWithOrderByMaterializesAsTable) {
+  // A query with ORDER BY should always be materialized, even if source is
+  // a simple table, since re-sorting on every downstream query is wasteful.
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec;
+  {
+    auto* query = spec->add_query();
+    query->set_id("ordered_query");
+    auto* table = query->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+    auto* order_by = query->set_order_by();
+    auto* ordering = order_by->add_ordering_specs();
+    ordering->set_column_name("ts");
+  }
+  auto spec_data = spec.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  SummarizerQueryResult info;
+  ASSERT_OK(summarizer_->Query("ordered_query", &info));
+  ASSERT_TRUE(info.exists);
+  EXPECT_FALSE(info.table_name.empty());
+  EXPECT_FALSE(info.is_view) << "ORDER BY query should be a table";
+}
+
+TEST_F(SummarizerTest, InnerQuerySourceMaterializesAsTable) {
+  // An embedded inner_query source can be arbitrarily complex, so it should
+  // always be materialized as a TABLE (not a VIEW).
+  protozero::HeapBuffered<protos::pbzero::TraceSummarySpec> spec;
+  {
+    auto* query = spec->add_query();
+    query->set_id("nested");
+    auto* inner = query->set_inner_query();
+    auto* table = inner->set_table();
+    table->set_table_name("slice");
+    table->add_column_names("id");
+    table->add_column_names("ts");
+  }
+  auto spec_data = spec.SerializeAsArray();
+
+  SummarizerUpdateSpecResult result;
+  ASSERT_OK(
+      summarizer_->UpdateSpec(spec_data.data(), spec_data.size(), &result));
+
+  SummarizerQueryResult info;
+  ASSERT_OK(summarizer_->Query("nested", &info));
+  ASSERT_TRUE(info.exists);
+  EXPECT_FALSE(info.table_name.empty());
+  EXPECT_FALSE(info.is_view) << "inner_query source should be a table";
+}
+
+TEST_F(SummarizerTest, SimpleSlicesSourceShouldUseView) {
+  // A query with a simple_slices source (no aggregation) should be classified
+  // as a view by ShouldUseView. We test the classification directly because
+  // simple_slices requires runtime PerfettoSQL modules that aren't available
+  // in the unit test environment.
+  protozero::HeapBuffered<protos::pbzero::PerfettoSqlStructuredQuery> query;
+  {
+    auto* slices = query->set_simple_slices();
+    slices->set_slice_name_glob("*");
+  }
+  auto query_data = query.SerializeAsArray();
+  EXPECT_TRUE(
+      SummarizerImpl::ShouldUseView(query_data.data(), query_data.size()))
+      << "simple_slices source should use a view";
+}
+
+TEST_F(SummarizerTest, SimpleSlicesWithGroupByShouldNotUseView) {
+  // A simple_slices source with GROUP BY should NOT be a view.
+  protozero::HeapBuffered<protos::pbzero::PerfettoSqlStructuredQuery> query;
+  {
+    auto* slices = query->set_simple_slices();
+    slices->set_slice_name_glob("*");
+    auto* group_by = query->set_group_by();
+    group_by->add_column_names("slice_name");
+  }
+  auto query_data = query.SerializeAsArray();
+  EXPECT_FALSE(
+      SummarizerImpl::ShouldUseView(query_data.data(), query_data.size()))
+      << "simple_slices with GROUP BY should materialize as a table";
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::summary


### PR DESCRIPTION
Optimize the Summarizer to create VIEWs instead of materialized TABLEs for  simple pass-through queries (table source, simple_slices, inner_query_id) that have no GROUP BY or ORDER BY, or multi source operations. This preserves source table indexes for downstream joins and avoids redundant data copies.
