### PR TITLE
sdk: Add track_event_buf_exhausted_policy to TracingInitArgs

### DIFF
--- a/include/perfetto/tracing/data_source.h
+++ b/include/perfetto/tracing/data_source.h
@@ -280,6 +280,12 @@ class DataSource : public DataSourceBase {
   constexpr static BufferExhaustedPolicy kBufferExhaustedPolicy =
       BufferExhaustedPolicy::kDrop;
 
+  // Returns the effective buffer exhausted policy. Derived classes can
+  // override this to provide a runtime value (e.g. from TracingInitArgs).
+  static BufferExhaustedPolicy GetDefaultBufferExhaustedPolicy() {
+    return DerivedDataSource::kBufferExhaustedPolicy;
+  }
+
   // Whether the kBufferExhaustedPolicy policy above is overridable via config.
   constexpr static bool kBufferExhaustedPolicyConfigurable = false;
 
@@ -506,7 +512,7 @@ class DataSource : public DataSourceBase {
     params.supports_multiple_instances =
         DerivedDataSource::kSupportsMultipleInstances;
     params.default_buffer_exhausted_policy =
-        DerivedDataSource::kBufferExhaustedPolicy;
+        DerivedDataSource::GetDefaultBufferExhaustedPolicy();
     params.buffer_exhausted_policy_configurable =
         DerivedDataSource::kBufferExhaustedPolicyConfigurable;
     return Helper::type().Register(

--- a/include/perfetto/tracing/internal/track_event_data_source.h
+++ b/include/perfetto/tracing/internal/track_event_data_source.h
@@ -246,6 +246,10 @@ class PERFETTO_EXPORT_COMPONENT TrackEventDataSource
  public:
   static constexpr bool kRequiresCallbacksUnderLock = false;
 
+  static BufferExhaustedPolicy GetDefaultBufferExhaustedPolicy() {
+    return TrackEventInternal::GetBufferExhaustedPolicy();
+  }
+
   // DataSource implementation.
   void OnSetup(const DataSourceBase::SetupArgs& args) override {
     auto config_raw = args.config->track_event_config_raw();
@@ -362,6 +366,8 @@ class PERFETTO_EXPORT_COMPONENT TrackEventDataSource
 
   static void ResetForTesting() {
     TrackEventInternal::GetInstance().ResetRegistriesForTesting();
+    TrackEventInternal::SetBufferExhaustedPolicy(
+        GetDefaultBufferExhaustedPolicy());
   }
 
  private:
@@ -373,6 +379,7 @@ template <const TrackEventCategoryRegistry* Registry>
 class TrackEvent {
  public:
   using TraceContext = TrackEventDataSource::TraceContext;
+
   static bool Register() { return TrackEventDataSource::AddRegistry(Registry); }
 
   // Add or remove a session observer for this track event data source. The

--- a/include/perfetto/tracing/internal/track_event_internal.h
+++ b/include/perfetto/tracing/internal/track_event_internal.h
@@ -354,6 +354,13 @@ class PERFETTO_EXPORT_COMPONENT TrackEventInternal {
     disallow_merging_with_system_tracks_ = disallow_merging_with_system_tracks;
   }
 
+  static inline BufferExhaustedPolicy GetBufferExhaustedPolicy() {
+    return buffer_exhausted_policy_;
+  }
+  static inline void SetBufferExhaustedPolicy(BufferExhaustedPolicy policy) {
+    buffer_exhausted_policy_ = policy;
+  }
+
   static int GetSessionCount();
 
   // Represents the default track for the calling thread.
@@ -387,6 +394,7 @@ class PERFETTO_EXPORT_COMPONENT TrackEventInternal {
 
   static protos::pbzero::BuiltinClock clock_;
   static bool disallow_merging_with_system_tracks_;
+  static BufferExhaustedPolicy buffer_exhausted_policy_;
 
   std::mutex mu_;
   std::vector<const TrackEventCategoryRegistry*> registries_;

--- a/include/perfetto/tracing/tracing.h
+++ b/include/perfetto/tracing/tracing.h
@@ -32,6 +32,7 @@
 #include "perfetto/base/export.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/tracing/backend_type.h"
+#include "perfetto/tracing/buffer_exhausted_policy.h"
 #include "perfetto/tracing/core/forward_decls.h"
 #include "perfetto/tracing/internal/in_process_tracing_backend.h"
 #include "perfetto/tracing/internal/system_tracing_backend.h"
@@ -152,6 +153,12 @@ struct TracingInitArgs {
   // making sure that Trace Processor doesn't merge track event and system
   // event tracks for the same thread.
   bool disallow_merging_with_system_tracks = false;
+
+  // [Optional] Sets the default buffer exhausted policy for TrackEvent.
+  // Defaults to kDrop. When set to kStall, the calling thread will block
+  // when the shared memory buffer is full instead of dropping trace data.
+  BufferExhaustedPolicy track_event_buffer_exhausted_policy =
+      BufferExhaustedPolicy::kDrop;
 
   // If set, this function will be called by the producer client to create a
   // socket for connection to the system service. The function takes one

--- a/src/tracing/internal/track_event_internal.cc
+++ b/src/tracing/internal/track_event_internal.cc
@@ -239,6 +239,10 @@ protos::pbzero::BuiltinClock TrackEventInternal::clock_ = kDefaultTraceClock;
 bool TrackEventInternal::disallow_merging_with_system_tracks_ = false;
 
 // static
+BufferExhaustedPolicy TrackEventInternal::buffer_exhausted_policy_ =
+    BufferExhaustedPolicy::kDrop;
+
+// static
 void TrackEventInternal::EnableRegistry(
     const TrackEventCategoryRegistry* registry,
     const protos::gen::TrackEventConfig& config,

--- a/src/tracing/test/api_integrationtest.cc
+++ b/src/tracing/test/api_integrationtest.cc
@@ -331,6 +331,7 @@ class MockTracingMuxer : public perfetto::internal::TracingMuxer {
   struct DataSource {
     perfetto::DataSourceDescriptor dsd;
     perfetto::internal::DataSourceStaticState* static_state;
+    perfetto::internal::DataSourceParams params;
   };
 
   MockTracingMuxer() : TracingMuxer(nullptr), prev_instance_(instance_) {
@@ -341,10 +342,10 @@ class MockTracingMuxer : public perfetto::internal::TracingMuxer {
   bool RegisterDataSource(
       const perfetto::DataSourceDescriptor& dsd,
       DataSourceFactory,
-      perfetto::internal::DataSourceParams,
+      perfetto::internal::DataSourceParams params,
       bool,
       perfetto::internal::DataSourceStaticState* static_state) override {
-    data_sources.emplace_back(DataSource{dsd, static_state});
+    data_sources.emplace_back(DataSource{dsd, static_state, params});
     return true;
   }
 
@@ -1943,6 +1944,38 @@ TEST_P(PerfettoApiTest, TrackEventDescriptor) {
   EXPECT_EQ("slow_category", desc.available_categories()[7].name());
   EXPECT_EQ("slow", desc.available_categories()[7].tags()[0]);
   EXPECT_EQ("disabled-by-default-cat", desc.available_categories()[8].name());
+}
+
+// Verifies that TracingInitArgs::track_event_buffer_exhausted_policy is
+// plumbed through to the DataSourceParams at registration time.
+//
+// In production, the policy is set via TracingInitArgs:
+//   perfetto::TracingInitArgs args;
+//   args.track_event_buffer_exhausted_policy =
+//       perfetto::BufferExhaustedPolicy::kStall;
+//   perfetto::Tracing::Initialize(args);
+//
+// This test uses MockTracingMuxer to inspect the params, so it calls the
+// internal API that Tracing::Initialize() delegates to.
+TEST_P(PerfettoApiTest, TrackEventSetBufferExhaustedPolicy) {
+  perfetto::internal::TrackEventDataSource::ResetForTesting();
+  MockTracingMuxer muxer;
+
+  // By default, the policy should be kDrop.
+  perfetto::TrackEvent::Register();
+  ASSERT_EQ(1u, muxer.data_sources.size());
+  EXPECT_EQ(perfetto::BufferExhaustedPolicy::kDrop,
+            muxer.data_sources[0].params.default_buffer_exhausted_policy);
+
+  // Simulate TracingInitArgs::track_event_buffer_exhausted_policy = kStall.
+  muxer.data_sources.clear();
+  perfetto::internal::TrackEventDataSource::ResetForTesting();
+  perfetto::internal::TrackEventInternal::SetBufferExhaustedPolicy(
+      perfetto::BufferExhaustedPolicy::kStall);
+  perfetto::TrackEvent::Register();
+  ASSERT_EQ(1u, muxer.data_sources.size());
+  EXPECT_EQ(perfetto::BufferExhaustedPolicy::kStall,
+            muxer.data_sources[0].params.default_buffer_exhausted_policy);
 }
 
 TEST_P(PerfettoApiTest, TrackEventSharedIncrementalState) {

--- a/src/tracing/tracing.cc
+++ b/src/tracing/tracing.cc
@@ -62,6 +62,9 @@ void Tracing::InitializeInternal(const TracingInitArgs& args) {
     if (args.disallow_merging_with_system_tracks) {
       internal::TrackEventInternal::SetDisallowMergingWithSystemTracks(true);
     }
+
+    internal::TrackEventInternal::SetBufferExhaustedPolicy(
+        args.track_event_buffer_exhausted_policy);
   }
 
   internal::TracingMuxerImpl::InitializeInstance(args);


### PR DESCRIPTION
Add a track_event_buffer_exhausted_policy field to TracingInitArgs,
allowing apps to set the buffer exhausted policy (drop vs stall)
for TrackEvent at initialization time.

The value is stashed in TrackEventInternal static state during
Tracing::Initialize() and read during TrackEvent::Register(),
following the same pattern as use_monotonic_clock and
disallow_merging_with_system_tracks. A protected Register(dsd,
params) overload on DataSource allows TrackEventDataSource to
inject custom DataSourceParams without intermediate storage.

TrackEvent is used in critical system services (e.g.,
system_server) where an accidental kStall policy could cause a
device soft-reboot. Plumbing through TracingInitArgs removes
ordering ambiguity (Initialize always precedes Register) and
avoids redundant state in DataSourceType. See https://github.com/google/perfetto/pull/1312 and
b/384007571.

I don't have a use-case for also allowing track_event_buf_exhaust_policy to be configurable.
For now, making a hard-choice when we initialize the process is ok.
If we need configurabilty, the extension points are natural; we can follow footsteps of this PR.

cc: @dreveman 