### PR TITLE
tp: add SubcommandContext to Subcommand interface

### DIFF
--- a/src/trace_processor/shell/find_subcommand_unittest.cc
+++ b/src/trace_processor/shell/find_subcommand_unittest.cc
@@ -26,7 +26,7 @@ class FakeSubcommand : public Subcommand {
   explicit FakeSubcommand(const char* n) : name_(n) {}
   const char* name() const override { return name_; }
   const char* description() const override { return ""; }
-  int Run(int, char**) override { return 0; }
+  int Run(const SubcommandContext&, int, char**) override { return 0; }
   void PrintUsage(const char*) override {}
 
  private:

--- a/src/trace_processor/shell/subcommand.h
+++ b/src/trace_processor/shell/subcommand.h
@@ -20,7 +20,16 @@
 #include <string>
 #include <vector>
 
+namespace perfetto::trace_processor {
+class TraceProcessorShell_PlatformInterface;
+}  // namespace perfetto::trace_processor
+
 namespace perfetto::trace_processor::shell {
+
+// Context passed to subcommands, providing access to shared resources.
+struct SubcommandContext {
+  TraceProcessorShell_PlatformInterface* platform = nullptr;
+};
 
 // Base class for all subcommands (query, export, serve, etc.).
 class Subcommand {
@@ -34,10 +43,11 @@ class Subcommand {
   // A short one-line description shown in help output.
   virtual const char* description() const = 0;
 
-  // Runs the subcommand. |argc| and |argv| point to the subcommand's own
-  // argument vector (i.e. argv[0] is the subcommand name).
+  // Runs the subcommand. |ctx| provides access to shared resources like the
+  // platform interface. |argc| and |argv| are the original command line with
+  // the subcommand name removed (argv[0] is the program name).
   // Returns 0 on success, non-zero on failure.
-  virtual int Run(int argc, char** argv) = 0;
+  virtual int Run(const SubcommandContext& ctx, int argc, char** argv) = 0;
 
   // Prints subcommand-specific usage to stderr.
   virtual void PrintUsage(const char* argv0) = 0;


### PR DESCRIPTION
## Summary
- Adds SubcommandContext struct with PlatformInterface* pointer
- Adds GetLongOptions() pure virtual to Subcommand (returns getopt option array)
- Updates FindSubcommandInArgs to derive flags_with_arg from GetLongOptions()
- Updates unit tests

Part 1/7 of the subcommand CLI implementation (RFC-0018).

## Stack
1. **#5134** ← this PR — SubcommandContext + GetLongOptions() interface
2. #5128 — common_flags + query + ClassicSubcommand + dispatcher
3. #5129 — repl + serve subcommands
4. #5130 — summarize + export subcommands
5. #5131 — metrics subcommand
6. #5132 — help system + file collision + classic edge case tests
7. #5133 — BUILD.gn consolidation