### PR TITLE
gpu: Add FUNCTION_NAME to ActivityNameFilter NameBase enum

### DIFF
--- a/protos/perfetto/config/gpu/gpu_counter_config.proto
+++ b/protos/perfetto/config/gpu/gpu_counter_config.proto
@@ -58,8 +58,25 @@ message GpuCounterConfig {
     // and the basis for matching (mangled or demangled kernel name).
     message ActivityNameFilter {
       enum NameBase {
+        // Match against the mangled (compiler-encoded) kernel name.
+        // Example: for a kernel whose demangled name is
+        // "matmul(float*,int,int)", the mangled name might be
+        // "_Z6matmulPfii". The glob pattern is matched against this
+        // mangled form.
         MANGLED_KERNEL_NAME = 0;
+
+        // Match against the fully demangled kernel name, including
+        // parameters, templates, and qualifiers.
+        // Example: "matmul(float*,int,int)". The glob pattern is
+        // matched against this full demangled form.
         DEMANGLED_KERNEL_NAME = 1;
+
+        // Match against only the function name portion of the
+        // demangled kernel name, without parameters, templates,
+        // return types, or namespaces.
+        // Example: "matmul". The glob pattern is matched against
+        // just the bare function name.
+        FUNCTION_NAME = 2;
       }
 
       // required. Glob pattern to use for GPU activity name filtering.


### PR DESCRIPTION
Add a third NameBase option that matches against only the function name portion of a demangled kernel name, without parameters, templates, return types, or namespaces. This allows filtering by bare function name (e.g. "matmul") rather than requiring the full mangled or demangled signature.

Also add documentation comments to all NameBase enum values with concrete examples using "matmul(float*,int,int)" as a reference kernel.