### PR TITLE
perfetto: add cut-canary GitHub Actions workflow

### DIFF
--- a/.github/workflows/cut-canary.yml
+++ b/.github/workflows/cut-canary.yml
@@ -1,0 +1,76 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Cuts canary by creating a merge commit on `canary` whose tree equals
+# the current tip of `main`. Manual trigger via the GitHub Actions UI.
+#
+# Uses the same tree-replacing merge pattern as merge-main-to-canary.yml
+# (git merge -s ours + git read-tree) so it always moves forward (no
+# force-push), preserves history on both sides, and handles the case of
+# cherry-picks on canary that have different SHAs than their
+# counterparts on main. Convention: every fix goes to main first and is
+# then cherry-picked to canary; anything canary-only would otherwise be
+# silently dropped by this operation.
+#
+# Pushes to canary subsequently trigger UI Cloud Build to redeploy the
+# canary channel. See RFC-0022.
+
+name: Cut canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write  # Required to push canary
+
+jobs:
+  cut-canary:
+    runs-on: ubuntu-latest
+    environment: canary
+    steps:
+      - name: Checkout canary
+        uses: actions/checkout@v4
+        with:
+          ref: canary
+          fetch-depth: 0
+
+      - name: Fetch main
+        run: git fetch origin main
+
+      - name: Short-circuit if canary already matches main
+        run: |
+          if [[ "$(git rev-parse HEAD^{tree})" == \
+                "$(git rev-parse origin/main^{tree})" ]]; then
+            echo "::notice::canary tree already matches main; nothing to do."
+            echo "SKIP=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure git
+        if: env.SKIP != '1'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into canary (replace tree with main)
+        if: env.SKIP != '1'
+        run: |
+          git merge -s ours origin/main --no-commit
+          git read-tree -m -u origin/main
+          git commit -m "Cut canary from main (automated)"
+
+      - name: Push canary
+        if: env.SKIP != '1'
+        run: |
+          git push origin HEAD:canary
+          echo "::notice::canary updated to tree of $(git rev-parse origin/main)."


### PR DESCRIPTION
Manually-triggered workflow that fast-forwards the canary branch to the
current tip of main. Fails (rather than force-pushing) if canary is not
an ancestor of main, which would indicate a cherry-pick landed on
canary without also being merged to main.

Pushes to canary subsequently trigger UI Cloud Build to redeploy the
canary channel. Per RFC-0022.
