### PR TITLE
ui: Improve checkbox appearance

### DIFF
--- a/ui/src/assets/widgets/checkbox.scss
+++ b/ui/src/assets/widgets/checkbox.scss
@@ -14,34 +14,14 @@
 
 @import "../theme";
 
-// This checkbox element is expected to contain a checkbox type input followed
-// by an empty span element.
-// The input is completely hidden and an entirely new checkbox is drawn inside
-// the span element. This allows us to style it how we like, and also add some
-// fancy transitions.
-// The box of the checkbox is a fixed sized span element. The tick is also a
-// fixed sized rectange rotated 45 degrees with only the bottom and right
-// borders visible.
-// When unchecked, the tick size and border width is 0, so the tick is
-// completely invsible. When we transition to checked, the border size on the
-// bottom and right sides is immmdiately set to full width, and the tick morphs
-// into view first by expanding along the x axis first, then expanding up the
-// y-axis. This has the effect of making the tick look like it's being drawn
-// onto the page with a pen.
-// When transitioning from checked to unchecked, the animation plays in reverse,
-// and the border width is set to 0 right at the end in order to make the tick
-// completely invisible again.
+// Custom checkbox element: a hidden native input followed by a styled span.
+// The tick is an inline SVG path, which gives crisp antialiased rendering at
+// any size. The switch variant uses CSS for the sliding thumb.
 
-$box-label-padding: 0.33em;
+$box-label-padding: 0.5em;
 
 .pf-checkbox {
-  $tick-anim-time-width: 100ms;
-  $tick-anim-time-height: 150ms;
-  $tick-anim-time: $tick-anim-time-width + $tick-anim-time-height;
-  $tick-easing: linear;
-
-  $tick-height: 0.55em;
-  $tick-width: 0.3em;
+  $tick-anim-time: 200ms;
 
   display: inline;
   align-items: baseline;
@@ -58,16 +38,10 @@ $box-label-padding: 0.33em;
 
   &__box {
     display: inline-block;
-    position: relative; // Align ::after to this box
+    position: relative;
     top: -0.1em;
     vertical-align: middle;
     height: 1em;
-    transition: background $anim-timing;
-
-    &:after {
-      content: "";
-      position: absolute;
-    }
   }
 
   input:focus-visible + .pf-checkbox__box {
@@ -89,29 +63,21 @@ $box-label-padding: 0.33em;
   }
 
   // 'Check' style checkbox
-
   &__box--check {
     aspect-ratio: 1;
     border-radius: $border-radius;
-    border: solid 2px currentColor;
+    border: solid 1px currentColor;
     background: none;
+    position: relative;
+  }
 
-    // The :after element forms the "tick" of the checkbox
-    &:after {
-      bottom: 0.4em;
-      left: 0em;
-      width: 0px;
-      height: 0px;
-      border-color: var(--pf-color-text-on-primary);
-      border-style: solid;
-      border-width: 0;
-      transform-origin: 0% 100%; // Put the origin at the short edge of the tick
-      transform: rotate(45deg);
-      transition:
-        height $tick-anim-time-height $tick-easing,
-        width $tick-anim-time-width $tick-anim-time-height $tick-easing,
-        border-width 0ms $tick-anim-time;
-    }
+  &__tick {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    color: var(--pf-color-text-on-primary);
+    opacity: 0;
   }
 
   &:hover .pf-checkbox__box--check {
@@ -123,14 +89,8 @@ $box-label-padding: 0.33em;
     background: var(--pf-color-primary);
   }
 
-  input:checked + .pf-checkbox__box--check:after {
-    width: $tick-width;
-    height: $tick-height;
-    border-width: 0 0.15em 0.15em 0;
-    transition:
-      width $tick-anim-time-height $tick-easing,
-      height $tick-anim-time-height $tick-anim-time-width $tick-easing,
-      border-width 0ms;
+  input:checked + .pf-checkbox__box--check .pf-checkbox__tick {
+    opacity: 1;
   }
 
   // 'Switch' style checkbox

--- a/ui/src/widgets/checkbox.ts
+++ b/ui/src/widgets/checkbox.ts
@@ -50,12 +50,26 @@ export class Checkbox implements m.ClassComponent<CheckboxAttrs> {
       },
       labelLeft !== undefined && m('span.pf-checkbox__label-left', labelLeft),
       m('input[type=checkbox]', {disabled, checked}),
-      m('span.pf-checkbox__box', {
-        className:
-          variant === 'switch'
-            ? 'pf-checkbox__box--switch'
-            : 'pf-checkbox__box--check',
-      }),
+      variant === 'switch'
+        ? m('span.pf-checkbox__box.pf-checkbox__box--switch')
+        : m(
+            'span.pf-checkbox__box.pf-checkbox__box--check',
+            m(
+              'svg.pf-checkbox__tick',
+              {
+                viewBox: '0 0 12 12',
+                fill: 'none',
+                xmlns: 'http://www.w3.org/2000/svg',
+              },
+              m('path', {
+                'd': 'M2.5 6.5L5 9L9.5 3.5',
+                'stroke': 'currentColor',
+                'stroke-width': '2',
+                'stroke-linecap': 'round',
+                'stroke-linejoin': 'round',
+              }),
+            ),
+          ),
       label !== undefined && m('span.pf-checkbox__label', label),
     );
   }


### PR DESCRIPTION
- Use an SVG for the tick instead of a div, scales better to different font sizes and zoom levels.
- Remove the elaborate animations.
- Thinner borders on unchecked box.

<img width="121" height="47" alt="image" src="https://github.com/user-attachments/assets/eacac297-03fc-41c6-a5d8-08723812babd" />
<img width="125" height="43" alt="image" src="https://github.com/user-attachments/assets/c5da1002-a2de-4274-af21-ac9b5c61053f" />
