### PR TITLE
perfetto: auto-derive Python package version from CHANGELOG

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,27 @@
+import os
+import re
+
 from distutils.core import setup
+
+
+def _version_from_changelog():
+  """Derives the PyPI package version from the top entry of CHANGELOG.
+
+  The CHANGELOG uses entries like 'vX.Y - YYYY-MM-DD:' for released versions
+  (and 'Unreleased:' at the top while a release is in flight). The first
+  matching 'vX.Y' line is mapped to the PyPI version '0.X.Y' — keeping the
+  package in the 0.x series while encoding the Perfetto release in the
+  minor/patch components.
+  """
+  changelog = os.path.join(
+      os.path.dirname(os.path.abspath(__file__)), os.pardir, 'CHANGELOG')
+  with open(changelog) as f:
+    for line in f:
+      m = re.match(r'^v(\d+)[.](\d+)\s', line)
+      if m:
+        return '0.%s.%s' % (m.group(1), m.group(2))
+  raise RuntimeError('No vX.Y entry found in %s' % changelog)
+
 
 setup(
     name='perfetto',
@@ -15,7 +38,7 @@ setup(
         'perfetto.trace_processor': ['*.descriptor'],
     },
     include_package_data=True,
-    version='0.16.0',
+    version=_version_from_changelog(),
     license='apache-2.0',
     description='Python APIs and bindings for Perfetto (perfetto.dev)',
     author='Perfetto',


### PR DESCRIPTION
Replaces the hardcoded 0.16.0 in python/setup.py with a read of the top
released vX.Y entry from the repo-root CHANGELOG, mapping vX.Y to the
PyPI version X.Y.0. This is a prerequisite for unified versioning across
SDK, UI, and Python package per RFC-0022.

Note: the next PyPI publish will jump from 0.16.0 to (current) 54.0.0.
This is intentional and monotonic.
