### PR TITLE
ui: Mark TabStrip as deprecated and point users towards Tabs instead

### DIFF
--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/tabstrip_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/tabstrip_demo.ts
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 import m from 'mithril';
+import {Anchor} from '../../../widgets/anchor';
+import {Callout} from '../../../widgets/callout';
+import {Intent} from '../../../widgets/common';
 import {TabStrip} from '../../../widgets/tab_strip';
 import {renderWidgetShowcase} from '../widgets_page_utils';
 
@@ -26,6 +29,13 @@ export function renderTabStrip(): m.Children {
       m(
         'p',
         'A horizontal tab navigation component for switching between different views or sections.',
+      ),
+      m(
+        Callout,
+        {intent: Intent.Warning, icon: 'warning'},
+        'Deprecated: use the ',
+        m(Anchor, {href: '#!/widgets/tabs'}, 'Tabs'),
+        ' widget instead, which supports close buttons, renaming, reordering, and a new tab button.',
       ),
     ),
     renderWidgetShowcase({

--- a/ui/src/widgets/tab_strip.ts
+++ b/ui/src/widgets/tab_strip.ts
@@ -15,6 +15,7 @@
 import m from 'mithril';
 import {Icon} from './icon';
 
+/** @deprecated Use {@link TabsTab} from `./tabs` instead. */
 export interface TabOption {
   readonly key: string;
   readonly title: string;
@@ -22,6 +23,7 @@ export interface TabOption {
   readonly rightIcon?: string | m.Children;
 }
 
+/** @deprecated Use {@link TabsAttrs} from `./tabs` instead. */
 export interface TabStripAttrs {
   readonly className?: string;
   readonly tabs: ReadonlyArray<TabOption>;
@@ -29,6 +31,7 @@ export interface TabStripAttrs {
   onTabChange(key: string): void;
 }
 
+/** @deprecated Use {@link Tabs} from `./tabs` instead. */
 export class TabStrip implements m.ClassComponent<TabStripAttrs> {
   view({attrs}: m.CVnode<TabStripAttrs>) {
     const {tabs, currentTabKey, onTabChange, className} = attrs;


### PR DESCRIPTION
- Add JSDocs to TabStrip widget with deprecated flag.
- Add callout in TabStrip demo page.