### PR TITLE
ui: Gate heapdump explorer button on plugin enabled

### DIFF
--- a/ui/src/core/embedder/default_plugins.ts
+++ b/ui/src/core/embedder/default_plugins.ts
@@ -38,6 +38,7 @@ export const defaultPlugins = [
   'com.android.CujFrameDebugTrack',
   'com.android.DayExplorer',
   'com.android.GpuWorkPeriod',
+  'com.android.HeapDumpExplorer',
   'com.android.LargeScreensPerf',
   'com.android.PinAndroidPerfMetrics',
   'com.android.PinSysUITracks',

--- a/ui/src/core/plugin_manager.ts
+++ b/ui/src/core/plugin_manager.ts
@@ -153,6 +153,11 @@ export class PluginManagerImpl {
     return this.registry.tryGet(id);
   }
 
+  isPluginEnabled(id: string): boolean {
+    const plugin = this.registry.tryGet(id);
+    return plugin?.traceContext !== undefined;
+  }
+
   getPlugin<T extends PerfettoPlugin>(
     pluginDescriptor: PerfettoPluginStatic<T>,
   ): T {

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -542,6 +542,9 @@ function getHeapGraphNodeOptionalActions(
   isDominator: boolean,
   onNodeSelected?: (pathHashes: string, isDominator: boolean) => void,
 ): ReadonlyArray<FlamegraphOptionalAction> {
+  if (!trace.plugins.isPluginEnabled('com.android.HeapDumpExplorer')) {
+    return [];
+  }
   return [
     {
       name: 'Open in Heapdump Explorer',

--- a/ui/src/public/plugin.ts
+++ b/ui/src/public/plugin.ts
@@ -43,4 +43,5 @@ export interface PerfettoPlugin {
 
 export interface PluginManager {
   getPlugin<T extends PerfettoPlugin>(plugin: PerfettoPluginStatic<T>): T;
+  isPluginEnabled(id: string): boolean;
 }


### PR DESCRIPTION
Only show "Open in Heapdump Explorer" in heap graph flamegraphs when the HeapDumpExplorer plugin is active. Also enable HeapDumpExplorer by default.