### PR TITLE
ui: Fix Wattson package aggregator and marker window queries

### DIFF
--- a/ui/src/plugins/org.kernel.Wattson/index.ts
+++ b/ui/src/plugins/org.kernel.Wattson/index.ts
@@ -179,8 +179,8 @@ async function hasCpuIdleCounters(engine: Engine): Promise<boolean> {
 
 async function hasWattsonMarkersSupport(engine: Engine): Promise<boolean> {
   const checkValue = await engine.query(`
-      INCLUDE PERFETTO MODULE wattson.utils;
-      SELECT COUNT(*) as numRows from _wattson_markers_window
+      INCLUDE PERFETTO MODULE wattson.windows;
+      SELECT COUNT(*) as numRows from wattson_window_markers
   `);
   return checkValue.firstRow({numRows: NUM}).numRows > 0;
 }

--- a/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
+++ b/ui/src/plugins/org.kernel.Wattson/package_aggregator.ts
@@ -155,48 +155,28 @@ export class WattsonCpuPackageSelectionAggregator extends WattsonBasePackageSele
 
   protected getQuery(
     _area: AreaSelection,
-    duration: bigint,
+    _duration: bigint,
     _probeResult: unknown,
   ): string {
     // Prerequisite tables might need to be generated if thread_aggregator didn't run,
     // but assuming it runs for now as per original code.
     return `
-      INCLUDE PERFETTO MODULE wattson.estimates;
-      INCLUDE PERFETTO MODULE wattson.tasks.idle_transitions_attribution;
-
-      -- Group idle attribution by package
-      CREATE OR REPLACE PERFETTO TABLE
-      wattson_plugin_per_package_idle_attribution AS
-      SELECT
-        SUM(idle_cost_mws) as idle_cost_mws,
-        uid
-      FROM wattson_plugin_idle_attribution
-      JOIN thread USING(utid)
-      JOIN process USING(upid)
-      GROUP BY uid;
-
       -- Grouped by UID and made CPU agnostic
       CREATE PERFETTO VIEW ${this.id} AS
       WITH base AS (
         SELECT
-          ROUND(SUM(total_pws) / ${duration}, 3) as active_mw,
-          ROUND(SUM(total_pws) / 1000000000, 3) as active_mws,
-          ROUND(COALESCE(idle_cost_mws, 0), 3) as idle_cost_mws,
-          ROUND(
-            COALESCE(idle_cost_mws, 0) + SUM(total_pws) / 1000000000,
-            3
-          ) as total_mws,
-          wattson_plugin_unioned_per_cpu_total.uid AS uid,
-          package_name
-        FROM wattson_plugin_unioned_per_cpu_total
-        LEFT JOIN wattson_plugin_per_package_idle_attribution
-          ON wattson_plugin_unioned_per_cpu_total.uid IS
-          wattson_plugin_per_package_idle_attribution.uid
-        GROUP BY wattson_plugin_unioned_per_cpu_total.uid, package_name
+          ROUND(SUM(estimated_mw), 3) AS active_mw,
+          ROUND(SUM(estimated_mws), 3) AS active_mws,
+          ROUND(SUM(idle_transitions_mws), 3) AS idle_cost_mws,
+          ROUND(SUM(total_mws), 3) AS total_mws,
+          package_name,
+          uid
+        FROM wattson_plugin_thread_summary
+        GROUP BY uid, package_name
       )
-      select *,
+      SELECT *,
         total_mws / (SUM(total_mws) OVER()) AS percent_of_total_energy
-        from base;
+      FROM base;
     `;
   }
 


### PR DESCRIPTION
Update `package_aggregator.ts` to use `wattson_plugin_thread_summary` directly, removing references to non-existent tables. This fixes runtime errors when aggregating by package. Also update `index.ts` to use the correct module `wattson.windows` and table `wattson_window_markers` instead of `wattson.utils` and `_wattson_markers_window`.

Bug: 499375826
Test: UI test
