### PR TITLE
Do not partition by layer_id when extending frames

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
@@ -33,7 +33,7 @@ WITH
   _frames_with_next AS (
     SELECT
       *,
-      lead(frame_ts) OVER (PARTITION BY cuj_id, layer_id ORDER BY frame_id) AS next_frame_start
+      lead(frame_ts) OVER (PARTITION BY cuj_id ORDER BY frame_id) AS next_frame_start
     FROM _android_distinct_frames_in_cuj
   ),
   _frames_with_extension_options AS (


### PR DESCRIPTION
If we start grouping frames by what layers' buffers they contain
when we decide how far to extend a frame, then our blocking call per frame
duration aggregations can contain double counted calls.

This is because one frame could "hover" over another frame
that animates a different layer, but they both would aggregate
a blocking call under the "hovered" frame.

Instead, just consider the next frame
and the next doFrame slices for frame extension.

Bug: 496794218
Test: tools/diff_test_trace_processor.py --name-filter ".*android.*" out/android/trace_processor_shell
Change-Id: Icfcd229d02aa7a3e5676a3f1593de094b318fdcf
