### PR TITLE
de: Add dashboard functionality

### DIFF
--- a/ui/src/assets/data_explorer/node_info/dashboard.md
+++ b/ui/src/assets/data_explorer/node_info/dashboard.md
@@ -1,0 +1,22 @@
+# Export to Dashboard
+
+Makes the upstream data source available to dashboard tabs. Each export node
+publishes its input columns so that dashboard charts can query the data.
+
+## Configuration
+
+- **Export name**: A human-readable label shown on dashboard charts and in the
+  data panel. Defaults to the name of the connected input node.
+
+## How It Works
+
+1. Connect an upstream node (table, filter, join, etc.) to this node.
+2. The node publishes the input's columns to the global dashboard registry.
+3. Open a Dashboard tab and add charts that reference this exported source.
+
+## Tips
+
+- Give exports descriptive names — they appear as data source labels on
+  dashboards.
+- The table is materialized on first use; dashboards trigger execution
+  automatically if the source hasn't been run yet.

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.scss
@@ -1,0 +1,381 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@import "../../../assets/theme";
+
+.pf-dashboard {
+  height: 100%;
+  display: flex;
+  overflow: hidden;
+}
+
+// Column wrapper for the filter bar + canvas (sits inside the row layout).
+.pf-dashboard__main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.pf-dashboard__canvas {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  position: relative;
+
+  // Reuse the same dot pattern as the node graph canvas.
+  background-color: color-mix(
+    in srgb,
+    var(--pf-color-background) 90%,
+    var(--pf-color-border-secondary) 10%
+  );
+  background-image: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--pf-color-border-secondary) 85%, black 15%) 1px,
+    transparent 0px
+  );
+  background-size: 20px 20px;
+}
+
+// Centered overlay for the empty state.
+.pf-dashboard__empty-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+// "+" add-item button in the top-left corner of the canvas.
+.pf-dashboard__add-button {
+  position: sticky;
+  top: 1rem;
+  left: 1rem;
+  z-index: 10;
+  width: 0;
+  height: 0;
+  overflow: visible;
+}
+
+// Horizontal filter bar below the tab strip.
+.pf-dashboard__filter-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 4px 12px;
+  border-bottom: 1px solid var(--pf-color-border);
+  background: var(--pf-color-background);
+}
+
+// Per-source group of chips inside the filter bar.
+.pf-dashboard__filter-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  background: var(--pf-color-background-secondary);
+  border: 1px solid var(--pf-color-border-secondary);
+  border-radius: 6px;
+}
+
+// Actions (clear all + collapse) pushed to the right.
+.pf-dashboard__filter-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+// Popup showing individual filter values for a column.
+.pf-dashboard__filter-popup {
+  display: flex;
+  flex-direction: column;
+  min-width: 120px;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+// Collapsed state: small circle in the top-right corner of the canvas.
+.pf-dashboard__filter-collapsed {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+}
+
+// Individual chart card on the dashboard canvas.
+.pf-dashboard__chart {
+  position: absolute;
+  width: 400px;
+  height: 294px;
+  background: var(--pf-color-background);
+  display: flex;
+  flex-direction: column;
+  user-select: none;
+
+  // Custom width/height via CSS custom properties set inline.
+  &--custom-width {
+    width: var(--pf-db-chart-width);
+  }
+
+  &--custom-height {
+    height: var(--pf-db-chart-height);
+  }
+
+  &--dragging {
+    opacity: 0.6;
+    z-index: 100;
+    cursor: grabbing;
+  }
+
+  // Position resize handles at the edges of the card.
+  > .pf-resize-handle--horizontal {
+    position: absolute;
+    right: -1px;
+    top: 0;
+    bottom: 0;
+  }
+
+  > .pf-resize-handle--vertical {
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+  }
+}
+
+.pf-dashboard__chart-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  cursor: grab;
+  flex-shrink: 0;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.pf-dashboard__source-chip {
+  flex-shrink: 0;
+  font-size: 11px;
+  max-width: 120px;
+}
+
+.pf-dashboard__chart-header-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+}
+
+.pf-dashboard__chart-title-input {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 500;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  border-bottom: 1px solid var(--pf-color-accent);
+}
+
+.pf-dashboard__chart-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.pf-dashboard__chart-content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding-top: 4px;
+}
+
+// Data panel — styled similarly to the query page's table list.
+.pf-dashboard__data-panel {
+  width: 300px;
+  height: 100%;
+  border-left: 1px solid var(--pf-color-border);
+  background: var(--pf-color-background);
+  display: flex;
+  flex-direction: column;
+}
+
+.pf-dashboard__input-list {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.pf-dashboard__panel-section-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--pf-color-text-muted);
+  text-transform: uppercase;
+  padding: 8px 12px 4px;
+}
+
+.pf-dashboard__input-name {
+  font-family: var(--pf-font-monospace);
+  font-size: 12px;
+}
+
+.pf-dashboard__source-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+// Detail rows (input name, column count).
+.pf-dashboard__detail-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.pf-dashboard__detail-label {
+  font-size: 11px;
+  color: var(--pf-color-text-muted);
+  text-transform: uppercase;
+  min-width: 50px;
+}
+
+.pf-dashboard__detail-value {
+  font-size: 12px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// Column list — matching query page's column list style.
+.pf-dashboard__columns {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pf-dashboard__column-list {
+  display: flex;
+  flex-direction: column;
+  margin-top: 4px;
+  border: 1px solid var(--pf-color-border-secondary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.pf-dashboard__column {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--pf-color-border-secondary);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: var(--pf-color-background-hover);
+  }
+}
+
+.pf-dashboard__column-icon {
+  font-size: 14px;
+  color: var(--pf-color-text-muted);
+  width: 16px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.pf-dashboard__column-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pf-dashboard__column-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.pf-dashboard__column-name {
+  font-size: 12px;
+}
+
+.pf-dashboard__column-type {
+  font-size: 11px;
+  color: var(--pf-color-text-muted);
+  margin-left: auto;
+}
+
+// "Add Chart" button inside the data panel source accordion.
+.pf-dashboard__add-chart-btn {
+  width: 100%;
+  margin-top: 8px;
+  justify-content: center;
+  border: 1px dashed var(--pf-color-border);
+  border-radius: 4px;
+  color: var(--pf-color-text-muted);
+  font-size: 12px;
+
+  &:hover {
+    border-color: var(--pf-color-accent);
+    color: var(--pf-color-accent);
+    background: color-mix(in srgb, var(--pf-color-accent) 5%, transparent);
+  }
+}
+
+// Side panel matching the builder's .pf-qb-side-panel style.
+.pf-dashboard__side-panel {
+  width: 60px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  border-left: 1px solid var(--pf-color-border);
+  align-items: stretch;
+
+  .pf-button {
+    width: 100%;
+    height: 60px;
+    font-size: var(--pf-font-size-xxl);
+    box-shadow: none;
+    border: none;
+    border-radius: 0;
+  }
+}

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
@@ -1,0 +1,833 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Trace} from '../../../public/trace';
+import {classNames} from '../../../base/classnames';
+import {
+  perfettoSqlTypeIcon,
+  perfettoSqlTypeToString,
+} from '../../../trace_processor/perfetto_sql_type';
+import {Accordion, AccordionItem} from '../../../widgets/accordion';
+import {Button} from '../../../widgets/button';
+import {Icons} from '../../../base/semantic_icons';
+import {Chip} from '../../../widgets/chip';
+import {EmptyState} from '../../../widgets/empty_state';
+import {Icon} from '../../../widgets/icon';
+import {MenuItem, PopupMenu} from '../../../widgets/menu';
+import {
+  DashboardBrushFilter,
+  DashboardDataSource,
+  DashboardItem,
+  DashboardSourceWithName,
+  getItemId,
+  getNextItemPosition,
+  snapToGrid,
+  sourceDisplayName,
+} from './dashboard_registry';
+import {
+  DashboardChartView,
+  createDefaultChartConfig,
+} from './dashboard_chart_view';
+import {ResizeHandle} from '../../../widgets/resize_handle';
+import {Card} from '../../../widgets/card';
+import {getDefaultChartLabel} from '../query_builder/nodes/visualisation_node';
+import {Popup, PopupPosition} from '../../../widgets/popup';
+import {renderChartConfigPopup} from '../query_builder/charts/chart_config_popup';
+import {RoundActionButton} from '../query_builder/widgets';
+
+// Default dimensions for dashboard chart cards (in pixels).
+const DEFAULT_CHART_WIDTH = 400;
+const DEFAULT_CHART_HEIGHT = 294;
+const MIN_CHART_WIDTH = 200;
+const MIN_CHART_HEIGHT = 150;
+
+function formatBrushFilter(f: DashboardBrushFilter): string {
+  if (f.op === 'is null') return 'IS NULL';
+  if (f.op === '=') return `= ${f.value}`;
+  return `${f.op} ${f.value}`;
+}
+
+function formatBrushFilterValue(f: DashboardBrushFilter): string {
+  if (f.op === 'is null') return 'NULL';
+  if (f.op === '=') return String(f.value);
+  return `${f.op} ${f.value}`;
+}
+
+function summarizeBrushFilters(
+  filters: ReadonlyArray<DashboardBrushFilter>,
+): string {
+  const eqValues = filters.filter((f) => f.op === '=');
+  const rangeFilters = filters.filter((f) => f.op === '>=' || f.op === '<');
+  const nullFilters = filters.filter((f) => f.op === 'is null');
+
+  const parts: string[] = [];
+  if (rangeFilters.length === 2) {
+    const min = rangeFilters.find((f) => f.op === '>=')?.value;
+    const max = rangeFilters.find((f) => f.op === '<')?.value;
+    if (min !== undefined && max !== undefined) {
+      parts.push(`${min}–${max}`);
+    }
+  } else if (rangeFilters.length > 0) {
+    parts.push(...rangeFilters.map((f) => formatBrushFilter(f)));
+  }
+  if (eqValues.length <= 3) {
+    parts.push(...eqValues.map((f) => String(f.value)));
+  } else {
+    parts.push(`${eqValues.length} values`);
+  }
+  if (nullFilters.length > 0) {
+    parts.push('NULL');
+  }
+  return parts.join(', ');
+}
+
+// Re-export types that are defined in dashboard_registry but used by callers
+// of this module (e.g. DataExplorer).
+export type {DashboardSourceWithName} from './dashboard_registry';
+
+export interface DashboardAttrs {
+  dashboardId: string;
+  trace: Trace;
+  items: DashboardItem[];
+  sources: ReadonlyArray<DashboardSourceWithName>;
+  brushFilters: Map<string, DashboardBrushFilter[]>;
+  onItemsChange: (items: DashboardItem[]) => void;
+  onBrushFiltersChange: (filters: Map<string, DashboardBrushFilter[]>) => void;
+}
+
+export class Dashboard implements m.ClassComponent<DashboardAttrs> {
+  private panelOpen = false;
+  private filtersExpanded = true;
+  private expandedInput: string | undefined = undefined;
+  private editingChartId?: string;
+
+  // Pointer-event drag state.
+  private draggingItemId?: string;
+  private dragOffset = {x: 0, y: 0};
+  private tempPositions = new Map<string, {x: number; y: number}>();
+  // Latest attrs — kept in sync every render so drag handlers never use stale
+  // references.
+  private latestAttrs?: DashboardAttrs;
+
+  view({attrs}: m.CVnode<DashboardAttrs>) {
+    this.latestAttrs = attrs;
+    const {items} = attrs;
+
+    return m('.pf-dashboard', [
+      m('.pf-dashboard__main', [
+        this.renderFilterBar(attrs),
+        m(
+          '.pf-dashboard__canvas',
+          {
+            onpointermove: (e: PointerEvent) => this.handlePointerMove(e),
+            onpointerup: () => this.handlePointerUp(),
+            onpointercancel: () => this.cancelDrag(),
+          },
+          [
+            this.renderAddButton(attrs),
+            this.renderCollapsedFilterButton(attrs),
+            items.length > 0
+              ? this.renderItems(attrs, items)
+              : m(
+                  '.pf-dashboard__empty-overlay',
+                  m(
+                    EmptyState,
+                    {icon: 'bar_chart', title: 'No charts yet'},
+                    'Use the + button to add charts.',
+                  ),
+                ),
+          ],
+        ),
+      ]),
+      this.panelOpen &&
+        m('.pf-dashboard__data-panel', this.renderDataPanel(attrs)),
+      m(
+        '.pf-dashboard__side-panel',
+        m(Button, {
+          icon: 'dataset',
+          title: 'Data',
+          className: classNames(this.panelOpen && 'pf-active'),
+          onclick: () => {
+            this.panelOpen = !this.panelOpen;
+          },
+        }),
+      ),
+    ]);
+  }
+
+  // --- "+" button ---
+
+  private renderAddButton(attrs: DashboardAttrs): m.Child {
+    const {sources, items} = attrs;
+    // Default to the source of the most recently added chart, or the first
+    // available source if there are no charts yet.
+    const lastChartItem = [...items].reverse().find((i) => i.kind === 'chart');
+    const lastSource =
+      (lastChartItem !== undefined
+        ? sources.find((s) => s.nodeId === lastChartItem.sourceNodeId)
+        : undefined) ?? (sources.length > 0 ? sources[0] : undefined);
+
+    return m(
+      '.pf-dashboard__add-button',
+      RoundActionButton({
+        icon: 'add',
+        title: 'Add chart',
+        disabled: lastSource === undefined,
+        onclick: () => {
+          if (lastSource !== undefined) {
+            this.addChartForSource(attrs, lastSource);
+          }
+        },
+      }),
+    );
+  }
+
+  // --- Canvas items ---
+
+  private renderItems(
+    attrs: DashboardAttrs,
+    items: DashboardItem[],
+  ): m.Children {
+    return items.map((item) => {
+      const source = attrs.sources.find((s) => s.nodeId === item.sourceNodeId);
+      if (source === undefined) {
+        return this.renderOrphanedChart(attrs, item);
+      }
+      return this.renderChart(attrs, source, item);
+    });
+  }
+
+  private renderChart(
+    attrs: DashboardAttrs,
+    source: DashboardSourceWithName,
+    chart: DashboardItem,
+  ): m.Child {
+    const config = chart.config;
+    const itemId = config.id;
+    const headerLabel = config.name ?? getDefaultChartLabel(config);
+
+    const editButton = m(
+      Popup,
+      {
+        trigger: m(Button, {
+          icon: 'settings',
+          title: 'Edit chart settings',
+          compact: true,
+        }),
+        position: PopupPosition.BottomEnd,
+        className: 'pf-chart-config-popup',
+      },
+      renderChartConfigPopup(
+        {
+          node: new DashboardChartView.Adapter(source, attrs, config),
+        },
+        config,
+        () => m.redraw(),
+      ),
+    );
+
+    const sourceChip = m(
+      PopupMenu,
+      {
+        trigger: m(Chip, {
+          label: sourceDisplayName(source, attrs.items, attrs.sources),
+          icon: 'database',
+          compact: true,
+          className: 'pf-dashboard__source-chip',
+          title: 'Change data source',
+        }),
+      },
+      ...attrs.sources.map((s) =>
+        m(MenuItem, {
+          label: s.name,
+          icon: s.nodeId === source.nodeId ? 'check' : undefined,
+          onclick: () => {
+            if (s.nodeId !== source.nodeId) {
+              this.changeChartSource(attrs, itemId, s);
+            }
+          },
+        }),
+      ),
+    );
+
+    return this.renderItemCard(attrs, itemId, chart, [
+      m(
+        '.pf-dashboard__chart-header',
+        {
+          onpointerdown: (e: PointerEvent) => this.startDrag(e, itemId),
+        },
+        [
+          this.editingChartId === itemId
+            ? m('input.pf-dashboard__chart-title-input', {
+                type: 'text',
+                value: config.name ?? '',
+                placeholder: getDefaultChartLabel(config),
+                oncreate: (vnode: m.VnodeDOM) => {
+                  const input = vnode.dom as HTMLInputElement;
+                  input.focus();
+                  input.select();
+                },
+                onblur: (e: Event) => {
+                  const target = e.target as HTMLInputElement;
+                  const name = target.value.trim() || undefined;
+                  this.updateChartName(attrs, itemId, name);
+                  this.editingChartId = undefined;
+                },
+                onkeydown: (e: KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === 'Escape') {
+                    this.editingChartId = undefined;
+                    (e.target as HTMLInputElement).blur();
+                  }
+                },
+                oninput: (e: Event) => {
+                  const target = e.target as HTMLInputElement;
+                  const name = target.value || undefined;
+                  this.updateChartName(attrs, itemId, name);
+                },
+              })
+            : m(
+                '.pf-dashboard__chart-header-text',
+                {
+                  onclick: (e: MouseEvent) => {
+                    e.stopPropagation();
+                    this.editingChartId = itemId;
+                  },
+                  title: 'Click to rename',
+                },
+                headerLabel,
+              ),
+          m('.pf-dashboard__chart-actions', [
+            sourceChip,
+            editButton,
+            this.deleteButton(attrs, itemId),
+          ]),
+        ],
+      ),
+      m(
+        '.pf-dashboard__chart-content',
+        m(DashboardChartView, {
+          trace: attrs.trace,
+          source,
+          config,
+          dashboardId: attrs.dashboardId,
+          items: attrs.items,
+          brushFilters: attrs.brushFilters,
+          onItemsChange: attrs.onItemsChange,
+          onBrushFiltersChange: attrs.onBrushFiltersChange,
+        }),
+      ),
+    ]);
+  }
+
+  private renderOrphanedChart(
+    attrs: DashboardAttrs,
+    chart: DashboardItem,
+  ): m.Child {
+    const itemId = chart.config.id;
+    return this.renderItemCard(attrs, itemId, chart, [
+      m(
+        '.pf-dashboard__chart-header',
+        {
+          onpointerdown: (e: PointerEvent) => this.startDrag(e, itemId),
+        },
+        [
+          m('.pf-dashboard__chart-header-text', chart.config.name ?? 'Chart'),
+          m('.pf-dashboard__chart-actions', [this.deleteButton(attrs, itemId)]),
+        ],
+      ),
+      m(
+        '.pf-dashboard__chart-content',
+        m(
+          EmptyState,
+          {icon: 'link_off', title: 'Data source removed'},
+          'The data source for this chart is no longer available. Delete or re-assign it.',
+        ),
+      ),
+    ]);
+  }
+
+  // --- Shared card wrapper with resize + absolute positioning ---
+
+  private renderItemCard(
+    attrs: DashboardAttrs,
+    itemId: string,
+    item: DashboardItem,
+    children: m.Children,
+  ): m.Child {
+    const isDragging = this.draggingItemId === itemId;
+    const hasCustomWidth = item.widthPx !== undefined;
+    const hasCustomHeight = item.heightPx !== undefined;
+
+    // Use temp position during drag, persisted position otherwise.
+    const temp = this.tempPositions.get(itemId);
+    const x = temp?.x ?? item.x ?? 0;
+    const y = temp?.y ?? item.y ?? 0;
+
+    const styleProps = [
+      `left: ${x}px`,
+      `top: ${y}px`,
+      hasCustomWidth ? `--pf-db-chart-width: ${item.widthPx}px` : '',
+      hasCustomHeight ? `--pf-db-chart-height: ${item.heightPx}px` : '',
+    ]
+      .filter(Boolean)
+      .join('; ');
+
+    return m(
+      Card,
+      {
+        key: itemId,
+        style: styleProps,
+        className: classNames(
+          'pf-dashboard__chart',
+          hasCustomWidth && 'pf-dashboard__chart--custom-width',
+          hasCustomHeight && 'pf-dashboard__chart--custom-height',
+          isDragging && 'pf-dashboard__chart--dragging',
+        ),
+      },
+      [
+        ...(Array.isArray(children) ? children : [children]),
+        m(ResizeHandle, {
+          direction: 'horizontal',
+          onResize: (deltaPx: number) => {
+            const currentWidth = item.widthPx ?? DEFAULT_CHART_WIDTH;
+            const newWidth = Math.max(MIN_CHART_WIDTH, currentWidth + deltaPx);
+            this.mapItems(attrs, (i) =>
+              getItemId(i) === itemId ? {...i, widthPx: newWidth} : i,
+            );
+          },
+        }),
+        m(ResizeHandle, {
+          direction: 'vertical',
+          onResize: (deltaPx: number) => {
+            const currentHeight = item.heightPx ?? DEFAULT_CHART_HEIGHT;
+            const newHeight = Math.max(
+              MIN_CHART_HEIGHT,
+              currentHeight + deltaPx,
+            );
+            this.mapItems(attrs, (i) =>
+              getItemId(i) === itemId ? {...i, heightPx: newHeight} : i,
+            );
+          },
+        }),
+      ],
+    );
+  }
+
+  // --- Pointer-event drag ---
+
+  private startDrag(e: PointerEvent, itemId: string): void {
+    if (e.button !== 0) return;
+    if ((e.target as HTMLElement).closest('button, input, .pf-resize-handle')) {
+      return;
+    }
+
+    const cardEl = (e.currentTarget as HTMLElement).closest(
+      '.pf-card',
+    ) as HTMLElement | null;
+    if (cardEl === null) return;
+
+    const canvasEl = cardEl.closest(
+      '.pf-dashboard__canvas',
+    ) as HTMLElement | null;
+    if (canvasEl === null) return;
+
+    const canvasRect = canvasEl.getBoundingClientRect();
+    this.draggingItemId = itemId;
+    this.dragOffset = {
+      x: e.clientX - canvasRect.left + canvasEl.scrollLeft - cardEl.offsetLeft,
+      y: e.clientY - canvasRect.top + canvasEl.scrollTop - cardEl.offsetTop,
+    };
+  }
+
+  private handlePointerMove(e: PointerEvent): void {
+    if (this.draggingItemId === undefined) return;
+
+    const canvasEl = e.currentTarget as HTMLElement;
+    const canvasRect = canvasEl.getBoundingClientRect();
+
+    const x = Math.max(
+      0,
+      e.clientX - canvasRect.left + canvasEl.scrollLeft - this.dragOffset.x,
+    );
+    const y = Math.max(
+      0,
+      e.clientY - canvasRect.top + canvasEl.scrollTop - this.dragOffset.y,
+    );
+
+    this.tempPositions.set(this.draggingItemId, {x, y});
+    m.redraw();
+  }
+
+  private handlePointerUp(): void {
+    if (this.draggingItemId === undefined) return;
+    const attrs = this.latestAttrs;
+    if (attrs === undefined) return;
+
+    const temp = this.tempPositions.get(this.draggingItemId);
+    if (temp !== undefined) {
+      const itemId = this.draggingItemId;
+      const x = snapToGrid(temp.x);
+      const y = snapToGrid(temp.y);
+      this.mapItems(attrs, (i) => (getItemId(i) === itemId ? {...i, x, y} : i));
+    }
+    this.cancelDrag();
+  }
+
+  private cancelDrag(): void {
+    this.draggingItemId = undefined;
+    this.tempPositions.clear();
+    m.redraw();
+  }
+
+  private deleteButton(attrs: DashboardAttrs, itemId: string): m.Child {
+    return m(Button, {
+      icon: 'close',
+      title: 'Delete',
+      compact: true,
+      onclick: (e: MouseEvent) => {
+        e.stopPropagation();
+        this.removeItem(attrs, itemId);
+      },
+    });
+  }
+
+  // --- Item mutations ---
+
+  /** Map over items, replacing those that match a predicate. */
+  private mapItems(
+    attrs: DashboardAttrs,
+    fn: (item: DashboardItem) => DashboardItem,
+  ): void {
+    attrs.onItemsChange(attrs.items.map(fn));
+  }
+
+  private changeChartSource(
+    attrs: DashboardAttrs,
+    chartId: string,
+    newSource: DashboardDataSource,
+  ): void {
+    this.mapItems(attrs, (i) =>
+      i.kind === 'chart' && i.config.id === chartId
+        ? {...i, sourceNodeId: newSource.nodeId}
+        : i,
+    );
+  }
+
+  private removeItem(attrs: DashboardAttrs, itemId: string): void {
+    attrs.onItemsChange(attrs.items.filter((i) => getItemId(i) !== itemId));
+  }
+
+  private updateChartName(
+    attrs: DashboardAttrs,
+    itemId: string,
+    name: string | undefined,
+  ): void {
+    this.mapItems(attrs, (i) =>
+      i.config.id === itemId ? {...i, config: {...i.config, name}} : i,
+    );
+  }
+
+  private clearBrushFiltersForColumn(
+    attrs: DashboardAttrs,
+    sourceNodeId: string,
+    column: string,
+  ): void {
+    const existing = attrs.brushFilters.get(sourceNodeId);
+    if (existing === undefined) return;
+    const filtered = existing.filter((f) => f.column !== column);
+    const newFilters = new Map(attrs.brushFilters);
+    if (filtered.length === 0) {
+      newFilters.delete(sourceNodeId);
+    } else {
+      newFilters.set(sourceNodeId, filtered);
+    }
+    attrs.onBrushFiltersChange(newFilters);
+  }
+
+  private removeSingleBrushFilter(
+    attrs: DashboardAttrs,
+    sourceNodeId: string,
+    filter: DashboardBrushFilter,
+  ): void {
+    const current = [...(attrs.brushFilters.get(sourceNodeId) ?? [])];
+    const updated = current.filter(
+      (f) =>
+        f.column !== filter.column ||
+        f.op !== filter.op ||
+        f.value !== filter.value,
+    );
+    const newFilters = new Map(attrs.brushFilters);
+    if (updated.length === 0) {
+      newFilters.delete(sourceNodeId);
+    } else {
+      newFilters.set(sourceNodeId, updated);
+    }
+    attrs.onBrushFiltersChange(newFilters);
+  }
+
+  // Collapsed filter icon — shown on the canvas when the bar is hidden.
+  private renderCollapsedFilterButton(attrs: DashboardAttrs): m.Child {
+    if (this.filtersExpanded) return null;
+    let count = 0;
+    for (const filters of attrs.brushFilters.values()) {
+      count += filters.length;
+    }
+    if (count === 0) return null;
+    return m('.pf-dashboard__filter-collapsed', [
+      m(Button, {
+        icon: 'filter_alt',
+        title: `Filters (${count})`,
+        onclick: () => {
+          this.filtersExpanded = true;
+        },
+      }),
+    ]);
+  }
+
+  // --- Filter bar (horizontal strip below tabs) ---
+
+  private renderFilterBar(attrs: DashboardAttrs): m.Child {
+    const {sources, brushFilters} = attrs;
+    // Collect filters from all sources.
+    const allEntries: {
+      sourceNodeId: string;
+      sourceName: string;
+      filters: ReadonlyArray<DashboardBrushFilter>;
+    }[] = [];
+    for (const source of sources) {
+      const filters = brushFilters.get(source.nodeId) ?? [];
+      if (filters.length > 0) {
+        allEntries.push({
+          sourceNodeId: source.nodeId,
+          sourceName: sourceDisplayName(source, attrs.items, attrs.sources),
+          filters,
+        });
+      }
+    }
+    if (allEntries.length === 0) return null;
+
+    if (!this.filtersExpanded) return null;
+
+    // Build chips grouped by source.
+    const groups: m.Child[] = [];
+    for (const {sourceNodeId, sourceName, filters} of allEntries) {
+      const columns = [...new Set(filters.map((f) => f.column))];
+      const chips = columns.map((col) => {
+        const colFilters = filters.filter((f) => f.column === col);
+        return m(
+          Popup,
+          {
+            trigger: m(Chip, {
+              label: `${col}: ${summarizeBrushFilters(colFilters)}`,
+              icon: 'filter_alt',
+              compact: true,
+              rounded: true,
+              removable: true,
+              onRemove: () => {
+                this.clearBrushFiltersForColumn(attrs, sourceNodeId, col);
+              },
+            }),
+            position: PopupPosition.Bottom,
+          },
+          m(
+            '.pf-dashboard__filter-popup',
+            colFilters.map((f) =>
+              m(MenuItem, {
+                label: formatBrushFilterValue(f),
+                icon: Icons.Checkbox,
+                onclick: () => {
+                  this.removeSingleBrushFilter(attrs, sourceNodeId, f);
+                },
+              }),
+            ),
+          ),
+        );
+      });
+
+      groups.push(
+        m('.pf-dashboard__filter-group', [
+          m(Chip, {
+            label: sourceName,
+            icon: 'database',
+            compact: true,
+            className: 'pf-dashboard__source-chip',
+          }),
+          ...chips,
+        ]),
+      );
+    }
+
+    return m('.pf-dashboard__filter-bar', [
+      ...groups,
+      m('.pf-dashboard__filter-bar-actions', [
+        m(Button, {
+          label: 'Clear all',
+          compact: true,
+          onclick: () => {
+            attrs.onBrushFiltersChange(new Map());
+          },
+        }),
+        m(Button, {
+          icon: 'unfold_less',
+          compact: true,
+          title: 'Collapse filters',
+          onclick: () => {
+            this.filtersExpanded = false;
+          },
+        }),
+      ]),
+    ]);
+  }
+
+  // --- Data panel ---
+
+  private renderDataPanel(attrs: DashboardAttrs): m.Children {
+    const allExported = attrs.sources;
+
+    if (allExported.length === 0) {
+      return m(
+        EmptyState,
+        {icon: 'dataset', title: 'No exported sources'},
+        'Use "Export to Dashboard" nodes in the graph builder to make data sources available here.',
+      );
+    }
+
+    // Partition sources into used (has at least one chart) and unused.
+    const items = attrs.items;
+    const usedNodeIds = new Set(
+      items.filter((i) => i.kind === 'chart').map((i) => i.sourceNodeId),
+    );
+    const used = allExported.filter((s) => usedNodeIds.has(s.nodeId));
+    const unused = allExported.filter((s) => !usedNodeIds.has(s.nodeId));
+
+    const makeSourceItems = (
+      srcs: DashboardSourceWithName[],
+    ): AccordionItem[] =>
+      srcs.map((source) => ({
+        id: source.nodeId,
+        header: m('.pf-dashboard__source-row', [
+          m(
+            'code.pf-dashboard__input-name',
+            sourceDisplayName(source, attrs.items, attrs.sources, true),
+          ),
+        ]),
+        content: this.renderInputContent(source, attrs),
+      }));
+
+    const sections: m.Child[] = [];
+    if (used.length > 0) {
+      sections.push(
+        m('.pf-dashboard__panel-section', [
+          m('.pf-dashboard__panel-section-title', 'Used'),
+          m(
+            '.pf-dashboard__input-list',
+            m(Accordion, {
+              items: makeSourceItems(used),
+              expanded: this.expandedInput,
+              onToggle: (id) => {
+                this.expandedInput = id;
+              },
+            }),
+          ),
+        ]),
+      );
+    }
+    if (unused.length > 0) {
+      sections.push(
+        m('.pf-dashboard__panel-section', [
+          m('.pf-dashboard__panel-section-title', 'Unused'),
+          m(
+            '.pf-dashboard__input-list',
+            m(Accordion, {
+              items: makeSourceItems(unused),
+              expanded: this.expandedInput,
+              onToggle: (id) => {
+                this.expandedInput = id;
+              },
+            }),
+          ),
+        ]),
+      );
+    }
+
+    return sections;
+  }
+
+  private renderInputContent(
+    source: DashboardDataSource,
+    attrs: DashboardAttrs,
+  ): m.Children {
+    return [
+      m(
+        '.pf-dashboard__detail-row',
+        m('span.pf-dashboard__detail-label', 'Columns'),
+        m('span.pf-dashboard__detail-value', `${source.columns.length}`),
+      ),
+      source.columns.length > 0 &&
+        m(
+          '.pf-dashboard__columns',
+          m(
+            '.pf-dashboard__column-list',
+            source.columns.map((col) =>
+              m(
+                '.pf-dashboard__column',
+                m(Icon, {
+                  icon: perfettoSqlTypeIcon(col.type),
+                  className: 'pf-dashboard__column-icon',
+                }),
+                m(
+                  '.pf-dashboard__column-info',
+                  m(
+                    '.pf-dashboard__column-header',
+                    m('code.pf-dashboard__column-name', col.name),
+                    m(
+                      'span.pf-dashboard__column-type',
+                      perfettoSqlTypeToString(col.type),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      m(Button, {
+        label: 'Add Chart',
+        icon: 'bar_chart',
+        compact: true,
+        className: 'pf-dashboard__add-chart-btn',
+        onclick: () => {
+          this.addChartForSource(attrs, source);
+        },
+      }),
+    ];
+  }
+
+  private addChartForSource(
+    attrs: DashboardAttrs,
+    source: DashboardDataSource,
+  ): void {
+    const items = [...attrs.items];
+    const newConfig = createDefaultChartConfig(source.columns);
+    const {x, y} = getNextItemPosition(items);
+    items.push({
+      kind: 'chart',
+      sourceNodeId: source.nodeId,
+      config: newConfig,
+      x,
+      y,
+    });
+    attrs.onItemsChange(items);
+  }
+}

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
@@ -1,0 +1,393 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Trace} from '../../../public/trace';
+import {
+  ChartConfig,
+  ChartType,
+  generateChartId,
+} from '../query_builder/nodes/visualisation_node';
+import {
+  ChartColumnProvider,
+  ChartLoaderEntry,
+  buildLoaderCacheKey,
+  createChartLoaders,
+  disposeChartLoaders,
+  renderChartByType,
+} from '../query_builder/charts/chart_renderers';
+import {ColumnInfo} from '../query_builder/column_info';
+import {
+  DashboardBrushFilter,
+  DashboardDataSource,
+  DashboardItem,
+  getItemId,
+} from './dashboard_registry';
+import {EmptyState} from '../../../widgets/empty_state';
+import {SqlValue} from '../../../trace_processor/query_result';
+import {
+  isQuantitativeType,
+  perfettoSqlTypeToString,
+} from '../../../trace_processor/perfetto_sql_type';
+
+export interface DashboardChartViewAttrs {
+  trace: Trace;
+  source: DashboardDataSource;
+  config: ChartConfig;
+  dashboardId: string;
+  items: DashboardItem[];
+  brushFilters: Map<string, DashboardBrushFilter[]>;
+  onItemsChange: (items: DashboardItem[]) => void;
+  onBrushFiltersChange: (filters: Map<string, DashboardBrushFilter[]>) => void;
+}
+
+/** Subset of DashboardChartViewAttrs needed by the adapter. */
+export interface DashboardChartCallbacks {
+  dashboardId: string;
+  items: DashboardItem[];
+  brushFilters: Map<string, DashboardBrushFilter[]>;
+  onItemsChange: (items: DashboardItem[]) => void;
+  onBrushFiltersChange: (filters: Map<string, DashboardBrushFilter[]>) => void;
+}
+
+/**
+ * Adapter implementing ChartColumnProvider for a DashboardDataSource.
+ * Config and brush-filter changes are propagated via callbacks on the
+ * owning dashboard tab (no global registry dependency).
+ */
+class DashboardChartAdapter implements ChartColumnProvider {
+  private readonly cols: ColumnInfo[];
+  private readonly sourceNodeId: string;
+  // Local mutable copy of brush filters for this source, so that
+  // clearChartFiltersForColumn + setBrushSelection works the same way as
+  // the visualisation node (synchronous mutations on the same array).
+  private filters: DashboardBrushFilter[];
+  private callbacks: DashboardChartCallbacks;
+  private config: ChartConfig;
+
+  constructor(
+    source: DashboardDataSource,
+    callbacks: DashboardChartCallbacks,
+    config: ChartConfig,
+  ) {
+    this.sourceNodeId = source.nodeId;
+    this.callbacks = callbacks;
+    this.config = config;
+    this.filters = [...(callbacks.brushFilters.get(source.nodeId) ?? [])];
+    this.cols = source.columns.map((col) => ({
+      name: col.name,
+      type: perfettoSqlTypeToString(col.type),
+      checked: false,
+      column: {name: col.name, type: col.type},
+    }));
+  }
+
+  /** Update mutable references so the adapter flushes to the latest attrs. */
+  updateCallbacks(callbacks: DashboardChartCallbacks, config: ChartConfig) {
+    this.callbacks = callbacks;
+    this.config = config;
+    this.filters = [...(callbacks.brushFilters.get(this.sourceNodeId) ?? [])];
+  }
+
+  get sourceCols(): ReadonlyArray<ColumnInfo> {
+    return this.cols;
+  }
+
+  getChartableColumns(chartType: ChartType): ReadonlyArray<ColumnInfo> {
+    if (
+      chartType === 'histogram' ||
+      chartType === 'line' ||
+      chartType === 'scatter' ||
+      chartType === 'cdf'
+    ) {
+      return this.cols.filter(
+        (col) =>
+          col.column.type !== undefined && isQuantitativeType(col.column.type),
+      );
+    }
+    return this.cols;
+  }
+
+  private flushFilters(): void {
+    const newMap = new Map(this.callbacks.brushFilters);
+    if (this.filters.length === 0) {
+      newMap.delete(this.sourceNodeId);
+    } else {
+      newMap.set(this.sourceNodeId, [...this.filters]);
+    }
+    this.callbacks.onBrushFiltersChange(newMap);
+  }
+
+  clearChartFiltersForColumn(column: string): void {
+    this.filters = this.filters.filter((f) => f.column !== column);
+    this.flushFilters();
+  }
+
+  setBrushSelection(column: string, values: SqlValue[]): void {
+    this.clearChartFiltersForColumn(column);
+    for (const value of values) {
+      if (value === null) {
+        this.filters.push({column, op: 'is null'});
+      } else {
+        this.filters.push({column, op: '=', value});
+      }
+    }
+    this.flushFilters();
+    m.redraw();
+  }
+
+  addRangeFilter(column: string, min: number, max: number): void {
+    this.clearChartFiltersForColumn(column);
+    this.filters.push({column, op: '>=', value: min});
+    this.filters.push({column, op: '<', value: max});
+    this.flushFilters();
+    m.redraw();
+  }
+
+  updateChart(
+    chartId: string,
+    updates: Partial<Omit<ChartConfig, 'id'>>,
+  ): void {
+    const items = this.callbacks.items.map((i) => {
+      if (i.kind === 'chart' && i.config.id === chartId) {
+        return {...i, config: {...i.config, ...updates}};
+      }
+      return i;
+    });
+    this.callbacks.onItemsChange(items);
+  }
+
+  removeChart(chartId: string): void {
+    const items = this.callbacks.items.filter((i) => getItemId(i) !== chartId);
+    this.callbacks.onItemsChange(items);
+  }
+
+  get state() {
+    return {chartConfigs: [this.config]};
+  }
+}
+
+/**
+ * Renders a single chart for a dashboard data source.
+ * Only renders chart content — the card wrapper, header, resize handles,
+ * and drag-and-drop are handled by the Dashboard component.
+ *
+ * Table name resolution is handled eagerly by DashboardNode — the source's
+ * `tableName` field is populated when the upstream node has been executed.
+ * If the table name is not yet available, this component triggers execution
+ * via `source.requestExecution()` and waits for a redraw.
+ */
+export class DashboardChartView
+  implements m.ClassComponent<DashboardChartViewAttrs>
+{
+  /** Adapter class exposed for use by Dashboard's config popup. */
+  static Adapter = DashboardChartAdapter;
+
+  private loaders = new Map<string, ChartLoaderEntry>();
+  private executionRequested = false;
+  private cachedAdapter?: DashboardChartAdapter;
+  private adapterSourceNodeId?: string;
+  private adapterConfigId?: string;
+
+  onremove() {
+    for (const entry of this.loaders.values()) {
+      disposeChartLoaders(entry);
+    }
+    this.loaders.clear();
+  }
+
+  private getAdapter(attrs: DashboardChartViewAttrs): DashboardChartAdapter {
+    // Re-create the adapter only when the source or config identity changes.
+    if (
+      this.cachedAdapter === undefined ||
+      this.adapterSourceNodeId !== attrs.source.nodeId ||
+      this.adapterConfigId !== attrs.config.id
+    ) {
+      this.cachedAdapter = new DashboardChartAdapter(
+        attrs.source,
+        attrs,
+        attrs.config,
+      );
+      this.adapterSourceNodeId = attrs.source.nodeId;
+      this.adapterConfigId = attrs.config.id;
+    } else {
+      // Update the callbacks reference so the adapter always flushes to
+      // the latest attrs (items, brushFilters, etc.).
+      this.cachedAdapter.updateCallbacks(attrs, attrs.config);
+    }
+    return this.cachedAdapter;
+  }
+
+  view({attrs}: m.CVnode<DashboardChartViewAttrs>) {
+    const adapter = this.getAdapter(attrs);
+    const config = attrs.config;
+
+    if (config.column === '') {
+      return m(EmptyState, {
+        icon: 'ssid_chart',
+        title: 'Select a column',
+      });
+    }
+
+    // Validate that the configured column exists in the current source.
+    const columnExists = attrs.source.columns.some(
+      (c) => c.name === config.column,
+    );
+    if (!columnExists) {
+      return m(
+        EmptyState,
+        {icon: 'warning', title: 'Invalid column'},
+        `Column "${config.column}" not found in this data source.`,
+      );
+    }
+
+    // If the table name isn't available yet, trigger execution once and wait.
+    if (attrs.source.tableName === undefined) {
+      if (!this.executionRequested && attrs.source.requestExecution) {
+        this.executionRequested = true;
+        attrs.source
+          .requestExecution()
+          .then(() => m.redraw())
+          .catch((e) => console.debug('Dashboard source execution failed:', e));
+      }
+      return m(EmptyState, {icon: 'hourglass_empty', title: 'Loading data…'});
+    }
+    this.executionRequested = false;
+
+    const entry = this.ensureLoader(attrs, config);
+    const ctx = {node: adapter, onFilterChange: () => m.redraw()};
+    return renderChartByType(ctx, config, entry);
+  }
+
+  private ensureLoader(
+    attrs: DashboardChartViewAttrs,
+    config: ChartConfig,
+  ): ChartLoaderEntry {
+    const tableName = attrs.source.tableName;
+    const columnValid = attrs.source.columns.some(
+      (c) => c.name === config.column,
+    );
+    if (tableName === undefined || config.column === '' || !columnValid) {
+      let entry = this.loaders.get(config.id);
+      if (!entry) {
+        entry = {key: ''};
+        this.loaders.set(config.id, entry);
+      }
+      return entry;
+    }
+
+    // Drop brush filters referencing columns that don't exist in the current
+    // source (can happen after switching the chart's data source).
+    const validColumns = new Set(attrs.source.columns.map((c) => c.name));
+    const filters = (attrs.brushFilters.get(attrs.source.nodeId) ?? []).filter(
+      (f) => validColumns.has(f.column),
+    );
+    const filterKey = JSON.stringify(filters);
+
+    const key = buildLoaderCacheKey(tableName, config, filterKey);
+
+    const existing = this.loaders.get(config.id);
+    if (existing && existing.key === key) return existing;
+
+    if (existing) {
+      disposeChartLoaders(existing);
+    }
+
+    const entry: ChartLoaderEntry = {key};
+    this.loaders.set(config.id, entry);
+
+    const engine = attrs.trace.engine;
+    const whereClause = buildWhereClause(filters);
+    const query = `SELECT * FROM ${tableName}${whereClause}`;
+    createChartLoaders(engine, query, config, entry);
+
+    return entry;
+  }
+}
+
+/**
+ * Build a SQL WHERE clause from dashboard brush filters.
+ * Same-column '=' filters are combined with OR (IN clause).
+ * Range filters and cross-column conditions are combined with AND.
+ */
+function buildWhereClause(
+  filters: ReadonlyArray<DashboardBrushFilter>,
+): string {
+  if (filters.length === 0) return '';
+
+  // Group filters by column.
+  const byColumn = new Map<string, DashboardBrushFilter[]>();
+  for (const f of filters) {
+    const list = byColumn.get(f.column) ?? [];
+    list.push(f);
+    byColumn.set(f.column, list);
+  }
+
+  const clauses: string[] = [];
+  for (const [column, colFilters] of byColumn) {
+    const eqValues: SqlValue[] = [];
+    let hasNull = false;
+    const rangeConditions: string[] = [];
+
+    for (const f of colFilters) {
+      if (f.op === '=') {
+        eqValues.push(f.value ?? null);
+      } else if (f.op === 'is null') {
+        hasNull = true;
+      } else {
+        // >= or <
+        rangeConditions.push(`${column} ${f.op} ${f.value}`);
+      }
+    }
+
+    if (eqValues.length > 0 || hasNull) {
+      const parts: string[] = [];
+      if (eqValues.length === 1) {
+        const v = eqValues[0];
+        parts.push(
+          `${column} = ${typeof v === 'string' ? `'${v.replace(/'/g, "''")}'` : v}`,
+        );
+      } else if (eqValues.length > 1) {
+        const formatted = eqValues.map((v) =>
+          typeof v === 'string' ? `'${v.replace(/'/g, "''")}'` : v,
+        );
+        parts.push(`${column} IN (${formatted.join(', ')})`);
+      }
+      if (hasNull) {
+        parts.push(`${column} IS NULL`);
+      }
+      clauses.push(parts.length > 1 ? `(${parts.join(' OR ')})` : parts[0]);
+    }
+
+    for (const rc of rangeConditions) {
+      clauses.push(rc);
+    }
+  }
+
+  return ` WHERE ${clauses.join(' AND ')}`;
+}
+
+/**
+ * Create a default ChartConfig for a data source, picking the first column.
+ */
+export function createDefaultChartConfig(
+  columns: ReadonlyArray<{name: string}>,
+): ChartConfig {
+  const column = columns.length > 0 ? columns[0].name : '';
+  return {
+    id: generateChartId(),
+    column,
+    chartType: 'bar',
+  };
+}

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry.ts
@@ -1,0 +1,242 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PerfettoSqlType} from '../../../trace_processor/perfetto_sql_type';
+import {SqlValue} from '../../../trace_processor/query_result';
+import {ChartConfig} from '../query_builder/nodes/visualisation_node';
+
+/**
+ * A data source exported by a DashboardNode in the graph builder.
+ * Global — not tied to any specific dashboard.
+ */
+export interface DashboardDataSource {
+  readonly name: string;
+  readonly nodeId: string;
+  readonly columns: ReadonlyArray<{name: string; type?: PerfettoSqlType}>;
+  // Stable ID of the graph tab that owns this source.
+  readonly graphId: string;
+  // Materialized SQL table name. Undefined until the source node has been
+  // executed. DashboardNode resolves this eagerly on publish/update.
+  tableName?: string;
+  // Trigger execution of this source node (sync + materialize).
+  requestExecution?: () => Promise<void>;
+}
+
+/** A data source enriched with its owning graph tab's display name. */
+export type DashboardSourceWithName = DashboardDataSource & {
+  graphName: string;
+};
+
+/**
+ * Build a display label for a data source, optionally appending the graph name.
+ *
+ * When `forceNamespace` is true (sidebar), the graph name is shown whenever
+ * the available sources span more than one graph.
+ *
+ * When `forceNamespace` is false (chart labels), the graph name is shown only
+ * when the charts currently in use pull from more than one graph.
+ */
+export function sourceDisplayName(
+  source: DashboardSourceWithName,
+  items: ReadonlyArray<DashboardItem>,
+  sources: ReadonlyArray<DashboardSourceWithName>,
+  forceNamespace = false,
+): string {
+  let candidates: ReadonlyArray<DashboardSourceWithName>;
+  if (forceNamespace) {
+    candidates = sources;
+  } else {
+    const usedNodeIds = new Set(
+      items.filter((i) => i.kind === 'chart').map((i) => i.sourceNodeId),
+    );
+    candidates = sources.filter((s) => usedNodeIds.has(s.nodeId));
+  }
+  const graphs = new Set(candidates.map((s) => s.graphId));
+  if (graphs.size > 1) {
+    return `${source.name} · ${source.graphName}`;
+  }
+  return source.name;
+}
+
+/** A single chart on a dashboard, linked to its data source. */
+export interface DashboardChart {
+  readonly sourceNodeId: string;
+  config: ChartConfig;
+  widthPx?: number;
+  heightPx?: number;
+  x?: number;
+  y?: number;
+}
+
+/** A dashboard canvas item (currently only charts). */
+export type DashboardItem = {readonly kind: 'chart'} & DashboardChart;
+
+/** Get the unique ID for a dashboard item. */
+export function getItemId(item: DashboardItem): string {
+  return item.config.id;
+}
+
+/** A brush filter applied by interacting with a dashboard chart. */
+export interface DashboardBrushFilter {
+  readonly column: string;
+  readonly op: '=' | '>=' | '<' | 'is null';
+  readonly value?: SqlValue;
+}
+
+/**
+ * Global pool of exported data sources.
+ *
+ * DashboardNode publishes sources here during query execution (outside the
+ * Mithril render cycle), so this must be a global singleton. Dashboard tabs
+ * read from this pool via DataExplorer, which passes sources as props.
+ *
+ * All other dashboard state (items, brush filters) lives on DataExplorerTab.
+ */
+class ExportedSourcesPool {
+  private sources = new Map<string, DashboardDataSource>();
+
+  /** Publish a data source from a DashboardNode. */
+  setExportedSource(source: DashboardDataSource): void {
+    this.sources.set(source.nodeId, source);
+  }
+
+  /** Remove an exported source (e.g. node deleted). */
+  removeExportedSource(nodeId: string): void {
+    this.sources.delete(nodeId);
+  }
+
+  /** Get a single exported source by node ID. */
+  getExportedSource(nodeId: string): DashboardDataSource | undefined {
+    return this.sources.get(nodeId);
+  }
+
+  /** Get all exported sources. */
+  getAllExportedSources(): ReadonlyArray<DashboardDataSource> {
+    return [...this.sources.values()];
+  }
+
+  clear(): void {
+    this.sources.clear();
+  }
+}
+
+export const dashboardRegistry = new ExportedSourcesPool();
+
+const GRID_SIZE = 20;
+
+export function snapToGrid(value: number): number {
+  return Math.round(value / GRID_SIZE) * GRID_SIZE;
+}
+
+export function getNextItemPosition(items: ReadonlyArray<DashboardItem>): {
+  x: number;
+  y: number;
+} {
+  const offset = (items.length % 10) * 40;
+  return {x: snapToGrid(20 + offset), y: snapToGrid(20 + offset)};
+}
+
+/**
+ * Serialized dashboard data for persistence (localStorage / permalinks).
+ */
+export interface SerializedDashboardData {
+  dashboardId?: string;
+  dashboardItems?: unknown[];
+  brushFilters?: Record<string, unknown[]>;
+}
+
+/**
+ * Collect dashboard-related data for a tab into a serializable form.
+ * Shared between localStorage persistence and permalink persistence.
+ */
+export function serializeDashboardData(
+  dashboardId: string | undefined,
+  items?: DashboardItem[],
+  brushFiltersMap?: Map<string, DashboardBrushFilter[]>,
+): SerializedDashboardData {
+  if (dashboardId === undefined) return {};
+  const dashboardItems =
+    items !== undefined && items.length > 0 ? (items as unknown[]) : undefined;
+  // Convert brush filters map to a plain record, bigint → number.
+  let brushFilters: Record<string, unknown[]> | undefined;
+  if (brushFiltersMap !== undefined && brushFiltersMap.size > 0) {
+    const raw: Record<string, DashboardBrushFilter[]> = {};
+    for (const [sourceNodeId, filters] of brushFiltersMap) {
+      raw[sourceNodeId] = filters;
+    }
+    brushFilters = JSON.parse(
+      JSON.stringify(raw, (_k, v) => (typeof v === 'bigint' ? Number(v) : v)),
+    );
+  }
+  return {dashboardId, dashboardItems, brushFilters};
+}
+
+/**
+ * Validate that an unknown value looks like a DashboardItem[].
+ * Returns undefined if validation fails.
+ */
+export function validateDashboardItems(
+  items: unknown[] | undefined,
+): DashboardItem[] | undefined {
+  if (items === undefined || items.length === 0) return undefined;
+  const validated: DashboardItem[] = [];
+  for (const item of items) {
+    if (typeof item !== 'object' || item === null) continue;
+    const obj = item as Record<string, unknown>;
+    if (obj.kind === 'chart') {
+      if (
+        typeof obj.sourceNodeId !== 'string' ||
+        typeof obj.config !== 'object' ||
+        obj.config === null
+      ) {
+        continue;
+      }
+      const cfg = obj.config as Record<string, unknown>;
+      if (
+        typeof cfg.id !== 'string' ||
+        typeof cfg.column !== 'string' ||
+        typeof cfg.chartType !== 'string'
+      ) {
+        continue;
+      }
+      validated.push(item as DashboardItem);
+    }
+  }
+  return validated.length > 0 ? validated : undefined;
+}
+
+/**
+ * Parse serialized brush filters into a Map.
+ * Validates each entry and drops invalid ones.
+ */
+export function parseBrushFilters(
+  raw: Record<string, unknown[]>,
+): Map<string, DashboardBrushFilter[]> {
+  const validOps = new Set(['=', '>=', '<', 'is null']);
+  const result = new Map<string, DashboardBrushFilter[]>();
+  for (const [sourceNodeId, entries] of Object.entries(raw)) {
+    const validated: DashboardBrushFilter[] = [];
+    for (const entry of entries) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const obj = entry as Record<string, unknown>;
+      if (typeof obj.column !== 'string') continue;
+      if (typeof obj.op !== 'string' || !validOps.has(obj.op)) continue;
+      validated.push(entry as DashboardBrushFilter);
+    }
+    if (validated.length > 0) {
+      result.set(sourceNodeId, validated);
+    }
+  }
+  return result;
+}

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry_unittest.ts
@@ -1,0 +1,414 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {PerfettoSqlType} from '../../../trace_processor/perfetto_sql_type';
+import {
+  DashboardDataSource,
+  DashboardItem,
+  dashboardRegistry,
+  getItemId,
+  getNextItemPosition,
+  parseBrushFilters,
+  serializeDashboardData,
+  snapToGrid,
+  validateDashboardItems,
+  sourceDisplayName,
+  DashboardSourceWithName,
+} from './dashboard_registry';
+
+let nextChartId = 0;
+function testChartId(): string {
+  return `test-chart-${nextChartId++}`;
+}
+
+function makeSource(
+  nodeId: string,
+  name: string,
+  columns: Array<{name: string; type?: PerfettoSqlType}> = [
+    {name: 'id', type: {kind: 'id', source: {table: 'test', column: 'id'}}},
+  ],
+  graphId = 'test-graph',
+): DashboardDataSource {
+  return {nodeId, name, columns, graphId};
+}
+
+function makeSourceWithName(
+  nodeId: string,
+  name: string,
+  graphId: string,
+  graphName: string,
+): DashboardSourceWithName {
+  return {
+    nodeId,
+    name,
+    columns: [{name: 'id', type: {kind: 'int'}}],
+    graphId,
+    graphName,
+  };
+}
+
+function makeChartItem(sourceNodeId: string, chartId?: string): DashboardItem {
+  return {
+    kind: 'chart',
+    sourceNodeId,
+    config: {
+      id: chartId ?? testChartId(),
+      column: 'id',
+      chartType: 'bar',
+    },
+  };
+}
+
+// --- Exported sources (the only state remaining in the registry) ---
+
+describe('ExportedSourcesPool', () => {
+  beforeEach(() => {
+    dashboardRegistry.clear();
+  });
+
+  test('set and get exported source', () => {
+    const source = makeSource('n1', 'Source A');
+    dashboardRegistry.setExportedSource(source);
+    expect(dashboardRegistry.getExportedSource('n1')).toBe(source);
+  });
+
+  test('getAllExportedSources returns all', () => {
+    dashboardRegistry.setExportedSource(makeSource('n1', 'A'));
+    dashboardRegistry.setExportedSource(makeSource('n2', 'B'));
+    expect(dashboardRegistry.getAllExportedSources()).toHaveLength(2);
+  });
+
+  test('removeExportedSource removes source', () => {
+    dashboardRegistry.setExportedSource(makeSource('n1', 'A'));
+    dashboardRegistry.removeExportedSource('n1');
+    expect(dashboardRegistry.getExportedSource('n1')).toBeUndefined();
+    expect(dashboardRegistry.getAllExportedSources()).toHaveLength(0);
+  });
+
+  test('setExportedSource overwrites existing', () => {
+    dashboardRegistry.setExportedSource(makeSource('n1', 'Old'));
+    dashboardRegistry.setExportedSource(makeSource('n1', 'New'));
+    expect(dashboardRegistry.getExportedSource('n1')?.name).toBe('New');
+    expect(dashboardRegistry.getAllExportedSources()).toHaveLength(1);
+  });
+
+  test('removeExportedSource on non-existent is a no-op', () => {
+    dashboardRegistry.removeExportedSource('non-existent');
+    // No error thrown.
+  });
+
+  test('clear removes all sources', () => {
+    dashboardRegistry.setExportedSource(makeSource('n1', 'A'));
+    dashboardRegistry.setExportedSource(makeSource('n2', 'B'));
+    dashboardRegistry.clear();
+    expect(dashboardRegistry.getAllExportedSources()).toHaveLength(0);
+  });
+});
+
+// --- Utility functions ---
+
+describe('getItemId', () => {
+  test('returns config.id for chart items', () => {
+    const chart = makeChartItem('n1', 'chart-123');
+    expect(getItemId(chart)).toBe('chart-123');
+  });
+});
+
+describe('snapToGrid', () => {
+  test('snaps to nearest 20px', () => {
+    expect(snapToGrid(0)).toBe(0);
+    expect(snapToGrid(10)).toBe(20);
+    expect(snapToGrid(19)).toBe(20);
+    expect(snapToGrid(20)).toBe(20);
+    expect(snapToGrid(29)).toBe(20);
+    expect(snapToGrid(30)).toBe(40);
+    expect(snapToGrid(31)).toBe(40);
+  });
+
+  test('handles negative values', () => {
+    expect(snapToGrid(-10)).toBe(-0); // Math.round(-0.5) = -0
+    expect(snapToGrid(-20)).toBe(-20);
+    expect(snapToGrid(-31)).toBe(-40);
+  });
+});
+
+describe('getNextItemPosition', () => {
+  test('returns offset based on item count', () => {
+    const pos0 = getNextItemPosition([]);
+    expect(pos0.x).toBe(20);
+    expect(pos0.y).toBe(20);
+
+    const pos1 = getNextItemPosition([makeChartItem('n1')]);
+    expect(pos1.x).toBe(60);
+    expect(pos1.y).toBe(60);
+  });
+
+  test('wraps after 10 items', () => {
+    const tenItems = Array.from({length: 10}, () => makeChartItem('n1'));
+    const pos = getNextItemPosition(tenItems);
+    // 10 % 10 = 0, same as empty
+    expect(pos.x).toBe(20);
+    expect(pos.y).toBe(20);
+  });
+});
+
+// --- Serialization ---
+
+describe('serializeDashboardData', () => {
+  test('returns empty object for undefined dashboardId', () => {
+    expect(serializeDashboardData(undefined)).toEqual({});
+  });
+
+  test('returns dashboardId with no items', () => {
+    const data = serializeDashboardData('db-1');
+    expect(data.dashboardId).toBe('db-1');
+    expect(data.dashboardItems).toBeUndefined();
+    expect(data.brushFilters).toBeUndefined();
+  });
+
+  test('serializes items when present', () => {
+    const chart = makeChartItem('n1');
+    const data = serializeDashboardData('db-1', [chart]);
+    expect(data.dashboardId).toBe('db-1');
+    expect(data.dashboardItems).toHaveLength(1);
+  });
+
+  test('serializes brush filters when present', () => {
+    const filters = new Map([
+      ['n1', [{column: 'x', op: '=' as const, value: 42}]],
+    ]);
+    const data = serializeDashboardData('db-1', [], filters);
+    expect(data.brushFilters).toEqual({
+      n1: [{column: 'x', op: '=', value: 42}],
+    });
+  });
+
+  test('omits empty items and filters', () => {
+    const data = serializeDashboardData('db-1', [], new Map());
+    expect(data.dashboardItems).toBeUndefined();
+    expect(data.brushFilters).toBeUndefined();
+  });
+
+  test('converts bigint values in filters to numbers', () => {
+    const filters = new Map([
+      ['n1', [{column: 'x', op: '=' as const, value: BigInt(42)}]],
+    ]);
+    const data = serializeDashboardData('db-1', [], filters);
+    expect(data.brushFilters).toEqual({
+      n1: [{column: 'x', op: '=', value: 42}],
+    });
+  });
+});
+
+// --- Validation ---
+
+describe('validateDashboardItems', () => {
+  test('returns undefined for undefined input', () => {
+    expect(validateDashboardItems(undefined)).toBeUndefined();
+  });
+
+  test('returns undefined for empty array', () => {
+    expect(validateDashboardItems([])).toBeUndefined();
+  });
+
+  test('validates chart items', () => {
+    const items = [
+      {
+        kind: 'chart',
+        sourceNodeId: 'n1',
+        config: {id: 'c1', column: 'x', chartType: 'bar'},
+      },
+    ];
+    const result = validateDashboardItems(items);
+    expect(result).toHaveLength(1);
+    expect(result?.[0].kind).toBe('chart');
+  });
+
+  test('rejects chart without sourceNodeId', () => {
+    const items = [
+      {kind: 'chart', config: {id: 'c1', column: 'x', chartType: 'bar'}},
+    ];
+    expect(validateDashboardItems(items)).toBeUndefined();
+  });
+
+  test('rejects chart without config', () => {
+    const items = [{kind: 'chart', sourceNodeId: 'n1'}];
+    expect(validateDashboardItems(items)).toBeUndefined();
+  });
+
+  test('rejects chart with null config', () => {
+    const items = [{kind: 'chart', sourceNodeId: 'n1', config: null}];
+    expect(validateDashboardItems(items)).toBeUndefined();
+  });
+
+  test('skips non-object items', () => {
+    const items = [
+      'string',
+      null,
+      42,
+      {
+        kind: 'chart',
+        sourceNodeId: 'n1',
+        config: {id: 'c1', column: 'x', chartType: 'bar'},
+      },
+    ];
+    const result = validateDashboardItems(items);
+    expect(result).toHaveLength(1);
+  });
+
+  test('skips unknown kinds', () => {
+    const items = [{kind: 'unknown', id: 'u1'}];
+    expect(validateDashboardItems(items)).toBeUndefined();
+  });
+
+  test('filters mix of valid and invalid', () => {
+    const items = [
+      {
+        kind: 'chart',
+        sourceNodeId: 'n1',
+        config: {id: 'c1', column: 'x', chartType: 'bar'},
+      },
+      {kind: 'chart', sourceNodeId: 'n2'}, // missing config
+    ];
+    const result = validateDashboardItems(items);
+    expect(result).toHaveLength(1);
+  });
+});
+
+// --- parseBrushFilters ---
+
+describe('parseBrushFilters', () => {
+  test('parses valid filters into a Map', () => {
+    const raw = {
+      n1: [{column: 'x', op: '=', value: 42}],
+      n2: [{column: 'y', op: '>=', value: 10}],
+    };
+    const result = parseBrushFilters(raw);
+    expect(result.size).toBe(2);
+    expect(result.get('n1')).toEqual([{column: 'x', op: '=', value: 42}]);
+    expect(result.get('n2')).toEqual([{column: 'y', op: '>=', value: 10}]);
+  });
+
+  test('drops invalid entries', () => {
+    const raw = {
+      n1: [
+        {column: 'x', op: '=', value: 1}, // valid
+        {op: '=', value: 2}, // missing column
+        {column: 'y', op: 'LIKE', value: 'foo'}, // invalid op
+        null, // non-object
+        'string', // non-object
+      ],
+    };
+    const result = parseBrushFilters(raw as Record<string, unknown[]>);
+    expect(result.size).toBe(1);
+    expect(result.get('n1')).toHaveLength(1);
+  });
+
+  test('omits sources with no valid filters', () => {
+    const raw = {
+      n1: [{op: '=', value: 1}], // all invalid — missing column
+    };
+    const result = parseBrushFilters(raw as Record<string, unknown[]>);
+    expect(result.size).toBe(0);
+  });
+
+  test('accepts all valid operators', () => {
+    const raw = {
+      n1: [
+        {column: 'a', op: '=', value: 1},
+        {column: 'b', op: '>=', value: 2},
+        {column: 'c', op: '<', value: 3},
+        {column: 'd', op: 'is null'},
+      ],
+    };
+    const result = parseBrushFilters(raw);
+    expect(result.get('n1')).toHaveLength(4);
+  });
+
+  test('returns empty map for empty input', () => {
+    const result = parseBrushFilters({});
+    expect(result.size).toBe(0);
+  });
+});
+
+// --- sourceDisplayName ---
+
+describe('sourceDisplayName', () => {
+  test('returns plain name when all charts use one graph', () => {
+    const s1 = makeSourceWithName('n1', 'thread_state', 'g1', 'Graph 1');
+    const s2 = makeSourceWithName('n2', 'sched', 'g1', 'Graph 1');
+    const items = [makeChartItem('n1'), makeChartItem('n2')];
+    const sources = [s1, s2];
+    expect(sourceDisplayName(s1, items, sources)).toBe('thread_state');
+    expect(sourceDisplayName(s2, items, sources)).toBe('sched');
+  });
+
+  test('appends graph name when charts use multiple graphs', () => {
+    const s1 = makeSourceWithName('n1', 'thread_state', 'g1', 'Graph 1');
+    const s2 = makeSourceWithName('n2', 'thread_state', 'g2', 'Graph 2');
+    const items = [makeChartItem('n1'), makeChartItem('n2')];
+    const sources = [s1, s2];
+    expect(sourceDisplayName(s1, items, sources)).toBe(
+      'thread_state · Graph 1',
+    );
+    expect(sourceDisplayName(s2, items, sources)).toBe(
+      'thread_state · Graph 2',
+    );
+  });
+
+  test('no namespacing when only one graph is used even if others available', () => {
+    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
+    const s2 = makeSourceWithName('n2', 'B', 'g2', 'Graph 2');
+    // Only s1 is used in charts; s2 is available but unused.
+    const items = [makeChartItem('n1')];
+    expect(sourceDisplayName(s1, items, [s1, s2])).toBe('A');
+  });
+
+  test('namespacing when two graphs are used even with different names', () => {
+    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
+    const s2 = makeSourceWithName('n2', 'B', 'g2', 'Graph 2');
+    const items = [makeChartItem('n1'), makeChartItem('n2')];
+    const sources = [s1, s2];
+    expect(sourceDisplayName(s1, items, sources)).toBe('A · Graph 1');
+    expect(sourceDisplayName(s2, items, sources)).toBe('B · Graph 2');
+  });
+
+  test('returns plain name with no charts', () => {
+    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
+    expect(sourceDisplayName(s1, [], [s1])).toBe('A');
+  });
+});
+
+// --- sourceDisplayName with forceNamespace ---
+
+describe('sourceDisplayName with forceNamespace', () => {
+  test('returns plain name when all sources are from one graph', () => {
+    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
+    const s2 = makeSourceWithName('n2', 'B', 'g1', 'Graph 1');
+    expect(sourceDisplayName(s1, [], [s1, s2], true)).toBe('A');
+    expect(sourceDisplayName(s2, [], [s1, s2], true)).toBe('B');
+  });
+
+  test('appends graph name when sources span multiple graphs', () => {
+    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
+    const s2 = makeSourceWithName('n2', 'B', 'g2', 'Graph 2');
+    expect(sourceDisplayName(s1, [], [s1, s2], true)).toBe('A · Graph 1');
+    expect(sourceDisplayName(s2, [], [s1, s2], true)).toBe('B · Graph 2');
+  });
+
+  test('returns plain name with single source', () => {
+    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
+    expect(sourceDisplayName(s1, [], [s1], true)).toBe('A');
+  });
+});

--- a/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
@@ -20,8 +20,9 @@ import {QueryNode} from './query_node';
 import {ensureAllNodeActions} from './node_actions';
 import {Trace} from '../../public/trace';
 import {getOrCreate} from '../../base/utils';
+import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {Tabs, TabsTab} from '../../widgets/tabs';
-import {MenuItem} from '../../widgets/menu';
+import {Button} from '../../widgets/button';
 import {serializeState, deserializeState} from './json_handler';
 
 import {
@@ -52,6 +53,13 @@ import {
   deleteSelectedNodes,
   removeNodeConnection,
 } from './node_crud_operations';
+import {Dashboard} from './dashboard/dashboard';
+import {isDashboardNode} from './query_builder/nodes/dashboard_node';
+import {
+  dashboardRegistry,
+  DashboardBrushFilter,
+  DashboardItem,
+} from './dashboard/dashboard_registry';
 import type {NodeCrudDeps} from './node_crud_operations';
 import {addFilter, addColumnFromJoinid} from './datagrid_node_creation';
 import {showHelp} from './help_modal';
@@ -66,6 +74,11 @@ export interface DataExplorerTab {
   readonly id: string;
   title: string;
   state: DataExplorerState;
+  // If set, this tab renders a dashboard instead of the graph builder.
+  dashboardId?: string;
+  // Dashboard-local state (only meaningful when dashboardId is set).
+  dashboardItems?: DashboardItem[];
+  dashboardBrushFilters?: Map<string, DashboardBrushFilter[]>;
 }
 
 export interface DataExplorerState {
@@ -85,7 +98,9 @@ export interface DataExplorerState {
 }
 
 type StateUpdateFn = (
-  update: DataExplorerState | ((current: DataExplorerState) => DataExplorerState),
+  update:
+    | DataExplorerState
+    | ((current: DataExplorerState) => DataExplorerState),
 ) => void;
 
 interface DataExplorerAttrs {
@@ -103,6 +118,7 @@ interface DataExplorerAttrs {
   readonly tabs: DataExplorerTab[];
   readonly activeTabId: string;
   readonly onTabAdd: () => void;
+  readonly onDashboardTabAdd: () => void;
   readonly onTabClose: (tabId: string) => void;
   readonly onTabChange: (tabId: string) => void;
   readonly onTabRename: (tabId: string, newName: string) => void;
@@ -117,6 +133,9 @@ interface DataExplorerAttrs {
     state: DataExplorerState,
     afterTabId: string,
   ) => void;
+  // Notify the plugin that dashboard-local state changed (items/filters)
+  // so it can trigger debounced saves.
+  readonly onDashboardStateChange: () => void;
 }
 
 // Per-tab service instances that live for the lifetime of the tab.
@@ -444,23 +463,46 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
         ),
     };
 
+    const allNodes = getAllNodes(state.rootNodes);
+
+    // Set callbacks on dashboard nodes so they can resolve table names and
+    // trigger execution even when the graph tab is not active.
+    for (const node of allNodes) {
+      if (!isDashboardNode(node)) continue;
+      // Propagate the stable tab ID so sources are namespaced by graph.
+      node.state.graphId = tab.id;
+      if (node.state.getTableNameForNode === undefined) {
+        node.state.getTableNameForNode = (nodeId: string) =>
+          services.queryExecutionService.getTableName(nodeId);
+      }
+      if (node.state.requestNodeExecution === undefined) {
+        node.state.requestNodeExecution = (nodeId: string) => {
+          const targetNode = allNodes.find((n) => n.nodeId === nodeId);
+          if (targetNode === undefined) return Promise.resolve();
+          return services.queryExecutionService
+            .processNode(targetNode, trace.engine, allNodes, {manual: true})
+            .then(() => {});
+        };
+      }
+    }
+
     // Only do full node processing for the active tab to avoid unnecessary work
     if (isActive) {
-      // Ensure all nodes have actions initialized
-      const allNodes = getAllNodes(state.rootNodes);
-      ensureAllNodeActions(
-        allNodes,
-        services.initializedNodes,
-        nodeCrudDeps.nodeActionHandlers,
-      );
-
-      // Provide getTableNameForNode callback
+      // Provide getTableNameForNode callback for all nodes (used by
+      // add_columns_node and others).
       for (const node of allNodes) {
         if (node.state.getTableNameForNode === undefined) {
           node.state.getTableNameForNode = (nodeId: string) =>
             services.queryExecutionService.getTableName(nodeId);
         }
       }
+
+      // Ensure all nodes have actions initialized
+      ensureAllNodeActions(
+        allNodes,
+        services.initializedNodes,
+        nodeCrudDeps.nodeActionHandlers,
+      );
 
       // Store deps for keyboard handler access
       this.activeNodeCrudDeps = nodeCrudDeps;
@@ -604,6 +646,20 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
   private activeNodeCrudDeps?: NodeCrudDeps;
   private activeGraphIODeps?: GraphIODeps;
 
+  /** Build the list of exported sources with graphName resolved from tabs. */
+  private buildDashboardSources(tabs: ReadonlyArray<DataExplorerTab>) {
+    return dashboardRegistry.getAllExportedSources().map((s) => ({
+      ...s,
+      graphName: tabs.find((t) => t.id === s.graphId)?.title ?? s.graphId,
+    }));
+  }
+
+  /** Trigger debounced saves after dashboard state changes. */
+  private triggerSave(attrs: DataExplorerAttrs) {
+    attrs.onDashboardStateChange();
+    m.redraw();
+  }
+
   view({attrs}: m.CVnode<DataExplorerAttrs>) {
     const {tabs, activeTabId} = attrs;
 
@@ -623,9 +679,29 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     const tabEntries: TabsTab[] = tabs.map((tab) => ({
       key: tab.id,
       title: tab.title,
-      leftIcon: 'account_tree',
+      leftIcon: tab.dashboardId !== undefined ? 'dashboard' : 'account_tree',
       closeButton: tabs.length > 1,
-      content: this.renderTabContent(attrs, tab, sqlModules),
+      content:
+        tab.dashboardId !== undefined
+          ? m(
+              '.pf-data-explorer__tab-content',
+              m(Dashboard, {
+                dashboardId: tab.dashboardId,
+                trace: attrs.trace,
+                items: tab.dashboardItems ?? [],
+                sources: this.buildDashboardSources(tabs),
+                brushFilters: tab.dashboardBrushFilters ?? new Map(),
+                onItemsChange: (items) => {
+                  tab.dashboardItems = items;
+                  this.triggerSave(attrs);
+                },
+                onBrushFiltersChange: (filters) => {
+                  tab.dashboardBrushFilters = filters;
+                  this.triggerSave(attrs);
+                },
+              }),
+            )
+          : this.renderTabContent(attrs, tab, sqlModules),
       menuItems: m(MenuItem, {
         label: 'Duplicate tab',
         icon: 'content_copy',
@@ -674,7 +750,25 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
         tabs: tabEntries,
         activeTabKey: activeTabId,
         reorderable: true,
-        onNewTab: () => attrs.onTabAdd(),
+        newTabContent: m(
+          PopupMenu,
+          {
+            trigger: m(Button, {
+              icon: 'add',
+              className: 'pf-tabs__new-tab-btn',
+            }),
+          },
+          m(MenuItem, {
+            label: 'New Graph',
+            icon: 'account_tree',
+            onclick: () => attrs.onTabAdd(),
+          }),
+          m(MenuItem, {
+            label: 'New Dashboard',
+            icon: 'dashboard',
+            onclick: () => attrs.onDashboardTabAdd(),
+          }),
+        ),
         onTabChange: (key) => attrs.onTabChange(key),
         onTabRename: (key, newTitle) => {
           attrs.onTabRename(key, newTitle);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer_tabs_storage.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer_tabs_storage.ts
@@ -15,6 +15,7 @@
 import {z} from 'zod';
 import {DataExplorerTab, DataExplorerState} from './data_explorer';
 import {serializeState} from './json_handler';
+import {serializeDashboardData} from './dashboard/dashboard_registry';
 
 const DATA_EXPLORER_TABS_STORAGE_KEY = 'perfettoDataExplorerTabs';
 
@@ -22,6 +23,9 @@ const PERSISTED_DATA_EXPLORER_TAB_SCHEMA = z.object({
   id: z.string(),
   title: z.string(),
   graphJson: z.string().optional(),
+  dashboardId: z.string().optional(),
+  dashboardItems: z.array(z.unknown()).optional(),
+  brushFilters: z.record(z.string(), z.array(z.unknown())).optional(),
 });
 
 const PERSISTED_DATA_EXPLORER_TABS_STATE_SCHEMA = z.object({
@@ -45,14 +49,22 @@ export type PersistedDataExplorerTabsState = z.infer<
 class DataExplorerTabsStorage {
   save(tabs: DataExplorerTab[], activeTabId: string): void {
     const state: PersistedDataExplorerTabsState = {
-      tabs: tabs.map((tab) => ({
-        id: tab.id,
-        title: tab.title,
-        graphJson:
-          tab.state.rootNodes.length > 0
-            ? serializeState(tab.state)
-            : undefined,
-      })),
+      tabs: tabs.map((tab) => {
+        const dbData = serializeDashboardData(
+          tab.dashboardId,
+          tab.dashboardItems,
+          tab.dashboardBrushFilters,
+        );
+        return {
+          id: tab.id,
+          title: tab.title,
+          graphJson:
+            tab.state.rootNodes.length > 0
+              ? serializeState(tab.state)
+              : undefined,
+          ...dbData,
+        };
+      }),
       activeTabId,
     };
     try {
@@ -85,7 +97,10 @@ class DataExplorerTabsStorage {
 // Singleton instance
 export const dataExplorerTabsStorage = new DataExplorerTabsStorage();
 
-export function createNewTabName(tabs: DataExplorerTab[], prefix = 'Graph'): string {
+export function createNewTabName(
+  tabs: DataExplorerTab[],
+  prefix = 'Graph',
+): string {
   const existingNames = new Set(tabs.map((t) => t.title));
   let count = 1;
   while (existingNames.has(`${prefix} ${count}`)) {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
@@ -21,16 +21,28 @@ import {getErrorMessage} from '../../base/errors';
 import {debounce} from '../../base/rate_limiters';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
 import SqlModulesPlugin from '../dev.perfetto.SqlModules';
-import {DataExplorer, DataExplorerState, DataExplorerTab} from './data_explorer';
+import {
+  DataExplorer,
+  DataExplorerState,
+  DataExplorerTab,
+} from './data_explorer';
 import {nodeRegistry} from './query_builder/node_registry';
 import {QueryNodeState} from './query_node';
 import {deserializeState, serializeState} from './json_handler';
 import {recentGraphsStorage} from './recent_graphs';
+import {getAllNodes} from './query_builder/graph_utils';
+import {isDashboardNode} from './query_builder/nodes/dashboard_node';
 import {
   dataExplorerTabsStorage,
   createNewTabName,
   createEmptyState,
 } from './data_explorer_tabs_storage';
+import {
+  dashboardRegistry,
+  parseBrushFilters,
+  serializeDashboardData,
+  validateDashboardItems,
+} from './dashboard/dashboard_registry';
 import type {PersistedDataExplorerTabData} from './data_explorer_tabs_storage';
 import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 
@@ -121,6 +133,20 @@ export default class implements PerfettoPlugin {
     const newTab = this.createNewTab();
     this.tabs.push(newTab);
     this.activeTabId = newTab.id;
+    this.debouncedSave();
+    m.redraw();
+  };
+
+  private handleDashboardTabAdd = (): void => {
+    const dashboardId = shortUuid();
+    const tab: DataExplorerTab = {
+      id: shortUuid(),
+      title: createNewTabName(this.tabs, 'Dashboard'),
+      state: createEmptyState(),
+      dashboardId,
+    };
+    this.tabs.push(tab);
+    this.activeTabId = tab.id;
     this.debouncedSave();
     m.redraw();
   };
@@ -262,12 +288,26 @@ export default class implements PerfettoPlugin {
     if (!this.permalinkStore) return;
 
     const tabsData: PersistedDataExplorerTabData[] = this.tabs
-      .filter((tab) => tab.state.rootNodes.length > 0)
-      .map((tab) => ({
-        id: tab.id,
-        title: tab.title,
-        graphJson: serializeState(tab.state),
-      }));
+      .filter(
+        (tab) =>
+          tab.state.rootNodes.length > 0 || tab.dashboardId !== undefined,
+      )
+      .map((tab) => {
+        const dbData = serializeDashboardData(
+          tab.dashboardId,
+          tab.dashboardItems,
+          tab.dashboardBrushFilters,
+        );
+        return {
+          id: tab.id,
+          title: tab.title,
+          graphJson:
+            tab.state.rootNodes.length > 0
+              ? serializeState(tab.state)
+              : undefined,
+          ...dbData,
+        };
+      });
 
     this.permalinkStore.edit((draft) => {
       draft.version = STORE_VERSION;
@@ -286,6 +326,9 @@ export default class implements PerfettoPlugin {
       id: string;
       title: string;
       graphJson?: string;
+      dashboardId?: string;
+      dashboardItems?: unknown[];
+      brushFilters?: Record<string, unknown[]>;
     }>,
     trace: Trace,
     sqlModules: SqlModules,
@@ -295,10 +338,31 @@ export default class implements PerfettoPlugin {
         tabData.graphJson !== undefined
           ? deserializeState(tabData.graphJson, trace, sqlModules)
           : createEmptyState();
+
+      // Stamp graphId on dashboard nodes and re-publish their sources.
+      // postDeserializeLate already called publishExportedSource but graphId
+      // was empty at that point because it's only known from the tab.
+      for (const node of getAllNodes(state.rootNodes)) {
+        if (isDashboardNode(node)) {
+          node.state.graphId = tabData.id;
+          node.onPrevNodesUpdated?.();
+        }
+      }
+
       return {
         id: tabData.id,
         title: tabData.title,
         state,
+        dashboardId: tabData.dashboardId,
+        dashboardItems:
+          tabData.dashboardId !== undefined
+            ? validateDashboardItems(tabData.dashboardItems)
+            : undefined,
+        dashboardBrushFilters:
+          tabData.dashboardId !== undefined &&
+          tabData.brushFilters !== undefined
+            ? parseBrushFilters(tabData.brushFilters)
+            : undefined,
       };
     });
   }
@@ -344,7 +408,10 @@ export default class implements PerfettoPlugin {
           return;
         } catch (e) {
           const msg = getErrorMessage(e);
-          console.warn('Failed to load Data Explorer tabs from permalink:', msg);
+          console.warn(
+            'Failed to load Data Explorer tabs from permalink:',
+            msg,
+          );
           this.tabs = [];
           // Fall through to try other sources
         }
@@ -386,7 +453,10 @@ export default class implements PerfettoPlugin {
           : this.tabs[0].id;
         return;
       } catch (e) {
-        console.debug('Failed to load Data Explorer tabs from localStorage:', e);
+        console.debug(
+          'Failed to load Data Explorer tabs from localStorage:',
+          e,
+        );
         this.tabs = [];
         // Fall through to try recent graphs
       }
@@ -404,7 +474,10 @@ export default class implements PerfettoPlugin {
         return;
       }
     } catch (e) {
-      console.debug('Failed to load Data Explorer state from recent graphs:', e);
+      console.debug(
+        'Failed to load Data Explorer state from recent graphs:',
+        e,
+      );
       recentGraphsStorage.clear();
     }
 
@@ -420,6 +493,8 @@ export default class implements PerfettoPlugin {
     trace.trash.defer(() => {
       window.removeEventListener('beforeunload', this.onBeforeUnload);
     });
+
+    trace.trash.defer(() => dashboardRegistry.clear());
 
     trace.pages.registerPage({
       route: '/explore',
@@ -446,11 +521,16 @@ export default class implements PerfettoPlugin {
           onStateUpdate: this.makeOnStateUpdate(this.activeTabId),
           makeOnStateUpdate: (tabId: string) => this.makeOnStateUpdate(tabId),
           onTabAdd: this.handleTabAdd,
+          onDashboardTabAdd: this.handleDashboardTabAdd,
           onTabClose: this.handleTabClose,
           onTabChange: this.handleTabChange,
           onTabRename: this.handleTabRename,
           onTabReorder: this.handleTabReorder,
           onTabAddWithState: this.handleTabAddWithState,
+          onDashboardStateChange: () => {
+            this.debouncedSave();
+            this.debouncedPermalinkSave();
+          },
         });
       },
     });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.scss
@@ -120,19 +120,6 @@
     gap: 0.5rem;
   }
 
-  // Shared styling for all round action buttons (undo/redo/add node)
-  .pf-qb-round-action-button {
-    width: 40px;
-    height: 40px;
-    font-size: var(--pf-font-size-xxl);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    transition: box-shadow 0.2s ease;
-
-    &:hover {
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    }
-  }
-
   .pf-qb-floating-warning {
     display: flex;
     align-items: center;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_column_formatters.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_column_formatters.ts
@@ -18,13 +18,13 @@ import {
   underlyingSqlType,
   PerfettoSqlType,
 } from '../../../../trace_processor/perfetto_sql_type';
-import {VisualisationNode} from '../nodes/visualisation_node';
+import {ChartColumnProvider} from './chart_renderers';
 
 /**
  * Whether a column's underlying SQL type is INTEGER.
  */
 export function isIntegerColumn(
-  node: VisualisationNode,
+  node: ChartColumnProvider,
   columnName: string,
 ): boolean {
   const columnInfo = node.sourceCols.find((col) => col.name === columnName);
@@ -38,7 +38,7 @@ export function isIntegerColumn(
  * Get the PerfettoSQL type kind for a column, if available.
  */
 export function getColumnTypeKind(
-  node: VisualisationNode,
+  node: ChartColumnProvider,
   columnName: string,
 ): PerfettoSqlType['kind'] | undefined {
   const columnInfo = node.sourceCols.find((col) => col.name === columnName);
@@ -50,7 +50,7 @@ export function getColumnTypeKind(
  * Returns undefined if the column doesn't need special formatting.
  */
 export function getNumericFormatter(
-  node: VisualisationNode,
+  node: ChartColumnProvider,
   columnName: string,
 ): ((value: number) => string) | undefined {
   const kind = getColumnTypeKind(node, columnName);
@@ -65,7 +65,7 @@ export function getNumericFormatter(
  * (e.g., timestamp/duration columns).
  */
 export function buildCellFormatters(
-  node: VisualisationNode,
+  node: ChartColumnProvider,
   columns: readonly string[],
 ): Record<string, CellFormatter> | undefined {
   const formatters: Record<string, CellFormatter> = {};

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_config_popup.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_config_popup.ts
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  VisualisationNode,
-  ChartConfig,
-  BarOrientation,
-} from '../nodes/visualisation_node';
+import {ChartConfig, BarOrientation} from '../nodes/visualisation_node';
 import {
   CHART_TYPES,
   getChartTypeDefinition,
@@ -26,9 +22,10 @@ import {
 import {ChartAggregation} from '../../../../components/widgets/charts/chart_utils';
 import {Select} from '../../../../widgets/select';
 import {Form, FormLabel} from '../../../../widgets/form';
+import {ChartColumnProvider} from './chart_renderers';
 
 export interface ChartConfigPopupContext {
-  readonly node: VisualisationNode;
+  readonly node: ChartColumnProvider;
   readonly onFilterChange?: () => void;
 }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_renderers.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_renderers.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {VisualisationNode, ChartConfig} from '../nodes/visualisation_node';
+import {ChartConfig, ChartType} from '../nodes/visualisation_node';
+import {ColumnInfo} from '../column_info';
 import {BarChart} from '../../../../components/widgets/charts/bar_chart';
 import {Histogram} from '../../../../components/widgets/charts/histogram';
 import {LineChart} from '../../../../components/widgets/charts/line_chart';
@@ -36,6 +37,7 @@ import {SQLHeatmapLoader} from '../../../../components/widgets/charts/heatmap_lo
 import {SQLCdfLoader} from '../../../../components/widgets/charts/cdf_loader';
 import {EmptyState} from '../../../../widgets/empty_state';
 import {SqlValue} from '../../../../trace_processor/query_result';
+import {Engine} from '../../../../trace_processor/engine';
 import {isIntegerColumn, getNumericFormatter} from './chart_column_formatters';
 
 /**
@@ -58,13 +60,183 @@ export interface ChartLoaderEntry {
 }
 
 /**
+ * Interface for chart-aware nodes/adapters. Implemented by VisualisationNode
+ * and the dashboard chart adapter so that chart renderers and config popup
+ * are decoupled from the specific node implementation.
+ */
+export interface ChartColumnProvider {
+  readonly sourceCols: ReadonlyArray<ColumnInfo>;
+  getChartableColumns(chartType: ChartType): ReadonlyArray<ColumnInfo>;
+  clearChartFiltersForColumn(column: string): void;
+  setBrushSelection(column: string, values: SqlValue[]): void;
+  addRangeFilter(column: string, min: number, max: number): void;
+  updateChart(chartId: string, updates: Partial<Omit<ChartConfig, 'id'>>): void;
+  removeChart(chartId: string): void;
+  readonly state: {readonly chartConfigs: ReadonlyArray<ChartConfig>};
+}
+
+/**
  * Minimal context passed to chart render functions.
  * Avoids passing the full ChartViewAttrs (which includes Trace and
  * QueryExecutionService that renderers don't need).
  */
 export interface ChartRenderContext {
-  readonly node: VisualisationNode;
+  readonly node: ChartColumnProvider;
   readonly onFilterChange?: () => void;
+}
+
+/** Dispose all loaders on a ChartLoaderEntry. */
+export function disposeChartLoaders(entry: ChartLoaderEntry): void {
+  entry.barLoader?.dispose();
+  entry.histogramLoader?.dispose();
+  entry.lineLoader?.dispose();
+  entry.scatterLoader?.dispose();
+  entry.pieLoader?.dispose();
+  entry.treemapLoader?.dispose();
+  entry.boxplotLoader?.dispose();
+  entry.heatmapLoader?.dispose();
+  entry.cdfLoader?.dispose();
+}
+
+/** Build a stable cache key for a chart loader entry. */
+export function buildLoaderCacheKey(
+  tableName: string,
+  config: ChartConfig,
+  ...extras: string[]
+): string {
+  return [
+    tableName,
+    config.chartType,
+    config.column,
+    config.measureColumn ?? '',
+    config.yColumn ?? '',
+    config.groupColumn ?? '',
+    config.sizeColumn ?? '',
+    ...extras,
+  ].join('|');
+}
+
+/** Create the appropriate SQL loader(s) for a chart config. */
+export function createChartLoaders(
+  engine: Engine,
+  query: string,
+  config: ChartConfig,
+  entry: ChartLoaderEntry,
+): void {
+  switch (config.chartType) {
+    case 'bar':
+      entry.barLoader = new SQLBarChartLoader({
+        engine,
+        query,
+        dimensionColumn: config.column,
+        measureColumn: config.measureColumn ?? config.column,
+      });
+      break;
+    case 'histogram':
+      entry.histogramLoader = new SQLHistogramLoader({
+        engine,
+        query: `SELECT ${config.column} FROM (${query})`,
+        valueColumn: config.column,
+      });
+      break;
+    case 'line':
+      if (config.yColumn) {
+        entry.lineLoader = new SQLLineChartLoader({
+          engine,
+          query,
+          xColumn: config.column,
+          yColumn: config.yColumn,
+          seriesColumn: config.groupColumn,
+        });
+      }
+      break;
+    case 'scatter':
+      if (config.yColumn) {
+        entry.scatterLoader = new SQLScatterChartLoader({
+          engine,
+          query,
+          xColumn: config.column,
+          yColumn: config.yColumn,
+          sizeColumn: config.sizeColumn,
+          seriesColumn: config.groupColumn,
+        });
+      }
+      break;
+    case 'pie':
+      entry.pieLoader = new SQLPieChartLoader({
+        engine,
+        query,
+        dimensionColumn: config.column,
+        measureColumn: config.measureColumn ?? config.column,
+      });
+      break;
+    case 'treemap':
+      entry.treemapLoader = new SQLTreemapLoader({
+        engine,
+        query,
+        labelColumn: config.column,
+        sizeColumn: config.measureColumn ?? config.column,
+        groupColumn: config.groupColumn,
+      });
+      break;
+    case 'boxplot':
+      if (config.yColumn) {
+        entry.boxplotLoader = new SQLBoxplotLoader({
+          engine,
+          query,
+          categoryColumn: config.column,
+          valueColumn: config.yColumn,
+        });
+      }
+      break;
+    case 'heatmap':
+      if (config.yColumn) {
+        entry.heatmapLoader = new SQLHeatmapLoader({
+          engine,
+          query,
+          xColumn: config.column,
+          yColumn: config.yColumn,
+          valueColumn: config.measureColumn ?? config.column,
+        });
+      }
+      break;
+    case 'cdf':
+      entry.cdfLoader = new SQLCdfLoader({
+        engine,
+        query,
+        valueColumn: config.column,
+        seriesColumn: config.groupColumn,
+      });
+      break;
+  }
+}
+
+/** Render the appropriate chart widget for a config + loader entry. */
+export function renderChartByType(
+  ctx: ChartRenderContext,
+  config: ChartConfig,
+  entry: ChartLoaderEntry,
+): m.Child {
+  switch (config.chartType) {
+    case 'bar':
+      return renderBarChart(ctx, config, entry);
+    case 'histogram':
+      return renderHistogram(ctx, config, entry);
+    case 'line':
+      return renderLineChart(ctx, config, entry);
+    case 'scatter':
+      return renderScatterChart(ctx, config, entry);
+    case 'pie':
+      return renderPieChart(ctx, config, entry);
+    case 'treemap':
+      return renderTreemap(ctx, config, entry);
+    case 'boxplot':
+      return renderBoxplot(ctx, config, entry);
+    case 'heatmap':
+      return renderHeatmap(ctx, config, entry);
+    case 'cdf':
+      return renderCdf(ctx, config, entry);
+  }
 }
 
 export function renderBarChart(

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_view.ts
@@ -19,27 +19,13 @@ import {
   ChartConfig,
   getDefaultChartLabel,
 } from '../nodes/visualisation_node';
-import {SQLBarChartLoader} from '../../../../components/widgets/charts/bar_chart_loader';
-import {SQLHistogramLoader} from '../../../../components/widgets/charts/histogram_loader';
-import {SQLLineChartLoader} from '../../../../components/widgets/charts/line_chart_loader';
-import {SQLScatterChartLoader} from '../../../../components/widgets/charts/scatterplot_loader';
-import {SQLPieChartLoader} from '../../../../components/widgets/charts/pie_chart_loader';
-import {SQLTreemapLoader} from '../../../../components/widgets/charts/treemap_loader';
-import {SQLBoxplotLoader} from '../../../../components/widgets/charts/boxplot_loader';
-import {SQLHeatmapLoader} from '../../../../components/widgets/charts/heatmap_loader';
-import {SQLCdfLoader} from '../../../../components/widgets/charts/cdf_loader';
 import {
   ChartLoaderEntry,
   ChartRenderContext,
-  renderBarChart,
-  renderHistogram,
-  renderLineChart,
-  renderScatterChart,
-  renderPieChart,
-  renderTreemap,
-  renderBoxplot,
-  renderHeatmap,
-  renderCdf,
+  buildLoaderCacheKey,
+  createChartLoaders,
+  disposeChartLoaders,
+  renderChartByType,
 } from './chart_renderers';
 import {renderChartConfigPopup} from './chart_config_popup';
 import {Button} from '../../../../widgets/button';
@@ -99,15 +85,7 @@ export class ChartView implements m.ClassComponent<ChartViewAttrs> {
       clearTimeout(this.binCountDebounceTimeout);
     }
     for (const entry of this.state.loaders.values()) {
-      entry.barLoader?.dispose();
-      entry.histogramLoader?.dispose();
-      entry.lineLoader?.dispose();
-      entry.scatterLoader?.dispose();
-      entry.pieLoader?.dispose();
-      entry.treemapLoader?.dispose();
-      entry.boxplotLoader?.dispose();
-      entry.heatmapLoader?.dispose();
-      entry.cdfLoader?.dispose();
+      disposeChartLoaders(entry);
     }
     this.state.loaders.clear();
   }
@@ -163,30 +141,13 @@ export class ChartView implements m.ClassComponent<ChartViewAttrs> {
       return entry;
     }
 
-    const key = [
-      tableName,
-      config.chartType,
-      config.column,
-      config.measureColumn ?? '',
-      config.yColumn ?? '',
-      config.groupColumn ?? '',
-      config.sizeColumn ?? '',
-    ].join('|');
+    const key = buildLoaderCacheKey(tableName, config);
     const existing = this.state.loaders.get(config.id);
 
     if (existing && existing.key === key) return existing;
 
-    // Dispose old loaders before creating new ones.
     if (existing) {
-      existing.barLoader?.dispose();
-      existing.histogramLoader?.dispose();
-      existing.lineLoader?.dispose();
-      existing.scatterLoader?.dispose();
-      existing.pieLoader?.dispose();
-      existing.treemapLoader?.dispose();
-      existing.boxplotLoader?.dispose();
-      existing.heatmapLoader?.dispose();
-      existing.cdfLoader?.dispose();
+      disposeChartLoaders(existing);
     }
 
     const entry: ChartLoaderEntry = {key};
@@ -194,93 +155,7 @@ export class ChartView implements m.ClassComponent<ChartViewAttrs> {
 
     const engine = attrs.trace.engine;
     const query = `SELECT * FROM ${tableName}`;
-
-    switch (config.chartType) {
-      case 'bar':
-        entry.barLoader = new SQLBarChartLoader({
-          engine,
-          query,
-          dimensionColumn: config.column,
-          measureColumn: config.measureColumn ?? config.column,
-        });
-        break;
-      case 'histogram':
-        entry.histogramLoader = new SQLHistogramLoader({
-          engine,
-          query: `SELECT ${config.column} FROM ${tableName}`,
-          valueColumn: config.column,
-        });
-        break;
-      case 'line':
-        if (config.yColumn) {
-          entry.lineLoader = new SQLLineChartLoader({
-            engine,
-            query,
-            xColumn: config.column,
-            yColumn: config.yColumn,
-            seriesColumn: config.groupColumn,
-          });
-        }
-        break;
-      case 'scatter':
-        if (config.yColumn) {
-          entry.scatterLoader = new SQLScatterChartLoader({
-            engine,
-            query,
-            xColumn: config.column,
-            yColumn: config.yColumn,
-            sizeColumn: config.sizeColumn,
-            seriesColumn: config.groupColumn,
-          });
-        }
-        break;
-      case 'pie':
-        entry.pieLoader = new SQLPieChartLoader({
-          engine,
-          query,
-          dimensionColumn: config.column,
-          measureColumn: config.measureColumn ?? config.column,
-        });
-        break;
-      case 'treemap':
-        entry.treemapLoader = new SQLTreemapLoader({
-          engine,
-          query,
-          labelColumn: config.column,
-          sizeColumn: config.measureColumn ?? config.column,
-          groupColumn: config.groupColumn,
-        });
-        break;
-      case 'boxplot':
-        if (config.yColumn) {
-          entry.boxplotLoader = new SQLBoxplotLoader({
-            engine,
-            query,
-            categoryColumn: config.column,
-            valueColumn: config.yColumn,
-          });
-        }
-        break;
-      case 'heatmap':
-        if (config.yColumn) {
-          entry.heatmapLoader = new SQLHeatmapLoader({
-            engine,
-            query,
-            xColumn: config.column,
-            yColumn: config.yColumn,
-            valueColumn: config.measureColumn ?? config.column,
-          });
-        }
-        break;
-      case 'cdf':
-        entry.cdfLoader = new SQLCdfLoader({
-          engine,
-          query,
-          valueColumn: config.column,
-          seriesColumn: config.groupColumn,
-        });
-        break;
-    }
+    createChartLoaders(engine, query, config, entry);
 
     return entry;
   }
@@ -403,35 +278,7 @@ export class ChartView implements m.ClassComponent<ChartViewAttrs> {
         ),
       ]);
     } else {
-      switch (config.chartType) {
-        case 'bar':
-          chartContent = renderBarChart(ctx, config, entry);
-          break;
-        case 'histogram':
-          chartContent = renderHistogram(ctx, config, entry);
-          break;
-        case 'line':
-          chartContent = renderLineChart(ctx, config, entry);
-          break;
-        case 'scatter':
-          chartContent = renderScatterChart(ctx, config, entry);
-          break;
-        case 'pie':
-          chartContent = renderPieChart(ctx, config, entry);
-          break;
-        case 'treemap':
-          chartContent = renderTreemap(ctx, config, entry);
-          break;
-        case 'boxplot':
-          chartContent = renderBoxplot(ctx, config, entry);
-          break;
-        case 'heatmap':
-          chartContent = renderHeatmap(ctx, config, entry);
-          break;
-        case 'cdf':
-          chartContent = renderCdf(ctx, config, entry);
-          break;
-      }
+      chartContent = renderChartByType(ctx, config, entry);
     }
 
     const isEditing = this.state.editingChartId === config.id;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/common.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/common.scss
@@ -66,6 +66,19 @@
   border-radius: 4px;
 }
 
+// Shared styling for all round action buttons (undo/redo/add node/dashboard).
+.pf-qb-round-action-button {
+  width: 40px;
+  height: 40px;
+  font-size: var(--pf-font-size-xxl);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+}
+
 // Menu label with hotkey
 .pf-exp-menu-label-with-hotkey {
   display: flex;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/core_nodes.ts
@@ -86,6 +86,7 @@ import {
   VisualisationNode,
   VisualisationNodeState,
 } from './nodes/visualisation_node';
+import {DashboardNode, DashboardSerializedState} from './nodes/dashboard_node';
 import {Icons} from '../../../base/semantic_icons';
 import {NodeType} from '../query_node';
 
@@ -606,6 +607,22 @@ export function registerCoreNodes() {
       }),
   });
 
+  nodeRegistry.register('dashboard', {
+    name: 'Export to Dashboard',
+    description: 'Export this data source so it can be used on dashboards.',
+    icon: 'dashboard',
+    type: 'export',
+    nodeType: NodeType.kDashboard,
+    hasPrimaryInput: true,
+    allowedChildren: [],
+    factory: (state) => new DashboardNode(state),
+    deserialize: (state) =>
+      new DashboardNode(
+        DashboardNode.deserializeState(state as DashboardSerializedState),
+      ),
+    postDeserializeLate: (node) => (node as DashboardNode).onPrevNodesUpdated(),
+  });
+
   nodeRegistry.register('trace_summary', {
     name: 'Trace Summary',
     description:
@@ -661,6 +678,7 @@ export function registerCoreNodes() {
     'join',
     'create_slices',
     'union_node',
+    'dashboard',
   ]);
 
   // Validate that all allowedChildren references point to registered nodes.

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/graph.ts
@@ -369,6 +369,8 @@ function getNodeHue(node: QueryNode): number {
       return 280; // Violet (#e1bee7)
     case NodeType.kVisualisation:
       return 30; // Orange (#ffe0b2)
+    case NodeType.kDashboard:
+      return 160; // Teal (#b2dfdb)
     default:
       return 65; // Lime (#f0f4c3)
   }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node.ts
@@ -1,0 +1,207 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import protos from '../../../../protos';
+import {
+  QueryNode,
+  QueryNodeState,
+  nextNodeId,
+  NodeType,
+} from '../../query_node';
+import {ColumnInfo} from '../column_info';
+import {NodeIssues} from '../node_issues';
+import {NodeModifyAttrs, NodeDetailsAttrs} from '../../node_types';
+import {loadNodeDoc} from '../node_doc_loader';
+import {NodeTitle} from '../node_styling_widgets';
+import {InlineField, ResultsPanelEmptyState} from '../widgets';
+import {
+  dashboardRegistry,
+  DashboardDataSource,
+} from '../../dashboard/dashboard_registry';
+
+export interface DashboardSerializedState {
+  exportName?: string;
+}
+
+export interface DashboardNodeState extends QueryNodeState {
+  // User-assigned name for this exported data source.
+  exportName?: string;
+  // Stable ID of the graph tab that owns this node (set by DataExplorer).
+  graphId?: string;
+}
+
+/** Type guard: returns true if the given node is a DashboardNode. */
+export function isDashboardNode(node: QueryNode): node is DashboardNode {
+  return node.type === NodeType.kDashboard;
+}
+
+export class DashboardNode implements QueryNode {
+  readonly nodeId: string;
+  readonly type = NodeType.kDashboard;
+  nextNodes: QueryNode[];
+  primaryInput?: QueryNode;
+  readonly state: DashboardNodeState;
+
+  get finalCols(): ColumnInfo[] {
+    return this.primaryInput?.finalCols ?? [];
+  }
+
+  constructor(state: DashboardNodeState) {
+    this.nodeId = nextNodeId();
+    this.state = state;
+    this.nextNodes = [];
+  }
+
+  private getExportName(): string {
+    return (
+      this.state.exportName?.trim() ||
+      this.primaryInput?.getTitle() ||
+      'Unnamed export'
+    );
+  }
+
+  validate(): boolean {
+    if (this.state.issues) {
+      this.state.issues.clear();
+    }
+
+    if (this.primaryInput === undefined) {
+      this.setValidationError('No input connected');
+      return false;
+    }
+
+    if (!this.primaryInput.validate()) {
+      this.setValidationError(
+        `Input '${this.primaryInput.getTitle()}' is invalid`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  private setValidationError(message: string): void {
+    if (!this.state.issues) {
+      this.state.issues = new NodeIssues();
+    }
+    this.state.issues.queryError = new Error(message);
+  }
+
+  getTitle(): string {
+    return 'Export to Dashboard';
+  }
+
+  nodeDetails(): NodeDetailsAttrs {
+    const details: m.Child[] = [NodeTitle(this.getTitle())];
+    details.push(m('div', `Exported as ${this.getExportName()}`));
+    return {content: details};
+  }
+
+  nodeSpecificModify(): NodeModifyAttrs {
+    return {
+      info: 'Export this data source to the dashboard. Give it a name so you can find it on dashboards.',
+      sections: [
+        {
+          content: m(InlineField, {
+            label: 'Export name',
+            value: this.state.exportName ?? '',
+            placeholder:
+              this.primaryInput?.getTitle() ?? 'Name for this data source',
+            onchange: (value: string) => {
+              this.state.exportName = value.trim() || undefined;
+              this.publishExportedSource();
+              this.state.onchange?.();
+            },
+          }),
+        },
+      ],
+    };
+  }
+
+  nodeInfo(): m.Children {
+    return loadNodeDoc('dashboard');
+  }
+
+  customResultsPanel(): m.Children {
+    return m(ResultsPanelEmptyState, {
+      icon: 'dashboard',
+      title: 'Data from this node is exported to dashboards.',
+    });
+  }
+
+  clone(): QueryNode {
+    return new DashboardNode({
+      exportName: this.state.exportName,
+      onchange: this.state.onchange,
+    });
+  }
+
+  getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
+    return this.primaryInput?.getStructuredQuery();
+  }
+
+  /** Publish this node's data to the global exported sources pool. */
+  private publishExportedSource(): void {
+    if (this.primaryInput === undefined) {
+      dashboardRegistry.removeExportedSource(this.nodeId);
+      return;
+    }
+    const parentNodeId = this.primaryInput.nodeId;
+    const source: DashboardDataSource = {
+      name: this.getExportName(),
+      nodeId: this.nodeId,
+      columns: this.finalCols.map((c) => ({name: c.name, type: c.column.type})),
+      graphId: this.state.graphId ?? '',
+      requestExecution: async () => {
+        await this.state.requestNodeExecution?.(parentNodeId);
+        // After execution, resolve the table name so the chart can render.
+        await this.resolveTableName(source, parentNodeId);
+      },
+    };
+    dashboardRegistry.setExportedSource(source);
+
+    // Eagerly resolve the table name. If the upstream node has already been
+    // executed this returns immediately (cached in QueryExecutionService).
+    this.resolveTableName(source, parentNodeId).catch((e: unknown) =>
+      console.debug('Dashboard table name resolution failed:', e),
+    );
+  }
+
+  private async resolveTableName(
+    source: DashboardDataSource,
+    parentNodeId: string,
+  ): Promise<void> {
+    const tableName = await this.state.getTableNameForNode?.(parentNodeId);
+    if (tableName !== undefined) {
+      source.tableName = tableName;
+      dashboardRegistry.setExportedSource(source);
+    }
+  }
+
+  onPrevNodesUpdated(): void {
+    this.publishExportedSource();
+  }
+
+  serializeState(): DashboardSerializedState & {primaryInputId?: string} {
+    return {
+      primaryInputId: this.primaryInput?.nodeId,
+      exportName: this.state.exportName,
+    };
+  }
+
+  static deserializeState(state: DashboardSerializedState): DashboardNodeState {
+    return {exportName: state.exportName};
+  }
+}

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node_unittest.ts
@@ -1,0 +1,393 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {NodeType} from '../../query_node';
+import {dashboardRegistry} from '../../dashboard/dashboard_registry';
+import {DashboardNode} from './dashboard_node';
+import {
+  createMockSourceNode,
+  createMockNode,
+  connectNodes,
+  expectValidationError,
+  expectValidationSuccess,
+  expectColumnNames,
+  createColumnInfo,
+  STANDARD_TABLE_COLUMNS,
+} from '../testing/test_utils';
+
+function makeNode(overrides: {exportName?: string} = {}): DashboardNode {
+  return new DashboardNode({
+    exportName: overrides.exportName,
+  });
+}
+
+describe('DashboardNode', () => {
+  beforeEach(() => {
+    dashboardRegistry.clear();
+  });
+
+  // --- Basic properties ---
+
+  describe('basic properties', () => {
+    test('type is kDashboard', () => {
+      const node = makeNode();
+      expect(node.type).toBe(NodeType.kDashboard);
+    });
+
+    test('has unique nodeId', () => {
+      const a = makeNode();
+      const b = makeNode();
+      expect(a.nodeId).not.toBe(b.nodeId);
+    });
+
+    test('starts with no primary input', () => {
+      const node = makeNode();
+      expect(node.primaryInput).toBeUndefined();
+    });
+
+    test('starts with empty nextNodes', () => {
+      const node = makeNode();
+      expect(node.nextNodes).toEqual([]);
+    });
+  });
+
+  // --- Title ---
+
+  describe('getTitle', () => {
+    test('returns fixed title', () => {
+      const node = makeNode();
+      expect(node.getTitle()).toBe('Export to Dashboard');
+    });
+
+    test('title does not change with export name', () => {
+      const node = makeNode({exportName: 'My Export'});
+      expect(node.getTitle()).toBe('Export to Dashboard');
+    });
+  });
+
+  // --- finalCols ---
+
+  describe('finalCols', () => {
+    test('returns empty array without input', () => {
+      const node = makeNode();
+      expect(node.finalCols).toEqual([]);
+    });
+
+    test('passes through input columns', () => {
+      const source = createMockSourceNode();
+      const node = makeNode();
+      connectNodes(source, node);
+      expectColumnNames(node, ['id', 'name', 'value']);
+    });
+  });
+
+  // --- Validation ---
+
+  describe('validation', () => {
+    test('fails without input connected', () => {
+      const node = makeNode();
+      expectValidationError(node, 'No input connected');
+    });
+
+    test('succeeds with valid input', () => {
+      const source = createMockSourceNode();
+      const node = makeNode();
+      connectNodes(source, node);
+      expectValidationSuccess(node);
+    });
+
+    test('fails when input is invalid', () => {
+      const invalidSource = createMockNode({
+        validate: () => false,
+        getTitle: () => 'Bad Source',
+      });
+      const node = makeNode();
+      connectNodes(invalidSource, node);
+      expectValidationError(node, "Input 'Bad Source' is invalid");
+    });
+
+    test('clears previous issues before validating', () => {
+      const node = makeNode();
+      // First validation: fails.
+      node.validate();
+      expect(node.state.issues?.queryError).toBeTruthy();
+
+      // Connect valid input, re-validate: succeeds.
+      const source = createMockSourceNode();
+      connectNodes(source, node);
+      expectValidationSuccess(node);
+    });
+
+    test('lazily creates issues object on first error', () => {
+      const node = makeNode();
+      expect(node.state.issues).toBeUndefined();
+      node.validate();
+      expect(node.state.issues).toBeDefined();
+    });
+  });
+
+  // --- Structured query ---
+
+  describe('getStructuredQuery', () => {
+    test('returns undefined without input', () => {
+      const node = makeNode();
+      expect(node.getStructuredQuery()).toBeUndefined();
+    });
+
+    test('passes through input structured query', () => {
+      const sq = {id: 'test-sq'};
+      const source = createMockNode({
+        getStructuredQuery: () =>
+          sq as ReturnType<typeof source.getStructuredQuery>,
+      });
+      const node = makeNode();
+      connectNodes(source, node);
+      expect(node.getStructuredQuery()).toBe(sq);
+    });
+  });
+
+  // --- Clone ---
+
+  describe('clone', () => {
+    test('creates a new node with same export name', () => {
+      const node = makeNode({exportName: 'My Export'});
+      const cloned = node.clone() as DashboardNode;
+      expect(cloned.nodeId).not.toBe(node.nodeId);
+      expect(cloned.state.exportName).toBe('My Export');
+    });
+
+    test('cloned node has no primary input', () => {
+      const source = createMockSourceNode();
+      const node = makeNode();
+      connectNodes(source, node);
+      const cloned = node.clone();
+      expect(cloned.primaryInput).toBeUndefined();
+    });
+  });
+
+  // --- Serialization ---
+
+  describe('serialization', () => {
+    test('serializes exportName', () => {
+      const node = makeNode({exportName: 'My Data'});
+      const serialized = node.serializeState();
+      expect(serialized.exportName).toBe('My Data');
+    });
+
+    test('serializes undefined exportName', () => {
+      const node = makeNode();
+      const serialized = node.serializeState();
+      expect(serialized.exportName).toBeUndefined();
+    });
+
+    test('serializes primaryInputId', () => {
+      const source = createMockSourceNode('source-123');
+      const node = makeNode();
+      connectNodes(source, node);
+      const serialized = node.serializeState();
+      expect(serialized.primaryInputId).toBe('source-123');
+    });
+
+    test('primaryInputId is undefined without input', () => {
+      const node = makeNode();
+      const serialized = node.serializeState();
+      expect(serialized.primaryInputId).toBeUndefined();
+    });
+
+    test('deserializeState restores exportName', () => {
+      const state = DashboardNode.deserializeState({exportName: 'Restored'});
+      expect(state.exportName).toBe('Restored');
+    });
+
+    test('deserializeState handles missing exportName', () => {
+      const state = DashboardNode.deserializeState({});
+      expect(state.exportName).toBeUndefined();
+    });
+
+    test('serialize then deserialize round-trip preserves exportName', () => {
+      const node = makeNode({exportName: 'Round Trip'});
+      const serialized = node.serializeState();
+      const restored = DashboardNode.deserializeState(serialized);
+      expect(restored.exportName).toBe('Round Trip');
+    });
+  });
+
+  // --- Publishing to registry ---
+
+  describe('publishExportedSource (via onPrevNodesUpdated)', () => {
+    test('publishes source to registry when input connected', () => {
+      const source = createMockSourceNode('src-1');
+      const node = makeNode({exportName: 'Test Export'});
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+
+      const exported = dashboardRegistry.getExportedSource(node.nodeId);
+      expect(exported).toBeDefined();
+      expect(exported?.name).toBe('Test Export');
+      expect(exported?.nodeId).toBe(node.nodeId);
+    });
+
+    test('published source has correct columns', () => {
+      const source = createMockSourceNode();
+      const node = makeNode();
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+
+      const exported = dashboardRegistry.getExportedSource(node.nodeId);
+      expect(exported?.columns).toEqual([
+        {name: 'id', type: {kind: 'int'}},
+        {name: 'name', type: {kind: 'string'}},
+        {name: 'value', type: {kind: 'int'}},
+      ]);
+    });
+
+    test('uses input title as name when no exportName', () => {
+      const source = createMockNode({
+        getTitle: () => 'Slices Table',
+        columns: STANDARD_TABLE_COLUMNS(),
+      });
+      const node = makeNode();
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+
+      const exported = dashboardRegistry.getExportedSource(node.nodeId);
+      expect(exported?.name).toBe('Slices Table');
+    });
+
+    test('removes exported source when input disconnected', () => {
+      const source = createMockSourceNode();
+      const node = makeNode();
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+      expect(dashboardRegistry.getExportedSource(node.nodeId)).toBeDefined();
+
+      // Disconnect input.
+      node.primaryInput = undefined;
+      node.onPrevNodesUpdated();
+      expect(dashboardRegistry.getExportedSource(node.nodeId)).toBeUndefined();
+    });
+
+    test('updates exported source when columns change', () => {
+      const source = createMockNode({
+        columns: [createColumnInfo('a', 'int')],
+      });
+      const node = makeNode();
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+      expect(dashboardRegistry.getExportedSource(node.nodeId)?.columns).toEqual(
+        [{name: 'a', type: {kind: 'int'}}],
+      );
+
+      // Change source columns.
+      (source as {finalCols: typeof source.finalCols}).finalCols = [
+        createColumnInfo('b', 'string'),
+        createColumnInfo('c', 'double'),
+      ];
+      node.onPrevNodesUpdated();
+      expect(dashboardRegistry.getExportedSource(node.nodeId)?.columns).toEqual(
+        [
+          {name: 'b', type: {kind: 'string'}},
+          {name: 'c', type: {kind: 'double'}},
+        ],
+      );
+    });
+
+    test('multiple onPrevNodesUpdated calls overwrite (not duplicate)', () => {
+      const source = createMockSourceNode();
+      const node = makeNode({exportName: 'First'});
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+      node.onPrevNodesUpdated();
+      node.onPrevNodesUpdated();
+
+      // Still exactly one exported source for this node.
+      const all = dashboardRegistry.getAllExportedSources();
+      const matching = all.filter((s) => s.nodeId === node.nodeId);
+      expect(matching).toHaveLength(1);
+    });
+
+    test('eagerly resolves tableName on publish', async () => {
+      const mockGetTable = jest.fn().mockResolvedValue('table_42');
+      const source = createMockSourceNode('src-1');
+      const node = new DashboardNode({
+        getTableNameForNode: mockGetTable,
+      });
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+
+      expect(mockGetTable).toHaveBeenCalledWith('src-1');
+      // Wait for the async resolution to complete.
+      await mockGetTable.mock.results[0].value;
+      const exported = dashboardRegistry.getExportedSource(node.nodeId);
+      expect(exported?.tableName).toBe('table_42');
+    });
+
+    test('published source includes requestExecution callback', () => {
+      const mockRequest = jest.fn().mockResolvedValue(undefined);
+      const source = createMockSourceNode('src-1');
+      const node = new DashboardNode({
+        requestNodeExecution: mockRequest,
+      });
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+
+      const exported = dashboardRegistry.getExportedSource(node.nodeId);
+      expect(exported?.requestExecution).toBeDefined();
+      exported?.requestExecution?.();
+      expect(mockRequest).toHaveBeenCalledWith('src-1');
+    });
+  });
+
+  // --- Export name resolution ---
+
+  describe('export name resolution', () => {
+    test('uses exportName when set', () => {
+      const source = createMockNode({getTitle: () => 'Source'});
+      const node = makeNode({exportName: 'Custom Name'});
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+      expect(dashboardRegistry.getExportedSource(node.nodeId)?.name).toBe(
+        'Custom Name',
+      );
+    });
+
+    test('falls back to input title when exportName is empty', () => {
+      const source = createMockNode({getTitle: () => 'My Table'});
+      const node = makeNode({exportName: ''});
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+      expect(dashboardRegistry.getExportedSource(node.nodeId)?.name).toBe(
+        'My Table',
+      );
+    });
+
+    test('falls back to input title when exportName is whitespace', () => {
+      const source = createMockNode({getTitle: () => 'My Table'});
+      const node = makeNode({exportName: '   '});
+      connectNodes(source, node);
+      node.onPrevNodesUpdated();
+      expect(dashboardRegistry.getExportedSource(node.nodeId)?.name).toBe(
+        'My Table',
+      );
+    });
+
+    test('uses "Unnamed export" when no exportName and no input', () => {
+      const node = makeNode();
+      const details = node.nodeDetails();
+      // Verify the rendered vnode tree contains the fallback text.
+      const rendered = JSON.stringify(details.content);
+      expect(rendered).toContain('Unnamed export');
+    });
+  });
+});

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_node.ts
@@ -66,6 +66,9 @@ export enum NodeType {
   // Visualization
   kVisualisation = 'visualisation',
 
+  // Dashboard
+  kDashboard = 'dashboard',
+
   // Deprecated (kept for backward compatibility)
   kMerge = kJoin,
   kMetrics = 'metrics',
@@ -85,6 +88,7 @@ export function singleNodeOperation(type: NodeType): boolean {
     case NodeType.kCounterToIntervals:
     case NodeType.kMetrics:
     case NodeType.kVisualisation:
+    case NodeType.kDashboard:
       return true;
     default:
       return false;
@@ -137,6 +141,10 @@ export interface QueryNodeState {
   // Returns the materialized table name for a given node ID.
   // Set by the parent component using the QueryExecutionService.
   getTableNameForNode?: (nodeId: string) => Promise<string | undefined>;
+
+  // Triggers execution (sync + materialize) of a node by ID.
+  // Used by dashboard nodes to force-execute their source nodes.
+  requestNodeExecution?: (nodeId: string) => Promise<void>;
 
   // Caching
   hasOperationChanged?: boolean;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/styles.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/styles.scss
@@ -14,6 +14,7 @@
 
 @import "./query_builder/builder.scss";
 @import "./query_builder/results_panel.scss";
+@import "./dashboard/dashboard.scss";
 
 .pf-data-explorer {
   height: 100%;

--- a/ui/src/plugins/dev.perfetto.QueryPage/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/table_list.ts
@@ -21,7 +21,7 @@ import {Icon} from '../../widgets/icon';
 import {TextInput} from '../../widgets/text_input';
 import {SqlModules, SqlTable} from '../dev.perfetto.SqlModules/sql_modules';
 import {
-  PerfettoSqlType,
+  perfettoSqlTypeIcon,
   perfettoSqlTypeToString,
 } from '../../trace_processor/perfetto_sql_type';
 import {EmptyState} from '../../widgets/empty_state';
@@ -35,32 +35,6 @@ function renderHighlightedName(segments: FuzzySegment[]): m.Children {
   return segments.map(({matching, value}) =>
     matching ? m('span.pf-simple-table-list__highlight', value) : value,
   );
-}
-
-// Returns a Material icon name for a given PerfettoSQL type
-function getTypeIcon(type?: PerfettoSqlType): string {
-  if (type === undefined) return 'help_outline';
-  switch (type.kind) {
-    case 'int':
-      return 'tag';
-    case 'double':
-      return 'decimal_increase';
-    case 'string':
-      return 'text_fields';
-    case 'boolean':
-      return 'toggle_on';
-    case 'timestamp':
-      return 'schedule';
-    case 'duration':
-      return 'timer';
-    case 'bytes':
-      return 'memory';
-    case 'id':
-    case 'joinid':
-      return 'key';
-    case 'arg_set_id':
-      return 'dataset';
-  }
 }
 
 export interface TableListAttrs {
@@ -206,7 +180,7 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
               m(
                 '.pf-simple-table-list__column',
                 m(Icon, {
-                  icon: getTypeIcon(col.type),
+                  icon: perfettoSqlTypeIcon(col.type),
                   className: 'pf-simple-table-list__column-icon',
                 }),
                 m(

--- a/ui/src/trace_processor/perfetto_sql_type.ts
+++ b/ui/src/trace_processor/perfetto_sql_type.ts
@@ -186,6 +186,32 @@ export function parsePerfettoSqlTypeFromString(args: {
   return errResult(`Unknown type: ${args.type}`);
 }
 
+/** Returns a Material icon name for a given PerfettoSQL type. */
+export function perfettoSqlTypeIcon(type?: PerfettoSqlType): string {
+  if (type === undefined) return 'help_outline';
+  switch (type.kind) {
+    case 'int':
+      return 'tag';
+    case 'double':
+      return 'decimal_increase';
+    case 'string':
+      return 'text_fields';
+    case 'boolean':
+      return 'toggle_on';
+    case 'timestamp':
+      return 'schedule';
+    case 'duration':
+      return 'timer';
+    case 'bytes':
+      return 'memory';
+    case 'id':
+    case 'joinid':
+      return 'key';
+    case 'arg_set_id':
+      return 'dataset';
+  }
+}
+
 export function perfettoSqlTypeToString(type?: PerfettoSqlType): string {
   if (type === undefined) {
     return 'ANY';

--- a/ui/src/widgets/tabs.ts
+++ b/ui/src/widgets/tabs.ts
@@ -61,6 +61,9 @@ export interface TabsAttrs {
   // Called when the "new tab" button is clicked. When set, a "+" button is
   // shown at the end of the tab bar.
   onNewTab?(): void;
+  // Custom content to render in place of the default "+" button. When set,
+  // onNewTab is ignored and this content is rendered instead.
+  readonly newTabContent?: m.Children;
   // Additional class name for the container.
   readonly className?: string;
 }
@@ -243,6 +246,7 @@ export class Tabs implements m.ClassComponent<TabsAttrs> {
       reorderable,
       onTabReorder,
       onNewTab,
+      newTabContent,
       className,
     } = attrs;
 
@@ -370,12 +374,13 @@ export class Tabs implements m.ClassComponent<TabsAttrs> {
             ),
           );
         }),
-        onNewTab &&
-          m(Button, {
-            icon: Icons.Add,
-            className: 'pf-tabs__new-tab-btn',
-            onclick: () => onNewTab(),
-          }),
+        newTabContent ??
+          (onNewTab &&
+            m(Button, {
+              icon: Icons.Add,
+              className: 'pf-tabs__new-tab-btn',
+              onclick: () => onNewTab(),
+            })),
       ),
       m(
         '.pf-tabs__content',


### PR DESCRIPTION
Add dashboard functionality to the Data Explorer, allowing users to create
dashboard tabs that display charts from exported data sources. Users connect
upstream nodes to "Export to Dashboard" nodes in graph tabs, then visualize
the exported data on free-form dashboard canvases with drag-and-drop,
resize, cross-chart brush filtering, and source switching.