### PR TITLE
de: Rename data_explorer to results_panel

### DIFF
--- a/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/explore_page.ts
@@ -54,7 +54,7 @@ import {
 } from './node_crud_operations';
 import type {NodeCrudDeps} from './node_crud_operations';
 import {addFilter, addColumnFromJoinid} from './datagrid_node_creation';
-import {showDataExplorerHelp} from './data_explorer_help_modal';
+import {showHelp} from './help_modal';
 
 import {copySelectedNodes, pasteClipboardNodes} from './clipboard_operations';
 import type {ClipboardResult} from './clipboard_operations';
@@ -224,7 +224,7 @@ export class ExplorePage implements m.ClassComponent<ExplorePageAttrs> {
 
     // Handle "?" to show help modal
     if (event.key === '?') {
-      showDataExplorerHelp();
+      showHelp();
       event.preventDefault();
       return;
     }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/help_modal.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/help_modal.ts
@@ -28,10 +28,10 @@ interface HelpSection {
   readonly entries: ReadonlyArray<HelpEntry>;
 }
 
-export function showDataExplorerHelp() {
+export function showHelp() {
   return showModal({
     title: 'Data Explorer Help',
-    content: () => m(DataExplorerHelpContent),
+    content: () => m(HelpContent),
   });
 }
 
@@ -145,7 +145,7 @@ function renderSection(section: HelpSection): m.Children {
   ];
 }
 
-class DataExplorerHelpContent implements m.ClassComponent {
+class HelpContent implements m.ClassComponent {
   view(): m.Children {
     return m('.pf-help-modal', getHelpSections().map(renderSection));
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/builder.ts
@@ -112,7 +112,7 @@ import {getPrimarySelectedNode} from '../selection_utils';
 import {isAQuery, queryToRun} from './query_builder_utils';
 import {NodeExplorer} from './node_explorer';
 import {Graph, GraphCallbacks} from './graph/graph';
-import {DataExplorer} from './data_explorer';
+import {ResultsPanel} from './results_panel';
 import {
   DrawerPanel,
   DrawerPanelVisibility,
@@ -124,7 +124,7 @@ import QueryPagePlugin from '../../dev.perfetto.QueryPage';
 import {SqlSourceNode} from './nodes/sources/sql_source';
 import {findErrors, findWarnings} from './query_builder_utils';
 import {NodeIssues} from './node_issues';
-import {DataExplorerEmptyState, RoundActionButton} from './widgets';
+import {ResultsPanelEmptyState, RoundActionButton} from './widgets';
 import {UIFilter} from './operations/filter';
 import {QueryExecutionService} from './query_execution_service';
 import {Column} from '../../../components/widgets/datagrid/model';
@@ -321,7 +321,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
     const explorer = hasMultipleNodesSelected
       ? m(
           '.pf-unselected-explorer',
-          m(DataExplorerEmptyState, {
+          m(ResultsPanelEmptyState, {
             icon: 'info',
             title: `${attrs.selectedNodes.size} nodes selected`,
           }),
@@ -398,13 +398,13 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
       },
       startingHeight: 300,
       drawerContent: hasMultipleNodesSelected
-        ? m(DataExplorerEmptyState, {
+        ? m(ResultsPanelEmptyState, {
             icon: 'info',
             title: `${attrs.selectedNodes.size} nodes selected`,
           })
-        : selectedNode?.customDataExplorer?.() ??
+        : selectedNode?.customResultsPanel?.() ??
           (selectedNode
-            ? m(DataExplorer, {
+            ? m(ResultsPanel, {
                 trace: this.trace,
                 query: this.query,
                 node: selectedNode,
@@ -444,7 +444,7 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
                   await this.exportToTimeline(selectedNode);
                 },
               })
-            : m(DataExplorerEmptyState, {
+            : m(ResultsPanelEmptyState, {
                 icon: 'info',
                 title: 'Select a node to see the data',
               })),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/join_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/join_widgets.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import {ColumnInfo} from './column_info';
 import {
   OutlinedField,
-  DataExplorerEmptyState,
+  ResultsPanelEmptyState,
   SelectDeselectAllButtons,
 } from './widgets';
 import {classNames} from '../../../base/classnames';
@@ -60,7 +60,7 @@ export class JoinSourceCard implements m.ClassComponent<JoinSourceCardAttrs> {
         m('.pf-join-source-card__header', label),
         m(
           '.pf-join-source-card__content',
-          m(DataExplorerEmptyState, {
+          m(ResultsPanelEmptyState, {
             icon: 'cable',
             title: `Connect a node to the ${label} input`,
           }),
@@ -355,7 +355,7 @@ export class JoinColumnSelector
         m(
           '.pf-join-column-list',
           leftColumns.length === 0
-            ? m(DataExplorerEmptyState, {
+            ? m(ResultsPanelEmptyState, {
                 icon: 'cable',
                 title: 'Connect left source',
               })
@@ -385,7 +385,7 @@ export class JoinColumnSelector
         m(
           '.pf-join-column-list',
           rightColumns.length === 0
-            ? m(DataExplorerEmptyState, {
+            ? m(ResultsPanelEmptyState, {
                 icon: 'cable',
                 title: 'Connect right source',
               })

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/node_explorer.ts
@@ -25,7 +25,7 @@ import {NodeIssues} from './node_issues';
 import {TabStrip} from '../../../widgets/tab_strip';
 import {NodeModifyAttrs} from './node_explorer_types';
 import {Button, ButtonAttrs, ButtonVariant} from '../../../widgets/button';
-import {DataExplorerEmptyState, InfoBox} from './widgets';
+import {ResultsPanelEmptyState, InfoBox} from './widgets';
 import {QueryExecutionService} from './query_execution_service';
 
 export interface NodeExplorerAttrs {
@@ -320,13 +320,13 @@ export class NodeExplorer implements m.ClassComponent<NodeExplorerAttrs> {
           this.resultTabMode === 'sql'
             ? isAQuery(query)
               ? m(CodeSnippet, {language: 'SQL', text: sql})
-              : m(DataExplorerEmptyState, {
+              : m(ResultsPanelEmptyState, {
                   icon: 'info',
                   title: 'SQL not available',
                 })
             : isAQuery(query)
               ? m(CodeSnippet, {text: textproto, language: 'textproto'})
-              : m(DataExplorerEmptyState, {
+              : m(ResultsPanelEmptyState, {
                   icon: 'info',
                   title: 'Proto not available',
                 }),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_suggestion_modal.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/add_columns_suggestion_modal.ts
@@ -18,7 +18,7 @@ import {Callout} from '../../../../widgets/callout';
 import {Form, FormSection} from '../../../../widgets/form';
 import {
   TableDescription,
-  DataExplorerEmptyState,
+  ResultsPanelEmptyState,
   IssueList,
   OutlinedFieldReadOnly,
 } from '../widgets';
@@ -191,7 +191,7 @@ export class AddColumnsSuggestionModal
         '.pf-join-modal-info',
         tableInfo
           ? m(TableDescription, {table: tableInfo})
-          : m(DataExplorerEmptyState, {
+          : m(ResultsPanelEmptyState, {
               icon: 'table',
               title: 'Table information will appear here',
             }),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_node.ts
@@ -31,7 +31,7 @@ import {
   NodeTitle,
 } from '../node_styling_widgets';
 import {MetricsNode} from './metrics_node';
-import {TraceSummaryDataExplorer} from './trace_summary_data_explorer';
+import {TraceSummaryResultsPanel} from './trace_summary_results_panel';
 import {Accordion} from '../../../../widgets/accordion';
 import {enumKeyToLabel} from './metrics_enum_utils';
 import {showModal} from '../../../../widgets/modal';
@@ -315,10 +315,10 @@ export class TraceSummaryNode implements QueryNode {
     return undefined;
   }
 
-  customDataExplorer(): m.Children {
+  customResultsPanel(): m.Children {
     const trace = this.state.trace;
     if (trace === undefined) return undefined;
-    return m(TraceSummaryDataExplorer, {
+    return m(TraceSummaryResultsPanel, {
       node: this,
       trace,
       onchange: () => this.state.onchange?.(),

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/trace_summary_results_panel.ts
@@ -29,7 +29,7 @@ import {
   getStructuredQueries,
   buildEmbeddedQueryTree,
 } from '../query_builder_utils';
-import {DataExplorerEmptyState} from '../widgets';
+import {ResultsPanelEmptyState} from '../widgets';
 
 // ============================================================================
 // Proto parsing helpers
@@ -162,20 +162,20 @@ type ExecutionState =
 // Component
 // ============================================================================
 
-export interface TraceSummaryDataExplorerAttrs {
+export interface TraceSummaryResultsPanelAttrs {
   readonly node: TraceSummaryNode;
   readonly trace: Trace;
   readonly onchange?: () => void;
 }
 
-export class TraceSummaryDataExplorer
-  implements m.ClassComponent<TraceSummaryDataExplorerAttrs>
+export class TraceSummaryResultsPanel
+  implements m.ClassComponent<TraceSummaryResultsPanelAttrs>
 {
   private executionState: ExecutionState = {kind: 'idle'};
   private activeTab?: string;
   private prevSpecHash?: string;
 
-  view({attrs}: m.CVnode<TraceSummaryDataExplorerAttrs>) {
+  view({attrs}: m.CVnode<TraceSummaryResultsPanelAttrs>) {
     const {node} = attrs;
     const autoExecute = node.state.autoExecute ?? true;
 
@@ -211,7 +211,7 @@ export class TraceSummaryDataExplorer
     return parts.join('|');
   }
 
-  private renderMenu(attrs: TraceSummaryDataExplorerAttrs): m.Children {
+  private renderMenu(attrs: TraceSummaryResultsPanelAttrs): m.Children {
     const autoExecute = attrs.node.state.autoExecute ?? true;
     const isLoading = this.executionState.kind === 'loading';
     const isStale = this.prevSpecHash !== this.computeSpecHash(attrs.node);
@@ -280,9 +280,9 @@ export class TraceSummaryDataExplorer
     return menuItems;
   }
 
-  private renderContent(attrs: TraceSummaryDataExplorerAttrs): m.Children {
+  private renderContent(attrs: TraceSummaryResultsPanelAttrs): m.Children {
     if (!attrs.node.validate()) {
-      return m(DataExplorerEmptyState, {
+      return m(ResultsPanelEmptyState, {
         icon: 'warning',
         title:
           attrs.node.state.issues?.queryError?.message ??
@@ -292,21 +292,21 @@ export class TraceSummaryDataExplorer
 
     switch (this.executionState.kind) {
       case 'idle':
-        return m(DataExplorerEmptyState, {
+        return m(ResultsPanelEmptyState, {
           icon: 'play_arrow',
           title: 'Click Run or enable Auto Execute',
         });
       case 'loading':
         return m('.pf-trace-summary-loading', m(Spinner));
       case 'error':
-        return m(DataExplorerEmptyState, {
+        return m(ResultsPanelEmptyState, {
           icon: 'error',
           title: this.executionState.message,
         });
       case 'done': {
         const {bundles} = this.executionState;
         if (bundles.length === 0) {
-          return m(DataExplorerEmptyState, {
+          return m(ResultsPanelEmptyState, {
             icon: 'info',
             title: 'No metric data returned',
           });
@@ -340,7 +340,7 @@ export class TraceSummaryDataExplorer
     }
   }
 
-  private async execute(attrs: TraceSummaryDataExplorerAttrs): Promise<void> {
+  private async execute(attrs: TraceSummaryResultsPanelAttrs): Promise<void> {
     const {node} = attrs;
     if (!node.validate()) return;
 

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/nodes/union_node.ts
@@ -32,7 +32,7 @@ import {NodeModifyAttrs, NodeDetailsAttrs} from '../node_explorer_types';
 import {
   DraggableItem,
   SelectDeselectAllButtons,
-  DataExplorerEmptyState,
+  ResultsPanelEmptyState,
 } from '../widgets';
 import {
   NodeDetailsMessage,
@@ -238,7 +238,7 @@ export class UnionNode implements QueryNode {
     if (totalCount === 0) {
       // Show empty state when no common columns
       sections.push({
-        content: m(DataExplorerEmptyState, {
+        content: m(ResultsPanelEmptyState, {
           icon: 'table',
           title: 'No common columns between sources',
           variant: 'warning',

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/results_panel.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/results_panel.scss
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.pf-data-explorer-empty-state {
+.pf-results-panel-empty-state {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -51,7 +51,7 @@
   &.pf-warning {
     color: var(--pf-color-text);
 
-    .pf-data-explorer-empty-state__icon {
+    .pf-results-panel-empty-state__icon {
       color: var(--pf-color-warning);
     }
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/results_panel.ts
@@ -30,7 +30,7 @@ import {Icons} from '../../../base/semantic_icons';
 import {MenuItem, PopupMenu} from '../../../widgets/menu';
 import {findErrors, isAQuery} from './query_builder_utils';
 import {UIFilter, normalizeDataGridFilter} from './operations/filter';
-import {DataExplorerEmptyState} from './widgets';
+import {ResultsPanelEmptyState} from './widgets';
 import {Trace} from '../../../public/trace';
 import {Timestamp} from '../../../components/widgets/timestamp';
 import {SqlModules} from '../../dev.perfetto.SqlModules/sql_modules';
@@ -65,7 +65,7 @@ function getColumnType(type: PerfettoSqlType): ColumnType {
   return 'quantitative';
 }
 
-export interface DataExplorerAttrs {
+export interface ResultsPanelAttrs {
   readonly trace: Trace;
   readonly node: QueryNode;
   readonly query?: Query | Error;
@@ -129,11 +129,11 @@ function getColumnInfo(
   return node.finalCols.find((col) => col.name === columnName);
 }
 
-export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
+export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
   // Track columns with sort state so that sorting persists across redraws.
   private columns: readonly Column[] = [];
 
-  view({attrs}: m.CVnode<DataExplorerAttrs>) {
+  view({attrs}: m.CVnode<ResultsPanelAttrs>) {
     return m(
       DetailsShell,
       {
@@ -145,7 +145,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     );
   }
 
-  private renderMenu(attrs: DataExplorerAttrs): m.Children {
+  private renderMenu(attrs: ResultsPanelAttrs): m.Children {
     const autoExecute = attrs.node.state.autoExecute ?? true;
 
     // Only show "Run Query" button when autoExecute is off AND node is stale
@@ -270,7 +270,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     return menuItems;
   }
 
-  private renderContent(attrs: DataExplorerAttrs): m.Children {
+  private renderContent(attrs: ResultsPanelAttrs): m.Children {
     const errors = findErrors(attrs.query, attrs.response);
 
     // Show validation errors first (queryError is set by validate() methods).
@@ -279,7 +279,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     if (!attrs.node.validate() && attrs.node.state.issues?.queryError) {
       // Clear any stale execution error when validation fails
       attrs.node.state.issues.clearExecutionError();
-      return m(DataExplorerEmptyState, {
+      return m(ResultsPanelEmptyState, {
         icon: 'warning',
         variant: 'warning',
         title: attrs.node.state.issues.queryError.message,
@@ -294,7 +294,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       const failingSql = isAQuery(attrs.query) ? attrs.query.sql : undefined;
 
       return m(
-        DataExplorerEmptyState,
+        ResultsPanelEmptyState,
         {
           icon: 'warning',
           variant: 'warning',
@@ -333,7 +333,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
 
     // Show execution errors with centered warning icon
     if (errors) {
-      return m(DataExplorerEmptyState, {
+      return m(ResultsPanelEmptyState, {
         icon: 'warning',
         variant: 'warning',
         title: `Error: ${errors.message}`,
@@ -342,7 +342,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
 
     // Show response warnings with centered warning icon
     if (attrs.node.state.issues?.responseError) {
-      return m(DataExplorerEmptyState, {
+      return m(ResultsPanelEmptyState, {
         icon: 'warning',
         variant: 'warning',
         title: attrs.node.state.issues.responseError.message,
@@ -351,7 +351,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
 
     // Show data errors (like "no rows returned") with centered warning icon
     if (attrs.node.state.issues?.dataError) {
-      return m(DataExplorerEmptyState, {
+      return m(ResultsPanelEmptyState, {
         icon: 'warning',
         variant: 'warning',
         title: attrs.node.state.issues.dataError.message,
@@ -360,7 +360,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
 
     // Show spinner overlay when query is running
     if (attrs.isQueryRunning) {
-      return m(DataExplorerEmptyState, {}, m(Spinner, {easing: true}));
+      return m(ResultsPanelEmptyState, {}, m(Spinner, {easing: true}));
     }
 
     // Show data if we have response and dataSource (even without query)
@@ -380,7 +380,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       // Show warning for multiple statements with centered icon
       const warning =
         attrs.response.statementWithOutputCount > 1
-          ? m(DataExplorerEmptyState, {
+          ? m(ResultsPanelEmptyState, {
               icon: 'warning',
               variant: 'warning',
               title:
@@ -590,7 +590,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     // and this node doesn't have a response yet (queued state).
     const isServiceBusy = attrs.queryExecutionService.isQueryExecuting();
     if (isServiceBusy && !attrs.response && !attrs.isQueryRunning) {
-      return m(DataExplorerEmptyState, {}, [
+      return m(ResultsPanelEmptyState, {}, [
         m('span.pf-status-indicator', 'Queued...'),
         m(Spinner, {easing: true}),
       ]);
@@ -605,7 +605,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       !attrs.isAnalyzing
     ) {
       return m(
-        DataExplorerEmptyState,
+        ResultsPanelEmptyState,
         {},
         m(Button, {
           label: 'Run Query',
@@ -621,7 +621,7 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     // Show spinner when analyzing or when no response is available yet
     // (for autoExecute=true nodes that haven't run yet)
     if (!attrs.response || attrs.isAnalyzing) {
-      return m(DataExplorerEmptyState, {}, m(Spinner, {easing: true}));
+      return m(ResultsPanelEmptyState, {}, m(Spinner, {easing: true}));
     }
 
     return null;

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_builder/widgets.ts
@@ -66,22 +66,22 @@ export function RoundActionButton(attrs: RoundActionButtonAttrs) {
 }
 
 // Empty state widget for the data explorer with warning variant support
-export type DataExplorerEmptyStateVariant = 'default' | 'warning';
+export type ResultsPanelEmptyStateVariant = 'default' | 'warning';
 
-export interface DataExplorerEmptyStateAttrs {
+export interface ResultsPanelEmptyStateAttrs {
   readonly icon?: string;
   readonly title?: string;
-  readonly variant?: DataExplorerEmptyStateVariant;
+  readonly variant?: ResultsPanelEmptyStateVariant;
 }
 
-export class DataExplorerEmptyState
-  implements m.ClassComponent<DataExplorerEmptyStateAttrs>
+export class ResultsPanelEmptyState
+  implements m.ClassComponent<ResultsPanelEmptyStateAttrs>
 {
-  view({attrs, children}: m.CVnode<DataExplorerEmptyStateAttrs>) {
+  view({attrs, children}: m.CVnode<ResultsPanelEmptyStateAttrs>) {
     const {icon, title, variant = 'default'} = attrs;
 
     return m(
-      '.pf-data-explorer-empty-state',
+      '.pf-results-panel-empty-state',
       {
         className: classNames(variant === 'warning' && 'pf-warning'),
       },
@@ -90,7 +90,7 @@ export class DataExplorerEmptyState
           className: 'pf-data-explorer-empty-state__icon',
           icon,
         }),
-      title && m('.pf-data-explorer-empty-state__message', title),
+      title && m('.pf-results-panel-empty-state__message', title),
       children,
     );
   }

--- a/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/query_node.ts
@@ -181,9 +181,9 @@ export interface QueryNode {
   serializeState(): object;
   onPrevNodesUpdated?(): void;
 
-  // Optional custom data explorer for the bottom drawer panel.
-  // If provided, Builder renders this instead of the standard DataExplorer.
-  customDataExplorer?(): m.Children;
+  // Optional custom results panel for the bottom drawer panel.
+  // If provided, Builder renders this instead of the standard ResultsPanel.
+  customResultsPanel?(): m.Children;
 }
 
 export interface Query {

--- a/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
+++ b/ui/src/plugins/dev.perfetto.ExplorePage/styles.scss
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 @import "./query_builder/builder.scss";
-@import "./query_builder/data_explorer.scss";
+@import "./query_builder/results_panel.scss";
 
 .pf-explore-page {
   height: 100%;
@@ -194,7 +194,7 @@
   }
 }
 
-// Chart view container (for DataExplorer integration)
+// Chart view container (for ResultsPanel integration)
 .pf-chart-view {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Absolutely noop rename from data_explorer (the bottom panel) to results_panel. A prework to rename the plugin DataExplorer