### PR TITLE
ui: Highlight same-name slices globally

### DIFF
--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -1100,11 +1100,12 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
   private highlightHoveredAndSameTitle(
     slices: readonly SliceOrInstant<T>[],
   ): readonly ColorVariant[] {
-    const variants = new Array<ColorVariant>(slices.length);
     const hoveredSlice = this.hoveredSlice;
-    if (hoveredSlice) {
-      const hoveredSliceId = hoveredSlice.id;
-      const hoveredTitle = hoveredSlice.title;
+    const highlightedSliceName = this.attrs.trace.timeline.highlightedSliceName;
+    const variants = new Array<ColorVariant>(slices.length);
+    if (hoveredSlice || highlightedSliceName !== undefined) {
+      const hoveredSliceId = hoveredSlice?.id;
+      const hoveredTitle = highlightedSliceName;
       // Index based iteration is more efficient than .map
       for (let i = 0; i < slices.length; i++) {
         const {id, title} = slices[i];
@@ -1261,6 +1262,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     this.hoveredSlice = this.findSlice(e);
     if (this.hoverMonitor.ifStateChanged()) {
       this.trace.timeline.highlightedSliceId = this.hoveredSlice?.id;
+      this.trace.timeline.highlightedSliceName = this.hoveredSlice?.title;
       if (this.hoveredSlice === undefined) {
         if (this.attrs.onSliceOut) {
           this.attrs.onSliceOut({slice: assertExists(prevHoveredSlice)});
@@ -1279,6 +1281,7 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
     this.hoveredSlice = undefined;
     if (this.hoverMonitor.ifStateChanged()) {
       this.trace.timeline.highlightedSliceId = undefined;
+      this.trace.timeline.highlightedSliceName = undefined;
       if (this.attrs.onSliceOut && prevHoveredSlice) {
         this.attrs.onSliceOut({slice: prevHoveredSlice});
       }

--- a/ui/src/core/timeline.ts
+++ b/ui/src/core/timeline.ts
@@ -39,6 +39,7 @@ export class TimelineImpl implements Timeline {
   private _visibleWindow: HighPrecisionTimeSpan;
   private _hoverCursorTimestamp?: time;
   private _highlightedSliceId?: number;
+  private _highlightedSliceName?: string;
   private _hoveredNoteTimestamp?: time;
   private _animationStartTime?: number;
   private _animationStartWindow?: HighPrecisionTimeSpan;
@@ -66,6 +67,16 @@ export class TimelineImpl implements Timeline {
   set highlightedSliceId(x) {
     if (this._highlightedSliceId === x) return;
     this._highlightedSliceId = x;
+    raf.scheduleCanvasRedraw();
+  }
+
+  get highlightedSliceName() {
+    return this._highlightedSliceName;
+  }
+
+  set highlightedSliceName(x) {
+    if (this._highlightedSliceName === x) return;
+    this._highlightedSliceName = x;
     raf.scheduleCanvasRedraw();
   }
 

--- a/ui/src/public/timeline.ts
+++ b/ui/src/public/timeline.ts
@@ -204,6 +204,7 @@ export interface Timeline {
 
   hoveredNoteTimestamp: time | undefined;
   highlightedSliceId: number | undefined;
+  highlightedSliceName: string | undefined;
 
   hoveredUtid: number | undefined;
   hoveredPid: bigint | undefined;

--- a/ui/src/public/timeline.ts
+++ b/ui/src/public/timeline.ts
@@ -203,7 +203,7 @@ export interface Timeline {
   hoverCursorTimestamp: time | undefined;
 
   hoveredNoteTimestamp: time | undefined;
-  highlightedSliceId: number | undefined;
+  highlightedSliceId: number | undefined; // Deprecated, only used for flows.
   highlightedSliceName: string | undefined;
 
   hoveredUtid: number | undefined;


### PR DESCRIPTION
When hovering a slice, highlight all slices across all tracks with the same name.

Related: https://github.com/google/perfetto/pull/5494