### PR TITLE
traced_probes: defer aflags Flush() callback on in-flight subprocess

### DIFF
--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -49,6 +49,8 @@ inline constexpr char kFopenReadFlag[] = "re";
 
 constexpr FileOpenMode kFileModeInvalid = static_cast<FileOpenMode>(-1);
 
+// Cross-platform variant of ReadFileDescriptor() that takes a PlatformHandle.
+// On Windows normalizes ERROR_BROKEN_PIPE to EOF so behavior matches POSIX.
 bool ReadPlatformHandle(PlatformHandle, std::string* out);
 
 // Reads from |fd|, appending what is currently available into |*out|.
@@ -59,7 +61,11 @@ bool ReadPlatformHandle(PlatformHandle, std::string* out);
 //    IsAgain(errno) and retry on the next readability notification.
 bool ReadFileDescriptor(int fd, std::string* out);
 
+// Convenience wrapper around ReadFileDescriptor() that takes a FILE*.
 bool ReadFileStream(FILE* f, std::string* out);
+
+// Opens |path| read-only and reads its contents into |*out|.
+// Returns false if the file cannot be opened.
 bool ReadFile(const std::string& path, std::string* out);
 
 // A wrapper around read(2). It deals with Linux vs Windows includes. It also

--- a/include/perfetto/ext/base/file_utils.h
+++ b/include/perfetto/ext/base/file_utils.h
@@ -50,7 +50,15 @@ inline constexpr char kFopenReadFlag[] = "re";
 constexpr FileOpenMode kFileModeInvalid = static_cast<FileOpenMode>(-1);
 
 bool ReadPlatformHandle(PlatformHandle, std::string* out);
+
+// Reads from |fd|, appending what is currently available into |*out|.
+// Returns:
+//  True: EOF reached (all writers of |fd| have closed their end).
+//  False: read error. On a non-blocking |fd| this includes EAGAIN (no data
+//    currently available but writers are still alive); callers can check
+//    IsAgain(errno) and retry on the next readability notification.
 bool ReadFileDescriptor(int fd, std::string* out);
+
 bool ReadFileStream(FILE* f, std::string* out);
 bool ReadFile(const std::string& path, std::string* out);
 

--- a/src/traced/probes/android_aflags/android_aflags_data_source.cc
+++ b/src/traced/probes/android_aflags/android_aflags_data_source.cc
@@ -36,6 +36,8 @@ namespace perfetto {
 namespace {
 constexpr uint32_t kMinPollPeriodMs = 1000;
 constexpr uint32_t kAflagsExitTimeoutMs = 100;
+// Should be smaller than ProbesProducer::kFlushTimeoutMs.
+constexpr uint32_t kAflagsFlushTimeoutMs = 800;
 }  // namespace
 
 // static
@@ -194,6 +196,11 @@ void AndroidAflagsDataSource::FinalizeAflagsCapture() {
   aflags_proto->AppendRawProtoBytes(decoded->data(), decoded->size());
   packet->Finalize();
   writer_->Flush();
+
+  // Drain any Flush() callbacks deferred while the subprocess was running.
+  while (!pending_flushes_.empty()) {
+    OnFlushComplete(pending_flushes_.begin()->first);
+  }
 }
 
 void AndroidAflagsDataSource::EmitErrorPacket(const std::string& error_msg) {
@@ -205,9 +212,43 @@ void AndroidAflagsDataSource::EmitErrorPacket(const std::string& error_msg) {
   writer_->Flush();
 }
 
-void AndroidAflagsDataSource::Flush(FlushRequestID,
+void AndroidAflagsDataSource::Flush(FlushRequestID flush_request_id,
                                     std::function<void()> callback) {
-  writer_->Flush(callback);
+  // Fast path: no subprocess in flight, flush immediately.
+  if (!aflags_process_) {
+    writer_->Flush(std::move(callback));
+    return;
+  }
+
+  // Subprocess still running. Defer the callback until FinalizeAflagsCapture()
+  // drains us; if the subprocess takes too long, kAflagsFlushTimeoutMs acts
+  // as safety net.
+  pending_flushes_[flush_request_id] = std::move(callback);
+  task_runner_->PostDelayedTask(
+      [weak_this = weak_factory_.GetWeakPtr(), flush_request_id] {
+        if (weak_this)
+          weak_this->OnFlushTimeout(flush_request_id);
+      },
+      kAflagsFlushTimeoutMs);
+}
+
+void AndroidAflagsDataSource::OnFlushTimeout(FlushRequestID flush_request_id) {
+  if (pending_flushes_.count(flush_request_id) == 0)
+    return;  // Already drained on the successful-completion path.
+
+  PERFETTO_ELOG("android.aflags Flush(%" PRIu64 ") timed out",
+                flush_request_id);
+  OnFlushComplete(flush_request_id);
+}
+
+void AndroidAflagsDataSource::OnFlushComplete(FlushRequestID flush_request_id) {
+  auto it = pending_flushes_.find(flush_request_id);
+  if (it == pending_flushes_.end())
+    return;
+
+  auto callback = std::move(it->second);
+  pending_flushes_.erase(it);
+  writer_->Flush(std::move(callback));
 }
 
 }  // namespace perfetto

--- a/src/traced/probes/android_aflags/android_aflags_data_source.h
+++ b/src/traced/probes/android_aflags/android_aflags_data_source.h
@@ -17,9 +17,11 @@
 #ifndef SRC_TRACED_PROBES_ANDROID_AFLAGS_ANDROID_AFLAGS_DATA_SOURCE_H_
 #define SRC_TRACED_PROBES_ANDROID_AFLAGS_ANDROID_AFLAGS_DATA_SOURCE_H_
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 
 #include "perfetto/ext/base/pipe.h"
 #include "perfetto/ext/base/subprocess.h"
@@ -73,11 +75,22 @@ class AndroidAflagsDataSource : public ProbesDataSource {
   // Emits a trace packet with AndroidAflags.error set to |error_msg|.
   void EmitErrorPacket(const std::string& error_msg);
 
+  // Safety net for a deferred Flush() |flush_request_id|: logs the timeout
+  // and delegates to OnFlushComplete.
+  void OnFlushTimeout(FlushRequestID);
+
+  // Invokes the deferred Flush() callback for |flush_request_id|, if any.
+  void OnFlushComplete(FlushRequestID);
+
   base::TaskRunner* const task_runner_;
   std::unique_ptr<TraceWriter> writer_;
 
   // Polling frequency in ms. 0 means one-shot capture at startup.
   uint32_t poll_period_ms_ = 0;
+
+  // Flush() callbacks deferred while an aflags subprocess is in flight.
+  // Drained when the subprocess completes (or when the flush timeout fires).
+  std::unordered_map<FlushRequestID, std::function<void()>> pending_flushes_;
 
   base::WeakPtrFactory<AndroidAflagsDataSource> weak_factory_;
 };

--- a/src/traced/probes/android_aflags/android_aflags_data_source_unittest.cc
+++ b/src/traced/probes/android_aflags/android_aflags_data_source_unittest.cc
@@ -19,6 +19,7 @@
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/task_runner.h"
 #include "perfetto/ext/base/base64.h"
+#include "perfetto/ext/base/subprocess.h"
 #include "perfetto/tracing/core/data_source_config.h"
 #include "src/base/test/test_task_runner.h"
 #include "src/tracing/core/trace_writer_for_testing.h"
@@ -51,6 +52,8 @@ class TestAndroidAflagsDataSource : public AndroidAflagsDataSource {
                                 session_id,
                                 std::move(writer)) {}
 
+  using AndroidAflagsDataSource::FinalizeAflagsCapture;
+
   struct FakeFlag {
     std::string pkg;
     std::string name;
@@ -64,9 +67,8 @@ class TestAndroidAflagsDataSource : public AndroidAflagsDataSource {
     uint32_t type;
   };
 
-  // Helper to simulate subprocess completion with given flags.
-  void FakeSubprocessCompletion(const std::vector<FakeFlag>& flags) {
-    // Generate proto binary (using aflags tool's field IDs)
+  // Seeds subprocess state as if a poll completed but did not finalize yet.
+  void SeedCompletedFakeSubprocess(const std::vector<FakeFlag>& flags) {
     protozero::HeapBuffered<protos::pbzero::AndroidAflags> msg;
     for (const auto& f : flags) {
       auto* flag_proto = msg->add_flags();
@@ -83,11 +85,13 @@ class TestAndroidAflagsDataSource : public AndroidAflagsDataSource {
     }
     std::vector<uint8_t> bytes = msg.SerializeAsArray();
     aflags_output_ = base::Base64Encode(bytes.data(), bytes.size());
-    // FinalizeAflagsCapture() expects aflags_process_ to be set because it
-    // calls Poll() and then resets it. We simulate this by using a Subprocess
-    // that has already finished.
     aflags_process_.emplace(std::initializer_list<std::string>{"/bin/true"});
     aflags_process_->Call();
+  }
+
+  // Helper to simulate subprocess completion with given flags.
+  void FakeSubprocessCompletion(const std::vector<FakeFlag>& flags) {
+    SeedCompletedFakeSubprocess(flags);
     FinalizeAflagsCapture();
   }
 
@@ -200,6 +204,76 @@ TEST_F(AndroidAflagsDataSourceTest,
   const auto& aflags = packet.android_aflags();
   EXPECT_TRUE(aflags.has_error());
   EXPECT_THAT(aflags.error(), HasSubstr("Failed to decode aflags output"));
+}
+
+TEST_F(AndroidAflagsDataSourceTest,
+       ANDROID_ONLY_TEST(FlushCompletesImmediatelyWhenIdle)) {
+  DataSourceConfig ds_config;
+  ds_config.set_name("android.aflags");
+  auto ds = CreateDataSource(ds_config);
+
+  bool callback_fired = false;
+  ds->Flush(/*flush_request_id=*/42,
+            [&callback_fired] { callback_fired = true; });
+
+  EXPECT_TRUE(callback_fired);
+}
+
+TEST_F(AndroidAflagsDataSourceTest,
+       ANDROID_ONLY_TEST(FlushDefersUntilSubprocessCompletes)) {
+  DataSourceConfig ds_config;
+  ds_config.set_name("android.aflags");
+  auto ds = CreateDataSource(ds_config);
+
+  std::vector<TestAndroidAflagsDataSource::FakeFlag> flags;
+  flags.push_back({
+      "com.android.test",
+      "a_flag",
+      "ns",
+      "system",
+      "enabled",
+      "disabled",
+      static_cast<uint32_t>(
+          protos::pbzero::AndroidAflags::FLAG_PERMISSION_READ_ONLY),
+      static_cast<uint32_t>(
+          protos::pbzero::AndroidAflags::VALUE_PICKED_FROM_DEFAULT),
+      static_cast<uint32_t>(
+          protos::pbzero::AndroidAflags::FLAG_STORAGE_BACKEND_ACONFIGD),
+      static_cast<uint32_t>(protos::pbzero::AndroidAflags::FLAG_TYPE_BOOLEAN),
+  });
+  ds->SeedCompletedFakeSubprocess(flags);
+
+  bool callback_fired = false;
+  ds->Flush(/*flush_request_id=*/1,
+            [&callback_fired] { callback_fired = true; });
+  EXPECT_FALSE(callback_fired);
+
+  ds->FinalizeAflagsCapture();
+
+  EXPECT_TRUE(callback_fired);
+  protos::gen::TracePacket packet = writer_raw_->GetOnlyTracePacket();
+  ASSERT_TRUE(packet.has_android_aflags());
+  EXPECT_EQ(packet.android_aflags().flags().size(), 1u);
+}
+
+TEST_F(AndroidAflagsDataSourceTest,
+       ANDROID_ONLY_TEST(FlushCallbackFiresOnTimeout)) {
+  DataSourceConfig ds_config;
+  ds_config.set_name("android.aflags");
+  auto ds = CreateDataSource(ds_config);
+
+  std::vector<TestAndroidAflagsDataSource::FakeFlag> flags;
+  ds->SeedCompletedFakeSubprocess(flags);
+
+  bool callback_fired = false;
+  ds->Flush(/*flush_request_id=*/1,
+            [&callback_fired] { callback_fired = true; });
+  EXPECT_FALSE(callback_fired);
+
+  // Advance past the 800ms timeout so the scheduled task fires.
+  task_runner_.AdvanceTimeAndRunUntilIdle(/*ms=*/801);
+
+  EXPECT_TRUE(callback_fired);
 }
 
 }  // namespace


### PR DESCRIPTION
When a trace with android.aflags enabled ends while the aflags_updatable subprocess is still running, the previous Flush() implementation acked the producer immediately. The producer then destroyed the data source, killing the subprocess mid-write and dropping the aflags packet from the trace.

```
  04-15 11:03:50.410 F DEBUG  : Abort message: 'failed printing to stdout: Broken pipe (os error 32)'
  ```

This change defers the Flush() callback while a subprocess is in flight:

- Fast path: if aflags_process_ is empty, flush the writer immediately.
- Deferred path: store the callback in pending_flushes_ keyed by flush_request_id, and arm an 800ms safety-net timeout.
- FinalizeAflagsCapture() drains pending_flushes_ at the end of its successful-completion path, so the producer is acked only after the aflags packet has been written. If the subprocess runs past the timeout, OnFlushTimeout logs it and delegates to OnFlushComplete so the producer isn't left waiting.

```
  04-20 15:05:27.694 I perfetto: Triggering final flush for 2
  04-20 15:05:27.696 I perfetto: ProbesProducer::Flush(2) begin
  04-20 15:05:27.913 I perfetto: Flush 2 acked by data source 2
  04-20 15:05:27.914 I perfetto: FlushAndDisableTracing(2) done, success=1
  04-20 15:05:27.916 I perfetto: Producer stop (id=2)
  04-20 15:05:27.964 I perfetto: Wrote 469696 bytes into /data/.../aflags.pftrace  
  04-20 15:05:27.694 I perfetto: Triggering final flush for 2
  04-20 15:05:27.696 I perfetto: ProbesProducer::Flush(2) begin
  04-20 15:05:27.913 I perfetto: Flush 2 acked by data source 2
  04-20 15:05:27.914 I perfetto: FlushAndDisableTracing(2) done, success=1
  04-20 15:05:27.916 I perfetto: Producer stop (id=2)
  04-20 15:05:27.964 I perfetto: Wrote 469696 bytes into /data/.../aflags.pftrace
  ```

Also documents ReadFileDescriptor()'s append-and-EOF-return semantics.

Bug: 502852101
Test: perfetto_unittests --gtest_filter='AndroidAflagsDataSourceTest.*' 
Test: manually captured a 100ms duration_ms trace on device with android.aflags enabled; aflags packet now lands in the trace instead of being dropped, no aflags_updatable tombstone.