### PR TITLE
ui: Accordion widget - Add 'multi' option

### DIFF
--- a/ui/src/assets/widgets/accordion.scss
+++ b/ui/src/assets/widgets/accordion.scss
@@ -15,16 +15,11 @@
 .pf-accordion {
   display: flex;
   flex-direction: column;
+}
 
-  &__item {
-    &.pf-expanded {
-      .pf-accordion__header {
-        background: var(--pf-color-background-tertiary);
-      }
-    }
-  }
-
-  &__header {
+.pf-accordion__item {
+  > summary {
+    list-style: none;
     display: flex;
     align-items: center;
     gap: 4px;
@@ -38,24 +33,48 @@
     &:hover {
       background: color_hover(transparent);
     }
+
+    // Remove the default WebKit disclosure triangle.
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &:focus-visible {
+      outline: 2px solid #1a73e8;
+      outline-offset: -2px;
+    }
   }
 
-  &__toggle {
-    color: var(--pf-color-text-muted);
-    display: flex;
-    align-items: center;
+  &[open] > summary {
+    background: var(--pf-color-background-tertiary);
+
+    .pf-accordion__toggle {
+      transform: rotate(0deg);
+    }
   }
 
-  &__header-content {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  &:not([open]) > summary {
+    .pf-accordion__toggle {
+      transform: rotate(-90deg);
+    }
   }
+}
 
-  &__content {
-    padding: 8px 16px 16px 16px;
-    background: var(--pf-color-background);
-  }
+.pf-accordion__toggle {
+  color: var(--pf-color-text-muted);
+  display: flex;
+  align-items: center;
+}
+
+.pf-accordion__header-content {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pf-accordion__content {
+  padding: 8px 16px 16px 16px;
+  background: var(--pf-color-background);
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard.ts
@@ -20,7 +20,7 @@ import {
   perfettoSqlTypeIcon,
   perfettoSqlTypeToString,
 } from '../../../trace_processor/perfetto_sql_type';
-import {Accordion, AccordionItem} from '../../../widgets/accordion';
+import {Accordion, AccordionSection} from '../../../widgets/accordion';
 import {Button} from '../../../widgets/button';
 import {Icons} from '../../../base/semantic_icons';
 import {Chip} from '../../../widgets/chip';
@@ -138,7 +138,6 @@ interface EditingChartContext {
 
 export class Dashboard implements m.ClassComponent<DashboardAttrs> {
   private activePanel?: SidePanelTab;
-  private expandedInput: string | undefined = undefined;
   private renamingChartId?: string;
   private editingChart?: EditingChartContext;
   private editPanelRenaming = false;
@@ -1325,30 +1324,29 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
     const used = allExported.filter((s) => usedNodeIds.has(s.nodeId));
     const unused = allExported.filter((s) => !usedNodeIds.has(s.nodeId));
 
-    const makeSourceItems = (srcs: DashboardDataSource[]): AccordionItem[] =>
-      srcs.map((source) => ({
-        id: source.nodeId,
-        header: m('.pf-dashboard__source-row', [
-          m('code.pf-dashboard__input-name', source.name),
-        ]),
-        content: this.renderInputContent(source, attrs),
-      }));
+    const renderSourceAccordion = (srcs: DashboardDataSource[]) =>
+      m(
+        Accordion,
+        srcs.map((source) =>
+          m(
+            AccordionSection,
+            {
+              key: source.nodeId,
+              summary: m('.pf-dashboard__source-row', [
+                m('code.pf-dashboard__input-name', source.name),
+              ]),
+            },
+            this.renderInputContent(source, attrs),
+          ),
+        ),
+      );
 
     const sections: m.Child[] = [];
     if (used.length > 0) {
       sections.push(
         m('.pf-dashboard__panel-section', [
           m('.pf-dashboard__panel-section-title', 'Used data sources'),
-          m(
-            '.pf-dashboard__input-list',
-            m(Accordion, {
-              items: makeSourceItems(used),
-              expanded: this.expandedInput,
-              onToggle: (id) => {
-                this.expandedInput = id;
-              },
-            }),
-          ),
+          m('.pf-dashboard__input-list', renderSourceAccordion(used)),
         ]),
       );
     }
@@ -1356,16 +1354,7 @@ export class Dashboard implements m.ClassComponent<DashboardAttrs> {
       sections.push(
         m('.pf-dashboard__panel-section', [
           m('.pf-dashboard__panel-section-title', 'Unused data sources'),
-          m(
-            '.pf-dashboard__input-list',
-            m(Accordion, {
-              items: makeSourceItems(unused),
-              expanded: this.expandedInput,
-              onToggle: (id) => {
-                this.expandedInput = id;
-              },
-            }),
-          ),
+          m('.pf-dashboard__input-list', renderSourceAccordion(unused)),
         ]),
       );
     }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_node.ts
@@ -32,7 +32,7 @@ import {
 } from '../node_styling_widgets';
 import {MetricsNode} from './metrics_node';
 import {TraceSummaryResultsPanel} from './trace_summary_results_panel';
-import {Accordion} from '../../../../widgets/accordion';
+import {Accordion, AccordionSection} from '../../../../widgets/accordion';
 import {enumKeyToLabel} from './metrics_enum_utils';
 import {showModal} from '../../../../widgets/modal';
 import {CodeSnippet} from '../../../../widgets/code_snippet';
@@ -183,13 +183,16 @@ export class TraceSummaryNode implements QueryNode {
       });
     } else {
       sections.push({
-        content: m(Accordion, {
-          items: metricsNodes.map((mn) => ({
-            id: mn.nodeId,
-            header: this.renderMetricHeader(mn),
-            content: this.renderMetricContent(mn),
-          })),
-        }),
+        content: m(
+          Accordion,
+          metricsNodes.map((mn) =>
+            m(
+              AccordionSection,
+              {key: mn.nodeId, summary: this.renderMetricHeader(mn)},
+              this.renderMetricContent(mn),
+            ),
+          ),
+        ),
       });
     }
 

--- a/ui/src/plugins/dev.perfetto.QueryPage/table_list.ts
+++ b/ui/src/plugins/dev.perfetto.QueryPage/table_list.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {FuzzyFinder, FuzzySegment} from '../../base/fuzzy';
-import {Accordion, AccordionItem} from '../../widgets/accordion';
+import {Accordion, AccordionSection} from '../../widgets/accordion';
 import {Button} from '../../widgets/button';
 import {CopyToClipboardButton} from '../../widgets/copy_to_clipboard_button';
 import {Icon} from '../../widgets/icon';
@@ -45,7 +45,6 @@ export interface TableListAttrs {
 
 export class TableList implements m.ClassComponent<TableListAttrs> {
   private searchQuery = '';
-  private expandedTable: string | undefined = undefined;
 
   view({attrs}: m.CVnode<TableListAttrs>): m.Children {
     const tables = attrs.sqlModules.listTables();
@@ -66,15 +65,6 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
       }));
     }
 
-    const items: AccordionItem[] = filteredTables.map(({table, segments}) => ({
-      id: table.name,
-      header: m(
-        'code.pf-simple-table-list__item-name',
-        renderHighlightedName(segments),
-      ),
-      content: this.renderTableContent(table, attrs.onQueryTable),
-    }));
-
     return m(
       '.pf-simple-table-list',
       m(TextInput, {
@@ -86,16 +76,25 @@ export class TableList implements m.ClassComponent<TableListAttrs> {
           this.searchQuery = value;
         },
       }),
-      items.length > 0
+      filteredTables.length > 0
         ? m(
             '.pf-simple-table-list__items',
-            m(Accordion, {
-              items,
-              expanded: this.expandedTable,
-              onToggle: (id) => {
-                this.expandedTable = id;
-              },
-            }),
+            m(
+              Accordion,
+              filteredTables.map(({table, segments}) =>
+                m(
+                  AccordionSection,
+                  {
+                    key: table.name,
+                    summary: m(
+                      'code.pf-simple-table-list__item-name',
+                      renderHighlightedName(segments),
+                    ),
+                  },
+                  this.renderTableContent(table, attrs.onQueryTable),
+                ),
+              ),
+            ),
           )
         : m(EmptyState, {
             title: 'No matching tables found',

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/accordion_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/accordion_demo.ts
@@ -14,6 +14,7 @@
 
 import m from 'mithril';
 import {Accordion, AccordionItem} from '../../../widgets/accordion';
+import {renderWidgetShowcase} from '../widgets_page_utils';
 
 const DEMO_ITEMS: AccordionItem[] = [
   {
@@ -48,26 +49,27 @@ export function renderAccordion(): m.Children {
       m('h1', 'Accordion'),
       m(
         'p',
-        'A collapsible panel component that displays a list of items where ' +
-          'only one item can be expanded at a time. Supports both controlled ' +
-          'and uncontrolled modes.',
+        'A collapsible panel component that displays a list of items. ' +
+          'In single mode only one item can be expanded at a time. ' +
+          'In multi mode all items can be open simultaneously and default to expanded.',
       ),
     ),
-    m('h2', 'Uncontrolled Mode'),
-    m(
-      'p',
-      'In uncontrolled mode, the accordion manages its own expanded state internally. ' +
-        'All items start collapsed.',
-    ),
-    m(
-      'div',
-      {
-        style: {
-          border: '1px solid var(--pf-color-border)',
-          borderRadius: '4px',
-        },
+
+    renderWidgetShowcase({
+      renderWidget: ({multi}) =>
+        m(
+          'div',
+          {
+            style: {
+              border: '1px solid var(--pf-color-border)',
+              borderRadius: '4px',
+            },
+          },
+          m(Accordion, {items: DEMO_ITEMS, multi}),
+        ),
+      initialOpts: {
+        multi: false,
       },
-      m(Accordion, {items: DEMO_ITEMS}),
-    ),
+    }),
   ];
 }

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/accordion_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/accordion_demo.ts
@@ -13,34 +13,8 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {Accordion, AccordionItem} from '../../../widgets/accordion';
+import {Accordion, AccordionSection} from '../../../widgets/accordion';
 import {renderWidgetShowcase} from '../widgets_page_utils';
-
-const DEMO_ITEMS: AccordionItem[] = [
-  {
-    id: 'section1',
-    header: 'Section 1',
-    content: m(
-      'div',
-      m('p', 'This is the content for section 1.'),
-      m('p', 'The accordion ensures only one section is expanded at a time.'),
-    ),
-  },
-  {
-    id: 'section2',
-    header: 'Section 2',
-    content: m(
-      'div',
-      m('p', 'Content for section 2.'),
-      m('p', 'Click another header to collapse this and expand that one.'),
-    ),
-  },
-  {
-    id: 'section3',
-    header: 'Section 3',
-    content: m('p', 'Content for section 3.'),
-  },
-];
 
 export function renderAccordion(): m.Children {
   return [
@@ -49,14 +23,13 @@ export function renderAccordion(): m.Children {
       m('h1', 'Accordion'),
       m(
         'p',
-        'A collapsible panel component that displays a list of items. ' +
-          'In single mode only one item can be expanded at a time. ' +
-          'In multi mode all items can be open simultaneously and default to expanded.',
+        'A collapsible panel component. Each section uses a native ' +
+          '<details> element and manages its own open/closed state.',
       ),
     ),
 
     renderWidgetShowcase({
-      renderWidget: ({multi}) =>
+      renderWidget: ({defaultOpen, ...rest}) =>
         m(
           'div',
           {
@@ -65,11 +38,38 @@ export function renderAccordion(): m.Children {
               borderRadius: '4px',
             },
           },
-          m(Accordion, {items: DEMO_ITEMS, multi}),
+          m(
+            Accordion,
+            {key: defaultOpen ? 'open' : 'closed', ...rest},
+            m(
+              AccordionSection,
+              {summary: 'Section 1', defaultOpen},
+              m(
+                'div',
+                m('p', 'This is the content for section 1.'),
+                m(
+                  'p',
+                  'Each section independently manages its open/closed state.',
+                ),
+              ),
+            ),
+            m(
+              AccordionSection,
+              {summary: 'Section 2', defaultOpen},
+              m(
+                'div',
+                m('p', 'Content for section 2.'),
+                m('p', 'Multiple sections can be open simultaneously.'),
+              ),
+            ),
+            m(
+              AccordionSection,
+              {summary: 'Section 3', defaultOpen},
+              m('p', 'Content for section 3. This section starts open.'),
+            ),
+          ),
         ),
-      initialOpts: {
-        multi: false,
-      },
+      initialOpts: {multi: false, defaultOpen: false},
     }),
   ];
 }

--- a/ui/src/widgets/accordion.ts
+++ b/ui/src/widgets/accordion.ts
@@ -28,7 +28,10 @@ export interface AccordionItem {
 export interface AccordionAttrs {
   // The list of accordion items to display.
   readonly items: AccordionItem[];
-  // Currently expanded item id (controlled mode).
+  // Allow multiple items to be open simultaneously. Defaults all items to
+  // expanded on first render. Incompatible with controlled mode (expanded).
+  readonly multi?: boolean;
+  // Currently expanded item id (controlled single-open mode).
   // If omitted, the accordion manages its own state (uncontrolled mode).
   readonly expanded?: string;
   // Callback when an item is toggled.
@@ -38,15 +41,56 @@ export interface AccordionAttrs {
 }
 
 export class Accordion implements m.ClassComponent<AccordionAttrs> {
-  // Internal state for uncontrolled mode.
+  // Internal state for uncontrolled single-open mode.
   private internalExpanded: string | undefined = undefined;
+  // Internal state for multi-open mode. Undefined until first render,
+  // at which point it is populated with all item ids (all open by default).
+  private internalExpandedSet: Set<string> | undefined = undefined;
   // Track which item should be scrolled into view after render.
   private pendingScrollId: string | undefined = undefined;
 
   view({attrs}: m.CVnode<AccordionAttrs>): m.Children {
-    const {items, onToggle, className} = attrs;
+    const {items, onToggle, className, multi} = attrs;
 
-    const expandedId = this.getExpandedId(attrs);
+    if (multi) {
+      if (this.internalExpandedSet === undefined) {
+        this.internalExpandedSet = new Set(items.map((i) => i.id));
+      }
+
+      return m(
+        '.pf-accordion',
+        {className},
+        items.map((item) => {
+          const isExpanded = this.internalExpandedSet!.has(item.id);
+          return m(
+            '.pf-accordion__item',
+            {key: item.id, className: classNames(isExpanded && 'pf-expanded')},
+            m(
+              '.pf-accordion__header',
+              {
+                onclick: () => {
+                  if (isExpanded) {
+                    this.internalExpandedSet!.delete(item.id);
+                  } else {
+                    this.internalExpandedSet!.add(item.id);
+                  }
+                  onToggle?.(item.id);
+                },
+              },
+              m(
+                '.pf-accordion__toggle',
+                m(Icon, {icon: isExpanded ? 'expand_more' : 'chevron_right'}),
+              ),
+              m('.pf-accordion__header-content', item.header),
+            ),
+            isExpanded && m('.pf-accordion__content', item.content),
+          );
+        }),
+      );
+    }
+
+    const expandedId =
+      attrs.expanded !== undefined ? attrs.expanded : this.internalExpanded;
 
     return m(
       '.pf-accordion',
@@ -64,7 +108,6 @@ export class Accordion implements m.ClassComponent<AccordionAttrs> {
                 this.pendingScrollId = undefined;
                 const header = vnode.dom as HTMLElement;
                 header?.scrollIntoView({behavior: 'instant', block: 'nearest'});
-                console.log('Scrolled accordion item into view', item.id);
               }
             },
           },
@@ -74,7 +117,6 @@ export class Accordion implements m.ClassComponent<AccordionAttrs> {
               onclick: () => {
                 const newExpanded = isExpanded ? undefined : item.id;
                 this.internalExpanded = newExpanded;
-                // Always scroll the toggled item into view (expand or collapse)
                 this.pendingScrollId = item.id;
                 onToggle?.(newExpanded);
               },
@@ -89,14 +131,5 @@ export class Accordion implements m.ClassComponent<AccordionAttrs> {
         );
       }),
     );
-  }
-
-  private getExpandedId(attrs: AccordionAttrs): string | undefined {
-    // If expanded is provided, use controlled mode.
-    // Otherwise use internal state (uncontrolled mode).
-    if (attrs.expanded !== undefined) {
-      return attrs.expanded;
-    }
-    return this.internalExpanded;
   }
 }

--- a/ui/src/widgets/accordion.ts
+++ b/ui/src/widgets/accordion.ts
@@ -13,123 +13,93 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {classNames} from '../base/classnames';
 import {Icon} from './icon';
+import {shortUuid} from '../base/uuid';
+import {createContext} from '../base/mithril_utils';
 
-export interface AccordionItem {
-  // Unique identifier for this item.
-  readonly id: string;
-  // Content to display in the header (always visible).
-  readonly header: m.Children;
-  // Content to display when expanded.
-  readonly content: m.Children;
-}
+const {Consumer, Provider} = createContext<string | undefined>(undefined);
 
 export interface AccordionAttrs {
-  // The list of accordion items to display.
-  readonly items: AccordionItem[];
-  // Allow multiple items to be open simultaneously. Defaults all items to
-  // expanded on first render. Incompatible with controlled mode (expanded).
-  readonly multi?: boolean;
-  // Currently expanded item id (controlled single-open mode).
-  // If omitted, the accordion manages its own state (uncontrolled mode).
-  readonly expanded?: string;
-  // Callback when an item is toggled.
-  readonly onToggle?: (id: string | undefined) => void;
   // Space delimited class list applied to the accordion element.
   readonly className?: string;
+  readonly key?: string;
+  readonly multi?: boolean;
 }
 
 export class Accordion implements m.ClassComponent<AccordionAttrs> {
-  // Internal state for uncontrolled single-open mode.
-  private internalExpanded: string | undefined = undefined;
-  // Internal state for multi-open mode. Undefined until first render,
-  // at which point it is populated with all item ids (all open by default).
-  private internalExpandedSet: Set<string> | undefined = undefined;
-  // Track which item should be scrolled into view after render.
-  private pendingScrollId: string | undefined = undefined;
+  private readonly uuid = shortUuid();
+  view({attrs, children}: m.CVnode<AccordionAttrs>): m.Children {
+    const {multi, className} = attrs;
+    // If multi is false, all sections share the same name and only one can be
+    // open at a time. If multi is true, each section gets a unique name and can
+    // be opened independently.
+    const sharedName = multi ? undefined : this.uuid;
+    return m(Provider, {value: sharedName}, [
+      m('.pf-accordion', {className}, children),
+    ]);
+  }
+}
 
-  view({attrs}: m.CVnode<AccordionAttrs>): m.Children {
-    const {items, onToggle, className, multi} = attrs;
+export interface AccordionSectionAttrs {
+  // Content to display in the summary (always visible).
+  readonly summary: m.Children;
+  // Space delimited class list applied to the details element.
+  readonly className?: string;
+  readonly defaultOpen?: boolean;
+}
 
-    if (multi) {
-      if (this.internalExpandedSet === undefined) {
-        this.internalExpandedSet = new Set(items.map((i) => i.id));
-      }
+export class AccordionSection
+  implements m.ClassComponent<AccordionSectionAttrs>
+{
+  private isOpen = false;
+  private pendingScrollOpen = false;
 
+  constructor({attrs}: m.Vnode<AccordionSectionAttrs>) {
+    this.isOpen = attrs.defaultOpen ?? false;
+  }
+
+  view({attrs, children}: m.CVnode<AccordionSectionAttrs>): m.Children {
+    const {summary: header, className} = attrs;
+    return m(Consumer, (groupName) => {
       return m(
-        '.pf-accordion',
-        {className},
-        items.map((item) => {
-          const isExpanded = this.internalExpandedSet!.has(item.id);
-          return m(
-            '.pf-accordion__item',
-            {key: item.id, className: classNames(isExpanded && 'pf-expanded')},
-            m(
-              '.pf-accordion__header',
-              {
-                onclick: () => {
-                  if (isExpanded) {
-                    this.internalExpandedSet!.delete(item.id);
-                  } else {
-                    this.internalExpandedSet!.add(item.id);
-                  }
-                  onToggle?.(item.id);
-                },
-              },
-              m(
-                '.pf-accordion__toggle',
-                m(Icon, {icon: isExpanded ? 'expand_more' : 'chevron_right'}),
-              ),
-              m('.pf-accordion__header-content', item.header),
-            ),
-            isExpanded && m('.pf-accordion__content', item.content),
-          );
-        }),
-      );
-    }
-
-    const expandedId =
-      attrs.expanded !== undefined ? attrs.expanded : this.internalExpanded;
-
-    return m(
-      '.pf-accordion',
-      {className},
-      items.map((item) => {
-        const isExpanded = expandedId === item.id;
-        const shouldScroll = this.pendingScrollId === item.id;
-        return m(
-          '.pf-accordion__item',
+        'details.pf-accordion__item',
+        {
+          className,
+          open: this.isOpen,
+          ...(groupName != null ? {name: groupName} : {}),
+          ontoggle: (e: Event) => {
+            this.isOpen = (e.target as HTMLDetailsElement).open;
+          },
+        },
+        m(
+          'summary.pf-accordion__header',
           {
-            key: item.id,
-            className: classNames(isExpanded && 'pf-expanded'),
-            onupdate: (vnode: m.VnodeDOM) => {
-              if (shouldScroll) {
-                this.pendingScrollId = undefined;
-                const header = vnode.dom as HTMLElement;
-                header?.scrollIntoView({behavior: 'instant', block: 'nearest'});
+            onclick: () => {
+              console.log('Clicked header', header);
+              // If we're closing this section manually, scroll it into view
+              if (this.isOpen) {
+                this.pendingScrollOpen = true;
               }
             },
           },
-          m(
-            '.pf-accordion__header',
-            {
-              onclick: () => {
-                const newExpanded = isExpanded ? undefined : item.id;
-                this.internalExpanded = newExpanded;
-                this.pendingScrollId = item.id;
-                onToggle?.(newExpanded);
-              },
-            },
-            m(
-              '.pf-accordion__toggle',
-              m(Icon, {icon: isExpanded ? 'expand_more' : 'chevron_right'}),
-            ),
-            m('.pf-accordion__header-content', item.header),
-          ),
-          isExpanded && m('.pf-accordion__content', item.content),
-        );
-      }),
-    );
+          m('.pf-accordion__toggle', m(Icon, {icon: 'expand_more'})),
+          m('.pf-accordion__header-content', header),
+        ),
+        m('.pf-accordion__content', children),
+      );
+    });
+  }
+
+  onupdate({dom}: m.VnodeDOM<AccordionSectionAttrs>) {
+    if (this.pendingScrollOpen) {
+      this.pendingScrollOpen = false;
+      dom.scrollIntoView({behavior: 'instant', block: 'nearest'});
+    }
+
+    // Mithril uses property assignment to clear DOM attributes, which
+    // stringifies null to "null". Remove it explicitly.
+    if (dom.getAttribute('name') === 'null') {
+      dom.removeAttribute('name');
+    }
   }
 }


### PR DESCRIPTION
Accordion widget currently only allows one section to be open at one time (by design - this is a feature).

It can be handy to be able to open and close multiple sections at once.

This patch adds a 'multi' option, to enable this behavior, and also allows each section to be start open with a `defaultOpen` prop.

This patch also refactors the Accordion widget to use a composite component approach:
```ts
m(Accordion,
  m(AccordionSection, {header: 'Foo'}, 'Foo content'),
  m(AccordionSection, {header: 'Bar'}, 'Bar content'),
)
```
