### PR TITLE
docs: add filter chips and spruce up visual language

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -1,27 +1,17 @@
-- [Getting started](#)
+- [Overview](#)
 
   - [What is Perfetto?](README.md)
   - [What is Tracing?](tracing-101.md)
   - [How do I start using Perfetto?](getting-started/start-using-perfetto.md)
 
+- [For Android](#)
+
   - [Tutorials](#)
 
-    - [Full-Stack Perfetto](#)
-
-      - [System Tracing](getting-started/system-tracing.md)
-      - [In-App Tracing](getting-started/in-app-tracing.md)
-      - [Memory Profiling](getting-started/memory-profiling.md)
-      - [CPU Profiling](getting-started/cpu-profiling.md)
-
-    - [Adding Tracepoints](#)
-
-      - [Android atrace](getting-started/atrace.md)
-      - [Linux ftrace](getting-started/ftrace.md)
-
-    - [Non-Perfetto Trace Analysis](#)
-
-      - [Supported trace formats](getting-started/other-formats.md)
-      - [Converting to Perfetto](getting-started/converting.md)
+    - [System Tracing](getting-started/system-tracing.md)
+    - [Instrumenting with atrace](getting-started/atrace.md)
+    - [Memory Profiling](getting-started/memory-profiling.md)
+    - [CPU Profiling](getting-started/cpu-profiling.md)
 
   - [Cookbooks](#)
 
@@ -30,29 +20,10 @@
 
   - [Case Studies](#)
 
-    - [Android Memory Usage](case-studies/memory.md)
-    - [Scheduling blockages](case-studies/scheduling-blockages.md)
-
-- [Learning more](#)
-
-  - [Concepts](#)
-
-    - [Trace configuration](concepts/config.md)
-    - [Buffers and dataflow](concepts/buffers.md)
-    - [Service model](concepts/service-model.md)
-    - [Clock synchronization](concepts/clock-sync.md)
-
-  - [Trace Recording](#)
-
-    - [Tracing in Background](learning-more/tracing-in-background.md)
-    - [More Android tracing](learning-more/android.md)
-    - [Chrome Tracing](getting-started/chrome-tracing.md)
-    - [Symbolization and deobfuscation](learning-more/symbolization.md)
-
-  - [Trace Instrumentation](#)
-
-    - [Tracing SDK](instrumentation/tracing-sdk.md)
-    - [Track Event](instrumentation/track-events.md)
+    - [Debugging Memory Usage](case-studies/memory.md)
+    - [Scheduling Blockages](case-studies/scheduling-blockages.md)
+    - [Boot Tracing](case-studies/android-boot-tracing.md)
+    - [OutOfMemoryError](case-studies/android-outofmemoryerror.md)
 
   - [Trace Analysis](#)
 
@@ -67,9 +38,11 @@
       - [Trace Processor (C++)](analysis/trace-processor.md)
       - [Trace Processor (Python)](analysis/trace-processor-python.md)
     - [Trace Summarization](analysis/trace-summary.md)
+    - [Batch Trace Processor](analysis/batch-trace-processor.md)
+    - [Legacy (v1) Metrics](analysis/metrics.md)
     - [Converting from Perfetto](quickstart/traceconv.md)
 
-  - [Trace Visualization](#)
+  - [Visualization](#)
 
     - [Perfetto UI](visualization/perfetto-ui.md)
     - [Opening large traces](visualization/large-traces.md)
@@ -82,125 +55,313 @@
       - [Commands and Macros](visualization/ui-automation.md)
       - [Extension Servers](visualization/extension-servers.md)
 
-  - [Contributing](#)
+  - [Reference](#)
 
-    - [Getting started](contributing/getting-started.md)
-    - [Common tasks](contributing/common-tasks.md)
-    - [Become a committer](contributing/become-a-committer.md)
-    - [UI](#)
+    - [Data Sources](#)
 
-      - [Getting started](contributing/ui-getting-started.md)
-      - [Plugins](contributing/ui-plugins.md)
-
-  - [FAQ](faq.md)
-
-- [Diving deep](#)
-
-  - [Data sources](#)
-
-    - [Memory Data sources](#)
-
-      - [Native Heap profiler](data-sources/native-heap-profiler.md)
-      - [Java heap dumps](data-sources/java-heap-profiler.md)
-      - [Counters and events](data-sources/memory-counters.md)
-
-    - [Ftrace Data Sources](#)
-
-      - [Scheduling events](data-sources/cpu-scheduling.md)
-      - [System calls](data-sources/syscalls.md)
-      - [Frequency scaling](data-sources/cpu-freq.md)
-
-    - [Android Data Sources](#)
-
-      - [Android Aflags](data-sources/android-aflags.md)
-      - [Atrace](data-sources/atrace.md)
-      - [Battery counters and rails](data-sources/battery-counters.md)
-      - [Frame Timeline](data-sources/frametimeline.md)
+      - [CPU Scheduling](data-sources/cpu-scheduling.md)
+      - [ATrace](data-sources/atrace.md)
       - [Logcat](data-sources/android-log.md)
-      - [Other data sources](data-sources/android-game-intervention-list.md)
+      - [Frame Timeline](data-sources/frametimeline.md)
+      - [Memory Counters](data-sources/memory-counters.md)
+      - [Native Heap Profiler](data-sources/native-heap-profiler.md)
+      - [Java Heap Dumps](data-sources/java-heap-profiler.md)
+      - [Battery & Power](data-sources/battery-counters.md)
+      - [GPU & Game Data](data-sources/android-game-intervention-list.md)
 
-  - [Trace Format Reference](#)
+    - [CLI Tools](#)
 
-    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
-    - [Advanced Programmatic Generation](reference/synthetic-track-event.md)
-
-  - [Advanced Trace Recording](#)
-
-    - [Trace Config Proto](reference/trace-config-proto.autogen)
-    - [Concurrent tracing sessions](concepts/concurrent-tracing-sessions.md)
-    - [Detached mode](concepts/detached-mode.md)
-
-    - [Android](#)
-
-      - [Boot Tracing](case-studies/android-boot-tracing.md)
-      - [OutOfMemoryError](case-studies/android-outofmemoryerror.md)
-      - [Android Version Notes](reference/android-version-notes.md)
-
-    - [Linux](#)
-
-      - [Kernel track events](reference/kernel-track-event.md)
-      - [Tracing across reboots](data-sources/previous-boot-trace.md)
-
-    - [Command Line Reference](#)
-
-      - [perfetto_cmd](reference/perfetto-cli.md)
+      - [perfetto](reference/perfetto-cli.md)
       - [traced](reference/traced.md)
       - [traced_probes](reference/traced_probes.md)
-      - [heap_profile cmdline](reference/heap_profile-cli.md)
+      - [heap_profile](reference/heap_profile-cli.md)
       - [tracebox](reference/tracebox.md)
-
-  - [Advanced Trace Analysis](#)
 
     - [PerfettoSQL](#)
 
-      - [Prelude tables](analysis/sql-tables.autogen)
-      - [Built-ins](analysis/builtin.md)
-      - [Stats Table Reference](analysis/sql-stats.autogen)
+      - [Prelude Tables](analysis/sql-tables.autogen)
+      - [Built-in Functions](analysis/builtin.md)
+      - [Stats Table](analysis/sql-stats.autogen)
 
-    - [Single Trace Analysis](#)
+    - [Trace Config Proto](reference/trace-config-proto.autogen)
+    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
+    - [Synthetic Track Events](reference/synthetic-track-event.md)
+    - [Android Version Notes](reference/android-version-notes.md)
+    - [Commands Reference](visualization/commands-automation-reference.md)
+    - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md)
+    - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md)
 
-      - [Legacy (v1) Metrics](analysis/metrics.md)
+  - [Concepts](#)
 
-    - [Multi Trace Analysis](#)
+    - [Trace Configuration](concepts/config.md)
+    - [Buffers and Dataflow](concepts/buffers.md)
+    - [Service Model](concepts/service-model.md)
+    - [Clock Synchronization](concepts/clock-sync.md)
+    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md)
+    - [Detached Mode](concepts/detached-mode.md)
+    - [Tracing in Background](learning-more/tracing-in-background.md)
+    - [More Android Tracing](learning-more/android.md)
 
-      - [Batch Trace Processor](analysis/batch-trace-processor.md)
-      - [Bigtrace](deployment/deploying-bigtrace-on-a-single-machine.md)
-      - [Bigtrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md)
+  - [FAQ](faq.md)
 
-  - [Advanced Perfetto SDK](#)
+- [For Linux](#)
 
+  - [Tutorials](#)
+
+    - [System Tracing](getting-started/system-tracing.md)
+    - [Linux ftrace](getting-started/ftrace.md)
+    - [CPU Profiling](getting-started/cpu-profiling.md)
+    - [Memory Profiling](getting-started/memory-profiling.md)
+
+  - [Trace Analysis](#)
+
+    - [Getting Started](analysis/getting-started.md)
+    - [PerfettoSQL](#)
+      - [Getting Started](analysis/perfetto-sql-getting-started.md)
+      - [Standard Library](analysis/stdlib-docs.autogen)
+      - [Syntax](analysis/perfetto-sql-syntax.md)
+      - [Style Guide](analysis/style-guide.md)
+      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md)
+    - [Trace Processor](#)
+      - [Trace Processor (C++)](analysis/trace-processor.md)
+      - [Trace Processor (Python)](analysis/trace-processor-python.md)
+    - [Trace Summarization](analysis/trace-summary.md)
+    - [Batch Trace Processor](analysis/batch-trace-processor.md)
+    - [Legacy (v1) Metrics](analysis/metrics.md)
+    - [Converting from Perfetto](quickstart/traceconv.md)
+
+  - [Visualization](#)
+
+    - [Perfetto UI](visualization/perfetto-ui.md)
+    - [Opening Large Traces](visualization/large-traces.md)
+    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
+    - [Debug Tracks](analysis/debug-tracks.md)
+    - [UI Automation](visualization/ui-automation.md)
+
+  - [Reference](#)
+
+    - [Data Sources](#)
+
+      - [CPU Scheduling](data-sources/cpu-scheduling.md)
+      - [System Calls](data-sources/syscalls.md)
+      - [CPU Frequency](data-sources/cpu-freq.md)
+      - [Memory Counters](data-sources/memory-counters.md)
+      - [Native Heap Profiler](data-sources/native-heap-profiler.md)
+
+    - [CLI Tools](#)
+
+      - [perfetto](reference/perfetto-cli.md)
+      - [traced](reference/traced.md)
+      - [traced_probes](reference/traced_probes.md)
+      - [heap_profile](reference/heap_profile-cli.md)
+      - [tracebox](reference/tracebox.md)
+
+    - [PerfettoSQL](#)
+
+      - [Prelude Tables](analysis/sql-tables.autogen)
+      - [Built-in Functions](analysis/builtin.md)
+      - [Stats Table](analysis/sql-stats.autogen)
+
+    - [Kernel Track Events](reference/kernel-track-event.md)
+    - [Tracing across Reboots](data-sources/previous-boot-trace.md)
+    - [Trace Config Proto](reference/trace-config-proto.autogen)
+    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
+    - [Synthetic Track Events](reference/synthetic-track-event.md)
+    - [Commands Reference](visualization/commands-automation-reference.md)
+    - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md)
+    - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md)
+
+  - [Concepts](#)
+
+    - [Trace Configuration](concepts/config.md)
+    - [Buffers and Dataflow](concepts/buffers.md)
+    - [Service Model](concepts/service-model.md)
+    - [Clock Synchronization](concepts/clock-sync.md)
+    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md)
+    - [Detached Mode](concepts/detached-mode.md)
+
+  - [FAQ](faq.md)
+
+- [For C/C++](#)
+
+  - [Tutorials](#)
+
+    - [In-App Tracing](getting-started/in-app-tracing.md)
+
+  - [Tracing SDK](#)
+
+    - [Tracing SDK](instrumentation/tracing-sdk.md)
+    - [Track Events](instrumentation/track-events.md)
     - [Interceptors](instrumentation/interceptors.md)
 
-  - [Advanced Trace Visualization](#)
+  - [Trace Analysis](#)
 
     - [Commands Automation Reference](visualization/commands-automation-reference.md)
     - [Extension Server Protocol](visualization/extension-server-protocol.md)
 
-  - [Contributor Reference](#)
+  - [Visualization](#)
 
+    - [Perfetto UI](visualization/perfetto-ui.md)
+    - [Opening Large Traces](visualization/large-traces.md)
+    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
+    - [Debug Tracks](analysis/debug-tracks.md)
+    - [UI Automation](visualization/ui-automation.md)
+
+  - [Reference](#)
+
+    - [PerfettoSQL](#)
+
+      - [Prelude Tables](analysis/sql-tables.autogen)
+      - [Built-in Functions](analysis/builtin.md)
+      - [Stats Table](analysis/sql-stats.autogen)
+
+    - [Trace Config Proto](reference/trace-config-proto.autogen)
+    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
+    - [Synthetic Track Events](reference/synthetic-track-event.md)
+    - [Commands Reference](visualization/commands-automation-reference.md)
+
+  - [Concepts](#)
+
+    - [Trace Configuration](concepts/config.md)
+    - [Buffers and Dataflow](concepts/buffers.md)
+    - [Service Model](concepts/service-model.md)
+    - [Clock Synchronization](concepts/clock-sync.md)
+
+  - [FAQ](faq.md)
+
+- [For Chrome](#)
+
+  - [Tutorials](#)
+
+    - [Recording Chrome Traces](getting-started/chrome-tracing.md)
+
+  - [Trace Analysis](#)
+
+    - [Getting Started](analysis/getting-started.md)
+    - [PerfettoSQL](#)
+      - [Getting Started](analysis/perfetto-sql-getting-started.md)
+      - [Standard Library](analysis/stdlib-docs.autogen)
+      - [Syntax](analysis/perfetto-sql-syntax.md)
+      - [Style Guide](analysis/style-guide.md)
+      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md)
+    - [Trace Processor](#)
+      - [Trace Processor (C++)](analysis/trace-processor.md)
+      - [Trace Processor (Python)](analysis/trace-processor-python.md)
+    - [Trace Summarization](analysis/trace-summary.md)
+    - [Batch Trace Processor](analysis/batch-trace-processor.md)
+    - [Legacy (v1) Metrics](analysis/metrics.md)
+    - [Converting from Perfetto](quickstart/traceconv.md)
+
+  - [Visualization](#)
+
+    - [Perfetto UI](visualization/perfetto-ui.md)
+    - [Opening Large Traces](visualization/large-traces.md)
+    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
+    - [Debug Tracks](analysis/debug-tracks.md)
+    - [UI Automation](visualization/ui-automation.md)
+
+  - [Reference](#)
+
+    - [PerfettoSQL](#)
+
+      - [Prelude Tables](analysis/sql-tables.autogen)
+      - [Built-in Functions](analysis/builtin.md)
+      - [Stats Table](analysis/sql-stats.autogen)
+
+    - [Trace Config Proto](reference/trace-config-proto.autogen)
+    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
+    - [Synthetic Track Events](reference/synthetic-track-event.md)
+    - [Commands Reference](visualization/commands-automation-reference.md)
+
+  - [Concepts](#)
+
+    - [Trace Configuration](concepts/config.md)
+    - [Clock Synchronization](concepts/clock-sync.md)
+
+  - [FAQ](faq.md)
+
+- [For Performance Engineers](#)
+
+  - [Getting Started](#)
+
+    - [Importing Other Formats](getting-started/other-formats.md)
+    - [Converting Data to Perfetto](getting-started/converting.md)
+
+  - [Trace Analysis](#)
+
+    - [Getting Started](analysis/getting-started.md)
+    - [PerfettoSQL](#)
+      - [Getting Started](analysis/perfetto-sql-getting-started.md)
+      - [Standard Library](analysis/stdlib-docs.autogen)
+      - [Syntax](analysis/perfetto-sql-syntax.md)
+      - [Style Guide](analysis/style-guide.md)
+      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md)
+    - [Trace Processor](#)
+      - [Trace Processor (C++)](analysis/trace-processor.md)
+      - [Trace Processor (Python)](analysis/trace-processor-python.md)
+    - [Trace Summarization](analysis/trace-summary.md)
+    - [Batch Trace Processor](analysis/batch-trace-processor.md)
+    - [Legacy (v1) Metrics](analysis/metrics.md)
+    - [Converting from Perfetto](quickstart/traceconv.md)
+
+  - [Visualization](#)
+
+    - [Perfetto UI](visualization/perfetto-ui.md)
+    - [Opening Large Traces](visualization/large-traces.md)
+    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
+    - [Debug Tracks](analysis/debug-tracks.md)
+    - [UI Automation](visualization/ui-automation.md)
+
+  - [Reference](#)
+
+    - [PerfettoSQL](#)
+
+      - [Prelude Tables](analysis/sql-tables.autogen)
+      - [Built-in Functions](analysis/builtin.md)
+      - [Stats Table](analysis/sql-stats.autogen)
+
+    - [Synthetic Track Events](reference/synthetic-track-event.md)
+    - [Trace Config Proto](reference/trace-config-proto.autogen)
+    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
+    - [Commands Reference](visualization/commands-automation-reference.md)
+
+  - [FAQ](faq.md)
+
+- [For Contributors](#)
+
+  - [Development](#)
+
+    - [Getting Started](contributing/getting-started.md)
+    - [Common Tasks](contributing/common-tasks.md)
     - [Building](contributing/build-instructions.md)
     - [Testing](contributing/testing.md)
-    - [Developer tools](contributing/developer-tools.md)
+    - [Developer Tools](contributing/developer-tools.md)
+    - [Become a Committer](contributing/become-a-committer.md)
 
-  - [Team documentation](#)
+  - [UI Development](#)
 
-    - [SDK release process](contributing/sdk-releasing.md)
-    - [Python release process](contributing/python-releasing.md)
-    - [UI release process](visualization/perfetto-ui-release-process.md)
-    - [Chrome branches](contributing/chrome-branches.md)
-    - [SQLite upgrade guide](contributing/sqlite-upgrade-guide.md)
+    - [Getting Started](contributing/ui-getting-started.md)
+    - [Plugins](contributing/ui-plugins.md)
 
-    - [Design documents](#)
-      - [API and ABI surface](design-docs/api-and-abi.md)
-      - [Life of a tracing session](design-docs/life-of-a-tracing-session.md)
-      - [ProtoZero](design-docs/protozero.md)
-      - [Security model](design-docs/security-model.md)
-      - [Statsd Checkpoint Atoms](design-docs/checkpoint-atoms.md)
-      - [Batch Trace Processor](design-docs/batch-trace-processor.md)
-      - [Trace Processor Architecture](design-docs/trace-processor-architecture.md)
-      - [Heapprofd design](design-docs/heapprofd-design.md)
-      - [Heapprofd wire protocol](design-docs/heapprofd-wire-protocol.md)
-      - [Heapprofd sampling](design-docs/heapprofd-sampling.md)
-      - [Perfetto CI](design-docs/continuous-integration.md)
-      - [LockFreeTaskRunner](design-docs/lock-free-task-runner.md)
+  - [Releases](#)
 
+    - [SDK Release](contributing/sdk-releasing.md)
+    - [Python Release](contributing/python-releasing.md)
+    - [UI Release](visualization/perfetto-ui-release-process.md)
+    - [Chrome Branches](contributing/chrome-branches.md)
+    - [SQLite Upgrade](contributing/sqlite-upgrade-guide.md)
+
+  - [Design Documents](#)
+
+    - [API and ABI Surface](design-docs/api-and-abi.md)
+    - [Life of a Tracing Session](design-docs/life-of-a-tracing-session.md)
+    - [ProtoZero](design-docs/protozero.md)
+    - [Security Model](design-docs/security-model.md)
+    - [Trace Processor Architecture](design-docs/trace-processor-architecture.md)
+    - [Heapprofd Design](design-docs/heapprofd-design.md)
+    - [Heapprofd Wire Protocol](design-docs/heapprofd-wire-protocol.md)
+    - [Heapprofd Sampling](design-docs/heapprofd-sampling.md)
+    - [Batch Trace Processor](design-docs/batch-trace-processor.md)
+    - [Statsd Checkpoint Atoms](design-docs/checkpoint-atoms.md)
+    - [Perfetto CI](design-docs/continuous-integration.md)
+    - [LockFreeTaskRunner](design-docs/lock-free-task-runner.md)

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -4,364 +4,163 @@
   - [What is Tracing?](tracing-101.md)
   - [How do I start using Perfetto?](getting-started/start-using-perfetto.md)
 
-- [For Android](#)
+- [Getting Started](#)
 
   - [Tutorials](#)
 
-    - [System Tracing](getting-started/system-tracing.md)
-    - [Instrumenting with atrace](getting-started/atrace.md)
-    - [Memory Profiling](getting-started/memory-profiling.md)
-    - [CPU Profiling](getting-started/cpu-profiling.md)
+    - [System Tracing](getting-started/system-tracing.md) `android linux`
+    - [In-App Tracing](getting-started/in-app-tracing.md) `cpp`
+    - [Memory Profiling](getting-started/memory-profiling.md) `android linux`
+    - [CPU Profiling](getting-started/cpu-profiling.md) `android linux`
+    - [Instrumenting with atrace](getting-started/atrace.md) `android`
+    - [Linux ftrace](getting-started/ftrace.md) `linux`
+    - [Recording Chrome Traces](getting-started/chrome-tracing.md) `chrome`
+    - [Importing Other Formats](getting-started/other-formats.md) `perf`
+    - [Converting Data to Perfetto](getting-started/converting.md) `perf`
 
   - [Cookbooks](#)
 
-    - [Analysing Android Traces](getting-started/android-trace-analysis.md)
-    - [Periodic Trace Snapshots](getting-started/periodic-trace-snapshots.md)
+    - [Analysing Android Traces](getting-started/android-trace-analysis.md) `android`
+    - [Periodic Trace Snapshots](getting-started/periodic-trace-snapshots.md) `android`
 
   - [Case Studies](#)
 
-    - [Debugging Memory Usage](case-studies/memory.md)
-    - [Scheduling Blockages](case-studies/scheduling-blockages.md)
-    - [Boot Tracing](case-studies/android-boot-tracing.md)
-    - [OutOfMemoryError](case-studies/android-outofmemoryerror.md)
+    - [Debugging Memory Usage](case-studies/memory.md) `android`
+    - [Scheduling Blockages](case-studies/scheduling-blockages.md) `android linux`
+    - [Boot Tracing](case-studies/android-boot-tracing.md) `android`
+    - [OutOfMemoryError](case-studies/android-outofmemoryerror.md) `android`
 
-  - [Trace Analysis](#)
+  - [Contributing](#)
 
-    - [Getting Started](analysis/getting-started.md)
-    - [PerfettoSQL](#)
-      - [Getting Started](analysis/perfetto-sql-getting-started.md)
-      - [Standard Library](analysis/stdlib-docs.autogen)
-      - [Syntax](analysis/perfetto-sql-syntax.md)
-      - [Style Guide](analysis/style-guide.md)
-      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md)
-    - [Trace Processor](#)
-      - [Trace Processor (C++)](analysis/trace-processor.md)
-      - [Trace Processor (Python)](analysis/trace-processor-python.md)
-    - [Trace Summarization](analysis/trace-summary.md)
-    - [Batch Trace Processor](analysis/batch-trace-processor.md)
-    - [Legacy (v1) Metrics](analysis/metrics.md)
-    - [Converting from Perfetto](quickstart/traceconv.md)
+    - [Getting Started](contributing/getting-started.md) `contrib`
+    - [Common Tasks](contributing/common-tasks.md) `contrib`
 
-  - [Visualization](#)
-
-    - [Perfetto UI](visualization/perfetto-ui.md)
-    - [Opening large traces](visualization/large-traces.md)
-    - [Deep linking](visualization/deep-linking-to-perfetto-ui.md)
-    - [Debug tracks](analysis/debug-tracks.md)
-
-    - [Extending the UI](#)
-
-      - [Overview](visualization/extending-the-ui.md)
-      - [Commands and Macros](visualization/ui-automation.md)
-      - [Extension Servers](visualization/extension-servers.md)
-
-  - [Reference](#)
-
-    - [Data Sources](#)
-
-      - [CPU Scheduling](data-sources/cpu-scheduling.md)
-      - [ATrace](data-sources/atrace.md)
-      - [Logcat](data-sources/android-log.md)
-      - [Frame Timeline](data-sources/frametimeline.md)
-      - [Memory Counters](data-sources/memory-counters.md)
-      - [Native Heap Profiler](data-sources/native-heap-profiler.md)
-      - [Java Heap Dumps](data-sources/java-heap-profiler.md)
-      - [Battery & Power](data-sources/battery-counters.md)
-      - [GPU & Game Data](data-sources/android-game-intervention-list.md)
-
-    - [CLI Tools](#)
-
-      - [perfetto](reference/perfetto-cli.md)
-      - [traced](reference/traced.md)
-      - [traced_probes](reference/traced_probes.md)
-      - [heap_profile](reference/heap_profile-cli.md)
-      - [tracebox](reference/tracebox.md)
-
-    - [PerfettoSQL](#)
-
-      - [Prelude Tables](analysis/sql-tables.autogen)
-      - [Built-in Functions](analysis/builtin.md)
-      - [Stats Table](analysis/sql-stats.autogen)
-
-    - [Trace Config Proto](reference/trace-config-proto.autogen)
-    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
-    - [Synthetic Track Events](reference/synthetic-track-event.md)
-    - [Android Version Notes](reference/android-version-notes.md)
-    - [Commands Reference](visualization/commands-automation-reference.md)
-    - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md)
-    - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md)
+- [Learning More](#)
 
   - [Concepts](#)
 
-    - [Trace Configuration](concepts/config.md)
-    - [Buffers and Dataflow](concepts/buffers.md)
-    - [Service Model](concepts/service-model.md)
-    - [Clock Synchronization](concepts/clock-sync.md)
-    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md)
-    - [Detached Mode](concepts/detached-mode.md)
-    - [Tracing in Background](learning-more/tracing-in-background.md)
-    - [More Android Tracing](learning-more/android.md)
-
-  - [FAQ](faq.md)
-
-- [For Linux](#)
-
-  - [Tutorials](#)
-
-    - [System Tracing](getting-started/system-tracing.md)
-    - [Linux ftrace](getting-started/ftrace.md)
-    - [CPU Profiling](getting-started/cpu-profiling.md)
-    - [Memory Profiling](getting-started/memory-profiling.md)
-
-  - [Trace Analysis](#)
-
-    - [Getting Started](analysis/getting-started.md)
-    - [PerfettoSQL](#)
-      - [Getting Started](analysis/perfetto-sql-getting-started.md)
-      - [Standard Library](analysis/stdlib-docs.autogen)
-      - [Syntax](analysis/perfetto-sql-syntax.md)
-      - [Style Guide](analysis/style-guide.md)
-      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md)
-    - [Trace Processor](#)
-      - [Trace Processor (C++)](analysis/trace-processor.md)
-      - [Trace Processor (Python)](analysis/trace-processor-python.md)
-    - [Trace Summarization](analysis/trace-summary.md)
-    - [Batch Trace Processor](analysis/batch-trace-processor.md)
-    - [Legacy (v1) Metrics](analysis/metrics.md)
-    - [Converting from Perfetto](quickstart/traceconv.md)
-
-  - [Visualization](#)
-
-    - [Perfetto UI](visualization/perfetto-ui.md)
-    - [Opening Large Traces](visualization/large-traces.md)
-    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
-    - [Debug Tracks](analysis/debug-tracks.md)
-    - [UI Automation](visualization/ui-automation.md)
-
-  - [Reference](#)
-
-    - [Data Sources](#)
-
-      - [CPU Scheduling](data-sources/cpu-scheduling.md)
-      - [System Calls](data-sources/syscalls.md)
-      - [CPU Frequency](data-sources/cpu-freq.md)
-      - [Memory Counters](data-sources/memory-counters.md)
-      - [Native Heap Profiler](data-sources/native-heap-profiler.md)
-
-    - [CLI Tools](#)
-
-      - [perfetto](reference/perfetto-cli.md)
-      - [traced](reference/traced.md)
-      - [traced_probes](reference/traced_probes.md)
-      - [heap_profile](reference/heap_profile-cli.md)
-      - [tracebox](reference/tracebox.md)
-
-    - [PerfettoSQL](#)
-
-      - [Prelude Tables](analysis/sql-tables.autogen)
-      - [Built-in Functions](analysis/builtin.md)
-      - [Stats Table](analysis/sql-stats.autogen)
-
-    - [Kernel Track Events](reference/kernel-track-event.md)
-    - [Tracing across Reboots](data-sources/previous-boot-trace.md)
-    - [Trace Config Proto](reference/trace-config-proto.autogen)
-    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
-    - [Synthetic Track Events](reference/synthetic-track-event.md)
-    - [Commands Reference](visualization/commands-automation-reference.md)
-    - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md)
-    - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md)
-
-  - [Concepts](#)
-
-    - [Trace Configuration](concepts/config.md)
-    - [Buffers and Dataflow](concepts/buffers.md)
-    - [Service Model](concepts/service-model.md)
-    - [Clock Synchronization](concepts/clock-sync.md)
-    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md)
-    - [Detached Mode](concepts/detached-mode.md)
-
-  - [FAQ](faq.md)
-
-- [For C/C++](#)
-
-  - [Tutorials](#)
-
-    - [In-App Tracing](getting-started/in-app-tracing.md)
+    - [Trace Configuration](concepts/config.md) `android linux cpp chrome`
+    - [Buffers and Dataflow](concepts/buffers.md) `android linux cpp`
+    - [Service Model](concepts/service-model.md) `android linux cpp`
+    - [Clock Synchronization](concepts/clock-sync.md) `android linux cpp chrome`
+    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) `android linux cpp`
+    - [Tracing in Background](learning-more/tracing-in-background.md) `android linux`
+    - [More Android Tracing](learning-more/android.md) `android`
 
   - [Tracing SDK](#)
 
-    - [Tracing SDK](instrumentation/tracing-sdk.md)
-    - [Track Events](instrumentation/track-events.md)
-    - [Interceptors](instrumentation/interceptors.md)
+    - [Tracing SDK](instrumentation/tracing-sdk.md) `cpp`
+    - [Track Events](instrumentation/track-events.md) `cpp`
 
   - [Trace Analysis](#)
 
-    - [Commands Automation Reference](visualization/commands-automation-reference.md)
-    - [Extension Server Protocol](visualization/extension-server-protocol.md)
+    - [Getting Started](analysis/getting-started.md) `android linux cpp chrome perf`
+    - [PerfettoSQL Getting Started](analysis/perfetto-sql-getting-started.md) `android linux cpp chrome perf`
+    - [PerfettoSQL Syntax](analysis/perfetto-sql-syntax.md) `android linux cpp chrome perf`
+    - [PerfettoSQL Style Guide](analysis/style-guide.md) `android linux cpp chrome perf`
+    - [PerfettoSQL Backwards Compatibility](analysis/perfetto-sql-backcompat.md) `android linux cpp chrome perf`
+    - [Trace Processor (C++)](analysis/trace-processor.md) `android linux cpp chrome perf`
+    - [Trace Processor (Python)](analysis/trace-processor-python.md) `android linux cpp chrome perf`
+    - [Trace Summarization](analysis/trace-summary.md) `android linux cpp chrome perf`
+    - [Converting from Perfetto](quickstart/traceconv.md) `android linux cpp chrome perf`
 
   - [Visualization](#)
 
-    - [Perfetto UI](visualization/perfetto-ui.md)
-    - [Opening Large Traces](visualization/large-traces.md)
-    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
-    - [Debug Tracks](analysis/debug-tracks.md)
-    - [UI Automation](visualization/ui-automation.md)
-
-  - [Reference](#)
-
-    - [PerfettoSQL](#)
-
-      - [Prelude Tables](analysis/sql-tables.autogen)
-      - [Built-in Functions](analysis/builtin.md)
-      - [Stats Table](analysis/sql-stats.autogen)
-
-    - [Trace Config Proto](reference/trace-config-proto.autogen)
-    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
-    - [Synthetic Track Events](reference/synthetic-track-event.md)
-    - [Commands Reference](visualization/commands-automation-reference.md)
-
-  - [Concepts](#)
-
-    - [Trace Configuration](concepts/config.md)
-    - [Buffers and Dataflow](concepts/buffers.md)
-    - [Service Model](concepts/service-model.md)
-    - [Clock Synchronization](concepts/clock-sync.md)
-
-  - [FAQ](faq.md)
-
-- [For Chrome](#)
-
-  - [Tutorials](#)
-
-    - [Recording Chrome Traces](getting-started/chrome-tracing.md)
-
-  - [Trace Analysis](#)
-
-    - [Getting Started](analysis/getting-started.md)
-    - [PerfettoSQL](#)
-      - [Getting Started](analysis/perfetto-sql-getting-started.md)
-      - [Standard Library](analysis/stdlib-docs.autogen)
-      - [Syntax](analysis/perfetto-sql-syntax.md)
-      - [Style Guide](analysis/style-guide.md)
-      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md)
-    - [Trace Processor](#)
-      - [Trace Processor (C++)](analysis/trace-processor.md)
-      - [Trace Processor (Python)](analysis/trace-processor-python.md)
-    - [Trace Summarization](analysis/trace-summary.md)
-    - [Batch Trace Processor](analysis/batch-trace-processor.md)
-    - [Legacy (v1) Metrics](analysis/metrics.md)
-    - [Converting from Perfetto](quickstart/traceconv.md)
-
-  - [Visualization](#)
-
-    - [Perfetto UI](visualization/perfetto-ui.md)
-    - [Opening Large Traces](visualization/large-traces.md)
-    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
-    - [Debug Tracks](analysis/debug-tracks.md)
-    - [UI Automation](visualization/ui-automation.md)
-
-  - [Reference](#)
-
-    - [PerfettoSQL](#)
-
-      - [Prelude Tables](analysis/sql-tables.autogen)
-      - [Built-in Functions](analysis/builtin.md)
-      - [Stats Table](analysis/sql-stats.autogen)
-
-    - [Trace Config Proto](reference/trace-config-proto.autogen)
-    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
-    - [Synthetic Track Events](reference/synthetic-track-event.md)
-    - [Commands Reference](visualization/commands-automation-reference.md)
-
-  - [Concepts](#)
-
-    - [Trace Configuration](concepts/config.md)
-    - [Clock Synchronization](concepts/clock-sync.md)
-
-  - [FAQ](faq.md)
-
-- [For Performance Engineers](#)
-
-  - [Getting Started](#)
-
-    - [Importing Other Formats](getting-started/other-formats.md)
-    - [Converting Data to Perfetto](getting-started/converting.md)
-
-  - [Trace Analysis](#)
-
-    - [Getting Started](analysis/getting-started.md)
-    - [PerfettoSQL](#)
-      - [Getting Started](analysis/perfetto-sql-getting-started.md)
-      - [Standard Library](analysis/stdlib-docs.autogen)
-      - [Syntax](analysis/perfetto-sql-syntax.md)
-      - [Style Guide](analysis/style-guide.md)
-      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md)
-    - [Trace Processor](#)
-      - [Trace Processor (C++)](analysis/trace-processor.md)
-      - [Trace Processor (Python)](analysis/trace-processor-python.md)
-    - [Trace Summarization](analysis/trace-summary.md)
-    - [Batch Trace Processor](analysis/batch-trace-processor.md)
-    - [Legacy (v1) Metrics](analysis/metrics.md)
-    - [Converting from Perfetto](quickstart/traceconv.md)
-
-  - [Visualization](#)
-
-    - [Perfetto UI](visualization/perfetto-ui.md)
-    - [Opening Large Traces](visualization/large-traces.md)
-    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md)
-    - [Debug Tracks](analysis/debug-tracks.md)
-    - [UI Automation](visualization/ui-automation.md)
-
-  - [Reference](#)
-
-    - [PerfettoSQL](#)
-
-      - [Prelude Tables](analysis/sql-tables.autogen)
-      - [Built-in Functions](analysis/builtin.md)
-      - [Stats Table](analysis/sql-stats.autogen)
-
-    - [Synthetic Track Events](reference/synthetic-track-event.md)
-    - [Trace Config Proto](reference/trace-config-proto.autogen)
-    - [Trace Packet Proto](reference/trace-packet-proto.autogen)
-    - [Commands Reference](visualization/commands-automation-reference.md)
-
-  - [FAQ](faq.md)
-
-- [For Contributors](#)
-
-  - [Development](#)
-
-    - [Getting Started](contributing/getting-started.md)
-    - [Common Tasks](contributing/common-tasks.md)
-    - [Building](contributing/build-instructions.md)
-    - [Testing](contributing/testing.md)
-    - [Developer Tools](contributing/developer-tools.md)
-    - [Become a Committer](contributing/become-a-committer.md)
+    - [Perfetto UI](visualization/perfetto-ui.md) `android linux cpp chrome perf`
+    - [Opening Large Traces](visualization/large-traces.md) `android linux cpp chrome perf`
+    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md) `android linux cpp chrome perf`
+    - [Debug Tracks](analysis/debug-tracks.md) `android linux cpp chrome perf`
+    - [UI Automation](visualization/ui-automation.md) `android linux cpp chrome perf`
+    - [Extending the UI](visualization/extending-the-ui.md) `android linux cpp chrome perf`
+    - [Extension Servers](visualization/extension-servers.md) `android linux cpp chrome perf`
 
   - [UI Development](#)
 
-    - [Getting Started](contributing/ui-getting-started.md)
-    - [Plugins](contributing/ui-plugins.md)
+    - [Getting Started](contributing/ui-getting-started.md) `contrib`
+    - [Plugins](contributing/ui-plugins.md) `contrib`
+
+  - [FAQ](faq.md) `android linux cpp chrome perf`
+
+- [Diving Deep](#)
+
+  - [Data Sources](#)
+
+    - [CPU Scheduling](data-sources/cpu-scheduling.md) `android linux`
+    - [System Calls](data-sources/syscalls.md) `linux`
+    - [CPU Frequency](data-sources/cpu-freq.md) `linux`
+    - [ATrace](data-sources/atrace.md) `android`
+    - [Logcat](data-sources/android-log.md) `android`
+    - [Frame Timeline](data-sources/frametimeline.md) `android`
+    - [Memory Counters](data-sources/memory-counters.md) `android linux`
+    - [Native Heap Profiler](data-sources/native-heap-profiler.md) `android linux`
+    - [Java Heap Dumps](data-sources/java-heap-profiler.md) `android`
+    - [Battery & Power](data-sources/battery-counters.md) `android`
+    - [GPU & Game Data](data-sources/android-game-intervention-list.md) `android`
+    - [Tracing across Reboots](data-sources/previous-boot-trace.md) `linux`
+
+  - [CLI Tools](#)
+
+    - [perfetto](reference/perfetto-cli.md) `android linux`
+    - [traced](reference/traced.md) `android linux`
+    - [traced_probes](reference/traced_probes.md) `android linux`
+    - [heap_profile](reference/heap_profile-cli.md) `android linux`
+    - [tracebox](reference/tracebox.md) `android linux`
+
+  - [PerfettoSQL Reference](#)
+
+    - [Standard Library](analysis/stdlib-docs.autogen) `android linux cpp chrome perf`
+    - [Prelude Tables](analysis/sql-tables.autogen) `android linux cpp chrome perf`
+    - [Built-in Functions](analysis/builtin.md) `android linux cpp chrome perf`
+    - [Stats Table](analysis/sql-stats.autogen) `android linux cpp chrome perf`
+
+  - [References](#)
+
+    - [Trace Config Proto](reference/trace-config-proto.autogen) `android linux cpp chrome perf`
+    - [Trace Packet Proto](reference/trace-packet-proto.autogen) `android linux cpp chrome perf`
+    - [Synthetic Track Events](reference/synthetic-track-event.md) `android linux cpp chrome perf`
+    - [Commands Reference](visualization/commands-automation-reference.md) `android linux cpp chrome perf`
+    - [Extension Server Protocol](visualization/extension-server-protocol.md) `cpp`
+    - [Android Version Notes](reference/android-version-notes.md) `android`
+    - [Kernel Track Events](reference/kernel-track-event.md) `linux`
+
+  - [Advanced Recording](#)
+
+    - [Detached Mode](concepts/detached-mode.md) `android`
+    - [Interceptors](instrumentation/interceptors.md) `cpp`
+
+  - [Advanced Analysis](#)
+
+    - [Legacy (v1) Metrics](analysis/metrics.md) `android linux cpp chrome perf`
+    - [Batch Trace Processor](analysis/batch-trace-processor.md) `android linux perf`
+    - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md) `android linux perf`
+    - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md) `android linux perf`
+
+  - [Contributor Reference](#)
+
+    - [Building](contributing/build-instructions.md) `contrib`
+    - [Testing](contributing/testing.md) `contrib`
+    - [Developer Tools](contributing/developer-tools.md) `contrib`
+    - [Become a Committer](contributing/become-a-committer.md) `contrib`
 
   - [Releases](#)
 
-    - [SDK Release](contributing/sdk-releasing.md)
-    - [Python Release](contributing/python-releasing.md)
-    - [UI Release](visualization/perfetto-ui-release-process.md)
-    - [Chrome Branches](contributing/chrome-branches.md)
-    - [SQLite Upgrade](contributing/sqlite-upgrade-guide.md)
+    - [SDK Release](contributing/sdk-releasing.md) `contrib`
+    - [Python Release](contributing/python-releasing.md) `contrib`
+    - [UI Release](visualization/perfetto-ui-release-process.md) `contrib`
+    - [Chrome Branches](contributing/chrome-branches.md) `contrib`
+    - [SQLite Upgrade](contributing/sqlite-upgrade-guide.md) `contrib`
 
   - [Design Documents](#)
 
-    - [API and ABI Surface](design-docs/api-and-abi.md)
-    - [Life of a Tracing Session](design-docs/life-of-a-tracing-session.md)
-    - [ProtoZero](design-docs/protozero.md)
-    - [Security Model](design-docs/security-model.md)
-    - [Trace Processor Architecture](design-docs/trace-processor-architecture.md)
-    - [Heapprofd Design](design-docs/heapprofd-design.md)
-    - [Heapprofd Wire Protocol](design-docs/heapprofd-wire-protocol.md)
-    - [Heapprofd Sampling](design-docs/heapprofd-sampling.md)
-    - [Batch Trace Processor](design-docs/batch-trace-processor.md)
-    - [Statsd Checkpoint Atoms](design-docs/checkpoint-atoms.md)
-    - [Perfetto CI](design-docs/continuous-integration.md)
-    - [LockFreeTaskRunner](design-docs/lock-free-task-runner.md)
+    - [API and ABI Surface](design-docs/api-and-abi.md) `contrib`
+    - [Life of a Tracing Session](design-docs/life-of-a-tracing-session.md) `contrib`
+    - [ProtoZero](design-docs/protozero.md) `contrib`
+    - [Security Model](design-docs/security-model.md) `contrib`
+    - [Trace Processor Architecture](design-docs/trace-processor-architecture.md) `contrib`
+    - [Heapprofd Design](design-docs/heapprofd-design.md) `contrib`
+    - [Heapprofd Wire Protocol](design-docs/heapprofd-wire-protocol.md) `contrib`
+    - [Heapprofd Sampling](design-docs/heapprofd-sampling.md) `contrib`
+    - [Batch Trace Processor](design-docs/batch-trace-processor.md) `contrib`
+    - [Statsd Checkpoint Atoms](design-docs/checkpoint-atoms.md) `contrib`
+    - [Perfetto CI](design-docs/continuous-integration.md) `contrib`
+    - [LockFreeTaskRunner](design-docs/lock-free-task-runner.md) `contrib`

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -8,160 +8,160 @@
 
   - [Tutorials](#)
 
-    - [System Tracing](getting-started/system-tracing.md) `android linux`
-    - [In-App Tracing](getting-started/in-app-tracing.md) `cpp`
-    - [Memory Profiling](getting-started/memory-profiling.md) `android linux`
-    - [CPU Profiling](getting-started/cpu-profiling.md) `android linux`
-    - [Instrumenting with atrace](getting-started/atrace.md) `android`
-    - [Linux ftrace](getting-started/ftrace.md) `linux`
-    - [Recording Chrome Traces](getting-started/chrome-tracing.md) `chrome`
-    - [Importing Other Formats](getting-started/other-formats.md) `perf`
-    - [Converting Data to Perfetto](getting-started/converting.md) `perf`
+    - [System Tracing](getting-started/system-tracing.md) {.tag-android .tag-linux}
+    - [In-App Tracing](getting-started/in-app-tracing.md) {.tag-cpp}
+    - [Memory Profiling](getting-started/memory-profiling.md) {.tag-android .tag-linux}
+    - [CPU Profiling](getting-started/cpu-profiling.md) {.tag-android .tag-linux}
+    - [Instrumenting with atrace](getting-started/atrace.md) {.tag-android}
+    - [Linux ftrace](getting-started/ftrace.md) {.tag-linux}
+    - [Recording Chrome Traces](getting-started/chrome-tracing.md) {.tag-chrome}
+    - [Importing Other Formats](getting-started/other-formats.md) {.tag-perf}
+    - [Converting Data to Perfetto](getting-started/converting.md) {.tag-perf}
 
   - [Cookbooks](#)
 
-    - [Analysing Android Traces](getting-started/android-trace-analysis.md) `android`
-    - [Periodic Trace Snapshots](getting-started/periodic-trace-snapshots.md) `android`
+    - [Analysing Android Traces](getting-started/android-trace-analysis.md) {.tag-android}
+    - [Periodic Trace Snapshots](getting-started/periodic-trace-snapshots.md) {.tag-android}
 
   - [Case Studies](#)
 
-    - [Debugging Memory Usage](case-studies/memory.md) `android`
-    - [Scheduling Blockages](case-studies/scheduling-blockages.md) `android linux`
-    - [Boot Tracing](case-studies/android-boot-tracing.md) `android`
-    - [OutOfMemoryError](case-studies/android-outofmemoryerror.md) `android`
+    - [Debugging Memory Usage](case-studies/memory.md) {.tag-android}
+    - [Scheduling Blockages](case-studies/scheduling-blockages.md) {.tag-android .tag-linux}
+    - [Boot Tracing](case-studies/android-boot-tracing.md) {.tag-android}
+    - [OutOfMemoryError](case-studies/android-outofmemoryerror.md) {.tag-android}
 
   - [Contributing](#)
 
-    - [Getting Started](contributing/getting-started.md) `contrib`
-    - [Common Tasks](contributing/common-tasks.md) `contrib`
+    - [Getting Started](contributing/getting-started.md) {.tag-contrib}
+    - [Common Tasks](contributing/common-tasks.md) {.tag-contrib}
 
 - [Learning More](#)
 
   - [Concepts](#)
 
-    - [Trace Configuration](concepts/config.md) `android linux cpp chrome`
-    - [Buffers and Dataflow](concepts/buffers.md) `android linux cpp`
-    - [Service Model](concepts/service-model.md) `android linux cpp`
-    - [Clock Synchronization](concepts/clock-sync.md) `android linux cpp chrome`
-    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) `android linux cpp`
-    - [Tracing in Background](learning-more/tracing-in-background.md) `android linux`
-    - [More Android Tracing](learning-more/android.md) `android`
-    - [Symbolization and Deobfuscation](learning-more/symbolization.md) `android linux`
+    - [Trace Configuration](concepts/config.md) {.tag-android .tag-linux .tag-cpp .tag-chrome}
+    - [Buffers and Dataflow](concepts/buffers.md) {.tag-android .tag-linux .tag-cpp}
+    - [Service Model](concepts/service-model.md) {.tag-android .tag-linux .tag-cpp}
+    - [Clock Synchronization](concepts/clock-sync.md) {.tag-android .tag-linux .tag-cpp .tag-chrome}
+    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) {.tag-android .tag-linux .tag-cpp}
+    - [Tracing in Background](learning-more/tracing-in-background.md) {.tag-android .tag-linux}
+    - [More Android Tracing](learning-more/android.md) {.tag-android}
+    - [Symbolization and Deobfuscation](learning-more/symbolization.md) {.tag-android .tag-linux}
 
   - [Tracing SDK](#)
 
-    - [Tracing SDK](instrumentation/tracing-sdk.md) `cpp`
-    - [Track Events](instrumentation/track-events.md) `cpp`
+    - [Tracing SDK](instrumentation/tracing-sdk.md) {.tag-cpp}
+    - [Track Events](instrumentation/track-events.md) {.tag-cpp}
 
   - [Trace Analysis](#)
 
-    - [Getting Started](analysis/getting-started.md) `android linux cpp chrome perf`
-    - [PerfettoSQL Getting Started](analysis/perfetto-sql-getting-started.md) `android linux cpp chrome perf`
-    - [PerfettoSQL Syntax](analysis/perfetto-sql-syntax.md) `android linux cpp chrome perf`
-    - [PerfettoSQL Style Guide](analysis/style-guide.md) `android linux cpp chrome perf`
-    - [PerfettoSQL Backwards Compatibility](analysis/perfetto-sql-backcompat.md) `android linux cpp chrome perf`
-    - [Trace Processor (C++)](analysis/trace-processor.md) `android linux cpp chrome perf`
-    - [Trace Processor (Python)](analysis/trace-processor-python.md) `android linux cpp chrome perf`
-    - [Trace Summarization](analysis/trace-summary.md) `android linux cpp chrome perf`
-    - [Converting from Perfetto](quickstart/traceconv.md) `android linux cpp chrome perf`
+    - [Getting Started](analysis/getting-started.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [PerfettoSQL Getting Started](analysis/perfetto-sql-getting-started.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [PerfettoSQL Syntax](analysis/perfetto-sql-syntax.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [PerfettoSQL Style Guide](analysis/style-guide.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [PerfettoSQL Backwards Compatibility](analysis/perfetto-sql-backcompat.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Trace Processor (C++)](analysis/trace-processor.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Trace Processor (Python)](analysis/trace-processor-python.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Trace Summarization](analysis/trace-summary.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Converting from Perfetto](quickstart/traceconv.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
 
   - [Visualization](#)
 
-    - [Perfetto UI](visualization/perfetto-ui.md) `android linux cpp chrome perf`
-    - [Opening Large Traces](visualization/large-traces.md) `android linux cpp chrome perf`
-    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md) `android linux cpp chrome perf`
-    - [Debug Tracks](analysis/debug-tracks.md) `android linux cpp chrome perf`
-    - [UI Automation](visualization/ui-automation.md) `android linux cpp chrome perf`
-    - [Extending the UI](visualization/extending-the-ui.md) `android linux cpp chrome perf`
-    - [Extension Servers](visualization/extension-servers.md) `android linux cpp chrome perf`
+    - [Perfetto UI](visualization/perfetto-ui.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Opening Large Traces](visualization/large-traces.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Debug Tracks](analysis/debug-tracks.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [UI Automation](visualization/ui-automation.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Extending the UI](visualization/extending-the-ui.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Extension Servers](visualization/extension-servers.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
 
   - [UI Development](#)
 
-    - [Getting Started](contributing/ui-getting-started.md) `contrib`
-    - [Plugins](contributing/ui-plugins.md) `contrib`
+    - [Getting Started](contributing/ui-getting-started.md) {.tag-contrib}
+    - [Plugins](contributing/ui-plugins.md) {.tag-contrib}
 
-  - [FAQ](faq.md) `android linux cpp chrome perf`
+  - [FAQ](faq.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
 
 - [Diving Deep](#)
 
   - [Data Sources](#)
 
-    - [CPU Scheduling](data-sources/cpu-scheduling.md) `android linux`
-    - [System Calls](data-sources/syscalls.md) `linux`
-    - [CPU Frequency](data-sources/cpu-freq.md) `linux`
-    - [ATrace](data-sources/atrace.md) `android`
-    - [Logcat](data-sources/android-log.md) `android`
-    - [Frame Timeline](data-sources/frametimeline.md) `android`
-    - [Memory Counters](data-sources/memory-counters.md) `android linux`
-    - [Native Heap Profiler](data-sources/native-heap-profiler.md) `android linux`
-    - [Java Heap Dumps](data-sources/java-heap-profiler.md) `android`
-    - [Battery & Power](data-sources/battery-counters.md) `android`
-    - [GPU & Game Data](data-sources/android-game-intervention-list.md) `android`
-    - [Tracing across Reboots](data-sources/previous-boot-trace.md) `linux`
+    - [CPU Scheduling](data-sources/cpu-scheduling.md) {.tag-android .tag-linux}
+    - [System Calls](data-sources/syscalls.md) {.tag-linux}
+    - [CPU Frequency](data-sources/cpu-freq.md) {.tag-linux}
+    - [ATrace](data-sources/atrace.md) {.tag-android}
+    - [Logcat](data-sources/android-log.md) {.tag-android}
+    - [Frame Timeline](data-sources/frametimeline.md) {.tag-android}
+    - [Memory Counters](data-sources/memory-counters.md) {.tag-android .tag-linux}
+    - [Native Heap Profiler](data-sources/native-heap-profiler.md) {.tag-android .tag-linux}
+    - [Java Heap Dumps](data-sources/java-heap-profiler.md) {.tag-android}
+    - [Battery & Power](data-sources/battery-counters.md) {.tag-android}
+    - [GPU & Game Data](data-sources/android-game-intervention-list.md) {.tag-android}
+    - [Tracing across Reboots](data-sources/previous-boot-trace.md) {.tag-linux}
 
   - [CLI Tools](#)
 
-    - [perfetto](reference/perfetto-cli.md) `android linux`
-    - [traced](reference/traced.md) `android linux`
-    - [traced_probes](reference/traced_probes.md) `android linux`
-    - [heap_profile](reference/heap_profile-cli.md) `android linux`
-    - [tracebox](reference/tracebox.md) `android linux`
+    - [perfetto](reference/perfetto-cli.md) {.tag-android .tag-linux}
+    - [traced](reference/traced.md) {.tag-android .tag-linux}
+    - [traced_probes](reference/traced_probes.md) {.tag-android .tag-linux}
+    - [heap_profile](reference/heap_profile-cli.md) {.tag-android .tag-linux}
+    - [tracebox](reference/tracebox.md) {.tag-android .tag-linux}
 
   - [PerfettoSQL Reference](#)
 
-    - [Standard Library](analysis/stdlib-docs.autogen) `android linux cpp chrome perf`
-    - [Prelude Tables](analysis/sql-tables.autogen) `android linux cpp chrome perf`
-    - [Built-in Functions](analysis/builtin.md) `android linux cpp chrome perf`
-    - [Stats Table](analysis/sql-stats.autogen) `android linux cpp chrome perf`
+    - [Standard Library](analysis/stdlib-docs.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Prelude Tables](analysis/sql-tables.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Built-in Functions](analysis/builtin.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Stats Table](analysis/sql-stats.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
 
   - [References](#)
 
-    - [Trace Config Proto](reference/trace-config-proto.autogen) `android linux cpp chrome perf`
-    - [Trace Packet Proto](reference/trace-packet-proto.autogen) `android linux cpp chrome perf`
-    - [Synthetic Track Events](reference/synthetic-track-event.md) `android linux cpp chrome perf`
-    - [Commands Reference](visualization/commands-automation-reference.md) `android linux cpp chrome perf`
-    - [Extension Server Protocol](visualization/extension-server-protocol.md) `cpp`
-    - [Android Version Notes](reference/android-version-notes.md) `android`
-    - [Kernel Track Events](reference/kernel-track-event.md) `linux`
+    - [Trace Config Proto](reference/trace-config-proto.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Trace Packet Proto](reference/trace-packet-proto.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Synthetic Track Events](reference/synthetic-track-event.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Commands Reference](visualization/commands-automation-reference.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Extension Server Protocol](visualization/extension-server-protocol.md) {.tag-cpp}
+    - [Android Version Notes](reference/android-version-notes.md) {.tag-android}
+    - [Kernel Track Events](reference/kernel-track-event.md) {.tag-linux}
 
   - [Advanced Recording](#)
 
-    - [Detached Mode](concepts/detached-mode.md) `android`
-    - [Interceptors](instrumentation/interceptors.md) `cpp`
+    - [Detached Mode](concepts/detached-mode.md) {.tag-android}
+    - [Interceptors](instrumentation/interceptors.md) {.tag-cpp}
 
   - [Advanced Analysis](#)
 
-    - [Legacy (v1) Metrics](analysis/metrics.md) `android linux cpp chrome perf`
-    - [Batch Trace Processor](analysis/batch-trace-processor.md) `android linux perf`
-    - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md) `android linux perf`
-    - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md) `android linux perf`
+    - [Legacy (v1) Metrics](analysis/metrics.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Batch Trace Processor](analysis/batch-trace-processor.md) {.tag-android .tag-linux .tag-perf}
+    - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md) {.tag-android .tag-linux .tag-perf}
+    - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md) {.tag-android .tag-linux .tag-perf}
 
   - [Contributor Reference](#)
 
-    - [Building](contributing/build-instructions.md) `contrib`
-    - [Testing](contributing/testing.md) `contrib`
-    - [Developer Tools](contributing/developer-tools.md) `contrib`
-    - [Become a Committer](contributing/become-a-committer.md) `contrib`
+    - [Building](contributing/build-instructions.md) {.tag-contrib}
+    - [Testing](contributing/testing.md) {.tag-contrib}
+    - [Developer Tools](contributing/developer-tools.md) {.tag-contrib}
+    - [Become a Committer](contributing/become-a-committer.md) {.tag-contrib}
 
   - [Releases](#)
 
-    - [SDK Release](contributing/sdk-releasing.md) `contrib`
-    - [Python Release](contributing/python-releasing.md) `contrib`
-    - [UI Release](visualization/perfetto-ui-release-process.md) `contrib`
-    - [Chrome Branches](contributing/chrome-branches.md) `contrib`
-    - [SQLite Upgrade](contributing/sqlite-upgrade-guide.md) `contrib`
+    - [SDK Release](contributing/sdk-releasing.md) {.tag-contrib}
+    - [Python Release](contributing/python-releasing.md) {.tag-contrib}
+    - [UI Release](visualization/perfetto-ui-release-process.md) {.tag-contrib}
+    - [Chrome Branches](contributing/chrome-branches.md) {.tag-contrib}
+    - [SQLite Upgrade](contributing/sqlite-upgrade-guide.md) {.tag-contrib}
 
   - [Design Documents](#)
 
-    - [API and ABI Surface](design-docs/api-and-abi.md) `contrib`
-    - [Life of a Tracing Session](design-docs/life-of-a-tracing-session.md) `contrib`
-    - [ProtoZero](design-docs/protozero.md) `contrib`
-    - [Security Model](design-docs/security-model.md) `contrib`
-    - [Trace Processor Architecture](design-docs/trace-processor-architecture.md) `contrib`
-    - [Heapprofd Design](design-docs/heapprofd-design.md) `contrib`
-    - [Heapprofd Wire Protocol](design-docs/heapprofd-wire-protocol.md) `contrib`
-    - [Heapprofd Sampling](design-docs/heapprofd-sampling.md) `contrib`
-    - [Batch Trace Processor](design-docs/batch-trace-processor.md) `contrib`
-    - [Statsd Checkpoint Atoms](design-docs/checkpoint-atoms.md) `contrib`
-    - [Perfetto CI](design-docs/continuous-integration.md) `contrib`
-    - [LockFreeTaskRunner](design-docs/lock-free-task-runner.md) `contrib`
+    - [API and ABI Surface](design-docs/api-and-abi.md) {.tag-contrib}
+    - [Life of a Tracing Session](design-docs/life-of-a-tracing-session.md) {.tag-contrib}
+    - [ProtoZero](design-docs/protozero.md) {.tag-contrib}
+    - [Security Model](design-docs/security-model.md) {.tag-contrib}
+    - [Trace Processor Architecture](design-docs/trace-processor-architecture.md) {.tag-contrib}
+    - [Heapprofd Design](design-docs/heapprofd-design.md) {.tag-contrib}
+    - [Heapprofd Wire Protocol](design-docs/heapprofd-wire-protocol.md) {.tag-contrib}
+    - [Heapprofd Sampling](design-docs/heapprofd-sampling.md) {.tag-contrib}
+    - [Batch Trace Processor](design-docs/batch-trace-processor.md) {.tag-contrib}
+    - [Statsd Checkpoint Atoms](design-docs/checkpoint-atoms.md) {.tag-contrib}
+    - [Perfetto CI](design-docs/continuous-integration.md) {.tag-contrib}
+    - [LockFreeTaskRunner](design-docs/lock-free-task-runner.md) {.tag-contrib}

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -46,6 +46,7 @@
     - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) `android linux cpp`
     - [Tracing in Background](learning-more/tracing-in-background.md) `android linux`
     - [More Android Tracing](learning-more/android.md) `android`
+    - [Symbolization and Deobfuscation](learning-more/symbolization.md) `android linux`
 
   - [Tracing SDK](#)
 

--- a/infra/perfetto.dev/build.js
+++ b/infra/perfetto.dev/build.js
@@ -124,7 +124,7 @@ function startServer() {
           res.end(data);
         });
       })
-      .listen(port, 'localhost');
+      .listen(port, '0.0.0.0');
 }
 
 function watchDir(dir) {

--- a/infra/perfetto.dev/src/assets/script.js
+++ b/infra/perfetto.dev/src/assets/script.js
@@ -148,70 +148,174 @@ function updateNav() {
   let curFileName = "";
   if (curDoc) curFileName = curDoc.dataset["mdFile"];
 
-  // First identify all the top-level nav entries (Quickstart, Data Sources,
-  // ...) and make them compressible.
-  const toplevelSections = document.querySelectorAll('.docs .nav > ul > li > ul > li');
-  const toplevelLinks = [];
-  for (const sec of toplevelSections) {
-    const childMenu = sec.querySelector("ul");
-    if (!childMenu) {
-      // Don't make it compressible if it has no children (e.g. the very
-      // first 'Introduction' link).
-      continue;
+  const nav = document.querySelector('.docs .nav');
+  if (!nav) return;
+  const rootUl = nav.querySelector(':scope > ul');
+  if (!rootUl) return;
+
+  const topSections = rootUl.querySelectorAll(':scope > li');
+
+  // Helper: get the display name of a top-level section.
+  const getSectionName = (section) => {
+    const link = section.querySelector(':scope > p > a') ||
+                 section.querySelector(':scope > a');
+    return link ? link.textContent.trim() : '';
+  };
+
+  // Helper: check if a section contains the current page.
+  const sectionContainsPage = (section) => {
+    const links = section.querySelectorAll('a[href]:not([href="#"])');
+    for (const link of links) {
+      const url = new URL(link.href);
+      if (url.pathname === curFileName ||
+          url.pathname + 'index.html' === curFileName) {
+        return true;
+      }
     }
+    return false;
+  };
 
-    // Don't make it compressible if the entry has an actual link (e.g. the very
-    // first 'Introduction' link), because otherwise it become ambiguous whether
-    // the link should toggle or open the link.
-    const link = sec.querySelector("a");
-    if (!link || !link.href.endsWith("#")) continue;
+  // --- Step 1: Find which top-level section contains the current page. ---
+  // When a page appears in multiple sections (e.g. shared tutorials),
+  // prefer the section the user last navigated into (stored in session).
+  const storedSection = sessionStorage.getItem('docs.nav.activeSection');
+  let activeTopSection = null;
+  let fallbackSection = null;
 
-    sec.classList.add("compressible");
+  for (const section of topSections) {
+    if (!sectionContainsPage(section)) continue;
+    // First match as fallback.
+    if (!fallbackSection) fallbackSection = section;
+    // Prefer the stored section if it contains this page.
+    if (getSectionName(section) === storedSection) {
+      activeTopSection = section;
+    }
+  }
+  if (!activeTopSection) activeTopSection = fallbackSection;
 
-    // Remember the compressed status as long as the page is opened, so clicking
-    // through links keeps the sidebar in a consistent visual state.
+  // Store the active section for future page loads.
+  if (activeTopSection) {
+    sessionStorage.setItem(
+      'docs.nav.activeSection', getSectionName(activeTopSection));
+  }
+
+  // --- Step 2: Set up top-level sections. ---
+  // The active section expands fully. All others collapse to a single
+  // clickable line linking to their first page, moved below the active one.
+  for (const section of topSections) {
+    const headerLink = section.querySelector(':scope > p > a') ||
+                       section.querySelector(':scope > a');
+    const childUl = section.querySelector(':scope > ul');
+
+    if (!headerLink || !headerLink.href ||
+        !headerLink.href.endsWith('#')) continue;
+
+    if (activeTopSection && section !== activeTopSection) {
+      // Inactive section: collapse and link to first page.
+      section.classList.add('inactive-section');
+      if (childUl) childUl.style.display = 'none';
+      const firstLink = section.querySelector('a[href]:not([href="#"])');
+      // Capture name before modifying text.
+      const sectionName = getSectionName(section);
+      if (firstLink) {
+        headerLink.href = firstLink.href;
+        headerLink.onclick = null;
+      }
+      // Show full name ("Perfetto for X") when collapsed as a link.
+      const text = headerLink.textContent.trim();
+      if (text.startsWith('For ')) {
+        headerLink.textContent = 'Perfetto ' + text.charAt(0).toLowerCase() + text.slice(1);
+      }
+      headerLink.addEventListener('click', () => {
+        sessionStorage.setItem('docs.nav.activeSection', sectionName);
+      });
+      // Move below the active section.
+      rootUl.appendChild(section);
+    } else {
+      // Active section: show full content.
+      section.classList.remove('inactive-section');
+      if (childUl) childUl.style.display = '';
+    }
+  }
+
+  // --- Step 3: Make inner sections (categories) compressible. ---
+  // Only process items inside the active section (or all if no active).
+  const scope = activeTopSection || nav;
+  const innerLis = scope.querySelectorAll('li');
+  for (const sec of innerLis) {
+    // Skip top-level sections — they're handled above.
+    if (sec.parentElement === rootUl) continue;
+
+    const childMenu = sec.querySelector(':scope > ul');
+    if (!childMenu) continue;
+
+    const link = sec.querySelector(':scope > p > a') ||
+                 sec.querySelector(':scope > a');
+    if (!link || !link.href || !link.href.endsWith('#')) continue;
+
+    sec.classList.add('compressible');
+
     const memoKey = `docs.nav.compressed[${link.innerHTML}]`;
-
-    if (sessionStorage.getItem(memoKey) === "1") {
-      sec.classList.add("compressed");
+    const stored = sessionStorage.getItem(memoKey);
+    if (stored === '1') {
+      sec.classList.add('compressed');
     }
+
     doAfterLoadEvent(() => {
       childMenu.style.maxHeight = `${childMenu.scrollHeight + 40}px`;
     });
 
-    toplevelLinks.push(link);
     link.onclick = (evt) => {
       evt.preventDefault();
-      sec.classList.toggle("compressed");
-      if (sec.classList.contains("compressed")) {
-        sessionStorage.setItem(memoKey, "1");
+      sec.classList.toggle('compressed');
+      if (sec.classList.contains('compressed')) {
+        sessionStorage.setItem(memoKey, '1');
       } else {
-        sessionStorage.removeItem(memoKey);
+        sessionStorage.setItem(memoKey, '0');
       }
     };
   }
 
-  const nav = document.querySelector(".docs .nav");
-  const exps = document.querySelectorAll(".docs .nav ul a");
+  // --- Step 4: Highlight the current page. ---
+  const allLinks = nav.querySelectorAll('ul a');
   let found = false;
-  for (const x of exps) {
-    // If the url of the entry matches the url of the page, mark the item as
-    // highlighted and expand all its parents.
+  for (const x of allLinks) {
     if (!x.href) continue;
     const url = new URL(x.href);
     if (x.href.endsWith("#")) {
-      // This is a non-leaf link to a menu.
-      if (toplevelLinks.indexOf(x) < 0) {
+      // Remove href from non-compressible # links.
+      const parentLi = x.closest('li');
+      if (parentLi && !parentLi.classList.contains('compressible') &&
+          !parentLi.classList.contains('inactive-section')) {
         x.removeAttribute("href");
       }
-    } else if ((url.pathname === curFileName || url.pathname + 'index.html' === curFileName) && !found) {
+    } else if ((url.pathname === curFileName ||
+                url.pathname + 'index.html' === curFileName) && !found) {
       x.classList.add('selected');
+
+      // Walk up the DOM to expand all ancestor compressible sections.
+      let el = x.closest('li');
+      while (el) {
+        if (el.classList.contains('compressible') &&
+            el.classList.contains('compressed')) {
+          el.classList.remove('compressed');
+          const elLink = el.querySelector(':scope > p > a') ||
+                         el.querySelector(':scope > a');
+          if (elLink) {
+            sessionStorage.setItem(
+              `docs.nav.compressed[${elLink.innerHTML}]`, '0');
+          }
+        }
+        el = el.parentElement ? el.parentElement.closest('li') : null;
+      }
+
       if (!onloadFired) {
         scrollIntoViewIfNeeded(x, nav);
       }
-      found = true;  // Highlight only the first occurrence.
+      found = true;
     }
   }
+
 }
 
 // If the page contains a ```mermaid ``` block, lazily loads the plugin and

--- a/infra/perfetto.dev/src/assets/script.js
+++ b/infra/perfetto.dev/src/assets/script.js
@@ -141,17 +141,13 @@ function scrollIntoViewIfNeeded(element, container, margin = 100) {
   }
 }
 
-// Audiences shown in the nav tag bar. Tags here must match the backtick
-// tags attached to leaf entries in docs/toc.md.
-const NAV_AUDIENCES = [
-  { tag: 'android', label: 'Android' },
-  { tag: 'linux', label: 'Linux' },
-  { tag: 'cpp', label: 'C++ dev' },
-  { tag: 'chrome', label: 'Chrome' },
-  { tag: 'perf', label: 'Perf dev' },
-  { tag: 'contrib', label: 'Contributors' },
-];
-const NAV_DEFAULT_TAGS = ['android'];
+const TAG_PREFIX = 'tag-';
+const TAG_LABELS = {cpp: 'C++'};
+const NAV_DEFAULT_TAG = 'android';
+
+function tagLabel(tag) {
+  return TAG_LABELS[tag] || tag.charAt(0).toUpperCase() + tag.slice(1);
+}
 
 // This function needs to be idempotent as it is called more than once (on every
 // resize).
@@ -165,21 +161,30 @@ function updateNav() {
   const rootUl = nav.querySelector(':scope > ul');
   if (!rootUl) return;
 
-  // --- Step 1: Load the set of active audience tags. ---
-  const validTags = new Set(NAV_AUDIENCES.map((a) => a.tag));
-  let activeTags = null;
-  try {
-    const raw = sessionStorage.getItem('docs.nav.activeTags');
-    if (raw) activeTags = JSON.parse(raw).filter((t) => validTags.has(t));
-  } catch (e) {
-    activeTags = null;
+  // --- Step 1: Discover available tags from CSS classes on <li> elements. ---
+  const tagOrder = [];
+  const tagSeen = new Set();
+  for (const li of rootUl.querySelectorAll('li')) {
+    for (const cls of li.classList) {
+      if (cls.startsWith(TAG_PREFIX)) {
+        const tag = cls.slice(TAG_PREFIX.length);
+        if (!tagSeen.has(tag)) {
+          tagSeen.add(tag);
+          tagOrder.push(tag);
+        }
+      }
+    }
   }
-  if (!activeTags) activeTags = NAV_DEFAULT_TAGS.slice();
-  const activeSet = new Set(activeTags);
-  sessionStorage.setItem(
-    'docs.nav.activeTags', JSON.stringify([...activeSet]));
 
-  // --- Step 2: Build/refresh the audience chip bar. ---
+  // --- Step 2: Load single active tag from session ('' = show all). ---
+  let activeTag = sessionStorage.getItem('docs.nav.activeTag');
+  if (activeTag === null) {
+    activeTag = NAV_DEFAULT_TAG;
+  } else if (activeTag !== '' && !tagSeen.has(activeTag)) {
+    activeTag = NAV_DEFAULT_TAG;
+  }
+
+  // --- Step 3: Build/refresh the audience chip bar (single-select + All). ---
   let filterBox = nav.querySelector(':scope > .audience-filter');
   if (!filterBox) {
     filterBox = document.createElement('div');
@@ -195,71 +200,44 @@ function updateNav() {
   }
   const chipBar = filterBox.querySelector(':scope > .audience-tags');
   chipBar.innerHTML = '';
-  for (const a of NAV_AUDIENCES) {
+
+  const makeChip = (label, tag) => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'audience-tag';
-    btn.textContent = a.label;
-    if (activeSet.has(a.tag)) btn.classList.add('active');
+    btn.textContent = label;
+    if (tag === activeTag) btn.classList.add('active');
     btn.addEventListener('click', () => {
-      const next = new Set(activeSet);
-      if (next.has(a.tag)) next.delete(a.tag);
-      else next.add(a.tag);
-      sessionStorage.setItem(
-        'docs.nav.activeTags', JSON.stringify([...next]));
+      sessionStorage.setItem('docs.nav.activeTag', tag);
       updateNav();
     });
     chipBar.appendChild(btn);
-  }
-
-  // --- Step 3: Parse per-leaf audience tags from <code> markers. ---
-  // Each leaf's tags come from a trailing `tag1 tag2` in the markdown,
-  // rendered by marked.js as a <code> child of the <li> (or its <p>).
-  const allLis = rootUl.querySelectorAll('li');
-  for (const li of allLis) {
-    if (li.dataset.navTagsParsed) continue;
-    const code = li.querySelector(':scope > code') ||
-                 li.querySelector(':scope > p > code');
-    if (code) {
-      li.dataset.navTags = code.textContent.trim();
-    }
-    li.dataset.navTagsParsed = '1';
-  }
-
-  // --- Step 4: Filter leaves by active audience, then collapse empty
-  // ancestors. Visibility is decided bottom-up. ---
-  const showAll = activeSet.size === 0;
-  const hasTag = (li) => {
-    if (!li.dataset.navTags) return null;
-    if (showAll) return true;
-    return li.dataset.navTags.split(/\s+/).some((t) => activeSet.has(t));
   };
+  for (const tag of tagOrder) makeChip(tagLabel(tag), tag);
+  makeChip('All', '');
 
-  const isVisible = new Map();
-  const setVisible = (li, v) => {
-    isVisible.set(li, v);
-    li.style.display = v ? '' : 'none';
+  // --- Step 4: Filter leaves by active tag, then collapse empty ancestors.
+  // Visibility is decided bottom-up so parents with no visible children hide. ---
+  const activeCls = activeTag ? TAG_PREFIX + activeTag : '';
+  const isTagged = (li) => {
+    for (const c of li.classList) if (c.startsWith(TAG_PREFIX)) return true;
+    return false;
   };
-
-  // Bottom-up pass: leaf visibility from tags; parent visible if any child is.
   const process = (li) => {
     const childUl = li.querySelector(':scope > ul');
     if (!childUl) {
-      // Leaf: visible iff untagged (universal) or tag set includes active tag.
-      const match = hasTag(li);
-      setVisible(li, match === null ? true : match);
-      return isVisible.get(li);
+      const vis = !isTagged(li) || !activeCls || li.classList.contains(activeCls);
+      li.style.display = vis ? '' : 'none';
+      return vis;
     }
-    let anyChildVisible = false;
+    let any = false;
     for (const child of childUl.querySelectorAll(':scope > li')) {
-      if (process(child)) anyChildVisible = true;
+      if (process(child)) any = true;
     }
-    setVisible(li, anyChildVisible);
-    return anyChildVisible;
+    li.style.display = any ? '' : 'none';
+    return any;
   };
-  for (const li of rootUl.querySelectorAll(':scope > li')) {
-    process(li);
-  }
+  for (const li of rootUl.querySelectorAll(':scope > li')) process(li);
 
   // --- Step 5: Make inner sections (categories) compressible. ---
   for (const sec of rootUl.querySelectorAll('li')) {

--- a/infra/perfetto.dev/src/assets/script.js
+++ b/infra/perfetto.dev/src/assets/script.js
@@ -141,6 +141,18 @@ function scrollIntoViewIfNeeded(element, container, margin = 100) {
   }
 }
 
+// Audiences shown in the nav tag bar. Tags here must match the backtick
+// tags attached to leaf entries in docs/toc.md.
+const NAV_AUDIENCES = [
+  { tag: 'android', label: 'Android' },
+  { tag: 'linux', label: 'Linux' },
+  { tag: 'cpp', label: 'C++ dev' },
+  { tag: 'chrome', label: 'Chrome' },
+  { tag: 'perf', label: 'Perf dev' },
+  { tag: 'contrib', label: 'Contributors' },
+];
+const NAV_DEFAULT_TAGS = ['android'];
+
 // This function needs to be idempotent as it is called more than once (on every
 // resize).
 function updateNav() {
@@ -153,97 +165,104 @@ function updateNav() {
   const rootUl = nav.querySelector(':scope > ul');
   if (!rootUl) return;
 
-  const topSections = rootUl.querySelectorAll(':scope > li');
+  // --- Step 1: Load the set of active audience tags. ---
+  const validTags = new Set(NAV_AUDIENCES.map((a) => a.tag));
+  let activeTags = null;
+  try {
+    const raw = sessionStorage.getItem('docs.nav.activeTags');
+    if (raw) activeTags = JSON.parse(raw).filter((t) => validTags.has(t));
+  } catch (e) {
+    activeTags = null;
+  }
+  if (!activeTags) activeTags = NAV_DEFAULT_TAGS.slice();
+  const activeSet = new Set(activeTags);
+  sessionStorage.setItem(
+    'docs.nav.activeTags', JSON.stringify([...activeSet]));
 
-  // Helper: get the display name of a top-level section.
-  const getSectionName = (section) => {
-    const link = section.querySelector(':scope > p > a') ||
-                 section.querySelector(':scope > a');
-    return link ? link.textContent.trim() : '';
+  // --- Step 2: Build/refresh the audience chip bar. ---
+  let filterBox = nav.querySelector(':scope > .audience-filter');
+  if (!filterBox) {
+    filterBox = document.createElement('div');
+    filterBox.className = 'audience-filter';
+    const caption = document.createElement('div');
+    caption.className = 'audience-filter-caption';
+    caption.textContent = 'Perfetto for:';
+    const chipBar = document.createElement('div');
+    chipBar.className = 'audience-tags';
+    filterBox.appendChild(caption);
+    filterBox.appendChild(chipBar);
+    nav.insertBefore(filterBox, rootUl);
+  }
+  const chipBar = filterBox.querySelector(':scope > .audience-tags');
+  chipBar.innerHTML = '';
+  for (const a of NAV_AUDIENCES) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'audience-tag';
+    btn.textContent = a.label;
+    if (activeSet.has(a.tag)) btn.classList.add('active');
+    btn.addEventListener('click', () => {
+      const next = new Set(activeSet);
+      if (next.has(a.tag)) next.delete(a.tag);
+      else next.add(a.tag);
+      sessionStorage.setItem(
+        'docs.nav.activeTags', JSON.stringify([...next]));
+      updateNav();
+    });
+    chipBar.appendChild(btn);
+  }
+
+  // --- Step 3: Parse per-leaf audience tags from <code> markers. ---
+  // Each leaf's tags come from a trailing `tag1 tag2` in the markdown,
+  // rendered by marked.js as a <code> child of the <li> (or its <p>).
+  const allLis = rootUl.querySelectorAll('li');
+  for (const li of allLis) {
+    if (li.dataset.navTagsParsed) continue;
+    const code = li.querySelector(':scope > code') ||
+                 li.querySelector(':scope > p > code');
+    if (code) {
+      li.dataset.navTags = code.textContent.trim();
+    }
+    li.dataset.navTagsParsed = '1';
+  }
+
+  // --- Step 4: Filter leaves by active audience, then collapse empty
+  // ancestors. Visibility is decided bottom-up. ---
+  const showAll = activeSet.size === 0;
+  const hasTag = (li) => {
+    if (!li.dataset.navTags) return null;
+    if (showAll) return true;
+    return li.dataset.navTags.split(/\s+/).some((t) => activeSet.has(t));
   };
 
-  // Helper: check if a section contains the current page.
-  const sectionContainsPage = (section) => {
-    const links = section.querySelectorAll('a[href]:not([href="#"])');
-    for (const link of links) {
-      const url = new URL(link.href);
-      if (url.pathname === curFileName ||
-          url.pathname + 'index.html' === curFileName) {
-        return true;
-      }
-    }
-    return false;
+  const isVisible = new Map();
+  const setVisible = (li, v) => {
+    isVisible.set(li, v);
+    li.style.display = v ? '' : 'none';
   };
 
-  // --- Step 1: Find which top-level section contains the current page. ---
-  // When a page appears in multiple sections (e.g. shared tutorials),
-  // prefer the section the user last navigated into (stored in session).
-  const storedSection = sessionStorage.getItem('docs.nav.activeSection');
-  let activeTopSection = null;
-  let fallbackSection = null;
-
-  for (const section of topSections) {
-    if (!sectionContainsPage(section)) continue;
-    // First match as fallback.
-    if (!fallbackSection) fallbackSection = section;
-    // Prefer the stored section if it contains this page.
-    if (getSectionName(section) === storedSection) {
-      activeTopSection = section;
+  // Bottom-up pass: leaf visibility from tags; parent visible if any child is.
+  const process = (li) => {
+    const childUl = li.querySelector(':scope > ul');
+    if (!childUl) {
+      // Leaf: visible iff untagged (universal) or tag set includes active tag.
+      const match = hasTag(li);
+      setVisible(li, match === null ? true : match);
+      return isVisible.get(li);
     }
-  }
-  if (!activeTopSection) activeTopSection = fallbackSection;
-
-  // Store the active section for future page loads.
-  if (activeTopSection) {
-    sessionStorage.setItem(
-      'docs.nav.activeSection', getSectionName(activeTopSection));
-  }
-
-  // --- Step 2: Set up top-level sections. ---
-  // The active section expands fully. All others collapse to a single
-  // clickable line linking to their first page, moved below the active one.
-  for (const section of topSections) {
-    const headerLink = section.querySelector(':scope > p > a') ||
-                       section.querySelector(':scope > a');
-    const childUl = section.querySelector(':scope > ul');
-
-    if (!headerLink || !headerLink.href ||
-        !headerLink.href.endsWith('#')) continue;
-
-    if (activeTopSection && section !== activeTopSection) {
-      // Inactive section: collapse and link to first page.
-      section.classList.add('inactive-section');
-      if (childUl) childUl.style.display = 'none';
-      const firstLink = section.querySelector('a[href]:not([href="#"])');
-      // Capture name before modifying text.
-      const sectionName = getSectionName(section);
-      if (firstLink) {
-        headerLink.href = firstLink.href;
-        headerLink.onclick = null;
-      }
-      // Show full name ("Perfetto for X") when collapsed as a link.
-      const text = headerLink.textContent.trim();
-      if (text.startsWith('For ')) {
-        headerLink.textContent = 'Perfetto ' + text.charAt(0).toLowerCase() + text.slice(1);
-      }
-      headerLink.addEventListener('click', () => {
-        sessionStorage.setItem('docs.nav.activeSection', sectionName);
-      });
-      // Move below the active section.
-      rootUl.appendChild(section);
-    } else {
-      // Active section: show full content.
-      section.classList.remove('inactive-section');
-      if (childUl) childUl.style.display = '';
+    let anyChildVisible = false;
+    for (const child of childUl.querySelectorAll(':scope > li')) {
+      if (process(child)) anyChildVisible = true;
     }
+    setVisible(li, anyChildVisible);
+    return anyChildVisible;
+  };
+  for (const li of rootUl.querySelectorAll(':scope > li')) {
+    process(li);
   }
 
-  // --- Step 3: Make inner sections (categories) compressible. ---
-  // Only process items inside the active section (or all if no active).
-  const scope = activeTopSection || nav;
-  const innerLis = scope.querySelectorAll('li');
-  for (const sec of innerLis) {
-    // Skip top-level sections — they're handled above.
+  // --- Step 5: Make inner sections (categories) compressible. ---
+  for (const sec of rootUl.querySelectorAll('li')) {
     if (sec.parentElement === rootUl) continue;
 
     const childMenu = sec.querySelector(':scope > ul');
@@ -256,9 +275,11 @@ function updateNav() {
     sec.classList.add('compressible');
 
     const memoKey = `docs.nav.compressed[${link.innerHTML}]`;
-    const stored = sessionStorage.getItem(memoKey);
-    if (stored === '1') {
+    const memo = sessionStorage.getItem(memoKey);
+    if (memo === '1') {
       sec.classList.add('compressed');
+    } else if (memo === '0') {
+      sec.classList.remove('compressed');
     }
 
     doAfterLoadEvent(() => {
@@ -276,7 +297,7 @@ function updateNav() {
     };
   }
 
-  // --- Step 4: Highlight the current page. ---
+  // --- Step 6: Highlight the current page. ---
   const allLinks = nav.querySelectorAll('ul a');
   let found = false;
   for (const x of allLinks) {
@@ -285,8 +306,7 @@ function updateNav() {
     if (x.href.endsWith("#")) {
       // Remove href from non-compressible # links.
       const parentLi = x.closest('li');
-      if (parentLi && !parentLi.classList.contains('compressible') &&
-          !parentLi.classList.contains('inactive-section')) {
+      if (parentLi && !parentLi.classList.contains('compressible')) {
         x.removeAttribute("href");
       }
     } else if ((url.pathname === curFileName ||
@@ -313,9 +333,10 @@ function updateNav() {
         scrollIntoViewIfNeeded(x, nav);
       }
       found = true;
+    } else {
+      x.classList.remove('selected');
     }
   }
-
 }
 
 // If the page contains a ```mermaid ``` block, lazily loads the plugin and

--- a/infra/perfetto.dev/src/assets/style.scss
+++ b/infra/perfetto.dev/src/assets/style.scss
@@ -15,7 +15,7 @@
 // Common + CSS reset
 // -----------------------------------------------------------------------------
 :root {
-  --site-header-height: 50px;
+  --site-header-height: 52px;
   --home-highlights-height: 128px;
   --content-max-width: 1100px;
   --anim-ease: cubic-bezier(0.4, 0, 0.2, 1);
@@ -26,6 +26,22 @@
   --anim-enabled: 0;
 
   --anim-time: calc(0.15s * var(--anim-enabled));
+
+  // Color system
+  --color-primary: hsl(210, 30%, 16%);
+  --color-primary-light: hsl(210, 25%, 22%);
+  --color-accent: #ecba2a;
+  --color-accent-hover: #d4a620;
+  --color-text: #2d3748;
+  --color-text-secondary: #5a6577;
+  --color-text-muted: #8896a6;
+  --color-border: #e2e8f0;
+  --color-border-light: #edf2f7;
+  --color-bg: #f7fafc;
+  --color-bg-white: #fff;
+  --color-link: #0e7c86;
+  --color-link-hover: #0a9ba8;
+  --color-link-visited: #7c4014;
 }
 
 $wide: "(max-width: 1100px)";
@@ -33,12 +49,15 @@ $mobile: "(max-width: 768px)";
 
 @mixin minimal-scrollbar {
   &::-webkit-scrollbar {
-    width: 8px;
+    width: 6px;
     background-color: transparent;
   }
   &::-webkit-scrollbar-thumb {
-    background-color: #ccc;
-    border-radius: 8px;
+    background-color: #cbd5e0;
+    border-radius: 6px;
+    &:hover {
+      background-color: #a0aec0;
+    }
   }
 }
 
@@ -79,15 +98,15 @@ h3 {
 // Site header
 // -----------------------------------------------------------------------------
 .site-header {
-  background-color: hsl(210, 30%, 16%);
+  background-color: var(--color-primary);
   color: hsl(210, 17%, 98%);
   position: sticky; // Sticky so the .docs element below doesn't start @ 0.
   top: 0;
   width: 100%;
-  --sh-padding-y: 5px;
+  --sh-padding-y: 6px;
   max-height: var(--site-header-height);
   padding: var(--sh-padding-y) 30px;
-  box-shadow: rgba(0, 0, 0, 0.3) 0 3px 3px 0;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
   overflow: hidden;
   display: flex;
   z-index: 10;
@@ -106,7 +125,7 @@ h3 {
     .brand-docs {
       text-transform: uppercase;
       font-size: 14px;
-      color: #ecba2a;
+      color: var(--color-accent);
       vertical-align: bottom;
       line-height: 30px;
       font-weight: 400;
@@ -114,16 +133,17 @@ h3 {
   }
   > *:not(:first-child) {
     line-height: calc(var(--site-header-height) - var(--sh-padding-y) * 2);
-    font-family: "Source Sans Pro", sans-serif;
+    font-family: Roboto, sans-serif;
     font-weight: 400;
     font-size: 1.1rem;
     margin: 0 20px;
     color: hsl(210, 17%, 85%);
+    transition: color ease 0.15s;
   }
   a {
     text-decoration: none;
     &:hover {
-      color: hsl(210, 17%, 100%);
+      color: #fff;
     }
   }
   .menu {
@@ -193,46 +213,61 @@ h3 {
     height: 32px;
     font-size: 1rem;
     color: #333;
-    background-color: rgba(255, 255, 255, 0.9);
-    border: 1px solid #eee;
-    border-radius: 2px;
-    background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48"><path d="M39.8 41.95 26.65 28.8q-1.5 1.3-3.5 2.025-2 .725-4.25.725-5.4 0-9.15-3.75T6 18.75q0-5.3 3.75-9.05 3.75-3.75 9.1-3.75 5.3 0 9.025 3.75 3.725 3.75 3.725 9.05 0 2.15-.7 4.15-.7 2-2.1 3.75L42 39.75Zm-20.95-13.4q4.05 0 6.9-2.875Q28.6 22.8 28.6 18.75t-2.85-6.925Q22.9 8.95 18.85 8.95q-4.1 0-6.975 2.875T9 18.75q0 4.05 2.875 6.925t6.975 2.875Z"/></svg>');
+    background-color: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 6px;
+    background-image: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" height="48" width="48" fill="%23999"><path d="M39.8 41.95 26.65 28.8q-1.5 1.3-3.5 2.025-2 .725-4.25.725-5.4 0-9.15-3.75T6 18.75q0-5.3 3.75-9.05 3.75-3.75 9.1-3.75 5.3 0 9.025 3.75 3.725 3.75 3.725 9.05 0 2.15-.7 4.15-.7 2-2.1 3.75L42 39.75Zm-20.95-13.4q4.05 0 6.9-2.875Q28.6 22.8 28.6 18.75t-2.85-6.925Q22.9 8.95 18.85 8.95q-4.1 0-6.975 2.875T9 18.75q0 4.05 2.875 6.925t6.975 2.875Z"/></svg>');
     background-repeat: no-repeat;
     background-size: contain;
     padding-left: 40px;
     outline: none;
-    &:hover,
+    color: rgba(255, 255, 255, 0.9);
+    transition: background-color ease 0.15s, border-color ease 0.15s;
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.5);
+    }
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.18);
+      border-color: rgba(255, 255, 255, 0.25);
+    }
     &:focus {
       background-color: rgba(255, 255, 255, 0.95);
+      border-color: var(--color-accent);
+      color: #333;
     }
   }
 
   #search-res {
     display: none;
     background-color: rgba(255, 255, 255, 1);
-    border: 1px solid #eee;
-    box-shadow: #aaa 0px 1px 5px;
+    border: 1px solid var(--color-border);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    border-radius: 8px;
     color: #333;
     line-height: initial;
-    margin-top: -4px;
+    margin-top: 4px;
     overflow-x: auto;
     position: fixed;
     top: var(--site-header-height);
     max-height: calc(100vh - var(--site-header-height));
     z-index: 10;
     > div {
-      padding: 10px;
+      padding: 12px 16px;
       margin: 0;
+      border-bottom: 1px solid var(--color-border-light);
+      &:last-child {
+        border-bottom: none;
+      }
       &:hover {
-        background-color: #f0f0f0;
+        background-color: #f7fafc;
       }
     }
     .sr-title {
-      color: #333;
-      font-weight: bold;
+      color: var(--color-text);
+      font-weight: 600;
     }
     .sr-snippet {
-      color: #444;
+      color: var(--color-text-secondary);
       font-size: 0.9rem;
     }
 
@@ -255,8 +290,8 @@ h3 {
 
 // Footer in the index page.
 .site-footer {
-  background-color: hsl(210, 30%, 16%);
-  padding: 1em 0;
+  background-color: var(--color-primary);
+  padding: 1.25em 0;
   font-size: 14px;
   color: #fff;
   text-align: center;
@@ -268,7 +303,7 @@ h3 {
       display: inline;
       padding: 0 10px;
       &:not(:last-child) {
-        border-right: solid 1px #fff;
+        border-right: solid 1px rgba(255, 255, 255, 0.3);
       }
     }
   }
@@ -286,10 +321,11 @@ h3 {
 .docs .site-footer {
   grid-area: footer;
   background: transparent;
-  color: #666;
+  color: var(--color-text-muted);
   text-align: left;
   margin: 0 20px;
-  padding: 12px 0;
+  padding: 16px 0;
+  font-size: 13px;
 
   .docs-footer-notice {
     padding: 0;
@@ -307,9 +343,9 @@ h3 {
 // -----------------------------------------------------------------------------
 .site-content {
   .section-wrapper {
-    border-bottom: solid 1px #eee;
+    border-bottom: solid 1px var(--color-border-light);
     &:nth-child(2n + 1) {
-      background-color: hsl(210, 17%, 98%);
+      background-color: var(--color-bg);
     }
   }
   section {
@@ -338,9 +374,9 @@ h3 {
     h1,
     h2 {
       margin: auto;
-      font-family: "Source Sans Pro", sans-serif;
+      font-family: Roboto, sans-serif;
       text-align: center;
-      color: hsl(0, 0, 35%);
+      color: var(--color-text);
       span {
         white-space: nowrap;
       }
@@ -356,6 +392,7 @@ h3 {
       font-size: calc(min(2rem, 6vw, 4vh));
       font-weight: 200;
       padding-top: 10px;
+      color: var(--color-text-secondary);
     }
     .home-img {
       padding: 1rem 0;
@@ -373,7 +410,7 @@ h3 {
 
   .home-highlights {
     &:before {
-      border-top: 1px solid hsl(210, 17%, 90%);
+      border-top: 1px solid var(--color-border);
     }
     height: var(--home-highlights-height);
     display: grid;
@@ -385,13 +422,14 @@ h3 {
       grid-template-columns: repeat(2, 1fr);
     }
     > a {
-      color: hsl(0, 0, 20%);
-      font-size: 22px;
-      font-weight: 400;
+      color: var(--color-text);
+      font-size: 20px;
+      font-weight: 500;
       text-align: center;
       padding: 20px 0;
-      font-family: "Source Sans Pro", sans-serif;
+      font-family: Roboto, sans-serif;
       text-decoration: none;
+      transition: background-color ease 0.15s;
       .icon {
         background-image: url("/assets/sprite.png");
         background-repeat: no-repeat;
@@ -415,7 +453,7 @@ h3 {
         background-position: -192px -64px;
       }
       &:hover {
-        background-color: hsl(210, 17%, 90%);
+        background-color: var(--color-bg);
         .icon {
           filter: grayscale(0);
         }
@@ -440,10 +478,10 @@ h3 {
       grid-area: content;
     }
     h2 {
-      font-family: "Source Sans Pro", sans-serif;
+      font-family: Roboto, sans-serif;
       font-weight: 600;
       font-size: 2.5rem;
-      color: #333;
+      color: var(--color-text);
       text-align: center;
     }
     &:nth-child(2n) {
@@ -482,16 +520,17 @@ h3 {
       grid-area: content;
       .button {
         display: inline-block;
-        background: #337ab7;
+        background: var(--color-link);
         font-weight: 500;
         color: #fff;
-        border-radius: 6px;
-        font-size: 18px;
-        padding: 10px 16px;
-        transition: background-color ease var(--anim-time);
+        border-radius: 8px;
+        font-size: 16px;
+        padding: 10px 20px;
+        transition: background-color ease 0.15s, transform ease 0.15s;
         text-decoration: none;
         &:hover {
-          background: #286090;
+          background: var(--color-link-hover);
+          transform: translateY(-1px);
         }
       }
     }
@@ -503,15 +542,14 @@ h3 {
       grid-column-gap: 20px;
       padding: 20px 30px;
       margin: 10px 0;
-      // border: 1px solid #eee;
-      font-family: "Source Sans Pro", sans-serif;
-      color: #111111;
+      font-family: Roboto, sans-serif;
+      color: var(--color-text);
       transition:
         filter var(--anim-ease) var(--anim-time),
         background-color var(--anim-ease) var(--anim-time),
         transform var(--anim-ease) var(--anim-time),
         box-shadow linear var(--anim-time);
-      border-radius: 6px;
+      border-radius: 8px;
       filter: opacity(0.6);
       &:hover {
         background-color: hsla(0, 0, 0, 0.02);
@@ -523,6 +561,7 @@ h3 {
         grid-area: img;
         margin: auto;
         font-size: 50px;
+        color: var(--color-text-muted);
       }
       > h3 {
         grid-area: title;
@@ -535,6 +574,7 @@ h3 {
         font-size: 1rem;
         font-weight: 400;
         margin: 1em 0;
+        color: var(--color-text-secondary);
       }
     }
   }
@@ -576,7 +616,7 @@ h3 {
 .docs {
   min-height: 100vh;
   display: grid;
-  --nav-width: 240px;
+  --nav-width: 260px;
   --toc-min-width: 180px;
   --toc-max-width: 320px;
 
@@ -590,85 +630,116 @@ h3 {
   grid-template-rows: 1fr max-content;
   grid-template-areas: "nav doc toc" "nav footer toc";
 
-  background-color: hsl(210, 10%, 97%);
+  background-color: var(--color-bg);
+
   .nav {
     grid-area: nav;
-    border-right: 1px solid hsl(210, 30%, 90%);
-    background-color: #fefefe;
-    padding: 20px 0;
-    padding-right: 16px;
-
+    border-right: 1px solid var(--color-border);
+    background-color: var(--color-bg-white);
+    padding: 0 12px 12px 0;
     position: sticky;
     top: var(--site-header-height);
     height: calc(100vh - var(--site-header-height));
     overflow-y: auto;
     @include minimal-scrollbar;
+    font-family: Roboto, sans-serif;
+    font-size: 0.9rem;
 
-    a {
-      color: inherit;
-      text-decoration: none;
-      line-height: 24px;
-      display: flex;
-      transition:
-        background-color var(--anim-ease) var(--anim-time),
-        visibility linear var(--anim-time);
-      border-radius: 0 10px 10px 0;
-      -webkit-tap-highlight-color: transparent;
-      &[href] {
-        &:hover {
-          color: #000;
-          background-color: #f1f3f4;
-        }
-        &.selected {
-          background-color: #ecba2a;
-        }
-      }
-    }
-
+    // ---- Base reset for all lists and links ----
     ul {
       list-style: none;
       margin: 0;
       padding: 0;
       overflow: hidden;
-      li {
-        font-size: 1rem;
-        font-weight: 400;
-        font-family: "Source Sans Pro", sans-serif;
-        color: #4a4a4a;
-        max-width: 100%;
-        margin: 3px 0;
+    }
+    p { margin: 0; }
+
+    a {
+      display: flex;
+      align-items: center;
+      color: var(--color-text-secondary);
+      text-decoration: none;
+      line-height: 1.4;
+      padding: 5px 16px;
+      border-radius: 0 6px 6px 0;
+      transition: background-color 0.12s ease, color 0.12s ease;
+      -webkit-tap-highlight-color: transparent;
+      &[href]:hover {
+        color: var(--color-text);
+        background-color: var(--color-bg);
       }
-      p {
-        margin: 0;
+      &.selected {
+        background-color: var(--color-bg);
+        color: var(--color-link);
+        font-weight: 600;
       }
     }
 
+    // ---- Top-level sections ----
+    // Active section shows full tree; inactive ones collapse to one line.
     > ul > li {
-      padding-bottom: 10px;
-      margin-bottom: 10px;
-      color: #000;
-
-      &:not(:last-child) {
-        border-bottom: 2px solid #ddd;
+      padding: 10px 0 4px;
+      & + li {
+        border-top: 1px solid var(--color-border-light);
       }
+
+      // Active section header.
+      > p > a {
+        font-weight: 700;
+        font-size: 0.95rem;
+        color: var(--color-link);
+        padding: 4px 16px;
+        letter-spacing: 0.01em;
+        text-transform: none;
+        border-left: 3px solid var(--color-link);
+      }
+
+      // Inactive sections: compact one-line links.
+      &.inactive-section {
+        padding: 0;
+        > p > a {
+          font-weight: 400;
+          font-size: 0.9rem;
+          color: var(--color-text-secondary);
+          padding: 4px 16px;
+          &:hover { color: var(--color-link); }
+        }
+        & + li.inactive-section {
+          border-top: none;
+        }
+      }
+
     }
 
-    a[href="#"],
+    // Separator before the first inactive section at the bottom.
+    > ul > li:not(.inactive-section) + li.inactive-section {
+      margin-top: 4px;
+      padding-top: 8px;
+      border-top: 1px solid var(--color-border);
+    }
+
+    // ---- Category headers (Tutorials, Reference, etc.) ----
+    .compressible > p > a,
     a:not([href]) {
       font-weight: 600;
+      font-size: 0.85rem;
+      color: var(--color-text);
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      padding: 6px 16px 4px;
     }
 
-    // Applies only to outer-level submenus.
+    // ---- Expand/collapse chevron ----
     .compressible {
       > p > a::after {
-        content: "keyboard_arrow_up";
-        font-family: "Material Icons Round";
-        font-size: 24px;
-        width: 24px;
+        content: "\25B4"; // ▴ small up triangle
+        font-size: 0.7em;
+        flex-shrink: 0;
+        width: 20px;
+        text-align: center;
+        margin-left: auto;
+        color: var(--color-text-muted);
         transition: transform var(--anim-ease) var(--anim-time);
-        margin: 0 0 0 auto;
-        font-weight: 200;
-        color: #666;
       }
       > ul {
         transition: max-height var(--anim-ease) var(--anim-time),
@@ -676,75 +747,66 @@ h3 {
         opacity: 1;
       }
       &.compressed {
-        // The JS will compute and set the maxHeight on each
-        // element depending on the size of their children.
-        // !important is needed to override the element-inline
-        // max-height property set by JS, which is prioritary.
         > ul {
+          // !important overrides the inline max-height set by JS.
           max-height: 0 !important;
           visibility: hidden;
           opacity: 0;
         }
         > p > a::after {
-          transform: scaleY(-1);
+          transform: rotate(180deg);
         }
       }
-    } // .compressible
+    }
 
-    li a {
-      padding-left: 16px;
-    }
-    li li a {
-      padding-left: 16px;
-    }
-    li li li a {
-      padding-left: 24px;
-    }
-    li li li li a {
-      padding-left: 32px;
-    }
-    .expanded a::after {
-      transform: rotate(180deg);
-    }
+    // ---- Indentation ----
+    li a { padding-left: 16px; }
+    li li a { padding-left: 16px; }
+    li li li a { padding-left: 28px; }
+    li li li li a { padding-left: 36px; }
   }
   .doc {
     grid-area: doc;
-    background-color: #fff;
+    background-color: var(--color-bg-white);
     margin: 20px;
-    padding: 30px 40px;
+    padding: 36px 48px;
     font-family: Roboto, sans-serif;
     font-size: 1rem;
     font-weight: 400;
-    line-height: 24px;
+    line-height: 1.7;
     -webkit-font-smoothing: antialiased;
-    color: #4a4a4a;
+    color: var(--color-text);
     position: relative;
+    border-radius: 8px;
     box-shadow:
-      0 1px 2px 0 rgba(60, 64, 67, 0.1),
-      0 1px 3px 1px rgba(60, 64, 67, 0.15);
+      0 1px 3px rgba(0, 0, 0, 0.06),
+      0 1px 2px rgba(0, 0, 0, 0.08);
     overflow: hidden;
 
     a {
       text-decoration: none;
+      transition: color ease 0.1s;
       &:link {
-        color: #007b83;
+        color: var(--color-link);
       }
       &:visited {
-        color: #8e3317;
+        color: var(--color-link-visited);
       }
       &:hover {
-        color: #009da8;
+        color: var(--color-link-hover);
+        text-decoration: underline;
       }
       &[href^="http"] {
         // External link.
         &:after {
           content: "open_in_new";
           font-family: "Material Icons Round";
-          color: #666;
+          color: var(--color-text-muted);
           text-decoration: none;
           margin-left: 2px;
           margin-right: 4px;
-          vertical-align: bottom;
+          font-size: 0.85em;
+          vertical-align: middle;
         }
       }
     }
@@ -755,43 +817,50 @@ h3 {
       margin: 10px 0;
       padding: 0;
       padding-top: 30px;
+      color: var(--color-text);
     }
     h1 {
       font-size: 2.25rem;
-      line-height: 2.25rem;
+      line-height: 1.2;
       margin: 0;
       padding: 0;
       margin-bottom: 1.5rem;
-      font-family: "Source Sans Pro", sans-serif;
+      font-family: Roboto, sans-serif;
+      font-weight: 700;
+      letter-spacing: -0.02em;
     }
     h2 {
       font-size: 1.5rem;
-      border-bottom: 1px solid #e8eaed;
-      padding-bottom: 6px;
+      font-weight: 600;
+      border-bottom: 2px solid var(--color-border-light);
+      padding-bottom: 8px;
     }
     h3 {
       font-size: 1.25rem;
+      font-weight: 600;
     }
     * {
       max-width: 100%;
     }
 
     img[alt$="screenshot"] {
-      box-shadow: 0 0 10px 2px #eee;
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+      border-radius: 6px;
     }
 
     code:not(.code-block) {
-      background: hsla(210, 17%, 90%, 0.2);
-      border: 1px solid #e8eaed;
-      border-radius: 6px;
-      padding: 1px 4px;
+      background: #f1f5f9;
+      border: 1px solid var(--color-border);
+      border-radius: 4px;
+      padding: 1px 6px;
+      font-size: 0.88em;
     }
     .code-block {
       overflow-x: auto;
       white-space: pre;
-      border-radius: 6px;
-      box-shadow: 1px 1px 6px #999;
-      border-top: 5px solid #8bc34a;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      border-top: 3px solid #8bc34a;
     }
     // Hide mermaid graphs until they are rendered, this is to avoid showing
     // the mermaid source while the renderer generates the SVG.
@@ -814,8 +883,8 @@ h3 {
       &::before {
         content: "insert_link";
         font-family: "Material Icons Round";
-        color: #333;
-        font-size: 24px;
+        color: var(--color-text-muted);
+        font-size: 22px;
       }
     }
     *:hover .anchor {
@@ -830,10 +899,12 @@ h3 {
       font-size: 14px;
       border-spacing: 0;
       border-collapse: collapse;
+      border-radius: 6px;
+      overflow: hidden;
       th,
       td {
-        padding: 8px;
-        border: 0 solid #dadce0;
+        padding: 10px 12px;
+        border: 0 solid var(--color-border);
         border-top-width: 1px;
         border-bottom-width: 1px;
       }
@@ -841,12 +912,16 @@ h3 {
         height: 20px;
       }
       tr:target {
-        background-color: #ecba2a;
+        background-color: #fef3cd;
       }
       thead {
         text-align: left;
-        background-color: #e8eaed;
-        color: #202124;
+        background-color: var(--color-bg);
+        color: var(--color-text);
+        font-weight: 600;
+      }
+      tbody tr:hover {
+        background-color: #fafbfc;
       }
     }
 
@@ -856,7 +931,7 @@ h3 {
       h3 {
         code {
           margin-left: 20px;
-          color: #666;
+          color: var(--color-text-secondary);
         }
       }
       table {
@@ -866,8 +941,8 @@ h3 {
         border-collapse: collapse;
         th,
         td {
-          padding: 8px;
-          border: 0 solid #dadce0;
+          padding: 10px 12px;
+          border: 0 solid var(--color-border);
           border-top-width: 1px;
           border-bottom-width: 1px;
         }
@@ -876,12 +951,12 @@ h3 {
         }
         thead {
           text-align: left;
-          background-color: #e8eaed;
-          color: #202124;
+          background-color: var(--color-bg);
+          color: var(--color-text);
         }
         td {
           &:first-child {
-            background: #f7f7f7;
+            background: #fafbfc;
           }
 
           /* Not really 100% but makes sure that the description
@@ -894,65 +969,65 @@ h3 {
     }
 
     .callout {
-      padding: 0.5rem 0.5rem 0.5rem 2rem;
+      padding: 1rem 1rem 1rem 2.5rem;
       border: none;
-      border-radius: 2px;
-      margin-left: auto;
-      margin-right: auto;
-      width: 90%;
-      border-left: 3px solid transparent;
+      border-radius: 8px;
+      margin: 1.25em auto;
+      width: 92%;
+      border-left: 4px solid transparent;
       box-shadow:
-        0 0.2rem 0.5rem rgba(0, 0, 0, 0.05),
-        0 0 0.05rem rgba(0, 0, 0, 0.1);
+        0 1px 4px rgba(0, 0, 0, 0.06),
+        0 0 1px rgba(0, 0, 0, 0.08);
+      line-height: 1.6;
 
       &:before {
         font-family: "Material Icons Round";
         position: absolute;
-        font-size: 1.5rem;
-        margin-left: -1.75rem;
-        margin-top: -2px;
+        font-size: 1.3rem;
+        margin-left: -2rem;
+        margin-top: 0;
       }
 
       &.note {
-        background-color: #e8f0fe;
-        border-color: #1967d2;
-        color: #1967d2;
+        background-color: #eff6ff;
+        border-color: #3b82f6;
+        color: #1e40af;
         &:before {
           content: "bookmark";
         }
       }
 
       &.summary {
-        background-color: #e4f7fb;
-        border-color: #129eaf;
-        color: #129eaf;
+        background-color: #ecfeff;
+        border-color: #06b6d4;
+        color: #0e7490;
         &:before {
           content: "sms";
         }
       }
 
       &.tip {
-        background-color: #e6f4ea;
-        border-color: #188038;
-        color: #188038;
+        background-color: #f0fdf4;
+        border-color: #22c55e;
+        color: #166534;
         &:before {
           content: "star";
         }
       }
 
       &.todo {
-        background-color: #f1f3f4;
-        border-color: #5f6368;
-        color: #5f6368;
+        background-color: #f8fafc;
+        border-color: #94a3b8;
+        color: #475569;
         &:before {
           content: "error";
         }
       }
 
       &.warning {
-        background-color: #fce8e6;
-        border-color: #c5221f;
-        color: #c5221f;
+        background-color: #fef2f2;
+        border-color: #ef4444;
+        color: #991b1b;
         &:before {
           content: "warning";
         }
@@ -960,13 +1035,15 @@ h3 {
     }
 
     .tab-box {
-      border: 1px solid #eee;
-      border-radius: 2px;
-      padding: 8px;
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      padding: 0;
+      overflow: hidden;
     }
 
     .tab-buttons {
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid var(--color-border);
+      background-color: var(--color-bg);
     }
 
     .tab-button {
@@ -974,19 +1051,24 @@ h3 {
       border: none;
       background: transparent;
       font-family: Roboto, sans-serif;
-      font-size: 1rem;
-      padding: 8px;
+      font-size: 0.95rem;
+      padding: 10px 16px;
+      font-weight: 500;
+      color: var(--color-text-secondary);
+      transition: color ease 0.1s, border-color ease 0.1s;
       &:hover {
-        background-color: hsl(0, 0%, 80%);
+        color: var(--color-text);
+        background-color: rgba(0, 0, 0, 0.03);
       }
       &.tab-button-selected {
-        border-bottom: 4px solid hsl(210, 29%, 30%);
+        color: var(--color-text);
+        border-bottom: 3px solid var(--color-accent);
       }
     }
 
     .tab-content {
       display: none;
-      padding: 8px;
+      padding: 12px 16px;
 
       &.tab-content-selected {
         display: block;
@@ -995,7 +1077,7 @@ h3 {
   }
   .toc {
     grid-area: toc;
-    padding: 20px 16px 20px 0;
+    padding: 24px 16px 24px 0;
     max-width: var(--toc-max-width);
 
     position: sticky;
@@ -1004,26 +1086,30 @@ h3 {
     overflow-y: auto;
     @include minimal-scrollbar;
 
-    font-family: "Source Sans Pro", sans-serif;
+    font-family: Roboto, sans-serif;
     word-break: break-word;
     a {
       text-decoration: none;
+      transition: color ease 0.1s;
     }
     a,
     a:visited {
-      color: #333;
+      color: var(--color-text-secondary);
+    }
+    a:hover {
+      color: var(--color-text);
     }
     a.highlighted {
-      font-weight: 500;
-      color: hsl(45, 100%, 40%);
+      font-weight: 600;
+      color: #b8860b;
     }
-    font-size: 0.875rem;
+    font-size: 0.85rem;
     ul {
       list-style: none;
       margin: 0;
       padding: 0;
       li {
-        margin: 5px 0;
+        margin: 4px 0;
         /* This make it so that a single word gets elided but if there
                  * are multiple words they span across lines.  */
         overflow: hidden;
@@ -1033,8 +1119,8 @@ h3 {
       }
     }
     > ul {
-      border-left: 4px solid #ecba2a;
-      padding-left: 10px;
+      border-left: 3px solid var(--color-accent);
+      padding-left: 12px;
       position: static; // Otherwise gets v-centered in the middle.
       top: calc(var(--site-header-height) + 25px);
     }
@@ -1051,6 +1137,7 @@ h3 {
     .doc {
       margin: 0;
       padding: 20px;
+      border-radius: 0;
     }
     .nav {
       // JS will persistently toggle to .after_first_click. This is to

--- a/infra/perfetto.dev/src/assets/style.scss
+++ b/infra/perfetto.dev/src/assets/style.scss
@@ -133,7 +133,7 @@ h3 {
   }
   > *:not(:first-child) {
     line-height: calc(var(--site-header-height) - var(--sh-padding-y) * 2);
-    font-family: Roboto, sans-serif;
+    font-family: "Source Sans Pro", sans-serif;
     font-weight: 400;
     font-size: 1.1rem;
     margin: 0 20px;
@@ -324,8 +324,7 @@ h3 {
   color: var(--color-text-muted);
   text-align: left;
   margin: 0 20px;
-  padding: 16px 0;
-  font-size: 13px;
+  padding: 12px 0;
 
   .docs-footer-notice {
     padding: 0;
@@ -374,7 +373,7 @@ h3 {
     h1,
     h2 {
       margin: auto;
-      font-family: Roboto, sans-serif;
+      font-family: "Source Sans Pro", sans-serif;
       text-align: center;
       color: var(--color-text);
       span {
@@ -423,11 +422,11 @@ h3 {
     }
     > a {
       color: var(--color-text);
-      font-size: 20px;
-      font-weight: 500;
+      font-size: 22px;
+      font-weight: 400;
       text-align: center;
       padding: 20px 0;
-      font-family: Roboto, sans-serif;
+      font-family: "Source Sans Pro", sans-serif;
       text-decoration: none;
       transition: background-color ease 0.15s;
       .icon {
@@ -478,7 +477,7 @@ h3 {
       grid-area: content;
     }
     h2 {
-      font-family: Roboto, sans-serif;
+      font-family: "Source Sans Pro", sans-serif;
       font-weight: 600;
       font-size: 2.5rem;
       color: var(--color-text);
@@ -523,9 +522,9 @@ h3 {
         background: var(--color-link);
         font-weight: 500;
         color: #fff;
-        border-radius: 8px;
-        font-size: 16px;
-        padding: 10px 20px;
+        border-radius: 6px;
+        font-size: 18px;
+        padding: 10px 16px;
         transition: background-color ease 0.15s, transform ease 0.15s;
         text-decoration: none;
         &:hover {
@@ -542,7 +541,7 @@ h3 {
       grid-column-gap: 20px;
       padding: 20px 30px;
       margin: 10px 0;
-      font-family: Roboto, sans-serif;
+      font-family: "Source Sans Pro", sans-serif;
       color: var(--color-text);
       transition:
         filter var(--anim-ease) var(--anim-time),
@@ -642,8 +641,6 @@ h3 {
     height: calc(100vh - var(--site-header-height));
     overflow-y: auto;
     @include minimal-scrollbar;
-    font-family: Roboto, sans-serif;
-    font-size: 0.9rem;
 
     // ---- Audience filter (caption + chips) ----
     .audience-filter {
@@ -691,20 +688,22 @@ h3 {
       }
     }
 
-    // Per-leaf tag markers in toc.md (e.g. `android linux`) are parsed by
-    // JS and should not be displayed.
-    code {
-      display: none;
-    }
-
     // ---- Base reset for all lists and links ----
     ul {
       list-style: none;
       margin: 0;
       padding: 0;
       overflow: hidden;
+      li {
+        font-size: 1rem;
+        font-weight: 400;
+        font-family: "Source Sans Pro", sans-serif;
+        color: #4a4a4a;
+        max-width: 100%;
+        margin: 0;
+      }
+      p { margin: 0; }
     }
-    p { margin: 0; }
 
     a {
       display: flex;
@@ -736,7 +735,6 @@ h3 {
 
       > p > a {
         font-weight: 700;
-        font-size: 0.95rem;
         color: var(--color-link);
         padding: 4px 16px;
         letter-spacing: 0.01em;
@@ -749,7 +747,6 @@ h3 {
     .compressible > p > a,
     a:not([href]) {
       font-weight: 600;
-      font-size: 0.85rem;
       color: var(--color-text);
       text-transform: uppercase;
       letter-spacing: 0.03em;
@@ -759,13 +756,13 @@ h3 {
     // ---- Expand/collapse chevron ----
     .compressible {
       > p > a::after {
-        content: "\25B4"; // ▴ small up triangle
+        content: "\25B4";
         font-size: 0.7em;
         flex-shrink: 0;
         width: 20px;
         text-align: center;
         margin-left: auto;
-        color: var(--color-text-muted);
+        color: #666;
         transition: transform var(--anim-ease) var(--anim-time);
       }
       > ul {
@@ -832,8 +829,7 @@ h3 {
           text-decoration: none;
           margin-left: 2px;
           margin-right: 4px;
-          font-size: 0.85em;
-          vertical-align: middle;
+          vertical-align: bottom;
         }
       }
     }
@@ -848,23 +844,19 @@ h3 {
     }
     h1 {
       font-size: 2.25rem;
-      line-height: 1.2;
+      line-height: 2.25rem;
       margin: 0;
       padding: 0;
       margin-bottom: 1.5rem;
-      font-family: Roboto, sans-serif;
-      font-weight: 700;
-      letter-spacing: -0.02em;
+      font-family: "Source Sans Pro", sans-serif;
     }
     h2 {
       font-size: 1.5rem;
-      font-weight: 600;
-      border-bottom: 2px solid var(--color-border-light);
-      padding-bottom: 8px;
+      border-bottom: 1px solid #e8eaed;
+      padding-bottom: 6px;
     }
     h3 {
       font-size: 1.25rem;
-      font-weight: 600;
     }
     * {
       max-width: 100%;
@@ -877,10 +869,9 @@ h3 {
 
     code:not(.code-block) {
       background: #f1f5f9;
-      border: 1px solid var(--color-border);
-      border-radius: 4px;
-      padding: 1px 6px;
-      font-size: 0.88em;
+      border: 1px solid #e8eaed;
+      border-radius: 6px;
+      padding: 1px 4px;
     }
     .code-block {
       overflow-x: auto;
@@ -910,8 +901,8 @@ h3 {
       &::before {
         content: "insert_link";
         font-family: "Material Icons Round";
-        color: var(--color-text-muted);
-        font-size: 22px;
+        color: #333;
+        font-size: 24px;
       }
     }
     *:hover .anchor {
@@ -1010,9 +1001,9 @@ h3 {
       &:before {
         font-family: "Material Icons Round";
         position: absolute;
-        font-size: 1.3rem;
-        margin-left: -2rem;
-        margin-top: 0;
+        font-size: 1.5rem;
+        margin-left: -1.75rem;
+        margin-top: -2px;
       }
 
       &.note {
@@ -1078,9 +1069,8 @@ h3 {
       border: none;
       background: transparent;
       font-family: Roboto, sans-serif;
-      font-size: 0.95rem;
-      padding: 10px 16px;
-      font-weight: 500;
+      font-size: 1rem;
+      padding: 8px;
       color: var(--color-text-secondary);
       transition: color ease 0.1s, border-color ease 0.1s;
       &:hover {
@@ -1113,7 +1103,7 @@ h3 {
     overflow-y: auto;
     @include minimal-scrollbar;
 
-    font-family: Roboto, sans-serif;
+    font-family: "Source Sans Pro", sans-serif;
     word-break: break-word;
     a {
       text-decoration: none;
@@ -1130,7 +1120,7 @@ h3 {
       font-weight: 600;
       color: #b8860b;
     }
-    font-size: 0.85rem;
+    font-size: 0.875rem;
     ul {
       list-style: none;
       margin: 0;

--- a/infra/perfetto.dev/src/assets/style.scss
+++ b/infra/perfetto.dev/src/assets/style.scss
@@ -645,6 +645,58 @@ h3 {
     font-family: Roboto, sans-serif;
     font-size: 0.9rem;
 
+    // ---- Audience filter (caption + chips) ----
+    .audience-filter {
+      padding: 10px 12px 10px 16px;
+      border-bottom: 1px solid var(--color-border-light);
+      margin-bottom: 4px;
+
+      .audience-filter-caption {
+        font-size: 0.72rem;
+        line-height: 1.2;
+        color: var(--color-text-muted);
+        margin-bottom: 6px;
+      }
+
+      .audience-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+      }
+
+      .audience-tag {
+        font-family: inherit;
+        font-size: 0.75rem;
+        font-weight: 500;
+        line-height: 1;
+        padding: 4px 8px;
+        border-radius: 999px;
+        border: 1px solid var(--color-border);
+        background-color: var(--color-bg-white);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: background-color 0.12s ease, color 0.12s ease,
+                    border-color 0.12s ease;
+        -webkit-tap-highlight-color: transparent;
+        white-space: nowrap;
+        &:hover {
+          color: var(--color-text);
+          border-color: var(--color-text-muted);
+        }
+        &.active {
+          background-color: var(--color-link);
+          border-color: var(--color-link);
+          color: #fff;
+        }
+      }
+    }
+
+    // Per-leaf tag markers in toc.md (e.g. `android linux`) are parsed by
+    // JS and should not be displayed.
+    code {
+      display: none;
+    }
+
     // ---- Base reset for all lists and links ----
     ul {
       list-style: none;
@@ -675,15 +727,13 @@ h3 {
       }
     }
 
-    // ---- Top-level sections ----
-    // Active section shows full tree; inactive ones collapse to one line.
+    // ---- Top-level sections (Overview, Getting Started, etc.) ----
     > ul > li {
       padding: 10px 0 4px;
       & + li {
         border-top: 1px solid var(--color-border-light);
       }
 
-      // Active section header.
       > p > a {
         font-weight: 700;
         font-size: 0.95rem;
@@ -693,29 +743,6 @@ h3 {
         text-transform: none;
         border-left: 3px solid var(--color-link);
       }
-
-      // Inactive sections: compact one-line links.
-      &.inactive-section {
-        padding: 0;
-        > p > a {
-          font-weight: 400;
-          font-size: 0.9rem;
-          color: var(--color-text-secondary);
-          padding: 4px 16px;
-          &:hover { color: var(--color-link); }
-        }
-        & + li.inactive-section {
-          border-top: none;
-        }
-      }
-
-    }
-
-    // Separator before the first inactive section at the bottom.
-    > ul > li:not(.inactive-section) + li.inactive-section {
-      margin-top: 4px;
-      padding-top: 8px;
-      border-top: 1px solid var(--color-border);
     }
 
     // ---- Category headers (Tutorials, Reference, etc.) ----

--- a/infra/perfetto.dev/src/markdown_render.js
+++ b/infra/perfetto.dev/src/markdown_render.js
@@ -142,6 +142,20 @@ function renderImage(originalImgFn, href, title, text) {
   return originalImgFn(href, title, text);
 }
 
+function renderListItem(text) {
+  // Detect a trailing {.class1 .class2} attribute block (used in toc.md to
+  // annotate audience, e.g. {.tag-android .tag-linux}).  Hoist the classes
+  // onto the <li> so the sidebar can filter with pure CSS.
+  const m = text.match(
+    /\s*\{(\.[a-z][a-z0-9-]*(?:\s+\.[a-z][a-z0-9-]*)*)\}(\s*<\/p>)?\s*$/);
+  if (m) {
+    const cls = m[1].split(/\s+/).map(c => c.slice(1)).join(' ');
+    const tail = m[2] || '';
+    return `<li class="${cls}">${text.slice(0, m.index)}${tail}</li>\n`;
+  }
+  return `<li>${text}</li>\n`;
+}
+
 function renderParagraph(text) {
   let cssClass = "";
   if (text.startsWith("NOTE:")) {
@@ -209,6 +223,7 @@ function render(rawMarkdown) {
   renderer.code = renderCode;
   renderer.heading = renderHeading;
   renderer.paragraph = renderParagraph;
+  renderer.listitem = renderListItem;
   const originalHtmlFn = renderer.html.bind(renderer);
   renderer.html = (html) => renderHtml(originalHtmlFn, html);
 

--- a/infra/perfetto.dev/src/template_header.html
+++ b/infra/perfetto.dev/src/template_header.html
@@ -10,7 +10,7 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="canonical" href="https://perfetto.dev<%= fileName.replace('/index.html', '/') %>">
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,500,600,800&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Roboto+Mono" rel="stylesheet">
+<link href="https://fonts.googleapis.com/icon?family=Roboto+Mono" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Round" rel="stylesheet">
   <link rel="stylesheet" href="/assets/style.css">
   <link rel="stylesheet" href="/assets/tomorrow-night.css">
@@ -20,12 +20,16 @@
 <body>
 <header class="site-header">
   <div class="brand">
+    <% if (fileName.startsWith('/docs/')) { %>
+    <a href="/docs/">
+      <img src="/assets/brand.png">
+      <span class="brand-docs">Docs</span>
+    </a>
+    <% } else { %>
     <a href="/">
       <img src="/assets/brand.png">
-      <% if (fileName.startsWith('/docs/')) { %>
-      <span class="brand-docs">Docs</span>
-      <% } %>
     </a>
+    <% } %>
   </div>
   <a href="#toggle" class="menu"><i class="material-icons-round">menu</i></a>
 
@@ -34,9 +38,10 @@
       <input id="search-box" type="text" placeholder="Search" autocomplete="off">
       <div id="search-res"></div>
     </div>
+    <a href="/">Home</a>
+  <% } else { %>
+    <a href="/docs/">Docs</a>
   <% } %>
-
-  <a href="/docs/">Docs</a>
   <a href="/docs/contributing/getting-started#community">Community</a>
   <a href="https://ui.perfetto.dev/">Trace Viewer</a>
   <a href="https://github.com/google/perfetto">GitHub</a>


### PR DESCRIPTION
The basic idea of this reorg is to let us "filter" the docs website based on the audience who is reading it. This allows for only showing things which are relevant to the reader instead of bombarding them with all the info, many of which might not be relevant.

At the same time, take the opportunity to spruce up the docs website a bit, udpating styles and in general making things a bit more modern.

<img width="3352" height="1858" alt="image" src="https://github.com/user-attachments/assets/2246d82e-96c1-4203-af76-9a64b33fb360" />
