### PR TITLE
ui: MenuTitle - use children instead of label attr

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.Timeline/timeline_toolbar.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/timeline_toolbar.ts
@@ -113,9 +113,9 @@ export class TimelineToolbar implements m.ClassComponent<TimelineToolbarAttrs> {
           },
           `Changes apply to all selected tracks`,
         ),
-        m(MenuTitle, {label: 'Workspace'}),
+        m(MenuTitle, 'Workspace'),
         this.renderCopySelectedTracksToWorkspace(trace, selection),
-        m(MenuTitle, {label: 'Bulk track settings'}),
+        m(MenuTitle, 'Bulk track settings'),
         settingsMenuItems,
       ],
     );
@@ -135,7 +135,7 @@ export class TimelineToolbar implements m.ClassComponent<TimelineToolbarAttrs> {
         }),
       },
       [
-        m(MenuTitle, {label: 'All workspaces'}),
+        m(MenuTitle, 'All workspaces'),
         workspaces.all.map((ws) => {
           return m(MenuItem, {
             label: ws.title,

--- a/ui/src/core_plugins/dev.perfetto.Timeline/track_view.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/track_view.ts
@@ -690,7 +690,7 @@ function renderTrackSettings(descriptor?: Track): m.Children[] {
   if (!settings || settings.length === 0) return [];
   return [
     m(MenuDivider),
-    m(MenuTitle, {label: 'Settings'}),
+    m(MenuTitle, 'Settings'),
     ...settings.map((setting) =>
       renderTrackSettingMenu(setting.descriptor, (v) => setting.update(v), [
         setting.value,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/graph.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/graph.ts
@@ -255,7 +255,7 @@ function buildAddMenuItems(
     if (i > 0) {
       menuItems.push(m(MenuDivider));
     }
-    menuItems.push(m(MenuTitle, {label: sections[i].title}));
+    menuItems.push(m(MenuTitle, sections[i].title));
     menuItems.push(...sections[i].items);
   }
   return menuItems;
@@ -744,7 +744,7 @@ export class Graph implements m.ClassComponent<GraphAttrs> {
       if (i > 0) {
         addNodeMenuItems.push(m(MenuDivider));
       }
-      addNodeMenuItems.push(m(MenuTitle, {label: sections[i].title}));
+      addNodeMenuItems.push(m(MenuTitle, sections[i].title));
       addNodeMenuItems.push(...sections[i].items);
     }
     addNodeMenuItems.push(m(MenuDivider));

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/node_box.ts
@@ -76,7 +76,7 @@ export function renderAddButton(attrs: NodeBoxAttrs): m.Child {
     if (i > 0) {
       menuItems.push(m(MenuDivider));
     }
-    menuItems.push(m(MenuTitle, {label: sections[i].title}));
+    menuItems.push(m(MenuTitle, sections[i].title));
     menuItems.push(...sections[i].items);
   }
 

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/menu_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/menu_demo.ts
@@ -30,7 +30,7 @@ export function renderMenu(): m.Children {
       renderWidget: () =>
         m(
           Menu,
-          m(MenuTitle, {label: 'Common Actions'}),
+          m(MenuTitle, 'Common Actions'),
           m(MenuItem, {label: 'New', icon: 'add'}),
           m(MenuItem, {label: 'Open', icon: 'folder_open'}),
           m(MenuItem, {label: 'Save', icon: 'save', disabled: true}),
@@ -42,7 +42,7 @@ export function renderMenu(): m.Children {
             {label: 'Share', icon: 'share'},
             m(MenuItem, {label: 'Everyone', icon: 'public'}),
             m(MenuItem, {label: 'Friends', icon: 'group'}),
-            m(MenuTitle, {label: 'Other'}),
+            m(MenuTitle, 'Other'),
             m(
               MenuItem,
               {label: 'Specific people', icon: 'person_add'},

--- a/ui/src/widgets/menu.ts
+++ b/ui/src/widgets/menu.ts
@@ -121,15 +121,10 @@ export class MenuDivider implements m.ClassComponent {
   }
 }
 
-export interface MenuTitleAttrs extends HTMLAttrs {
-  // Text to display in the title.
-  readonly label?: string;
-}
-
 // An element which shows a dividing line between menu items.
 export class MenuTitle implements m.ClassComponent {
-  view({attrs}: m.CVnode<MenuTitleAttrs>) {
-    return m('.pf-menu-title', attrs.label);
+  view({children}: m.CVnode) {
+    return m('.pf-menu-title', children);
   }
 }
 


### PR DESCRIPTION
MenuTitle - Use children to inject the title content instead of the label attr.

Before:
```ts
m(MenuTitle, {label: 'Foo'})
```

After:
```ts
m(MenuTitle, 'Foo')
```