### PR TITLE
ci: fix PyJWT failure caused by rebuilding frontend

### DIFF
--- a/infra/ci/common_utils.py
+++ b/infra/ci/common_utils.py
@@ -71,7 +71,7 @@ def get_github_installation_token():
   payload = {
       'iat': now,
       'exp': now + (10 * 60),  # JWT valid for 10 minutes
-      'iss': GITHUB_APP_ID
+      'iss': str(GITHUB_APP_ID)
   }
   jwt_token = jwt.encode(payload, gh_private_key, algorithm='RS256')
   url = f'{GITHUB_API_URL}/app/installations/{GITHUB_APP_INSTALLATION_ID}/access_tokens'


### PR DESCRIPTION
Fixes the stack:
```
TypeError: Issuer (iss) must be a string.

at .encode ( /layers/google.python.pip/pip/lib/python3.12/site-packages/jwt/api_jwt.py:139 )
at .get_github_installation_token ( /srv/common_utils.py:76 )
at .get_cached_github_token ( /srv/main.py:62 )
```
