### PR TITLE
ui: Auto-compute chart grid spacing from measured label width

### DIFF
--- a/ui/src/components/widgets/charts/bar_chart.ts
+++ b/ui/src/components/widgets/charts/bar_chart.ts
@@ -248,9 +248,7 @@ function buildBarOption(
 
   const option: Record<string, unknown> = {
     animation: false,
-    grid: buildGridOption({
-      bottom: dimensionLabel && !horizontal ? 45 : 25,
-    }),
+    grid: buildGridOption(),
     tooltip: buildTooltipOption({
       trigger: 'axis' as const,
       axisPointer: {type: 'shadow' as const},

--- a/ui/src/components/widgets/charts/boxplot.ts
+++ b/ui/src/components/widgets/charts/boxplot.ts
@@ -175,9 +175,7 @@ function buildBoxplotOption(
 
   const option: Record<string, unknown> = {
     animation: false,
-    grid: buildGridOption({
-      bottom: horizontal ? 25 : categoryLabel ? 40 : 25,
-    }),
+    grid: buildGridOption(),
     xAxis: horizontal ? valueAxis : categoryAxis,
     yAxis: horizontal ? categoryAxis : valueAxis,
     tooltip: buildTooltipOption({

--- a/ui/src/components/widgets/charts/chart_option_builder.ts
+++ b/ui/src/components/widgets/charts/chart_option_builder.ts
@@ -22,6 +22,9 @@
 
 import type {EChartsCoreOption} from 'echarts/core';
 
+/** Font size used for axis tick labels across all charts. */
+export const AXIS_LABEL_FONT_SIZE = 10;
+
 /**
  * Configuration for an axis in a chart.
  */
@@ -56,19 +59,24 @@ export interface BrushConfig {
 /**
  * Build an axis option from config.
  * Theme colors are applied by EChartView, so we omit color settings here.
+ *
+ * Only X-axis gets a default `nameGap`. Y-axis `nameGap` is intentionally
+ * left unset when the caller doesn't provide one, so that EChartView's
+ * auto-spacing can measure tick-label width and set it dynamically.
  */
 export function buildAxisOption(
   config: AxisConfig,
   isXAxis: boolean,
 ): Record<string, unknown> {
+  const nameGap = config.nameGap ?? (isXAxis ? 25 : undefined);
   const axis: Record<string, unknown> = {
     type: config.type,
     name: config.name,
-    nameLocation: isXAxis ? ('middle' as const) : ('end' as const),
-    nameGap: config.nameGap ?? (isXAxis ? 25 : 10),
+    nameLocation: 'middle' as const,
+    ...(nameGap !== undefined && {nameGap}),
     nameTextStyle: {fontSize: 11},
     axisLabel: {
-      fontSize: 10,
+      fontSize: AXIS_LABEL_FONT_SIZE,
       ...(config.formatter !== undefined && {formatter: config.formatter}),
       ...(config.labelOverflow !== undefined && {
         overflow: config.labelOverflow,
@@ -100,7 +108,8 @@ export function buildAxisOption(
 }
 
 /**
- * Build a grid option.
+ * Build a grid option. Spacing is auto-computed by EChartView; only pass
+ * explicit overrides for non-standard needs (e.g. heatmap color legend).
  */
 export function buildGridOption(opts?: {
   top?: number;
@@ -110,10 +119,10 @@ export function buildGridOption(opts?: {
   containLabel?: boolean;
 }): Record<string, unknown> {
   return {
-    top: opts?.top ?? 20,
-    right: opts?.right ?? 10,
-    bottom: opts?.bottom ?? 25,
-    left: opts?.left ?? 10,
+    ...(opts?.top !== undefined && {top: opts.top}),
+    ...(opts?.right !== undefined && {right: opts.right}),
+    ...(opts?.bottom !== undefined && {bottom: opts.bottom}),
+    ...(opts?.left !== undefined && {left: opts.left}),
     containLabel: opts?.containLabel ?? true,
   };
 }
@@ -244,4 +253,104 @@ export function buildChartOption(config: {
   }
 
   return option as EChartsCoreOption;
+}
+
+export type LabelFormatter = (value: number | string) => string;
+
+/** Format a label value using an ECharts formatter (function or string). */
+export function formatLabel(
+  value: number | string,
+  formatter: LabelFormatter | string | undefined,
+): string {
+  if (typeof formatter === 'function') return formatter(value);
+  if (typeof formatter === 'string') {
+    return formatter.replace('{value}', String(value));
+  }
+  return String(value);
+}
+
+/** Extract representative Y-axis label values for width measurement. */
+export function collectYAxisLabels(
+  opt: Record<string, unknown>,
+): Array<number | string> {
+  if (Array.isArray(opt.yAxis)) return [];
+  const yAxis = opt.yAxis as Record<string, unknown> | undefined;
+  if (yAxis === undefined) return [];
+  const axisType = (yAxis.type as string) ?? 'value';
+
+  if (axisType === 'category') {
+    const data = yAxis.data;
+    if (Array.isArray(data)) return data as string[];
+    return [];
+  }
+
+  const series = opt.series;
+  if (!Array.isArray(series)) return [];
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const s of series as Array<Record<string, unknown>>) {
+    const data = s.data;
+    if (!Array.isArray(data)) continue;
+    for (const d of data) {
+      if (typeof d === 'number') {
+        if (isFinite(d)) {
+          if (d < min) min = d;
+          if (d > max) max = d;
+        }
+      } else if (Array.isArray(d)) {
+        // Handles [x, y] pairs and boxplot [min, Q1, median, Q3, max].
+        for (const el of d) {
+          if (typeof el === 'number' && isFinite(el)) {
+            if (el < min) min = el;
+            if (el > max) max = el;
+          }
+        }
+      } else if (typeof d === 'object' && d !== null) {
+        const v = (d as {value?: unknown}).value;
+        if (typeof v === 'number' && isFinite(v)) {
+          if (v < min) min = v;
+          if (v > max) max = v;
+        }
+      }
+    }
+  }
+
+  if (!isFinite(min) || !isFinite(max)) return [];
+
+  return generateNiceTicks(min, max, axisType === 'log');
+}
+
+/** Generate ~5 nice tick values for a range (approximate, for width estimation). */
+export function generateNiceTicks(
+  min: number,
+  max: number,
+  isLog: boolean,
+): number[] {
+  if (isLog) {
+    const minExp = Math.floor(Math.log10(Math.max(min, 1)));
+    const maxExp = Math.ceil(Math.log10(Math.max(max, 1)));
+    const ticks: number[] = [];
+    for (let e = minExp; e <= maxExp; e++) {
+      ticks.push(Math.pow(10, e));
+    }
+    return ticks;
+  }
+
+  const range = max - min;
+  if (range <= 0) return [min];
+
+  const roughInterval = range / 5;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(roughInterval)));
+  const residual = roughInterval / magnitude;
+  const niceMultiplier =
+    residual <= 1.5 ? 1 : residual <= 3 ? 2 : residual <= 7 ? 5 : 10;
+  const interval = niceMultiplier * magnitude;
+
+  const ticks: number[] = [];
+  const start = Math.floor(min / interval) * interval;
+  for (let v = start; v <= max + interval * 0.5; v += interval) {
+    ticks.push(v);
+  }
+  return ticks;
 }

--- a/ui/src/components/widgets/charts/chart_option_builder_unittest.ts
+++ b/ui/src/components/widgets/charts/chart_option_builder_unittest.ts
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  collectYAxisLabels,
+  formatLabel,
+  generateNiceTicks,
+} from './chart_option_builder';
+
+describe('formatLabel', () => {
+  test('returns string representation when no formatter', () => {
+    expect(formatLabel(42, undefined)).toBe('42');
+    expect(formatLabel('hello', undefined)).toBe('hello');
+  });
+
+  test('applies function formatter', () => {
+    const fmt = (v: number | string) => `${v} ms`;
+    expect(formatLabel(100, fmt)).toBe('100 ms');
+  });
+
+  test('applies function formatter to category string value', () => {
+    const fmt = (v: number | string) =>
+      typeof v === 'string' ? v.toUpperCase() : String(v);
+    expect(formatLabel('abc', fmt)).toBe('ABC');
+  });
+
+  test('applies string formatter with {value} placeholder', () => {
+    expect(formatLabel(100, '{value} kg')).toBe('100 kg');
+    expect(formatLabel('A', 'Category: {value}')).toBe('Category: A');
+  });
+
+  test('handles string formatter without placeholder', () => {
+    expect(formatLabel(42, 'fixed')).toBe('fixed');
+  });
+});
+
+describe('generateNiceTicks', () => {
+  test('returns single value for zero range', () => {
+    expect(generateNiceTicks(5, 5, false)).toEqual([5]);
+  });
+
+  test('generates ticks for 0-100 range', () => {
+    const ticks = generateNiceTicks(0, 100, false);
+    expect(ticks.length).toBeGreaterThanOrEqual(3);
+    expect(ticks[0]).toBeLessThanOrEqual(0);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(100);
+  });
+
+  test('generates ticks for non-zero-based range', () => {
+    const ticks = generateNiceTicks(100, 200, false);
+    // Should NOT include 0 since data starts at 100.
+    expect(ticks[0]).toBeGreaterThanOrEqual(100);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(200);
+  });
+
+  test('generates ticks for negative range', () => {
+    const ticks = generateNiceTicks(-50, 50, false);
+    expect(ticks[0]).toBeLessThanOrEqual(-50);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(50);
+  });
+
+  test('generates log-scale ticks', () => {
+    const ticks = generateNiceTicks(1, 10000, true);
+    expect(ticks).toEqual([1, 10, 100, 1000, 10000]);
+  });
+
+  test('log-scale with small values clamps to 1', () => {
+    const ticks = generateNiceTicks(0.5, 100, true);
+    expect(ticks[0]).toBe(1);
+    expect(ticks[ticks.length - 1]).toBeGreaterThanOrEqual(100);
+  });
+});
+
+describe('collectYAxisLabels', () => {
+  test('returns empty for array yAxis (dual-axis)', () => {
+    const opt = {
+      yAxis: [{type: 'value'}, {type: 'value'}],
+      series: [{data: [1, 2, 3]}],
+    };
+    expect(collectYAxisLabels(opt)).toEqual([]);
+  });
+
+  test('returns category data directly', () => {
+    const opt = {
+      yAxis: {type: 'category', data: ['A', 'B', 'C']},
+      series: [],
+    };
+    expect(collectYAxisLabels(opt)).toEqual(['A', 'B', 'C']);
+  });
+
+  test('returns empty for category with no data', () => {
+    const opt = {yAxis: {type: 'category'}, series: []};
+    expect(collectYAxisLabels(opt)).toEqual([]);
+  });
+
+  test('extracts min/max from numeric series data', () => {
+    const opt = {
+      yAxis: {type: 'value'},
+      series: [{data: [10, 20, 30]}],
+    };
+    const labels = collectYAxisLabels(opt);
+    expect(labels.length).toBeGreaterThanOrEqual(2);
+    expect(labels[0]).toBeLessThanOrEqual(10);
+    expect(labels[labels.length - 1]).toBeGreaterThanOrEqual(30);
+  });
+
+  test('handles [x, y] pair data', () => {
+    const opt = {
+      yAxis: {type: 'value'},
+      series: [
+        {
+          data: [
+            [0, 5],
+            [1, 15],
+            [2, 25],
+          ],
+        },
+      ],
+    };
+    const labels = collectYAxisLabels(opt);
+    expect(labels.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('handles boxplot data [min, Q1, median, Q3, max]', () => {
+    const opt = {
+      yAxis: {type: 'value'},
+      series: [{data: [[10, 20, 30, 40, 500]]}],
+    };
+    const labels = collectYAxisLabels(opt);
+    // Should include ticks covering up to 500, not just Q1 (20).
+    expect(labels[labels.length - 1]).toBeGreaterThanOrEqual(500);
+  });
+
+  test('handles {value: n} object data', () => {
+    const opt = {
+      yAxis: {type: 'value'},
+      series: [{data: [{value: 100}, {value: 200}]}],
+    };
+    const labels = collectYAxisLabels(opt);
+    expect(labels.length).toBeGreaterThanOrEqual(2);
+    expect(labels[labels.length - 1]).toBeGreaterThanOrEqual(200);
+  });
+
+  test('returns empty when no series data', () => {
+    const opt = {yAxis: {type: 'value'}, series: []};
+    expect(collectYAxisLabels(opt)).toEqual([]);
+  });
+
+  test('returns empty when series has no data arrays', () => {
+    const opt = {yAxis: {type: 'value'}, series: [{type: 'bar'}]};
+    expect(collectYAxisLabels(opt)).toEqual([]);
+  });
+});

--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -27,6 +27,12 @@
  */
 
 import m from 'mithril';
+import {
+  AXIS_LABEL_FONT_SIZE,
+  LabelFormatter,
+  collectYAxisLabels,
+  formatLabel,
+} from './chart_option_builder';
 import * as echarts from 'echarts/core';
 import {
   BarChart as EBarChart,
@@ -136,6 +142,126 @@ function buildEChartsTheme(colors: ChartThemeColors): Record<string, unknown> {
         color: [colors.chartColors[0] + '22', colors.chartColors[0]],
       },
     },
+  };
+}
+
+// Top padding (grid.top) defaults.
+const LEGEND_TOP = 30;
+const TICK_LABEL_TOP = 10; // Prevents topmost tick label clipping.
+
+// Horizontal spacing constants.
+const NAME_GAP_PADDING = 14; // Extra gap between tick labels and axis name.
+const GRID_LEFT_INNER_PAD = 6; // Padding between axis line and grid edge.
+
+// Bottom spacing (grid.bottom) default when the X-axis has a name.
+const X_AXIS_NAME_BOTTOM = 30;
+
+const AXIS_LABEL_FONT = `${AXIS_LABEL_FONT_SIZE}px sans-serif`;
+
+// Minimal shape we rely on from a CanvasRenderingContext2D-like object, so we
+// can substitute a no-op stub when canvas creation fails (e.g. in tests or
+// restricted environments) without crashing the chart.
+interface TextMeasurer {
+  font: string;
+  measureText(text: string): {width: number};
+}
+
+// Fallback used when canvas 2d context isn't available (e.g. in tests or
+// restricted environments). Auto-spacing becomes a no-op but the chart still
+// renders.
+const NOOP_MEASURER: TextMeasurer = {
+  font: '',
+  measureText: () => ({width: 0}),
+};
+
+// Intentionally cached for the page lifetime — canvas context creation is
+// expensive and font metrics don't change between chart renders.
+let measureCtx: TextMeasurer | undefined;
+
+function getMeasureCtx(): TextMeasurer {
+  if (measureCtx === undefined) {
+    const canvas = document.createElement('canvas');
+    measureCtx = canvas.getContext('2d') ?? NOOP_MEASURER;
+  }
+  return measureCtx;
+}
+
+function measureTextWidth(text: string, font: string): number {
+  const ctx = getMeasureCtx();
+  ctx.font = font;
+  return ctx.measureText(text).width;
+}
+
+/**
+ * Auto-compute grid spacing from axis/legend context before rendering.
+ * Y-axis nameGap and grid.left are measured from actual tick label width.
+ */
+function autoAdjustGridSpacing(
+  option: echarts.EChartsCoreOption,
+): echarts.EChartsCoreOption {
+  const opt = option as Record<string, unknown>;
+  // Nothing to adjust for charts without axes (e.g. treemap, pie).
+  if (opt.xAxis === undefined && opt.yAxis === undefined) return option;
+  const grid = {...((opt.grid ?? {}) as Record<string, unknown>)};
+  // Skip array yAxis (dual Y-axis) — auto-spacing only handles single axis.
+  const yAxis = !Array.isArray(opt.yAxis)
+    ? (opt.yAxis as Record<string, unknown> | undefined)
+    : undefined;
+  const xAxis = opt.xAxis as Record<string, unknown> | undefined;
+  const legend = opt.legend as Record<string, unknown> | undefined;
+  let yAxisPatch: Record<string, unknown> | undefined;
+
+  if (grid.top === undefined) {
+    const hasLegend = legend !== undefined && legend.show !== false;
+    grid.top = hasLegend ? LEGEND_TOP : TICK_LABEL_TOP;
+  }
+
+  if (grid.bottom === undefined) {
+    const xAxisName = xAxis?.name as string | undefined;
+    if (xAxisName !== undefined && xAxisName !== '') {
+      grid.bottom = X_AXIS_NAME_BOTTOM;
+    }
+  }
+
+  if (yAxis !== undefined) {
+    const yName = yAxis.name as string | undefined;
+    const nameLocation = yAxis.nameLocation as string | undefined;
+    const hasRotatedName =
+      yName !== undefined &&
+      yName !== '' &&
+      (nameLocation === undefined || nameLocation === 'middle');
+
+    if (hasRotatedName && yAxis.nameGap === undefined) {
+      const labels = collectYAxisLabels(opt);
+      if (labels.length > 0) {
+        const axisLabel = yAxis.axisLabel as
+          | Record<string, unknown>
+          | undefined;
+        const formatter = axisLabel?.formatter as
+          | LabelFormatter
+          | string
+          | undefined;
+        let maxWidth = 0;
+        for (const l of labels) {
+          const text = formatLabel(l, formatter);
+          const w = measureTextWidth(text, AXIS_LABEL_FONT);
+          if (w > maxWidth) maxWidth = w;
+        }
+        const requiredGap = Math.ceil(maxWidth) + NAME_GAP_PADDING;
+        yAxisPatch = {...yAxis, nameGap: requiredGap};
+        if (grid.left === undefined) {
+          // The grid's left padding holds the rotated axis name (width
+          // NAME_GAP_PADDING once trimmed) plus a bit of inner padding.
+          grid.left = NAME_GAP_PADDING + GRID_LEFT_INNER_PAD;
+        }
+      }
+    }
+  }
+
+  return {
+    ...opt,
+    grid,
+    ...(yAxisPatch !== undefined ? {yAxis: yAxisPatch} : {}),
   };
 }
 
@@ -327,7 +453,10 @@ export class EChartView implements m.ClassComponent<EChartViewAttrs> {
     attrs: EChartViewAttrs,
     colors: ChartThemeColors,
   ): echarts.EChartsCoreOption {
-    return attrs.resolveOption ? attrs.resolveOption(option, colors) : option;
+    const resolved = attrs.resolveOption
+      ? attrs.resolveOption(option, colors)
+      : option;
+    return autoAdjustGridSpacing(resolved);
   }
 
   private disposeChart(): void {

--- a/ui/src/components/widgets/charts/heatmap.ts
+++ b/ui/src/components/widgets/charts/heatmap.ts
@@ -137,11 +137,7 @@ function buildHeatmapOption(
 
   const option: Record<string, unknown> = {
     animation: false,
-    grid: buildGridOption({
-      top: 10,
-      right: 80,
-      bottom: xAxisLabel ? 40 : 25,
-    }),
+    grid: buildGridOption({right: 80}),
     xAxis: {
       ...buildAxisOption(
         {

--- a/ui/src/components/widgets/charts/histogram.ts
+++ b/ui/src/components/widgets/charts/histogram.ts
@@ -156,7 +156,6 @@ function buildOption(
   }
 
   const option = buildChartOption({
-    grid: {bottom: xAxisLabel ? 40 : 25},
     xAxis: {
       type: 'category',
       data: categories,

--- a/ui/src/components/widgets/charts/line_chart.ts
+++ b/ui/src/components/widgets/charts/line_chart.ts
@@ -242,10 +242,6 @@ function buildLineOption(
   });
 
   const option = buildChartOption({
-    grid: {
-      top: displayLegend ? 30 : 10,
-      bottom: xAxisLabel ? 40 : 25,
-    },
     xAxis: {
       // Nasty ECharts quirk: when stacking, the xAxis must be type 'category'
       // or 'time'. Since we want to support x-values at irregular intervals, we

--- a/ui/src/components/widgets/charts/scatterplot.ts
+++ b/ui/src/components/widgets/charts/scatterplot.ts
@@ -277,10 +277,6 @@ function buildScatterOption(
   });
 
   const option = buildChartOption({
-    grid: {
-      top: displayLegend ? 30 : 10,
-      bottom: xAxisLabel !== undefined ? 40 : 25,
-    },
     xAxis: {
       type: logScaleX ? 'log' : 'value',
       name: xAxisLabel,

--- a/ui/src/components/widgets/charts/treemap.ts
+++ b/ui/src/components/widgets/charts/treemap.ts
@@ -137,6 +137,12 @@ function buildTreemapOption(
       {
         type: 'treemap',
         data: convertNodes(data.nodes),
+        // Series-level insets (NOT grid): treemap has no axes, so fill the
+        // full container instead of leaving axis-placeholder padding.
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
         roam: enableDrillDown ? 'move' : false,
         nodeClick: enableDrillDown ? 'zoomToNode' : false,
         visibleMin,


### PR DESCRIPTION
## Summary

Previously each chart type (bar, boxplot, histogram, line, scatter, heatmap) hard-coded its own `grid.bottom`, `grid.top`, and Y-axis `nameGap` values. These magic numbers were brittle - any change to axis labels, tick formatting, or chart size would silently clip or misalign axis names.

This change centralizes all grid-spacing logic into a single `autoAdjustGridSpacing` pass in `EChartView`, which runs on every option update before passing to ECharts. It measures actual Y-axis tick label widths using `canvas.measureText` and computes `nameGap` and `grid.left` dynamically, so charts self-adjust regardless of data range or formatting.

## Notes

`collectYAxisLabels` approximates which tick values ECharts will render by scanning series data for min/max and generating nice ticks - it does not read ECharts' internal model. This means the measured width can be slightly off if ECharts chooses a tick value outside the data range. The consequence is cosmetic (minor nameGap over/under-shoot), and a post-render approach would require a significantly more complex layout pass. The approximation is an intentional trade-off.