### PR TITLE
perfetto: add --only-binary=:all: for public PyPI installs

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 grpcio==1.76.0
-pandas==2.3.3
+pandas==2.3.2
 protobuf==6.33.5
 sqlglot==26.9.0
 yapf==0.40.2

--- a/tools/install-build-deps
+++ b/tools/install-build-deps
@@ -809,7 +809,7 @@ def InstallPythonVenv(public_pypi=False):
   cmd = [python_interpreter, '-m', 'venv', PYTHON_VENV_DIR]
   logging.info(f'Installing python venv {" ".join(cmd)}')
   subprocess.check_call(cmd)
-  cmd = [venv_pip, 'install']
+  cmd = [venv_pip, 'install', '--only-binary=:all:']
   if public_pypi:
     cmd += ['--index-url', 'https://pypi.org/simple/']
   cmd += ['-r', PYTHON_REQUIREMENTS]


### PR DESCRIPTION
Prevents pip from building packages from source when using the
public PyPI index, which avoids build failures on systems that
lack the required native toolchains.
