### PR TITLE
protovm: adds the surfaceflinger patch to the trace packet

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -8105,8 +8105,11 @@ genrule {
     name: "perfetto_protos_perfetto_trace_android_winscope_extensions_zero_gen",
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
+        ":perfetto_protos_perfetto_common_zero",
+        ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_winscope_common_zero",
         ":perfetto_protos_perfetto_trace_android_winscope_extensions_zero",
+        ":perfetto_protos_perfetto_trace_android_winscope_regular_zero",
     ],
     tools: [
         "aprotoc",
@@ -8162,8 +8165,11 @@ genrule {
     name: "perfetto_protos_perfetto_trace_android_winscope_extensions_zero_gen_headers",
     srcs: [
         ":libprotobuf-internal-descriptor-proto",
+        ":perfetto_protos_perfetto_common_zero",
+        ":perfetto_protos_perfetto_protovm_zero",
         ":perfetto_protos_perfetto_trace_android_winscope_common_zero",
         ":perfetto_protos_perfetto_trace_android_winscope_extensions_zero",
+        ":perfetto_protos_perfetto_trace_android_winscope_regular_zero",
     ],
     tools: [
         "aprotoc",
@@ -20579,19 +20585,28 @@ cc_library_static {
         ":perfetto_include_perfetto_public_abi_base",
         ":perfetto_include_perfetto_public_base",
         ":perfetto_include_perfetto_public_protozero",
+        ":perfetto_protos_perfetto_common_zero_gen",
+        ":perfetto_protos_perfetto_protovm_zero_gen",
         ":perfetto_protos_perfetto_trace_android_winscope_common_zero_gen",
         ":perfetto_protos_perfetto_trace_android_winscope_extensions_zero_gen",
+        ":perfetto_protos_perfetto_trace_android_winscope_regular_zero_gen",
         ":perfetto_src_base_base",
         ":perfetto_src_protozero_protozero",
     ],
     host_supported: true,
     generated_headers: [
+        "perfetto_protos_perfetto_common_zero_gen_headers",
+        "perfetto_protos_perfetto_protovm_zero_gen_headers",
         "perfetto_protos_perfetto_trace_android_winscope_common_zero_gen_headers",
         "perfetto_protos_perfetto_trace_android_winscope_extensions_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_android_winscope_regular_zero_gen_headers",
     ],
     export_generated_headers: [
+        "perfetto_protos_perfetto_common_zero_gen_headers",
+        "perfetto_protos_perfetto_protovm_zero_gen_headers",
         "perfetto_protos_perfetto_trace_android_winscope_common_zero_gen_headers",
         "perfetto_protos_perfetto_trace_android_winscope_extensions_zero_gen_headers",
+        "perfetto_protos_perfetto_trace_android_winscope_regular_zero_gen_headers",
     ],
     defaults: [
         "perfetto_defaults",

--- a/BUILD
+++ b/BUILD
@@ -5737,8 +5737,11 @@ perfetto_proto_library(
     name = "winscope_proto",
     visibility = PERFETTO_CONFIG.public_visibility,
     deps = [
+        ":protos_perfetto_common_protos",
+        ":protos_perfetto_protovm_protos",
         ":protos_perfetto_trace_android_winscope_common_protos",
         ":protos_perfetto_trace_android_winscope_extensions_protos",
+        ":protos_perfetto_trace_android_winscope_regular_protos",
     ],
 )
 
@@ -7456,10 +7459,14 @@ perfetto_proto_library(
         PERFETTO_CONFIG.proto_library_visibility,
     ],
     deps = [
+        ":protos_perfetto_common_protos",
+        ":protos_perfetto_protovm_protos",
         ":protos_perfetto_trace_android_winscope_common_protos",
+        ":protos_perfetto_trace_android_winscope_regular_protos",
     ] + PERFETTO_CONFIG.deps.protobuf_descriptor_proto,
     exports = [
         ":protos_perfetto_trace_android_winscope_common_protos",
+        ":protos_perfetto_trace_android_winscope_regular_protos",
     ],
 )
 
@@ -7467,8 +7474,11 @@ perfetto_proto_library(
 perfetto_cc_protozero_library(
     name = "protos_perfetto_trace_android_winscope_extensions_zero",
     deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_protovm_zero",
         ":protos_perfetto_trace_android_winscope_common_zero",
         ":protos_perfetto_trace_android_winscope_extensions_protos",
+        ":protos_perfetto_trace_android_winscope_regular_zero",
     ],
 )
 

--- a/protos/perfetto/trace/android/BUILD.gn
+++ b/protos/perfetto/trace/android/BUILD.gn
@@ -69,7 +69,10 @@ perfetto_proto_library("winscope_regular_@TYPE@") {
 # Winscope messages added to TracePacket as extensions
 perfetto_proto_library("winscope_extensions_@TYPE@") {
   proto_generators = [ "zero" ]
-  public_deps = [ ":winscope_common_@TYPE@" ]
+  public_deps = [
+    ":winscope_common_@TYPE@",
+    ":winscope_regular_@TYPE@",
+  ]
   sources = [
     "android_input_event.proto",
     "app/statusbarmanager.proto",

--- a/protos/perfetto/trace/android/winscope_extensions.proto
+++ b/protos/perfetto/trace/android/winscope_extensions.proto
@@ -19,5 +19,5 @@ syntax = "proto2";
 package perfetto.protos;
 
 message WinscopeExtensions {
-  extensions 1 to 6;
+  extensions 1 to 7;
 }

--- a/protos/perfetto/trace/android/winscope_extensions_impl.proto
+++ b/protos/perfetto/trace/android/winscope_extensions_impl.proto
@@ -23,6 +23,7 @@ import "protos/perfetto/trace/android/android_input_event.proto";
 import "protos/perfetto/trace/android/inputmethodeditor.proto";
 import "protos/perfetto/trace/android/viewcapture.proto";
 import "protos/perfetto/trace/android/windowmanager.proto";
+import "protos/perfetto/trace/android/surfaceflinger_layers.proto";
 
 message WinscopeExtensionsImpl {
   extend WinscopeExtensions {
@@ -33,5 +34,6 @@ message WinscopeExtensionsImpl {
     optional ViewCapture viewcapture = 4;
     optional AndroidInputEvent android_input_event = 5;
     optional WindowManagerTraceEntry windowmanager = 6;
+    optional LayersPatchProto surfaceflinger_layers_patch = 7;
   }
 }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -7683,7 +7683,7 @@ message AndroidUserList {
 // Begin of protos/perfetto/trace/android/winscope_extensions.proto
 
 message WinscopeExtensions {
-  extensions 1 to 6;
+  extensions 1 to 7;
 }
 
 // End of protos/perfetto/trace/android/winscope_extensions.proto


### PR DESCRIPTION
Adds the LayersPatchProto message to the winscope extensions proto message.