### PR TITLE
tp: fix BFS/DFS excluding start nodes not in graph

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/graph_traversal.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/graph_traversal.cc
@@ -86,7 +86,12 @@ struct Dfs : public sqlite::AggregateFunction<Dfs> {
     }
     PERFETTO_DCHECK(!start_ids->empty());
 
-    std::vector<bool> visited(graph->size());
+    uint32_t graph_size = static_cast<uint32_t>(graph->size());
+    uint32_t max_id = graph_size;
+    for (int64_t x : *start_ids) {
+      max_id = std::max(max_id, static_cast<uint32_t>(x) + 1);
+    }
+    std::vector<bool> visited(max_id);
     std::vector<State> stack;
     for (int64_t x : *start_ids) {
       stack.emplace_back(State{static_cast<uint32_t>(x), std::nullopt});
@@ -95,14 +100,16 @@ struct Dfs : public sqlite::AggregateFunction<Dfs> {
       State state = stack.back();
       stack.pop_back();
 
-      auto& node = (*graph)[state.id];
       if (visited[state.id]) {
         continue;
       }
       table->Insert({state.id, state.parent_id});
       visited[state.id] = true;
 
-      const auto& children = node.outgoing_edges;
+      if (state.id >= graph_size) {
+        continue;
+      }
+      const auto& children = (*graph)[state.id].outgoing_edges;
       for (auto it = children.rbegin(); it != children.rend(); ++it) {
         stack.emplace_back(State{*it, state.id});
       }
@@ -151,11 +158,16 @@ struct Bfs : public sqlite::AggregateFunction<Bfs> {
     }
     PERFETTO_DCHECK(!start_ids->empty());
 
-    std::vector<bool> visited(graph->size());
+    uint32_t graph_size = static_cast<uint32_t>(graph->size());
+    uint32_t max_id = graph_size;
+    for (int64_t raw_id : *start_ids) {
+      max_id = std::max(max_id, static_cast<uint32_t>(raw_id) + 1);
+    }
+    std::vector<bool> visited(max_id);
     base::CircularQueue<State> queue;
     for (int64_t raw_id : *start_ids) {
       auto id = static_cast<uint32_t>(raw_id);
-      if (id >= graph->size() || visited[id]) {
+      if (visited[id]) {
         continue;
       }
       visited[id] = true;
@@ -166,6 +178,9 @@ struct Bfs : public sqlite::AggregateFunction<Bfs> {
       queue.pop_front();
       data.Insert({state.id, state.parent_id});
 
+      if (state.id >= graph_size) {
+        continue;
+      }
       auto& node = (*graph)[state.id];
       for (uint32_t n : node.outgoing_edges) {
         if (visited[n]) {

--- a/test/trace_processor/diff_tests/stdlib/android/heap_graph_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/android/heap_graph_tests.py
@@ -100,6 +100,7 @@ class HeapGraph(TestSuite):
           "A",2,200,4,11200
           "java.lang.String",1,10000,1,10000
           "B",1,1000,1,1000
+          "java.lang.String",1,666,1,666
         """))
 
   def test_heap_graph_stats(self):

--- a/test/trace_processor/diff_tests/stdlib/graphs/search_tests.py
+++ b/test/trace_processor/diff_tests/stdlib/graphs/search_tests.py
@@ -135,6 +135,82 @@ class GraphSearchTests(TestSuite):
           "R","[NULL]"
         """))
 
+  def test_dfs_start_node_not_in_graph(self):
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE graphs.search;
+
+          WITH foo AS (
+            SELECT 0 AS source_node_id, 1 AS dest_node_id
+          )
+          SELECT * FROM graph_reachable_dfs!(foo, (SELECT 99 AS node_id));
+        """,
+        out=Csv("""
+        "node_id","parent_node_id"
+        99,"[NULL]"
+        """))
+
+  def test_dfs_mixed_start_nodes_in_and_not_in_graph(self):
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE graphs.search;
+
+          WITH foo AS (
+            SELECT 0 AS source_node_id, 1 AS dest_node_id
+          )
+          SELECT * FROM graph_reachable_dfs!(
+            foo,
+            (SELECT 0 AS node_id UNION ALL SELECT 99)
+          )
+          ORDER BY node_id;
+        """,
+        out=Csv("""
+        "node_id","parent_node_id"
+        0,"[NULL]"
+        1,0
+        99,"[NULL]"
+        """))
+
+  def test_bfs_start_node_not_in_graph(self):
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE graphs.search;
+
+          WITH foo AS (
+            SELECT 0 AS source_node_id, 1 AS dest_node_id
+          )
+          SELECT * FROM graph_reachable_bfs!(foo, (SELECT 99 AS node_id));
+        """,
+        out=Csv("""
+        "node_id","parent_node_id"
+        99,"[NULL]"
+        """))
+
+  def test_bfs_mixed_start_nodes_in_and_not_in_graph(self):
+    return DiffTestBlueprint(
+        trace=DataPath('counters.json'),
+        query="""
+          INCLUDE PERFETTO MODULE graphs.search;
+
+          WITH foo AS (
+            SELECT 0 AS source_node_id, 1 AS dest_node_id
+          )
+          SELECT * FROM graph_reachable_bfs!(
+            foo,
+            (SELECT 0 AS node_id UNION ALL SELECT 99)
+          )
+          ORDER BY node_id;
+        """,
+        out=Csv("""
+        "node_id","parent_node_id"
+        0,"[NULL]"
+        1,0
+        99,"[NULL]"
+        """))
+
   def test_bfs_empty_table(self):
     return DiffTestBlueprint(
         trace=DataPath('counters.json'),


### PR DESCRIPTION
- BFS silently dropped start nodes with id >= graph size
- DFS had an out-of-bounds access for the same case
- Both now compute visited vector size from max(graph_size, max_start_id + 1) and skip edge traversal (not the node itself) when the node has no edges

Bug: b/492610709