### PR TITLE
ui: QuerySlot: Don't require queue to be passed to QuerySlot constructor.

### DIFF
--- a/ui/src/base/query_slot.ts
+++ b/ui/src/base/query_slot.ts
@@ -202,7 +202,9 @@ export class QuerySlot<T> {
   // Stores error keyed by keyStr - thrown on next use() with same key
   private error?: {keyStr: string; error: Error};
 
-  constructor(private readonly queue: SerialTaskQueue) {}
+  constructor(
+    private readonly queue: SerialTaskQueue = new SerialTaskQueue(),
+  ) {}
 
   /**
    * Call every render cycle to get the current query result.

--- a/ui/src/base/query_slot_unittest.ts
+++ b/ui/src/base/query_slot_unittest.ts
@@ -18,8 +18,7 @@ import {QuerySlot, SerialTaskQueue, QUERY_CANCELLED} from './query_slot';
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 test('basic query execution', async () => {
-  const queue = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(queue);
+  const slot = new QuerySlot<number>();
 
   const queryFn = jest.fn().mockImplementation(async () => 42);
 
@@ -44,8 +43,7 @@ test('basic query execution', async () => {
 });
 
 test('cached result is returned without re-query', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(executor);
+  const slot = new QuerySlot<number>();
 
   const queryFn = jest.fn().mockResolvedValue(42);
 
@@ -120,8 +118,7 @@ test('multiple slots same executor run serially', async () => {
 });
 
 test('rapid key changes on same slot only runs first and last', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(executor);
+  const slot = new QuerySlot<number>();
 
   const queryFn1 = jest.fn().mockResolvedValue(1);
   const queryFn2 = jest.fn().mockResolvedValue(2);
@@ -143,8 +140,7 @@ test('rapid key changes on same slot only runs first and last', async () => {
 });
 
 test('retainOn allows showing previous data during compatible changes', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(executor);
+  const slot = new QuerySlot<number>();
 
   const queryFn1 = jest.fn().mockResolvedValue(100);
 
@@ -191,8 +187,7 @@ test('retainOn allows showing previous data during compatible changes', async ()
 });
 
 test('enabled prevents query from running', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(executor);
+  const slot = new QuerySlot<number>();
 
   const queryFn = jest.fn().mockResolvedValue(42);
 
@@ -227,8 +222,7 @@ test('enabled prevents query from running', async () => {
 });
 
 test('use after dispose throws', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(executor);
+  const slot = new QuerySlot<number>();
 
   const queryFn = jest.fn().mockResolvedValue(42);
 
@@ -270,8 +264,7 @@ test('queued work is cancelled when slot is disposed', async () => {
 });
 
 test('AsyncDisposable is disposed before running next queryFn', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<AsyncDisposable>(executor);
+  const slot = new QuerySlot<AsyncDisposable>();
 
   const events: string[] = [];
 
@@ -312,8 +305,7 @@ test('AsyncDisposable is disposed before running next queryFn', async () => {
 });
 
 test('slot dispose calls AsyncDisposable dispose after in-flight task completes', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<AsyncDisposable>(executor);
+  const slot = new QuerySlot<AsyncDisposable>();
 
   const events: string[] = [];
   let resolveQuery: () => void;
@@ -359,8 +351,7 @@ test('slot dispose calls AsyncDisposable dispose after in-flight task completes'
 });
 
 test('cancellation signal is set when new query is scheduled', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(executor);
+  const slot = new QuerySlot<number>();
 
   const events: string[] = [];
   let query1Signal: {isCancelled: boolean} | undefined;
@@ -417,8 +408,7 @@ test('cancellation signal is set when new query is scheduled', async () => {
 });
 
 test('QUERY_CANCELLED result is not cached', async () => {
-  const executor = new SerialTaskQueue();
-  const slot = new QuerySlot<number>(executor);
+  const slot = new QuerySlot<number>();
 
   // Query that always returns QUERY_CANCELLED
   const queryFn = jest.fn().mockImplementation(async () => QUERY_CANCELLED);

--- a/ui/src/components/widgets/charts/boxplot_loader.ts
+++ b/ui/src/components/widgets/charts/boxplot_loader.ts
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  QuerySlot,
-  SerialTaskQueue,
-  type QueryResult,
-} from '../../../base/query_slot';
+import {QuerySlot, type QueryResult} from '../../../base/query_slot';
 import {Engine} from '../../../trace_processor/engine';
 import {NUM, STR} from '../../../trace_processor/query_result';
 import {BoxplotData} from './boxplot';
@@ -62,8 +58,7 @@ export class SQLBoxplotLoader {
   private readonly query: string;
   private readonly categoryColumn: string;
   private readonly valueColumn: string;
-  private readonly taskQueue = new SerialTaskQueue();
-  private readonly querySlot = new QuerySlot<BoxplotData>(this.taskQueue);
+  private readonly querySlot = new QuerySlot<BoxplotData>();
 
   constructor(opts: SQLBoxplotLoaderOpts) {
     validateColumnName(opts.categoryColumn);

--- a/ui/src/components/widgets/charts/chart_sql_source.ts
+++ b/ui/src/components/widgets/charts/chart_sql_source.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {assertUnreachable} from '../../../base/assert';
-import {QuerySlot, SerialTaskQueue} from '../../../base/query_slot';
+import {QuerySlot} from '../../../base/query_slot';
 import type {Engine} from '../../../trace_processor/engine';
 import type {QueryResult as TPQueryResult} from '../../../trace_processor/query_result';
 import {Filter} from '../datagrid/model';
@@ -657,8 +657,7 @@ export interface ChartLoaderResult<TData> {
 export abstract class SQLChartLoader<TConfig, TData> {
   private readonly engine: Engine;
   protected readonly source: ChartSource;
-  private readonly taskQueue = new SerialTaskQueue();
-  private readonly querySlot = new QuerySlot<TData>(this.taskQueue);
+  private readonly querySlot = new QuerySlot<TData>();
 
   constructor(engine: Engine, source: ChartSource) {
     this.engine = engine;

--- a/ui/src/components/widgets/charts/heatmap_loader.ts
+++ b/ui/src/components/widgets/charts/heatmap_loader.ts
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  QuerySlot,
-  SerialTaskQueue,
-  type QueryResult,
-} from '../../../base/query_slot';
+import {QuerySlot, type QueryResult} from '../../../base/query_slot';
 import {Engine} from '../../../trace_processor/engine';
 import {
   NUM,
@@ -74,8 +70,7 @@ export class SQLHeatmapLoader {
   private readonly xColumn: string;
   private readonly yColumn: string;
   private readonly valueColumn: string;
-  private readonly taskQueue = new SerialTaskQueue();
-  private readonly querySlot = new QuerySlot<HeatmapData>(this.taskQueue);
+  private readonly querySlot = new QuerySlot<HeatmapData>();
 
   constructor(opts: SQLHeatmapLoaderOpts) {
     validateColumnName(opts.xColumn);

--- a/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
+++ b/ui/src/plugins/com.android.AndroidInputLifecycle/android_input_event_source.ts
@@ -23,7 +23,7 @@ import {
   getTrackUriForTrackId,
   enrichDepths,
 } from '../../components/related_events/utils';
-import {QuerySlot, QueryResult, SerialTaskQueue} from '../../base/query_slot';
+import {QuerySlot, QueryResult} from '../../base/query_slot';
 
 export interface NavTarget {
   id: number;
@@ -54,8 +54,7 @@ export interface InputChainRow {
 }
 
 export class AndroidInputEventSource {
-  private readonly queue = new SerialTaskQueue();
-  private readonly dataSlot = new QuerySlot<InputChainRow[]>(this.queue);
+  private readonly dataSlot = new QuerySlot<InputChainRow[]>();
 
   constructor(private readonly trace: Trace) {}
 

--- a/ui/src/plugins/com.android.AndroidLockContention/android_lock_contention_event_source.ts
+++ b/ui/src/plugins/com.android.AndroidLockContention/android_lock_contention_event_source.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {QueryResult, QuerySlot, SerialTaskQueue} from '../../base/query_slot';
+import {QueryResult, QuerySlot} from '../../base/query_slot';
 import {duration, Duration, time, Time} from '../../base/time';
 import {getTrackUriForTrackId} from '../../components/related_events/utils';
 import {Trace} from '../../public/trace';
@@ -77,10 +77,7 @@ export interface LockContentionDetails {
 }
 
 export class AndroidLockContentionEventSource {
-  private readonly queue = new SerialTaskQueue();
-  private readonly dataSlot = new QuerySlot<LockContentionDetails | null>(
-    this.queue,
-  );
+  private readonly dataSlot = new QuerySlot<LockContentionDetails | null>();
 
   constructor(private readonly trace: Trace) {}
 

--- a/ui/src/plugins/dev.perfetto.Sched/waker_overlay.ts
+++ b/ui/src/plugins/dev.perfetto.Sched/waker_overlay.ts
@@ -14,7 +14,7 @@
 
 import {canvasSave, drawDoubleHeadedArrow} from '../../base/canvas_utils';
 import {Size2D} from '../../base/geom';
-import {QuerySlot, SerialTaskQueue} from '../../base/query_slot';
+import {QuerySlot} from '../../base/query_slot';
 import {Duration, time} from '../../base/time';
 import {TimeScale} from '../../base/time_scale';
 import {drawVerticalLineAtTime} from '../../base/vertical_line_helper';
@@ -36,10 +36,7 @@ const ARROW_HEIGHT = 12;
 
 export class WakerOverlay implements Overlay {
   private readonly trace: Trace;
-  private readonly queue = new SerialTaskQueue();
-  private readonly wakeupSlot = new QuerySlot<SchedWakeupInfo | undefined>(
-    this.queue,
-  );
+  private readonly wakeupSlot = new QuerySlot<SchedWakeupInfo | undefined>();
 
   constructor(trace: Trace) {
     this.trace = trace;

--- a/ui/src/plugins/org.chromium.V8/v8_sources_tab.ts
+++ b/ui/src/plugins/org.chromium.V8/v8_sources_tab.ts
@@ -31,7 +31,7 @@ import {Tabs} from '../../widgets/tabs';
 import {TextInput} from '../../widgets/text_input';
 import {Tree, TreeNode} from '../../widgets/tree';
 import {formatFileSize} from '../../base/file_utils';
-import {QuerySlot, SerialTaskQueue} from '../../base/query_slot';
+import {QuerySlot} from '../../base/query_slot';
 
 interface V8JsScript {
   v8_js_script_id: number;
@@ -106,9 +106,7 @@ const TAB_FUNCTIONS = 'functions';
 
 export class V8SourcesTab implements Tab {
   private currentTab = TAB_SOURCE;
-  private readonly slot = new QuerySlot<ScriptResults | undefined>(
-    new SerialTaskQueue(),
-  );
+  private readonly slot = new QuerySlot<ScriptResults | undefined>();
   private selectedScriptId: number | undefined = undefined;
   private trace: Trace;
   private dataSource: SQLDataSource;


### PR DESCRIPTION
QuerySlot always requires a TaskQueue. This is useful for if you want multiple QuerySlots to execute sequentially. If one is not passed, construct one by default. This removes the boilerplate of passing in a taskqueue when we only have one queryslot.

e.g.

Before
```ts
const queue = new SerialTaskQueue();
new QuerySlot<T>(queue);
```

After:
```ts
new QuerySlot<T>();
```