### PR TITLE
perfetto: fix YAML syntax in release workflows

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -59,8 +59,7 @@ jobs:
         run: |
           if ! gh release view "$VERSION" --repo "${{ github.repository }}" \
                > /dev/null 2>&1; then
-            echo "::error::No release found for tag $VERSION. Push the tag \
-first (via promote-stable.yml) to create the draft."
+            echo "::error::No release found for tag $VERSION. Push the tag first (via promote-stable.yml) to create the draft."
             exit 1
           fi
 
@@ -81,6 +80,4 @@ first (via promote-stable.yml) to create the draft."
           STAGING="/tmp/perfetto-${VERSION}-github-release"
           gh release upload "$VERSION" "$STAGING"/*.zip \
             --repo "${{ github.repository }}" --clobber
-          echo "::notice::Artifacts attached. Review the draft release at \
-https://github.com/${{ github.repository }}/releases and publish it \
-manually when ready."
+          echo "::notice::Artifacts attached. Review the draft release at https://github.com/${{ github.repository }}/releases and publish it manually when ready."

--- a/.github/workflows/promote-stable.yml
+++ b/.github/workflows/promote-stable.yml
@@ -49,8 +49,7 @@ jobs:
         run: |
           if [[ "$(git rev-parse HEAD^{tree})" == \
                 "$(git rev-parse origin/canary^{tree})" ]]; then
-            echo "::error::stable tree already matches canary; nothing to \
-promote. Cut canary first."
+            echo "::error::stable tree already matches canary; nothing to promote. Cut canary first."
             exit 1
           fi
 
@@ -64,9 +63,7 @@ promote. Cut canary first."
           FIRST=$(git show "origin/canary:CHANGELOG" \
                   | grep -m1 -E '^[^[:space:]]' || true)
           if ! [[ "$FIRST" =~ ^(v[0-9]+\.[0-9]+)[[:space:]]+-[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}: ]]; then
-            echo "::error::CHANGELOG top entry is not a released version \
-header (got: '$FIRST'). Update CHANGELOG to 'vX.Y - YYYY-MM-DD:' on main, \
-re-cut canary, and retry."
+            echo "::error::CHANGELOG top entry is not a released version header (got: '$FIRST'). Update CHANGELOG to 'vX.Y - YYYY-MM-DD:' on main, re-cut canary, and retry."
             exit 1
           fi
           VERSION="${BASH_REMATCH[1]}"
@@ -77,8 +74,7 @@ re-cut canary, and retry."
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
-            echo "::error::Tag $VERSION already exists. Bump CHANGELOG to \
-the next version on main and re-cut canary."
+            echo "::error::Tag $VERSION already exists. Bump CHANGELOG to the next version on main and re-cut canary."
             exit 1
           fi
 
@@ -102,5 +98,4 @@ the next version on main and re-cut canary."
           VERSION="${{ steps.version.outputs.version }}"
           git tag -a "$VERSION" HEAD -m "Perfetto $VERSION"
           git push origin "refs/tags/$VERSION"
-          echo "::notice::Tagged $VERSION at $(git rev-parse HEAD). \
-LUCI, Cloud Build, and draft-release.yml have been triggered."
+          echo "::notice::Tagged $VERSION at $(git rev-parse HEAD). LUCI, Cloud Build, and draft-release.yml have been triggered."


### PR DESCRIPTION
Backslash line continuations in `run: |` block scalars resumed at
column 0, which dedented below the block's indentation and ended
the scalar prematurely, breaking the workflow files. Join the
affected echo lines onto a single line.
