### PR TITLE
traced: Simpler config for perf tracing

### DIFF
--- a/protos/perfetto/common/perf_events.proto
+++ b/protos/perfetto/common/perf_events.proto
@@ -171,6 +171,11 @@ message PerfEvents {
     // Android: the relevant sysfs paths are not allowlisted by default, so
     // this option will require a rooted device with selinux disabled.
     optional string pmu_name = 5;
+
+    // The name of an event under
+    // /sys/bus/event_source/devices/<pmu_name>/events (e.g. "l3d_cache"). If
+    // set, leave |config| unset.
+    optional string event_name = 6;
   }
 
   // Subset of clocks that is supported by perf timestamping.

--- a/src/profiling/perf/event_config.cc
+++ b/src/profiling/perf/event_config.cc
@@ -100,6 +100,38 @@ std::optional<uint32_t> ReadPmuTypeFromSysfs(const std::string& pmu_name) {
   return base::StringToUInt32(base::TrimWhitespace(buf));
 }
 
+std::optional<uint64_t> ReadEventConfigFromSysfs(
+    const std::string& pmu_name,
+    const std::string& event_name) {
+  if (pmu_name.empty() || event_name.empty())
+    return std::nullopt;
+  if (base::Contains(pmu_name, '/') || base::StartsWith(pmu_name, ".."))
+    return std::nullopt;
+  if (base::Contains(event_name, '/') || base::StartsWith(event_name, ".."))
+    return std::nullopt;
+
+  std::string format_path =
+      "/sys/bus/event_source/devices/" + pmu_name + "/format/event";
+  std::string format_buf;
+  if (!base::ReadFile(format_path, &format_buf)) {
+    PERFETTO_ELOG("Failed to read %s", format_path.c_str());
+    return std::nullopt;
+  }
+  if (!base::StartsWith(base::TrimWhitespace(format_buf), "config:0-")) {
+    PERFETTO_ELOG("Unsupported event format '%s' for PMU '%s'",
+                  base::TrimWhitespace(format_buf).c_str(), pmu_name.c_str());
+    return std::nullopt;
+  }
+
+  std::string event_path =
+      "/sys/bus/event_source/devices/" + pmu_name + "/events/" + event_name;
+  std::string buf;
+  if (!base::ReadFile(event_path, &buf))
+    return std::nullopt;
+
+  return EventConfig::ParseEventConfigValue(buf);
+}
+
 // |T| is either gen::PerfEventConfig or gen::PerfEventConfig::Scope.
 // Note: the semantics of target_cmdline and exclude_cmdline were changed since
 // their original introduction. They used to be put through a canonicalization
@@ -321,6 +353,10 @@ std::optional<PerfCounter> MakePerfCounter(
         PERFETTO_ELOG("raw_event cannot specify both type and pmu_name.");
         return std::nullopt;
       }
+      if (!raw.event_name().empty() && raw.has_config()) {
+        PERFETTO_ELOG("raw_event cannot specify both config and event_name.");
+        return std::nullopt;
+      }
       std::optional<uint32_t> raw_type =
           raw.has_type() ? std::make_optional(raw.type())
                          : ReadPmuTypeFromSysfs(raw.pmu_name());
@@ -330,8 +366,22 @@ std::optional<PerfCounter> MakePerfCounter(
             "the profiler process has permissions to read from sysfs.");
         return std::nullopt;
       }
-      return PerfCounter::RawEvent(name, *raw_type, raw.config(), raw.config1(),
-                                   raw.config2());
+      std::optional<uint64_t> raw_config =
+          raw.has_config()
+              ? std::make_optional(raw.config())
+              : ReadEventConfigFromSysfs(raw.pmu_name(), raw.event_name());
+      if (!raw_config) {
+        PERFETTO_ELOG(
+            "Failed to resolve raw_event config. Ensure that "
+            "the profiler process has permissions to read from sysfs.");
+        return std::nullopt;
+      }
+      std::string computed_name = name;
+      if (computed_name.empty() && !raw.event_name().empty()) {
+        computed_name = raw.pmu_name() + "-" + raw.event_name();
+      }
+      return PerfCounter::RawEvent(computed_name, *raw_type, *raw_config,
+                                   raw.config1(), raw.config2());
     } else {
       return PerfCounter::BuiltinCounter(
           name, protos::gen::PerfEvents::PerfEvents::SW_CPU_CLOCK,
@@ -361,6 +411,19 @@ bool IsSupportedUnwindMode(
 }
 
 }  // namespace
+
+std::optional<uint64_t> EventConfig::ParseEventConfigValue(
+    const std::string& content) {
+  for (const auto& part : base::SplitString(content, ",")) {
+    std::string trimmed = base::TrimWhitespace(part);
+    if (base::StartsWith(trimmed, "event=")) {
+      return base::StringToUInt64(trimmed.substr(6), 16);
+    }
+  }
+
+  // Try parsing as a raw number (hex or dec)
+  return base::StringToUInt64(base::TrimWhitespace(content), 0);
+}
 
 // static
 PerfCounter PerfCounter::BuiltinCounter(

--- a/src/profiling/perf/event_config.h
+++ b/src/profiling/perf/event_config.h
@@ -144,6 +144,10 @@ class EventConfig {
   bool kernel_frames() const { return kernel_frames_; }
   // clang-format on
 
+  // Public for testing.
+  static std::optional<uint64_t> ParseEventConfigValue(
+      const std::string& content);
+
  private:
   static bool IsUserFramesEnabled(
       const protos::gen::PerfEventConfig::UnwindMode& unwind_mode);

--- a/src/profiling/perf/event_config_unittest.cc
+++ b/src/profiling/perf/event_config_unittest.cc
@@ -544,6 +544,17 @@ TEST(EventConfigTest, EventModifiers) {
   EXPECT_TRUE(follower_attr.exclude_hv);
 }
 
+TEST(EventConfigTest, ParseEventConfigValue) {
+  EXPECT_EQ(EventConfig::ParseEventConfigValue("0x43"), 0x43u);
+  EXPECT_EQ(EventConfig::ParseEventConfigValue("event=0x43"), 0x43u);
+  EXPECT_EQ(EventConfig::ParseEventConfigValue("event=0x43,umask=0x1"), 0x43u);
+  EXPECT_EQ(EventConfig::ParseEventConfigValue("umask=0x1,event=0x43"), 0x43u);
+  EXPECT_EQ(EventConfig::ParseEventConfigValue(" 0x43 "), 0x43u);
+  EXPECT_EQ(EventConfig::ParseEventConfigValue(" event=0x43 "), 0x43u);
+  EXPECT_FALSE(EventConfig::ParseEventConfigValue("").has_value());
+  EXPECT_FALSE(EventConfig::ParseEventConfigValue("not_a_number").has_value());
+}
+
 }  // namespace
 }  // namespace profiling
 }  // namespace perfetto


### PR DESCRIPTION
This change allows users to specify hardware events by their name (e.g.,
'l3d_cache') instead of raw config IDs. The profiler resolves these
names at runtime by reading from sysfs. To ensure safety, it also reads
the PMU's format/event file to verify the event variable maps directly
to the lowest bits of the config field.

Example Perfetto config:

Old:
raw_event {
  pmu_name: "arm_dsu_0"
  config: 43
}

New:
raw_event {
  pmu_name: "arm_dsu_0"
  event_name: "l3d_cache"
}

Bug: 501821381
Test: manual test
Signed-off-by: Samuel Wu <wusamuel@google.com>