### PR TITLE
de: Use PerfettoSqlType everywhere

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/datagrid_node_creation_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/datagrid_node_creation_unittest.ts
@@ -41,7 +41,6 @@ describe('datagrid_node_creation', () => {
   ): ColumnInfo {
     return {
       name,
-      type: 'JOINID',
       checked: true,
       column: {
         name,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/history_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/history_manager_unittest.ts
@@ -761,7 +761,6 @@ describe('HistoryManager', () => {
     // State 4: Add aggregation after filter
     const groupByColumn: ColumnInfo = {
       name: 'id',
-      type: 'STRING',
       checked: true,
       column: {name: 'id', type: {kind: 'string'}},
     };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
@@ -155,7 +155,6 @@ describe('JSON serialization/deserialization', () => {
       groupByColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -164,7 +163,6 @@ describe('JSON serialization/deserialization', () => {
         {
           column: {
             name: 'dur',
-            type: 'TIMESTAMP_NS',
             checked: true,
             column: sliceTable.columns[2],
           },
@@ -903,8 +901,8 @@ describe('JSON serialization/deserialization', () => {
       (c) => c.column.name === 'renamed_column',
     );
     expect(renamedCol).toBeDefined();
-    expect(renamedCol?.type).toBe(columnToRename.type);
-    expect(renamedCol?.type).not.toBe('NA'); // Type should be preserved, not 'NA'
+    expect(renamedCol?.column.type).toBe(columnToRename.column.type);
+    expect(renamedCol?.column.type).toBeDefined(); // Type should be preserved, not undefined
 
     // Now test serialization/deserialization preserves this
     const initialState: DataExplorerState = {
@@ -952,8 +950,10 @@ describe('JSON serialization/deserialization', () => {
       (c) => c.column.name === 'renamed_column',
     );
     expect(deserializedRenamedCol).toBeDefined();
-    expect(deserializedRenamedCol?.type).toBe(columnToRename.type);
-    expect(deserializedRenamedCol?.type).not.toBe('NA'); // Type should still be preserved
+    expect(deserializedRenamedCol?.column.type).toEqual(
+      columnToRename.column.type,
+    );
+    expect(deserializedRenamedCol?.column.type).toBeDefined(); // Type should still be preserved
   });
 
   test('aggregation node can group by aliased column from modify columns node', () => {
@@ -1440,13 +1440,11 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
         {
           name: 'ts',
-          type: 'TIMESTAMP_NS',
           checked: true,
           column: sliceTable.columns[1],
         },
@@ -1574,13 +1572,11 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
         {
           name: 'ts',
-          type: 'TIMESTAMP_NS',
           checked: false,
           column: sliceTable.columns[1],
         },
@@ -1691,13 +1687,11 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
         {
           name: 'ts',
-          type: 'TIMESTAMP_NS',
           checked: true,
           column: sliceTable.columns[1],
         },
@@ -1765,13 +1759,11 @@ describe('JSON serialization/deserialization', () => {
       groupByColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
         {
           name: 'ts',
-          type: 'TIMESTAMP_NS',
           checked: true,
           column: sliceTable.columns[1],
         },
@@ -1780,7 +1772,6 @@ describe('JSON serialization/deserialization', () => {
         {
           column: {
             name: 'dur',
-            type: 'TIMESTAMP_NS',
             checked: true,
             column: sliceTable.columns[2],
           },
@@ -1790,7 +1781,6 @@ describe('JSON serialization/deserialization', () => {
         {
           column: {
             name: 'dur',
-            type: 'TIMESTAMP_NS',
             checked: true,
             column: sliceTable.columns[2],
           },
@@ -1800,7 +1790,6 @@ describe('JSON serialization/deserialization', () => {
         {
           column: {
             name: 'dur',
-            type: 'TIMESTAMP_NS',
             checked: true,
             column: sliceTable.columns[2],
           },
@@ -1872,7 +1861,6 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -1884,7 +1872,6 @@ describe('JSON serialization/deserialization', () => {
       groupByColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -1893,7 +1880,6 @@ describe('JSON serialization/deserialization', () => {
         {
           column: {
             name: 'dur_ms',
-            type: 'TIMESTAMP_NS',
             checked: true,
             column: sliceTable.columns[2],
           },
@@ -1974,7 +1960,6 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -1986,7 +1971,6 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'ts',
-          type: 'TIMESTAMP_NS',
           checked: true,
           column: sliceTable.columns[1],
         },
@@ -2138,7 +2122,6 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -2204,7 +2187,6 @@ describe('JSON serialization/deserialization', () => {
       groupByColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -2213,7 +2195,6 @@ describe('JSON serialization/deserialization', () => {
         {
           column: {
             name: 'dur',
-            type: 'TIMESTAMP_NS',
             checked: true,
             column: sliceTable.columns[2],
           },
@@ -2298,7 +2279,6 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -2424,7 +2404,6 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },
@@ -2479,7 +2458,6 @@ describe('JSON serialization/deserialization', () => {
       selectedColumns: [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: sliceTable.columns[0],
         },

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {perfettoSqlTypeToString} from '../../../trace_processor/perfetto_sql_type';
 import {SqlColumn} from '../../dev.perfetto.SqlModules/sql_modules';
 
 export interface ColumnInfo {
   name: string;
-  type: string;
   checked: boolean;
   column: SqlColumn;
   alias?: string;
@@ -32,7 +30,6 @@ export function columnInfoFromSqlColumn(
 ): ColumnInfo {
   return {
     name: column.name,
-    type: perfettoSqlTypeToString(column.type),
     checked,
     column: column,
   };
@@ -44,7 +41,6 @@ export function columnInfoFromName(
 ): ColumnInfo {
   return {
     name,
-    type: 'NA',
     checked,
     column: {name},
   };
@@ -57,7 +53,6 @@ export function newColumnInfo(
   const finalName = col.alias ?? col.column.name;
   return {
     name: finalName,
-    type: perfettoSqlTypeToString(col.column.type),
     column: {...col.column, name: finalName},
     alias: undefined,
     checked: checked ?? col.checked,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
@@ -20,7 +20,10 @@ import {
   newColumnInfoList,
 } from './column_info';
 import {SqlColumn} from '../../dev.perfetto.SqlModules/sql_modules';
-import {PerfettoSqlType} from '../../../trace_processor/perfetto_sql_type';
+import {
+  PerfettoSqlType,
+  PerfettoSqlTypes,
+} from '../../../trace_processor/perfetto_sql_type';
 
 describe('column_info utilities', () => {
   const stringType: PerfettoSqlType = {
@@ -43,7 +46,7 @@ describe('column_info utilities', () => {
       const result = columnInfoFromSqlColumn(sqlColumn);
 
       expect(result.name).toBe('id');
-      expect(result.type).toBe('INT');
+      expect(result.column.type).toEqual(PerfettoSqlTypes.INT);
       expect(result.checked).toBe(false);
       expect(result.column).toBe(sqlColumn);
       expect(result.alias).toBeUndefined();
@@ -58,7 +61,7 @@ describe('column_info utilities', () => {
       const result = columnInfoFromSqlColumn(sqlColumn, true);
 
       expect(result.name).toBe('name');
-      expect(result.type).toBe('STRING');
+      expect(result.column.type).toEqual(PerfettoSqlTypes.STRING);
       expect(result.checked).toBe(true);
       expect(result.column).toBe(sqlColumn);
     });
@@ -72,7 +75,7 @@ describe('column_info utilities', () => {
       const result = columnInfoFromSqlColumn(sqlColumn, false);
 
       expect(result.name).toBe('ts');
-      expect(result.type).toBe('TIMESTAMP');
+      expect(result.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
       expect(result.checked).toBe(false);
     });
   });
@@ -82,7 +85,7 @@ describe('column_info utilities', () => {
       const result = columnInfoFromName('test_column');
 
       expect(result.name).toBe('test_column');
-      expect(result.type).toBe('NA');
+      expect(result.column.type).toBeUndefined();
       expect(result.checked).toBe(false);
       expect(result.column.name).toBe('test_column');
       expect(result.column.type).toBe(undefined);
@@ -92,7 +95,7 @@ describe('column_info utilities', () => {
       const result = columnInfoFromName('another_column', true);
 
       expect(result.name).toBe('another_column');
-      expect(result.type).toBe('NA');
+      expect(result.column.type).toBeUndefined();
       expect(result.checked).toBe(true);
     });
 
@@ -100,7 +103,7 @@ describe('column_info utilities', () => {
       const result = columnInfoFromName('');
 
       expect(result.name).toBe('');
-      expect(result.type).toBe('NA');
+      expect(result.column.type).toBeUndefined();
       expect(result.checked).toBe(false);
     });
   });
@@ -109,7 +112,6 @@ describe('column_info utilities', () => {
     it('should create new ColumnInfo preserving column info', () => {
       const original: ColumnInfo = {
         name: 'id',
-        type: 'INTEGER',
         checked: false,
         column: {name: 'id', type: intType},
       };
@@ -117,7 +119,7 @@ describe('column_info utilities', () => {
       const result = newColumnInfo(original);
 
       expect(result.name).toBe('id');
-      expect(result.type).toBe('INT');
+      expect(result.column.type).toEqual(PerfettoSqlTypes.INT);
       expect(result.checked).toBe(false);
       // column is now a copy with name updated (not same reference)
       expect(result.column.name).toBe('id');
@@ -128,7 +130,6 @@ describe('column_info utilities', () => {
     it('should use alias as name if present', () => {
       const original: ColumnInfo = {
         name: 'id',
-        type: 'INTEGER',
         checked: false,
         column: {name: 'id', type: intType},
         alias: 'identifier',
@@ -137,7 +138,7 @@ describe('column_info utilities', () => {
       const result = newColumnInfo(original);
 
       expect(result.name).toBe('identifier');
-      expect(result.type).toBe('INT');
+      expect(result.column.type).toEqual(PerfettoSqlTypes.INT);
       // column.name should also be replaced with the alias so child nodes see the aliased name
       expect(result.column.name).toBe('identifier');
       expect(result.alias).toBeUndefined();
@@ -146,7 +147,6 @@ describe('column_info utilities', () => {
     it('should override checked state when specified', () => {
       const original: ColumnInfo = {
         name: 'name',
-        type: 'STRING',
         checked: false,
         column: {name: 'name', type: stringType},
       };
@@ -160,7 +160,6 @@ describe('column_info utilities', () => {
     it('should preserve checked state when not overridden', () => {
       const original: ColumnInfo = {
         name: 'name',
-        type: 'STRING',
         checked: true,
         column: {name: 'name', type: stringType},
       };
@@ -173,7 +172,6 @@ describe('column_info utilities', () => {
     it('should handle undefined checked parameter', () => {
       const original: ColumnInfo = {
         name: 'ts',
-        type: 'TIMESTAMP_NS',
         checked: true,
         column: {name: 'ts', type: timestampType},
       };
@@ -186,7 +184,6 @@ describe('column_info utilities', () => {
     it('should clear alias in new column', () => {
       const original: ColumnInfo = {
         name: 'id',
-        type: 'INTEGER',
         checked: false,
         column: {name: 'id', type: intType},
         alias: 'identifier',
@@ -203,19 +200,16 @@ describe('column_info utilities', () => {
       const original: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: false,
           column: {name: 'id', type: intType},
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: false,
           column: {name: 'name', type: stringType},
         },
         {
           name: 'ts',
-          type: 'TIMESTAMP_NS',
           checked: true,
           column: {name: 'ts', type: timestampType},
         },
@@ -236,13 +230,11 @@ describe('column_info utilities', () => {
       const original: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: false,
           column: {name: 'id', type: intType},
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: false,
           column: {name: 'name', type: stringType},
         },
@@ -265,14 +257,12 @@ describe('column_info utilities', () => {
       const original: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: false,
           column: {name: 'id', type: intType},
           alias: 'identifier',
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: false,
           column: {name: 'full_name', type: stringType},
           alias: 'name',
@@ -292,7 +282,6 @@ describe('column_info utilities', () => {
       const original: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: false,
           column: {name: 'id', type: intType},
         },

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal.ts
@@ -21,9 +21,15 @@ import {FunctionArgBinding, NewColumn} from './add_columns_types';
 import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
 import {ColumnInfo} from '../column_info';
 import {
+  PerfettoSqlType,
   parsePerfettoSqlTypeFromString,
   isQuantitativeType,
 } from '../../../../trace_processor/perfetto_sql_type';
+
+function parseReturnType(returnType: string): PerfettoSqlType | undefined {
+  const result = parsePerfettoSqlTypeFromString({type: returnType});
+  return result.ok ? result.value : undefined;
+}
 
 /**
  * The step in the function modal flow
@@ -167,7 +173,7 @@ export function createFunctionColumn(
     module: state.selectedFunctionWithModule.module.includeKey,
     functionName: state.selectedFunctionWithModule.fn.name,
     functionArgs: state.argBindings,
-    sqlType: state.selectedFunctionWithModule.fn.returnType,
+    sqlType: parseReturnType(state.selectedFunctionWithModule.fn.returnType),
   };
 }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal_unittest.ts
@@ -93,7 +93,6 @@ function createMockColumnInfo(
 ): ColumnInfo {
   return {
     name,
-    type: type ? type.kind.toUpperCase() : 'UNKNOWN',
     checked: false,
     column: {name, type},
   };
@@ -346,7 +345,7 @@ describe('createFunctionColumn', () => {
     expect(result?.module).toBe('prelude.time');
     expect(result?.functionName).toBe('dur_ns_to_ms');
     expect(result?.functionArgs).toEqual(state.argBindings);
-    expect(result?.sqlType).toBe('DOUBLE');
+    expect(result?.sqlType).toEqual({kind: 'double'});
   });
 
   it('should return undefined when no function is selected', () => {
@@ -393,7 +392,7 @@ describe('createFunctionModalState', () => {
       functionArgs: [
         {argName: 'arg1', value: 'col1', isCustomExpression: false},
       ],
-      sqlType: 'INT',
+      sqlType: PerfettoSqlTypes.INT,
     };
 
     const state = createFunctionModalState(true, existingColumn, sqlModules);
@@ -412,7 +411,7 @@ describe('createFunctionModalState', () => {
       module: 'unknown.module',
       functionName: 'unknown_func',
       functionArgs: [],
-      sqlType: 'INT',
+      sqlType: PerfettoSqlTypes.INT,
     };
 
     const state = createFunctionModalState(true, existingColumn, sqlModules);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
@@ -25,8 +25,8 @@ import {
   columnInfoFromSqlColumn,
 } from '../column_info';
 import {
+  PerfettoSqlType,
   PerfettoSqlTypes,
-  parsePerfettoSqlTypeFromString,
 } from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 import m from 'mithril';
@@ -155,17 +155,7 @@ export class AddColumnsNode implements QueryNode {
           const sourceCol = this.rightCols.find((col) => col.name === c);
           if (sourceCol) {
             // Use stored type if available, otherwise use source type
-            let finalType = sourceCol.column.type;
-
-            if (storedType) {
-              // Parse the stored type string
-              const parsedType = parsePerfettoSqlTypeFromString({
-                type: storedType,
-              });
-              if (parsedType.ok) {
-                finalType = parsedType.value;
-              }
-            }
+            const finalType = storedType ?? sourceCol.column.type;
 
             return columnInfoFromSqlColumn({
               name: alias ?? c,
@@ -183,28 +173,19 @@ export class AddColumnsNode implements QueryNode {
       this.state.computedColumns
         ?.filter((c) => this.isComputedColumnValid(c))
         .map((col) => {
-          // Use stored sqlType if available (from deserialization)
+          // Use stored sqlType if available (from deserialization or user change)
           if (col.sqlType) {
-            // Parse the stored type string and use it
-            const parsedType = parsePerfettoSqlTypeFromString({
-              type: col.sqlType,
-            });
-            if (!parsedType.ok) {
-              console.warn(
-                `Failed to parse stored type '${col.sqlType}' for column '${col.name}', defaulting to INT`,
-              );
-            }
             return columnInfoFromSqlColumn({
               name: col.name,
-              type: parsedType.ok ? parsedType.value : PerfettoSqlTypes.INT,
+              type: col.sqlType,
             });
           }
           // Try to preserve type information if the expression is a simple column reference
           const sourceCol = this.sourceCols.find(
             (c) => c.column.name === col.expression,
           );
-          if (sourceCol && sourceCol.column.type) {
-            col.sqlType = sourceCol.type;
+          if (sourceCol?.column.type) {
+            col.sqlType = sourceCol.column.type;
             return columnInfoFromSqlColumn({
               name: col.name,
               type: sourceCol.column.type,
@@ -1230,12 +1211,11 @@ export class AddColumnsNode implements QueryNode {
     // Create a ColumnInfo-like object for renderTypeSelector
     const colInfo: ColumnInfo = {
       name: col.name || '(unnamed)',
-      type: col.sqlType ?? 'UNKNOWN',
       checked: true,
-      column: {name: col.name},
+      column: {name: col.name, type: col.sqlType},
     };
 
-    const handleTypeChange = (_index: number, newType: string) => {
+    const handleTypeChange = (_index: number, newType: PerfettoSqlType) => {
       if (!this.state.computedColumns) return;
       const newComputedColumns = [...this.state.computedColumns];
       newComputedColumns[index] = {
@@ -1800,13 +1780,15 @@ export class AddColumnsNode implements QueryNode {
             )
           : undefined,
       columnTypes:
-        (serializedState.columnTypes as unknown as Record<string, string>) !==
-        undefined
+        (serializedState.columnTypes as unknown as Record<
+          string,
+          PerfettoSqlType
+        >) !== undefined
           ? new Map(
               Object.entries(
                 serializedState.columnTypes as unknown as Record<
                   string,
-                  string
+                  PerfettoSqlType
                 >,
               ),
             )

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_types.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_types.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 import {QueryNodeState} from '../../query_node';
 
 /**
@@ -63,7 +64,7 @@ export interface NewColumn {
   functionArgs?: FunctionArgBinding[];
 
   // SQL type for preserving type information across serialization
-  sqlType?: string;
+  sqlType?: PerfettoSqlType;
 }
 
 /**
@@ -90,7 +91,7 @@ export interface AddColumnsNodeState extends QueryNodeState {
   suggestionAliases?: Map<string, string>;
 
   // Map from column name to its type (for type casting added columns)
-  columnTypes?: Map<string, string>;
+  columnTypes?: Map<string, PerfettoSqlType>;
 
   // Track if connection was made through guided suggestion
   isGuidedConnection?: boolean;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/aggregation_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/aggregation_node_unittest.ts
@@ -25,6 +25,7 @@ import {
   createColumnInfo,
   connectNodes,
 } from '../testing/test_utils';
+import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
 
 describe('AggregationNode', () => {
   function createMockTrace(): Trace {
@@ -725,7 +726,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('count_dur');
-      expect(node.finalCols[0].type).toBe('INT');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.INT);
     });
 
     it('should set INT type for COUNT(*) aggregation', () => {
@@ -748,14 +749,13 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('total_count');
-      expect(node.finalCols[0].type).toBe('INT');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.INT);
     });
 
     it('should preserve type for SUM aggregation', () => {
       const inputCols = [
         {
           name: 'dur',
-          type: 'DURATION',
           checked: false,
           column: {
             name: 'dur',
@@ -782,14 +782,13 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('total_dur');
-      expect(node.finalCols[0].type).toBe('DURATION');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DURATION);
     });
 
     it('should preserve type for MIN/MAX aggregations', () => {
       const inputCols = [
         {
           name: 'ts',
-          type: 'TIMESTAMP',
           checked: false,
           column: {
             name: 'ts',
@@ -822,9 +821,9 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(2);
       expect(node.finalCols[0].name).toBe('min_ts');
-      expect(node.finalCols[0].type).toBe('TIMESTAMP');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
       expect(node.finalCols[1].name).toBe('max_ts');
-      expect(node.finalCols[1].type).toBe('TIMESTAMP');
+      expect(node.finalCols[1].column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
     });
 
     it('should set DOUBLE type for MEAN aggregation', () => {
@@ -848,7 +847,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('avg_value');
-      expect(node.finalCols[0].type).toBe('DOUBLE');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should set DOUBLE type for MEDIAN aggregation', () => {
@@ -872,7 +871,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('median_dur');
-      expect(node.finalCols[0].type).toBe('DOUBLE');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should set DOUBLE type for DURATION_WEIGHTED_MEAN aggregation', () => {
@@ -896,7 +895,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('weighted_avg_dur');
-      expect(node.finalCols[0].type).toBe('DOUBLE');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should set DOUBLE type for PERCENTILE aggregation', () => {
@@ -921,14 +920,13 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('p95_dur');
-      expect(node.finalCols[0].type).toBe('DOUBLE');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should include GROUP BY columns with their original types', () => {
       const inputCols = [
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: {
             name: 'name',
@@ -958,9 +956,9 @@ describe('AggregationNode', () => {
       // Second column should be the aggregation result (total_value) with INT type
       expect(node.finalCols.length).toBe(2);
       expect(node.finalCols[0].name).toBe('name');
-      expect(node.finalCols[0].type).toBe('STRING');
+      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.STRING);
       expect(node.finalCols[1].name).toBe('total_value');
-      expect(node.finalCols[1].type).toBe('INT');
+      expect(node.finalCols[1].column.type).toEqual(PerfettoSqlTypes.INT);
     });
   });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/computed_column_components.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/computed_column_components.ts
@@ -105,7 +105,7 @@ export class SwitchComponent implements m.ClassComponent<SwitchComponentAttrs> {
     const selectedColumn = columns.find(
       (c) => c.column.name === column.switchOn,
     );
-    const isStringColumn = selectedColumn?.type === 'STRING';
+    const isStringColumn = selectedColumn?.column.type?.kind === 'string';
 
     return m('.pf-inline-edit-list', [
       m(

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/connections_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/connections_unittest.ts
@@ -73,27 +73,40 @@ function createMockPrevNode(id: string, columns: ColumnInfo[]): QueryNode {
 // Helper to create a ColumnInfo with basic type
 function createColumnInfo(
   name: string,
-  type: string,
+  _type: string,
   checked: boolean = true,
 ): ColumnInfo {
+  const sqlType = stringToSqlType(_type);
   return {
     name,
-    type,
     checked,
-    column: {name},
+    column: {name, type: sqlType},
   };
+}
+
+function stringToSqlType(s: string): PerfettoSqlType {
+  switch (s.toUpperCase()) {
+    case 'INT':
+    case 'INT64':
+      return PerfettoSqlTypes.INT;
+    case 'STRING':
+      return PerfettoSqlTypes.STRING;
+    case 'DOUBLE':
+      return PerfettoSqlTypes.DOUBLE;
+    default:
+      return PerfettoSqlTypes.INT;
+  }
 }
 
 // Helper to create a ColumnInfo with full SQL type
 function createColumnInfoWithSqlType(
   name: string,
-  displayType: string,
+  _displayType: string,
   sqlType: PerfettoSqlType,
   checked: boolean = true,
 ): ColumnInfo {
   return {
     name,
-    type: displayType,
     checked,
     column: {name, type: sqlType},
   };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node.ts
@@ -67,7 +67,6 @@ export class CounterToIntervalsNode implements QueryNode {
     // dur: the duration until the next counter value
     cols.push({
       name: 'dur',
-      type: 'DURATION',
       checked: true,
       column: {name: 'dur', type: PerfettoSqlTypes.DURATION},
     });
@@ -75,7 +74,6 @@ export class CounterToIntervalsNode implements QueryNode {
     // next_value: the value of the next counter
     cols.push({
       name: 'next_value',
-      type: 'DOUBLE',
       checked: true,
       column: {name: 'next_value', type: PerfettoSqlTypes.DOUBLE},
     });
@@ -83,7 +81,6 @@ export class CounterToIntervalsNode implements QueryNode {
     // delta_value: the change in value (next_value - value)
     cols.push({
       name: 'delta_value',
-      type: 'DOUBLE',
       checked: true,
       column: {name: 'delta_value', type: PerfettoSqlTypes.DOUBLE},
     });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node_unittest.ts
@@ -18,6 +18,10 @@ import {
 } from './counter_to_intervals_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
+import {
+  PerfettoSqlType,
+  PerfettoSqlTypes,
+} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 
 describe('CounterToIntervalsNode', () => {
@@ -46,16 +50,30 @@ describe('CounterToIntervalsNode', () => {
     } as QueryNode;
   }
 
+  function stringToSqlType(s: string): PerfettoSqlType {
+    switch (s.toUpperCase()) {
+      case 'INT':
+      case 'INT64':
+        return PerfettoSqlTypes.INT;
+      case 'STRING':
+        return PerfettoSqlTypes.STRING;
+      case 'DOUBLE':
+        return PerfettoSqlTypes.DOUBLE;
+      default:
+        return PerfettoSqlTypes.INT;
+    }
+  }
+
   function createColumnInfo(
     name: string,
     type: string,
     checked: boolean = true,
   ): ColumnInfo {
+    const sqlType = stringToSqlType(type);
     return {
       name,
-      type,
       checked,
-      column: {name},
+      column: {name, type: sqlType},
     };
   }
 
@@ -136,9 +154,9 @@ describe('CounterToIntervalsNode', () => {
       const nextValueCol = finalCols.find((c) => c.name === 'next_value');
       const deltaValueCol = finalCols.find((c) => c.name === 'delta_value');
 
-      expect(durCol?.type).toBe('DURATION');
-      expect(nextValueCol?.type).toBe('DOUBLE');
-      expect(deltaValueCol?.type).toBe('DOUBLE');
+      expect(durCol?.column.type).toEqual({kind: 'duration'});
+      expect(nextValueCol?.column.type).toEqual({kind: 'double'});
+      expect(deltaValueCol?.column.type).toEqual({kind: 'double'});
     });
 
     it('should preserve input column order', () => {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/create_slices_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/create_slices_node_unittest.ts
@@ -148,10 +148,10 @@ describe('CreateSlicesNode', () => {
 
       expect(finalCols.length).toBe(2);
       expect(finalCols[0].name).toBe('ts');
-      expect(finalCols[0].type).toBe('TIMESTAMP');
+      expect(finalCols[0].column.type).toEqual({kind: 'timestamp'});
       expect(finalCols[0].checked).toBe(true);
       expect(finalCols[1].name).toBe('dur');
-      expect(finalCols[1].type).toBe('DURATION');
+      expect(finalCols[1].column.type).toEqual({kind: 'duration'});
       expect(finalCols[1].checked).toBe(true);
     });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node.ts
@@ -80,6 +80,7 @@ import {NodeModifyAttrs, NodeDetailsAttrs} from '../../node_types';
 import {NodeDetailsMessage, ColumnName} from '../node_styling_widgets';
 import {notifyNextNodes} from '../graph_utils';
 import {getCommonColumns} from '../utils';
+import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 
 export interface FilterDuringNodeState extends QueryNodeState {
   partitionColumns?: string[]; // Columns to partition by during interval intersection
@@ -162,7 +163,7 @@ export class FilterDuringNode implements QueryNode {
     ];
     return getCommonColumns(columnArrays, {
       excludedColumns: new Set(['id', 'ts', 'dur']),
-      excludedTypes: new Set(['STRING', 'BYTES']),
+      excludedTypes: new Set<PerfettoSqlType['kind']>(['string', 'bytes']),
     });
   }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node_unittest.ts
@@ -15,6 +15,10 @@
 import {FilterDuringNode, FilterDuringNodeState} from './filter_during_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
+import {
+  PerfettoSqlType,
+  PerfettoSqlTypes,
+} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 
 // Interface for accessing private methods during testing
@@ -49,16 +53,32 @@ describe('FilterDuringNode', () => {
     } as QueryNode;
   }
 
+  function stringToSqlType(s: string): PerfettoSqlType {
+    switch (s.toUpperCase()) {
+      case 'INT':
+      case 'INT64':
+        return PerfettoSqlTypes.INT;
+      case 'STRING':
+        return PerfettoSqlTypes.STRING;
+      case 'DOUBLE':
+        return PerfettoSqlTypes.DOUBLE;
+      case 'BYTES':
+        return {kind: 'bytes'};
+      default:
+        return PerfettoSqlTypes.INT;
+    }
+  }
+
   function createColumnInfo(
     name: string,
     type: string,
     checked: boolean = true,
   ): ColumnInfo {
+    const sqlType = stringToSqlType(type);
     return {
       name,
-      type,
       checked,
-      column: {name},
+      column: {name, type: sqlType},
     };
   }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node.ts
@@ -23,7 +23,12 @@ import {
 import {notifyNextNodes} from '../graph_utils';
 import protos from '../../../../protos';
 import {ColumnInfo} from '../column_info';
-import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
+import {
+  PerfettoSqlType,
+  PerfettoSqlTypes,
+  perfettoSqlTypeToString,
+  typesEqual,
+} from '../../../../trace_processor/perfetto_sql_type';
 import {Callout} from '../../../../widgets/callout';
 import {EmptyState} from '../../../../widgets/empty_state';
 import {NodeIssues} from '../node_issues';
@@ -91,7 +96,6 @@ export class IntervalIntersectNode implements QueryNode {
 
       finalCols.push({
         name: 'id',
-        type: sourceIdCol?.type ?? 'NA',
         checked: true,
         column: idColumnType ? {name: 'id', type: idColumnType} : {name: 'id'},
       });
@@ -102,13 +106,11 @@ export class IntervalIntersectNode implements QueryNode {
     // but aliased from different sources based on tsDurSource
     finalCols.push({
       name: 'ts',
-      type: 'TIMESTAMP',
       checked: true,
       column: {name: 'ts', type: PerfettoSqlTypes.TIMESTAMP},
     });
     finalCols.push({
       name: 'dur',
-      type: 'DURATION',
       checked: true,
       column: {name: 'dur', type: PerfettoSqlTypes.DURATION},
     });
@@ -125,9 +127,9 @@ export class IntervalIntersectNode implements QueryNode {
         const sourceCol = firstNodeCols.find((c) => c.name === colName);
 
         // Validate that partition column types match across all input nodes
-        // Skip validation if type is unknown/NA
-        const sourceType = sourceCol?.type;
-        if (sourceType && sourceType !== 'NA' && sourceType !== 'UNKNOWN') {
+        // Skip validation if type is unknown
+        const sourceType = sourceCol?.column.type;
+        if (sourceType !== undefined) {
           for (let i = 1; i < inputNodes.length; i++) {
             const node = inputNodes[i];
             if (node === undefined) {
@@ -139,18 +141,13 @@ export class IntervalIntersectNode implements QueryNode {
 
             const nodeCols = this.getEffectiveCols(node);
             const otherCol = nodeCols.find((c) => c.name === colName);
-            const otherType = otherCol?.type;
+            const otherType = otherCol?.column.type;
 
             // Only warn if both types are known and different
-            if (
-              otherType &&
-              otherType !== 'NA' &&
-              otherType !== 'UNKNOWN' &&
-              otherType !== sourceType
-            ) {
+            if (otherType !== undefined && !typesEqual(sourceType, otherType)) {
               console.warn(
                 `[IntervalIntersect] Partition column "${colName}" has inconsistent types: ` +
-                  `node 0 has "${sourceType}", node ${i} has "${otherType}". ` +
+                  `node 0 has "${perfettoSqlTypeToString(sourceType)}", node ${i} has "${perfettoSqlTypeToString(otherType)}". ` +
                   `Using type from first node.`,
               );
             }
@@ -161,7 +158,6 @@ export class IntervalIntersectNode implements QueryNode {
         const columnType = sourceCol?.column.type;
         finalCols.push({
           name: colName,
-          type: sourceCol?.type ?? 'NA',
           checked: true,
           column: columnType
             ? {name: colName, type: columnType}
@@ -221,7 +217,6 @@ export class IntervalIntersectNode implements QueryNode {
       const idColumnType = idCol?.column.type;
       finalCols.push({
         name: `id_${i}`,
-        type: idCol?.type ?? 'NA',
         checked: true,
         column: idColumnType
           ? {name: `id_${i}`, type: idColumnType}
@@ -230,14 +225,12 @@ export class IntervalIntersectNode implements QueryNode {
       // ts_N columns are TIMESTAMP type
       finalCols.push({
         name: `ts_${i}`,
-        type: 'TIMESTAMP',
         checked: true,
         column: {name: `ts_${i}`, type: PerfettoSqlTypes.TIMESTAMP},
       });
       // dur_N columns are DURATION type
       finalCols.push({
         name: `dur_${i}`,
-        type: 'DURATION',
         checked: true,
         column: {name: `dur_${i}`, type: PerfettoSqlTypes.DURATION},
       });
@@ -551,7 +544,7 @@ export class IntervalIntersectNode implements QueryNode {
       this.inputNodesList.map((n) => n.finalCols),
       {
         excludedColumns: new Set(['id', 'ts', 'dur']),
-        excludedTypes: new Set(['STRING', 'BYTES']),
+        excludedTypes: new Set<PerfettoSqlType['kind']>(['string', 'bytes']),
       },
     );
   }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node_unittest.ts
@@ -32,29 +32,42 @@ describe('IntervalIntersectNode', () => {
     });
   }
 
+  function stringToSqlType(s: string): PerfettoSqlType {
+    switch (s.toUpperCase()) {
+      case 'INT':
+      case 'INT64':
+        return PerfettoSqlTypes.INT;
+      case 'STRING':
+        return PerfettoSqlTypes.STRING;
+      case 'DOUBLE':
+        return PerfettoSqlTypes.DOUBLE;
+      default:
+        return PerfettoSqlTypes.INT;
+    }
+  }
+
   function createColumnInfo(
     name: string,
     type: string,
     checked: boolean = true,
   ): ColumnInfo {
+    const sqlType = stringToSqlType(type);
     return {
       name,
-      type,
       checked,
-      column: {name},
+      column: {name, type: sqlType},
     };
   }
 
   // Creates a ColumnInfo with full PerfettoSqlType for the column.type field
   function createColumnInfoWithSqlType(
     name: string,
-    displayType: string,
+    _displayType: string,
     sqlType: PerfettoSqlType,
     checked: boolean = true,
   ): ColumnInfo {
     return {
       name,
-      type: displayType,
       checked,
       column: {name, type: sqlType},
     };
@@ -150,27 +163,27 @@ describe('IntervalIntersectNode', () => {
 
       // After ts, dur (indexes 0, 1), we should have id_0, ts_0, dur_0
       expect(cols[2].name).toBe('id_0');
-      expect(cols[2].type).toBe('INT');
+      expect(cols[2].column.type).toEqual({kind: 'int'});
       expect(cols[3].name).toBe('ts_0');
-      expect(cols[3].type).toBe('TIMESTAMP'); // ts columns are TIMESTAMP type
+      expect(cols[3].column.type).toEqual({kind: 'timestamp'}); // ts columns are TIMESTAMP type
       expect(cols[4].name).toBe('dur_0');
-      expect(cols[4].type).toBe('DURATION'); // dur columns are DURATION type
+      expect(cols[4].column.type).toEqual({kind: 'duration'}); // dur columns are DURATION type
 
       // Then id_1, ts_1, dur_1
       expect(cols[5].name).toBe('id_1');
-      expect(cols[5].type).toBe('INT');
+      expect(cols[5].column.type).toEqual({kind: 'int'});
       expect(cols[6].name).toBe('ts_1');
-      expect(cols[6].type).toBe('TIMESTAMP');
+      expect(cols[6].column.type).toEqual({kind: 'timestamp'});
       expect(cols[7].name).toBe('dur_1');
-      expect(cols[7].type).toBe('DURATION');
+      expect(cols[7].column.type).toEqual({kind: 'duration'});
 
       // Then id_2, ts_2, dur_2
       expect(cols[8].name).toBe('id_2');
-      expect(cols[8].type).toBe('INT');
+      expect(cols[8].column.type).toEqual({kind: 'int'});
       expect(cols[9].name).toBe('ts_2');
-      expect(cols[9].type).toBe('TIMESTAMP');
+      expect(cols[9].column.type).toEqual({kind: 'timestamp'});
       expect(cols[10].name).toBe('dur_2');
-      expect(cols[10].type).toBe('DURATION');
+      expect(cols[10].column.type).toEqual({kind: 'duration'});
     });
 
     it('should include non-duplicated columns from all inputs', () => {
@@ -212,11 +225,11 @@ describe('IntervalIntersectNode', () => {
 
       // Verify types are preserved
       const nameCol = cols.find((c) => c.name === 'name');
-      expect(nameCol?.type).toBe('STRING');
+      expect(nameCol?.column.type).toEqual({kind: 'string'});
       const valueCol = cols.find((c) => c.name === 'value');
-      expect(valueCol?.type).toBe('INT');
+      expect(valueCol?.column.type).toEqual({kind: 'int'});
       const statusCol = cols.find((c) => c.name === 'status');
-      expect(statusCol?.type).toBe('STRING');
+      expect(statusCol?.column.type).toEqual({kind: 'string'});
     });
 
     it('should exclude duplicated columns entirely', () => {
@@ -366,39 +379,39 @@ describe('IntervalIntersectNode', () => {
       // Check id_N, ts_N, dur_N types for each input
       // ts columns are TIMESTAMP type, dur columns are DURATION type
       const id0 = cols.find((c) => c.name === 'id_0');
-      expect(id0?.type).toBe('INT');
+      expect(id0?.column.type).toEqual({kind: 'int'});
       const ts0 = cols.find((c) => c.name === 'ts_0');
-      expect(ts0?.type).toBe('TIMESTAMP');
+      expect(ts0?.column.type).toEqual({kind: 'timestamp'});
       const dur0 = cols.find((c) => c.name === 'dur_0');
-      expect(dur0?.type).toBe('DURATION');
+      expect(dur0?.column.type).toEqual({kind: 'duration'});
 
       const id1 = cols.find((c) => c.name === 'id_1');
-      expect(id1?.type).toBe('INT');
+      expect(id1?.column.type).toEqual({kind: 'int'});
       const ts1 = cols.find((c) => c.name === 'ts_1');
-      expect(ts1?.type).toBe('TIMESTAMP');
+      expect(ts1?.column.type).toEqual({kind: 'timestamp'});
       const dur1 = cols.find((c) => c.name === 'dur_1');
-      expect(dur1?.type).toBe('DURATION');
+      expect(dur1?.column.type).toEqual({kind: 'duration'});
 
       const id2 = cols.find((c) => c.name === 'id_2');
-      expect(id2?.type).toBe('INT');
+      expect(id2?.column.type).toEqual({kind: 'int'});
       const ts2 = cols.find((c) => c.name === 'ts_2');
-      expect(ts2?.type).toBe('TIMESTAMP');
+      expect(ts2?.column.type).toEqual({kind: 'timestamp'});
       const dur2 = cols.find((c) => c.name === 'dur_2');
-      expect(dur2?.type).toBe('DURATION');
+      expect(dur2?.column.type).toEqual({kind: 'duration'});
 
       // Check non-duplicated columns preserve their types
       const name = cols.find((c) => c.name === 'name');
-      expect(name?.type).toBe('STRING');
+      expect(name?.column.type).toEqual({kind: 'string'});
       const value = cols.find((c) => c.name === 'value');
-      expect(value?.type).toBe('DOUBLE');
+      expect(value?.column.type).toEqual({kind: 'double'});
       const count = cols.find((c) => c.name === 'count');
-      expect(count?.type).toBe('LONG');
+      expect(count?.column.type).toEqual({kind: 'int'});
       const status = cols.find((c) => c.name === 'status');
-      expect(status?.type).toBe('STRING');
+      expect(status?.column.type).toEqual({kind: 'string'});
       const priority = cols.find((c) => c.name === 'priority');
-      expect(priority?.type).toBe('INT');
+      expect(priority?.column.type).toEqual({kind: 'int'});
       const category = cols.find((c) => c.name === 'category');
-      expect(category?.type).toBe('STRING');
+      expect(category?.column.type).toEqual({kind: 'string'});
     });
 
     it('should exclude columns with conflicting types', () => {
@@ -935,37 +948,37 @@ describe('IntervalIntersectNode', () => {
       // Verify ts column has TIMESTAMP type
       const tsCol = selectedCols.find((c) => c.name === 'ts');
       expect(tsCol).toBeDefined();
-      expect(tsCol?.type).toBe('TIMESTAMP');
+      expect(tsCol?.column.type).toEqual({kind: 'timestamp'});
       expect(tsCol?.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
 
       // Verify dur column has DURATION type
       const durCol = selectedCols.find((c) => c.name === 'dur');
       expect(durCol).toBeDefined();
-      expect(durCol?.type).toBe('DURATION');
+      expect(durCol?.column.type).toEqual({kind: 'duration'});
       expect(durCol?.column.type).toEqual(PerfettoSqlTypes.DURATION);
 
       // Verify ts_0 column has TIMESTAMP type
       const ts0Col = selectedCols.find((c) => c.name === 'ts_0');
       expect(ts0Col).toBeDefined();
-      expect(ts0Col?.type).toBe('TIMESTAMP');
+      expect(ts0Col?.column.type).toEqual({kind: 'timestamp'});
       expect(ts0Col?.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
 
       // Verify dur_0 column has DURATION type
       const dur0Col = selectedCols.find((c) => c.name === 'dur_0');
       expect(dur0Col).toBeDefined();
-      expect(dur0Col?.type).toBe('DURATION');
+      expect(dur0Col?.column.type).toEqual({kind: 'duration'});
       expect(dur0Col?.column.type).toEqual(PerfettoSqlTypes.DURATION);
 
       // Verify ts_1 column has TIMESTAMP type
       const ts1Col = selectedCols.find((c) => c.name === 'ts_1');
       expect(ts1Col).toBeDefined();
-      expect(ts1Col?.type).toBe('TIMESTAMP');
+      expect(ts1Col?.column.type).toEqual({kind: 'timestamp'});
       expect(ts1Col?.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
 
       // Verify dur_1 column has DURATION type
       const dur1Col = selectedCols.find((c) => c.name === 'dur_1');
       expect(dur1Col).toBeDefined();
-      expect(dur1Col?.type).toBe('DURATION');
+      expect(dur1Col?.column.type).toEqual({kind: 'duration'});
       expect(dur1Col?.column.type).toEqual(PerfettoSqlTypes.DURATION);
     });
 
@@ -1016,7 +1029,7 @@ describe('IntervalIntersectNode', () => {
       // Verify utid column preserves its type
       const utidCol = selectedCols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.type).toBe('INT');
+      expect(utidCol?.column.type).toEqual({kind: 'int'});
       expect(utidCol?.column.type).toEqual(PerfettoSqlTypes.INT);
     });
 
@@ -1112,17 +1125,17 @@ describe('IntervalIntersectNode', () => {
       // Verify non-duplicated columns preserve their types
       const nameCol = selectedCols.find((c) => c.name === 'name');
       expect(nameCol).toBeDefined();
-      expect(nameCol?.type).toBe('STRING');
+      expect(nameCol?.column.type).toEqual({kind: 'string'});
       expect(nameCol?.column.type).toEqual(PerfettoSqlTypes.STRING);
 
       const valueCol = selectedCols.find((c) => c.name === 'value');
       expect(valueCol).toBeDefined();
-      expect(valueCol?.type).toBe('DOUBLE');
+      expect(valueCol?.column.type).toEqual({kind: 'double'});
       expect(valueCol?.column.type).toEqual(PerfettoSqlTypes.DOUBLE);
 
       const statusCol = selectedCols.find((c) => c.name === 'status');
       expect(statusCol).toBeDefined();
-      expect(statusCol?.type).toBe('STRING');
+      expect(statusCol?.column.type).toEqual({kind: 'string'});
       expect(statusCol?.column.type).toEqual(PerfettoSqlTypes.STRING);
     });
 
@@ -1246,12 +1259,12 @@ describe('IntervalIntersectNode', () => {
       // Should now include utid and track_id partition columns
       const utidCol = selectedCols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.type).toBe('INT');
+      expect(utidCol?.column.type).toEqual({kind: 'int'});
       expect(utidCol?.column.type).toEqual(PerfettoSqlTypes.INT);
 
       const trackIdCol = selectedCols.find((c) => c.name === 'track_id');
       expect(trackIdCol).toBeDefined();
-      expect(trackIdCol?.type).toBe('INT');
+      expect(trackIdCol?.column.type).toEqual({kind: 'int'});
       expect(trackIdCol?.column.type).toEqual(PerfettoSqlTypes.INT);
 
       // Verify the column count increased by 2 (the 2 partition columns)
@@ -1298,12 +1311,12 @@ describe('IntervalIntersectNode', () => {
       // Should still create partition columns, but with 'NA' type as fallback
       const utidCol = cols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.type).toBe('NA');
+      expect(utidCol?.column.type).toBeUndefined();
       expect(utidCol?.column.type).toBeUndefined();
 
       const trackIdCol = cols.find((c) => c.name === 'track_id');
       expect(trackIdCol).toBeDefined();
-      expect(trackIdCol?.type).toBe('NA');
+      expect(trackIdCol?.column.type).toBeUndefined();
       expect(trackIdCol?.column.type).toBeUndefined();
     });
 
@@ -1348,7 +1361,7 @@ describe('IntervalIntersectNode', () => {
       // Should use the type from the FIRST input node
       const utidCol = cols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.type).toBe('INT'); // From node1, not STRING from node2
+      expect(utidCol?.column.type).toEqual({kind: 'int'}); // From node1, not STRING from node2
       expect(utidCol?.column.type).toEqual(PerfettoSqlTypes.INT);
     });
 
@@ -1522,7 +1535,7 @@ describe('IntervalIntersectNode', () => {
       // Check id type matches input 0
       let idCol = node.finalCols.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.type).toBe('INT');
+      expect(idCol?.column.type).toEqual({kind: 'int'});
 
       // Change to input 1
       node.state.tsDurSource = 1;
@@ -1530,7 +1543,7 @@ describe('IntervalIntersectNode', () => {
       // Check id type should now match input 1
       idCol = node.finalCols.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.type).toBe('STRING');
+      expect(idCol?.column.type).toEqual({kind: 'string'});
     });
 
     it('should propagate id column type change to downstream ModifyColumnsNode when tsDurSource changes', () => {
@@ -1579,7 +1592,7 @@ describe('IntervalIntersectNode', () => {
       // Verify id column has INT type from input 0
       let idCol = modifyNode.state.selectedColumns.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.type).toBe('INT');
+      expect(idCol?.column.type).toEqual({kind: 'int'});
 
       // Change tsDurSource to input 1
       intervalNode.state.tsDurSource = 1;
@@ -1588,7 +1601,7 @@ describe('IntervalIntersectNode', () => {
       // Verify id column type updated to STRING from input 1
       idCol = modifyNode.state.selectedColumns.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.type).toBe('STRING');
+      expect(idCol?.column.type).toEqual({kind: 'string'});
     });
 
     it('should preserve user-modified type in ModifyColumnsNode when tsDurSource changes', () => {
@@ -1634,13 +1647,17 @@ describe('IntervalIntersectNode', () => {
       intervalNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
-      // Simulate user manually changing the id column type to CUSTOM_TYPE
+      // Simulate user manually changing the id column type to a custom type
+      const customType: PerfettoSqlType = {kind: 'double'};
       const idColIndex = modifyNode.state.selectedColumns.findIndex(
         (c) => c.name === 'id',
       );
       modifyNode.state.selectedColumns[idColIndex] = {
         ...modifyNode.state.selectedColumns[idColIndex],
-        type: 'CUSTOM_TYPE',
+        column: {
+          ...modifyNode.state.selectedColumns[idColIndex].column,
+          type: customType,
+        },
         typeUserModified: true,
       };
 
@@ -1653,7 +1670,7 @@ describe('IntervalIntersectNode', () => {
         (c) => c.name === 'id',
       );
       expect(idCol).toBeDefined();
-      expect(idCol?.type).toBe('CUSTOM_TYPE');
+      expect(idCol?.column.type).toEqual(customType);
       expect(idCol?.typeUserModified).toBe(true);
     });
   });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
@@ -23,6 +23,7 @@ import {
 import {getSecondaryInput} from '../graph_utils';
 import protos from '../../../../protos';
 import {ColumnInfo, newColumnInfoList} from '../column_info';
+import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
 import {Switch} from '../../../../widgets/switch';
@@ -49,14 +50,14 @@ export interface JoinSerializedState {
   comment?: string;
   leftColumns?: {
     name: string;
-    type: string;
+    type?: PerfettoSqlType;
     checked: boolean;
     alias?: string;
     columnName: string; // Original source column name
   }[];
   rightColumns?: {
     name: string;
-    type: string;
+    type?: PerfettoSqlType;
     checked: boolean;
     alias?: string;
     columnName: string; // Original source column name
@@ -527,14 +528,14 @@ export class JoinNode implements QueryNode {
       sqlExpression: this.state.sqlExpression,
       leftColumns: (this.state.leftColumns ?? []).map((c) => ({
         name: c.name,
-        type: c.type,
+        type: c.column.type,
         checked: c.checked,
         alias: c.alias,
         columnName: c.column.name, // Save original source column name
       })),
       rightColumns: (this.state.rightColumns ?? []).map((c) => ({
         name: c.name,
-        type: c.type,
+        type: c.column.type,
         checked: c.checked,
         alias: c.alias,
         columnName: c.column.name, // Save original source column name
@@ -554,17 +555,15 @@ export class JoinNode implements QueryNode {
       leftColumns:
         state.leftColumns?.map((c) => ({
           name: c.name,
-          type: c.type,
           checked: c.checked,
-          column: {name: c.columnName ?? c.name}, // Use original column name
+          column: {name: c.columnName ?? c.name, type: c.type}, // Use original column name
           alias: c.alias,
         })) ?? [],
       rightColumns:
         state.rightColumns?.map((c) => ({
           name: c.name,
-          type: c.type,
           checked: c.checked,
-          column: {name: c.columnName ?? c.name}, // Use original column name
+          column: {name: c.columnName ?? c.name, type: c.type}, // Use original column name
           alias: c.alias,
         })) ?? [],
     };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
@@ -38,12 +38,11 @@ describe('JoinNode', () => {
 
   function createColumnInfo(
     name: string,
-    type: string,
+    _type: string,
     checked: boolean = true,
   ): ColumnInfo {
     return {
       name,
-      type,
       checked,
       column: {name},
     };
@@ -55,7 +54,6 @@ describe('JoinNode', () => {
   ): ColumnInfo[] {
     return columns.map((c) => ({
       name: c.name,
-      type: c.type,
       checked: c.checked ?? true,
       column: {name: c.name},
     }));

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node.ts
@@ -33,10 +33,16 @@ import {
   NodeTitle,
 } from '../node_styling_widgets';
 import {isNumericType} from '../utils';
+import {
+  PerfettoSqlType,
+  perfettoSqlTypeToString,
+} from '../../../../trace_processor/perfetto_sql_type';
 
 // Metrics value columns accept numeric types and ANY (unknown/unresolved type).
-function isMetricsValueType(typeStr: string): boolean {
-  return isNumericType(typeStr) || typeStr.toUpperCase() === 'ANY';
+function isMetricsValueType(type?: PerfettoSqlType): boolean {
+  // undefined means unknown/unresolved type — treat as acceptable
+  if (type === undefined) return true;
+  return isNumericType(type);
 }
 import {classNames} from '../../../../base/classnames';
 import {Icons} from '../../../../base/semantic_icons';
@@ -127,7 +133,7 @@ export class MetricsNode implements QueryNode {
     // Remove value columns whose column no longer exists or is no longer numeric.
     this.state.valueColumns = this.state.valueColumns.filter((vc) => {
       const col = this.state.availableColumns.find((c) => c.name === vc.column);
-      return col !== undefined && isMetricsValueType(col.type);
+      return col !== undefined && isMetricsValueType(col.column.type);
     });
   }
 
@@ -174,9 +180,9 @@ export class MetricsNode implements QueryNode {
         );
         return false;
       }
-      if (!isMetricsValueType(col.type)) {
+      if (!isMetricsValueType(col.column.type)) {
         this.setValidationError(
-          `Value column '${vc.column}' must be numeric (got ${col.type})`,
+          `Value column '${vc.column}' must be numeric (got ${perfettoSqlTypeToString(col.column.type)})`,
         );
         return false;
       }
@@ -368,7 +374,7 @@ export class MetricsNode implements QueryNode {
         dimensionCols.length === 0
           ? m('.pf-metrics-v2-empty-hint', 'No dimensions')
           : dimensionCols.map((col) => {
-              const numeric = isMetricsValueType(col.type);
+              const numeric = isMetricsValueType(col.column.type);
               return m(
                 '.pf-metrics-v2-column-item',
                 {
@@ -402,7 +408,10 @@ export class MetricsNode implements QueryNode {
                     })
                   : m('span.pf-metrics-v2-drag-handle'),
                 m('span.pf-metrics-v2-col-name', col.name),
-                m('span.pf-metrics-v2-col-type', col.type),
+                m(
+                  'span.pf-metrics-v2-col-type',
+                  perfettoSqlTypeToString(col.column.type),
+                ),
                 numeric
                   ? m(Button, {
                       icon: 'arrow_forward',
@@ -427,12 +436,12 @@ export class MetricsNode implements QueryNode {
         const col = this.state.availableColumns.find(
           (c) => c.name === this.dragPayload?.columnName,
         );
-        return col !== undefined && !isMetricsValueType(col.type);
+        return col !== undefined && !isMetricsValueType(col.column.type);
       })();
 
     // Numeric (or ANY) columns available to add (not already in values).
     const numericDimensions = dimensionCols.filter((c) =>
-      isMetricsValueType(c.type),
+      isMetricsValueType(c.column.type),
     );
 
     return m(
@@ -450,7 +459,7 @@ export class MetricsNode implements QueryNode {
             const col = this.state.availableColumns.find(
               (c) => c.name === this.dragPayload?.columnName,
             );
-            if (col !== undefined && isMetricsValueType(col.type)) {
+            if (col !== undefined && isMetricsValueType(col.column.type)) {
               e.preventDefault();
             }
             // Non-numeric: don't preventDefault → drop not allowed.
@@ -511,7 +520,11 @@ export class MetricsNode implements QueryNode {
                 [
                   m('option', {value: '', disabled: true}, 'Select column...'),
                   ...numericDimensions.map((col) =>
-                    m('option', {value: col.name}, `${col.name} (${col.type})`),
+                    m(
+                      'option',
+                      {value: col.name},
+                      `${col.name} (${perfettoSqlTypeToString(col.column.type)})`,
+                    ),
                   ),
                 ],
               ),
@@ -523,7 +536,10 @@ export class MetricsNode implements QueryNode {
 
   private renderValueItem(vc: ValueColumnConfig, index: number): m.Children {
     const col = this.state.availableColumns.find((c) => c.name === vc.column);
-    const colType = col?.type ?? '?';
+    const colType =
+      col?.column.type !== undefined
+        ? perfettoSqlTypeToString(col.column.type)
+        : '?';
     const needsCustomUnit = vc.unit === 'CUSTOM';
     const isExpanded = vc.expanded ?? false;
 
@@ -646,7 +662,7 @@ export class MetricsNode implements QueryNode {
       const col = this.state.availableColumns.find(
         (c) => c.name === columnName,
       );
-      if (col === undefined || !isMetricsValueType(col.type)) return;
+      if (col === undefined || !isMetricsValueType(col.column.type)) return;
 
       // Add to values with default config.
       const alreadyExists = this.state.valueColumns.some(

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
@@ -22,7 +22,7 @@ import {
 import {Checkbox} from '../../../../widgets/checkbox';
 import {TextInput} from '../../../../widgets/text_input';
 import {ColumnInfo, newColumnInfoList} from '../column_info';
-import {parsePerfettoSqlTypeFromString} from '../../../../trace_processor/perfetto_sql_type';
+import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 import {NodeIssues} from '../node_issues';
 import {StructuredQueryBuilder, ColumnSpec} from '../structured_query_builder';
@@ -41,7 +41,7 @@ export interface ModifyColumnsSerializedState {
   primaryInputId?: string;
   selectedColumns: {
     name: string;
-    type: string;
+    type?: PerfettoSqlType;
     checked: boolean;
     alias?: string;
     typeUserModified?: boolean;
@@ -102,7 +102,6 @@ export class ModifyColumnsNode implements QueryNode {
         newCol.alias = oldCol.alias;
         // Only preserve type if user explicitly modified it
         if (oldCol.typeUserModified) {
-          newCol.type = oldCol.type;
           newCol.column = {
             ...newCol.column,
             type: oldCol.column.type,
@@ -127,9 +126,8 @@ export class ModifyColumnsNode implements QueryNode {
       sqlModules,
       selectedColumns: serializedState.selectedColumns.map((c) => ({
         name: c.name,
-        type: c.type,
         checked: c.checked,
-        column: {name: c.name},
+        column: {name: c.name, type: c.type},
         alias: c.alias,
         typeUserModified: c.typeUserModified,
       })),
@@ -353,18 +351,14 @@ export class ModifyColumnsNode implements QueryNode {
       this.state.onchange?.();
     };
 
-    const handleTypeChange = (index: number, newType: string) => {
+    const handleTypeChange = (index: number, newType: PerfettoSqlType) => {
       const newSelectedColumns = [...this.state.selectedColumns];
-
-      // Try to parse the type string (handles simple types, ID, and JOINID)
-      const parsedType = parsePerfettoSqlTypeFromString({type: newType});
 
       newSelectedColumns[index] = {
         ...newSelectedColumns[index],
-        type: newType,
         column: {
           ...newSelectedColumns[index].column,
-          type: parsedType.ok ? parsedType.value : col.column.type,
+          type: newType,
         },
         // Mark as user-modified so it's preserved when upstream changes
         typeUserModified: true,
@@ -476,7 +470,7 @@ export class ModifyColumnsNode implements QueryNode {
       primaryInputId: this.primaryInput?.nodeId,
       selectedColumns: this.state.selectedColumns.map((c) => ({
         name: c.name,
-        type: c.type,
+        type: c.column.type,
         checked: c.checked,
         alias: c.alias,
         typeUserModified: c.typeUserModified,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
@@ -19,6 +19,7 @@ import {
   createColumnInfo,
   connectNodes,
 } from '../testing/test_utils';
+import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
 
 describe('ModifyColumnsNode', () => {
   function createMockPrevNode(): QueryNode {
@@ -230,13 +231,11 @@ describe('ModifyColumnsNode', () => {
       // Verify initial state - all columns should be from source
       expect(modifyNode.state.selectedColumns.length).toBe(3);
       expect(modifyNode.state.selectedColumns[2].name).toBe('value');
-      expect(modifyNode.state.selectedColumns[2].type).toBe('INT');
-      expect(modifyNode.state.selectedColumns[2].column.type).toEqual({
-        kind: 'int',
-      });
+      expect(modifyNode.state.selectedColumns[2].column.type).toEqual(
+        PerfettoSqlTypes.INT,
+      );
 
       // User modifies the type of 'value' column to 'duration'
-      modifyNode.state.selectedColumns[2].type = 'DURATION';
       modifyNode.state.selectedColumns[2].column = {
         ...modifyNode.state.selectedColumns[2].column,
         type: {kind: 'duration'},
@@ -244,10 +243,9 @@ describe('ModifyColumnsNode', () => {
       modifyNode.state.selectedColumns[2].typeUserModified = true;
 
       // Verify the type was modified
-      expect(modifyNode.state.selectedColumns[2].type).toBe('DURATION');
-      expect(modifyNode.state.selectedColumns[2].column.type).toEqual({
-        kind: 'duration',
-      });
+      expect(modifyNode.state.selectedColumns[2].column.type).toEqual(
+        PerfettoSqlTypes.DURATION,
+      );
 
       // Simulate inserting a new node between source and modify
       // (e.g., user adds a Limit node between slices and modify)
@@ -270,10 +268,9 @@ describe('ModifyColumnsNode', () => {
 
       // The modified type should be preserved!
       expect(modifyNode.state.selectedColumns[2].name).toBe('value');
-      expect(modifyNode.state.selectedColumns[2].type).toBe('DURATION');
-      expect(modifyNode.state.selectedColumns[2].column.type).toEqual({
-        kind: 'duration',
-      });
+      expect(modifyNode.state.selectedColumns[2].column.type).toEqual(
+        PerfettoSqlTypes.DURATION,
+      );
     });
 
     it('should preserve checked status and aliases when input changes', () => {
@@ -373,7 +370,7 @@ describe('ModifyColumnsNode', () => {
 
     it('should preserve typeUserModified flag when cloning', () => {
       const col = createColumnInfo('value', 'int');
-      col.type = 'DURATION';
+      col.column = {...col.column, type: PerfettoSqlTypes.DURATION};
       col.typeUserModified = true;
       const node = createModifyColumnsNodeWithInput(
         {
@@ -384,7 +381,9 @@ describe('ModifyColumnsNode', () => {
 
       const clonedNode = node.clone() as ModifyColumnsNode;
 
-      expect(clonedNode.state.selectedColumns[0].type).toBe('DURATION');
+      expect(clonedNode.state.selectedColumns[0].column.type).toEqual(
+        PerfettoSqlTypes.DURATION,
+      );
       expect(clonedNode.state.selectedColumns[0].typeUserModified).toBe(true);
     });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_utils.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_utils.ts
@@ -15,9 +15,11 @@
 import m from 'mithril';
 import {MenuItem, PopupMenu} from '../../../../widgets/menu';
 import {
+  PerfettoSqlType,
   SIMPLE_TYPE_KINDS,
   isIdType,
   perfettoSqlTypeToString,
+  typesEqual,
 } from '../../../../trace_processor/perfetto_sql_type';
 import {ColumnInfo} from '../column_info';
 import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
@@ -59,14 +61,15 @@ export function renderTypeSelector(
   col: ColumnInfo,
   index: number,
   sqlModules: SqlModules | undefined,
-  onColumnType?: (index: number, type: string) => void,
+  onColumnType?: (index: number, type: PerfettoSqlType) => void,
 ): m.Child {
   // If no callback provided, don't render type selector
   if (!onColumnType) {
     return null;
   }
 
-  const currentType = col.type ?? 'UNKNOWN';
+  const currentType = col.column.type;
+  const currentTypeStr = perfettoSqlTypeToString(currentType);
   const originalType = col.column.type;
 
   // Build the list of menu items
@@ -78,20 +81,25 @@ export function renderTypeSelector(
     menuItems.push(
       m(MenuItem, {
         label: idTypeStr,
-        active: currentType === idTypeStr,
-        onclick: () => onColumnType(index, idTypeStr),
+        active:
+          currentType !== undefined && typesEqual(currentType, originalType),
+        onclick: () => onColumnType(index, originalType),
       }),
     );
   }
 
   // Add all simple types
-  for (const type of SIMPLE_TYPE_KINDS) {
-    const typeUpper = type.toUpperCase();
+  for (const kind of SIMPLE_TYPE_KINDS) {
+    const simpleType: PerfettoSqlType = {kind};
+    const typeStr = kind.toUpperCase();
     menuItems.push(
       m(MenuItem, {
-        label: typeUpper,
-        active: currentType === typeUpper,
-        onclick: () => onColumnType(index, typeUpper),
+        label: typeStr,
+        active:
+          currentType !== undefined &&
+          currentType.kind === kind &&
+          !isIdType(currentType),
+        onclick: () => onColumnType(index, simpleType),
       }),
     );
   }
@@ -101,10 +109,14 @@ export function renderTypeSelector(
   const joinidMenuItems =
     tablesWithId.length > 0
       ? tablesWithId.map(({tableName, columnName}) => {
-          const joinidType = `JOINID(${tableName}.${columnName})`;
+          const joinidType: PerfettoSqlType = {
+            kind: 'joinid',
+            source: {table: tableName, column: columnName},
+          };
           return m(MenuItem, {
             label: `${tableName}.${columnName}`,
-            active: currentType === joinidType,
+            active:
+              currentType !== undefined && typesEqual(currentType, joinidType),
             onclick: () => onColumnType(index, joinidType),
           });
         })
@@ -130,7 +142,7 @@ export function renderTypeSelector(
   return m(
     PopupMenu,
     {
-      trigger: m('.pf-column-type', currentType),
+      trigger: m('.pf-column-type', currentTypeStr),
     },
     menuItems,
   );

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source_unittest.ts
@@ -474,11 +474,11 @@ describe('TimeRangeSourceNode', () => {
 
       expect(node.finalCols.length).toBe(3);
       expect(node.finalCols[0].name).toBe('id');
-      expect(node.finalCols[0].type).toBe('INT');
+      expect(node.finalCols[0].column.type).toEqual({kind: 'int'});
       expect(node.finalCols[1].name).toBe('ts');
-      expect(node.finalCols[1].type).toBe('TIMESTAMP');
+      expect(node.finalCols[1].column.type).toEqual({kind: 'timestamp'});
       expect(node.finalCols[2].name).toBe('dur');
-      expect(node.finalCols[2].type).toBe('DURATION');
+      expect(node.finalCols[2].column.type).toEqual({kind: 'duration'});
     });
   });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter.ts
@@ -412,7 +412,7 @@ function partitionValuesByType(
     if (typeof value === 'string') {
       stringValues.push(value);
     } else if (typeof value === 'number' || typeof value === 'bigint') {
-      if (column && (column.type === 'long' || column.type === 'int')) {
+      if (column?.column.type?.kind === 'int') {
         int64Values.push(Number(value));
       } else {
         doubleValues.push(Number(value));
@@ -498,7 +498,7 @@ export function createFiltersProto(
           if (typeof value === 'string') {
             result.stringRhs = [value];
           } else if (typeof value === 'number' || typeof value === 'bigint') {
-            if (col && (col.type === 'long' || col.type === 'int')) {
+            if (col?.column.type?.kind === 'int') {
               result.int64Rhs = [Number(value)];
             } else {
               result.doubleRhs = [Number(value)];

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter_unittest.ts
@@ -38,25 +38,21 @@ describe('filter operations', () => {
     const sourceCols: ColumnInfo[] = [
       {
         name: 'id',
-        type: 'int',
         checked: false,
         column: {name: 'id', type: {kind: 'int'}},
       },
       {
         name: 'name',
-        type: 'string',
         checked: false,
         column: {name: 'name', type: {kind: 'string'}},
       },
       {
         name: 'age',
-        type: 'int',
         checked: false,
         column: {name: 'age', type: {kind: 'int'}},
       },
       {
         name: 'status',
-        type: 'string',
         checked: false,
         column: {name: 'status', type: {kind: 'string'}},
       },

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
@@ -413,11 +413,11 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
           }
 
           // Check if this is a timestamp column
-          if (columnInfo.type === 'TIMESTAMP') {
+          if (columnInfo.column.type?.kind === 'timestamp') {
             cellRenderer = createTimestampCellRenderer(attrs.trace);
           }
           // Check if this is a duration column
-          else if (columnInfo.type === 'DURATION') {
+          else if (columnInfo.column.type?.kind === 'duration') {
             cellRenderer = createDurationCellRenderer(attrs.trace);
           }
         }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder_unittest.ts
@@ -49,13 +49,11 @@ describe('StructuredQueryBuilder', () => {
       const columns: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: true,
           column: {name: 'id', type: intType},
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: true,
           column: {name: 'name', type: stringType},
         },
@@ -72,19 +70,16 @@ describe('StructuredQueryBuilder', () => {
       const columns: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: true,
           column: {name: 'id', type: intType},
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: false,
           column: {name: 'name', type: stringType},
         },
         {
           name: 'age',
-          type: 'INTEGER',
           checked: true,
           column: {name: 'age', type: intType},
         },
@@ -103,14 +98,12 @@ describe('StructuredQueryBuilder', () => {
       const columns: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: true,
           column: {name: 'id', type: intType},
           alias: 'identifier',
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: false,
           column: {name: 'name', type: stringType},
         },
@@ -139,13 +132,11 @@ describe('StructuredQueryBuilder', () => {
       const columns: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: false,
           column: {name: 'id', type: intType},
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: false,
           column: {name: 'name', type: stringType},
         },

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/testing/test_utils.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/testing/test_utils.ts
@@ -24,21 +24,17 @@ import {ColumnInfo} from '../column_info';
 import {NodeDetailsAttrs} from '../../node_types';
 import {NodeIssues} from '../node_issues';
 import protos from '../../../../protos';
+import {
+  PerfettoSqlType,
+  SimpleTypeKind,
+} from '../../../../trace_processor/perfetto_sql_type';
 
 // ============================================================================
 // TYPES
 // ============================================================================
 
 /** Column type strings supported by the test utilities */
-export type ColumnType =
-  | 'int'
-  | 'double'
-  | 'boolean'
-  | 'string'
-  | 'bytes'
-  | 'timestamp'
-  | 'duration'
-  | 'arg_set_id';
+export type ColumnType = SimpleTypeKind;
 
 /** Options for creating a mock node */
 export interface MockNodeOptions {
@@ -183,39 +179,37 @@ export function createColumnInfo(
   options: ColumnInfoOptions = {},
 ): ColumnInfo {
   const {checked = true, alias} = options;
+  const sqlType: PerfettoSqlType = {kind: type};
 
   return {
     name,
-    type: type.toUpperCase(),
     checked,
-    column: {name, type: {kind: type}},
+    column: {name, type: sqlType},
     alias,
   };
 }
 
 /**
- * Creates a ColumnInfo with type string format matching the perfetto SQL types.
+ * Creates a ColumnInfo with an explicit PerfettoSqlType.
  *
- * This is useful when you need the type string to match exactly what
- * perfettoSqlTypeToString returns (e.g., 'INT', 'STRING', 'TIMESTAMP').
+ * This is useful when you need to provide a specific PerfettoSqlType
+ * (e.g., id or joinid types with source information).
  *
  * @param name - Column name
- * @param type - Column type in uppercase format
+ * @param type - PerfettoSqlType to use
  * @param options - Additional options (checked, alias)
  */
-export function createColumnInfoWithTypeString(
+export function createColumnInfoWithType(
   name: string,
-  type: string,
+  type: PerfettoSqlType,
   options: ColumnInfoOptions = {},
 ): ColumnInfo {
   const {checked = true, alias} = options;
-  const kind = type.toLowerCase() as ColumnType;
 
   return {
     name,
-    type,
     checked,
-    column: {name, type: {kind}},
+    column: {name, type},
     alias,
   };
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils.ts
@@ -16,37 +16,35 @@
  * Utility functions for the query builder.
  */
 
+import {
+  PerfettoSqlType,
+  isQuantitativeType,
+  typesEqual,
+} from '../../../trace_processor/perfetto_sql_type';
 import {ColumnInfo} from './column_info';
 
 /**
  * Checks if a column type is numeric/quantitative.
- * Numeric types include: INT, DOUBLE, DURATION, TIMESTAMP, BOOLEAN, ID types, and ARG_SET_ID.
+ * Numeric types include: int, double, duration, timestamp, boolean, id,
+ * joinid, and arg_set_id.
  *
- * @param typeStr The column type string (case-insensitive)
+ * @param type The PerfettoSqlType to check
  * @returns true if the type is numeric
  */
-export function isNumericType(typeStr: string): boolean {
-  const normalized = typeStr.toUpperCase();
-  return (
-    normalized === 'INT' ||
-    normalized === 'DOUBLE' ||
-    normalized === 'DURATION' ||
-    normalized === 'TIMESTAMP' ||
-    normalized === 'BOOLEAN' ||
-    normalized.startsWith('ID(') ||
-    normalized.startsWith('JOINID(') ||
-    normalized === 'ARG_SET_ID'
-  );
+export function isNumericType(type?: PerfettoSqlType): boolean {
+  if (type === undefined) return false;
+  return isQuantitativeType(type);
 }
 
 /**
  * Checks if a column type is a string type.
  *
- * @param typeStr The column type string (case-insensitive)
+ * @param type The PerfettoSqlType to check
  * @returns true if the type is a string
  */
-export function isStringType(typeStr: string): boolean {
-  return typeStr.toUpperCase() === 'STRING';
+export function isStringType(type?: PerfettoSqlType): boolean {
+  if (type === undefined) return false;
+  return type.kind === 'string';
 }
 
 /**
@@ -62,9 +60,8 @@ export function isColumnValidForAggregation(
 ): boolean {
   if (!op) return true;
 
-  const typeStr = col.type;
-  const isNumeric = isNumericType(typeStr);
-  const isString = isStringType(typeStr);
+  const isNumeric = isNumericType(col.column.type);
+  const isString = isStringType(col.column.type);
 
   switch (op) {
     case 'MEAN':
@@ -117,8 +114,8 @@ export function getAggregationTypeRequirements(op: string): string {
 export interface GetCommonColumnsOptions {
   // Column names to exclude from the result
   excludedColumns?: Set<string>;
-  // Column types to exclude from the result (e.g., 'STRING', 'BYTES')
-  excludedTypes?: Set<string>;
+  // Column types to exclude from the result
+  excludedTypes?: Set<PerfettoSqlType['kind']>;
 }
 
 /**
@@ -140,20 +137,29 @@ export function getCommonColumns(
   const excludedColumns = options?.excludedColumns ?? new Set();
   const excludedTypes = options?.excludedTypes ?? new Set();
 
+  const isTypeExcluded = (type?: PerfettoSqlType): boolean => {
+    if (type === undefined) return false;
+    return excludedTypes.has(type.kind);
+  };
+
   // Start with columns from the first array
   const firstArray = columnArrays[0];
   const commonColumns = new Set(
     firstArray
-      .filter((c) => !excludedColumns.has(c.name) && !excludedTypes.has(c.type))
+      .filter(
+        (c) => !excludedColumns.has(c.name) && !isTypeExcluded(c.column.type),
+      )
       .map((c) => c.name),
   );
 
   // Intersect with columns from remaining arrays
   for (let i = 1; i < columnArrays.length; i++) {
-    const colsMap = new Map(columnArrays[i].map((c) => [c.name, c.type]));
+    const colsMap = new Map(
+      columnArrays[i].map((c) => [c.name, c.column.type]),
+    );
     for (const col of commonColumns) {
       const colType = colsMap.get(col);
-      if (colType === undefined || excludedTypes.has(colType)) {
+      if (colType === undefined || isTypeExcluded(colType)) {
         commonColumns.delete(col);
       }
     }
@@ -161,3 +167,9 @@ export function getCommonColumns(
 
   return Array.from(commonColumns).sort();
 }
+
+/**
+ * Checks if two PerfettoSqlType values are equal.
+ * Convenience re-export for use in the query builder.
+ */
+export {typesEqual};

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils_unittest.ts
@@ -19,82 +19,96 @@ import {
   getAggregationTypeRequirements,
 } from './utils';
 import {ColumnInfo} from './column_info';
+import {
+  PerfettoSqlType,
+  PerfettoSqlTypes,
+} from '../../../trace_processor/perfetto_sql_type';
 
 describe('utils', () => {
   describe('isNumericType', () => {
     it('should return true for INT type', () => {
-      expect(isNumericType('INT')).toBe(true);
-      expect(isNumericType('int')).toBe(true);
+      expect(isNumericType(PerfettoSqlTypes.INT)).toBe(true);
     });
 
     it('should return true for DOUBLE type', () => {
-      expect(isNumericType('DOUBLE')).toBe(true);
-      expect(isNumericType('double')).toBe(true);
+      expect(isNumericType(PerfettoSqlTypes.DOUBLE)).toBe(true);
     });
 
     it('should return true for DURATION type', () => {
-      expect(isNumericType('DURATION')).toBe(true);
-      expect(isNumericType('duration')).toBe(true);
+      expect(isNumericType(PerfettoSqlTypes.DURATION)).toBe(true);
     });
 
     it('should return true for TIMESTAMP type', () => {
-      expect(isNumericType('TIMESTAMP')).toBe(true);
-      expect(isNumericType('timestamp')).toBe(true);
+      expect(isNumericType(PerfettoSqlTypes.TIMESTAMP)).toBe(true);
     });
 
     it('should return true for BOOLEAN type', () => {
-      expect(isNumericType('BOOLEAN')).toBe(true);
-      expect(isNumericType('boolean')).toBe(true);
+      expect(isNumericType(PerfettoSqlTypes.BOOLEAN)).toBe(true);
     });
 
     it('should return true for ID types', () => {
-      expect(isNumericType('ID(slice)')).toBe(true);
-      expect(isNumericType('ID(thread)')).toBe(true);
-      expect(isNumericType('id(process)')).toBe(true);
+      expect(
+        isNumericType({kind: 'id', source: {table: 'slice', column: 'id'}}),
+      ).toBe(true);
+      expect(
+        isNumericType({kind: 'id', source: {table: 'thread', column: 'id'}}),
+      ).toBe(true);
+      expect(
+        isNumericType({kind: 'id', source: {table: 'process', column: 'id'}}),
+      ).toBe(true);
     });
 
     it('should return true for JOINID types', () => {
-      expect(isNumericType('JOINID(slice.id)')).toBe(true);
-      expect(isNumericType('joinid(thread.id)')).toBe(true);
+      expect(
+        isNumericType({
+          kind: 'joinid',
+          source: {table: 'slice', column: 'id'},
+        }),
+      ).toBe(true);
+      expect(
+        isNumericType({
+          kind: 'joinid',
+          source: {table: 'thread', column: 'id'},
+        }),
+      ).toBe(true);
     });
 
     it('should return true for ARG_SET_ID type', () => {
-      expect(isNumericType('ARG_SET_ID')).toBe(true);
-      expect(isNumericType('arg_set_id')).toBe(true);
+      expect(isNumericType(PerfettoSqlTypes.ARG_SET_ID)).toBe(true);
     });
 
     it('should return false for STRING type', () => {
-      expect(isNumericType('STRING')).toBe(false);
-      expect(isNumericType('string')).toBe(false);
+      expect(isNumericType(PerfettoSqlTypes.STRING)).toBe(false);
     });
 
-    it('should return false for unknown types', () => {
-      expect(isNumericType('UNKNOWN')).toBe(false);
-      expect(isNumericType('BLOB')).toBe(false);
+    it('should return false for undefined type', () => {
+      expect(isNumericType(undefined)).toBe(false);
     });
   });
 
   describe('isStringType', () => {
     it('should return true for STRING type', () => {
-      expect(isStringType('STRING')).toBe(true);
-      expect(isStringType('string')).toBe(true);
+      expect(isStringType(PerfettoSqlTypes.STRING)).toBe(true);
     });
 
     it('should return false for non-string types', () => {
-      expect(isStringType('INT')).toBe(false);
-      expect(isStringType('DOUBLE')).toBe(false);
-      expect(isStringType('DURATION')).toBe(false);
+      expect(isStringType(PerfettoSqlTypes.INT)).toBe(false);
+      expect(isStringType(PerfettoSqlTypes.DOUBLE)).toBe(false);
+      expect(isStringType(PerfettoSqlTypes.DURATION)).toBe(false);
     });
   });
 
   describe('isColumnValidForAggregation', () => {
-    function createColumnInfo(name: string, type: string): ColumnInfo {
+    function createColumnInfo(
+      name: string,
+      type?: PerfettoSqlType,
+    ): ColumnInfo {
       return {
         name,
-        type,
         checked: false,
         column: {
           name,
+          type,
         },
       };
     }
@@ -102,17 +116,20 @@ describe('utils', () => {
     describe('MEAN operation', () => {
       it('should allow numeric columns', () => {
         expect(
-          isColumnValidForAggregation(createColumnInfo('dur', 'INT'), 'MEAN'),
-        ).toBe(true);
-        expect(
           isColumnValidForAggregation(
-            createColumnInfo('value', 'DOUBLE'),
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
             'MEAN',
           ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('ts', 'TIMESTAMP'),
+            createColumnInfo('value', PerfettoSqlTypes.DOUBLE),
+            'MEAN',
+          ),
+        ).toBe(true);
+        expect(
+          isColumnValidForAggregation(
+            createColumnInfo('ts', PerfettoSqlTypes.TIMESTAMP),
             'MEAN',
           ),
         ).toBe(true);
@@ -121,7 +138,7 @@ describe('utils', () => {
       it('should reject string columns', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'MEAN',
           ),
         ).toBe(false);
@@ -131,11 +148,14 @@ describe('utils', () => {
     describe('MEDIAN operation', () => {
       it('should allow numeric columns', () => {
         expect(
-          isColumnValidForAggregation(createColumnInfo('dur', 'INT'), 'MEDIAN'),
+          isColumnValidForAggregation(
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
+            'MEDIAN',
+          ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('value', 'DOUBLE'),
+            createColumnInfo('value', PerfettoSqlTypes.DOUBLE),
             'MEDIAN',
           ),
         ).toBe(true);
@@ -144,7 +164,7 @@ describe('utils', () => {
       it('should reject string columns', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'MEDIAN',
           ),
         ).toBe(false);
@@ -155,19 +175,22 @@ describe('utils', () => {
       it('should allow numeric columns', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('dur', 'INT'),
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
             'PERCENTILE',
           ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('value', 'DOUBLE'),
+            createColumnInfo('value', PerfettoSqlTypes.DOUBLE),
             'PERCENTILE',
           ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('id', 'ID(slice)'),
+            createColumnInfo('id', {
+              kind: 'id',
+              source: {table: 'slice', column: 'id'},
+            }),
             'PERCENTILE',
           ),
         ).toBe(true);
@@ -176,7 +199,7 @@ describe('utils', () => {
       it('should reject string columns', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'PERCENTILE',
           ),
         ).toBe(false);
@@ -187,13 +210,13 @@ describe('utils', () => {
       it('should allow numeric columns', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('value', 'INT'),
+            createColumnInfo('value', PerfettoSqlTypes.INT),
             'DURATION_WEIGHTED_MEAN',
           ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('dur', 'DURATION'),
+            createColumnInfo('dur', PerfettoSqlTypes.DURATION),
             'DURATION_WEIGHTED_MEAN',
           ),
         ).toBe(true);
@@ -202,7 +225,7 @@ describe('utils', () => {
       it('should reject string columns', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'DURATION_WEIGHTED_MEAN',
           ),
         ).toBe(false);
@@ -213,7 +236,7 @@ describe('utils', () => {
       it('should allow string columns', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'GLOB',
           ),
         ).toBe(true);
@@ -221,11 +244,14 @@ describe('utils', () => {
 
       it('should reject numeric columns', () => {
         expect(
-          isColumnValidForAggregation(createColumnInfo('dur', 'INT'), 'GLOB'),
+          isColumnValidForAggregation(
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
+            'GLOB',
+          ),
         ).toBe(false);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('value', 'DOUBLE'),
+            createColumnInfo('value', PerfettoSqlTypes.DOUBLE),
             'GLOB',
           ),
         ).toBe(false);
@@ -236,16 +262,19 @@ describe('utils', () => {
       it('should allow all column types', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'COUNT',
           ),
         ).toBe(true);
         expect(
-          isColumnValidForAggregation(createColumnInfo('dur', 'INT'), 'COUNT'),
+          isColumnValidForAggregation(
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
+            'COUNT',
+          ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('value', 'DOUBLE'),
+            createColumnInfo('value', PerfettoSqlTypes.DOUBLE),
             'COUNT',
           ),
         ).toBe(true);
@@ -256,13 +285,13 @@ describe('utils', () => {
       it('should allow all column types', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'COUNT(*)',
           ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('dur', 'INT'),
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
             'COUNT(*)',
           ),
         ).toBe(true);
@@ -273,12 +302,15 @@ describe('utils', () => {
       it('should allow all column types', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'SUM',
           ),
         ).toBe(true);
         expect(
-          isColumnValidForAggregation(createColumnInfo('dur', 'INT'), 'SUM'),
+          isColumnValidForAggregation(
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
+            'SUM',
+          ),
         ).toBe(true);
       });
     });
@@ -287,21 +319,27 @@ describe('utils', () => {
       it('should allow all column types', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'MIN',
           ),
         ).toBe(true);
         expect(
-          isColumnValidForAggregation(createColumnInfo('dur', 'INT'), 'MIN'),
+          isColumnValidForAggregation(
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
+            'MIN',
+          ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             'MAX',
           ),
         ).toBe(true);
         expect(
-          isColumnValidForAggregation(createColumnInfo('dur', 'INT'), 'MAX'),
+          isColumnValidForAggregation(
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
+            'MAX',
+          ),
         ).toBe(true);
       });
     });
@@ -310,13 +348,13 @@ describe('utils', () => {
       it('should return true for undefined operation', () => {
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('name', 'STRING'),
+            createColumnInfo('name', PerfettoSqlTypes.STRING),
             undefined,
           ),
         ).toBe(true);
         expect(
           isColumnValidForAggregation(
-            createColumnInfo('dur', 'INT'),
+            createColumnInfo('dur', PerfettoSqlTypes.INT),
             undefined,
           ),
         ).toBe(true);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_node_unittest.ts
@@ -23,7 +23,10 @@ import {
 import {queryToRun, isAQuery} from './query_builder/query_builder_utils';
 import {notifyNextNodes} from './query_builder/graph_utils';
 import {ColumnInfo, newColumnInfoList} from './query_builder/column_info';
-import {PerfettoSqlType} from '../../trace_processor/perfetto_sql_type';
+import {
+  PerfettoSqlType,
+  PerfettoSqlTypes,
+} from '../../trace_processor/perfetto_sql_type';
 
 describe('query_node utilities', () => {
   describe('nextNodeId', () => {
@@ -69,13 +72,11 @@ describe('query_node utilities', () => {
       const sourceCols: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: false,
           column: {name: 'id', type: stringType},
         },
         {
           name: 'name',
-          type: 'STRING',
           checked: false,
           column: {name: 'name', type: stringType},
         },
@@ -92,7 +93,6 @@ describe('query_node utilities', () => {
       const sourceCols: ColumnInfo[] = [
         {
           name: 'id',
-          type: 'INTEGER',
           checked: false,
           column: {name: 'id', type: stringType},
           alias: 'identifier',
@@ -102,7 +102,7 @@ describe('query_node utilities', () => {
       const result = newColumnInfoList(sourceCols, true);
 
       expect(result[0].name).toBe('identifier');
-      expect(result[0].type).toBe('STRING');
+      expect(result[0].column.type).toEqual(PerfettoSqlTypes.STRING);
       // column.name should also be replaced with the alias so child nodes see the aliased name
       expect(result[0].column.name).toBe('identifier');
     });

--- a/ui/src/trace_processor/perfetto_sql_type.ts
+++ b/ui/src/trace_processor/perfetto_sql_type.ts
@@ -18,16 +18,18 @@ import {errResult, okResult, Result} from '../base/result';
 // https://perfetto.dev/docs/analysis/perfetto-sql-syntax#types
 export type PerfettoSqlType = SimpleType | PerfettoSqlIdType;
 
+export type SimpleTypeKind =
+  | 'int'
+  | 'double'
+  | 'boolean'
+  | 'string'
+  | 'bytes'
+  | 'timestamp'
+  | 'duration'
+  | 'arg_set_id';
+
 type SimpleType = {
-  kind:
-    | 'int'
-    | 'double'
-    | 'boolean'
-    | 'string'
-    | 'bytes'
-    | 'timestamp'
-    | 'duration'
-    | 'arg_set_id';
+  kind: SimpleTypeKind;
 };
 
 type PerfettoSqlIdType = {


### PR DESCRIPTION
Column types in Data Explorer were confusing - constantly converting between string and PerfettoSqlType. This change is the first attempt to bring it all to PerfettoSqlType.
