### PR TITLE
tp: Use import public for TrackEvent in gpu_track_event.proto

### DIFF
--- a/protos/perfetto/trace/gpu/gpu_track_event.proto
+++ b/protos/perfetto/trace/gpu/gpu_track_event.proto
@@ -16,7 +16,7 @@ syntax = "proto2";
 
 package perfetto.protos;
 
-import "protos/perfetto/trace/track_event/track_event.proto";
+import public "protos/perfetto/trace/track_event/track_event.proto";
 
 // Correlates a track event with GPU render stage events.
 message GpuCorrelation {


### PR DESCRIPTION
The generated gpu_track_event.pbzero.h declares GpuTrackEvent as inheriting from TrackEvent (due to the `extend TrackEvent` block), but without `import public`, the protozero generator does not transitively breaking stricter Bazel/Blaze builds. 

This matches the pattern already used by android_track_event.proto and chrome_track_event.proto.
