### PR TITLE
ui: add extension server documentation

### DIFF
--- a/docs/toc.md
+++ b/docs/toc.md
@@ -73,7 +73,12 @@
     - [Opening large traces](visualization/large-traces.md)
     - [Deep linking](visualization/deep-linking-to-perfetto-ui.md)
     - [Debug tracks](analysis/debug-tracks.md)
-    - [UI Automation](visualization/ui-automation.md)
+
+    - [Extending the UI](#)
+
+      - [Overview](visualization/extending-the-ui.md)
+      - [Commands and Macros](visualization/ui-automation.md)
+      - [Extension Servers](visualization/extension-servers.md)
 
   - [Contributing](#)
 
@@ -166,6 +171,7 @@
   - [Advanced Trace Visualization](#)
 
     - [Commands Automation Reference](visualization/commands-automation-reference.md)
+    - [Extension Server Protocol](visualization/extension-server-protocol.md)
 
   - [Contributor Reference](#)
 

--- a/docs/visualization/extending-the-ui.md
+++ b/docs/visualization/extending-the-ui.md
@@ -1,0 +1,114 @@
+# Extending the Perfetto UI
+
+Perfetto offers several ways to extend and customize the UI. The right choice
+depends on what you want to do and who you want to share it with.
+
+## Which approach should I use?
+
+```mermaid
+graph TD
+    Start["How do I extend the Perfetto UI?"]
+    Q1{"Do you want simple things?<br>(queries, pinning tracks,<br>selecting events, etc.)"}
+
+    Start --> Q1
+
+    Q2{"For yourself or<br>to share with others?"}
+    Q3{"Are you OK contributing<br>your changes upstream?"}
+
+    Q1 -->|Yes| Q2
+    Q1 -->|No| Q3
+
+    Out1["Use Macros +<br>Startup Commands"]
+    Out2["Use Extension Servers"]
+
+    Q2 -->|For myself| Out1
+    Q2 -->|To share| Out2
+
+    Out3["Contribute a<br>UI Plugin Upstream"]
+    Q4{"Do you work<br>at Google?"}
+
+    Q3 -->|Yes| Out3
+    Q3 -->|No| Q4
+
+    Out4["Please speak to us"]
+    Out5["Fork Perfetto &<br>maintain your own instance"]
+
+    Q4 -->|Yes| Out4
+    Q4 -->|No| Out5
+
+    Out6["Use Plugins for<br>UI-affecting changes"]
+    Out7["Use Embedder for<br>central infra<br>(analytics, branding, etc.)"]
+
+    Out5 --> Out6
+    Out5 --> Out7
+
+    click Out1 "/docs/visualization/ui-automation" "Commands and Macros"
+    click Out2 "/docs/visualization/extension-servers" "Extension Server Setup"
+    click Out3 "/docs/contributing/ui-plugins" "UI Plugins"
+    click Out4 "https://github.com/google/perfetto/issues" "Open an issue"
+    click Out6 "/docs/contributing/ui-plugins" "UI Plugins"
+
+    %% Styling
+    style Start fill:#6b9ae8,color:#fff,stroke:none
+
+    style Q1 fill:#ece5ff,stroke:#d0c4eb,color:#333
+    style Q2 fill:#ece5ff,stroke:#d0c4eb,color:#333
+    style Q3 fill:#ece5ff,stroke:#d0c4eb,color:#333
+    style Q4 fill:#ece5ff,stroke:#d0c4eb,color:#333
+
+    style Out1 fill:#36a265,color:#fff,stroke:none
+    style Out2 fill:#36a265,color:#fff,stroke:none
+    style Out3 fill:#36a265,color:#fff,stroke:none
+
+    style Out4 fill:#ece5ff,stroke:#d0c4eb,color:#333
+    style Out5 fill:#ece5ff,stroke:#d0c4eb,color:#333
+
+    style Out6 fill:#ef991c,color:#fff,stroke:none
+    style Out7 fill:#ef991c,color:#fff,stroke:none
+```
+
+## Commands, startup commands, and macros
+
+**Commands** are individual UI actions (pin a track, run a query, create a debug
+track). **Startup commands** run automatically every time you open a trace.
+**Macros** are named sequences of commands you trigger manually from the command
+palette.
+
+These are configured locally in Settings and are the simplest way to customize
+your own workflow. No server or sharing infrastructure needed.
+
+See [Commands and Macros](/docs/visualization/ui-automation.md) for how to set
+these up, and the
+[Commands Automation Reference](/docs/visualization/commands-automation-reference.md)
+for the full list of available commands.
+
+## Extension servers
+
+**Extension servers** are HTTP(S) endpoints that distribute macros, SQL modules,
+and proto descriptors to the Perfetto UI. They are the recommended way for teams
+to share reusable trace analysis workflows — instead of everyone copy-pasting
+JSON, you host extensions on a server and anyone with access can load them.
+
+The easiest way to get started is to fork a GitHub template repository and push
+your extensions there. The Perfetto UI can load directly from GitHub repos.
+
+See [Extension Servers](/docs/visualization/extension-servers.md) for how they
+work and how to set one up.
+
+## Plugins
+
+**Plugins** are TypeScript modules that run inside the Perfetto UI and can add
+new tracks, tabs, commands, and visualizations. Unlike macros and extension
+servers (which are declarative), plugins can execute code and deeply integrate
+with the UI.
+
+If you want to contribute a plugin upstream, see
+[UI Plugins](/docs/contributing/ui-plugins.md).
+
+## Forking Perfetto
+
+If you need changes that go beyond what plugins, macros, and extension servers
+offer — such as custom branding, analytics integration, or deep infrastructure
+changes — you can fork Perfetto and maintain your own instance. Within a fork,
+you can use the **embedder API** for central infrastructure concerns (analytics,
+branding) and **plugins** for UI-affecting changes.

--- a/docs/visualization/extension-server-protocol.md
+++ b/docs/visualization/extension-server-protocol.md
@@ -1,0 +1,277 @@
+# Extension Server Protocol Reference
+
+This page documents the HTTP protocol that extension servers must implement. Use
+this if you are building a custom extension server rather than using the
+[GitHub template approach](/docs/visualization/extension-servers.md).
+
+## Endpoints
+
+Extension servers implement these HTTP(S) endpoints:
+
+```
+{base_url}/manifest                              GET  (required)
+{base_url}/modules/{module_id}/macros            GET  (optional)
+{base_url}/modules/{module_id}/sql_modules       GET  (optional)
+{base_url}/modules/{module_id}/proto_descriptors GET  (optional)
+```
+
+The UI only fetches optional endpoints for features declared in the manifest.
+
+## Manifest
+
+**Endpoint:** `GET {base_url}/manifest`
+
+Returns server metadata, supported features, and available modules.
+
+```json
+{
+  "name": "Acme Corp Extensions",
+  "namespace": "com.acme",
+  "features": [
+    {"name": "macros"},
+    {"name": "sql_modules"},
+    {"name": "proto_descriptors"}
+  ],
+  "modules": [
+    {"id": "default", "name": "Default"},
+    {"id": "android", "name": "Android"},
+    {"id": "chrome", "name": "Chrome"}
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Human-readable server name, shown in Settings and command palette source chips. |
+| `namespace` | string | Yes | Unique identifier in reverse-domain notation (e.g., `com.acme`). Used to enforce naming constraints on macros and SQL modules. |
+| `features` | array | Yes | Features this server supports. Each entry has a `name` field. Valid names: `macros`, `sql_modules`, `proto_descriptors`. |
+| `modules` | array | Yes | Available modules. Each entry has an `id` (used in URL paths and settings) and a `name` (human-readable display name). |
+
+For single-module servers, use `[{"id": "default", "name": "Default"}]`.
+
+## Macros
+
+**Endpoint:** `GET {base_url}/modules/{module_id}/macros`
+
+Only fetched if `features` includes `{"name": "macros"}`.
+
+```json
+{
+  "macros": [
+    {
+      "id": "com.acme.StartupAnalysis",
+      "name": "Startup Analysis",
+      "run": [
+        {"id": "dev.perfetto.RunQuery", "args": ["SELECT 1"]},
+        {"id": "dev.perfetto.PinTracksByRegex", "args": [".*CPU.*"]}
+      ]
+    }
+  ]
+}
+```
+
+### Macro fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique identifier. Must start with the server's namespace followed by `.` (e.g., `com.acme.StartupAnalysis`). |
+| `name` | string | Display name shown in the command palette. |
+| `run` | array | Commands to execute in sequence. Each entry has a command `id` and an `args` array. |
+
+See the
+[Commands Automation Reference](/docs/visualization/commands-automation-reference.md)
+for the full list of available command IDs and their arguments.
+
+## SQL modules
+
+**Endpoint:** `GET {base_url}/modules/{module_id}/sql_modules`
+
+Only fetched if `features` includes `{"name": "sql_modules"}`.
+
+```json
+{
+  "sql_modules": [
+    {
+      "name": "com.acme.startup",
+      "sql": "CREATE PERFETTO TABLE _startup_events AS SELECT ts, dur, name FROM slice WHERE name GLOB 'startup*';"
+    },
+    {
+      "name": "com.acme.memory",
+      "sql": "CREATE PERFETTO FUNCTION com_acme_rss_mb(upid INT) RETURNS FLOAT AS SELECT CAST(value AS FLOAT) / 1048576 FROM counter WHERE track_id IN (SELECT id FROM process_counter_track WHERE upid = $upid AND name = 'mem.rss') ORDER BY ts DESC LIMIT 1;"
+    }
+  ]
+}
+```
+
+### SQL module fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Module name. Must start with the server's namespace followed by `.` (e.g., `com.acme.startup`). Users reference this with `INCLUDE PERFETTO MODULE com.acme.startup;`. |
+| `sql` | string | SQL text. Can contain `CREATE PERFETTO TABLE`, `CREATE PERFETTO FUNCTION`, `CREATE PERFETTO VIEW`, or any valid PerfettoSQL. |
+
+## Proto descriptors
+
+**Endpoint:** `GET {base_url}/modules/{module_id}/proto_descriptors`
+
+Only fetched if `features` includes `{"name": "proto_descriptors"}`.
+
+```json
+{
+  "proto_descriptors": [
+    "CgdteV9wcm90bxIHbXlwcm90byI...",
+    "Cghhbm90aGVyEghhbm90aGVyIi..."
+  ]
+}
+```
+
+### Proto descriptor fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `proto_descriptors` | array of strings | Base64-encoded `FileDescriptorSet` protocol buffer messages. These allow the UI to decode custom protobuf messages in traces. |
+
+Proto descriptors are not subject to namespace enforcement since protobuf
+messages have their own package-based namespacing.
+
+## Namespace enforcement
+
+All macro IDs and SQL module names must start with the server's `namespace`
+value from the manifest, followed by a `.`. For example, a server with namespace
+`com.acme` can only serve:
+
+- Macro IDs like `com.acme.StartupAnalysis`, `com.acme.MemoryCheck`
+- SQL module names like `com.acme.startup`, `com.acme.memory.helpers`
+
+The UI validates this and rejects extensions that violate the convention. This
+prevents naming conflicts when users configure multiple extension servers.
+
+## CORS requirements
+
+All HTTPS extension servers must set CORS headers to allow the Perfetto UI to
+make cross-origin requests:
+
+```
+Access-Control-Allow-Origin: https://ui.perfetto.dev
+Access-Control-Allow-Methods: GET
+Access-Control-Allow-Headers: Authorization, Content-Type
+```
+
+If your server supports multiple Perfetto UI deployments, you can reflect the
+`Origin` request header instead of hardcoding a single origin.
+
+GitHub-hosted servers do not need CORS configuration —
+`raw.githubusercontent.com` and the GitHub API already set appropriate headers.
+
+CORS failures appear as network errors in the browser console. The affected
+server is skipped and other servers continue to load normally.
+
+## Authentication headers
+
+The Perfetto UI constructs authentication headers based on the server's
+configured auth type:
+
+| Auth type | Header |
+|-----------|--------|
+| `none` | No auth headers |
+| `github_pat` | `Authorization: token <pat>` (via GitHub API) |
+| `https_basic` | `Authorization: Basic <base64(username:password)>` |
+| `https_apikey` (bearer) | `Authorization: Bearer <key>` |
+| `https_apikey` (x_api_key) | `X-API-Key: <key>` |
+| `https_apikey` (custom) | `<custom_header_name>: <key>` |
+| `https_sso` | No header; request sent with `credentials: 'include'` |
+
+For SSO authentication, if a request returns HTTP 403, the UI loads the server's
+base URL in a hidden iframe to refresh the SSO session cookie, then retries the
+request once.
+
+## GitHub server URL construction
+
+For GitHub-hosted extension servers, the UI constructs fetch URLs automatically:
+
+- **Unauthenticated (public repos):** Uses `raw.githubusercontent.com` to avoid
+  GitHub API rate limits.
+  ```
+  https://raw.githubusercontent.com/{repo}/{ref}/{path}/manifest
+  ```
+- **Authenticated (private repos):** Uses the GitHub Contents API.
+  ```
+  https://api.github.com/repos/{repo}/contents/{path}/manifest?ref={ref}
+  ```
+  With header: `Accept: application/vnd.github.raw+json`
+
+## Example: minimal static server
+
+A complete extension server can be a set of static JSON files:
+
+```
+my-extensions/
+  manifest
+  modules/
+    default/
+      macros
+      sql_modules
+```
+
+Serve these with any static file server (nginx, Caddy, GCS, S3) that sets the
+required CORS headers. No dynamic server logic is needed for basic use cases.
+
+## Example: dynamic server (Python/Flask)
+
+```python
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/manifest')
+def manifest():
+    return jsonify({
+        "name": "My Extensions",
+        "namespace": "com.example",
+        "features": [{"name": "macros"}, {"name": "sql_modules"}],
+        "modules": [{"id": "default", "name": "Default"}],
+    })
+
+@app.route('/modules/<module>/macros')
+def macros(module):
+    return jsonify({
+        "macros": [
+            {
+                "id": "com.example.ShowLongSlices",
+                "name": "Show Long Slices",
+                "run": [
+                    {
+                        "id": "dev.perfetto.RunQueryAndShowTab",
+                        "args": ["SELECT * FROM slice ORDER BY dur DESC LIMIT 20"]
+                    }
+                ]
+            }
+        ]
+    })
+
+@app.route('/modules/<module>/sql_modules')
+def sql_modules(module):
+    return jsonify({
+        "sql_modules": [
+            {"name": "com.example.helpers", "sql": "CREATE PERFETTO TABLE ...;"}
+        ]
+    })
+
+@app.after_request
+def add_cors(response):
+    response.headers['Access-Control-Allow-Origin'] = 'https://ui.perfetto.dev'
+    response.headers['Access-Control-Allow-Methods'] = 'GET'
+    response.headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type'
+    return response
+```
+
+## See also
+
+- [Extension Server Setup Guide](/docs/visualization/extension-servers.md) —
+  Step-by-step setup using the GitHub template
+- [Extension Servers](/docs/visualization/extension-servers.md) —
+  What extension servers are and how they work
+- [Commands Automation Reference](/docs/visualization/commands-automation-reference.md) —
+  Available command IDs for macros

--- a/docs/visualization/extension-servers.md
+++ b/docs/visualization/extension-servers.md
@@ -1,0 +1,392 @@
+# Extension Servers
+
+Extension servers are HTTP(S) endpoints that distribute shared
+[macros](/docs/visualization/ui-automation.md), SQL modules, and proto
+descriptors to the Perfetto UI. They are the recommended way for teams and
+organizations to share reusable trace analysis workflows.
+
+## Why extension servers?
+
+Without extension servers, sharing macros or SQL modules means copy-pasting JSON
+between teammates. This doesn't scale: definitions get out of date, new team
+members miss them, and there's no single source of truth. Extension servers solve
+this by letting you host extensions in one place and have everyone load them
+automatically.
+
+## Key properties
+
+Extension servers are **optional and never load-bearing**. The Perfetto UI works
+fully without any servers configured — servers only provide optional
+enhancements.
+
+All extensions are **declarative and safe**:
+
+- **Macros** are sequences of UI commands — no JavaScript execution.
+- **SQL modules** run inside trace processor's existing sandbox.
+- **Proto descriptors** are binary type definitions (data only).
+
+## What extension servers provide
+
+### Macros
+
+Macros loaded from extension servers appear in the command palette
+(`Ctrl+Shift+P`) alongside locally-defined macros. They show the server and
+module name as a source label so you can tell where each macro comes from.
+
+See [Commands and Macros](/docs/visualization/ui-automation.md) for how macros
+work.
+
+### SQL modules
+
+SQL modules become available for use in the query editor and in
+[startup commands](/docs/visualization/ui-automation.md). Use them with:
+
+```sql
+INCLUDE PERFETTO MODULE <namespace>.<module_name>;
+```
+
+For example, if a server with namespace `com.acme` provides a module called
+`com.acme.startup`, you would write:
+
+```sql
+INCLUDE PERFETTO MODULE com.acme.startup;
+```
+
+See
+[PerfettoSQL Getting Started](/docs/analysis/perfetto-sql-getting-started.md)
+for more on SQL modules.
+
+### Proto descriptors
+
+Proto descriptors allow the UI to decode and display custom protobuf messages
+embedded in traces without needing the `.proto` files compiled into the UI.
+These are registered automatically when the extension server loads.
+
+## How extension servers work
+
+Each extension server hosts a **manifest** that declares:
+
+- The server's **name** and **namespace** (e.g., `com.acme`)
+- Which **features** it supports (macros, SQL modules, proto descriptors)
+- Which **modules** are available (named collections of extensions)
+
+When the Perfetto UI starts, it fetches the manifest from each configured server,
+then loads extensions from the enabled modules. If a server is unreachable or
+returns errors, it is skipped — other servers and the rest of the UI are
+unaffected.
+
+### Modules
+
+Extension servers organize content into **modules**. For example, a corporate
+server might offer:
+
+- `default` — General-purpose macros and SQL modules
+- `android` — Android-specific analysis workflows
+- `chrome` — Chrome rendering performance tools
+
+When you add a server, the `default` module is selected automatically. Other
+modules are opt-in.
+
+### Namespacing
+
+All macro IDs and SQL module names from a server must start with the server's
+namespace (e.g., `com.acme.`). This prevents naming conflicts when multiple
+extension servers are configured. The UI enforces this and rejects extensions
+that violate the convention.
+
+### Lifecycle
+
+Extensions are loaded **once at UI startup**. If you change your extension
+server configuration (add/remove servers, change modules), you need to reload
+the page for changes to take effect.
+
+## Server types and authentication
+
+Extension servers come in two types:
+
+- **GitHub** — Extensions hosted in a GitHub repository. The UI fetches files
+  directly from `raw.githubusercontent.com` (public repos) or the GitHub API
+  (private repos). This is the easiest option — no server infrastructure needed.
+- **HTTPS** — Extensions hosted on any HTTPS endpoint: a static file host
+  (GCS, S3, nginx), a dynamic server (Flask, Express), or corporate
+  infrastructure. The server must set
+  [CORS headers](/docs/visualization/extension-server-protocol.md#cors-requirements)
+  to allow the Perfetto UI to fetch from it.
+
+Each server type supports different authentication methods:
+
+| Server type | Auth method | When to use |
+|-------------|-------------|-------------|
+| GitHub | None | Public repositories |
+| GitHub | Personal Access Token | Private repositories |
+| HTTPS | None | Publicly accessible servers |
+| HTTPS | Basic Auth | Username/password protected servers |
+| HTTPS | API Key | Bearer token, X-API-Key, or custom header |
+| HTTPS | SSO | Corporate SSO with cookie-based authentication |
+
+For most use cases (public GitHub repos + link sharing), no authentication is
+needed. See the
+[protocol reference](/docs/visualization/extension-server-protocol.md#authentication-headers)
+for the exact headers the UI sends for each auth type.
+
+## Creating extensions with GitHub
+
+The easiest way to create an extension server is to use a GitHub repository — no
+custom server infrastructure needed.
+
+### Fork the template repository
+
+Start by forking (or importing, for a private copy) the
+[perfetto-test-extensions](https://github.com/LalitMaganti/perfetto-test-extensions)
+template repository on GitHub. This gives you a ready-made structure with a
+GitHub Action that automatically builds the endpoint files when you push.
+
+### Configure your server
+
+Edit `config.yaml` to set your extension's name and namespace:
+
+```yaml
+name: My Team Extensions
+namespace: com.example.myteam
+```
+
+The **namespace** must be unique to your organization and follows reverse-domain
+notation. All macro IDs and SQL module names must start with this namespace.
+
+You can also configure which modules your server offers. By default, the template
+includes a `default` module. Add more if you want to organize extensions by team
+or topic:
+
+```yaml
+name: My Team Extensions
+namespace: com.example.myteam
+modules:
+  - id: default
+    name: Default
+  - id: android
+    name: Android
+  - id: chrome
+    name: Chrome
+```
+
+### Add SQL modules
+
+Add `.sql` files under `src/{module}/sql_modules/`. The filename determines the
+SQL module name based on your namespace:
+
+- `src/default/sql_modules/helpers.sql` becomes
+  `INCLUDE PERFETTO MODULE com.example.myteam.helpers;`
+- `src/default/sql_modules/foo/bar.sql` becomes
+  `INCLUDE PERFETTO MODULE com.example.myteam.foo.bar;`
+
+You can organize SQL files into subdirectories — each path component becomes a
+dot-separated part of the module name.
+
+See
+[PerfettoSQL Getting Started](/docs/analysis/perfetto-sql-getting-started.md)
+for how to write SQL modules.
+
+### Add macros
+
+Add `.yaml` or `.json` files under `src/{module}/macros/`. Each macro has an
+`id`, a display `name`, and a `run` list of commands.
+
+YAML example (`src/default/macros/show_long_tasks.yaml`):
+
+```yaml
+id: com.example.myteam.ShowLongTasks
+name: Show Long Tasks
+run:
+  - id: dev.perfetto.RunQueryAndShowTab
+    args:
+      - "SELECT * FROM slice WHERE dur > 50000000"
+```
+
+Equivalent JSON (`src/default/macros/show_long_tasks.json`):
+
+```json
+{
+  "id": "com.example.myteam.ShowLongTasks",
+  "name": "Show Long Tasks",
+  "run": [
+    {
+      "id": "dev.perfetto.RunQueryAndShowTab",
+      "args": ["SELECT * FROM slice WHERE dur > 50000000"]
+    }
+  ]
+}
+```
+
+Macro IDs must start with your namespace (e.g., `com.example.myteam.`). See the
+[Commands Automation Reference](/docs/visualization/commands-automation-reference.md)
+for the full list of available commands to use in macros.
+
+### Push and deploy
+
+Push your changes to `main`. The included GitHub Action builds the generated
+endpoint files (`manifest`, `modules/*/macros`, etc.) and commits them
+automatically.
+
+## Adding an extension server in the Perfetto UI
+
+### Add a GitHub server
+
+1. Go to **Settings** (gear icon in the sidebar) and scroll to **Extension
+   Servers**, or open
+   [the settings directly](https://ui.perfetto.dev/#!/settings/dev.perfetto.ExtensionServers).
+2. Click **Add Server** and select **GitHub**.
+3. Enter the repository in `owner/repo` format (e.g.,
+   `my-org/perfetto-extensions`).
+4. Enter the branch or tag in the **Ref** field (e.g., `main`).
+5. The UI fetches the manifest and shows available modules. The `default` module
+   is selected automatically; enable others as needed.
+6. Click **Save** and reload the page.
+
+For **private repositories**, select **Personal Access Token (PAT)** under
+authentication:
+
+1. Go to
+   [GitHub personal access tokens](https://github.com/settings/personal-access-tokens)
+   and click **Generate new token**.
+2. Under **Repository access**, select **Only select repositories** and choose
+   your extension repo.
+3. Under **Permissions > Repository permissions**, set **Contents** to
+   **Read-only**.
+4. Generate the token and enter it in the Perfetto UI when adding the server.
+
+### Add an HTTPS server
+
+1. Click **Add Server** and select **HTTPS**.
+2. Enter the server URL (e.g., `https://perfetto-ext.corp.example.com`). The
+   `https://` prefix is added automatically if omitted.
+3. Select modules and configure authentication (see below).
+4. Click **Save** and reload the page.
+
+## Sharing extension servers
+
+Click the **Share** button on any server in Settings to copy a shareable URL.
+When someone opens the link:
+
+- If they don't have the server configured, the **Add Server** dialog opens
+  pre-populated with the shared configuration.
+- If they already have the server, the **Edit** dialog opens with the shared
+  modules merged in.
+
+Secrets (PATs, passwords, API keys) are automatically stripped from shared URLs.
+Recipients enter their own credentials if the server requires authentication.
+
+## Managing servers
+
+In the Extension Servers settings section, use the action buttons to:
+
+- **Toggle** — Enable or disable a server without removing it.
+- **Edit** — Change modules, authentication, or other settings.
+- **Share** — Copy a shareable URL to the clipboard.
+- **Delete** — Remove the server.
+
+Changes require a **page reload** to take effect.
+
+## Creating an HTTPS extension server
+
+If you need more control than a GitHub repository provides — dynamic content,
+corporate SSO, or integration with internal systems — you can host an extension
+server on any HTTPS endpoint.
+
+An extension server is a set of JSON endpoints. At minimum you need:
+
+```
+https://your-server.example.com/manifest          → server metadata
+https://your-server.example.com/modules/default/macros      → macros (optional)
+https://your-server.example.com/modules/default/sql_modules → SQL modules (optional)
+```
+
+You can serve these as static files (nginx, GCS, S3) or from a dynamic server
+(Flask, Express, etc.). The server must set CORS headers to allow the Perfetto
+UI to make cross-origin requests.
+
+See the
+[Extension Server Protocol Reference](/docs/visualization/extension-server-protocol.md)
+for the full endpoint specification, JSON schemas, CORS requirements, and
+examples including a minimal Python/Flask server.
+
+## Troubleshooting
+
+If extensions fail to load, the UI shows an error dialog listing what went wrong.
+Errors are non-blocking — the UI works normally and extensions from other servers
+that loaded successfully remain available.
+
+Below are the error messages you may see and how to fix them.
+
+### "Failed to fetch \<url\>: \<error\>"
+
+The UI could not reach the server at all. This is usually a network or CORS
+issue.
+
+- **Check the URL.** Open the URL in a new browser tab. If you can't reach it,
+  the server may be down, the URL may be wrong, or you may need to be on a VPN.
+- **Check CORS headers.** If the URL loads in a tab but the UI shows a fetch
+  error, the server likely isn't setting CORS headers. Open the browser console
+  (`F12`) and look for "CORS policy" errors. See the
+  [CORS requirements](/docs/visualization/extension-server-protocol.md#cors-requirements)
+  for what headers to set. GitHub-hosted servers don't need CORS configuration.
+- **Check for mixed content.** The Perfetto UI is served over HTTPS, so it
+  cannot fetch from `http://` URLs. Use `https://` for your server.
+
+### "Fetch failed: \<url\> returned \<status\>"
+
+The server was reachable but returned an HTTP error.
+
+- **401 or 403** — Authentication failed. For GitHub PATs, check that the token
+  hasn't expired and has read access to the repository (Settings > Personal
+  access tokens). For HTTPS servers with SSO, try logging into the server
+  directly in a new tab to refresh your session, then reload the Perfetto UI.
+- **404** — The endpoint doesn't exist. Check that the server implements the
+  expected [endpoint paths](/docs/visualization/extension-server-protocol.md#endpoints)
+  and that the repository/branch/path are correct.
+
+### "Failed to parse JSON from \<url\>: \<error\>"
+
+The server returned a response that isn't valid JSON.
+
+- Check that the endpoint returns `Content-Type: application/json` and valid
+  JSON. If using the GitHub template, make sure the GitHub Action has run
+  successfully after your last push — check the Actions tab in your repository.
+
+### "Invalid response from \<url\>: \<error\>"
+
+The server returned valid JSON but it doesn't match the expected schema.
+
+- Compare your response against the expected format in the
+  [protocol reference](/docs/visualization/extension-server-protocol.md). Common
+  mistakes include missing required fields (`name`, `namespace`, `features`,
+  `modules` in the manifest) or using the wrong field names.
+
+### "Module '\<name\>' not found on server"
+
+You have a module enabled in settings that the server's manifest doesn't list.
+
+- Edit the server in Settings and check which modules are enabled. If a module
+  was renamed or removed from the server, deselect it and save.
+
+### "Macro ID '\<id\>' must start with namespace '\<ns\>.'"
+
+A macro's `id` field doesn't match the server's namespace.
+
+- If you maintain the server: update the macro ID to start with your namespace
+  (e.g., change `MyMacro` to `com.acme.MyMacro`). See
+  [namespace enforcement](/docs/visualization/extension-server-protocol.md#namespace-enforcement).
+- If you don't maintain the server: contact the server maintainer.
+
+### "SQL module name '\<name\>' must start with namespace '\<ns\>.'"
+
+Same as above, but for SQL modules. The module's `name` field must start with
+the server's namespace.
+
+## See also
+
+- [Extending the UI](/docs/visualization/extending-the-ui.md) —
+  Overview of all Perfetto UI extension mechanisms
+- [Extension Server Protocol Reference](/docs/visualization/extension-server-protocol.md) —
+  Full specification for building custom servers
+- [Commands and Macros](/docs/visualization/ui-automation.md) — How to create
+  macros and startup commands

--- a/docs/visualization/perfetto-ui.md
+++ b/docs/visualization/perfetto-ui.md
@@ -85,8 +85,10 @@ command and Enter to run it.
 </video>
 
 For comprehensive documentation on automating the UI with commands, startup
-commands, and macros, see the
-[UI Automation guide](/docs/visualization/ui-automation.md).
+commands, and macros, see
+[Commands and Macros](/docs/visualization/ui-automation.md). For an overview of
+all extension mechanisms, see
+[Extending the UI](/docs/visualization/extending-the-ui.md).
 
 ## Showing/hiding the tab drawer
 
@@ -119,11 +121,17 @@ palette, or press the '?' hotkey to display all configured hotkeys.
 
 ## Next Steps
 
-Once you're comfortable with the basic UI interactions, you can significantly
-speed up your analysis workflow through automation:
+Once you're comfortable with the basic UI interactions, you can customize and
+extend the UI to speed up your analysis workflow:
 
 - **Automate repetitive tasks:** Use
-  [UI Automation](/docs/visualization/ui-automation.md) to configure startup
-  commands that automatically pin tracks or create debug tracks every time you
-  open a trace, and create macros for specific analysis workflows you run
-  occasionally.
+  [commands and macros](/docs/visualization/ui-automation.md) to configure
+  startup commands that automatically pin tracks or create debug tracks every
+  time you open a trace, and create macros for specific analysis workflows you
+  run occasionally.
+- **Share workflows with your team:** Use
+  [extension servers](/docs/visualization/extension-servers.md) to distribute
+  macros, SQL modules, and proto descriptors to your team.
+- **See all extension options:**
+  [Extending the UI](/docs/visualization/extending-the-ui.md) covers all the
+  ways to customize Perfetto, from simple macros to plugins.

--- a/docs/visualization/ui-automation.md
+++ b/docs/visualization/ui-automation.md
@@ -1,108 +1,38 @@
-# UI Automation
+# Commands and Macros
 
-This page covers how to automate common Perfetto UI tasks to speed up your trace
-analysis workflow using commands, startup commands, and macros.
+This page covers how to automate common Perfetto UI tasks using commands,
+startup commands, and macros. For an overview of all ways to extend the UI, see
+[Extending the UI](/docs/visualization/extending-the-ui.md).
 
-## Commands System Overview
+## Running commands
 
-### Commands
+Commands are individual UI actions — pin a track, run a query, create a debug
+track. Run them through:
 
-**Commands** are individual UI actions that can be triggered manually or
-automatically. Examples include pinning tracks, running queries, or creating
-debug tracks. Access commands through:
+- **Command palette:** `Ctrl+Shift+P` (Windows/Linux) or `Cmd+Shift+P` (Mac)
+- **Omnibox:** Type `>` to transform it into a command palette
 
-- Command palette: `Ctrl-Shift-P` (Windows/Linux) or `Cmd-Shift-P` (Mac)
-- Omnibox: Type `>` to transform it into a command palette
-- Commands support fuzzy matching and autocomplete
+Commands support fuzzy matching and autocomplete. See the
+[Commands Automation Reference](/docs/visualization/commands-automation-reference.md)
+for the full list of stable commands.
 
-### Startup Commands
+## Setting up startup commands
 
-**Startup commands** run automatically every time you open any trace. Configure
-them in **Settings > Startup Commands** to set up your preferred view
-immediately. These affect only the UI display - the trace file itself is
-unchanged.
+Startup commands run automatically every time you open any trace. Configure them
+in **Settings > Startup Commands**.
 
-#### JSON Schema
+Startup commands are a JSON array of command objects:
 
-Startup commands must be a JSON array of command objects:
-
-```typescript
+```json
 [
-  {
-    "id": string,      // Command identifier
-    "args": unknown[]  // Array of arguments (types depend on the commands)
-  },
-  ...
+  {"id": "command.id", "args": ["arg1", "arg2"]}
 ]
 ```
 
-#### Notes
-
-- Commands execute in the order specified
-- Invalid JSON or unknown command IDs will cause errors
-- These commands affect only the UI display - the trace file is unchanged
-
-### Macros
-
-**Macros** are named sequences of commands you trigger manually when needed.
-Configure them in **Settings > Macros** and run them via the command palette
-(`Ctrl-Shift-P` and then type `>macro name`). Use macros for analysis workflows
-you run occasionally rather than always.
-
-#### JSON Schema
-
-Macros must be a JSON array of macro objects:
-
-```typescript
-[
-  {
-    "id": string,        // Unique identifier for the macro
-    "name": string,      // Display name shown in command palette
-    "run": [             // Commands to run when this macro is executed
-      {
-        "id": string,      // Command identifier
-        "args": unknown[]  // Array of arguments (types depend on the command)
-      },
-      ...
-    ]
-  },
-  ...
-]
-```
-
-#### Notes
-
-- **id**: A unique identifier for your macro. Use reverse-domain style naming
-  (e.g., `user.myteam.MemoryAnalysis`, `com.mycompany.LatencyCheck`). Avoid
-  spaces - use PascalCase or camelCase. Keep IDs stable as they are used when
-  referencing macros from startup commands.
-- **name**: The display name shown in the command palette. Can contain spaces.
-- Run macros by typing `>name` in the command palette (e.g., `>Memory Analysis`)
-- Commands in a macro execute sequentially
-
-> **Note (Migration):** The macros format was changed from a dictionary to an
-> array structure. If you had existing macros, they were automatically migrated
-> to the new format. The migrated macros use IDs in the format
-> `dev.perfetto.UserMacro.<old_name>`.
-
-### Common Issues
-
-- **JSON syntax errors**: Missing commas, trailing commas, or unescaped quotes
-- **Invalid command IDs**: Use autocomplete in the command palette to find valid
-  IDs
-- **Wrong argument types**: All arguments must be strings, even numbers
-- **Wrong argument count**: Each command expects a specific number of arguments
-- **Module dependency errors**: If your debug track query uses Perfetto modules
-  (e.g., `android.screen_state`), you must include a `RunQuery` command with the
-  module include statement before the debug track command. The module include
-  must come first in the command sequence.
-
-## Startup Command Examples
+Commands execute in order. These affect only the UI display — the trace file
+is unchanged.
 
 ### Pin important tracks automatically
-
-Add this to **Settings > Startup Commands** to always pin CPU tracks when
-opening traces:
 
 ```json
 [
@@ -113,12 +43,7 @@ opening traces:
 ]
 ```
 
-This runs every time you open a trace, ensuring your most important tracks are
-always visible.
-
 ### Create debug tracks for custom metrics
-
-This startup command creates a debug track showing thread scheduling latency:
 
 ```json
 [
@@ -132,12 +57,10 @@ This startup command creates a debug track showing thread scheduling latency:
 ]
 ```
 
-### Debug tracks using Perfetto modules
+### Use Perfetto SQL modules in debug tracks
 
-When your query uses Perfetto modules (like `android.screen_state` or
-`android.memory.lmk`), you must include the module first as a separate command.
-**Important: The module include command must come before the query that uses
-it.**
+When your query uses Perfetto modules, include the module first as a separate
+command:
 
 ```json
 [
@@ -155,37 +78,18 @@ it.**
 ]
 ```
 
-Another example with memory LMK events:
-
-```json
-[
-  {
-    "id": "dev.perfetto.RunQuery",
-    "args": ["include perfetto module android.memory.lmk"]
-  },
-  {
-    "id": "dev.perfetto.AddDebugSliceTrackWithPivot",
-    "args": [
-      "SELECT ts, process_name as name, 0 as dur FROM android_lmk_events",
-      "name",
-      "LMK Events by Process"
-    ]
-  }
-]
-```
-
 Debug tracks visualize SQL query results on the timeline. The query must return:
 
 - `ts` (timestamp)
 - For slice tracks: `dur` (duration)
 - For counter tracks: `value` (the metric value)
-- Optional pivot column. The query results will be grouped by the unique values
-  in this column, with each group appearing in its own track.
+- Optional pivot column — results are grouped by unique values, each in its own
+  track.
 
 **Command argument patterns:**
 
-- Without pivot: `AddDebugSliceTrack` - [query, title]
-- With pivot: `AddDebugSliceTrackWithPivot` - [query, pivot_column, title]
+- Without pivot: `AddDebugSliceTrack` — `[query, title]`
+- With pivot: `AddDebugSliceTrackWithPivot` — `[query, pivot_column, title]`
 
 ### Standard analysis setup
 
@@ -216,12 +120,41 @@ This comprehensive startup configuration prepares the UI for system analysis:
 ]
 ```
 
-## Macro Examples
+## Creating macros
 
-### Focus on specific subsystem
+Macros are named sequences of commands you trigger manually from the command
+palette. Configure them in **Settings > Macros**.
 
-Add this to **Settings > Macros** for analyzing memory when needed. This macro
-creates a new workspace to isolate memory-related tracks from the main view:
+Macros are a JSON array of macro objects:
+
+```json
+[
+  {
+    "id": "user.example.MacroName",
+    "name": "Display Name",
+    "run": [
+      {"id": "command.id", "args": ["arg1"]}
+    ]
+  }
+]
+```
+
+- **id**: Unique identifier. Use reverse-domain naming (e.g.,
+  `user.myteam.MemoryAnalysis`). Keep IDs stable — they are used when
+  referencing macros from startup commands.
+- **name**: Display name shown in the command palette. Can contain spaces.
+- **run**: Commands to execute in sequence.
+
+Run macros by typing `>name` in the command palette (e.g., `>Memory Analysis`).
+
+> **Note (Migration):** The macros format was changed from a dictionary to an
+> array structure. If you had existing macros, they were automatically migrated
+> to the new format. The migrated macros use IDs in the format
+> `dev.perfetto.UserMacro.<old_name>`.
+
+### Focus on a specific subsystem
+
+This macro creates a workspace to isolate memory-related tracks:
 
 ```json
 [
@@ -254,10 +187,7 @@ creates a new workspace to isolate memory-related tracks from the main view:
 ]
 ```
 
-Run this macro by typing `>Memory Analysis` in the command palette when you need
-to investigate memory issues.
-
-### Latency investigation
+### Investigate latency
 
 This macro helps identify performance bottlenecks:
 
@@ -292,11 +222,9 @@ This macro helps identify performance bottlenecks:
 
 ## Combining with trace recording
 
-When recording traces, you can specify startup commands that will execute when
-the trace opens in the UI:
+When recording traces, specify startup commands that run when the trace opens:
 
 ```bash
-# These commands affect only the UI view when the trace opens from the script.
 ./record_android_trace \
   --app com.example.app \
   --ui-startup-commands '[
@@ -305,39 +233,56 @@ the trace opens in the UI:
   ]'
 ```
 
-## Tips for effective automation
+## Tips
 
-1. **Use startup commands for always-needed views**: If you always want certain
+1. **Startup commands for always-needed views.** If you always want certain
    tracks pinned, use startup commands.
 
-2. **Use macros for specific investigations**: Create macros for workflows you
-   run occasionally (memory analysis, latency hunting, etc.).
+2. **Macros for specific investigations.** Create macros for workflows you run
+   occasionally (memory analysis, latency hunting, etc.).
 
-3. **Test interactively first**: Use the command palette (`Ctrl/Cmd+Shift+P`) to
-   test commands before adding to settings. Type commands to see available
-   options with autocomplete.
+3. **Test interactively first.** Use the command palette (`Ctrl/Cmd+Shift+P`)
+   to try commands before adding them to settings.
 
-4. **Start clean**: Begin command sequences with `CollapseTracksByRegex` using
+4. **Start clean.** Begin command sequences with `CollapseTracksByRegex` using
    `".*"` to collapse all tracks first.
 
-5. **Common regex patterns**:
-
+5. **Common regex patterns:**
    - Escape dots in package names: `"com\\.example\\.app"`
    - Match any digit: `\\d+`
    - Match beginning/end: `^` and `$`
 
-6. **Debug tracks need good queries**: Ensure your SQL returns `ts` and either
-   `dur` (for slices) or `value` (for counters) columns. Use the pivot commands
-   to split into multiple tracks. For Android use cases, see
-   [Android Trace Analysis Cookbook](/docs/getting-started/android-trace-analysis.md)
-   for examples of common queries used by Android engineers.
+6. **Debug tracks need good queries.** Ensure SQL returns `ts` and either `dur`
+   (for slices) or `value` (for counters). For Android use cases, see
+   [Android Trace Analysis Cookbook](/docs/getting-started/android-trace-analysis.md).
 
-## See Also
+## Sharing with your team
 
-- [Commands Automation Reference](/docs/visualization/commands-automation-reference.md) -
-  Complete reference for stable automation commands with backwards compatibility
-  guarantees
-- [Perfetto UI Guide](/docs/visualization/perfetto-ui.md) - General UI
-  documentation including commands configuration
-- [Deep Linking](/docs/visualization/deep-linking-to-perfetto-ui.md) - Opening
+If you want to share macros and SQL modules with others rather than maintaining
+them locally, use
+[Extension Servers](/docs/visualization/extension-servers.md).
+
+## Common issues
+
+- **JSON syntax errors**: Missing commas, trailing commas, or unescaped quotes.
+- **Invalid command IDs**: Use autocomplete in the command palette to find valid
+  IDs, or see the
+  [Commands Automation Reference](/docs/visualization/commands-automation-reference.md).
+- **Wrong argument types**: All arguments must be strings, even numbers.
+- **Wrong argument count**: Each command expects a specific number of arguments.
+- **Module dependency errors**: If your debug track query uses Perfetto modules
+  (e.g., `android.screen_state`), include the module first with a `RunQuery`
+  command.
+
+## See also
+
+- [Extending the UI](/docs/visualization/extending-the-ui.md) — Overview of all
+  extension mechanisms
+- [Commands Automation Reference](/docs/visualization/commands-automation-reference.md) —
+  Full reference for stable automation commands
+- [Extension Servers](/docs/visualization/extension-servers.md) — Share macros
+  and SQL modules with your team
+- [Perfetto UI Guide](/docs/visualization/perfetto-ui.md) — General UI
+  documentation
+- [Deep Linking](/docs/visualization/deep-linking-to-perfetto-ui.md) — Opening
   traces with pre-configured commands via URLs

--- a/ui/src/core_plugins/dev.perfetto.ExtensionServers/extension_server.ts
+++ b/ui/src/core_plugins/dev.perfetto.ExtensionServers/extension_server.ts
@@ -385,7 +385,7 @@ export function showErrorsOnCompletion(results: Result<unknown>[]): void {
           m(
             Anchor,
             {
-              href: 'https://perfetto.dev/docs/visualization/extensions',
+              href: 'https://perfetto.dev/docs/visualization/extension-servers#troubleshooting',
               target: '_blank',
             },
             'extension servers documentation',


### PR DESCRIPTION
Add documentation for extension servers following the Diátaxis
framework:
- extending-the-ui.md: Explanation page with Mermaid decision
  flowchart linking to all UI extension mechanisms
- extension-servers.md: Combined explanation + how-to covering
  what extension servers are, GitHub template setup, UI
  configuration, sharing, auth, and error troubleshooting
- extension-server-protocol.md: Reference page with manifest
  schema, endpoint specs, JSON formats, CORS, and auth headers

Refactor ui-automation.md into a focused how-to for commands and
macros. Update perfetto-ui.md cross-links and toc.md to add an
"Extending the UI" subsection. Fix error modal link to point to
the troubleshooting section.

Fixes: https://github.com/google/perfetto/issues/3085