### PR TITLE
ci: install gh CLI in sync-protos and stop gating gen_merged_protos

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -37,6 +37,21 @@ jobs:
 
       - uses: ./.github/actions/install-build-deps
 
+      - name: Install GitHub CLI
+        run: |
+          if ! command -v gh >/dev/null 2>&1; then
+            (type -p wget >/dev/null || sudo apt-get install -y wget)
+            sudo mkdir -p -m 755 /etc/apt/keyrings
+            wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+              | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update
+            sudo apt-get install -y gh
+          fi
+          gh --version
+
       - name: Setup build directory
         run: |
           tools/gn gen out/proto_sync --args="is_debug=false"

--- a/tools/run_presubmit
+++ b/tools/run_presubmit
@@ -538,35 +538,6 @@ def CheckBinaryDescriptors(changed_files: List[str]) -> List[str]:
   return []
 
 
-def CheckMergedTraceConfigProto(changed_files: List[str]) -> List[str]:
-  if sys.platform == 'win32':
-    return []
-  tool_rel_path = 'tools/gen_merged_protos'
-  tool = os.path.join(REPO_ROOT, tool_rel_path)
-  # Use fnmatch patterns
-  files_to_check_list = filter_files(
-      changed_files, files_to_check=['protos/perfetto/*.proto', tool_rel_path])
-  if not files_to_check_list:
-    return []
-
-  tool_changed = tool_rel_path in [os.path.normpath(f) for f in changed_files]
-  source_files_changed = any(f != tool_rel_path for f in files_to_check_list)
-
-  if not tool_changed and not source_files_changed:
-    return []
-
-  try:
-    run_command([sys.executable, tool, '--check-only'], cwd=REPO_ROOT)
-  except FileNotFoundError:
-    return [f"Tool not found: {tool}"]
-  except subprocess.CalledProcessError:
-    return [
-        'perfetto_config.proto or perfetto_trace.proto is out of ' +
-        f'date. Please run python {tool} to update it.'
-    ]
-  return []
-
-
 def CheckProtoEventList(changed_files: List[str],
                         merge_base: Optional[str]) -> List[str]:
   target_file = 'src/tools/ftrace_proto_gen/event_list'
@@ -1032,7 +1003,6 @@ def main():
       (CheckBuild, [changed_files]),
       (CheckAndroidBlueprint, [changed_files]),
       (CheckBinaryDescriptors, [changed_files]),
-      (CheckMergedTraceConfigProto, [changed_files]),
       (CheckProtoEventList, [changed_files, merge_base]),  # Needs merge_base
       (CheckBannedCpp, [changed_files]),
       (CheckSqlModules, [changed_files]),  # Includes --check-includes


### PR DESCRIPTION
The self-hosted runner used by the daily sync-protos workflow doesn't
ship with the gh CLI, so the "Close existing proto sync PRs" step has
been failing with "gh: command not found" on every run. Install gh via
the official apt repo at the top of the job so the step can run.

Also drop CheckMergedTraceConfigProto from tools/run_presubmit so that
perfetto_config.proto / perfetto_trace.proto freshness is handled by
the sync-protos action rather than blocking CL presubmit.
