### PR TITLE
perfetto: sync-protos gh install — use curl instead of wget

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -46,7 +46,7 @@ jobs:
             GH_SHA256=b2aef7b23ec6899bf27f37a32c57a7935d0a178568ac33dc9bb03842f724195a
             GH_TARBALL="gh_${GH_VERSION}_linux_amd64.tar.gz"
             mkdir -p "$HOME/.local/bin"
-            wget -q "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}"
+            curl -fsSLO "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_TARBALL}"
             echo "${GH_SHA256}  ${GH_TARBALL}" | sha256sum --check --status
             tar -xzf "${GH_TARBALL}" --strip-components=2 -C "$HOME/.local/bin" \
               "gh_${GH_VERSION}_linux_amd64/bin/gh"


### PR DESCRIPTION
Follow-up to #5490.

wget is not installed on the self-hosted runner — the original sudo+apt
path hid this because the first sudo failure short-circuited the step
before wget ran. Replace wget with curl, which is universally
available on our runners.