### PR TITLE
stdlib: Add core category for tables like 'slice' or 'counter'

### DIFF
--- a/python/generators/sql_processing/stdlib_tags.py
+++ b/python/generators/sql_processing/stdlib_tags.py
@@ -392,19 +392,23 @@ _validate_tags()
 # Table importance levels for documentation.
 # Importance levels help users discover the most relevant tables for their use case.
 # Levels:
+#   'core': Core tables - Fundamental built-in tables present in every trace
 #   'high': Very frequent - Most commonly used, fundamental tables for trace analysis
 #   'mid': Frequent - Important for specific use cases, moderately common
 #   'low': Specialized or advanced tables, less frequently needed
 #   None/absent: Normal importance (default)
 TABLE_IMPORTANCE = {
-    # HIGH IMPORTANCE - Core tables, fundamental for most analyses
+    # CORE - Fundamental built-in tables present in every trace
+    'slice': 'core',  # All slices (spans of time with a name)
+    'counter': 'core',  # Time-series metrics: memory, battery, custom counters
+    'thread': 'core',  # Thread metadata and information
+    'process': 'core',  # Process metadata and information
+    'track': 'core',  # Tracks for organizing slices and counters
+    'sched': 'core',  # Kernel scheduling events table
     'thread_state':
-        'high',  # CPU scheduling: what threads ran when and for how long
-    'sched': 'high',  # Kernel scheduling events table
-    'thread': 'high',  # Thread metadata and information
-    'process': 'high',  # Process metadata and information
-    'counter': 'high',  # Time-series metrics: memory, battery, custom counters
-    'track': 'high',  # Tracks for organizing slices and counters
+        'core',  # CPU scheduling: what threads ran when and for how long
+
+    # HIGH IMPORTANCE - Commonly used derived tables
     'thread_or_process_slice':
         'high',  # Unified slice table for thread and process slices
 
@@ -453,6 +457,6 @@ def get_table_importance(table_name: str) -> Optional[str]:
     table_name: Name of the table/view
 
   Returns:
-    The importance level ('high', 'mid', 'low') or None for normal importance
+    The importance level ('core', 'high', 'mid', 'low') or None for normal importance
   """
   return TABLE_IMPORTANCE.get(table_name)

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/help.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/help.scss
@@ -79,6 +79,10 @@
       font-weight: 500;
     }
 
+    .pf-importance-core {
+      background-color: var(--pf-color-primary);
+    }
+
     .pf-importance-high {
       background-color: var(--pf-color-success);
     }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/table_list.ts
@@ -52,8 +52,12 @@ type MatchType =
   | 'column-description';
 
 // Helper function to get the display label for importance levels.
-function getImportanceLabel(importance: 'high' | 'mid' | 'low'): string {
+function getImportanceLabel(
+  importance: 'core' | 'high' | 'mid' | 'low',
+): string {
   switch (importance) {
+    case 'core':
+      return 'Core';
     case 'high':
       return 'Very common';
     case 'mid':
@@ -452,13 +456,14 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
         matchType: MatchType;
       }>,
     ) => {
+      const core = results.filter((r) => r.item.table.importance === 'core');
       const high = results.filter((r) => r.item.table.importance === 'high');
       const mid = results.filter((r) => r.item.table.importance === 'mid');
       const normal = results.filter(
         (r) => r.item.table.importance === undefined,
       );
       const low = results.filter((r) => r.item.table.importance === 'low');
-      return [...high, ...mid, ...normal, ...low];
+      return [...core, ...high, ...mid, ...normal, ...low];
     };
 
     // Group by match type (already ordered by searchTables), then sort by importance within each group

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules.ts
@@ -91,7 +91,7 @@ export interface SqlTable {
   readonly includeKey?: string;
   readonly description: string;
   readonly type: string;
-  readonly importance?: 'high' | 'mid' | 'low';
+  readonly importance?: 'core' | 'high' | 'mid' | 'low';
   readonly columns: SqlColumn[];
 
   // Returns all columns as TableColumns.

--- a/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_impl.ts
+++ b/ui/src/plugins/dev.perfetto.SqlModules/sql_modules_impl.ts
@@ -367,7 +367,7 @@ class SqlTableImpl implements SqlTable {
   includeKey?: string;
   description: string;
   type: string;
-  importance?: 'high' | 'mid' | 'low';
+  importance?: 'core' | 'high' | 'mid' | 'low';
   columns: SqlColumn[];
   idColumn: SqlColumn | undefined;
 
@@ -441,7 +441,7 @@ const DATA_OBJECT_SCHEMA = z.object({
   desc: z.string(),
   summary_desc: z.string(),
   type: z.string(),
-  importance: z.enum(['high', 'mid', 'low']).nullish(),
+  importance: z.enum(['core', 'high', 'mid', 'low']).nullish(),
   cols: z.array(ARG_OR_COL_SCHEMA),
 });
 type DocsDataObjectSchemaType = z.infer<typeof DATA_OBJECT_SCHEMA>;


### PR DESCRIPTION
This category is reserved for tables that should be shown as important, but shouldn't really always be looked into. This will be useful for future work on the smart graph.