### PR TITLE
tperf: allow raw perf events to specify dynamic pmu by name

### DIFF
--- a/protos/perfetto/common/perf_events.proto
+++ b/protos/perfetto/common/perf_events.proto
@@ -160,10 +160,17 @@ message PerfEvents {
   // struct. Primarily for local use-cases, since the event availability and
   // encoding is hardware-specific.
   message RawEvent {
+    // Either |type| or |pmu_name| can be set.
     optional uint32 type = 1;
     optional uint64 config = 2;
     optional uint64 config1 = 3;
     optional uint64 config2 = 4;
+    // The name of a dynamic PMU under /sys/bus/event_source/devices
+    // (e.g. "armv8_pmuv3").
+    // If set, leave |type| unset.
+    // Android: the relevant sysfs paths are not allowlisted by default, so
+    // this option will require a rooted device with selinux disabled.
+    optional string pmu_name = 5;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/src/profiling/perf/event_config.cc
+++ b/src/profiling/perf/event_config.cc
@@ -26,6 +26,8 @@
 #include <unwindstack/Regs.h>
 
 #include "perfetto/base/flat_set.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/utils.h"
 #include "protos/perfetto/common/perf_events.gen.h"
 #include "protos/perfetto/config/profiling/perf_event_config.gen.h"
@@ -82,6 +84,20 @@ std::optional<uint32_t> ParseTracepointAndResolveId(
     return std::nullopt;
   }
   return std::make_optional(tracepoint_id);
+}
+
+std::optional<uint32_t> ReadPmuTypeFromSysfs(const std::string& pmu_name) {
+  if (pmu_name.empty())
+    return std::nullopt;
+  if (base::Contains(pmu_name, '/') || base::StartsWith(pmu_name, ".."))
+    return std::nullopt;
+
+  std::string type_path = "/sys/bus/event_source/devices/" + pmu_name + "/type";
+  std::string buf;
+  if (!base::ReadFile(type_path, &buf))
+    return std::nullopt;
+
+  return base::StringToUInt32(base::TrimWhitespace(buf));
 }
 
 // |T| is either gen::PerfEventConfig or gen::PerfEventConfig::Scope.
@@ -301,8 +317,21 @@ std::optional<PerfCounter> MakePerfCounter(
                                      tracepoint_pb.filter(), *maybe_id);
     } else if (event_desc.has_raw_event()) {
       const auto& raw = event_desc.raw_event();
-      return PerfCounter::RawEvent(name, raw.type(), raw.config(),
-                                   raw.config1(), raw.config2());
+      if (!raw.pmu_name().empty() && raw.has_type()) {
+        PERFETTO_ELOG("raw_event cannot specify both type and pmu_name.");
+        return std::nullopt;
+      }
+      std::optional<uint32_t> raw_type =
+          raw.has_type() ? std::make_optional(raw.type())
+                         : ReadPmuTypeFromSysfs(raw.pmu_name());
+      if (!raw_type) {
+        PERFETTO_ELOG(
+            "Failed to resolve raw_event.pmu_name to a type value. Ensure that "
+            "the profiler process has permissions to read from sysfs.");
+        return std::nullopt;
+      }
+      return PerfCounter::RawEvent(name, *raw_type, raw.config(), raw.config1(),
+                                   raw.config2());
     } else {
       return PerfCounter::BuiltinCounter(
           name, protos::gen::PerfEvents::PerfEvents::SW_CPU_CLOCK,

--- a/src/profiling/perf/event_config_unittest.cc
+++ b/src/profiling/perf/event_config_unittest.cc
@@ -494,6 +494,19 @@ TEST(EventConfigTest, GroupMultipleType) {
   EXPECT_TRUE(tracepoint.sample_type & PERF_SAMPLE_READ);
 }
 
+TEST(EventConfigTest, RawEventRejectsTypeAndPmu) {
+  protos::gen::PerfEventConfig cfg;
+  auto* follower = cfg.add_followers();
+  follower->set_name("raw");
+  auto* raw_event = follower->mutable_raw_event();
+  raw_event->set_type(8);
+  raw_event->set_config(8);
+  raw_event->set_perf_device("armv8_pmuv3");
+
+  std::optional<EventConfig> event_config = CreateEventConfig(cfg);
+  EXPECT_FALSE(event_config.has_value());
+}
+
 TEST(EventConfigTest, EventModifiers) {
   protos::gen::PerfEventConfig cfg;
   {

--- a/src/profiling/perf/event_config_unittest.cc
+++ b/src/profiling/perf/event_config_unittest.cc
@@ -501,7 +501,7 @@ TEST(EventConfigTest, RawEventRejectsTypeAndPmu) {
   auto* raw_event = follower->mutable_raw_event();
   raw_event->set_type(8);
   raw_event->set_config(8);
-  raw_event->set_perf_device("armv8_pmuv3");
+  raw_event->set_pmu_name("armv8_pmuv3");
 
   std::optional<EventConfig> event_config = CreateEventConfig(cfg);
   EXPECT_FALSE(event_config.has_value());


### PR DESCRIPTION
[notes from rsavitski@]:
Patched Ali's go/pgh/4744 on top of main, and addressed a couple of nits that weren't worth going through another set of review back and forth.

Minimal QOL for configs using the raw event encoding. Also particularly beneficial on some platforms where the PMU id assignment changes per boot.