### PR TITLE
traced_probes: Refactor + Remove timeout from aflags invocation

### DIFF
--- a/include/perfetto/ext/base/subprocess.h
+++ b/include/perfetto/ext/base/subprocess.h
@@ -207,6 +207,10 @@ class Subprocess {
 
   Status Poll();
 
+  // Kills the process (SIGKILL if not specified) but doesn't wait for its
+  // termination.
+  void Kill(int sig_num = 0);
+
   // Sends a signal (SIGKILL if not specified) and wait for process termination.
   void KillAndWaitForTermination(int sig_num = 0);
 

--- a/src/base/subprocess_posix.cc
+++ b/src/base/subprocess_posix.cc
@@ -441,8 +441,12 @@ void Subprocess::TryReadStdoutAndErr() {
   }
 }
 
-void Subprocess::KillAndWaitForTermination(int sig_num) {
+void Subprocess::Kill(int sig_num) {
   kill(s_->pid, sig_num ? sig_num : SIGKILL);
+}
+
+void Subprocess::KillAndWaitForTermination(int sig_num) {
+  Kill(sig_num);
   Wait();
   // TryReadExitStatus must have joined the thread.
   PERFETTO_DCHECK(!s_->waitpid_thread.joinable());

--- a/src/base/subprocess_windows.cc
+++ b/src/base/subprocess_windows.cc
@@ -323,9 +323,13 @@ bool Subprocess::Wait(int timeout_ms) {
   return true;
 }
 
-void Subprocess::KillAndWaitForTermination(int exit_code) {
+void Subprocess::Kill(int exit_code) {
   auto code = exit_code ? static_cast<DWORD>(exit_code) : STATUS_CONTROL_C_EXIT;
   ::TerminateProcess(*s_->win_proc_handle, code);
+}
+
+void Subprocess::KillAndWaitForTermination(int exit_code) {
+  Kill(exit_code);
   Wait();
   // TryReadExitStatus must have joined the threads.
   PERFETTO_DCHECK(!s_->stdin_thread.joinable());

--- a/src/traced/probes/android_aflags/android_aflags_data_source.cc
+++ b/src/traced/probes/android_aflags/android_aflags_data_source.cc
@@ -35,9 +35,7 @@
 namespace perfetto {
 namespace {
 constexpr uint32_t kMinPollPeriodMs = 1000;
-constexpr uint32_t kAflagsExitTimeoutMs = 100;
-// Should be smaller than ProbesProducer::kFlushTimeoutMs.
-constexpr uint32_t kAflagsFlushTimeoutMs = 800;
+constexpr uint32_t kAflagsExitPollMs = 100;
 }  // namespace
 
 // static
@@ -69,7 +67,17 @@ AndroidAflagsDataSource::AndroidAflagsDataSource(
 
 AndroidAflagsDataSource::~AndroidAflagsDataSource() {
   if (aflags_output_pipe_) {
-    task_runner_->RemoveFileDescriptorWatch(*aflags_output_pipe_->rd);
+    task_runner_->RemoveFileDescriptorWatch(*aflags_output_pipe_);
+  }
+  if (aflags_process_) {
+    // At this point we want to kill the process to avoid leaking subprocesses
+    // if there is any bug with aflags. But also we don't want to needlessly
+    // block traced_probes' main thread waiting for a process we don't care
+    // about (the kernel might take time to process the SIGKILL).
+    task_runner_->PostDelayedTask(
+        [process = std::shared_ptr<base::Subprocess>(std::move(
+             aflags_process_))] { process->KillAndWaitForTermination(); },
+        10000);
   }
 }
 
@@ -101,10 +109,11 @@ void AndroidAflagsDataSource::Tick() {
     return;
   }
 
-  aflags_output_pipe_ = base::Pipe::Create(base::Pipe::kRdNonBlock);
+  auto pipe_pair = base::Pipe::Create(base::Pipe::kRdNonBlock);
+  aflags_output_pipe_ = std::move(pipe_pair.rd);
   // Watch the read end of the pipe for output from the aflags process.
   task_runner_->AddFileDescriptorWatch(
-      *aflags_output_pipe_->rd, [weak_this = weak_factory_.GetWeakPtr()] {
+      *aflags_output_pipe_, [weak_this = weak_factory_.GetWeakPtr()] {
         if (weak_this) {
           weak_this->OnAflagsOutput();
         }
@@ -114,38 +123,43 @@ void AndroidAflagsDataSource::Tick() {
 
   // It returns a base64-encoded binary proto that needs to be decoded before
   // being written to the trace.
-  aflags_process_.emplace(std::initializer_list<std::string>{
-      "/system/bin/aflags", "list", "--format", "proto"});
+  aflags_process_ =
+      std::make_unique<base::Subprocess>(std::initializer_list<std::string>{
+          "/system/bin/aflags", "list", "--format", "proto"});
   aflags_process_->args.stdout_mode = base::Subprocess::OutputMode::kFd;
   aflags_process_->args.stderr_mode = base::Subprocess::OutputMode::kFd;
   // Keeps track of both stdout and stderr in the same pipe.
-  aflags_process_->args.out_fd = std::move(aflags_output_pipe_->wr);
+  aflags_process_->args.out_fd = std::move(pipe_pair.wr);
   aflags_process_->Start();
 }
 
 void AndroidAflagsDataSource::OnAflagsOutput() {
   errno = 0;
-  if (base::ReadFileDescriptor(*aflags_output_pipe_->rd, &aflags_output_)) {
-    task_runner_->RemoveFileDescriptorWatch(*aflags_output_pipe_->rd);
-    FinalizeAflagsCapture();
-    return;
-  }
 
-  if (base::IsAgain(errno)) {
+  bool eof = base::ReadFileDescriptor(*aflags_output_pipe_, &aflags_output_);
+  if (!eof && base::IsAgain(errno)) {
     return;  // Read is blocked, wait for the next notification.
   }
 
-  PERFETTO_PLOG("Error reading from aflags output pipe.");
-  task_runner_->RemoveFileDescriptorWatch(*aflags_output_pipe_->rd);
+  // If we get here either EOF or read() error out (unlikely, but SELinux).
+  task_runner_->RemoveFileDescriptorWatch(*aflags_output_pipe_);
 
-  EmitErrorPacket("Error reading from aflags output pipe: " + aflags_output_);
+  std::string error;
+  if (!eof) {
+    base::StackString<255> err_str("aflags failed: pipe read (%d, %s)", errno,
+                                   strerror(errno));
+    if (aflags_process_)
+      aflags_process_->Kill();
+    error = err_str.ToStdString();
+  }
 
-  aflags_process_.reset();
-  aflags_output_pipe_.reset();
-  aflags_output_.clear();
+  FinalizeAflagsCapture(std::move(error));
 }
 
-void AndroidAflagsDataSource::FinalizeAflagsCapture() {
+// We get to this function if either we read the stdout through EOF or if the
+// stdot.read() failed. In either case the process might have not terminated
+// yet (a subprocess usually terminates a bit after closing stdout/err).
+void AndroidAflagsDataSource::FinalizeAflagsCapture(std::string error) {
   if (!aflags_process_) {
     return;
   }
@@ -155,11 +169,11 @@ void AndroidAflagsDataSource::FinalizeAflagsCapture() {
   if (status == base::Subprocess::kRunning) {
     // Process hasn't finished running yet, reschedule and check later.
     task_runner_->PostDelayedTask(
-        [weak_this = weak_factory_.GetWeakPtr()] {
+        [weak_this = weak_factory_.GetWeakPtr(), error_mv = std::move(error)] {
           if (weak_this)
-            weak_this->FinalizeAflagsCapture();
+            weak_this->FinalizeAflagsCapture(std::move(error_mv));
         },
-        kAflagsExitTimeoutMs);
+        kAflagsExitPollMs);
     return;
   }
 
@@ -167,12 +181,24 @@ void AndroidAflagsDataSource::FinalizeAflagsCapture() {
   aflags_process_.reset();
   aflags_output_pipe_.reset();
 
-  if (status != base::Subprocess::kTerminated || returncode != 0) {
-    PERFETTO_ELOG("aflags failed: status: %d, code: %d", status, returncode);
-    EmitErrorPacket(
+  if (error.empty() &&
+      !(status == base::Subprocess::kTerminated && returncode == 0)) {
+    error =
         "aflags failed: status: " + std::to_string(static_cast<int>(status)) +
-        ", code: " + std::to_string(returncode) +
-        ". Output: " + aflags_output_);
+        ", code: " + std::to_string(returncode) + ". Output: " + aflags_output_;
+  }
+
+  // Whether we error or not, at this point we decided that we are going to
+  // write _something_ in the trace, hence we should ack the pending flushes.
+  auto ack_pending_flushes_on_exit = base::OnScopeExit([&] {
+    // Drain any Flush() callbacks deferred while the subprocess was running.
+    auto pending_flushes_vector = std::move(pending_flushes_);
+    for (auto& flush_callback : pending_flushes_vector)
+      flush_callback();
+  });
+
+  if (!error.empty()) {
+    EmitErrorPacket(error);
     aflags_output_.clear();
     return;
   }
@@ -184,9 +210,8 @@ void AndroidAflagsDataSource::FinalizeAflagsCapture() {
   std::optional<std::string> decoded =
       base::Base64Decode(output.data(), output.size());
   if (!decoded) {
-    PERFETTO_ELOG("Failed to decode aflags output (length: %zu)",
-                  output.size());
-    EmitErrorPacket("Failed to decode aflags output: " + output);
+    EmitErrorPacket("Failed to decode aflags output (len=" +
+                    std::to_string(output.size()) + "): " + output);
     return;
   }
 
@@ -196,14 +221,10 @@ void AndroidAflagsDataSource::FinalizeAflagsCapture() {
   aflags_proto->AppendRawProtoBytes(decoded->data(), decoded->size());
   packet->Finalize();
   writer_->Flush();
-
-  // Drain any Flush() callbacks deferred while the subprocess was running.
-  while (!pending_flushes_.empty()) {
-    OnFlushComplete(pending_flushes_.begin()->first);
-  }
 }
 
 void AndroidAflagsDataSource::EmitErrorPacket(const std::string& error_msg) {
+  PERFETTO_ELOG("%s", error_msg.c_str());
   auto packet = writer_->NewTracePacket();
   packet->set_timestamp(static_cast<uint64_t>(base::GetBootTimeNs().count()));
   auto* aflags_proto = packet->set_android_aflags();
@@ -212,7 +233,7 @@ void AndroidAflagsDataSource::EmitErrorPacket(const std::string& error_msg) {
   writer_->Flush();
 }
 
-void AndroidAflagsDataSource::Flush(FlushRequestID flush_request_id,
+void AndroidAflagsDataSource::Flush(FlushRequestID,
                                     std::function<void()> callback) {
   // Fast path: no subprocess in flight, flush immediately.
   if (!aflags_process_) {
@@ -220,35 +241,16 @@ void AndroidAflagsDataSource::Flush(FlushRequestID flush_request_id,
     return;
   }
 
-  // Subprocess still running. Defer the callback until FinalizeAflagsCapture()
-  // drains us; if the subprocess takes too long, kAflagsFlushTimeoutMs acts
-  // as safety net.
-  pending_flushes_[flush_request_id] = std::move(callback);
-  task_runner_->PostDelayedTask(
-      [weak_this = weak_factory_.GetWeakPtr(), flush_request_id] {
-        if (weak_this)
-          weak_this->OnFlushTimeout(flush_request_id);
-      },
-      kAflagsFlushTimeoutMs);
-}
-
-void AndroidAflagsDataSource::OnFlushTimeout(FlushRequestID flush_request_id) {
-  if (pending_flushes_.count(flush_request_id) == 0)
-    return;  // Already drained on the successful-completion path.
-
-  PERFETTO_ELOG("android.aflags Flush(%" PRIu64 ") timed out",
-                flush_request_id);
-  OnFlushComplete(flush_request_id);
-}
-
-void AndroidAflagsDataSource::OnFlushComplete(FlushRequestID flush_request_id) {
-  auto it = pending_flushes_.find(flush_request_id);
-  if (it == pending_flushes_.end())
-    return;
-
-  auto callback = std::move(it->second);
-  pending_flushes_.erase(it);
-  writer_->Flush(std::move(callback));
+  // Subprocess still running. Defer the callback until FinalizeAflagsCapture().
+  // If the subprocess takes longer than the flush timeout, we don't do anything
+  // special here, as ProbesProducer already has its own timeout to gate the
+  // flush of all the various data sources.
+  // What we really want to acheive here is the following: if aflags takes
+  // time to respond (normally it takes ~350ms) AND if the trace is short
+  // (some heap dump traces has 1s duration) we want to stall the trace
+  // termination to maximize the change we get the aflags output in the trace,
+  // up to ProbesProducer::kFlushTimeoutMs.
+  pending_flushes_.emplace_back(std::move(callback));
 }
 
 }  // namespace perfetto

--- a/src/traced/probes/android_aflags/android_aflags_data_source.cc
+++ b/src/traced/probes/android_aflags/android_aflags_data_source.cc
@@ -34,8 +34,9 @@
 
 namespace perfetto {
 namespace {
-constexpr uint32_t kMinPollPeriodMs = 1000;
 constexpr uint32_t kAflagsExitPollMs = 100;
+constexpr uint32_t kMinPollPeriodMs = 1000;
+constexpr uint32_t kAflagsExitTimeoutMs = 10000;
 }  // namespace
 
 // static
@@ -71,14 +72,21 @@ AndroidAflagsDataSource::~AndroidAflagsDataSource() {
   }
   if (aflags_process_) {
     // At this point we want to kill the process to avoid leaking subprocesses
-    // if there is any bug with aflags. But also we don't want to needlessly
-    // block traced_probes' main thread waiting for a process we don't care
-    // about (the kernel might take time to process the SIGKILL).
+    // if there is any bug with aflags.
+    // Send SIGKILL synchronously, then defer the waitpid() by
+    // kAflagsExitTimeoutMs so the child almost certainly has exited by then and
+    // Wait() returns without blocking the task runner.
+    aflags_process_->Kill();
     task_runner_->PostDelayedTask(
-        [process = std::shared_ptr<base::Subprocess>(std::move(
-             aflags_process_))] { process->KillAndWaitForTermination(); },
-        10000);
+        [process = std::shared_ptr<base::Subprocess>(
+             std::move(aflags_process_))] { process->Wait(); },
+        kAflagsExitTimeoutMs);
   }
+
+  // It is theoretically possible that at this point pending_flushes_ will
+  // be non-empty. If it is the case there is nothing we can do. We cannot
+  // flush now because the tracing session has already terminated.
+  // TracingServiceImpl will deal with timeout detection.
 }
 
 void AndroidAflagsDataSource::Start() {
@@ -141,15 +149,16 @@ void AndroidAflagsDataSource::OnAflagsOutput() {
     return;  // Read is blocked, wait for the next notification.
   }
 
-  // If we get here either EOF or read() error out (unlikely, but SELinux).
+  // If we get here either EOF or read() errored out (unlikely, but SELinux).
   task_runner_->RemoveFileDescriptorWatch(*aflags_output_pipe_);
 
   std::string error;
   if (!eof) {
     base::StackString<255> err_str("aflags failed: pipe read (%d, %s)", errno,
                                    strerror(errno));
-    if (aflags_process_)
+    if (aflags_process_) {
       aflags_process_->Kill();
+    }
     error = err_str.ToStdString();
   }
 
@@ -157,7 +166,7 @@ void AndroidAflagsDataSource::OnAflagsOutput() {
 }
 
 // We get to this function if either we read the stdout through EOF or if the
-// stdot.read() failed. In either case the process might have not terminated
+// stdout.read() failed. In either case the process might have not terminated
 // yet (a subprocess usually terminates a bit after closing stdout/err).
 void AndroidAflagsDataSource::FinalizeAflagsCapture(std::string error) {
   if (!aflags_process_) {
@@ -245,10 +254,10 @@ void AndroidAflagsDataSource::Flush(FlushRequestID,
   // If the subprocess takes longer than the flush timeout, we don't do anything
   // special here, as ProbesProducer already has its own timeout to gate the
   // flush of all the various data sources.
-  // What we really want to acheive here is the following: if aflags takes
+  // What we really want to achieve here is the following: if aflags takes
   // time to respond (normally it takes ~350ms) AND if the trace is short
-  // (some heap dump traces has 1s duration) we want to stall the trace
-  // termination to maximize the change we get the aflags output in the trace,
+  // (some heap dump traces have 1s duration) we want to stall the trace
+  // termination to maximize the chance we get the aflags output in the trace,
   // up to ProbesProducer::kFlushTimeoutMs.
   pending_flushes_.emplace_back(std::move(callback));
 }

--- a/src/traced/probes/android_aflags/android_aflags_data_source.h
+++ b/src/traced/probes/android_aflags/android_aflags_data_source.h
@@ -19,10 +19,9 @@
 
 #include <functional>
 #include <memory>
-#include <optional>
 #include <string>
+#include <vector>
 
-#include "perfetto/ext/base/pipe.h"
 #include "perfetto/ext/base/subprocess.h"
 #include "perfetto/ext/base/weak_ptr.h"
 #include "perfetto/ext/tracing/core/trace_writer.h"

--- a/src/traced/probes/android_aflags/android_aflags_data_source.h
+++ b/src/traced/probes/android_aflags/android_aflags_data_source.h
@@ -21,7 +21,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 #include "perfetto/ext/base/pipe.h"
 #include "perfetto/ext/base/subprocess.h"
@@ -53,15 +52,15 @@ class AndroidAflagsDataSource : public ProbesDataSource {
  protected:
   // Finalizes the capture of aflags data. Decodes the collected
   // base64-encoded output and emits it to the trace.
-  void FinalizeAflagsCapture();
+  void FinalizeAflagsCapture(std::string error);
 
   // Non-blocking pipe to asynchronously read the output of `aflags list`.
   // This must be declared before aflags_process_ to ensure the pipe outlives
   // the subprocess.
-  std::optional<base::Pipe> aflags_output_pipe_;
+  base::ScopedPlatformHandle aflags_output_pipe_;
 
   // The running `aflags list` process.
-  std::optional<base::Subprocess> aflags_process_;
+  std::unique_ptr<base::Subprocess> aflags_process_;
 
   // Buffer used to accumulate the base64-encoded output of `aflags list`.
   std::string aflags_output_;
@@ -75,13 +74,6 @@ class AndroidAflagsDataSource : public ProbesDataSource {
   // Emits a trace packet with AndroidAflags.error set to |error_msg|.
   void EmitErrorPacket(const std::string& error_msg);
 
-  // Safety net for a deferred Flush() |flush_request_id|: logs the timeout
-  // and delegates to OnFlushComplete.
-  void OnFlushTimeout(FlushRequestID);
-
-  // Invokes the deferred Flush() callback for |flush_request_id|, if any.
-  void OnFlushComplete(FlushRequestID);
-
   base::TaskRunner* const task_runner_;
   std::unique_ptr<TraceWriter> writer_;
 
@@ -90,7 +82,7 @@ class AndroidAflagsDataSource : public ProbesDataSource {
 
   // Flush() callbacks deferred while an aflags subprocess is in flight.
   // Drained when the subprocess completes (or when the flush timeout fires).
-  std::unordered_map<FlushRequestID, std::function<void()>> pending_flushes_;
+  std::vector<std::function<void()>> pending_flushes_;
 
   base::WeakPtrFactory<AndroidAflagsDataSource> weak_factory_;
 };

--- a/src/traced/probes/android_aflags/android_aflags_data_source_unittest.cc
+++ b/src/traced/probes/android_aflags/android_aflags_data_source_unittest.cc
@@ -85,28 +85,31 @@ class TestAndroidAflagsDataSource : public AndroidAflagsDataSource {
     }
     std::vector<uint8_t> bytes = msg.SerializeAsArray();
     aflags_output_ = base::Base64Encode(bytes.data(), bytes.size());
-    aflags_process_.emplace(std::initializer_list<std::string>{"/bin/true"});
+    aflags_process_ = std::make_unique<base::Subprocess>(
+        std::initializer_list<std::string>{"/bin/true"});
     aflags_process_->Call();
   }
 
   // Helper to simulate subprocess completion with given flags.
   void FakeSubprocessCompletion(const std::vector<FakeFlag>& flags) {
     SeedCompletedFakeSubprocess(flags);
-    FinalizeAflagsCapture();
+    FinalizeAflagsCapture(/*error=*/"");
   }
 
   void FakeSubprocessError(const std::string& output) {
     aflags_output_ = output;
-    aflags_process_.emplace(std::initializer_list<std::string>{"/bin/false"});
+    aflags_process_ = std::make_unique<base::Subprocess>(
+        std::initializer_list<std::string>{"/bin/false"});
     aflags_process_->Call();
-    FinalizeAflagsCapture();
+    FinalizeAflagsCapture(/*error=*/"");
   }
 
   void FakeInvalidBase64() {
     aflags_output_ = "!!!not-base64!!!";
-    aflags_process_.emplace(std::initializer_list<std::string>{"/bin/true"});
+    aflags_process_ = std::make_unique<base::Subprocess>(
+        std::initializer_list<std::string>{"/bin/true"});
     aflags_process_->Call();
-    FinalizeAflagsCapture();
+    FinalizeAflagsCapture(/*error=*/"");
   }
 };
 
@@ -248,32 +251,12 @@ TEST_F(AndroidAflagsDataSourceTest,
             [&callback_fired] { callback_fired = true; });
   EXPECT_FALSE(callback_fired);
 
-  ds->FinalizeAflagsCapture();
+  ds->FinalizeAflagsCapture(/*error=*/"");
 
   EXPECT_TRUE(callback_fired);
   protos::gen::TracePacket packet = writer_raw_->GetOnlyTracePacket();
   ASSERT_TRUE(packet.has_android_aflags());
   EXPECT_EQ(packet.android_aflags().flags().size(), 1u);
-}
-
-TEST_F(AndroidAflagsDataSourceTest,
-       ANDROID_ONLY_TEST(FlushCallbackFiresOnTimeout)) {
-  DataSourceConfig ds_config;
-  ds_config.set_name("android.aflags");
-  auto ds = CreateDataSource(ds_config);
-
-  std::vector<TestAndroidAflagsDataSource::FakeFlag> flags;
-  ds->SeedCompletedFakeSubprocess(flags);
-
-  bool callback_fired = false;
-  ds->Flush(/*flush_request_id=*/1,
-            [&callback_fired] { callback_fired = true; });
-  EXPECT_FALSE(callback_fired);
-
-  // Advance past the 800ms timeout so the scheduled task fires.
-  task_runner_.AdvanceTimeAndRunUntilIdle(/*ms=*/801);
-
-  EXPECT_TRUE(callback_fired);
 }
 
 }  // namespace


### PR DESCRIPTION
- Remove the timeout on flush: this is unnecessary and
  adds just another timing parameter that makes the code
  harder to reason about. If aflags takes too long, the
  existing code in both TracingServiceImpl (5s) and
  ProbesProducer (1s) will take care of it.
- Unify some of the code paths that handle error cases.
- Added Subprocess::Kill (without Wait). This is to avoid
  suspending traced_probes' main thread waiting for the
  termination of a process in case of timeouts: if aflags
  takes too long, the trace will be finalized, hence the
  AndroidAflagsDataSource will be destroyed. By default
  the Subprocess dtor does a KillAndWait (and cannot
  do otherwise to avoid zombie processes). So we try
  to reduce the chance of waiting by allowing up to
  10 seconds between the kill and the waitpid().

Bug: 502852101