### PR TITLE
Allow heapprofd_standalone_client to build for Chrome

### DIFF
--- a/gn/BUILD.gn
+++ b/gn/BUILD.gn
@@ -424,8 +424,13 @@ if (enable_perfetto_trace_processor_linenoise) {
 # Only used by src/profiling in standalone and android builds.
 if (enable_perfetto_heapprofd || enable_perfetto_traced_perf) {
   group("libunwindstack") {
-    public_configs = [ "//buildtools:libunwindstack_config" ]
-    public_deps = [ "//buildtools:libunwindstack" ]
+    if (build_with_chromium && is_android) {
+      public_configs = [ "//third_party/libunwindstack:libunwindstack_config" ]
+      public_deps = [ "//third_party/libunwindstack" ]
+    } else {
+      public_configs = [ "//buildtools:libunwindstack_config" ]
+      public_deps = [ "//buildtools:libunwindstack" ]
+    }
   }
 }
 

--- a/gn/perfetto.gni
+++ b/gn/perfetto.gni
@@ -178,7 +178,7 @@ declare_args() {
   # but is built on Linux as well for test/compiler coverage.
   # On Android, it requires API level 26 due to libunwindstack.
   enable_perfetto_heapprofd =
-      perfetto_build_with_android ||
+      perfetto_build_with_android || (build_with_chromium && is_android) ||
       (perfetto_build_standalone && is_clang &&
        (is_linux || (is_android && android_api_level >= 26)))
 

--- a/src/profiling/common/proc_utils.h
+++ b/src/profiling/common/proc_utils.h
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 
 #include <cinttypes>
+#include <cstdlib>
 #include <optional>
 #include <set>
 #include <vector>

--- a/src/profiling/common/profiler_guardrails.cc
+++ b/src/profiling/common/profiler_guardrails.cc
@@ -20,9 +20,13 @@
 #include <algorithm>
 #include <optional>
 
+#include "perfetto/base/build_config.h"
 #include "perfetto/ext/base/file_utils.h"
 #include "perfetto/ext/base/scoped_file.h"
+
+#if PERFETTO_BUILDFLAG(PERFETTO_WATCHDOG)
 #include "perfetto/ext/base/watchdog_posix.h"
+#endif
 
 namespace perfetto {
 namespace profiling {
@@ -36,6 +40,7 @@ std::optional<uint64_t> GetCputimeSecForCurrentProcess(
     base::ScopedFile stat_fd) {
   if (!stat_fd)
     return std::nullopt;
+#if PERFETTO_BUILDFLAG(PERFETTO_WATCHDOG)
   base::ProcStat stat;
   if (!ReadProcStat(stat_fd.get(), &stat)) {
     PERFETTO_ELOG("Failed to read stat file to enforce guardrails.");
@@ -43,6 +48,9 @@ std::optional<uint64_t> GetCputimeSecForCurrentProcess(
   }
   return (stat.utime + stat.stime) /
          static_cast<unsigned long>(sysconf(_SC_CLK_TCK));
+#else
+  return std::nullopt;
+#endif
 }
 
 ProfilerMemoryGuardrails::ProfilerMemoryGuardrails()

--- a/src/profiling/memory/BUILD.gn
+++ b/src/profiling/memory/BUILD.gn
@@ -135,12 +135,16 @@ shared_library("heapprofd_api_noop") {
 
   # This target does absolutely nothing, so we do not want to depend on
   # liblog.
-  configs -= [ "//gn/standalone:android_liblog" ]  # nogncheck
+  if (perfetto_build_standalone) {
+    configs -= [ "//gn/standalone:android_liblog" ]  # nogncheck
+  }
   sources = [ "client_api_noop.cc" ]
 }
 
 shared_library("heapprofd_client_api") {
-  configs -= [ "//gn/standalone:android_liblog" ]  # nogncheck
+  if (perfetto_build_standalone) {
+    configs -= [ "//gn/standalone:android_liblog" ]  # nogncheck
+  }
   if (perfetto_build_with_android) {
     cflags = [ "-DPERFETTO_ANDROID_ASYNC_SAFE_LOG" ]
   } else {
@@ -352,33 +356,35 @@ perfetto_unittest_source_set("unittests") {
   }
 }
 
-source_set("end_to_end_tests") {
-  testonly = true
-  deps = [
-    ":client",
-    ":daemon",
-    ":wire_protocol",
-    "../../../gn:default_deps",
-    "../../../gn:gtest_and_gmock",
-    "../../../gn:libunwindstack",
-    "../../../protos/perfetto/config/profiling:cpp",
-    "../../../protos/perfetto/trace/interned_data:cpp",
-    "../../../protos/perfetto/trace/profiling:cpp",
-    "../../../test:integrationtest_initializer",
-    "../../../test:test_helper",
-    "../../base",
-    "../../base:test_support",
-    "../../trace_processor:lib",
-    "../../tracing/test:test_support",
-  ]
-  sources = [
-    "heapprofd_end_to_end_test.cc",
-    "heapprofd_producer_integrationtest.cc",
-  ]
-  if (perfetto_build_with_android) {
-    deps += [ ":heapprofd_client_api" ]
-  } else {
-    deps += [ ":heapprofd_standalone_client" ]
+if (enable_perfetto_integration_tests) {
+  source_set("end_to_end_tests") {
+    testonly = true
+    deps = [
+      ":client",
+      ":daemon",
+      ":wire_protocol",
+      "../../../gn:default_deps",
+      "../../../gn:gtest_and_gmock",
+      "../../../gn:libunwindstack",
+      "../../../protos/perfetto/config/profiling:cpp",
+      "../../../protos/perfetto/trace/interned_data:cpp",
+      "../../../protos/perfetto/trace/profiling:cpp",
+      "../../../test:integrationtest_initializer",
+      "../../../test:test_helper",
+      "../../base",
+      "../../base:test_support",
+      "../../trace_processor:lib",
+      "../../tracing/test:test_support",
+    ]
+    sources = [
+      "heapprofd_end_to_end_test.cc",
+      "heapprofd_producer_integrationtest.cc",
+    ]
+    if (perfetto_build_with_android) {
+      deps += [ ":heapprofd_client_api" ]
+    } else {
+      deps += [ ":heapprofd_standalone_client" ]
+    }
   }
 }
 

--- a/src/profiling/memory/unwinding.cc
+++ b/src/profiling/memory/unwinding.cc
@@ -75,7 +75,8 @@ constexpr size_t kMaxAllocRecordArenaSize = 2 * kRecordBatchSize;
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
 #pragma GCC diagnostic ignored "-Wexit-time-destructors"
 static std::vector<std::string> kSkipMaps{"heapprofd_client.so",
-                                          "heapprofd_client_api.so"};
+                                          "heapprofd_client_api.so",
+                                          "libheapprofd_standalone_client.so"};
 #pragma GCC diagnostic pop
 
 size_t GetRegsSize(unwindstack::Regs* regs) {

--- a/src/profiling/memory/wire_protocol.h
+++ b/src/profiling/memory/wire_protocol.h
@@ -47,7 +47,7 @@ constexpr size_t kMaxRegisterDataSize =
               sizeof(uint64_t) * unwindstack::ARM64_REG_LAST,
               sizeof(uint32_t) * unwindstack::X86_REG_LAST,
               sizeof(uint64_t) * unwindstack::X86_64_REG_LAST,
-              sizeof(uint64_t) * unwindstack::RISCV64_REG_COUNT});
+              sizeof(uint64_t) * unwindstack::RISCV64_REG_MAX});
 
 // Types needed for the wire format used for communication between the client
 // and heapprofd. The basic format of a record sent by the client is

--- a/src/traced/probes/packages_list/BUILD.gn
+++ b/src/traced/probes/packages_list/BUILD.gn
@@ -25,37 +25,39 @@ source_set("packages_list_parser") {
   ]
 }
 
-source_set("packages_list") {
-  public_deps = [ "../../../tracing/core" ]
-  deps = [
-    ":packages_list_parser",
-    "..:data_source",
-    "../../../../gn:default_deps",
-    "../../../../include/perfetto/ext/traced",
-    "../../../../protos/perfetto/common:zero",
-    "../../../../protos/perfetto/config/android:zero",
-    "../../../../protos/perfetto/trace:zero",
-    "../../../../protos/perfetto/trace/android:zero",
-    "../../../base",
-    "../common",
-  ]
-  sources = [
-    "packages_list_data_source.cc",
-    "packages_list_data_source.h",
-  ]
-}
+if (enable_perfetto_traced_probes) {
+  source_set("packages_list") {
+    public_deps = [ "../../../tracing/core" ]
+    deps = [
+      ":packages_list_parser",
+      "..:data_source",
+      "../../../../gn:default_deps",
+      "../../../../include/perfetto/ext/traced",
+      "../../../../protos/perfetto/common:zero",
+      "../../../../protos/perfetto/config/android:zero",
+      "../../../../protos/perfetto/trace:zero",
+      "../../../../protos/perfetto/trace/android:zero",
+      "../../../base",
+      "../common",
+    ]
+    sources = [
+      "packages_list_data_source.cc",
+      "packages_list_data_source.h",
+    ]
+  }
 
-perfetto_unittest_source_set("unittests") {
-  testonly = true
-  deps = [
-    ":packages_list",
-    ":packages_list_parser",
-    "../../../../gn:default_deps",
-    "../../../../gn:gtest_and_gmock",
-    "../../../../protos/perfetto/trace/android:cpp",
-    "../../../../protos/perfetto/trace/android:zero",
-    "../../../../src/base:test_support",
-    "../../../../src/tracing/test:test_support",
-  ]
-  sources = [ "packages_list_unittest.cc" ]
+  perfetto_unittest_source_set("unittests") {
+    testonly = true
+    deps = [
+      ":packages_list",
+      ":packages_list_parser",
+      "../../../../gn:default_deps",
+      "../../../../gn:gtest_and_gmock",
+      "../../../../protos/perfetto/trace/android:cpp",
+      "../../../../protos/perfetto/trace/android:zero",
+      "../../../../src/base:test_support",
+      "../../../../src/tracing/test:test_support",
+    ]
+    sources = [ "packages_list_unittest.cc" ]
+  }
 }


### PR DESCRIPTION
This allows libheaprofd_standalone_client.so to be included in the chrome_public_apk target for tracing Chrome's custom allocators.

Main changes:
* Re-plumbs the GN build to remove/simplify dependencies for Chromium.
* Adds a "lib" prefix to `kSkipMaps`.

AI disclosure: I used Gemini CLI to get started and find the main things that needed to change. This PR is derived from that, alongside human review and cleanup.