### PR TITLE
tp: fix temp file handle leak in Python trace processor API

### DIFF
--- a/python/perfetto/trace_processor/api.py
+++ b/python/perfetto/trace_processor/api.py
@@ -291,7 +291,7 @@ class TraceProcessor:
       parsed = p.netloc if p.netloc else p.path
       return TraceProcessorHttp(parsed, protos=self.protos)
 
-    url, self.subprocess = load_shell(
+    url, self.subprocess, self._tp_stdout, self._tp_stderr = load_shell(
         self.config.bin_path,
         self.config.unique_port,
         self.config.verbose,
@@ -345,6 +345,12 @@ class TraceProcessor:
       self.subprocess.wait()
       # Set to None so __del__ doesn't call this again.
       self.subprocess = None
+      if hasattr(self, '_tp_stdout') and self._tp_stdout:
+        self._tp_stdout.close()
+        self._tp_stdout = None
+      if hasattr(self, '_tp_stderr') and self._tp_stderr:
+        self._tp_stderr.close()
+        self._tp_stderr = None
 
     if hasattr(self, 'http'):
       self.http.conn.close()

--- a/python/perfetto/trace_processor/shell.py
+++ b/python/perfetto/trace_processor/shell.py
@@ -113,7 +113,9 @@ def load_shell(
     stdout = temp_stdout.read().decode("utf-8")
     temp_stderr.seek(0)
     stderr = temp_stderr.read().decode("utf-8")
+    temp_stdout.close()
+    temp_stderr.close()
     raise PerfettoException("Trace processor failed to start.\n"
                             f"stdout: {stdout}\nstderr: {stderr}\n")
 
-  return url, p
+  return url, p, temp_stdout, temp_stderr


### PR DESCRIPTION
Return temp stdout/stderr file handles from load_shell so they
can be properly closed when the TraceProcessor is shut down,
preventing resource leaks.

Fixes: https://github.com/google/perfetto/issues/5099
