### PR TITLE
de: Reenable the data availability checks

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/index.ts
@@ -419,6 +419,11 @@ export default class implements PerfettoPlugin {
     trace.pages.registerPage({
       route: '/explore',
       render: () => {
+        // Ensure SQL modules initialization is triggered (no-op if already
+        // started). This kicks off the data availability checks that determine
+        // which modules should be marked as "No data".
+        trace.plugins.getPlugin(SqlModulesPlugin).ensureInitialized();
+
         // Try to load saved state lazily (waits for SQL modules to be ready).
         this.tryLoadState(trace);
 


### PR DESCRIPTION
Restore the `ensureInitialized()` call that was accidentally removed in #4994 (Add tabs to Data Explorer). Without it, the data availability checks never run, so every stdlib module appears as having data in the Data Explorer