### PR TITLE
Allow partial recovery on packet drop for ProtoLog messages

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_reader.cc
+++ b/src/trace_processor/importers/proto/proto_trace_reader.cc
@@ -367,7 +367,12 @@ base::Status ProtoTraceReader::ParsePacket(TraceBlobView packet) {
     }
     scoped_state->needs_incremental_state_total++;
 
-    if (!state->IsIncrementalStateValid()) {
+    protos::pbzero::TracePacket::Decoder local_decoder(packet.data(),
+                                                       packet.length());
+    if (!state->IsIncrementalStateValid() &&
+        !local_decoder
+             .Get(protos::pbzero::TracePacket::kProtologMessageFieldNumber)
+             .valid()) {
       if (context_->content_analyzer) {
         // Account for the skipped packet for trace proto content analysis,
         // with a special annotation.

--- a/src/trace_processor/importers/proto/winscope/protolog_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/protolog_parser.cc
@@ -92,9 +92,8 @@ void ProtoLogParser::ParseProtoLogMessage(
           protos::pbzero::InternedData::kProtologStringArgsFieldNumber,
           protos::pbzero::InternedString>(it.field().as_uint32());
       if (!decoder) {
-        // This shouldn't happen since we already checked the incremental
-        // state is valid.
-        string_params.emplace_back("<ERROR>");
+        // This can happen if incremental state was lost due to packet drop.
+        string_params.emplace_back("[LOST_STRING]");
         storage->IncrementStats(
             stats::winscope_protolog_missing_interned_arg_parse_errors);
         continue;
@@ -138,10 +137,14 @@ void ProtoLogParser::ParseProtoLogMessage(
         decoded_message.message, stacktrace, location);
   } else {
     // Failed to fully decode the message.
-    // This shouldn't happen since we should have processed all viewer config
-    // messages in the tokenization state, and process the protolog messages
-    // only in the parsing state.
     storage->IncrementStats(stats::winscope_protolog_message_decoding_failed);
+    std::string dummy_tag = "UNKNOWN";
+    std::string error_msg = "[MISSING_VIEWER_CONFIG] (ID: " +
+                            std::to_string(protolog_message.message_id()) + ")";
+    std::optional<std::string> no_location = std::nullopt;
+    PopulateReservedRowWithMessage(row_id, static_cast<ProtoLogLevel>(0),
+                                   dummy_tag, error_msg, stacktrace,
+                                   no_location);
   }
 }
 

--- a/test/trace_processor/diff_tests/parser/android/protolog_missing_config.textproto
+++ b/test/trace_processor/diff_tests/parser/android/protolog_missing_config.textproto
@@ -1,0 +1,31 @@
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 3
+  sequence_flags: 1
+  previous_packet_dropped: true
+  trusted_pid: 1716
+  first_packet_on_sequence: true
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 3
+  interned_data {
+    protolog_string_args {
+      iid: 1
+      str: "MyTestString"
+    }
+  }
+  trusted_pid: 1716
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 3
+  sequence_flags: 2
+  trusted_pid: 1716
+  timestamp: 857384130
+  protolog_message {
+    message_id: 6924537961316301726
+    str_param_iids: 1
+    str_param_iids: 1
+  }
+}

--- a/test/trace_processor/diff_tests/parser/android/protolog_multisequence_loss.textproto
+++ b/test/trace_processor/diff_tests/parser/android/protolog_multisequence_loss.textproto
@@ -1,0 +1,68 @@
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 1
+  sequence_flags: 1
+  first_packet_on_sequence: true
+  trusted_pid: 1716
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 1
+  interned_data {
+    protolog_string_args {
+      iid: 1
+      str: "Seq1String"
+    }
+  }
+  trusted_pid: 1716
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 1
+  sequence_flags: 2
+  trusted_pid: 1716
+  timestamp: 857384130
+  protolog_message {
+    message_id: 6924537961316301726
+    str_param_iids: 1
+    str_param_iids: 1
+  }
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 2
+  sequence_flags: 1
+  previous_packet_dropped: true
+  trusted_pid: 1716
+  first_packet_on_sequence: true
+}
+packet {
+  trusted_uid: 1000
+  trusted_packet_sequence_id: 2
+  sequence_flags: 2
+  trusted_pid: 1716
+  timestamp: 857384131
+  protolog_message {
+    message_id: 6924537961316301726
+    str_param_iids: 1
+    str_param_iids: 1
+  }
+}
+packet {
+  trusted_uid: 10224
+  trusted_packet_sequence_id: 10
+  protolog_viewer_config {
+    messages {
+      message_id: 6924537961316301726
+      message: "Test message with two strings: %s and %s"
+      level: PROTOLOG_LEVEL_DEBUG
+      location: "com/test/TestClass.java:123"
+      group_id: 1
+    }
+    groups {
+      id: 1
+      name: "MY_FIRST_GROUP"
+      tag: "MyFirstGroup"
+    }
+  }
+}

--- a/test/trace_processor/diff_tests/parser/android/protolog_packet_loss.textproto
+++ b/test/trace_processor/diff_tests/parser/android/protolog_packet_loss.textproto
@@ -61,8 +61,8 @@ packet {
   timestamp: 857384130
   protolog_message {
     message_id: 6924537961316301726
-    str_param_iids: 2
-    str_param_iids: 2
+    str_param_iids: 3
+    str_param_iids: 3
   }
 }
 packet {

--- a/test/trace_processor/diff_tests/parser/android/tests_protolog.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_protolog.py
@@ -40,5 +40,26 @@ class ProtoLog(TestSuite):
         out=Csv("""
         "id","ts","level","tag","message","location","stacktrace"
         0,857384130,"DEBUG","MyFirstGroup","Test message with two strings: MyTestString and MyTestString","com/test/TestClass.java:123","[NULL]"
-        1,857384130,"DEBUG","MyFirstGroup","Test message with two strings: MyNextTestString and MyNextTestString","com/test/TestClass.java:123","[NULL]"
+        1,857384130,"DEBUG","MyFirstGroup","Test message with two strings: MyTestString and MyOtherTestString","com/test/TestClass.java:123","[NULL]"
+        2,857384130,"DEBUG","MyFirstGroup","Test message with two strings: [LOST_STRING] and [LOST_STRING]","com/test/TestClass.java:123","[NULL]"
+        3,857384130,"DEBUG","MyFirstGroup","Test message with two strings: MyNextTestString and MyNextTestString","com/test/TestClass.java:123","[NULL]"
+        """))
+
+  def test_missing_config(self):
+    return DiffTestBlueprint(
+        trace=Path('protolog_missing_config.textproto'),
+        query="SELECT id, ts, level, tag, message, stacktrace, location FROM protolog;",
+        out=Csv("""
+        "id","ts","level","tag","message","stacktrace","location"
+        0,857384130,"UNKNOWN","UNKNOWN","[MISSING_VIEWER_CONFIG] (ID: 6924537961316301726)","[NULL]","[NULL]"
+        """))
+
+  def test_multisequence_loss(self):
+    return DiffTestBlueprint(
+        trace=Path('protolog_multisequence_loss.textproto'),
+        query="SELECT id, ts, level, tag, message, stacktrace, location FROM protolog;",
+        out=Csv("""
+        "id","ts","level","tag","message","stacktrace","location"
+        0,857384130,"DEBUG","MyFirstGroup","Test message with two strings: Seq1String and Seq1String","[NULL]","com/test/TestClass.java:123"
+        1,857384131,"DEBUG","MyFirstGroup","Test message with two strings: [LOST_STRING] and [LOST_STRING]","[NULL]","com/test/TestClass.java:123"
         """))


### PR DESCRIPTION
Currently, we strictly drops packets with the SEQ_NEEDS_INCREMENTAL_STATE flag when the sequence state is invalid (e.g., after a packet drop). This causes some ProtoLog messages to be unnecessarily lost, even when they could be partially recovered or decoded.