### PR TITLE
traced_perf - support setting period/frequency for follower events.

### DIFF
--- a/protos/perfetto/common/perf_events.proto
+++ b/protos/perfetto/common/perf_events.proto
@@ -209,4 +209,8 @@ message FollowerEvent {
   // trace. Does *not* affect the profiling itself. If unset, the trace
   // parser will choose a suitable name.
   optional string name = 4;
+  oneof interval {
+    uint64 frequency = 6;
+    uint64 period = 7;
+  }
 }

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -2477,6 +2477,10 @@ message FollowerEvent {
   // trace. Does *not* affect the profiling itself. If unset, the trace
   // parser will choose a suitable name.
   optional string name = 4;
+  oneof interval {
+    uint64 frequency = 6;
+    uint64 period = 7;
+  }
 }
 
 // End of protos/perfetto/common/perf_events.proto

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -2477,6 +2477,10 @@ message FollowerEvent {
   // trace. Does *not* affect the profiling itself. If unset, the trace
   // parser will choose a suitable name.
   optional string name = 4;
+  oneof interval {
+    uint64 frequency = 6;
+    uint64 period = 7;
+  }
 }
 
 // End of protos/perfetto/common/perf_events.proto

--- a/src/profiling/perf/event_config.cc
+++ b/src/profiling/perf/event_config.cc
@@ -436,6 +436,11 @@ std::optional<EventConfig> EventConfig::Create(
     if (!maybe_follower_counter) {
       return std::nullopt;
     }
+    if (event.has_period()) {
+      maybe_follower_counter->period = event.period();
+    } else if (event.has_frequency()) {
+      maybe_follower_counter->frequency = event.frequency();
+    }
     followers.push_back(std::move(*maybe_follower_counter));
   }
 
@@ -670,6 +675,7 @@ std::optional<EventConfig> EventConfig::CreateSampling(
   // configured as a separate call to perf_event_open.
   std::vector<perf_event_attr> pe_followers;
   if (!followers.empty()) {
+    pe.sample_type |= PERF_SAMPLE_STREAM_ID;
     pe.read_format = PERF_FORMAT_GROUP;
     pe_followers.reserve(followers.size());
   }
@@ -687,9 +693,16 @@ std::optional<EventConfig> EventConfig::CreateSampling(
     pe_follower.exclude_hv = e.attr_exclude_hv;
     // Some arguments must match the timebase:
     pe_follower.sample_type = pe.sample_type;
+    pe_follower.read_format = pe.read_format;
     pe_follower.clockid = pe.clockid;
     pe_follower.use_clockid = pe.use_clockid;
-
+    // Set the period/frequency
+    if (e.period.has_value()) {
+      pe_follower.sample_period = e.period.value();
+    } else if (e.frequency.has_value()) {
+      pe_follower.freq = true;
+      pe_follower.sample_freq = e.frequency.value();
+    }
     pe_followers.push_back(pe_follower);
   }
 

--- a/src/profiling/perf/event_config.h
+++ b/src/profiling/perf/event_config.h
@@ -89,6 +89,10 @@ struct PerfCounter {
   bool attr_exclude_kernel = false;
   bool attr_exclude_hv = false;
 
+  // period/frequency
+  std::optional<uint64_t> period;
+  std::optional<uint64_t> frequency;
+
   Type event_type() const { return type; }
 
   static PerfCounter BuiltinCounter(std::string name,

--- a/src/profiling/perf/event_config_unittest.cc
+++ b/src/profiling/perf/event_config_unittest.cc
@@ -544,6 +544,60 @@ TEST(EventConfigTest, EventModifiers) {
   EXPECT_TRUE(follower_attr.exclude_hv);
 }
 
+TEST(EventConfigTest, GroupFollowerEventPeriod) {
+  protos::gen::PerfEventConfig cfg;
+  {
+    // leader:
+    auto* mutable_timebase = cfg.mutable_timebase();
+    mutable_timebase->set_name("leader");
+    mutable_timebase->set_period(1);
+    protos::gen::PerfEvents::Tracepoint* mutable_tracepoint =
+        mutable_timebase->mutable_tracepoint();
+    mutable_tracepoint->set_name("sched:sched_switch");
+
+    // associate with period:
+    auto* counter_associate_1 = cfg.add_followers();
+    counter_associate_1->set_name("counter");
+    counter_associate_1->set_counter(protos::gen::PerfEvents::SW_CPU_CLOCK);
+    counter_associate_1->set_period(1000000);
+
+    // associate with frequency:
+    auto* counter_associate_2 = cfg.add_followers();
+    counter_associate_2->set_name("counter");
+    counter_associate_2->set_counter(
+        protos::gen::PerfEvents::HW_BRANCH_INSTRUCTIONS);
+    counter_associate_2->set_frequency(4000);
+  }
+
+  auto id_lookup = [](const std::string& group, const std::string& name) {
+    return (group == "sched" && name == "sched_switch") ? 42 : 0;
+  };
+  std::optional<EventConfig> event_config = CreateEventConfig(cfg, id_lookup);
+  ASSERT_TRUE(event_config.has_value());
+
+  {
+    EXPECT_TRUE(event_config->perf_attr()->sample_type & PERF_SAMPLE_READ);
+    EXPECT_TRUE(event_config->perf_attr()->sample_type & PERF_SAMPLE_STREAM_ID);
+    EXPECT_TRUE(event_config->perf_attr()->read_format & PERF_FORMAT_GROUP);
+
+    ASSERT_EQ(event_config->perf_attr_followers().size(), 2u);
+
+    const auto& counter_associate_1 = event_config->perf_attr_followers().at(0);
+    EXPECT_TRUE(counter_associate_1.sample_type & PERF_SAMPLE_READ);
+    EXPECT_TRUE(counter_associate_1.sample_type & PERF_SAMPLE_STREAM_ID);
+    EXPECT_TRUE(counter_associate_1.read_format & PERF_FORMAT_GROUP);
+    EXPECT_EQ(counter_associate_1.sample_period, 1000000u);
+    EXPECT_EQ(counter_associate_1.freq, 0u);
+
+    const auto& counter_associate_2 = event_config->perf_attr_followers().at(1);
+    EXPECT_TRUE(counter_associate_2.sample_type & PERF_SAMPLE_READ);
+    EXPECT_TRUE(counter_associate_2.sample_type & PERF_SAMPLE_STREAM_ID);
+    EXPECT_TRUE(counter_associate_2.read_format & PERF_FORMAT_GROUP);
+    EXPECT_EQ(counter_associate_2.sample_period, 4000u);
+    EXPECT_EQ(counter_associate_2.freq, 1u);
+  }
+}
+
 }  // namespace
 }  // namespace profiling
 }  // namespace perfetto

--- a/src/profiling/perf/event_reader.cc
+++ b/src/profiling/perf/event_reader.cc
@@ -84,6 +84,14 @@ bool MaybeApplyTracepointFilter(int fd, const PerfCounter& event) {
   return true;
 }
 
+std::optional<uint64_t> GetPerfEventId(int fd) {
+  uint64_t id = 0;
+  if (ioctl(fd, PERF_EVENT_IOC_ID, &id) != 0) {
+    return std::nullopt;
+  }
+  return id;
+}
+
 }  // namespace
 
 PerfRingBuffer::PerfRingBuffer(PerfRingBuffer&& other) noexcept
@@ -212,11 +220,15 @@ EventReader::EventReader(uint32_t cpu,
                          perf_event_attr event_attr,
                          base::ScopedFile perf_fd,
                          std::vector<base::ScopedFile> followers_fds,
+                         uint64_t timebase_stream_id,
+                         std::vector<uint64_t> follower_stream_ids,
                          std::optional<PerfRingBuffer> ring_buffer)
     : cpu_(cpu),
       event_attr_(event_attr),
       perf_fd_(std::move(perf_fd)),
       follower_fds_(std::move(followers_fds)),
+      timebase_stream_id_(timebase_stream_id),
+      follower_stream_ids_(std::move(follower_stream_ids)),
       ring_buffer_(std::move(ring_buffer)) {}
 
 EventReader& EventReader::operator=(EventReader&& other) noexcept {
@@ -237,15 +249,30 @@ std::optional<EventReader> EventReader::ConfigureEvents(
     return std::nullopt;
   }
 
+  auto timebase_stream_id = GetPerfEventId(timebase_fd.get());
+  if (!timebase_stream_id) {
+    PERFETTO_PLOG("Failed to get perf event id for timebase");
+    return std::nullopt;
+  }
+
   // Open followers.
   std::vector<base::ScopedFile> follower_fds;
+  std::vector<uint64_t> follower_stream_ids;
   for (auto follower_attr : event_cfg.perf_attr_followers()) {
     auto follower_fd = PerfEventOpen(cpu, &follower_attr, timebase_fd.get());
     if (!follower_fd) {
       PERFETTO_PLOG("Failed perf_event_open (follower)");
       return std::nullopt;
     }
+
+    auto follower_stream_id = GetPerfEventId(follower_fd.get());
+    if (!follower_stream_id) {
+      PERFETTO_PLOG("Failed to get perf event id for follower");
+      return std::nullopt;
+    }
+
     follower_fds.push_back(std::move(follower_fd));
+    follower_stream_ids.push_back(*follower_stream_id);
   }
 
   // Optional: apply the tracepoint filter to the timebase.
@@ -272,8 +299,15 @@ std::optional<EventReader> EventReader::ConfigureEvents(
       return std::nullopt;
     }
   }
+
+  // redirect the follower events to the leader's buffer.
+  for (size_t i = 0; i < follower_fds.size(); ++i) {
+    ioctl(follower_fds[i].get(), PERF_EVENT_IOC_SET_OUTPUT, timebase_fd.get());
+  }
+
   return EventReader(cpu, *event_cfg.perf_attr(), std::move(timebase_fd),
-                     std::move(follower_fds), std::move(ring_buffer));
+                     std::move(follower_fds), *timebase_stream_id,
+                     std::move(follower_stream_ids), std::move(ring_buffer));
 }
 
 std::optional<CommonSampleData> EventReader::ReadCounters() {
@@ -387,7 +421,7 @@ ParsedSample EventReader::ParseSampleRecord(uint32_t cpu,
   if (event_attr_.sample_type &
       (~uint64_t(PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_STACK_USER |
                  PERF_SAMPLE_REGS_USER | PERF_SAMPLE_CALLCHAIN |
-                 PERF_SAMPLE_READ))) {
+                 PERF_SAMPLE_READ | PERF_SAMPLE_STREAM_ID))) {
     PERFETTO_FATAL("Unsupported sampling option");
   }
 
@@ -401,6 +435,7 @@ ParsedSample EventReader::ParseSampleRecord(uint32_t cpu,
   // Parse the payload, which consists of concatenated data for each
   // |attr.sample_type| flag.
   const char* parse_pos = record_start + sizeof(perf_event_header);
+  std::optional<uint64_t> stream_id;
 
   if (event_attr_.sample_type & PERF_SAMPLE_TID) {
     uint32_t pid = 0;
@@ -413,6 +448,12 @@ ParsedSample EventReader::ParseSampleRecord(uint32_t cpu,
 
   if (event_attr_.sample_type & PERF_SAMPLE_TIME) {
     parse_pos = ReadValue(&sample.common.timestamp, parse_pos);
+  }
+
+  if (event_attr_.sample_type & PERF_SAMPLE_STREAM_ID) {
+    uint64_t raw_stream_id = 0;
+    parse_pos = ReadValue(&raw_stream_id, parse_pos);
+    stream_id = raw_stream_id;
   }
 
   if (event_attr_.sample_type & PERF_SAMPLE_READ) {
@@ -431,7 +472,25 @@ ParsedSample EventReader::ParseSampleRecord(uint32_t cpu,
         parse_pos = ReadValue(&sample.common.follower_counts[i], parse_pos);
       }
     } else {
-      parse_pos = ReadValue(&sample.common.timebase_count, parse_pos);
+      if (stream_id.has_value()) {
+        uint64_t count = 0;
+        parse_pos = ReadValue(&count, parse_pos);
+        if (*stream_id == timebase_stream_id_) {
+          sample.common.timebase_count = count;
+        } else {
+          bool found = false;
+          for (size_t i = 0; i < follower_stream_ids_.size(); ++i) {
+            if (follower_stream_ids_[i] == *stream_id) {
+              sample.common.follower_counts[i] = count;
+              found = true;
+              break;
+            }
+          }
+          PERFETTO_CHECK(found);
+        }
+      } else {
+        parse_pos = ReadValue(&sample.common.timebase_count, parse_pos);
+      }
     }
   }
 

--- a/src/profiling/perf/event_reader.h
+++ b/src/profiling/perf/event_reader.h
@@ -107,15 +107,22 @@ class EventReader {
               perf_event_attr event_attr,
               base::ScopedFile perf_fd,
               std::vector<base::ScopedFile> followers_fds,
+              uint64_t timebase_stream_id,
+              std::vector<uint64_t> follower_stream_ids,
               std::optional<PerfRingBuffer> ring_buffer);
 
   ParsedSample ParseSampleRecord(uint32_t cpu, const char* record_start);
+  bool SetSingleReadValue(uint64_t stream_id,
+                          uint64_t count,
+                          CommonSampleData* sample) const;
 
   // All events are cpu-bound (thread-scoped events not supported).
   const uint32_t cpu_;
   const perf_event_attr event_attr_;
   base::ScopedFile perf_fd_;
   std::vector<base::ScopedFile> follower_fds_;
+  const uint64_t timebase_stream_id_;
+  const std::vector<uint64_t> follower_stream_ids_;
   // Ring buffer is absent if and only if we're polling counters.
   std::optional<PerfRingBuffer> ring_buffer_;
 };


### PR DESCRIPTION
This change adds support for configuring the sampling period or frequency for follower  events.

Previously, only the group leader event could be configured to trigger samples. With this change, follower events can also independently trigger samples by specifying the 'period' or 'frequency' field in the config.

This aligns Perfetto's behavior more closely with `perf` semantics, e.g., `perf record -e '{context-switches,cpu-clock/period=<SAMPLE_PERIOD>}'`, and allows more flexible PMU event sampling.