### PR TITLE
ui: InputEvents negative end_to_end_latency_dur bug

### DIFF
--- a/ui/src/plugins/com.android.InputEvents/index.ts
+++ b/ui/src/plugins/com.android.InputEvents/index.ts
@@ -61,7 +61,7 @@ export default class AndroidInputEvents implements PerfettoPlugin {
             end_to_end_latency_dur AS dur,
             CONCAT(event_type, ' ', event_action, ': ', process_name, ' (', input_event_id, ')') as name
           FROM android_input_events
-          WHERE end_to_end_latency_dur IS NOT NULL
+          WHERE end_to_end_latency_dur > 0
         `,
         schema: {
           ts: LONG,


### PR DESCRIPTION
This change fixes a bug with the InputEvents plugin: `WHERE end_to_end_latency_dur IS NOT NULL` doesn't filter out negative durations and the plugin crashes. We fix this by modifying the condition to `WHERE end_to_end_latency_dur > 0`.

