### PR TITLE
de: Propagate column set changes to visualizations

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
@@ -301,12 +301,13 @@ export class DashboardChartView
         this.executionRequested = true;
         attrs.source
           .requestExecution()
-          .then(() => m.redraw())
-          .catch((e) => console.debug('Dashboard source execution failed:', e));
+          .catch((e) => console.debug('Dashboard source execution failed:', e))
+          .finally(() => {
+            this.executionRequested = false;
+          });
       }
       return m(EmptyState, {icon: 'hourglass_empty', title: 'Loading data…'});
     }
-    this.executionRequested = false;
 
     const entry = this.ensureLoader(attrs, config);
     const ctx = {node: adapter, onFilterChange: () => m.redraw()};

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node.ts
@@ -171,12 +171,6 @@ export class DashboardNode implements QueryNode {
       },
     };
     dashboardRegistry.setExportedSource(source);
-
-    // Eagerly resolve the table name. If the upstream node has already been
-    // executed this returns immediately (cached in QueryExecutionService).
-    this.resolveTableName(source, parentNodeId).catch((e: unknown) =>
-      console.debug('Dashboard table name resolution failed:', e),
-    );
   }
 
   private async resolveTableName(
@@ -192,6 +186,7 @@ export class DashboardNode implements QueryNode {
 
   onPrevNodesUpdated(): void {
     this.publishExportedSource();
+    this.state.onchange?.();
   }
 
   serializeState(): DashboardSerializedState & {primaryInputId?: string} {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node_unittest.ts
@@ -317,19 +317,25 @@ describe('DashboardNode', () => {
       expect(matching).toHaveLength(1);
     });
 
-    test('eagerly resolves tableName on publish', async () => {
+    test('resolves tableName via requestExecution', async () => {
       const mockGetTable = jest.fn().mockResolvedValue('table_42');
+      const mockRequest = jest.fn().mockResolvedValue(undefined);
       const source = createMockSourceNode('src-1');
       const node = new DashboardNode({
         getTableNameForNode: mockGetTable,
+        requestNodeExecution: mockRequest,
       });
       connectNodes(source, node);
       node.onPrevNodesUpdated();
 
-      expect(mockGetTable).toHaveBeenCalledWith('src-1');
-      // Wait for the async resolution to complete.
-      await mockGetTable.mock.results[0].value;
+      // Table name is not eagerly resolved on publish.
+      expect(mockGetTable).not.toHaveBeenCalled();
+
+      // Calling requestExecution triggers both execution and table resolution.
       const exported = dashboardRegistry.getExportedSource(node.nodeId);
+      await exported?.requestExecution?.();
+      expect(mockRequest).toHaveBeenCalledWith('src-1');
+      expect(mockGetTable).toHaveBeenCalledWith('src-1');
       expect(exported?.tableName).toBe('table_42');
     });
 


### PR DESCRIPTION
Fix: If the column was removed from/added to the dataSource, this change wouldn't propagate properly to the charts.