### PR TITLE
stdlib: Remove invalid check for android_input_events

### DIFF
--- a/python/perfetto/trace_data_checks.py
+++ b/python/perfetto/trace_data_checks.py
@@ -83,8 +83,6 @@ MODULE_DATA_CHECK_SQL = {
     # INTRINSIC-BASED TABLES - Android
     'android.cpu.cpu_per_uid':
         'SELECT 1 FROM __intrinsic_android_cpu_per_uid_track',
-    'android.input':
-        'SELECT 1 FROM __intrinsic_android_key_events',
     'android.kernel_wakelocks':
         'SELECT 1 FROM track WHERE name = \'android_kernel_wakelock\'',
     'android.network_packets':


### PR DESCRIPTION
This check wasn't actually checking the validiting of android.input module - remove it.