### PR TITLE
Add stack samples to ETW events

### DIFF
--- a/protos/perfetto/config/etw/etw_config.proto
+++ b/protos/perfetto/config/etw/etw_config.proto
@@ -43,4 +43,6 @@ message EtwConfig {
   repeated string memory_provider_events = 3;
   // Provides events relating to file I/O.
   repeated string file_provider_events = 4;
+  // Events for which stacks should be collected.
+  repeated string stack_sampling_events = 5;
 }

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -1089,6 +1089,8 @@ message EtwConfig {
   repeated string memory_provider_events = 3;
   // Provides events relating to file I/O.
   repeated string file_provider_events = 4;
+  // Events for which stacks should be collected.
+  repeated string stack_sampling_events = 5;
 }
 
 // End of protos/perfetto/config/etw/etw_config.proto

--- a/protos/perfetto/trace/etw/etw.proto
+++ b/protos/perfetto/trace/etw/etw.proto
@@ -270,3 +270,11 @@ message FileIoOpEndEtwEvent {
   optional uint64 extra_info = 2;
   optional uint32 nt_status = 3;
 }
+
+// Proto definition based on the `StackWalk_Event` class definition. See
+// `Callstack` in `perfetto/protos/perfetto/trace/track_event/track_event.proto`
+// for context on what is contained in it.
+message StackWalkEtwEvent {
+  optional string trigger = 1;
+  optional uint64 callstack_iid = 2;
+}

--- a/protos/perfetto/trace/etw/etw_event.proto
+++ b/protos/perfetto/trace/etw/etw_event.proto
@@ -34,5 +34,6 @@ message EtwTraceEvent {
     FileIoReadWriteEtwEvent file_io_read_write = 10;
     FileIoSimpleOpEtwEvent file_io_simple_op = 11;
     FileIoOpEndEtwEvent file_io_op_end = 12;
+    StackWalkEtwEvent stack_walk = 13;
   }
 }

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -1089,6 +1089,8 @@ message EtwConfig {
   repeated string memory_provider_events = 3;
   // Provides events relating to file I/O.
   repeated string file_provider_events = 4;
+  // Events for which stacks should be collected.
+  repeated string stack_sampling_events = 5;
 }
 
 // End of protos/perfetto/config/etw/etw_config.proto
@@ -8047,6 +8049,14 @@ message FileIoOpEndEtwEvent {
   optional uint32 nt_status = 3;
 }
 
+// Proto definition based on the `StackWalk_Event` class definition. See
+// `Callstack` in `perfetto/protos/perfetto/trace/track_event/track_event.proto`
+// for context on what is contained in it.
+message StackWalkEtwEvent {
+  optional string trigger = 1;
+  optional uint64 callstack_iid = 2;
+}
+
 // End of protos/perfetto/trace/etw/etw.proto
 
 // Begin of protos/perfetto/trace/etw/etw_event.proto
@@ -8066,6 +8076,7 @@ message EtwTraceEvent {
     FileIoReadWriteEtwEvent file_io_read_write = 10;
     FileIoSimpleOpEtwEvent file_io_simple_op = 11;
     FileIoOpEndEtwEvent file_io_op_end = 12;
+    StackWalkEtwEvent stack_walk = 13;
   }
 }
 


### PR DESCRIPTION
This is the preliminary proto change to allow chromium to start parsing ETW StackWalk events into perfetto.

These will be grouped by TID post-facto by the traceprocessor.