### PR TITLE
de: Fix the fallout from changing to PerfettoSqlType

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {
+  PerfettoSqlType,
+  parsePerfettoSqlTypeFromString,
+} from '../../../trace_processor/perfetto_sql_type';
 import {SqlColumn} from '../../dev.perfetto.SqlModules/sql_modules';
 
 export interface ColumnInfo {
@@ -58,6 +62,21 @@ export function newColumnInfo(
     checked: checked ?? col.checked,
     typeUserModified: col.typeUserModified,
   };
+}
+
+// Handle legacy serialized state where type was a string (e.g. "INT")
+// instead of a PerfettoSqlType object (e.g. {kind: 'int'}).
+export function legacyDeserializeType(
+  type: PerfettoSqlType | string | undefined,
+): PerfettoSqlType | undefined {
+  if (type === undefined) return undefined;
+  if (typeof type === 'string') {
+    const parsed = parsePerfettoSqlTypeFromString({type});
+    return parsed.ok ? parsed.value : undefined;
+  }
+  // Already a proper PerfettoSqlType object
+  if (type.kind !== undefined) return type;
+  return undefined;
 }
 
 export function newColumnInfoList(

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
@@ -16,6 +16,7 @@ import {
   ColumnInfo,
   columnInfoFromSqlColumn,
   columnInfoFromName,
+  legacyDeserializeType,
   newColumnInfo,
   newColumnInfoList,
 } from './column_info';
@@ -291,6 +292,85 @@ describe('column_info utilities', () => {
 
       expect(original[0].checked).toBe(false);
       expect(result[0].checked).toBe(true);
+    });
+  });
+
+  describe('legacyDeserializeType', () => {
+    it('should return undefined for undefined input', () => {
+      expect(legacyDeserializeType(undefined)).toBeUndefined();
+    });
+
+    it('should pass through valid PerfettoSqlType objects', () => {
+      expect(legacyDeserializeType(intType)).toEqual(intType);
+      expect(legacyDeserializeType(stringType)).toEqual(stringType);
+      expect(legacyDeserializeType(timestampType)).toEqual(timestampType);
+    });
+
+    it('should pass through ID types', () => {
+      const idType: PerfettoSqlType = {
+        kind: 'id',
+        source: {table: 'thread', column: 'id'},
+      };
+      expect(legacyDeserializeType(idType)).toEqual(idType);
+    });
+
+    it('should pass through JOINID types', () => {
+      const joinidType: PerfettoSqlType = {
+        kind: 'joinid',
+        source: {table: 'thread', column: 'id'},
+      };
+      expect(legacyDeserializeType(joinidType)).toEqual(joinidType);
+    });
+
+    it('should convert legacy string types to PerfettoSqlType', () => {
+      expect(
+        legacyDeserializeType('INT' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'int'});
+      expect(
+        legacyDeserializeType('STRING' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'string'});
+      expect(
+        legacyDeserializeType('TIMESTAMP' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'timestamp'});
+      expect(
+        legacyDeserializeType('DURATION' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'duration'});
+      expect(
+        legacyDeserializeType('DOUBLE' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'double'});
+      expect(
+        legacyDeserializeType('BOOLEAN' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'boolean'});
+      expect(
+        legacyDeserializeType('BYTES' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'bytes'});
+      expect(
+        legacyDeserializeType('ARG_SET_ID' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'arg_set_id'});
+    });
+
+    it('should handle lowercase legacy string types', () => {
+      expect(
+        legacyDeserializeType('int' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'int'});
+      expect(
+        legacyDeserializeType('string' as unknown as PerfettoSqlType),
+      ).toEqual({kind: 'string'});
+    });
+
+    it('should return undefined for unrecognized legacy strings', () => {
+      expect(
+        legacyDeserializeType('UNKNOWN' as unknown as PerfettoSqlType),
+      ).toBeUndefined();
+      expect(
+        legacyDeserializeType('NA' as unknown as PerfettoSqlType),
+      ).toBeUndefined();
+    });
+
+    it('should return undefined for objects without kind', () => {
+      expect(
+        legacyDeserializeType({} as unknown as PerfettoSqlType),
+      ).toBeUndefined();
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
@@ -23,6 +23,7 @@ import {
   ColumnInfo,
   columnInfoFromName,
   columnInfoFromSqlColumn,
+  legacyDeserializeType,
 } from '../column_info';
 import {
   PerfettoSqlType,
@@ -1790,7 +1791,18 @@ export class AddColumnsNode implements QueryNode {
                   string,
                   PerfettoSqlType
                 >,
-              ),
+              )
+                .map(
+                  ([k, v]) =>
+                    [k, legacyDeserializeType(v)] as [
+                      string,
+                      PerfettoSqlType | undefined,
+                    ],
+                )
+                .filter(
+                  (entry): entry is [string, PerfettoSqlType] =>
+                    entry[1] !== undefined,
+                ),
             )
           : undefined,
     };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
@@ -22,7 +22,11 @@ import {
 } from '../../query_node';
 import {getSecondaryInput} from '../graph_utils';
 import protos from '../../../../protos';
-import {ColumnInfo, newColumnInfoList} from '../column_info';
+import {
+  ColumnInfo,
+  legacyDeserializeType,
+  newColumnInfoList,
+} from '../column_info';
 import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
@@ -556,14 +560,20 @@ export class JoinNode implements QueryNode {
         state.leftColumns?.map((c) => ({
           name: c.name,
           checked: c.checked,
-          column: {name: c.columnName ?? c.name, type: c.type}, // Use original column name
+          column: {
+            name: c.columnName ?? c.name,
+            type: legacyDeserializeType(c.type),
+          },
           alias: c.alias,
         })) ?? [],
       rightColumns:
         state.rightColumns?.map((c) => ({
           name: c.name,
           checked: c.checked,
-          column: {name: c.columnName ?? c.name, type: c.type}, // Use original column name
+          column: {
+            name: c.columnName ?? c.name,
+            type: legacyDeserializeType(c.type),
+          },
           alias: c.alias,
         })) ?? [],
     };

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {JoinNode} from './join_node';
+import {JoinNode, JoinSerializedState} from './join_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
+import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 
 describe('JoinNode', () => {
@@ -939,6 +940,70 @@ describe('JoinNode', () => {
       expect(state.conditionType).toBe('equality');
       expect(state.leftColumn).toBe('id');
       expect(state.rightColumn).toBe('id');
+    });
+
+    it('should deserialize legacy string types into PerfettoSqlType', () => {
+      const legacySerialized = {
+        leftNodeId: 'node1',
+        rightNodeId: 'node2',
+        leftQueryAlias: 'left',
+        rightQueryAlias: 'right',
+        conditionType: 'equality' as const,
+        leftColumn: 'id',
+        rightColumn: 'id',
+        leftColumns: [
+          {name: 'id', type: 'INT', checked: true, columnName: 'id'},
+          {name: 'ts', type: 'TIMESTAMP', checked: false, columnName: 'ts'},
+        ],
+        rightColumns: [
+          {name: 'val', type: 'DOUBLE', checked: true, columnName: 'val'},
+        ],
+      } as unknown as JoinSerializedState;
+
+      const state = JoinNode.deserializeState(legacySerialized);
+
+      expect(state.leftColumns?.[0].column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(state.leftColumns?.[1].column.type).toEqual(
+        PerfettoSqlTypes.TIMESTAMP,
+      );
+      expect(state.rightColumns?.[0].column.type).toEqual(
+        PerfettoSqlTypes.DOUBLE,
+      );
+    });
+
+    it('should deserialize new PerfettoSqlType objects correctly', () => {
+      const newSerialized: JoinSerializedState = {
+        leftNodeId: 'node1',
+        rightNodeId: 'node2',
+        leftQueryAlias: 'left',
+        rightQueryAlias: 'right',
+        conditionType: 'equality',
+        leftColumn: 'id',
+        rightColumn: 'id',
+        leftColumns: [
+          {
+            name: 'id',
+            type: {kind: 'int'},
+            checked: true,
+            columnName: 'id',
+          },
+        ],
+        rightColumns: [
+          {
+            name: 'dur',
+            type: {kind: 'duration'},
+            checked: true,
+            columnName: 'dur',
+          },
+        ],
+      };
+
+      const state = JoinNode.deserializeState(newSerialized);
+
+      expect(state.leftColumns?.[0].column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(state.rightColumns?.[0].column.type).toEqual(
+        PerfettoSqlTypes.DURATION,
+      );
     });
   });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
@@ -21,7 +21,11 @@ import {
 } from '../../query_node';
 import {Checkbox} from '../../../../widgets/checkbox';
 import {TextInput} from '../../../../widgets/text_input';
-import {ColumnInfo, newColumnInfoList} from '../column_info';
+import {
+  ColumnInfo,
+  legacyDeserializeType,
+  newColumnInfoList,
+} from '../column_info';
 import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 import {NodeIssues} from '../node_issues';
@@ -127,7 +131,7 @@ export class ModifyColumnsNode implements QueryNode {
       selectedColumns: serializedState.selectedColumns.map((c) => ({
         name: c.name,
         checked: c.checked,
-        column: {name: c.name, type: c.type},
+        column: {name: c.name, type: legacyDeserializeType(c.type)},
         alias: c.alias,
         typeUserModified: c.typeUserModified,
       })),

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ModifyColumnsNode, ModifyColumnsState} from './modify_columns_node';
+import {
+  ModifyColumnsNode,
+  ModifyColumnsSerializedState,
+  ModifyColumnsState,
+} from './modify_columns_node';
 import {QueryNode} from '../../query_node';
 import {
   createMockNode,
@@ -20,6 +24,7 @@ import {
   connectNodes,
 } from '../testing/test_utils';
 import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
+import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
 
 describe('ModifyColumnsNode', () => {
   function createMockPrevNode(): QueryNode {
@@ -169,6 +174,100 @@ describe('ModifyColumnsNode', () => {
 
       expect(serialized.selectedColumns[0].checked).toBe(true);
       expect(serialized.selectedColumns[1].checked).toBe(false);
+    });
+
+    it('should serialize column types as PerfettoSqlType objects', () => {
+      const col1 = createColumnInfo('id', 'int');
+      const col2 = createColumnInfo('ts', 'timestamp');
+      const node = createModifyColumnsNodeWithInput(
+        {selectedColumns: [col1, col2]},
+        createMockPrevNode(),
+      );
+
+      const serialized = node.serializeState();
+
+      expect(serialized.selectedColumns[0].type).toEqual({kind: 'int'});
+      expect(serialized.selectedColumns[1].type).toEqual({kind: 'timestamp'});
+    });
+  });
+
+  describe('legacy deserialization', () => {
+    const mockSqlModules = {
+      listTables: () => [],
+      listModules: () => [],
+    } as unknown as SqlModules;
+
+    it('should deserialize legacy string types into PerfettoSqlType', () => {
+      // Simulate old serialized state where type was a string like "INT"
+      const legacyState = {
+        selectedColumns: [
+          {name: 'id', type: 'INT', checked: true},
+          {name: 'name', type: 'STRING', checked: true},
+          {name: 'ts', type: 'TIMESTAMP', checked: false},
+        ],
+      } as unknown as ModifyColumnsSerializedState;
+
+      const state = ModifyColumnsNode.deserializeState(
+        mockSqlModules,
+        legacyState,
+      );
+
+      expect(state.selectedColumns[0].column.type).toEqual(
+        PerfettoSqlTypes.INT,
+      );
+      expect(state.selectedColumns[1].column.type).toEqual(
+        PerfettoSqlTypes.STRING,
+      );
+      expect(state.selectedColumns[2].column.type).toEqual(
+        PerfettoSqlTypes.TIMESTAMP,
+      );
+    });
+
+    it('should deserialize new PerfettoSqlType objects correctly', () => {
+      const newState: ModifyColumnsSerializedState = {
+        selectedColumns: [
+          {name: 'id', type: {kind: 'int'}, checked: true},
+          {name: 'dur', type: {kind: 'duration'}, checked: true},
+        ],
+      };
+
+      const state = ModifyColumnsNode.deserializeState(
+        mockSqlModules,
+        newState,
+      );
+
+      expect(state.selectedColumns[0].column.type).toEqual(
+        PerfettoSqlTypes.INT,
+      );
+      expect(state.selectedColumns[1].column.type).toEqual(
+        PerfettoSqlTypes.DURATION,
+      );
+    });
+
+    it('should handle undefined types gracefully', () => {
+      const stateWithNoTypes = {
+        selectedColumns: [{name: 'col1', checked: true}],
+      } as unknown as ModifyColumnsSerializedState;
+
+      const state = ModifyColumnsNode.deserializeState(
+        mockSqlModules,
+        stateWithNoTypes,
+      );
+
+      expect(state.selectedColumns[0].column.type).toBeUndefined();
+    });
+
+    it('should handle unrecognized legacy string types', () => {
+      const stateWithUnknown = {
+        selectedColumns: [{name: 'col1', type: 'NA', checked: true}],
+      } as unknown as ModifyColumnsSerializedState;
+
+      const state = ModifyColumnsNode.deserializeState(
+        mockSqlModules,
+        stateWithUnknown,
+      );
+
+      expect(state.selectedColumns[0].column.type).toBeUndefined();
     });
   });
 

--- a/ui/src/trace_processor/perfetto_sql_type.ts
+++ b/ui/src/trace_processor/perfetto_sql_type.ts
@@ -105,7 +105,10 @@ export class PerfettoSqlTypes {
   static readonly ARG_SET_ID: PerfettoSqlType = {kind: 'arg_set_id'};
 }
 
+// Maps PerfettoSQL type name strings to their canonical SimpleTypeKind.
+// Used by parsePerfettoSqlTypeFromString (input is lowercased before lookup).
 const SIMPLE_TYPES: Record<string, SimpleType['kind']> = {
+  // Canonical PerfettoSQL type names.
   long: 'int',
   int: 'int',
   bool: 'boolean',
@@ -116,6 +119,12 @@ const SIMPLE_TYPES: Record<string, SimpleType['kind']> = {
   timestamp: 'timestamp',
   duration: 'duration',
   argsetid: 'arg_set_id',
+
+  // Legacy aliases: the old serialized format stored types as
+  // SimpleTypeKind values (e.g. "boolean", "arg_set_id") which don't
+  // match the canonical PerfettoSQL names above.
+  boolean: 'boolean',
+  arg_set_id: 'arg_set_id',
 };
 
 // List of all simple PerfettoSQL type kinds (excluding ID types).


### PR DESCRIPTION
R 5098 changed column types from strings (e.g., "INT", "TIMESTAMP") to PerfettoSqlType objects (e.g., {kind: 'int'}). This change wasn't backwards compatible, so now add backwards compatibility and update the json files.