### PR TITLE
de: Dashboard tweaks and fixes

### DIFF
--- a/ui/src/components/widgets/charts/bar_chart.ts
+++ b/ui/src/components/widgets/charts/bar_chart.ts
@@ -25,6 +25,7 @@ import {
   buildAxisOption,
   buildGridOption,
   buildBrushOption,
+  buildLegendOption,
   buildTooltipOption,
   SELECTION_COLOR,
 } from './chart_option_builder';
@@ -40,11 +41,26 @@ export interface BarChartItem {
 }
 
 /**
+ * A named series of bars (used for stacked/grouped bar charts).
+ */
+export interface BarChartSeries {
+  /** Display name for this series (shown in legend). */
+  readonly name: string;
+  /** Bars in this series. */
+  readonly items: readonly BarChartItem[];
+}
+
+/**
  * Data provided to a BarChart.
+ *
+ * Use `items` for a simple single-series bar chart, or `series` for
+ * stacked/grouped bar charts. When `series` is provided, `items` is ignored.
  */
 export interface BarChartData {
-  /** The bars to display. */
+  /** The bars to display (single series). */
   readonly items: readonly BarChartItem[];
+  /** Multiple named series for stacked bar charts. */
+  readonly series?: readonly BarChartSeries[];
 }
 
 export interface BarChartAttrs {
@@ -145,7 +161,8 @@ export class BarChart implements m.ClassComponent<BarChartAttrs> {
     const {data, height, fillParent, className, onBrush, orientation} = attrs;
     const horizontal = orientation === 'horizontal';
 
-    const isEmpty = data !== undefined && data.items.length === 0;
+    const isStacked = data?.series !== undefined && data.series.length > 0;
+    const isEmpty = data !== undefined && !isStacked && data.items.length === 0;
     const option =
       data !== undefined && !isEmpty ? buildBarOption(attrs, data) : undefined;
 
@@ -181,7 +198,13 @@ function buildBarOption(
   const fmtDimension = formatDimension ?? String;
   const fmtMeasure = formatMeasure ?? formatNumber;
   const horizontal = orientation === 'horizontal';
-  const labels = data.items.map((item) => fmtDimension(item.label));
+
+  const isStacked = data.series !== undefined && data.series.length > 0;
+
+  // Collect unique dimension labels across all series.
+  const labels = isStacked
+    ? collectStackedLabels(data.series, fmtDimension)
+    : data.items.map((item) => fmtDimension(item.label));
 
   // Map visual grid line direction to axis splitLine settings.
   // Horizontal visual lines come from the Y axis; vertical from the X axis.
@@ -217,6 +240,12 @@ function buildBarOption(
     horizontal,
   );
 
+  // Build ECharts series — one per named series for stacked charts, or a
+  // single series for simple bar charts.
+  const echartsSeries = isStacked
+    ? buildStackedSeries(data.series, labels, fmtDimension)
+    : [buildSingleSeries(data, attrs, barColor, barHoverColor)];
+
   const option: Record<string, unknown> = {
     animation: false,
     grid: buildGridOption({
@@ -225,32 +254,17 @@ function buildBarOption(
     tooltip: buildTooltipOption({
       trigger: 'axis' as const,
       axisPointer: {type: 'shadow' as const},
-      formatter: (params: Array<{name?: string; value?: number}>) => {
-        const p = Array.isArray(params) ? params[0] : params;
-        return `${p.name ?? ''}<br>${measureLabel}: ${fmtMeasure(p.value ?? 0)}`;
-      },
+      formatter: isStacked
+        ? undefined
+        : (params: Array<{name?: string; value?: number}>) => {
+            const p = Array.isArray(params) ? params[0] : params;
+            return `${p.name ?? ''}<br>${measureLabel}: ${fmtMeasure(p.value ?? 0)}`;
+          },
     }),
     xAxis: horizontal ? valueAxis : categoryAxis,
     yAxis: horizontal ? categoryAxis : valueAxis,
-    series: [
-      {
-        type: 'bar',
-        data: data.items.map((item) => {
-          const selected =
-            attrs.selection !== undefined &&
-            attrs.selection.includes(item.label);
-          return {
-            value: item.value,
-            ...(selected ? {itemStyle: {color: SELECTION_COLOR}} : {}),
-          };
-        }),
-        itemStyle: barColor !== undefined ? {color: barColor} : undefined,
-        emphasis:
-          barHoverColor !== undefined
-            ? {itemStyle: {color: barHoverColor}}
-            : undefined,
-      },
-    ],
+    legend: isStacked ? buildLegendOption() : {show: false},
+    series: echartsSeries,
   };
 
   if (attrs.onBrush) {
@@ -266,15 +280,113 @@ function buildBarOption(
   return option;
 }
 
+/** Build a single ECharts bar series (non-stacked). */
+function buildSingleSeries(
+  data: BarChartData,
+  attrs: BarChartAttrs,
+  barColor: string | undefined,
+  barHoverColor: string | undefined,
+): Record<string, unknown> {
+  return {
+    type: 'bar',
+    data: data.items.map((item) => {
+      const selected =
+        attrs.selection !== undefined && attrs.selection.includes(item.label);
+      return {
+        value: item.value,
+        ...(selected ? {itemStyle: {color: SELECTION_COLOR}} : {}),
+      };
+    }),
+    itemStyle: barColor !== undefined ? {color: barColor} : undefined,
+    emphasis:
+      barHoverColor !== undefined
+        ? {itemStyle: {color: barHoverColor}}
+        : undefined,
+  };
+}
+
+/**
+ * Collect unique dimension labels across all series, preserving the order
+ * from the first series they appear in.
+ */
+function collectStackedLabels(
+  series: readonly BarChartSeries[],
+  fmtDimension: (v: string | number) => string,
+): string[] {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const s of series) {
+    for (const item of s.items) {
+      const label = fmtDimension(item.label);
+      if (!seen.has(label)) {
+        seen.add(label);
+        labels.push(label);
+      }
+    }
+  }
+  return labels;
+}
+
+/**
+ * Collect unique items (by label) across all series, preserving order.
+ * Used so brush handlers have a flat item list for stacked charts.
+ */
+function collectAllStackedItems(
+  series: readonly BarChartSeries[],
+): BarChartItem[] {
+  const seen = new Set<string | number>();
+  const items: BarChartItem[] = [];
+  for (const s of series) {
+    for (const item of s.items) {
+      if (!seen.has(item.label)) {
+        seen.add(item.label);
+        items.push(item);
+      }
+    }
+  }
+  return items;
+}
+
+/** Build ECharts series array for stacked bar charts. */
+function buildStackedSeries(
+  series: readonly BarChartSeries[],
+  labels: readonly string[],
+  fmtDimension: (v: string | number) => string,
+): Array<Record<string, unknown>> {
+  return series.map((s) => {
+    // Build a lookup from formatted label → value for this series.
+    const valueByLabel = new Map<string, number>();
+    for (const item of s.items) {
+      valueByLabel.set(fmtDimension(item.label), item.value);
+    }
+    return {
+      type: 'bar',
+      name: s.name,
+      stack: 'total',
+      data: labels.map((label) => valueByLabel.get(label) ?? 0),
+      emphasis: {focus: 'series' as const},
+    };
+  });
+}
+
 function buildBarEventHandlers(
   attrs: BarChartAttrs,
   data: BarChartData | undefined,
 ): ReadonlyArray<EChartEventHandler> {
-  if (!attrs.onBrush || data === undefined || data.items.length === 0) {
+  const isStacked = data?.series !== undefined && data.series.length > 0;
+  if (
+    !attrs.onBrush ||
+    data === undefined ||
+    (!isStacked && data.items.length === 0)
+  ) {
     return [];
   }
   const onBrush = attrs.onBrush;
-  const items = data.items;
+  // For stacked charts, collect all unique labels from all series;
+  // for single-series charts, use items directly.
+  const items: readonly BarChartItem[] = isStacked
+    ? collectAllStackedItems(data.series)
+    : data.items;
 
   return [
     {

--- a/ui/src/components/widgets/charts/bar_chart_loader.ts
+++ b/ui/src/components/widgets/charts/bar_chart_loader.ts
@@ -18,9 +18,10 @@ import {
   STR_NULL,
   QueryResult,
 } from '../../../trace_processor/query_result';
-import {BarChartData, BarChartItem} from './bar_chart';
+import {BarChartData, BarChartItem, BarChartSeries} from './bar_chart';
 import {
   ChartSource,
+  ColumnType,
   SQLChartLoader,
   QueryConfig,
   ChartLoaderResult,
@@ -51,6 +52,12 @@ export interface SQLBarChartLoaderOpts {
    * Column name for the measure (numeric values to aggregate).
    */
   readonly measureColumn: string;
+
+  /**
+   * Optional column for stacked bar series. Each unique value in this column
+   * becomes a separate stacked series.
+   */
+  readonly seriesColumn?: string;
 }
 
 /**
@@ -88,26 +95,36 @@ export class SQLBarChartLoader extends SQLChartLoader<
 > {
   private readonly dimensionColumn: string;
   private readonly measureColumn: string;
+  private readonly seriesColumn?: string;
 
   constructor(opts: SQLBarChartLoaderOpts) {
+    const schema: Record<string, ColumnType> = {
+      [opts.dimensionColumn]: 'text',
+      [opts.measureColumn]: 'real',
+    };
+    if (opts.seriesColumn !== undefined) {
+      schema[opts.seriesColumn] = 'text';
+    }
     super(
       opts.engine,
       new ChartSource({
         query: opts.query,
-        schema: {
-          [opts.dimensionColumn]: 'text',
-          [opts.measureColumn]: 'real',
-        },
+        schema,
       }),
     );
     this.dimensionColumn = opts.dimensionColumn;
     this.measureColumn = opts.measureColumn;
+    this.seriesColumn = opts.seriesColumn;
   }
 
   protected buildQueryConfig(config: BarChartLoaderConfig): QueryConfig {
+    const dimensions = [{column: this.dimensionColumn}];
+    if (this.seriesColumn !== undefined) {
+      dimensions.push({column: this.seriesColumn});
+    }
     return {
       type: 'aggregated',
-      dimensions: [{column: this.dimensionColumn}],
+      dimensions,
       measures: [{column: this.measureColumn, aggregation: config.aggregation}],
       filters: inFilter(this.dimensionColumn, config.filter),
       limit: config.limit,
@@ -115,11 +132,41 @@ export class SQLBarChartLoader extends SQLChartLoader<
   }
 
   protected parseResult(queryResult: QueryResult): BarChartData {
+    if (this.seriesColumn !== undefined) {
+      return this.parseStacked(queryResult);
+    }
     const items: BarChartItem[] = [];
     const iter = queryResult.iter({_dim: STR_NULL, _value: NUM});
     for (; iter.valid(); iter.next()) {
       items.push({label: iter._dim ?? '(null)', value: iter._value});
     }
     return {items};
+  }
+
+  private parseStacked(queryResult: QueryResult): BarChartData {
+    // ChartSource names dimension columns as _dim, _dim_1, _dim_2, …
+    // (see buildAggregatedQuery in chart_sql_source.ts). Here _dim is
+    // the primary category and _dim_1 is the series/group column.
+    const seriesMap = new Map<string, BarChartItem[]>();
+    const iter = queryResult.iter({
+      _dim: STR_NULL,
+      _dim_1: STR_NULL,
+      _value: NUM,
+    });
+    for (; iter.valid(); iter.next()) {
+      const seriesName = iter._dim_1 ?? '(null)';
+      const label = iter._dim ?? '(null)';
+      let items = seriesMap.get(seriesName);
+      if (items === undefined) {
+        items = [];
+        seriesMap.set(seriesName, items);
+      }
+      items.push({label, value: iter._value});
+    }
+    const series: BarChartSeries[] = [];
+    for (const [name, items] of seriesMap) {
+      series.push({name, items});
+    }
+    return {items: [], series};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.scss
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.scss
@@ -50,25 +50,26 @@
   // (24 columns + 2 × 0.5-cell margin).
   background-size: var(--pf-grid-cell-size, 100px)
     var(--pf-grid-cell-size, 100px);
-  // Offset dots to align with the grid margin.
-  background-position: var(--pf-grid-margin-px, 0) var(--pf-grid-margin-px, 0);
+  // The radial-gradient dot is centred within each tile, so shift back by
+  // half a cell so that dots land on grid-line intersections (where item
+  // corners snap to).
+  background-position: calc(
+      var(--pf-grid-margin-px, 0px) - (var(--pf-grid-cell-size, 100px) / 2)
+    )
+    calc(var(--pf-grid-margin-px, 0px) - (var(--pf-grid-cell-size, 100px) / 2));
 
-  // Show grid lines while dragging or resizing items.
-  &.pf-dashboard__canvas--grid-visible {
-    background-image: repeating-linear-gradient(
-        to right,
-        color-mix(in srgb, var(--pf-color-border-secondary) 50%, transparent) 0
-          1px,
-        transparent 1px var(--pf-grid-cell-size)
-      ),
-      repeating-linear-gradient(
-        to bottom,
-        color-mix(in srgb, var(--pf-color-border-secondary) 50%, transparent) 0
-          1px,
-        transparent 1px var(--pf-grid-cell-size)
-      );
-    background-size: auto;
+  &--no-dots {
+    background-image: none;
   }
+}
+
+// Invisible spacer that extends the canvas scroll area below the last item.
+.pf-dashboard__canvas-spacer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  pointer-events: none;
 }
 
 // Centered overlay for the empty state.
@@ -563,6 +564,40 @@
   white-space: nowrap;
 }
 
+// Editable title in the edit panel.
+.pf-dashboard__edit-panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 16px 12px 8px;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+    text-decoration-style: dotted;
+  }
+}
+
+// Inline rename input for the edit panel title.
+.pf-dashboard__edit-panel-title-input {
+  display: block;
+  width: calc(100% - 24px);
+  margin: 16px 12px 8px;
+  font-size: 13px;
+  font-weight: 600;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  border-bottom: 1px solid var(--pf-color-accent);
+}
+
+// Generic padded row inside the edit panel.
+.pf-dashboard__edit-panel-row {
+  padding: 0 12px;
+}
+
 // Side panel matching the builder's .pf-qb-side-panel style.
 .pf-dashboard__side-panel {
   width: 60px;
@@ -587,4 +622,17 @@
       color: var(--pf-color-text-on-primary);
     }
   }
+}
+
+// Row inside the settings panel.
+.pf-dashboard__settings-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+}
+
+.pf-dashboard__settings-label {
+  font-size: 12px;
+  white-space: nowrap;
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
@@ -58,6 +58,8 @@ import {
 import {Popup, PopupPosition} from '../../../widgets/popup';
 import {renderChartConfigPopup} from '../query_builder/charts/chart_config_popup';
 import {renderChartTypePickerGrid} from '../query_builder/charts/chart_type_picker';
+import {Switch} from '../../../widgets/switch';
+import {Select} from '../../../widgets/select';
 
 const DEFAULT_DIVIDER_LABEL = 'Filter boundary';
 // CSS selector for elements that should not initiate a card drag.
@@ -117,7 +119,17 @@ export interface DashboardAttrs {
   onBrushFiltersChange: (filters: Map<string, DashboardBrushFilter[]>) => void;
 }
 
-type SidePanelTab = 'add' | 'data' | 'linked' | 'edit';
+type SidePanelTab = 'add' | 'data' | 'linked' | 'edit' | 'settings';
+
+interface DashboardSettings {
+  showGridDots: boolean;
+  chartGridLines?: 'horizontal' | 'vertical' | 'both';
+}
+
+const DEFAULT_SETTINGS: DashboardSettings = {
+  showGridDots: true,
+  chartGridLines: undefined,
+};
 
 interface EditingChartContext {
   readonly itemId: string;
@@ -129,6 +141,8 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
   private expandedInput: string | undefined = undefined;
   private renamingChartId?: string;
   private editingChart?: EditingChartContext;
+  private editPanelRenaming = false;
+  private settings: DashboardSettings = {...DEFAULT_SETTINGS};
   // Incremented when filters are removed from the filter bar, so that
   // chart brush overlays are cleared in sync.
   private brushClearGen = 0;
@@ -151,9 +165,6 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
   // references.
   private latestAttrs?: DashboardAttrs;
 
-  // Whether a resize handle is currently active (shows grid lines).
-  private isResizing = false;
-
   private get cellSize(): number {
     return this.canvasWidth / (GRID_COLUMNS + 2 * GRID_MARGIN);
   }
@@ -168,11 +179,10 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
         m(
           '.pf-dashboard__canvas',
           {
-            style: `--pf-grid-cell-size: ${this.cellSize}px; --pf-grid-margin-px: ${GRID_MARGIN * this.cellSize}px`,
             className: classNames(
-              (this.draggingItemId !== undefined || this.isResizing) &&
-                'pf-dashboard__canvas--grid-visible',
+              !this.settings.showGridDots && 'pf-dashboard__canvas--no-dots',
             ),
+            style: `--pf-grid-cell-size: ${this.cellSize}px; --pf-grid-margin-px: ${GRID_MARGIN * this.cellSize}px`,
             oncreate: (vnode: m.VnodeDOM) => {
               const el = vnode.dom as HTMLElement;
               this.canvasWidth = el.clientWidth;
@@ -197,7 +207,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
           },
           [
             items.length > 0
-              ? this.renderItems(attrs, items)
+              ? [this.renderItems(attrs, items), this.renderCanvasSpacer(items)]
               : m(
                   '.pf-dashboard__empty-overlay',
                   attrs.sources.length > 0
@@ -224,6 +234,8 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
       this.activePanel === 'edit' &&
         this.editingChart !== undefined &&
         m('.pf-dashboard__content-panel', this.renderEditPanel(attrs)),
+      this.activePanel === 'settings' &&
+        m('.pf-dashboard__content-panel', this.renderSettingsPanel()),
       m('.pf-dashboard__side-panel', [
         m(Button, {
           icon: 'add',
@@ -234,7 +246,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
           },
         }),
         m(Button, {
-          icon: 'dataset',
+          icon: 'storage',
           title: 'Data',
           className: classNames(this.activePanel === 'data' && 'pf-active'),
           onclick: () => {
@@ -248,6 +260,15 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
           onclick: () => {
             this.activePanel =
               this.activePanel === 'linked' ? undefined : 'linked';
+          },
+        }),
+        m(Button, {
+          icon: 'tune',
+          title: 'Dashboard settings',
+          className: classNames(this.activePanel === 'settings' && 'pf-active'),
+          onclick: () => {
+            this.activePanel =
+              this.activePanel === 'settings' ? undefined : 'settings';
           },
         }),
         this.activePanel === 'edit' &&
@@ -356,7 +377,60 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
 
     return [
       m('.pf-dashboard__panel-section', [
-        m('.pf-dashboard__panel-section-title', headerLabel),
+        this.editPanelRenaming
+          ? m('input.pf-dashboard__edit-panel-title-input', {
+              type: 'text',
+              value: config.name ?? '',
+              placeholder: getDefaultChartLabel(config),
+              oncreate: (vnode: m.VnodeDOM) => {
+                const input = vnode.dom as HTMLInputElement;
+                input.focus();
+                input.select();
+              },
+              onblur: () => {
+                if (!this.editPanelRenaming) return;
+                this.editPanelRenaming = false;
+              },
+              onkeydown: (e: KeyboardEvent) => {
+                if (e.key === 'Escape') {
+                  // Revert to the name before editing.
+                  this.updateChartName(attrs, config.id, config.name);
+                  this.editPanelRenaming = false;
+                  (e.target as HTMLInputElement).blur();
+                } else if (e.key === 'Enter') {
+                  this.editPanelRenaming = false;
+                  (e.target as HTMLInputElement).blur();
+                }
+              },
+              oninput: (e: Event) => {
+                const target = e.target as HTMLInputElement;
+                const name = target.value.trim() || undefined;
+                this.updateChartName(attrs, config.id, name);
+              },
+            })
+          : m(
+              '.pf-dashboard__edit-panel-title',
+              {
+                onclick: () => {
+                  this.editPanelRenaming = true;
+                },
+                title: 'Click to rename',
+              },
+              headerLabel,
+            ),
+        m('.pf-dashboard__panel-section-subtitle', 'Data Source'),
+        m(
+          '.pf-dashboard__edit-panel-row',
+          this.renderSourceChangePopup(
+            attrs,
+            config.id,
+            source,
+            undefined,
+            (s) => {
+              this.editingChart = {itemId: config.id, source: s};
+            },
+          ),
+        ),
         m('.pf-dashboard__panel-section-subtitle', 'Chart Type'),
         renderChartTypePickerGrid((newType) => {
           if (newType === config.chartType) return;
@@ -381,6 +455,100 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
         ),
       ]),
     ];
+  }
+
+  // --- Settings panel ---
+
+  private renderSettingsPanel(): m.Children {
+    return [
+      m('.pf-dashboard__panel-section', [
+        m('.pf-dashboard__panel-section-title', 'Dashboard Settings'),
+        m('.pf-dashboard__panel-section-subtitle', 'Canvas'),
+        m(
+          '.pf-dashboard__settings-row',
+          m(Switch, {
+            label: 'Show grid dots',
+            checked: this.settings.showGridDots,
+            onchange: (e: Event) => {
+              this.settings.showGridDots = (
+                e.target as HTMLInputElement
+              ).checked;
+            },
+          }),
+        ),
+        m('.pf-dashboard__panel-section-subtitle', 'Charts'),
+        m('.pf-dashboard__settings-row', [
+          m('label.pf-dashboard__settings-label', 'Grid lines'),
+          m(
+            Select,
+            {
+              value: this.settings.chartGridLines ?? 'none',
+              onchange: (e: Event) => {
+                const val = (e.target as HTMLSelectElement).value;
+                this.settings.chartGridLines =
+                  val === 'none'
+                    ? undefined
+                    : (val as 'horizontal' | 'vertical' | 'both');
+              },
+            },
+            [
+              m('option', {value: 'none'}, 'None'),
+              m('option', {value: 'horizontal'}, 'Horizontal'),
+              m('option', {value: 'vertical'}, 'Vertical'),
+              m('option', {value: 'both'}, 'Both'),
+            ],
+          ),
+        ]),
+      ]),
+    ];
+  }
+
+  // Invisible spacer that extends 2 grid rows below the lowest item,
+  // ensuring there is always room to scroll past the last chart.
+  private renderCanvasSpacer(items: DashboardItem[]): m.Child {
+    let maxRow = 0;
+    for (const item of items) {
+      const b = getItemBounds(item);
+      maxRow = Math.max(maxRow, b.row + b.rowSpan);
+    }
+    const cs = this.cellSize;
+    const height = (maxRow + 2 + GRID_MARGIN) * cs;
+    return m('.pf-dashboard__canvas-spacer', {
+      style: `height:${height}px`,
+    });
+  }
+
+  /** Reusable source-change popup menu for a chart. */
+  private renderSourceChangePopup(
+    attrs: DashboardAttrs,
+    chartId: string,
+    currentSource: DashboardDataSource,
+    chipOpts?: {compact?: boolean; className?: string},
+    onChanged?: (newSource: DashboardDataSource) => void,
+  ): m.Child {
+    return m(
+      PopupMenu,
+      {
+        trigger: m(Chip, {
+          label: currentSource.name,
+          icon: 'storage',
+          title: 'Change data source',
+          ...chipOpts,
+        }),
+      },
+      ...attrs.sources.map((s) =>
+        m(MenuItem, {
+          label: s.name,
+          icon: s.nodeId === currentSource.nodeId ? 'check' : undefined,
+          onclick: () => {
+            if (s.nodeId !== currentSource.nodeId) {
+              this.changeChartSource(attrs, chartId, s);
+              onChanged?.(s);
+            }
+          },
+        }),
+      ),
+    );
   }
 
   // --- Canvas items ---
@@ -429,33 +597,15 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
         } else {
           this.editingChart = {itemId, source};
           this.activePanel = 'edit';
+          this.editPanelRenaming = false;
         }
       },
     });
 
-    const sourceChip = m(
-      PopupMenu,
-      {
-        trigger: m(Chip, {
-          label: source.name,
-          icon: 'database',
-          compact: true,
-          className: 'pf-dashboard__source-chip',
-          title: 'Change data source',
-        }),
-      },
-      ...attrs.sources.map((s) =>
-        m(MenuItem, {
-          label: s.name,
-          icon: s.nodeId === source.nodeId ? 'check' : undefined,
-          onclick: () => {
-            if (s.nodeId !== source.nodeId) {
-              this.changeChartSource(attrs, itemId, s);
-            }
-          },
-        }),
-      ),
-    );
+    const sourceChip = this.renderSourceChangePopup(attrs, itemId, source, {
+      compact: true,
+      className: classNames('pf-dashboard__source-chip'),
+    });
 
     return this.renderItemCard(attrs, itemId, chart, [
       m('.pf-dashboard__chart-header', [
@@ -531,6 +681,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
           onItemsChange: attrs.onItemsChange,
           onBrushFiltersChange: attrs.onBrushFiltersChange,
           isDriverChart: chartIsDriver,
+          gridLines: this.settings.chartGridLines,
         }),
       ),
     ]);
@@ -673,14 +824,8 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
         ...(Array.isArray(children) ? children : [children]),
         m(ResizeHandle, {
           direction: 'horizontal',
-          onResizeStart: () => {
-            this.isResizing = true;
-            m.redraw();
-          },
-          onResizeEnd: () => {
-            this.isResizing = false;
-            m.redraw();
-          },
+          onResizeStart: () => m.redraw(),
+          onResizeEnd: () => m.redraw(),
           onResizeAbsolute: (positionPx: number) => {
             const itemCol = item.col ?? 0;
             const itemRow = item.row ?? 0;
@@ -708,14 +853,8 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
         }),
         m(ResizeHandle, {
           direction: 'vertical',
-          onResizeStart: () => {
-            this.isResizing = true;
-            m.redraw();
-          },
-          onResizeEnd: () => {
-            this.isResizing = false;
-            m.redraw();
-          },
+          onResizeStart: () => m.redraw(),
+          onResizeEnd: () => m.redraw(),
           onResizeAbsolute: (positionPx: number) => {
             const itemCol = item.col ?? 0;
             const itemRow = item.row ?? 0;
@@ -1138,9 +1277,9 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
           m('.pf-dashboard__filter-group', [
             m(Chip, {
               label,
-              icon: 'database',
+              icon: 'storage',
               compact: true,
-              className: 'pf-dashboard__source-chip',
+              className: classNames('pf-dashboard__source-chip'),
             }),
             ...chips,
           ]),
@@ -1173,7 +1312,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
     if (allExported.length === 0) {
       return m(
         ResultsPanelEmptyState,
-        {icon: 'dataset', title: 'No exported sources'},
+        {icon: 'storage', title: 'No exported sources'},
         'Use "Export to Dashboard" nodes in the graph builder to make data sources available here.',
       );
     }
@@ -1199,7 +1338,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
     if (used.length > 0) {
       sections.push(
         m('.pf-dashboard__panel-section', [
-          m('.pf-dashboard__panel-section-title', 'Used'),
+          m('.pf-dashboard__panel-section-title', 'Used data sources'),
           m(
             '.pf-dashboard__input-list',
             m(Accordion, {
@@ -1216,7 +1355,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
     if (unused.length > 0) {
       sections.push(
         m('.pf-dashboard__panel-section', [
-          m('.pf-dashboard__panel-section-title', 'Unused'),
+          m('.pf-dashboard__panel-section-title', 'Unused data sources'),
           m(
             '.pf-dashboard__input-list',
             m(Accordion, {
@@ -1330,7 +1469,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
                 '.pf-dashboard__column',
                 m(Icon, {
                   icon: perfettoSqlTypeIcon(col.type),
-                  className: 'pf-dashboard__column-icon',
+                  className: classNames('pf-dashboard__column-icon'),
                 }),
                 m(
                   '.pf-dashboard__column-info',
@@ -1354,7 +1493,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
             label: 'Add Chart',
             icon: 'bar_chart',
             compact: true,
-            className: 'pf-dashboard__add-chart-btn',
+            className: classNames('pf-dashboard__add-chart-btn'),
           }),
           fitContent: true,
         },

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
@@ -59,6 +59,8 @@ export interface DashboardChartViewAttrs {
    * consumer charts below dividers.
    */
   isDriverChart?: boolean;
+  /** Grid lines setting passed through to chart widgets. */
+  gridLines?: 'horizontal' | 'vertical' | 'both';
 }
 
 /** Subset of DashboardChartViewAttrs needed by the adapter. */
@@ -320,7 +322,11 @@ export class DashboardChartView
     }
 
     const entry = this.ensureLoader(attrs, config);
-    const ctx = {node: adapter, onFilterChange: () => m.redraw()};
+    const ctx = {
+      node: adapter,
+      onFilterChange: () => m.redraw(),
+      gridLines: attrs.gridLines,
+    };
     return renderChartByType(ctx, config, entry);
   }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_config_popup.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_config_popup.ts
@@ -169,10 +169,10 @@ export function renderChartConfigPopup(
           ],
         ),
       ]),
-      // Y column — for line and scatter
+      // Y column — for line, scatter, boxplot, heatmap
       def?.supportsYColumn &&
         m(FormLabel, [
-          m('span', 'Y Column'),
+          m('span', def.yColumnLabel ?? 'Y Column'),
           m(
             Select,
             {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_renderers.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_renderers.ts
@@ -110,6 +110,8 @@ export interface ChartColumnProvider {
 export interface ChartRenderContext {
   readonly node: ChartColumnProvider;
   readonly onFilterChange?: () => void;
+  /** When set, charts that support grid lines will render them. */
+  readonly gridLines?: 'horizontal' | 'vertical' | 'both';
 }
 
 /** Dispose all loaders on a ChartLoaderEntry. */
@@ -158,6 +160,7 @@ export function createChartLoaders(
         query,
         dimensionColumn: config.column,
         measureColumn: config.measureColumn ?? config.column,
+        seriesColumn: config.groupColumn,
       });
       break;
     case 'histogram':
@@ -310,6 +313,7 @@ export function renderBarChart(
     fillParent: true,
     formatDimension,
     formatMeasure,
+    gridLines: ctx.gridLines,
     onBrush: (labels) => handleBarBrush(ctx, config, labels),
   });
 }
@@ -368,6 +372,7 @@ export function renderLineChart(
     scaleAxes: true,
     formatXValue,
     formatYValue,
+    gridLines: ctx.gridLines,
     onBrush: (range) =>
       handleHistogramBrush(ctx, config, range.start, range.end),
   });
@@ -398,6 +403,7 @@ export function renderScatterChart(
     scaleAxes: true,
     formatXValue,
     formatYValue,
+    gridLines: ctx.gridLines,
   });
 }
 
@@ -486,6 +492,7 @@ export function renderBoxplot(
     valueLabel: config.yColumn,
     fillParent: true,
     formatValue,
+    gridLines: ctx.gridLines,
   });
 }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/chart_type_registry.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/chart_type_registry.ts
@@ -65,6 +65,9 @@ export interface ChartTypeDefinition {
    */
   readonly supportsYColumn: boolean;
 
+  /** Label shown for the Y column picker (defaults to "Y Column"). */
+  readonly yColumnLabel?: string;
+
   /**
    * Whether the chart supports an optional grouping/series column (any type).
    * When true, a group column picker is shown in the config popup.
@@ -99,7 +102,7 @@ export const CHART_TYPES: readonly ChartTypeDefinition[] = [
     requiresNumericDimension: false,
     primaryColumnLabel: 'Dimension',
     supportsYColumn: false,
-    supportsGroupColumn: false,
+    supportsGroupColumn: true,
     supportsSizeColumn: false,
     description: 'Compare categories using vertical or horizontal bars',
   },
@@ -188,8 +191,9 @@ export const CHART_TYPES: readonly ChartTypeDefinition[] = [
     supportsAggregation: true,
     supportsBinning: false,
     requiresNumericDimension: false,
-    primaryColumnLabel: 'X Column',
+    primaryColumnLabel: 'X Dimension',
     supportsYColumn: true,
+    yColumnLabel: 'Y Dimension',
     supportsGroupColumn: false,
     supportsSizeColumn: false,
     description: 'Visualize magnitude across two dimensions using color',


### PR DESCRIPTION
Dashboard tweaks: adds stacked bar chart support, a settings panel for
canvas/chart display options, and improves the edit panel with inline
renaming and data source switching.

## Changes

- **Stacked bar charts**: bar charts now support a `groupColumn` that
  splits data into multiple stacked series with a legend
- **Settings panel**: new sidebar tab with grid dot toggle and chart
  grid lines dropdown (none/horizontal/vertical/both)
- **Edit panel**: inline title renaming and data source picker
- **Canvas spacer**: invisible element extends scroll area below the
  last item
- **Grid dot alignment**: dots now land on grid-line intersections
- **Polish**: consistent `storage` icon, clarified section titles,
  `classNames()` wrappers, removed `isResizing` state, heatmap
  `yColumnLabel` support