### PR TITLE
tp: Add gpu_context table for InternedGraphicsContext

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16870,6 +16870,7 @@ genrule {
         "src/trace_processor/perfetto_sql/stdlib/stack_trace/jit.sql",
         "src/trace_processor/perfetto_sql/stdlib/stacks/cpu_profiling.sql",
         "src/trace_processor/perfetto_sql/stdlib/stacks/symbolization_candidates.sql",
+        "src/trace_processor/perfetto_sql/stdlib/std/gpu/context.sql",
         "src/trace_processor/perfetto_sql/stdlib/std/traceinfo/metadata_for_primary_scope.sql",
         "src/trace_processor/perfetto_sql/stdlib/std/traceinfo/trace.sql",
         "src/trace_processor/perfetto_sql/stdlib/std/trees/filter.sql",

--- a/BUILD
+++ b/BUILD
@@ -3969,6 +3969,14 @@ perfetto_filegroup(
     ],
 )
 
+# GN target: //src/trace_processor/perfetto_sql/stdlib/std/gpu:gpu
+perfetto_filegroup(
+    name = "src_trace_processor_perfetto_sql_stdlib_std_gpu_gpu",
+    srcs = [
+        "src/trace_processor/perfetto_sql/stdlib/std/gpu/context.sql",
+    ],
+)
+
 # GN target: //src/trace_processor/perfetto_sql/stdlib/std/traceinfo:traceinfo
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
@@ -4118,6 +4126,7 @@ perfetto_cc_amalgamated_sql(
         ":src_trace_processor_perfetto_sql_stdlib_slices_slices",
         ":src_trace_processor_perfetto_sql_stdlib_stack_trace_stack_trace",
         ":src_trace_processor_perfetto_sql_stdlib_stacks_stacks",
+        ":src_trace_processor_perfetto_sql_stdlib_std_gpu_gpu",
         ":src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
         ":src_trace_processor_perfetto_sql_stdlib_std_trees_trees",
         ":src_trace_processor_perfetto_sql_stdlib_time_time",

--- a/python/generators/sql_processing/utils.py
+++ b/python/generators/sql_processing/utils.py
@@ -38,6 +38,7 @@ ALLOWED_PREFIXES = {
     ],
     'linux': ['cpu', 'memory'],
     'stacks': ['cpu_profiling'],
+    'std/gpu': ['gpu'],
 }
 
 # Allows for nonstandard object names.

--- a/src/trace_processor/importers/proto/gpu_event_parser.cc
+++ b/src/trace_processor/importers/proto/gpu_event_parser.cc
@@ -257,6 +257,24 @@ const char* MeasureUnitToString(int32_t unit) {
   }
 }
 
+const char* GraphicsApiToString(int32_t api) {
+  using Api = protos::pbzero::InternedGraphicsContext::Api;
+  switch (api) {
+    case Api::OPEN_GL:
+      return "OPEN_GL";
+    case Api::VULKAN:
+      return "VULKAN";
+    case Api::OPEN_CL:
+      return "OPEN_CL";
+    case Api::CUDA:
+      return "CUDA";
+    case Api::HIP:
+      return "HIP";
+    default:
+      return "UNDEFINED";
+  }
+}
+
 }  // namespace
 
 StringId GpuEventParser::FormatCounterUnit(
@@ -652,6 +670,26 @@ StringId GpuEventParser::ParseRenderSubpasses(
   return context_->storage->InternString(writer.GetStringView());
 }
 
+void GpuEventParser::InternGpuContext(
+    uint64_t context_id,
+    const protos::pbzero::InternedGraphicsContext::Decoder& ctx) {
+  if (gpu_contexts_inserted_.Find(context_id)) {
+    return;
+  }
+  gpu_contexts_inserted_[context_id] = true;
+
+  tables::GpuContextTable::Row row;
+  row.context_id = static_cast<uint32_t>(context_id);
+  if (ctx.has_pid()) {
+    row.pid = static_cast<uint32_t>(ctx.pid());
+  }
+  if (ctx.has_api()) {
+    row.api = context_->storage->InternString(
+        base::StringView(GraphicsApiToString(ctx.api())));
+  }
+  context_->storage->mutable_gpu_context_table()->Insert(row);
+}
+
 void GpuEventParser::ParseGpuRenderStageEvent(
     int64_t ts,
     PacketSequenceStateGeneration* sequence_state,
@@ -692,6 +730,7 @@ void GpuEventParser::ParseGpuRenderStageEvent(
         protos::pbzero::InternedGraphicsContext>(context_id);
     if (decoder) {
       pid = decoder->pid();
+      InternGpuContext(context_id, *decoder);
     }
   }
 
@@ -821,8 +860,6 @@ void GpuEventParser::ParseGpuRenderStageEvent(
             inserter->AddArg(name_id, Variadic::String(value));
           }
 
-          // TODO: Create table for graphics context and lookup
-          // InternedGraphicsContext.
           inserter->AddArg(context_id_id_,
                            Variadic::UnsignedInteger(event.context()));
           inserter->AddArg(

--- a/src/trace_processor/importers/proto/gpu_event_parser.h
+++ b/src/trace_processor/importers/proto/gpu_event_parser.h
@@ -171,8 +171,15 @@ class GpuEventParser {
   std::vector<std::optional<HwQueueInfo>> gpu_hw_queue_ids_;
   base::FlatHashMap<uint64_t, bool> gpu_hw_queue_ids_name_to_set_;
 
+  void InternGpuContext(
+      uint64_t context_id,
+      const protos::pbzero::InternedGraphicsContext::Decoder& ctx);
+
   // Map of stage ID -> pair(stage name, stage description)
   std::vector<std::pair<StringId, StringId>> gpu_render_stage_ids_;
+
+  // Graphics contexts already inserted into gpu_context table.
+  base::FlatHashMap<uint64_t, bool> gpu_contexts_inserted_;
 
   // For VulkanMemoryEvent
   std::unordered_map<protos::pbzero::VulkanMemoryEvent::AllocationScope,

--- a/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
@@ -35,6 +35,7 @@ perfetto_amalgamated_sql_header("stdlib") {
     "slices",
     "stack_trace",
     "stacks",
+    "std/gpu",
     "std/traceinfo",
     "std/trees",
     "time",

--- a/src/trace_processor/perfetto_sql/stdlib/std/gpu/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/std/gpu/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../../../gn/perfetto_sql.gni")
+
+perfetto_sql_source_set("gpu") {
+  sources = [ "context.sql" ]
+}

--- a/src/trace_processor/perfetto_sql/stdlib/std/gpu/context.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/std/gpu/context.sql
@@ -1,0 +1,33 @@
+--
+-- Copyright 2026 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Maps GPU graphics context IDs to process and API type.
+--
+-- Each row represents a unique graphics context seen in the trace,
+-- populated from InternedGraphicsContext data attached to
+-- GpuRenderStageEvent packets.
+CREATE PERFETTO VIEW gpu_context (
+  -- The id of the row.
+  id ID,
+  -- The graphics context handle (GL context, VkDevice, CUDA context, etc.).
+  context_id LONG,
+  -- Process ID associated with this context.
+  pid LONG,
+  -- Graphics API type (OPEN_GL, VULKAN, OPEN_CL, CUDA, HIP, or UNDEFINED).
+  api STRING
+) AS
+SELECT
+  *
+FROM __intrinsic_gpu_context;

--- a/src/trace_processor/storage/trace_storage.h
+++ b/src/trace_processor/storage/trace_storage.h
@@ -346,6 +346,13 @@ class TraceStorage {
     return mutable_table<tables::TrackTable>();
   }
 
+  const tables::GpuContextTable& gpu_context_table() const {
+    return table<tables::GpuContextTable>();
+  }
+  tables::GpuContextTable* mutable_gpu_context_table() {
+    return mutable_table<tables::GpuContextTable>();
+  }
+
   const tables::GpuCounterGroupTable& gpu_counter_group_table() const {
     return table<tables::GpuCounterGroupTable>();
   }

--- a/src/trace_processor/tables/profiler_tables.py
+++ b/src/trace_processor/tables/profiler_tables.py
@@ -1247,6 +1247,34 @@ GPU_COUNTER_GROUP_TABLE = Table(
                 '''Group description. NULL for legacy enum-based groups.''',
         }))
 
+GPU_CONTEXT_TABLE = Table(
+    python_module=__file__,
+    class_name='GpuContextTable',
+    sql_name='__intrinsic_gpu_context',
+    wrapping_sql_view=WrappingSqlView('gpu_context'),
+    columns=[
+        C('context_id', CppUint32()),
+        C('pid', CppOptional(CppUint32())),
+        C('api', CppOptional(CppString())),
+    ],
+    tabledoc=TableDoc(
+        doc='''Maps GPU graphics context IDs to process and API type.
+
+Each row represents a unique graphics context seen in the trace,
+populated from InternedGraphicsContext data attached to
+GpuRenderStageEvent packets.''',
+        group='Misc',
+        columns={
+            'context_id':
+                '''The graphics context handle (GL context, VkDevice,
+                CUDA context, etc.).''',
+            'pid':
+                '''Process ID associated with this context.''',
+            'api':
+                '''Graphics API type (OPEN_GL, VULKAN, OPEN_CL, CUDA,
+                HIP, or UNDEFINED).''',
+        }))
+
 # TODO(lalitm): delete this once we have proper tree functions.
 EXPERIMENTAL_FLAMEGRAPH_TABLE = Table(
     python_module=__file__,
@@ -1370,6 +1398,7 @@ ALL_TABLES = [
     AGGREGATE_SAMPLE_TABLE,
     CPU_PROFILE_STACK_SAMPLE_TABLE,
     EXPERIMENTAL_FLAMEGRAPH_TABLE,
+    GPU_CONTEXT_TABLE,
     GPU_COUNTER_GROUP_TABLE,
     HEAP_GRAPH_CLASS_TABLE,
     HEAP_GRAPH_OBJECT_DATA_TABLE,

--- a/src/trace_processor/trace_processor_impl.cc
+++ b/src/trace_processor/trace_processor_impl.cc
@@ -1132,6 +1132,7 @@ std::vector<PerfettoSqlEngine::StaticTable> TraceProcessorImpl::GetStaticTables(
   AddStaticTable(tables, storage->mutable_experimental_proto_content_table());
   AddStaticTable(tables, storage->mutable_file_table());
   AddStaticTable(tables, storage->mutable_filedescriptor_table());
+  AddStaticTable(tables, storage->mutable_gpu_context_table());
   AddStaticTable(tables, storage->mutable_gpu_counter_group_table());
   AddStaticTable(tables, storage->mutable_gpu_table());
   AddStaticTable(tables, storage->mutable_instruments_sample_table());

--- a/test/trace_processor/diff_tests/parser/graphics/gpu_context.textproto
+++ b/test/trace_processor/diff_tests/parser/graphics/gpu_context.textproto
@@ -1,0 +1,56 @@
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  interned_data {
+    graphics_contexts {
+      iid: 1
+      pid: 100
+      api: VULKAN
+    }
+    graphics_contexts {
+      iid: 2
+      pid: 200
+      api: CUDA
+    }
+    gpu_specifications {
+      iid: 1
+      name: "queue"
+      description: "render queue"
+      category: GRAPHICS
+    }
+    gpu_specifications {
+      iid: 2
+      name: "stage"
+      description: "render stage"
+      category: GRAPHICS
+    }
+  }
+  sequence_flags: 1  # SEQ_INCREMENTAL_STATE_CLEARED
+}
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 100
+  gpu_render_stage_event {
+    event_id: 0
+    duration: 10
+    hw_queue_iid: 1
+    stage_iid: 2
+    context: 1
+  }
+  sequence_flags: 2  # SEQ_NEEDS_INCREMENTAL_STATE
+}
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 200
+  gpu_render_stage_event {
+    event_id: 1
+    duration: 20
+    hw_queue_iid: 1
+    stage_iid: 2
+    context: 2
+  }
+  sequence_flags: 2  # SEQ_NEEDS_INCREMENTAL_STATE
+}

--- a/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
+++ b/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
@@ -149,6 +149,21 @@ class GraphicsGpuTrace(TestSuite):
         100,"L2 Cache","L2 cache counters","Counter C"
         """))
 
+  def test_gpu_context(self):
+    return DiffTestBlueprint(
+        trace=Path('gpu_context.textproto'),
+        query="""
+        INCLUDE PERFETTO MODULE std.gpu.context;
+        SELECT context_id, pid, api
+        FROM gpu_context
+        ORDER BY context_id;
+        """,
+        out=Csv("""
+        "context_id","pid","api"
+        1,100,"VULKAN"
+        2,200,"CUDA"
+        """))
+
   def test_gpu_render_stages(self):
     return DiffTestBlueprint(
         trace=Path('gpu_render_stages.py'),

--- a/tools/check_sql_modules.py
+++ b/tools/check_sql_modules.py
@@ -68,6 +68,7 @@ ALLOWED_TOPLEVEL_PUBLIC_PACKAGES = frozenset({
     "sched",
     "slices",
     "stacks",
+    "std",
     "time",
     "traced",
     "v8",


### PR DESCRIPTION
Add a new gpu_context table that maps GPU graphics context IDs to their associated process ID and API type (OPEN_GL, VULKAN, OPEN_CL, CUDA, HIP). This resolves the TODO in gpu_event_parser.cc to create a proper table for graphics context data.

Previously, the context field on GpuRenderStageEvent was used to look up InternedGraphicsContext but only the pid was extracted -- the api field was ignored and no structured table existed for context metadata. Now the full context metadata is materialized into a queryable table.

The table is populated lazily: each unique context_id is inserted on first encounter during GpuRenderStageEvent parsing.

The view is exposed via a new gpu stdlib module at gpu.context, accessible with INCLUDE PERFETTO MODULE gpu.context.

Schema:
  gpu_context(id, context_id, pid, api)

Example query:
  INCLUDE PERFETTO MODULE gpu.context;
  SELECT gc.api, gs.name, gs.dur
  FROM gpu_slice gs
  JOIN gpu_context gc ON gs.context_id = gc.context_id
  WHERE gc.api = 'CUDA'

Related: https://github.com/google/perfetto/issues/5097