### PR TITLE
ui: dev server env-var overrides via env var

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,8 @@ Unreleased:
   Trace Processor:
    *
   UI:
-   *
+   * Dev server: support overriding CLI flags via PERFETTO_UI_<FLAG> env or
+     ~/.config/perfetto/ui-dev-server.env.
 
 
 v54.0 - 2026-02-27:

--- a/ui/build.js
+++ b/ui/build.js
@@ -144,8 +144,51 @@ let liveServerDebounceTimerId = 0;
 const notifyLiveServerPendingFiles = new Set();
 
 
+// Loads ~/.config/perfetto/ui-dev-server.env and injects any KEY=VALUE pairs
+// into process.env, without overriding variables already set in the environment.
+function loadDevServerEnvFile() {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const envFile =
+      path.join(home, '.config', 'perfetto', 'ui-dev-server.env');
+  let content;
+  try {
+    content = fs.readFileSync(envFile, 'utf8');
+  } catch (e) {
+    return;  // File absent or unreadable — not an error.
+  }
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx < 0) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
 async function main() {
-  const parser = new argparse.ArgumentParser();
+  const parser = new argparse.ArgumentParser({
+    formatter_class: argparse.RawDescriptionHelpFormatter,
+    epilog: `
+Env-var overrides:
+  Any flag can be set via a PERFETTO_UI_<FLAG> environment variable,
+  where <FLAG> is the flag name uppercased with hyphens replaced by
+  underscores. Boolean flags are activated by "1" or "true". CLI flags
+  always take precedence over environment variables.
+
+  Examples:
+    PERFETTO_UI_SERVE_HOST=0.0.0.0
+    PERFETTO_UI_SERVE_PORT=10000
+    PERFETTO_UI_NO_BUILD=1
+    PERFETTO_UI_TITLE=my-instance
+
+  Defaults can also be persisted in:
+    ~/.config/perfetto/ui-dev-server.env
+  (one KEY=VALUE per line, # comments supported). Shell env vars take
+  precedence over the file.
+`,
+  });
   parser.add_argument('--out', {help: 'Output directory'});
   parser.add_argument('--minify-js', {
     help: 'Minify js files',
@@ -179,7 +222,25 @@ async function main() {
     help: 'Override the page title (useful for distinguishing multiple instances)',
   });
 
-  const args = parser.parse_args();
+  // Load ~/.config/perfetto/ui-dev-server.env defaults, then map any
+  // PERFETTO_UI_* env vars to synthetic argv entries prepended before the
+  // real argv so that explicit CLI flags always take precedence.
+  loadDevServerEnvFile();
+  const envPrefix = 'PERFETTO_UI_';
+  const syntheticArgv = [];
+  for (const [key, val] of Object.entries(process.env)) {
+    if (!key.startsWith(envPrefix)) continue;
+    const flag = '--' + key.slice(envPrefix.length).toLowerCase().replace(/_/g, '-');
+    const action = parser._actions.find(a => (a.option_strings || []).includes(flag));
+    if (!action) continue;
+    const isBoolFlag = action.nargs === 0;
+    if (isBoolFlag) {
+      if (val === '1' || val.toLowerCase() === 'true') syntheticArgv.push(flag);
+    } else {
+      syntheticArgv.push(`${flag}=${val}`);
+    }
+  }
+  const args = parser.parse_args([...syntheticArgv, ...process.argv.slice(2)]);
   const clean = !args.no_build;
   cfg.outDir = path.resolve(ensureDir(args.out || cfg.outDir));
   cfg.lockFile = pjoin(cfg.outDir, "watch.lock");


### PR DESCRIPTION
Any CLI flag can now be set via PERFETTO_UI_<FLAG>
(e.g. PERFETTO_UI_SERVE_HOST=0.0.0.0).
Defaults can be persisted in ~/.config/perfetto/ui-dev-server.env.
CLI flags always take precedence. Run with --help for details.