### PR TITLE
ui: Move legacy trace actions to a dedicated plugin (disabled by default)

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.Catapult/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.Catapult/index.ts
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {App} from '../../public/app';
+import {PerfettoPlugin} from '../../public/plugin';
+import {Trace} from '../../public/trace';
+import {
+  isLegacyTrace,
+  openFileWithLegacyTraceViewer,
+  openInOldUIWithSizeCheck,
+} from './legacy_trace_viewer';
+
+const OPEN_LEGACY_COMMAND_ID = 'dev.perfetto.OpenTraceInLegacyUi';
+
+export default class implements PerfettoPlugin {
+  static readonly id = 'dev.perfetto.Catapult';
+
+  static onActivate(app: App): void {
+    app.commands.registerCommand({
+      id: OPEN_LEGACY_COMMAND_ID,
+      name: 'Open with legacy UI',
+      callback: () => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.style.display = 'none';
+        document.body.appendChild(input);
+        input.addEventListener('change', async () => {
+          const file = input.files?.[0];
+          input.remove();
+          if (!file) return;
+          app.analytics.logEvent('Trace Actions', 'Open trace in Legacy UI');
+          if (await isLegacyTrace(file)) {
+            await openFileWithLegacyTraceViewer(file);
+          } else {
+            await openInOldUIWithSizeCheck(file);
+          }
+        });
+        input.click();
+      },
+    });
+
+    app.sidebar.addMenuItem({
+      commandId: OPEN_LEGACY_COMMAND_ID,
+      section: 'trace_files',
+      icon: 'filter_none',
+    });
+  }
+
+  async onTraceLoad(trace: Trace): Promise<void> {
+    trace.sidebar.addMenuItem({
+      section: 'convert_trace',
+      text: 'Switch to legacy UI',
+      icon: 'filter_none',
+      disabled: () => {
+        return trace.traceInfo.downloadable
+          ? false
+          : 'Cannot download external trace';
+      },
+      action: async () => {
+        trace.analytics.logEvent(
+          'Trace Actions',
+          'Open current trace in legacy UI',
+        );
+        const file = await trace.getTraceFile();
+        await openInOldUIWithSizeCheck(file);
+      },
+    });
+  }
+}

--- a/ui/src/core_plugins/dev.perfetto.Catapult/legacy_trace_viewer.ts
+++ b/ui/src/core_plugins/dev.perfetto.Catapult/legacy_trace_viewer.ts
@@ -14,14 +14,14 @@
 
 import m from 'mithril';
 import {inflate} from 'pako';
-import {assertTrue} from '../base/assert';
-import {isString} from '../base/object_utils';
-import {showModal} from '../widgets/modal';
-import {utf8Decode} from '../base/string_utils';
-import {convertToJson} from './trace_converter';
-import {assetSrc} from '../base/assets';
-import {Anchor} from '../widgets/anchor';
-import {Icons} from '../base/semantic_icons';
+import {assertTrue} from '../../base/assert';
+import {isString} from '../../base/object_utils';
+import {showModal} from '../../widgets/modal';
+import {utf8Decode} from '../../base/string_utils';
+import {convertToJson} from '../../frontend/trace_converter';
+import {assetSrc} from '../../base/assets';
+import {Anchor} from '../../widgets/anchor';
+import {Icons} from '../../base/semantic_icons';
 
 const CTRACE_HEADER = 'TRACE:\n';
 

--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -32,11 +32,6 @@ import {
 } from '../../core/state_serialization';
 import {TraceImpl} from '../../core/trace_impl';
 import {trackMatchesFilter} from '../../core/track_manager';
-import {
-  isLegacyTrace,
-  openFileWithLegacyTraceViewer,
-  openInOldUIWithSizeCheck,
-} from '../../frontend/legacy_trace_viewer';
 import {shareTrace} from '../../frontend/trace_share_utils';
 import {PerfettoPlugin} from '../../public/plugin';
 import {DurationPrecision, TimestampFormat} from '../../public/timeline';
@@ -114,13 +109,6 @@ group by
  c.name
 order by total_self_size desc
 limit 100;`;
-
-const SHOW_OPEN_WITH_LEGACY_UI_BUTTON = featureFlags.register({
-  id: 'showOpenWithLegacyUiButton',
-  name: 'Show "Open with legacy UI" button',
-  description: 'Show "Open with legacy UI" button in the sidebar',
-  defaultValue: false,
-});
 
 function getOrPromptForTimestamp(tsRaw: unknown): time | undefined {
   if (exists(tsRaw)) {
@@ -246,7 +234,6 @@ export default class CoreCommands implements PerfettoPlugin {
       id: OPEN_TRACE_COMMAND_ID,
       name: 'Open trace file',
       callback: () => {
-        delete input.dataset['useCatapultLegacyUi'];
         input.click();
       },
       defaultHotkey: '!Mod+O',
@@ -257,23 +244,6 @@ export default class CoreCommands implements PerfettoPlugin {
       icon: 'folder_open',
       sortOrder: 1,
     });
-
-    const OPEN_LEGACY_COMMAND_ID = 'dev.perfetto.OpenTraceInLegacyUi';
-    ctx.commands.registerCommand({
-      id: OPEN_LEGACY_COMMAND_ID,
-      name: 'Open with legacy UI',
-      callback: () => {
-        input.dataset['useCatapultLegacyUi'] = '1';
-        input.click();
-      },
-    });
-    if (SHOW_OPEN_WITH_LEGACY_UI_BUTTON.get()) {
-      ctx.sidebar.addMenuItem({
-        commandId: OPEN_LEGACY_COMMAND_ID,
-        section: 'trace_files',
-        icon: 'filter_none',
-      });
-    }
 
     ctx.commands.registerCommand({
       id: 'dev.perfetto.CloseTrace',
@@ -904,23 +874,6 @@ function onInputElementFileSelectionChanged(e: Event) {
   // Reset the value so onchange will be fired with the same file.
   e.target.value = '';
 
-  if (e.target.dataset['useCatapultLegacyUi'] === '1') {
-    openWithLegacyUi(file);
-    return;
-  }
-
   AppImpl.instance.analytics.logEvent('Trace Actions', 'Open trace from file');
   AppImpl.instance.openTraceFromFile(file);
-}
-
-async function openWithLegacyUi(file: File) {
-  // Switch back to the old catapult UI.
-  AppImpl.instance.analytics.logEvent(
-    'Trace Actions',
-    'Open trace in Legacy UI',
-  );
-  if (await isLegacyTrace(file)) {
-    return await openFileWithLegacyTraceViewer(file);
-  }
-  return await openInOldUIWithSizeCheck(file);
 }

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -39,7 +39,6 @@ import {
   convertTraceToJson,
   convertTraceToSystrace,
   downloadTrace,
-  openCurrentTraceWithOldUI,
   toggleMetatrace,
 } from './trace_actions';
 import {shareTrace} from './trace_share_utils';
@@ -561,15 +560,6 @@ function getConvertTraceItems(trace: TraceImpl): SidebarMenuItemInternal[] {
   const downloadDisabled = trace.traceInfo.downloadable
     ? false
     : 'Cannot download external trace';
-
-  items.push({
-    id: 'perfetto.LegacyUI',
-    section: 'convert_trace',
-    text: 'Switch to legacy UI',
-    action: async () => await openCurrentTraceWithOldUI(trace),
-    icon: 'filter_none',
-    disabled: downloadDisabled,
-  });
 
   items.push({
     id: 'perfetto.ConvertToJson',

--- a/ui/src/frontend/trace_actions.ts
+++ b/ui/src/frontend/trace_actions.ts
@@ -28,20 +28,10 @@ import {
   convertTraceToJsonAndDownload,
   convertTraceToSystraceAndDownload,
 } from './trace_converter';
-import {openInOldUIWithSizeCheck} from './legacy_trace_viewer';
 import {showModal} from '../widgets/modal';
 import {assertExists} from '../base/assert';
 
 const TRACE_SUFFIX = '.perfetto-trace';
-
-export async function openCurrentTraceWithOldUI(trace: Trace): Promise<void> {
-  AppImpl.instance.analytics.logEvent(
-    'Trace Actions',
-    'Open current trace in legacy UI',
-  );
-  const file = await trace.getTraceFile();
-  await openInOldUIWithSizeCheck(file);
-}
 
 export async function convertTraceToSystrace(trace: Trace): Promise<void> {
   AppImpl.instance.analytics.logEvent('Trace Actions', 'Convert to .systrace');


### PR DESCRIPTION
This patch moves the 'Open in legacy UI' and 'Switch to legacy UI' sidebar actions as well as the corresponding commands and logic to a new 'dev.perfetto.Catapult' plugin, which is disabled by default.

It's there is anyone really wants it, but it's hidden by default. We could remove this in the future very simply by deleting the plugin.