### PR TITLE
Fix handling of spaces in query regex

### DIFF
--- a/ui/src/plugins/com.android.AndroidStartup/optimizations.ts
+++ b/ui/src/plugins/com.android.AndroidStartup/optimizations.ts
@@ -84,7 +84,7 @@ export async function optimizationsTrack(
       AS
       SELECT
         MAX(slice_ts) AS compile_ts,
-        regexp_extract(slice_name, 'filter=([^\\s]+)') as filter
+        regexp_extract(slice_name, 'filter=([^ ]+)') as filter
       FROM android_thread_slices_for_all_startups
       WHERE slice_name GLOB 'location=* status=* filter=* reason=*'
         AND startup_id = $startup_id;


### PR DESCRIPTION
The '\\s' doesn't seem to behave as expected in regex, causing filters. For instance when the slice name is as follows:

```
location=/data/app/.../oat/arm64/split_MeasurementDynamite_installtime.vdex status=up-to-date filter=verify reason=vdex
```

...then we get `filter=verify rea` because the regex reads until it sees the letter 's', not whitespace.

Before: 
<img width="1243" height="131" alt="before" src="https://github.com/user-attachments/assets/5e9fea83-828a-4983-b220-1aabef8e9377" />

After:
<img width="1243" height="131" alt="after" src="https://github.com/user-attachments/assets/1c466002-fc91-4954-90a4-60d97bd6cd32" />
