### PR TITLE
ui: Record page - allow pasting custom configs

### DIFF
--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/pages/target_selection_page.ts
@@ -36,6 +36,7 @@ import {Card} from '../../../widgets/card';
 import {showModal} from '../../../widgets/modal';
 import {traceConfigToPb} from '../../../base/proto_utils_wasm';
 import protos from '../../../protos';
+import {ImportConfigDialog} from '../views/import_config';
 
 type RecMgrAttrs = {recMgr: RecordingManager};
 
@@ -358,7 +359,7 @@ class RecordConfigSelector implements m.ClassComponent<RecMgrAttrs> {
       Card,
       {
         className: 'pf-preset-card pf-preset-card--dashed',
-        onclick: () => this.openImportDialog(recMgr),
+        onclick: () => this.openRawTextProtoModal(recMgr),
         tabindex: 0,
       },
       m(Icon, {icon: 'upload_file'}),
@@ -367,25 +368,44 @@ class RecordConfigSelector implements m.ClassComponent<RecMgrAttrs> {
     );
   }
 
-  private openImportDialog(recMgr: RecordingManager) {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.onchange = async () => {
-      const file = input.files?.[0];
-      if (!file) return;
-      const text = await file.text();
-      const res = await traceConfigToPb(text);
-      if (!res.ok) {
-        showModal({
-          title: 'Import error',
-          content: `Failed to parse config: ${res.error}`,
-        });
-        return;
-      }
-      const config = protos.TraceConfig.decode(res.value);
-      recMgr.setCustomTraceConfig(config, file.name);
-    };
-    input.click();
+  private openRawTextProtoModal(recMgr: RecordingManager) {
+    let config = '';
+    return showModal({
+      title: 'Import trace config from textproto',
+      content: () =>
+        m(ImportConfigDialog, {
+          config,
+          onUpdate: (x) => {
+            config = x;
+          },
+        }),
+      buttons: [
+        {
+          text: 'Add config',
+          primary: true,
+          action: async () => {
+            await this.addCustomConfig(recMgr, config, 'textproto');
+          },
+        },
+      ],
+    });
+  }
+
+  private async addCustomConfig(
+    recMgr: RecordingManager,
+    text: string,
+    name: string,
+  ) {
+    const res = await traceConfigToPb(text);
+    if (!res.ok) {
+      showModal({
+        title: 'Import error',
+        content: `Failed to parse config: ${res.error}`,
+      });
+      return;
+    }
+    const config = protos.TraceConfig.decode(res.value);
+    recMgr.setCustomTraceConfig(config, name);
   }
 
   private renderCard(

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/styles.scss
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/styles.scss
@@ -15,6 +15,8 @@
 @import "../../assets/theme";
 @import "../../assets/widgets/checkbox";
 
+@import "views/import_config";
+
 // The whole record page.
 .pf-record-page {
   position: relative;

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/views/import_config.scss
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/views/import_config.scss
@@ -1,0 +1,34 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.pf-import-config {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &__textarea {
+    width: 100%;
+    height: 300px;
+    color: var(--pf-color-text);
+    background: var(--pf-color-void);
+    border: 1px solid var(--pf-color-border);
+    border-radius: 4px;
+    font-family: var(--pf-font-monospace);
+
+    &:focus {
+      outline: none;
+      border-color: var(--pf-color-accent);
+    }
+  }
+}

--- a/ui/src/plugins/dev.perfetto.RecordTraceV2/views/import_config.ts
+++ b/ui/src/plugins/dev.perfetto.RecordTraceV2/views/import_config.ts
@@ -1,0 +1,69 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import {Button, ButtonBar, ButtonVariant} from '../../../widgets/button';
+import {errResult, okResult, Result} from '../../../base/result';
+
+export interface ImportConfigDialogAttrs {
+  readonly config: string;
+  readonly onUpdate: (config: string) => void;
+}
+
+export function ImportConfigDialog(): m.Component<ImportConfigDialogAttrs> {
+  return {
+    view({attrs}: m.Vnode<ImportConfigDialogAttrs>) {
+      const {config, onUpdate} = attrs;
+      return m('.pf-import-config', [
+        m(ButtonBar, [
+          m(Button, {
+            label: 'Import from file',
+            icon: 'file_upload',
+            variant: ButtonVariant.Filled,
+            onclick: async () => {
+              const file = await importFile();
+              if (file.ok) {
+                const text = await file.value.text();
+                m.redraw();
+                onUpdate(text);
+              }
+            },
+          }),
+        ]),
+        m('textarea.pf-import-config__textarea', {
+          value: config,
+          oninput: (e: Event) =>
+            onUpdate((e.target as HTMLTextAreaElement).value),
+        }),
+      ]);
+    },
+  };
+}
+
+function importFile(): Promise<Result<File>> {
+  return new Promise((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.onchange = async () => {
+      m.redraw();
+      const file = input.files?.[0];
+      if (file) {
+        resolve(okResult(file));
+      } else {
+        resolve(errResult('No file selected'));
+      }
+    };
+    input.click();
+  });
+}


### PR DESCRIPTION
Add a dialog box which allows pasting a config directly as txtproto, rather than always having to upload as a file from disk.

<img width="851" height="655" alt="image" src="https://github.com/user-attachments/assets/c1d48bca-f7f9-496c-9c30-bac3a9c13992" />
