### PR TITLE
ci: upgrade sandbox image to ubuntu 22.04

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -46,8 +46,8 @@ jobs:
           - name: clang-x86-release
             PERFETTO_TEST_GN_ARGS: 'is_debug=false target_cpu=\"x86\" cc_wrapper=\"ccache\"'
             PERFETTO_INSTALL_BUILD_DEPS_ARGS: ''
-          - name: gcc8-x86_64-release
-            PERFETTO_TEST_GN_ARGS: 'is_debug=false is_clang=false enable_perfetto_grpc=true cc=\"gcc-8\" cxx=\"g++-8\" cc_wrapper=\"ccache\" enable_perfetto_llvm_symbolizer=true'
+          - name: gcc9-x86_64-release
+            PERFETTO_TEST_GN_ARGS: 'is_debug=false is_clang=false enable_perfetto_grpc=true cc=\"gcc-9\" cxx=\"g++-9\" cc_wrapper=\"ccache\" enable_perfetto_llvm_symbolizer=true'
             PERFETTO_INSTALL_BUILD_DEPS_ARGS: '--grpc'
     env:
       PERFETTO_CI_BUILD_CACHE_KEY: build-cache-${{ matrix.config.name }}

--- a/infra/ci/frontend/static/script.js
+++ b/infra/ci/frontend/static/script.js
@@ -18,7 +18,7 @@
 
 // If you add or remove job types, do not forget to fix the colspans below.
 const JOB_TYPES = [
-  { id: "linux/gcc8-x86_64-release", label: "rel" },
+  { id: "linux/gcc9-x86_64-release", label: "rel" },
   { id: "linux/clang-x86_64-debug", label: "dbg" },
   { id: "linux/clang-x86_64-tsan", label: "tsan" },
   { id: "linux/clang-x86_64-msan", label: "msan" },
@@ -189,7 +189,7 @@ var CLsPageRenderer = {
             ),
             m(
               "tr",
-              m("td", "gcc8"),
+              m("td", "gcc9"),
               m("td[colspan=7]", "clang"),
               m("td[colspan=1]", "ui"),
               m("td[colspan=1]", "clang-arm"),
@@ -482,10 +482,10 @@ async function fetchChecksForPR(id, commitHash) {
 
     // Extract the job ID from the long concatenated Github Actions string.
     // The input can be either
-    // linux / linux (gcc8-x86_64-release, is_debug=false  (when using matrix)
+    // linux / linux (gcc9-x86_64-release, is_debug=false  (when using matrix)
     // or just
     // bazel / bazel
-    // We want in output: 'linux/gcc8-x86_64-release' or 'bazel'.
+    // We want in output: 'linux/gcc9-x86_64-release' or 'bazel'.
     const m = check.name.match(
       /^([\w-]+)\s*\/\s*[\w-]+(?:\s*\(\s*([^,\s)]+))?/,
     );

--- a/infra/ci/sandbox/Dockerfile
+++ b/infra/ci/sandbox/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Creates an image that can check out / build / test the perfetto source.
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -22,11 +22,10 @@ RUN set -ex; \
     dpkg --add-architecture i386; \
     apt-get update; \
     apt-get -y install --no-install-recommends \
-        python3.9 \
+        python3.10 \
         python3-pip \
-        python3.9-dev \
-        python3.9-venv \
-        python3.9-distutils \
+        python3.10-dev \
+        python3.10-venv \
         python-is-python3 \
         git \
         curl \
@@ -51,23 +50,23 @@ RUN set -ex; \
         zlib1g-dev \
         unzip \
         xz-utils \
-        gcc-8 \
-        g++-8 \
-        gcc-8-multilib \
+        gcc-9 \
+        g++-9 \
+        gcc-9-multilib \
         openjdk-11-jdk \
-        clang-8 \
-        libc++-8-dev \
+        clang-11 \
+        libc++-11-dev \
         llvm-dev \
-        libc++abi-8-dev; \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1; \
+        libc++abi-11-dev; \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1; \
     python3 -m pip install --no-cache-dir protobuf pandas grpcio; \
     python3 --version; \
     python --version; \
     pip3 --version; \
-    gcc-8 --version; \
-    g++-8 --version; \
-    clang-8 --version; \
-    clang++-8 --version; \
+    gcc-9 --version; \
+    g++-9 --version; \
+    clang-11 --version; \
+    clang++-11 --version; \
     java -version
 
 # Chrome/puppeteer deps.


### PR DESCRIPTION
Python 3.9 has been EOLed and is causing some dependencies to no longer
show up on Pypi. Ubunutu 22.04 has been around long enough that we
should probably uprev.
