### PR TITLE
perfetto: add string_view overloads for base::TrimWhitespace

### DIFF
--- a/include/perfetto/ext/base/string_utils.h
+++ b/include/perfetto/ext/base/string_utils.h
@@ -25,6 +25,7 @@
 #include <cinttypes>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <vector>
 
@@ -188,7 +189,9 @@ std::vector<std::string> SplitString(const std::string& text,
                                      const std::string& delimiter);
 std::string StripPrefix(const std::string& str, const std::string& prefix);
 std::string StripSuffix(const std::string& str, const std::string& suffix);
+std::string_view TrimWhitespace(std::string_view str);
 std::string TrimWhitespace(const std::string& str);
+std::string_view TrimWhitespace(const char* str);
 std::string ToLower(const std::string& str);
 std::string ToUpper(const std::string& str);
 std::string StripChars(const std::string& str,

--- a/src/base/string_utils.cc
+++ b/src/base/string_utils.cc
@@ -134,8 +134,9 @@ std::string_view TrimWhitespace(std::string_view str) {
     return {};
   std::string_view front_trimmed = str.substr(front_idx);
   size_t end_idx = front_trimmed.find_last_not_of(kWhitespaces);
-  return end_idx == std::string_view::npos ? std::string_view()
-                                           : front_trimmed.substr(0, end_idx + 1);
+  return end_idx == std::string_view::npos
+             ? std::string_view()
+             : front_trimmed.substr(0, end_idx + 1);
 }
 
 std::string TrimWhitespace(const std::string& str) {

--- a/src/base/string_utils.cc
+++ b/src/base/string_utils.cc
@@ -127,16 +127,23 @@ std::vector<std::string> SplitString(const std::string& text,
   return output;
 }
 
+std::string_view TrimWhitespace(std::string_view str) {
+  static constexpr char kWhitespaces[] = "\t\n ";
+  size_t front_idx = str.find_first_not_of(kWhitespaces);
+  if (front_idx == std::string_view::npos)
+    return {};
+  std::string_view front_trimmed = str.substr(front_idx);
+  size_t end_idx = front_trimmed.find_last_not_of(kWhitespaces);
+  return end_idx == std::string_view::npos ? std::string_view()
+                                           : front_trimmed.substr(0, end_idx + 1);
+}
+
 std::string TrimWhitespace(const std::string& str) {
-  std::string whitespaces = "\t\n ";
+  return std::string(TrimWhitespace(std::string_view(str)));
+}
 
-  size_t front_idx = str.find_first_not_of(whitespaces);
-  std::string front_trimmed =
-      front_idx == std::string::npos ? "" : str.substr(front_idx);
-
-  size_t end_idx = front_trimmed.find_last_not_of(whitespaces);
-  return end_idx == std::string::npos ? ""
-                                      : front_trimmed.substr(0, end_idx + 1);
+std::string_view TrimWhitespace(const char* str) {
+  return TrimWhitespace(std::string_view(str));
 }
 
 std::string StripPrefix(const std::string& str, const std::string& prefix) {

--- a/src/base/string_utils.cc
+++ b/src/base/string_utils.cc
@@ -134,9 +134,8 @@ std::string_view TrimWhitespace(std::string_view str) {
     return {};
   std::string_view front_trimmed = str.substr(front_idx);
   size_t end_idx = front_trimmed.find_last_not_of(kWhitespaces);
-  return end_idx == std::string_view::npos
-             ? std::string_view()
-             : front_trimmed.substr(0, end_idx + 1);
+  PERFETTO_DCHECK(end_idx != std::string_view::npos);
+  return front_trimmed.substr(0, end_idx + 1);
 }
 
 std::string TrimWhitespace(const std::string& str) {


### PR DESCRIPTION
Introduces std::string_view and const char* overloads of
base::TrimWhitespace and refactors the existing std::string
implementation on top of them.  This avoids a mandatory copy when
callers only need to observe the trimmed range and opens the door to
using TrimWhitespace in code that already works in terms of
string_view.
