### PR TITLE
tp: fix MSan false positives from SQLite on glibc 2.35+

### DIFF
--- a/gn/standalone/hash_file.py
+++ b/gn/standalone/hash_file.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prints a short hex digest of the given file. Used from GN to fold a file's
+# contents into a compile flag, so that ccache (which doesn't follow files
+# referenced by flags like -fsanitize-ignorelist=) invalidates when the file
+# changes.
+
+import hashlib
+import sys
+
+
+def main():
+  with open(sys.argv[1], 'rb') as f:
+    print(hashlib.sha256(f.read()).hexdigest()[:16])
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/gn/standalone/sanitizers/BUILD.gn
+++ b/gn/standalone/sanitizers/BUILD.gn
@@ -43,11 +43,20 @@ copy("ignorelist_copy") {
 config("sanitizers_cflags") {
   if (using_sanitizer) {
     ignorelist_path_ = rebase_path("ignorelist.txt", root_build_dir)
+
+    # -fsanitize-ignorelist only exposes the *path* on the command line, so
+    # ccache (which hashes arguments and source files but not files referenced
+    # by arguments) happily serves stale objects when the ignorelist contents
+    # change. Fold a content hash of the ignorelist into a -D define so any
+    # edit to it alters the compile command and invalidates the cache.
+    ignorelist_hash_ = exec_script("//gn/standalone/hash_file.py",
+                                   [ rebase_path("ignorelist.txt") ],
+                                   "trim string")
     cflags = [
       "-fno-omit-frame-pointer",
       "-fsanitize-ignorelist=$ignorelist_path_",
     ]
-    defines = []
+    defines = [ "PERFETTO_SANITIZERS_IGNORELIST_HASH=\"$ignorelist_hash_\"" ]
 
     if (is_asan) {
       cflags += [ "-fsanitize=address" ]

--- a/gn/standalone/sanitizers/ignorelist.txt
+++ b/gn/standalone/sanitizers/ignorelist.txt
@@ -1,8 +1,15 @@
 # The rules in this file are only applied at compile time.
 [memory]
-fun:vdbeChangeP4Full
+
+# MSan's readlink/fstat interceptors do not correctly mark the output buffer
+# as initialised on newer glibc, so any code that consumes the result trips
+# spurious use-of-uninitialized-value warnings. SQLite hits this throughout
+# its VFS layer (unixFullPathname, verifyDbFile, fileHasMoved, ...), so we
+# just ignore the whole amalgamation; it's upstream code we don't own.
+src:*sqlite3.c
+
+# Same problem, in libprotobuf's DiskSourceTree::OpenDiskFile -> fstat().
 fun:*OpenDiskFile*
 
-# Failure is being caused by MSAN not correctly realising that fstat initializes
-# stat buffer.
+# Same problem, in libunwindstack's MemoryFileAtOffset::Init -> fstat().
 fun:_ZN11unwindstack18MemoryFileAtOffset4InitERKNSt4__Cr12basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEEmm

--- a/src/base/file_utils.cc
+++ b/src/base/file_utils.cc
@@ -409,6 +409,9 @@ base::Status ListFilesRecursive(const std::string& dir_path,
       struct stat dirstat;
       std::string full_path = cur_dir + dirent->d_name;
       PERFETTO_CHECK(stat(full_path.c_str(), &dirstat) == 0);
+      // MSan's stat() interceptor on glibc 2.35+ does not mark the output
+      // buffer as initialized (the syscall goes through statx).
+      PERFETTO_MSAN_UNPOISON(&dirstat, sizeof(dirstat));
       if (S_ISDIR(dirstat.st_mode)) {
         dir_queue.push_back(full_path + '/');
       } else if (S_ISREG(dirstat.st_mode)) {

--- a/src/profiling/memory/heapprofd_producer.cc
+++ b/src/profiling/memory/heapprofd_producer.cc
@@ -111,6 +111,10 @@ bool IsFile(int fd, const char* fn) {
     PERFETTO_PLOG("lstat");
     return false;
   }
+  // MSan's fstat()/lstat() interceptors on glibc 2.35+ do not mark the output
+  // buffer as initialized (the syscall goes through statx).
+  PERFETTO_MSAN_UNPOISON(&fdstat, sizeof(fdstat));
+  PERFETTO_MSAN_UNPOISON(&fnstat, sizeof(fnstat));
   return fdstat.st_ino == fnstat.st_ino;
 }
 


### PR DESCRIPTION
MSan's readlink() and fstat() interceptors on newer glibc do not mark
the output buffer as initialized, so any code that consumes the result
trips a use-of-uninitialized-value warning. SQLite hits this throughout
its unix VFS layer (unixFullPathname -> appendOnePathElement, unixOpen
-> verifyDbFile, fileHasMoved, ...), which broke the ClassicExport and
ExportSubcommandSqlite integration tests as soon as the CI image was
upgraded to Ubuntu 22.04.

Rather than play whack-a-mole with individual fun: entries (the failure
chains through at least six SQLite functions and will move again on
the next SQLite upgrade), ignorelist the whole amalgamation with
src:*sqlite3.c. This subsumes the previously-needed vdbeChangeP4Full
and *OpenDiskFile* entries, both of which were stale after the 3.44.2
bump.

Also fold a sha256 of ignorelist.txt into a -D define so ccache
invalidates when the file changes. The -fsanitize-ignorelist=PATH flag
only exposes the path, not the contents, and ccache does not follow
files referenced by flags -- so without this, editing the ignorelist
silently serves stale objects.
