### PR TITLE
perfetto: add draft-release GitHub Actions workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,63 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates a draft GitHub Release on vX.Y tag push.
+#
+# The body is pre-populated with the matching CHANGELOG section as a
+# starting point. A maintainer is expected to edit it into full prose
+# release notes before clicking `finalize-release` to publish.
+#
+# Idempotent: re-running on an existing tag re-creates the draft only if
+# one does not exist; it never clobbers a release that has already been
+# published or edited.
+
+name: Draft release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+'
+
+permissions:
+  contents: write  # Required to create the release
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Extract CHANGELOG section for this tag
+        run: |
+          python3 tools/release/extract_changelog_section.py \
+            "${{ github.ref_name }}" > /tmp/release_body.txt
+          echo "--- Draft release body ---"
+          cat /tmp/release_body.txt
+
+      - name: Create draft release (if missing)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — leaving body untouched."
+          else
+            gh release create "$TAG" \
+              --draft \
+              --title "Perfetto $TAG" \
+              --notes-file /tmp/release_body.txt
+          fi

--- a/tools/release/extract_changelog_section.py
+++ b/tools/release/extract_changelog_section.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extracts a specific vX.Y section from the CHANGELOG to stdout.
+
+Used by the draft-release GitHub Actions workflow to pre-populate the
+release body with the matching CHANGELOG entry. The body is then
+expected to be hand-edited into full release notes before publishing.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+PROJECT_ROOT = os.path.abspath(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+
+
+def extract(changelog_text, version):
+  """Returns the CHANGELOG body for `version` (e.g. 'v54.0').
+
+  The body spans from the line after the header 'vX.Y - DATE:' up to (but
+  not including) the next 'vA.B - DATE:' header or end of file. Leading and
+  trailing blank lines are trimmed.
+  """
+  header_re = re.compile(r'^v\d+[.]\d+\s+-\s+\d{4}-\d{2}-\d{2}:\s*$')
+  target_re = re.compile(r'^%s\s+-\s+\d{4}-\d{2}-\d{2}:\s*$' %
+                         re.escape(version))
+
+  lines = changelog_text.splitlines()
+  start = None
+  for i, line in enumerate(lines):
+    if target_re.match(line):
+      start = i + 1
+      break
+  if start is None:
+    raise RuntimeError('Version %s not found in CHANGELOG' % version)
+
+  end = len(lines)
+  for i in range(start, len(lines)):
+    if header_re.match(lines[i]):
+      end = i
+      break
+
+  body = lines[start:end]
+  while body and not body[0].strip():
+    body.pop(0)
+  while body and not body[-1].strip():
+    body.pop()
+  return '\n'.join(body)
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  parser.add_argument('version', help='Version to extract, e.g. v54.0')
+  parser.add_argument(
+      '--changelog',
+      default=os.path.join(PROJECT_ROOT, 'CHANGELOG'),
+      help='Path to CHANGELOG (default: repo root)')
+  args = parser.parse_args()
+
+  with open(args.changelog) as f:
+    text = f.read()
+  sys.stdout.write(extract(text, args.version))
+  sys.stdout.write('\n')
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
Creates a draft GitHub Release on vX.Y tag push, pre-populated with the
matching CHANGELOG section. A maintainer is expected to edit the body
into full prose release notes before finalizing and publishing, per
RFC-0022 §Artifact flow.

Idempotent: if a release already exists for the tag (e.g. from a
previous run or a manually-created one), the workflow leaves it alone
rather than clobbering any human edits.

Also adds tools/release/extract_changelog_section.py to pull a single
vX.Y block out of the CHANGELOG, used by this workflow and callable
standalone.
