### PR TITLE
tp: plumb aflags flag type

### DIFF
--- a/protos/perfetto/trace/android/android_aflags.proto
+++ b/protos/perfetto/trace/android/android_aflags.proto
@@ -49,6 +49,15 @@ message AndroidAflags {
     FLAG_STORAGE_BACKEND_DEVICE_CONFIG = 3;
   }
 
+  // The value type of the flag.
+  enum FlagType {
+    // Flag type unspecified. This flag type means the flag is an old version
+    // boolean flag or unknown newer type.
+    FLAG_TYPE_UNSPECIFIED = 0;
+    FLAG_TYPE_BOOLEAN = 1;
+    FLAG_TYPE_INTEGER = 2;
+  }
+
   // Representation of an aconfig flag and its metadata.
   message Flag {
     optional string flag_namespace = 1;
@@ -67,6 +76,7 @@ message AndroidAflags {
     optional FlagPermission permission = 7;
     optional ValuePickedFrom value_picked_from = 8;
     optional FlagStorageBackend storage_backend = 9;
+    optional FlagType type = 10;
   }
 
   // A collection of flags.

--- a/src/trace_processor/importers/proto/android_probes_parser.cc
+++ b/src/trace_processor/importers/proto/android_probes_parser.cc
@@ -162,6 +162,8 @@ AndroidProbesParser::AndroidProbesParser(TraceProcessorContext* context,
       aflags_none_id_(context->storage->InternString("none")),
       aflags_aconfigd_id_(context->storage->InternString("aconfigd")),
       aflags_device_config_id_(context->storage->InternString("device_config")),
+      aflags_boolean_id_(context->storage->InternString("boolean")),
+      aflags_integer_id_(context->storage->InternString("integer")),
       aflags_unspecified_id_(context->storage->InternString("unspecified")) {}
 
 void AndroidProbesParser::ParseRailDescriptor(
@@ -747,6 +749,18 @@ StringId AndroidProbesParser::ToStorageBackendId(int32_t backend) {
   }
 }
 
+StringId AndroidProbesParser::ToFlagTypeId(int32_t type) {
+  switch (type) {
+    case protos::pbzero::AndroidAflags::FLAG_TYPE_BOOLEAN:
+      return aflags_boolean_id_;
+    case protos::pbzero::AndroidAflags::FLAG_TYPE_INTEGER:
+      return aflags_integer_id_;
+    case protos::pbzero::AndroidAflags::FLAG_TYPE_UNSPECIFIED:
+    default:
+      return aflags_unspecified_id_;
+  }
+}
+
 void AndroidProbesParser::ParseAndroidAflags(int64_t ts, ConstBytes blob) {
   protos::pbzero::AndroidAflags::Decoder decoder(blob.data, blob.size);
   if (decoder.has_error()) {
@@ -776,6 +790,7 @@ void AndroidProbesParser::ParseAndroidAflags(int64_t ts, ConstBytes blob) {
     row.permission = ToPermissionId(flag.permission());
     row.value_picked_from = ToValuePickedFromId(flag.value_picked_from());
     row.storage_backend = ToStorageBackendId(flag.storage_backend());
+    row.type = ToFlagTypeId(flag.type());
 
     context_->storage->mutable_android_aflags_table()->Insert(row);
   }

--- a/src/trace_processor/importers/proto/android_probes_parser.h
+++ b/src/trace_processor/importers/proto/android_probes_parser.h
@@ -59,6 +59,7 @@ class AndroidProbesParser {
   StringId ToPermissionId(int32_t);
   StringId ToValuePickedFromId(int32_t);
   StringId ToStorageBackendId(int32_t);
+  StringId ToFlagTypeId(int32_t);
 
   TraceProcessorContext* const context_;
   AndroidProbesTracker* const tracker_;
@@ -89,6 +90,8 @@ class AndroidProbesParser {
   const StringId aflags_none_id_;
   const StringId aflags_aconfigd_id_;
   const StringId aflags_device_config_id_;
+  const StringId aflags_boolean_id_;
+  const StringId aflags_integer_id_;
   const StringId aflags_unspecified_id_;
 };
 }  // namespace perfetto::trace_processor

--- a/src/trace_processor/perfetto_sql/stdlib/android/aflags.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/aflags.sql
@@ -46,7 +46,9 @@ CREATE PERFETTO VIEW android_aflags (
   -- Where the current value was picked from (e.g. "default", "local", "server").
   value_picked_from STRING,
   -- The underlying storage backend for this flag (e.g. "aconfigd", "device_config").
-  storage_backend STRING
+  storage_backend STRING,
+  -- Value type of the flag (e.g. "boolean", "integer").
+  type STRING
 ) AS
 SELECT
   ts,
@@ -58,5 +60,6 @@ SELECT
   staged_value,
   permission,
   value_picked_from,
-  storage_backend
+  storage_backend,
+  type
 FROM __intrinsic_android_aflags;

--- a/src/trace_processor/tables/android_tables.py
+++ b/src/trace_processor/tables/android_tables.py
@@ -374,6 +374,7 @@ ANDROID_AFLAGS_TABLE = Table(
         C('permission', CppString()),
         C('value_picked_from', CppString()),
         C('storage_backend', CppString()),
+        C('type', CppString()),
     ],
     tabledoc=TableDoc(
         doc='''
@@ -392,6 +393,7 @@ ANDROID_AFLAGS_TABLE = Table(
             'permission': 'Permission of the flag (read-only or read-write).',
             'value_picked_from': 'Source of the current flag value.',
             'storage_backend': 'The storage backend that owns this flag.',
+            'type': 'Value type of the flag (boolean or integer).',
         },
     ),
 )

--- a/src/traced/probes/android_aflags/android_aflags_data_source_unittest.cc
+++ b/src/traced/probes/android_aflags/android_aflags_data_source_unittest.cc
@@ -61,6 +61,7 @@ class TestAndroidAflagsDataSource : public AndroidAflagsDataSource {
     uint32_t permission;
     uint32_t value_picked_from;
     uint32_t storage_backend;
+    uint32_t type;
   };
 
   // Helper to simulate subprocess completion with given flags.
@@ -78,6 +79,7 @@ class TestAndroidAflagsDataSource : public AndroidAflagsDataSource {
       flag_proto->AppendVarInt(7, f.permission);
       flag_proto->AppendVarInt(8, f.value_picked_from);
       flag_proto->AppendVarInt(9, f.storage_backend);
+      flag_proto->AppendVarInt(10, f.type);
     }
     std::vector<uint8_t> bytes = msg.SerializeAsArray();
     aflags_output_ = base::Base64Encode(bytes.data(), bytes.size());
@@ -140,6 +142,7 @@ TEST_F(AndroidAflagsDataSourceTest, ANDROID_ONLY_TEST(EmitAflags)) {
           protos::pbzero::AndroidAflags::VALUE_PICKED_FROM_LOCAL),
       static_cast<uint32_t>(
           protos::pbzero::AndroidAflags::FLAG_STORAGE_BACKEND_ACONFIGD),
+      static_cast<uint32_t>(protos::pbzero::AndroidAflags::FLAG_TYPE_BOOLEAN),
   });
 
   ds->FakeSubprocessCompletion(flags);
@@ -161,6 +164,8 @@ TEST_F(AndroidAflagsDataSourceTest, ANDROID_ONLY_TEST(EmitAflags)) {
             protos::gen::AndroidAflags::VALUE_PICKED_FROM_LOCAL);
   EXPECT_EQ(aflags.flags()[0].storage_backend(),
             protos::gen::AndroidAflags::FLAG_STORAGE_BACKEND_ACONFIGD);
+  EXPECT_EQ(aflags.flags()[0].type(),
+            protos::gen::AndroidAflags::FLAG_TYPE_BOOLEAN);
 }
 
 TEST_F(AndroidAflagsDataSourceTest,

--- a/test/trace_processor/diff_tests/parser/android/tests_aflags.py
+++ b/test/trace_processor/diff_tests/parser/android/tests_aflags.py
@@ -37,18 +37,19 @@ class AndroidAflags(TestSuite):
               permission: FLAG_PERMISSION_READ_WRITE
               value_picked_from: VALUE_PICKED_FROM_LOCAL
               storage_backend: FLAG_STORAGE_BACKEND_ACONFIGD
+              type: FLAG_TYPE_BOOLEAN
             }
           }
         }
         """),
         query="""
         INCLUDE PERFETTO MODULE android.aflags;
-        SELECT ts, package, name, flag_namespace, container, value, staged_value, permission, value_picked_from, storage_backend
+        SELECT ts, package, name, flag_namespace, container, value, staged_value, permission, value_picked_from, storage_backend, type
         FROM android_aflags;
         """,
         out=Csv("""
-        "ts","package","name","flag_namespace","container","value","staged_value","permission","value_picked_from","storage_backend"
-        1000,"com.android.settings","my_flag","settings_ns","system","enabled","disabled","read-write","local","aconfigd"
+        "ts","package","name","flag_namespace","container","value","staged_value","permission","value_picked_from","storage_backend","type"
+        1000,"com.android.settings","my_flag","settings_ns","system","enabled","disabled","read-write","local","aconfigd","boolean"
         """))
 
   def test_android_aflags_error(self):


### PR DESCRIPTION
Upstream aflags proto added a FlagType enum (UNSPECIFIED/BOOLEAN/INTEGER) and an optional `type` field (tag 10) on Flag. 

- add the enum to the trace proto
- extend the traced_probes unit test fake,
- thread the field through AndroidProbesParser into a new `type` column on android_aflags
- expose it on the SQL view, and cover it in the diff test.

Bug: **http://b/500985508**

Test: out/linux_clang_release/perfetto_unittests --gtest_filter='AndroidAflagsDataSourceTest.*'
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter='AndroidAflags.*'
