### PR TITLE
tp: implement subcommand-based CLI for trace_processor_shell

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16744,59 +16744,24 @@ filegroup {
     ],
 }
 
-// GN: //src/trace_processor/shell:interactive
+// GN: //src/trace_processor/shell:shell
 filegroup {
-    name: "perfetto_src_trace_processor_shell_interactive",
+    name: "perfetto_src_trace_processor_shell_shell",
     srcs: [
+        "src/trace_processor/shell/common_flags.cc",
+        "src/trace_processor/shell/export_subcommand.cc",
         "src/trace_processor/shell/interactive.cc",
-    ],
-}
-
-// GN: //src/trace_processor/shell:metatrace
-filegroup {
-    name: "perfetto_src_trace_processor_shell_metatrace",
-    srcs: [
         "src/trace_processor/shell/metatrace.cc",
-    ],
-}
-
-// GN: //src/trace_processor/shell:metrics
-filegroup {
-    name: "perfetto_src_trace_processor_shell_metrics",
-    srcs: [
         "src/trace_processor/shell/metrics.cc",
-    ],
-}
-
-// GN: //src/trace_processor/shell:query
-filegroup {
-    name: "perfetto_src_trace_processor_shell_query",
-    srcs: [
+        "src/trace_processor/shell/metrics_subcommand.cc",
         "src/trace_processor/shell/query.cc",
-    ],
-}
-
-// GN: //src/trace_processor/shell:shell_utils
-filegroup {
-    name: "perfetto_src_trace_processor_shell_shell_utils",
-    srcs: [
+        "src/trace_processor/shell/query_subcommand.cc",
+        "src/trace_processor/shell/repl_subcommand.cc",
+        "src/trace_processor/shell/serve_subcommand.cc",
         "src/trace_processor/shell/shell_utils.cc",
-    ],
-}
-
-// GN: //src/trace_processor/shell:sql_packages
-filegroup {
-    name: "perfetto_src_trace_processor_shell_sql_packages",
-    srcs: [
         "src/trace_processor/shell/sql_packages.cc",
-    ],
-}
-
-// GN: //src/trace_processor/shell:subcommand
-filegroup {
-    name: "perfetto_src_trace_processor_shell_subcommand",
-    srcs: [
         "src/trace_processor/shell/subcommand.cc",
+        "src/trace_processor/shell/summarize_subcommand.cc",
     ],
 }
 
@@ -17133,12 +17098,7 @@ cc_library_static {
         ":perfetto_src_trace_processor_rpc_httpd",
         ":perfetto_src_trace_processor_rpc_rpc",
         ":perfetto_src_trace_processor_rpc_stdiod",
-        ":perfetto_src_trace_processor_shell_interactive",
-        ":perfetto_src_trace_processor_shell_metatrace",
-        ":perfetto_src_trace_processor_shell_metrics",
-        ":perfetto_src_trace_processor_shell_query",
-        ":perfetto_src_trace_processor_shell_shell_utils",
-        ":perfetto_src_trace_processor_shell_sql_packages",
+        ":perfetto_src_trace_processor_shell_shell",
         ":perfetto_src_trace_processor_sorter_sorter",
         ":perfetto_src_trace_processor_sqlite_bindings_bindings",
         ":perfetto_src_trace_processor_sqlite_sqlite",
@@ -19237,6 +19197,7 @@ cc_test {
         ":perfetto_include_perfetto_ext_trace_processor_export_json",
         ":perfetto_include_perfetto_ext_trace_processor_importers_memory_tracker_memory_tracker",
         ":perfetto_include_perfetto_ext_trace_processor_rpc_query_result_serializer",
+        ":perfetto_include_perfetto_ext_trace_processor_trace_processor_shell",
         ":perfetto_include_perfetto_ext_traced_sys_stats_counters",
         ":perfetto_include_perfetto_ext_traced_traced",
         ":perfetto_include_perfetto_ext_tracing_core_core",
@@ -19580,9 +19541,11 @@ cc_test {
         ":perfetto_src_trace_processor_perfetto_sql_tokenizer_tokenize_internal",
         ":perfetto_src_trace_processor_perfetto_sql_tokenizer_tokenizer",
         ":perfetto_src_trace_processor_perfetto_sql_tokenizer_unittests",
+        ":perfetto_src_trace_processor_rpc_httpd",
         ":perfetto_src_trace_processor_rpc_rpc",
+        ":perfetto_src_trace_processor_rpc_stdiod",
         ":perfetto_src_trace_processor_rpc_unittests",
-        ":perfetto_src_trace_processor_shell_subcommand",
+        ":perfetto_src_trace_processor_shell_shell",
         ":perfetto_src_trace_processor_shell_unittests",
         ":perfetto_src_trace_processor_sorter_sorter",
         ":perfetto_src_trace_processor_sorter_unittests",

--- a/BUILD
+++ b/BUILD
@@ -642,12 +642,7 @@ perfetto_cc_library(
         ":src_trace_processor_rpc_httpd",
         ":src_trace_processor_rpc_rpc",
         ":src_trace_processor_rpc_stdiod",
-        ":src_trace_processor_shell_interactive",
-        ":src_trace_processor_shell_metatrace",
-        ":src_trace_processor_shell_metrics",
-        ":src_trace_processor_shell_query",
-        ":src_trace_processor_shell_shell_utils",
-        ":src_trace_processor_shell_sql_packages",
+        ":src_trace_processor_shell_shell",
         ":src_trace_processor_sorter_sorter",
         ":src_trace_processor_sqlite_bindings_bindings",
         ":src_trace_processor_sqlite_sqlite",
@@ -4088,57 +4083,38 @@ perfetto_filegroup(
     ],
 )
 
-# GN target: //src/trace_processor/shell:interactive
+# GN target: //src/trace_processor/shell:shell
 perfetto_filegroup(
-    name = "src_trace_processor_shell_interactive",
+    name = "src_trace_processor_shell_shell",
     srcs = [
+        "src/trace_processor/shell/common_flags.cc",
+        "src/trace_processor/shell/common_flags.h",
+        "src/trace_processor/shell/export_subcommand.cc",
+        "src/trace_processor/shell/export_subcommand.h",
         "src/trace_processor/shell/interactive.cc",
         "src/trace_processor/shell/interactive.h",
-    ],
-)
-
-# GN target: //src/trace_processor/shell:metatrace
-perfetto_filegroup(
-    name = "src_trace_processor_shell_metatrace",
-    srcs = [
         "src/trace_processor/shell/metatrace.cc",
         "src/trace_processor/shell/metatrace.h",
-    ],
-)
-
-# GN target: //src/trace_processor/shell:metrics
-perfetto_filegroup(
-    name = "src_trace_processor_shell_metrics",
-    srcs = [
         "src/trace_processor/shell/metrics.cc",
         "src/trace_processor/shell/metrics.h",
-    ],
-)
-
-# GN target: //src/trace_processor/shell:query
-perfetto_filegroup(
-    name = "src_trace_processor_shell_query",
-    srcs = [
+        "src/trace_processor/shell/metrics_subcommand.cc",
+        "src/trace_processor/shell/metrics_subcommand.h",
         "src/trace_processor/shell/query.cc",
         "src/trace_processor/shell/query.h",
-    ],
-)
-
-# GN target: //src/trace_processor/shell:shell_utils
-perfetto_filegroup(
-    name = "src_trace_processor_shell_shell_utils",
-    srcs = [
+        "src/trace_processor/shell/query_subcommand.cc",
+        "src/trace_processor/shell/query_subcommand.h",
+        "src/trace_processor/shell/repl_subcommand.cc",
+        "src/trace_processor/shell/repl_subcommand.h",
+        "src/trace_processor/shell/serve_subcommand.cc",
+        "src/trace_processor/shell/serve_subcommand.h",
         "src/trace_processor/shell/shell_utils.cc",
         "src/trace_processor/shell/shell_utils.h",
-    ],
-)
-
-# GN target: //src/trace_processor/shell:sql_packages
-perfetto_filegroup(
-    name = "src_trace_processor_shell_sql_packages",
-    srcs = [
         "src/trace_processor/shell/sql_packages.cc",
         "src/trace_processor/shell/sql_packages.h",
+        "src/trace_processor/shell/subcommand.cc",
+        "src/trace_processor/shell/subcommand.h",
+        "src/trace_processor/shell/summarize_subcommand.cc",
+        "src/trace_processor/shell/summarize_subcommand.h",
     ],
 )
 

--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -254,12 +254,7 @@ if (enable_perfetto_trace_processor_sqlite) {
       "perfetto_sql/generator",
       "rpc",
       "rpc:stdiod",
-      "shell:interactive",
-      "shell:metatrace",
-      "shell:metrics",
-      "shell:query",
-      "shell:shell_utils",
-      "shell:sql_packages",
+      "shell",
       "sqlite",
       "trace_summary",
       "util:stdlib",
@@ -267,9 +262,6 @@ if (enable_perfetto_trace_processor_sqlite) {
       "util/symbolizer",
       "util/symbolizer:symbolize_database",
     ]
-    if (enable_perfetto_trace_processor_linenoise) {
-      deps += [ "../../gn:linenoise" ]
-    }
     if (enable_perfetto_trace_processor_httpd) {
       deps += [ "rpc:httpd" ]
     }

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -14,94 +14,54 @@
 
 import("../../../gn/perfetto.gni")
 
-source_set("subcommand") {
+source_set("shell") {
   sources = [
-    "subcommand.cc",
-    "subcommand.h",
-  ]
-  deps = [ "../../../gn:default_deps" ]
-}
-
-source_set("interactive") {
-  sources = [
+    "common_flags.cc",
+    "common_flags.h",
+    "export_subcommand.cc",
+    "export_subcommand.h",
     "interactive.cc",
     "interactive.h",
+    "metatrace.cc",
+    "metatrace.h",
+    "metrics.cc",
+    "metrics.h",
+    "metrics_subcommand.cc",
+    "metrics_subcommand.h",
+    "query.cc",
+    "query.h",
+    "query_subcommand.cc",
+    "query_subcommand.h",
+    "repl_subcommand.cc",
+    "repl_subcommand.h",
+    "serve_subcommand.cc",
+    "serve_subcommand.h",
+    "shell_utils.cc",
+    "shell_utils.h",
+    "sql_packages.cc",
+    "sql_packages.h",
+    "subcommand.cc",
+    "subcommand.h",
+    "summarize_subcommand.cc",
+    "summarize_subcommand.h",
   ]
   deps = [
-    ":metrics",
-    ":query",
-    ":shell_utils",
     "../../../gn:default_deps",
+    "../../../gn:protobuf_full",
+    "../../../include/perfetto/ext/trace_processor:trace_processor_shell",
     "../../base",
+    "../metrics",
+    "../rpc",
+    "../rpc:stdiod",
+    "../trace_summary",
+    "../util:stdlib",
   ]
   if (enable_perfetto_trace_processor_linenoise) {
     deps += [ "../../../gn:linenoise" ]
   }
-  public_deps = [ "../../../include/perfetto/trace_processor:trace_processor" ]
-}
-
-source_set("metatrace") {
-  sources = [
-    "metatrace.cc",
-    "metatrace.h",
-  ]
-  deps = [
-    "../../../gn:default_deps",
-    "../../base",
-  ]
-  public_deps = [ "../../../include/perfetto/trace_processor:trace_processor" ]
-}
-
-source_set("metrics") {
-  sources = [
-    "metrics.cc",
-    "metrics.h",
-  ]
-  deps = [
-    "../../../gn:default_deps",
-    "../../base",
-    "../metrics",
-  ]
-  public_deps = [
-    "../../../gn:protobuf_full",
-    "../../../include/perfetto/trace_processor:trace_processor",
-  ]
-}
-
-source_set("sql_packages") {
-  sources = [
-    "sql_packages.cc",
-    "sql_packages.h",
-  ]
-  deps = [
-    "../../../gn:default_deps",
-    "../../base",
-    "../util:stdlib",
-  ]
-  public_deps = [ "../../../include/perfetto/trace_processor:trace_processor" ]
-}
-
-source_set("shell_utils") {
-  sources = [
-    "shell_utils.cc",
-    "shell_utils.h",
-  ]
-  deps = [
-    "../../../gn:default_deps",
-    "../../base",
-  ]
-  public_deps = [ "../../../include/perfetto/trace_processor:trace_processor" ]
-}
-
-source_set("query") {
-  sources = [
-    "query.cc",
-    "query.h",
-  ]
-  deps = [
-    "../../../gn:default_deps",
-    "../../base",
-  ]
+  if (enable_perfetto_trace_processor_httpd) {
+    deps += [ "../rpc:httpd" ]
+  }
   public_deps = [ "../../../include/perfetto/trace_processor:trace_processor" ]
 }
 
@@ -109,7 +69,7 @@ source_set("unittests") {
   testonly = true
   sources = [ "find_subcommand_unittest.cc" ]
   deps = [
-    ":subcommand",
+    ":shell",
     "../../../gn:default_deps",
     "../../../gn:gtest_and_gmock",
   ]

--- a/src/trace_processor/shell/common_flags.cc
+++ b/src/trace_processor/shell/common_flags.cc
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/common_flags.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/status_macros.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "perfetto/trace_processor/basic_types.h"
+#include "perfetto/trace_processor/metatrace_config.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/shell/metatrace.h"
+#include "src/trace_processor/shell/shell_utils.h"
+#include "src/trace_processor/shell/sql_packages.h"
+
+namespace perfetto::trace_processor::shell {
+
+bool HandleGlobalOption(int option, const char* optarg, GlobalOptions& opts) {
+  switch (option) {
+    case 'm':
+      opts.metatrace_path = optarg;
+      return true;
+    case OPT_GLOBAL_FULL_SORT:
+      opts.force_full_sort = true;
+      return true;
+    case OPT_GLOBAL_NO_FTRACE_RAW:
+      opts.no_ftrace_raw = true;
+      return true;
+    case OPT_GLOBAL_ANALYZE_TRACE_PROTO_CONTENT:
+      opts.analyze_trace_proto_content = true;
+      return true;
+    case OPT_GLOBAL_CROP_TRACK_EVENTS:
+      opts.crop_track_events = true;
+      return true;
+    case OPT_GLOBAL_DEV:
+      opts.dev = true;
+      return true;
+    case OPT_GLOBAL_DEV_FLAG:
+      opts.dev_flags.emplace_back(optarg);
+      return true;
+    case OPT_GLOBAL_EXTRA_CHECKS:
+      opts.extra_checks = true;
+      return true;
+    case OPT_GLOBAL_ADD_SQL_PACKAGE:
+      opts.sql_package_paths.emplace_back(optarg);
+      return true;
+    case OPT_GLOBAL_OVERRIDE_SQL_PACKAGE:
+      opts.override_sql_package_paths.emplace_back(optarg);
+      return true;
+    case OPT_GLOBAL_OVERRIDE_STDLIB:
+      opts.override_stdlib_path = optarg;
+      return true;
+    case OPT_GLOBAL_REGISTER_FILES_DIR:
+      opts.register_files_dir = optarg;
+      return true;
+    case OPT_GLOBAL_METATRACE_BUFFER_CAPACITY:
+      opts.metatrace_buffer_capacity = static_cast<size_t>(atoi(optarg));
+      return true;
+    case OPT_GLOBAL_METATRACE_CATEGORIES:
+      opts.metatrace_categories = ParseMetatraceCategories(optarg);
+      return true;
+    default:
+      return false;
+  }
+}
+
+Config BuildConfig(const GlobalOptions& opts,
+                   TraceProcessorShell_PlatformInterface* platform) {
+  Config config = platform->DefaultConfig();
+  config.sorting_mode = opts.force_full_sort ? SortingMode::kForceFullSort
+                                             : SortingMode::kDefaultHeuristics;
+  config.ingest_ftrace_in_raw_table = !opts.no_ftrace_raw;
+  config.analyze_trace_proto_content = opts.analyze_trace_proto_content;
+  config.drop_track_event_data_before =
+      opts.crop_track_events
+          ? DropTrackEventDataBefore::kTrackEventRangeOfInterest
+          : DropTrackEventDataBefore::kNoDrop;
+  if (opts.dev) {
+    config.enable_dev_features = true;
+    for (const auto& flag_pair : opts.dev_flags) {
+      auto kv = base::SplitString(flag_pair, "=");
+      if (kv.size() != 2) {
+        PERFETTO_ELOG("Ignoring unknown dev flag format %s", flag_pair.c_str());
+        continue;
+      }
+      config.dev_flags.emplace(kv[0], kv[1]);
+    }
+  }
+  if (opts.extra_checks) {
+    config.enable_extra_checks = true;
+  }
+  return config;
+}
+
+base::StatusOr<std::unique_ptr<TraceProcessor>> SetupTraceProcessor(
+    const GlobalOptions& opts,
+    const Config& config,
+    TraceProcessorShell_PlatformInterface* platform) {
+  auto tp = TraceProcessor::CreateInstance(config);
+  RETURN_IF_ERROR(platform->OnTraceProcessorCreated(tp.get()));
+
+  // SQL packages.
+  if (!opts.override_stdlib_path.empty()) {
+    if (!opts.dev) {
+      return base::ErrStatus("Overriding stdlib requires --dev flag");
+    }
+    RETURN_IF_ERROR(LoadOverridenStdlib(tp.get(), opts.override_stdlib_path));
+  }
+  for (const auto& path : opts.override_sql_package_paths) {
+    RETURN_IF_ERROR(IncludeSqlPackage(tp.get(), path, true));
+  }
+  for (const auto& path : opts.sql_package_paths) {
+    RETURN_IF_ERROR(IncludeSqlPackage(tp.get(), path, false));
+  }
+
+  // Metatrace.
+  if (!opts.metatrace_path.empty()) {
+    metatrace::MetatraceConfig metatrace_config;
+    metatrace_config.override_buffer_size = opts.metatrace_buffer_capacity;
+    metatrace_config.categories = opts.metatrace_categories;
+    tp->EnableMetatrace(metatrace_config);
+  }
+
+  // Register files.
+  if (!opts.register_files_dir.empty()) {
+    RETURN_IF_ERROR(RegisterAllFilesInFolder(opts.register_files_dir, *tp));
+  }
+
+  return std::move(tp);
+}
+
+base::StatusOr<base::TimeNanos> LoadTraceFile(
+    TraceProcessor* tp,
+    TraceProcessorShell_PlatformInterface* platform,
+    const std::string& trace_file) {
+  base::TimeNanos t_load_start = base::GetWallTimeNs();
+  double size_mb = 0;
+  base::Status status =
+      platform->LoadTrace(tp, trace_file, [&size_mb](size_t parsed_size) {
+        size_mb = static_cast<double>(parsed_size) / 1E6;
+        fprintf(stderr, "\rLoading trace: %.2f MB\r", size_mb);
+      });
+  if (!status.ok()) {
+    return base::ErrStatus("Could not read trace file (path: %s): %s",
+                           trace_file.c_str(), status.c_message());
+  }
+  RETURN_IF_ERROR(tp->NotifyEndOfFile());
+  base::TimeNanos t_load = base::GetWallTimeNs() - t_load_start;
+
+  double t_load_s = static_cast<double>(t_load.count()) / 1E9;
+  PERFETTO_ILOG("Trace loaded: %.2f MB in %.2fs (%.1f MB/s)", size_mb, t_load_s,
+                size_mb / t_load_s);
+
+  RETURN_IF_ERROR(PrintStats(tp));
+  return t_load;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/common_flags.h
+++ b/src/trace_processor/shell/common_flags.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_COMMON_FLAGS_H_
+#define SRC_TRACE_PROCESSOR_SHELL_COMMON_FLAGS_H_
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/trace_processor/metatrace_config.h"
+#include "perfetto/trace_processor/trace_processor.h"
+
+namespace perfetto::trace_processor {
+class TraceProcessorShell_PlatformInterface;
+}  // namespace perfetto::trace_processor
+
+namespace perfetto::trace_processor::shell {
+
+// Global options shared by all subcommands.
+struct GlobalOptions {
+  std::string trace_file;
+  bool force_full_sort = false;
+  bool no_ftrace_raw = false;
+  bool analyze_trace_proto_content = false;
+  bool crop_track_events = false;
+  bool dev = false;
+  std::vector<std::string> dev_flags;
+  bool extra_checks = false;
+  std::vector<std::string> sql_package_paths;
+  std::vector<std::string> override_sql_package_paths;
+  std::string override_stdlib_path;
+  std::string register_files_dir;
+  std::string metatrace_path;
+  size_t metatrace_buffer_capacity = 0;
+  metatrace::MetatraceCategories metatrace_categories =
+      static_cast<metatrace::MetatraceCategories>(
+          metatrace::MetatraceCategories::QUERY_TIMELINE |
+          metatrace::MetatraceCategories::API_TIMELINE);
+};
+
+// Long option IDs for global flags, starting at 1000 to avoid collisions
+// with subcommand-specific option IDs (which should start below 1000).
+enum GlobalLongOption {
+  OPT_GLOBAL_FULL_SORT = 1000,
+  OPT_GLOBAL_NO_FTRACE_RAW,
+  OPT_GLOBAL_ANALYZE_TRACE_PROTO_CONTENT,
+  OPT_GLOBAL_CROP_TRACK_EVENTS,
+  OPT_GLOBAL_DEV,
+  OPT_GLOBAL_DEV_FLAG,
+  OPT_GLOBAL_EXTRA_CHECKS,
+  OPT_GLOBAL_ADD_SQL_PACKAGE,
+  OPT_GLOBAL_OVERRIDE_SQL_PACKAGE,
+  OPT_GLOBAL_OVERRIDE_STDLIB,
+  OPT_GLOBAL_REGISTER_FILES_DIR,
+  OPT_GLOBAL_METATRACE_BUFFER_CAPACITY,
+  OPT_GLOBAL_METATRACE_CATEGORIES,
+};
+
+// getopt_long entries for global flags. Subcommands should append these
+// to their own option arrays. The 'm' short option is for --metatrace.
+// Note: does NOT include the terminating {nullptr,0,nullptr,0} sentinel.
+#define GLOBAL_LONG_OPTIONS                                              \
+  {"full-sort", no_argument, nullptr, OPT_GLOBAL_FULL_SORT},             \
+      {"no-ftrace-raw", no_argument, nullptr, OPT_GLOBAL_NO_FTRACE_RAW}, \
+      {"analyze-trace-proto-content", no_argument, nullptr,              \
+       OPT_GLOBAL_ANALYZE_TRACE_PROTO_CONTENT},                          \
+      {"crop-track-events", no_argument, nullptr,                        \
+       OPT_GLOBAL_CROP_TRACK_EVENTS},                                    \
+      {"dev", no_argument, nullptr, OPT_GLOBAL_DEV},                     \
+      {"dev-flag", required_argument, nullptr, OPT_GLOBAL_DEV_FLAG},     \
+      {"extra-checks", no_argument, nullptr, OPT_GLOBAL_EXTRA_CHECKS},   \
+      {"add-sql-package", required_argument, nullptr,                    \
+       OPT_GLOBAL_ADD_SQL_PACKAGE},                                      \
+      {"override-sql-package", required_argument, nullptr,               \
+       OPT_GLOBAL_OVERRIDE_SQL_PACKAGE},                                 \
+      {"override-stdlib", required_argument, nullptr,                    \
+       OPT_GLOBAL_OVERRIDE_STDLIB},                                      \
+      {"register-files-dir", required_argument, nullptr,                 \
+       OPT_GLOBAL_REGISTER_FILES_DIR},                                   \
+      {"metatrace", required_argument, nullptr, 'm'},                    \
+      {"metatrace-buffer-capacity", required_argument, nullptr,          \
+       OPT_GLOBAL_METATRACE_BUFFER_CAPACITY},                            \
+      {"metatrace-categories", required_argument, nullptr,               \
+       OPT_GLOBAL_METATRACE_CATEGORIES},
+
+// Attempts to handle |option| as a global flag, updating |opts|.
+// Returns true if handled, false if the option is not a global flag.
+bool HandleGlobalOption(int option, const char* optarg, GlobalOptions& opts);
+
+// Builds a TraceProcessor Config from global options.
+Config BuildConfig(const GlobalOptions& opts,
+                   TraceProcessorShell_PlatformInterface* platform);
+
+// Creates a TraceProcessor from the given Config, then applies SQL packages,
+// metatrace, and file registration from global options. The caller is free to
+// modify |config| between BuildConfig() and this call.
+base::StatusOr<std::unique_ptr<TraceProcessor>> SetupTraceProcessor(
+    const GlobalOptions& opts,
+    const Config& config,
+    TraceProcessorShell_PlatformInterface* platform);
+
+// Loads a trace file using the platform interface. Returns the load time.
+base::StatusOr<base::TimeNanos> LoadTraceFile(
+    TraceProcessor* tp,
+    TraceProcessorShell_PlatformInterface* platform,
+    const std::string& trace_file);
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_COMMON_FLAGS_H_

--- a/src/trace_processor/shell/export_subcommand.cc
+++ b/src/trace_processor/shell/export_subcommand.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/export_subcommand.h"
+
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/shell/common_flags.h"
+#include "src/trace_processor/shell/shell_utils.h"
+
+namespace perfetto::trace_processor::shell {
+
+const char* ExportSubcommand::name() const {
+  return "export";
+}
+
+const char* ExportSubcommand::description() const {
+  return "Export trace to a database file.";
+}
+
+void ExportSubcommand::PrintUsage(const char* argv0) {
+  PERFETTO_ELOG(R"(
+Export trace to a database file.
+
+Usage: %s export <format> -o FILE trace_file
+
+Formats: sqlite
+)",
+                argv0);
+}
+
+int ExportSubcommand::Run(const SubcommandContext& ctx, int argc, char** argv) {
+  GlobalOptions global;
+  std::string output_path;
+
+  static const option long_options[] = {
+      {"output", required_argument, nullptr, 'o'},
+      GLOBAL_LONG_OPTIONS{nullptr, 0, nullptr, 0}};
+
+  optind = 1;
+  for (;;) {
+    int option = getopt_long(argc, argv, "o:m:h", long_options, nullptr);
+    if (option == -1)
+      break;
+    if (HandleGlobalOption(option, optarg, global))
+      continue;
+    if (option == 'o') {
+      output_path = optarg;
+      continue;
+    }
+    PrintUsage(argv[0]);
+    return option == 'h' ? 0 : 1;
+  }
+
+  // First positional arg is the format.
+  if (optind >= argc) {
+    PERFETTO_ELOG("export: must specify format (sqlite)");
+    PrintUsage(argv[0]);
+    return 1;
+  }
+  const char* format = argv[optind++];
+
+  if (strcmp(format, "sqlite") != 0) {
+    PERFETTO_ELOG("export: unknown format '%s' (expected sqlite)", format);
+    return 1;
+  }
+
+  if (output_path.empty()) {
+    PERFETTO_ELOG("export: -o FILE is required");
+    return 1;
+  }
+
+  // Trace file is the last positional argument.
+  if (optind == argc - 1 && argv[optind]) {
+    global.trace_file = argv[optind];
+  } else {
+    PERFETTO_ELOG("export: trace file is required");
+    return 1;
+  }
+
+  auto config = BuildConfig(global, ctx.platform);
+  auto tp_or = SetupTraceProcessor(global, config, ctx.platform);
+  if (!tp_or.ok()) {
+    PERFETTO_ELOG("%s", tp_or.status().c_message());
+    return 1;
+  }
+  auto tp = std::move(*tp_or);
+
+  auto t_load_or = LoadTraceFile(tp.get(), ctx.platform, global.trace_file);
+  if (!t_load_or.ok()) {
+    PERFETTO_ELOG("%s", t_load_or.status().c_message());
+    return 1;
+  }
+
+  auto status = ExportTraceToDatabase(tp.get(), output_path);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+
+  return 0;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/export_subcommand.h
+++ b/src/trace_processor/shell/export_subcommand.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_EXPORT_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_EXPORT_SUBCOMMAND_H_
+
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+class ExportSubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  int Run(const SubcommandContext& ctx, int argc, char** argv) override;
+  void PrintUsage(const char* argv0) override;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_EXPORT_SUBCOMMAND_H_

--- a/src/trace_processor/shell/find_subcommand_unittest.cc
+++ b/src/trace_processor/shell/find_subcommand_unittest.cc
@@ -26,7 +26,7 @@ class FakeSubcommand : public Subcommand {
   explicit FakeSubcommand(const char* n) : name_(n) {}
   const char* name() const override { return name_; }
   const char* description() const override { return ""; }
-  int Run(int, char**) override { return 0; }
+  int Run(const SubcommandContext&, int, char**) override { return 0; }
   void PrintUsage(const char*) override {}
 
  private:

--- a/src/trace_processor/shell/metrics_subcommand.cc
+++ b/src/trace_processor/shell/metrics_subcommand.cc
@@ -1,0 +1,234 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/metrics_subcommand.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/shell/common_flags.h"
+#include "src/trace_processor/shell/interactive.h"
+#include "src/trace_processor/shell/metatrace.h"
+#include "src/trace_processor/shell/metrics.h"
+#include "src/trace_processor/shell/query.h"
+
+#include <google/protobuf/descriptor.h>
+
+namespace perfetto::trace_processor::shell {
+
+const char* MetricsSubcommand::name() const {
+  return "metrics";
+}
+
+const char* MetricsSubcommand::description() const {
+  return "Run v1 metrics (deprecated).";
+}
+
+void MetricsSubcommand::PrintUsage(const char* argv0) {
+  PERFETTO_ELOG(R"(
+Run v1 metrics (deprecated).
+
+Usage: %s metrics [flags] trace_file
+
+Flags:
+  --run NAMES            Comma-separated metric names.
+  --pre FILE             SQL file before metrics.
+  --output [binary|text|json]
+  --extension DISK@VIRTUAL
+  --post-query FILE      SQL file after metrics.
+)",
+                argv0);
+}
+
+int MetricsSubcommand::Run(const SubcommandContext& ctx,
+                           int argc,
+                           char** argv) {
+  GlobalOptions global;
+  std::string metric_names;
+  std::string pre_path;
+  std::string metric_output;
+  std::vector<std::string> raw_extensions;
+  std::string post_query_path;
+  bool interactive = false;
+
+  enum LocalOption {
+    OPT_RUN = 500,
+    OPT_PRE,
+    OPT_OUTPUT,
+    OPT_EXTENSION,
+    OPT_POST_QUERY,
+  };
+
+  static const option long_options[] = {
+      {"run", required_argument, nullptr, OPT_RUN},
+      {"pre", required_argument, nullptr, OPT_PRE},
+      {"output", required_argument, nullptr, OPT_OUTPUT},
+      {"extension", required_argument, nullptr, OPT_EXTENSION},
+      {"post-query", required_argument, nullptr, OPT_POST_QUERY},
+      {"interactive", no_argument, nullptr, 'i'},
+      GLOBAL_LONG_OPTIONS{nullptr, 0, nullptr, 0}};
+
+  optind = 1;
+  for (;;) {
+    int option = getopt_long(argc, argv, "im:h", long_options, nullptr);
+    if (option == -1)
+      break;
+    if (HandleGlobalOption(option, optarg, global))
+      continue;
+    if (option == OPT_RUN) {
+      metric_names = optarg;
+      continue;
+    }
+    if (option == OPT_PRE) {
+      pre_path = optarg;
+      continue;
+    }
+    if (option == OPT_OUTPUT) {
+      metric_output = optarg;
+      continue;
+    }
+    if (option == OPT_EXTENSION) {
+      raw_extensions.emplace_back(optarg);
+      continue;
+    }
+    if (option == OPT_POST_QUERY) {
+      post_query_path = optarg;
+      continue;
+    }
+    if (option == 'i') {
+      interactive = true;
+      continue;
+    }
+    PrintUsage(argv[0]);
+    return option == 'h' ? 0 : 1;
+  }
+
+  if (metric_names.empty()) {
+    PERFETTO_ELOG("metrics: --run is required");
+    PrintUsage(argv[0]);
+    return 1;
+  }
+
+  if (optind == argc - 1 && argv[optind]) {
+    global.trace_file = argv[optind];
+  } else {
+    PERFETTO_ELOG("metrics: trace file is required");
+    return 1;
+  }
+
+  // Parse metric extensions.
+  std::vector<MetricExtension> metric_extensions;
+  auto ext_status =
+      ParseMetricExtensionPaths(global.dev, raw_extensions, metric_extensions);
+  if (!ext_status.ok()) {
+    PERFETTO_ELOG("%s", ext_status.c_message());
+    return 1;
+  }
+
+  auto config = BuildConfig(global, ctx.platform);
+  auto tp_or = SetupTraceProcessor(global, config, ctx.platform);
+  if (!tp_or.ok()) {
+    PERFETTO_ELOG("%s", tp_or.status().c_message());
+    return 1;
+  }
+  auto tp = std::move(*tp_or);
+
+  // Descriptor pool for metric output.
+  google::protobuf::DescriptorPool pool(
+      google::protobuf::DescriptorPool::generated_pool());
+  auto status = PopulateDescriptorPool(pool, metric_extensions);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+  for (const auto& extension : metric_extensions) {
+    status = LoadMetricExtension(tp.get(), extension, pool);
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  auto t_load_or = LoadTraceFile(tp.get(), ctx.platform, global.trace_file);
+  if (!t_load_or.ok()) {
+    PERFETTO_ELOG("%s", t_load_or.status().c_message());
+    return 1;
+  }
+
+  // Pre-metrics query.
+  if (!pre_path.empty()) {
+    status = RunQueriesFromFile(tp.get(), pre_path, false);
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  // Load and run metrics.
+  std::vector<MetricNameAndPath> metrics;
+  status = LoadMetrics(tp.get(), metric_names, pool, metrics);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+
+  MetricV1OutputFormat format = MetricV1OutputFormat::kTextProto;
+  if (metric_output == "binary") {
+    format = MetricV1OutputFormat::kBinaryProto;
+  } else if (metric_output == "json") {
+    format = MetricV1OutputFormat::kJson;
+  }
+
+  status = RunMetrics(tp.get(), metrics, format);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+
+  // Post-query.
+  if (!post_query_path.empty()) {
+    status = RunQueriesFromFile(tp.get(), post_query_path, true);
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  if (interactive) {
+    status = StartInteractiveShell(
+        tp.get(),
+        InteractiveOptions{20u, format, metric_extensions, metrics, &pool});
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  status = MaybeWriteMetatrace(tp.get(), global.metatrace_path);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+  return 0;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/metrics_subcommand.h
+++ b/src/trace_processor/shell/metrics_subcommand.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_METRICS_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_METRICS_SUBCOMMAND_H_
+
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+class MetricsSubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  int Run(const SubcommandContext& ctx, int argc, char** argv) override;
+  void PrintUsage(const char* argv0) override;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_METRICS_SUBCOMMAND_H_

--- a/src/trace_processor/shell/query_subcommand.cc
+++ b/src/trace_processor/shell/query_subcommand.cc
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/query_subcommand.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/base/time.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/shell/common_flags.h"
+#include "src/trace_processor/shell/interactive.h"
+#include "src/trace_processor/shell/metatrace.h"
+#include "src/trace_processor/shell/query.h"
+
+namespace perfetto::trace_processor::shell {
+
+const char* QuerySubcommand::name() const {
+  return "query";
+}
+
+const char* QuerySubcommand::description() const {
+  return "Run SQL queries against a trace.";
+}
+
+void QuerySubcommand::PrintUsage(const char* argv0) {
+  PERFETTO_ELOG(R"(
+Run SQL queries against a trace.
+
+Usage: %s query [flags] trace_file
+
+Flags:
+  -f, --file FILE        Read and execute SQL from a file.
+  -c, --sql STRING       Execute the given SQL string.
+  -i, --interactive      Drop into REPL after query.
+  -W, --wide             Double column width for output.
+  -p, --perf-file FILE   Write timing data to FILE.
+)",
+                argv0);
+}
+
+int QuerySubcommand::Run(const SubcommandContext& ctx, int argc, char** argv) {
+  GlobalOptions global;
+  std::string query_file;
+  std::string query_string;
+  bool interactive = false;
+  bool wide = false;
+  std::string perf_file;
+
+  static const option long_options[] = {
+      {"file", required_argument, nullptr, 'f'},
+      {"sql", required_argument, nullptr, 'c'},
+      {"interactive", no_argument, nullptr, 'i'},
+      {"wide", no_argument, nullptr, 'W'},
+      {"perf-file", required_argument, nullptr, 'p'},
+      GLOBAL_LONG_OPTIONS{nullptr, 0, nullptr, 0}};
+
+  optind = 1;
+  for (;;) {
+    int option = getopt_long(argc, argv, "f:c:iWp:m:h", long_options, nullptr);
+    if (option == -1)
+      break;
+    if (HandleGlobalOption(option, optarg, global))
+      continue;
+
+    if (option == 'f') {
+      query_file = optarg;
+      continue;
+    }
+    if (option == 'c') {
+      query_string = optarg;
+      continue;
+    }
+    if (option == 'i') {
+      interactive = true;
+      continue;
+    }
+    if (option == 'W') {
+      wide = true;
+      continue;
+    }
+    if (option == 'p') {
+      perf_file = optarg;
+      continue;
+    }
+
+    PrintUsage(argv[0]);
+    return option == 'h' ? 0 : 1;
+  }
+
+  if (query_file.empty() && query_string.empty()) {
+    PERFETTO_ELOG("query: must specify -f FILE or -c STRING");
+    PrintUsage(argv[0]);
+    return 1;
+  }
+  if (!perf_file.empty() && interactive) {
+    PERFETTO_ELOG("query: -p and -i are mutually exclusive");
+    return 1;
+  }
+  if (optind == argc - 1 && argv[optind]) {
+    global.trace_file = argv[optind];
+  } else {
+    PERFETTO_ELOG("query: trace file is required");
+    return 1;
+  }
+
+  auto config = BuildConfig(global, ctx.platform);
+  auto tp_or = SetupTraceProcessor(global, config, ctx.platform);
+  if (!tp_or.ok()) {
+    PERFETTO_ELOG("%s", tp_or.status().c_message());
+    return 1;
+  }
+  auto tp = std::move(*tp_or);
+
+  auto t_load_or = LoadTraceFile(tp.get(), ctx.platform, global.trace_file);
+  if (!t_load_or.ok()) {
+    PERFETTO_ELOG("%s", t_load_or.status().c_message());
+    return 1;
+  }
+  base::TimeNanos t_load = *t_load_or;
+
+  base::TimeNanos t_query_start = base::GetWallTimeNs();
+
+  if (!query_file.empty()) {
+    auto status = RunQueriesFromFile(tp.get(), query_file, true);
+    if (!status.ok()) {
+      MaybeWriteMetatrace(tp.get(), global.metatrace_path);
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+  if (!query_string.empty()) {
+    auto status = RunQueries(tp.get(), query_string, true);
+    if (!status.ok()) {
+      MaybeWriteMetatrace(tp.get(), global.metatrace_path);
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  base::TimeNanos t_query = base::GetWallTimeNs() - t_query_start;
+
+  if (interactive) {
+    auto status = StartInteractiveShell(
+        tp.get(),
+        InteractiveOptions{
+            wide ? 40u : 20u, MetricV1OutputFormat::kNone, {}, {}, nullptr});
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  } else if (!perf_file.empty()) {
+    auto status = PrintPerfFile(perf_file, t_load, t_query);
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  auto status = MaybeWriteMetatrace(tp.get(), global.metatrace_path);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+
+  return 0;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/query_subcommand.h
+++ b/src/trace_processor/shell/query_subcommand.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_QUERY_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_QUERY_SUBCOMMAND_H_
+
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+class QuerySubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  int Run(const SubcommandContext& ctx, int argc, char** argv) override;
+  void PrintUsage(const char* argv0) override;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_QUERY_SUBCOMMAND_H_

--- a/src/trace_processor/shell/repl_subcommand.cc
+++ b/src/trace_processor/shell/repl_subcommand.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/repl_subcommand.h"
+
+#include <memory>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/shell/common_flags.h"
+#include "src/trace_processor/shell/interactive.h"
+#include "src/trace_processor/shell/metatrace.h"
+
+namespace perfetto::trace_processor::shell {
+
+const char* ReplSubcommand::name() const {
+  return "repl";
+}
+
+const char* ReplSubcommand::description() const {
+  return "Interactive SQL shell.";
+}
+
+void ReplSubcommand::PrintUsage(const char* argv0) {
+  PERFETTO_ELOG(R"(
+Interactive SQL shell.
+
+Usage: %s repl [flags] trace_file
+
+Flags:
+  -W, --wide             Double column width for output.
+)",
+                argv0);
+}
+
+int ReplSubcommand::Run(const SubcommandContext& ctx, int argc, char** argv) {
+  GlobalOptions global;
+  bool wide = false;
+
+  static const option long_options[] = {
+      {"wide", no_argument, nullptr, 'W'},
+      GLOBAL_LONG_OPTIONS{nullptr, 0, nullptr, 0}};
+
+  optind = 1;
+  for (;;) {
+    int option = getopt_long(argc, argv, "Wm:h", long_options, nullptr);
+    if (option == -1)
+      break;
+    if (HandleGlobalOption(option, optarg, global))
+      continue;
+    if (option == 'W') {
+      wide = true;
+      continue;
+    }
+    PrintUsage(argv[0]);
+    return option == 'h' ? 0 : 1;
+  }
+
+  if (optind == argc - 1 && argv[optind]) {
+    global.trace_file = argv[optind];
+  } else {
+    PERFETTO_ELOG("repl: trace file is required");
+    return 1;
+  }
+
+  auto config = BuildConfig(global, ctx.platform);
+  auto tp_or = SetupTraceProcessor(global, config, ctx.platform);
+  if (!tp_or.ok()) {
+    PERFETTO_ELOG("%s", tp_or.status().c_message());
+    return 1;
+  }
+  auto tp = std::move(*tp_or);
+
+  auto t_load_or = LoadTraceFile(tp.get(), ctx.platform, global.trace_file);
+  if (!t_load_or.ok()) {
+    PERFETTO_ELOG("%s", t_load_or.status().c_message());
+    return 1;
+  }
+
+  auto status = StartInteractiveShell(
+      tp.get(),
+      InteractiveOptions{
+          wide ? 40u : 20u, MetricV1OutputFormat::kNone, {}, {}, nullptr});
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+
+  status = MaybeWriteMetatrace(tp.get(), global.metatrace_path);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+  return 0;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/repl_subcommand.h
+++ b/src/trace_processor/shell/repl_subcommand.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_REPL_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_REPL_SUBCOMMAND_H_
+
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+class ReplSubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  int Run(const SubcommandContext& ctx, int argc, char** argv) override;
+  void PrintUsage(const char* argv0) override;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_REPL_SUBCOMMAND_H_

--- a/src/trace_processor/shell/serve_subcommand.cc
+++ b/src/trace_processor/shell/serve_subcommand.cc
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/serve_subcommand.h"
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/build_config.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/rpc/rpc.h"
+#include "src/trace_processor/rpc/stdiod.h"
+#include "src/trace_processor/shell/common_flags.h"
+
+#if PERFETTO_BUILDFLAG(PERFETTO_TP_HTTPD)
+#include "src/trace_processor/rpc/httpd.h"
+#endif
+
+namespace perfetto::trace_processor::shell {
+
+const char* ServeSubcommand::name() const {
+  return "serve";
+}
+
+const char* ServeSubcommand::description() const {
+  return "Start an RPC server.";
+}
+
+void ServeSubcommand::PrintUsage(const char* argv0) {
+  PERFETTO_ELOG(R"(
+Start an RPC server.
+
+Usage: %s serve <mode> [flags] [trace_file]
+
+Modes: http, stdio
+
+Flags (http mode only):
+  --port PORT            HTTP port.
+  --ip-address IP        HTTP bind address.
+  --additional-cors-origins O1,O2,...
+)",
+                argv0);
+}
+
+int ServeSubcommand::Run(const SubcommandContext& ctx, int argc, char** argv) {
+  GlobalOptions global;
+  std::string port_number;
+  std::string listen_ip;
+  std::vector<std::string> additional_cors_origins;
+
+  enum LocalOption {
+    OPT_PORT = 500,
+    OPT_IP_ADDRESS,
+    OPT_ADDITIONAL_CORS_ORIGINS,
+  };
+
+  static const option long_options[] = {
+      {"port", required_argument, nullptr, OPT_PORT},
+      {"ip-address", required_argument, nullptr, OPT_IP_ADDRESS},
+      {"additional-cors-origins", required_argument, nullptr,
+       OPT_ADDITIONAL_CORS_ORIGINS},
+      GLOBAL_LONG_OPTIONS{nullptr, 0, nullptr, 0}};
+
+  optind = 1;
+  for (;;) {
+    int option = getopt_long(argc, argv, "m:h", long_options, nullptr);
+    if (option == -1)
+      break;
+    if (HandleGlobalOption(option, optarg, global))
+      continue;
+    if (option == OPT_PORT) {
+      port_number = optarg;
+      continue;
+    }
+    if (option == OPT_IP_ADDRESS) {
+      listen_ip = optarg;
+      continue;
+    }
+    if (option == OPT_ADDITIONAL_CORS_ORIGINS) {
+      additional_cors_origins = base::SplitString(optarg, ",");
+      continue;
+    }
+    PrintUsage(argv[0]);
+    return option == 'h' ? 0 : 1;
+  }
+
+  // First positional arg is the mode.
+  if (optind >= argc) {
+    PERFETTO_ELOG("serve: must specify mode (http or stdio)");
+    PrintUsage(argv[0]);
+    return 1;
+  }
+  const char* mode = argv[optind++];
+
+  // Optional trace file.
+  if (optind < argc) {
+    global.trace_file = argv[optind];
+  }
+
+  auto config = BuildConfig(global, ctx.platform);
+  auto tp_or = SetupTraceProcessor(global, config, ctx.platform);
+  if (!tp_or.ok()) {
+    PERFETTO_ELOG("%s", tp_or.status().c_message());
+    return 1;
+  }
+  auto tp = std::move(*tp_or);
+
+  if (!global.trace_file.empty()) {
+    auto t_load_or = LoadTraceFile(tp.get(), ctx.platform, global.trace_file);
+    if (!t_load_or.ok()) {
+      PERFETTO_ELOG("%s", t_load_or.status().c_message());
+      return 1;
+    }
+  }
+
+  bool has_trace = !global.trace_file.empty();
+
+  if (strcmp(mode, "stdio") == 0) {
+    Rpc rpc(std::move(tp), has_trace, config, [&ctx](TraceProcessor* new_tp) {
+      ctx.platform->OnTraceProcessorCreated(new_tp);
+    });
+    auto status = RunStdioRpcServer(rpc);
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+    return 0;
+  }
+
+  if (strcmp(mode, "http") == 0) {
+#if PERFETTO_BUILDFLAG(PERFETTO_TP_HTTPD)
+    Rpc rpc(std::move(tp), has_trace, config, [&ctx](TraceProcessor* new_tp) {
+      ctx.platform->OnTraceProcessorCreated(new_tp);
+    });
+    RunHttpRPCServer(rpc, listen_ip, port_number, additional_cors_origins);
+    PERFETTO_FATAL("Should never return");
+#else
+    PERFETTO_ELOG("HTTP RPC module not supported in this build");
+    return 1;
+#endif
+  }
+
+  PERFETTO_ELOG("serve: unknown mode '%s' (expected http or stdio)", mode);
+  PrintUsage(argv[0]);
+  return 1;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/serve_subcommand.h
+++ b/src/trace_processor/shell/serve_subcommand.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_SERVE_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_SERVE_SUBCOMMAND_H_
+
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+class ServeSubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  int Run(const SubcommandContext& ctx, int argc, char** argv) override;
+  void PrintUsage(const char* argv0) override;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_SERVE_SUBCOMMAND_H_

--- a/src/trace_processor/shell/subcommand.h
+++ b/src/trace_processor/shell/subcommand.h
@@ -20,7 +20,16 @@
 #include <string>
 #include <vector>
 
+namespace perfetto::trace_processor {
+class TraceProcessorShell_PlatformInterface;
+}  // namespace perfetto::trace_processor
+
 namespace perfetto::trace_processor::shell {
+
+// Context passed to subcommands, providing access to shared resources.
+struct SubcommandContext {
+  TraceProcessorShell_PlatformInterface* platform = nullptr;
+};
 
 // Base class for all subcommands (query, export, serve, etc.).
 class Subcommand {
@@ -34,10 +43,11 @@ class Subcommand {
   // A short one-line description shown in help output.
   virtual const char* description() const = 0;
 
-  // Runs the subcommand. |argc| and |argv| point to the subcommand's own
-  // argument vector (i.e. argv[0] is the subcommand name).
+  // Runs the subcommand. |ctx| provides access to shared resources like the
+  // platform interface. |argc| and |argv| are the original command line with
+  // the subcommand name removed (argv[0] is the program name).
   // Returns 0 on success, non-zero on failure.
-  virtual int Run(int argc, char** argv) = 0;
+  virtual int Run(const SubcommandContext& ctx, int argc, char** argv) = 0;
 
   // Prints subcommand-specific usage to stderr.
   virtual void PrintUsage(const char* argv0) = 0;

--- a/src/trace_processor/shell/summarize_subcommand.cc
+++ b/src/trace_processor/shell/summarize_subcommand.cc
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/summarize_subcommand.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "perfetto/base/logging.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/getopt.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "perfetto/trace_processor/trace_processor.h"
+#include "src/trace_processor/shell/common_flags.h"
+#include "src/trace_processor/shell/interactive.h"
+#include "src/trace_processor/shell/metatrace.h"
+#include "src/trace_processor/shell/query.h"
+#include "src/trace_processor/trace_summary/summary.h"
+
+namespace perfetto::trace_processor::shell {
+
+const char* SummarizeSubcommand::name() const {
+  return "summarize";
+}
+
+const char* SummarizeSubcommand::description() const {
+  return "Run trace summarization.";
+}
+
+void SummarizeSubcommand::PrintUsage(const char* argv0) {
+  PERFETTO_ELOG(R"(
+Run trace summarization.
+
+Usage: %s summarize [flags] trace_file
+
+Flags:
+  --spec PATH            TraceSummarySpec proto path.
+  --metrics-v2 IDS       Metric IDs, or "all".
+  --metadata-query ID    Metadata query ID.
+  --format [text|binary] Output format.
+  --post-query FILE      SQL file to run after summarization.
+)",
+                argv0);
+}
+
+int SummarizeSubcommand::Run(const SubcommandContext& ctx,
+                             int argc,
+                             char** argv) {
+  GlobalOptions global;
+  std::string metrics_v2;
+  std::string metadata_query;
+  std::vector<std::string> spec_paths;
+  std::string output_format;
+  std::string post_query_path;
+  bool interactive = false;
+
+  enum LocalOption {
+    OPT_SPEC = 500,
+    OPT_METRICS_V2,
+    OPT_METADATA_QUERY,
+    OPT_FORMAT,
+    OPT_POST_QUERY,
+  };
+
+  static const option long_options[] = {
+      {"spec", required_argument, nullptr, OPT_SPEC},
+      {"metrics-v2", required_argument, nullptr, OPT_METRICS_V2},
+      {"metadata-query", required_argument, nullptr, OPT_METADATA_QUERY},
+      {"format", required_argument, nullptr, OPT_FORMAT},
+      {"post-query", required_argument, nullptr, OPT_POST_QUERY},
+      {"interactive", no_argument, nullptr, 'i'},
+      GLOBAL_LONG_OPTIONS{nullptr, 0, nullptr, 0}};
+
+  optind = 1;
+  for (;;) {
+    int option = getopt_long(argc, argv, "im:h", long_options, nullptr);
+    if (option == -1)
+      break;
+    if (HandleGlobalOption(option, optarg, global))
+      continue;
+    if (option == OPT_SPEC) {
+      spec_paths.emplace_back(optarg);
+      continue;
+    }
+    if (option == OPT_METRICS_V2) {
+      metrics_v2 = optarg;
+      continue;
+    }
+    if (option == OPT_METADATA_QUERY) {
+      metadata_query = optarg;
+      continue;
+    }
+    if (option == OPT_FORMAT) {
+      output_format = optarg;
+      continue;
+    }
+    if (option == OPT_POST_QUERY) {
+      post_query_path = optarg;
+      continue;
+    }
+    if (option == 'i') {
+      interactive = true;
+      continue;
+    }
+    PrintUsage(argv[0]);
+    return option == 'h' ? 0 : 1;
+  }
+
+  if (optind == argc - 1 && argv[optind]) {
+    global.trace_file = argv[optind];
+  } else {
+    PERFETTO_ELOG("summarize: trace file is required");
+    return 1;
+  }
+
+  auto config = BuildConfig(global, ctx.platform);
+  auto tp_or = SetupTraceProcessor(global, config, ctx.platform);
+  if (!tp_or.ok()) {
+    PERFETTO_ELOG("%s", tp_or.status().c_message());
+    return 1;
+  }
+  auto tp = std::move(*tp_or);
+
+  auto t_load_or = LoadTraceFile(tp.get(), ctx.platform, global.trace_file);
+  if (!t_load_or.ok()) {
+    PERFETTO_ELOG("%s", t_load_or.status().c_message());
+    return 1;
+  }
+
+  // Load spec files.
+  std::vector<std::string> spec_content;
+  spec_content.reserve(spec_paths.size());
+  for (const auto& s : spec_paths) {
+    spec_content.emplace_back();
+    if (!base::ReadFile(s, &spec_content.back())) {
+      PERFETTO_ELOG("Unable to read summary spec file %s", s.c_str());
+      return 1;
+    }
+  }
+
+  std::vector<TraceSummarySpecBytes> specs;
+  specs.reserve(spec_paths.size());
+  for (uint32_t i = 0; i < spec_paths.size(); ++i) {
+    auto format = TraceSummarySpecBytes::Format::kTextProto;
+    if (base::EndsWith(spec_paths[i], ".pb")) {
+      format = TraceSummarySpecBytes::Format::kBinaryProto;
+    }
+    specs.emplace_back(TraceSummarySpecBytes{
+        reinterpret_cast<const uint8_t*>(spec_content[i].data()),
+        spec_content[i].size(),
+        format,
+    });
+  }
+
+  TraceSummaryComputationSpec computation_config;
+  if (metrics_v2.empty()) {
+    computation_config.v2_metric_ids = std::vector<std::string>();
+  } else if (base::CaseInsensitiveEqual(metrics_v2, "all")) {
+    computation_config.v2_metric_ids = std::nullopt;
+  } else {
+    computation_config.v2_metric_ids = base::SplitString(metrics_v2, ",");
+  }
+  computation_config.metadata_query_id =
+      metadata_query.empty() ? std::nullopt
+                             : std::make_optional(metadata_query);
+
+  TraceSummaryOutputSpec output_spec;
+  if (output_format == "binary") {
+    output_spec.format = TraceSummaryOutputSpec::Format::kBinaryProto;
+  } else {
+    output_spec.format = TraceSummaryOutputSpec::Format::kTextProto;
+  }
+
+  std::vector<uint8_t> output;
+  auto status = tp->Summarize(computation_config, specs, &output, output_spec);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+
+  if (post_query_path.empty()) {
+    fwrite(output.data(), sizeof(char), output.size(), stdout);
+  }
+
+  if (!post_query_path.empty()) {
+    status = RunQueriesFromFile(tp.get(), post_query_path, true);
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  if (interactive) {
+    status = StartInteractiveShell(
+        tp.get(),
+        InteractiveOptions{20u, MetricV1OutputFormat::kNone, {}, {}, nullptr});
+    if (!status.ok()) {
+      PERFETTO_ELOG("%s", status.c_message());
+      return 1;
+    }
+  }
+
+  status = MaybeWriteMetatrace(tp.get(), global.metatrace_path);
+  if (!status.ok()) {
+    PERFETTO_ELOG("%s", status.c_message());
+    return 1;
+  }
+  return 0;
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/summarize_subcommand.h
+++ b/src/trace_processor/shell/summarize_subcommand.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_SUMMARIZE_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_SUMMARIZE_SUBCOMMAND_H_
+
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+class SummarizeSubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  int Run(const SubcommandContext& ctx, int argc, char** argv) override;
+  void PrintUsage(const char* argv0) override;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_SUMMARIZE_SUBCOMMAND_H_

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -67,12 +67,20 @@
 #include "src/trace_processor/read_trace_internal.h"
 #include "src/trace_processor/rpc/rpc.h"
 #include "src/trace_processor/rpc/stdiod.h"
+#include "src/trace_processor/shell/common_flags.h"
+#include "src/trace_processor/shell/export_subcommand.h"
 #include "src/trace_processor/shell/interactive.h"
 #include "src/trace_processor/shell/metatrace.h"
 #include "src/trace_processor/shell/metrics.h"
+#include "src/trace_processor/shell/metrics_subcommand.h"
 #include "src/trace_processor/shell/query.h"
+#include "src/trace_processor/shell/query_subcommand.h"
+#include "src/trace_processor/shell/repl_subcommand.h"
+#include "src/trace_processor/shell/serve_subcommand.h"
 #include "src/trace_processor/shell/shell_utils.h"
 #include "src/trace_processor/shell/sql_packages.h"
+#include "src/trace_processor/shell/subcommand.h"
+#include "src/trace_processor/shell/summarize_subcommand.h"
 #include "src/trace_processor/trace_summary/summary.h"
 #include "src/trace_processor/util/deobfuscation/deobfuscator.h"
 #include "src/trace_processor/util/sql_modules.h"
@@ -115,8 +123,10 @@ TraceSummarySpecBytes::Format GuessSummarySpecFormat(
     const std::string& content);
 
 struct CommandLineOptions {
-  std::string trace_file_path;
+  // Global options shared with subcommands (TP config, metatrace, etc.).
+  shell::GlobalOptions global;
 
+  // Classic-only options.
   bool enable_httpd = false;
   std::string port_number;
   std::string listen_ip;
@@ -124,15 +134,10 @@ struct CommandLineOptions {
   bool enable_stdiod = false;
   bool launch_shell = false;
 
-  bool force_full_sort = false;
-  bool no_ftrace_raw = false;
-
   std::string query_file_path;
   std::string query_string;
   std::vector<std::string> structured_query_specs;
   std::string structured_query_id;
-  std::vector<std::string> sql_package_paths;
-  std::vector<std::string> override_sql_package_paths;
 
   bool summary = false;
   std::string summary_metrics_v2;
@@ -140,23 +145,9 @@ struct CommandLineOptions {
   std::vector<std::string> summary_specs;
   std::string summary_output;
 
-  std::string metatrace_path;
-  size_t metatrace_buffer_capacity = 0;
-  metatrace::MetatraceCategories metatrace_categories =
-      static_cast<metatrace::MetatraceCategories>(
-          metatrace::MetatraceCategories::QUERY_TIMELINE |
-          metatrace::MetatraceCategories::API_TIMELINE);
-
-  bool dev = false;
-  std::vector<std::string> dev_flags;
-  bool extra_checks = false;
   std::string export_file_path;
   std::string perf_file_path;
   bool wide = false;
-  bool analyze_trace_proto_content = false;
-  bool crop_track_events = false;
-  std::string register_files_dir;
-  std::string override_stdlib_path;
 
   std::string pre_metrics_v1_path;
   std::string metric_v1_names;
@@ -164,7 +155,59 @@ struct CommandLineOptions {
   std::vector<std::string> raw_metric_v1_extensions;
 };
 
-void PrintUsage(char** argv) {
+void PrintSubcommandHelp(const char* argv0) {
+  PERFETTO_ELOG(R"(
+Perfetto Trace Processor.
+Usage: %s [command] [flags] [trace_file]
+
+If no command is given, opens an interactive SQL shell on the trace file.
+
+Commands:
+
+  query         Run SQL queries against a trace.
+                  %s query -c "SELECT ts, dur FROM slice" trace.pb
+                  %s query -f query.sql trace.pb
+                Flags: -f FILE, -c STRING, -i (interactive after), -W (wide)
+
+  repl          Interactive SQL shell (default).
+                  %s trace.pb
+                  %s repl trace.pb
+                Flags: -W (wide)
+
+  serve         Start an RPC server.
+                  %s serve http trace.pb
+                  %s serve http --port 9001 trace.pb
+                  %s serve stdio
+                Modes: http, stdio
+
+  summarize     Run trace summarization.
+                  %s summarize --metrics-v2 all --spec spec.textproto trace.pb
+                Flags: --spec PATH, --metrics-v2 IDS, --format [text|binary]
+
+  metrics       Run v1 metrics (deprecated).
+                  %s metrics --run android_cpu trace.pb
+                Flags: --run NAMES, --output [binary|text|json]
+
+  export        Export trace to a database file.
+                  %s export sqlite -o out.db trace.pb
+                Formats: sqlite
+
+Global flags (apply to all commands):
+  --dev, --full-sort, --no-ftrace-raw, --metatrace FILE, ...
+  Run '%s help <command>' for full flag details.
+
+Previous versions of trace_processor_shell used a flat flag interface
+(e.g. -q file.sql, --httpd, --summary, -e output.db). This interface
+is fully supported and will remain so permanently. If you have existing
+scripts or are following older documentation that uses these flags, they
+will continue to work exactly as before.
+  Run '%s --help-classic' to see the flat flag reference.
+)",
+                argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0, argv0,
+                argv0, argv0, argv0, argv0);
+}
+
+void PrintClassicUsage(char** argv) {
   PERFETTO_ELOG(R"(
 Interactive trace processor shell.
 Usage: %s [FLAGS] trace_file.pb
@@ -408,10 +451,13 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
     OPT_PRE_METRICS,
     OPT_METRICS_OUTPUT,
     OPT_METRIC_EXTENSION,
+
+    OPT_HELP_CLASSIC,
   };
 
   static const option long_options[] = {
       {"help", no_argument, nullptr, 'h'},
+      {"help-classic", no_argument, nullptr, OPT_HELP_CLASSIC},
       {"version", no_argument, nullptr, 'v'},
 
       {"httpd", no_argument, nullptr, 'D'},
@@ -545,59 +591,60 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
     }
 
     if (option == 'm') {
-      command_line_options.metatrace_path = optarg;
+      command_line_options.global.metatrace_path = optarg;
       continue;
     }
 
     if (option == OPT_METATRACE_BUFFER_CAPACITY) {
-      command_line_options.metatrace_buffer_capacity =
+      command_line_options.global.metatrace_buffer_capacity =
           static_cast<size_t>(atoi(optarg));
       continue;
     }
 
     if (option == OPT_METATRACE_CATEGORIES) {
-      command_line_options.metatrace_categories =
+      command_line_options.global.metatrace_categories =
           ParseMetatraceCategories(optarg);
       continue;
     }
 
     if (option == OPT_FORCE_FULL_SORT) {
-      command_line_options.force_full_sort = true;
+      command_line_options.global.force_full_sort = true;
       continue;
     }
 
     if (option == OPT_NO_FTRACE_RAW) {
-      command_line_options.no_ftrace_raw = true;
+      command_line_options.global.no_ftrace_raw = true;
       continue;
     }
 
     if (option == OPT_ANALYZE_TRACE_PROTO_CONTENT) {
-      command_line_options.analyze_trace_proto_content = true;
+      command_line_options.global.analyze_trace_proto_content = true;
       continue;
     }
 
     if (option == OPT_CROP_TRACK_EVENTS) {
-      command_line_options.crop_track_events = true;
+      command_line_options.global.crop_track_events = true;
       continue;
     }
 
     if (option == OPT_DEV) {
-      command_line_options.dev = true;
+      command_line_options.global.dev = true;
       continue;
     }
 
     if (option == OPT_EXTRA_CHECKS) {
-      command_line_options.extra_checks = true;
+      command_line_options.global.extra_checks = true;
       continue;
     }
 
     if (option == OPT_ADD_SQL_PACKAGE) {
-      command_line_options.sql_package_paths.emplace_back(optarg);
+      command_line_options.global.sql_package_paths.emplace_back(optarg);
       continue;
     }
 
     if (option == OPT_OVERRIDE_SQL_PACKAGE) {
-      command_line_options.override_sql_package_paths.emplace_back(optarg);
+      command_line_options.global.override_sql_package_paths.emplace_back(
+          optarg);
       continue;
     }
 
@@ -612,7 +659,7 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
     }
 
     if (option == OPT_OVERRIDE_STDLIB) {
-      command_line_options.override_stdlib_path = optarg;
+      command_line_options.global.override_stdlib_path = optarg;
       continue;
     }
 
@@ -637,12 +684,12 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
     }
 
     if (option == OPT_DEV_FLAG) {
-      command_line_options.dev_flags.emplace_back(optarg);
+      command_line_options.global.dev_flags.emplace_back(optarg);
       continue;
     }
 
     if (option == OPT_REGISTER_FILES_DIR) {
-      command_line_options.register_files_dir = optarg;
+      command_line_options.global.register_files_dir = optarg;
       continue;
     }
 
@@ -671,8 +718,16 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
       continue;
     }
 
-    PrintUsage(argv);
-    exit(option == 'h' ? 0 : 1);
+    if (option == OPT_HELP_CLASSIC) {
+      PrintClassicUsage(argv);
+      exit(0);
+    }
+    if (option == 'h') {
+      PrintSubcommandHelp(argv[0]);
+      exit(0);
+    }
+    PrintClassicUsage(argv);
+    exit(1);
   }
 
   command_line_options.launch_shell =
@@ -687,7 +742,7 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
   // Only allow non-interactive queries to emit perf data.
   if (!command_line_options.perf_file_path.empty() &&
       command_line_options.launch_shell) {
-    PrintUsage(argv);
+    PrintClassicUsage(argv);
     exit(1);
   }
 
@@ -701,10 +756,10 @@ CommandLineOptions ParseCommandLineOptions(int argc, char** argv) {
   // in --httpd or --stdiod mode. In all other cases, the last argument must be
   // the trace file.
   if (optind == argc - 1 && argv[optind]) {
-    command_line_options.trace_file_path = argv[optind];
+    command_line_options.global.trace_file = argv[optind];
   } else if (!command_line_options.enable_httpd &&
              !command_line_options.enable_stdiod) {
-    PrintUsage(argv);
+    PrintClassicUsage(argv);
     exit(1);
   }
 
@@ -803,42 +858,6 @@ MetricV1OutputFormat ParseMetricV1OutputFormat(
   return MetricV1OutputFormat::kTextProto;
 }
 
-base::Status MaybeUpdateSqlPackages(TraceProcessor* trace_processor,
-                                    const CommandLineOptions& options) {
-  if (!options.override_stdlib_path.empty()) {
-    if (!options.dev)
-      return base::ErrStatus("Overriding stdlib requires --dev flag");
-
-    auto status =
-        LoadOverridenStdlib(trace_processor, options.override_stdlib_path);
-    if (!status.ok())
-      return base::ErrStatus("Couldn't override stdlib: %s",
-                             status.c_message());
-  }
-
-  if (!options.override_sql_package_paths.empty()) {
-    for (const auto& override_sql_package_path :
-         options.override_sql_package_paths) {
-      auto status =
-          IncludeSqlPackage(trace_processor, override_sql_package_path, true);
-      if (!status.ok())
-        return base::ErrStatus("Couldn't override stdlib package: %s",
-                               status.c_message());
-    }
-  }
-
-  if (!options.sql_package_paths.empty()) {
-    for (const auto& add_sql_package_path : options.sql_package_paths) {
-      auto status =
-          IncludeSqlPackage(trace_processor, add_sql_package_path, false);
-      if (!status.ok())
-        return base::ErrStatus("Couldn't add SQL package: %s",
-                               status.c_message());
-    }
-  }
-  return base::OkStatus();
-}
-
 TraceSummarySpecBytes::Format GuessSummarySpecFormat(
     const std::string& path,
     const std::string& content) {
@@ -910,58 +929,129 @@ TraceProcessorShell::CreateWithDefaultPlatform() {
 }
 
 base::Status TraceProcessorShell::Run(int argc, char** argv) {
+  // Check for subcommands before classic flag parsing.
+  shell::QuerySubcommand query_subcommand;
+  shell::ReplSubcommand repl_subcommand;
+  shell::ServeSubcommand serve_subcommand;
+  shell::SummarizeSubcommand summarize_subcommand;
+  shell::MetricsSubcommand metrics_subcommand;
+  shell::ExportSubcommand export_subcommand;
+  std::vector<shell::Subcommand*> subcommands = {
+      &query_subcommand,     &repl_subcommand,    &serve_subcommand,
+      &summarize_subcommand, &metrics_subcommand, &export_subcommand,
+  };
+
+  // All flags (both global and classic) that consume a following argument.
+  // Needed so FindSubcommandInArgs can skip flag values during the scan.
+  // Using a C array of string_view to avoid exit-time destructor warnings.
+  static constexpr std::string_view kFlagsWithArgArr[] = {
+      // Global flags.
+      "--dev-flag",
+      "--add-sql-package",
+      "--override-sql-package",
+      "--override-stdlib",
+      "--metatrace",
+      "-m",
+      "--metatrace-buffer-capacity",
+      "--metatrace-categories",
+      "--register-files-dir",
+      // Classic-only flags (still needed so scanner skips their values).
+      "--http-port",
+      "--http-ip-address",
+      "--http-additional-cors-origins",
+      "--query-file",
+      "-q",
+      "--query-string",
+      "-Q",
+      "--structured-query-spec",
+      "--structured-query-id",
+      "--summary-metrics-v2",
+      "--summary-metadata-query",
+      "--summary-spec",
+      "--summary-format",
+      "--export",
+      "-e",
+      "--perf-file",
+      "-p",
+      "--run-metrics",
+      "--pre-metrics",
+      "--metrics-output",
+      "--metric-extension",
+  };
+  std::vector<std::string> flags_with_arg(std::begin(kFlagsWithArgArr),
+                                          std::end(kFlagsWithArgArr));
+
+  // Handle "help" pseudo-subcommand: `tp help <command>` or bare `tp help`.
+  for (int i = 1; i < argc; ++i) {
+    if (argv[i][0] == '-')
+      continue;
+    if (strcmp(argv[i], "help") == 0) {
+      if (i + 1 < argc) {
+        // `help <command>` — find the named subcommand and print its usage.
+        for (auto* sc : subcommands) {
+          if (strcmp(sc->name(), argv[i + 1]) == 0) {
+            sc->PrintUsage(argv[0]);
+            exit(0);
+          }
+        }
+        PERFETTO_ELOG("Unknown command '%s'.", argv[i + 1]);
+        PrintSubcommandHelp(argv[0]);
+        exit(1);
+      }
+      // Bare `help` — same as --help.
+      PrintSubcommandHelp(argv[0]);
+      exit(0);
+    }
+    break;  // First non-flag, non-help positional → stop.
+  }
+
+  auto result =
+      shell::FindSubcommandInArgs(argc, argv, subcommands, flags_with_arg);
+  if (result.subcommand) {
+    // If the matched word is also a file on disk, it's ambiguous — the user
+    // might have meant it as a trace file. Emit a hint.
+    if (base::FileExists(argv[result.argv_index])) {
+      PERFETTO_ELOG(
+          "Note: '%s' matches both a subcommand and a file on disk. "
+          "Interpreting as subcommand. To use it as a trace file, use './%s'.",
+          argv[result.argv_index], argv[result.argv_index]);
+    }
+    // Build a new argv with the subcommand name removed.
+    std::vector<char*> new_argv;
+    for (int i = 0; i < argc; ++i) {
+      if (i != result.argv_index) {
+        new_argv.push_back(argv[i]);
+      }
+    }
+    shell::SubcommandContext ctx;
+    ctx.platform = platform_interface_.get();
+    int ret = result.subcommand->Run(ctx, static_cast<int>(new_argv.size()),
+                                     new_argv.data());
+    // The subcommand handles its own error reporting. Use exit() to avoid
+    // TraceProcessorShellMain printing a redundant error message. This
+    // matches the precedent set by ParseCommandLineOptions which also
+    // calls exit() on errors.
+    exit(ret);
+  }
+
   CommandLineOptions options = ParseCommandLineOptions(argc, argv);
 
-  Config config = platform_interface_->DefaultConfig();
-  config.sorting_mode = options.force_full_sort
-                            ? SortingMode::kForceFullSort
-                            : SortingMode::kDefaultHeuristics;
-  config.ingest_ftrace_in_raw_table = !options.no_ftrace_raw;
-  config.analyze_trace_proto_content = options.analyze_trace_proto_content;
-  config.drop_track_event_data_before =
-      options.crop_track_events
-          ? DropTrackEventDataBefore::kTrackEventRangeOfInterest
-          : DropTrackEventDataBefore::kNoDrop;
+  // Build config and apply metric extension skip paths before TP creation.
+  const auto& global = options.global;
+  Config config = shell::BuildConfig(global, platform_interface_.get());
 
   std::vector<MetricExtension> metric_extensions;
   RETURN_IF_ERROR(ParseMetricExtensionPaths(
-      options.dev, options.raw_metric_v1_extensions, metric_extensions));
-
+      global.dev, options.raw_metric_v1_extensions, metric_extensions));
   for (const auto& extension : metric_extensions) {
     config.skip_builtin_metric_paths.push_back(extension.virtual_path());
   }
 
-  if (options.dev) {
-    config.enable_dev_features = true;
-    for (const auto& flag_pair : options.dev_flags) {
-      auto kv = base::SplitString(flag_pair, "=");
-      if (kv.size() != 2) {
-        PERFETTO_ELOG("Ignoring unknown dev flag format %s", flag_pair.c_str());
-        continue;
-      }
-      config.dev_flags.emplace(kv[0], kv[1]);
-    }
-  }
-
-  if (options.extra_checks) {
-    config.enable_extra_checks = true;
-  }
-
-  std::unique_ptr<TraceProcessor> tp = TraceProcessor::CreateInstance(config);
-  platform_interface_->OnTraceProcessorCreated(tp.get());
-  RETURN_IF_ERROR(MaybeUpdateSqlPackages(tp.get(), options));
-
-  // Enable metatracing as soon as possible.
-  if (!options.metatrace_path.empty()) {
-    metatrace::MetatraceConfig metatrace_config;
-    metatrace_config.override_buffer_size = options.metatrace_buffer_capacity;
-    metatrace_config.categories = options.metatrace_categories;
-    tp->EnableMetatrace(metatrace_config);
-  }
-
-  if (!options.register_files_dir.empty()) {
-    RETURN_IF_ERROR(RegisterAllFilesInFolder(options.register_files_dir, *tp));
-  }
+  // Create TP with the modified config, then apply SQL packages, metatrace,
+  // and file registration.
+  ASSIGN_OR_RETURN(
+      std::unique_ptr<TraceProcessor> tp,
+      shell::SetupTraceProcessor(global, config, platform_interface_.get()));
 
   // Descriptor pool used for printing output as textproto. Building on top of
   // generated pool so default protos in google.protobuf.descriptor.proto are
@@ -981,11 +1071,11 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
   }
 
   base::TimeNanos t_load{};
-  if (!options.trace_file_path.empty()) {
+  if (!global.trace_file.empty()) {
     base::TimeNanos t_load_start = base::GetWallTimeNs();
     double size_mb = 0;
     RETURN_IF_ERROR(LoadTrace(tp.get(), platform_interface_.get(),
-                              options.trace_file_path, &size_mb));
+                              global.trace_file, &size_mb));
     t_load = base::GetWallTimeNs() - t_load_start;
 
     double t_load_s = static_cast<double>(t_load.count()) / 1E9;
@@ -1076,7 +1166,7 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
         RunQueriesFromFile(tp.get(), options.query_file_path, true);
     if (!status.ok()) {
       // Write metatrace if needed before exiting.
-      RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), options.metatrace_path));
+      RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), global.metatrace_path));
       return status;
     }
   }
@@ -1085,7 +1175,7 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
     base::Status status = RunQueries(tp.get(), options.query_string, true);
     if (!status.ok()) {
       // Write metatrace if needed before exiting.
-      RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), options.metatrace_path));
+      RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), global.metatrace_path));
       return status;
     }
   }
@@ -1120,7 +1210,7 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
         tp.get(), specs, options.structured_query_id, &output);
     if (!status.ok()) {
       // Write metatrace if needed before exiting.
-      RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), options.metatrace_path));
+      RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), global.metatrace_path));
       return status;
     }
 
@@ -1136,7 +1226,7 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
 
   if (options.enable_httpd) {
 #if PERFETTO_BUILDFLAG(PERFETTO_TP_HTTPD)
-    Rpc rpc(std::move(tp), !options.trace_file_path.empty(), config,
+    Rpc rpc(std::move(tp), !global.trace_file.empty(), config,
             [this](TraceProcessor* tp) {
               platform_interface_->OnTraceProcessorCreated(tp);
             });
@@ -1144,13 +1234,13 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
 #if PERFETTO_HAS_SIGNAL_H()
     static Rpc* g_rpc_for_signal_handler = &rpc;
 
-    if (options.metatrace_path.empty()) {
+    if (global.metatrace_path.empty()) {
       // Restore the default signal handler to allow the user to terminate
       // httpd server via Ctrl-C.
       signal(SIGINT, SIG_DFL);
     } else {
       // Write metatrace to file before exiting.
-      static std::string* metatrace_path = &options.metatrace_path;
+      static const std::string* metatrace_path = &global.metatrace_path;
       signal(SIGINT, [](int) {
         MaybeWriteMetatrace(g_rpc_for_signal_handler->trace_processor(),
                             *metatrace_path);
@@ -1178,7 +1268,7 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
   }
 
   if (options.enable_stdiod) {
-    Rpc rpc(std::move(tp), !options.trace_file_path.empty(), config,
+    Rpc rpc(std::move(tp), !global.trace_file.empty(), config,
             [this](TraceProcessor* tp) {
               platform_interface_->OnTraceProcessorCreated(tp);
             });
@@ -1200,7 +1290,7 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
     RETURN_IF_ERROR(PrintPerfFile(options.perf_file_path, t_load, t_query));
   }
 
-  RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), options.metatrace_path));
+  RETURN_IF_ERROR(MaybeWriteMetatrace(tp.get(), global.metatrace_path));
 
   return base::OkStatus();
 }

--- a/test/trace_processor_shell_integrationtest.cc
+++ b/test/trace_processor_shell_integrationtest.cc
@@ -16,6 +16,7 @@
 
 #include <string_view>
 
+#include "perfetto/base/build_config.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/subprocess.h"
 #include "perfetto/ext/base/temp_file.h"
@@ -23,6 +24,12 @@
 #include "protos/perfetto/trace_processor/trace_processor.gen.h"
 #include "test/gtest_and_gmock.h"
 #include "test/test_helper.h"
+
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) || \
+    PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+#include <unistd.h>
+#include <climits>
+#endif
 
 namespace perfetto::trace_processor {
 namespace {
@@ -94,10 +101,78 @@ TEST(TraceProcessorShellIntegrationTest, ClassicVersion) {
 }
 
 TEST(TraceProcessorShellIntegrationTest, ClassicHelp) {
+  // --help now shows the subcommand-aware help.
   auto result = RunShell({"-h"});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("Perfetto Trace Processor"));
+  EXPECT_THAT(result.out, HasSubstr("Commands:"));
+  EXPECT_THAT(result.out, HasSubstr("query"));
+  EXPECT_THAT(result.out, HasSubstr("repl"));
+  EXPECT_THAT(result.out, HasSubstr("serve"));
+  EXPECT_THAT(result.out, HasSubstr("summarize"));
+  EXPECT_THAT(result.out, HasSubstr("metrics"));
+  EXPECT_THAT(result.out, HasSubstr("export"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, HelpClassic) {
+  auto result = RunShell({"--help-classic"});
   EXPECT_EQ(result.exit_code, 0);
   EXPECT_THAT(result.out, HasSubstr("Interactive trace processor shell"));
 }
+
+TEST(TraceProcessorShellIntegrationTest, HelpCommand) {
+  auto result = RunShell({"help", "query"});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("Run SQL queries"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, HelpBare) {
+  auto result = RunShell({"help"});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("Commands:"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, HelpUnknownCommand) {
+  auto result = RunShell({"help", "nonexistent"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, NoFileCollisionHintOnNormalUsage) {
+  // Normal subcommand usage should not emit the file collision hint.
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"query", "-c", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, Not(HasSubstr("matches both a subcommand")));
+}
+
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) || \
+    PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+TEST(TraceProcessorShellIntegrationTest, FileCollisionHint) {
+  // Create a file named "query" in a temp dir, chdir there, and run the shell
+  // with bare "query" as an arg. The dispatcher should match "query" as a
+  // subcommand but also notice the file and emit a hint.
+  auto tmpdir = base::TempDir::Create();
+  std::string file_path = std::string(tmpdir.path()) + "/query";
+  base::WriteAll(*base::OpenFile(file_path, O_WRONLY | O_CREAT | O_TRUNC, 0600),
+                 kSimpleSystrace.data(),
+                 static_cast<size_t>(kSimpleSystrace.size()));
+
+  // RAII guard: restore CWD and clean up the file no matter how the test exits.
+  char old_cwd[PATH_MAX];
+  ASSERT_NE(getcwd(old_cwd, sizeof(old_cwd)), nullptr);
+  ASSERT_EQ(chdir(tmpdir.path().c_str()), 0);
+  auto cleanup = base::OnScopeExit([&] {
+    chdir(old_cwd);
+    remove(file_path.c_str());
+  });
+
+  // "query" is interpreted as the subcommand (which fails — no -f/-c), but
+  // the hint should appear because a file named "query" exists in CWD.
+  auto result = RunShell({"query"});
+  EXPECT_NE(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("matches both a subcommand and a file"));
+}
+#endif
 
 TEST(TraceProcessorShellIntegrationTest, ClassicUnknownFlag) {
   auto result = RunShell({"--nonexistent"});
@@ -188,6 +263,250 @@ TEST(TraceProcessorShellIntegrationTest, ClassicSummaryAndMetricsConflict) {
   auto trace = WriteSimpleSystrace();
   auto result =
       RunShell({"--summary", "--run-metrics", "android_cpu", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicWide) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"-W", "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicPerfFile) {
+  auto trace = WriteSimpleSystrace();
+  auto perf = base::TempFile::Create();
+  auto result = RunShell({"-p", perf.path(), "-Q", "SELECT 1", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicPerfFileWithoutQueryFails) {
+  auto trace = WriteSimpleSystrace();
+  auto perf = base::TempFile::Create();
+  // -p without -q/-Q means interactive mode, which rejects -p.
+  auto result = RunShell({"-p", perf.path(), trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicExportWithQuery) {
+  auto trace = WriteSimpleSystrace();
+  auto out_db = base::TempFile::Create();
+  auto query = WriteTempFile("SELECT 1;");
+  auto result =
+      RunShell({"-e", out_db.path(), "-q", query.path(), trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_TRUE(base::FileExists(out_db.path()));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicSummaryWithQuery) {
+  // --summary + -q: summary output suppressed, query runs.
+  auto trace = WriteSimpleSystrace();
+  auto query = WriteTempFile("SELECT 42 AS val;");
+  auto result = RunShell({"--summary", "-q", query.path(), trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("42"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicInteractiveWithQuery) {
+  // -i + -Q: runs query then drops into REPL (which exits on /dev/null stdin).
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"-i", "-Q", "SELECT 1 AS x", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("x"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicDefaultInteractive) {
+  // No flags other than trace = interactive mode (exits on /dev/null stdin).
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicOverrideStdlibWithoutDevFails) {
+  auto trace = WriteSimpleSystrace();
+  auto result =
+      RunShell({"--override-stdlib", "/tmp", "-Q", "SELECT 1", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ClassicStdiodNoTrace) {
+  // --stdiod without trace file should work.
+  TraceProcessorRpcStream req;
+  auto* rpc = req.add_msg();
+  rpc->set_request(TraceProcessorRpc::TPM_QUERY_STREAMING);
+  rpc->mutable_query_args()->set_sql_query("SELECT 1 AS x");
+
+  base::Subprocess process({ShellPath(), "--stdiod"});
+  process.args.stdin_mode = base::Subprocess::InputMode::kBuffer;
+  process.args.stdout_mode = base::Subprocess::OutputMode::kBuffer;
+  process.args.stderr_mode = base::Subprocess::OutputMode::kBuffer;
+  process.args.input = req.SerializeAsString();
+  process.Start();
+
+  ASSERT_TRUE(process.Wait(kDefaultTestTimeoutMs));
+
+  TraceProcessorRpcStream stream;
+  stream.ParseFromString(process.output());
+  ASSERT_THAT(stream.msg(), SizeIs(1));
+  ASSERT_EQ(stream.msg()[0].response(), TraceProcessorRpc::TPM_QUERY_STREAMING);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: query
+// ---------------------------------------------------------------------------
+
+TEST(TraceProcessorShellIntegrationTest, QuerySubcommandSqlString) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"query", "-c", "SELECT 1 AS x", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("x"));
+  EXPECT_THAT(result.out, HasSubstr("1"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, QuerySubcommandSqlFile) {
+  auto trace = WriteSimpleSystrace();
+  auto query = WriteTempFile("SELECT 42 AS val;");
+  auto result = RunShell({"query", "-f", query.path(), trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("val"));
+  EXPECT_THAT(result.out, HasSubstr("42"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, QuerySubcommandGlobalFlagBefore) {
+  auto trace = WriteSimpleSystrace();
+  auto result =
+      RunShell({"--dev", "query", "-c", "SELECT 1 AS x", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_THAT(result.out, HasSubstr("1"));
+}
+
+TEST(TraceProcessorShellIntegrationTest, QuerySubcommandNoQueryFails) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"query", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, QuerySubcommandNoTraceFails) {
+  auto result = RunShell({"query", "-c", "SELECT 1"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, QuerySubcommandBadFileFails) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"query", "-f", "/nonexistent.sql", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: repl
+// ---------------------------------------------------------------------------
+
+TEST(TraceProcessorShellIntegrationTest, ReplSubcommand) {
+  // With stdin=/dev/null the REPL exits immediately.
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"repl", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ReplSubcommandWide) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"repl", "-W", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ReplSubcommandNoTraceFails) {
+  auto result = RunShell({"repl"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ReplSubcommandGlobalFlagBefore) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"--dev", "repl", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: serve
+// ---------------------------------------------------------------------------
+
+TEST(TraceProcessorShellIntegrationTest, ServeSubcommandStdio) {
+  TraceProcessorRpcStream req;
+  auto* rpc = req.add_msg();
+  rpc->set_request(TraceProcessorRpc::TPM_QUERY_STREAMING);
+  rpc->mutable_query_args()->set_sql_query("SELECT 1 AS x");
+
+  base::Subprocess process({ShellPath(), "serve", "stdio"});
+  process.args.stdin_mode = base::Subprocess::InputMode::kBuffer;
+  process.args.stdout_mode = base::Subprocess::OutputMode::kBuffer;
+  process.args.stderr_mode = base::Subprocess::OutputMode::kBuffer;
+  process.args.input = req.SerializeAsString();
+  process.Start();
+
+  ASSERT_TRUE(process.Wait(kDefaultTestTimeoutMs));
+
+  TraceProcessorRpcStream stream;
+  stream.ParseFromString(process.output());
+
+  ASSERT_THAT(stream.msg(), SizeIs(1));
+  ASSERT_EQ(stream.msg()[0].response(), TraceProcessorRpc::TPM_QUERY_STREAMING);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ServeSubcommandNoModeFails) {
+  auto result = RunShell({"serve"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ServeSubcommandBadModeFails) {
+  auto result = RunShell({"serve", "badmode"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: summarize
+// ---------------------------------------------------------------------------
+
+TEST(TraceProcessorShellIntegrationTest, SummarizeSubcommand) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"summarize", trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, SummarizeSubcommandNoTraceFails) {
+  auto result = RunShell({"summarize"});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: metrics
+// ---------------------------------------------------------------------------
+
+TEST(TraceProcessorShellIntegrationTest, MetricsSubcommandNoRunFails) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"metrics", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand: export
+// ---------------------------------------------------------------------------
+
+TEST(TraceProcessorShellIntegrationTest, ExportSubcommandSqlite) {
+  auto trace = WriteSimpleSystrace();
+  auto out_db = base::TempFile::Create();
+  auto result =
+      RunShell({"export", "sqlite", "-o", out_db.path(), trace.path()});
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_TRUE(base::FileExists(out_db.path()));
+}
+
+TEST(TraceProcessorShellIntegrationTest, ExportSubcommandNoFormatFails) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"export", trace.path()});
+  EXPECT_NE(result.exit_code, 0);
+}
+
+TEST(TraceProcessorShellIntegrationTest, ExportSubcommandNoOutputFails) {
+  auto trace = WriteSimpleSystrace();
+  auto result = RunShell({"export", "sqlite", trace.path()});
   EXPECT_NE(result.exit_code, 0);
 }
 


### PR DESCRIPTION
Implements RFC-0018: adds subcommands (query, repl, serve, summarize,
metrics, export) to trace_processor_shell while keeping the classic
flag-based interface permanently supported.

Key changes:
- Subcommand infrastructure: base class, argv scanner, dispatcher
- All 6 subcommands with per-subcommand flag parsing
- Shared GlobalOptions/BuildConfig/SetupTraceProcessor/LoadTraceFile
  used by both subcommands and the refactored classic path
- Three-tier help: --help (subcommand listing), help <cmd>, --help-classic
- File collision detection (hint when trace file matches subcommand name)
- 51 integration tests covering classic edge cases and all subcommands
