### PR TITLE
frametimeline: remove experimental from some fields

### DIFF
--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
@@ -210,8 +210,8 @@ FrameTimelineEventParser::FrameTimelineEventParser(
           context->storage->InternString("Display frame token")),
       present_delay_millis_id_(
           context->storage->InternString("Present Delay (ms)")),
-      vsync_resynced_jitter_millis_id_(context->storage->InternString(
-          "Vsync Resynced Jitter (ms)")),
+      vsync_resynced_jitter_millis_id_(
+          context->storage->InternString("Vsync Resynced Jitter (ms)")),
       present_type_id_(context->storage->InternString("Present type")),
       present_type_experimental_id_(
           context->storage->InternString("Present type (experimental)")),

--- a/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
+++ b/src/trace_processor/importers/proto/frame_timeline_event_parser.cc
@@ -209,9 +209,9 @@ FrameTimelineEventParser::FrameTimelineEventParser(
       display_frame_token_id_(
           context->storage->InternString("Display frame token")),
       present_delay_millis_id_(
-          context->storage->InternString("Present Delay (ms) (experimental)")),
+          context->storage->InternString("Present Delay (ms)")),
       vsync_resynced_jitter_millis_id_(context->storage->InternString(
-          "Vsync Resynced Jitter (ms) (experimental)")),
+          "Vsync Resynced Jitter (ms)")),
       present_type_id_(context->storage->InternString("Present type")),
       present_type_experimental_id_(
           context->storage->InternString("Present type (experimental)")),
@@ -223,7 +223,7 @@ FrameTimelineEventParser::FrameTimelineEventParser(
       jank_severity_type_id_(
           context->storage->InternString("Jank severity type")),
       jank_severity_score_id_(
-          context->storage->InternString("Jank Severity Score (experimental)")),
+          context->storage->InternString("Jank Severity Score")),
       jank_debug_metadata_id_(
           context->storage->InternString("Jank Metadata (debugging only)")),
       layer_name_id_(context->storage->InternString("Layer name")),

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/events.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/events.sql
@@ -349,7 +349,7 @@ SELECT
   extract_arg(s.arg_set_id, 'Prediction type') AS prediction_type,
   extract_arg(s.arg_set_id, 'Jank tag') AS jank_tag,
   extract_arg(s.arg_set_id, 'Jank tag (experimental)') AS jank_tag_experimental,
-  extract_arg(s.arg_set_id, 'Jank Severity Score (experimental)') AS jank_score,
+  extract_arg(s.arg_set_id, 'Jank Severity Score') AS jank_score,
   extract_arg(s.arg_set_id, 'Latched unsignaled count') AS latched_unsignaled_count,
   extract_arg(s.arg_set_id, 'Addressable unsignaled latch count') AS addressable_unsignaled_latch_count,
   extract_arg(s.arg_set_id, 'Latched fence state') AS latched_fence_state


### PR DESCRIPTION
the experimental jank types are now tracking the legacy jank type, so removing the tag experimental from the fields that are used by the jank classification by default.
