### PR TITLE
Fix ProtoLog string formatting

### DIFF
--- a/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc
@@ -59,6 +59,7 @@ std::optional<DecodedMessage> ProtoLogMessageDecoder::Decode(
     if (message.at(i) == '%' && i + 1 < message.length()) {
       switch (message.at(i + 1)) {
         case '%':
+          formatted_message.push_back('%');
           break;
         case 'd': {
           if (sint64_params_itr == sint64_params.end()) {

--- a/test/trace_processor/diff_tests/parser/android/protolog.textproto
+++ b/test/trace_processor/diff_tests/parser/android/protolog.textproto
@@ -151,12 +151,30 @@ packet {
   }
 }
 packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 2
+  sequence_flags: 2
+  trusted_pid: 1716
+  timestamp: 857384150
+  protolog_message {
+    message_id: 555
+    str_param_iids: 1
+  }
+}
+packet {
   trusted_uid: 10224
   trusted_packet_sequence_id: 10
   previous_packet_dropped: true
   trusted_pid: 2063
   first_packet_on_sequence: true
   protolog_viewer_config {
+    messages {
+      message_id: 555
+      message: "Test message with percent sign: %% and a string %s"
+      level: PROTOLOG_LEVEL_DEBUG
+      location: "com/test/TestClass.java:888"
+      group_id: 1
+    }
     messages {
       message_id: 6924537961316301726
       message: "Test message with a string (%s), an int (%d), a double %g, and a boolean %b."

--- a/test/trace_processor/diff_tests/parser/android/tests_protolog.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_protolog.py
@@ -23,7 +23,7 @@ class ProtoLog(TestSuite):
 
   def test_has_expected_protolog_rows(self):
     return DiffTestBlueprint(
-        trace=Path('protolog.textproto'),
+        trace=Path("protolog.textproto"),
         query="SELECT id, ts, level, tag, message, location, stacktrace FROM protolog;",
         out=Csv("""
         "id","ts","level","tag","message","location","stacktrace"
@@ -31,14 +31,17 @@ class ProtoLog(TestSuite):
         1,857384110,"WARN","MySecondGroup","Test message with different int formats: 888, 0o1570, 0x378, 888.000000, 8.880000e+02.","com/test/TestClass.java:567","[NULL]"
         2,857384130,"ERROR","MyThirdGroup","Message re-using interned string 'MyOtherTestString' == 'MyOtherTestString', but 'SomeOtherTestString' != 'MyOtherTestString'","com/test/TestClass.java:527","[NULL]"
         3,857384140,"VERBOSE","MyNonProcessedGroup","My non-processed proto message with a string (MyTestString), an int (888), a double 8.88, and a boolean true.","[NULL]","[NULL]"
-        """))
+        4,857384150,"DEBUG","MyFirstGroup","Test message with percent sign: % and a string MyTestString","com/test/TestClass.java:888","[NULL]"
+        """),
+    )
 
   def test_handles_packet_loss(self):
     return DiffTestBlueprint(
-        trace=Path('protolog_packet_loss.textproto'),
+        trace=Path("protolog_packet_loss.textproto"),
         query="SELECT id, ts, level, tag, message, location, stacktrace FROM protolog;",
         out=Csv("""
         "id","ts","level","tag","message","location","stacktrace"
         0,857384130,"DEBUG","MyFirstGroup","Test message with two strings: MyTestString and MyTestString","com/test/TestClass.java:123","[NULL]"
         1,857384130,"DEBUG","MyFirstGroup","Test message with two strings: MyNextTestString and MyNextTestString","com/test/TestClass.java:123","[NULL]"
-        """))
+        """),
+    )


### PR DESCRIPTION
Correctly handles %% escaping.
