### PR TITLE
tbV2: fix write_wrap_count under-counting and discard-mode overwrite

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -783,7 +783,11 @@ void TraceBufferV2::CopyChunkUntrusted(
     if (overwrite_policy_ == kDiscard)
       return DiscardWrite();
 
-    DeleteNextChunksFor(cached_size_to_end);
+    // Skip the tail cleanup if the previous write landed exactly at the end
+    // of the buffer (|wr_| == |size_|): there is no leftover tail to clear.
+    if (cached_size_to_end > 0)
+      DeleteNextChunksFor(cached_size_to_end);
+
     wr_ = 0;
     stats_.set_write_wrap_count(stats_.write_wrap_count() + 1);
     PERFETTO_DCHECK(size_to_end() >= tbchunk_outer_size);
@@ -880,7 +884,6 @@ void TraceBufferV2::CopyChunkUntrusted(
 
   wr_ += tbchunk_outer_size;
   PERFETTO_DCHECK(wr_ <= size_ && wr_ <= used_size_);
-  wr_ = wr_ >= size_ ? 0 : wr_;
 
   stats_.set_chunks_written(stats_.chunks_written() + 1);
   stats_.set_bytes_written(stats_.bytes_written() + tbchunk_outer_size);

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -213,8 +213,8 @@ TEST_F(TraceBufferV2Test, ReadWrite_FillTillEnd) {
                          .AddPacket(2048 - 16, 'd')
                          .CopyIntoTraceBuffer());
 
-    // At this point the write pointer should have been reset at the beginning.
-    ASSERT_EQ(4096u, size_to_end());
+    // The write pointer lands exactly at the end of the buffer.
+    ASSERT_EQ(0u, size_to_end());
 
     trace_buffer()->BeginRead();
     ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(512 - 16, 'a')));
@@ -301,7 +301,7 @@ TEST_F(TraceBufferV2Test, ReadWrite_MinimalPadding) {
   ASSERT_EQ(16u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(3))
                      .CopyIntoTraceBuffer());
 
-  ASSERT_EQ(4096u, size_to_end());
+  ASSERT_EQ(0u, size_to_end());
 
   ASSERT_EQ(2032u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(4))
                        .AddPacket(2032 - 16, 'd')
@@ -315,7 +315,7 @@ TEST_F(TraceBufferV2Test, ReadWrite_MinimalPadding) {
                        .AddPacket(1008 - 16, 'f')
                        .CopyIntoTraceBuffer());
 
-  ASSERT_EQ(4096u, size_to_end());
+  ASSERT_EQ(0u, size_to_end());
 
   // The expected read sequence now is: c3, c4, c5.
   trace_buffer()->BeginRead();
@@ -2092,6 +2092,57 @@ TEST_F(TraceBufferV2Test, Alignment_ExactBufferBoundaryFragmentation) {
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 
+// In discard mode, once the buffer fills exactly (chunks land at the end),
+// subsequent writes must be dropped rather than overwriting earlier data.
+TEST_F(TraceBufferV2Test, DiscardPolicy_FillsExactlyThenDiscards) {
+  ResetBuffer(4096, TraceBufferV2::kDiscard);
+
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(2030, 'a')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(2030, 'b')
+      .CopyIntoTraceBuffer();
+
+  // Buffer is now full. This write must be discarded.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
+      .AddPacket(2030, 'c')
+      .CopyIntoTraceBuffer();
+
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(2030, 'a')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(2030, 'b')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+}
+
+// Verify write_wrap_count increments every time a write needs to wrap, and
+// that filling the buffer exactly defers the increment until the next write.
+TEST_F(TraceBufferV2Test, WriteWrapCount) {
+  ResetBuffer(4096);
+  EXPECT_EQ(0u, trace_buffer()->stats().write_wrap_count());
+
+  // Fill the buffer exactly. Wrap is not processed yet.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(2030, 'a')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(2030, 'b')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(0u, trace_buffer()->stats().write_wrap_count());
+
+  // Next write: buffer has no tail space, wrap is processed.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
+      .AddPacket(3054, 'c')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+
+  // Next write: tail space insufficient for the chunk, wrap again.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(3))
+      .AddPacket(2030, 'd')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(2u, trace_buffer()->stats().write_wrap_count());
+}
+
 // Test out-of-order patch application with fragmentation
 TEST_F(TraceBufferV2Test, Patching_OutOfOrderPatchesWithFragmentation) {
   ResetBuffer(4096);
@@ -2335,7 +2386,7 @@ TEST_F(TraceBufferV2Test, Overwrite_SizeDiffLessThanChunkHeader) {
   ASSERT_EQ(pad_size, CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
                           .AddPacket(pad_size - 16, 'b')
                           .CopyIntoTraceBuffer());
-  ASSERT_EQ(4096u, size_to_end());
+  ASSERT_EQ(0u, size_to_end());
 
   ASSERT_EQ(32u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
                      .AddPacket(32 - 16, 'c')


### PR DESCRIPTION
Two bugs caused by the silent natural-wrap path in CopyChunkUntrusted
(|wr_| silently resetting to 0 when a chunk landed exactly at the end
of the buffer):

1. write_wrap_count did not include these wraps, so bytes_written
   could be many multiples of buffer_size while the stat still read 0.
2. In kDiscard mode, subsequent writes were accepted and overwrote
   already-written data because the silent path did not consult
   overwrite_policy_, violating the DISCARD contract.

Fix: remove the silent wrap. |wr_| is allowed to equal |size_| after a
chunk lands exactly at the end; the next CopyChunkUntrusted() call
then sees size_to_end() == 0 and goes through the panic-wrap branch,
which already honors kDiscard and increments write_wrap_count. Adds a
guard around DeleteNextChunksFor since cached_size_to_end can now be 0.

Found on go/trace-uuid/8d33bb4e-c6bb-d440-d346-8401a3638868 which shows traced_buf_bytes_overwritten > 0 but no traced_buf_write_wrap_count
