### PR TITLE
perfetto: fix sync-protos gh install on self-hosted runner

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -40,15 +40,19 @@ jobs:
       - name: Install GitHub CLI
         run: |
           if ! command -v gh >/dev/null 2>&1; then
-            (type -p wget >/dev/null || sudo apt-get install -y wget)
-            sudo mkdir -p -m 755 /etc/apt/keyrings
-            wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-              | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
-            sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-              | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt-get update
-            sudo apt-get install -y gh
+            # When bumping, re-verify GH_SHA256 against the upstream checksums:
+            # https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_checksums.txt
+            GH_VERSION=2.90.0
+            GH_SHA256=b2aef7b23ec6899bf27f37a32c57a7935d0a178568ac33dc9bb03842f724195a
+            GH_TARBALL="gh_${GH_VERSION}_linux_amd64.tar.gz"
+            mkdir -p "$HOME/.local/bin"
+            wget -q "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}"
+            echo "${GH_SHA256}  ${GH_TARBALL}" | sha256sum --check --status
+            tar -xzf "${GH_TARBALL}" --strip-components=2 -C "$HOME/.local/bin" \
+              "gh_${GH_VERSION}_linux_amd64/bin/gh"
+            rm "${GH_TARBALL}"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+            export PATH="$HOME/.local/bin:$PATH"
           fi
           gh --version
 


### PR DESCRIPTION
The sync-protos workflow assumed GitHub-hosted runner semantics and
relied on passwordless sudo + apt to install the GitHub CLI. On the
self-hosted runner sudo prompts for a password and the step dies
before anything else runs.

Replace the apt path with a direct download of the upstream gh
release tarball into $HOME/.local/bin, with a pinned version and
SHA256 so the binary is verified before use. No sudo, no system
writes.
