### PR TITLE
tp: Wattson: improve static power attribution using bitmasks

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/estimates.sql
@@ -19,6 +19,8 @@ INCLUDE PERFETTO MODULE wattson.curves.utils;
 
 INCLUDE PERFETTO MODULE wattson.device_infos;
 
+INCLUDE PERFETTO MODULE wattson.utils;
+
 -- Get estimates per unique configuration, establishing the 1-to-1 map from CPU
 -- configuration to the config_hash
 CREATE PERFETTO TABLE _unique_estimates_mw AS
@@ -32,11 +34,7 @@ SELECT
   coalesce(base.cpu5_curve, lut5.curve_value) AS cpu5_mw,
   coalesce(base.cpu6_curve, lut6.curve_value) AS cpu6_mw,
   coalesce(base.cpu7_curve, lut7.curve_value) AS cpu7_mw,
-  iif(
-    no_static = 1,
-    0.0,
-    iif(0 IN _device_policies, coalesce(lut0.static, 0), 0) + iif(1 IN _device_policies, coalesce(lut1.static, 0), 0) + iif(2 IN _device_policies, coalesce(lut2.static, 0), 0) + iif(3 IN _device_policies, coalesce(lut3.static, 0), 0) + iif(4 IN _device_policies, coalesce(lut4.static, 0), 0) + iif(5 IN _device_policies, coalesce(lut5.static, 0), 0) + iif(6 IN _device_policies, coalesce(lut6.static, 0), 0) + iif(7 IN _device_policies, coalesce(lut7.static, 0), 0) + static_1d
-  ) AS static_mw,
+  iif(0 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 0), coalesce(lut0.static, 0), 0) + iif(1 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 1), coalesce(lut1.static, 0), 0) + iif(2 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 2), coalesce(lut2.static, 0), 0) + iif(3 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 3), coalesce(lut3.static, 0), 0) + iif(4 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 4), coalesce(lut4.static, 0), 0) + iif(5 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 5), coalesce(lut5.static, 0), 0) + iif(6 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 6), coalesce(lut6.static, 0), 0) + iif(7 IN _device_policies AND _extract_bit!(policy_cpus_on_mask, 7), coalesce(lut7.static, 0), 0) + static_1d AS static_mw,
   l3_lut.l3_hit,
   l3_lut.l3_miss
 FROM _w_dependent_cpus_unique AS base

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/freq_idle.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/freq_idle.sql
@@ -58,18 +58,10 @@ SELECT
   -- Set idle since subsequent calculations are based on number of idle/active
   -- CPUs. If offline/suspended, set the CPU to the device specific deepest idle
   -- state.
-  iif(
-    suspend.suspended OR hotplug.offline,
-    (
-      SELECT
-        idle
-      FROM _deepest_idle
-    ),
-    idle.idle
-  ) AS idle,
+  iif(suspend.suspended OR hotplug.offline, deepest.idle, idle.idle) AS idle,
   -- If CPU is suspended or offline, set power estimate to 0
   iif(suspend.suspended OR hotplug.offline, 0, lut.curve_value) AS curve_value,
-  iif(suspend.suspended OR hotplug.offline, 0, lut.static) AS static
+  lut.static
 FROM _interval_intersect!(
   (
     _ii_subquery!(_valid_window),
@@ -90,4 +82,5 @@ JOIN _gapless_suspend_slices AS suspend
   ON suspend._auto_id = id_4
 -- Left join since some CPUs may only match the 2D LUT
 LEFT JOIN _filtered_curves_1d AS lut
-  ON freq.policy = lut.policy AND freq.freq = lut.freq_khz AND idle.idle = lut.idle;
+  ON freq.policy = lut.policy AND freq.freq = lut.freq_khz AND idle.idle = lut.idle
+CROSS JOIN _deepest_idle AS deepest;

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/pivot.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/cpu/pivot.sql
@@ -105,14 +105,100 @@ SELECT
   *
 FROM _cpu_stats_subquery!(7, cpu7_curve, cpu7_static, freq_7, idle_7);
 
--- Does calculations for CPUs that are independent of other CPUs or frequencies
--- This is the last generic table before going to device specific table calcs
-CREATE PERFETTO TABLE _w_independent_cpus_calc AS
+CREATE PERFETTO TABLE _all_stats AS
 SELECT
   base.ts,
   base.dur,
   cast_int!(l3_hit_rate * base.dur) AS l3_hit_count,
   cast_int!(l3_miss_rate * base.dur) AS l3_miss_count,
+  freq_0,
+  idle_0,
+  freq_1,
+  idle_1,
+  freq_2,
+  idle_2,
+  freq_3,
+  idle_3,
+  freq_4,
+  idle_4,
+  freq_5,
+  idle_5,
+  freq_6,
+  idle_6,
+  freq_7,
+  idle_7,
+  _stats_cpu0.cpu0_curve,
+  _stats_cpu1.cpu1_curve,
+  _stats_cpu2.cpu2_curve,
+  _stats_cpu3.cpu3_curve,
+  _stats_cpu4.cpu4_curve,
+  _stats_cpu5.cpu5_curve,
+  _stats_cpu6.cpu6_curve,
+  _stats_cpu7.cpu7_curve,
+  _stats_cpu0.cpu0_static,
+  _stats_cpu1.cpu1_static,
+  _stats_cpu2.cpu2_static,
+  _stats_cpu3.cpu3_static,
+  _stats_cpu4.cpu4_static,
+  _stats_cpu5.cpu5_static,
+  _stats_cpu6.cpu6_static,
+  _stats_cpu7.cpu7_static,
+  _wattson_dsu_frequency.dsu_freq,
+  CAST(_bitmask8!(
+    idle_0 != deepest.idle,
+    idle_1 != deepest.idle,
+    idle_2 != deepest.idle,
+    idle_3 != deepest.idle,
+    idle_4 != deepest.idle,
+    idle_5 != deepest.idle,
+    idle_6 != deepest.idle,
+    idle_7 != deepest.idle
+  ) AS INTEGER) AS cpus_on_mask
+FROM _interval_intersect!(
+  (
+    _ii_subquery!(_stats_cpu0),
+    _ii_subquery!(_stats_cpu1),
+    _ii_subquery!(_stats_cpu2),
+    _ii_subquery!(_stats_cpu3),
+    _ii_subquery!(_stats_cpu4),
+    _ii_subquery!(_stats_cpu5),
+    _ii_subquery!(_stats_cpu6),
+    _ii_subquery!(_stats_cpu7),
+    _ii_subquery!(_wattson_dsu_frequency),
+    _ii_subquery!(_arm_l3_rates)
+  ),
+  ()
+) AS base
+JOIN _stats_cpu0
+  ON _stats_cpu0._auto_id = base.id_0
+JOIN _stats_cpu1
+  ON _stats_cpu1._auto_id = base.id_1
+JOIN _stats_cpu2
+  ON _stats_cpu2._auto_id = base.id_2
+JOIN _stats_cpu3
+  ON _stats_cpu3._auto_id = base.id_3
+JOIN _stats_cpu4
+  ON _stats_cpu4._auto_id = base.id_4
+JOIN _stats_cpu5
+  ON _stats_cpu5._auto_id = base.id_5
+JOIN _stats_cpu6
+  ON _stats_cpu6._auto_id = base.id_6
+JOIN _stats_cpu7
+  ON _stats_cpu7._auto_id = base.id_7
+JOIN _wattson_dsu_frequency
+  ON _wattson_dsu_frequency._auto_id = base.id_8
+JOIN _arm_l3_rates
+  ON _arm_l3_rates._auto_id = base.id_9
+CROSS JOIN _deepest_idle AS deepest;
+
+-- Does calculations for CPUs that are independent of other CPUs or frequencies
+-- This is the last generic table before going to device specific table calcs
+CREATE PERFETTO TABLE _w_independent_cpus_calc AS
+SELECT
+  ts,
+  dur,
+  l3_hit_count,
+  l3_miss_count,
   hash(
     freq_0,
     idle_0,
@@ -148,51 +234,28 @@ SELECT
   idle_6,
   freq_7,
   idle_7,
-  _stats_cpu0.cpu0_curve,
-  _stats_cpu1.cpu1_curve,
-  _stats_cpu2.cpu2_curve,
-  _stats_cpu3.cpu3_curve,
-  _stats_cpu4.cpu4_curve,
-  _stats_cpu5.cpu5_curve,
-  _stats_cpu6.cpu6_curve,
-  _stats_cpu7.cpu7_curve,
-  _wattson_dsu_frequency.dsu_freq,
-  cpu0_static + cpu1_static + cpu2_static + cpu3_static + cpu4_static + cpu5_static + cpu6_static + cpu7_static AS static_1d
-FROM _interval_intersect!(
-  (
-    _ii_subquery!(_stats_cpu0),
-    _ii_subquery!(_stats_cpu1),
-    _ii_subquery!(_stats_cpu2),
-    _ii_subquery!(_stats_cpu3),
-    _ii_subquery!(_stats_cpu4),
-    _ii_subquery!(_stats_cpu5),
-    _ii_subquery!(_stats_cpu6),
-    _ii_subquery!(_stats_cpu7),
-    _ii_subquery!(_wattson_dsu_frequency),
-    _ii_subquery!(_arm_l3_rates)
-  ),
-  ()
-) AS base
-JOIN _stats_cpu0
-  ON _stats_cpu0._auto_id = base.id_0
-JOIN _stats_cpu1
-  ON _stats_cpu1._auto_id = base.id_1
-JOIN _stats_cpu2
-  ON _stats_cpu2._auto_id = base.id_2
-JOIN _stats_cpu3
-  ON _stats_cpu3._auto_id = base.id_3
-JOIN _stats_cpu4
-  ON _stats_cpu4._auto_id = base.id_4
-JOIN _stats_cpu5
-  ON _stats_cpu5._auto_id = base.id_5
-JOIN _stats_cpu6
-  ON _stats_cpu6._auto_id = base.id_6
-JOIN _stats_cpu7
-  ON _stats_cpu7._auto_id = base.id_7
-JOIN _wattson_dsu_frequency
-  ON _wattson_dsu_frequency._auto_id = base.id_8
-JOIN _arm_l3_rates
-  ON _arm_l3_rates._auto_id = base.id_9;
+  cpu0_curve,
+  cpu1_curve,
+  cpu2_curve,
+  cpu3_curve,
+  cpu4_curve,
+  cpu5_curve,
+  cpu6_curve,
+  cpu7_curve,
+  dsu_freq,
+  CAST(_bitmask8!(
+    cpus_on_mask & m0,
+    cpus_on_mask & m1,
+    cpus_on_mask & m2,
+    cpus_on_mask & m3,
+    cpus_on_mask & m4,
+    cpus_on_mask & m5,
+    cpus_on_mask & m6,
+    cpus_on_mask & m7
+  ) AS INTEGER) AS policy_cpus_on_mask,
+  iif(cpus_on_mask & m0, cpu0_static, 0) + iif(cpus_on_mask & m1, cpu1_static, 0) + iif(cpus_on_mask & m2, cpu2_static, 0) + iif(cpus_on_mask & m3, cpu3_static, 0) + iif(cpus_on_mask & m4, cpu4_static, 0) + iif(cpus_on_mask & m5, cpu5_static, 0) + iif(cpus_on_mask & m6, cpu6_static, 0) + iif(cpus_on_mask & m7, cpu7_static, 0) AS static_1d
+FROM _all_stats
+CROSS JOIN _policy_masks;
 
 -- Slices view with all UNIQUE configs of independent and dependent CPU data
 CREATE PERFETTO VIEW _w_dependent_cpus_unique AS
@@ -210,17 +273,6 @@ WITH
       max(cpu = 6) AS dsu_6,
       max(cpu = 7) AS dsu_7
     FROM _cpu_w_dsu_dependency
-  ),
-  _static_checks AS (
-    SELECT
-      0 IN _cpus_for_static AS c0,
-      1 IN _cpus_for_static AS c1,
-      2 IN _cpus_for_static AS c2,
-      3 IN _cpus_for_static AS c3,
-      4 IN _cpus_for_static AS c4,
-      5 IN _cpus_for_static AS c5,
-      6 IN _cpus_for_static AS c6,
-      7 IN _cpus_for_static AS c7
   ),
   _w_unique_configs AS (
     SELECT
@@ -251,19 +303,8 @@ WITH
       cpu7_curve,
       dsu_freq,
       static_1d,
-      min(idle_0, idle_1, idle_2, idle_3, idle_4, idle_5, idle_6, idle_7) AS all_cpu_deep_idle,
-      min(
-        iif(sc.c0, idle_0, 1),
-        iif(sc.c1, idle_1, 1),
-        iif(sc.c2, idle_2, 1),
-        iif(sc.c3, idle_3, 1),
-        iif(sc.c4, idle_4, 1),
-        iif(sc.c5, idle_5, 1),
-        iif(sc.c6, idle_6, 1),
-        iif(sc.c7, idle_7, 1)
-      ) AS no_static
+      policy_cpus_on_mask
     FROM _w_independent_cpus_calc
-    CROSS JOIN _static_checks AS sc
     GROUP BY
       config_hash
   ),

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/device_infos.sql
@@ -15,6 +15,8 @@
 
 INCLUDE PERFETTO MODULE android.device;
 
+INCLUDE PERFETTO MODULE wattson.utils;
+
 -- Device specific info for deep idle time offsets
 CREATE PERFETTO TABLE _device_cpu_deep_idle_offsets AS
 WITH
@@ -204,6 +206,34 @@ CREATE PERFETTO TABLE _device_policies AS
 SELECT DISTINCT
   policy
 FROM _dev_cpu_policy_map;
+
+-- Defines bitmasks for each CPU where bits are set for all cores sharing the same
+-- cpufreq policy. This is used to determine if a cluster is active (any core on)
+-- to correctly attribute shared static power.
+CREATE PERFETTO TABLE _policy_masks AS
+WITH
+  _dev_policies AS (
+    SELECT
+      max(iif(cpu = 0, policy, -1)) AS p0,
+      max(iif(cpu = 1, policy, -1)) AS p1,
+      max(iif(cpu = 2, policy, -1)) AS p2,
+      max(iif(cpu = 3, policy, -1)) AS p3,
+      max(iif(cpu = 4, policy, -1)) AS p4,
+      max(iif(cpu = 5, policy, -1)) AS p5,
+      max(iif(cpu = 6, policy, -1)) AS p6,
+      max(iif(cpu = 7, policy, -1)) AS p7
+    FROM _dev_cpu_policy_map
+  )
+SELECT
+  _policy_mask!(p0, p0, p1, p2, p3, p4, p5, p6, p7) AS m0,
+  _policy_mask!(p1, p0, p1, p2, p3, p4, p5, p6, p7) AS m1,
+  _policy_mask!(p2, p0, p1, p2, p3, p4, p5, p6, p7) AS m2,
+  _policy_mask!(p3, p0, p1, p2, p3, p4, p5, p6, p7) AS m3,
+  _policy_mask!(p4, p0, p1, p2, p3, p4, p5, p6, p7) AS m4,
+  _policy_mask!(p5, p0, p1, p2, p3, p4, p5, p6, p7) AS m5,
+  _policy_mask!(p6, p0, p1, p2, p3, p4, p5, p6, p7) AS m6,
+  _policy_mask!(p7, p0, p1, p2, p3, p4, p5, p6, p7) AS m7
+FROM _dev_policies;
 
 -- Devices that require using devfreq
 CREATE PERFETTO TABLE _use_devfreq AS

--- a/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/wattson/utils.sql
@@ -52,3 +52,93 @@ RETURNS TableOrSubquery AS
 CREATE PERFETTO MACRO _dsu_dep()
 RETURNS Expr AS
 255;
+
+-- Constructs an 8-bit mask from 8 boolean expressions
+CREATE PERFETTO MACRO _bitmask8(
+    b0 Expr,
+    b1 Expr,
+    b2 Expr,
+    b3 Expr,
+    b4 Expr,
+    b5 Expr,
+    b6 Expr,
+    b7 Expr
+)
+RETURNS Expr AS
+(
+  (
+    (
+      $b0 != 0
+    ) | (
+      (
+        $b1 != 0
+      ) << 1
+    ) | (
+      (
+        $b2 != 0
+      ) << 2
+    ) | (
+      (
+        $b3 != 0
+      ) << 3
+    ) | (
+      (
+        $b4 != 0
+      ) << 4
+    ) | (
+      (
+        $b5 != 0
+      ) << 5
+    ) | (
+      (
+        $b6 != 0
+      ) << 6
+    ) | (
+      (
+        $b7 != 0
+      ) << 7
+    )
+  )
+);
+
+-- Extracts the bit at 'bit' index from 'mask'
+CREATE PERFETTO MACRO _extract_bit(
+    mask Expr,
+    bit Expr
+)
+RETURNS Expr AS
+(
+  (
+    (
+      $mask
+    ) >> (
+      $bit
+    )
+  ) & 1
+);
+
+-- Constructs an 8-bit mask based on policy matches
+CREATE PERFETTO MACRO _policy_mask(
+    target Expr,
+    p0 Expr,
+    p1 Expr,
+    p2 Expr,
+    p3 Expr,
+    p4 Expr,
+    p5 Expr,
+    p6 Expr,
+    p7 Expr
+)
+RETURNS Expr AS
+(
+  _bitmask8!(
+    $p0 != -1 AND $p0 = $target,
+    $p1 != -1 AND $p1 = $target,
+    $p2 != -1 AND $p2 = $target,
+    $p3 != -1 AND $p3 = $target,
+    $p4 != -1 AND $p4 = $target,
+    $p5 != -1 AND $p5 = $target,
+    $p6 != -1 AND $p6 = $target,
+    $p7 != -1 AND $p7 = $target
+  )
+);


### PR DESCRIPTION
Introduces bitmasks to track CPU cluster activity more accurately, allowing for generic attribution of shared static power.

Static power (leakage) for a cluster without inter-cluster dependency was only supported for a single cluster before. Update to using bitmasks to support multiple cluster static power calculations when the cluster do not have inter-cluster power dependency.

This is achieved by:
1. Adding new SQL macros for 8-bit bitwise operations in wattson/utils.sql.
2. Creating a policy-based bitmask table in wattson/device_infos.sql to map CPUs to their respective clusters.
3. Updating the pivot operation to calculate cluster activity masks.
4. Refining the final power estimate calculations to use these masks.

Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter '.*wattson.*'
Bug: 495918677
