### PR TITLE
de: Dashboard can connect to only one graph

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.scss
@@ -57,6 +57,8 @@
   align-items: center;
   justify-content: center;
   pointer-events: none;
+  text-align: center;
+  padding: 24px;
 }
 
 // "+" add-item button in the top-left corner of the canvas.

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
@@ -31,11 +31,9 @@ import {
   DashboardBrushFilter,
   DashboardDataSource,
   DashboardItem,
-  DashboardSourceWithName,
   getItemId,
   getNextItemPosition,
   snapToGrid,
-  sourceDisplayName,
 } from './dashboard_registry';
 import {
   DashboardChartView,
@@ -94,15 +92,11 @@ function summarizeBrushFilters(
   return parts.join(', ');
 }
 
-// Re-export types that are defined in dashboard_registry but used by callers
-// of this module (e.g. DataExplorer).
-export type {DashboardSourceWithName} from './dashboard_registry';
-
 export interface DashboardAttrs {
   dashboardId: string;
   trace: Trace;
   items: DashboardItem[];
-  sources: ReadonlyArray<DashboardSourceWithName>;
+  sources: ReadonlyArray<DashboardDataSource>;
   brushFilters: Map<string, DashboardBrushFilter[]>;
   onItemsChange: (items: DashboardItem[]) => void;
   onBrushFiltersChange: (filters: Map<string, DashboardBrushFilter[]>) => void;
@@ -231,7 +225,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
 
   private renderChart(
     attrs: DashboardAttrs,
-    source: DashboardSourceWithName,
+    source: DashboardDataSource,
     chart: DashboardItem & {kind: 'chart'},
   ): m.Child {
     const config = chart.config;
@@ -262,7 +256,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
       PopupMenu,
       {
         trigger: m(Chip, {
-          label: sourceDisplayName(source, attrs.items, attrs.sources),
+          label: source.name,
           icon: 'database',
           compact: true,
           className: 'pf-dashboard__source-chip',
@@ -675,7 +669,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
       if (filters.length > 0) {
         allEntries.push({
           sourceNodeId: source.nodeId,
-          sourceName: sourceDisplayName(source, attrs.items, attrs.sources),
+          sourceName: source.name,
           filters,
         });
       }
@@ -776,16 +770,11 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
     const used = allExported.filter((s) => usedNodeIds.has(s.nodeId));
     const unused = allExported.filter((s) => !usedNodeIds.has(s.nodeId));
 
-    const makeSourceItems = (
-      srcs: DashboardSourceWithName[],
-    ): AccordionItem[] =>
+    const makeSourceItems = (srcs: DashboardDataSource[]): AccordionItem[] =>
       srcs.map((source) => ({
         id: source.nodeId,
         header: m('.pf-dashboard__source-row', [
-          m(
-            'code.pf-dashboard__input-name',
-            sourceDisplayName(source, attrs.items, attrs.sources, true),
-          ),
+          m('code.pf-dashboard__input-name', source.name),
         ]),
         content: this.renderInputContent(source, attrs),
       }));

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry.ts
@@ -33,42 +33,6 @@ export interface DashboardDataSource {
   requestExecution?: () => Promise<void>;
 }
 
-/** A data source enriched with its owning graph tab's display name. */
-export type DashboardSourceWithName = DashboardDataSource & {
-  graphName: string;
-};
-
-/**
- * Build a display label for a data source, optionally appending the graph name.
- *
- * When `forceNamespace` is true (sidebar), the graph name is shown whenever
- * the available sources span more than one graph.
- *
- * When `forceNamespace` is false (chart labels), the graph name is shown only
- * when the charts currently in use pull from more than one graph.
- */
-export function sourceDisplayName(
-  source: DashboardSourceWithName,
-  items: ReadonlyArray<DashboardItem>,
-  sources: ReadonlyArray<DashboardSourceWithName>,
-  forceNamespace = false,
-): string {
-  let candidates: ReadonlyArray<DashboardSourceWithName>;
-  if (forceNamespace) {
-    candidates = sources;
-  } else {
-    const usedNodeIds = new Set(
-      items.filter((i) => i.kind === 'chart').map((i) => i.sourceNodeId),
-    );
-    candidates = sources.filter((s) => usedNodeIds.has(s.nodeId));
-  }
-  const graphs = new Set(candidates.map((s) => s.graphId));
-  if (graphs.size > 1) {
-    return `${source.name} · ${source.graphName}`;
-  }
-  return source.name;
-}
-
 /** A single chart on a dashboard, linked to its data source. */
 export interface DashboardChart {
   readonly sourceNodeId: string;
@@ -138,6 +102,13 @@ class ExportedSourcesPool {
     return [...this.sources.values()];
   }
 
+  /** Get exported sources belonging to a specific graph tab. */
+  getExportedSourcesForGraph(
+    graphId: string,
+  ): ReadonlyArray<DashboardDataSource> {
+    return [...this.sources.values()].filter((s) => s.graphId === graphId);
+  }
+
   clear(): void {
     this.sources.clear();
   }
@@ -160,38 +131,14 @@ export function getNextItemPosition(items: ReadonlyArray<DashboardItem>): {
 }
 
 /**
- * Serialized dashboard data for persistence (localStorage / permalinks).
+ * Convert dashboard items to a serializable array, or undefined if empty.
  */
-export interface SerializedDashboardData {
-  dashboardId?: string;
-  dashboardItems?: unknown[];
-  brushFilters?: Record<string, unknown[]>;
-}
-
-/**
- * Collect dashboard-related data for a tab into a serializable form.
- * Shared between localStorage persistence and permalink persistence.
- */
-export function serializeDashboardData(
-  dashboardId: string | undefined,
+export function serializeDashboardItems(
   items?: DashboardItem[],
-  brushFiltersMap?: Map<string, DashboardBrushFilter[]>,
-): SerializedDashboardData {
-  if (dashboardId === undefined) return {};
-  const dashboardItems =
-    items !== undefined && items.length > 0 ? (items as unknown[]) : undefined;
-  // Convert brush filters map to a plain record, bigint → number.
-  let brushFilters: Record<string, unknown[]> | undefined;
-  if (brushFiltersMap !== undefined && brushFiltersMap.size > 0) {
-    const raw: Record<string, DashboardBrushFilter[]> = {};
-    for (const [sourceNodeId, filters] of brushFiltersMap) {
-      raw[sourceNodeId] = filters;
-    }
-    brushFilters = JSON.parse(
-      JSON.stringify(raw, (_k, v) => (typeof v === 'bigint' ? Number(v) : v)),
-    );
-  }
-  return {dashboardId, dashboardItems, brushFilters};
+): unknown[] | undefined {
+  return items !== undefined && items.length > 0
+    ? (items as unknown[])
+    : undefined;
 }
 
 /**

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_registry_unittest.ts
@@ -20,11 +20,8 @@ import {
   getItemId,
   getNextItemPosition,
   parseBrushFilters,
-  serializeDashboardData,
   snapToGrid,
   validateDashboardItems,
-  sourceDisplayName,
-  DashboardSourceWithName,
 } from './dashboard_registry';
 
 let nextChartId = 0;
@@ -41,21 +38,6 @@ function makeSource(
   graphId = 'test-graph',
 ): DashboardDataSource {
   return {nodeId, name, columns, graphId};
-}
-
-function makeSourceWithName(
-  nodeId: string,
-  name: string,
-  graphId: string,
-  graphName: string,
-): DashboardSourceWithName {
-  return {
-    nodeId,
-    name,
-    columns: [{name: 'id', type: {kind: 'int'}}],
-    graphId,
-    graphName,
-  };
 }
 
 function makeLabelItem(id = 'label-1', text = ''): DashboardItem {
@@ -172,54 +154,6 @@ describe('getNextItemPosition', () => {
     // 10 % 10 = 0, same as empty
     expect(pos.x).toBe(20);
     expect(pos.y).toBe(20);
-  });
-});
-
-// --- Serialization ---
-
-describe('serializeDashboardData', () => {
-  test('returns empty object for undefined dashboardId', () => {
-    expect(serializeDashboardData(undefined)).toEqual({});
-  });
-
-  test('returns dashboardId with no items', () => {
-    const data = serializeDashboardData('db-1');
-    expect(data.dashboardId).toBe('db-1');
-    expect(data.dashboardItems).toBeUndefined();
-    expect(data.brushFilters).toBeUndefined();
-  });
-
-  test('serializes items when present', () => {
-    const chart = makeChartItem('n1');
-    const data = serializeDashboardData('db-1', [chart]);
-    expect(data.dashboardId).toBe('db-1');
-    expect(data.dashboardItems).toHaveLength(1);
-  });
-
-  test('serializes brush filters when present', () => {
-    const filters = new Map([
-      ['n1', [{column: 'x', op: '=' as const, value: 42}]],
-    ]);
-    const data = serializeDashboardData('db-1', [], filters);
-    expect(data.brushFilters).toEqual({
-      n1: [{column: 'x', op: '=', value: 42}],
-    });
-  });
-
-  test('omits empty items and filters', () => {
-    const data = serializeDashboardData('db-1', [], new Map());
-    expect(data.dashboardItems).toBeUndefined();
-    expect(data.brushFilters).toBeUndefined();
-  });
-
-  test('converts bigint values in filters to numbers', () => {
-    const filters = new Map([
-      ['n1', [{column: 'x', op: '=' as const, value: BigInt(42)}]],
-    ]);
-    const data = serializeDashboardData('db-1', [], filters);
-    expect(data.brushFilters).toEqual({
-      n1: [{column: 'x', op: '=', value: 42}],
-    });
   });
 });
 
@@ -373,73 +307,26 @@ describe('parseBrushFilters', () => {
   });
 });
 
-// --- sourceDisplayName ---
+// --- getExportedSourcesForGraph ---
 
-describe('sourceDisplayName', () => {
-  test('returns plain name when all charts use one graph', () => {
-    const s1 = makeSourceWithName('n1', 'thread_state', 'g1', 'Graph 1');
-    const s2 = makeSourceWithName('n2', 'sched', 'g1', 'Graph 1');
-    const items = [makeChartItem('n1'), makeChartItem('n2')];
-    const sources = [s1, s2];
-    expect(sourceDisplayName(s1, items, sources)).toBe('thread_state');
-    expect(sourceDisplayName(s2, items, sources)).toBe('sched');
+describe('getExportedSourcesForGraph', () => {
+  beforeEach(() => {
+    dashboardRegistry.clear();
   });
 
-  test('appends graph name when charts use multiple graphs', () => {
-    const s1 = makeSourceWithName('n1', 'thread_state', 'g1', 'Graph 1');
-    const s2 = makeSourceWithName('n2', 'thread_state', 'g2', 'Graph 2');
-    const items = [makeChartItem('n1'), makeChartItem('n2')];
-    const sources = [s1, s2];
-    expect(sourceDisplayName(s1, items, sources)).toBe(
-      'thread_state · Graph 1',
+  test('returns only sources matching graphId', () => {
+    dashboardRegistry.setExportedSource(makeSource('n1', 'A', [], 'g1'));
+    dashboardRegistry.setExportedSource(makeSource('n2', 'B', [], 'g2'));
+    dashboardRegistry.setExportedSource(makeSource('n3', 'C', [], 'g1'));
+    const g1Sources = dashboardRegistry.getExportedSourcesForGraph('g1');
+    expect(g1Sources).toHaveLength(2);
+    expect(g1Sources.map((s) => s.name)).toEqual(['A', 'C']);
+  });
+
+  test('returns empty array for unknown graphId', () => {
+    dashboardRegistry.setExportedSource(makeSource('n1', 'A', [], 'g1'));
+    expect(dashboardRegistry.getExportedSourcesForGraph('g999')).toHaveLength(
+      0,
     );
-    expect(sourceDisplayName(s2, items, sources)).toBe(
-      'thread_state · Graph 2',
-    );
-  });
-
-  test('no namespacing when only one graph is used even if others available', () => {
-    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
-    const s2 = makeSourceWithName('n2', 'B', 'g2', 'Graph 2');
-    // Only s1 is used in charts; s2 is available but unused.
-    const items = [makeChartItem('n1')];
-    expect(sourceDisplayName(s1, items, [s1, s2])).toBe('A');
-  });
-
-  test('namespacing when two graphs are used even with different names', () => {
-    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
-    const s2 = makeSourceWithName('n2', 'B', 'g2', 'Graph 2');
-    const items = [makeChartItem('n1'), makeChartItem('n2')];
-    const sources = [s1, s2];
-    expect(sourceDisplayName(s1, items, sources)).toBe('A · Graph 1');
-    expect(sourceDisplayName(s2, items, sources)).toBe('B · Graph 2');
-  });
-
-  test('returns plain name with no charts', () => {
-    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
-    expect(sourceDisplayName(s1, [], [s1])).toBe('A');
-  });
-});
-
-// --- sourceDisplayName with forceNamespace ---
-
-describe('sourceDisplayName with forceNamespace', () => {
-  test('returns plain name when all sources are from one graph', () => {
-    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
-    const s2 = makeSourceWithName('n2', 'B', 'g1', 'Graph 1');
-    expect(sourceDisplayName(s1, [], [s1, s2], true)).toBe('A');
-    expect(sourceDisplayName(s2, [], [s1, s2], true)).toBe('B');
-  });
-
-  test('appends graph name when sources span multiple graphs', () => {
-    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
-    const s2 = makeSourceWithName('n2', 'B', 'g2', 'Graph 2');
-    expect(sourceDisplayName(s1, [], [s1, s2], true)).toBe('A · Graph 1');
-    expect(sourceDisplayName(s2, [], [s1, s2], true)).toBe('B · Graph 2');
-  });
-
-  test('returns plain name with single source', () => {
-    const s1 = makeSourceWithName('n1', 'A', 'g1', 'Graph 1');
-    expect(sourceDisplayName(s1, [], [s1], true)).toBe('A');
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
@@ -20,9 +20,10 @@ import {QueryNode} from './query_node';
 import {ensureAllNodeActions} from './node_actions';
 import {Trace} from '../../public/trace';
 import {getOrCreate} from '../../base/utils';
-import {MenuItem, PopupMenu} from '../../widgets/menu';
+import {shortUuid} from '../../base/uuid';
+import {MenuItem} from '../../widgets/menu';
 import {Tabs, TabsTab} from '../../widgets/tabs';
-import {Button} from '../../widgets/button';
+import {Button, ButtonBar} from '../../widgets/button';
 import {serializeState, deserializeState} from './json_handler';
 
 import {
@@ -70,15 +71,22 @@ import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 
 registerCoreNodes();
 
+/** State for a single dashboard within a graph tab. */
+export interface DashboardTabState {
+  readonly id: string;
+  title: string;
+  items: DashboardItem[];
+  brushFilters: Map<string, DashboardBrushFilter[]>;
+}
+
 export interface DataExplorerTab {
   readonly id: string;
   title: string;
   state: DataExplorerState;
-  // If set, this tab renders a dashboard instead of the graph builder.
-  dashboardId?: string;
-  // Dashboard-local state (only meaningful when dashboardId is set).
-  dashboardItems?: DashboardItem[];
-  dashboardBrushFilters?: Map<string, DashboardBrushFilter[]>;
+  // Each graph tab has one or more dashboards.
+  dashboards: DashboardTabState[];
+  // Which sub-tab is active: 'graph' (default) or a dashboard ID.
+  activeSubTab?: string;
 }
 
 export interface DataExplorerState {
@@ -118,7 +126,6 @@ interface DataExplorerAttrs {
   readonly tabs: DataExplorerTab[];
   readonly activeTabId: string;
   readonly onTabAdd: () => void;
-  readonly onDashboardTabAdd: () => void;
   readonly onTabClose: (tabId: string) => void;
   readonly onTabChange: (tabId: string) => void;
   readonly onTabRename: (tabId: string, newName: string) => void;
@@ -338,7 +345,9 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     // Handle other shortcuts
     switch (event.key) {
       case 'i':
-        importGraph(graphIODeps, state);
+        importGraph(graphIODeps, (title, newState) =>
+          attrs.onTabAddWithState(title, newState, attrs.activeTabId),
+        );
         break;
       case 'e':
         exportGraph(state, attrs.trace);
@@ -470,7 +479,12 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     for (const node of allNodes) {
       if (!isDashboardNode(node)) continue;
       // Propagate the stable tab ID so sources are namespaced by graph.
+      // Re-publish if the graphId changed so the registry has the right key.
+      const prevGraphId = node.state.graphId;
       node.state.graphId = tab.id;
+      if (prevGraphId !== tab.id) {
+        node.onPrevNodesUpdated?.();
+      }
       if (node.state.getTableNameForNode === undefined) {
         node.state.getTableNameForNode = (nodeId: string) =>
           services.queryExecutionService.getTableName(nodeId);
@@ -596,7 +610,10 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
               isSecondaryInput,
             );
           },
-          onImport: () => importGraph(graphIODeps, state),
+          onImport: () =>
+            importGraph(graphIODeps, (title, newState) =>
+              attrs.onTabAddWithState(title, newState, tab.id),
+            ),
           onExport: () => exportGraph(state, trace),
         },
         onLoadEmptyTemplate: async () => {
@@ -646,18 +663,107 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
   private activeNodeCrudDeps?: NodeCrudDeps;
   private activeGraphIODeps?: GraphIODeps;
 
-  /** Build the list of exported sources with graphName resolved from tabs. */
-  private buildDashboardSources(tabs: ReadonlyArray<DataExplorerTab>) {
-    return dashboardRegistry.getAllExportedSources().map((s) => ({
-      ...s,
-      graphName: tabs.find((t) => t.id === s.graphId)?.title ?? s.graphId,
-    }));
+  /** Get exported sources for a specific graph tab. */
+  private getDashboardSources(graphTabId: string) {
+    return dashboardRegistry.getExportedSourcesForGraph(graphTabId);
   }
 
   /** Trigger debounced saves after dashboard state changes. */
   private triggerSave(attrs: DataExplorerAttrs) {
     attrs.onDashboardStateChange();
     m.redraw();
+  }
+
+  private addDashboard(tab: DataExplorerTab, attrs: DataExplorerAttrs): void {
+    const existingNames = new Set(tab.dashboards.map((d) => d.title));
+    let num = 1;
+    while (existingNames.has(`Dashboard ${num}`)) {
+      num++;
+    }
+    const db: DashboardTabState = {
+      id: shortUuid(),
+      title: `Dashboard ${num}`,
+      items: [],
+      brushFilters: new Map(),
+    };
+    tab.dashboards.push(db);
+    tab.activeSubTab = db.id;
+    this.triggerSave(attrs);
+  }
+
+  /**
+   * Render a graph tab with nested sub-tabs (Graph | Dashboard 1 | ... | +).
+   * The graph builder is always initialized (for dashboard node execution),
+   * but we conditionally show either the builder or the dashboard view.
+   */
+  private renderTabWithSubTabs(
+    attrs: DataExplorerAttrs,
+    tab: DataExplorerTab,
+    sqlModules: SqlModules,
+  ): m.Children {
+    const activeSubTab = tab.activeSubTab ?? 'graph';
+    const graphContent = this.renderTabContent(attrs, tab, sqlModules);
+
+    const subTabBar = m(
+      '.pf-data-explorer__sub-tab-bar',
+      m(
+        ButtonBar,
+        m(Button, {
+          label: 'Graph',
+          icon: 'account_tree',
+          active: activeSubTab === 'graph',
+          onclick: () => {
+            tab.activeSubTab = 'graph';
+            m.redraw();
+          },
+        }),
+        ...tab.dashboards.map((db) =>
+          m(Button, {
+            label: db.title,
+            icon: 'dashboard',
+            active: activeSubTab === db.id,
+            onclick: () => {
+              tab.activeSubTab = db.id;
+              m.redraw();
+            },
+          }),
+        ),
+        m(Button, {
+          icon: 'add',
+          title: 'Add dashboard',
+          onclick: () => this.addDashboard(tab, attrs),
+        }),
+      ),
+    );
+
+    // Find active dashboard if any.
+    const activeDashboard = tab.dashboards.find((db) => db.id === activeSubTab);
+
+    if (activeDashboard !== undefined) {
+      return m('.pf-data-explorer__tab-with-subtabs', [
+        subTabBar,
+        m(
+          '.pf-data-explorer__tab-content',
+          m(Dashboard, {
+            dashboardId: activeDashboard.id,
+            trace: attrs.trace,
+            items: activeDashboard.items,
+            sources: this.getDashboardSources(tab.id),
+            brushFilters: activeDashboard.brushFilters,
+            onItemsChange: (items) => {
+              activeDashboard.items = items;
+              this.triggerSave(attrs);
+            },
+            onBrushFiltersChange: (filters) => {
+              activeDashboard.brushFilters = filters;
+              this.triggerSave(attrs);
+            },
+          }),
+        ),
+      ]);
+    }
+
+    return m('.pf-data-explorer__tab-with-subtabs', [subTabBar, graphContent]);
   }
 
   view({attrs}: m.CVnode<DataExplorerAttrs>) {
@@ -679,29 +785,9 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
     const tabEntries: TabsTab[] = tabs.map((tab) => ({
       key: tab.id,
       title: tab.title,
-      leftIcon: tab.dashboardId !== undefined ? 'dashboard' : 'account_tree',
+      leftIcon: 'account_tree',
       closeButton: tabs.length > 1,
-      content:
-        tab.dashboardId !== undefined
-          ? m(
-              '.pf-data-explorer__tab-content',
-              m(Dashboard, {
-                dashboardId: tab.dashboardId,
-                trace: attrs.trace,
-                items: tab.dashboardItems ?? [],
-                sources: this.buildDashboardSources(tabs),
-                brushFilters: tab.dashboardBrushFilters ?? new Map(),
-                onItemsChange: (items) => {
-                  tab.dashboardItems = items;
-                  this.triggerSave(attrs);
-                },
-                onBrushFiltersChange: (filters) => {
-                  tab.dashboardBrushFilters = filters;
-                  this.triggerSave(attrs);
-                },
-              }),
-            )
-          : this.renderTabContent(attrs, tab, sqlModules),
+      content: this.renderTabWithSubTabs(attrs, tab, sqlModules),
       menuItems: m(MenuItem, {
         label: 'Duplicate tab',
         icon: 'content_copy',
@@ -750,25 +836,11 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
         tabs: tabEntries,
         activeTabKey: activeTabId,
         reorderable: true,
-        newTabContent: m(
-          PopupMenu,
-          {
-            trigger: m(Button, {
-              icon: 'add',
-              className: 'pf-tabs__new-tab-btn',
-            }),
-          },
-          m(MenuItem, {
-            label: 'New Graph',
-            icon: 'account_tree',
-            onclick: () => attrs.onTabAdd(),
-          }),
-          m(MenuItem, {
-            label: 'New Dashboard',
-            icon: 'dashboard',
-            onclick: () => attrs.onDashboardTabAdd(),
-          }),
-        ),
+        newTabContent: m(Button, {
+          icon: 'add',
+          className: 'pf-tabs__new-tab-btn',
+          onclick: () => attrs.onTabAdd(),
+        }),
         onTabChange: (key) => attrs.onTabChange(key),
         onTabRename: (key, newTitle) => {
           attrs.onTabRename(key, newTitle);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer_tabs_storage.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer_tabs_storage.ts
@@ -15,23 +15,34 @@
 import {z} from 'zod';
 import {DataExplorerTab, DataExplorerState} from './data_explorer';
 import {serializeState} from './json_handler';
-import {serializeDashboardData} from './dashboard/dashboard_registry';
+import {serializeDashboardItems} from './dashboard/dashboard_registry';
 
 const DATA_EXPLORER_TABS_STORAGE_KEY = 'perfettoDataExplorerTabs';
 
+// Tab schema — unchanged from the original format.
 const PERSISTED_DATA_EXPLORER_TAB_SCHEMA = z.object({
   id: z.string(),
   title: z.string(),
   graphJson: z.string().optional(),
-  dashboardId: z.string().optional(),
-  dashboardItems: z.array(z.unknown()).optional(),
+});
+
+// Dashboard schema — new, flat list with a reference to the parent graph tab.
+const PERSISTED_DASHBOARD_SCHEMA = z.object({
+  id: z.string(),
+  title: z.string(),
+  graphTabId: z.string(),
+  items: z.array(z.unknown()).optional(),
   brushFilters: z.record(z.string(), z.array(z.unknown())).optional(),
 });
 
 const PERSISTED_DATA_EXPLORER_TABS_STATE_SCHEMA = z.object({
   tabs: z.array(PERSISTED_DATA_EXPLORER_TAB_SCHEMA).min(1),
   activeTabId: z.string(),
+  // Optional — old data without dashboards still loads fine.
+  dashboards: z.array(PERSISTED_DASHBOARD_SCHEMA).optional(),
 });
+
+export type PersistedDashboardData = z.infer<typeof PERSISTED_DASHBOARD_SCHEMA>;
 
 export type PersistedDataExplorerTabData = z.infer<
   typeof PERSISTED_DATA_EXPLORER_TAB_SCHEMA
@@ -49,23 +60,16 @@ export type PersistedDataExplorerTabsState = z.infer<
 class DataExplorerTabsStorage {
   save(tabs: DataExplorerTab[], activeTabId: string): void {
     const state: PersistedDataExplorerTabsState = {
-      tabs: tabs.map((tab) => {
-        const dbData = serializeDashboardData(
-          tab.dashboardId,
-          tab.dashboardItems,
-          tab.dashboardBrushFilters,
-        );
-        return {
-          id: tab.id,
-          title: tab.title,
-          graphJson:
-            tab.state.rootNodes.length > 0
-              ? serializeState(tab.state)
-              : undefined,
-          ...dbData,
-        };
-      }),
+      tabs: tabs.map((tab) => ({
+        id: tab.id,
+        title: tab.title,
+        graphJson:
+          tab.state.rootNodes.length > 0
+            ? serializeState(tab.state)
+            : undefined,
+      })),
       activeTabId,
+      dashboards: serializeAllDashboards(tabs),
     };
     try {
       window.localStorage.setItem(
@@ -116,4 +120,36 @@ export function createEmptyState(): DataExplorerState {
     nodeLayouts: new Map(),
     labels: [],
   };
+}
+
+/** Flatten all dashboards across all tabs into a single serializable list. */
+export function serializeAllDashboards(
+  tabs: DataExplorerTab[],
+): PersistedDashboardData[] | undefined {
+  const result: PersistedDashboardData[] = [];
+  for (const tab of tabs) {
+    for (const db of tab.dashboards) {
+      const items = serializeDashboardItems(db.items);
+      let brushFilters: Record<string, unknown[]> | undefined;
+      if (db.brushFilters.size > 0) {
+        const raw: Record<string, unknown[]> = {};
+        for (const [sourceNodeId, filters] of db.brushFilters) {
+          raw[sourceNodeId] = filters;
+        }
+        brushFilters = JSON.parse(
+          JSON.stringify(raw, (_k, v) =>
+            typeof v === 'bigint' ? Number(v) : v,
+          ),
+        );
+      }
+      result.push({
+        id: db.id,
+        title: db.title,
+        graphTabId: tab.id,
+        items,
+        brushFilters,
+      });
+    }
+  }
+  return result.length > 0 ? result : undefined;
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/graph_io.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/graph_io.ts
@@ -81,7 +81,7 @@ export async function loadGraphFromJson(
 
 export async function importGraph(
   deps: GraphIODeps,
-  state: DataExplorerState,
+  onCreateTab: (title: string, state: DataExplorerState) => void,
 ): Promise<void> {
   const input = document.createElement('input');
   input.type = 'file';
@@ -90,9 +90,6 @@ export async function importGraph(
     const files = (event.target as HTMLInputElement).files;
     if (files && files.length > 0) {
       const file = files[0];
-
-      if (!(await confirmAndFinalizeCurrentGraph(state))) return;
-
       const reader = new FileReader();
       reader.onload = async (e) => {
         const json = e.target?.result as string;
@@ -100,7 +97,9 @@ export async function importGraph(
           console.error('The selected file is empty or could not be read.');
           return;
         }
-        await loadGraphFromJson(deps, state.rootNodes, json);
+        const newState = deserializeState(json, deps.trace, deps.sqlModules);
+        const name = file.name.replace(/\.json$/i, '');
+        onCreateTab(name, newState);
       };
       reader.readAsText(file);
     }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
@@ -36,14 +36,18 @@ import {
   dataExplorerTabsStorage,
   createNewTabName,
   createEmptyState,
+  serializeAllDashboards,
 } from './data_explorer_tabs_storage';
 import {
   dashboardRegistry,
   parseBrushFilters,
-  serializeDashboardData,
   validateDashboardItems,
 } from './dashboard/dashboard_registry';
-import type {PersistedDataExplorerTabData} from './data_explorer_tabs_storage';
+import type {DashboardTabState} from './data_explorer';
+import type {
+  PersistedDataExplorerTabData,
+  PersistedDashboardData,
+} from './data_explorer_tabs_storage';
 import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 
 // --- Permalink persistence ---
@@ -55,6 +59,8 @@ interface DataExplorerPersistedState {
   // Multi-tab format (version 2+)
   tabs?: PersistedDataExplorerTabData[];
   activeTabId?: string;
+  // Flat list of dashboards, each referencing its parent graph tab.
+  dashboards?: PersistedDashboardData[];
   // Old single-graph format (version 1) - kept for backward compat
   graphJson?: string;
 }
@@ -68,6 +74,36 @@ function isValidPersistedState(
   const version = (init as {version: unknown}).version;
   // Accept both v1 (old single-graph) and v2 (multi-tab)
   return version === 1 || version === STORE_VERSION;
+}
+
+// --- Dashboard deserialization helpers ---
+
+function hydrateDashboardsForTab(
+  tabId: string,
+  allDashboards?: ReadonlyArray<PersistedDashboardData>,
+): DashboardTabState[] {
+  if (allDashboards !== undefined) {
+    const matching = allDashboards.filter((db) => db.graphTabId === tabId);
+    if (matching.length > 0) {
+      return matching.map((db) => ({
+        id: db.id,
+        title: db.title,
+        items: validateDashboardItems(db.items) ?? [],
+        brushFilters:
+          db.brushFilters !== undefined
+            ? parseBrushFilters(db.brushFilters)
+            : new Map(),
+      }));
+    }
+  }
+  return [
+    {
+      id: shortUuid(),
+      title: 'Dashboard 1',
+      items: [],
+      brushFilters: new Map(),
+    },
+  ];
 }
 
 // --- Plugin ---
@@ -112,6 +148,14 @@ export default class implements PerfettoPlugin {
       id: shortUuid(),
       title: title ?? createNewTabName(this.tabs),
       state: createEmptyState(),
+      dashboards: [
+        {
+          id: shortUuid(),
+          title: 'Dashboard 1',
+          items: [],
+          brushFilters: new Map(),
+        },
+      ],
     };
   }
 
@@ -133,20 +177,6 @@ export default class implements PerfettoPlugin {
     const newTab = this.createNewTab();
     this.tabs.push(newTab);
     this.activeTabId = newTab.id;
-    this.debouncedSave();
-    m.redraw();
-  };
-
-  private handleDashboardTabAdd = (): void => {
-    const dashboardId = shortUuid();
-    const tab: DataExplorerTab = {
-      id: shortUuid(),
-      title: createNewTabName(this.tabs, 'Dashboard'),
-      state: createEmptyState(),
-      dashboardId,
-    };
-    this.tabs.push(tab);
-    this.activeTabId = tab.id;
     this.debouncedSave();
     m.redraw();
   };
@@ -222,6 +252,14 @@ export default class implements PerfettoPlugin {
       id: shortUuid(),
       title,
       state,
+      dashboards: [
+        {
+          id: shortUuid(),
+          title: 'Dashboard 1',
+          items: [],
+          brushFilters: new Map(),
+        },
+      ],
     };
 
     const afterIndex = this.tabs.findIndex((t) => t.id === afterTabId);
@@ -287,32 +325,27 @@ export default class implements PerfettoPlugin {
   private saveToPermalinkStore(): void {
     if (!this.permalinkStore) return;
 
+    const hasDashboardContent = (tab: DataExplorerTab): boolean =>
+      tab.dashboards.some((db) => db.items.length > 0);
+
     const tabsData: PersistedDataExplorerTabData[] = this.tabs
       .filter(
-        (tab) =>
-          tab.state.rootNodes.length > 0 || tab.dashboardId !== undefined,
+        (tab) => tab.state.rootNodes.length > 0 || hasDashboardContent(tab),
       )
-      .map((tab) => {
-        const dbData = serializeDashboardData(
-          tab.dashboardId,
-          tab.dashboardItems,
-          tab.dashboardBrushFilters,
-        );
-        return {
-          id: tab.id,
-          title: tab.title,
-          graphJson:
-            tab.state.rootNodes.length > 0
-              ? serializeState(tab.state)
-              : undefined,
-          ...dbData,
-        };
-      });
+      .map((tab) => ({
+        id: tab.id,
+        title: tab.title,
+        graphJson:
+          tab.state.rootNodes.length > 0
+            ? serializeState(tab.state)
+            : undefined,
+      }));
 
     this.permalinkStore.edit((draft) => {
       draft.version = STORE_VERSION;
       draft.tabs = tabsData.length > 0 ? tabsData : undefined;
       draft.activeTabId = this.activeTabId;
+      draft.dashboards = serializeAllDashboards(this.tabs);
       // Clear deprecated single-graph field
       draft.graphJson = undefined;
     });
@@ -322,16 +355,10 @@ export default class implements PerfettoPlugin {
 
   /** Hydrate tabs from persisted tab data, returning the list of loaded tabs. */
   private hydrateTabs(
-    tabsData: ReadonlyArray<{
-      id: string;
-      title: string;
-      graphJson?: string;
-      dashboardId?: string;
-      dashboardItems?: unknown[];
-      brushFilters?: Record<string, unknown[]>;
-    }>,
+    tabsData: ReadonlyArray<PersistedDataExplorerTabData>,
     trace: Trace,
     sqlModules: SqlModules,
+    allDashboards?: ReadonlyArray<PersistedDashboardData>,
   ): DataExplorerTab[] {
     return tabsData.map((tabData) => {
       const state =
@@ -353,16 +380,7 @@ export default class implements PerfettoPlugin {
         id: tabData.id,
         title: tabData.title,
         state,
-        dashboardId: tabData.dashboardId,
-        dashboardItems:
-          tabData.dashboardId !== undefined
-            ? validateDashboardItems(tabData.dashboardItems)
-            : undefined,
-        dashboardBrushFilters:
-          tabData.dashboardId !== undefined &&
-          tabData.brushFilters !== undefined
-            ? parseBrushFilters(tabData.brushFilters)
-            : undefined,
+        dashboards: hydrateDashboardsForTab(tabData.id, allDashboards),
       };
     });
   }
@@ -399,7 +417,12 @@ export default class implements PerfettoPlugin {
       // Try multi-tab format first (version 2+)
       if (permalinkState.tabs !== undefined && permalinkState.tabs.length > 0) {
         try {
-          this.tabs = this.hydrateTabs(permalinkState.tabs, trace, sqlModules);
+          this.tabs = this.hydrateTabs(
+            permalinkState.tabs,
+            trace,
+            sqlModules,
+            permalinkState.dashboards,
+          );
           this.activeTabId =
             permalinkState.activeTabId !== undefined &&
             this.tabs.some((t) => t.id === permalinkState.activeTabId)
@@ -441,11 +464,16 @@ export default class implements PerfettoPlugin {
       }
     }
 
-    // Priority 2: Check new localStorage tabs key
+    // Priority 2: Check localStorage tabs
     const persistedTabs = dataExplorerTabsStorage.load();
     if (persistedTabs !== undefined) {
       try {
-        this.tabs = this.hydrateTabs(persistedTabs.tabs, trace, sqlModules);
+        this.tabs = this.hydrateTabs(
+          persistedTabs.tabs,
+          trace,
+          sqlModules,
+          persistedTabs.dashboards,
+        );
         this.activeTabId = this.tabs.some(
           (t) => t.id === persistedTabs.activeTabId,
         )
@@ -521,7 +549,6 @@ export default class implements PerfettoPlugin {
           onStateUpdate: this.makeOnStateUpdate(this.activeTabId),
           makeOnStateUpdate: (tabId: string) => this.makeOnStateUpdate(tabId),
           onTabAdd: this.handleTabAdd,
-          onDashboardTabAdd: this.handleDashboardTabAdd,
           onTabClose: this.handleTabClose,
           onTabChange: this.handleTabChange,
           onTabRename: this.handleTabRename,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/styles.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/styles.scss
@@ -37,11 +37,27 @@
     }
   }
 
+  // Wrapper with nested sub-tabs (Graph | Dashboard). Uses flex column
+  // so the sub-tab bar gets its natural height and the content fills rest.
+  &__tab-with-subtabs {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  &__sub-tab-bar {
+    flex-shrink: 0;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--pf-color-border);
+  }
+
   // Wrapper for each tab's Builder content. The Tabs widget uses Gate
   // (display:contents) which has clientHeight === 0; DrawerPanel needs
   // a real sized parent to measure its container height.
   &__tab-content {
     height: 100%;
+    min-height: 0;
+    flex: 1;
   }
 }
 


### PR DESCRIPTION
From now on dashboards can't have datasources from multiple graphs. This is enforced in the UX by adding dashboard on a separate tab level, rather than a sibling to the dashboard.
Also made it so that imported json files will be shown in a different tab.