### PR TITLE
de: Further simplify serialization

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/clipboard_operations_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/clipboard_operations_unittest.ts
@@ -284,10 +284,10 @@ describe('clipboard_operations', () => {
         listTables: () => [],
         getTable: () => undefined,
       } as unknown as SqlModules;
-      const realNode = new TableSourceNode({
-        trace: mockTrace,
-        sqlModules: mockSqlModules,
-      });
+      const realNode = new TableSourceNode(
+        {},
+        {trace: mockTrace, sqlModules: mockSqlModules},
+      );
 
       const clipboard = {
         clipboardNodes: [

--- a/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/dashboard/dashboard_chart_view.ts
@@ -37,10 +37,7 @@ import {
 } from './dashboard_registry';
 import {ResultsPanelEmptyState} from '../query_builder/widgets';
 import {SqlValue} from '../../../trace_processor/query_result';
-import {
-  isQuantitativeType,
-  perfettoSqlTypeToString,
-} from '../../../trace_processor/perfetto_sql_type';
+import {isQuantitativeType} from '../../../trace_processor/perfetto_sql_type';
 
 export interface DashboardChartViewAttrs {
   trace: Trace;
@@ -103,9 +100,8 @@ class DashboardChartAdapter implements ChartColumnProvider {
     this.filters = [...(callbacks.brushFilters.get(source.nodeId) ?? [])];
     this.cols = source.columns.map((col) => ({
       name: col.name,
-      type: perfettoSqlTypeToString(col.type),
       checked: false,
-      column: {name: col.name, type: col.type},
+      type: col.type,
     }));
   }
 
@@ -128,8 +124,7 @@ class DashboardChartAdapter implements ChartColumnProvider {
       chartType === 'cdf'
     ) {
       return this.cols.filter(
-        (col) =>
-          col.column.type !== undefined && isQuantitativeType(col.column.type),
+        (col) => col.type !== undefined && isQuantitativeType(col.type),
       );
     }
     return this.cols;
@@ -225,7 +220,7 @@ class DashboardChartAdapter implements ChartColumnProvider {
     this.callbacks.onItemsChange(items);
   }
 
-  get state() {
+  get attrs() {
     return {chartConfigs: [this.config]};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/data_explorer.ts
@@ -500,17 +500,17 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       if (!isDashboardNode(node)) continue;
       // Propagate the stable tab ID so sources are namespaced by graph.
       // Re-publish if the graphId changed so the registry has the right key.
-      const prevGraphId = node.state.graphId;
-      node.state.graphId = tab.id;
+      const prevGraphId = node.graphId;
+      node.graphId = tab.id;
       if (prevGraphId !== tab.id) {
         node.onPrevNodesUpdated?.();
       }
-      if (node.state.getTableNameForNode === undefined) {
-        node.state.getTableNameForNode = (nodeId: string) =>
+      if (node.context.getTableNameForNode === undefined) {
+        node.context.getTableNameForNode = (nodeId: string) =>
           services.queryExecutionService.getTableName(nodeId);
       }
-      if (node.state.requestNodeExecution === undefined) {
-        node.state.requestNodeExecution = (nodeId: string) => {
+      if (node.context.requestNodeExecution === undefined) {
+        node.context.requestNodeExecution = (nodeId: string) => {
           const targetNode = allNodes.find((n) => n.nodeId === nodeId);
           if (targetNode === undefined) return Promise.resolve();
           return services.queryExecutionService
@@ -525,8 +525,8 @@ export class DataExplorer implements m.ClassComponent<DataExplorerAttrs> {
       // Provide getTableNameForNode callback for all nodes (used by
       // add_columns_node and others).
       for (const node of allNodes) {
-        if (node.state.getTableNameForNode === undefined) {
-          node.state.getTableNameForNode = (nodeId: string) =>
+        if (node.context.getTableNameForNode === undefined) {
+          node.context.getTableNameForNode = (nodeId: string) =>
             services.queryExecutionService.getTableName(nodeId);
         }
       }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/datagrid_node_creation.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/datagrid_node_creation.ts
@@ -48,9 +48,10 @@ function setFiltersOnNode(
   filters: UIFilter[],
   filterOperator?: 'AND' | 'OR',
 ): void {
-  node.state.filters = filters;
+  const filterNode = node as FilterNode;
+  filterNode.attrs.filters = filters;
   if (filterOperator) {
-    node.state.filterOperator = filterOperator;
+    filterNode.attrs.filterOperator = filterOperator;
   }
 }
 
@@ -84,7 +85,7 @@ export function parseJoinidColumnField(
 
   if (
     joinidColumnInfo === undefined ||
-    joinidColumnInfo.column.type?.kind !== 'joinid'
+    joinidColumnInfo.type?.kind !== 'joinid'
   ) {
     return undefined;
   }
@@ -92,8 +93,8 @@ export function parseJoinidColumnField(
   return {
     joinidColumnName,
     targetColumnName,
-    targetTable: joinidColumnInfo.column.type.source.table,
-    targetJoinColumn: joinidColumnInfo.column.type.source.column,
+    targetTable: joinidColumnInfo.type.source.table,
+    targetJoinColumn: joinidColumnInfo.type.source.column,
   };
 }
 
@@ -108,8 +109,8 @@ export function findMatchingAddColumnsNode(
   if (sourceNode.type === NodeType.kAddColumns) {
     const addColumnsNode = sourceNode as AddColumnsNode;
     if (
-      addColumnsNode.state.leftColumn === joinidColumnName &&
-      addColumnsNode.state.rightColumn === targetJoinColumn
+      addColumnsNode.attrs.leftColumn === joinidColumnName &&
+      addColumnsNode.attrs.rightColumn === targetJoinColumn
     ) {
       return addColumnsNode;
     }
@@ -122,8 +123,8 @@ export function findMatchingAddColumnsNode(
   ) {
     const existingAddColumnsNode = sourceNode.nextNodes[0] as AddColumnsNode;
     if (
-      existingAddColumnsNode.state.leftColumn === joinidColumnName &&
-      existingAddColumnsNode.state.rightColumn === targetJoinColumn
+      existingAddColumnsNode.attrs.leftColumn === joinidColumnName &&
+      existingAddColumnsNode.attrs.rightColumn === targetJoinColumn
     ) {
       return existingAddColumnsNode;
     }
@@ -145,7 +146,10 @@ export async function addFilter(
   if (sourceNode.type === NodeType.kFilter) {
     setFiltersOnNode(
       sourceNode,
-      [...(sourceNode.state.filters ?? []), ...filters] as UIFilter[],
+      [
+        ...((sourceNode as FilterNode).attrs.filters ?? []),
+        ...filters,
+      ] as UIFilter[],
       filterOperator,
     );
     deps.onStateUpdate((currentState) => ({...currentState}));
@@ -160,7 +164,10 @@ export async function addFilter(
     const existingFilterNode = sourceNode.nextNodes[0];
     setFiltersOnNode(
       existingFilterNode,
-      [...(existingFilterNode.state.filters ?? []), ...filters] as UIFilter[],
+      [
+        ...((existingFilterNode as FilterNode).attrs.filters ?? []),
+        ...filters,
+      ] as UIFilter[],
       filterOperator,
     );
     deps.onStateUpdate((currentState) => ({
@@ -172,11 +179,10 @@ export async function addFilter(
 
   // Otherwise, create a new FilterNode after the source node
   // Create it with filters already configured to avoid multiple undo points
-  const newFilterNode = new FilterNode({
-    filters,
-    filterOperator,
-    sqlModules: deps.sqlModules,
-  });
+  const newFilterNode = new FilterNode(
+    {filters, filterOperator},
+    {sqlModules: deps.sqlModules},
+  );
 
   // Mark as initialized
   deps.initializedNodes.add(newFilterNode.nodeId);
@@ -229,17 +235,17 @@ export function addColumnFromJoinid(
 
   if (existingNode !== undefined) {
     // Check if the column is already added
-    if (existingNode.state.selectedColumns?.includes(targetColumnName)) {
+    if (existingNode.attrs.selectedColumns?.includes(targetColumnName)) {
       console.warn(`Cannot add column: "${targetColumnName}" is already added`);
       return;
     }
 
     // Add the column to the existing AddColumnsNode
-    existingNode.state.selectedColumns = [
-      ...(existingNode.state.selectedColumns ?? []),
+    existingNode.attrs.selectedColumns = [
+      ...(existingNode.attrs.selectedColumns ?? []),
       targetColumnName,
     ];
-    existingNode.state.onchange?.();
+    existingNode.context.onchange?.();
     if (existingNode !== sourceNode) {
       deps.onStateUpdate((currentState) => ({
         ...currentState,
@@ -252,16 +258,17 @@ export function addColumnFromJoinid(
   // Create a new AddColumnsNode with the join configuration
   // Note: selectedColumns is set after connecting the table node because
   // onPrevNodesUpdated() resets selectedColumns when rightNode is not connected
-  const newAddColumnsNode = new AddColumnsNode({
-    leftColumn: joinidColumnName,
-    rightColumn: targetJoinColumn,
-    isGuidedConnection: true,
-    sqlModules: deps.sqlModules,
-    trace: deps.trace,
-  });
+  const newAddColumnsNode = new AddColumnsNode(
+    {
+      leftColumn: joinidColumnName,
+      rightColumn: targetJoinColumn,
+      isGuidedConnection: true,
+    },
+    {sqlModules: deps.sqlModules, trace: deps.trace},
+  );
 
   // Set actions now that the node is created
-  newAddColumnsNode.state.actions = createNodeActions(
+  newAddColumnsNode.context.actions = createNodeActions(
     newAddColumnsNode,
     deps.nodeActionHandlers,
   );
@@ -307,7 +314,7 @@ export function addColumnFromJoinid(
 
   // Now that rightNode is connected, set the selected column
   // (must be done after connection because onPrevNodesUpdated resets it otherwise)
-  newAddColumnsNode.state.selectedColumns = [targetColumnName];
+  newAddColumnsNode.attrs.selectedColumns = [targetColumnName];
 
   // Update state with both new nodes
   deps.onStateUpdate((currentState) => ({

--- a/ui/src/plugins/dev.perfetto.DataExplorer/datagrid_node_creation_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/datagrid_node_creation_unittest.ts
@@ -42,12 +42,9 @@ describe('datagrid_node_creation', () => {
     return {
       name,
       checked: true,
-      column: {
-        name,
-        type: {
-          kind: 'joinid',
-          source: {table: targetTable, column: targetColumn},
-        },
+      type: {
+        kind: 'joinid',
+        source: {table: targetTable, column: targetColumn},
       },
     };
   }
@@ -136,12 +133,13 @@ describe('datagrid_node_creation', () => {
     });
 
     it('should return the source node when it is an AddColumnsNode with matching join', () => {
-      const addColumnsNode = new AddColumnsNode({
-        leftColumn: 'track_id',
-        rightColumn: 'id',
-        sqlModules: mockSqlModules,
-        trace: mockTrace,
-      });
+      const addColumnsNode = new AddColumnsNode(
+        {
+          leftColumn: 'track_id',
+          rightColumn: 'id',
+        },
+        {sqlModules: mockSqlModules, trace: mockTrace},
+      );
 
       const result = findMatchingAddColumnsNode(
         addColumnsNode,
@@ -152,12 +150,13 @@ describe('datagrid_node_creation', () => {
     });
 
     it('should return undefined when source AddColumnsNode has different join columns', () => {
-      const addColumnsNode = new AddColumnsNode({
-        leftColumn: 'other_column',
-        rightColumn: 'pk',
-        sqlModules: mockSqlModules,
-        trace: mockTrace,
-      });
+      const addColumnsNode = new AddColumnsNode(
+        {
+          leftColumn: 'other_column',
+          rightColumn: 'pk',
+        },
+        {sqlModules: mockSqlModules, trace: mockTrace},
+      );
 
       const result = findMatchingAddColumnsNode(
         addColumnsNode,
@@ -169,12 +168,13 @@ describe('datagrid_node_creation', () => {
 
     it('should find matching AddColumnsNode in immediate child', () => {
       const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
-      const addColumnsChild = new AddColumnsNode({
-        leftColumn: 'track_id',
-        rightColumn: 'id',
-        sqlModules: mockSqlModules,
-        trace: mockTrace,
-      });
+      const addColumnsChild = new AddColumnsNode(
+        {
+          leftColumn: 'track_id',
+          rightColumn: 'id',
+        },
+        {sqlModules: mockSqlModules, trace: mockTrace},
+      );
 
       parent.nextNodes = [addColumnsChild as QueryNode];
 
@@ -184,12 +184,13 @@ describe('datagrid_node_creation', () => {
 
     it('should return undefined when child AddColumnsNode has different join', () => {
       const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
-      const addColumnsChild = new AddColumnsNode({
-        leftColumn: 'other',
-        rightColumn: 'pk',
-        sqlModules: mockSqlModules,
-        trace: mockTrace,
-      });
+      const addColumnsChild = new AddColumnsNode(
+        {
+          leftColumn: 'other',
+          rightColumn: 'pk',
+        },
+        {sqlModules: mockSqlModules, trace: mockTrace},
+      );
 
       parent.nextNodes = [addColumnsChild as QueryNode];
 
@@ -199,12 +200,13 @@ describe('datagrid_node_creation', () => {
 
     it('should not check children when parent has multiple children', () => {
       const parent = createMockNode({nodeId: 'parent', type: NodeType.kTable});
-      const child1 = new AddColumnsNode({
-        leftColumn: 'track_id',
-        rightColumn: 'id',
-        sqlModules: mockSqlModules,
-        trace: mockTrace,
-      });
+      const child1 = new AddColumnsNode(
+        {
+          leftColumn: 'track_id',
+          rightColumn: 'id',
+        },
+        {sqlModules: mockSqlModules, trace: mockTrace},
+      );
       const child2 = createMockNode({nodeId: 'c2', type: NodeType.kFilter});
 
       parent.nextNodes = [child1 as QueryNode, child2];
@@ -249,17 +251,17 @@ describe('datagrid_node_creation', () => {
     }
 
     it('should add filters to a FilterNode source directly', async () => {
-      const filterNode = new FilterNode({filters: []});
+      const filterNode = new FilterNode({filters: []}, {});
       const newFilter = createTestFilter('name', 'alice');
 
       await addFilter(deps, filterNode, newFilter);
 
-      expect(filterNode.state.filters).toHaveLength(1);
+      expect(filterNode.attrs.filters).toHaveLength(1);
       expect(stateUpdates).toHaveLength(1);
     });
 
     it('should add multiple filters at once to a FilterNode source', async () => {
-      const filterNode = new FilterNode({filters: []});
+      const filterNode = new FilterNode({filters: []}, {});
       const filters = [
         createTestFilter('name', 'alice'),
         createTestFilter('name', 'bob'),
@@ -267,27 +269,27 @@ describe('datagrid_node_creation', () => {
 
       await addFilter(deps, filterNode, filters);
 
-      expect(filterNode.state.filters).toHaveLength(2);
+      expect(filterNode.attrs.filters).toHaveLength(2);
     });
 
     it('should set filter operator on a FilterNode source', async () => {
-      const filterNode = new FilterNode({filters: []});
+      const filterNode = new FilterNode({filters: []}, {});
       const newFilter = createTestFilter('name', 'alice');
 
       await addFilter(deps, filterNode, newFilter, 'OR');
 
-      expect(filterNode.state.filterOperator).toBe('OR');
+      expect(filterNode.attrs.filterOperator).toBe('OR');
     });
 
     it('should add filters to child FilterNode when source has one', async () => {
       const source = createMockNode({nodeId: 'src', type: NodeType.kTable});
-      const existingFilter = new FilterNode({filters: []});
+      const existingFilter = new FilterNode({filters: []}, {});
       connectNodes(source, existingFilter as QueryNode);
 
       const newFilter = createTestFilter('name', 'alice');
       await addFilter(deps, source, newFilter);
 
-      expect(existingFilter.state.filters).toHaveLength(1);
+      expect(existingFilter.attrs.filters).toHaveLength(1);
       // Should select the existing filter node
       expect(stateUpdates).toHaveLength(1);
     });
@@ -312,7 +314,7 @@ describe('datagrid_node_creation', () => {
       await addFilter(deps, source, newFilter, 'OR');
 
       const createdFilter = source.nextNodes[0] as FilterNode;
-      expect(createdFilter.state.filterOperator).toBe('OR');
+      expect(createdFilter.attrs.filterOperator).toBe('OR');
     });
 
     it('should not create new FilterNode when source has non-filter child', async () => {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/graph_io.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/graph_io.ts
@@ -213,7 +213,7 @@ export async function createDataExplorerGraph(
 
   // Create slices source node (right side), only if slice data exists
   if (!isTableEffectivelyDisabled(sqlModules, 'slice')) {
-    const slicesNode = new SlicesSourceNode({sqlModules, trace});
+    const slicesNode = new SlicesSourceNode({}, {sqlModules, trace});
     rightNodes.push(slicesNode);
   }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/history_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/history_manager_unittest.ts
@@ -87,11 +87,10 @@ describe('HistoryManager', () => {
 
   test('should track node addition', () => {
     // Create a table node
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
     // Initial state with table node
     const state1: DataExplorerState = {
@@ -103,10 +102,10 @@ describe('HistoryManager', () => {
     historyManager.pushState(state1);
 
     // Add an aggregation node
-    const aggNode = new AggregationNode({
-      groupByColumns: [],
-      aggregations: [],
-    });
+    const aggNode = new AggregationNode(
+      {groupByColumns: [], aggregations: []},
+      {},
+    );
     addConnection(tableNode, aggNode);
 
     const state2: DataExplorerState = {
@@ -127,11 +126,10 @@ describe('HistoryManager', () => {
   });
 
   test('should ignore layout-only changes', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
     const state1: DataExplorerState = {
       rootNodes: [tableNode],
@@ -155,16 +153,18 @@ describe('HistoryManager', () => {
   });
 
   test('should ignore selectedNode changes', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const aggNode = new AggregationNode({
-      groupByColumns: [],
-      aggregations: [],
-    });
+    const aggNode = new AggregationNode(
+      {
+        groupByColumns: [],
+        aggregations: [],
+      },
+      {},
+    );
     addConnection(tableNode, aggNode);
 
     const state1: DataExplorerState = {
@@ -209,11 +209,10 @@ describe('HistoryManager', () => {
     };
     historyManager.pushState(state1);
 
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
     const state2: DataExplorerState = {
       rootNodes: [tableNode],
@@ -242,11 +241,10 @@ describe('HistoryManager', () => {
     };
     historyManager.pushState(state1);
 
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
     const state2: DataExplorerState = {
       rootNodes: [tableNode],
@@ -280,11 +278,7 @@ describe('HistoryManager', () => {
       // Create i nodes to make each state unique
       for (let j = 0; j <= i; j++) {
         nodes.push(
-          new TableSourceNode({
-            trace,
-            sqlModules,
-            sqlTable: sqlModules.getTable('test_table')!,
-          }),
+          new TableSourceNode({sqlTable: 'test_table'}, {trace, sqlModules}),
         );
       }
       const state: DataExplorerState = {
@@ -311,16 +305,18 @@ describe('HistoryManager', () => {
   // ========================================
 
   test('should track connection removal', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const aggNode = new AggregationNode({
-      groupByColumns: [],
-      aggregations: [],
-    });
+    const aggNode = new AggregationNode(
+      {
+        groupByColumns: [],
+        aggregations: [],
+      },
+      {},
+    );
 
     // State 1: Table node connected to aggregation node
     addConnection(tableNode, aggNode);
@@ -357,21 +353,26 @@ describe('HistoryManager', () => {
   });
 
   test('should track multiple connection changes', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const aggNode1 = new AggregationNode({
-      groupByColumns: [],
-      aggregations: [],
-    });
+    const aggNode1 = new AggregationNode(
+      {
+        groupByColumns: [],
+        aggregations: [],
+      },
+      {},
+    );
 
-    const aggNode2 = new AggregationNode({
-      groupByColumns: [],
-      aggregations: [],
-    });
+    const aggNode2 = new AggregationNode(
+      {
+        groupByColumns: [],
+        aggregations: [],
+      },
+      {},
+    );
 
     // State 1: No connections
     const state1: DataExplorerState = {
@@ -421,15 +422,17 @@ describe('HistoryManager', () => {
   // ========================================
 
   test('should track filter additions to FilterNode', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     // State 1: Filter node with no filters
@@ -447,7 +450,7 @@ describe('HistoryManager', () => {
       op: '=',
       value: '123',
     };
-    filterNode.state.filters = [filter1];
+    filterNode.attrs.filters = [filter1];
     const state2: DataExplorerState = {
       rootNodes: [tableNode],
       selectedNodes: new Set(),
@@ -463,15 +466,15 @@ describe('HistoryManager', () => {
     expect(undoneState).not.toBeNull();
     const restoredFilterNode = undoneState!.rootNodes[0]
       .nextNodes[0] as FilterNode;
-    expect(restoredFilterNode.state.filters?.length ?? 0).toBe(0);
+    expect(restoredFilterNode.attrs.filters?.length ?? 0).toBe(0);
 
     // Redo: filter should be back
     const redoneState = historyManager.redo();
     expect(redoneState).not.toBeNull();
     const redoneFilterNode = redoneState!.rootNodes[0]
       .nextNodes[0] as FilterNode;
-    expect(redoneFilterNode.state.filters?.length ?? 0).toBe(1);
-    const redoneFilter = redoneFilterNode.state.filters?.[0];
+    expect(redoneFilterNode.attrs.filters?.length ?? 0).toBe(1);
+    const redoneFilter = redoneFilterNode.attrs.filters?.[0];
     if (redoneFilter && 'value' in redoneFilter) {
       // Numeric strings are converted to numbers during deserialization
       expect(redoneFilter.value).toBe(123);
@@ -479,15 +482,17 @@ describe('HistoryManager', () => {
   });
 
   test('should track multiple filter additions', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     // State 1: No filters
@@ -505,7 +510,7 @@ describe('HistoryManager', () => {
       op: '=',
       value: '123',
     };
-    filterNode.state.filters = [filter1];
+    filterNode.attrs.filters = [filter1];
     const state2: DataExplorerState = {
       rootNodes: [tableNode],
       selectedNodes: new Set(),
@@ -520,7 +525,7 @@ describe('HistoryManager', () => {
       op: '=',
       value: 'test',
     };
-    filterNode.state.filters = [filter1, filter2];
+    filterNode.attrs.filters = [filter1, filter2];
     const state3: DataExplorerState = {
       rootNodes: [tableNode],
       selectedNodes: new Set(),
@@ -530,14 +535,14 @@ describe('HistoryManager', () => {
     historyManager.pushState(state3);
 
     // Should have 2 filters
-    expect(filterNode.state.filters?.length).toBe(2);
+    expect(filterNode.attrs.filters?.length).toBe(2);
 
     // Undo once: should have 1 filter
     const undoneState1 = historyManager.undo();
     expect(undoneState1).not.toBeNull();
     const filterNode1 = undoneState1!.rootNodes[0].nextNodes[0] as FilterNode;
-    expect(filterNode1.state.filters?.length ?? 0).toBe(1);
-    const undoneFilter1 = filterNode1.state.filters?.[0];
+    expect(filterNode1.attrs.filters?.length ?? 0).toBe(1);
+    const undoneFilter1 = filterNode1.attrs.filters?.[0];
     if (undoneFilter1 && 'value' in undoneFilter1) {
       // Numeric strings are converted to numbers during deserialization
       expect(undoneFilter1.value).toBe(123);
@@ -547,27 +552,29 @@ describe('HistoryManager', () => {
     const undoneState2 = historyManager.undo();
     expect(undoneState2).not.toBeNull();
     const filterNode2 = undoneState2!.rootNodes[0].nextNodes[0] as FilterNode;
-    expect(filterNode2.state.filters?.length ?? 0).toBe(0);
+    expect(filterNode2.attrs.filters?.length ?? 0).toBe(0);
 
     // Redo twice: should have 2 filters back
     historyManager.redo();
     const redoneState = historyManager.redo();
     expect(redoneState).not.toBeNull();
     const filterNode3 = redoneState!.rootNodes[0].nextNodes[0] as FilterNode;
-    expect(filterNode3.state.filters?.length ?? 0).toBe(2);
+    expect(filterNode3.attrs.filters?.length ?? 0).toBe(2);
   });
 
   test('should track aggregation node property changes', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const aggNode = new AggregationNode({
-      groupByColumns: [],
-      aggregations: [],
-    });
+    const aggNode = new AggregationNode(
+      {
+        groupByColumns: [],
+        aggregations: [],
+      },
+      {},
+    );
     addConnection(tableNode, aggNode);
 
     // After addConnection, onPrevNodesUpdated populates columns from input (all unchecked)
@@ -581,7 +588,7 @@ describe('HistoryManager', () => {
     historyManager.pushState(state1);
 
     // State 2: Check the 'id' column for grouping
-    aggNode.state.groupByColumns = aggNode.state.groupByColumns.map((c) => ({
+    aggNode.attrs.groupByColumns = aggNode.attrs.groupByColumns.map((c) => ({
       ...c,
       checked: c.name === 'id',
     }));
@@ -600,7 +607,7 @@ describe('HistoryManager', () => {
     expect(undoneState).not.toBeNull();
     const restoredAggNode = undoneState!.rootNodes[0]
       .nextNodes[0] as AggregationNode;
-    const uncheckedCols = restoredAggNode.state.groupByColumns?.filter(
+    const uncheckedCols = restoredAggNode.attrs.groupByColumns?.filter(
       (c) => c.checked,
     );
     expect(uncheckedCols?.length ?? 0).toBe(0);
@@ -610,7 +617,7 @@ describe('HistoryManager', () => {
     expect(redoneState).not.toBeNull();
     const redoneAggNode = redoneState!.rootNodes[0]
       .nextNodes[0] as AggregationNode;
-    const checkedCols = redoneAggNode.state.groupByColumns?.filter(
+    const checkedCols = redoneAggNode.attrs.groupByColumns?.filter(
       (c) => c.checked,
     );
     expect(checkedCols?.length ?? 0).toBe(1);
@@ -622,17 +629,15 @@ describe('HistoryManager', () => {
   // ========================================
 
   test('should track node deletion from root', () => {
-    const tableNode1 = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
     // State 1: Two root nodes
     const state1: DataExplorerState = {
@@ -666,16 +671,18 @@ describe('HistoryManager', () => {
   });
 
   test('should track deletion of connected node', () => {
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
-    const aggNode = new AggregationNode({
-      groupByColumns: [],
-      aggregations: [],
-    });
+    const aggNode = new AggregationNode(
+      {
+        groupByColumns: [],
+        aggregations: [],
+      },
+      {},
+    );
     addConnection(tableNode, aggNode);
 
     // State 1: Table with aggregation
@@ -715,11 +722,10 @@ describe('HistoryManager', () => {
 
   test('should handle complex multi-step operation', () => {
     // This test simulates: add table -> add filter -> modify filter -> add aggregation
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
     // State 1: Just table
     const state1: DataExplorerState = {
@@ -731,9 +737,12 @@ describe('HistoryManager', () => {
     historyManager.pushState(state1);
 
     // State 2: Add filter node
-    const filterNode = new FilterNode({
-      filters: [],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
     const state2: DataExplorerState = {
       rootNodes: [tableNode],
@@ -749,7 +758,7 @@ describe('HistoryManager', () => {
       op: '=',
       value: '123',
     };
-    filterNode.state.filters = [filter];
+    filterNode.attrs.filters = [filter];
     const state3: DataExplorerState = {
       rootNodes: [tableNode],
       selectedNodes: new Set(),
@@ -762,12 +771,15 @@ describe('HistoryManager', () => {
     const groupByColumn: ColumnInfo = {
       name: 'id',
       checked: true,
-      column: {name: 'id', type: {kind: 'string'}},
+      type: {kind: 'string'},
     };
-    const aggNode = new AggregationNode({
-      groupByColumns: [groupByColumn],
-      aggregations: [],
-    });
+    const aggNode = new AggregationNode(
+      {
+        groupByColumns: [groupByColumn],
+        aggregations: [],
+      },
+      {},
+    );
     addConnection(filterNode, aggNode);
     const state4: DataExplorerState = {
       rootNodes: [tableNode],
@@ -788,13 +800,13 @@ describe('HistoryManager', () => {
     expect(state3Restored).not.toBeNull();
     const filterNode3 = state3Restored!.rootNodes[0].nextNodes[0] as FilterNode;
     expect(filterNode3.nextNodes.length).toBe(0);
-    expect(filterNode3.state.filters?.length).toBe(1);
+    expect(filterNode3.attrs.filters?.length).toBe(1);
 
     // Undo to state 2: filter should be empty
     const state2Restored = historyManager.undo();
     expect(state2Restored).not.toBeNull();
     const filterNode2 = state2Restored!.rootNodes[0].nextNodes[0] as FilterNode;
-    expect(filterNode2.state.filters?.length ?? 0).toBe(0);
+    expect(filterNode2.attrs.filters?.length ?? 0).toBe(0);
 
     // Undo to state 1: no filter node
     const state1Restored = historyManager.undo();
@@ -816,11 +828,10 @@ describe('HistoryManager', () => {
   test('should create single undo point when operation is atomic', () => {
     // This test shows the CORRECT pattern: multiple mutations with single state update
 
-    const tableNode = new TableSourceNode({
-      trace,
-      sqlModules,
-      sqlTable: sqlModules.getTable('test_table')!,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'test_table'},
+      {trace, sqlModules},
+    );
 
     // State 1: Just table
     const state1: DataExplorerState = {
@@ -832,9 +843,12 @@ describe('HistoryManager', () => {
     historyManager.pushState(state1);
 
     // Perform multiple mutations THEN single state update (correct pattern)
-    const filterNode = new FilterNode({
-      filters: [],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     const filter: UIFilter = {
@@ -842,7 +856,7 @@ describe('HistoryManager', () => {
       op: '=',
       value: '123',
     };
-    filterNode.state.filters = [filter];
+    filterNode.attrs.filters = [filter];
 
     // Single state update captures all mutations
     const state2: DataExplorerState = {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/index.ts
@@ -27,7 +27,6 @@ import {
   DataExplorerTab,
 } from './data_explorer';
 import {nodeRegistry} from './query_builder/node_registry';
-import {QueryNodeState} from './query_node';
 import {deserializeState, serializeState} from './json_handler';
 import {recentGraphsStorage} from './recent_graphs';
 import {getAllNodes} from './query_builder/graph_utils';
@@ -337,7 +336,7 @@ export default class implements PerfettoPlugin {
       // was empty at that point because it's only known from the tab.
       for (const node of getAllNodes(state.rootNodes)) {
         if (isDashboardNode(node)) {
-          node.state.graphId = tabData.id;
+          node.graphId = tabData.id;
           node.onPrevNodesUpdated?.();
         }
       }
@@ -568,11 +567,10 @@ export default class implements PerfettoPlugin {
         }
 
         // Create the TimeRange node with captured values
-        const newNode = descriptor.factory({
-          trace,
-          start,
-          end,
-        } as unknown as QueryNodeState);
+        const newNode = descriptor.factory(
+          {start, end},
+          {allNodes: [], context: {trace}},
+        );
 
         // Ensure we have an active tab
         this.ensureAtLeastOneTab();

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
@@ -32,6 +32,7 @@ export interface SerializedNode {
   // node state, or node-specific fields like leftNodeId, intervalNodes, etc.).
   primaryInputId?: string;
   secondaryInputIds?: {[port: string]: string};
+  innerNodeIds?: string[];
 
   // Deprecated: kept for backward compatibility with old saved graphs.
   inputNodeIds?: string[];
@@ -54,14 +55,10 @@ export interface SerializedGraph {
 }
 
 function serializeNode(node: QueryNode): SerializedNode {
-  if (typeof node.serializeState !== 'function') {
-    throw new Error(`Node type ${node.type} is not serializable.`);
-  }
-
   const serialized: SerializedNode = {
     nodeId: node.nodeId,
     type: node.type,
-    state: node.serializeState(),
+    state: node.attrs,
     nextNodes: node.nextNodes.map((n: QueryNode) => n.nodeId),
   };
 
@@ -74,6 +71,9 @@ function serializeNode(node: QueryNode): SerializedNode {
     for (const [port, inputNode] of node.secondaryInputs.connections) {
       serialized.secondaryInputIds[port.toString()] = inputNode.nodeId;
     }
+  }
+  if (node.innerNodes !== undefined) {
+    serialized.innerNodeIds = node.innerNodes.map((n) => n.nodeId);
   }
 
   return serialized;
@@ -331,7 +331,12 @@ export function deserializeState(
 
     // Custom connection restoration (e.g. GroupNode rebuilding inner nodes).
     const descriptor = nodeRegistry.getByNodeType(serializedNode.type);
-    descriptor?.deserializeConnections?.(node, serializedNode.state, nodes);
+    descriptor?.deserializeConnections?.(
+      node,
+      serializedNode.state,
+      nodes,
+      serializedNode.innerNodeIds,
+    );
   }
 
   // Fourth pass: post-deserialization (resolve internal references, then

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
@@ -96,7 +96,7 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes a simple graph', () => {
-    const sliceNode = new SlicesSourceNode({});
+    const sliceNode = new SlicesSourceNode({}, {});
     const initialState: DataExplorerState = {
       rootNodes: [sliceNode],
       selectedNodes: new Set(),
@@ -113,14 +113,11 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('handles multiple nodes and connections', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const modifyNode = new ModifyColumnsNode({
-      selectedColumns: [],
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
     addConnection(tableNode, modifyNode);
 
     const initialState: DataExplorerState = {
@@ -152,33 +149,33 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes aggregation node', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
     const sliceTable = sqlModules.getTable('slice')!;
-    const aggregationNode = new AggregationNode({
-      groupByColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-      aggregations: [
-        {
-          column: {
-            name: 'dur',
+    const aggregationNode = new AggregationNode(
+      {
+        groupByColumns: [
+          {
+            name: 'name',
             checked: true,
-            column: sliceTable.columns[2],
+            type: sliceTable.columns[0].type,
           },
-          aggregationOp: 'SUM',
-          newColumnName: 'total_dur',
-        },
-      ],
-    });
+        ],
+        aggregations: [
+          {
+            column: {
+              name: 'dur',
+              type: sliceTable.columns[2].type,
+            },
+            aggregationOp: 'SUM',
+            newColumnName: 'total_dur',
+          },
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, aggregationNode);
 
     const initialState: DataExplorerState = {
@@ -199,22 +196,19 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedAggregationNode.primaryInput?.nodeId).toBe(
       deserializedTableNode.nodeId,
     );
-    expect(deserializedAggregationNode.state.groupByColumns[0].name).toBe(
+    expect(deserializedAggregationNode.attrs.groupByColumns[0].name).toBe(
       'name',
     );
     expect(
-      deserializedAggregationNode.state.aggregations[0].aggregationOp,
+      deserializedAggregationNode.attrs.aggregations[0].aggregationOp,
     ).toBe('SUM');
-    expect(deserializedAggregationNode.state.aggregations[0].column?.name).toBe(
+    expect(deserializedAggregationNode.attrs.aggregations[0].column?.name).toBe(
       'dur',
     );
   });
 
   test('serializes and deserializes sql source node', () => {
-    const sqlNode = new SqlSourceNode({
-      sql: 'SELECT * FROM slice',
-      trace,
-    });
+    const sqlNode = new SqlSourceNode({sql: 'SELECT * FROM slice'}, {trace});
     const initialState: DataExplorerState = {
       rootNodes: [sqlNode],
       selectedNodes: new Set(),
@@ -227,26 +221,24 @@ describe('JSON serialization/deserialization', () => {
 
     expect(deserializedState.rootNodes.length).toBe(1);
     const deserializedNode = deserializedState.rootNodes[0] as SqlSourceNode;
-    expect(deserializedNode.state.sql).toBe('SELECT * FROM slice');
+    expect(deserializedNode.attrs.sql).toBe('SELECT * FROM slice');
   });
 
   test('serializes and deserializes sql source node with input connections', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('thread'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'thread'},
+      {trace, sqlModules},
+    );
 
-    const sqlNode = new SqlSourceNode({
-      sql: 'SELECT * FROM $input_0 JOIN $input_1',
-      trace,
-    });
+    const sqlNode = new SqlSourceNode(
+      {sql: 'SELECT * FROM $input_0 JOIN $input_1'},
+      {trace},
+    );
 
     // Connect inputs
     tableNode1.nextNodes.push(sqlNode);
@@ -271,7 +263,7 @@ describe('JSON serialization/deserialization', () => {
     const deserializedSqlNode = deserializedTableNode1
       .nextNodes[0] as SqlSourceNode;
 
-    expect(deserializedSqlNode.state.sql).toBe(
+    expect(deserializedSqlNode.attrs.sql).toBe(
       'SELECT * FROM $input_0 JOIN $input_1',
     );
     expect(deserializedSqlNode.secondaryInputs.connections.size).toBe(2);
@@ -287,21 +279,22 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes interval intersect node', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const intervalIntersectNode = new IntervalIntersectNode({
-      inputNodes: [tableNode1, tableNode2],
-    });
+    const intervalIntersectNode = new IntervalIntersectNode(
+      {
+        inputNodes: [tableNode1, tableNode2],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(intervalIntersectNode);
     tableNode2.nextNodes.push(intervalIntersectNode);
 
@@ -338,28 +331,28 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes interval intersect node with partition columns and filters', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode3 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode3 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const intervalIntersectNode = new IntervalIntersectNode({
-      inputNodes: [tableNode1, tableNode2, tableNode3],
-      partitionColumns: ['name'],
-    });
+    const intervalIntersectNode = new IntervalIntersectNode(
+      {
+        inputNodes: [tableNode1, tableNode2, tableNode3],
+        partitionColumns: ['name'],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(intervalIntersectNode);
     tableNode2.nextNodes.push(intervalIntersectNode);
     tableNode3.nextNodes.push(intervalIntersectNode);
@@ -404,26 +397,26 @@ describe('JSON serialization/deserialization', () => {
 
     // Verify partition columns
     expect(
-      deserializedIntervalIntersectNode.state.partitionColumns,
+      (deserializedIntervalIntersectNode as IntervalIntersectNode).attrs
+        .partitionColumns,
     ).toBeDefined();
     expect(
-      deserializedIntervalIntersectNode.state.partitionColumns?.length,
+      (deserializedIntervalIntersectNode as IntervalIntersectNode).attrs
+        .partitionColumns?.length,
     ).toBe(1);
-    expect(deserializedIntervalIntersectNode.state.partitionColumns?.[0]).toBe(
-      'name',
-    );
+    expect(
+      (deserializedIntervalIntersectNode as IntervalIntersectNode).attrs
+        .partitionColumns?.[0],
+    ).toBe('name');
   });
 
   test('serializes and deserializes sql source node with reference', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const modifyNode = new ModifyColumnsNode({
-      selectedColumns: [],
-    });
+    const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
     addConnection(tableNode, modifyNode);
 
     const initialState: DataExplorerState = {
@@ -447,21 +440,23 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes node with string filters', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'name',
-          op: '=',
-          value: 'test',
-        },
-      ],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'name',
+            op: '=',
+            value: 'test',
+          },
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -479,8 +474,8 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedFilterNode = deserializedTableNode
       .nextNodes[0] as FilterNode;
-    expect(deserializedFilterNode.state.filters?.length).toBe(1);
-    const filter = deserializedFilterNode.state.filters?.[0];
+    expect(deserializedFilterNode.attrs.filters?.length).toBe(1);
+    const filter = deserializedFilterNode.attrs.filters?.[0];
     expect(filter?.column).toBe('name');
     expect(filter?.op).toBe('=');
     if (filter !== undefined && 'value' in filter) {
@@ -491,21 +486,23 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes node with numeric filters', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'dur',
-          op: '>',
-          value: 1000,
-        },
-      ],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'dur',
+            op: '>',
+            value: 1000,
+          },
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -523,8 +520,8 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedFilterNode = deserializedTableNode
       .nextNodes[0] as FilterNode;
-    expect(deserializedFilterNode.state.filters?.length).toBe(1);
-    const filter = deserializedFilterNode.state.filters?.[0];
+    expect(deserializedFilterNode.attrs.filters?.length).toBe(1);
+    const filter = deserializedFilterNode.attrs.filters?.[0];
     expect(filter?.column).toBe('dur');
     expect(filter?.op).toBe('>');
     if (filter !== undefined && 'value' in filter) {
@@ -537,13 +534,12 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes node layouts', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const sliceNode = new SlicesSourceNode({});
+    const sliceNode = new SlicesSourceNode({}, {});
 
     const initialState: DataExplorerState = {
       rootNodes: [tableNode, sliceNode],
@@ -574,21 +570,23 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes node with BigInt filter', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'id',
-          op: '=',
-          value: 12345678901234567890n,
-        },
-      ],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'id',
+            op: '=',
+            value: 12345678901234567890n,
+          },
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -606,8 +604,8 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedFilterNode = deserializedTableNode
       .nextNodes[0] as FilterNode;
-    expect(deserializedFilterNode.state.filters?.length).toBe(1);
-    const filter = deserializedFilterNode.state.filters?.[0];
+    expect(deserializedFilterNode.attrs.filters?.length).toBe(1);
+    const filter = deserializedFilterNode.attrs.filters?.[0];
     expect(filter?.column).toBe('id');
     expect(filter?.op).toBe('=');
     if (filter !== undefined && 'value' in filter) {
@@ -641,14 +639,11 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('deserializes graph with primaryInput connections', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const modifyNode = new ModifyColumnsNode({
-      selectedColumns: [],
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
     addConnection(tableNode, modifyNode);
 
     const initialState: DataExplorerState = {
@@ -675,26 +670,26 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes modify columns node', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const modifyColumnsNode = new ModifyColumnsNode({
-      selectedColumns: [],
-    });
+    const modifyColumnsNode = new ModifyColumnsNode({selectedColumns: []}, {});
     addConnection(tableNode, modifyColumnsNode);
 
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'new_col',
-          op: '=',
-          value: '1',
-        },
-      ],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'new_col',
+            op: '=',
+            value: '1',
+          },
+        ],
+      },
+      {},
+    );
     addConnection(modifyColumnsNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -715,21 +710,23 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedModifyNode.nextNodes.length).toBe(1);
     const deserializedFilterNode = deserializedModifyNode
       .nextNodes[0] as FilterNode;
-    expect(deserializedFilterNode.state.filters).toBeDefined();
-    expect(deserializedFilterNode.state.filters?.length).toBe(1);
-    expect(deserializedFilterNode.state.filters?.[0].column).toBe('new_col');
+    expect(deserializedFilterNode.attrs.filters).toBeDefined();
+    expect(deserializedFilterNode.attrs.filters?.length).toBe(1);
+    expect(deserializedFilterNode.attrs.filters?.[0].column).toBe('new_col');
   });
 
   test('serializes and deserializes add columns node', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const addColumnsNode = new AddColumnsNode({
-      selectedColumns: ['name'],
-    });
+    const addColumnsNode = new AddColumnsNode(
+      {
+        selectedColumns: ['name'],
+      },
+      {},
+    );
     // Manually connect without triggering onPrevNodesUpdated to preserve
     // the test's explicitly provided selectedColumns
     tableNode.nextNodes.push(addColumnsNode);
@@ -750,34 +747,35 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedNode = deserializedTableNode
       .nextNodes[0] as AddColumnsNode;
-    expect(deserializedNode.state.selectedColumns).toEqual(['name']);
+    expect(deserializedNode.attrs.selectedColumns).toEqual(['name']);
     // Note: sqlTable is no longer part of AddColumnsNodeState
   });
 
   test('serializes and deserializes add columns node with inputNodes connection', () => {
     // Create the main data flow: tableNode1 -> addColumnsNode
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const addColumnsNode = new AddColumnsNode({
-      selectedColumns: ['name', 'ts'],
-      leftColumn: 'id',
-      rightColumn: 'id',
-    });
+    const addColumnsNode = new AddColumnsNode(
+      {
+        selectedColumns: ['name', 'ts'],
+        leftColumn: 'id',
+        rightColumn: 'id',
+      },
+      {},
+    );
     // Manually connect without triggering onPrevNodesUpdated to preserve
     // the test's explicitly provided selectedColumns
     tableNode1.nextNodes.push(addColumnsNode);
     addColumnsNode.primaryInput = tableNode1;
 
     // Create the side input: tableNode2 connected to inputNodes[0]
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
     // Connect tableNode2 to addColumnsNode's secondaryInputs port 0 (left-side port)
     addColumnsNode.secondaryInputs.connections.set(0, tableNode2);
@@ -828,12 +826,12 @@ describe('JSON serialization/deserialization', () => {
     );
 
     // Verify node state
-    expect(deserializedAddColumnsNode.state.selectedColumns).toEqual([
+    expect(deserializedAddColumnsNode.attrs.selectedColumns).toEqual([
       'name',
       'ts',
     ]);
-    expect(deserializedAddColumnsNode.state.leftColumn).toBe('id');
-    expect(deserializedAddColumnsNode.state.rightColumn).toBe('id');
+    expect(deserializedAddColumnsNode.attrs.leftColumn).toBe('id');
+    expect(deserializedAddColumnsNode.attrs.rightColumn).toBe('id');
 
     // Verify layouts are preserved (after normalization)
     // Original: tableNode1 (0, 0), addColumnsNode (0, 100), tableNode2 (-200, 100)
@@ -852,11 +850,10 @@ describe('JSON serialization/deserialization', () => {
 
   test('add columns node uses renamed columns from modify columns node', () => {
     // Create table source
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
     // Get all columns from the table to find one to rename
     const allColumns = tableNode1.finalCols;
@@ -873,22 +870,25 @@ describe('JSON serialization/deserialization', () => {
       ...allColumns.slice(1, 3).map((col) => ({...col, checked: true})),
     ];
 
-    const modifyColumnsNode = new ModifyColumnsNode({
-      selectedColumns: selectedColumnsWithAlias,
-    });
+    const modifyColumnsNode = new ModifyColumnsNode(
+      {selectedColumns: selectedColumnsWithAlias},
+      {},
+    );
     addConnection(tableNode1, modifyColumnsNode);
 
     // Create another table to join with
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
     // Create add columns node that should see the renamed column 'duration_ns'
-    const addColumnsNode = new AddColumnsNode({
-      selectedColumns: [],
-    });
+    const addColumnsNode = new AddColumnsNode(
+      {
+        selectedColumns: [],
+      },
+      {},
+    );
     addConnection(tableNode2, addColumnsNode);
 
     // Connect modifyColumnsNode to addColumnsNode's secondaryInputs port 0
@@ -897,20 +897,18 @@ describe('JSON serialization/deserialization', () => {
 
     // Check that addColumnsNode can see the renamed column
     const rightCols = addColumnsNode.rightCols;
-    const colNames = rightCols.map((c: ColumnInfo) => c.column.name);
+    const colNames = rightCols.map((c: ColumnInfo) => c.name);
 
     // Should see the renamed column
     expect(colNames).toContain('renamed_column');
     // Should NOT see the original column name
-    expect(colNames).not.toContain(columnToRename.column.name);
+    expect(colNames).not.toContain(columnToRename.name);
 
     // Verify the type is preserved for the renamed column
-    const renamedCol = rightCols.find(
-      (c) => c.column.name === 'renamed_column',
-    );
+    const renamedCol = rightCols.find((c) => c.name === 'renamed_column');
     expect(renamedCol).toBeDefined();
-    expect(renamedCol?.column.type).toBe(columnToRename.column.type);
-    expect(renamedCol?.column.type).toBeDefined(); // Type should be preserved, not undefined
+    expect(renamedCol?.type).toBe(columnToRename.type);
+    expect(renamedCol?.type).toBeDefined(); // Type should be preserved, not undefined
 
     // Now test serialization/deserialization preserves this
     const initialState: DataExplorerState = {
@@ -946,41 +944,39 @@ describe('JSON serialization/deserialization', () => {
 
     // Most importantly: verify that renamed columns are still accessible
     const deserializedRightCols = deserializedAddColumnsNode.rightCols;
-    const deserializedColNames = deserializedRightCols.map(
-      (c) => c.column.name,
-    );
+    const deserializedColNames = deserializedRightCols.map((c) => c.name);
 
     expect(deserializedColNames).toContain('renamed_column');
-    expect(deserializedColNames).not.toContain(columnToRename.column.name);
+    expect(deserializedColNames).not.toContain(columnToRename.name);
 
     // Verify the type is preserved after serialization/deserialization
     const deserializedRenamedCol = deserializedRightCols.find(
-      (c) => c.column.name === 'renamed_column',
+      (c) => c.name === 'renamed_column',
     );
     expect(deserializedRenamedCol).toBeDefined();
-    expect(deserializedRenamedCol?.column.type).toEqual(
-      columnToRename.column.type,
-    );
-    expect(deserializedRenamedCol?.column.type).toBeDefined(); // Type should still be preserved
+    expect(deserializedRenamedCol?.type).toEqual(columnToRename.type);
+    expect(deserializedRenamedCol?.type).toBeDefined(); // Type should still be preserved
   });
 
   test('aggregation node can group by aliased column from modify columns node', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
     // Create a ModifyColumnsNode that aliases a column
-    const modifyNode = new ModifyColumnsNode({
-      selectedColumns: tableNode.finalCols.map((col) => {
-        // Alias the 'ts' column to 'timestamp_alias'
-        if (col.name === 'ts') {
-          return {...col, alias: 'timestamp_alias'};
-        }
-        return col;
-      }),
-    });
+    const modifyNode = new ModifyColumnsNode(
+      {
+        selectedColumns: tableNode.finalCols.map((col) => {
+          // Alias the 'ts' column to 'timestamp_alias'
+          if (col.name === 'ts') {
+            return {...col, alias: 'timestamp_alias'};
+          }
+          return col;
+        }),
+      },
+      {},
+    );
     // Manually connect without triggering onPrevNodesUpdated to preserve
     // the test's explicitly provided selectedColumns
     tableNode.nextNodes.push(modifyNode);
@@ -993,24 +989,24 @@ describe('JSON serialization/deserialization', () => {
     );
     expect(tsColumn).toBeUndefined(); // Original name should not be visible
     expect(aliasedColumn).toBeDefined(); // Aliased name should be visible
-    expect(aliasedColumn?.column.name).toBe('timestamp_alias'); // column.name should also use alias
+    expect(aliasedColumn?.name).toBe('timestamp_alias'); // column.name should also use alias
 
     // Create an AggregationNode that groups by the aliased column
-    const aggregationNode = new AggregationNode({
-      groupByColumns: [aliasedColumn!],
-      aggregations: [],
-    });
+    const aggregationNode = new AggregationNode(
+      {groupByColumns: [aliasedColumn!], aggregations: []},
+      {},
+    );
     // Manually connect without triggering onPrevNodesUpdated to preserve
     // the test's explicitly provided groupByColumns
     modifyNode.nextNodes.push(aggregationNode);
     aggregationNode.primaryInput = modifyNode;
 
     // Verify the aggregation node sees the aliased column
-    expect(aggregationNode.state.groupByColumns.length).toBe(1);
-    expect(aggregationNode.state.groupByColumns[0].name).toBe(
+    expect(aggregationNode.attrs.groupByColumns.length).toBe(1);
+    expect(aggregationNode.attrs.groupByColumns[0].name).toBe(
       'timestamp_alias',
     );
-    expect(aggregationNode.state.groupByColumns[0].column.name).toBe(
+    expect(aggregationNode.attrs.groupByColumns[0].name).toBe(
       'timestamp_alias',
     );
 
@@ -1045,7 +1041,7 @@ describe('JSON serialization/deserialization', () => {
     );
     expect(deserializedTsColumn).toBeUndefined(); // Original name should not be visible
     expect(deserializedAliasedColumn).toBeDefined(); // Aliased name should be visible
-    expect(deserializedAliasedColumn?.column.name).toBe('timestamp_alias');
+    expect(deserializedAliasedColumn?.name).toBe('timestamp_alias');
 
     // Verify the aggregation node still sees the aliased column
     expect(deserializedModifyNode?.nextNodes.length).toBe(1);
@@ -1054,26 +1050,28 @@ describe('JSON serialization/deserialization', () => {
       | undefined;
     expect(deserializedAggNode).toBeDefined();
     expect(deserializedAggNode?.type).toBe(NodeType.kAggregation);
-    expect(deserializedAggNode?.state.groupByColumns.length).toBe(1);
-    expect(deserializedAggNode?.state.groupByColumns[0].name).toBe(
+    expect(deserializedAggNode?.attrs.groupByColumns.length).toBe(1);
+    expect(deserializedAggNode?.attrs.groupByColumns[0].name).toBe(
       'timestamp_alias',
     );
-    expect(deserializedAggNode?.state.groupByColumns[0].column.name).toBe(
+    expect(deserializedAggNode?.attrs.groupByColumns[0].name).toBe(
       'timestamp_alias',
     );
   });
 
   test('serializes and deserializes limit and offset node', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const limitAndOffsetNode = new LimitAndOffsetNode({
-      limit: 100,
-      offset: 20,
-    });
+    const limitAndOffsetNode = new LimitAndOffsetNode(
+      {
+        limit: 100,
+        offset: 20,
+      },
+      {},
+    );
     addConnection(tableNode, limitAndOffsetNode);
 
     const initialState: DataExplorerState = {
@@ -1091,23 +1089,25 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedNode = deserializedTableNode
       .nextNodes[0] as LimitAndOffsetNode;
-    expect(deserializedNode.state.limit).toEqual(100);
-    expect(deserializedNode.state.offset).toEqual(20);
+    expect(deserializedNode.attrs.limit).toEqual(100);
+    expect(deserializedNode.attrs.offset).toEqual(20);
   });
 
   test('serializes and deserializes sort node', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const sortNode = new SortNode({
-      sortCriteria: [
-        {colName: 'name', direction: 'ASC'},
-        {colName: 'ts', direction: 'DESC'},
-      ],
-    });
+    const sortNode = new SortNode(
+      {
+        sortCriteria: [
+          {colName: 'name', direction: 'ASC'},
+          {colName: 'ts', direction: 'DESC'},
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, sortNode);
 
     const initialState: DataExplorerState = {
@@ -1124,34 +1124,36 @@ describe('JSON serialization/deserialization', () => {
     const deserializedTableNode = deserializedState.rootNodes[0];
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedNode = deserializedTableNode.nextNodes[0] as SortNode;
-    expect(deserializedNode.state.sortCriteria).toEqual([
+    expect(deserializedNode.attrs.sortCriteria).toEqual([
       {colName: 'name', direction: 'ASC'},
       {colName: 'ts', direction: 'DESC'},
     ]);
   });
 
   test('serializes and deserializes filter node', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'name',
-          op: '=',
-          value: 'test',
-        },
-        {
-          column: 'dur',
-          op: '>',
-          value: 1000,
-        },
-      ],
-      filterOperator: 'AND',
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'name',
+            op: '=',
+            value: 'test',
+          },
+          {
+            column: 'dur',
+            op: '>',
+            value: 1000,
+          },
+        ],
+        filterOperator: 'AND',
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -1170,27 +1172,27 @@ describe('JSON serialization/deserialization', () => {
     const deserializedNode = deserializedTableNode.nextNodes[0] as FilterNode;
 
     // Verify filters
-    expect(deserializedNode.state.filters).toBeDefined();
-    expect(deserializedNode.state.filters?.length).toBe(2);
-    expect(deserializedNode.state.filters?.[0].column).toBe('name');
-    expect(deserializedNode.state.filters?.[0].op).toBe('=');
+    expect(deserializedNode.attrs.filters).toBeDefined();
+    expect(deserializedNode.attrs.filters?.length).toBe(2);
+    expect(deserializedNode.attrs.filters?.[0].column).toBe('name');
+    expect(deserializedNode.attrs.filters?.[0].op).toBe('=');
     if (
-      deserializedNode.state.filters?.[0] &&
-      'value' in deserializedNode.state.filters[0]
+      deserializedNode.attrs.filters?.[0] &&
+      'value' in deserializedNode.attrs.filters[0]
     ) {
-      expect(deserializedNode.state.filters[0].value).toBe('test');
+      expect(deserializedNode.attrs.filters[0].value).toBe('test');
     }
-    expect(deserializedNode.state.filters?.[1].column).toBe('dur');
-    expect(deserializedNode.state.filters?.[1].op).toBe('>');
+    expect(deserializedNode.attrs.filters?.[1].column).toBe('dur');
+    expect(deserializedNode.attrs.filters?.[1].op).toBe('>');
     if (
-      deserializedNode.state.filters?.[1] &&
-      'value' in deserializedNode.state.filters[1]
+      deserializedNode.attrs.filters?.[1] &&
+      'value' in deserializedNode.attrs.filters[1]
     ) {
-      expect(deserializedNode.state.filters[1].value).toBe(1000);
+      expect(deserializedNode.attrs.filters[1].value).toBe(1000);
     }
 
     // Verify filter operator
-    expect(deserializedNode.state.filterOperator).toBe('AND');
+    expect(deserializedNode.attrs.filterOperator).toBe('AND');
 
     // Verify primaryInput connection
     expect(deserializedNode.primaryInput?.nodeId).toBe(
@@ -1199,20 +1201,22 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes filter node with null filter', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'name',
-          op: 'is null',
-        },
-      ],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'name',
+            op: 'is null',
+          },
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -1231,42 +1235,44 @@ describe('JSON serialization/deserialization', () => {
     const deserializedNode = deserializedTableNode.nextNodes[0] as FilterNode;
 
     // Verify filter
-    expect(deserializedNode.state.filters).toBeDefined();
-    expect(deserializedNode.state.filters?.length).toBe(1);
-    expect(deserializedNode.state.filters?.[0].column).toBe('name');
-    expect(deserializedNode.state.filters?.[0].op).toBe('is null');
+    expect(deserializedNode.attrs.filters).toBeDefined();
+    expect(deserializedNode.attrs.filters?.length).toBe(1);
+    expect(deserializedNode.attrs.filters?.[0].column).toBe('name');
+    expect(deserializedNode.attrs.filters?.[0].op).toBe('is null');
     // Null filters don't have a value property
-    expect('value' in deserializedNode.state.filters![0]).toBe(false);
+    expect('value' in deserializedNode.attrs.filters![0]).toBe(false);
   });
 
   test('serializes and deserializes merge node with equality condition', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const joinNode = new JoinNode({
-      leftNode: tableNode1,
-      rightNode: tableNode2,
-      leftQueryAlias: 'left',
-      rightQueryAlias: 'right',
-      conditionType: 'equality',
-      joinType: 'INNER',
-      leftColumn: 'name',
-      rightColumn: 'name',
-      sqlExpression: '',
-      leftColumns: undefined,
-      rightColumns: undefined,
-    });
+    const joinNode = new JoinNode(
+      {
+        leftQueryAlias: 'left',
+        rightQueryAlias: 'right',
+        conditionType: 'equality',
+        joinType: 'INNER',
+        leftColumn: 'name',
+        rightColumn: 'name',
+        sqlExpression: '',
+        leftColumns: undefined,
+        rightColumns: undefined,
+      },
+      {},
+    );
+    joinNode.secondaryInputs.connections.set(0, tableNode1);
     tableNode1.nextNodes.push(joinNode);
+    joinNode.secondaryInputs.connections.set(1, tableNode2);
     tableNode2.nextNodes.push(joinNode);
+    joinNode.onPrevNodesUpdated?.();
 
     const initialState: DataExplorerState = {
       rootNodes: [tableNode1, tableNode2],
@@ -1292,41 +1298,43 @@ describe('JSON serialization/deserialization', () => {
     expect(
       deserializedJoinNode.secondaryInputs.connections.get(1)?.nodeId,
     ).toBe(deserializedTableNode2.nodeId);
-    expect(deserializedJoinNode.state.leftQueryAlias).toBe('left');
-    expect(deserializedJoinNode.state.rightQueryAlias).toBe('right');
-    expect(deserializedJoinNode.state.conditionType).toBe('equality');
-    expect(deserializedJoinNode.state.leftColumn).toBe('name');
-    expect(deserializedJoinNode.state.rightColumn).toBe('name');
+    expect(deserializedJoinNode.attrs.leftQueryAlias).toBe('left');
+    expect(deserializedJoinNode.attrs.rightQueryAlias).toBe('right');
+    expect(deserializedJoinNode.attrs.conditionType).toBe('equality');
+    expect(deserializedJoinNode.attrs.leftColumn).toBe('name');
+    expect(deserializedJoinNode.attrs.rightColumn).toBe('name');
   });
 
   test('serializes and deserializes merge node with freeform condition', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const joinNode = new JoinNode({
-      leftNode: tableNode1,
-      rightNode: tableNode2,
-      leftQueryAlias: 't1',
-      rightQueryAlias: 't2',
-      conditionType: 'freeform',
-      joinType: 'INNER',
-      leftColumn: '',
-      rightColumn: '',
-      sqlExpression: 't1.id = t2.parent_id',
-      leftColumns: undefined,
-      rightColumns: undefined,
-    });
+    const joinNode = new JoinNode(
+      {
+        leftQueryAlias: 't1',
+        rightQueryAlias: 't2',
+        conditionType: 'freeform',
+        joinType: 'INNER',
+        leftColumn: '',
+        rightColumn: '',
+        sqlExpression: 't1.id = t2.parent_id',
+        leftColumns: undefined,
+        rightColumns: undefined,
+      },
+      {},
+    );
+    joinNode.secondaryInputs.connections.set(0, tableNode1);
     tableNode1.nextNodes.push(joinNode);
+    joinNode.secondaryInputs.connections.set(1, tableNode2);
     tableNode2.nextNodes.push(joinNode);
+    joinNode.onPrevNodesUpdated?.();
 
     const initialState: DataExplorerState = {
       rootNodes: [tableNode1, tableNode2],
@@ -1343,10 +1351,10 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode1.nextNodes.length).toBe(1);
     const deserializedJoinNode = deserializedTableNode1
       .nextNodes[0] as JoinNode;
-    expect(deserializedJoinNode.state.leftQueryAlias).toBe('t1');
-    expect(deserializedJoinNode.state.rightQueryAlias).toBe('t2');
-    expect(deserializedJoinNode.state.conditionType).toBe('freeform');
-    expect(deserializedJoinNode.state.sqlExpression).toBe(
+    expect(deserializedJoinNode.attrs.leftQueryAlias).toBe('t1');
+    expect(deserializedJoinNode.attrs.rightQueryAlias).toBe('t2');
+    expect(deserializedJoinNode.attrs.conditionType).toBe('freeform');
+    expect(deserializedJoinNode.attrs.sqlExpression).toBe(
       't1.id = t2.parent_id',
     );
   });
@@ -1411,11 +1419,11 @@ describe('JSON serialization/deserialization', () => {
     expect(joinNode.type).toBe(NodeType.kJoin); // kMerge should equal kJoin
 
     // Verify the state was preserved
-    expect(joinNode.state.leftQueryAlias).toBe('left');
-    expect(joinNode.state.rightQueryAlias).toBe('right');
-    expect(joinNode.state.conditionType).toBe('equality');
-    expect(joinNode.state.leftColumn).toBe('id');
-    expect(joinNode.state.rightColumn).toBe('id');
+    expect(joinNode.attrs.leftQueryAlias).toBe('left');
+    expect(joinNode.attrs.rightQueryAlias).toBe('right');
+    expect(joinNode.attrs.conditionType).toBe('equality');
+    expect(joinNode.attrs.leftColumn).toBe('id');
+    expect(joinNode.attrs.rightColumn).toBe('id');
 
     // Verify the connections are correct
     expect(joinNode.secondaryInputs.connections.size).toBe(2);
@@ -1424,40 +1432,36 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes union node', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode3 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
-    const sliceTable = sqlModules.getTable('slice')!;
-    const unionNode = new UnionNode({
-      inputNodes: [tableNode1, tableNode2, tableNode3],
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-        {
-          name: 'ts',
-          checked: true,
-          column: sliceTable.columns[1],
-        },
-      ],
-    });
+    const tableNode3 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const unionNode = new UnionNode(
+      {
+        inputNodes: [tableNode1, tableNode2, tableNode3],
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+          },
+          {
+            name: 'ts',
+            checked: true,
+          },
+        ],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(unionNode);
     tableNode2.nextNodes.push(unionNode);
     tableNode3.nextNodes.push(unionNode);
@@ -1490,51 +1494,66 @@ describe('JSON serialization/deserialization', () => {
     expect(
       deserializedUnionNode.secondaryInputs.connections.get(2)?.nodeId,
     ).toBe(deserializedTableNode3.nodeId);
-    expect(deserializedUnionNode.state.selectedColumns.length).toBe(2);
-    expect(deserializedUnionNode.state.selectedColumns[0].name).toBe('name');
-    expect(deserializedUnionNode.state.selectedColumns[0].checked).toBe(true);
-    expect(deserializedUnionNode.state.selectedColumns[1].name).toBe('ts');
-    expect(deserializedUnionNode.state.selectedColumns[1].checked).toBe(true);
+    expect(
+      (deserializedUnionNode as UnionNode).attrs.selectedColumns.length,
+    ).toBe(2);
+    expect(
+      (deserializedUnionNode as UnionNode).attrs.selectedColumns[0].name,
+    ).toBe('name');
+    expect(
+      (deserializedUnionNode as UnionNode).attrs.selectedColumns[0].checked,
+    ).toBe(true);
+    expect(
+      (deserializedUnionNode as UnionNode).attrs.selectedColumns[1].name,
+    ).toBe('ts');
+    expect(
+      (deserializedUnionNode as UnionNode).attrs.selectedColumns[1].checked,
+    ).toBe(true);
   });
 
   test('serializes and deserializes merge node with filters and comment', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const joinNode = new JoinNode({
-      leftNode: tableNode1,
-      rightNode: tableNode2,
-      leftQueryAlias: 'left',
-      rightQueryAlias: 'right',
-      conditionType: 'equality',
-      joinType: 'INNER',
-      leftColumn: 'name',
-      rightColumn: 'name',
-      sqlExpression: '',
-      leftColumns: undefined,
-      rightColumns: undefined,
-    });
+    const joinNode = new JoinNode(
+      {
+        leftQueryAlias: 'left',
+        rightQueryAlias: 'right',
+        conditionType: 'equality',
+        joinType: 'INNER',
+        leftColumn: 'name',
+        rightColumn: 'name',
+        sqlExpression: '',
+        leftColumns: undefined,
+        rightColumns: undefined,
+      },
+      {},
+    );
+    joinNode.secondaryInputs.connections.set(0, tableNode1);
     tableNode1.nextNodes.push(joinNode);
+    joinNode.secondaryInputs.connections.set(1, tableNode2);
     tableNode2.nextNodes.push(joinNode);
+    joinNode.onPrevNodesUpdated?.();
 
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'dur',
-          op: '>',
-          value: '1000',
-        },
-      ],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'dur',
+            op: '>',
+            value: '1000',
+          },
+        ],
+      },
+      {},
+    );
     addConnection(joinNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -1555,42 +1574,38 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedJoinNode.nextNodes.length).toBe(1);
     const deserializedFilterNode = deserializedJoinNode
       .nextNodes[0] as FilterNode;
-    expect(deserializedFilterNode.state.filters).toBeDefined();
-    expect(deserializedFilterNode.state.filters?.length).toBe(1);
-    expect(deserializedFilterNode.state.filters?.[0].column).toBe('dur');
-    expect(deserializedFilterNode.state.filters?.[0].op).toBe('>');
+    expect(deserializedFilterNode.attrs.filters).toBeDefined();
+    expect(deserializedFilterNode.attrs.filters?.length).toBe(1);
+    expect(deserializedFilterNode.attrs.filters?.[0].column).toBe('dur');
+    expect(deserializedFilterNode.attrs.filters?.[0].op).toBe('>');
   });
 
-  test('serializes and deserializes union node with filters and comment', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+  test('serializes and deserializes union node', () => {
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
-    const sliceTable = sqlModules.getTable('slice')!;
-    const unionNode = new UnionNode({
-      inputNodes: [tableNode1, tableNode2],
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-        {
-          name: 'ts',
-          checked: false,
-          column: sliceTable.columns[1],
-        },
-      ],
-    });
-    unionNode.comment = 'Union of slice sources excluding idle';
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const unionNode = new UnionNode(
+      {
+        inputNodes: [tableNode1, tableNode2],
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+          },
+          {
+            name: 'ts',
+            checked: false,
+          },
+        ],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(unionNode);
     tableNode2.nextNodes.push(unionNode);
 
@@ -1610,57 +1625,57 @@ describe('JSON serialization/deserialization', () => {
     const deserializedUnionNode = deserializedTableNode1
       .nextNodes[0] as UnionNode;
     // Verify unchecked column is preserved
-    expect(deserializedUnionNode.state.selectedColumns[1].checked).toBe(false);
+    expect(
+      (deserializedUnionNode as UnionNode).attrs.selectedColumns[1].checked,
+    ).toBe(false);
   });
 
   test('join node requires explicit column selection', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
     // Both tables have the same columns
     // When leftColumns/rightColumns are undefined, columns default to unchecked
-    const joinNode = new JoinNode({
-      leftNode: tableNode1,
-      rightNode: tableNode2,
-      leftQueryAlias: 'left',
-      rightQueryAlias: 'right',
-      conditionType: 'equality',
-      joinType: 'INNER',
-      leftColumn: 'name',
-      rightColumn: 'name',
-      sqlExpression: '',
-      leftColumns: undefined,
-      rightColumns: undefined,
-    });
+    const joinNode = new JoinNode(
+      {
+        leftQueryAlias: 'left',
+        rightQueryAlias: 'right',
+        conditionType: 'equality',
+        joinType: 'INNER',
+        leftColumn: 'name',
+        rightColumn: 'name',
+        sqlExpression: '',
+        leftColumns: undefined,
+        rightColumns: undefined,
+      },
+      {},
+    );
+    joinNode.secondaryInputs.connections.set(0, tableNode1);
     tableNode1.nextNodes.push(joinNode);
+    joinNode.secondaryInputs.connections.set(1, tableNode2);
     tableNode2.nextNodes.push(joinNode);
+    joinNode.onPrevNodesUpdated?.();
 
     // With no columns checked, finalCols should be empty
     expect(joinNode.finalCols).toEqual([]);
 
     // Now explicitly check some columns
-    expect(joinNode.state.leftColumns).toBeDefined();
+    expect(joinNode.attrs.leftColumns).toBeDefined();
     // Find and check the 'name' column from left
-    const nameCol = joinNode.state.leftColumns!.find(
-      (c) => c.column.name === 'name',
-    );
+    const nameCol = joinNode.attrs.leftColumns!.find((c) => c.name === 'name');
     expect(nameCol).toBeDefined();
     nameCol!.checked = true;
 
-    expect(joinNode.state.rightColumns).toBeDefined();
+    expect(joinNode.attrs.rightColumns).toBeDefined();
     // Find and check 'ts' column from right (to show we can select any column)
-    const tsCol = joinNode.state.rightColumns!.find(
-      (c) => c.column.name === 'ts',
-    );
+    const tsCol = joinNode.attrs.rightColumns!.find((c) => c.name === 'ts');
     expect(tsCol).toBeDefined();
     tsCol!.checked = true;
 
@@ -1684,27 +1699,28 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes modify columns node with selected columns', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
     const sliceTable = sqlModules.getTable('slice')!;
-    const modifyColumnsNode = new ModifyColumnsNode({
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-        {
-          name: 'ts',
-          checked: true,
-          column: sliceTable.columns[1],
-        },
-      ],
-    });
+    const modifyColumnsNode = new ModifyColumnsNode(
+      {
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+            type: sliceTable.columns[0].type,
+          },
+          {
+            name: 'ts',
+            checked: true,
+            type: sliceTable.columns[1].type,
+          },
+        ],
+      },
+      {},
+    );
     // Manually connect without triggering onPrevNodesUpdated to preserve
     // the test's explicitly provided selectedColumns
     tableNode.nextNodes.push(modifyColumnsNode);
@@ -1725,16 +1741,14 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedNode = deserializedTableNode
       .nextNodes[0] as ModifyColumnsNode;
-    expect(deserializedNode.state.selectedColumns.length).toBe(2);
-    expect(deserializedNode.state.selectedColumns[0].name).toBe('name');
-    expect(deserializedNode.state.selectedColumns[1].name).toBe('ts');
+    expect(deserializedNode.attrs.selectedColumns.length).toBe(2);
+    expect(deserializedNode.attrs.selectedColumns[0].name).toBe('name');
+    expect(deserializedNode.attrs.selectedColumns[1].name).toBe('ts');
   });
 
   test('serializes modify columns node without primaryInput', () => {
     // Create a modify columns node without a primaryInput (edge case)
-    const modifyColumnsNode = new ModifyColumnsNode({
-      selectedColumns: [],
-    });
+    const modifyColumnsNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
     const initialState: DataExplorerState = {
       rootNodes: [modifyColumnsNode],
@@ -1756,56 +1770,54 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes aggregation node with multiple aggregations', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
     const sliceTable = sqlModules.getTable('slice')!;
-    const aggregationNode = new AggregationNode({
-      groupByColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-        {
-          name: 'ts',
-          checked: true,
-          column: sliceTable.columns[1],
-        },
-      ],
-      aggregations: [
-        {
-          column: {
-            name: 'dur',
+    const aggregationNode = new AggregationNode(
+      {
+        groupByColumns: [
+          {
+            name: 'name',
             checked: true,
-            column: sliceTable.columns[2],
+            type: sliceTable.columns[0].type,
           },
-          aggregationOp: 'SUM',
-          newColumnName: 'total_dur',
-        },
-        {
-          column: {
-            name: 'dur',
+          {
+            name: 'ts',
             checked: true,
-            column: sliceTable.columns[2],
+            type: sliceTable.columns[1].type,
           },
-          aggregationOp: 'AVG',
-          newColumnName: 'avg_dur',
-        },
-        {
-          column: {
-            name: 'dur',
-            checked: true,
-            column: sliceTable.columns[2],
+        ],
+        aggregations: [
+          {
+            column: {
+              name: 'dur',
+              type: sliceTable.columns[2].type,
+            },
+            aggregationOp: 'SUM',
+            newColumnName: 'total_dur',
           },
-          aggregationOp: 'COUNT',
-          newColumnName: 'count',
-        },
-      ],
-    });
+          {
+            column: {
+              name: 'dur',
+              type: sliceTable.columns[2].type,
+            },
+            aggregationOp: 'AVG',
+            newColumnName: 'avg_dur',
+          },
+          {
+            column: {
+              name: 'dur',
+              type: sliceTable.columns[2].type,
+            },
+            aggregationOp: 'COUNT',
+            newColumnName: 'count',
+          },
+        ],
+      },
+      {},
+    );
     // Manually connect without triggering onPrevNodesUpdated to preserve
     // the test's explicitly provided groupByColumns
     tableNode.nextNodes.push(aggregationNode);
@@ -1826,87 +1838,99 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedTableNode.nextNodes.length).toBe(1);
     const deserializedAggregationNode = deserializedTableNode
       .nextNodes[0] as AggregationNode;
-    expect(deserializedAggregationNode.state.groupByColumns.length).toBe(2);
-    expect(deserializedAggregationNode.state.groupByColumns[1].name).toBe('ts');
-    expect(deserializedAggregationNode.state.aggregations.length).toBe(3);
+    expect(deserializedAggregationNode.attrs.groupByColumns.length).toBe(2);
+    expect(deserializedAggregationNode.attrs.groupByColumns[1].name).toBe('ts');
+    expect(deserializedAggregationNode.attrs.aggregations.length).toBe(3);
     expect(
-      deserializedAggregationNode.state.aggregations[0].aggregationOp,
+      deserializedAggregationNode.attrs.aggregations[0].aggregationOp,
     ).toBe('SUM');
     expect(
-      deserializedAggregationNode.state.aggregations[0].newColumnName,
+      deserializedAggregationNode.attrs.aggregations[0].newColumnName,
     ).toBe('total_dur');
     expect(
-      deserializedAggregationNode.state.aggregations[1].aggregationOp,
+      deserializedAggregationNode.attrs.aggregations[1].aggregationOp,
     ).toBe('AVG');
     expect(
-      deserializedAggregationNode.state.aggregations[1].newColumnName,
+      deserializedAggregationNode.attrs.aggregations[1].newColumnName,
     ).toBe('avg_dur');
     expect(
-      deserializedAggregationNode.state.aggregations[2].aggregationOp,
+      deserializedAggregationNode.attrs.aggregations[2].aggregationOp,
     ).toBe('COUNT');
   });
 
   test('serializes and deserializes complex multi-node chain', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
-    const filterNode = new FilterNode({
-      filters: [
-        {
-          column: 'name',
-          op: '!=',
-          value: 'idle',
-        },
-      ],
-    });
-    addConnection(tableNode, filterNode);
-
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
     const sliceTable = sqlModules.getTable('slice')!;
-    const modifyNode = new ModifyColumnsNode({
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-    });
+
+    const filterNode = new FilterNode(
+      {
+        filters: [
+          {
+            column: 'name',
+            op: '!=',
+            value: 'idle',
+          },
+        ],
+      },
+      {},
+    );
+    addConnection(tableNode, filterNode);
+    const modifyNode = new ModifyColumnsNode(
+      {
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+            type: sliceTable.columns[0].type,
+          },
+        ],
+      },
+      {},
+    );
     addConnection(filterNode, modifyNode);
 
-    const aggregationNode = new AggregationNode({
-      groupByColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-      aggregations: [
-        {
-          column: {
-            name: 'dur_ms',
+    const aggregationNode = new AggregationNode(
+      {
+        groupByColumns: [
+          {
+            name: 'name',
             checked: true,
-            column: sliceTable.columns[2],
+            type: sliceTable.columns[0].type,
           },
-          aggregationOp: 'SUM',
-          newColumnName: 'total_dur_ms',
-        },
-      ],
-    });
+        ],
+        aggregations: [
+          {
+            column: {
+              name: 'dur_ms',
+              type: sliceTable.columns[2].type,
+            },
+            aggregationOp: 'SUM',
+            newColumnName: 'total_dur_ms',
+          },
+        ],
+      },
+      {},
+    );
     addConnection(modifyNode, aggregationNode);
 
-    const sortNode = new SortNode({
-      sortCriteria: [{colName: 'total_dur_ms', direction: 'ASC'}],
-    });
+    const sortNode = new SortNode(
+      {
+        sortCriteria: [{colName: 'total_dur_ms', direction: 'ASC'}],
+      },
+      {},
+    );
     addConnection(aggregationNode, sortNode);
 
-    const limitNode = new LimitAndOffsetNode({
-      limit: 10,
-      offset: 0,
-    });
+    const limitNode = new LimitAndOffsetNode(
+      {
+        limit: 10,
+        offset: 0,
+      },
+      {},
+    );
     addConnection(sortNode, limitNode);
 
     const initialState: DataExplorerState = {
@@ -1933,7 +1957,7 @@ describe('JSON serialization/deserialization', () => {
 
     const node2 = node1.nextNodes[0] as FilterNode;
     expect(node2.primaryInput?.nodeId).toBe(node1.nodeId);
-    expect(node2.state.filters?.length).toBe(1);
+    expect(node2.attrs.filters?.length).toBe(1);
     expect(node2.nextNodes.length).toBe(1);
 
     const node3 = node2.nextNodes[0] as ModifyColumnsNode;
@@ -1950,40 +1974,44 @@ describe('JSON serialization/deserialization', () => {
 
     const node6 = node5.nextNodes[0] as LimitAndOffsetNode;
     expect(node6.primaryInput?.nodeId).toBe(node5.nodeId);
-    expect(node6.state.limit).toBe(10);
+    expect(node6.attrs.limit).toBe(10);
 
     // Verify all layouts preserved
     expect(deserializedState.nodeLayouts.size).toBe(6);
   });
 
   test('serializes and deserializes branching graph', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
     const sliceTable = sqlModules.getTable('slice')!;
-    const modifyNode1 = new ModifyColumnsNode({
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-    });
+    const modifyNode1 = new ModifyColumnsNode(
+      {
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+            type: sliceTable.columns[0].type,
+          },
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, modifyNode1);
 
-    const modifyNode2 = new ModifyColumnsNode({
-      selectedColumns: [
-        {
-          name: 'ts',
-          checked: true,
-          column: sliceTable.columns[1],
-        },
-      ],
-    });
+    const modifyNode2 = new ModifyColumnsNode(
+      {
+        selectedColumns: [
+          {
+            name: 'ts',
+            checked: true,
+            type: sliceTable.columns[1].type,
+          },
+        ],
+      },
+      {},
+    );
     addConnection(tableNode, modifyNode2);
 
     const initialState: DataExplorerState = {
@@ -2009,7 +2037,7 @@ describe('JSON serialization/deserialization', () => {
 
   test('deserializes graph without nodeLayouts field (auto-layout)', () => {
     // Create a real node and serialize it
-    const sliceNode = new SlicesSourceNode({});
+    const sliceNode = new SlicesSourceNode({}, {});
     const initialState: DataExplorerState = {
       rootNodes: [sliceNode],
       selectedNodes: new Set(),
@@ -2040,13 +2068,16 @@ describe('JSON serialization/deserialization', () => {
   // ========================================
 
   test('serializes and deserializes filter during node with single secondary input', () => {
-    const slicesNode = new SlicesSourceNode({});
-    const timeRangeNode = new TimeRangeSourceNode({trace});
+    const slicesNode = new SlicesSourceNode({}, {});
+    const timeRangeNode = new TimeRangeSourceNode({}, {trace});
 
-    const filterDuringNode = new FilterDuringNode({
-      partitionColumns: ['utid'],
-      clipToIntervals: false,
-    });
+    const filterDuringNode = new FilterDuringNode(
+      {
+        partitionColumns: ['utid'],
+        clipToIntervals: false,
+      },
+      {},
+    );
 
     // Connect slicesNode as primaryInput (from above)
     slicesNode.nextNodes.push(filterDuringNode);
@@ -2089,10 +2120,12 @@ describe('JSON serialization/deserialization', () => {
     );
 
     // Verify state preserved
-    expect(deserializedFilterDuringNode.state.partitionColumns).toEqual([
-      'utid',
-    ]);
-    expect(deserializedFilterDuringNode.state.clipToIntervals).toBe(false);
+    expect(
+      (deserializedFilterDuringNode as FilterDuringNode).attrs.partitionColumns,
+    ).toEqual(['utid']);
+    expect(
+      (deserializedFilterDuringNode as FilterDuringNode).attrs.clipToIntervals,
+    ).toBe(false);
   });
 
   // ========================================
@@ -2102,39 +2135,43 @@ describe('JSON serialization/deserialization', () => {
   test('serializes and deserializes complex graph with diamond pattern', () => {
     // Diamond pattern: table -> filter -> |
     //                  table -> sort   -> | -> union
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [{column: 'name', op: '=', value: 'foo'}],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [{column: 'name', op: '=', value: 'foo'}],
+      },
+      {},
+    );
     addConnection(tableNode1, filterNode);
 
-    const sortNode = new SortNode({
-      sortCriteria: [{colName: 'ts', direction: 'ASC'}],
-    });
+    const sortNode = new SortNode(
+      {
+        sortCriteria: [{colName: 'ts', direction: 'ASC'}],
+      },
+      {},
+    );
     addConnection(tableNode2, sortNode);
-
-    const sliceTable = sqlModules.getTable('slice')!;
-    const unionNode = new UnionNode({
-      inputNodes: [filterNode, sortNode],
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-    });
+    const unionNode = new UnionNode(
+      {
+        inputNodes: [filterNode, sortNode],
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+          },
+        ],
+      },
+      {},
+    );
     filterNode.nextNodes.push(unionNode);
     sortNode.nextNodes.push(unionNode);
 
@@ -2169,51 +2206,60 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes deep chain with 6+ nodes', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const sliceTable = sqlModules.getTable('slice')!;
 
-    const filterNode1 = new FilterNode({
-      filters: [{column: 'name', op: '!=', value: 'idle'}],
-    });
+    const filterNode1 = new FilterNode(
+      {
+        filters: [{column: 'name', op: '!=', value: 'idle'}],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode1);
 
-    const filterNode2 = new FilterNode({
-      filters: [{column: 'dur', op: '>', value: 1000}],
-    });
+    const filterNode2 = new FilterNode(
+      {
+        filters: [{column: 'dur', op: '>', value: 1000}],
+      },
+      {},
+    );
     addConnection(filterNode1, filterNode2);
 
-    const sortNode = new SortNode({
-      sortCriteria: [{colName: 'ts', direction: 'ASC'}],
-    });
+    const sortNode = new SortNode(
+      {
+        sortCriteria: [{colName: 'ts', direction: 'ASC'}],
+      },
+      {},
+    );
     addConnection(filterNode2, sortNode);
-
-    const sliceTable = sqlModules.getTable('slice')!;
-    const aggregationNode = new AggregationNode({
-      groupByColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-      aggregations: [
-        {
-          column: {
-            name: 'dur',
+    const aggregationNode = new AggregationNode(
+      {
+        groupByColumns: [
+          {
+            name: 'name',
             checked: true,
-            column: sliceTable.columns[2],
+            type: sliceTable.columns[0].type,
           },
-          aggregationOp: 'SUM',
-          newColumnName: 'total_dur',
-        },
-      ],
-    });
+        ],
+        aggregations: [
+          {
+            column: {
+              name: 'dur',
+              type: sliceTable.columns[2].type,
+            },
+            aggregationOp: 'SUM',
+            newColumnName: 'total_dur',
+          },
+        ],
+      },
+      {},
+    );
     addConnection(sortNode, aggregationNode);
 
-    const limitNode = new LimitAndOffsetNode({limit: 100, offset: 0});
+    const limitNode = new LimitAndOffsetNode({limit: 100, offset: 0}, {});
     addConnection(aggregationNode, limitNode);
 
     const initialState: DataExplorerState = {
@@ -2255,43 +2301,44 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes graph with interval intersect and union combined', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode3 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode3 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
     // Create interval intersect with first two tables
-    const intervalIntersectNode = new IntervalIntersectNode({
-      inputNodes: [tableNode1, tableNode2],
-    });
+    const intervalIntersectNode = new IntervalIntersectNode(
+      {
+        inputNodes: [tableNode1, tableNode2],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(intervalIntersectNode);
     tableNode2.nextNodes.push(intervalIntersectNode);
 
     // Create union with interval intersect result and third table
-    const sliceTable = sqlModules.getTable('slice')!;
-    const unionNode = new UnionNode({
-      inputNodes: [intervalIntersectNode, tableNode3],
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-    });
+    const unionNode = new UnionNode(
+      {
+        inputNodes: [intervalIntersectNode, tableNode3],
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+          },
+        ],
+      },
+      {},
+    );
     intervalIntersectNode.nextNodes.push(unionNode);
     tableNode3.nextNodes.push(unionNode);
 
@@ -2335,23 +2382,28 @@ describe('JSON serialization/deserialization', () => {
   // ========================================
 
   test('handles removing connection from middle of chain', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const filterNode = new FilterNode({
-      filters: [{column: 'name', op: '=', value: 'foo'}],
-    });
+    const filterNode = new FilterNode(
+      {
+        filters: [{column: 'name', op: '=', value: 'foo'}],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
-    const sortNode = new SortNode({
-      sortCriteria: [{colName: 'ts', direction: 'ASC'}],
-    });
+    const sortNode = new SortNode(
+      {
+        sortCriteria: [{colName: 'ts', direction: 'ASC'}],
+      },
+      {},
+    );
     addConnection(filterNode, sortNode);
 
-    const limitNode = new LimitAndOffsetNode({limit: 10, offset: 0});
+    const limitNode = new LimitAndOffsetNode({limit: 10, offset: 0}, {});
     addConnection(sortNode, limitNode);
 
     // Remove the filter node from the chain
@@ -2388,35 +2440,32 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('handles removing one input from multi-input node', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode3 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
-    const sliceTable = sqlModules.getTable('slice')!;
-    const unionNode = new UnionNode({
-      inputNodes: [tableNode1, tableNode2, tableNode3],
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-    });
+    const tableNode3 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const unionNode = new UnionNode(
+      {
+        inputNodes: [tableNode1, tableNode2, tableNode3],
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+          },
+        ],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(unionNode);
     tableNode2.nextNodes.push(unionNode);
     tableNode3.nextNodes.push(unionNode);
@@ -2448,29 +2497,27 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('handles removing all inputs from multi-input node', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-
-    const sliceTable = sqlModules.getTable('slice')!;
-    const unionNode = new UnionNode({
-      inputNodes: [tableNode1, tableNode2],
-      selectedColumns: [
-        {
-          name: 'name',
-          checked: true,
-          column: sliceTable.columns[0],
-        },
-      ],
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const unionNode = new UnionNode(
+      {
+        inputNodes: [tableNode1, tableNode2],
+        selectedColumns: [
+          {
+            name: 'name',
+            checked: true,
+          },
+        ],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(unionNode);
     tableNode2.nextNodes.push(unionNode);
 
@@ -2501,31 +2548,35 @@ describe('JSON serialization/deserialization', () => {
 
   test('handles graph with multiple disconnected subgraphs', () => {
     // First subgraph: table1 -> filter
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const filterNode = new FilterNode({
-      filters: [{column: 'name', op: '=', value: 'foo'}],
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const filterNode = new FilterNode(
+      {
+        filters: [{column: 'name', op: '=', value: 'foo'}],
+      },
+      {},
+    );
     addConnection(tableNode1, filterNode);
 
     // Second subgraph: table2 -> sort -> limit
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const sortNode = new SortNode({
-      sortCriteria: [{colName: 'ts', direction: 'ASC'}],
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const sortNode = new SortNode(
+      {
+        sortCriteria: [{colName: 'ts', direction: 'ASC'}],
+      },
+      {},
+    );
     addConnection(tableNode2, sortNode);
-    const limitNode = new LimitAndOffsetNode({limit: 100, offset: 0});
+    const limitNode = new LimitAndOffsetNode({limit: 100, offset: 0}, {});
     addConnection(sortNode, limitNode);
 
     // Third subgraph: standalone slices source
-    const slicesNode = new SlicesSourceNode({});
+    const slicesNode = new SlicesSourceNode({}, {});
 
     const initialState: DataExplorerState = {
       rootNodes: [tableNode1, tableNode2, slicesNode],
@@ -2561,11 +2612,10 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes and deserializes time range source node', () => {
-    const timeRangeNode = new TimeRangeSourceNode({
-      trace,
-      start: Time.fromRaw(1000n),
-      end: Time.fromRaw(2000n),
-    });
+    const timeRangeNode = new TimeRangeSourceNode(
+      {start: '1000', end: '2000'},
+      {trace},
+    );
 
     const initialState: DataExplorerState = {
       rootNodes: [timeRangeNode],
@@ -2581,12 +2631,12 @@ describe('JSON serialization/deserialization', () => {
     const deserializedNode = deserializedState
       .rootNodes[0] as TimeRangeSourceNode;
     expect(deserializedNode).toBeInstanceOf(TimeRangeSourceNode);
-    expect(deserializedNode.state.start).toEqual(Time.fromRaw(1000n));
-    expect(deserializedNode.state.end).toEqual(Time.fromRaw(2000n));
+    expect(deserializedNode.start).toEqual(Time.fromRaw(1000n));
+    expect(deserializedNode.end).toEqual(Time.fromRaw(2000n));
   });
 
   test('serializes and deserializes labels', () => {
-    const sliceNode = new SlicesSourceNode({});
+    const sliceNode = new SlicesSourceNode({}, {});
     const labels = [
       {
         id: 'label-1',
@@ -2636,7 +2686,7 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('handles state without labels', () => {
-    const sliceNode = new SlicesSourceNode({});
+    const sliceNode = new SlicesSourceNode({}, {});
     const initialState: DataExplorerState = {
       rootNodes: [sliceNode],
       selectedNodes: new Set(),
@@ -2651,7 +2701,7 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('handles empty labels array', () => {
-    const sliceNode = new SlicesSourceNode({});
+    const sliceNode = new SlicesSourceNode({}, {});
     const initialState: DataExplorerState = {
       rootNodes: [sliceNode],
       selectedNodes: new Set(),
@@ -2666,7 +2716,7 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('labels survive JSON round-trip with special characters', () => {
-    const sliceNode = new SlicesSourceNode({});
+    const sliceNode = new SlicesSourceNode({}, {});
     const labels = [
       {
         id: 'label-1',
@@ -2698,12 +2748,11 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('normalizes coordinates so top-left corner starts at minimum coordinates', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const sliceNode = new SlicesSourceNode({});
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const sliceNode = new SlicesSourceNode({}, {});
 
     const initialState: DataExplorerState = {
       rootNodes: [tableNode, sliceNode],
@@ -2749,11 +2798,10 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('does not modify coordinates when already normalized at (0, 0)', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
 
     const initialState: DataExplorerState = {
       rootNodes: [tableNode],
@@ -2773,12 +2821,11 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializeState normalizes coordinates in the exported JSON', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const sliceNode = new SlicesSourceNode({});
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const sliceNode = new SlicesSourceNode({}, {});
 
     // State with non-zero minimum coordinates
     const initialState: DataExplorerState = {
@@ -2815,12 +2862,11 @@ describe('JSON serialization/deserialization', () => {
 
   test('serializes and deserializes a group node', () => {
     // Build a chain: tableNode → modifyNode, then group them.
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
     addConnection(tableNode, modifyNode);
 
     // Create the group
@@ -2832,7 +2878,7 @@ describe('JSON serialization/deserialization', () => {
     );
     applyGroupRewiring(group);
 
-    group.name = 'My Test Group';
+    group.attrs.name = 'My Test Group';
 
     // rootNodes includes only the group (inner nodes are discovered
     // via GroupNode.innerNodes traversal inside getAllNodes).
@@ -2853,7 +2899,7 @@ describe('JSON serialization/deserialization', () => {
     expect(deserializedGroup).toBeInstanceOf(GroupNode);
 
     if (!(deserializedGroup instanceof GroupNode)) return;
-    expect(deserializedGroup.name).toBe('My Test Group');
+    expect(deserializedGroup.attrs.name).toBe('My Test Group');
     expect(deserializedGroup.innerNodes).toHaveLength(2);
     expect(deserializedGroup.endNode).toBeDefined();
 
@@ -2865,13 +2911,12 @@ describe('JSON serialization/deserialization', () => {
 
   test('group node serialization preserves inner connections', () => {
     // Build: tableNode → modifyNode → filterNode, group modify+filter
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const modifyNode = new ModifyColumnsNode({selectedColumns: []});
-    const filterNode = new FilterNode({filters: []});
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
+    const filterNode = new FilterNode({filters: []}, {});
     addConnection(tableNode, modifyNode);
     addConnection(modifyNode, filterNode);
 
@@ -2918,14 +2963,16 @@ describe('JSON serialization/deserialization', () => {
   // =========================================================================
 
   test('serializes primaryInput at graph level, not in node state', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const filterNode = new FilterNode({
-      filters: [{column: 'name', op: '=', value: 'test'}],
-    });
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const filterNode = new FilterNode(
+      {
+        filters: [{column: 'name', op: '=', value: 'test'}],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
     const initialState: DataExplorerState = {
@@ -2947,19 +2994,20 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('serializes secondaryInputs at graph level, not in node state', () => {
-    const tableNode1 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const intervalNode = new IntervalIntersectNode({
-      inputNodes: [tableNode1, tableNode2],
-    });
+    const tableNode1 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const intervalNode = new IntervalIntersectNode(
+      {
+        inputNodes: [tableNode1, tableNode2],
+      },
+      {},
+    );
     tableNode1.nextNodes.push(intervalNode);
     tableNode2.nextNodes.push(intervalNode);
 
@@ -2985,25 +3033,30 @@ describe('JSON serialization/deserialization', () => {
   });
 
   test('deserializes connections from graph-level fields', () => {
-    const tableNode = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const filterNode = new FilterNode({
-      filters: [{column: 'name', op: '=', value: 'x'}],
-    });
+    // Build a graph: table -> filter (primaryInput) and table1, table2 -> union (secondaryInputs)
+    const tableNode = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const filterNode = new FilterNode(
+      {
+        filters: [{column: 'name', op: '=', value: 'x'}],
+      },
+      {},
+    );
     addConnection(tableNode, filterNode);
 
-    const tableNode2 = new TableSourceNode({
-      sqlTable: sqlModules.getTable('slice'),
-      trace,
-      sqlModules,
-    });
-    const unionNode = new UnionNode({
-      inputNodes: [],
-      selectedColumns: [],
-    });
+    const tableNode2 = new TableSourceNode(
+      {sqlTable: 'slice'},
+      {trace, sqlModules},
+    );
+    const unionNode = new UnionNode(
+      {
+        inputNodes: [],
+        selectedColumns: [],
+      },
+      {},
+    );
     tableNode.nextNodes.push(unionNode);
     tableNode2.nextNodes.push(unionNode);
     unionNode.secondaryInputs.connections.set(0, tableNode);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/multi_node_operations_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/multi_node_operations_unittest.ts
@@ -62,16 +62,14 @@ describe('Multi-node operations', () => {
 
   describe('Multi-node copy', () => {
     test('should capture relative positions of multiple nodes', () => {
-      const node1 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node2 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
+      const node1 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node2 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
 
       const state: DataExplorerState = {
         rootNodes: [node1, node2],
@@ -115,12 +113,11 @@ describe('Multi-node operations', () => {
     });
 
     test('should capture connections between selected nodes', () => {
-      const node1 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node2 = new FilterNode({filters: []});
+      const node1 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node2 = new FilterNode({filters: []}, {});
       addConnection(node1, node2);
 
       // Verify connection exists
@@ -129,12 +126,11 @@ describe('Multi-node operations', () => {
     });
 
     test('should handle docked nodes (nodes without explicit layout)', () => {
-      const node1 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node2 = new FilterNode({filters: []});
+      const node1 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node2 = new FilterNode({filters: []}, {});
       addConnection(node1, node2);
 
       const nodeLayouts = new Map([[node1.nodeId, {x: 100, y: 200}]]);
@@ -147,11 +143,10 @@ describe('Multi-node operations', () => {
 
   describe('Multi-node paste', () => {
     test('should paste multiple times from same clipboard', () => {
-      const node1 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
+      const node1 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
 
       const clipboardNodes = [
         {
@@ -175,12 +170,11 @@ describe('Multi-node operations', () => {
     });
 
     test('should restore connections between pasted nodes', () => {
-      const node1 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node2 = new FilterNode({filters: []});
+      const node1 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node2 = new FilterNode({filters: []}, {});
       addConnection(node1, node2);
 
       // Clone nodes for clipboard
@@ -204,21 +198,18 @@ describe('Multi-node operations', () => {
     test('should create single undo entry when using handleDeleteSelectedNodes', () => {
       // This test verifies that the batched multi-node deletion creates
       // only ONE undo entry, so users can restore all deleted nodes at once
-      const node1 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node2 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node3 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
+      const node1 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node2 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node3 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
 
       // Initial state with 3 nodes
       const state1: DataExplorerState = {
@@ -250,13 +241,12 @@ describe('Multi-node operations', () => {
 
     test('should restore connected nodes properly after undo', () => {
       // Create a chain: table -> filter1 -> filter2
-      const tableNode = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const filter1 = new FilterNode({filters: []});
-      const filter2 = new FilterNode({filters: []});
+      const tableNode = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const filter1 = new FilterNode({filters: []}, {});
+      const filter2 = new FilterNode({filters: []}, {});
 
       addConnection(tableNode, filter1);
       addConnection(filter1, filter2);
@@ -307,21 +297,18 @@ describe('Multi-node operations', () => {
 
   describe('Multi-node selection', () => {
     test('should maintain primary selected node when removing from selection', () => {
-      const node1 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node2 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
-      const node3 = new TableSourceNode({
-        trace,
-        sqlModules,
-        sqlTable: sqlModules.getTable('test_table')!,
-      });
+      const node1 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node2 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
+      const node3 = new TableSourceNode(
+        {sqlTable: 'test_table'},
+        {trace, sqlModules},
+      );
 
       const state: DataExplorerState = {
         rootNodes: [node1, node2, node3],

--- a/ui/src/plugins/dev.perfetto.DataExplorer/node_actions.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/node_actions.ts
@@ -90,8 +90,8 @@ export function ensureAllNodeActions(
     if (initializedNodes.has(node.nodeId)) {
       continue;
     }
-    if (!node.state.actions) {
-      node.state.actions = createNodeActions(node, handlers);
+    if (!node.context.actions) {
+      node.context.actions = createNodeActions(node, handlers);
     }
     initializedNodes.add(node.nodeId);
   }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/node_actions_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/node_actions_unittest.ts
@@ -155,8 +155,8 @@ describe('node_actions', () => {
 
       ensureAllNodeActions([node1, node2], initializedNodes, handlers);
 
-      expect(node1.state.actions).toBeDefined();
-      expect(node2.state.actions).toBeDefined();
+      expect(node1.context.actions).toBeDefined();
+      expect(node2.context.actions).toBeDefined();
       expect(initializedNodes.has('n1')).toBe(true);
       expect(initializedNodes.has('n2')).toBe(true);
     });
@@ -168,7 +168,7 @@ describe('node_actions', () => {
       ensureAllNodeActions([node], initializedNodes, handlers);
 
       // Actions should not be set because the node was already tracked
-      expect(node.state.actions).toBeUndefined();
+      expect(node.context.actions).toBeUndefined();
     });
 
     it('should preserve existing actions on nodes', () => {
@@ -177,14 +177,14 @@ describe('node_actions', () => {
       };
       const node = createMockNode({
         nodeId: 'n1',
-        state: {actions: existingActions},
+        context: {actions: existingActions},
       });
       const initializedNodes = new Set<string>();
 
       ensureAllNodeActions([node], initializedNodes, handlers);
 
       // Existing actions should be preserved (not overwritten)
-      expect(node.state.actions).toBe(existingActions);
+      expect(node.context.actions).toBe(existingActions);
       // But node should still be marked as initialized
       expect(initializedNodes.has('n1')).toBe(true);
     });
@@ -202,7 +202,7 @@ describe('node_actions', () => {
       ensureAllNodeActions([node], initializedNodes, handlers);
 
       // The created actions should actually work
-      node.state.actions?.onAddAndConnectTable?.('test_table', 0);
+      node.context.actions?.onAddAndConnectTable?.('test_table', 0);
 
       expect(addAndConnectTableCalls).toHaveLength(1);
       expect(addAndConnectTableCalls[0].tableName).toBe('test_table');

--- a/ui/src/plugins/dev.perfetto.DataExplorer/node_crud_operations.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/node_crud_operations.ts
@@ -17,12 +17,7 @@ import type {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 import type {CleanupManager} from './query_builder/cleanup_manager';
 import type {NodeActionHandlers} from './node_actions';
 import {createDeferredNodeActions} from './node_actions';
-import {
-  QueryNode,
-  QueryNodeState,
-  NodeType,
-  singleNodeOperation,
-} from './query_node';
+import {QueryNode, NodeType, singleNodeOperation} from './query_node';
 import {nodeRegistry, type PreCreateState} from './query_builder/node_registry';
 import {
   getAllNodes,
@@ -119,17 +114,13 @@ export async function addOperationNode(
     // Use a wrapper object to hold the node reference (allows mutation without 'let')
     const nodeRef: {current?: QueryNode} = {};
 
-    const nodeState: QueryNodeState = {
-      ...(initialState as Partial<QueryNodeState>),
-      sqlModules: deps.sqlModules,
-      trace: deps.trace,
-      // Provide actions for nodes that need to interact with the graph
-      // We use a deferred pattern because the node doesn't exist yet
-      actions: createDeferredNodeActions(nodeRef, deps.nodeActionHandlers),
-    };
-
-    const newNode = descriptor.factory(nodeState, {
+    const newNode = descriptor.factory(initialState, {
       allNodes: state.rootNodes,
+      context: {
+        sqlModules: deps.sqlModules,
+        trace: deps.trace,
+        actions: createDeferredNodeActions(nodeRef, deps.nodeActionHandlers),
+      },
     });
 
     // Set the reference so the callback can use it
@@ -241,14 +232,10 @@ export async function addSourceNode(
   const newNodes: QueryNode[] = [];
   for (const stateItem of statesToCreate) {
     try {
-      const newNode = descriptor.factory(
-        {
-          ...stateItem,
-          trace: deps.trace,
-          sqlModules: deps.sqlModules,
-        } as QueryNodeState,
-        {allNodes: state.rootNodes},
-      );
+      const newNode = descriptor.factory(stateItem, {
+        allNodes: state.rootNodes,
+        context: {trace: deps.trace, sqlModules: deps.sqlModules},
+      });
       newNodes.push(newNode);
     } catch (error) {
       console.error('Failed to create node:', error);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/pbtxt_import_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/pbtxt_import_unittest.ts
@@ -2598,7 +2598,7 @@ describe('pbtxt import - end-to-end validation', () => {
     for (const node of allNodes) {
       const valid = node.validate();
       if (!valid) {
-        const err = node.state.issues?.queryError?.message ?? 'unknown';
+        const err = node.context.issues?.queryError?.message ?? 'unknown';
         fail(`${node.type} (${node.nodeId}) failed validation: ${err}`);
       }
     }
@@ -2608,25 +2608,30 @@ describe('pbtxt import - end-to-end validation', () => {
     const allNodes = hydrateSpec();
     const join = allNodes.find((n) => n.type === NodeType.kJoin);
     expect(join).toBeDefined();
-    const state = join!.state as {
-      leftColumns?: Array<{checked: boolean}>;
-      rightColumns?: Array<{checked: boolean}>;
-    };
-    expect(state.leftColumns?.some((c) => c.checked)).toBe(true);
-    expect(state.rightColumns?.some((c) => c.checked)).toBe(true);
+    const joinAttrs = (
+      join as {
+        attrs?: {
+          leftColumns?: Array<{checked: boolean}>;
+          rightColumns?: Array<{checked: boolean}>;
+        };
+      }
+    ).attrs;
+    expect(joinAttrs?.leftColumns?.some((c) => c.checked)).toBe(true);
+    expect(joinAttrs?.rightColumns?.some((c) => c.checked)).toBe(true);
   });
 
   it('Metrics node preserves value columns after fixups', () => {
     const allNodes = hydrateSpec();
     const metrics = allNodes.find((n) => n.type === NodeType.kMetrics);
     expect(metrics).toBeDefined();
-    const state = metrics!.state as {
-      metricIdPrefix: string;
-      valueColumns: Array<{column: string}>;
-    };
-    expect(state.metricIdPrefix).toBe('x');
-    expect(state.valueColumns.length).toBe(1);
-    expect(state.valueColumns[0].column).toBe('utid');
+    const metricsAttrs = (
+      metrics as {
+        attrs?: {metricIdPrefix: string; valueColumns: Array<{column: string}>};
+      }
+    ).attrs;
+    expect(metricsAttrs?.metricIdPrefix).toBe('x');
+    expect(metricsAttrs?.valueColumns.length).toBe(1);
+    expect(metricsAttrs?.valueColumns[0].column).toBe('utid');
   });
 
   it('Metrics node has correct dimensions from cached availableColumns', () => {
@@ -2634,13 +2639,10 @@ describe('pbtxt import - end-to-end validation', () => {
     const metrics = allNodes.find((n) => n.type === NodeType.kMetrics);
     expect(metrics).toBeDefined();
 
-    // Test the CACHED state.availableColumns — this is what the UI renders.
+    // Test the CACHED availableColumns — this is what the UI renders.
     // It's set during updateAvailableColumns() and NOT recomputed on read.
-    const state = metrics!.state as {
-      availableColumns: Array<{name: string}>;
-      valueColumns: Array<{column: string}>;
-    };
-    const availNames = state.availableColumns.map((c) => c.name);
+    const metricsNode = metrics as {availableColumns?: Array<{name: string}>};
+    const availNames = (metricsNode.availableColumns ?? []).map((c) => c.name);
     // Must include all 4 columns: id, name, utid, total_running_time.
     expect(availNames).toContain('id');
     expect(availNames).toContain('name');

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/builder.ts
@@ -481,7 +481,8 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
                   },
                   m(
                     '.pf-error-details',
-                    selectedNode.state.issues?.getTitle() ?? 'No error details',
+                    selectedNode.context.issues?.getTitle() ??
+                      'No error details',
                   ),
                 ),
             ),
@@ -760,16 +761,16 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
         : undefined;
 
     if (error || warning || noDataWarning) {
-      if (!node.state.issues) {
-        node.state.issues = new NodeIssues();
+      if (!node.context.issues) {
+        node.context.issues = new NodeIssues();
       }
-      node.state.issues.queryError = error;
-      node.state.issues.responseError = warning;
-      node.state.issues.dataError = noDataWarning;
+      node.context.issues.queryError = error;
+      node.context.issues.responseError = warning;
+      node.context.issues.dataError = noDataWarning;
       // Clear any previous execution error since we got a successful response
-      node.state.issues.clearExecutionError();
+      node.context.issues.clearExecutionError();
     } else {
-      node.state.issues = undefined;
+      node.context.issues = undefined;
     }
   }
 
@@ -790,12 +791,12 @@ export class Builder implements m.ClassComponent<BuilderAttrs> {
     // Clear response and data source but keep query so Retry can re-execute
     this.dataSource = undefined;
     this.response = undefined;
-    if (!node.state.issues) {
-      node.state.issues = new NodeIssues();
+    if (!node.context.issues) {
+      node.context.issues = new NodeIssues();
     }
     // Use executionError (not queryError) so error persists across re-renders
     // that trigger validate() - queryError gets cleared during validation
-    node.state.issues.executionError =
+    node.context.issues.executionError =
       e instanceof Error ? e : new Error(String(e));
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_column_formatters.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_column_formatters.ts
@@ -28,7 +28,7 @@ export function isIntegerColumn(
   columnName: string,
 ): boolean {
   const columnInfo = node.sourceCols.find((col) => col.name === columnName);
-  const columnType = columnInfo?.column.type;
+  const columnType = columnInfo?.type;
   return (
     columnType !== undefined && underlyingSqlType(columnType) === 'INTEGER'
   );
@@ -42,7 +42,7 @@ export function getColumnTypeKind(
   columnName: string,
 ): PerfettoSqlType['kind'] | undefined {
   const columnInfo = node.sourceCols.find((col) => col.name === columnName);
-  return columnInfo?.column.type?.kind;
+  return columnInfo?.type?.kind;
 }
 
 /**

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_config_popup.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_config_popup.ts
@@ -98,7 +98,7 @@ export function renderChartConfigPopup(
   // Orientation only applies to bar charts.
   const showOrientation = config.chartType === 'bar';
 
-  const showDelete = ctx.node.state.chartConfigs.length > 1;
+  const showDelete = ctx.node.attrs.chartConfigs.length > 1;
 
   return m(
     Form,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_renderers.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_renderers.ts
@@ -99,7 +99,7 @@ export interface ChartColumnProvider {
   addRangeFilter(column: string, min: number, max: number): void;
   updateChart(chartId: string, updates: Partial<Omit<ChartConfig, 'id'>>): void;
   removeChart(chartId: string): void;
-  readonly state: {readonly chartConfigs: ReadonlyArray<ChartConfig>};
+  readonly attrs: {readonly chartConfigs: ReadonlyArray<ChartConfig>};
 }
 
 /**

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_view.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/charts/chart_view.ts
@@ -162,8 +162,8 @@ export class ChartView implements m.ClassComponent<ChartViewAttrs> {
   }
 
   view({attrs}: m.CVnode<ChartViewAttrs>) {
-    const configs = attrs.node.state.chartConfigs;
-    const filters = attrs.node.state.chartFilters ?? [];
+    const configs = attrs.node.attrs.chartConfigs;
+    const filters = attrs.node.attrs.chartFilters ?? [];
     const hasFilters = filters.some((f) => f.enabled !== false);
 
     if (configs.length === 0) {
@@ -391,7 +391,7 @@ export class ChartView implements m.ClassComponent<ChartViewAttrs> {
       onResize: (deltaPx: number) => {
         const currentWidth =
           config.widthPx ??
-          this.getDefaultChartWidth(attrs.node.state.chartConfigs.length);
+          this.getDefaultChartWidth(attrs.node.attrs.chartConfigs.length);
         const newWidth = Math.max(200, currentWidth + deltaPx);
         attrs.node.updateChart(config.id, {widthPx: newWidth});
       },

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/cleanup_manager_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/cleanup_manager_unittest.ts
@@ -52,10 +52,10 @@ describe('CleanupManager', () => {
   });
 
   function createTestNode(id: string): QueryNode {
-    const node = new TableSourceNode({
-      trace: mockTrace,
-      sqlModules: mockSqlModules,
-    }) as QueryNode;
+    const node = new TableSourceNode(
+      {},
+      {trace: mockTrace, sqlModules: mockSqlModules},
+    ) as QueryNode;
     // Use Object.defineProperty to set nodeId since it's readonly
     Object.defineProperty(node, 'nodeId', {value: id, writable: false});
     return node;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
@@ -20,8 +20,9 @@ import {SqlColumn} from '../../dev.perfetto.SqlModules/sql_modules';
 
 export interface ColumnInfo {
   name: string;
+  type?: PerfettoSqlType;
+  description?: string;
   checked: boolean;
-  column: SqlColumn;
   alias?: string;
   // When true, the type was explicitly modified by the user and should be
   // preserved even when upstream columns change.
@@ -34,19 +35,9 @@ export function columnInfoFromSqlColumn(
 ): ColumnInfo {
   return {
     name: column.name,
+    type: column.type,
+    description: column.description,
     checked,
-    column: column,
-  };
-}
-
-export function columnInfoFromName(
-  name: string,
-  checked: boolean = false,
-): ColumnInfo {
-  return {
-    name,
-    checked,
-    column: {name},
   };
 }
 
@@ -54,10 +45,11 @@ export function newColumnInfo(
   col: ColumnInfo,
   checked?: boolean | undefined,
 ): ColumnInfo {
-  const finalName = col.alias ?? col.column.name;
+  const finalName = col.alias ?? col.name;
   return {
     name: finalName,
-    column: {...col.column, name: finalName},
+    type: col.type,
+    description: col.description,
     alias: undefined,
     checked: checked ?? col.checked,
     typeUserModified: col.typeUserModified,
@@ -77,11 +69,4 @@ export function legacyDeserializeType(
   // Already a proper PerfettoSqlType object
   if (type.kind !== undefined) return type;
   return undefined;
-}
-
-export function newColumnInfoList(
-  oldCols: ColumnInfo[],
-  checked?: boolean | undefined,
-): ColumnInfo[] {
-  return oldCols.map((col) => newColumnInfo(col, checked));
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
@@ -15,10 +15,8 @@
 import {
   ColumnInfo,
   columnInfoFromSqlColumn,
-  columnInfoFromName,
   legacyDeserializeType,
   newColumnInfo,
-  newColumnInfoList,
 } from './column_info';
 import {SqlColumn} from '../../dev.perfetto.SqlModules/sql_modules';
 import {
@@ -47,9 +45,8 @@ describe('column_info utilities', () => {
       const result = columnInfoFromSqlColumn(sqlColumn);
 
       expect(result.name).toBe('id');
-      expect(result.column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(result.type).toEqual(PerfettoSqlTypes.INT);
       expect(result.checked).toBe(false);
-      expect(result.column).toBe(sqlColumn);
       expect(result.alias).toBeUndefined();
     });
 
@@ -62,9 +59,8 @@ describe('column_info utilities', () => {
       const result = columnInfoFromSqlColumn(sqlColumn, true);
 
       expect(result.name).toBe('name');
-      expect(result.column.type).toEqual(PerfettoSqlTypes.STRING);
+      expect(result.type).toEqual(PerfettoSqlTypes.STRING);
       expect(result.checked).toBe(true);
-      expect(result.column).toBe(sqlColumn);
     });
 
     it('should handle timestamp type', () => {
@@ -76,35 +72,7 @@ describe('column_info utilities', () => {
       const result = columnInfoFromSqlColumn(sqlColumn, false);
 
       expect(result.name).toBe('ts');
-      expect(result.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
-      expect(result.checked).toBe(false);
-    });
-  });
-
-  describe('columnInfoFromName', () => {
-    it('should create ColumnInfo from name with default unchecked', () => {
-      const result = columnInfoFromName('test_column');
-
-      expect(result.name).toBe('test_column');
-      expect(result.column.type).toBeUndefined();
-      expect(result.checked).toBe(false);
-      expect(result.column.name).toBe('test_column');
-      expect(result.column.type).toBe(undefined);
-    });
-
-    it('should create ColumnInfo with checked=true when specified', () => {
-      const result = columnInfoFromName('another_column', true);
-
-      expect(result.name).toBe('another_column');
-      expect(result.column.type).toBeUndefined();
-      expect(result.checked).toBe(true);
-    });
-
-    it('should handle empty name', () => {
-      const result = columnInfoFromName('');
-
-      expect(result.name).toBe('');
-      expect(result.column.type).toBeUndefined();
+      expect(result.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
       expect(result.checked).toBe(false);
     });
   });
@@ -114,17 +82,17 @@ describe('column_info utilities', () => {
       const original: ColumnInfo = {
         name: 'id',
         checked: false,
-        column: {name: 'id', type: intType},
+        type: intType,
       };
 
       const result = newColumnInfo(original);
 
       expect(result.name).toBe('id');
-      expect(result.column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(result.type).toEqual(PerfettoSqlTypes.INT);
       expect(result.checked).toBe(false);
       // column is now a copy with name updated (not same reference)
-      expect(result.column.name).toBe('id');
-      expect(result.column.type).toBe(intType);
+      expect(result.name).toBe('id');
+      expect(result.type).toBe(intType);
       expect(result.alias).toBeUndefined();
     });
 
@@ -132,16 +100,16 @@ describe('column_info utilities', () => {
       const original: ColumnInfo = {
         name: 'id',
         checked: false,
-        column: {name: 'id', type: intType},
+        type: intType,
         alias: 'identifier',
       };
 
       const result = newColumnInfo(original);
 
       expect(result.name).toBe('identifier');
-      expect(result.column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(result.type).toEqual(PerfettoSqlTypes.INT);
       // column.name should also be replaced with the alias so child nodes see the aliased name
-      expect(result.column.name).toBe('identifier');
+      expect(result.name).toBe('identifier');
       expect(result.alias).toBeUndefined();
     });
 
@@ -149,7 +117,7 @@ describe('column_info utilities', () => {
       const original: ColumnInfo = {
         name: 'name',
         checked: false,
-        column: {name: 'name', type: stringType},
+        type: stringType,
       };
 
       const result = newColumnInfo(original, true);
@@ -162,7 +130,7 @@ describe('column_info utilities', () => {
       const original: ColumnInfo = {
         name: 'name',
         checked: true,
-        column: {name: 'name', type: stringType},
+        type: stringType,
       };
 
       const result = newColumnInfo(original);
@@ -174,7 +142,7 @@ describe('column_info utilities', () => {
       const original: ColumnInfo = {
         name: 'ts',
         checked: true,
-        column: {name: 'ts', type: timestampType},
+        type: timestampType,
       };
 
       const result = newColumnInfo(original, undefined);
@@ -186,112 +154,13 @@ describe('column_info utilities', () => {
       const original: ColumnInfo = {
         name: 'id',
         checked: false,
-        column: {name: 'id', type: intType},
+        type: intType,
         alias: 'identifier',
       };
 
       const result = newColumnInfo(original);
 
       expect(result.alias).toBeUndefined();
-    });
-  });
-
-  describe('newColumnInfoList', () => {
-    it('should create new list preserving all columns', () => {
-      const original: ColumnInfo[] = [
-        {
-          name: 'id',
-          checked: false,
-          column: {name: 'id', type: intType},
-        },
-        {
-          name: 'name',
-          checked: false,
-          column: {name: 'name', type: stringType},
-        },
-        {
-          name: 'ts',
-          checked: true,
-          column: {name: 'ts', type: timestampType},
-        },
-      ];
-
-      const result = newColumnInfoList(original);
-
-      expect(result.length).toBe(3);
-      expect(result[0].name).toBe('id');
-      expect(result[0].checked).toBe(false);
-      expect(result[1].name).toBe('name');
-      expect(result[1].checked).toBe(false);
-      expect(result[2].name).toBe('ts');
-      expect(result[2].checked).toBe(true);
-    });
-
-    it('should override checked state for all columns when specified', () => {
-      const original: ColumnInfo[] = [
-        {
-          name: 'id',
-          checked: false,
-          column: {name: 'id', type: intType},
-        },
-        {
-          name: 'name',
-          checked: false,
-          column: {name: 'name', type: stringType},
-        },
-      ];
-
-      const result = newColumnInfoList(original, true);
-
-      expect(result.length).toBe(2);
-      expect(result[0].checked).toBe(true);
-      expect(result[1].checked).toBe(true);
-    });
-
-    it('should handle empty list', () => {
-      const result = newColumnInfoList([]);
-
-      expect(result).toEqual([]);
-    });
-
-    it('should handle aliases', () => {
-      const original: ColumnInfo[] = [
-        {
-          name: 'id',
-          checked: false,
-          column: {name: 'id', type: intType},
-          alias: 'identifier',
-        },
-        {
-          name: 'name',
-          checked: false,
-          column: {name: 'full_name', type: stringType},
-          alias: 'name',
-        },
-      ];
-
-      const result = newColumnInfoList(original);
-
-      expect(result.length).toBe(2);
-      expect(result[0].name).toBe('identifier');
-      expect(result[0].alias).toBeUndefined();
-      expect(result[1].name).toBe('name');
-      expect(result[1].alias).toBeUndefined();
-    });
-
-    it('should create independent copies', () => {
-      const original: ColumnInfo[] = [
-        {
-          name: 'id',
-          checked: false,
-          column: {name: 'id', type: intType},
-        },
-      ];
-
-      const result = newColumnInfoList(original, true);
-
-      expect(original[0].checked).toBe(false);
-      expect(result[0].checked).toBe(true);
     });
   });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_selector.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_selector.ts
@@ -89,7 +89,7 @@ export class ColumnSelector implements m.ClassComponent<ColumnSelectorAttrs> {
             columns.map((col, index) => {
               const checkbox = m(Checkbox, {
                 checked: col.checked,
-                label: col.column.name,
+                label: col.name,
                 onchange: (e) => {
                   const newColumns = [...columns];
                   newColumns[index] = {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/core_nodes.ts
@@ -17,89 +17,67 @@ import {SlicesSourceNode} from './nodes/sources/slices_source';
 import {
   modalForTableSelection,
   TableSourceNode,
-  TableSourceState,
-  TableSourceSerializedState,
+  TableSourceNodeAttrs,
 } from './nodes/sources/table_source';
-import {
-  SqlSourceNode,
-  SqlSourceState,
-  SqlSourceSerializedState,
-} from './nodes/sources/sql_source';
+import {SqlSourceNode, SqlSourceNodeAttrs} from './nodes/sources/sql_source';
 import {
   TimeRangeSourceNode,
-  TimeRangeSourceState,
-  TimeRangeSourceSerializedState,
+  TimeRangeSourceNodeAttrs,
 } from './nodes/sources/timerange_source';
-import {
-  AggregationNode,
-  AggregationNodeState,
-  AggregationSerializedState,
-} from './nodes/aggregation_node';
+import {AggregationNode, AggregationNodeAttrs} from './nodes/aggregation_node';
 import {
   ModifyColumnsNode,
-  ModifyColumnsState,
-  ModifyColumnsSerializedState,
+  ModifyColumnsNodeAttrs,
 } from './nodes/modify_columns_node';
-import {AddColumnsNode, AddColumnsNodeState} from './nodes/add_columns_node';
+import {AddColumnsNode, AddColumnsNodeAttrs} from './nodes/add_columns_node';
 import {
   FilterDuringNode,
-  FilterDuringNodeState,
+  FilterDuringNodeAttrs,
 } from './nodes/filter_during_node';
-import {FilterInNode, FilterInNodeState} from './nodes/filter_in_node';
+import {FilterInNode, FilterInNodeAttrs} from './nodes/filter_in_node';
 import {
   IntervalIntersectNode,
-  IntervalIntersectNodeState,
-  IntervalIntersectSerializedState,
+  IntervalIntersectNodeAttrs,
 } from './nodes/interval_intersect_node';
-import {JoinNode, JoinNodeState, JoinSerializedState} from './nodes/join_node';
+import {JoinNode, JoinNodeAttrs} from './nodes/join_node';
 import {
   CreateSlicesNode,
-  CreateSlicesNodeState,
-  CreateSlicesSerializedState,
+  CreateSlicesNodeAttrs,
 } from './nodes/create_slices_node';
-import {SortNode, SortNodeState} from './nodes/sort_node';
-import {FilterNode, FilterNodeState} from './nodes/filter_node';
-import {
-  UnionNode,
-  UnionNodeState,
-  UnionSerializedState,
-} from './nodes/union_node';
+import {SortNode, SortNodeAttrs} from './nodes/sort_node';
+import {FilterNode, FilterNodeAttrs} from './nodes/filter_node';
+import {UnionNode, UnionNodeAttrs} from './nodes/union_node';
 import {
   LimitAndOffsetNode,
-  LimitAndOffsetNodeState,
+  LimitAndOffsetNodeAttrs,
 } from './nodes/limit_and_offset_node';
 import {
   CounterToIntervalsNode,
-  CounterToIntervalsNodeState,
+  CounterToIntervalsNodeAttrs,
 } from './nodes/counter_to_intervals_node';
-import {
-  MetricsNode,
-  MetricsNodeState,
-  MetricsSerializedState,
-} from './nodes/metrics_node';
+import {MetricsNode, MetricsNodeAttrs} from './nodes/metrics_node';
 import {
   TraceSummaryNode,
-  TraceSummaryNodeState,
-  TraceSummarySerializedState,
+  TraceSummaryNodeAttrs,
 } from './nodes/trace_summary_node';
 import {
   VisualisationNode,
-  VisualisationNodeState,
+  VisualisationNodeAttrs,
 } from './nodes/visualisation_node';
-import {DashboardNode, DashboardSerializedState} from './nodes/dashboard_node';
+import {DashboardNode, DashboardNodeAttrs} from './nodes/dashboard_node';
 import {Icons} from '../../../base/semantic_icons';
 import {NodeType, QueryNode} from '../query_node';
-import {GroupNode, GroupSerializedState} from './nodes/group_node';
+import {GroupNode} from './nodes/group_node';
 
 // After JoinNode.onPrevNodesUpdated() defaults all columns to unchecked on
 // first initialization, check the columns that the downstream ModifyColumns
 // node needs. For JSON import this is a no-op because columns are restored
-// from serialized state (already have checked values).
+// from serialized _attrs (already have checked values).
 function applyJoinColumnDefaults(joinNode: JoinNode): void {
-  const leftCols = joinNode.state.leftColumns ?? [];
-  const rightCols = joinNode.state.rightColumns ?? [];
+  const leftCols = joinNode.attrs.leftColumns ?? [];
+  const rightCols = joinNode.attrs.rightColumns ?? [];
 
-  // If any columns are already checked, the serialized state was restored
+  // If any columns are already checked, the serialized _attrs was restored
   // correctly (JSON import path) — nothing to do.
   if (leftCols.some((c) => c.checked) || rightCols.some((c) => c.checked)) {
     return;
@@ -109,7 +87,7 @@ function applyJoinColumnDefaults(joinNode: JoinNode): void {
   // Check only columns needed by the downstream ModifyColumns node.
   const mc = joinNode.nextNodes.find((n) => n.type === NodeType.kModifyColumns);
   if (mc !== undefined) {
-    const mcState = mc.state as {
+    const mcState = (mc as {attrs?: object}).attrs as {
       selectedColumns?: Array<{name: string; checked: boolean}>;
     };
     const needed = new Set(
@@ -145,9 +123,10 @@ export function registerCoreNodes() {
     type: 'source',
     showOnLandingPage: true,
     nodeType: NodeType.kSimpleSlices,
-    factory: (state) => new SlicesSourceNode(state),
+    factory: (_attrs, factoryCtx) =>
+      new SlicesSourceNode({}, factoryCtx?.context ?? {}),
     deserialize: (_state, trace, sqlModules) =>
-      new SlicesSourceNode({trace, sqlModules}),
+      new SlicesSourceNode({}, {trace, sqlModules}),
   });
 
   nodeRegistry.register('table', {
@@ -163,20 +142,15 @@ export function registerCoreNodes() {
       if (selections && selections.length > 0) {
         // Return an array of states, one for each selected table
         return selections.map((selection) => ({
-          sqlTable: selection.sqlTable,
+          sqlTable: selection.sqlTable.name,
         }));
       }
       return null;
     },
-    factory: (state) => new TableSourceNode(state as TableSourceState),
-    deserialize: (state, trace, sqlModules) =>
-      new TableSourceNode(
-        TableSourceNode.deserializeState(
-          trace,
-          sqlModules,
-          state as TableSourceSerializedState,
-        ),
-      ),
+    factory: (_attrs) =>
+      new TableSourceNode(_attrs as TableSourceNodeAttrs, {}),
+    deserialize: (_attrs, trace, sqlModules) =>
+      new TableSourceNode(_attrs as TableSourceNodeAttrs, {trace, sqlModules}),
   });
 
   nodeRegistry.register('sql', {
@@ -188,12 +162,13 @@ export function registerCoreNodes() {
     type: 'source',
     showOnLandingPage: true,
     nodeType: NodeType.kSqlSource,
-    factory: (state) => new SqlSourceNode(state as SqlSourceState),
-    deserialize: (state, trace) =>
-      new SqlSourceNode({
-        ...(state as SqlSourceSerializedState),
-        trace,
-      }),
+    factory: (_attrs, factoryCtx) =>
+      new SqlSourceNode(
+        _attrs as SqlSourceNodeAttrs,
+        factoryCtx?.context ?? {},
+      ),
+    deserialize: (_attrs, trace) =>
+      new SqlSourceNode(_attrs as SqlSourceNodeAttrs, {trace}),
   });
 
   nodeRegistry.register('timerange', {
@@ -204,52 +179,47 @@ export function registerCoreNodes() {
     type: 'source',
     showOnLandingPage: false, // Available in menus but not on landing page
     nodeType: NodeType.kTimeRangeSource,
-    factory: (state) => {
+    factory: (_attrs, factoryCtx) => {
       // If start/end are already set, this is being restored from serialization
       // or created programmatically - use those values
       if (
-        'start' in state &&
-        state.start !== undefined &&
-        'end' in state &&
-        state.end !== undefined
+        'start' in _attrs &&
+        _attrs.start !== undefined &&
+        'end' in _attrs &&
+        _attrs.end !== undefined
       ) {
-        if (!state.trace) {
+        if (!factoryCtx?.context?.trace) {
           throw new Error('TimeRange node requires a trace instance');
         }
-        return new TimeRangeSourceNode({
-          ...state,
-          trace: state.trace,
+        const attrs: TimeRangeSourceNodeAttrs = {
+          start: String(_attrs.start),
+          end: String(_attrs.end),
           isDynamic:
-            'isDynamic' in state && state.isDynamic === true ? true : false,
-        } as TimeRangeSourceState);
+            'isDynamic' in _attrs && _attrs.isDynamic === true ? true : false,
+        };
+        return new TimeRangeSourceNode(attrs, factoryCtx?.context ?? {});
       }
 
       // New node - initialize from current selection
-      if (!state.trace) {
+      if (!factoryCtx?.context?.trace) {
         throw new Error('TimeRange node requires a trace instance');
       }
 
-      const timeRange = state.trace.selection.getTimeSpanOfSelection();
+      const timeRange =
+        factoryCtx!.context!.trace!.selection.getTimeSpanOfSelection();
       // Note: If there's no selection, start/end will be undefined and the node
-      // will be in an invalid state (validate() will return false and show error).
+      // will be in an invalid _attrs (validate() will return false and show error).
       // This is intentional - the user can fix it by clicking "Update from Selection"
       // or by entering times manually.
-      const fullState: TimeRangeSourceState = {
-        ...state,
-        start: timeRange?.start,
-        end: timeRange?.end,
+      const attrs: TimeRangeSourceNodeAttrs = {
+        start: timeRange?.start?.toString(),
+        end: timeRange?.end?.toString(),
         isDynamic: false, // Default to static mode
-        trace: state.trace,
       };
-      return new TimeRangeSourceNode(fullState);
+      return new TimeRangeSourceNode(attrs, factoryCtx?.context ?? {});
     },
-    deserialize: (state, trace) =>
-      new TimeRangeSourceNode(
-        TimeRangeSourceNode.deserializeState(
-          trace,
-          state as TimeRangeSourceSerializedState,
-        ),
-      ),
+    deserialize: (_attrs, trace) =>
+      new TimeRangeSourceNode(_attrs as TimeRangeSourceNodeAttrs, {trace}),
   });
 
   nodeRegistry.register('add_columns', {
@@ -260,22 +230,15 @@ export function registerCoreNodes() {
     type: 'modification',
     category: 'Columns',
     nodeType: NodeType.kAddColumns,
-    factory: (state) => {
-      const fullState: AddColumnsNodeState = {
-        ...state,
-        selectedColumns: (state as AddColumnsNodeState).selectedColumns ?? [],
-        leftColumn: (state as AddColumnsNodeState).leftColumn ?? 'id',
-        rightColumn: (state as AddColumnsNodeState).rightColumn ?? 'id',
-      };
-      return new AddColumnsNode(fullState);
-    },
-    deserialize: (state, trace, sqlModules) =>
+    factory: (_attrs, factoryCtx) =>
       new AddColumnsNode(
-        AddColumnsNode.deserializeState(
-          trace,
-          sqlModules,
-          state as AddColumnsNodeState,
-        ),
+        _attrs as AddColumnsNodeAttrs,
+        factoryCtx?.context ?? {},
+      ),
+    deserialize: (_attrs, trace, sqlModules) =>
+      new AddColumnsNode(
+        AddColumnsNode.deserializeState(_attrs as AddColumnsNodeAttrs),
+        {trace, sqlModules},
       ),
   });
 
@@ -286,15 +249,13 @@ export function registerCoreNodes() {
     type: 'modification',
     category: 'Columns',
     nodeType: NodeType.kModifyColumns,
-    factory: (state) => new ModifyColumnsNode(state as ModifyColumnsState),
-    deserialize: (state, _trace, sqlModules) =>
+    factory: (_attrs) =>
+      new ModifyColumnsNode(_attrs as unknown as ModifyColumnsNodeAttrs, {}),
+    deserialize: (_attrs, _trace, _sqlModules) =>
       new ModifyColumnsNode(
-        ModifyColumnsNode.deserializeState(
-          sqlModules,
-          state as ModifyColumnsSerializedState,
-        ),
+        ModifyColumnsNode.deserializeState(_attrs as ModifyColumnsNodeAttrs),
+        {},
       ),
-    postDeserializeLate: (node) => (node as ModifyColumnsNode).resolveColumns(),
   });
 
   nodeRegistry.register('aggregation', {
@@ -303,15 +264,13 @@ export function registerCoreNodes() {
     icon: 'functions',
     type: 'modification',
     nodeType: NodeType.kAggregation,
-    factory: (state) => new AggregationNode(state as AggregationNodeState),
-    deserialize: (state, _trace, sqlModules) =>
-      new AggregationNode({
-        ...AggregationNode.deserializeState(
-          state as AggregationSerializedState,
-        ),
-        sqlModules,
-      }),
-    postDeserializeLate: (node) => (node as AggregationNode).resolveColumns(),
+    factory: (_attrs) =>
+      new AggregationNode(_attrs as unknown as AggregationNodeAttrs, {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new AggregationNode(
+        AggregationNode.deserializeState(_attrs as AggregationNodeAttrs),
+        {sqlModules},
+      ),
   });
 
   nodeRegistry.register('filter_node', {
@@ -321,12 +280,10 @@ export function registerCoreNodes() {
     type: 'modification',
     category: 'Filter',
     nodeType: NodeType.kFilter,
-    factory: (state) => new FilterNode(state as FilterNodeState),
-    deserialize: (state, _trace, sqlModules) =>
-      new FilterNode({
-        ...FilterNode.deserializeState(state as FilterNodeState),
-        sqlModules,
-      }),
+    factory: (_attrs, factoryCtx) =>
+      new FilterNode(_attrs as FilterNodeAttrs, factoryCtx?.context ?? {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new FilterNode(_attrs as FilterNodeAttrs, {sqlModules}),
   });
 
   nodeRegistry.register('filter_during', {
@@ -337,14 +294,10 @@ export function registerCoreNodes() {
     type: 'modification',
     category: 'Filter',
     nodeType: NodeType.kFilterDuring,
-    factory: (state) => {
-      return new FilterDuringNode(state as FilterDuringNodeState);
-    },
-    deserialize: (state, _trace, sqlModules) =>
-      new FilterDuringNode({
-        ...FilterDuringNode.deserializeState(state as FilterDuringNodeState),
-        sqlModules,
-      }),
+    factory: (_attrs) =>
+      new FilterDuringNode(_attrs as FilterDuringNodeAttrs, {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new FilterDuringNode(_attrs as FilterDuringNodeAttrs, {sqlModules}),
   });
 
   nodeRegistry.register('filter_in', {
@@ -355,13 +308,10 @@ export function registerCoreNodes() {
     type: 'modification',
     category: 'Filter',
     nodeType: NodeType.kFilterIn,
-    factory: (state) => {
-      return new FilterInNode(state as FilterInNodeState);
-    },
-    deserialize: (state) =>
-      new FilterInNode(
-        FilterInNode.deserializeState(state as FilterInNodeState),
-      ),
+    factory: (_attrs, factoryCtx) =>
+      new FilterInNode(_attrs as FilterInNodeAttrs, factoryCtx?.context ?? {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new FilterInNode(_attrs as FilterInNodeAttrs, {sqlModules}),
   });
 
   nodeRegistry.register('interval_intersect', {
@@ -371,23 +321,10 @@ export function registerCoreNodes() {
     type: 'multisource',
     category: 'Time',
     nodeType: NodeType.kIntervalIntersect,
-    factory: (state, context) => {
-      if (!context) {
-        throw new Error(
-          'NodeFactoryContext is required for IntervalIntersectNode',
-        );
-      }
-      const fullState: IntervalIntersectNodeState = {
-        ...state,
-        inputNodes: [],
-      };
-      return new IntervalIntersectNode(fullState);
-    },
-    deserialize: (state, _trace, sqlModules) =>
-      new IntervalIntersectNode({
-        ...IntervalIntersectNode.deserializeState(
-          state as IntervalIntersectSerializedState,
-        ),
+    factory: (_attrs) =>
+      new IntervalIntersectNode(_attrs as IntervalIntersectNodeAttrs, {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new IntervalIntersectNode(_attrs as IntervalIntersectNodeAttrs, {
         sqlModules,
       }),
   });
@@ -399,9 +336,8 @@ export function registerCoreNodes() {
     icon: 'merge',
     type: 'multisource',
     nodeType: NodeType.kJoin,
-    factory: (state) => {
-      const fullState: JoinNodeState = {
-        ...state,
+    factory: (_attrs, factoryCtx) => {
+      const attrs: JoinNodeAttrs = {
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
@@ -412,11 +348,10 @@ export function registerCoreNodes() {
         leftColumns: undefined,
         rightColumns: undefined,
       };
-      return new JoinNode(fullState);
+      return new JoinNode(attrs, factoryCtx?.context ?? {});
     },
-    deserialize: (state, _trace, sqlModules) =>
-      new JoinNode({
-        ...JoinNode.deserializeState(state as JoinSerializedState),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new JoinNode(JoinNode.deserializeState(_attrs as JoinNodeAttrs), {
         sqlModules,
       }),
     postDeserializeLate: (node) => {
@@ -436,21 +371,17 @@ export function registerCoreNodes() {
     type: 'multisource',
     category: 'Time',
     nodeType: NodeType.kCreateSlices,
-    factory: (state) => {
-      const fullState: CreateSlicesNodeState = {
-        ...state,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      };
-      return new CreateSlicesNode(fullState);
-    },
-    deserialize: (state, _trace, sqlModules) =>
-      new CreateSlicesNode({
-        ...CreateSlicesNode.deserializeState(
-          state as CreateSlicesSerializedState,
-        ),
-        sqlModules,
-      }),
+    factory: (_attrs) =>
+      new CreateSlicesNode(
+        {
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+          ..._attrs,
+        } as CreateSlicesNodeAttrs,
+        _attrs,
+      ),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new CreateSlicesNode(_attrs as CreateSlicesNodeAttrs, {sqlModules}),
   });
 
   nodeRegistry.register('sort_node', {
@@ -459,12 +390,10 @@ export function registerCoreNodes() {
     icon: 'sort',
     type: 'modification',
     nodeType: NodeType.kSort,
-    factory: (state) => new SortNode(state as SortNodeState),
-    deserialize: (state, _trace, sqlModules) =>
-      new SortNode({
-        ...SortNode.deserializeState(state as SortNodeState),
-        sqlModules,
-      }),
+    factory: (_attrs, factoryCtx) =>
+      new SortNode(_attrs as SortNodeAttrs, factoryCtx?.context ?? {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new SortNode(_attrs as SortNodeAttrs, {sqlModules}),
   });
 
   nodeRegistry.register('union_node', {
@@ -473,21 +402,16 @@ export function registerCoreNodes() {
     icon: 'merge_type',
     type: 'multisource',
     nodeType: NodeType.kUnion,
-    factory: (state) => {
-      const fullState: UnionNodeState = {
-        ...state,
-        inputNodes: [],
-        selectedColumns: [],
-      };
-      const node = new UnionNode(fullState);
+    factory: (_attrs, factoryCtx) => {
+      const node = new UnionNode(
+        {selectedColumns: [], ..._attrs} as UnionNodeAttrs,
+        factoryCtx?.context ?? {},
+      );
       node.onPrevNodesUpdated();
       return node;
     },
-    deserialize: (state, _trace, sqlModules) =>
-      new UnionNode({
-        ...UnionNode.deserializeState(state as UnionSerializedState),
-        sqlModules,
-      }),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new UnionNode(_attrs as UnionNodeAttrs, {sqlModules}),
   });
 
   nodeRegistry.register('limit_and_offset_node', {
@@ -496,15 +420,10 @@ export function registerCoreNodes() {
     icon: Icons.Filter,
     type: 'modification',
     nodeType: NodeType.kLimitAndOffset,
-    factory: (state) =>
-      new LimitAndOffsetNode(state as LimitAndOffsetNodeState),
-    deserialize: (state, _trace, sqlModules) =>
-      new LimitAndOffsetNode({
-        ...LimitAndOffsetNode.deserializeState(
-          state as LimitAndOffsetNodeState,
-        ),
-        sqlModules,
-      }),
+    factory: (_attrs) =>
+      new LimitAndOffsetNode(_attrs as LimitAndOffsetNodeAttrs, {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new LimitAndOffsetNode(_attrs as LimitAndOffsetNodeAttrs, {sqlModules}),
   });
 
   nodeRegistry.register('metrics', {
@@ -515,13 +434,16 @@ export function registerCoreNodes() {
     type: 'export',
     nodeType: NodeType.kMetrics,
     allowedChildren: ['trace_summary'],
-    factory: (state) => new MetricsNode(state as MetricsNodeState),
-    deserialize: (state, trace, sqlModules) =>
-      new MetricsNode({
-        ...MetricsNode.deserializeState(state as MetricsSerializedState),
-        trace,
-        sqlModules,
-      }),
+    factory: (_attrs, factoryCtx) =>
+      new MetricsNode(
+        _attrs as unknown as MetricsNodeAttrs,
+        factoryCtx?.context ?? {},
+      ),
+    deserialize: (_attrs, trace, sqlModules) =>
+      new MetricsNode(
+        MetricsNode.deserializeState(_attrs as MetricsNodeAttrs),
+        {trace, sqlModules},
+      ),
     postDeserializeLate: (node) => (node as MetricsNode).onPrevNodesUpdated(),
   });
 
@@ -532,10 +454,10 @@ export function registerCoreNodes() {
     icon: 'bar_chart',
     type: 'modification',
     nodeType: NodeType.kVisualisation,
-    factory: (state) => new VisualisationNode(state as VisualisationNodeState),
-    deserialize: (state, _trace, sqlModules) =>
-      new VisualisationNode({
-        ...VisualisationNode.deserializeState(state as VisualisationNodeState),
+    factory: (_attrs) =>
+      new VisualisationNode(_attrs as unknown as VisualisationNodeAttrs, {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new VisualisationNode(_attrs as unknown as VisualisationNodeAttrs, {
         sqlModules,
       }),
   });
@@ -548,13 +470,10 @@ export function registerCoreNodes() {
     type: 'modification',
     category: 'Advanced',
     nodeType: NodeType.kCounterToIntervals,
-    factory: (state) =>
-      new CounterToIntervalsNode(state as CounterToIntervalsNodeState),
-    deserialize: (state, _trace, sqlModules) =>
-      new CounterToIntervalsNode({
-        ...CounterToIntervalsNode.deserializeState(
-          state as CounterToIntervalsNodeState,
-        ),
+    factory: (_attrs) =>
+      new CounterToIntervalsNode(_attrs as CounterToIntervalsNodeAttrs, {}),
+    deserialize: (_attrs, _trace, sqlModules) =>
+      new CounterToIntervalsNode(_attrs as CounterToIntervalsNodeAttrs, {
         sqlModules,
       }),
   });
@@ -566,11 +485,13 @@ export function registerCoreNodes() {
     type: 'export',
     nodeType: NodeType.kDashboard,
     allowedChildren: [],
-    factory: (state) => new DashboardNode(state),
-    deserialize: (state) =>
+    factory: (_attrs, factoryCtx) =>
       new DashboardNode(
-        DashboardNode.deserializeState(state as DashboardSerializedState),
+        _attrs as DashboardNodeAttrs,
+        factoryCtx?.context ?? {},
       ),
+    deserialize: (_attrs) =>
+      new DashboardNode(_attrs as DashboardNodeAttrs, {}),
     postDeserializeLate: (node) => (node as DashboardNode).onPrevNodesUpdated(),
   });
 
@@ -582,14 +503,10 @@ export function registerCoreNodes() {
     type: 'export',
     nodeType: NodeType.kTraceSummary,
     allowedChildren: [],
-    factory: (state) => new TraceSummaryNode(state as TraceSummaryNodeState),
-    deserialize: (state, trace) =>
-      new TraceSummaryNode({
-        ...TraceSummaryNode.deserializeState(
-          state as TraceSummarySerializedState,
-        ),
-        trace,
-      }),
+    factory: (_attrs) =>
+      new TraceSummaryNode(_attrs as TraceSummaryNodeAttrs, {}),
+    deserialize: (_attrs, trace) =>
+      new TraceSummaryNode(_attrs as TraceSummaryNodeAttrs, {trace}),
   });
 
   // Groups use type 'source' because they are root-level nodes in the outer
@@ -602,22 +519,23 @@ export function registerCoreNodes() {
     type: 'source',
     showOnLandingPage: false,
     nodeType: NodeType.kGroup,
-    factory: () => new GroupNode([], undefined, []),
-    deserialize: (state) => {
-      const s = state as GroupSerializedState;
+    factory: () => new GroupNode({name: 'Group'}, {}),
+    deserialize: (_attrs) => {
+      const s = _attrs as {name?: string};
       // Create a placeholder GroupNode; inner nodes are restored in
       // deserializeConnections once all nodes are available.
-      return new GroupNode([], undefined, [], {}, s.name ?? 'Group');
+      return new GroupNode({name: s.name ?? 'Group'}, {});
     },
-    deserializeConnections: (node, state, allNodes) => {
+    deserializeConnections: (node, _attrs, allNodes, innerNodeIds) => {
       if (!(node instanceof GroupNode)) return;
-      const s = state as GroupSerializedState;
 
-      // Inner nodes are identified by the innerNodeIds list stored in the
-      // group's own serialized state.
-      const innerNodeIds = Array.isArray(s.innerNodeIds) ? s.innerNodeIds : [];
+      // Prefer graph-level innerNodeIds (new format); fall back to the old
+      // format where they were stored inside the node's state blob.
+      const s = _attrs as {innerNodeIds?: string[]};
+      const ids =
+        innerNodeIds ?? (Array.isArray(s.innerNodeIds) ? s.innerNodeIds : []);
       const innerNodes: QueryNode[] = [];
-      for (const id of innerNodeIds) {
+      for (const id of ids) {
         const n = allNodes.get(id);
         if (n !== undefined) {
           innerNodes.push(n);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/node_box.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph/node_box.ts
@@ -29,14 +29,14 @@ export interface NodeBoxAttrs {
 }
 
 export function renderWarningIcon(node: QueryNode): m.Child {
-  if (!node.state.issues || !node.state.issues.hasIssues()) return null;
+  if (!node.context.issues || !node.context.issues.hasIssues()) return null;
 
   const iconClasses = classNames('pf-exp-node-box__warning-icon');
 
   return m(Icon, {
     className: iconClasses,
     icon: 'warning',
-    title: node.state.issues.getTitle(),
+    title: node.context.issues.getTitle(),
   });
 }
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph_utils.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph_utils.ts
@@ -744,7 +744,13 @@ export function createGroupFromSelection(
   const outerNodes = endNode.nextNodes.filter((n) => !innerSet.has(n.nodeId));
 
   // Create the GroupNode (no mutations yet).
-  const groupNode = new GroupNode(innerNodes, endNode, externalConnections);
+  const groupNode = new GroupNode(
+    {name: 'Group'},
+    {},
+    innerNodes,
+    endNode,
+    externalConnections,
+  );
   groupNode.nextNodes = [...outerNodes];
 
   return okResult(groupNode);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph_utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/graph_utils_unittest.ts
@@ -58,10 +58,10 @@ describe('graph_utils', () => {
 
   // Helper to create a simple test node (source node)
   function createTestNode(): QueryNode {
-    return new TableSourceNode({
-      trace: mockTrace,
-      sqlModules: mockSqlModules,
-    }) as QueryNode;
+    return new TableSourceNode(
+      {},
+      {trace: mockTrace, sqlModules: mockSqlModules},
+    ) as QueryNode;
   }
 
   describe('getAllNodes', () => {
@@ -843,7 +843,7 @@ describe('graph_utils', () => {
 
   describe('applyGroupRewiring - edge cases', () => {
     it('should be a no-op when endNode is undefined', () => {
-      const group = new GroupNode([], undefined, []);
+      const group = new GroupNode({}, {}, [], undefined, []);
       // Should not throw
       applyGroupRewiring(group);
     });
@@ -893,7 +893,7 @@ describe('graph_utils', () => {
     it('should handle group with undefined endNode gracefully', () => {
       const a = createMockNode({nodeId: 'a'});
 
-      const group = new GroupNode([a], undefined, []);
+      const group = new GroupNode({}, {}, [a], undefined, []);
 
       // Should not throw
       ungroupNode(group);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/join_widgets.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/join_widgets.ts
@@ -97,10 +97,10 @@ export class JoinSourceCard implements m.ClassComponent<JoinSourceCardAttrs> {
               m(
                 'option',
                 {
-                  value: col.column.name,
-                  selected: col.column.name === selectedColumn,
+                  value: col.name,
+                  selected: col.name === selectedColumn,
                 },
-                col.column.name,
+                col.name,
               ),
             ),
           ],
@@ -118,11 +118,11 @@ export class JoinSourceCard implements m.ClassComponent<JoinSourceCardAttrs> {
               columns.map((col, index) => {
                 // Check if this column's final name conflicts with the other side
                 // Use alias if available, otherwise use the column name
-                const finalName = col.alias ?? col.column.name;
+                const finalName = col.alias ?? col.name;
                 const isDuplicate = otherSideColumns.some(
                   (otherCol) =>
                     otherCol.checked &&
-                    (otherCol.alias ?? otherCol.column.name) === finalName,
+                    (otherCol.alias ?? otherCol.name) === finalName,
                 );
                 const isDisabled = isDuplicate && !col.checked;
 
@@ -134,7 +134,7 @@ export class JoinSourceCard implements m.ClassComponent<JoinSourceCardAttrs> {
                   m(Checkbox, {
                     checked: col.checked,
                     disabled: isDisabled,
-                    label: col.column.name,
+                    label: col.name,
                     onchange: (e) => {
                       onColumnToggle(
                         index,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_panel.ts
@@ -84,13 +84,13 @@ export class NodePanel implements m.ClassComponent<NodePanelAttrs> {
   private updateQuery(node: QueryNode, attrs: NodePanelAttrs) {
     // TODO: Re-implement WITH statement dependencies for SqlSourceNode
     // This was removed during the connection model migration
-    if (node instanceof SqlSourceNode && node.state.sql) {
+    if (node instanceof SqlSourceNode && node.attrs.sql) {
       // Validate that the node doesn't reference itself
       const nodeIds = node.findDependencies();
       for (const nodeId of nodeIds) {
         if (nodeId === node.nodeId) {
-          node.state.issues = new NodeIssues();
-          node.state.issues.queryError = new Error(
+          node.context.issues = new NodeIssues();
+          node.context.issues.queryError = new Error(
             'Node cannot depend on itself',
           );
           return;
@@ -125,9 +125,9 @@ export class NodePanel implements m.ClassComponent<NodePanelAttrs> {
 
     const curSqString = JSON.stringify(sq.toJSON(), null, 2);
 
-    if (curSqString !== this.prevSqString || node.state.hasOperationChanged) {
-      if (node.state.hasOperationChanged) {
-        node.state.hasOperationChanged = false;
+    if (curSqString !== this.prevSqString || node.context.hasOperationChanged) {
+      if (node.context.hasOperationChanged) {
+        node.context.hasOperationChanged = false;
       }
 
       // Use the centralized service to handle analysis and execution.
@@ -365,7 +365,7 @@ export class NodePanel implements m.ClassComponent<NodePanelAttrs> {
 
     // Update the node's onchange callback to point to our attrs.onchange
     // This ensures that changes in the node's UI components trigger the callback chain
-    node.state.onchange = attrs.onchange;
+    node.context.onchange = attrs.onchange;
 
     // When a different node is selected, reset the service's initialization
     // state for it so the next processNode call performs a full TP sync

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_propagation_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_propagation_unittest.ts
@@ -29,11 +29,11 @@ describe('Node Propagation', () => {
 
       // Setup: Source -> Modify -> Aggregation
       const sourceNode = createMockSourceNode();
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
 
       // Connect the nodes
       connectNodes(sourceNode, modifyNode);
@@ -43,21 +43,21 @@ describe('Node Propagation', () => {
       initializeNodeChain([modifyNode, aggNode]);
 
       // Initial state: AggregationNode should have columns: id, name, value
-      expect(aggNode.state.groupByColumns.map((c) => c.name)).toEqual([
+      expect(aggNode.attrs.groupByColumns.map((c) => c.name)).toEqual([
         'id',
         'name',
         'value',
       ]);
 
       // THE BUG: Rename 'name' to 'user_name' in ModifyColumnsNode
-      modifyNode.state.selectedColumns[1].alias = 'user_name';
+      modifyNode.attrs.selectedColumns[1].alias = 'user_name';
 
       // BEFORE FIX: AggregationNode would still show 'id', 'name', 'value'
       // AFTER FIX: We need to call onPrevNodesUpdated to propagate the change
       aggNode.onPrevNodesUpdated?.();
 
       // Verify the fix: AggregationNode should now see the renamed column
-      const columnNames = aggNode.state.groupByColumns.map((c) => c.name);
+      const columnNames = aggNode.attrs.groupByColumns.map((c) => c.name);
       expect(columnNames).toContain('user_name');
       expect(columnNames).not.toContain('name');
       expect(columnNames).toEqual(['id', 'user_name', 'value']);
@@ -66,11 +66,11 @@ describe('Node Propagation', () => {
     it('should propagate renamed columns from ModifyColumnsNode to AggregationNode', () => {
       // Setup: Source -> Modify -> Aggregation
       const sourceNode = createMockSourceNode();
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
 
       // Connect the nodes
       connectNodes(sourceNode, modifyNode);
@@ -80,22 +80,22 @@ describe('Node Propagation', () => {
       modifyNode.onPrevNodesUpdated?.();
 
       // Verify modify node has the original columns
-      expect(modifyNode.state.selectedColumns).toHaveLength(3);
-      expect(modifyNode.state.selectedColumns[0].name).toBe('id');
-      expect(modifyNode.state.selectedColumns[1].name).toBe('name');
-      expect(modifyNode.state.selectedColumns[2].name).toBe('value');
+      expect(modifyNode.attrs.selectedColumns).toHaveLength(3);
+      expect(modifyNode.attrs.selectedColumns[0].name).toBe('id');
+      expect(modifyNode.attrs.selectedColumns[1].name).toBe('name');
+      expect(modifyNode.attrs.selectedColumns[2].name).toBe('value');
 
       // Initialize the aggregation node
       aggNode.onPrevNodesUpdated?.();
 
       // Verify aggregation node has the original columns
-      expect(aggNode.state.groupByColumns).toHaveLength(3);
-      expect(aggNode.state.groupByColumns[0].name).toBe('id');
-      expect(aggNode.state.groupByColumns[1].name).toBe('name');
-      expect(aggNode.state.groupByColumns[2].name).toBe('value');
+      expect(aggNode.attrs.groupByColumns).toHaveLength(3);
+      expect(aggNode.attrs.groupByColumns[0].name).toBe('id');
+      expect(aggNode.attrs.groupByColumns[1].name).toBe('name');
+      expect(aggNode.attrs.groupByColumns[2].name).toBe('value');
 
       // Now rename 'name' to 'user_name' in the modify node
-      modifyNode.state.selectedColumns[1].alias = 'user_name';
+      modifyNode.attrs.selectedColumns[1].alias = 'user_name';
 
       // Verify the finalCols of modify node uses the alias
       const modifyFinalCols = modifyNode.finalCols;
@@ -108,20 +108,20 @@ describe('Node Propagation', () => {
       aggNode.onPrevNodesUpdated?.();
 
       // Verify aggregation node now sees the renamed column
-      expect(aggNode.state.groupByColumns).toHaveLength(3);
-      expect(aggNode.state.groupByColumns[0].name).toBe('id');
-      expect(aggNode.state.groupByColumns[1].name).toBe('user_name'); // Should see the alias
-      expect(aggNode.state.groupByColumns[2].name).toBe('value');
+      expect(aggNode.attrs.groupByColumns).toHaveLength(3);
+      expect(aggNode.attrs.groupByColumns[0].name).toBe('id');
+      expect(aggNode.attrs.groupByColumns[1].name).toBe('user_name'); // Should see the alias
+      expect(aggNode.attrs.groupByColumns[2].name).toBe('value');
     });
 
     it('should preserve checked status when columns are renamed', () => {
       // Setup: Source -> Modify -> Aggregation
       const sourceNode = createMockSourceNode();
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
 
       // Connect the nodes
       connectNodes(sourceNode, modifyNode);
@@ -131,10 +131,10 @@ describe('Node Propagation', () => {
       initializeNodeChain([modifyNode, aggNode]);
 
       // Check a column in the aggregation node
-      aggNode.state.groupByColumns[1].checked = true; // Check 'name'
+      aggNode.attrs.groupByColumns[1].checked = true; // Check 'name'
 
       // Rename the checked column in modify node
-      modifyNode.state.selectedColumns[1].alias = 'user_name';
+      modifyNode.attrs.selectedColumns[1].alias = 'user_name';
 
       // Notify downstream
       aggNode.onPrevNodesUpdated?.();
@@ -142,7 +142,7 @@ describe('Node Propagation', () => {
       // The checked status should be lost because the column name changed
       // This is expected behavior - the aggregation node can't know that
       // 'user_name' is the same as 'name'
-      const userNameCol = aggNode.state.groupByColumns.find(
+      const userNameCol = aggNode.attrs.groupByColumns.find(
         (c) => c.name === 'user_name',
       );
       expect(userNameCol).toBeDefined();
@@ -152,11 +152,11 @@ describe('Node Propagation', () => {
     it('should handle column removal in ModifyColumnsNode', () => {
       // Setup: Source -> Modify -> Aggregation
       const sourceNode = createMockSourceNode();
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
 
       // Connect the nodes
       connectNodes(sourceNode, modifyNode);
@@ -166,10 +166,10 @@ describe('Node Propagation', () => {
       initializeNodeChain([modifyNode, aggNode]);
 
       // Initially should have 3 columns
-      expect(aggNode.state.groupByColumns).toHaveLength(3);
+      expect(aggNode.attrs.groupByColumns).toHaveLength(3);
 
       // Uncheck 'name' column in modify node (removes it from output)
-      modifyNode.state.selectedColumns[1].checked = false;
+      modifyNode.attrs.selectedColumns[1].checked = false;
 
       // Verify modify node's finalCols only has 2 columns now
       expect(modifyNode.finalCols).toHaveLength(2);
@@ -180,19 +180,19 @@ describe('Node Propagation', () => {
       aggNode.onPrevNodesUpdated?.();
 
       // Aggregation node should now only have 2 columns
-      expect(aggNode.state.groupByColumns).toHaveLength(2);
-      expect(aggNode.state.groupByColumns[0].name).toBe('id');
-      expect(aggNode.state.groupByColumns[1].name).toBe('value');
+      expect(aggNode.attrs.groupByColumns).toHaveLength(2);
+      expect(aggNode.attrs.groupByColumns[0].name).toBe('id');
+      expect(aggNode.attrs.groupByColumns[1].name).toBe('value');
     });
 
     it('should handle column reordering in ModifyColumnsNode', () => {
       // Setup: Source -> Modify -> Aggregation
       const sourceNode = createMockSourceNode();
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
 
       // Connect the nodes
       connectNodes(sourceNode, modifyNode);
@@ -205,8 +205,8 @@ describe('Node Propagation', () => {
       expectColumnNames(modifyNode, ['id', 'name', 'value']);
 
       // Reorder: move 'value' to the front
-      const cols = modifyNode.state.selectedColumns;
-      modifyNode.state.selectedColumns = [cols[2], cols[0], cols[1]];
+      const cols = modifyNode.attrs.selectedColumns;
+      modifyNode.attrs.selectedColumns = [cols[2], cols[0], cols[1]];
 
       // Verify modify node's finalCols are reordered
       expectColumnNames(modifyNode, ['value', 'id', 'name']);
@@ -215,9 +215,9 @@ describe('Node Propagation', () => {
       aggNode.onPrevNodesUpdated?.();
 
       // Aggregation node should see the new order
-      expect(aggNode.state.groupByColumns[0].name).toBe('value');
-      expect(aggNode.state.groupByColumns[1].name).toBe('id');
-      expect(aggNode.state.groupByColumns[2].name).toBe('name');
+      expect(aggNode.attrs.groupByColumns[0].name).toBe('value');
+      expect(aggNode.attrs.groupByColumns[1].name).toBe('id');
+      expect(aggNode.attrs.groupByColumns[2].name).toBe('name');
     });
   });
 
@@ -225,9 +225,9 @@ describe('Node Propagation', () => {
     it('should propagate changes through chain: Source -> Modify1 -> Modify2 -> Modify3', () => {
       // Setup: Source -> Modify1 -> Modify2 -> Modify3
       const sourceNode = createMockSourceNode();
-      const modify1 = new ModifyColumnsNode({selectedColumns: []});
-      const modify2 = new ModifyColumnsNode({selectedColumns: []});
-      const modify3 = new ModifyColumnsNode({selectedColumns: []});
+      const modify1 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify2 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify3 = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, modify1);
@@ -243,7 +243,7 @@ describe('Node Propagation', () => {
       expectColumnNames(modify3, ['id', 'name', 'value']);
 
       // Rename 'name' to 'user_name' in modify1
-      modify1.state.selectedColumns[1].alias = 'user_name';
+      modify1.attrs.selectedColumns[1].alias = 'user_name';
 
       // Notify all downstream nodes (simulating builder's onchange)
       initializeNodeChain([modify2, modify3]);
@@ -257,11 +257,11 @@ describe('Node Propagation', () => {
     it('should propagate changes through 5-node chain with middle node edit', () => {
       // Setup: Source -> Modify1 -> Modify2 -> Modify3 -> Modify4 -> Modify5
       const sourceNode = createMockSourceNode();
-      const modify1 = new ModifyColumnsNode({selectedColumns: []});
-      const modify2 = new ModifyColumnsNode({selectedColumns: []});
-      const modify3 = new ModifyColumnsNode({selectedColumns: []});
-      const modify4 = new ModifyColumnsNode({selectedColumns: []});
-      const modify5 = new ModifyColumnsNode({selectedColumns: []});
+      const modify1 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify2 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify3 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify4 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify5 = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, modify1);
@@ -274,7 +274,7 @@ describe('Node Propagation', () => {
       initializeNodeChain([modify1, modify2, modify3, modify4, modify5]);
 
       // Edit the MIDDLE node (modify3) - rename 'value' to 'amount'
-      modify3.state.selectedColumns[2].alias = 'amount';
+      modify3.attrs.selectedColumns[2].alias = 'amount';
 
       // Notify all downstream nodes (simulating builder's onchange)
       initializeNodeChain([modify4, modify5]);
@@ -292,12 +292,12 @@ describe('Node Propagation', () => {
     it('should propagate changes through mixed node types: Modify -> Agg -> Modify', () => {
       // Setup: Source -> Modify1 -> Agg -> Modify2
       const sourceNode = createMockSourceNode();
-      const modify1 = new ModifyColumnsNode({selectedColumns: []});
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modify2 = new ModifyColumnsNode({selectedColumns: []});
+      const modify1 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modify2 = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, modify1);
@@ -308,8 +308,8 @@ describe('Node Propagation', () => {
       initializeNodeChain([modify1, aggNode]);
 
       // Check columns BEFORE renaming and BEFORE initializing modify2
-      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
-      aggNode.state.groupByColumns[1].checked = true; // Check 'name'
+      aggNode.attrs.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.attrs.groupByColumns[1].checked = true; // Check 'name'
 
       // Now initialize modify2 after aggNode has checked columns
       modify2.onPrevNodesUpdated?.();
@@ -319,7 +319,7 @@ describe('Node Propagation', () => {
       expect(modify2.finalCols.map((c) => c.name)).toContain('name');
 
       // Rename 'name' to 'user_name' in modify1
-      modify1.state.selectedColumns[1].alias = 'user_name';
+      modify1.attrs.selectedColumns[1].alias = 'user_name';
 
       // Notify all downstream nodes
       initializeNodeChain([aggNode, modify2]);
@@ -327,16 +327,16 @@ describe('Node Propagation', () => {
       // Aggregation should see the renamed column in its available columns
       // Note: The old 'name' column is preserved as a "missing" column
       // because it was checked before the rename (intentional behavior)
-      expect(aggNode.state.groupByColumns.map((c) => c.name)).toContain(
+      expect(aggNode.attrs.groupByColumns.map((c) => c.name)).toContain(
         'user_name',
       );
 
       // The checked status is lost when column is renamed (expected behavior)
       // But we can check it again with the new name
-      const userNameCol = aggNode.state.groupByColumns.find(
+      const userNameCol = aggNode.attrs.groupByColumns.find(
         (c) => c.name === 'user_name',
       );
-      const idCol = aggNode.state.groupByColumns.find((c) => c.name === 'id');
+      const idCol = aggNode.attrs.groupByColumns.find((c) => c.name === 'id');
       if (userNameCol) {
         userNameCol.checked = true;
       }
@@ -355,9 +355,9 @@ describe('Node Propagation', () => {
     it('should handle multiple sequential edits in a chain', () => {
       // Setup: Source -> Modify1 -> Modify2 -> Modify3
       const sourceNode = createMockSourceNode();
-      const modify1 = new ModifyColumnsNode({selectedColumns: []});
-      const modify2 = new ModifyColumnsNode({selectedColumns: []});
-      const modify3 = new ModifyColumnsNode({selectedColumns: []});
+      const modify1 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify2 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify3 = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, modify1);
@@ -368,19 +368,19 @@ describe('Node Propagation', () => {
       initializeNodeChain([modify1, modify2, modify3]);
 
       // First edit: modify1 renames 'name' to 'user_name'
-      modify1.state.selectedColumns[1].alias = 'user_name';
+      modify1.attrs.selectedColumns[1].alias = 'user_name';
       initializeNodeChain([modify2, modify3]);
 
       expectColumnNames(modify3, ['id', 'user_name', 'value']);
 
       // Second edit: modify2 renames 'user_name' to 'username'
-      modify2.state.selectedColumns[1].alias = 'username';
+      modify2.attrs.selectedColumns[1].alias = 'username';
       modify3.onPrevNodesUpdated?.();
 
       expectColumnNames(modify3, ['id', 'username', 'value']);
 
       // Third edit: modify2 also renames 'id' to 'identifier'
-      modify2.state.selectedColumns[0].alias = 'identifier';
+      modify2.attrs.selectedColumns[0].alias = 'identifier';
       modify3.onPrevNodesUpdated?.();
 
       expectColumnNames(modify3, ['identifier', 'username', 'value']);
@@ -389,10 +389,10 @@ describe('Node Propagation', () => {
     it('should propagate column removal through entire chain', () => {
       // Setup: Source -> Modify1 -> Modify2 -> Modify3 -> Modify4
       const sourceNode = createMockSourceNode();
-      const modify1 = new ModifyColumnsNode({selectedColumns: []});
-      const modify2 = new ModifyColumnsNode({selectedColumns: []});
-      const modify3 = new ModifyColumnsNode({selectedColumns: []});
-      const modify4 = new ModifyColumnsNode({selectedColumns: []});
+      const modify1 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify2 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify3 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify4 = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, modify1);
@@ -407,7 +407,7 @@ describe('Node Propagation', () => {
       expect(modify4.finalCols).toHaveLength(3);
 
       // Remove 'name' column in modify2 (middle of chain)
-      modify2.state.selectedColumns[1].checked = false;
+      modify2.attrs.selectedColumns[1].checked = false;
       initializeNodeChain([modify3, modify4]);
 
       // All downstream nodes should only have 2 columns now
@@ -421,11 +421,11 @@ describe('Node Propagation', () => {
   describe('onPrevNodesUpdated behavior', () => {
     it('should be called on downstream nodes when upstream changes', () => {
       const sourceNode = createMockSourceNode();
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
 
       // Connect the nodes
       connectNodes(sourceNode, modifyNode);
@@ -444,7 +444,7 @@ describe('Node Propagation', () => {
       aggOnPrevNodesUpdatedSpy.mockClear();
 
       // Make a change in modify node and trigger propagation
-      modifyNode.state.selectedColumns[0].alias = 'identifier';
+      modifyNode.attrs.selectedColumns[0].alias = 'identifier';
       aggNode.onPrevNodesUpdated?.();
 
       // Verify it was called
@@ -462,11 +462,11 @@ describe('Node Propagation', () => {
 
       // Setup: Source -> Aggregation -> ModifyColumns
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, aggNode);
@@ -476,26 +476,26 @@ describe('Node Propagation', () => {
       aggNode.onPrevNodesUpdated?.();
 
       // User adds an aggregation: COUNT(*) AS "count"
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'COUNT(*)',
         newColumnName: 'count',
       });
 
       // Check a column to include in output
-      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.attrs.groupByColumns[0].checked = true; // Check 'id'
 
       // User adds a modify columns node below
       // Initialize it - it should see 'id' and 'count' from aggregation
       modifyNode.onPrevNodesUpdated?.();
 
       // Verify modify node initially sees 'id' and 'count'
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
         'count',
       ]);
 
       // User goes back to aggregation and renames "count" to "my_count"
-      aggNode.state.aggregations[0].newColumnName = 'my_count';
+      aggNode.attrs.aggregations[0].newColumnName = 'my_count';
 
       // Simulate the builder's onchange behavior: notify downstream nodes
       // This is what SHOULD happen automatically when user edits in UI
@@ -505,16 +505,16 @@ describe('Node Propagation', () => {
       // - Old "count" column should be GONE
       // - New "my_count" column should appear
       // - It should be checked by default (all new columns are checked)
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
         'my_count',
       ]);
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'count',
       );
 
       // Verify the new column is checked by default
-      const myCountCol = modifyNode.state.selectedColumns.find(
+      const myCountCol = modifyNode.attrs.selectedColumns.find(
         (c) => c.name === 'my_count',
       );
       expect(myCountCol?.checked).toBe(true);
@@ -523,11 +523,11 @@ describe('Node Propagation', () => {
     it('should propagate multiple aggregation column name changes', () => {
       // Setup: Source -> Aggregation -> ModifyColumns
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, aggNode);
@@ -537,38 +537,38 @@ describe('Node Propagation', () => {
       aggNode.onPrevNodesUpdated?.();
 
       // Add multiple aggregations
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'COUNT(*)',
         newColumnName: 'count',
       });
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'SUM',
-        column: aggNode.state.groupByColumns.find((c) => c.name === 'value'),
+        column: aggNode.attrs.groupByColumns.find((c) => c.name === 'value'),
         newColumnName: 'total',
       });
 
       // Check a group by column
-      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.attrs.groupByColumns[0].checked = true; // Check 'id'
 
       // Initialize the modify node
       modifyNode.onPrevNodesUpdated?.();
 
       // Verify initial state
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
         'count',
         'total',
       ]);
 
       // Rename both aggregation columns
-      aggNode.state.aggregations[0].newColumnName = 'num_rows';
-      aggNode.state.aggregations[1].newColumnName = 'sum_value';
+      aggNode.attrs.aggregations[0].newColumnName = 'num_rows';
+      aggNode.attrs.aggregations[1].newColumnName = 'sum_value';
 
       // Propagate changes
       modifyNode.onPrevNodesUpdated?.();
 
       // Verify the changes propagated
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
         'num_rows',
         'sum_value',
@@ -578,12 +578,12 @@ describe('Node Propagation', () => {
     it('should handle propagation through: Source -> Agg -> ModifyColumns1 -> ModifyColumns2', () => {
       // Setup: Source -> Aggregation -> Modify1 -> Modify2
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modify1 = new ModifyColumnsNode({selectedColumns: []});
-      const modify2 = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modify1 = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modify2 = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, aggNode);
@@ -592,8 +592,8 @@ describe('Node Propagation', () => {
 
       // Initialize
       aggNode.onPrevNodesUpdated?.();
-      aggNode.state.groupByColumns[1].checked = true; // Check 'name'
-      aggNode.state.aggregations.push({
+      aggNode.attrs.groupByColumns[1].checked = true; // Check 'name'
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'COUNT(*)',
         newColumnName: 'count',
       });
@@ -605,7 +605,7 @@ describe('Node Propagation', () => {
       expectColumnNames(modify2, ['name', 'count']);
 
       // Rename aggregation column
-      aggNode.state.aggregations[0].newColumnName = 'total_count';
+      aggNode.attrs.aggregations[0].newColumnName = 'total_count';
 
       // Propagate to both downstream nodes
       initializeNodeChain([modify1, modify2]);
@@ -619,12 +619,12 @@ describe('Node Propagation', () => {
       // This test requires FilterNode, but we'll use ModifyColumns as a proxy
       // to test the general propagation pattern
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const middleNode = new ModifyColumnsNode({selectedColumns: []});
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const middleNode = new ModifyColumnsNode({selectedColumns: []}, {});
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect: Source -> Agg -> MiddleNode -> ModifyColumns
       connectNodes(sourceNode, aggNode);
@@ -633,8 +633,8 @@ describe('Node Propagation', () => {
 
       // Initialize
       aggNode.onPrevNodesUpdated?.();
-      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
-      aggNode.state.aggregations.push({
+      aggNode.attrs.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'COUNT(*)',
         newColumnName: 'count',
       });
@@ -645,7 +645,7 @@ describe('Node Propagation', () => {
       expectColumnNames(modifyNode, ['id', 'count']);
 
       // Rename aggregation column
-      aggNode.state.aggregations[0].newColumnName = 'row_count';
+      aggNode.attrs.aggregations[0].newColumnName = 'row_count';
 
       // Propagate through middle node to modify node
       initializeNodeChain([middleNode, modifyNode]);
@@ -656,15 +656,15 @@ describe('Node Propagation', () => {
 
     it('should handle multiple stacked aggregations: Source -> Agg1 -> Agg2 -> ModifyColumns', () => {
       const sourceNode = createMockSourceNode();
-      const agg1 = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const agg2 = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const agg1 = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const agg2 = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect: Source -> Agg1 -> Agg2 -> ModifyColumns
       connectNodes(sourceNode, agg1);
@@ -673,23 +673,23 @@ describe('Node Propagation', () => {
 
       // Initialize agg1
       agg1.onPrevNodesUpdated?.();
-      agg1.state.groupByColumns[0].checked = true; // Group by 'id'
-      agg1.state.aggregations.push({
+      agg1.attrs.groupByColumns[0].checked = true; // Group by 'id'
+      agg1.attrs.aggregations.push({
         aggregationOp: 'SUM',
-        column: agg1.state.groupByColumns.find((c) => c.name === 'value'),
+        column: agg1.attrs.groupByColumns.find((c) => c.name === 'value'),
         newColumnName: 'total',
       });
 
       // Initialize agg2 - it should see 'id' and 'total' from agg1
       agg2.onPrevNodesUpdated?.();
-      expect(agg2.state.groupByColumns.map((c) => c.name)).toEqual([
+      expect(agg2.attrs.groupByColumns.map((c) => c.name)).toEqual([
         'id',
         'total',
       ]);
 
       // In agg2, do another aggregation
-      agg2.state.groupByColumns[0].checked = true; // Group by 'id'
-      agg2.state.aggregations.push({
+      agg2.attrs.groupByColumns[0].checked = true; // Group by 'id'
+      agg2.attrs.aggregations.push({
         aggregationOp: 'COUNT(*)',
         newColumnName: 'count',
       });
@@ -699,7 +699,7 @@ describe('Node Propagation', () => {
       expectColumnNames(modifyNode, ['id', 'count']);
 
       // Now change column name in FIRST aggregation (agg1)
-      agg1.state.aggregations[0].newColumnName = 'sum_value';
+      agg1.attrs.aggregations[0].newColumnName = 'sum_value';
 
       // Propagate through the chain
       agg2.onPrevNodesUpdated?.();
@@ -712,7 +712,7 @@ describe('Node Propagation', () => {
       expectColumnNames(modifyNode, ['id', 'count']);
 
       // Now also change column name in SECOND aggregation (agg2)
-      agg2.state.aggregations[0].newColumnName = 'num_groups';
+      agg2.attrs.aggregations[0].newColumnName = 'num_groups';
 
       // Propagate to modify node
       modifyNode.onPrevNodesUpdated?.();
@@ -725,11 +725,11 @@ describe('Node Propagation', () => {
       // it should NOT appear in the modify columns node below
 
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, aggNode);
@@ -739,8 +739,8 @@ describe('Node Propagation', () => {
       aggNode.onPrevNodesUpdated?.();
 
       // Add a valid aggregation
-      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
-      aggNode.state.aggregations.push({
+      aggNode.attrs.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'COUNT(*)',
         newColumnName: 'count',
       });
@@ -749,24 +749,24 @@ describe('Node Propagation', () => {
       modifyNode.onPrevNodesUpdated?.();
 
       // Should see 'id' and 'count'
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
         'count',
       ]);
 
       // Now make the aggregation INVALID by removing the operation
       // (simulating user deleting the operation while editing)
-      aggNode.state.aggregations[0].aggregationOp = undefined;
+      aggNode.attrs.aggregations[0].aggregationOp = undefined;
 
       // Notify downstream
       modifyNode.onPrevNodesUpdated?.();
 
       // EXPECTED: The invalid aggregation should NOT appear in modify node
       // Should only see 'id', NOT 'count'
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
       ]);
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'count',
       );
     });
@@ -776,11 +776,11 @@ describe('Node Propagation', () => {
       // it should appear in downstream nodes
 
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, aggNode);
@@ -788,10 +788,10 @@ describe('Node Propagation', () => {
 
       // Initialize
       aggNode.onPrevNodesUpdated?.();
-      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.attrs.groupByColumns[0].checked = true; // Check 'id'
 
       // Start with an INVALID aggregation (no operation selected)
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: undefined, // Invalid!
         newColumnName: 'my_agg',
       });
@@ -800,18 +800,18 @@ describe('Node Propagation', () => {
       modifyNode.onPrevNodesUpdated?.();
 
       // Should only see 'id', not the invalid aggregation
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
       ]);
 
       // Now make it valid by adding an operation
-      aggNode.state.aggregations[0].aggregationOp = 'COUNT(*)';
+      aggNode.attrs.aggregations[0].aggregationOp = 'COUNT(*)';
 
       // Notify downstream
       modifyNode.onPrevNodesUpdated?.();
 
       // EXPECTED: Now that it's valid, it should appear
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
         'my_agg',
       ]);
@@ -821,11 +821,11 @@ describe('Node Propagation', () => {
       // When there are multiple aggregations, only valid ones should propagate
 
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, aggNode);
@@ -833,23 +833,23 @@ describe('Node Propagation', () => {
 
       // Initialize
       aggNode.onPrevNodesUpdated?.();
-      aggNode.state.groupByColumns[0].checked = true; // Check 'id'
+      aggNode.attrs.groupByColumns[0].checked = true; // Check 'id'
 
       // Add multiple aggregations: some valid, some invalid
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'COUNT(*)',
         newColumnName: 'count', // VALID
       });
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: undefined, // INVALID - no operation
         newColumnName: 'invalid1',
       });
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'SUM',
-        column: aggNode.state.groupByColumns.find((c) => c.name === 'value'),
+        column: aggNode.attrs.groupByColumns.find((c) => c.name === 'value'),
         newColumnName: 'sum_value', // VALID
       });
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'SUM',
         column: undefined, // INVALID - SUM requires a column
         newColumnName: 'invalid2',
@@ -859,15 +859,15 @@ describe('Node Propagation', () => {
       modifyNode.onPrevNodesUpdated?.();
 
       // EXPECTED: Should only see 'id' and the two valid aggregations
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toEqual([
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toEqual([
         'id',
         'count',
         'sum_value',
       ]);
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'invalid1',
       );
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'invalid2',
       );
     });
@@ -878,11 +878,11 @@ describe('Node Propagation', () => {
 
       // Setup: Source -> Aggregation -> ModifyColumns
       const sourceNode = createMockSourceNode();
-      const aggNode = new AggregationNode({
-        groupByColumns: [],
-        aggregations: [],
-      });
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const aggNode = new AggregationNode(
+        {groupByColumns: [], aggregations: []},
+        {},
+      );
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Connect the nodes
       connectNodes(sourceNode, aggNode);
@@ -890,58 +890,58 @@ describe('Node Propagation', () => {
 
       // Initialize
       aggNode.onPrevNodesUpdated?.();
-      aggNode.state.groupByColumns[0].checked = true;
+      aggNode.attrs.groupByColumns[0].checked = true;
 
       // Scenario 1: User creates aggregation WITHOUT manual name (uses placeholder)
-      aggNode.state.aggregations.push({
+      aggNode.attrs.aggregations.push({
         aggregationOp: 'SUM',
-        column: aggNode.state.groupByColumns.find((c) => c.name === 'value'),
+        column: aggNode.attrs.groupByColumns.find((c) => c.name === 'value'),
         // No newColumnName - should use placeholder "sum_value"
       });
 
       modifyNode.onPrevNodesUpdated?.();
 
       // Should see the placeholder name "sum_value"
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toContain(
         'sum_value',
       );
 
       // Scenario 2: User manually enters their own name "my_custom_sum"
-      aggNode.state.aggregations[0].newColumnName = 'my_custom_sum';
+      aggNode.attrs.aggregations[0].newColumnName = 'my_custom_sum';
       modifyNode.onPrevNodesUpdated?.();
 
       // Should now see manual name, NOT placeholder
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toContain(
         'my_custom_sum',
       );
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'sum_value',
       );
 
       // Scenario 3: User changes manual name to something else
-      aggNode.state.aggregations[0].newColumnName = 'total_amount';
+      aggNode.attrs.aggregations[0].newColumnName = 'total_amount';
       modifyNode.onPrevNodesUpdated?.();
 
       // Should see the new manual name
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toContain(
         'total_amount',
       );
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'my_custom_sum',
       );
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'sum_value',
       );
 
       // Scenario 4: User changes the operation (manual name still takes precedence)
-      aggNode.state.aggregations[0].aggregationOp = 'AVG';
+      aggNode.attrs.aggregations[0].aggregationOp = 'AVG';
       modifyNode.onPrevNodesUpdated?.();
 
       // Should STILL see "total_amount" (manual name), NOT "avg_value" (placeholder)
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).toContain(
         'total_amount',
       );
-      expect(modifyNode.state.selectedColumns.map((c) => c.name)).not.toContain(
+      expect(modifyNode.attrs.selectedColumns.map((c) => c.name)).not.toContain(
         'avg_value',
       );
     });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_registry.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_registry.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {QueryNode, QueryNodeState, NodeType} from '../query_node';
+import {QueryNode, NodeType} from '../query_node';
 import {SqlModules} from '../../../plugins/dev.perfetto.SqlModules/sql_modules';
 import {Trace} from '../../../public/trace';
 
@@ -24,6 +24,8 @@ export interface PreCreateContext {
 // The context provided to the node factory.
 export interface NodeFactoryContext {
   allNodes: QueryNode[];
+  // Runtime context (trace, sqlModules, actions) provided by the caller.
+  context?: import('../query_node').NodeContext;
 }
 
 // The initial state returned by preCreate, which will be merged with
@@ -60,7 +62,7 @@ export interface NodeDescriptor {
   ) => Promise<PreCreateState | PreCreateState[] | null>;
 
   // A function that creates a new instance of the node.
-  factory: (state: QueryNodeState, context?: NodeFactoryContext) => QueryNode;
+  factory: (attrs: PreCreateState, context?: NodeFactoryContext) => QueryNode;
 
   /**
    * Whether this node should be shown on the landing page.
@@ -91,6 +93,7 @@ export interface NodeDescriptor {
     node: QueryNode,
     state: object,
     allNodes: Map<string, QueryNode>,
+    innerNodeIds?: string[],
   ) => void;
 
   // Post-deserialization hook (phase 1). Called after all connections are

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_registry_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/node_registry_unittest.ts
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {NodeRegistry, NodeDescriptor, PreCreateContext} from './node_registry';
-import {QueryNode, NodeType, QueryNodeState} from '../query_node';
+import {
+  NodeRegistry,
+  NodeDescriptor,
+  PreCreateContext,
+  PreCreateState,
+} from './node_registry';
+import {QueryNode, NodeType} from '../query_node';
 
 describe('NodeRegistry', () => {
   function createMockNode(nodeId: string): QueryNode {
@@ -22,7 +27,8 @@ describe('NodeRegistry', () => {
       type: NodeType.kTable,
       nextNodes: [],
       finalCols: [],
-      state: {},
+      attrs: {},
+      context: {},
       validate: () => true,
       getTitle: () => 'Test',
       nodeSpecificModify: () => null,
@@ -30,7 +36,6 @@ describe('NodeRegistry', () => {
       nodeInfo: () => null,
       clone: () => createMockNode(nodeId),
       getStructuredQuery: () => undefined,
-      serializeState: () => ({}),
     } as QueryNode;
   }
 
@@ -49,7 +54,7 @@ describe('NodeRegistry', () => {
         description: 'A test node',
         icon: 'test-icon',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('test'),
+        factory: (_state: PreCreateState) => createMockNode('test'),
       };
 
       registry.register('test-node', descriptor);
@@ -66,7 +71,7 @@ describe('NodeRegistry', () => {
         description: 'First node',
         icon: 'icon1',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('node1'),
+        factory: (_state: PreCreateState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
         ...defaults,
@@ -74,7 +79,7 @@ describe('NodeRegistry', () => {
         description: 'Second node',
         icon: 'icon2',
         type: 'modification',
-        factory: (_state: QueryNodeState) => createMockNode('node2'),
+        factory: (_state: PreCreateState) => createMockNode('node2'),
       };
 
       registry.register('node1', descriptor1);
@@ -92,7 +97,7 @@ describe('NodeRegistry', () => {
         description: 'First node',
         icon: 'icon1',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('node1'),
+        factory: (_state: PreCreateState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
         ...defaults,
@@ -100,7 +105,7 @@ describe('NodeRegistry', () => {
         description: 'Updated node',
         icon: 'icon1-updated',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('node1-updated'),
+        factory: (_state: PreCreateState) => createMockNode('node1-updated'),
       };
 
       registry.register('node1', descriptor1);
@@ -122,7 +127,7 @@ describe('NodeRegistry', () => {
         type: 'multisource',
         hotkey: 'ctrl+a',
         preCreate,
-        factory: (_state: QueryNodeState) => createMockNode('advanced'),
+        factory: (_state: PreCreateState) => createMockNode('advanced'),
       };
 
       registry.register('advanced-node', descriptor);
@@ -150,7 +155,7 @@ describe('NodeRegistry', () => {
         description: 'A test node',
         icon: 'test-icon',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('test'),
+        factory: (_state: PreCreateState) => createMockNode('test'),
       };
 
       registry.register('test-node', descriptor);
@@ -168,7 +173,7 @@ describe('NodeRegistry', () => {
         description: 'Node with special id',
         icon: 'special-icon',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('special'),
+        factory: (_state: PreCreateState) => createMockNode('special'),
       };
 
       registry.register('node:with:special-chars_123', descriptor);
@@ -195,7 +200,7 @@ describe('NodeRegistry', () => {
         description: 'First node',
         icon: 'icon1',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('node1'),
+        factory: (_state: PreCreateState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
         ...defaults,
@@ -203,7 +208,7 @@ describe('NodeRegistry', () => {
         description: 'Second node',
         icon: 'icon2',
         type: 'modification',
-        factory: (_state: QueryNodeState) => createMockNode('node2'),
+        factory: (_state: PreCreateState) => createMockNode('node2'),
       };
       const descriptor3: NodeDescriptor = {
         ...defaults,
@@ -211,7 +216,7 @@ describe('NodeRegistry', () => {
         description: 'Third node',
         icon: 'icon3',
         type: 'multisource',
-        factory: (_state: QueryNodeState) => createMockNode('node3'),
+        factory: (_state: PreCreateState) => createMockNode('node3'),
       };
 
       registry.register('node1', descriptor1);
@@ -234,7 +239,7 @@ describe('NodeRegistry', () => {
         description: 'A test node',
         icon: 'test-icon',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('test'),
+        factory: (_state: PreCreateState) => createMockNode('test'),
       };
 
       registry.register('test-node', descriptor);
@@ -254,7 +259,7 @@ describe('NodeRegistry', () => {
         description: 'First node',
         icon: 'icon1',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('node1'),
+        factory: (_state: PreCreateState) => createMockNode('node1'),
       };
       const descriptor2: NodeDescriptor = {
         ...defaults,
@@ -262,7 +267,7 @@ describe('NodeRegistry', () => {
         description: 'Updated node',
         icon: 'icon1-updated',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('node1-updated'),
+        factory: (_state: PreCreateState) => createMockNode('node1-updated'),
       };
 
       registry.register('node1', descriptor1);
@@ -542,7 +547,7 @@ describe('NodeRegistry', () => {
         description: 'A source node',
         icon: 'source-icon',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('source'),
+        factory: (_state: PreCreateState) => createMockNode('source'),
       };
       registry.register('source-node', descriptor1);
       expect(registry.list().length).toBe(1);
@@ -555,7 +560,7 @@ describe('NodeRegistry', () => {
         description: 'A modification node',
         icon: 'modify-icon',
         type: 'modification',
-        factory: (_state: QueryNodeState) => createMockNode('modify'),
+        factory: (_state: PreCreateState) => createMockNode('modify'),
       };
       registry.register('modify-node', descriptor2);
       expect(registry.list().length).toBe(2);
@@ -568,7 +573,7 @@ describe('NodeRegistry', () => {
         description: 'Updated source node',
         icon: 'source-icon-updated',
         type: 'source',
-        factory: (_state: QueryNodeState) => createMockNode('source-updated'),
+        factory: (_state: PreCreateState) => createMockNode('source-updated'),
       };
       registry.register('source-node', descriptor1Updated);
       expect(registry.list().length).toBe(2);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_configuration_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_configuration_modal.ts
@@ -30,7 +30,7 @@ export interface AddColumnsConfigurationModalAttrs {
   readonly leftColumn?: string;
   readonly rightColumn?: string;
   readonly selectedColumns: string[];
-  readonly columnAliases?: Map<string, string>;
+  readonly columnAliases?: Record<string, string>;
 
   // Callbacks
   readonly getJoinColumnErrors: (
@@ -66,8 +66,8 @@ export class AddColumnsConfigurationModal
     // Create rightCols with checked state based on selectedColumns
     const rightColsWithChecked = rightCols.map((col) => ({
       ...col,
-      checked: selectedColumns.includes(col.column.name),
-      alias: columnAliases?.get(col.column.name),
+      checked: selectedColumns.includes(col.name),
+      alias: columnAliases?.[col.name],
     }));
 
     return m(
@@ -116,10 +116,10 @@ export class AddColumnsConfigurationModal
               m(
                 'option',
                 {
-                  value: col.column.name,
-                  selected: col.column.name === leftColumn,
+                  value: col.name,
+                  selected: col.name === leftColumn,
                 },
-                col.column.name,
+                col.name,
               ),
             ),
           ],
@@ -138,11 +138,11 @@ export class AddColumnsConfigurationModal
           onRightColumnChange(columnName);
         },
         onColumnToggle: (index: number, checked: boolean) => {
-          const colName = rightCols[index].column.name;
+          const colName = rightCols[index].name;
           onColumnToggle(colName, checked);
         },
         onColumnAlias: (index: number, alias: string) => {
-          const colName = rightCols[index].column.name;
+          const colName = rightCols[index].name;
           onColumnAlias(colName, alias);
         },
       }),

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal.ts
@@ -111,7 +111,7 @@ export function getColumnsForArgType(
   const argTypeResult = parsePerfettoSqlTypeFromString({type: argType});
   if (!argTypeResult.ok) {
     // Unknown arg type - show all columns
-    return sourceCols.map((col) => col.column.name);
+    return sourceCols.map((col) => col.name);
   }
   const parsedArgType = argTypeResult.value;
   const argIsQuantitative = isQuantitativeType(parsedArgType);
@@ -119,7 +119,7 @@ export function getColumnsForArgType(
 
   return sourceCols
     .filter((col) => {
-      const colType = col.column.type;
+      const colType = col.type;
       if (colType === undefined) {
         // Unknown column type - include it
         return true;
@@ -133,7 +133,7 @@ export function getColumnsForArgType(
       // For other types (like bytes), show all columns
       return true;
     })
-    .map((col) => col.column.name);
+    .map((col) => col.name);
 }
 
 /**

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_function_modal_unittest.ts
@@ -91,11 +91,7 @@ function createMockColumnInfo(
   name: string,
   type?: PerfettoSqlType,
 ): ColumnInfo {
-  return {
-    name,
-    checked: false,
-    column: {name, type},
-  };
+  return {name, type, checked: false};
 }
 
 describe('buildFunctionExpression', () => {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
@@ -17,11 +17,11 @@ import {
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {getSecondaryInput} from '../graph_utils';
 import {
   ColumnInfo,
-  columnInfoFromName,
   columnInfoFromSqlColumn,
   legacyDeserializeType,
 } from '../column_info';
@@ -43,8 +43,6 @@ import {
 import {setValidationError} from '../node_issues';
 import {EmptyState} from '../../../../widgets/empty_state';
 import {Callout} from '../../../../widgets/callout';
-import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
-import {Trace} from '../../../../public/trace';
 import {Form, FormSection} from '../../../../widgets/form';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../../node_types';
 import {NodeDetailsMessage, ColumnName} from '../node_styling_widgets';
@@ -52,7 +50,7 @@ import {Spinner} from '../../../../widgets/spinner';
 import {STR} from '../../../../trace_processor/query_result';
 import {sqliteString} from '../../../../base/string_utils';
 import {loadNodeDoc} from '../node_doc_loader';
-import {NewColumn, AddColumnsNodeState} from './add_columns_types';
+import {NewColumn, AddColumnsNodeAttrs} from './add_columns_types';
 import {SwitchComponent, IfComponent} from './computed_column_components';
 import {AddColumnsSuggestionModal} from './add_columns_suggestion_modal';
 import {AddColumnsConfigurationModal} from './add_columns_configuration_modal';
@@ -69,7 +67,7 @@ import {
 } from './add_columns_function_modal';
 
 // Re-export types for backwards compatibility
-export {NewColumn, AddColumnsNodeState} from './add_columns_types';
+export {NewColumn, AddColumnsNodeAttrs} from './add_columns_types';
 
 export class AddColumnsNode implements QueryNode {
   readonly nodeId: string;
@@ -77,11 +75,24 @@ export class AddColumnsNode implements QueryNode {
   primaryInput?: QueryNode;
   secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
-  readonly state: AddColumnsNodeState;
+  readonly attrs: AddColumnsNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: AddColumnsNodeState) {
+  constructor(attrs: AddColumnsNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = state;
+    this.attrs = {
+      ...attrs,
+      selectedColumns: attrs.selectedColumns ?? [],
+      leftColumn: attrs.leftColumn ?? 'id',
+      rightColumn: attrs.rightColumn ?? 'id',
+      suggestionSelections: attrs.suggestionSelections ?? {},
+      expandedSuggestions: attrs.expandedSuggestions ?? [],
+      columnAliases: attrs.columnAliases ?? {},
+      suggestionAliases: attrs.suggestionAliases ?? {},
+      columnTypes: attrs.columnTypes ?? {},
+      computedColumns: attrs.computedColumns ?? [],
+    };
+    this.context = {...context, autoExecute: context.autoExecute ?? true};
     this.secondaryInputs = {
       connections: new Map(),
       min: 1,
@@ -89,43 +100,31 @@ export class AddColumnsNode implements QueryNode {
       portNames: ['Table'],
     };
     this.nextNodes = [];
-    this.state.selectedColumns = this.state.selectedColumns ?? [];
-    this.state.leftColumn = this.state.leftColumn ?? 'id';
-    this.state.rightColumn = this.state.rightColumn ?? 'id';
-    this.state.autoExecute = this.state.autoExecute ?? true;
-    this.state.suggestionSelections =
-      this.state.suggestionSelections ?? new Map();
-    this.state.expandedSuggestions =
-      this.state.expandedSuggestions ?? new Set();
-    this.state.columnAliases = this.state.columnAliases ?? new Map();
-    this.state.suggestionAliases = this.state.suggestionAliases ?? new Map();
-    this.state.columnTypes = this.state.columnTypes ?? new Map();
-    this.state.computedColumns = this.state.computedColumns ?? [];
   }
 
   // Called when a node is connected/disconnected to inputNodes
   onPrevNodesUpdated(): void {
     // If node is disconnected, reset everything
     if (!this.rightNode) {
-      this.state.selectedColumns = [];
-      this.state.isGuidedConnection = false;
-      this.state.onchange?.();
+      this.attrs.selectedColumns = [];
+      this.attrs.isGuidedConnection = false;
+      this.context.onchange?.();
       return;
     }
 
     // Check if the join column is still valid
-    if (this.state.rightColumn) {
+    if (this.attrs.rightColumn) {
       const rightColExists = this.rightCols.some(
-        (c) => c.column.name === this.state.rightColumn,
+        (c) => c.name === this.attrs.rightColumn,
       );
       if (!rightColExists) {
         // Join column no longer exists - reset selection
-        this.state.selectedColumns = [];
-        this.state.rightColumn = undefined;
+        this.attrs.selectedColumns = [];
+        this.attrs.rightColumn = undefined;
       }
     }
 
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   get sourceCols(): ColumnInfo[] {
@@ -148,15 +147,15 @@ export class AddColumnsNode implements QueryNode {
     if (this.rightNode) {
       // Add only selected columns (with aliases and types if provided)
       const newCols =
-        this.state.selectedColumns?.map((c) => {
-          const alias = this.state.columnAliases?.get(c);
-          const storedType = this.state.columnTypes?.get(c);
+        this.attrs.selectedColumns?.map((c) => {
+          const alias = this.attrs.columnAliases?.[c];
+          const storedType = this.attrs.columnTypes?.[c];
 
           // Find the column in rightCols to get type information
           const sourceCol = this.rightCols.find((col) => col.name === c);
           if (sourceCol) {
             // Use stored type if available, otherwise use source type
-            const finalType = storedType ?? sourceCol.column.type;
+            const finalType = storedType ?? sourceCol.type;
 
             return columnInfoFromSqlColumn({
               name: alias ?? c,
@@ -164,14 +163,14 @@ export class AddColumnsNode implements QueryNode {
             });
           }
           // Fallback if column not found (shouldn't happen in valid state)
-          return columnInfoFromName(alias ?? c);
+          return {name: alias ?? c, checked: false};
         }) ?? [];
       cols = [...cols, ...newCols];
     }
 
     // Add computed columns (expressions, SWITCH, IF)
     const computedCols =
-      this.state.computedColumns
+      this.attrs.computedColumns
         ?.filter((c) => this.isComputedColumnValid(c))
         .map((col) => {
           // Use stored sqlType if available (from deserialization or user change)
@@ -183,13 +182,13 @@ export class AddColumnsNode implements QueryNode {
           }
           // Try to preserve type information if the expression is a simple column reference
           const sourceCol = this.sourceCols.find(
-            (c) => c.column.name === col.expression,
+            (c) => c.name === col.expression,
           );
-          if (sourceCol?.column.type) {
-            col.sqlType = sourceCol.column.type;
+          if (sourceCol?.type) {
+            col.sqlType = sourceCol.type;
             return columnInfoFromSqlColumn({
               name: col.name,
-              type: sourceCol.column.type,
+              type: sourceCol.type,
             });
           }
           // For complex expressions, we can't infer the type, use INT as default
@@ -224,16 +223,16 @@ export class AddColumnsNode implements QueryNode {
 
     // Check against source columns (use alias if present, otherwise column name)
     for (const c of this.sourceCols) {
-      const effectiveName = c.alias ?? c.column.name;
+      const effectiveName = c.alias ?? c.name;
       if (effectiveName === trimmedName) {
         return `Column "${trimmedName}" already exists in the source data`;
       }
     }
 
     // Check against selected columns from joined source (with aliases)
-    if (this.state.selectedColumns) {
-      for (const colName of this.state.selectedColumns) {
-        const alias = this.state.columnAliases?.get(colName);
+    if (this.attrs.selectedColumns) {
+      for (const colName of this.attrs.selectedColumns) {
+        const alias = this.attrs.columnAliases?.[colName];
         const effectiveName = alias ?? colName;
         if (effectiveName === trimmedName) {
           return `Column "${trimmedName}" already exists in joined columns`;
@@ -242,9 +241,9 @@ export class AddColumnsNode implements QueryNode {
     }
 
     // Check against other computed columns
-    for (let i = 0; i < (this.state.computedColumns?.length ?? 0); i++) {
+    for (let i = 0; i < (this.attrs.computedColumns?.length ?? 0); i++) {
       if (i === excludeIndex) continue; // Skip the column being edited
-      const col = this.state.computedColumns![i];
+      const col = this.attrs.computedColumns![i];
       if (col.name.trim() === trimmedName) {
         return `Column "${trimmedName}" already exists in computed columns`;
       }
@@ -266,12 +265,12 @@ export class AddColumnsNode implements QueryNode {
     }> = [];
 
     for (const col of this.sourceCols) {
-      const colType = col.column.type;
+      const colType = col.type;
 
       // Check if this column has a JOINID type with explicit source information
       if (colType && colType.kind === 'joinid') {
         suggestions.push({
-          colName: col.column.name,
+          colName: col.name,
           suggestedTable: colType.source.table,
           targetColumn: colType.source.column,
         });
@@ -291,16 +290,16 @@ export class AddColumnsNode implements QueryNode {
 
   // Get full table info for a suggested table
   private getTable(tableName: string) {
-    if (!this.state.sqlModules) return undefined;
+    if (!this.context.sqlModules) return undefined;
 
-    return this.state.sqlModules.listTables().find((t) => t.name === tableName);
+    return this.context.sqlModules
+      .listTables()
+      .find((t) => t.name === tableName);
   }
 
   // Find all arg_set_id columns in source columns
   getArgSetIdColumns(): ColumnInfo[] {
-    return this.sourceCols.filter(
-      (col) => col.column.type?.kind === 'arg_set_id',
-    );
+    return this.sourceCols.filter((col) => col.type?.kind === 'arg_set_id');
   }
 
   // Fetch available arg keys for the given arg_set_id column.
@@ -308,19 +307,19 @@ export class AddColumnsNode implements QueryNode {
   // to avoid creating a competing summarizer (which would conflict with
   // the main QueryExecutionService's materialized tables).
   async fetchAvailableArgKeys(argSetIdCol: ColumnInfo): Promise<string[]> {
-    const trace = this.state.trace;
+    const trace = this.context.trace;
     if (!trace) return [];
 
     const primaryInput = this.primaryInput;
     if (!primaryInput) return [];
 
     // Get the materialized table name for the primary input node
-    const tableName = await this.state.getTableNameForNode?.(
+    const tableName = await this.context.getTableNameForNode?.(
       primaryInput.nodeId,
     );
     if (!tableName) return [];
 
-    const argColName = argSetIdCol.column.name;
+    const argColName = argSetIdCol.name;
     const sql = `
       SELECT DISTINCT args.flat_key as key
       FROM ${tableName} data
@@ -350,28 +349,28 @@ export class AddColumnsNode implements QueryNode {
   isApplyDisabled(): boolean {
     // When no rightNode exists, require table and columns selection
     if (!this.rightNode) {
-      const selectedTable = this.state.selectedSuggestionTable;
+      const selectedTable = this.attrs.selectedSuggestionTable;
       if (!selectedTable) return true;
       const selectedColumns =
-        this.state.suggestionSelections?.get(selectedTable) ?? [];
+        this.attrs.suggestionSelections?.[selectedTable] ?? [];
       if (selectedColumns.length === 0) return true;
       // Also disable if there are duplicate column name errors
       return this.getJoinColumnErrors(selectedColumns, true).length > 0;
     }
     // When rightNode exists, require both join columns to be specified
-    if (!this.state.leftColumn || !this.state.rightColumn) {
+    if (!this.attrs.leftColumn || !this.attrs.rightColumn) {
       return true;
     }
     // Require columns to be selected
     if (
-      !this.state.selectedColumns ||
-      this.state.selectedColumns.length === 0
+      !this.attrs.selectedColumns ||
+      this.attrs.selectedColumns.length === 0
     ) {
       return true;
     }
     // Also disable if there are duplicate column name errors
     return (
-      this.getJoinColumnErrors(this.state.selectedColumns, false).length > 0
+      this.getJoinColumnErrors(this.attrs.selectedColumns, false).length > 0
     );
   }
 
@@ -383,19 +382,19 @@ export class AddColumnsNode implements QueryNode {
   ): Array<{column: string; error: string}> {
     const errors: Array<{column: string; error: string}> = [];
     const aliasMap = useSuggestionAliases
-      ? this.state.suggestionAliases
-      : this.state.columnAliases;
+      ? this.attrs.suggestionAliases
+      : this.attrs.columnAliases;
 
     // Get effective names (alias or original name) for all selected columns
     const effectiveNames = new Map<string, string>();
     for (const col of selectedColumns) {
-      const alias = aliasMap?.get(col);
-      effectiveNames.set(col, alias || col);
+      const alias = aliasMap?.[col];
+      effectiveNames.set(col, alias !== undefined ? alias : col);
     }
 
     // Check each column against source columns
     const sourceColNames = new Set(
-      this.sourceCols.map((c) => c.alias ?? c.column.name),
+      this.sourceCols.map((c) => c.alias ?? c.name),
     );
     for (const col of selectedColumns) {
       const effectiveName = effectiveNames.get(col) ?? col;
@@ -427,9 +426,9 @@ export class AddColumnsNode implements QueryNode {
 
   nodeDetails(): NodeDetailsAttrs {
     const hasConnectedNode = this.rightNode !== undefined;
-    const hasComputedColumns = (this.state.computedColumns?.length ?? 0) > 0;
+    const hasComputedColumns = (this.attrs.computedColumns?.length ?? 0) > 0;
     const hasSelectedColumns =
-      this.state.selectedColumns && this.state.selectedColumns.length > 0;
+      this.attrs.selectedColumns && this.attrs.selectedColumns.length > 0;
 
     if (!hasSelectedColumns && !hasComputedColumns) {
       return {
@@ -443,8 +442,8 @@ export class AddColumnsNode implements QueryNode {
     if (hasConnectedNode && hasSelectedColumns) {
       items.push(m('div', 'Add columns from input node:'));
       const columns = [];
-      for (const col of this.state.selectedColumns ?? []) {
-        const alias = this.state.columnAliases?.get(col);
+      for (const col of this.attrs.selectedColumns ?? []) {
+        const alias = this.attrs.columnAliases?.[col];
         const displayName = alias || col;
         columns.push(displayName);
       }
@@ -463,7 +462,7 @@ export class AddColumnsNode implements QueryNode {
         items.push(m('.pf-section-spacer'));
       }
       items.push(m('div', 'Add computed columns:'));
-      for (const col of this.state.computedColumns ?? []) {
+      for (const col of this.attrs.computedColumns ?? []) {
         const name = col.name || '(unnamed)';
         let description = '';
 
@@ -577,42 +576,42 @@ export class AddColumnsNode implements QueryNode {
           disabled: () => this.isApplyDisabled(),
           action: () => {
             // If there's no rightNode, connect the selected suggestion table
-            if (!this.rightNode && this.state.selectedSuggestionTable) {
+            if (!this.rightNode && this.attrs.selectedSuggestionTable) {
               const suggestions = this.getJoinSuggestions();
               const selectedSuggestion = suggestions.find(
-                (s) => s.suggestedTable === this.state.selectedSuggestionTable,
+                (s) => s.suggestedTable === this.attrs.selectedSuggestionTable,
               );
               const selectedColumns =
-                this.state.suggestionSelections?.get(
-                  this.state.selectedSuggestionTable,
-                ) ?? [];
+                this.attrs.suggestionSelections?.[
+                  this.attrs.selectedSuggestionTable
+                ] ?? [];
 
               if (selectedSuggestion && selectedColumns.length > 0) {
-                if (this.state.actions?.onAddAndConnectTable) {
-                  this.state.isGuidedConnection = true;
-                  this.state.actions.onAddAndConnectTable(
+                if (this.context.actions?.onAddAndConnectTable) {
+                  this.attrs.isGuidedConnection = true;
+                  this.context.actions.onAddAndConnectTable(
                     selectedSuggestion.suggestedTable,
                     0,
                   );
-                  this.state.leftColumn = selectedSuggestion.colName;
-                  this.state.rightColumn = selectedSuggestion.targetColumn;
-                  this.state.selectedColumns = [...selectedColumns];
+                  this.attrs.leftColumn = selectedSuggestion.colName;
+                  this.attrs.rightColumn = selectedSuggestion.targetColumn;
+                  this.attrs.selectedColumns = [...selectedColumns];
                   // Copy suggestion aliases to column aliases
-                  if (this.state.suggestionAliases) {
-                    if (!this.state.columnAliases) {
-                      this.state.columnAliases = new Map();
+                  if (this.attrs.suggestionAliases) {
+                    if (!this.attrs.columnAliases) {
+                      this.attrs.columnAliases = {};
                     }
                     for (const col of selectedColumns) {
-                      const alias = this.state.suggestionAliases.get(col);
+                      const alias = this.attrs.suggestionAliases[col];
                       if (alias) {
-                        this.state.columnAliases.set(col, alias);
+                        this.attrs.columnAliases[col] = alias;
                       }
                     }
                   }
                 }
               }
             }
-            this.state.onchange?.();
+            this.context.onchange?.();
           },
         },
       ],
@@ -654,8 +653,8 @@ export class AddColumnsNode implements QueryNode {
 
     // Create a temporary copy to work with in the modal
     let tempColumn: NewColumn;
-    if (isEditing && this.state.computedColumns?.[columnIndex]) {
-      const source = this.state.computedColumns[columnIndex];
+    if (isEditing && this.attrs.computedColumns?.[columnIndex]) {
+      const source = this.attrs.computedColumns[columnIndex];
       tempColumn = {
         ...source,
         cases: source.cases?.map((c) => ({...c})),
@@ -691,17 +690,17 @@ export class AddColumnsNode implements QueryNode {
           action: () => {
             if (isEditing && columnIndex !== undefined) {
               const newComputedColumns = [
-                ...(this.state.computedColumns ?? []),
+                ...(this.attrs.computedColumns ?? []),
               ];
               newComputedColumns[columnIndex] = tempColumn;
-              this.state.computedColumns = newComputedColumns;
+              this.attrs.computedColumns = newComputedColumns;
             } else {
-              this.state.computedColumns = [
-                ...(this.state.computedColumns ?? []),
+              this.attrs.computedColumns = [
+                ...(this.attrs.computedColumns ?? []),
                 tempColumn,
               ];
             }
-            this.state.onchange?.();
+            this.context.onchange?.();
           },
         },
       ],
@@ -774,7 +773,7 @@ export class AddColumnsNode implements QueryNode {
     };
 
     const getArgSetIdColDisplayName = (col: ColumnInfo): string => {
-      return col.alias ?? col.column.name;
+      return col.alias ?? col.name;
     };
 
     showModal({
@@ -794,7 +793,7 @@ export class AddColumnsNode implements QueryNode {
                   onchange: (e: Event) => {
                     const value = (e.target as HTMLSelectElement).value;
                     selectedArgSetIdCol = argSetIdCols.find(
-                      (col) => col.column.name === value,
+                      (col) => col.name === value,
                     );
                     if (selectedArgSetIdCol) {
                       fetchKeysForColumn(selectedArgSetIdCol);
@@ -815,7 +814,7 @@ export class AddColumnsNode implements QueryNode {
                   m(
                     'option',
                     {
-                      value: col.column.name,
+                      value: col.name,
                       selected: col === selectedArgSetIdCol,
                     },
                     getArgSetIdColDisplayName(col),
@@ -940,7 +939,7 @@ export class AddColumnsNode implements QueryNode {
           action: () => {
             if (!isValid() || !selectedKey || !selectedArgSetIdCol) return;
 
-            const argSetIdColName = selectedArgSetIdCol.column.name;
+            const argSetIdColName = selectedArgSetIdCol.name;
             // Create expression using extract_arg
             const expression = `extract_arg(${argSetIdColName}, ${sqliteString(selectedKey)})`;
 
@@ -949,11 +948,11 @@ export class AddColumnsNode implements QueryNode {
               name: columnName.trim(),
             };
 
-            this.state.computedColumns = [
-              ...(this.state.computedColumns ?? []),
+            this.attrs.computedColumns = [
+              ...(this.attrs.computedColumns ?? []),
               newColumn,
             ];
-            this.state.onchange?.();
+            this.context.onchange?.();
             closeModal(modalKey);
           },
         },
@@ -965,14 +964,14 @@ export class AddColumnsNode implements QueryNode {
     const modalKey = 'add-function-modal';
     const isEditing = columnIndex !== undefined;
     const existingColumn = isEditing
-      ? this.state.computedColumns?.[columnIndex]
+      ? this.attrs.computedColumns?.[columnIndex]
       : undefined;
 
     // Create modal state using the helper
     const modalState: FunctionModalState = createFunctionModalState(
       isEditing,
       existingColumn,
-      this.state.sqlModules,
+      this.context.sqlModules,
     );
 
     // Generate a unique column name by appending a number suffix if needed
@@ -1022,7 +1021,7 @@ export class AddColumnsNode implements QueryNode {
         content: () => {
           if (modalState.step === 'select') {
             return m(FunctionSelectStep, {
-              sqlModules: this.state.sqlModules!,
+              sqlModules: this.context.sqlModules!,
               searchQuery: modalState.searchQuery,
               selectedFunction: modalState.selectedFunctionWithModule?.fn.name,
               onSearchQueryChange: (query) => {
@@ -1078,17 +1077,17 @@ export class AddColumnsNode implements QueryNode {
 
               if (isEditing && columnIndex !== undefined) {
                 const newComputedColumns = [
-                  ...(this.state.computedColumns ?? []),
+                  ...(this.attrs.computedColumns ?? []),
                 ];
                 newComputedColumns[columnIndex] = newColumn;
-                this.state.computedColumns = newComputedColumns;
+                this.attrs.computedColumns = newComputedColumns;
               } else {
-                this.state.computedColumns = [
-                  ...(this.state.computedColumns ?? []),
+                this.attrs.computedColumns = [
+                  ...(this.attrs.computedColumns ?? []),
                   newColumn,
                 ];
               }
-              this.state.onchange?.();
+              this.context.onchange?.();
               closeModal(modalKey);
             },
           },
@@ -1101,9 +1100,9 @@ export class AddColumnsNode implements QueryNode {
 
   private renderAddedColumnsList(): m.Child {
     const hasConnectedNode = this.rightNode !== undefined;
-    const hasComputedColumns = (this.state.computedColumns?.length ?? 0) > 0;
+    const hasComputedColumns = (this.attrs.computedColumns?.length ?? 0) > 0;
     const hasSelectedColumns =
-      this.state.selectedColumns && this.state.selectedColumns.length > 0;
+      this.attrs.selectedColumns && this.attrs.selectedColumns.length > 0;
 
     if (!hasSelectedColumns && !hasComputedColumns) {
       return m(EmptyState, {
@@ -1119,7 +1118,7 @@ export class AddColumnsNode implements QueryNode {
     }
 
     // Show computed columns
-    for (const [index, col] of (this.state.computedColumns ?? []).entries()) {
+    for (const [index, col] of (this.attrs.computedColumns ?? []).entries()) {
       const icon =
         col.type === 'switch'
           ? 'alt_route'
@@ -1156,10 +1155,10 @@ export class AddColumnsNode implements QueryNode {
   }
 
   private renderJoinedColumnsRow(): m.Child {
-    const count = this.state.selectedColumns?.length ?? 0;
-    const columnNames = (this.state.selectedColumns ?? [])
+    const count = this.attrs.selectedColumns?.length ?? 0;
+    const columnNames = (this.attrs.selectedColumns ?? [])
       .map((colName) => {
-        const alias = this.state.columnAliases?.get(colName);
+        const alias = this.attrs.columnAliases?.[colName];
         return alias || colName;
       })
       .join(', ');
@@ -1192,10 +1191,10 @@ export class AddColumnsNode implements QueryNode {
           icon: 'close',
           compact: true,
           onclick: () => {
-            this.state.selectedColumns = [];
-            this.state.columnAliases?.clear();
-            this.state.columnTypes?.clear();
-            this.state.onchange?.();
+            this.attrs.selectedColumns = [];
+            this.attrs.columnAliases = {};
+            this.attrs.columnTypes = {};
+            this.context.onchange?.();
           },
           title: 'Remove all joined columns',
         }),
@@ -1213,18 +1212,18 @@ export class AddColumnsNode implements QueryNode {
     const colInfo: ColumnInfo = {
       name: col.name || '(unnamed)',
       checked: true,
-      column: {name: col.name, type: col.sqlType},
+      type: col.sqlType,
     };
 
     const handleTypeChange = (_index: number, newType: PerfettoSqlType) => {
-      if (!this.state.computedColumns) return;
-      const newComputedColumns = [...this.state.computedColumns];
+      if (!this.attrs.computedColumns) return;
+      const newComputedColumns = [...this.attrs.computedColumns];
       newComputedColumns[index] = {
         ...newComputedColumns[index],
         sqlType: newType,
       };
-      this.state.computedColumns = newComputedColumns;
-      this.state.onchange?.();
+      this.attrs.computedColumns = newComputedColumns;
+      this.context.onchange?.();
     };
 
     return m(
@@ -1244,7 +1243,7 @@ export class AddColumnsNode implements QueryNode {
         renderTypeSelector(
           colInfo,
           index,
-          this.state.sqlModules,
+          this.context.sqlModules,
           handleTypeChange,
         ),
         m(Button, {
@@ -1268,8 +1267,8 @@ export class AddColumnsNode implements QueryNode {
           icon: 'close',
           compact: true,
           onclick: () => {
-            this.state.computedColumns?.splice(index, 1);
-            this.state.onchange?.();
+            this.attrs.computedColumns?.splice(index, 1);
+            this.context.onchange?.();
           },
           title: 'Remove item',
         }),
@@ -1285,9 +1284,9 @@ export class AddColumnsNode implements QueryNode {
 
   private renderSuggestionMode(): m.Child {
     const suggestions = this.getJoinSuggestions();
-    const selectedTable = this.state.selectedSuggestionTable;
+    const selectedTable = this.attrs.selectedSuggestionTable;
     const selectedColumns = selectedTable
-      ? this.state.suggestionSelections?.get(selectedTable) ?? []
+      ? this.attrs.suggestionSelections?.[selectedTable] ?? []
       : [];
 
     return m(AddColumnsSuggestionModal, {
@@ -1295,21 +1294,20 @@ export class AddColumnsNode implements QueryNode {
       sourceCols: this.sourceCols,
       selectedTable,
       selectedColumns,
-      suggestionAliases: this.state.suggestionAliases,
+      suggestionAliases: this.attrs.suggestionAliases,
       getTable: (tableName: string) => this.getTable(tableName),
       getJoinColumnErrors: (cols: string[]) =>
         this.getJoinColumnErrors(cols, true),
       onTableSelect: (tableName: string | undefined) => {
-        this.state.selectedSuggestionTable = tableName;
+        this.attrs.selectedSuggestionTable = tableName;
         m.redraw();
       },
       onColumnToggle: (colName: string, checked: boolean) => {
         if (!selectedTable) return;
-        if (!this.state.suggestionSelections) {
-          this.state.suggestionSelections = new Map();
+        if (!this.attrs.suggestionSelections) {
+          this.attrs.suggestionSelections = {};
         }
-        const current =
-          this.state.suggestionSelections.get(selectedTable) ?? [];
+        const current = this.attrs.suggestionSelections[selectedTable] ?? [];
         let updated = [...current];
         if (checked) {
           if (!updated.includes(colName)) {
@@ -1317,19 +1315,21 @@ export class AddColumnsNode implements QueryNode {
           }
         } else {
           updated = updated.filter((c) => c !== colName);
-          this.state.suggestionAliases?.delete(colName);
+          if (this.attrs.suggestionAliases) {
+            delete this.attrs.suggestionAliases[colName];
+          }
         }
-        this.state.suggestionSelections.set(selectedTable, updated);
+        this.attrs.suggestionSelections[selectedTable] = updated;
         redrawModal();
       },
       onColumnAlias: (colName: string, alias: string) => {
-        if (!this.state.suggestionAliases) {
-          this.state.suggestionAliases = new Map();
+        if (!this.attrs.suggestionAliases) {
+          this.attrs.suggestionAliases = {};
         }
         if (alias.trim() === '') {
-          this.state.suggestionAliases.delete(colName);
+          delete this.attrs.suggestionAliases[colName];
         } else {
-          this.state.suggestionAliases.set(colName, alias);
+          this.attrs.suggestionAliases[colName] = alias;
         }
         redrawModal();
       },
@@ -1337,50 +1337,52 @@ export class AddColumnsNode implements QueryNode {
   }
 
   private renderJoinConfiguration(): m.Child {
-    const selectedColumns = this.state.selectedColumns ?? [];
+    const selectedColumns = this.attrs.selectedColumns ?? [];
 
     return m(AddColumnsConfigurationModal, {
       sourceCols: this.sourceCols,
       rightCols: this.rightCols,
-      leftColumn: this.state.leftColumn,
-      rightColumn: this.state.rightColumn,
+      leftColumn: this.attrs.leftColumn,
+      rightColumn: this.attrs.rightColumn,
       selectedColumns,
-      columnAliases: this.state.columnAliases,
+      columnAliases: this.attrs.columnAliases,
       getJoinColumnErrors: (cols: string[]) =>
         this.getJoinColumnErrors(cols, false),
       onLeftColumnChange: (columnName: string) => {
-        this.state.leftColumn = columnName;
+        this.attrs.leftColumn = columnName;
         redrawModal();
       },
       onRightColumnChange: (columnName: string) => {
-        this.state.rightColumn = columnName;
+        this.attrs.rightColumn = columnName;
         redrawModal();
       },
       onColumnToggle: (colName: string, checked: boolean) => {
-        if (!this.state.selectedColumns) {
-          this.state.selectedColumns = [];
+        if (!this.attrs.selectedColumns) {
+          this.attrs.selectedColumns = [];
         }
         if (checked) {
-          if (!this.state.selectedColumns.includes(colName)) {
-            this.state.selectedColumns.push(colName);
+          if (!this.attrs.selectedColumns.includes(colName)) {
+            this.attrs.selectedColumns.push(colName);
           }
         } else {
-          this.state.selectedColumns = this.state.selectedColumns.filter(
+          this.attrs.selectedColumns = this.attrs.selectedColumns.filter(
             (c) => c !== colName,
           );
-          this.state.columnAliases?.delete(colName);
-          this.state.columnTypes?.delete(colName);
+          if (this.attrs.columnAliases) {
+            delete this.attrs.columnAliases[colName];
+          }
+          if (this.attrs.columnTypes) delete this.attrs.columnTypes[colName];
         }
         redrawModal();
       },
       onColumnAlias: (colName: string, alias: string) => {
-        if (!this.state.columnAliases) {
-          this.state.columnAliases = new Map();
+        if (!this.attrs.columnAliases) {
+          this.attrs.columnAliases = {};
         }
         if (alias.trim() === '') {
-          this.state.columnAliases.delete(colName);
+          delete this.attrs.columnAliases[colName];
         } else {
-          this.state.columnAliases.set(colName, alias);
+          this.attrs.columnAliases[colName] = alias;
         }
         redrawModal();
       },
@@ -1473,17 +1475,17 @@ export class AddColumnsNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
-      setValidationError(this.state, 'No input node connected');
+      setValidationError(this.context, 'No input node connected');
       return false;
     }
 
     if (!this.primaryInput.validate()) {
-      setValidationError(this.state, 'Previous node is invalid');
+      setValidationError(this.context, 'Previous node is invalid');
       return false;
     }
 
@@ -1491,17 +1493,17 @@ export class AddColumnsNode implements QueryNode {
     if (this.rightNode) {
       if (!this.rightNode.validate()) {
         setValidationError(
-          this.state,
-          this.rightNode.state.issues?.queryError?.message ??
+          this.context,
+          this.rightNode.context.issues?.queryError?.message ??
             `Lookup table node '${this.rightNode.getTitle()}' is invalid`,
         );
         return false;
       }
 
       // We need valid join columns
-      if (!this.state.leftColumn || !this.state.rightColumn) {
+      if (!this.attrs.leftColumn || !this.attrs.rightColumn) {
         setValidationError(
-          this.state,
+          this.context,
           'Join requires both left and right join columns to be selected',
         );
         return false;
@@ -1514,40 +1516,39 @@ export class AddColumnsNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: AddColumnsNodeState = {
-      selectedColumns: this.state.selectedColumns
-        ? [...this.state.selectedColumns]
+    const attrsCopy: AddColumnsNodeAttrs = {
+      selectedColumns: this.attrs.selectedColumns
+        ? [...this.attrs.selectedColumns]
         : undefined,
-      leftColumn: this.state.leftColumn,
-      rightColumn: this.state.rightColumn,
-      suggestionSelections: this.state.suggestionSelections
-        ? new Map(this.state.suggestionSelections)
+      leftColumn: this.attrs.leftColumn,
+      rightColumn: this.attrs.rightColumn,
+      suggestionSelections: this.attrs.suggestionSelections
+        ? {...this.attrs.suggestionSelections}
         : undefined,
-      expandedSuggestions: this.state.expandedSuggestions
-        ? new Set(this.state.expandedSuggestions)
+      expandedSuggestions: this.attrs.expandedSuggestions
+        ? [...this.attrs.expandedSuggestions]
         : undefined,
-      selectedSuggestionTable: this.state.selectedSuggestionTable,
-      columnAliases: this.state.columnAliases
-        ? new Map(this.state.columnAliases)
+      selectedSuggestionTable: this.attrs.selectedSuggestionTable,
+      columnAliases: this.attrs.columnAliases
+        ? {...this.attrs.columnAliases}
         : undefined,
-      suggestionAliases: this.state.suggestionAliases
-        ? new Map(this.state.suggestionAliases)
+      suggestionAliases: this.attrs.suggestionAliases
+        ? {...this.attrs.suggestionAliases}
         : undefined,
-      columnTypes: this.state.columnTypes
-        ? new Map(this.state.columnTypes)
+      columnTypes: this.attrs.columnTypes
+        ? {...this.attrs.columnTypes}
         : undefined,
-      isGuidedConnection: this.state.isGuidedConnection,
-      computedColumns: this.state.computedColumns?.map((col) => ({
+      isGuidedConnection: this.attrs.isGuidedConnection,
+      computedColumns: this.attrs.computedColumns?.map((col) => ({
         ...col,
         cases: col.cases?.map((c) => ({...c})),
         clauses: col.clauses?.map((c) => ({...c})),
       })),
-      filters: this.state.filters?.map((f) => ({...f})),
-      filterOperator: this.state.filterOperator,
-      onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
     };
-    return new AddColumnsNode(stateCopy);
+    return new AddColumnsNode(attrsCopy, {
+      onchange: this.context.onchange,
+      sqlModules: this.context.sqlModules,
+    });
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -1557,7 +1558,7 @@ export class AddColumnsNode implements QueryNode {
     // If there's no rightNode, we only add computed columns (no JOIN)
     if (!this.rightNode) {
       const computedColumns: ColumnSpec[] = [];
-      for (const col of this.state.computedColumns ?? []) {
+      for (const col of this.attrs.computedColumns ?? []) {
         if (!this.isComputedColumnValid(col)) continue;
         computedColumns.push({
           columnNameOrExpression: col.expression,
@@ -1577,14 +1578,14 @@ export class AddColumnsNode implements QueryNode {
       // Build column specifications including existing columns and computed columns
       const allColumns: ColumnSpec[] = [
         ...this.sourceCols.map((col) => ({
-          columnNameOrExpression: col.column.name,
-          alias: col.column.name, // Explicitly set alias to avoid protobuf empty string default
+          columnNameOrExpression: col.name,
+          alias: col.name, // Explicitly set alias to avoid protobuf empty string default
         })),
         ...computedColumns,
       ];
 
       // Collect referenced modules
-      const referencedModules = this.state.computedColumns
+      const referencedModules = this.attrs.computedColumns
         ?.filter((col) => col.module)
         .map((col) => col.module!);
 
@@ -1600,9 +1601,9 @@ export class AddColumnsNode implements QueryNode {
     }
 
     // Prepare columns to add from the JOIN
-    const joinColumns: ColumnSpec[] = (this.state.selectedColumns ?? []).map(
+    const joinColumns: ColumnSpec[] = (this.attrs.selectedColumns ?? []).map(
       (colName) => {
-        const explicitAlias = this.state.columnAliases?.get(colName);
+        const explicitAlias = this.attrs.columnAliases?.[colName];
         // Use explicit alias if provided, otherwise default to the column name
         const alias =
           explicitAlias && explicitAlias.trim() !== ''
@@ -1617,7 +1618,7 @@ export class AddColumnsNode implements QueryNode {
 
     // Prepare computed columns (expressions)
     const computedColumns: ColumnSpec[] = [];
-    for (const col of this.state.computedColumns ?? []) {
+    for (const col of this.attrs.computedColumns ?? []) {
       if (!this.isComputedColumnValid(col)) continue;
       computedColumns.push({
         columnNameOrExpression: col.expression,
@@ -1630,13 +1631,13 @@ export class AddColumnsNode implements QueryNode {
     let condition: JoinCondition | undefined;
     if (
       joinColumns.length > 0 &&
-      this.state.leftColumn !== undefined &&
-      this.state.rightColumn !== undefined
+      this.attrs.leftColumn !== undefined &&
+      this.attrs.rightColumn !== undefined
     ) {
       condition = {
         type: 'equality',
-        leftColumn: this.state.leftColumn,
-        rightColumn: this.state.rightColumn,
+        leftColumn: this.attrs.leftColumn,
+        rightColumn: this.attrs.rightColumn,
       };
     } else if (joinColumns.length > 0) {
       // If we have JOIN columns but no condition, this is an invalid state
@@ -1645,7 +1646,7 @@ export class AddColumnsNode implements QueryNode {
     }
 
     // Collect referenced modules from computed columns
-    const referencedModules = this.state.computedColumns
+    const referencedModules = this.attrs.computedColumns
       ?.map((col) => col.module)
       .filter((mod): mod is string => mod !== undefined);
 
@@ -1656,8 +1657,8 @@ export class AddColumnsNode implements QueryNode {
 
     // Get all base columns from the source (needed when we have JOIN or computed columns)
     const allBaseColumns: ColumnSpec[] = this.sourceCols.map((col) => ({
-      columnNameOrExpression: col.column.name,
-      alias: col.column.name, // Explicitly set alias to avoid protobuf empty string default
+      columnNameOrExpression: col.name,
+      alias: col.name, // Explicitly set alias to avoid protobuf empty string default
     }));
 
     // Use the builder to handle the complexity of composing JOIN + computed columns
@@ -1675,130 +1676,17 @@ export class AddColumnsNode implements QueryNode {
     );
   }
 
-  serializeState(): object {
-    return {
-      selectedColumns: this.state.selectedColumns,
-      leftColumn: this.state.leftColumn,
-      rightColumn: this.state.rightColumn,
-      suggestionSelections: this.state.suggestionSelections
-        ? Object.fromEntries(this.state.suggestionSelections)
-        : undefined,
-      expandedSuggestions: this.state.expandedSuggestions
-        ? Array.from(this.state.expandedSuggestions)
-        : undefined,
-      selectedSuggestionTable: this.state.selectedSuggestionTable,
-      columnAliases: this.state.columnAliases
-        ? Object.fromEntries(this.state.columnAliases)
-        : undefined,
-      suggestionAliases: this.state.suggestionAliases
-        ? Object.fromEntries(this.state.suggestionAliases)
-        : undefined,
-      columnTypes: this.state.columnTypes
-        ? Object.fromEntries(this.state.columnTypes)
-        : undefined,
-      isGuidedConnection: this.state.isGuidedConnection,
-      autoExecute: this.state.autoExecute,
-      computedColumns: this.state.computedColumns?.map((c) => ({
-        expression: c.expression,
-        name: c.name,
-        module: c.module,
-        type: c.type,
-        switchOn: c.switchOn,
-        cases: c.cases
-          ? c.cases.map((cs) => ({when: cs.when, then: cs.then}))
-          : undefined,
-        defaultValue: c.defaultValue,
-        useGlob: c.useGlob,
-        clauses: c.clauses
-          ? c.clauses.map((cl) => ({if: cl.if, then: cl.then}))
-          : undefined,
-        elseValue: c.elseValue,
-        sqlType: c.sqlType,
-        functionName: c.functionName,
-        functionArgs: c.functionArgs,
-      })),
-    };
-  }
-
   static deserializeState(
-    trace: Trace,
-    sqlModules: SqlModules,
-    serializedState: AddColumnsNodeState,
-  ): AddColumnsNodeState {
-    return {
-      ...serializedState,
-      trace,
-      sqlModules,
-      suggestionSelections:
-        (serializedState.suggestionSelections as unknown as Record<
-          string,
-          string[]
-        >) !== undefined
-          ? new Map(
-              Object.entries(
-                serializedState.suggestionSelections as unknown as Record<
-                  string,
-                  string[]
-                >,
-              ),
-            )
-          : undefined,
-      expandedSuggestions:
-        (serializedState.expandedSuggestions as unknown as string[]) !==
-        undefined
-          ? new Set(serializedState.expandedSuggestions as unknown as string[])
-          : undefined,
-      columnAliases:
-        (serializedState.columnAliases as unknown as Record<string, string>) !==
-        undefined
-          ? new Map(
-              Object.entries(
-                serializedState.columnAliases as unknown as Record<
-                  string,
-                  string
-                >,
-              ),
-            )
-          : undefined,
-      suggestionAliases:
-        (serializedState.suggestionAliases as unknown as Record<
-          string,
-          string
-        >) !== undefined
-          ? new Map(
-              Object.entries(
-                serializedState.suggestionAliases as unknown as Record<
-                  string,
-                  string
-                >,
-              ),
-            )
-          : undefined,
-      columnTypes:
-        (serializedState.columnTypes as unknown as Record<
-          string,
-          PerfettoSqlType
-        >) !== undefined
-          ? new Map(
-              Object.entries(
-                serializedState.columnTypes as unknown as Record<
-                  string,
-                  PerfettoSqlType
-                >,
-              )
-                .map(
-                  ([k, v]) =>
-                    [k, legacyDeserializeType(v)] as [
-                      string,
-                      PerfettoSqlType | undefined,
-                    ],
-                )
-                .filter(
-                  (entry): entry is [string, PerfettoSqlType] =>
-                    entry[1] !== undefined,
-                ),
-            )
-          : undefined,
-    };
+    serializedState: AddColumnsNodeAttrs,
+  ): AddColumnsNodeAttrs {
+    // Migrate columnTypes: apply legacyDeserializeType to each value.
+    const columnTypes = serializedState.columnTypes
+      ? Object.fromEntries(
+          Object.entries(serializedState.columnTypes)
+            .map(([k, v]) => [k, legacyDeserializeType(v)] as const)
+            .filter((e): e is [string, PerfettoSqlType] => e[1] !== undefined),
+        )
+      : undefined;
+    return {...serializedState, columnTypes};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {AddColumnsNode, AddColumnsNodeState} from './add_columns_node';
+import {AddColumnsNode, AddColumnsNodeAttrs} from './add_columns_node';
 import {QueryNode} from '../../query_node';
 import protos from '../../../../protos';
 import {createMockNode, createColumnInfo} from '../testing/test_utils';
@@ -59,11 +59,11 @@ describe('AddColumnsNode', () => {
   }
 
   function createAddColumnsNodeWithInputs(
-    state: AddColumnsNodeState,
+    state: AddColumnsNodeAttrs,
     primaryNode?: QueryNode,
     secondaryNode?: QueryNode,
   ): AddColumnsNode {
-    const node = new AddColumnsNode(state);
+    const node = new AddColumnsNode(state, {});
     if (primaryNode) {
       primaryNode.nextNodes.push(node);
       node.primaryInput = primaryNode;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_suggestion_modal.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_suggestion_modal.ts
@@ -43,7 +43,7 @@ export interface AddColumnsSuggestionModalAttrs {
   readonly sourceCols: ColumnInfo[];
   readonly selectedTable?: string;
   readonly selectedColumns: string[];
-  readonly suggestionAliases?: Map<string, string>;
+  readonly suggestionAliases?: Record<string, string>;
 
   // Callbacks
   readonly getTable: (tableName: string) => SqlTable | undefined;
@@ -100,7 +100,7 @@ export class AddColumnsSuggestionModal
       ? tableInfo.columns.map((col: SqlColumn) => ({
           ...columnInfoFromSqlColumn(col),
           checked: selectedColumns.includes(col.name),
-          alias: suggestionAliases?.get(col.name),
+          alias: suggestionAliases?.[col.name],
         }))
       : [];
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_types.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_types.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
-import {QueryNodeState} from '../../query_node';
 
 /**
  * Represents an IF clause for conditional column expressions.
@@ -68,30 +67,30 @@ export interface NewColumn {
 }
 
 /**
- * State interface for the AddColumnsNode.
+ * Serializable node configuration for AddColumnsNode.
  */
-export interface AddColumnsNodeState extends QueryNodeState {
+export interface AddColumnsNodeAttrs {
   selectedColumns?: string[];
   leftColumn?: string;
   rightColumn?: string;
 
   // Pre-selected columns for each suggested table (before connecting)
-  suggestionSelections?: Map<string, string[]>;
+  suggestionSelections?: Record<string, string[]>;
 
   // Track which suggestions are expanded to show column selection
-  expandedSuggestions?: Set<string>;
+  expandedSuggestions?: string[];
 
   // Currently selected suggestion table (for single-selection UI)
   selectedSuggestionTable?: string;
 
   // Map from column name to its alias (for renaming added columns)
-  columnAliases?: Map<string, string>;
+  columnAliases?: Record<string, string>;
 
   // Map from column name to its alias for suggestion mode (before applying)
-  suggestionAliases?: Map<string, string>;
+  suggestionAliases?: Record<string, string>;
 
   // Map from column name to its type (for type casting added columns)
-  columnTypes?: Map<string, PerfettoSqlType>;
+  columnTypes?: Record<string, PerfettoSqlType>;
 
   // Track if connection was made through guided suggestion
   isGuidedConnection?: boolean;

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/aggregation_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/aggregation_node.ts
@@ -13,19 +13,9 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import protos from '../../../../protos';
-import {
-  ColumnInfo,
-  columnInfoFromName,
-  columnInfoFromSqlColumn,
-  newColumnInfoList,
-} from '../column_info';
+import {ColumnInfo, columnInfoFromSqlColumn} from '../column_info';
 import {
   PerfettoSqlTypes,
   PerfettoSqlType,
@@ -48,25 +38,14 @@ import {NodeModifyAttrs, NodeDetailsAttrs} from '../../node_types';
 import {loadNodeDoc} from '../node_doc_loader';
 import {ColumnName, NodeDetailsSpacer} from '../node_styling_widgets';
 
-export interface AggregationSerializedState {
-  groupByColumns: {name: string; checked: boolean}[];
-  aggregations: {
-    column?: ColumnInfo;
-    aggregationOp?: string;
-    newColumnName?: string;
-    percentile?: number;
-    isValid?: boolean;
-  }[];
-  comment?: string;
-}
-
-export interface AggregationNodeState extends QueryNodeState {
+// Serializable node configuration.
+export interface AggregationNodeAttrs {
   groupByColumns: ColumnInfo[];
   aggregations: Aggregation[];
 }
 
 export interface Aggregation {
-  column?: ColumnInfo;
+  column?: {name: string; type?: PerfettoSqlType};
   aggregationOp?: string;
   newColumnName?: string;
   percentile?: number;
@@ -78,40 +57,38 @@ export class AggregationNode implements QueryNode {
   readonly type = NodeType.kAggregation;
   primaryInput?: QueryNode;
   nextNodes: QueryNode[];
-  readonly state: AggregationNodeState;
+  readonly attrs: AggregationNodeAttrs;
+  readonly context: NodeContext;
 
   get finalCols(): ColumnInfo[] {
-    // When there's no primaryInput, aggregation doesn't make sense
-    // Return empty array to indicate no output columns
     if (this.primaryInput === undefined) {
       return [];
     }
-    const selected = this.state.groupByColumns.filter((c) => c.checked);
+    const cols: ColumnInfo[] = this.attrs.groupByColumns
+      .filter((c) => c.checked)
+      .map((d) => ({
+        name: d.name,
+        type: d.type,
+        checked: true,
+      }));
     // IMPORTANT: Only include VALID aggregations in output
-    // This prevents incomplete/invalid aggregations from propagating downstream
-    for (const agg of this.state.aggregations) {
-      if (!validateAggregation(agg)) {
-        continue; // Skip invalid aggregations
-      }
+    for (const agg of this.attrs.aggregations) {
+      if (!validateAggregation(agg)) continue;
       const resultType = getAggregationResultType(agg);
       const resultName = agg.newColumnName ?? placeholderNewColumnName(agg);
-      selected.push(
-        columnInfoFromSqlColumn({
-          name: resultName,
-          type: resultType,
-        }),
-      );
+      cols.push(columnInfoFromSqlColumn({name: resultName, type: resultType}));
     }
-    return newColumnInfoList(selected, true);
+    return cols;
   }
 
-  constructor(state: AggregationNodeState) {
+  constructor(attrs: AggregationNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...state,
-      groupByColumns: state.groupByColumns ?? [],
-      aggregations: state.aggregations ?? [],
+    this.attrs = {
+      ...attrs,
+      groupByColumns: attrs.groupByColumns ?? [],
+      aggregations: attrs.aggregations ?? [],
     };
+    this.context = context;
     this.nextNodes = [];
   }
 
@@ -123,29 +100,30 @@ export class AggregationNode implements QueryNode {
     if (this.primaryInput === undefined) {
       return;
     }
-    const newGroupByColumns = newColumnInfoList(
-      this.primaryInput.finalCols ?? [],
-      false,
-    );
-    for (const oldCol of this.state.groupByColumns) {
+    const newGroupByColumns: ColumnInfo[] = (
+      this.primaryInput.finalCols ?? []
+    ).map((col) => ({
+      name: col.name,
+      type: col.type,
+      checked: false,
+    }));
+    for (const oldCol of this.attrs.groupByColumns) {
       if (oldCol.checked) {
         const newCol = newGroupByColumns.find((c) => c.name === oldCol.name);
         if (newCol) {
           newCol.checked = true;
         } else {
-          const missingCol = columnInfoFromName(oldCol.name);
-          missingCol.checked = true;
-          newGroupByColumns.push(missingCol);
+          newGroupByColumns.push({name: oldCol.name, checked: true});
         }
       }
     }
-    this.state.groupByColumns = newGroupByColumns;
+    this.attrs.groupByColumns = newGroupByColumns;
   }
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
@@ -160,7 +138,7 @@ export class AggregationNode implements QueryNode {
       (this.primaryInput.finalCols ?? []).map((c) => c.name),
     );
     const missingCols: string[] = [];
-    for (const col of this.state.groupByColumns) {
+    for (const col of this.attrs.groupByColumns) {
       if (col.checked && !sourceColNames.has(col.name)) {
         missingCols.push(col.name);
       }
@@ -174,14 +152,14 @@ export class AggregationNode implements QueryNode {
     }
 
     // Must have at least one of: group by columns OR aggregation functions
-    const hasGroupBy = this.state.groupByColumns.find((c) => c.checked);
+    const hasGroupBy = this.attrs.groupByColumns.find((c) => c.checked);
 
     // Validate aggregations first
-    for (const agg of this.state.aggregations) {
+    for (const agg of this.attrs.aggregations) {
       agg.isValid = validateAggregation(agg);
     }
     const hasAggregations =
-      this.state.aggregations.filter((a) => a.isValid).length > 0;
+      this.attrs.aggregations.filter((a) => a.isValid).length > 0;
 
     if (!hasGroupBy && !hasAggregations) {
       this.setValidationError(
@@ -191,7 +169,7 @@ export class AggregationNode implements QueryNode {
     }
 
     // Check for duplicate column names
-    const selectedGroupBy = this.state.groupByColumns.filter((c) => c.checked);
+    const selectedGroupBy = this.attrs.groupByColumns.filter((c) => c.checked);
     const columnNames = new Set<string>();
 
     // Add group-by column names
@@ -200,7 +178,7 @@ export class AggregationNode implements QueryNode {
     }
 
     // Check aggregation result column names for duplicates
-    for (const agg of this.state.aggregations) {
+    for (const agg of this.attrs.aggregations) {
       if (!agg.isValid) continue;
       const resultName = agg.newColumnName ?? placeholderNewColumnName(agg);
       if (columnNames.has(resultName)) {
@@ -216,10 +194,10 @@ export class AggregationNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -227,7 +205,7 @@ export class AggregationNode implements QueryNode {
   }
 
   nodeDetails(): NodeDetailsAttrs {
-    const selectedGroupBy = this.state.groupByColumns.filter((c) => c.checked);
+    const selectedGroupBy = this.attrs.groupByColumns.filter((c) => c.checked);
 
     const details: m.Child[] = [];
 
@@ -247,7 +225,7 @@ export class AggregationNode implements QueryNode {
       details.push(m('div', 'Group by: None'));
     }
 
-    const validAggregations = this.state.aggregations.filter(
+    const validAggregations = this.attrs.aggregations.filter(
       (agg) => agg.isValid,
     );
 
@@ -326,7 +304,7 @@ export class AggregationNode implements QueryNode {
   }
 
   private renderGroupBySection(): m.Child {
-    const groupByOptions: MultiSelectOption[] = this.state.groupByColumns.map(
+    const groupByOptions: MultiSelectOption[] = this.attrs.groupByColumns.map(
       (col) => ({
         id: col.name,
         name: col.name,
@@ -334,7 +312,7 @@ export class AggregationNode implements QueryNode {
       }),
     );
 
-    const selectedGroupBy = this.state.groupByColumns.filter((c) => c.checked);
+    const selectedGroupBy = this.attrs.groupByColumns.filter((c) => c.checked);
     const label =
       selectedGroupBy.length > 0
         ? selectedGroupBy.map((c) => c.name).join(', ')
@@ -349,14 +327,14 @@ export class AggregationNode implements QueryNode {
         showNumSelected: false,
         onChange: (diffs: MultiSelectDiff[]) => {
           for (const diff of diffs) {
-            const column = this.state.groupByColumns.find(
+            const column = this.attrs.groupByColumns.find(
               (c) => c.name === diff.id,
             );
             if (column) {
               column.checked = diff.checked;
             }
           }
-          this.state.onchange?.();
+          this.context.onchange?.();
         },
       }),
     );
@@ -364,17 +342,17 @@ export class AggregationNode implements QueryNode {
 
   private renderAggregationsList(): m.Child {
     return m(InlineEditList<Aggregation>, {
-      items: this.state.aggregations,
+      items: this.attrs.aggregations,
       validate: validateAggregation,
       renderControls: (agg, _index, onUpdate) =>
         this.renderAggregationFormControls(agg, onUpdate),
       onUpdate: (aggregations) => {
-        this.state.aggregations = aggregations;
-        this.state.onchange?.();
+        this.attrs.aggregations = aggregations;
+        this.context.onchange?.();
       },
       onValidChange: () => {
         // Also trigger when validation state changes (invalid -> valid)
-        this.state.onchange?.();
+        this.context.onchange?.();
       },
       addButtonLabel: 'Add aggregation',
       addButtonIcon: 'add',
@@ -390,8 +368,11 @@ export class AggregationNode implements QueryNode {
     agg: Aggregation,
     onUpdate: (updated: Aggregation) => void,
   ): m.Children {
-    const columnOptions = this.state.groupByColumns.map((col) => {
-      const isValid = isColumnValidForAggregation(col, agg.aggregationOp);
+    const columnOptions = this.attrs.groupByColumns.map((col) => {
+      const isValid = isColumnValidForAggregation(
+        {type: col.type},
+        agg.aggregationOp,
+      );
       return m(
         'option',
         {
@@ -458,12 +439,12 @@ export class AggregationNode implements QueryNode {
               value: agg.column?.name ?? '',
               onchange: (e: Event) => {
                 const value = (e.target as HTMLSelectElement).value;
-                const column = this.state.groupByColumns.find(
+                const col = this.attrs.groupByColumns.find(
                   (c) => c.name === value,
                 );
                 onUpdate({
                   ...agg,
-                  column,
+                  column: col ? {name: col.name, type: col.type} : undefined,
                 });
               },
             },
@@ -509,13 +490,13 @@ export class AggregationNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: AggregationNodeState = {
-      groupByColumns: newColumnInfoList(this.state.groupByColumns),
-      aggregations: this.state.aggregations.map((a) => ({...a})),
-      onchange: this.state.onchange,
-      issues: this.state.issues,
-    };
-    return new AggregationNode(stateCopy);
+    return new AggregationNode(
+      {
+        groupByColumns: this.attrs.groupByColumns.map((c) => ({...c})),
+        aggregations: this.attrs.aggregations.map((a) => ({...a})),
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -525,20 +506,20 @@ export class AggregationNode implements QueryNode {
     if (this.primaryInput === undefined) return undefined;
 
     // Prepare groupByColumns
-    const groupByColumns = this.state.groupByColumns
+    const groupByColumns = this.attrs.groupByColumns
       .filter((c) => c.checked)
-      .map((c) => c.column.name);
+      .map((c) => c.name);
 
     // Prepare aggregations
     const aggregations: AggregationSpec[] = [];
-    for (const agg of this.state.aggregations) {
+    for (const agg of this.attrs.aggregations) {
       agg.isValid = validateAggregation(agg);
       if (agg.isValid && agg.aggregationOp) {
         // Map COUNT(*) to COUNT for the proto (COUNT(*) is UI-only)
         const protoOp = isCountAll(agg) ? 'COUNT' : agg.aggregationOp;
 
         const aggSpec: AggregationSpec = {
-          columnName: agg.column?.column.name, // Optional for COUNT(*)
+          columnName: agg.column?.name, // Optional for COUNT(*)
           op: protoOp,
           resultColumnName: agg.newColumnName ?? placeholderNewColumnName(agg),
         };
@@ -591,67 +572,15 @@ export class AggregationNode implements QueryNode {
     return sq;
   }
 
-  resolveColumns() {
-    if (this.primaryInput === undefined) {
-      return;
-    }
-    const sourceCols = this.primaryInput.finalCols ?? [];
-    this.state.groupByColumns.forEach((c) => {
-      const sourceCol = sourceCols.find((s) => s.name === c.name);
-      if (sourceCol) {
-        c.column = sourceCol.column;
-      }
-    });
-    this.state.aggregations.forEach((a) => {
-      if (a.column) {
-        const sourceCol = sourceCols.find((s) => s.name === a.column?.name);
-        if (sourceCol) {
-          a.column = sourceCol;
-        }
-      }
-    });
-  }
-
-  serializeState(): AggregationSerializedState {
+  static deserializeState(state: AggregationNodeAttrs): AggregationNodeAttrs {
     return {
-      groupByColumns: this.state.groupByColumns.map((c) => ({
-        name: c.name,
-        checked: c.checked,
+      groupByColumns: state.groupByColumns.map((c) => ({...c})),
+      aggregations: state.aggregations.map((a) => ({
+        ...a,
+        // Migrate old COUNT_ALL to COUNT(*) for backward compatibility
+        aggregationOp:
+          a.aggregationOp === 'COUNT_ALL' ? 'COUNT(*)' : a.aggregationOp,
       })),
-      aggregations: this.state.aggregations.map((a) => ({
-        column: a.column,
-        aggregationOp: a.aggregationOp,
-        newColumnName: a.newColumnName,
-        percentile: a.percentile,
-        isValid: a.isValid,
-      })),
-    };
-  }
-
-  static deserializeState(
-    state: AggregationSerializedState,
-  ): AggregationNodeState {
-    const groupByColumns = state.groupByColumns.map((c) => {
-      const col = columnInfoFromName(c.name);
-      col.checked = c.checked;
-      return col;
-    });
-    const aggregations = state.aggregations.map((a) => {
-      // Migrate old COUNT_ALL to COUNT(*) for backward compatibility
-      const aggregationOp =
-        a.aggregationOp === 'COUNT_ALL' ? 'COUNT(*)' : a.aggregationOp;
-      return {
-        column: a.column,
-        aggregationOp,
-        newColumnName: a.newColumnName,
-        percentile: a.percentile,
-        isValid: a.isValid,
-      };
-    });
-    return {
-      ...state,
-      groupByColumns,
-      aggregations,
     };
   }
 }
@@ -664,7 +593,7 @@ export function createGroupByProto(
   const groupByProto = new protos.PerfettoSqlStructuredQuery.GroupBy();
   groupByProto.columnNames = groupByColumns
     .filter((c) => c.checked)
-    .map((c) => c.column.name);
+    .map((c) => c.name);
 
   for (const agg of aggregations) {
     agg.isValid = validateAggregation(agg);
@@ -718,7 +647,7 @@ export function GroupByAggregationAttrsToProto(
 
   // COUNT(*) doesn't have a column; all other operations do
   if (agg.column) {
-    newAgg.columnName = agg.column.column.name;
+    newAgg.columnName = agg.column.name;
   }
 
   newAgg.op = stringToAggregateOp(agg.aggregationOp!);
@@ -783,12 +712,12 @@ function getAggregationResultType(agg: Aggregation): PerfettoSqlType {
     case 'MIN':
     case 'MAX':
       // Preserve the input column type for SUM, MIN, MAX
-      if (!agg.column?.column.type) {
+      if (!agg.column?.type) {
         console.warn(
           `${agg.aggregationOp} aggregation missing column type information, defaulting to INT`,
         );
       }
-      return agg.column?.column.type ?? PerfettoSqlTypes.INT;
+      return agg.column?.type ?? PerfettoSqlTypes.INT;
 
     case 'MEAN':
     case 'MEDIAN':

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/aggregation_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/aggregation_node_unittest.ts
@@ -16,7 +16,7 @@ import {
   AggregationNode,
   placeholderNewColumnName,
   Aggregation,
-  AggregationNodeState,
+  AggregationNodeAttrs,
 } from './aggregation_node';
 import {Trace} from '../../../../public/trace';
 import {QueryNode} from '../../query_node';
@@ -33,10 +33,11 @@ describe('AggregationNode', () => {
   }
 
   function createAggregationNodeWithInput(
-    state: AggregationNodeState,
+    state: AggregationNodeAttrs & {trace?: Trace},
     inputNode?: QueryNode,
   ): AggregationNode {
-    const node = new AggregationNode(state);
+    const {trace, ...attrs} = state;
+    const node = new AggregationNode(attrs, {trace});
     if (inputNode) {
       connectNodes(inputNode, node);
     }
@@ -120,7 +121,7 @@ describe('AggregationNode', () => {
     });
 
     it('should validate COUNT(*) without column', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'COUNT(*)',
           isValid: false,
@@ -128,17 +129,17 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         agg.isValid =
           agg.aggregationOp === 'COUNT(*)' ||
           (agg.column !== undefined && agg.aggregationOp !== undefined);
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(true);
+      expect(node.attrs.aggregations[0].isValid).toBe(true);
     });
 
     it('should validate PERCENTILE with column and percentile value', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'PERCENTILE',
           column: createColumnInfo('dur', 'int'),
@@ -148,7 +149,7 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         if (agg.aggregationOp === 'PERCENTILE') {
           agg.isValid =
             agg.column !== undefined &&
@@ -158,11 +159,11 @@ describe('AggregationNode', () => {
         }
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(true);
+      expect(node.attrs.aggregations[0].isValid).toBe(true);
     });
 
     it('should invalidate PERCENTILE with percentile value out of range', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'PERCENTILE',
           column: createColumnInfo('dur', 'int'),
@@ -172,7 +173,7 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         if (agg.aggregationOp === 'PERCENTILE') {
           agg.isValid =
             agg.column !== undefined &&
@@ -182,11 +183,11 @@ describe('AggregationNode', () => {
         }
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(false);
+      expect(node.attrs.aggregations[0].isValid).toBe(false);
     });
 
     it('should invalidate PERCENTILE without percentile value', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'PERCENTILE',
           column: createColumnInfo('dur', 'int'),
@@ -195,7 +196,7 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         if (agg.aggregationOp === 'PERCENTILE') {
           agg.isValid =
             agg.column !== undefined &&
@@ -205,11 +206,11 @@ describe('AggregationNode', () => {
         }
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(false);
+      expect(node.attrs.aggregations[0].isValid).toBe(false);
     });
 
     it('should invalidate PERCENTILE without column', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'PERCENTILE',
           percentile: 50,
@@ -218,7 +219,7 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         if (agg.aggregationOp === 'PERCENTILE') {
           agg.isValid =
             agg.column !== undefined &&
@@ -228,11 +229,11 @@ describe('AggregationNode', () => {
         }
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(false);
+      expect(node.attrs.aggregations[0].isValid).toBe(false);
     });
 
     it('should validate MEDIAN with column', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'MEDIAN',
           column: createColumnInfo('value', 'double'),
@@ -241,7 +242,7 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         if (
           agg.aggregationOp !== 'COUNT(*)' &&
           agg.aggregationOp !== 'PERCENTILE'
@@ -251,11 +252,11 @@ describe('AggregationNode', () => {
         }
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(true);
+      expect(node.attrs.aggregations[0].isValid).toBe(true);
     });
 
     it('should invalidate MEDIAN without column', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'MEDIAN',
           isValid: false,
@@ -263,7 +264,7 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         if (
           agg.aggregationOp !== 'COUNT(*)' &&
           agg.aggregationOp !== 'PERCENTILE'
@@ -273,11 +274,11 @@ describe('AggregationNode', () => {
         }
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(false);
+      expect(node.attrs.aggregations[0].isValid).toBe(false);
     });
 
     it('should validate SUM with column', () => {
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'SUM',
           column: createColumnInfo('dur', 'int'),
@@ -286,7 +287,7 @@ describe('AggregationNode', () => {
       ];
 
       // Simulate validation
-      for (const agg of node.state.aggregations) {
+      for (const agg of node.attrs.aggregations) {
         if (
           agg.aggregationOp !== 'COUNT(*)' &&
           agg.aggregationOp !== 'PERCENTILE'
@@ -296,7 +297,7 @@ describe('AggregationNode', () => {
         }
       }
 
-      expect(node.state.aggregations[0].isValid).toBe(true);
+      expect(node.attrs.aggregations[0].isValid).toBe(true);
     });
   });
 
@@ -311,7 +312,7 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'PERCENTILE',
           column: createColumnInfo('dur', 'int'),
@@ -321,13 +322,11 @@ describe('AggregationNode', () => {
         },
       ];
 
-      const serialized = node.serializeState();
-
-      expect(serialized.aggregations).toBeDefined();
-      expect(serialized.aggregations.length).toBe(1);
-      expect(serialized.aggregations[0].aggregationOp).toBe('PERCENTILE');
-      expect(serialized.aggregations[0].percentile).toBe(95);
-      expect(serialized.aggregations[0].newColumnName).toBe('p95_dur');
+      expect(node.attrs.aggregations).toBeDefined();
+      expect(node.attrs.aggregations.length).toBe(1);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('PERCENTILE');
+      expect(node.attrs.aggregations[0].percentile).toBe(95);
+      expect(node.attrs.aggregations[0].newColumnName).toBe('p95_dur');
     });
 
     it('should serialize COUNT(*) aggregation without column', () => {
@@ -340,7 +339,7 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'COUNT(*)',
           newColumnName: 'total_count',
@@ -348,13 +347,11 @@ describe('AggregationNode', () => {
         },
       ];
 
-      const serialized = node.serializeState();
-
-      expect(serialized.aggregations).toBeDefined();
-      expect(serialized.aggregations.length).toBe(1);
-      expect(serialized.aggregations[0].aggregationOp).toBe('COUNT(*)');
-      expect(serialized.aggregations[0].column).toBeUndefined();
-      expect(serialized.aggregations[0].newColumnName).toBe('total_count');
+      expect(node.attrs.aggregations).toBeDefined();
+      expect(node.attrs.aggregations.length).toBe(1);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('COUNT(*)');
+      expect(node.attrs.aggregations[0].column).toBeUndefined();
+      expect(node.attrs.aggregations[0].newColumnName).toBe('total_count');
     });
 
     it('should serialize MEDIAN aggregation', () => {
@@ -367,22 +364,20 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'MEDIAN',
-          column: createColumnInfo('value', 'double'),
+          column: {name: 'value', type: {kind: 'int' as const}},
           newColumnName: 'median_value',
           isValid: true,
         },
       ];
 
-      const serialized = node.serializeState();
-
-      expect(serialized.aggregations).toBeDefined();
-      expect(serialized.aggregations.length).toBe(1);
-      expect(serialized.aggregations[0].aggregationOp).toBe('MEDIAN');
-      expect(serialized.aggregations[0].column?.name).toBe('value');
-      expect(serialized.aggregations[0].newColumnName).toBe('median_value');
+      expect(node.attrs.aggregations).toBeDefined();
+      expect(node.attrs.aggregations.length).toBe(1);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('MEDIAN');
+      expect(node.attrs.aggregations[0].column?.name).toBe('value');
+      expect(node.attrs.aggregations[0].newColumnName).toBe('median_value');
     });
 
     it('should serialize multiple aggregations including new types', () => {
@@ -395,7 +390,7 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      node.state.aggregations = [
+      node.attrs.aggregations = [
         {
           aggregationOp: 'COUNT(*)',
           newColumnName: 'count',
@@ -403,26 +398,24 @@ describe('AggregationNode', () => {
         },
         {
           aggregationOp: 'MEDIAN',
-          column: createColumnInfo('dur', 'int'),
+
           newColumnName: 'median_dur',
           isValid: true,
         },
         {
           aggregationOp: 'PERCENTILE',
-          column: createColumnInfo('dur', 'int'),
+
           percentile: 99,
           newColumnName: 'p99_dur',
           isValid: true,
         },
       ];
 
-      const serialized = node.serializeState();
-
-      expect(serialized.aggregations.length).toBe(3);
-      expect(serialized.aggregations[0].aggregationOp).toBe('COUNT(*)');
-      expect(serialized.aggregations[1].aggregationOp).toBe('MEDIAN');
-      expect(serialized.aggregations[2].aggregationOp).toBe('PERCENTILE');
-      expect(serialized.aggregations[2].percentile).toBe(99);
+      expect(node.attrs.aggregations.length).toBe(3);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('COUNT(*)');
+      expect(node.attrs.aggregations[1].aggregationOp).toBe('MEDIAN');
+      expect(node.attrs.aggregations[2].aggregationOp).toBe('PERCENTILE');
+      expect(node.attrs.aggregations[2].percentile).toBe(99);
     });
   });
 
@@ -445,10 +438,10 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      expect(node.state.aggregations.length).toBe(1);
-      expect(node.state.aggregations[0].aggregationOp).toBe('PERCENTILE');
-      expect(node.state.aggregations[0].percentile).toBe(95);
-      expect(node.state.aggregations[0].newColumnName).toBe('p95_dur');
+      expect(node.attrs.aggregations.length).toBe(1);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('PERCENTILE');
+      expect(node.attrs.aggregations[0].percentile).toBe(95);
+      expect(node.attrs.aggregations[0].newColumnName).toBe('p95_dur');
     });
 
     it('should deserialize COUNT(*) aggregation without column', () => {
@@ -467,10 +460,10 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      expect(node.state.aggregations.length).toBe(1);
-      expect(node.state.aggregations[0].aggregationOp).toBe('COUNT(*)');
-      expect(node.state.aggregations[0].column).toBeUndefined();
-      expect(node.state.aggregations[0].newColumnName).toBe('total_count');
+      expect(node.attrs.aggregations.length).toBe(1);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('COUNT(*)');
+      expect(node.attrs.aggregations[0].column).toBeUndefined();
+      expect(node.attrs.aggregations[0].newColumnName).toBe('total_count');
     });
 
     it('should deserialize MEDIAN aggregation', () => {
@@ -490,10 +483,10 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      expect(node.state.aggregations.length).toBe(1);
-      expect(node.state.aggregations[0].aggregationOp).toBe('MEDIAN');
-      expect(node.state.aggregations[0].column?.name).toBe('value');
-      expect(node.state.aggregations[0].newColumnName).toBe('median_value');
+      expect(node.attrs.aggregations.length).toBe(1);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('MEDIAN');
+      expect(node.attrs.aggregations[0].column?.name).toBe('value');
+      expect(node.attrs.aggregations[0].newColumnName).toBe('median_value');
     });
 
     it('should migrate old COUNT_ALL to COUNT(*) for backward compatibility', () => {
@@ -514,10 +507,10 @@ describe('AggregationNode', () => {
         createMockNode(),
       );
 
-      expect(node.state.aggregations.length).toBe(1);
-      expect(node.state.aggregations[0].aggregationOp).toBe('COUNT(*)');
-      expect(node.state.aggregations[0].column).toBeUndefined();
-      expect(node.state.aggregations[0].newColumnName).toBe('total_count');
+      expect(node.attrs.aggregations.length).toBe(1);
+      expect(node.attrs.aggregations[0].aggregationOp).toBe('COUNT(*)');
+      expect(node.attrs.aggregations[0].column).toBeUndefined();
+      expect(node.attrs.aggregations[0].newColumnName).toBe('total_count');
     });
   });
 
@@ -607,7 +600,7 @@ describe('AggregationNode', () => {
       );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'requires at least one group by column or aggregation function',
       );
     });
@@ -677,25 +670,27 @@ describe('AggregationNode', () => {
       );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'not found in input',
       );
     });
 
     it('should invalidate node without primaryInput', () => {
-      const node = new AggregationNode({
-        trace: createMockTrace(),
-        groupByColumns: [],
-        aggregations: [
-          {
-            aggregationOp: 'COUNT(*)',
-            isValid: true,
-          },
-        ],
-      });
+      const node = new AggregationNode(
+        {
+          groupByColumns: [],
+          aggregations: [
+            {
+              aggregationOp: 'COUNT(*)',
+              isValid: true,
+            },
+          ],
+        },
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toBe(
+      expect(node.context.issues?.queryError?.message).toBe(
         'No input node connected',
       );
     });
@@ -726,7 +721,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('count_dur');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.INT);
     });
 
     it('should set INT type for COUNT(*) aggregation', () => {
@@ -749,7 +744,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('total_count');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.INT);
     });
 
     it('should preserve type for SUM aggregation', () => {
@@ -757,10 +752,7 @@ describe('AggregationNode', () => {
         {
           name: 'dur',
           checked: false,
-          column: {
-            name: 'dur',
-            type: {kind: 'duration' as const},
-          },
+          type: {kind: 'duration' as const},
         },
       ];
       const mockInput = createMockNode({columns: inputCols});
@@ -782,7 +774,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('total_dur');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DURATION);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.DURATION);
     });
 
     it('should preserve type for MIN/MAX aggregations', () => {
@@ -790,10 +782,7 @@ describe('AggregationNode', () => {
         {
           name: 'ts',
           checked: false,
-          column: {
-            name: 'ts',
-            type: {kind: 'timestamp' as const},
-          },
+          type: {kind: 'timestamp' as const},
         },
       ];
       const mockInput = createMockNode({columns: inputCols});
@@ -821,9 +810,9 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(2);
       expect(node.finalCols[0].name).toBe('min_ts');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.TIMESTAMP);
       expect(node.finalCols[1].name).toBe('max_ts');
-      expect(node.finalCols[1].column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
+      expect(node.finalCols[1].type).toEqual(PerfettoSqlTypes.TIMESTAMP);
     });
 
     it('should set DOUBLE type for MEAN aggregation', () => {
@@ -847,7 +836,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('avg_value');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should set DOUBLE type for MEDIAN aggregation', () => {
@@ -871,7 +860,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('median_dur');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should set DOUBLE type for DURATION_WEIGHTED_MEAN aggregation', () => {
@@ -895,7 +884,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('weighted_avg_dur');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should set DOUBLE type for PERCENTILE aggregation', () => {
@@ -920,7 +909,7 @@ describe('AggregationNode', () => {
 
       expect(node.finalCols.length).toBe(1);
       expect(node.finalCols[0].name).toBe('p95_dur');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.DOUBLE);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should include GROUP BY columns with their original types', () => {
@@ -928,10 +917,7 @@ describe('AggregationNode', () => {
         {
           name: 'name',
           checked: true,
-          column: {
-            name: 'name',
-            type: {kind: 'string' as const},
-          },
+          type: {kind: 'string' as const},
         },
         createColumnInfo('value', 'int'),
       ];
@@ -939,7 +925,13 @@ describe('AggregationNode', () => {
       const node = createAggregationNodeWithInput(
         {
           trace: createMockTrace(),
-          groupByColumns: [{...inputCols[0]}],
+          groupByColumns: [
+            {
+              name: inputCols[0].name,
+              type: inputCols[0].type,
+              checked: true,
+            },
+          ],
           aggregations: [
             {
               aggregationOp: 'SUM',
@@ -956,9 +948,9 @@ describe('AggregationNode', () => {
       // Second column should be the aggregation result (total_value) with INT type
       expect(node.finalCols.length).toBe(2);
       expect(node.finalCols[0].name).toBe('name');
-      expect(node.finalCols[0].column.type).toEqual(PerfettoSqlTypes.STRING);
+      expect(node.finalCols[0].type).toEqual(PerfettoSqlTypes.STRING);
       expect(node.finalCols[1].name).toBe('total_value');
-      expect(node.finalCols[1].column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(node.finalCols[1].type).toEqual(PerfettoSqlTypes.INT);
     });
   });
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/computed_column_components.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/computed_column_components.ts
@@ -83,7 +83,7 @@ export class SwitchComponent implements m.ClassComponent<SwitchComponentAttrs> {
     };
 
     if (column.switchOn === undefined || column.switchOn === '') {
-      const columnNames = columns.map((c) => c.column.name);
+      const columnNames = columns.map((c) => c.name);
       return m(
         OutlinedField,
         {
@@ -100,12 +100,10 @@ export class SwitchComponent implements m.ClassComponent<SwitchComponentAttrs> {
       );
     }
 
-    const columnNames = columns.map((c) => c.column.name);
+    const columnNames = columns.map((c) => c.name);
 
-    const selectedColumn = columns.find(
-      (c) => c.column.name === column.switchOn,
-    );
-    const isStringColumn = selectedColumn?.column.type?.kind === 'string';
+    const selectedColumn = columns.find((c) => c.name === column.switchOn);
+    const isStringColumn = selectedColumn?.type?.kind === 'string';
 
     return m('.pf-inline-edit-list', [
       m(

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/connections_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/connections_unittest.ts
@@ -59,8 +59,8 @@ function createMockPrevNode(id: string, columns: ColumnInfo[]): QueryNode {
     finalCols: columns,
     getTitle: () => id,
     validate: () => true,
-    state: {},
-    serializeState: () => ({}),
+    context: {},
+    attrs: {},
     nodeSpecificModify: () => null,
     nodeDetails: () => ({content: null, message: ''}),
     nodeInfo: () => null,
@@ -80,7 +80,7 @@ function createColumnInfo(
   return {
     name,
     checked,
-    column: {name, type: sqlType},
+    type: sqlType,
   };
 }
 
@@ -108,7 +108,7 @@ function createColumnInfoWithSqlType(
   return {
     name,
     checked,
-    column: {name, type: sqlType},
+    type: sqlType,
   };
 }
 
@@ -132,9 +132,12 @@ describe('Connection Management', () => {
         createColumnInfo('extra', 'STRING'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
 
@@ -168,9 +171,12 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2, node3],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2, node3],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
       node3.nextNodes.push(intervalNode);
@@ -196,9 +202,12 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
 
@@ -228,26 +237,29 @@ describe('Connection Management', () => {
         createColumnInfo('unique_col', 'STRING'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
 
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       intervalNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'unique_col'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'unique_col'),
       ).toBeUndefined();
 
       addConnection(node3, intervalNode);
       notifyNextNodes(intervalNode);
 
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'unique_col'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'unique_col'),
       ).toBeDefined();
     });
 
@@ -268,9 +280,12 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
 
@@ -302,9 +317,12 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
 
@@ -361,32 +379,35 @@ describe('Connection Management', () => {
         ),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
 
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       intervalNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'unique_col1'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'unique_col1'),
       ).toBeDefined();
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'unique_col2'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'unique_col2'),
       ).toBeDefined();
 
       removeConnection(node2, intervalNode);
       notifyNextNodes(intervalNode);
 
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'unique_col1'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'unique_col1'),
       ).toBeDefined();
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'unique_col2'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'unique_col2'),
       ).toBeUndefined();
     });
   });
@@ -398,7 +419,7 @@ describe('Connection Management', () => {
         createColumnInfo('name', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
 
       addConnection(primaryNode, addColsNode);
 
@@ -416,7 +437,7 @@ describe('Connection Management', () => {
         createColumnInfo('extra_col', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
 
       // Connect primary first
       addConnection(primaryNode, addColsNode);
@@ -434,7 +455,7 @@ describe('Connection Management', () => {
         createColumnInfo('name', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
       addConnection(primaryNode, addColsNode);
 
       expect(addColsNode.primaryInput).toBe(primaryNode);
@@ -455,7 +476,7 @@ describe('Connection Management', () => {
         createColumnInfo('extra_col', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
       addConnection(primaryNode, addColsNode);
       addConnection(lookupNode, addColsNode, 0);
 
@@ -479,15 +500,15 @@ describe('Connection Management', () => {
         createColumnInfo('another_col', 'INT'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
       addConnection(primaryNode, addColsNode);
       addConnection(lookupNode, addColsNode, 0);
 
       // Set selected columns AFTER connection (simulating user selection)
-      addColsNode.state.selectedColumns = ['extra_col', 'another_col'];
+      addColsNode.attrs.selectedColumns = ['extra_col', 'another_col'];
 
       // Verify columns are selected
-      expect(addColsNode.state.selectedColumns).toEqual([
+      expect(addColsNode.attrs.selectedColumns).toEqual([
         'extra_col',
         'another_col',
       ]);
@@ -496,7 +517,7 @@ describe('Connection Management', () => {
       removeConnection(lookupNode, addColsNode);
 
       // Verify selectedColumns were reset
-      expect(addColsNode.state.selectedColumns).toEqual([]);
+      expect(addColsNode.attrs.selectedColumns).toEqual([]);
     });
 
     it('should have correct finalCols with both inputs connected', () => {
@@ -509,15 +530,18 @@ describe('Connection Management', () => {
         createColumnInfo('extra_col', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({
-        leftColumn: 'id',
-        rightColumn: 'lookup_id',
-      });
+      const addColsNode = new AddColumnsNode(
+        {
+          leftColumn: 'id',
+          rightColumn: 'lookup_id',
+        },
+        {},
+      );
       addConnection(primaryNode, addColsNode);
       addConnection(lookupNode, addColsNode, 0);
 
       // Set selected columns AFTER connection (simulating user selection)
-      addColsNode.state.selectedColumns = ['extra_col'];
+      addColsNode.attrs.selectedColumns = ['extra_col'];
 
       const cols = addColsNode.finalCols;
 
@@ -538,9 +562,12 @@ describe('Connection Management', () => {
         createColumnInfo('extra_col', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({
-        selectedColumns: ['extra_col'],
-      });
+      const addColsNode = new AddColumnsNode(
+        {
+          selectedColumns: ['extra_col'],
+        },
+        {},
+      );
       addConnection(primaryNode, addColsNode);
       addConnection(lookupNode, addColsNode, 0);
 
@@ -562,7 +589,7 @@ describe('Connection Management', () => {
         createColumnInfo('name', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
       addConnection(primaryNode, addColsNode);
 
       expect(addColsNode.finalCols.length).toBeGreaterThan(0);
@@ -582,22 +609,22 @@ describe('Connection Management', () => {
         createColumnInfo('extra_col', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
       addConnection(primaryNode, addColsNode);
       addConnection(lookupNode, addColsNode, 0);
 
       // Set selected columns AFTER connection (simulating user selection)
-      addColsNode.state.selectedColumns = ['extra_col'];
+      addColsNode.attrs.selectedColumns = ['extra_col'];
 
       // Create downstream ModifyColumnsNode
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = addColsNode;
       addColsNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       // Initially should have extra_col
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'extra_col'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'extra_col'),
       ).toBeDefined();
 
       // Disconnect lookup table
@@ -606,7 +633,7 @@ describe('Connection Management', () => {
 
       // After disconnection, extra_col should be gone
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'extra_col'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'extra_col'),
       ).toBeUndefined();
     });
   });
@@ -619,7 +646,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
 
       addConnection(primaryNode, filterNode);
 
@@ -639,7 +666,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
       addConnection(primaryNode, filterNode);
       addConnection(intervalNode, filterNode, 0);
 
@@ -655,7 +682,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
       addConnection(primaryNode, filterNode);
 
       expect(filterNode.primaryInput).toBe(primaryNode);
@@ -678,7 +705,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
       addConnection(primaryNode, filterNode);
       addConnection(intervalNode, filterNode, 0);
 
@@ -703,7 +730,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
       addConnection(primaryNode, filterNode);
       addConnection(intervalNode, filterNode, 0);
 
@@ -723,7 +750,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
       addConnection(primaryNode, filterNode);
 
       expect(filterNode.finalCols.length).toBeGreaterThan(0);
@@ -745,7 +772,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
       addConnection(primaryNode, filterNode);
       addConnection(intervalNode, filterNode, 0);
 
@@ -769,19 +796,19 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterNode = new FilterDuringNode({});
+      const filterNode = new FilterDuringNode({}, {});
       addConnection(primaryNode, filterNode);
       addConnection(intervalNode, filterNode, 0);
 
       // Create downstream ModifyColumnsNode
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = filterNode;
       filterNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       // Initially should have unique_col
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'unique_col'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'unique_col'),
       ).toBeDefined();
 
       // Disconnect primary
@@ -789,7 +816,7 @@ describe('Connection Management', () => {
       notifyNextNodes(filterNode);
 
       // After disconnection, all columns should be gone
-      expect(modifyNode.state.selectedColumns.length).toBe(0);
+      expect(modifyNode.attrs.selectedColumns.length).toBe(0);
     });
   });
 
@@ -817,18 +844,21 @@ describe('Connection Management', () => {
       ]);
 
       // Create nodes
-      const addColsNode = new AddColumnsNode({
-        leftColumn: 'id',
-        rightColumn: 'id',
-      });
-      const filterNode = new FilterDuringNode({});
+      const addColsNode = new AddColumnsNode(
+        {
+          leftColumn: 'id',
+          rightColumn: 'id',
+        },
+        {},
+      );
+      const filterNode = new FilterDuringNode({}, {});
 
       // Build chain: table -> addCols -> filter
       addConnection(tableNode, addColsNode);
       addConnection(lookupNode, addColsNode, 0);
 
       // Set selected columns AFTER connection (simulating user selection)
-      addColsNode.state.selectedColumns = ['extra_data'];
+      addColsNode.attrs.selectedColumns = ['extra_data'];
 
       addConnection(addColsNode, filterNode);
       addConnection(intervalSource, filterNode, 0);
@@ -864,22 +894,22 @@ describe('Connection Management', () => {
         createColumnInfo('extra', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
-      const modifyNode = new ModifyColumnsNode({selectedColumns: []});
+      const addColsNode = new AddColumnsNode({}, {});
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Build chain: table -> addCols -> modify
       addConnection(tableNode, addColsNode);
       addConnection(lookupNode, addColsNode, 0);
 
       // Set selected columns AFTER connection (simulating user selection)
-      addColsNode.state.selectedColumns = ['extra'];
+      addColsNode.attrs.selectedColumns = ['extra'];
 
       addConnection(addColsNode, modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       // Verify initial state
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'extra'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'extra'),
       ).toBeDefined();
 
       // Disconnect lookup from addCols
@@ -888,7 +918,7 @@ describe('Connection Management', () => {
 
       // Verify downstream is updated
       expect(
-        modifyNode.state.selectedColumns.find((c) => c.name === 'extra'),
+        modifyNode.attrs.selectedColumns.find((c) => c.name === 'extra'),
       ).toBeUndefined();
     });
 
@@ -900,8 +930,8 @@ describe('Connection Management', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const intervalNode1 = new IntervalIntersectNode({inputNodes: []});
-      const intervalNode2 = new IntervalIntersectNode({inputNodes: []});
+      const intervalNode1 = new IntervalIntersectNode({inputNodes: []}, {});
+      const intervalNode2 = new IntervalIntersectNode({inputNodes: []}, {});
 
       // Connect table to both interval nodes as input
       addConnection(tableNode, intervalNode1, 0);
@@ -934,7 +964,7 @@ describe('Connection Management', () => {
         createColumnInfo('state', 'STRING'),
       ]);
 
-      const filterDuringNode = new FilterDuringNode({});
+      const filterDuringNode = new FilterDuringNode({}, {});
 
       // Connect slices to FilterDuring's primary input
       addConnection(slicesNode, filterDuringNode);
@@ -948,7 +978,7 @@ describe('Connection Management', () => {
       );
 
       // Create a filter node to insert between thread_state and FilterDuring
-      const filterNode = new FilterNode({});
+      const filterNode = new FilterNode({}, {});
 
       // Insert filter between thread_state and FilterDuring
       insertNodeBetween(
@@ -994,9 +1024,12 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2, node3],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2, node3],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
       node3.nextNodes.push(intervalNode);
@@ -1007,7 +1040,7 @@ describe('Connection Management', () => {
       expect(intervalNode.secondaryInputs.connections.get(2)).toBe(node3);
 
       // Create a filter node to insert between node2 (port 1) and IntervalIntersect
-      const filterNode = new FilterNode({});
+      const filterNode = new FilterNode({}, {});
 
       // Insert filter between node2 and IntervalIntersect
       insertNodeBetween(node2, filterNode, addConnection, removeConnection);
@@ -1035,7 +1068,7 @@ describe('Connection Management', () => {
         createColumnInfo('extra_col', 'STRING'),
       ]);
 
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
 
       // Connect primary to AddColumns primary input
       addConnection(primaryNode, addColsNode);
@@ -1048,7 +1081,7 @@ describe('Connection Management', () => {
       expect(addColsNode.rightNode).toBe(lookupNode);
 
       // Create a filter node to insert between lookup and AddColumns
-      const filterNode = new FilterNode({});
+      const filterNode = new FilterNode({}, {});
 
       // Insert filter between lookup and AddColumns
       insertNodeBetween(
@@ -1080,7 +1113,7 @@ describe('Connection Management', () => {
       ]);
 
       // Create a child to make nextNodes non-empty
-      const childNode = new FilterNode({});
+      const childNode = new FilterNode({}, {});
       addConnection(node, childNode);
 
       // Attempting to insert the same node between itself should throw
@@ -1100,7 +1133,7 @@ describe('Connection Management', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const existingFilterNode = new FilterNode({});
+      const existingFilterNode = new FilterNode({}, {});
 
       // Connect source to existing filter's primary input
       addConnection(sourceNode, existingFilterNode);
@@ -1110,7 +1143,7 @@ describe('Connection Management', () => {
       expect(sourceNode.nextNodes).toContain(existingFilterNode);
 
       // Create a new filter node to insert between source and existing filter
-      const newFilterNode = new FilterNode({});
+      const newFilterNode = new FilterNode({}, {});
 
       // Insert new filter between source and existing filter
       insertNodeBetween(
@@ -1146,9 +1179,9 @@ describe('Connection Management', () => {
       ]);
 
       // child1 receives parent as primary input
-      const child1 = new FilterNode({});
+      const child1 = new FilterNode({}, {});
       // child2 (FilterDuring) receives parent as secondary input
-      const child2 = new FilterDuringNode({});
+      const child2 = new FilterDuringNode({}, {});
 
       // Set up another node as primary for child2
       const otherPrimaryNode = createMockPrevNode('otherPrimary', [
@@ -1169,7 +1202,7 @@ describe('Connection Management', () => {
       expect(parentNode.nextNodes).toContain(child2);
 
       // Create new node to insert
-      const newNode = new FilterNode({});
+      const newNode = new FilterNode({}, {});
 
       // Insert between parent and both children
       insertNodeBetween(parentNode, newNode, addConnection, removeConnection);
@@ -1199,7 +1232,7 @@ describe('Connection Management', () => {
         createColumnInfo('name', 'STRING'),
       ]);
 
-      const childNode = new FilterNode({});
+      const childNode = new FilterNode({}, {});
       addConnection(sourceNode, childNode);
 
       // Create newNode that already has a connection
@@ -1207,7 +1240,7 @@ describe('Connection Management', () => {
         createColumnInfo('id', 'INT'),
         createColumnInfo('value', 'INT'),
       ]);
-      const newNode = new FilterNode({});
+      const newNode = new FilterNode({}, {});
       addConnection(existingParent, newNode);
 
       // Verify newNode already has a primaryInput
@@ -1237,7 +1270,7 @@ describe('Connection Management', () => {
       // Verify parent has no children
       expect(parentNode.nextNodes.length).toBe(0);
 
-      const newNode = new FilterNode({});
+      const newNode = new FilterNode({}, {});
 
       // Insert newNode (but parent has no children to reconnect)
       insertNodeBetween(parentNode, newNode, addConnection, removeConnection);
@@ -1277,8 +1310,8 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const nodeX = new FilterDuringNode({});
-      const childZ = new ModifyColumnsNode({selectedColumns: []});
+      const nodeX = new FilterDuringNode({}, {});
+      const childZ = new ModifyColumnsNode({selectedColumns: []}, {});
 
       // Set up connections:
       // nodeA -> nodeX (primary)
@@ -1361,9 +1394,9 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const nodeY = new FilterNode({});
+      const nodeY = new FilterNode({}, {});
 
-      const nodeZ = new FilterDuringNode({});
+      const nodeZ = new FilterDuringNode({}, {});
 
       // Set up another node as primary input for nodeZ
       const primaryNode = createMockPrevNode('primary', [
@@ -1465,7 +1498,7 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const filterDuringNode = new FilterDuringNode({});
+      const filterDuringNode = new FilterDuringNode({}, {});
 
       // Connect sliceSource to FilterDuring's primary input
       addConnection(sliceSource, filterDuringNode);
@@ -1473,7 +1506,7 @@ describe('Connection Management', () => {
       addConnection(intervalsSource, filterDuringNode, 0);
 
       // Add a child node downstream of FilterDuring
-      const childNode = new ModifyColumnsNode({selectedColumns: []});
+      const childNode = new ModifyColumnsNode({selectedColumns: []}, {});
       addConnection(filterDuringNode, childNode);
 
       // Verify initial state
@@ -1526,14 +1559,17 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
       node1.nextNodes.push(intervalNode);
       node2.nextNodes.push(intervalNode);
 
       // Add a child downstream
-      const childNode = new ModifyColumnsNode({selectedColumns: []});
+      const childNode = new ModifyColumnsNode({selectedColumns: []}, {});
       addConnection(intervalNode, childNode);
 
       // Verify initial state
@@ -1577,10 +1613,10 @@ describe('Connection Management', () => {
         createColumnInfo('ts', 'INT64'),
       ]);
 
-      const nodeB = new FilterNode({});
+      const nodeB = new FilterNode({}, {});
       addConnection(nodeA, nodeB); // A → B
 
-      const nodeC = new FilterNode({});
+      const nodeC = new FilterNode({}, {});
       addConnection(nodeB, nodeC); // B → C (C.primaryInput = B)
 
       // Simulate the edge case: A is already connected to C directly
@@ -1648,10 +1684,10 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const nodeB = new FilterNode({});
+      const nodeB = new FilterNode({}, {});
       addConnection(nodeA, nodeB); // A → B
 
-      const nodeC = new FilterDuringNode({});
+      const nodeC = new FilterDuringNode({}, {});
       const primary = createMockPrevNode('primary', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
@@ -1758,10 +1794,10 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const nodeB = new FilterNode({});
+      const nodeB = new FilterNode({}, {});
       addConnection(nodeA, nodeB); // A → B (primary)
 
-      const nodeD = new FilterDuringNode({});
+      const nodeD = new FilterDuringNode({}, {});
       const primary = createMockPrevNode('primary', [
         createColumnInfo('id', 'INT'),
         createColumnInfo('ts', 'INT64'),
@@ -1837,7 +1873,7 @@ describe('Connection Management', () => {
         createColumnInfo('ts', 'INT64'),
         createColumnInfo('dur', 'INT64'),
       ]);
-      const filterDuring = new FilterDuringNode({});
+      const filterDuring = new FilterDuringNode({}, {});
 
       // Connect: TableSource → FilterDuring (primary)
       addConnection(tableSource, filterDuring);
@@ -1910,15 +1946,18 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const intervalIntersect = new IntervalIntersectNode({
-        inputNodes: [source1, source2],
-      });
+      const intervalIntersect = new IntervalIntersectNode(
+        {
+          inputNodes: [source1, source2],
+        },
+        {},
+      );
 
       // IntervalIntersectNode only has secondary inputs (no primary)
       addConnection(source1, intervalIntersect, 0); // secondary port 0
       addConnection(source2, intervalIntersect, 1); // secondary port 1
 
-      const childNode = new FilterNode({});
+      const childNode = new FilterNode({}, {});
       addConnection(intervalIntersect, childNode); // primary connection
 
       // Verify initial state
@@ -2009,13 +2048,13 @@ describe('Connection Management', () => {
         createColumnInfo('ts', 'INT64'),
       ]);
 
-      const nodeB = new FilterNode({});
+      const nodeB = new FilterNode({}, {});
       addConnection(nodeA, nodeB); // A → B
 
-      const nodeC = new FilterNode({});
+      const nodeC = new FilterNode({}, {});
       addConnection(nodeA, nodeC); // A → C
 
-      const nodeD = new FilterNode({});
+      const nodeD = new FilterNode({}, {});
       addConnection(nodeB, nodeD); // B → D
 
       // Simulate nodeLayouts map
@@ -2102,9 +2141,9 @@ describe('Connection Management', () => {
       // - B should inherit A's layout (appear at A's position)
       // - B should become a root node
 
-      const nodeA = new FilterNode({});
+      const nodeA = new FilterNode({}, {});
 
-      const nodeB = new FilterNode({});
+      const nodeB = new FilterNode({}, {});
       addConnection(nodeA, nodeB); // A → B
 
       // Simulate nodeLayouts map
@@ -2175,12 +2214,12 @@ describe('Connection Management', () => {
         createColumnInfo('ts', 'INT64'),
       ]);
 
-      const nodeB = new FilterNode({});
+      const nodeB = new FilterNode({}, {});
       addConnection(nodeA, nodeB); // A → B
 
-      const nodeC = new FilterNode({});
-      const nodeD = new FilterNode({});
-      const nodeE = new FilterNode({});
+      const nodeC = new FilterNode({}, {});
+      const nodeD = new FilterNode({}, {});
+      const nodeE = new FilterNode({}, {});
 
       addConnection(nodeB, nodeC); // B → C
       addConnection(nodeB, nodeD); // B → D
@@ -2281,10 +2320,10 @@ describe('Connection Management', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const nodeB = new FilterDuringNode({});
+      const nodeB = new FilterDuringNode({}, {});
       addConnection(nodeA, nodeB); // A → B (primary)
 
-      const nodeC = new FilterNode({});
+      const nodeC = new FilterNode({}, {});
       addConnection(nodeB, nodeC); // B → C
 
       // Add a secondary input that will become orphaned
@@ -2486,9 +2525,10 @@ describe('Connection Management', () => {
       ]);
 
       // SETUP: Create node B (filter, docked to A)
-      const nodeB = new FilterNode({
-        filters: [{column: 'id', op: '=', value: '1'}],
-      });
+      const nodeB = new FilterNode(
+        {filters: [{column: 'id', op: '=', value: '1'}]},
+        {},
+      );
       // Connect A → B (B becomes docked since it's a modification node)
       addConnection(nodeA, nodeB);
 
@@ -2523,7 +2563,7 @@ describe('Connection Management', () => {
       }
 
       // STEP 3: Now add the multi-source node
-      const nodeC = new IntervalIntersectNode({inputNodes: []});
+      const nodeC = new IntervalIntersectNode({inputNodes: []}, {});
       addConnection(nodeA, nodeC);
       // Give C a layout (it's a root node)
       nodeLayouts.set(nodeC.nodeId, {x: 550, y: 100});
@@ -2579,15 +2619,17 @@ describe('Connection Management', () => {
       ]);
 
       // SETUP: Create node B (filter, docked to A)
-      const nodeB = new FilterNode({
-        filters: [{column: 'id', op: '=', value: '1'}],
-      });
+      const nodeB = new FilterNode(
+        {filters: [{column: 'id', op: '=', value: '1'}]},
+        {},
+      );
       addConnection(nodeA, nodeB);
 
       // SETUP: Create node C (filter, docked to B)
-      const nodeC = new FilterNode({
-        filters: [{column: 'name', op: '=', value: "'test'"}],
-      });
+      const nodeC = new FilterNode(
+        {filters: [{column: 'name', op: '=', value: "'test'"}]},
+        {},
+      );
       addConnection(nodeB, nodeC);
 
       // SETUP: nodeLayouts - ONLY A has layout, B and C are docked (no layouts)
@@ -2627,7 +2669,7 @@ describe('Connection Management', () => {
       }
 
       // STEP 4: Now add the multi-source node
-      const nodeD = new IntervalIntersectNode({inputNodes: []});
+      const nodeD = new IntervalIntersectNode({inputNodes: []}, {});
       addConnection(nodeB, nodeD);
       nodeLayouts.set(nodeD.nodeId, {x: 550, y: 100});
 
@@ -2675,7 +2717,7 @@ describe('Connection Management', () => {
       ]);
 
       // SETUP: Create node B (FilterDuring, docked to A)
-      const nodeB = new FilterDuringNode({});
+      const nodeB = new FilterDuringNode({}, {});
       addConnection(nodeA, nodeB); // B's primaryInput = A
 
       // SETUP: Create node C (source for intervals) with layout
@@ -2803,7 +2845,7 @@ describe('Connection Management', () => {
       expect(nodeA.nextNodes.length).toBe(0);
 
       // ACT: Create AddColumns and connect it to A
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
       addConnection(nodeA, addColsNode);
 
       // VERIFY: AddColumns is a single-node operation
@@ -2832,7 +2874,7 @@ describe('Connection Management', () => {
     it('should get secondary input at specified port', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
-      const intervalNode = new IntervalIntersectNode({inputNodes: []});
+      const intervalNode = new IntervalIntersectNode({inputNodes: []}, {});
 
       addConnection(node1, intervalNode, 0);
       addConnection(node2, intervalNode, 1);
@@ -2844,7 +2886,7 @@ describe('Connection Management', () => {
 
     it('should set secondary input at specified port', () => {
       const node1 = createMockPrevNode('node1', []);
-      const intervalNode = new IntervalIntersectNode({inputNodes: []});
+      const intervalNode = new IntervalIntersectNode({inputNodes: []}, {});
 
       setSecondaryInput(intervalNode, 0, node1);
 
@@ -2853,7 +2895,7 @@ describe('Connection Management', () => {
 
     it('should throw when setting secondary input on node without support', () => {
       const node1 = createMockPrevNode('node1', []);
-      const filterNode = new FilterNode({});
+      const filterNode = new FilterNode({}, {});
 
       expect(() => {
         setSecondaryInput(filterNode, 0, node1);
@@ -2862,7 +2904,7 @@ describe('Connection Management', () => {
 
     it('should remove secondary input at specified port', () => {
       const node1 = createMockPrevNode('node1', []);
-      const intervalNode = new IntervalIntersectNode({inputNodes: []});
+      const intervalNode = new IntervalIntersectNode({inputNodes: []}, {});
 
       addConnection(node1, intervalNode, 0);
       expect(getSecondaryInput(intervalNode, 0)).toBe(node1);
@@ -2872,14 +2914,14 @@ describe('Connection Management', () => {
     });
 
     it('should handle removing non-existent secondary input', () => {
-      const intervalNode = new IntervalIntersectNode({inputNodes: []});
+      const intervalNode = new IntervalIntersectNode({inputNodes: []}, {});
 
       // Should not throw
       removeSecondaryInput(intervalNode, 5);
     });
 
     it('should handle removing secondary input from node without support', () => {
-      const filterNode = new FilterNode({});
+      const filterNode = new FilterNode({}, {});
 
       // Should not throw
       removeSecondaryInput(filterNode, 0);
@@ -2887,7 +2929,7 @@ describe('Connection Management', () => {
 
     it('should validate secondary inputs meet minimum cardinality', () => {
       const node1 = createMockPrevNode('node1', []);
-      const intervalNode = new IntervalIntersectNode({inputNodes: []});
+      const intervalNode = new IntervalIntersectNode({inputNodes: []}, {});
 
       // IntervalIntersect requires min 2 inputs
       const error1 = validateSecondaryInputs(intervalNode);
@@ -2900,7 +2942,7 @@ describe('Connection Management', () => {
     });
 
     it('should validate secondary inputs meet maximum cardinality', () => {
-      const addColsNode = new AddColumnsNode({});
+      const addColsNode = new AddColumnsNode({}, {});
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
@@ -2915,7 +2957,10 @@ describe('Connection Management', () => {
     });
 
     it('should validate unbounded maximum cardinality', () => {
-      const unionNode = new UnionNode({inputNodes: [], selectedColumns: []});
+      const unionNode = new UnionNode(
+        {inputNodes: [], selectedColumns: []},
+        {},
+      );
       const nodes = Array.from({length: 10}, (_, i) =>
         createMockPrevNode(`node${i}`, []),
       );
@@ -2931,7 +2976,10 @@ describe('Connection Management', () => {
     });
 
     it('should return undefined when validation passes', () => {
-      const unionNode = new UnionNode({inputNodes: [], selectedColumns: []});
+      const unionNode = new UnionNode(
+        {inputNodes: [], selectedColumns: []},
+        {},
+      );
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
@@ -2943,7 +2991,7 @@ describe('Connection Management', () => {
     });
 
     it('should return undefined for nodes without secondary inputs', () => {
-      const filterNode = new FilterNode({});
+      const filterNode = new FilterNode({}, {});
       const error = validateSecondaryInputs(filterNode);
       expect(error).toBeUndefined();
     });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node.ts
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  QueryNode,
-  nextNodeId,
-  NodeType,
-  QueryNodeState,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
 import m from 'mithril';
@@ -28,23 +23,29 @@ import {NodeDetailsMessage} from '../node_styling_widgets';
 import {loadNodeDoc} from '../node_doc_loader';
 import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
 
-export interface CounterToIntervalsNodeState extends QueryNodeState {}
+// Serializable node configuration (empty — no config fields).
+export interface CounterToIntervalsNodeAttrs {}
 
 export class CounterToIntervalsNode implements QueryNode {
   readonly nodeId: string;
   readonly type = NodeType.kCounterToIntervals;
   primaryInput?: QueryNode;
   nextNodes: QueryNode[];
-  readonly state: CounterToIntervalsNodeState;
+  readonly attrs: CounterToIntervalsNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: CounterToIntervalsNodeState = {}) {
+  constructor(
+    attrs: CounterToIntervalsNodeAttrs = {},
+    context: NodeContext = {},
+  ) {
     this.nodeId = nextNodeId();
-    this.state = state;
+    this.attrs = {...attrs};
+    this.context = context;
     this.nextNodes = [];
   }
 
   onPrevNodesUpdated(): void {
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   get sourceCols(): ColumnInfo[] {
@@ -68,21 +69,21 @@ export class CounterToIntervalsNode implements QueryNode {
     cols.push({
       name: 'dur',
       checked: true,
-      column: {name: 'dur', type: PerfettoSqlTypes.DURATION},
+      type: PerfettoSqlTypes.DURATION,
     });
 
     // next_value: the value of the next counter
     cols.push({
       name: 'next_value',
       checked: true,
-      column: {name: 'next_value', type: PerfettoSqlTypes.DOUBLE},
+      type: PerfettoSqlTypes.DOUBLE,
     });
 
     // delta_value: the change in value (next_value - value)
     cols.push({
       name: 'delta_value',
       checked: true,
-      column: {name: 'delta_value', type: PerfettoSqlTypes.DOUBLE},
+      type: PerfettoSqlTypes.DOUBLE,
     });
 
     return cols;
@@ -104,30 +105,30 @@ export class CounterToIntervalsNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
-      setValidationError(this.state, 'No input node connected');
+      setValidationError(this.context, 'No input node connected');
       return false;
     }
 
     if (!this.primaryInput.validate()) {
-      setValidationError(this.state, 'Previous node is invalid');
+      setValidationError(this.context, 'Previous node is invalid');
       return false;
     }
 
     // Verify that source has at least one row of data (not empty)
     if (this.sourceCols.length === 0) {
-      setValidationError(this.state, 'Input has no columns');
+      setValidationError(this.context, 'Input has no columns');
       return false;
     }
 
     // Check that input has required columns for counter data
     if (!this.hasRequiredColumns()) {
       setValidationError(
-        this.state,
+        this.context,
         'Input must have id, ts, track_id, and value columns',
       );
       return false;
@@ -136,7 +137,7 @@ export class CounterToIntervalsNode implements QueryNode {
     // Check that input does NOT already have dur (it's counter data, not interval data)
     if (this.hasDurColumn()) {
       setValidationError(
-        this.state,
+        this.context,
         'Input already has dur column (already interval data)',
       );
       return false;
@@ -162,10 +163,7 @@ export class CounterToIntervalsNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: CounterToIntervalsNodeState = {
-      onchange: this.state.onchange,
-    };
-    return new CounterToIntervalsNode(stateCopy);
+    return new CounterToIntervalsNode({}, this.context);
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -176,15 +174,5 @@ export class CounterToIntervalsNode implements QueryNode {
       this.primaryInput,
       this.nodeId,
     );
-  }
-
-  serializeState(): object {
-    return {};
-  }
-
-  static deserializeState(
-    _serializedState: CounterToIntervalsNodeState,
-  ): CounterToIntervalsNodeState {
-    return {};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/counter_to_intervals_node_unittest.ts
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  CounterToIntervalsNode,
-  CounterToIntervalsNodeState,
-} from './counter_to_intervals_node';
+import {CounterToIntervalsNode} from './counter_to_intervals_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import {
@@ -31,7 +28,8 @@ describe('CounterToIntervalsNode', () => {
       type: NodeType.kTable,
       nextNodes: [],
       finalCols: columns,
-      state: {},
+      attrs: {},
+      context: {},
       validate: () => true,
       getTitle: () => `Mock ${id}`,
       nodeSpecificModify: () => ({sections: []}),
@@ -46,7 +44,6 @@ describe('CounterToIntervalsNode', () => {
         sq.table.columnNames = columns.map((c) => c.name);
         return sq;
       },
-      serializeState: () => ({}),
     } as QueryNode;
   }
 
@@ -73,7 +70,7 @@ describe('CounterToIntervalsNode', () => {
     return {
       name,
       checked,
-      column: {name, type: sqlType},
+      type: sqlType,
     };
   }
 
@@ -81,7 +78,7 @@ describe('CounterToIntervalsNode', () => {
     it('should initialize with empty state', () => {
       const node = new CounterToIntervalsNode({});
 
-      expect(node.state).toBeDefined();
+      expect(node.attrs).toBeDefined();
     });
 
     it('should have correct node type', () => {
@@ -154,9 +151,9 @@ describe('CounterToIntervalsNode', () => {
       const nextValueCol = finalCols.find((c) => c.name === 'next_value');
       const deltaValueCol = finalCols.find((c) => c.name === 'delta_value');
 
-      expect(durCol?.column.type).toEqual({kind: 'duration'});
-      expect(nextValueCol?.column.type).toEqual({kind: 'double'});
-      expect(deltaValueCol?.column.type).toEqual({kind: 'double'});
+      expect(durCol?.type).toEqual({kind: 'duration'});
+      expect(nextValueCol?.type).toEqual({kind: 'double'});
+      expect(deltaValueCol?.type).toEqual({kind: 'double'});
     });
 
     it('should preserve input column order', () => {
@@ -187,7 +184,7 @@ describe('CounterToIntervalsNode', () => {
       const node = new CounterToIntervalsNode({});
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'No input node connected',
       );
     });
@@ -200,7 +197,7 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Previous node is invalid',
       );
     });
@@ -217,7 +214,7 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Input must have id, ts, track_id, and value columns',
       );
     });
@@ -234,7 +231,7 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Input must have id, ts, track_id, and value columns',
       );
     });
@@ -251,7 +248,7 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Input must have id, ts, track_id, and value columns',
       );
     });
@@ -268,7 +265,7 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Input must have id, ts, track_id, and value columns',
       );
     });
@@ -287,7 +284,7 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Input already has dur column',
       );
     });
@@ -299,7 +296,7 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Input has no columns',
       );
     });
@@ -354,7 +351,7 @@ describe('CounterToIntervalsNode', () => {
       expect(node.validate()).toBe(true);
 
       // Issues should be cleared
-      expect(node.state.issues?.queryError).toBeUndefined();
+      expect(node.context.issues?.queryError).toBeUndefined();
     });
   });
 
@@ -433,7 +430,7 @@ describe('CounterToIntervalsNode', () => {
       const node = new CounterToIntervalsNode({});
       node.primaryInput = inputNode;
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
       expect(serialized).toEqual({});
     });
@@ -441,25 +438,9 @@ describe('CounterToIntervalsNode', () => {
     it('should handle missing input gracefully', () => {
       const node = new CounterToIntervalsNode({});
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
       expect(serialized).toEqual({});
-    });
-  });
-
-  describe('deserializeState', () => {
-    it('should return empty state', () => {
-      const state = CounterToIntervalsNode.deserializeState({});
-
-      expect(state).toEqual({});
-    });
-
-    it('should ignore unknown properties', () => {
-      const state = CounterToIntervalsNode.deserializeState({
-        unknownProp: 'value',
-      } as CounterToIntervalsNodeState);
-
-      expect(state).toEqual({});
     });
   });
 
@@ -475,11 +456,11 @@ describe('CounterToIntervalsNode', () => {
 
     it('should preserve onchange callback', () => {
       const onchange = jest.fn();
-      const node = new CounterToIntervalsNode({onchange});
+      const node = new CounterToIntervalsNode({}, {onchange});
 
       const cloned = node.clone() as CounterToIntervalsNode;
 
-      expect(cloned.state.onchange).toBe(onchange);
+      expect(cloned.context.onchange).toBe(onchange);
     });
   });
 
@@ -494,7 +475,7 @@ describe('CounterToIntervalsNode', () => {
   describe('onPrevNodesUpdated', () => {
     it('should trigger onchange callback when called', () => {
       const onchange = jest.fn();
-      const node = new CounterToIntervalsNode({onchange});
+      const node = new CounterToIntervalsNode({}, {onchange});
 
       node.onPrevNodesUpdated();
 
@@ -563,7 +544,7 @@ describe('CounterToIntervalsNode', () => {
 
       // Should fail validation because it already has dur
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'already interval data',
       );
     });
@@ -580,15 +561,10 @@ describe('CounterToIntervalsNode', () => {
       node.primaryInput = inputNode;
 
       // Serialize
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
-      // Deserialize
-      const restoredState = CounterToIntervalsNode.deserializeState(
-        serialized as CounterToIntervalsNodeState,
-      );
-
-      // Create new node with restored state
-      const restoredNode = new CounterToIntervalsNode(restoredState);
+      // Create new node with restored attrs
+      const restoredNode = new CounterToIntervalsNode(serialized);
 
       // Should have same structure (but no input node since that's reconnected separately)
       expect(restoredNode.type).toBe(node.type);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/create_slices_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/create_slices_node.ts
@@ -15,10 +15,10 @@
 import m from 'mithril';
 import {
   QueryNode,
-  QueryNodeState,
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {getSecondaryInput} from '../graph_utils';
 import protos from '../../../../protos';
@@ -44,19 +44,8 @@ const DEFAULT_TS_COLUMN = 'ts';
 const COMPUTED_STARTS_END_TS_COLUMN = 'exp_tmp_starts_computed_end_ts';
 const COMPUTED_ENDS_END_TS_COLUMN = 'exp_tmp_ends_computed_end_ts';
 
-export interface CreateSlicesSerializedState {
-  startsMode?: TimestampMode;
-  endsMode?: TimestampMode;
-  startsTsColumn: string;
-  endsTsColumn: string;
-  startsDurColumn?: string;
-  endsDurColumn?: string;
-  comment?: string;
-}
-
-export interface CreateSlicesNodeState extends QueryNodeState {
-  startsNode?: QueryNode;
-  endsNode?: QueryNode;
+// Serializable node configuration.
+export interface CreateSlicesNodeAttrs {
   startsMode?: TimestampMode;
   endsMode?: TimestampMode;
   startsTsColumn: string;
@@ -70,7 +59,8 @@ export class CreateSlicesNode implements QueryNode {
   readonly type = NodeType.kCreateSlices;
   secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
-  readonly state: CreateSlicesNodeState;
+  readonly attrs: CreateSlicesNodeAttrs;
+  readonly context: NodeContext;
 
   get startsNode(): QueryNode | undefined {
     return getSecondaryInput(this, 0);
@@ -98,38 +88,45 @@ export class CreateSlicesNode implements QueryNode {
     ];
   }
 
-  constructor(state: CreateSlicesNodeState) {
+  constructor(
+    attrs: CreateSlicesNodeAttrs & {
+      startsNode?: QueryNode;
+      endsNode?: QueryNode;
+    },
+    context: NodeContext,
+  ) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...state,
-      autoExecute: state.autoExecute ?? false,
-      startsMode: state.startsMode ?? 'ts',
-      endsMode: state.endsMode ?? 'ts',
-      startsTsColumn: state.startsTsColumn ?? DEFAULT_TS_COLUMN,
-      endsTsColumn: state.endsTsColumn ?? DEFAULT_TS_COLUMN,
-      startsDurColumn: state.startsDurColumn,
-      endsDurColumn: state.endsDurColumn,
+    const {startsNode, endsNode, ...rest} = attrs;
+    this.attrs = {
+      ...rest,
+      startsMode: rest.startsMode ?? 'ts',
+      endsMode: rest.endsMode ?? 'ts',
+      startsTsColumn: rest.startsTsColumn ?? DEFAULT_TS_COLUMN,
+      endsTsColumn: rest.endsTsColumn ?? DEFAULT_TS_COLUMN,
+      startsDurColumn: rest.startsDurColumn,
+      endsDurColumn: rest.endsDurColumn,
     };
+    this.context = context;
     this.secondaryInputs = {
       connections: new Map(),
       min: 2,
       max: 2,
       portNames: ['Starts', 'Ends'],
     };
-    // Initialize connections from state
-    if (state.startsNode) {
-      this.secondaryInputs.connections.set(0, state.startsNode);
+    // Initialize connections from startsNode/endsNode
+    if (startsNode) {
+      this.secondaryInputs.connections.set(0, startsNode);
     }
-    if (state.endsNode) {
-      this.secondaryInputs.connections.set(1, state.endsNode);
+    if (endsNode) {
+      this.secondaryInputs.connections.set(1, endsNode);
     }
     this.nextNodes = [];
   }
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (
@@ -157,9 +154,9 @@ export class CreateSlicesNode implements QueryNode {
     // Validate starts input based on mode
     if (
       !this.validateInputSource(
-        this.state.startsMode ?? 'ts',
-        this.state.startsTsColumn,
-        this.state.startsDurColumn,
+        this.attrs.startsMode ?? 'ts',
+        this.attrs.startsTsColumn,
+        this.attrs.startsDurColumn,
         this.startsNode,
         'Starts',
       )
@@ -170,9 +167,9 @@ export class CreateSlicesNode implements QueryNode {
     // Validate ends input based on mode
     if (
       !this.validateInputSource(
-        this.state.endsMode ?? 'ts',
-        this.state.endsTsColumn,
-        this.state.endsDurColumn,
+        this.attrs.endsMode ?? 'ts',
+        this.attrs.endsTsColumn,
+        this.attrs.endsDurColumn,
         this.endsNode,
         'Ends',
       )
@@ -188,42 +185,38 @@ export class CreateSlicesNode implements QueryNode {
 
     // Auto-select timestamp columns based on type only
     const startsTimestampCols = this.startsNode.finalCols.filter(
-      (c) =>
-        c.column.type && typesEqual(c.column.type, PerfettoSqlTypes.TIMESTAMP),
+      (c) => c.type && typesEqual(c.type, PerfettoSqlTypes.TIMESTAMP),
     );
     const endsTimestampCols = this.endsNode.finalCols.filter(
-      (c) =>
-        c.column.type && typesEqual(c.column.type, PerfettoSqlTypes.TIMESTAMP),
+      (c) => c.type && typesEqual(c.type, PerfettoSqlTypes.TIMESTAMP),
     );
 
     // Auto-select starts timestamp if there's only one option
-    if (startsTimestampCols.length === 1 && !this.state.startsTsColumn) {
-      this.state.startsTsColumn = startsTimestampCols[0].name;
+    if (startsTimestampCols.length === 1 && !this.attrs.startsTsColumn) {
+      this.attrs.startsTsColumn = startsTimestampCols[0].name;
     }
 
     // Auto-select ends timestamp if there's only one option
-    if (endsTimestampCols.length === 1 && !this.state.endsTsColumn) {
-      this.state.endsTsColumn = endsTimestampCols[0].name;
+    if (endsTimestampCols.length === 1 && !this.attrs.endsTsColumn) {
+      this.attrs.endsTsColumn = endsTimestampCols[0].name;
     }
 
     // Auto-select duration columns in ts_dur mode
-    if (this.state.startsMode === 'ts_dur') {
+    if (this.attrs.startsMode === 'ts_dur') {
       const startsDurationCols = this.startsNode.finalCols.filter(
-        (c) =>
-          c.column.type && typesEqual(c.column.type, PerfettoSqlTypes.DURATION),
+        (c) => c.type && typesEqual(c.type, PerfettoSqlTypes.DURATION),
       );
-      if (startsDurationCols.length === 1 && !this.state.startsDurColumn) {
-        this.state.startsDurColumn = startsDurationCols[0].name;
+      if (startsDurationCols.length === 1 && !this.attrs.startsDurColumn) {
+        this.attrs.startsDurColumn = startsDurationCols[0].name;
       }
     }
 
-    if (this.state.endsMode === 'ts_dur') {
+    if (this.attrs.endsMode === 'ts_dur') {
       const endsDurationCols = this.endsNode.finalCols.filter(
-        (c) =>
-          c.column.type && typesEqual(c.column.type, PerfettoSqlTypes.DURATION),
+        (c) => c.type && typesEqual(c.type, PerfettoSqlTypes.DURATION),
       );
-      if (endsDurationCols.length === 1 && !this.state.endsDurColumn) {
-        this.state.endsDurColumn = endsDurationCols[0].name;
+      if (endsDurationCols.length === 1 && !this.attrs.endsDurColumn) {
+        this.attrs.endsDurColumn = endsDurationCols[0].name;
       }
     }
   }
@@ -231,7 +224,7 @@ export class CreateSlicesNode implements QueryNode {
   private validateSourceNode(node: QueryNode, nodeName: string): boolean {
     if (!node.validate()) {
       this.setValidationError(
-        node.state.issues?.queryError?.message ??
+        node.context.issues?.queryError?.message ??
           `${nodeName} node '${node.getTitle()}' is invalid`,
       );
       return false;
@@ -286,10 +279,10 @@ export class CreateSlicesNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -307,15 +300,15 @@ export class CreateSlicesNode implements QueryNode {
   nodeDetails(): NodeDetailsAttrs {
     const content: m.Children[] = [NodeTitle(this.getTitle())];
 
-    if (this.state.startsTsColumn && this.state.endsTsColumn) {
+    if (this.attrs.startsTsColumn && this.attrs.endsTsColumn) {
       content.push(
         m(
           '.pf-exp-create-slices-details',
           m('div', [
             m('span', 'Start: '),
-            ColumnName(this.state.startsTsColumn),
+            ColumnName(this.attrs.startsTsColumn),
           ]),
-          m('div', [m('span', 'End: '), ColumnName(this.state.endsTsColumn)]),
+          m('div', [m('span', 'End: '), ColumnName(this.attrs.endsTsColumn)]),
         ),
       );
     }
@@ -327,7 +320,7 @@ export class CreateSlicesNode implements QueryNode {
 
   nodeSpecificModify(): NodeModifyAttrs {
     this.validate();
-    const error = this.state.issues?.queryError;
+    const error = this.context.issues?.queryError;
 
     const sections: NodeModifyAttrs['sections'] = [];
 
@@ -340,12 +333,12 @@ export class CreateSlicesNode implements QueryNode {
 
     // Add starts input section
     if (this.startsNode) {
-      const startsMode = this.state.startsMode ?? 'ts';
+      const startsMode = this.attrs.startsMode ?? 'ts';
       const startsValid = this.validateInputConfig(
         this.startsNode,
         startsMode,
-        this.state.startsTsColumn,
-        this.state.startsDurColumn,
+        this.attrs.startsTsColumn,
+        this.attrs.startsDurColumn,
       );
 
       sections.push({
@@ -357,18 +350,18 @@ export class CreateSlicesNode implements QueryNode {
           children: this.renderInputDetails(
             this.startsNode,
             startsMode,
-            this.state.startsTsColumn,
-            this.state.startsDurColumn,
+            this.attrs.startsTsColumn,
+            this.attrs.startsDurColumn,
             (mode) => {
-              this.state.startsMode = mode;
-              this.state.onchange?.();
+              this.attrs.startsMode = mode;
+              this.context.onchange?.();
             },
             (ts, dur) => {
-              this.state.startsTsColumn = ts;
+              this.attrs.startsTsColumn = ts;
               if (dur !== undefined) {
-                this.state.startsDurColumn = dur;
+                this.attrs.startsDurColumn = dur;
               }
-              this.state.onchange?.();
+              this.context.onchange?.();
             },
           ),
         }),
@@ -377,12 +370,12 @@ export class CreateSlicesNode implements QueryNode {
 
     // Add ends input section
     if (this.endsNode) {
-      const endsMode = this.state.endsMode ?? 'ts';
+      const endsMode = this.attrs.endsMode ?? 'ts';
       const endsValid = this.validateInputConfig(
         this.endsNode,
         endsMode,
-        this.state.endsTsColumn,
-        this.state.endsDurColumn,
+        this.attrs.endsTsColumn,
+        this.attrs.endsDurColumn,
       );
 
       sections.push({
@@ -394,18 +387,18 @@ export class CreateSlicesNode implements QueryNode {
           children: this.renderInputDetails(
             this.endsNode,
             endsMode,
-            this.state.endsTsColumn,
-            this.state.endsDurColumn,
+            this.attrs.endsTsColumn,
+            this.attrs.endsDurColumn,
             (mode) => {
-              this.state.endsMode = mode;
-              this.state.onchange?.();
+              this.attrs.endsMode = mode;
+              this.context.onchange?.();
             },
             (ts, dur) => {
-              this.state.endsTsColumn = ts;
+              this.attrs.endsTsColumn = ts;
               if (dur !== undefined) {
-                this.state.endsDurColumn = dur;
+                this.attrs.endsDurColumn = dur;
               }
-              this.state.onchange?.();
+              this.context.onchange?.();
             },
           ),
         }),
@@ -452,12 +445,10 @@ export class CreateSlicesNode implements QueryNode {
   ): m.Children {
     const cols = node.finalCols;
     const timestampCols = cols.filter(
-      (c) =>
-        c.column.type && typesEqual(c.column.type, PerfettoSqlTypes.TIMESTAMP),
+      (c) => c.type && typesEqual(c.type, PerfettoSqlTypes.TIMESTAMP),
     );
     const durationCols = cols.filter(
-      (c) =>
-        c.column.type && typesEqual(c.column.type, PerfettoSqlTypes.DURATION),
+      (c) => c.type && typesEqual(c.type, PerfettoSqlTypes.DURATION),
     );
 
     // Display the auto-selected column if there's only one option
@@ -537,16 +528,17 @@ export class CreateSlicesNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: CreateSlicesNodeState = {
-      onchange: this.state.onchange,
-      startsMode: this.state.startsMode ?? 'ts',
-      endsMode: this.state.endsMode ?? 'ts',
-      startsTsColumn: this.state.startsTsColumn,
-      endsTsColumn: this.state.endsTsColumn,
-      startsDurColumn: this.state.startsDurColumn,
-      endsDurColumn: this.state.endsDurColumn,
-    };
-    return new CreateSlicesNode(stateCopy);
+    return new CreateSlicesNode(
+      {
+        startsMode: this.attrs.startsMode ?? 'ts',
+        endsMode: this.attrs.endsMode ?? 'ts',
+        startsTsColumn: this.attrs.startsTsColumn,
+        endsTsColumn: this.attrs.endsTsColumn,
+        startsDurColumn: this.attrs.startsDurColumn,
+        endsDurColumn: this.attrs.endsDurColumn,
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -560,9 +552,9 @@ export class CreateSlicesNode implements QueryNode {
     // Process starts input
     const startsResult = this.processInputQuery(
       startsQuery,
-      this.state.startsMode ?? 'ts',
-      this.state.startsTsColumn,
-      this.state.startsDurColumn,
+      this.attrs.startsMode ?? 'ts',
+      this.attrs.startsTsColumn,
+      this.attrs.startsDurColumn,
       this.startsNode.finalCols,
       'starts',
       COMPUTED_STARTS_END_TS_COLUMN,
@@ -571,9 +563,9 @@ export class CreateSlicesNode implements QueryNode {
     // Process ends input
     const endsResult = this.processInputQuery(
       endsQuery,
-      this.state.endsMode ?? 'ts',
-      this.state.endsTsColumn,
-      this.state.endsDurColumn,
+      this.attrs.endsMode ?? 'ts',
+      this.attrs.endsTsColumn,
+      this.attrs.endsDurColumn,
       this.endsNode.finalCols,
       'ends',
       COMPUTED_ENDS_END_TS_COLUMN,
@@ -630,29 +622,5 @@ export class CreateSlicesNode implements QueryNode {
       ) ?? query;
 
     return {query: processedQuery, tsColumnName: computedColName};
-  }
-
-  serializeState(): CreateSlicesSerializedState {
-    return {
-      startsMode: this.state.startsMode ?? 'ts',
-      endsMode: this.state.endsMode ?? 'ts',
-      startsTsColumn: this.state.startsTsColumn,
-      endsTsColumn: this.state.endsTsColumn,
-      startsDurColumn: this.state.startsDurColumn,
-      endsDurColumn: this.state.endsDurColumn,
-    };
-  }
-
-  static deserializeState(
-    state: CreateSlicesSerializedState,
-  ): CreateSlicesNodeState {
-    return {
-      startsMode: state.startsMode ?? 'ts',
-      endsMode: state.endsMode ?? 'ts',
-      startsTsColumn: state.startsTsColumn ?? DEFAULT_TS_COLUMN,
-      endsTsColumn: state.endsTsColumn ?? DEFAULT_TS_COLUMN,
-      startsDurColumn: state.startsDurColumn,
-      endsDurColumn: state.endsDurColumn,
-    };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/create_slices_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/create_slices_node_unittest.ts
@@ -51,31 +51,37 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
-      expect(createSlicesNode.state.startsTsColumn).toBe('ts');
-      expect(createSlicesNode.state.endsTsColumn).toBe('ts');
-      expect(createSlicesNode.state.autoExecute).toBe(false);
+      expect(createSlicesNode.attrs.startsTsColumn).toBe('ts');
+      expect(createSlicesNode.attrs.endsTsColumn).toBe('ts');
+      expect(createSlicesNode.context.autoExecute).toBeUndefined();
     });
 
     it('should use default timestamp columns when not provided', () => {
       const startsNode = createMockPrevNode('starts', []);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: undefined!,
-        endsTsColumn: undefined!,
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: undefined!,
+          endsTsColumn: undefined!,
+        },
+        {},
+      );
 
-      expect(createSlicesNode.state.startsTsColumn).toBe('ts');
-      expect(createSlicesNode.state.endsTsColumn).toBe('ts');
+      expect(createSlicesNode.attrs.startsTsColumn).toBe('ts');
+      expect(createSlicesNode.attrs.endsTsColumn).toBe('ts');
     });
 
     it('should accept custom timestamp column names', () => {
@@ -86,15 +92,18 @@ describe('CreateSlicesNode', () => {
         createCol('release_ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'acquire_ts',
-        endsTsColumn: 'release_ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'acquire_ts',
+          endsTsColumn: 'release_ts',
+        },
+        {},
+      );
 
-      expect(createSlicesNode.state.startsTsColumn).toBe('acquire_ts');
-      expect(createSlicesNode.state.endsTsColumn).toBe('release_ts');
+      expect(createSlicesNode.attrs.startsTsColumn).toBe('acquire_ts');
+      expect(createSlicesNode.attrs.endsTsColumn).toBe('release_ts');
     });
   });
 
@@ -104,12 +113,15 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode: undefined,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode: undefined,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.finalCols).toEqual([]);
     });
@@ -119,12 +131,15 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode: undefined,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode: undefined,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.finalCols).toEqual([]);
     });
@@ -137,21 +152,24 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       const finalCols = createSlicesNode.finalCols;
 
       expect(finalCols.length).toBe(2);
       expect(finalCols[0].name).toBe('ts');
-      expect(finalCols[0].column.type).toEqual({kind: 'timestamp'});
+      expect(finalCols[0].type).toEqual({kind: 'timestamp'});
       expect(finalCols[0].checked).toBe(true);
       expect(finalCols[1].name).toBe('dur');
-      expect(finalCols[1].column.type).toEqual({kind: 'duration'});
+      expect(finalCols[1].type).toEqual({kind: 'duration'});
       expect(finalCols[1].checked).toBe(true);
     });
 
@@ -166,12 +184,15 @@ describe('CreateSlicesNode', () => {
         createCol('lock_id', 'int'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'acquire_ts',
-        endsTsColumn: 'release_ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'acquire_ts',
+          endsTsColumn: 'release_ts',
+        },
+        {},
+      );
 
       const finalCols = createSlicesNode.finalCols;
 
@@ -184,15 +205,18 @@ describe('CreateSlicesNode', () => {
     it('should fail when only starts node is provided', () => {
       const startsNode = createMockPrevNode('starts', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode: undefined,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode: undefined,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         'exactly two sources',
       );
     });
@@ -200,15 +224,18 @@ describe('CreateSlicesNode', () => {
     it('should fail when only ends node is provided', () => {
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode: undefined,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode: undefined,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         'exactly two sources',
       );
     });
@@ -217,15 +244,18 @@ describe('CreateSlicesNode', () => {
       const startsNode = createMockPrevNode('starts', []);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: '',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: '',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         'Starts timestamp column is required',
       );
     });
@@ -236,15 +266,18 @@ describe('CreateSlicesNode', () => {
       ]);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: '',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: '',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         'Ends timestamp column is required',
       );
     });
@@ -254,7 +287,7 @@ describe('CreateSlicesNode', () => {
         nodeId: 'starts',
         columns: [createCol('ts', 'timestamp')],
         validate: () => false,
-        state: {
+        context: {
           issues: createNodeIssuesWithQueryError('Starts node has errors'),
         },
       });
@@ -262,15 +295,18 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         'Starts node has errors',
       );
     });
@@ -283,20 +319,23 @@ describe('CreateSlicesNode', () => {
         nodeId: 'ends',
         columns: [createCol('ts', 'timestamp')],
         validate: () => false,
-        state: {
+        context: {
           issues: createNodeIssuesWithQueryError('Ends node has errors'),
         },
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         'Ends node has errors',
       );
     });
@@ -309,15 +348,18 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         "Starts timestamp column 'ts' not found",
       );
     });
@@ -330,15 +372,18 @@ describe('CreateSlicesNode', () => {
         createCol('other_column', 'int'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(false);
-      expect(createSlicesNode.state.issues?.queryError?.message).toContain(
+      expect(createSlicesNode.context.issues?.queryError?.message).toContain(
         "Ends timestamp column 'ts' not found",
       );
     });
@@ -351,12 +396,15 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(true);
     });
@@ -371,12 +419,15 @@ describe('CreateSlicesNode', () => {
         createCol('lock_id', 'int'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'acquire_ts',
-        endsTsColumn: 'release_ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'acquire_ts',
+          endsTsColumn: 'release_ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.validate()).toBe(true);
     });
@@ -387,12 +438,15 @@ describe('CreateSlicesNode', () => {
       const startsNode = createMockPrevNode('starts', []);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.getTitle()).toBe('Create Slices');
     });
@@ -403,12 +457,15 @@ describe('CreateSlicesNode', () => {
       const startsNode = createMockPrevNode('starts', []);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.getInputLabels()).toEqual(['Starts', 'Ends']);
     });
@@ -419,50 +476,59 @@ describe('CreateSlicesNode', () => {
       const startsNode = createMockPrevNode('starts', []);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'acquire_ts',
-        endsTsColumn: 'release_ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'acquire_ts',
+          endsTsColumn: 'release_ts',
+        },
+        {},
+      );
 
       const cloned = createSlicesNode.clone() as CreateSlicesNode;
 
       expect(cloned).not.toBe(createSlicesNode);
-      expect(cloned.state.startsTsColumn).toBe('acquire_ts');
-      expect(cloned.state.endsTsColumn).toBe('release_ts');
+      expect(cloned.attrs.startsTsColumn).toBe('acquire_ts');
+      expect(cloned.attrs.endsTsColumn).toBe('release_ts');
     });
 
     it('should not share state with original', () => {
       const startsNode = createMockPrevNode('starts', []);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       const cloned = createSlicesNode.clone() as CreateSlicesNode;
 
       // Modify the cloned state
-      cloned.state.startsTsColumn = 'modified';
+      cloned.attrs.startsTsColumn = 'modified';
 
       // Original should not be affected
-      expect(createSlicesNode.state.startsTsColumn).toBe('ts');
+      expect(createSlicesNode.attrs.startsTsColumn).toBe('ts');
     });
 
     it('should not share connections with original', () => {
       const startsNode = createMockPrevNode('starts', []);
       const endsNode = createMockPrevNode('ends', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       const cloned = createSlicesNode.clone() as CreateSlicesNode;
 
@@ -482,12 +548,15 @@ describe('CreateSlicesNode', () => {
     it('should return undefined if validation fails', () => {
       const startsNode = createMockPrevNode('starts', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode: undefined,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode: undefined,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.getStructuredQuery()).toBeUndefined();
     });
@@ -502,12 +571,15 @@ describe('CreateSlicesNode', () => {
         getStructuredQuery: () => new protos.PerfettoSqlStructuredQuery(),
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.getStructuredQuery()).toBeUndefined();
     });
@@ -522,12 +594,15 @@ describe('CreateSlicesNode', () => {
         createCol('ts', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       expect(createSlicesNode.getStructuredQuery()).toBeUndefined();
     });
@@ -548,12 +623,15 @@ describe('CreateSlicesNode', () => {
         getStructuredQuery: () => mockSq2,
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       const sq = createSlicesNode.getStructuredQuery();
 
@@ -581,12 +659,15 @@ describe('CreateSlicesNode', () => {
         getStructuredQuery: () => mockSq2,
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'acquire_ts',
-        endsTsColumn: 'release_ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'acquire_ts',
+          endsTsColumn: 'release_ts',
+        },
+        {},
+      );
 
       const sq = createSlicesNode.getStructuredQuery();
 
@@ -611,12 +692,15 @@ describe('CreateSlicesNode', () => {
         getStructuredQuery: () => mockSq2,
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       const sq = createSlicesNode.getStructuredQuery();
 
@@ -640,15 +724,18 @@ describe('CreateSlicesNode', () => {
         getStructuredQuery: () => mockSq2,
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsMode: 'ts_dur',
-        endsMode: 'ts',
-        startsTsColumn: 'ts',
-        startsDurColumn: 'dur',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsMode: 'ts_dur',
+          endsMode: 'ts',
+          startsTsColumn: 'ts',
+          startsDurColumn: 'dur',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
       const sq = createSlicesNode.getStructuredQuery();
 
@@ -684,15 +771,18 @@ describe('CreateSlicesNode', () => {
         getStructuredQuery: () => mockSq2,
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsMode: 'ts',
-        endsMode: 'ts_dur',
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-        endsDurColumn: 'dur',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsMode: 'ts',
+          endsMode: 'ts_dur',
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+          endsDurColumn: 'dur',
+        },
+        {},
+      );
 
       const sq = createSlicesNode.getStructuredQuery();
 
@@ -728,16 +818,19 @@ describe('CreateSlicesNode', () => {
         getStructuredQuery: () => mockSq2,
       });
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsMode: 'ts_dur',
-        endsMode: 'ts_dur',
-        startsTsColumn: 'ts',
-        startsDurColumn: 'dur',
-        endsTsColumn: 'ts',
-        endsDurColumn: 'dur',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsMode: 'ts_dur',
+          endsMode: 'ts_dur',
+          startsTsColumn: 'ts',
+          startsDurColumn: 'dur',
+          endsTsColumn: 'ts',
+          endsDurColumn: 'dur',
+        },
+        {},
+      );
 
       const sq = createSlicesNode.getStructuredQuery();
 
@@ -765,57 +858,59 @@ describe('CreateSlicesNode', () => {
       const startsNode = createMockPrevNode('starts_node_id', []);
       const endsNode = createMockPrevNode('ends_node_id', []);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: 'acquire_ts',
-        endsTsColumn: 'release_ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: 'acquire_ts',
+          endsTsColumn: 'release_ts',
+        },
+        {},
+      );
 
-      const serialized = createSlicesNode.serializeState();
+      const serialized = createSlicesNode.attrs;
 
       expect(serialized.startsTsColumn).toBe('acquire_ts');
       expect(serialized.endsTsColumn).toBe('release_ts');
     });
 
     it('should handle empty node IDs', () => {
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode: undefined,
-        endsNode: undefined,
-        startsTsColumn: 'ts',
-        endsTsColumn: 'ts',
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode: undefined,
+          endsNode: undefined,
+          startsTsColumn: 'ts',
+          endsTsColumn: 'ts',
+        },
+        {},
+      );
 
-      const serialized = createSlicesNode.serializeState();
+      const serialized = createSlicesNode.attrs;
 
       expect(serialized.startsTsColumn).toBe('ts');
       expect(serialized.endsTsColumn).toBe('ts');
     });
   });
 
-  describe('deserializeState', () => {
-    it('should deserialize state correctly', () => {
-      const serialized = {
-        startsTsColumn: 'acquire_ts',
-        endsTsColumn: 'release_ts',
-      };
+  describe('deserialize', () => {
+    it('should restore state via constructor', () => {
+      const node = new CreateSlicesNode(
+        {startsTsColumn: 'acquire_ts', endsTsColumn: 'release_ts'},
+        {},
+      );
 
-      const state = CreateSlicesNode.deserializeState(serialized);
-
-      expect(state.startsTsColumn).toBe('acquire_ts');
-      expect(state.endsTsColumn).toBe('release_ts');
+      expect(node.attrs.startsTsColumn).toBe('acquire_ts');
+      expect(node.attrs.endsTsColumn).toBe('release_ts');
     });
 
     it('should use default values when fields are missing', () => {
-      const serialized = {
-        startsTsColumn: undefined!,
-        endsTsColumn: undefined!,
-      };
+      const node = new CreateSlicesNode(
+        {startsTsColumn: undefined!, endsTsColumn: undefined!},
+        {},
+      );
 
-      const state = CreateSlicesNode.deserializeState(serialized);
-
-      expect(state.startsTsColumn).toBe('ts');
-      expect(state.endsTsColumn).toBe('ts');
+      expect(node.attrs.startsTsColumn).toBe('ts');
+      expect(node.attrs.endsTsColumn).toBe('ts');
     });
   });
 
@@ -830,18 +925,21 @@ describe('CreateSlicesNode', () => {
         createCol('another_ts_name', 'timestamp'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsTsColumn: '', // Empty to trigger auto-selection
-        endsTsColumn: '', // Empty to trigger auto-selection
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsTsColumn: '', // Empty to trigger auto-selection
+          endsTsColumn: '', // Empty to trigger auto-selection
+        },
+        {},
+      );
 
       // Validation should pass because there's only one timestamp column
       // and it should be auto-selected based on TYPE, not name
       expect(createSlicesNode.validate()).toBe(true);
-      expect(createSlicesNode.state.startsTsColumn).toBe('custom_timestamp');
-      expect(createSlicesNode.state.endsTsColumn).toBe('another_ts_name');
+      expect(createSlicesNode.attrs.startsTsColumn).toBe('custom_timestamp');
+      expect(createSlicesNode.attrs.endsTsColumn).toBe('another_ts_name');
     });
 
     it('should auto-select duration column based on type, not name', () => {
@@ -854,23 +952,26 @@ describe('CreateSlicesNode', () => {
         createCol('end_duration', 'duration'),
       ]);
 
-      const createSlicesNode = new CreateSlicesNode({
-        startsNode,
-        endsNode,
-        startsMode: 'ts_dur',
-        endsMode: 'ts_dur',
-        startsTsColumn: '', // Empty to trigger auto-selection
-        endsTsColumn: '', // Empty to trigger auto-selection
-        startsDurColumn: '', // Empty to trigger auto-selection
-        endsDurColumn: '', // Empty to trigger auto-selection
-      });
+      const createSlicesNode = new CreateSlicesNode(
+        {
+          startsNode,
+          endsNode,
+          startsMode: 'ts_dur',
+          endsMode: 'ts_dur',
+          startsTsColumn: '', // Empty to trigger auto-selection
+          endsTsColumn: '', // Empty to trigger auto-selection
+          startsDurColumn: '', // Empty to trigger auto-selection
+          endsDurColumn: '', // Empty to trigger auto-selection
+        },
+        {},
+      );
 
       // Validation should pass and auto-select based on type
       expect(createSlicesNode.validate()).toBe(true);
-      expect(createSlicesNode.state.startsTsColumn).toBe('my_ts');
-      expect(createSlicesNode.state.endsTsColumn).toBe('end_ts');
-      expect(createSlicesNode.state.startsDurColumn).toBe('my_duration');
-      expect(createSlicesNode.state.endsDurColumn).toBe('end_duration');
+      expect(createSlicesNode.attrs.startsTsColumn).toBe('my_ts');
+      expect(createSlicesNode.attrs.endsTsColumn).toBe('end_ts');
+      expect(createSlicesNode.attrs.startsDurColumn).toBe('my_duration');
+      expect(createSlicesNode.attrs.endsDurColumn).toBe('end_duration');
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node.ts
@@ -14,12 +14,7 @@
 
 import m from 'mithril';
 import protos from '../../../../protos';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import {NodeIssues} from '../node_issues';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../../node_types';
@@ -31,15 +26,9 @@ import {
   DashboardDataSource,
 } from '../../dashboard/dashboard_registry';
 
-export interface DashboardSerializedState {
+// Serializable node configuration.
+export interface DashboardNodeAttrs {
   exportName?: string;
-}
-
-export interface DashboardNodeState extends QueryNodeState {
-  // User-assigned name for this exported data source.
-  exportName?: string;
-  // Stable ID of the graph tab that owns this node (set by DataExplorer).
-  graphId?: string;
 }
 
 /** Type guard: returns true if the given node is a DashboardNode. */
@@ -52,29 +41,35 @@ export class DashboardNode implements QueryNode {
   readonly type = NodeType.kDashboard;
   nextNodes: QueryNode[];
   primaryInput?: QueryNode;
-  readonly state: DashboardNodeState;
+  readonly attrs: DashboardNodeAttrs;
+  readonly context: NodeContext;
+
+  // Stable ID of the graph tab that owns this node (set by DataExplorer).
+  // Runtime-only — not serialized.
+  graphId?: string;
 
   get finalCols(): ColumnInfo[] {
     return this.primaryInput?.finalCols ?? [];
   }
 
-  constructor(state: DashboardNodeState) {
+  constructor(attrs: DashboardNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = state;
+    this.attrs = attrs;
+    this.context = context;
     this.nextNodes = [];
   }
 
   private getExportName(): string {
     return (
-      this.state.exportName?.trim() ||
+      this.attrs.exportName?.trim() ||
       this.primaryInput?.getTitle() ||
       'Unnamed export'
     );
   }
 
   validate(): boolean {
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
@@ -93,10 +88,10 @@ export class DashboardNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -116,13 +111,13 @@ export class DashboardNode implements QueryNode {
         {
           content: m(InlineField, {
             label: 'Export name',
-            value: this.state.exportName ?? '',
+            value: this.attrs.exportName ?? '',
             placeholder:
               this.primaryInput?.getTitle() ?? 'Name for this data source',
             onchange: (value: string) => {
-              this.state.exportName = value.trim() || undefined;
+              this.attrs.exportName = value.trim() || undefined;
               this.publishExportedSource();
-              this.state.onchange?.();
+              this.context.onchange?.();
             },
           }),
         },
@@ -142,10 +137,7 @@ export class DashboardNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    return new DashboardNode({
-      exportName: this.state.exportName,
-      onchange: this.state.onchange,
-    });
+    return new DashboardNode({exportName: this.attrs.exportName}, this.context);
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -162,10 +154,10 @@ export class DashboardNode implements QueryNode {
     const source: DashboardDataSource = {
       name: this.getExportName(),
       nodeId: this.nodeId,
-      columns: this.finalCols.map((c) => ({name: c.name, type: c.column.type})),
-      graphId: this.state.graphId ?? '',
+      columns: this.finalCols.map((c) => ({name: c.name, type: c.type})),
+      graphId: this.graphId ?? '',
       requestExecution: async () => {
-        await this.state.requestNodeExecution?.(parentNodeId);
+        await this.context.requestNodeExecution?.(parentNodeId);
         // After execution, resolve the table name so the chart can render.
         await this.resolveTableName(source, parentNodeId);
       },
@@ -177,7 +169,7 @@ export class DashboardNode implements QueryNode {
     source: DashboardDataSource,
     parentNodeId: string,
   ): Promise<void> {
-    const tableName = await this.state.getTableNameForNode?.(parentNodeId);
+    const tableName = await this.context.getTableNameForNode?.(parentNodeId);
     if (tableName !== undefined) {
       source.tableName = tableName;
       dashboardRegistry.setExportedSource(source);
@@ -186,16 +178,6 @@ export class DashboardNode implements QueryNode {
 
   onPrevNodesUpdated(): void {
     this.publishExportedSource();
-    this.state.onchange?.();
-  }
-
-  serializeState(): DashboardSerializedState {
-    return {
-      exportName: this.state.exportName,
-    };
-  }
-
-  static deserializeState(state: DashboardSerializedState): DashboardNodeState {
-    return {exportName: state.exportName};
+    this.context.onchange?.();
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/dashboard_node_unittest.ts
@@ -27,9 +27,7 @@ import {
 } from '../testing/test_utils';
 
 function makeNode(overrides: {exportName?: string} = {}): DashboardNode {
-  return new DashboardNode({
-    exportName: overrides.exportName,
-  });
+  return new DashboardNode({exportName: overrides.exportName}, {});
 }
 
 describe('DashboardNode', () => {
@@ -121,7 +119,7 @@ describe('DashboardNode', () => {
       const node = makeNode();
       // First validation: fails.
       node.validate();
-      expect(node.state.issues?.queryError).toBeTruthy();
+      expect(node.context.issues?.queryError).toBeTruthy();
 
       // Connect valid input, re-validate: succeeds.
       const source = createMockSourceNode();
@@ -131,9 +129,9 @@ describe('DashboardNode', () => {
 
     test('lazily creates issues object on first error', () => {
       const node = makeNode();
-      expect(node.state.issues).toBeUndefined();
+      expect(node.context.issues).toBeUndefined();
       node.validate();
-      expect(node.state.issues).toBeDefined();
+      expect(node.context.issues).toBeDefined();
     });
   });
 
@@ -164,7 +162,7 @@ describe('DashboardNode', () => {
       const node = makeNode({exportName: 'My Export'});
       const cloned = node.clone() as DashboardNode;
       expect(cloned.nodeId).not.toBe(node.nodeId);
-      expect(cloned.state.exportName).toBe('My Export');
+      expect(cloned.attrs.exportName).toBe('My Export');
     });
 
     test('cloned node has no primary input', () => {
@@ -179,33 +177,14 @@ describe('DashboardNode', () => {
   // --- Serialization ---
 
   describe('serialization', () => {
-    test('serializes exportName', () => {
+    test('attrs preserves exportName', () => {
       const node = makeNode({exportName: 'My Data'});
-      const serialized = node.serializeState();
-      expect(serialized.exportName).toBe('My Data');
+      expect(node.attrs.exportName).toBe('My Data');
     });
 
-    test('serializes undefined exportName', () => {
+    test('attrs exportName is undefined when not set', () => {
       const node = makeNode();
-      const serialized = node.serializeState();
-      expect(serialized.exportName).toBeUndefined();
-    });
-
-    test('deserializeState restores exportName', () => {
-      const state = DashboardNode.deserializeState({exportName: 'Restored'});
-      expect(state.exportName).toBe('Restored');
-    });
-
-    test('deserializeState handles missing exportName', () => {
-      const state = DashboardNode.deserializeState({});
-      expect(state.exportName).toBeUndefined();
-    });
-
-    test('serialize then deserialize round-trip preserves exportName', () => {
-      const node = makeNode({exportName: 'Round Trip'});
-      const serialized = node.serializeState();
-      const restored = DashboardNode.deserializeState(serialized);
-      expect(restored.exportName).toBe('Round Trip');
+      expect(node.attrs.exportName).toBeUndefined();
     });
   });
 
@@ -307,10 +286,13 @@ describe('DashboardNode', () => {
       const mockGetTable = jest.fn().mockResolvedValue('table_42');
       const mockRequest = jest.fn().mockResolvedValue(undefined);
       const source = createMockSourceNode('src-1');
-      const node = new DashboardNode({
-        getTableNameForNode: mockGetTable,
-        requestNodeExecution: mockRequest,
-      });
+      const node = new DashboardNode(
+        {},
+        {
+          getTableNameForNode: mockGetTable,
+          requestNodeExecution: mockRequest,
+        },
+      );
       connectNodes(source, node);
       node.onPrevNodesUpdated();
 
@@ -328,9 +310,12 @@ describe('DashboardNode', () => {
     test('published source includes requestExecution callback', () => {
       const mockRequest = jest.fn().mockResolvedValue(undefined);
       const source = createMockSourceNode('src-1');
-      const node = new DashboardNode({
-        requestNodeExecution: mockRequest,
-      });
+      const node = new DashboardNode(
+        {},
+        {
+          requestNodeExecution: mockRequest,
+        },
+      );
       connectNodes(source, node);
       node.onPrevNodesUpdated();
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node.ts
@@ -55,10 +55,10 @@
 
 import {
   QueryNode,
-  QueryNodeState,
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
@@ -82,7 +82,8 @@ import {notifyNextNodes} from '../graph_utils';
 import {getCommonColumns} from '../utils';
 import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 
-export interface FilterDuringNodeState extends QueryNodeState {
+// Serializable node configuration.
+export interface FilterDuringNodeAttrs {
   partitionColumns?: string[]; // Columns to partition by during interval intersection
   clipToIntervals?: boolean; // When true (default), use intersected ts/dur; when false, use original ts/dur from primary
 }
@@ -93,11 +94,13 @@ export class FilterDuringNode implements QueryNode {
   primaryInput?: QueryNode;
   secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
-  readonly state: FilterDuringNodeState;
+  readonly attrs: FilterDuringNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: FilterDuringNodeState) {
+  constructor(attrs: FilterDuringNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = state;
+    this.attrs = attrs;
+    this.context = context;
     this.secondaryInputs = {
       connections: new Map(),
       min: 1,
@@ -105,7 +108,6 @@ export class FilterDuringNode implements QueryNode {
       portNames: ['Filter intervals'],
     };
     this.nextNodes = [];
-    this.state.autoExecute = this.state.autoExecute ?? false;
   }
 
   // Get the node connected to the secondary input port (the intervals to filter during)
@@ -125,7 +127,7 @@ export class FilterDuringNode implements QueryNode {
 
   nodeDetails(): NodeDetailsAttrs {
     const details: m.Child[] = [
-      this.state.clipToIntervals
+      this.attrs.clipToIntervals
         ? NodeDetailsMessage(
             'Filters time to intervals that occurred during input intervals.',
           )
@@ -135,14 +137,14 @@ export class FilterDuringNode implements QueryNode {
     ];
 
     // Display partition columns (read-only)
-    if (this.state.partitionColumns && this.state.partitionColumns.length > 0) {
+    if (this.attrs.partitionColumns && this.attrs.partitionColumns.length > 0) {
       details.push(
         m(
           'div',
           'Partition by: ',
-          this.state.partitionColumns.map((col, index) => [
+          this.attrs.partitionColumns.map((col, index) => [
             ColumnName(col),
-            index < this.state.partitionColumns!.length - 1 ? ', ' : '',
+            index < this.attrs.partitionColumns!.length - 1 ? ', ' : '',
           ]),
         ),
       );
@@ -169,8 +171,8 @@ export class FilterDuringNode implements QueryNode {
 
   private cleanupPartitionColumns(): void {
     if (
-      !this.state.partitionColumns ||
-      this.state.partitionColumns.length === 0
+      !this.attrs.partitionColumns ||
+      this.attrs.partitionColumns.length === 0
     ) {
       return;
     }
@@ -178,25 +180,25 @@ export class FilterDuringNode implements QueryNode {
     const commonColumns = new Set(this.getCommonColumnsForPartition());
 
     // Remove partition columns that no longer exist in all inputs
-    const validPartitionCols = this.state.partitionColumns.filter((colName) =>
+    const validPartitionCols = this.attrs.partitionColumns.filter((colName) =>
       commonColumns.has(colName),
     );
 
-    if (validPartitionCols.length !== this.state.partitionColumns.length) {
-      const removed = this.state.partitionColumns.filter(
+    if (validPartitionCols.length !== this.attrs.partitionColumns.length) {
+      const removed = this.attrs.partitionColumns.filter(
         (c) => !validPartitionCols.includes(c),
       );
       console.warn(
         `[FilterDuring] Removing partition columns no longer available in all inputs: ${removed.join(', ')}`,
       );
-      this.state.partitionColumns = validPartitionCols;
+      this.attrs.partitionColumns = validPartitionCols;
     }
   }
 
   private renderPartitionSelector(): m.Child {
     // Initialize partition columns if needed
-    if (!this.state.partitionColumns) {
-      this.state.partitionColumns = [];
+    if (!this.attrs.partitionColumns) {
+      this.attrs.partitionColumns = [];
     }
 
     // Get common columns for partition selection
@@ -208,12 +210,12 @@ export class FilterDuringNode implements QueryNode {
     const partitionOptions: MultiSelectOption[] = commonColumns.map((col) => ({
       id: col,
       name: col,
-      checked: this.state.partitionColumns?.includes(col) ?? false,
+      checked: this.attrs.partitionColumns?.includes(col) ?? false,
     }));
 
     const label =
-      this.state.partitionColumns.length > 0
-        ? this.state.partitionColumns.join(', ')
+      this.attrs.partitionColumns.length > 0
+        ? this.attrs.partitionColumns.join(', ')
         : 'None';
 
     return m(
@@ -224,24 +226,24 @@ export class FilterDuringNode implements QueryNode {
         options: partitionOptions,
         showNumSelected: false,
         onChange: (diffs: MultiSelectDiff[]) => {
-          if (!this.state.partitionColumns) {
-            this.state.partitionColumns = [];
+          if (!this.attrs.partitionColumns) {
+            this.attrs.partitionColumns = [];
           }
           for (const diff of diffs) {
             if (diff.checked) {
-              if (!this.state.partitionColumns.includes(diff.id)) {
-                this.state.partitionColumns.push(diff.id);
+              if (!this.attrs.partitionColumns.includes(diff.id)) {
+                this.attrs.partitionColumns.push(diff.id);
               }
             } else {
-              const index = this.state.partitionColumns.indexOf(diff.id);
+              const index = this.attrs.partitionColumns.indexOf(diff.id);
               if (index !== -1) {
-                this.state.partitionColumns.splice(index, 1);
+                this.attrs.partitionColumns.splice(index, 1);
               }
             }
           }
           // Notify downstream nodes about the column change
           notifyNextNodes(this);
-          this.state.onchange?.();
+          this.context.onchange?.();
         },
       }),
     );
@@ -250,7 +252,7 @@ export class FilterDuringNode implements QueryNode {
   nodeSpecificModify(): NodeModifyAttrs {
     // Run validation to populate error state
     this.validate();
-    const error = this.state.issues?.queryError;
+    const error = this.context.issues?.queryError;
 
     const secondaryNodes = this.secondaryNodes;
 
@@ -285,7 +287,7 @@ export class FilterDuringNode implements QueryNode {
       'Filters the primary input to only show intervals that occurred during the intervals from the secondary input.';
 
     // Get clipToIntervals for use in switch below
-    const clipToIntervals = this.state.clipToIntervals ?? true;
+    const clipToIntervals = this.attrs.clipToIntervals ?? true;
 
     // Add partition selector
     const partitionSelector = this.renderPartitionSelector();
@@ -305,8 +307,8 @@ export class FilterDuringNode implements QueryNode {
             ? 'Clip to intervals (use intersected ts/dur)'
             : 'Use original timestamps (from primary input)',
           onchange: () => {
-            this.state.clipToIntervals = !clipToIntervals;
-            this.state.onchange?.();
+            this.attrs.clipToIntervals = !clipToIntervals;
+            this.context.onchange?.();
           },
         }),
       ),
@@ -344,27 +346,27 @@ export class FilterDuringNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
       setValidationError(
-        this.state,
+        this.context,
         'Connect a node to be filtered to the top port',
       );
       return false;
     }
 
     if (!this.primaryInput.validate()) {
-      setValidationError(this.state, 'Node to be filtered is invalid');
+      setValidationError(this.context, 'Node to be filtered is invalid');
       return false;
     }
 
     const secondaryInput = this.secondaryInputs.connections.get(0);
     if (secondaryInput === undefined) {
       setValidationError(
-        this.state,
+        this.context,
         'Connect a node with intervals to the port on the left',
       );
       return false;
@@ -373,11 +375,11 @@ export class FilterDuringNode implements QueryNode {
     // Validate the secondary input
     if (!secondaryInput.validate()) {
       const childError =
-        secondaryInput.state.issues?.queryError !== undefined
-          ? `: ${secondaryInput.state.issues.queryError.message}`
+        secondaryInput.context.issues?.queryError !== undefined
+          ? `: ${secondaryInput.context.issues.queryError.message}`
           : '';
       setValidationError(
-        this.state,
+        this.context,
         `Filter intervals input is invalid${childError}`,
       );
       return false;
@@ -389,7 +391,7 @@ export class FilterDuringNode implements QueryNode {
     const missingPrimary = requiredCols.filter((c) => !primaryCols.has(c));
     if (missingPrimary.length > 0) {
       setValidationError(
-        this.state,
+        this.context,
         `Node to be filtered is missing required columns: ${missingPrimary.join(', ')}`,
       );
       return false;
@@ -403,7 +405,7 @@ export class FilterDuringNode implements QueryNode {
     );
     if (missingSecondary.length > 0) {
       setValidationError(
-        this.state,
+        this.context,
         `Filter intervals input is missing required columns: ${missingSecondary.join(', ')}`,
       );
       return false;
@@ -413,16 +415,15 @@ export class FilterDuringNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: FilterDuringNodeState = {
-      partitionColumns: this.state.partitionColumns
-        ? [...this.state.partitionColumns]
-        : undefined,
-      clipToIntervals: this.state.clipToIntervals,
-      filters: this.state.filters?.map((f) => ({...f})),
-      filterOperator: this.state.filterOperator,
-      onchange: this.state.onchange,
-    };
-    return new FilterDuringNode(stateCopy);
+    return new FilterDuringNode(
+      {
+        partitionColumns: this.attrs.partitionColumns
+          ? [...this.attrs.partitionColumns]
+          : undefined,
+        clipToIntervals: this.attrs.clipToIntervals,
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -437,7 +438,7 @@ export class FilterDuringNode implements QueryNode {
     // can prepend clipped ts/dur and append original_ts/original_dur at the end.
     // When clip_to_intervals is false, the order doesn't matter as much, but
     // we still put ts and dur first for consistency.
-    const clipToIntervals = this.state.clipToIntervals ?? true;
+    const clipToIntervals = this.attrs.clipToIntervals ?? true;
     const allColumns = this.primaryInput.finalCols.map((c) => c.name);
 
     let selectColumns: string[];
@@ -460,27 +461,11 @@ export class FilterDuringNode implements QueryNode {
     return StructuredQueryBuilder.withFilterToIntervals(
       this.primaryInput,
       secondaryInput,
-      this.state.partitionColumns,
-      this.state.clipToIntervals ?? true,
+      this.attrs.partitionColumns,
+      this.attrs.clipToIntervals ?? true,
       this.nodeId,
       selectColumns,
     );
-  }
-
-  serializeState(): object {
-    return {
-      partitionColumns: this.state.partitionColumns,
-      clipToIntervals: this.state.clipToIntervals,
-    };
-  }
-
-  static deserializeState(
-    serializedState: FilterDuringNodeState,
-  ): FilterDuringNodeState {
-    return {
-      partitionColumns: serializedState.partitionColumns,
-      clipToIntervals: serializedState.clipToIntervals,
-    };
   }
 
   // Called when a node is connected/disconnected to secondary inputs
@@ -490,7 +475,7 @@ export class FilterDuringNode implements QueryNode {
 
     // Notify next nodes that our columns have changed
     notifyNextNodes(this);
-    this.state.onchange?.();
+    this.context.onchange?.();
     m.redraw();
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_during_node_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {FilterDuringNode, FilterDuringNodeState} from './filter_during_node';
+import {FilterDuringNode} from './filter_during_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import {
@@ -34,7 +34,7 @@ describe('FilterDuringNode', () => {
       type: NodeType.kTable,
       nextNodes: [],
       finalCols: columns,
-      state: {},
+      context: {},
       validate: () => true,
       getTitle: () => `Mock ${id}`,
       nodeSpecificModify: () => ({sections: []}),
@@ -49,7 +49,7 @@ describe('FilterDuringNode', () => {
         sq.table.columnNames = columns.map((c) => c.name);
         return sq;
       },
-      serializeState: () => ({}),
+      attrs: {},
     } as QueryNode;
   }
 
@@ -78,19 +78,19 @@ describe('FilterDuringNode', () => {
     return {
       name,
       checked,
-      column: {name, type: sqlType},
+      type: sqlType,
     };
   }
 
   describe('constructor', () => {
     it('should have correct node type', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(node.type).toBe(NodeType.kFilterDuring);
     });
 
     it('should initialize with no secondary input', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(node.secondaryInputs.connections.get(0)).toBeUndefined();
     });
@@ -98,7 +98,7 @@ describe('FilterDuringNode', () => {
 
   describe('finalCols', () => {
     it('should return empty array when no primary input', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(node.finalCols).toEqual([]);
     });
@@ -113,7 +113,7 @@ describe('FilterDuringNode', () => {
       ];
       const primaryNode = createMockNode('primary', primaryCols);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
 
       expect(node.finalCols).toEqual(primaryCols);
@@ -129,7 +129,7 @@ describe('FilterDuringNode', () => {
       ];
       const primaryNode = createMockNode('primary', primaryCols);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
 
       const finalCols = node.finalCols;
@@ -145,10 +145,10 @@ describe('FilterDuringNode', () => {
 
   describe('validate', () => {
     it('should fail validation when no primary input', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Connect a node to be filtered to the top port',
       );
     });
@@ -160,11 +160,11 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Connect a node with intervals to the port on the left',
       );
     });
@@ -179,12 +179,12 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Node to be filtered is invalid',
       );
     });
@@ -199,12 +199,12 @@ describe('FilterDuringNode', () => {
       const secondaryNode = createMockNode('secondary', []);
       secondaryNode.validate = () => false;
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Filter intervals input is invalid',
       );
     });
@@ -220,12 +220,12 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Node to be filtered is missing required columns',
       );
     });
@@ -241,12 +241,12 @@ describe('FilterDuringNode', () => {
         createColumnInfo('name', 'STRING'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'Filter intervals input is missing required columns',
       );
     });
@@ -265,7 +265,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -285,7 +285,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -295,7 +295,7 @@ describe('FilterDuringNode', () => {
 
   describe('getStructuredQuery', () => {
     it('should return undefined when validation fails', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(node.getStructuredQuery()).toBeUndefined();
     });
@@ -314,7 +314,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -339,7 +339,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -375,7 +375,7 @@ describe('FilterDuringNode', () => {
       ]);
 
       // Dur filter is always applied
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -402,7 +402,7 @@ describe('FilterDuringNode', () => {
       ]);
 
       // Dur filter is always applied
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -428,7 +428,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({clipToIntervals: false});
+      const node = new FilterDuringNode({clipToIntervals: false}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -450,7 +450,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({clipToIntervals: true});
+      const node = new FilterDuringNode({clipToIntervals: true}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -484,7 +484,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -509,14 +509,17 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({
-        partitionColumns: ['utid'],
-        clipToIntervals: false,
-      });
+      const node = new FilterDuringNode(
+        {
+          partitionColumns: ['utid'],
+          clipToIntervals: false,
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, secondaryNode);
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
       expect(serialized).toEqual({
         partitionColumns: ['utid'],
@@ -525,41 +528,36 @@ describe('FilterDuringNode', () => {
     });
 
     it('should handle missing inputs gracefully', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
-      expect(serialized).toEqual({
-        partitionColumns: undefined,
-        clipToIntervals: undefined,
-      });
+      expect(serialized).toEqual({});
     });
   });
 
   describe('clone', () => {
     it('should create a new node with same state', () => {
-      const node = new FilterDuringNode({
-        partitionColumns: ['utid', 'cpu'],
-        clipToIntervals: false,
-      });
+      const node = new FilterDuringNode(
+        {
+          partitionColumns: ['utid', 'cpu'],
+          clipToIntervals: false,
+        },
+        {},
+      );
 
       const cloned = node.clone() as FilterDuringNode;
 
       expect(cloned).toBeInstanceOf(FilterDuringNode);
-      expect((cloned.state as FilterDuringNodeState).partitionColumns).toEqual([
-        'utid',
-        'cpu',
-      ]);
-      expect((cloned.state as FilterDuringNodeState).clipToIntervals).toBe(
-        false,
-      );
+      expect(cloned.attrs.partitionColumns).toEqual(['utid', 'cpu']);
+      expect(cloned.attrs.clipToIntervals).toBe(false);
       expect(cloned.nodeId).not.toBe(node.nodeId); // Should have different ID
     });
   });
 
   describe('getTitle', () => {
     it('should return correct title', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(node.getTitle()).toBe('Filter During');
     });
@@ -567,7 +565,7 @@ describe('FilterDuringNode', () => {
 
   describe('secondaryNodes getter', () => {
     it('should return empty array when no secondary input', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(node.secondaryNodes).toEqual([]);
     });
@@ -579,7 +577,7 @@ describe('FilterDuringNode', () => {
         createColumnInfo('dur', 'DURATION'),
       ]);
 
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
       node.secondaryInputs.connections.set(0, secondaryNode);
 
       expect(node.secondaryNodes).toEqual([secondaryNode]);
@@ -589,9 +587,7 @@ describe('FilterDuringNode', () => {
   describe('onPrevNodesUpdated', () => {
     it('should trigger onchange callback when called', () => {
       const onchange = jest.fn();
-      const node = new FilterDuringNode({
-        onchange,
-      });
+      const node = new FilterDuringNode({}, {onchange});
 
       node.onPrevNodesUpdated();
 
@@ -599,7 +595,7 @@ describe('FilterDuringNode', () => {
     });
 
     it('should not throw when onchange is not defined', () => {
-      const node = new FilterDuringNode({});
+      const node = new FilterDuringNode({}, {});
 
       expect(() => node.onPrevNodesUpdated()).not.toThrow();
     });
@@ -608,23 +604,31 @@ describe('FilterDuringNode', () => {
   describe('partition columns', () => {
     describe('initialization', () => {
       it('should initialize with empty partition columns by default', () => {
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
 
-        expect(node.state.partitionColumns).toBeUndefined();
+        expect(
+          (node as FilterDuringNode).attrs.partitionColumns,
+        ).toBeUndefined();
       });
 
       it('should preserve provided partition columns', () => {
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid', 'cpu'],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid', 'cpu'],
+          },
+          {},
+        );
 
-        expect(node.state.partitionColumns).toEqual(['utid', 'cpu']);
+        expect((node as FilterDuringNode).attrs.partitionColumns).toEqual([
+          'utid',
+          'cpu',
+        ]);
       });
     });
 
     describe('getCommonColumnsForPartition', () => {
       it('should return empty array when no primary input', () => {
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
 
         // Access private method for testing
         const commonColumns = (
@@ -642,7 +646,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('utid', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
         node.primaryInput = primaryNode;
 
         const commonColumns = (
@@ -670,7 +674,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('cpu', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -694,7 +698,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('dur', 'DURATION'),
         ]);
 
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -724,7 +728,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('utid', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -754,7 +758,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('mmm', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -768,7 +772,7 @@ describe('FilterDuringNode', () => {
 
     describe('cleanupPartitionColumns', () => {
       it('should not throw when partitionColumns is undefined', () => {
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
 
         expect(() =>
           (
@@ -778,9 +782,12 @@ describe('FilterDuringNode', () => {
       });
 
       it('should not throw when partitionColumns is empty', () => {
-        const node = new FilterDuringNode({
-          partitionColumns: [],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: [],
+          },
+          {},
+        );
 
         expect(() =>
           (
@@ -804,9 +811,12 @@ describe('FilterDuringNode', () => {
           createColumnInfo('utid', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid', 'cpu'], // 'cpu' doesn't exist
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid', 'cpu'], // 'cpu' doesn't exist
+          },
+          {},
+        );
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -814,7 +824,9 @@ describe('FilterDuringNode', () => {
           node as unknown as FilterDuringNodeWithPrivates
         ).cleanupPartitionColumns();
 
-        expect(node.state.partitionColumns).toEqual(['utid']);
+        expect((node as FilterDuringNode).attrs.partitionColumns).toEqual([
+          'utid',
+        ]);
       });
 
       it('should clear all partition columns when none are available', () => {
@@ -830,9 +842,12 @@ describe('FilterDuringNode', () => {
           createColumnInfo('dur', 'DURATION'),
         ]);
 
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid', 'cpu'],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid', 'cpu'],
+          },
+          {},
+        );
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -840,7 +855,7 @@ describe('FilterDuringNode', () => {
           node as unknown as FilterDuringNodeWithPrivates
         ).cleanupPartitionColumns();
 
-        expect(node.state.partitionColumns).toEqual([]);
+        expect((node as FilterDuringNode).attrs.partitionColumns).toEqual([]);
       });
 
       it('should preserve valid partition columns', () => {
@@ -860,9 +875,12 @@ describe('FilterDuringNode', () => {
           createColumnInfo('cpu', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid', 'cpu'],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid', 'cpu'],
+          },
+          {},
+        );
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -870,7 +888,10 @@ describe('FilterDuringNode', () => {
           node as unknown as FilterDuringNodeWithPrivates
         ).cleanupPartitionColumns();
 
-        expect(node.state.partitionColumns).toEqual(['utid', 'cpu']);
+        expect((node as FilterDuringNode).attrs.partitionColumns).toEqual([
+          'utid',
+          'cpu',
+        ]);
       });
     });
 
@@ -890,13 +911,16 @@ describe('FilterDuringNode', () => {
           createColumnInfo('utid', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid'],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid'],
+          },
+          {},
+        );
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
-        const serialized = node.serializeState();
+        const serialized = node.attrs;
 
         expect(serialized).toEqual({
           partitionColumns: ['utid'],
@@ -905,68 +929,81 @@ describe('FilterDuringNode', () => {
       });
 
       it('should handle undefined partition columns', () => {
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
 
-        const serialized = node.serializeState() as Record<string, unknown>;
+        const serialized = node.attrs;
 
-        expect(serialized).toHaveProperty('partitionColumns');
         expect(serialized.partitionColumns).toBeUndefined();
       });
     });
 
-    describe('deserializeState with partition columns', () => {
-      it('should restore partition columns from serialized state', () => {
-        const state = FilterDuringNode.deserializeState({
-          partitionColumns: ['utid', 'cpu'],
-          clipToIntervals: false,
-        });
+    describe('deserialize with partition columns', () => {
+      it('should restore partition columns via constructor', () => {
+        const node = new FilterDuringNode(
+          {partitionColumns: ['utid', 'cpu'], clipToIntervals: false},
+          {},
+        );
 
-        expect(state.partitionColumns).toEqual(['utid', 'cpu']);
-        expect(state.clipToIntervals).toBe(false);
+        expect(node.attrs.partitionColumns).toEqual(['utid', 'cpu']);
+        expect(node.attrs.clipToIntervals).toBe(false);
       });
 
-      it('should handle missing partition columns in serialized state', () => {
-        const state = FilterDuringNode.deserializeState({
-          clipToIntervals: true,
-        });
+      it('should handle missing partition columns', () => {
+        const node = new FilterDuringNode({clipToIntervals: true}, {});
 
-        expect(state.partitionColumns).toBeUndefined();
-        expect(state.clipToIntervals).toBe(true);
+        expect(node.attrs.partitionColumns).toBeUndefined();
+        expect(node.attrs.clipToIntervals).toBe(true);
       });
     });
 
     describe('clone with partition columns', () => {
       it('should clone partition columns', () => {
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid', 'cpu'],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid', 'cpu'],
+          },
+          {},
+        );
 
         const cloned = node.clone() as FilterDuringNode;
 
-        expect(cloned.state.partitionColumns).toEqual(['utid', 'cpu']);
+        expect((cloned as FilterDuringNode).attrs.partitionColumns).toEqual([
+          'utid',
+          'cpu',
+        ]);
       });
 
       it('should create independent copy of partition columns array', () => {
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid'],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid'],
+          },
+          {},
+        );
 
         const cloned = node.clone() as FilterDuringNode;
 
         // Modify cloned partition columns
-        cloned.state.partitionColumns?.push('cpu');
+        (cloned as FilterDuringNode).attrs.partitionColumns?.push('cpu');
 
         // Original should not be affected
-        expect(node.state.partitionColumns).toEqual(['utid']);
-        expect(cloned.state.partitionColumns).toEqual(['utid', 'cpu']);
+        expect((node as FilterDuringNode).attrs.partitionColumns).toEqual([
+          'utid',
+        ]);
+        expect((cloned as FilterDuringNode).attrs.partitionColumns).toEqual([
+          'utid',
+          'cpu',
+        ]);
       });
 
       it('should handle undefined partition columns', () => {
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
 
         const cloned = node.clone() as FilterDuringNode;
 
-        expect(cloned.state.partitionColumns).toBeUndefined();
+        expect(
+          (cloned as FilterDuringNode).attrs.partitionColumns,
+        ).toBeUndefined();
       });
     });
 
@@ -986,9 +1023,12 @@ describe('FilterDuringNode', () => {
           createColumnInfo('utid', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid'],
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid'],
+          },
+          {},
+        );
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -1017,7 +1057,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('utid', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({});
+        const node = new FilterDuringNode({}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -1044,16 +1084,21 @@ describe('FilterDuringNode', () => {
           createColumnInfo('utid', 'INT'),
         ]);
 
-        const node = new FilterDuringNode({
-          partitionColumns: ['utid', 'cpu'], // 'cpu' doesn't exist
-        });
+        const node = new FilterDuringNode(
+          {
+            partitionColumns: ['utid', 'cpu'], // 'cpu' doesn't exist
+          },
+          {},
+        );
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
         node.onPrevNodesUpdated();
 
         // 'cpu' should be removed as it doesn't exist in inputs
-        expect(node.state.partitionColumns).toEqual(['utid']);
+        expect((node as FilterDuringNode).attrs.partitionColumns).toEqual([
+          'utid',
+        ]);
       });
     });
 
@@ -1073,7 +1118,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('dur', 'DURATION'),
         ]);
 
-        const node = new FilterDuringNode({clipToIntervals: true});
+        const node = new FilterDuringNode({clipToIntervals: true}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -1109,7 +1154,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('dur', 'DURATION'),
         ]);
 
-        const node = new FilterDuringNode({clipToIntervals: false});
+        const node = new FilterDuringNode({clipToIntervals: false}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -1141,7 +1186,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('dur', 'DURATION'),
         ]);
 
-        const node = new FilterDuringNode({clipToIntervals: true});
+        const node = new FilterDuringNode({clipToIntervals: true}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 
@@ -1174,7 +1219,7 @@ describe('FilterDuringNode', () => {
           createColumnInfo('dur', 'DURATION'),
         ]);
 
-        const node = new FilterDuringNode({clipToIntervals: false});
+        const node = new FilterDuringNode({clipToIntervals: false}, {});
         node.primaryInput = primaryNode;
         node.secondaryInputs.connections.set(0, secondaryNode);
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_in_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_in_node.ts
@@ -48,10 +48,10 @@
 
 import {
   QueryNode,
-  QueryNodeState,
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
@@ -67,7 +67,8 @@ import {NodeDetailsMessage, ColumnName} from '../node_styling_widgets';
 import {notifyNextNodes} from '../graph_utils';
 import {getCommonColumns} from '../utils';
 
-export interface FilterInNodeState extends QueryNodeState {
+// Serializable node configuration.
+export interface FilterInNodeAttrs {
   baseColumn?: string; // Column name in the primary input to filter on
   matchColumn?: string; // Column name in the match values input to match against
 }
@@ -78,11 +79,13 @@ export class FilterInNode implements QueryNode {
   primaryInput?: QueryNode;
   secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
-  readonly state: FilterInNodeState;
+  readonly attrs: FilterInNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: FilterInNodeState) {
+  constructor(attrs: FilterInNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = state;
+    this.attrs = attrs;
+    this.context = context;
     this.secondaryInputs = {
       connections: new Map(),
       min: 1,
@@ -90,7 +93,6 @@ export class FilterInNode implements QueryNode {
       portNames: ['Input'],
     };
     this.nextNodes = [];
-    this.state.autoExecute = this.state.autoExecute ?? false;
   }
 
   // Get the node connected to the secondary input port (the match values)
@@ -114,11 +116,11 @@ export class FilterInNode implements QueryNode {
     ]);
     if (commonCols.length === 1) {
       const commonCol = commonCols[0];
-      if (!this.state.baseColumn) {
-        this.state.baseColumn = commonCol;
+      if (!this.attrs.baseColumn) {
+        this.attrs.baseColumn = commonCol;
       }
-      if (!this.state.matchColumn) {
-        this.state.matchColumn = commonCol;
+      if (!this.attrs.matchColumn) {
+        this.attrs.matchColumn = commonCol;
       }
     }
   }
@@ -128,8 +130,8 @@ export class FilterInNode implements QueryNode {
   }
 
   nodeDetails(): NodeDetailsAttrs {
-    const baseCol = this.state.baseColumn;
-    const matchCol = this.state.matchColumn;
+    const baseCol = this.attrs.baseColumn;
+    const matchCol = this.attrs.matchColumn;
 
     if (baseCol && matchCol) {
       if (baseCol === matchCol) {
@@ -166,7 +168,7 @@ export class FilterInNode implements QueryNode {
   nodeSpecificModify(): NodeModifyAttrs {
     // Run validation to populate error state
     this.validate();
-    const error = this.state.issues?.queryError;
+    const error = this.context.issues?.queryError;
 
     const matchValuesNode = this.matchValuesNode;
 
@@ -207,10 +209,10 @@ export class FilterInNode implements QueryNode {
           OutlinedField,
           {
             label: 'Base column',
-            value: this.state.baseColumn ?? '',
+            value: this.attrs.baseColumn ?? '',
             onchange: (e: Event) => {
-              this.state.baseColumn = (e.target as HTMLSelectElement).value;
-              this.state.onchange?.();
+              this.attrs.baseColumn = (e.target as HTMLSelectElement).value;
+              this.context.onchange?.();
             },
           },
           [
@@ -224,10 +226,10 @@ export class FilterInNode implements QueryNode {
           OutlinedField,
           {
             label: 'Match column',
-            value: this.state.matchColumn ?? '',
+            value: this.attrs.matchColumn ?? '',
             onchange: (e: Event) => {
-              this.state.matchColumn = (e.target as HTMLSelectElement).value;
-              this.state.onchange?.();
+              this.attrs.matchColumn = (e.target as HTMLSelectElement).value;
+              this.context.onchange?.();
             },
           },
           [
@@ -270,27 +272,27 @@ export class FilterInNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
       setValidationError(
-        this.state,
+        this.context,
         'Connect a node with rows to filter to the top port',
       );
       return false;
     }
 
     if (!this.primaryInput.validate()) {
-      setValidationError(this.state, 'Primary input is invalid');
+      setValidationError(this.context, 'Primary input is invalid');
       return false;
     }
 
     const matchValuesNode = this.matchValuesNode;
     if (matchValuesNode === undefined) {
       setValidationError(
-        this.state,
+        this.context,
         'Connect a node with match values to the port on the left',
       );
       return false;
@@ -299,41 +301,41 @@ export class FilterInNode implements QueryNode {
     // Validate the secondary input
     if (!matchValuesNode.validate()) {
       const childError =
-        matchValuesNode.state.issues?.queryError !== undefined
-          ? `: ${matchValuesNode.state.issues.queryError.message}`
+        matchValuesNode.context.issues?.queryError !== undefined
+          ? `: ${matchValuesNode.context.issues.queryError.message}`
           : '';
-      setValidationError(this.state, `Input node is invalid${childError}`);
+      setValidationError(this.context, `Input node is invalid${childError}`);
       return false;
     }
 
     // Check that base column is specified
-    if (!this.state.baseColumn) {
-      setValidationError(this.state, 'Select a base column to filter on');
+    if (!this.attrs.baseColumn) {
+      setValidationError(this.context, 'Select a base column to filter on');
       return false;
     }
 
     // Check that match column is specified
-    if (!this.state.matchColumn) {
-      setValidationError(this.state, 'Select a match column');
+    if (!this.attrs.matchColumn) {
+      setValidationError(this.context, 'Select a match column');
       return false;
     }
 
     // Check that base column exists in primary input
     const primaryCols = new Set(this.primaryInput.finalCols.map((c) => c.name));
-    if (!primaryCols.has(this.state.baseColumn)) {
+    if (!primaryCols.has(this.attrs.baseColumn)) {
       setValidationError(
-        this.state,
-        `Primary input is missing column: ${this.state.baseColumn}`,
+        this.context,
+        `Primary input is missing column: ${this.attrs.baseColumn}`,
       );
       return false;
     }
 
     // Check that match column exists in match values input
     const matchCols = new Set(matchValuesNode.finalCols.map((c) => c.name));
-    if (!matchCols.has(this.state.matchColumn)) {
+    if (!matchCols.has(this.attrs.matchColumn)) {
       setValidationError(
-        this.state,
-        `Input node is missing column: ${this.state.matchColumn}`,
+        this.context,
+        `Input node is missing column: ${this.attrs.matchColumn}`,
       );
       return false;
     }
@@ -342,14 +344,13 @@ export class FilterInNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: FilterInNodeState = {
-      baseColumn: this.state.baseColumn,
-      matchColumn: this.state.matchColumn,
-      filters: this.state.filters?.map((f) => ({...f})),
-      filterOperator: this.state.filterOperator,
-      onchange: this.state.onchange,
-    };
-    return new FilterInNode(stateCopy);
+    return new FilterInNode(
+      {
+        baseColumn: this.attrs.baseColumn,
+        matchColumn: this.attrs.matchColumn,
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -359,8 +360,8 @@ export class FilterInNode implements QueryNode {
     const matchValuesNode = this.matchValuesNode;
     if (matchValuesNode === undefined) return undefined;
 
-    const baseColumn = this.state.baseColumn;
-    const matchColumn = this.state.matchColumn;
+    const baseColumn = this.attrs.baseColumn;
+    const matchColumn = this.attrs.matchColumn;
     if (!baseColumn || !matchColumn) return undefined;
 
     return StructuredQueryBuilder.withFilterIn(
@@ -372,37 +373,21 @@ export class FilterInNode implements QueryNode {
     );
   }
 
-  serializeState(): object {
-    return {
-      baseColumn: this.state.baseColumn,
-      matchColumn: this.state.matchColumn,
-    };
-  }
-
-  static deserializeState(
-    serializedState: FilterInNodeState,
-  ): FilterInNodeState {
-    return {
-      baseColumn: serializedState.baseColumn,
-      matchColumn: serializedState.matchColumn,
-    };
-  }
-
   private cleanupStaleColumns(): void {
-    if (this.primaryInput !== undefined && this.state.baseColumn) {
+    if (this.primaryInput !== undefined && this.attrs.baseColumn) {
       const primaryCols = new Set(
         this.primaryInput.finalCols.map((c) => c.name),
       );
-      if (!primaryCols.has(this.state.baseColumn)) {
-        this.state.baseColumn = undefined;
+      if (!primaryCols.has(this.attrs.baseColumn)) {
+        this.attrs.baseColumn = undefined;
       }
     }
 
     const matchNode = this.matchValuesNode;
-    if (matchNode !== undefined && this.state.matchColumn) {
+    if (matchNode !== undefined && this.attrs.matchColumn) {
       const matchCols = new Set(matchNode.finalCols.map((c) => c.name));
-      if (!matchCols.has(this.state.matchColumn)) {
-        this.state.matchColumn = undefined;
+      if (!matchCols.has(this.attrs.matchColumn)) {
+        this.attrs.matchColumn = undefined;
       }
     }
   }
@@ -417,7 +402,7 @@ export class FilterInNode implements QueryNode {
 
     // Notify next nodes that our columns may have changed
     notifyNextNodes(this);
-    this.state.onchange?.();
+    this.context.onchange?.();
     m.redraw();
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_in_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_in_node_unittest.ts
@@ -33,36 +33,39 @@ interface FilterInNodeWithPrivates {
 describe('FilterInNode', () => {
   describe('constructor', () => {
     it('should have correct node type', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       expect(node.type).toBe(NodeType.kFilterIn);
     });
 
     it('should initialize with no inputs', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       expect(node.primaryInput).toBeUndefined();
       expect(node.matchValuesNode).toBeUndefined();
     });
 
     it('should have one secondary input port named Input', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       expect(node.secondaryInputs.min).toBe(1);
       expect(node.secondaryInputs.max).toBe(1);
       expect(node.secondaryInputs.portNames).toEqual(['Input']);
     });
 
     it('should preserve state from constructor', () => {
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
-      expect(node.state.baseColumn).toBe('utid');
-      expect(node.state.matchColumn).toBe('id');
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'id',
+        },
+        {},
+      );
+      expect(node.attrs.baseColumn).toBe('utid');
+      expect(node.attrs.matchColumn).toBe('id');
     });
   });
 
   describe('finalCols', () => {
     it('should return empty array when no primary input', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       expect(node.finalCols).toEqual([]);
     });
 
@@ -74,7 +77,7 @@ describe('FilterInNode', () => {
       ];
       const primaryNode = createMockNode({columns: primaryCols});
 
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       node.primaryInput = primaryNode;
 
       expect(node.finalCols).toEqual(primaryCols);
@@ -98,7 +101,7 @@ describe('FilterInNode', () => {
         columns: matchCols,
       });
 
-      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'});
+      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'}, {});
       connectNodes(primaryNode, node);
       connectSecondary(matchNode, node, 0);
 
@@ -108,7 +111,7 @@ describe('FilterInNode', () => {
 
   describe('validate', () => {
     it('should fail when no primary input', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       expectValidationError(node, 'Connect a node with rows to filter');
     });
 
@@ -116,7 +119,7 @@ describe('FilterInNode', () => {
       const primaryNode = createMockNode({validate: () => false});
       const matchNode = createMockNode({nodeId: 'match'});
 
-      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'});
+      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -128,7 +131,7 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('id', 'int')],
       });
 
-      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'});
+      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'}, {});
       node.primaryInput = primaryNode;
 
       expectValidationError(node, 'Connect a node with match values');
@@ -144,7 +147,7 @@ describe('FilterInNode', () => {
         validate: () => false,
       });
 
-      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'});
+      const node = new FilterInNode({baseColumn: 'id', matchColumn: 'id'}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -161,7 +164,7 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('id', 'int')],
       });
 
-      const node = new FilterInNode({matchColumn: 'id'});
+      const node = new FilterInNode({matchColumn: 'id'}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -178,7 +181,7 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('id', 'int')],
       });
 
-      const node = new FilterInNode({baseColumn: 'id'});
+      const node = new FilterInNode({baseColumn: 'id'}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -195,10 +198,13 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('id', 'int')],
       });
 
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'id',
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -215,10 +221,13 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('name', 'string')],
       });
 
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'thread_id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'thread_id',
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -239,10 +248,13 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('thread_id', 'int')],
       });
 
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'thread_id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'thread_id',
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -259,10 +271,13 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('id', 'int')],
       });
 
-      const node = new FilterInNode({
-        baseColumn: 'track_id',
-        matchColumn: 'id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'track_id',
+          matchColumn: 'id',
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -272,7 +287,7 @@ describe('FilterInNode', () => {
 
   describe('getStructuredQuery', () => {
     it('should return undefined when validation fails', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       expect(node.getStructuredQuery()).toBeUndefined();
     });
 
@@ -285,10 +300,13 @@ describe('FilterInNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'id',
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
@@ -319,14 +337,14 @@ describe('FilterInNode', () => {
         ],
       });
 
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
       (node as unknown as FilterInNodeWithPrivates).autoSuggestColumns();
 
-      expect(node.state.baseColumn).toBe('utid');
-      expect(node.state.matchColumn).toBe('utid');
+      expect(node.attrs.baseColumn).toBe('utid');
+      expect(node.attrs.matchColumn).toBe('utid');
     });
 
     it('should not auto-suggest when multiple common columns', () => {
@@ -345,14 +363,14 @@ describe('FilterInNode', () => {
         ],
       });
 
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
       (node as unknown as FilterInNodeWithPrivates).autoSuggestColumns();
 
-      expect(node.state.baseColumn).toBeUndefined();
-      expect(node.state.matchColumn).toBeUndefined();
+      expect(node.attrs.baseColumn).toBeUndefined();
+      expect(node.attrs.matchColumn).toBeUndefined();
     });
 
     it('should not auto-suggest when no common columns', () => {
@@ -365,14 +383,14 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('track_id', 'int')],
       });
 
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
       (node as unknown as FilterInNodeWithPrivates).autoSuggestColumns();
 
-      expect(node.state.baseColumn).toBeUndefined();
-      expect(node.state.matchColumn).toBeUndefined();
+      expect(node.attrs.baseColumn).toBeUndefined();
+      expect(node.attrs.matchColumn).toBeUndefined();
     });
 
     it('should not overwrite existing column selection', () => {
@@ -391,27 +409,30 @@ describe('FilterInNode', () => {
         ],
       });
 
-      const node = new FilterInNode({
-        baseColumn: 'name',
-        matchColumn: 'other',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'name',
+          matchColumn: 'other',
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
       (node as unknown as FilterInNodeWithPrivates).autoSuggestColumns();
 
       // Should not overwrite existing selections
-      expect(node.state.baseColumn).toBe('name');
-      expect(node.state.matchColumn).toBe('other');
+      expect(node.attrs.baseColumn).toBe('name');
+      expect(node.attrs.matchColumn).toBe('other');
     });
 
     it('should not suggest when no inputs connected', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
 
       (node as unknown as FilterInNodeWithPrivates).autoSuggestColumns();
 
-      expect(node.state.baseColumn).toBeUndefined();
-      expect(node.state.matchColumn).toBeUndefined();
+      expect(node.attrs.baseColumn).toBeUndefined();
+      expect(node.attrs.matchColumn).toBeUndefined();
     });
   });
 
@@ -422,12 +443,12 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('name', 'string')],
       });
 
-      const node = new FilterInNode({baseColumn: 'utid'});
+      const node = new FilterInNode({baseColumn: 'utid'}, {});
       node.primaryInput = primaryNode;
 
       (node as unknown as FilterInNodeWithPrivates).cleanupStaleColumns();
 
-      expect(node.state.baseColumn).toBeUndefined();
+      expect(node.attrs.baseColumn).toBeUndefined();
     });
 
     it('should clear matchColumn when it no longer exists in match node', () => {
@@ -436,12 +457,12 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('name', 'string')],
       });
 
-      const node = new FilterInNode({matchColumn: 'id'});
+      const node = new FilterInNode({matchColumn: 'id'}, {});
       node.secondaryInputs.connections.set(0, matchNode);
 
       (node as unknown as FilterInNodeWithPrivates).cleanupStaleColumns();
 
-      expect(node.state.matchColumn).toBeUndefined();
+      expect(node.attrs.matchColumn).toBeUndefined();
     });
 
     it('should keep columns that still exist', () => {
@@ -457,82 +478,91 @@ describe('FilterInNode', () => {
         columns: [createColumnInfo('id', 'int')],
       });
 
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'id',
+        },
+        {},
+      );
       node.primaryInput = primaryNode;
       node.secondaryInputs.connections.set(0, matchNode);
 
       (node as unknown as FilterInNodeWithPrivates).cleanupStaleColumns();
 
-      expect(node.state.baseColumn).toBe('utid');
-      expect(node.state.matchColumn).toBe('id');
+      expect(node.attrs.baseColumn).toBe('utid');
+      expect(node.attrs.matchColumn).toBe('id');
     });
 
     it('should handle no inputs gracefully', () => {
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'id',
+        },
+        {},
+      );
 
       (node as unknown as FilterInNodeWithPrivates).cleanupStaleColumns();
 
       // No primary input, so baseColumn is not checked (kept as-is)
-      expect(node.state.baseColumn).toBe('utid');
+      expect(node.attrs.baseColumn).toBe('utid');
       // No match node, so matchColumn is not checked (kept as-is)
-      expect(node.state.matchColumn).toBe('id');
+      expect(node.attrs.matchColumn).toBe('id');
     });
   });
 
   describe('clone', () => {
     it('should create independent copy with same state', () => {
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'id',
+        },
+        {},
+      );
 
       const cloned = node.clone() as FilterInNode;
 
       expect(cloned.type).toBe(NodeType.kFilterIn);
-      expect(cloned.state.baseColumn).toBe('utid');
-      expect(cloned.state.matchColumn).toBe('id');
+      expect((cloned as FilterInNode).attrs.baseColumn).toBe('utid');
+      expect((cloned as FilterInNode).attrs.matchColumn).toBe('id');
       expect(cloned.nodeId).not.toBe(node.nodeId);
     });
   });
 
   describe('serializeState', () => {
     it('should serialize column selections', () => {
-      const node = new FilterInNode({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
+      const node = new FilterInNode(
+        {
+          baseColumn: 'utid',
+          matchColumn: 'id',
+        },
+        {},
+      );
 
-      const serialized = node.serializeState() as {
-        baseColumn: string;
-        matchColumn: string;
-      };
+      const serialized = node.attrs;
 
       expect(serialized.baseColumn).toBe('utid');
       expect(serialized.matchColumn).toBe('id');
     });
   });
 
-  describe('deserializeState', () => {
-    it('should restore column selections', () => {
-      const state = FilterInNode.deserializeState({
-        baseColumn: 'utid',
-        matchColumn: 'id',
-      });
+  describe('deserialize', () => {
+    it('should restore column selections via constructor', () => {
+      const node = new FilterInNode(
+        {baseColumn: 'utid', matchColumn: 'id'},
+        {},
+      );
 
-      expect(state.baseColumn).toBe('utid');
-      expect(state.matchColumn).toBe('id');
+      expect(node.attrs.baseColumn).toBe('utid');
+      expect(node.attrs.matchColumn).toBe('id');
     });
   });
 
   describe('getTitle', () => {
     it('should return Filter In', () => {
-      const node = new FilterInNode({});
+      const node = new FilterInNode({}, {});
       expect(node.getTitle()).toBe('Filter In');
     });
   });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_node.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
 import {
@@ -46,9 +41,12 @@ import {SqlValue} from '../../../../trace_processor/query_result';
 // Maximum length for truncated SQL display
 const SQL_TRUNCATE_LENGTH = 50;
 
-export interface FilterNodeState extends QueryNodeState {
+// Serializable node configuration.
+export interface FilterNodeAttrs {
   filterMode?: 'structured' | 'freeform';
   sqlExpression?: string;
+  filters?: Partial<UIFilter>[];
+  filterOperator?: 'AND' | 'OR';
 }
 
 export class FilterNode implements QueryNode {
@@ -57,14 +55,30 @@ export class FilterNode implements QueryNode {
   primaryInput?: QueryNode;
   secondaryInputs?: undefined; // FilterNode doesn't support secondary inputs
   nextNodes: QueryNode[];
-  readonly state: FilterNodeState;
+  readonly attrs: FilterNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: FilterNodeState) {
+  constructor(attrs: FilterNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...state,
-      filters: state.filters ?? [],
+    // Migrate filter values from strings back to numbers when appropriate.
+    // This is needed because JSON serialization converts BigInt to string,
+    // and we want numeric values to be stored as numbers for proper filtering.
+    const filters = attrs.filters?.map((f): Partial<UIFilter> => {
+      if ('value' in f && typeof f.value === 'string') {
+        if (!Array.isArray(f.value)) {
+          const parsed = parseFilterValue(f.value);
+          if (parsed !== undefined && parsed !== f.value) {
+            return {...f, value: parsed} as Partial<UIFilter>;
+          }
+        }
+      }
+      return f;
+    });
+    this.attrs = {
+      ...attrs,
+      filters: filters ?? [],
     };
+    this.context = context;
     this.nextNodes = [];
   }
 
@@ -100,20 +114,20 @@ export class FilterNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   nodeDetails(): NodeDetailsAttrs {
     this.validate();
 
-    const mode = this.state.filterMode ?? 'structured';
+    const mode = this.attrs.filterMode ?? 'structured';
 
     // Freeform SQL mode
     if (mode === 'freeform') {
-      const sql = this.state.sqlExpression?.trim();
+      const sql = this.attrs.sqlExpression?.trim();
       if (!sql) {
         return {
           content: NodeDetailsMessage('No filter clause'),
@@ -133,7 +147,7 @@ export class FilterNode implements QueryNode {
 
     // Structured mode - only show valid filters in nodeDetails
     const validFilters =
-      this.state.filters?.filter((f) => this.isFilterValid(f)) ?? [];
+      this.attrs.filters?.filter((f) => this.isFilterValid(f)) ?? [];
 
     if (validFilters.length === 0) {
       return {
@@ -144,8 +158,8 @@ export class FilterNode implements QueryNode {
     return {
       content: formatFilterDetails(
         validFilters,
-        this.state.filterOperator,
-        this.state, // Pass state for interactive toggling and removal
+        this.attrs.filterOperator,
+        {filters: this.attrs.filters, onchange: this.context.onchange},
         undefined, // onRemove - handled internally by formatFilterDetails
         true, // compact mode for smaller font
         undefined, // No edit callback - editing happens in nodeSpecificModify
@@ -156,12 +170,12 @@ export class FilterNode implements QueryNode {
   nodeSpecificModify(): NodeModifyAttrs {
     this.validate();
 
-    const mode = this.state.filterMode ?? 'structured';
-    const filters = this.state.filters ?? [];
-    const operator = this.state.filterOperator ?? 'AND';
+    const mode = this.attrs.filterMode ?? 'structured';
+    const filters = this.attrs.filters ?? [];
+    const operator = this.attrs.filterOperator ?? 'AND';
 
     // Set autoExecute based on mode
-    this.state.autoExecute = mode === 'structured';
+    this.context.autoExecute = mode === 'structured';
 
     // Build bottom buttons
     const bottomLeftButtons: NodeModifyAttrs['bottomLeftButtons'] = [];
@@ -173,8 +187,8 @@ export class FilterNode implements QueryNode {
         label: operator === 'OR' ? 'OR' : 'AND',
         icon: operator === 'OR' ? 'alt_route' : 'join',
         onclick: () => {
-          this.state.filterOperator = operator === 'OR' ? 'AND' : 'OR';
-          this.state.onchange?.();
+          this.attrs.filterOperator = operator === 'OR' ? 'AND' : 'OR';
+          this.context.onchange?.();
         },
       });
     }
@@ -223,10 +237,10 @@ export class FilterNode implements QueryNode {
   }
 
   private renderFiltersList(): m.Child {
-    const mode = this.state.filterMode ?? 'structured';
+    const mode = this.attrs.filterMode ?? 'structured';
     const hasSqlExpression =
-      this.state.sqlExpression !== undefined &&
-      this.state.sqlExpression.trim() !== '';
+      this.attrs.sqlExpression !== undefined &&
+      this.attrs.sqlExpression.trim() !== '';
 
     if (mode === 'freeform') {
       if (!hasSqlExpression) {
@@ -240,7 +254,7 @@ export class FilterNode implements QueryNode {
         m(ListItem, {
           icon: 'code',
           name: 'WHERE clause',
-          description: this.truncateSql(this.state.sqlExpression ?? ''),
+          description: this.truncateSql(this.attrs.sqlExpression ?? ''),
           actions: [
             {
               label: 'Edit',
@@ -249,9 +263,9 @@ export class FilterNode implements QueryNode {
             },
           ],
           onRemove: () => {
-            this.state.sqlExpression = '';
-            this.state.filterMode = 'structured';
-            this.state.onchange?.();
+            this.attrs.sqlExpression = '';
+            this.attrs.filterMode = 'structured';
+            this.context.onchange?.();
           },
         }),
       );
@@ -259,15 +273,15 @@ export class FilterNode implements QueryNode {
 
     // Structured mode - use InlineEditList widget
     return m(InlineEditList<Partial<UIFilter>>, {
-      items: this.state.filters ?? [],
+      items: this.attrs.filters ?? [],
       validate: (filter) => this.isFilterValid(filter),
       renderControls: (filter, _index, onUpdate) =>
         this.renderFilterFormControls(filter, onUpdate),
       onUpdate: (filters) => {
-        this.state.filters = filters;
+        this.attrs.filters = filters;
       },
       onValidChange: () => {
-        this.state.onchange?.();
+        this.context.onchange?.();
       },
       addButtonLabel: 'Add filter',
       addButtonIcon: 'add',
@@ -360,23 +374,23 @@ export class FilterNode implements QueryNode {
     if (currentMode === 'structured') {
       // Switching to freeform: if no SQL expression yet, open modal first
       const hasExpression =
-        this.state.sqlExpression !== undefined &&
-        this.state.sqlExpression.trim() !== '';
+        this.attrs.sqlExpression !== undefined &&
+        this.attrs.sqlExpression.trim() !== '';
       if (hasExpression) {
-        this.state.filterMode = 'freeform';
-        this.state.onchange?.();
+        this.attrs.filterMode = 'freeform';
+        this.context.onchange?.();
       } else {
         this.showSqlExpressionModal();
       }
     } else {
       // Switching to structured
-      this.state.filterMode = 'structured';
-      this.state.onchange?.();
+      this.attrs.filterMode = 'structured';
+      this.context.onchange?.();
     }
   }
 
   private showSqlExpressionModal(): void {
-    let tempExpression = this.state.sqlExpression ?? '';
+    let tempExpression = this.attrs.sqlExpression ?? '';
 
     showModal({
       title: 'SQL Filter Expression',
@@ -401,11 +415,11 @@ export class FilterNode implements QueryNode {
           text: 'Apply',
           primary: true,
           action: () => {
-            this.state.sqlExpression = tempExpression;
+            this.attrs.sqlExpression = tempExpression;
             if (tempExpression.trim() !== '') {
-              this.state.filterMode = 'freeform';
+              this.attrs.filterMode = 'freeform';
             }
-            this.state.onchange?.();
+            this.context.onchange?.();
           },
         },
       ],
@@ -426,8 +440,8 @@ export class FilterNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
@@ -452,24 +466,25 @@ export class FilterNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: FilterNodeState = {
-      filterMode: this.state.filterMode,
-      sqlExpression: this.state.sqlExpression,
-      filters: this.state.filters?.map((f) => ({...f})),
-      filterOperator: this.state.filterOperator,
-      onchange: this.state.onchange,
-    };
-    return new FilterNode(stateCopy);
+    return new FilterNode(
+      {
+        filterMode: this.attrs.filterMode,
+        sqlExpression: this.attrs.sqlExpression,
+        filters: this.attrs.filters?.map((f) => ({...f})),
+        filterOperator: this.attrs.filterOperator,
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (this.primaryInput === undefined) return undefined;
 
-    const mode = this.state.filterMode ?? 'structured';
+    const mode = this.attrs.filterMode ?? 'structured';
 
     if (mode === 'freeform') {
       // Use SQL expression for freeform filtering
-      if (!this.state.sqlExpression || this.state.sqlExpression.trim() === '') {
+      if (!this.attrs.sqlExpression || this.attrs.sqlExpression.trim() === '') {
         // No filter expression - return passthrough to maintain reference chain
         return StructuredQueryBuilder.passthrough(
           this.primaryInput,
@@ -482,7 +497,7 @@ export class FilterNode implements QueryNode {
         new protos.PerfettoSqlStructuredQuery.ExperimentalFilterGroup({
           op: protos.PerfettoSqlStructuredQuery.ExperimentalFilterGroup.Operator
             .AND,
-          sqlExpressions: [this.state.sqlExpression],
+          sqlExpressions: [this.attrs.sqlExpression],
         });
 
       return StructuredQueryBuilder.withFilter(
@@ -494,7 +509,7 @@ export class FilterNode implements QueryNode {
 
     // Structured mode - only use valid filters for query building
     const validFilters =
-      this.state.filters?.filter((f) => this.isFilterValid(f)) ?? [];
+      this.attrs.filters?.filter((f) => this.isFilterValid(f)) ?? [];
 
     if (validFilters.length === 0) {
       // No valid filters - return passthrough to maintain reference chain
@@ -504,7 +519,7 @@ export class FilterNode implements QueryNode {
     const filtersProto = createExperimentalFiltersProto(
       validFilters,
       this.sourceCols,
-      this.state.filterOperator,
+      this.attrs.filterOperator,
     );
 
     if (filtersProto === undefined) {
@@ -517,60 +532,5 @@ export class FilterNode implements QueryNode {
       filtersProto,
       this.nodeId,
     );
-  }
-
-  serializeState(): object {
-    return {
-      filters: this.state.filters?.map((f) => {
-        if ('value' in f) {
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
-      filterOperator: this.state.filterOperator,
-      filterMode: this.state.filterMode,
-      sqlExpression: this.state.sqlExpression,
-    };
-  }
-
-  /**
-   * Deserializes a FilterNodeState from JSON.
-   *
-   * IMPORTANT: This method returns a state with primaryInput set to undefined.
-   * The caller (typically json_handler.ts) is responsible for:
-   * 1. Creating all nodes first with undefined primaryInput references
-   * 2. Reconnecting the graph by setting primaryInput references based on serialized node IDs
-   * 3. Calling validate() on each node after reconnection to ensure graph integrity
-   *
-   * @param state The serialized state
-   * @returns A FilterNodeState ready for construction
-   */
-  static deserializeState(state: FilterNodeState): FilterNodeState {
-    // Convert filter values from strings back to numbers when appropriate.
-    // This is needed because JSON serialization converts BigInt to string,
-    // and we want numeric values to be stored as numbers for proper filtering.
-    const filters = state.filters?.map((f): Partial<UIFilter> => {
-      if ('value' in f && typeof f.value === 'string') {
-        // Only convert single string values, not arrays (for 'in' / 'not in')
-        if (!Array.isArray(f.value)) {
-          const parsed = parseFilterValue(f.value);
-          if (parsed !== undefined && parsed !== f.value) {
-            return {...f, value: parsed} as Partial<UIFilter>;
-          }
-        }
-      }
-      return f;
-    });
-    return {...state, filters};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/filter_node_unittest.ts
@@ -28,26 +28,32 @@ describe('FilterNode', () => {
       const tableNode = createMockSourceNode('mock-table');
 
       // Create a ModifyColumnsNode that aliases 'name' to 'full_name'
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string', {alias: 'full_name'}),
-          createColumnInfo('value', 'int'),
-        ],
-      });
+      const modifyNode = new ModifyColumnsNode(
+        {
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string', {alias: 'full_name'}),
+            createColumnInfo('value', 'int'),
+          ],
+        },
+        {},
+      );
       connectNodes(tableNode, modifyNode);
 
       // Create a FilterNode that filters on 'name' (the original column name)
-      const filterNode = new FilterNode({
-        filters: [
-          {
-            column: 'name',
-            op: '=',
-            value: 'test',
-            enabled: true,
-          } as UIFilter,
-        ],
-      });
+      const filterNode = new FilterNode(
+        {
+          filters: [
+            {
+              column: 'name',
+              op: '=',
+              value: 'test',
+              enabled: true,
+            } as UIFilter,
+          ],
+        },
+        {},
+      );
       connectNodes(modifyNode, filterNode);
 
       // The filter should be invalid because 'name' doesn't exist in finalCols
@@ -67,7 +73,7 @@ describe('FilterNode', () => {
       // The filter on 'name' should be considered invalid
       // Currently this test will fail because isFilterDefinitionValid
       // doesn't check if the column exists in sourceCols
-      const filter = filterNode.state.filters?.[0];
+      const filter = filterNode.attrs.filters?.[0];
       expect(filter).toBeDefined();
 
       // Check if the column exists in sourceCols
@@ -88,26 +94,32 @@ describe('FilterNode', () => {
       const tableNode = createMockSourceNode('mock-table');
 
       // Create a ModifyColumnsNode that unchecks 'name'
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string', {checked: false}),
-          createColumnInfo('value', 'int'),
-        ],
-      });
+      const modifyNode = new ModifyColumnsNode(
+        {
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string', {checked: false}),
+            createColumnInfo('value', 'int'),
+          ],
+        },
+        {},
+      );
       connectNodes(tableNode, modifyNode);
 
       // Create a FilterNode that filters on 'name'
-      const filterNode = new FilterNode({
-        filters: [
-          {
-            column: 'name',
-            op: '=',
-            value: 'test',
-            enabled: true,
-          } as UIFilter,
-        ],
-      });
+      const filterNode = new FilterNode(
+        {
+          filters: [
+            {
+              column: 'name',
+              op: '=',
+              value: 'test',
+              enabled: true,
+            } as UIFilter,
+          ],
+        },
+        {},
+      );
       connectNodes(modifyNode, filterNode);
 
       // The filter should be invalid because 'name' doesn't exist in finalCols
@@ -118,7 +130,7 @@ describe('FilterNode', () => {
       expect(hasNameColumn).toBe(false);
 
       // The filter on 'name' should be considered invalid
-      const filter = filterNode.state.filters?.[0];
+      const filter = filterNode.attrs.filters?.[0];
       expect(filter).toBeDefined();
 
       // Check if the column exists in sourceCols
@@ -139,26 +151,32 @@ describe('FilterNode', () => {
       const tableNode = createMockSourceNode('mock-table');
 
       // Create a ModifyColumnsNode that aliases 'name' to 'full_name'
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string', {alias: 'full_name'}),
-          createColumnInfo('value', 'int'),
-        ],
-      });
+      const modifyNode = new ModifyColumnsNode(
+        {
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string', {alias: 'full_name'}),
+            createColumnInfo('value', 'int'),
+          ],
+        },
+        {},
+      );
       connectNodes(tableNode, modifyNode);
 
       // Create a FilterNode that filters on 'full_name' (the aliased name)
-      const filterNode = new FilterNode({
-        filters: [
-          {
-            column: 'full_name',
-            op: '=',
-            value: 'test',
-            enabled: true,
-          } as UIFilter,
-        ],
-      });
+      const filterNode = new FilterNode(
+        {
+          filters: [
+            {
+              column: 'full_name',
+              op: '=',
+              value: 'test',
+              enabled: true,
+            } as UIFilter,
+          ],
+        },
+        {},
+      );
       connectNodes(modifyNode, filterNode);
 
       // The filter should be valid because 'full_name' exists in finalCols
@@ -171,7 +189,7 @@ describe('FilterNode', () => {
       expect(hasFullNameColumn).toBe(true);
 
       // The filter should be valid
-      const filter = filterNode.state.filters?.[0];
+      const filter = filterNode.attrs.filters?.[0];
       expect(filter).toBeDefined();
 
       // Check if the column exists in sourceCols

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/group_node/group_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/group_node/group_node_unittest.ts
@@ -25,18 +25,18 @@ import {unwrapResult} from '../../../../../base/result';
 describe('GroupNode', () => {
   describe('constructor', () => {
     it('should set type to kGroup', () => {
-      const group = new GroupNode([], undefined, []);
+      const group = new GroupNode({}, {}, [], undefined, []);
       expect(group.type).toBe(NodeType.kGroup);
     });
 
     it('should use default name "Group"', () => {
-      const group = new GroupNode([], undefined, []);
-      expect(group.name).toBe('Group');
+      const group = new GroupNode({}, {}, [], undefined, []);
+      expect(group.attrs.name).toBe('Group');
     });
 
     it('should accept a custom name', () => {
-      const group = new GroupNode([], undefined, [], {}, 'My Group');
-      expect(group.name).toBe('My Group');
+      const group = new GroupNode({name: 'My Group'}, {}, [], undefined, []);
+      expect(group.attrs.name).toBe('My Group');
     });
 
     it('should populate secondaryInputs from external connections', () => {
@@ -52,7 +52,7 @@ describe('GroupNode', () => {
         },
       ];
 
-      const group = new GroupNode([inner], inner, conns);
+      const group = new GroupNode({}, {}, [inner], inner, conns);
       expect(group.secondaryInputs.connections.size).toBe(1);
       expect(group.secondaryInputs.connections.get(0)).toBe(ext);
     });
@@ -62,75 +62,86 @@ describe('GroupNode', () => {
     it('should delegate to endNode finalCols', () => {
       const cols = STANDARD_TABLE_COLUMNS();
       const endNode = createMockNode({nodeId: 'end', columns: cols});
-      const group = new GroupNode([endNode], endNode, []);
+      const group = new GroupNode({}, {}, [endNode], endNode, []);
 
       expect(group.finalCols).toEqual(cols);
     });
 
     it('should return empty array when endNode is undefined', () => {
-      const group = new GroupNode([], undefined, []);
+      const group = new GroupNode({}, {}, [], undefined, []);
       expect(group.finalCols).toEqual([]);
     });
   });
 
   describe('validate', () => {
     it('should return false when innerNodes is empty', () => {
-      const group = new GroupNode([], createMockNode({nodeId: 'end'}), []);
+      const group = new GroupNode(
+        {},
+        {},
+        [],
+        createMockNode({nodeId: 'end'}),
+        [],
+      );
       expect(group.validate()).toBe(false);
     });
 
     it('should return false when endNode is undefined', () => {
       const inner = createMockNode({nodeId: 'a'});
-      const group = new GroupNode([inner], undefined, []);
+      const group = new GroupNode({}, {}, [inner], undefined, []);
       expect(group.validate()).toBe(false);
     });
 
     it('should return true when all inner nodes validate', () => {
       const a = createMockNode({nodeId: 'a', validate: () => true});
       const b = createMockNode({nodeId: 'b', validate: () => true});
-      const group = new GroupNode([a, b], b, []);
+      const group = new GroupNode({}, {}, [a, b], b, []);
       expect(group.validate()).toBe(true);
     });
 
     it('should return false when any inner node fails validation', () => {
       const a = createMockNode({nodeId: 'a', validate: () => true});
       const b = createMockNode({nodeId: 'b', validate: () => false});
-      const group = new GroupNode([a, b], b, []);
+      const group = new GroupNode({}, {}, [a, b], b, []);
       expect(group.validate()).toBe(false);
     });
   });
 
   describe('getTitle', () => {
     it('should return the group name', () => {
-      const group = new GroupNode([], undefined, [], {}, 'Test Group');
+      const group = new GroupNode({name: 'Test Group'}, {}, [], undefined, []);
       expect(group.getTitle()).toBe('Test Group');
     });
 
     it('should reflect name changes', () => {
-      const group = new GroupNode([], undefined, []);
-      group.name = 'Renamed';
+      const group = new GroupNode({}, {}, [], undefined, []);
+      group.attrs.name = 'Renamed';
       expect(group.getTitle()).toBe('Renamed');
     });
   });
 
-  describe('serializeState', () => {
-    it('should serialize name and innerNodeIds', () => {
+  describe('attrs', () => {
+    it('should store name in attrs', () => {
       const inner = createMockNode({nodeId: 'a'});
-      const group = new GroupNode([inner], inner, [], {}, 'Custom Name');
-      const serialized = group.serializeState();
-      expect(serialized).toEqual({name: 'Custom Name', innerNodeIds: ['a']});
+      const group = new GroupNode(
+        {name: 'Custom Name'},
+        {},
+        [inner],
+        inner,
+        [],
+      );
+      expect(group.attrs).toEqual({name: 'Custom Name'});
     });
   });
 
   describe('getStructuredQuery', () => {
     it('should return undefined when endNode is undefined', () => {
-      const group = new GroupNode([], undefined, []);
+      const group = new GroupNode({}, {}, [], undefined, []);
       expect(group.getStructuredQuery()).toBeUndefined();
     });
 
     it('should return passthrough query referencing endNode', () => {
       const endNode = createMockNode({nodeId: 'end'});
-      const group = new GroupNode([endNode], endNode, []);
+      const group = new GroupNode({}, {}, [endNode], endNode, []);
       const sq = group.getStructuredQuery();
       expect(sq).toBeDefined();
       if (sq !== undefined) {
@@ -163,10 +174,10 @@ describe('GroupNode', () => {
       const group = unwrapResult(
         createGroupFromSelection(new Set(['a', 'b']), [a, b]),
       );
-      group.name = 'My Custom Group';
+      group.attrs.name = 'My Custom Group';
       const cloned = group.clone();
 
-      expect(cloned.name).toBe('My Custom Group');
+      expect(cloned.attrs.name).toBe('My Custom Group');
     });
 
     it('should deep clone inner nodes', () => {
@@ -237,14 +248,14 @@ describe('GroupNode', () => {
       cloned.innerNodes.pop();
       expect(group.innerNodes).toHaveLength(2);
 
-      cloned.name = 'Changed';
-      expect(group.name).toBe('Group');
+      cloned.attrs.name = 'Changed';
+      expect(group.attrs.name).toBe('Group');
     });
   });
 
   describe('secondaryInputs port names', () => {
     it('should generate port names based on index', () => {
-      const group = new GroupNode([], undefined, []);
+      const group = new GroupNode({}, {}, [], undefined, []);
       const portNames = group.secondaryInputs.portNames;
       if (typeof portNames === 'function') {
         expect(portNames(0)).toBe('Input 1');

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/group_node/index.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/group_node/index.ts
@@ -16,7 +16,7 @@ import m from 'mithril';
 import protos from '../../../../../protos';
 import {
   QueryNode,
-  QueryNodeState,
+  NodeContext,
   NodeType,
   nextNodeId,
   SecondaryInputSpec,
@@ -28,12 +28,9 @@ import {StructuredQueryBuilder} from '../../structured_query_builder';
 import {InnerGraphPreview} from './inner_graph_preview';
 import {perfettoSqlTypeToString} from '../../../../../trace_processor/perfetto_sql_type';
 
-/**
- * Serialized shape of a GroupNode's state (used for JSON round-tripping).
- */
-export interface GroupSerializedState {
-  readonly name?: string;
-  readonly innerNodeIds?: string[];
+// Serializable node configuration.
+export interface GroupNodeAttrs {
+  name?: string;
 }
 
 /**
@@ -66,7 +63,8 @@ export class GroupNode implements QueryNode {
   readonly type = NodeType.kGroup;
   nextNodes: QueryNode[] = [];
   primaryInput?: QueryNode = undefined;
-  readonly state: QueryNodeState;
+  readonly attrs: GroupNodeAttrs;
+  readonly context: NodeContext;
 
   // The nodes contained inside this group.
   innerNodes: QueryNode[];
@@ -78,26 +76,23 @@ export class GroupNode implements QueryNode {
   // inner node connections.
   externalConnections: ExternalGroupConnection[];
 
-  // User-editable display name for the group.
-  name: string;
-
   // Not readonly because postDeserialize rebuilds it after restoring
   // external connections.
   secondaryInputs: SecondaryInputSpec;
 
   constructor(
-    innerNodes: QueryNode[],
-    endNode: QueryNode | undefined,
-    externalConnections: ExternalGroupConnection[],
-    state: QueryNodeState = {},
-    name = 'Group',
+    attrs: GroupNodeAttrs,
+    context: NodeContext,
+    innerNodes: QueryNode[] = [],
+    endNode: QueryNode | undefined = undefined,
+    externalConnections: ExternalGroupConnection[] = [],
   ) {
     this.nodeId = nextNodeId();
+    this.attrs = {name: attrs.name ?? 'Group'};
+    this.context = context;
     this.innerNodes = innerNodes;
     this.endNode = endNode;
     this.externalConnections = externalConnections;
-    this.state = state;
-    this.name = name;
 
     const connections = new Map<number, QueryNode>();
     for (const conn of externalConnections) {
@@ -168,12 +163,12 @@ export class GroupNode implements QueryNode {
   }
 
   getTitle(): string {
-    return this.name;
+    return this.attrs.name ?? 'Group';
   }
 
   nodeDetails(): NodeDetailsAttrs {
     return {
-      content: this.name,
+      content: this.attrs.name ?? 'Group',
     };
   }
 
@@ -184,10 +179,10 @@ export class GroupNode implements QueryNode {
       {
         title: 'Name',
         content: m(TextInput, {
-          value: this.name,
+          value: this.attrs.name ?? 'Group',
           onInput: (value: string) => {
-            this.name = value;
-            this.state.onchange?.();
+            this.attrs.name = value;
+            this.context.onchange?.();
           },
         }),
       },
@@ -202,10 +197,7 @@ export class GroupNode implements QueryNode {
           cols.map((col) =>
             m('.pf-exp-draggable-item.pf-group-column-readonly', [
               m('span.pf-checkbox-label', col.name),
-              m(
-                'span.pf-column-type',
-                perfettoSqlTypeToString(col.column.type),
-              ),
+              m('span.pf-column-type', perfettoSqlTypeToString(col.type)),
             ]),
           ),
         ),
@@ -269,11 +261,11 @@ export class GroupNode implements QueryNode {
       }));
 
     return new GroupNode(
+      {name: this.attrs.name},
+      this.context,
       clonedInnerNodes,
       clonedEndNode,
       clonedExternalConnections,
-      {...this.state},
-      this.name,
     );
   }
 
@@ -283,12 +275,5 @@ export class GroupNode implements QueryNode {
     // can be looked up by it.
     if (this.endNode === undefined) return undefined;
     return StructuredQueryBuilder.passthrough(this.endNode, this.nodeId);
-  }
-
-  serializeState(): object {
-    return {
-      name: this.name,
-      innerNodeIds: this.innerNodes.map((n) => n.nodeId),
-    };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node.ts
@@ -15,10 +15,10 @@
 import m from 'mithril';
 import {
   QueryNode,
-  QueryNodeState,
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {notifyNextNodes} from '../graph_utils';
 import protos from '../../../../protos';
@@ -47,14 +47,8 @@ import {NodeTitle, ColumnName} from '../node_styling_widgets';
 import {loadNodeDoc} from '../node_doc_loader';
 import {getCommonColumns} from '../utils';
 
-export interface IntervalIntersectSerializedState {
-  comment?: string;
-  partitionColumns?: string[]; // Columns to partition by during interval intersection
-  tsDurSource?: 'intersection' | number; // Source for ts/dur: 'intersection' or input index
-}
-
-export interface IntervalIntersectNodeState extends QueryNodeState {
-  inputNodes: QueryNode[];
+// Serializable node configuration.
+export interface IntervalIntersectNodeAttrs {
   partitionColumns?: string[]; // Columns to partition by during interval intersection
   tsDurSource?: 'intersection' | number; // Source for ts/dur: 'intersection' or input index
 }
@@ -64,7 +58,8 @@ export class IntervalIntersectNode implements QueryNode {
   readonly type = NodeType.kIntervalIntersect;
   secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
-  readonly state: IntervalIntersectNodeState;
+  readonly attrs: IntervalIntersectNodeAttrs;
+  readonly context: NodeContext;
 
   get inputNodesList(): QueryNode[] {
     return [...this.secondaryInputs.connections.entries()]
@@ -83,7 +78,7 @@ export class IntervalIntersectNode implements QueryNode {
 
     // Add id column only when tsDurSource is a specific input (not intersection)
     // Intersection doesn't have a single id, but a specific input does
-    const tsDurSource = this.state.tsDurSource ?? 'intersection';
+    const tsDurSource = this.attrs.tsDurSource ?? 'intersection';
     if (typeof tsDurSource === 'number') {
       // Get the id type from the selected input
       const sourceNode = inputNodes[tsDurSource];
@@ -91,12 +86,12 @@ export class IntervalIntersectNode implements QueryNode {
         sourceNode !== undefined
           ? this.getEffectiveCols(sourceNode).find((c) => c.name === 'id')
           : undefined;
-      const idColumnType = sourceIdCol?.column.type;
+      const idColumnType = sourceIdCol?.type;
 
       finalCols.push({
         name: 'id',
         checked: true,
-        column: idColumnType ? {name: 'id', type: idColumnType} : {name: 'id'},
+        type: idColumnType,
       });
       seenColumns.add('id');
     }
@@ -106,28 +101,28 @@ export class IntervalIntersectNode implements QueryNode {
     finalCols.push({
       name: 'ts',
       checked: true,
-      column: {name: 'ts', type: PerfettoSqlTypes.TIMESTAMP},
+      type: PerfettoSqlTypes.TIMESTAMP,
     });
     finalCols.push({
       name: 'dur',
       checked: true,
-      column: {name: 'dur', type: PerfettoSqlTypes.DURATION},
+      type: PerfettoSqlTypes.DURATION,
     });
     seenColumns.add('ts');
     seenColumns.add('dur');
 
     // Add partition columns (without suffix)
     // Partition columns preserve their type from the first input node
-    if (this.state.partitionColumns) {
+    if (this.attrs.partitionColumns) {
       const firstNode = inputNodes[0];
       const firstNodeCols =
         firstNode !== undefined ? this.getEffectiveCols(firstNode) : [];
-      for (const colName of this.state.partitionColumns) {
+      for (const colName of this.attrs.partitionColumns) {
         const sourceCol = firstNodeCols.find((c) => c.name === colName);
 
         // Validate that partition column types match across all input nodes
         // Skip validation if type is unknown
-        const sourceType = sourceCol?.column.type;
+        const sourceType = sourceCol?.type;
         if (sourceType !== undefined) {
           for (let i = 1; i < inputNodes.length; i++) {
             const node = inputNodes[i];
@@ -140,7 +135,7 @@ export class IntervalIntersectNode implements QueryNode {
 
             const nodeCols = this.getEffectiveCols(node);
             const otherCol = nodeCols.find((c) => c.name === colName);
-            const otherType = otherCol?.column.type;
+            const otherType = otherCol?.type;
 
             // Only warn if both types are known and different
             if (otherType !== undefined && !typesEqual(sourceType, otherType)) {
@@ -154,13 +149,10 @@ export class IntervalIntersectNode implements QueryNode {
         }
 
         // Create column with explicit type handling
-        const columnType = sourceCol?.column.type;
         finalCols.push({
           name: colName,
           checked: true,
-          column: columnType
-            ? {name: colName, type: columnType}
-            : {name: colName},
+          type: sourceCol?.type,
         });
         seenColumns.add(colName);
       }
@@ -213,55 +205,56 @@ export class IntervalIntersectNode implements QueryNode {
       const idCol = nodeCols.find((c) => c.name === 'id');
 
       // Create id_N column with explicit type handling
-      const idColumnType = idCol?.column.type;
+      const idColumnType = idCol?.type;
       finalCols.push({
         name: `id_${i}`,
         checked: true,
-        column: idColumnType
-          ? {name: `id_${i}`, type: idColumnType}
-          : {name: `id_${i}`},
+        type: idColumnType,
       });
       // ts_N columns are TIMESTAMP type
       finalCols.push({
         name: `ts_${i}`,
         checked: true,
-        column: {name: `ts_${i}`, type: PerfettoSqlTypes.TIMESTAMP},
+        type: PerfettoSqlTypes.TIMESTAMP,
       });
       // dur_N columns are DURATION type
       finalCols.push({
         name: `dur_${i}`,
         checked: true,
-        column: {name: `dur_${i}`, type: PerfettoSqlTypes.DURATION},
+        type: PerfettoSqlTypes.DURATION,
       });
     }
 
     return finalCols;
   }
 
-  constructor(state: IntervalIntersectNodeState) {
+  constructor(
+    attrs: IntervalIntersectNodeAttrs & {inputNodes?: QueryNode[]},
+    context: NodeContext,
+  ) {
     this.nodeId = nextNodeId();
-
-    this.state = {
-      ...state,
-      autoExecute: state.autoExecute ?? false,
-    };
+    const {inputNodes, ...rest} = attrs;
+    this.attrs = rest as IntervalIntersectNodeAttrs;
+    this.context = context;
     this.secondaryInputs = {
       connections: new Map(),
       min: 2,
       max: 6,
       portNames: (portIndex: number) => `Input ${portIndex}`,
     };
-    // Initialize connections from state.inputNodes
-    for (let i = 0; i < state.inputNodes.length; i++) {
-      this.secondaryInputs.connections.set(i, state.inputNodes[i]);
+    // Initialize connections from inputNodes
+    if (inputNodes) {
+      for (let i = 0; i < inputNodes.length; i++) {
+        this.secondaryInputs.connections.set(i, inputNodes[i]);
+      }
     }
     this.nextNodes = [];
   }
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     const inputNodes = this.inputNodesList;
@@ -276,7 +269,7 @@ export class IntervalIntersectNode implements QueryNode {
     for (const inputNode of inputNodes) {
       if (!inputNode.validate()) {
         this.setValidationError(
-          inputNode.state.issues?.queryError?.message ??
+          inputNode.context.issues?.queryError?.message ??
             `Input node '${inputNode.getTitle()}' is invalid`,
         );
         return false;
@@ -303,8 +296,8 @@ export class IntervalIntersectNode implements QueryNode {
     }
 
     // Validate partition columns exist in all inputs
-    if (this.state.partitionColumns && this.state.partitionColumns.length > 0) {
-      for (const partitionCol of this.state.partitionColumns) {
+    if (this.attrs.partitionColumns && this.attrs.partitionColumns.length > 0) {
+      for (const partitionCol of this.attrs.partitionColumns) {
         for (let i = 0; i < inputNodes.length; i++) {
           const node = inputNodes[i];
           const cols = new Set(node.finalCols.map((c) => c.name));
@@ -322,10 +315,10 @@ export class IntervalIntersectNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -338,8 +331,8 @@ export class IntervalIntersectNode implements QueryNode {
 
   private renderPartitionSelector(): m.Child {
     // Initialize partition columns if needed
-    if (!this.state.partitionColumns) {
-      this.state.partitionColumns = [];
+    if (!this.attrs.partitionColumns) {
+      this.attrs.partitionColumns = [];
     }
 
     // Get common columns for partition selection
@@ -349,7 +342,7 @@ export class IntervalIntersectNode implements QueryNode {
     // This ensures we show invalid partition columns so the user can deselect them
     const allPartitionOptions = new Set([
       ...commonColumns,
-      ...(this.state.partitionColumns ?? []),
+      ...(this.attrs.partitionColumns ?? []),
     ]);
 
     // If there are no options at all (no common columns and no partitions set), don't show
@@ -362,12 +355,12 @@ export class IntervalIntersectNode implements QueryNode {
     ).map((col) => ({
       id: col,
       name: col,
-      checked: this.state.partitionColumns?.includes(col) ?? false,
+      checked: this.attrs.partitionColumns?.includes(col) ?? false,
     }));
 
     const label =
-      this.state.partitionColumns.length > 0
-        ? this.state.partitionColumns.join(', ')
+      this.attrs.partitionColumns.length > 0
+        ? this.attrs.partitionColumns.join(', ')
         : 'None';
 
     return m(
@@ -378,24 +371,24 @@ export class IntervalIntersectNode implements QueryNode {
         options: partitionOptions,
         showNumSelected: false,
         onChange: (diffs: MultiSelectDiff[]) => {
-          if (!this.state.partitionColumns) {
-            this.state.partitionColumns = [];
+          if (!this.attrs.partitionColumns) {
+            this.attrs.partitionColumns = [];
           }
           for (const diff of diffs) {
             if (diff.checked) {
-              if (!this.state.partitionColumns.includes(diff.id)) {
-                this.state.partitionColumns.push(diff.id);
+              if (!this.attrs.partitionColumns.includes(diff.id)) {
+                this.attrs.partitionColumns.push(diff.id);
               }
             } else {
-              const index = this.state.partitionColumns.indexOf(diff.id);
+              const index = this.attrs.partitionColumns.indexOf(diff.id);
               if (index !== -1) {
-                this.state.partitionColumns.splice(index, 1);
+                this.attrs.partitionColumns.splice(index, 1);
               }
             }
           }
           // Notify downstream nodes about the column change
           notifyNextNodes(this);
-          this.state.onchange?.();
+          this.context.onchange?.();
         },
       }),
     );
@@ -407,7 +400,7 @@ export class IntervalIntersectNode implements QueryNode {
       return null;
     }
 
-    const currentSource = this.state.tsDurSource ?? 'intersection';
+    const currentSource = this.attrs.tsDurSource ?? 'intersection';
     const currentValue =
       currentSource === 'intersection' ? 'intersection' : String(currentSource);
 
@@ -429,12 +422,12 @@ export class IntervalIntersectNode implements QueryNode {
           const target = e.target as HTMLSelectElement;
           const value = target.value;
           if (value === 'intersection') {
-            this.state.tsDurSource = 'intersection';
+            this.attrs.tsDurSource = 'intersection';
           } else {
-            this.state.tsDurSource = parseInt(value, 10);
+            this.attrs.tsDurSource = parseInt(value, 10);
           }
           notifyNextNodes(this);
-          this.state.onchange?.();
+          this.context.onchange?.();
         },
       },
       options,
@@ -445,7 +438,7 @@ export class IntervalIntersectNode implements QueryNode {
     const details: m.Child[] = [NodeTitle(this.getTitle())];
 
     // Display id/ts/dur source (read-only)
-    const tsDurSource = this.state.tsDurSource ?? 'intersection';
+    const tsDurSource = this.attrs.tsDurSource ?? 'intersection';
     const tsDurSourceLabel =
       tsDurSource === 'intersection' ? 'Intersection' : `Input ${tsDurSource}`;
     if (tsDurSource !== 'intersection') {
@@ -453,14 +446,14 @@ export class IntervalIntersectNode implements QueryNode {
     }
 
     // Display partition columns (read-only)
-    if (this.state.partitionColumns && this.state.partitionColumns.length > 0) {
+    if (this.attrs.partitionColumns && this.attrs.partitionColumns.length > 0) {
       details.push(
         m(
           'div',
           'Partition by: ',
-          this.state.partitionColumns.map((col, index) => [
+          this.attrs.partitionColumns.map((col, index) => [
             ColumnName(col),
-            index < this.state.partitionColumns!.length - 1 ? ', ' : '',
+            index < this.attrs.partitionColumns!.length - 1 ? ', ' : '',
           ]),
         ),
       );
@@ -473,19 +466,19 @@ export class IntervalIntersectNode implements QueryNode {
 
   private cleanupPartitionColumns(): void {
     if (
-      !this.state.partitionColumns ||
-      this.state.partitionColumns.length === 0
+      !this.attrs.partitionColumns ||
+      this.attrs.partitionColumns.length === 0
     ) {
       return;
     }
 
     const inputNodes = this.inputNodesList;
     if (inputNodes.length === 0) {
-      if (this.state.partitionColumns.length > 0) {
+      if (this.attrs.partitionColumns.length > 0) {
         console.warn(
           '[IntervalIntersect] Clearing partition columns - no input nodes available',
         );
-        this.state.partitionColumns = [];
+        this.attrs.partitionColumns = [];
       }
       return;
     }
@@ -501,7 +494,7 @@ export class IntervalIntersectNode implements QueryNode {
 
     // Notify next nodes that our columns have changed
     notifyNextNodes(this);
-    this.state.onchange?.();
+    this.context.onchange?.();
     m.redraw();
   }
 
@@ -510,7 +503,7 @@ export class IntervalIntersectNode implements QueryNode {
     const columnToInputs = new Map<string, number[]>();
 
     // Also exclude columns used for partitioning (they're intentionally in all inputs)
-    const partitionColumns = new Set(this.state.partitionColumns ?? []);
+    const partitionColumns = new Set(this.attrs.partitionColumns ?? []);
 
     // Track which inputs each column appears in
     for (let i = 0; i < this.inputNodesList.length; i++) {
@@ -550,7 +543,7 @@ export class IntervalIntersectNode implements QueryNode {
 
   nodeSpecificModify(): NodeModifyAttrs {
     this.validate();
-    const error = this.state.issues?.queryError;
+    const error = this.context.issues?.queryError;
     const duplicateWarnings = this.checkDuplicateColumns();
 
     // Map inputNodes to UI elements with their indices
@@ -627,8 +620,8 @@ export class IntervalIntersectNode implements QueryNode {
           actions.push({
             label: 'Convert to Intervals',
             onclick: () => {
-              if (this.state.actions?.onInsertCounterToIntervalsNode) {
-                this.state.actions.onInsertCounterToIntervalsNode(index);
+              if (this.context.actions?.onInsertCounterToIntervalsNode) {
+                this.context.actions.onInsertCounterToIntervalsNode(index);
               }
             },
           });
@@ -639,8 +632,8 @@ export class IntervalIntersectNode implements QueryNode {
           icon: 'view_column',
           title: 'Pick columns',
           onclick: () => {
-            if (this.state.actions?.onInsertModifyColumnsNode) {
-              this.state.actions.onInsertModifyColumnsNode(index);
+            if (this.context.actions?.onInsertModifyColumnsNode) {
+              this.context.actions.onInsertModifyColumnsNode(index);
             }
           },
         });
@@ -679,15 +672,15 @@ export class IntervalIntersectNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: IntervalIntersectNodeState = {
-      inputNodes: [...this.state.inputNodes],
-      partitionColumns: this.state.partitionColumns
-        ? [...this.state.partitionColumns]
-        : undefined,
-      tsDurSource: this.state.tsDurSource,
-      onchange: this.state.onchange,
-    };
-    return new IntervalIntersectNode(stateCopy);
+    return new IntervalIntersectNode(
+      {
+        partitionColumns: this.attrs.partitionColumns
+          ? [...this.attrs.partitionColumns]
+          : undefined,
+        tsDurSource: this.attrs.tsDurSource,
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -696,13 +689,13 @@ export class IntervalIntersectNode implements QueryNode {
     const sq = StructuredQueryBuilder.withIntervalIntersect(
       this.inputNodesList[0],
       this.inputNodesList.slice(1),
-      this.state.partitionColumns,
+      this.attrs.partitionColumns,
       this.nodeId,
     );
 
     if (sq === undefined) return undefined;
 
-    const tsDurSource = this.state.tsDurSource ?? 'intersection';
+    const tsDurSource = this.attrs.tsDurSource ?? 'intersection';
 
     // Build select_columns with aliasing based on tsDurSource
     sq.selectColumns = this.buildSelectColumns(tsDurSource);
@@ -744,22 +737,5 @@ export class IntervalIntersectNode implements QueryNode {
     }
 
     return selectColumns;
-  }
-
-  serializeState(): IntervalIntersectSerializedState {
-    return {
-      partitionColumns: this.state.partitionColumns,
-      tsDurSource: this.state.tsDurSource,
-    };
-  }
-
-  static deserializeState(
-    state: IntervalIntersectSerializedState,
-  ): IntervalIntersectNodeState {
-    return {
-      inputNodes: [],
-      partitionColumns: state.partitionColumns,
-      tsDurSource: state.tsDurSource,
-    };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/interval_intersect_node_unittest.ts
@@ -55,7 +55,7 @@ describe('IntervalIntersectNode', () => {
     return {
       name,
       checked,
-      column: {name, type: sqlType},
+      type: sqlType,
     };
   }
 
@@ -69,25 +69,31 @@ describe('IntervalIntersectNode', () => {
     return {
       name,
       checked,
-      column: {name, type: sqlType},
+      type: sqlType,
     };
   }
 
   describe('constructor', () => {
     it('should set autoExecute to false by default', () => {
-      const node = new IntervalIntersectNode({
-        inputNodes: [],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [],
+        },
+        {},
+      );
 
-      expect(node.state.autoExecute).toBe(false);
+      expect(node.context.autoExecute).toBeUndefined();
     });
   });
 
   describe('finalCols', () => {
     it('should return empty array when no prev nodes', () => {
-      const node = new IntervalIntersectNode({
-        inputNodes: [],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [],
+        },
+        {},
+      );
 
       expect(node.finalCols).toEqual([]);
     });
@@ -104,9 +110,12 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       expect(cols[0].name).toBe('ts');
@@ -127,10 +136,13 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('utid', 'INT'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       expect(cols[0].name).toBe('ts');
@@ -155,35 +167,38 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2, node3],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2, node3],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
 
       // After ts, dur (indexes 0, 1), we should have id_0, ts_0, dur_0
       expect(cols[2].name).toBe('id_0');
-      expect(cols[2].column.type).toEqual({kind: 'int'});
+      expect(cols[2].type).toEqual({kind: 'int'});
       expect(cols[3].name).toBe('ts_0');
-      expect(cols[3].column.type).toEqual({kind: 'timestamp'}); // ts columns are TIMESTAMP type
+      expect(cols[3].type).toEqual({kind: 'timestamp'}); // ts columns are TIMESTAMP type
       expect(cols[4].name).toBe('dur_0');
-      expect(cols[4].column.type).toEqual({kind: 'duration'}); // dur columns are DURATION type
+      expect(cols[4].type).toEqual({kind: 'duration'}); // dur columns are DURATION type
 
       // Then id_1, ts_1, dur_1
       expect(cols[5].name).toBe('id_1');
-      expect(cols[5].column.type).toEqual({kind: 'int'});
+      expect(cols[5].type).toEqual({kind: 'int'});
       expect(cols[6].name).toBe('ts_1');
-      expect(cols[6].column.type).toEqual({kind: 'timestamp'});
+      expect(cols[6].type).toEqual({kind: 'timestamp'});
       expect(cols[7].name).toBe('dur_1');
-      expect(cols[7].column.type).toEqual({kind: 'duration'});
+      expect(cols[7].type).toEqual({kind: 'duration'});
 
       // Then id_2, ts_2, dur_2
       expect(cols[8].name).toBe('id_2');
-      expect(cols[8].column.type).toEqual({kind: 'int'});
+      expect(cols[8].type).toEqual({kind: 'int'});
       expect(cols[9].name).toBe('ts_2');
-      expect(cols[9].column.type).toEqual({kind: 'timestamp'});
+      expect(cols[9].type).toEqual({kind: 'timestamp'});
       expect(cols[10].name).toBe('dur_2');
-      expect(cols[10].column.type).toEqual({kind: 'duration'});
+      expect(cols[10].type).toEqual({kind: 'duration'});
     });
 
     it('should include non-duplicated columns from all inputs', () => {
@@ -201,9 +216,12 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('status', 'STRING'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       const colNames = cols.map((c) => c.name);
@@ -225,11 +243,11 @@ describe('IntervalIntersectNode', () => {
 
       // Verify types are preserved
       const nameCol = cols.find((c) => c.name === 'name');
-      expect(nameCol?.column.type).toEqual({kind: 'string'});
+      expect(nameCol?.type).toEqual({kind: 'string'});
       const valueCol = cols.find((c) => c.name === 'value');
-      expect(valueCol?.column.type).toEqual({kind: 'int'});
+      expect(valueCol?.type).toEqual({kind: 'int'});
       const statusCol = cols.find((c) => c.name === 'status');
-      expect(statusCol?.column.type).toEqual({kind: 'string'});
+      expect(statusCol?.type).toEqual({kind: 'string'});
     });
 
     it('should exclude duplicated columns entirely', () => {
@@ -248,9 +266,12 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('status', 'STRING'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       const colNames = cols.map((c) => c.name);
@@ -278,10 +299,13 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('status', 'STRING'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       const colNames = cols.map((c) => c.name);
@@ -311,10 +335,13 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('upid', 'INT'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid', 'upid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid', 'upid'],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       expect(cols[0].name).toBe('ts');
@@ -336,9 +363,12 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64', false),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       // All columns should be checked
@@ -370,48 +400,51 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('category', 'STRING'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2, node3],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2, node3],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
 
       // Check id_N, ts_N, dur_N types for each input
       // ts columns are TIMESTAMP type, dur columns are DURATION type
       const id0 = cols.find((c) => c.name === 'id_0');
-      expect(id0?.column.type).toEqual({kind: 'int'});
+      expect(id0?.type).toEqual({kind: 'int'});
       const ts0 = cols.find((c) => c.name === 'ts_0');
-      expect(ts0?.column.type).toEqual({kind: 'timestamp'});
+      expect(ts0?.type).toEqual({kind: 'timestamp'});
       const dur0 = cols.find((c) => c.name === 'dur_0');
-      expect(dur0?.column.type).toEqual({kind: 'duration'});
+      expect(dur0?.type).toEqual({kind: 'duration'});
 
       const id1 = cols.find((c) => c.name === 'id_1');
-      expect(id1?.column.type).toEqual({kind: 'int'});
+      expect(id1?.type).toEqual({kind: 'int'});
       const ts1 = cols.find((c) => c.name === 'ts_1');
-      expect(ts1?.column.type).toEqual({kind: 'timestamp'});
+      expect(ts1?.type).toEqual({kind: 'timestamp'});
       const dur1 = cols.find((c) => c.name === 'dur_1');
-      expect(dur1?.column.type).toEqual({kind: 'duration'});
+      expect(dur1?.type).toEqual({kind: 'duration'});
 
       const id2 = cols.find((c) => c.name === 'id_2');
-      expect(id2?.column.type).toEqual({kind: 'int'});
+      expect(id2?.type).toEqual({kind: 'int'});
       const ts2 = cols.find((c) => c.name === 'ts_2');
-      expect(ts2?.column.type).toEqual({kind: 'timestamp'});
+      expect(ts2?.type).toEqual({kind: 'timestamp'});
       const dur2 = cols.find((c) => c.name === 'dur_2');
-      expect(dur2?.column.type).toEqual({kind: 'duration'});
+      expect(dur2?.type).toEqual({kind: 'duration'});
 
       // Check non-duplicated columns preserve their types
       const name = cols.find((c) => c.name === 'name');
-      expect(name?.column.type).toEqual({kind: 'string'});
+      expect(name?.type).toEqual({kind: 'string'});
       const value = cols.find((c) => c.name === 'value');
-      expect(value?.column.type).toEqual({kind: 'double'});
+      expect(value?.type).toEqual({kind: 'double'});
       const count = cols.find((c) => c.name === 'count');
-      expect(count?.column.type).toEqual({kind: 'int'});
+      expect(count?.type).toEqual({kind: 'int'});
       const status = cols.find((c) => c.name === 'status');
-      expect(status?.column.type).toEqual({kind: 'string'});
+      expect(status?.type).toEqual({kind: 'string'});
       const priority = cols.find((c) => c.name === 'priority');
-      expect(priority?.column.type).toEqual({kind: 'int'});
+      expect(priority?.type).toEqual({kind: 'int'});
       const category = cols.find((c) => c.name === 'category');
-      expect(category?.column.type).toEqual({kind: 'string'});
+      expect(category?.type).toEqual({kind: 'string'});
     });
 
     it('should exclude columns with conflicting types', () => {
@@ -430,9 +463,12 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('unique2', 'INT'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       const cols = node.finalCols;
       const colNames = cols.map((c) => c.name);
@@ -453,12 +489,15 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'requires at least two inputs',
       );
     });
@@ -475,9 +514,12 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(true);
     });
@@ -493,15 +535,18 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'missing required columns',
       );
-      expect(node.state.issues?.queryError?.message).toContain('id');
+      expect(node.context.issues?.queryError?.message).toContain('id');
     });
 
     it('should fail validation when input is missing required ts column', () => {
@@ -515,15 +560,18 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'missing required columns',
       );
-      expect(node.state.issues?.queryError?.message).toContain('ts');
+      expect(node.context.issues?.queryError?.message).toContain('ts');
     });
 
     it('should fail validation when input is missing required dur column', () => {
@@ -537,15 +585,18 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('ts', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'missing required columns',
       );
-      expect(node.state.issues?.queryError?.message).toContain('dur');
+      expect(node.context.issues?.queryError?.message).toContain('dur');
     });
 
     it('should fail validation when prev node validation fails', () => {
@@ -561,12 +612,15 @@ describe('IntervalIntersectNode', () => {
       ]);
       node2.validate = () => false;
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain('is invalid');
+      expect(node.context.issues?.queryError?.message).toContain('is invalid');
     });
 
     it('should clear previous errors when validation starts', () => {
@@ -576,13 +630,16 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1],
+        },
+        {},
+      );
 
       // First validation should fail
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError).toBeDefined();
+      expect(node.context.issues?.queryError).toBeDefined();
 
       // Add second node to make it valid
       const node2 = createMockPrevNode('node2', [
@@ -594,7 +651,7 @@ describe('IntervalIntersectNode', () => {
 
       // Second validation should pass and clear errors
       expect(node.validate()).toBe(true);
-      expect(node.state.issues?.queryError).toBeUndefined();
+      expect(node.context.issues?.queryError).toBeUndefined();
     });
 
     it('should fail validation when partition column is missing from an input', () => {
@@ -617,16 +674,19 @@ describe('IntervalIntersectNode', () => {
         // Missing 'utid' column
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2, node3],
-        partitionColumns: ['utid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2, node3],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         "Partition column 'utid' is missing from Input 2",
       );
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         'remove the partitioning',
       );
     });
@@ -651,10 +711,13 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('utid', 'INT'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2, node3],
-        partitionColumns: ['utid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2, node3],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(true);
     });
@@ -675,13 +738,16 @@ describe('IntervalIntersectNode', () => {
         // Missing 'upid' column
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid', 'upid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid', 'upid'],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError?.message).toContain(
+      expect(node.context.issues?.queryError?.message).toContain(
         "Partition column 'upid' is missing from Input 1",
       );
     });
@@ -699,21 +765,27 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: [],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: [],
+        },
+        {},
+      );
 
       expect(node.validate()).toBe(true);
-      expect(node.state.issues?.queryError).toBeUndefined();
+      expect(node.context.issues?.queryError).toBeUndefined();
     });
   });
 
   describe('getTitle', () => {
     it('should return "Interval Intersect"', () => {
-      const node = new IntervalIntersectNode({
-        inputNodes: [],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [],
+        },
+        {},
+      );
 
       expect(node.getTitle()).toBe('Interval Intersect');
     });
@@ -732,16 +804,21 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       const cloned = node.clone() as IntervalIntersectNode;
 
       expect(cloned).toBeInstanceOf(IntervalIntersectNode);
       expect(cloned.nodeId).not.toBe(node.nodeId);
-      expect(cloned.state.partitionColumns).toEqual(['utid']);
+      expect((cloned as IntervalIntersectNode).attrs.partitionColumns).toEqual([
+        'utid',
+      ]);
     });
 
     it('should not share state arrays with original', () => {
@@ -756,18 +833,21 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       const cloned = node.clone() as IntervalIntersectNode;
 
       // Modify cloned arrays
-      cloned.state.partitionColumns!.push('upid');
+      (cloned as IntervalIntersectNode).attrs.partitionColumns!.push('upid');
 
       // Original should not be affected
-      expect(node.state.partitionColumns).toEqual(['utid']);
+      expect(node.attrs.partitionColumns).toEqual(['utid']);
     });
   });
 
@@ -789,12 +869,15 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2, node3],
-        partitionColumns: ['utid'],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2, node3],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
       expect(serialized.partitionColumns).toEqual(['utid']);
     });
@@ -811,35 +894,30 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
       expect(serialized.partitionColumns).toBeUndefined();
     });
   });
 
-  describe('deserializeState', () => {
-    it('should deserialize partition columns', () => {
-      const serialized = {
-        partitionColumns: ['utid'],
-      };
+  describe('deserialize', () => {
+    it('should restore partition columns via constructor', () => {
+      const node = new IntervalIntersectNode({partitionColumns: ['utid']}, {});
 
-      const deserialized = IntervalIntersectNode.deserializeState(serialized);
-
-      expect(deserialized.partitionColumns).toEqual(['utid']);
-      expect(deserialized.inputNodes).toEqual([]);
+      expect(node.attrs.partitionColumns).toEqual(['utid']);
     });
 
     it('should handle missing partition columns', () => {
-      const serialized = {};
+      const node = new IntervalIntersectNode({}, {});
 
-      const deserialized = IntervalIntersectNode.deserializeState(serialized);
-
-      expect(deserialized.partitionColumns).toBeUndefined();
-      expect(deserialized.inputNodes).toEqual([]);
+      expect(node.attrs.partitionColumns).toBeUndefined();
     });
   });
 
@@ -879,54 +957,55 @@ describe('IntervalIntersectNode', () => {
         ),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       // Create ModifyColumnsNode with IntervalIntersectNode as input
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       modifyNode.onPrevNodesUpdated();
 
-      const selectedCols = modifyNode.state.selectedColumns;
+      const selectedCols = modifyNode.attrs.selectedColumns;
 
       // Verify ts column has TIMESTAMP type
       const tsCol = selectedCols.find((c) => c.name === 'ts');
       expect(tsCol).toBeDefined();
-      expect(tsCol?.column.type).toEqual({kind: 'timestamp'});
-      expect(tsCol?.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
+      expect(tsCol?.type).toEqual({kind: 'timestamp'});
+      expect(tsCol?.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
 
       // Verify dur column has DURATION type
       const durCol = selectedCols.find((c) => c.name === 'dur');
       expect(durCol).toBeDefined();
-      expect(durCol?.column.type).toEqual({kind: 'duration'});
-      expect(durCol?.column.type).toEqual(PerfettoSqlTypes.DURATION);
+      expect(durCol?.type).toEqual({kind: 'duration'});
+      expect(durCol?.type).toEqual(PerfettoSqlTypes.DURATION);
 
       // Verify ts_0 column has TIMESTAMP type
       const ts0Col = selectedCols.find((c) => c.name === 'ts_0');
       expect(ts0Col).toBeDefined();
-      expect(ts0Col?.column.type).toEqual({kind: 'timestamp'});
-      expect(ts0Col?.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
+      expect(ts0Col?.type).toEqual({kind: 'timestamp'});
+      expect(ts0Col?.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
 
       // Verify dur_0 column has DURATION type
       const dur0Col = selectedCols.find((c) => c.name === 'dur_0');
       expect(dur0Col).toBeDefined();
-      expect(dur0Col?.column.type).toEqual({kind: 'duration'});
-      expect(dur0Col?.column.type).toEqual(PerfettoSqlTypes.DURATION);
+      expect(dur0Col?.type).toEqual({kind: 'duration'});
+      expect(dur0Col?.type).toEqual(PerfettoSqlTypes.DURATION);
 
       // Verify ts_1 column has TIMESTAMP type
       const ts1Col = selectedCols.find((c) => c.name === 'ts_1');
       expect(ts1Col).toBeDefined();
-      expect(ts1Col?.column.type).toEqual({kind: 'timestamp'});
-      expect(ts1Col?.column.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
+      expect(ts1Col?.type).toEqual({kind: 'timestamp'});
+      expect(ts1Col?.type).toEqual(PerfettoSqlTypes.TIMESTAMP);
 
       // Verify dur_1 column has DURATION type
       const dur1Col = selectedCols.find((c) => c.name === 'dur_1');
       expect(dur1Col).toBeDefined();
-      expect(dur1Col?.column.type).toEqual({kind: 'duration'});
-      expect(dur1Col?.column.type).toEqual(PerfettoSqlTypes.DURATION);
+      expect(dur1Col?.type).toEqual({kind: 'duration'});
+      expect(dur1Col?.type).toEqual(PerfettoSqlTypes.DURATION);
     });
 
     it('should pass partition columns with original types to ModifyColumnsNode', () => {
@@ -959,25 +1038,26 @@ describe('IntervalIntersectNode', () => {
         createColumnInfoWithSqlType('utid', 'INT', PerfettoSqlTypes.INT),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid'],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       // Create ModifyColumnsNode with IntervalIntersectNode as input
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       modifyNode.onPrevNodesUpdated();
 
-      const selectedCols = modifyNode.state.selectedColumns;
+      const selectedCols = modifyNode.attrs.selectedColumns;
 
       // Verify utid column preserves its type
       const utidCol = selectedCols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.column.type).toEqual({kind: 'int'});
-      expect(utidCol?.column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(utidCol?.type).toEqual({kind: 'int'});
+      expect(utidCol?.type).toEqual(PerfettoSqlTypes.INT);
     });
 
     it('should pass all expected columns to ModifyColumnsNode', () => {
@@ -994,18 +1074,19 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('status', 'STRING'),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       // Create ModifyColumnsNode with IntervalIntersectNode as input
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       modifyNode.onPrevNodesUpdated();
 
-      const colNames = modifyNode.state.selectedColumns.map((c) => c.name);
+      const colNames = modifyNode.attrs.selectedColumns.map((c) => c.name);
 
       // Should have all expected columns
       expect(colNames).toContain('ts');
@@ -1056,34 +1137,35 @@ describe('IntervalIntersectNode', () => {
         ),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       // Create ModifyColumnsNode with IntervalIntersectNode as input
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       modifyNode.onPrevNodesUpdated();
 
-      const selectedCols = modifyNode.state.selectedColumns;
+      const selectedCols = modifyNode.attrs.selectedColumns;
 
       // Verify non-duplicated columns preserve their types
       const nameCol = selectedCols.find((c) => c.name === 'name');
       expect(nameCol).toBeDefined();
-      expect(nameCol?.column.type).toEqual({kind: 'string'});
-      expect(nameCol?.column.type).toEqual(PerfettoSqlTypes.STRING);
+      expect(nameCol?.type).toEqual({kind: 'string'});
+      expect(nameCol?.type).toEqual(PerfettoSqlTypes.STRING);
 
       const valueCol = selectedCols.find((c) => c.name === 'value');
       expect(valueCol).toBeDefined();
-      expect(valueCol?.column.type).toEqual({kind: 'double'});
-      expect(valueCol?.column.type).toEqual(PerfettoSqlTypes.DOUBLE);
+      expect(valueCol?.type).toEqual({kind: 'double'});
+      expect(valueCol?.type).toEqual(PerfettoSqlTypes.DOUBLE);
 
       const statusCol = selectedCols.find((c) => c.name === 'status');
       expect(statusCol).toBeDefined();
-      expect(statusCol?.column.type).toEqual({kind: 'string'});
-      expect(statusCol?.column.type).toEqual(PerfettoSqlTypes.STRING);
+      expect(statusCol?.type).toEqual({kind: 'string'});
+      expect(statusCol?.type).toEqual(PerfettoSqlTypes.STRING);
     });
 
     it('should have column.type set correctly on finalCols', () => {
@@ -1115,27 +1197,30 @@ describe('IntervalIntersectNode', () => {
         ),
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       const cols = intervalNode.finalCols;
 
       // Check ts column
       const tsCol = cols.find((c) => c.name === 'ts');
-      expect(tsCol?.column.type).toEqual({kind: 'timestamp'});
+      expect(tsCol?.type).toEqual({kind: 'timestamp'});
 
       // Check dur column
       const durCol = cols.find((c) => c.name === 'dur');
-      expect(durCol?.column.type).toEqual({kind: 'duration'});
+      expect(durCol?.type).toEqual({kind: 'duration'});
 
       // Check ts_0 column
       const ts0Col = cols.find((c) => c.name === 'ts_0');
-      expect(ts0Col?.column.type).toEqual({kind: 'timestamp'});
+      expect(ts0Col?.type).toEqual({kind: 'timestamp'});
 
       // Check dur_0 column
       const dur0Col = cols.find((c) => c.name === 'dur_0');
-      expect(dur0Col?.column.type).toEqual({kind: 'duration'});
+      expect(dur0Col?.type).toEqual({kind: 'duration'});
     });
 
     it('should propagate partition columns to ModifyColumnsNode when added after creation', () => {
@@ -1172,20 +1257,21 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       // Create IntervalIntersectNode WITHOUT partition columns initially
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       // Create ModifyColumnsNode with IntervalIntersectNode as input
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       intervalNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       // Verify initial columns (no partition columns yet)
-      let selectedCols = modifyNode.state.selectedColumns;
+      let selectedCols = modifyNode.attrs.selectedColumns;
       expect(selectedCols.find((c) => c.name === 'utid')).toBeUndefined();
       expect(selectedCols.find((c) => c.name === 'track_id')).toBeUndefined();
 
@@ -1194,25 +1280,25 @@ describe('IntervalIntersectNode', () => {
       expect(initialColCount).toBe(8);
 
       // NOW add partition columns to the interval intersect node
-      intervalNode.state.partitionColumns = ['utid', 'track_id'];
+      intervalNode.attrs.partitionColumns = ['utid', 'track_id'];
 
       // Notify downstream nodes about the column change
       notifyNextNodes(intervalNode);
-      intervalNode.state.onchange?.();
+      intervalNode.context.onchange?.();
 
       // Verify that ModifyColumnsNode received the updated columns including partitions
-      selectedCols = modifyNode.state.selectedColumns;
+      selectedCols = modifyNode.attrs.selectedColumns;
 
       // Should now include utid and track_id partition columns
       const utidCol = selectedCols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.column.type).toEqual({kind: 'int'});
-      expect(utidCol?.column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(utidCol?.type).toEqual({kind: 'int'});
+      expect(utidCol?.type).toEqual(PerfettoSqlTypes.INT);
 
       const trackIdCol = selectedCols.find((c) => c.name === 'track_id');
       expect(trackIdCol).toBeDefined();
-      expect(trackIdCol?.column.type).toEqual({kind: 'int'});
-      expect(trackIdCol?.column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(trackIdCol?.type).toEqual({kind: 'int'});
+      expect(trackIdCol?.type).toEqual(PerfettoSqlTypes.INT);
 
       // Verify the column count increased by 2 (the 2 partition columns)
       expect(selectedCols.length).toBe(initialColCount + 2);
@@ -1248,23 +1334,26 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       // Create IntervalIntersectNode with partition columns that DON'T exist
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid', 'track_id'], // These columns don't exist!
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid', 'track_id'], // These columns don't exist!
+        },
+        {},
+      );
 
       const cols = intervalNode.finalCols;
 
       // Should still create partition columns, but with 'NA' type as fallback
       const utidCol = cols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.column.type).toBeUndefined();
-      expect(utidCol?.column.type).toBeUndefined();
+      expect(utidCol?.type).toBeUndefined();
+      expect(utidCol?.type).toBeUndefined();
 
       const trackIdCol = cols.find((c) => c.name === 'track_id');
       expect(trackIdCol).toBeDefined();
-      expect(trackIdCol?.column.type).toBeUndefined();
-      expect(trackIdCol?.column.type).toBeUndefined();
+      expect(trackIdCol?.type).toBeUndefined();
+      expect(trackIdCol?.type).toBeUndefined();
     });
 
     it('should use first input node type for partition columns when types differ', () => {
@@ -1298,18 +1387,21 @@ describe('IntervalIntersectNode', () => {
         createColumnInfoWithSqlType('utid', 'STRING', PerfettoSqlTypes.STRING), // Different type!
       ]);
 
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        partitionColumns: ['utid'],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          partitionColumns: ['utid'],
+        },
+        {},
+      );
 
       const cols = intervalNode.finalCols;
 
       // Should use the type from the FIRST input node
       const utidCol = cols.find((c) => c.name === 'utid');
       expect(utidCol).toBeDefined();
-      expect(utidCol?.column.type).toEqual({kind: 'int'}); // From node1, not STRING from node2
-      expect(utidCol?.column.type).toEqual(PerfettoSqlTypes.INT);
+      expect(utidCol?.type).toEqual({kind: 'int'}); // From node1, not STRING from node2
+      expect(utidCol?.type).toEqual(PerfettoSqlTypes.INT);
     });
 
     it('should handle empty input nodes gracefully', () => {
@@ -1329,9 +1421,12 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       // Test edge case: undefined input node (implementation handles this gracefully)
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, undefined] as QueryNode[],
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, undefined] as QueryNode[],
+        },
+        {},
+      );
 
       const cols = intervalNode.finalCols;
 
@@ -1359,9 +1454,12 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       // Test with default (intersection) - no id column
-      const nodeDefault = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-      });
+      const nodeDefault = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+        },
+        {},
+      );
 
       let cols = nodeDefault.finalCols;
       let colNames = cols.map((c) => c.name);
@@ -1377,10 +1475,13 @@ describe('IntervalIntersectNode', () => {
       expect(colNames).toContain('dur_1');
 
       // Test with tsDurSource = 0 - has id column
-      const nodeSource0 = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        tsDurSource: 0,
-      });
+      const nodeSource0 = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          tsDurSource: 0,
+        },
+        {},
+      );
 
       cols = nodeSource0.finalCols;
       colNames = cols.map((c) => c.name);
@@ -1396,10 +1497,13 @@ describe('IntervalIntersectNode', () => {
       expect(colNames).toContain('dur_1');
 
       // Test with tsDurSource = 1 - has id column
-      const nodeSource1 = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        tsDurSource: 1,
-      });
+      const nodeSource1 = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          tsDurSource: 1,
+        },
+        {},
+      );
 
       cols = nodeSource1.finalCols;
       colNames = cols.map((c) => c.name);
@@ -1427,16 +1531,19 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        tsDurSource: 1,
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          tsDurSource: 1,
+        },
+        {},
+      );
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
       expect(serialized.tsDurSource).toBe(1);
 
-      const deserialized = IntervalIntersectNode.deserializeState(serialized);
-      expect(deserialized.tsDurSource).toBe(1);
+      const restored = new IntervalIntersectNode(serialized, {});
+      expect(restored.attrs.tsDurSource).toBe(1);
     });
 
     it('should include tsDurSource in clone', () => {
@@ -1451,14 +1558,17 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        tsDurSource: 0,
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          tsDurSource: 0,
+        },
+        {},
+      );
 
       const cloned = node.clone() as IntervalIntersectNode;
 
-      expect(cloned.state.tsDurSource).toBe(0);
+      expect((cloned as IntervalIntersectNode).attrs.tsDurSource).toBe(0);
     });
 
     it('should update id column type when tsDurSource changes to different input', () => {
@@ -1474,23 +1584,26 @@ describe('IntervalIntersectNode', () => {
         createColumnInfo('dur', 'INT64'),
       ]);
 
-      const node = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        tsDurSource: 0, // Start with input 0
-      });
+      const node = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          tsDurSource: 0, // Start with input 0
+        },
+        {},
+      );
 
       // Check id type matches input 0
       let idCol = node.finalCols.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.column.type).toEqual({kind: 'int'});
+      expect(idCol?.type).toEqual({kind: 'int'});
 
       // Change to input 1
-      node.state.tsDurSource = 1;
+      node.attrs.tsDurSource = 1;
 
       // Check id type should now match input 1
       idCol = node.finalCols.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.column.type).toEqual({kind: 'string'});
+      expect(idCol?.type).toEqual({kind: 'string'});
     });
 
     it('should propagate id column type change to downstream ModifyColumnsNode when tsDurSource changes', () => {
@@ -1523,32 +1636,33 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       // Create IntervalIntersectNode with tsDurSource = 0
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        tsDurSource: 0,
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          tsDurSource: 0,
+        },
+        {},
+      );
 
       // Create ModifyColumnsNode downstream
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       intervalNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       // Verify id column has INT type from input 0
-      let idCol = modifyNode.state.selectedColumns.find((c) => c.name === 'id');
+      let idCol = modifyNode.attrs.selectedColumns.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.column.type).toEqual({kind: 'int'});
+      expect(idCol?.type).toEqual({kind: 'int'});
 
       // Change tsDurSource to input 1
-      intervalNode.state.tsDurSource = 1;
+      intervalNode.attrs.tsDurSource = 1;
       notifyNextNodes(intervalNode);
 
       // Verify id column type updated to STRING from input 1
-      idCol = modifyNode.state.selectedColumns.find((c) => c.name === 'id');
+      idCol = modifyNode.attrs.selectedColumns.find((c) => c.name === 'id');
       expect(idCol).toBeDefined();
-      expect(idCol?.column.type).toEqual({kind: 'string'});
+      expect(idCol?.type).toEqual({kind: 'string'});
     });
 
     it('should preserve user-modified type in ModifyColumnsNode when tsDurSource changes', () => {
@@ -1581,43 +1695,41 @@ describe('IntervalIntersectNode', () => {
       ]);
 
       // Create IntervalIntersectNode with tsDurSource = 0
-      const intervalNode = new IntervalIntersectNode({
-        inputNodes: [node1, node2],
-        tsDurSource: 0,
-      });
+      const intervalNode = new IntervalIntersectNode(
+        {
+          inputNodes: [node1, node2],
+          tsDurSource: 0,
+        },
+        {},
+      );
 
       // Create ModifyColumnsNode downstream
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       modifyNode.primaryInput = intervalNode;
       intervalNode.nextNodes.push(modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       // Simulate user manually changing the id column type to a custom type
       const customType: PerfettoSqlType = {kind: 'double'};
-      const idColIndex = modifyNode.state.selectedColumns.findIndex(
+      const idColIndex = modifyNode.attrs.selectedColumns.findIndex(
         (c) => c.name === 'id',
       );
-      modifyNode.state.selectedColumns[idColIndex] = {
-        ...modifyNode.state.selectedColumns[idColIndex],
-        column: {
-          ...modifyNode.state.selectedColumns[idColIndex].column,
-          type: customType,
-        },
+      modifyNode.attrs.selectedColumns[idColIndex] = {
+        ...modifyNode.attrs.selectedColumns[idColIndex],
+        type: customType,
         typeUserModified: true,
       };
 
       // Change tsDurSource to input 1
-      intervalNode.state.tsDurSource = 1;
+      intervalNode.attrs.tsDurSource = 1;
       notifyNextNodes(intervalNode);
 
       // Verify user-modified type is PRESERVED (not overwritten by STRING)
-      const idCol = modifyNode.state.selectedColumns.find(
+      const idCol = modifyNode.attrs.selectedColumns.find(
         (c) => c.name === 'id',
       );
       expect(idCol).toBeDefined();
-      expect(idCol?.column.type).toEqual(customType);
+      expect(idCol?.type).toEqual(customType);
       expect(idCol?.typeUserModified).toBe(true);
     });
   });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
@@ -15,19 +15,14 @@
 import m from 'mithril';
 import {
   QueryNode,
-  QueryNodeState,
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {getSecondaryInput} from '../graph_utils';
 import protos from '../../../../protos';
-import {
-  ColumnInfo,
-  legacyDeserializeType,
-  newColumnInfoList,
-} from '../column_info';
-import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
+import {ColumnInfo, legacyDeserializeType} from '../column_info';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
 import {Switch} from '../../../../widgets/switch';
@@ -41,34 +36,8 @@ import {NodeTitle} from '../node_styling_widgets';
 import {JoinConditionSelector, JoinConditionDisplay} from '../join_widgets';
 import {ResizableSqlEditor} from '../widgets';
 
-export interface JoinSerializedState {
-  leftQueryAlias: string;
-  rightQueryAlias: string;
-  conditionType: 'equality' | 'freeform';
-  joinType?: 'INNER' | 'LEFT';
-  leftColumn?: string;
-  rightColumn?: string;
-  sqlExpression?: string;
-  comment?: string;
-  leftColumns?: {
-    name: string;
-    type?: PerfettoSqlType;
-    checked: boolean;
-    alias?: string;
-    columnName: string; // Original source column name
-  }[];
-  rightColumns?: {
-    name: string;
-    type?: PerfettoSqlType;
-    checked: boolean;
-    alias?: string;
-    columnName: string; // Original source column name
-  }[];
-}
-
-export interface JoinNodeState extends QueryNodeState {
-  leftNode?: QueryNode;
-  rightNode?: QueryNode;
+// Serializable node configuration.
+export interface JoinNodeAttrs {
   leftQueryAlias: string;
   rightQueryAlias: string;
   conditionType: 'equality' | 'freeform';
@@ -86,7 +55,8 @@ export class JoinNode implements QueryNode {
   readonly type = NodeType.kJoin;
   secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
-  readonly state: JoinNodeState;
+  readonly attrs: JoinNodeAttrs;
+  readonly context: NodeContext;
 
   get leftNode(): QueryNode | undefined {
     return getSecondaryInput(this, 0);
@@ -97,40 +67,33 @@ export class JoinNode implements QueryNode {
   }
 
   get finalCols(): ColumnInfo[] {
-    // Return only checked columns from both left and right sources
     const result: ColumnInfo[] = [];
-
-    // Add checked columns from left
-    for (const col of this.state.leftColumns ?? []) {
-      if (col.checked) {
-        result.push(col);
-      }
+    for (const col of this.attrs.leftColumns ?? []) {
+      if (col.checked) result.push(col);
     }
-
-    // Add checked columns from right
-    for (const col of this.state.rightColumns ?? []) {
-      if (col.checked) {
-        result.push(col);
-      }
+    for (const col of this.attrs.rightColumns ?? []) {
+      if (col.checked) result.push(col);
     }
-
     return result;
   }
 
-  constructor(state: JoinNodeState) {
+  constructor(attrs: JoinNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...state,
-      autoExecute: state.autoExecute ?? false,
-      leftQueryAlias: state.leftQueryAlias ?? 'left',
-      rightQueryAlias: state.rightQueryAlias ?? 'right',
-      conditionType: state.conditionType ?? 'equality',
-      joinType: state.joinType ?? 'INNER',
-      leftColumn: state.leftColumn ?? '',
-      rightColumn: state.rightColumn ?? '',
-      sqlExpression: state.sqlExpression ?? '',
-      leftColumns: state.leftColumns ?? [],
-      rightColumns: state.rightColumns ?? [],
+    this.attrs = {
+      ...attrs,
+      leftQueryAlias: attrs.leftQueryAlias ?? 'left',
+      rightQueryAlias: attrs.rightQueryAlias ?? 'right',
+      conditionType: attrs.conditionType ?? 'equality',
+      joinType: attrs.joinType ?? 'INNER',
+      leftColumn: attrs.leftColumn ?? '',
+      rightColumn: attrs.rightColumn ?? '',
+      sqlExpression: attrs.sqlExpression ?? '',
+      leftColumns: attrs.leftColumns ?? [],
+      rightColumns: attrs.rightColumns ?? [],
+    };
+    this.context = {
+      ...context,
+      autoExecute: context.autoExecute ?? false,
     };
     this.secondaryInputs = {
       connections: new Map(),
@@ -138,16 +101,9 @@ export class JoinNode implements QueryNode {
       max: 2,
       portNames: (portIndex: number) =>
         portIndex === 0
-          ? this.state.leftQueryAlias
-          : this.state.rightQueryAlias,
+          ? this.attrs.leftQueryAlias
+          : this.attrs.rightQueryAlias,
     };
-    // Initialize connections from state
-    if (state.leftNode) {
-      this.secondaryInputs.connections.set(0, state.leftNode);
-    }
-    if (state.rightNode) {
-      this.secondaryInputs.connections.set(1, state.rightNode);
-    }
     this.nextNodes = [];
 
     // Initialize column arrays from connected nodes if empty
@@ -156,8 +112,8 @@ export class JoinNode implements QueryNode {
     // we should preserve them. updateColumnArrays() will be called later
     // when connections are restored via onPrevNodesUpdated()
     if (
-      (!this.state.leftColumns || this.state.leftColumns.length === 0) &&
-      (!this.state.rightColumns || this.state.rightColumns.length === 0)
+      (!this.attrs.leftColumns || this.attrs.leftColumns.length === 0) &&
+      (!this.attrs.rightColumns || this.attrs.rightColumns.length === 0)
     ) {
       this.updateColumnArrays();
     }
@@ -170,69 +126,47 @@ export class JoinNode implements QueryNode {
 
   // Update column arrays when nodes change or on initialization
   private updateColumnArrays() {
-    // Update left columns if left node is connected
+    const buildDescriptors = (
+      sourceCols: ColumnInfo[],
+      existing: ColumnInfo[],
+    ): ColumnInfo[] => {
+      const isFirstInit = existing.length === 0;
+      return sourceCols.map((col) => {
+        const oldCol = existing.find((c) => c.name === col.name);
+        return {
+          name: col.name,
+          type: col.type,
+          description: col.description,
+          checked: isFirstInit ? false : oldCol?.checked ?? false,
+          alias: oldCol?.alias,
+          typeUserModified: oldCol?.typeUserModified,
+        };
+      });
+    };
+
     if (this.leftNode) {
-      const sourceCols = this.leftNode.finalCols;
-      const newLeftColumns = newColumnInfoList(sourceCols);
-
-      // Preserve checked status and aliases for columns that still exist
-      const existingLeftColumns = this.state.leftColumns ?? [];
-      for (const oldCol of existingLeftColumns) {
-        const newCol = newLeftColumns.find(
-          (c) => c.column.name === oldCol.column.name,
-        );
-        if (newCol) {
-          newCol.checked = oldCol.checked;
-          newCol.alias = oldCol.alias;
-        }
-      }
-
-      // Default all to unchecked if this is first initialization
-      if (existingLeftColumns.length === 0) {
-        for (const col of newLeftColumns) {
-          col.checked = false;
-        }
-      }
-
-      this.state.leftColumns = newLeftColumns;
+      this.attrs.leftColumns = buildDescriptors(
+        this.leftNode.finalCols,
+        this.attrs.leftColumns ?? [],
+      );
     } else {
-      this.state.leftColumns = [];
+      this.attrs.leftColumns = [];
     }
 
-    // Update right columns if right node is connected
     if (this.rightNode) {
-      const sourceCols = this.rightNode.finalCols;
-      const newRightColumns = newColumnInfoList(sourceCols);
-
-      // Preserve checked status and aliases for columns that still exist
-      const existingRightColumns = this.state.rightColumns ?? [];
-      for (const oldCol of existingRightColumns) {
-        const newCol = newRightColumns.find(
-          (c) => c.column.name === oldCol.column.name,
-        );
-        if (newCol) {
-          newCol.checked = oldCol.checked;
-          newCol.alias = oldCol.alias;
-        }
-      }
-
-      // Default all to unchecked if this is first initialization
-      if (existingRightColumns.length === 0) {
-        for (const col of newRightColumns) {
-          col.checked = false;
-        }
-      }
-
-      this.state.rightColumns = newRightColumns;
+      this.attrs.rightColumns = buildDescriptors(
+        this.rightNode.finalCols,
+        this.attrs.rightColumns ?? [],
+      );
     } else {
-      this.state.rightColumns = [];
+      this.attrs.rightColumns = [];
     }
   }
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (
@@ -246,22 +180,22 @@ export class JoinNode implements QueryNode {
       return false;
     }
 
-    if (!this.state.leftQueryAlias || !this.state.rightQueryAlias) {
+    if (!this.attrs.leftQueryAlias || !this.attrs.rightQueryAlias) {
       this.setValidationError(
         'Both left and right query aliases are required.',
       );
       return false;
     }
 
-    if (this.state.conditionType === 'equality') {
-      if (!this.state.leftColumn || !this.state.rightColumn) {
+    if (this.attrs.conditionType === 'equality') {
+      if (!this.attrs.leftColumn || !this.attrs.rightColumn) {
         this.setValidationError(
           'Both left and right columns are required for equality join.',
         );
         return false;
       }
     } else {
-      if (!this.state.sqlExpression) {
+      if (!this.attrs.sqlExpression) {
         this.setValidationError(
           'SQL expression for join condition is required.',
         );
@@ -271,7 +205,7 @@ export class JoinNode implements QueryNode {
 
     if (!this.leftNode.validate()) {
       this.setValidationError(
-        this.leftNode.state.issues?.queryError?.message ??
+        this.leftNode.context.issues?.queryError?.message ??
           `Left node '${this.leftNode.getTitle()}' is invalid`,
       );
       return false;
@@ -279,15 +213,15 @@ export class JoinNode implements QueryNode {
 
     if (!this.rightNode.validate()) {
       this.setValidationError(
-        this.rightNode.state.issues?.queryError?.message ??
+        this.rightNode.context.issues?.queryError?.message ??
           `Right node '${this.rightNode.getTitle()}' is invalid`,
       );
       return false;
     }
 
     // Check if there are any columns selected
-    const leftColumns = this.state.leftColumns ?? [];
-    const rightColumns = this.state.rightColumns ?? [];
+    const leftColumns = this.attrs.leftColumns ?? [];
+    const rightColumns = this.attrs.rightColumns ?? [];
     const hasCheckedColumns =
       leftColumns.some((c) => c.checked) || rightColumns.some((c) => c.checked);
 
@@ -302,10 +236,10 @@ export class JoinNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -319,20 +253,20 @@ export class JoinNode implements QueryNode {
   nodeDetails(): NodeDetailsAttrs {
     let content: m.Children;
 
-    if (this.state.conditionType === 'equality') {
-      if (this.state.leftColumn && this.state.rightColumn) {
+    if (this.attrs.conditionType === 'equality') {
+      if (this.attrs.leftColumn && this.attrs.rightColumn) {
         content = m(JoinConditionDisplay, {
-          leftAlias: this.state.leftQueryAlias,
-          rightAlias: this.state.rightQueryAlias,
-          leftColumn: this.state.leftColumn,
-          rightColumn: this.state.rightColumn,
+          leftAlias: this.attrs.leftQueryAlias,
+          rightAlias: this.attrs.rightQueryAlias,
+          leftColumn: this.attrs.leftColumn,
+          rightColumn: this.attrs.rightColumn,
         });
       } else {
         content = m('.pf-exp-node-details-message', 'No condition set');
       }
     } else {
-      if (this.state.sqlExpression) {
-        content = m('code.pf-exp-sql-expression', this.state.sqlExpression);
+      if (this.attrs.sqlExpression) {
+        content = m('code.pf-exp-sql-expression', this.attrs.sqlExpression);
       } else {
         content = m('.pf-exp-node-details-message', 'No condition set');
       }
@@ -345,7 +279,7 @@ export class JoinNode implements QueryNode {
 
   nodeSpecificModify(): NodeModifyAttrs {
     this.validate();
-    const error = this.state.issues?.queryError;
+    const error = this.context.issues?.queryError;
 
     const sections: NodeModifyAttrs['sections'] = [];
     const bottomRightButtons: NodeModifyAttrs['bottomRightButtons'] = [];
@@ -361,12 +295,12 @@ export class JoinNode implements QueryNode {
     sections.push({
       title: 'Join Type',
       content: m(Switch, {
-        checked: this.state.joinType === 'LEFT',
+        checked: this.attrs.joinType === 'LEFT',
         label: 'Left Join',
         onchange: (e: Event) => {
           const target = e.target as HTMLInputElement;
-          this.state.joinType = target.checked ? 'LEFT' : 'INNER';
-          this.state.onchange?.();
+          this.attrs.joinType = target.checked ? 'LEFT' : 'INNER';
+          this.context.onchange?.();
         },
       }),
     });
@@ -374,57 +308,57 @@ export class JoinNode implements QueryNode {
     // Join condition section with integrated column selection
     sections.push({
       content:
-        this.state.conditionType === 'equality'
+        this.attrs.conditionType === 'equality'
           ? m(JoinConditionSelector, {
               leftLabel: 'Left',
               rightLabel: 'Right',
-              leftColumns: this.state.leftColumns ?? [],
-              rightColumns: this.state.rightColumns ?? [],
-              leftColumn: this.state.leftColumn,
-              rightColumn: this.state.rightColumn,
+              leftColumns: this.attrs.leftColumns ?? [],
+              rightColumns: this.attrs.rightColumns ?? [],
+              leftColumn: this.attrs.leftColumn,
+              rightColumn: this.attrs.rightColumn,
               onLeftColumnChange: (columnName: string) => {
-                this.state.leftColumn = columnName;
-                this.state.onchange?.();
+                this.attrs.leftColumn = columnName;
+                this.context.onchange?.();
               },
               onRightColumnChange: (columnName: string) => {
-                this.state.rightColumn = columnName;
-                this.state.onchange?.();
+                this.attrs.rightColumn = columnName;
+                this.context.onchange?.();
               },
               onLeftColumnToggle: (index: number, checked: boolean) => {
-                if (this.state.leftColumns) {
-                  this.state.leftColumns[index].checked = checked;
-                  this.state.onchange?.();
+                if (this.attrs.leftColumns) {
+                  this.attrs.leftColumns[index].checked = checked;
+                  this.context.onchange?.();
                 }
               },
               onRightColumnToggle: (index: number, checked: boolean) => {
-                if (this.state.rightColumns) {
-                  this.state.rightColumns[index].checked = checked;
-                  this.state.onchange?.();
+                if (this.attrs.rightColumns) {
+                  this.attrs.rightColumns[index].checked = checked;
+                  this.context.onchange?.();
                 }
               },
               onLeftColumnAlias: (index: number, alias: string) => {
-                if (this.state.leftColumns) {
-                  this.state.leftColumns[index].alias =
+                if (this.attrs.leftColumns) {
+                  this.attrs.leftColumns[index].alias =
                     alias.trim() === '' ? undefined : alias;
-                  this.state.onchange?.();
+                  this.context.onchange?.();
                 }
               },
               onRightColumnAlias: (index: number, alias: string) => {
-                if (this.state.rightColumns) {
-                  this.state.rightColumns[index].alias =
+                if (this.attrs.rightColumns) {
+                  this.attrs.rightColumns[index].alias =
                     alias.trim() === '' ? undefined : alias;
-                  this.state.onchange?.();
+                  this.context.onchange?.();
                 }
               },
             })
           : m(ResizableSqlEditor, {
-              sql: this.state.sqlExpression,
+              sql: this.attrs.sqlExpression,
               onUpdate: (text: string) => {
-                this.state.sqlExpression = text;
+                this.attrs.sqlExpression = text;
                 m.redraw();
               },
               onExecute: (text: string) => {
-                this.state.sqlExpression = text.trim();
+                this.attrs.sqlExpression = text.trim();
                 m.redraw();
               },
             }),
@@ -433,16 +367,16 @@ export class JoinNode implements QueryNode {
     // Mode switch button
     bottomRightButtons.push({
       label:
-        this.state.conditionType === 'equality'
+        this.attrs.conditionType === 'equality'
           ? 'Switch to freeform SQL'
           : 'Switch to equality',
-      icon: this.state.conditionType === 'equality' ? 'code' : 'view_column',
+      icon: this.attrs.conditionType === 'equality' ? 'code' : 'view_column',
       onclick: () => {
-        this.state.conditionType =
-          this.state.conditionType === 'equality' ? 'freeform' : 'equality';
+        this.attrs.conditionType =
+          this.attrs.conditionType === 'equality' ? 'freeform' : 'equality';
         // Disable auto-execute in freeform SQL mode
-        this.state.autoExecute = this.state.conditionType === 'equality';
-        this.state.onchange?.();
+        this.context.autoExecute = this.attrs.conditionType === 'equality';
+        this.context.onchange?.();
       },
       compact: true,
     });
@@ -455,48 +389,37 @@ export class JoinNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: JoinNodeState = {
-      leftNode: this.leftNode,
-      rightNode: this.rightNode,
-      onchange: this.state.onchange,
-      leftQueryAlias: this.state.leftQueryAlias,
-      rightQueryAlias: this.state.rightQueryAlias,
-      conditionType: this.state.conditionType,
-      joinType: this.state.joinType,
-      leftColumn: this.state.leftColumn,
-      rightColumn: this.state.rightColumn,
-      sqlExpression: this.state.sqlExpression,
-      leftColumns: this.state.leftColumns
-        ? newColumnInfoList(this.state.leftColumns)
-        : undefined,
-      rightColumns: this.state.rightColumns
-        ? newColumnInfoList(this.state.rightColumns)
-        : undefined,
-    };
-    return new JoinNode(stateCopy);
+    return new JoinNode(
+      {
+        ...this.attrs,
+        leftColumns: this.attrs.leftColumns?.map((c) => ({...c})),
+        rightColumns: this.attrs.rightColumns?.map((c) => ({...c})),
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (!this.validate() || !this.leftNode || !this.rightNode) return;
 
     const condition: JoinCondition =
-      this.state.conditionType === 'equality'
+      this.attrs.conditionType === 'equality'
         ? {
             type: 'equality',
-            leftColumn: this.state.leftColumn,
-            rightColumn: this.state.rightColumn,
+            leftColumn: this.attrs.leftColumn,
+            rightColumn: this.attrs.rightColumn,
           }
         : {
             type: 'freeform',
-            leftQueryAlias: this.state.leftQueryAlias,
-            rightQueryAlias: this.state.rightQueryAlias,
-            sqlExpression: this.state.sqlExpression,
+            leftQueryAlias: this.attrs.leftQueryAlias,
+            rightQueryAlias: this.attrs.rightQueryAlias,
+            sqlExpression: this.attrs.sqlExpression,
           };
 
     const sq = StructuredQueryBuilder.withJoin(
       this.leftNode,
       this.rightNode,
-      this.state.joinType,
+      this.attrs.joinType,
       condition,
       this.nodeId,
     );
@@ -507,7 +430,7 @@ export class JoinNode implements QueryNode {
     // Include aliases if specified
     sq.selectColumns = this.finalCols.map((col) => {
       const selectCol = new protos.PerfettoSqlStructuredQuery.SelectColumn();
-      selectCol.columnNameOrExpression = col.column.name;
+      selectCol.columnNameOrExpression = col.name;
       if (col.alias) {
         selectCol.alias = col.alias;
       }
@@ -517,61 +440,32 @@ export class JoinNode implements QueryNode {
     return sq;
   }
 
-  serializeState(): JoinSerializedState {
-    return {
-      leftQueryAlias: this.state.leftQueryAlias,
-      rightQueryAlias: this.state.rightQueryAlias,
-      conditionType: this.state.conditionType,
-      joinType: this.state.joinType,
-      leftColumn: this.state.leftColumn,
-      rightColumn: this.state.rightColumn,
-      sqlExpression: this.state.sqlExpression,
-      leftColumns: (this.state.leftColumns ?? []).map((c) => ({
-        name: c.name,
-        type: c.column.type,
+  static deserializeState(attrs: JoinNodeAttrs): JoinNodeAttrs {
+    // Migrate legacy columnName field and string types
+    const migrateColumns = (
+      cols?: (ColumnInfo & {columnName?: string})[],
+    ): ColumnInfo[] =>
+      (cols ?? []).map((c) => ({
+        name: c.columnName ?? c.name,
+        type: legacyDeserializeType(c.type),
         checked: c.checked,
         alias: c.alias,
-        columnName: c.column.name, // Save original source column name
-      })),
-      rightColumns: (this.state.rightColumns ?? []).map((c) => ({
-        name: c.name,
-        type: c.column.type,
-        checked: c.checked,
-        alias: c.alias,
-        columnName: c.column.name, // Save original source column name
-      })),
-    };
-  }
+        typeUserModified: c.typeUserModified,
+      }));
 
-  static deserializeState(state: JoinSerializedState): JoinNodeState {
     return {
-      leftQueryAlias: state.leftQueryAlias,
-      rightQueryAlias: state.rightQueryAlias,
-      conditionType: state.conditionType ?? 'equality',
-      joinType: state.joinType ?? 'INNER',
-      leftColumn: state.leftColumn ?? '',
-      rightColumn: state.rightColumn ?? '',
-      sqlExpression: state.sqlExpression ?? '',
-      leftColumns:
-        state.leftColumns?.map((c) => ({
-          name: c.name,
-          checked: c.checked,
-          column: {
-            name: c.columnName ?? c.name,
-            type: legacyDeserializeType(c.type),
-          },
-          alias: c.alias,
-        })) ?? [],
-      rightColumns:
-        state.rightColumns?.map((c) => ({
-          name: c.name,
-          checked: c.checked,
-          column: {
-            name: c.columnName ?? c.name,
-            type: legacyDeserializeType(c.type),
-          },
-          alias: c.alias,
-        })) ?? [],
+      ...attrs,
+      conditionType: attrs.conditionType ?? 'equality',
+      joinType: attrs.joinType ?? 'INNER',
+      leftColumn: attrs.leftColumn ?? '',
+      rightColumn: attrs.rightColumn ?? '',
+      sqlExpression: attrs.sqlExpression ?? '',
+      leftColumns: migrateColumns(
+        attrs.leftColumns as (ColumnInfo & {columnName?: string})[],
+      ),
+      rightColumns: migrateColumns(
+        attrs.rightColumns as (ColumnInfo & {columnName?: string})[],
+      ),
     };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {JoinNode, JoinSerializedState} from './join_node';
+import {JoinNode, JoinNodeAttrs} from './join_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
@@ -25,7 +25,8 @@ describe('JoinNode', () => {
       type: NodeType.kTable,
       nextNodes: [],
       finalCols: columns,
-      state: {},
+      attrs: {},
+      context: {},
       validate: () => true,
       getTitle: () => `Mock ${id}`,
       nodeSpecificModify: () => null,
@@ -33,7 +34,6 @@ describe('JoinNode', () => {
       nodeInfo: () => null,
       clone: () => createMockPrevNode(id, columns),
       getStructuredQuery: () => undefined,
-      serializeState: () => ({}),
     } as QueryNode;
   }
 
@@ -45,19 +45,62 @@ describe('JoinNode', () => {
     return {
       name,
       checked,
-      column: {name},
     };
   }
 
   // Helper to create pre-checked column arrays for join node state
   function createCheckedColumns(
-    columns: Array<{name: string; type: string; checked?: boolean}>,
+    columns: Array<{name: string; type?: string; checked?: boolean}>,
   ): ColumnInfo[] {
     return columns.map((c) => ({
       name: c.name,
       checked: c.checked ?? true,
-      column: {name: c.name},
     }));
+  }
+
+  // Helper to create a JoinNode and connect left/right secondary inputs
+  function createJoinNodeWithInputs(
+    leftNode: QueryNode | undefined,
+    rightNode: QueryNode | undefined,
+    attrs: Partial<{
+      leftQueryAlias: string;
+      rightQueryAlias: string;
+      conditionType: 'equality' | 'freeform';
+      joinType: 'INNER' | 'LEFT';
+      leftColumn: string;
+      rightColumn: string;
+      sqlExpression: string;
+      leftColumns: ColumnInfo[] | undefined;
+      rightColumns: ColumnInfo[] | undefined;
+    }>,
+    context: Record<string, unknown> = {},
+  ): JoinNode {
+    const node = new JoinNode(
+      {
+        leftQueryAlias: attrs.leftQueryAlias ?? 'left',
+        rightQueryAlias: attrs.rightQueryAlias ?? 'right',
+        conditionType: attrs.conditionType ?? 'equality',
+        joinType: attrs.joinType ?? 'INNER',
+        leftColumn: attrs.leftColumn ?? '',
+        rightColumn: attrs.rightColumn ?? '',
+        sqlExpression: attrs.sqlExpression ?? '',
+        leftColumns: attrs.leftColumns,
+        rightColumns: attrs.rightColumns,
+      },
+      context,
+    );
+    if (leftNode) {
+      node.secondaryInputs.connections.set(0, leftNode);
+      leftNode.nextNodes.push(node);
+    }
+    if (rightNode) {
+      node.secondaryInputs.connections.set(1, rightNode);
+      rightNode.nextNodes.push(node);
+    }
+    if (leftNode || rightNode) {
+      node.onPrevNodesUpdated?.();
+    }
+    return node;
   }
 
   describe('constructor', () => {
@@ -71,48 +114,54 @@ describe('JoinNode', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
-      expect(joinNode.state.leftQueryAlias).toBe('left');
-      expect(joinNode.state.rightQueryAlias).toBe('right');
-      expect(joinNode.state.conditionType).toBe('equality');
-      expect(joinNode.state.leftColumn).toBe('id');
-      expect(joinNode.state.rightColumn).toBe('id');
-      expect(joinNode.state.autoExecute).toBe(false);
+      expect(joinNode.attrs.leftQueryAlias).toBe('left');
+      expect(joinNode.attrs.rightQueryAlias).toBe('right');
+      expect(joinNode.attrs.conditionType).toBe('equality');
+      expect(joinNode.attrs.leftColumn).toBe('id');
+      expect(joinNode.attrs.rightColumn).toBe('id');
+      expect(joinNode.context.autoExecute).toBe(false);
     });
 
     it('should use default aliases when not provided', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: undefined!,
-        rightQueryAlias: undefined!,
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: undefined!,
+          rightQueryAlias: undefined!,
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
-      expect(joinNode.state.leftQueryAlias).toBe('left');
-      expect(joinNode.state.rightQueryAlias).toBe('right');
+      expect(joinNode.attrs.leftQueryAlias).toBe('left');
+      expect(joinNode.attrs.rightQueryAlias).toBe('right');
     });
   });
 
@@ -122,19 +171,22 @@ describe('JoinNode', () => {
         createColumnInfo('id', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: undefined,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        undefined,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.finalCols).toEqual([]);
     });
@@ -151,19 +203,22 @@ describe('JoinNode', () => {
 
       // When leftColumns/rightColumns are undefined, updateColumnArrays()
       // initializes all columns with checked: false
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       // All columns default to unchecked, so finalCols should be empty
       expect(joinNode.finalCols).toEqual([]);
@@ -178,25 +233,27 @@ describe('JoinNode', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'value',
-        sqlExpression: '',
-        // Pre-set leftColumns with only 'id' checked
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-          {name: 'name', type: 'STRING', checked: false},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'value', type: 'INT', checked: false},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'value',
+          sqlExpression: '', // Pre-set leftColumns with only 'id' checked
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+            {name: 'name', type: 'STRING', checked: false},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'value', type: 'INT', checked: false},
+          ]),
+        },
+        {},
+      );
 
       const finalCols = joinNode.finalCols;
       expect(finalCols.length).toBe(1);
@@ -212,24 +269,27 @@ describe('JoinNode', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'parent_id',
-        sqlExpression: '',
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: false},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'parent_id', type: 'INT', checked: true},
-          {name: 'value', type: 'INT', checked: true},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'parent_id',
+          sqlExpression: '',
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: false},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'parent_id', type: 'INT', checked: true},
+            {name: 'value', type: 'INT', checked: true},
+          ]),
+        },
+        {},
+      );
 
       const finalCols = joinNode.finalCols;
       const colNames = finalCols.map((c: ColumnInfo) => c.name);
@@ -250,26 +310,29 @@ describe('JoinNode', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'parent_id',
-        sqlExpression: '',
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-          {name: 'name', type: 'STRING', checked: false},
-          {name: 'ts', type: 'INT64', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'parent_id', type: 'INT', checked: false},
-          {name: 'value', type: 'INT', checked: true},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'parent_id',
+          sqlExpression: '',
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+            {name: 'name', type: 'STRING', checked: false},
+            {name: 'ts', type: 'INT64', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'parent_id', type: 'INT', checked: false},
+            {name: 'value', type: 'INT', checked: true},
+          ]),
+        },
+        {},
+      );
 
       const finalCols = joinNode.finalCols;
       const colNames = finalCols.map((c: ColumnInfo) => c.name);
@@ -286,19 +349,22 @@ describe('JoinNode', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.finalCols).toEqual([]);
     });
@@ -312,24 +378,27 @@ describe('JoinNode', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'value',
-        sqlExpression: '',
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-          {name: 'name', type: 'STRING', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'value', type: 'INT', checked: true},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'value',
+          sqlExpression: '',
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+            {name: 'name', type: 'STRING', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'value', type: 'INT', checked: true},
+          ]),
+        },
+        {},
+      );
 
       const finalCols = joinNode.finalCols;
 
@@ -354,19 +423,22 @@ describe('JoinNode', () => {
       ]);
       rightCols[0].alias = 'right_id';
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: leftCols,
-        rightColumns: rightCols,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: leftCols,
+          rightColumns: rightCols,
+        },
+        {},
+      );
 
       const finalCols = joinNode.finalCols;
 
@@ -380,22 +452,25 @@ describe('JoinNode', () => {
     it('should fail when only one node is provided', () => {
       const node1 = createMockPrevNode('node1', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: undefined,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        undefined,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.validate()).toBe(false);
-      expect(joinNode.state.issues?.queryError?.message).toContain(
+      expect(joinNode.context.issues?.queryError?.message).toContain(
         'exactly two sources',
       );
     });
@@ -408,24 +483,26 @@ describe('JoinNode', () => {
         createColumnInfo('id', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: undefined!,
-        rightQueryAlias: undefined!,
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        // Provide checked columns for validation to pass
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: false},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: undefined!,
+          rightQueryAlias: undefined!,
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '', // Provide checked columns for validation to pass
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: false},
+          ]),
+        },
+        {},
+      );
 
       // Constructor sets default aliases to 'left' and 'right', so this should pass
       expect(joinNode.validate()).toBe(true);
@@ -435,22 +512,25 @@ describe('JoinNode', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.validate()).toBe(false);
-      expect(joinNode.state.issues?.queryError?.message).toContain(
+      expect(joinNode.context.issues?.queryError?.message).toContain(
         'Both left and right columns are required',
       );
     });
@@ -459,22 +539,25 @@ describe('JoinNode', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'freeform',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'freeform',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.validate()).toBe(false);
-      expect(joinNode.state.issues?.queryError?.message).toContain(
+      expect(joinNode.context.issues?.queryError?.message).toContain(
         'SQL expression',
       );
     });
@@ -487,24 +570,26 @@ describe('JoinNode', () => {
         createColumnInfo('id', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        // Provide at least one checked column
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: false},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '', // Provide at least one checked column
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: false},
+          ]),
+        },
+        {},
+      );
 
       expect(joinNode.validate()).toBe(true);
     });
@@ -519,29 +604,31 @@ describe('JoinNode', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        // All columns unchecked
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: false},
-          {name: 'name', type: 'STRING', checked: false},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: false},
-          {name: 'value', type: 'INT', checked: false},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '', // All columns unchecked
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: false},
+            {name: 'name', type: 'STRING', checked: false},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: false},
+            {name: 'value', type: 'INT', checked: false},
+          ]),
+        },
+        {},
+      );
 
       expect(joinNode.validate()).toBe(false);
-      expect(joinNode.state.issues?.queryError?.message).toContain(
+      expect(joinNode.context.issues?.queryError?.message).toContain(
         'No columns selected',
       );
     });
@@ -557,22 +644,25 @@ describe('JoinNode', () => {
         createColumnInfo('value', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.validate()).toBe(false);
-      expect(joinNode.state.issues?.queryError?.message).toContain(
+      expect(joinNode.context.issues?.queryError?.message).toContain(
         'No columns selected',
       );
     });
@@ -585,24 +675,26 @@ describe('JoinNode', () => {
         createColumnInfo('parent_id', 'INT'),
       ]);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 't1',
-        rightQueryAlias: 't2',
-        conditionType: 'freeform',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: 't1.id = t2.parent_id',
-        // Provide at least one checked column
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'parent_id', type: 'INT', checked: true},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 't1',
+          rightQueryAlias: 't2',
+          conditionType: 'freeform',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: 't1.id = t2.parent_id', // Provide at least one checked column
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'parent_id', type: 'INT', checked: true},
+          ]),
+        },
+        {},
+      );
 
       expect(joinNode.validate()).toBe(true);
     });
@@ -613,19 +705,22 @@ describe('JoinNode', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.getTitle()).toBe('Join');
     });
@@ -636,19 +731,22 @@ describe('JoinNode', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'foo',
-        rightQueryAlias: 'bar',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'foo',
+          rightQueryAlias: 'bar',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       const portNames = joinNode.secondaryInputs.portNames;
       expect(typeof portNames).toBe('function');
@@ -664,55 +762,61 @@ describe('JoinNode', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       const cloned = joinNode.clone() as JoinNode;
 
       expect(cloned).not.toBe(joinNode);
-      expect(cloned.state.leftQueryAlias).toBe('left');
-      expect(cloned.state.rightQueryAlias).toBe('right');
-      expect(cloned.state.conditionType).toBe('equality');
-      expect(cloned.state.leftColumn).toBe('id');
-      expect(cloned.state.rightColumn).toBe('id');
+      expect(cloned.attrs.leftQueryAlias).toBe('left');
+      expect(cloned.attrs.rightQueryAlias).toBe('right');
+      expect(cloned.attrs.conditionType).toBe('equality');
+      expect(cloned.attrs.leftColumn).toBe('id');
+      expect(cloned.attrs.rightColumn).toBe('id');
     });
 
     it('should not share state with original', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       const cloned = joinNode.clone() as JoinNode;
 
       // Modify the cloned state
-      cloned.state.leftQueryAlias = 'modified';
+      cloned.attrs.leftQueryAlias = 'modified';
 
       // Original should not be affected
-      expect(joinNode.state.leftQueryAlias).toBe('left');
+      expect(joinNode.attrs.leftQueryAlias).toBe('left');
     });
   });
 
@@ -720,19 +824,22 @@ describe('JoinNode', () => {
     it('should return undefined if validation fails', () => {
       const node1 = createMockPrevNode('node1', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: undefined,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        undefined,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
       expect(joinNode.getStructuredQuery()).toBeUndefined();
     });
@@ -758,26 +865,28 @@ describe('JoinNode', () => {
         getStructuredQuery: () => mockSq2,
       } as QueryNode;
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        // Provide checked columns
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-          {name: 'name', type: 'STRING', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: false},
-          {name: 'value', type: 'INT', checked: true},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '', // Provide checked columns
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+            {name: 'name', type: 'STRING', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: false},
+            {name: 'value', type: 'INT', checked: true},
+          ]),
+        },
+        {},
+      );
 
       const sq = joinNode.getStructuredQuery();
 
@@ -808,24 +917,26 @@ describe('JoinNode', () => {
         getStructuredQuery: () => mockSq2,
       } as QueryNode;
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        // Provide checked columns
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: false},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '', // Provide checked columns
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: false},
+          ]),
+        },
+        {},
+      );
 
       const sq = joinNode.getStructuredQuery();
 
@@ -851,24 +962,26 @@ describe('JoinNode', () => {
         getStructuredQuery: () => mockSq2,
       } as QueryNode;
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 't1',
-        rightQueryAlias: 't2',
-        conditionType: 'freeform',
-        joinType: 'INNER',
-        leftColumn: '',
-        rightColumn: '',
-        sqlExpression: 't1.id = t2.parent_id',
-        // Provide checked columns
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'parent_id', type: 'INT', checked: true},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 't1',
+          rightQueryAlias: 't2',
+          conditionType: 'freeform',
+          joinType: 'INNER',
+          leftColumn: '',
+          rightColumn: '',
+          sqlExpression: 't1.id = t2.parent_id', // Provide checked columns
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'parent_id', type: 'INT', checked: true},
+          ]),
+        },
+        {},
+      );
 
       const sq = joinNode.getStructuredQuery();
 
@@ -887,32 +1000,33 @@ describe('JoinNode', () => {
     });
   });
 
-  describe('serializeState', () => {
-    it('should serialize all state fields', () => {
+  describe('attrs serialization', () => {
+    it('should have all state fields in attrs', () => {
       const node1 = createMockPrevNode('node1', []);
       const node2 = createMockPrevNode('node2', []);
 
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: undefined,
+          rightColumns: undefined,
+        },
+        {},
+      );
 
-      const serialized = joinNode.serializeState();
-
-      expect(serialized.leftQueryAlias).toBe('left');
-      expect(serialized.rightQueryAlias).toBe('right');
-      expect(serialized.conditionType).toBe('equality');
-      expect(serialized.leftColumn).toBe('id');
-      expect(serialized.rightColumn).toBe('id');
+      expect(joinNode.attrs.leftQueryAlias).toBe('left');
+      expect(joinNode.attrs.rightQueryAlias).toBe('right');
+      expect(joinNode.attrs.conditionType).toBe('equality');
+      expect(joinNode.attrs.leftColumn).toBe('id');
+      expect(joinNode.attrs.rightColumn).toBe('id');
     });
   });
 
@@ -922,6 +1036,7 @@ describe('JoinNode', () => {
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality' as const,
+        joinType: 'INNER' as const,
         leftColumn: 'id',
         rightColumn: 'id',
         sqlExpression: '',
@@ -952,50 +1067,32 @@ describe('JoinNode', () => {
         rightColumns: [
           {name: 'val', type: 'DOUBLE', checked: true, columnName: 'val'},
         ],
-      } as unknown as JoinSerializedState;
+      } as unknown as JoinNodeAttrs;
 
       const state = JoinNode.deserializeState(legacySerialized);
 
-      expect(state.leftColumns?.[0].column.type).toEqual(PerfettoSqlTypes.INT);
-      expect(state.leftColumns?.[1].column.type).toEqual(
-        PerfettoSqlTypes.TIMESTAMP,
-      );
-      expect(state.rightColumns?.[0].column.type).toEqual(
-        PerfettoSqlTypes.DOUBLE,
-      );
+      expect(state.leftColumns?.[0].type).toEqual(PerfettoSqlTypes.INT);
+      expect(state.leftColumns?.[1].type).toEqual(PerfettoSqlTypes.TIMESTAMP);
+      expect(state.rightColumns?.[0].type).toEqual(PerfettoSqlTypes.DOUBLE);
     });
 
     it('should deserialize new PerfettoSqlType objects correctly', () => {
-      const newSerialized: JoinSerializedState = {
+      const newSerialized: JoinNodeAttrs = {
         leftQueryAlias: 'left',
         rightQueryAlias: 'right',
         conditionType: 'equality',
+        joinType: 'INNER',
         leftColumn: 'id',
         rightColumn: 'id',
-        leftColumns: [
-          {
-            name: 'id',
-            type: {kind: 'int'},
-            checked: true,
-            columnName: 'id',
-          },
-        ],
-        rightColumns: [
-          {
-            name: 'dur',
-            type: {kind: 'duration'},
-            checked: true,
-            columnName: 'dur',
-          },
-        ],
+        sqlExpression: '',
+        leftColumns: [{name: 'id', type: {kind: 'int'}, checked: true}],
+        rightColumns: [{name: 'dur', type: {kind: 'duration'}, checked: true}],
       };
 
       const state = JoinNode.deserializeState(newSerialized);
 
-      expect(state.leftColumns?.[0].column.type).toEqual(PerfettoSqlTypes.INT);
-      expect(state.rightColumns?.[0].column.type).toEqual(
-        PerfettoSqlTypes.DURATION,
-      );
+      expect(state.leftColumns?.[0].type).toEqual(PerfettoSqlTypes.INT);
+      expect(state.rightColumns?.[0].type).toEqual(PerfettoSqlTypes.DURATION);
     });
   });
 
@@ -1011,53 +1108,54 @@ describe('JoinNode', () => {
       ]);
 
       // Create a join node with specific columns checked
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'value',
-        sqlExpression: '',
-        leftColumns: createCheckedColumns([
-          {name: 'id', type: 'INT', checked: true},
-          {name: 'name', type: 'STRING', checked: false},
-        ]),
-        rightColumns: createCheckedColumns([
-          {name: 'value', type: 'INT', checked: true},
-        ]),
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'value',
+          sqlExpression: '',
+          leftColumns: createCheckedColumns([
+            {name: 'id', type: 'INT', checked: true},
+            {name: 'name', type: 'STRING', checked: false},
+          ]),
+          rightColumns: createCheckedColumns([
+            {name: 'value', type: 'INT', checked: true},
+          ]),
+        },
+        {},
+      );
 
       // Verify initial state
-      expect(joinNode.state.leftColumns?.[0].checked).toBe(true);
-      expect(joinNode.state.leftColumns?.[1].checked).toBe(false);
-      expect(joinNode.state.rightColumns?.[0].checked).toBe(true);
+      expect(joinNode.attrs.leftColumns?.[0].checked).toBe(true);
+      expect(joinNode.attrs.leftColumns?.[1].checked).toBe(false);
+      expect(joinNode.attrs.rightColumns?.[0].checked).toBe(true);
 
-      // Serialize the state
-      const serialized = joinNode.serializeState();
+      // Serialize the state via attrs
+      const serialized = joinNode.attrs;
 
       // Deserialize the state
       const deserializedState = JoinNode.deserializeState(serialized);
 
       // Create a new join node from deserialized state
       // Connections are now restored at the graph level by json_handler
-      const restoredNode = new JoinNode({
-        ...deserializedState,
-        leftNode: node1,
-        rightNode: node2,
-      });
+      const restoredNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {...deserializedState},
+        {},
+      );
 
-      // BUG: After deserialization and reconstruction, checked status is lost
-      // because updateColumnArrays() can't match columns properly
-      expect(restoredNode.state.leftColumns?.length).toBe(2);
-      expect(restoredNode.state.rightColumns?.length).toBe(1);
+      expect(restoredNode.attrs.leftColumns?.length).toBe(2);
+      expect(restoredNode.attrs.rightColumns?.length).toBe(1);
 
-      // These should pass but currently fail:
-      expect(restoredNode.state.leftColumns?.[0].checked).toBe(true);
-      expect(restoredNode.state.leftColumns?.[1].checked).toBe(false);
-      expect(restoredNode.state.rightColumns?.[0].checked).toBe(true);
+      expect(restoredNode.attrs.leftColumns?.[0].checked).toBe(true);
+      expect(restoredNode.attrs.leftColumns?.[1].checked).toBe(false);
+      expect(restoredNode.attrs.rightColumns?.[0].checked).toBe(true);
     });
 
     it('should preserve column aliases after serialization and deserialization', () => {
@@ -1081,43 +1179,46 @@ describe('JoinNode', () => {
       rightCols[0].alias = 'right_id';
 
       // Create a join node with aliases
-      const joinNode = new JoinNode({
-        leftNode: node1,
-        rightNode: node2,
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: leftCols,
-        rightColumns: rightCols,
-      });
+      const joinNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {
+          leftQueryAlias: 'left',
+          rightQueryAlias: 'right',
+          conditionType: 'equality',
+          joinType: 'INNER',
+          leftColumn: 'id',
+          rightColumn: 'id',
+          sqlExpression: '',
+          leftColumns: leftCols,
+          rightColumns: rightCols,
+        },
+        {},
+      );
 
       // Verify initial state has aliases
-      expect(joinNode.state.leftColumns?.[0].alias).toBe('left_id');
-      expect(joinNode.state.rightColumns?.[0].alias).toBe('right_id');
+      expect(joinNode.attrs.leftColumns?.[0].alias).toBe('left_id');
+      expect(joinNode.attrs.rightColumns?.[0].alias).toBe('right_id');
 
-      // Serialize the state
-      const serialized = joinNode.serializeState();
+      // Serialize the state via attrs
+      const serialized = joinNode.attrs;
 
       // Deserialize the state
       const deserializedState = JoinNode.deserializeState(serialized);
 
       // Create a new join node from deserialized state
       // Connections are now restored at the graph level by json_handler
-      const restoredNode = new JoinNode({
-        ...deserializedState,
-        leftNode: node1,
-        rightNode: node2,
-      });
+      const restoredNode = createJoinNodeWithInputs(
+        node1,
+        node2,
+        {...deserializedState},
+        {},
+      );
 
-      // BUG: Aliases and checked status are both lost after deserialization
-      expect(restoredNode.state.leftColumns?.[0].alias).toBe('left_id');
-      expect(restoredNode.state.rightColumns?.[0].alias).toBe('right_id');
-      expect(restoredNode.state.leftColumns?.[0].checked).toBe(true);
-      expect(restoredNode.state.rightColumns?.[0].checked).toBe(true);
+      expect(restoredNode.attrs.leftColumns?.[0].alias).toBe('left_id');
+      expect(restoredNode.attrs.rightColumns?.[0].alias).toBe('right_id');
+      expect(restoredNode.attrs.leftColumns?.[0].checked).toBe(true);
+      expect(restoredNode.attrs.rightColumns?.[0].checked).toBe(true);
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/limit_and_offset_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/limit_and_offset_node.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
 import {StructuredQueryBuilder} from '../structured_query_builder';
@@ -28,23 +23,29 @@ import {NodeDetailsAttrs, NodeModifyAttrs} from '../../node_types';
 import {createErrorSections} from '../widgets';
 import {loadNodeDoc} from '../node_doc_loader';
 
-export interface LimitAndOffsetNodeState extends QueryNodeState {
+// Serializable node configuration.
+export interface LimitAndOffsetNodeAttrs {
   limit?: number;
   offset?: number;
 }
+
 export class LimitAndOffsetNode implements QueryNode {
   readonly nodeId: string;
   readonly type = NodeType.kLimitAndOffset;
   primaryInput?: QueryNode;
   nextNodes: QueryNode[];
-  readonly state: LimitAndOffsetNodeState;
+  readonly attrs: LimitAndOffsetNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: LimitAndOffsetNodeState) {
+  constructor(attrs: LimitAndOffsetNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = state;
+    this.attrs = {
+      ...attrs,
+      limit: attrs.limit ?? 10,
+      offset: attrs.offset ?? 0,
+    };
+    this.context = context;
     this.nextNodes = [];
-    this.state.limit = this.state.limit ?? 10;
-    this.state.offset = this.state.offset ?? 0;
   }
 
   get sourceCols(): ColumnInfo[] {
@@ -60,9 +61,9 @@ export class LimitAndOffsetNode implements QueryNode {
   }
 
   nodeDetails(): NodeDetailsAttrs {
-    const hasOffset = this.state.offset !== undefined && this.state.offset > 0;
-    const limitText = `Limit: ${this.state.limit ?? 10}`;
-    const offsetText = hasOffset ? `, Offset: ${this.state.offset}` : '';
+    const hasOffset = this.attrs.offset !== undefined && this.attrs.offset > 0;
+    const limitText = `Limit: ${this.attrs.limit ?? 10}`;
+    const offsetText = hasOffset ? `, Offset: ${this.attrs.offset}` : '';
 
     return {
       content: m('div', limitText + offsetText),
@@ -81,7 +82,7 @@ export class LimitAndOffsetNode implements QueryNode {
         m(InlineField, {
           label: 'Limit',
           icon: 'filter_list',
-          value: this.state.limit?.toString() ?? '10',
+          value: this.attrs.limit?.toString() ?? '10',
           placeholder: 'Number of rows',
           type: 'number',
           validate: (value: string) => {
@@ -92,15 +93,15 @@ export class LimitAndOffsetNode implements QueryNode {
           onchange: (value: string) => {
             const parsed = parseInt(value.trim(), 10);
             // Save the parsed value if valid, otherwise keep current value
-            this.state.limit =
-              !isNaN(parsed) && parsed >= 0 ? parsed : this.state.limit;
-            this.state.onchange?.();
+            this.attrs.limit =
+              !isNaN(parsed) && parsed >= 0 ? parsed : this.attrs.limit;
+            this.context.onchange?.();
           },
         }),
         m(InlineField, {
           label: 'Offset',
           icon: 'skip_next',
-          value: this.state.offset?.toString() ?? '0',
+          value: this.attrs.offset?.toString() ?? '0',
           placeholder: 'Number of rows to skip',
           type: 'number',
           validate: (value: string) => {
@@ -111,9 +112,9 @@ export class LimitAndOffsetNode implements QueryNode {
           onchange: (value: string) => {
             const parsed = parseInt(value.trim(), 10);
             // Save the parsed value if valid, otherwise keep current value
-            this.state.offset =
-              !isNaN(parsed) && parsed >= 0 ? parsed : this.state.offset;
-            this.state.onchange?.();
+            this.attrs.offset =
+              !isNaN(parsed) && parsed >= 0 ? parsed : this.attrs.offset;
+            this.context.onchange?.();
           },
         }),
       ),
@@ -131,17 +132,17 @@ export class LimitAndOffsetNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
-      setValidationError(this.state, 'No input node connected');
+      setValidationError(this.context, 'No input node connected');
       return false;
     }
 
     if (!this.primaryInput.validate()) {
-      setValidationError(this.state, 'Previous node is invalid');
+      setValidationError(this.context, 'Previous node is invalid');
       return false;
     }
 
@@ -149,21 +150,20 @@ export class LimitAndOffsetNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: LimitAndOffsetNodeState = {
-      limit: this.state.limit,
-      offset: this.state.offset,
-      filters: this.state.filters?.map((f) => ({...f})),
-      filterOperator: this.state.filterOperator,
-      onchange: this.state.onchange,
-    };
-    return new LimitAndOffsetNode(stateCopy);
+    return new LimitAndOffsetNode(
+      {
+        limit: this.attrs.limit,
+        offset: this.attrs.offset,
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (this.primaryInput === undefined) return undefined;
 
-    const hasLimit = this.state.limit !== undefined && this.state.limit >= 0;
-    const hasOffset = this.state.offset !== undefined && this.state.offset > 0;
+    const hasLimit = this.attrs.limit !== undefined && this.attrs.limit >= 0;
+    const hasOffset = this.attrs.offset !== undefined && this.attrs.offset > 0;
 
     if (!hasLimit && !hasOffset) {
       // No limit/offset - return passthrough to maintain reference chain
@@ -172,24 +172,9 @@ export class LimitAndOffsetNode implements QueryNode {
 
     return StructuredQueryBuilder.withLimitOffset(
       this.primaryInput,
-      this.state.limit,
-      this.state.offset,
+      this.attrs.limit,
+      this.attrs.offset,
       this.nodeId,
     );
-  }
-
-  serializeState(): object {
-    // Only return serializable fields, excluding callbacks and objects
-    // that might contain circular references
-    return {
-      limit: this.state.limit,
-      offset: this.state.offset,
-    };
-  }
-
-  static deserializeState(
-    state: LimitAndOffsetNodeState,
-  ): LimitAndOffsetNodeState {
-    return {...state};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node.ts
@@ -13,14 +13,9 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import protos from '../../../../protos';
-import {ColumnInfo, newColumnInfoList} from '../column_info';
+import {ColumnInfo, newColumnInfo} from '../column_info';
 import {NodeIssues} from '../node_issues';
 import {OutlinedField} from '../widgets';
 import {NodeModifyAttrs, NodeDetailsAttrs} from '../../node_types';
@@ -83,7 +78,6 @@ function sqlTypeToDimensionType(
 export interface DimensionConfig {
   displayName?: string;
   displayHelp?: string;
-  expanded?: boolean;
 }
 
 export interface ValueColumnConfig {
@@ -93,21 +87,17 @@ export interface ValueColumnConfig {
   polarity: string;
   displayName?: string;
   displayHelp?: string;
-  expanded?: boolean;
 }
 
-export interface MetricsSerializedState {
-  metricIdPrefix: string;
-  valueColumns?: ValueColumnConfig[];
-  dimensionConfigs?: Record<string, DimensionConfig>;
-  dimensionUniqueness: string;
-}
-
-export interface MetricsNodeState extends QueryNodeState {
+// Serializable node configuration.
+export interface MetricsNodeAttrs {
   metricIdPrefix: string;
   valueColumns: ValueColumnConfig[];
   dimensionConfigs: Record<string, DimensionConfig>;
   dimensionUniqueness: string;
+}
+
+export interface MetricsNodeState extends MetricsNodeAttrs {
   availableColumns: ColumnInfo[];
 }
 
@@ -124,7 +114,15 @@ export class MetricsNode implements QueryNode {
   readonly type = NodeType.kMetrics;
   primaryInput?: QueryNode;
   nextNodes: QueryNode[];
-  readonly state: MetricsNodeState;
+  readonly attrs: MetricsNodeAttrs;
+  readonly context: NodeContext;
+
+  // Transient: rebuilt by updateAvailableColumns, not serialized.
+  availableColumns: ColumnInfo[];
+
+  // Transient UI expansion state (not serialized).
+  private expandedDimensions = new Set<string>();
+  private expandedValueColumns = new Set<string>();
 
   // Transient drag-and-drop state (not serialized).
   private dragOverTarget?: 'dimensions' | 'values';
@@ -134,22 +132,25 @@ export class MetricsNode implements QueryNode {
     return this.primaryInput?.finalCols ?? [];
   }
 
-  constructor(state: MetricsNodeState) {
+  constructor(attrs: MetricsNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...state,
-      metricIdPrefix: state.metricIdPrefix ?? '',
-      valueColumns: state.valueColumns ?? [],
-      dimensionConfigs: state.dimensionConfigs ?? {},
-      dimensionUniqueness: state.dimensionUniqueness ?? 'NOT_UNIQUE',
-      availableColumns: state.availableColumns ?? [],
+    this.attrs = {
+      metricIdPrefix: attrs.metricIdPrefix ?? '',
+      valueColumns: attrs.valueColumns ?? [],
+      dimensionConfigs: attrs.dimensionConfigs ?? {},
+      dimensionUniqueness: attrs.dimensionUniqueness ?? 'NOT_UNIQUE',
     };
+    this.context = context;
+    // availableColumns is derived from primaryInput, but tests may seed it
+    // via the attrs bag for direct testing.
+    this.availableColumns =
+      (attrs as {availableColumns?: ColumnInfo[]}).availableColumns ?? [];
     this.nextNodes = [];
   }
 
   getDimensions(): string[] {
-    const valueNames = new Set(this.state.valueColumns.map((vc) => vc.column));
-    return this.state.availableColumns
+    const valueNames = new Set(this.attrs.valueColumns.map((vc) => vc.column));
+    return this.availableColumns
       .filter((c) => !valueNames.has(c.name))
       .map((c) => c.name);
   }
@@ -162,33 +163,30 @@ export class MetricsNode implements QueryNode {
     if (this.primaryInput === undefined) {
       return;
     }
-    this.state.availableColumns = newColumnInfoList(
-      this.primaryInput.finalCols ?? [],
-      false,
+    this.availableColumns = (this.primaryInput.finalCols ?? []).map((col) =>
+      newColumnInfo(col, false),
     );
 
     // Remove value columns whose column no longer exists or is no longer numeric.
     // Skip filtering when available columns are empty (upstream hasn't resolved
     // yet) to avoid destructively wiping value columns during deserialization.
-    if (this.state.availableColumns.length > 0) {
-      this.state.valueColumns = this.state.valueColumns.filter((vc) => {
-        const col = this.state.availableColumns.find(
-          (c) => c.name === vc.column,
-        );
+    if (this.availableColumns.length > 0) {
+      this.attrs.valueColumns = this.attrs.valueColumns.filter((vc) => {
+        const col = this.availableColumns.find((c) => c.name === vc.column);
         // Keep value columns when the type is unknown (e.g. pbtxt import
         // where column types aren't available yet). Once the type resolves,
         // non-numeric columns will be filtered on the next update.
         return (
           col !== undefined &&
-          (col.column.type === undefined || isMetricsValueType(col.column.type))
+          (col.type === undefined || isMetricsValueType(col.type))
         );
       });
     }
   }
 
   validate(): boolean {
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
@@ -200,18 +198,18 @@ export class MetricsNode implements QueryNode {
       return false;
     }
 
-    if (!this.state.metricIdPrefix || this.state.metricIdPrefix.trim() === '') {
+    if (!this.attrs.metricIdPrefix || this.attrs.metricIdPrefix.trim() === '') {
       this.setValidationError('Metric ID prefix is required');
       return false;
     }
 
-    if (this.state.valueColumns.length === 0) {
+    if (this.attrs.valueColumns.length === 0) {
       this.setValidationError('At least one value column is required');
       return false;
     }
 
     const inputCols = this.primaryInput.finalCols ?? [];
-    for (const vc of this.state.valueColumns) {
+    for (const vc of this.attrs.valueColumns) {
       if (
         vc.unit === 'CUSTOM' &&
         (!vc.customUnit || vc.customUnit.trim() === '')
@@ -229,9 +227,9 @@ export class MetricsNode implements QueryNode {
         );
         return false;
       }
-      if (!isMetricsValueType(col.column.type)) {
+      if (!isMetricsValueType(col.type)) {
         this.setValidationError(
-          `Value column '${vc.column}' must be numeric (got ${perfettoSqlTypeToString(col.column.type)})`,
+          `Value column '${vc.column}' must be numeric (got ${perfettoSqlTypeToString(col.type)})`,
         );
         return false;
       }
@@ -241,10 +239,10 @@ export class MetricsNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -254,7 +252,7 @@ export class MetricsNode implements QueryNode {
   nodeDetails(): NodeDetailsAttrs {
     const details: m.Child[] = [NodeTitle(this.getTitle())];
 
-    if (!this.state.metricIdPrefix || this.state.metricIdPrefix.trim() === '') {
+    if (!this.attrs.metricIdPrefix || this.attrs.metricIdPrefix.trim() === '') {
       details.push(NodeDetailsMessage('Metric ID prefix required'));
       return {
         content: m('.pf-metrics-v2-node-details', details),
@@ -262,20 +260,20 @@ export class MetricsNode implements QueryNode {
     }
 
     details.push(
-      m('div', 'ID prefix: ', ColumnName(this.state.metricIdPrefix)),
+      m('div', 'ID prefix: ', ColumnName(this.attrs.metricIdPrefix)),
     );
 
-    if (this.state.valueColumns.length > 0) {
+    if (this.attrs.valueColumns.length > 0) {
       details.push(NodeDetailsSpacer());
       const label =
-        this.state.valueColumns.length === 1 ? 'Value: ' : 'Values: ';
+        this.attrs.valueColumns.length === 1 ? 'Value: ' : 'Values: ';
       details.push(
         m(
           'div',
           label,
-          this.state.valueColumns.map((vc, i) => [
+          this.attrs.valueColumns.map((vc, i) => [
             ColumnName(vc.column),
-            i < this.state.valueColumns.length - 1 ? ', ' : '',
+            i < this.attrs.valueColumns.length - 1 ? ', ' : '',
           ]),
         ),
       );
@@ -306,18 +304,18 @@ export class MetricsNode implements QueryNode {
     // Metric ID prefix and Export button row.
     const canExport =
       this.primaryInput !== undefined &&
-      !!this.state.metricIdPrefix?.trim() &&
-      this.state.valueColumns.length > 0;
+      !!this.attrs.metricIdPrefix?.trim() &&
+      this.attrs.valueColumns.length > 0;
     sections.push({
       content: m(
         '.pf-metrics-header-row',
         m(OutlinedField, {
           label: 'Metric ID prefix',
-          value: this.state.metricIdPrefix,
+          value: this.attrs.metricIdPrefix,
           placeholder: 'e.g., memory_per_process',
           oninput: (e: Event) => {
-            this.state.metricIdPrefix = (e.target as HTMLInputElement).value;
-            this.state.onchange?.();
+            this.attrs.metricIdPrefix = (e.target as HTMLInputElement).value;
+            this.context.onchange?.();
           },
         }),
         m(Button, {
@@ -342,12 +340,12 @@ export class MetricsNode implements QueryNode {
         OutlinedField,
         {
           label: 'Dimension uniqueness',
-          value: this.state.dimensionUniqueness,
+          value: this.attrs.dimensionUniqueness,
           onchange: (e: Event) => {
-            this.state.dimensionUniqueness = (
+            this.attrs.dimensionUniqueness = (
               e.target as HTMLSelectElement
             ).value;
-            this.state.onchange?.();
+            this.context.onchange?.();
           },
         },
         getDimensionUniquenessOptions().map((d) =>
@@ -355,7 +353,7 @@ export class MetricsNode implements QueryNode {
             'option',
             {
               value: d.value,
-              selected: this.state.dimensionUniqueness === d.value,
+              selected: this.attrs.dimensionUniqueness === d.value,
             },
             d.label,
           ),
@@ -382,8 +380,8 @@ export class MetricsNode implements QueryNode {
   }
 
   private getDimensionColumns(): ColumnInfo[] {
-    const valueNames = new Set(this.state.valueColumns.map((vc) => vc.column));
-    return this.state.availableColumns.filter((c) => !valueNames.has(c.name));
+    const valueNames = new Set(this.attrs.valueColumns.map((vc) => vc.column));
+    return this.availableColumns.filter((c) => !valueNames.has(c.name));
   }
 
   private renderDimensionsPanel(dimensionCols: ColumnInfo[]): m.Children {
@@ -423,9 +421,9 @@ export class MetricsNode implements QueryNode {
         dimensionCols.length === 0
           ? m('.pf-metrics-v2-empty-hint', 'No dimensions')
           : dimensionCols.map((col) => {
-              const numeric = isMetricsValueType(col.column.type);
-              const cfg = this.state.dimensionConfigs[col.name];
-              const isExpanded = cfg?.expanded ?? false;
+              const numeric = isMetricsValueType(col.type);
+              const cfg = this.attrs.dimensionConfigs[col.name];
+              const isExpanded = this.expandedDimensions.has(col.name);
               return m(
                 '.pf-metrics-v2-column-item.pf-metrics-v2-dim-item',
                 {
@@ -463,17 +461,18 @@ export class MetricsNode implements QueryNode {
                   m('span.pf-metrics-v2-col-name', col.name),
                   m(
                     'span.pf-metrics-v2-col-type',
-                    perfettoSqlTypeToString(col.column.type),
+                    perfettoSqlTypeToString(col.type),
                   ),
                   m(Button, {
                     icon: isExpanded ? 'expand_more' : 'chevron_right',
                     compact: true,
                     title: isExpanded ? 'Collapse config' : 'Expand config',
                     onclick: () => {
-                      this.state.dimensionConfigs[col.name] = {
-                        ...cfg,
-                        expanded: !isExpanded,
-                      };
+                      if (isExpanded) {
+                        this.expandedDimensions.delete(col.name);
+                      } else {
+                        this.expandedDimensions.add(col.name);
+                      }
                     },
                   }),
                   numeric
@@ -493,12 +492,12 @@ export class MetricsNode implements QueryNode {
                       value: cfg?.displayName ?? '',
                       placeholder: 'e.g., OOM bucket',
                       oninput: (e: Event) => {
-                        this.state.dimensionConfigs[col.name] = {
+                        this.attrs.dimensionConfigs[col.name] = {
                           ...cfg,
                           displayName:
                             (e.target as HTMLInputElement).value || undefined,
                         };
-                        this.state.onchange?.();
+                        this.context.onchange?.();
                       },
                     }),
                     m(OutlinedField, {
@@ -506,12 +505,12 @@ export class MetricsNode implements QueryNode {
                       value: cfg?.displayHelp ?? '',
                       placeholder: 'Description for this dimension...',
                       oninput: (e: Event) => {
-                        this.state.dimensionConfigs[col.name] = {
+                        this.attrs.dimensionConfigs[col.name] = {
                           ...cfg,
                           displayHelp:
                             (e.target as HTMLInputElement).value || undefined,
                         };
-                        this.state.onchange?.();
+                        this.context.onchange?.();
                       },
                     }),
                   ),
@@ -528,15 +527,15 @@ export class MetricsNode implements QueryNode {
       isDropTarget &&
       this.dragPayload?.source === 'dimensions' &&
       (() => {
-        const col = this.state.availableColumns.find(
+        const col = this.availableColumns.find(
           (c) => c.name === this.dragPayload?.columnName,
         );
-        return col !== undefined && !isMetricsValueType(col.column.type);
+        return col !== undefined && !isMetricsValueType(col.type);
       })();
 
     // Numeric (or ANY) columns available to add (not already in values).
     const numericDimensions = dimensionCols.filter((c) =>
-      isMetricsValueType(c.column.type),
+      isMetricsValueType(c.type),
     );
 
     return m(
@@ -551,10 +550,10 @@ export class MetricsNode implements QueryNode {
           this.dragOverTarget = 'values';
           // Only allow drop of numeric columns from dimensions.
           if (this.dragPayload?.source === 'dimensions') {
-            const col = this.state.availableColumns.find(
+            const col = this.availableColumns.find(
               (c) => c.name === this.dragPayload?.columnName,
             );
-            if (col !== undefined && isMetricsValueType(col.column.type)) {
+            if (col !== undefined && isMetricsValueType(col.type)) {
               e.preventDefault();
             }
             // Non-numeric: don't preventDefault → drop not allowed.
@@ -585,13 +584,13 @@ export class MetricsNode implements QueryNode {
       },
       m(
         '.pf-metrics-v2-column-panel__header',
-        `Values (${this.state.valueColumns.length})`,
+        `Values (${this.attrs.valueColumns.length})`,
       ),
       m(
         '.pf-metrics-v2-column-panel__list',
-        this.state.valueColumns.length === 0
+        this.attrs.valueColumns.length === 0
           ? m('.pf-metrics-v2-empty-hint', 'Drag numeric columns here')
-          : this.state.valueColumns.map((vc, index) =>
+          : this.attrs.valueColumns.map((vc, index) =>
               this.renderValueItem(vc, index),
             ),
         // "Add value column" button if there are numeric dimensions available.
@@ -618,7 +617,7 @@ export class MetricsNode implements QueryNode {
                     m(
                       'option',
                       {value: col.name},
-                      `${col.name} (${perfettoSqlTypeToString(col.column.type)})`,
+                      `${col.name} (${perfettoSqlTypeToString(col.type)})`,
                     ),
                   ),
                 ],
@@ -630,13 +629,11 @@ export class MetricsNode implements QueryNode {
   }
 
   private renderValueItem(vc: ValueColumnConfig, index: number): m.Children {
-    const col = this.state.availableColumns.find((c) => c.name === vc.column);
+    const col = this.availableColumns.find((c) => c.name === vc.column);
     const colType =
-      col?.column.type !== undefined
-        ? perfettoSqlTypeToString(col.column.type)
-        : '?';
+      col?.type !== undefined ? perfettoSqlTypeToString(col.type) : '?';
     const needsCustomUnit = vc.unit === 'CUSTOM';
-    const isExpanded = vc.expanded ?? false;
+    const isExpanded = this.expandedValueColumns.has(vc.column);
 
     return m(
       '.pf-metrics-v2-column-item.pf-metrics-v2-value-item',
@@ -670,7 +667,11 @@ export class MetricsNode implements QueryNode {
           compact: true,
           title: isExpanded ? 'Collapse config' : 'Expand config',
           onclick: () => {
-            this.state.valueColumns[index] = {...vc, expanded: !isExpanded};
+            if (isExpanded) {
+              this.expandedValueColumns.delete(vc.column);
+            } else {
+              this.expandedValueColumns.add(vc.column);
+            }
           },
         }),
         m(Button, {
@@ -691,12 +692,12 @@ export class MetricsNode implements QueryNode {
               value: vc.unit,
               onchange: (e: Event) => {
                 const newUnit = (e.target as HTMLSelectElement).value;
-                this.state.valueColumns[index] = {
+                this.attrs.valueColumns[index] = {
                   ...vc,
                   unit: newUnit,
                   customUnit: newUnit !== 'CUSTOM' ? undefined : vc.customUnit,
                 };
-                this.state.onchange?.();
+                this.context.onchange?.();
               },
             },
             getMetricUnitOptions().map((u) =>
@@ -713,11 +714,11 @@ export class MetricsNode implements QueryNode {
                 value: vc.customUnit ?? '',
                 placeholder: 'Enter custom unit...',
                 oninput: (e: Event) => {
-                  this.state.valueColumns[index] = {
+                  this.attrs.valueColumns[index] = {
                     ...vc,
                     customUnit: (e.target as HTMLInputElement).value,
                   };
-                  this.state.onchange?.();
+                  this.context.onchange?.();
                 },
               })
             : undefined,
@@ -727,11 +728,11 @@ export class MetricsNode implements QueryNode {
               label: 'Polarity',
               value: vc.polarity,
               onchange: (e: Event) => {
-                this.state.valueColumns[index] = {
+                this.attrs.valueColumns[index] = {
                   ...vc,
                   polarity: (e.target as HTMLSelectElement).value,
                 };
-                this.state.onchange?.();
+                this.context.onchange?.();
               },
             },
             getPolarityOptions().map((p) =>
@@ -747,11 +748,11 @@ export class MetricsNode implements QueryNode {
             value: vc.displayName ?? '',
             placeholder: 'Human-readable name...',
             oninput: (e: Event) => {
-              this.state.valueColumns[index] = {
+              this.attrs.valueColumns[index] = {
                 ...vc,
                 displayName: (e.target as HTMLInputElement).value || undefined,
               };
-              this.state.onchange?.();
+              this.context.onchange?.();
             },
           }),
           m(OutlinedField, {
@@ -759,11 +760,11 @@ export class MetricsNode implements QueryNode {
             value: vc.displayHelp ?? '',
             placeholder: 'Description for this value...',
             oninput: (e: Event) => {
-              this.state.valueColumns[index] = {
+              this.attrs.valueColumns[index] = {
                 ...vc,
                 displayHelp: (e.target as HTMLInputElement).value || undefined,
               };
-              this.state.onchange?.();
+              this.context.onchange?.();
             },
           }),
         ),
@@ -778,18 +779,16 @@ export class MetricsNode implements QueryNode {
   private moveToValues(columnName: string, toValues: boolean): void {
     if (toValues) {
       // Guard: only numeric columns can be value columns.
-      const col = this.state.availableColumns.find(
-        (c) => c.name === columnName,
-      );
-      if (col === undefined || !isMetricsValueType(col.column.type)) return;
+      const col = this.availableColumns.find((c) => c.name === columnName);
+      if (col === undefined || !isMetricsValueType(col.type)) return;
 
       // Add to values with default config.
-      const alreadyExists = this.state.valueColumns.some(
+      const alreadyExists = this.attrs.valueColumns.some(
         (vc) => vc.column === columnName,
       );
       if (alreadyExists) return;
-      this.state.valueColumns = [
-        ...this.state.valueColumns,
+      this.attrs.valueColumns = [
+        ...this.attrs.valueColumns,
         {
           column: columnName,
           unit: 'COUNT',
@@ -798,11 +797,11 @@ export class MetricsNode implements QueryNode {
       ];
     } else {
       // Remove from values (moves back to dimensions implicitly).
-      this.state.valueColumns = this.state.valueColumns.filter(
+      this.attrs.valueColumns = this.attrs.valueColumns.filter(
         (vc) => vc.column !== columnName,
       );
     }
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   private readDragPayload(e: DragEvent): DragPayload | undefined {
@@ -822,10 +821,10 @@ export class MetricsNode implements QueryNode {
     await showMetricsExportModal({
       templateSpec,
       primaryInput: this.primaryInput,
-      metricIdPrefix: this.state.metricIdPrefix,
+      metricIdPrefix: this.attrs.metricIdPrefix,
       dimensions: this.getDimensions(),
-      valueColumns: [...this.state.valueColumns],
-      engine: this.state.trace?.engine,
+      valueColumns: [...this.attrs.valueColumns],
+      engine: this.context.trace?.engine,
     });
   }
 
@@ -834,20 +833,27 @@ export class MetricsNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: MetricsNodeState = {
-      metricIdPrefix: this.state.metricIdPrefix,
-      valueColumns: this.state.valueColumns.map((vc) => ({...vc})),
+    const attrsCopy: MetricsNodeAttrs = {
+      metricIdPrefix: this.attrs.metricIdPrefix,
+      valueColumns: this.attrs.valueColumns.map((vc) => ({...vc})),
       dimensionConfigs: Object.fromEntries(
-        Object.entries(this.state.dimensionConfigs).map(([k, v]) => [
+        Object.entries(this.attrs.dimensionConfigs).map(([k, v]) => [
           k,
           {...v},
         ]),
       ),
-      dimensionUniqueness: this.state.dimensionUniqueness,
-      availableColumns: newColumnInfoList(this.state.availableColumns),
-      onchange: this.state.onchange,
+      dimensionUniqueness: this.attrs.dimensionUniqueness,
     };
-    return new MetricsNode(stateCopy);
+    // Clone gets a fresh context (no shared issues).
+    const cloned = new MetricsNode(attrsCopy, {
+      trace: this.context.trace,
+      sqlModules: this.context.sqlModules,
+      onchange: this.context.onchange,
+    });
+    cloned.availableColumns = this.availableColumns.map((col) =>
+      newColumnInfo(col),
+    );
+    return cloned;
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -871,16 +877,16 @@ export class MetricsNode implements QueryNode {
     if (inputQuery === undefined) return undefined;
 
     const templateSpec = new protos.TraceMetricV2TemplateSpec();
-    templateSpec.idPrefix = this.state.metricIdPrefix;
+    templateSpec.idPrefix = this.attrs.metricIdPrefix;
     templateSpec.dimensionsSpecs = this.getDimensions().map((dimName) => {
       const spec = new protos.TraceMetricV2Spec.DimensionSpec();
       spec.name = dimName;
       // Infer dimension type from the SQL column type.
-      const col = this.state.availableColumns.find((c) => c.name === dimName);
-      if (col?.column.type !== undefined) {
-        spec.type = sqlTypeToDimensionType(col.column.type);
+      const col = this.availableColumns.find((c) => c.name === dimName);
+      if (col?.type !== undefined) {
+        spec.type = sqlTypeToDimensionType(col.type);
       }
-      const cfg = this.state.dimensionConfigs[dimName];
+      const cfg = this.attrs.dimensionConfigs[dimName];
       if (cfg?.displayName) {
         spec.displayName = cfg.displayName;
       }
@@ -891,7 +897,7 @@ export class MetricsNode implements QueryNode {
     });
     templateSpec.query = inputQuery;
 
-    if (this.state.dimensionUniqueness === 'UNIQUE') {
+    if (this.attrs.dimensionUniqueness === 'UNIQUE') {
       templateSpec.dimensionUniqueness =
         protos.TraceMetricV2Spec.DimensionUniqueness.UNIQUE;
     } else {
@@ -899,7 +905,7 @@ export class MetricsNode implements QueryNode {
         protos.TraceMetricV2Spec.DimensionUniqueness.NOT_UNIQUE;
     }
 
-    templateSpec.valueColumnSpecs = this.state.valueColumns.map((vc) => {
+    templateSpec.valueColumnSpecs = this.attrs.valueColumns.map((vc) => {
       const valueSpec = new protos.TraceMetricV2TemplateSpec.ValueColumnSpec();
       valueSpec.name = vc.column;
 
@@ -936,25 +942,7 @@ export class MetricsNode implements QueryNode {
     return templateSpec;
   }
 
-  serializeState(): MetricsSerializedState {
-    // Strip transient `expanded` from dimension configs before serializing.
-    const dimensionConfigs: Record<string, DimensionConfig> = {};
-    for (const [name, cfg] of Object.entries(this.state.dimensionConfigs)) {
-      const {expanded: _, ...rest} = cfg;
-      if (rest.displayName || rest.displayHelp) {
-        dimensionConfigs[name] = rest;
-      }
-    }
-    return {
-      metricIdPrefix: this.state.metricIdPrefix,
-      valueColumns: this.state.valueColumns.map(({expanded: _, ...vc}) => vc),
-      dimensionConfigs:
-        Object.keys(dimensionConfigs).length > 0 ? dimensionConfigs : undefined,
-      dimensionUniqueness: this.state.dimensionUniqueness,
-    };
-  }
-
-  static deserializeState(state: MetricsSerializedState): MetricsNodeState {
+  static deserializeState(state: MetricsNodeAttrs): MetricsNodeAttrs {
     // Handle migration from old metricId to metricIdPrefix.
     const metricIdPrefix =
       state.metricIdPrefix ??
@@ -1008,7 +996,6 @@ export class MetricsNode implements QueryNode {
       valueColumns,
       dimensionConfigs: state.dimensionConfigs ?? {},
       dimensionUniqueness: state.dimensionUniqueness ?? 'NOT_UNIQUE',
-      availableColumns: [],
     };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/metrics_node_unittest.ts
@@ -14,8 +14,8 @@
 
 import {
   MetricsNode,
+  MetricsNodeAttrs,
   MetricsNodeState,
-  MetricsSerializedState,
   ValueColumnConfig,
 } from './metrics_node';
 import {parseMetricBundleForValue} from './metrics_export_modal';
@@ -59,28 +59,28 @@ function makeValueCol(
 describe('MetricsNode', () => {
   describe('constructor', () => {
     it('should initialize with default state', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
-      expect(node.state.metricIdPrefix).toBe('');
-      expect(node.state.valueColumns).toEqual([]);
-      expect(node.state.dimensionUniqueness).toBe('NOT_UNIQUE');
-      expect(node.state.availableColumns).toEqual([]);
+      expect(node.attrs.metricIdPrefix).toBe('');
+      expect(node.attrs.valueColumns).toEqual([]);
+      expect(node.attrs.dimensionUniqueness).toBe('NOT_UNIQUE');
+      expect(node.availableColumns).toEqual([]);
     });
 
     it('should have correct node type', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       expect(node.type).toBe(NodeType.kMetrics);
     });
 
     it('should initialize with no primary input', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       expect(node.primaryInput).toBeUndefined();
     });
 
     it('should initialize with empty nextNodes array', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       expect(node.nextNodes).toEqual([]);
     });
@@ -92,14 +92,15 @@ describe('MetricsNode', () => {
           valueColumns: [makeValueCol('value1', 'BYTES', 'HIGHER_IS_BETTER')],
           dimensionUniqueness: 'UNIQUE',
         }),
+        {},
       );
 
-      expect(node.state.metricIdPrefix).toBe('my_metric');
-      expect(node.state.valueColumns).toHaveLength(1);
-      expect(node.state.valueColumns[0].column).toBe('value1');
-      expect(node.state.valueColumns[0].unit).toBe('BYTES');
-      expect(node.state.valueColumns[0].polarity).toBe('HIGHER_IS_BETTER');
-      expect(node.state.dimensionUniqueness).toBe('UNIQUE');
+      expect(node.attrs.metricIdPrefix).toBe('my_metric');
+      expect(node.attrs.valueColumns).toHaveLength(1);
+      expect(node.attrs.valueColumns[0].column).toBe('value1');
+      expect(node.attrs.valueColumns[0].unit).toBe('BYTES');
+      expect(node.attrs.valueColumns[0].polarity).toBe('HIGHER_IS_BETTER');
+      expect(node.attrs.dimensionUniqueness).toBe('UNIQUE');
     });
 
     it('should preserve multiple value columns', () => {
@@ -110,17 +111,18 @@ describe('MetricsNode', () => {
             makeValueCol('mem_bytes', 'BYTES', 'LOWER_IS_BETTER'),
           ],
         }),
+        {},
       );
 
-      expect(node.state.valueColumns).toHaveLength(2);
-      expect(node.state.valueColumns[0].column).toBe('cpu_time');
-      expect(node.state.valueColumns[1].column).toBe('mem_bytes');
+      expect(node.attrs.valueColumns).toHaveLength(2);
+      expect(node.attrs.valueColumns[0].column).toBe('cpu_time');
+      expect(node.attrs.valueColumns[1].column).toBe('mem_bytes');
     });
   });
 
   describe('finalCols', () => {
     it('should return empty array when no primary input', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       expect(node.finalCols).toEqual([]);
     });
@@ -133,7 +135,7 @@ describe('MetricsNode', () => {
       ];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
       node.primaryInput = inputNode;
 
       expect(node.finalCols).toEqual(inputCols);
@@ -150,6 +152,7 @@ describe('MetricsNode', () => {
             createColumnInfo('name', 'string'),
           ],
         }),
+        {},
       );
 
       expect(node.getDimensions()).toEqual(['id', 'name']);
@@ -166,6 +169,7 @@ describe('MetricsNode', () => {
             createColumnInfo('category', 'string'),
           ],
         }),
+        {},
       );
 
       expect(node.getDimensions()).toEqual(['id', 'name', 'category']);
@@ -182,6 +186,7 @@ describe('MetricsNode', () => {
             createColumnInfo('pid', 'int'),
           ],
         }),
+        {},
       );
 
       expect(node.getDimensions()).toEqual(['process', 'pid']);
@@ -193,6 +198,7 @@ describe('MetricsNode', () => {
           valueColumns: [makeValueCol('value')],
           availableColumns: [createColumnInfo('value', 'double')],
         }),
+        {},
       );
 
       expect(node.getDimensions()).toEqual([]);
@@ -201,7 +207,7 @@ describe('MetricsNode', () => {
 
   describe('validate', () => {
     it('should fail validation when no primary input', () => {
-      const node = new MetricsNode(makeState());
+      const node = new MetricsNode(makeState(), {});
 
       expectValidationError(node, 'No input node connected');
     });
@@ -209,7 +215,7 @@ describe('MetricsNode', () => {
     it('should fail validation when primary input is invalid', () => {
       const inputNode = createMockNode({validate: () => false});
 
-      const node = new MetricsNode(makeState());
+      const node = new MetricsNode(makeState(), {});
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'Previous node is invalid');
@@ -219,7 +225,7 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode(makeState({metricIdPrefix: ''}));
+      const node = new MetricsNode(makeState({metricIdPrefix: ''}), {});
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'Metric ID prefix is required');
@@ -229,7 +235,7 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode(makeState({metricIdPrefix: '   '}));
+      const node = new MetricsNode(makeState({metricIdPrefix: '   '}), {});
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'Metric ID prefix is required');
@@ -239,7 +245,7 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode(makeState({valueColumns: []}));
+      const node = new MetricsNode(makeState({valueColumns: []}), {});
       connectNodes(inputNode, node);
 
       expectValidationError(node, 'At least one value column is required');
@@ -251,6 +257,7 @@ describe('MetricsNode', () => {
 
       const node = new MetricsNode(
         makeState({valueColumns: [makeValueCol('missing_column')]}),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -263,6 +270,7 @@ describe('MetricsNode', () => {
 
       const node = new MetricsNode(
         makeState({valueColumns: [makeValueCol('name')]}),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -277,6 +285,7 @@ describe('MetricsNode', () => {
         makeState({
           valueColumns: [makeValueCol('value', 'CUSTOM', 'NOT_APPLICABLE', '')],
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -297,6 +306,7 @@ describe('MetricsNode', () => {
             makeValueCol('mem', 'CUSTOM', 'NOT_APPLICABLE', ''), // missing custom unit
           ],
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -316,6 +326,7 @@ describe('MetricsNode', () => {
 
       const node = new MetricsNode(
         makeState({valueColumns: [makeValueCol('value')]}),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -337,6 +348,7 @@ describe('MetricsNode', () => {
             makeValueCol('mem', 'BYTES', 'LOWER_IS_BETTER'),
           ],
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -353,6 +365,7 @@ describe('MetricsNode', () => {
             makeValueCol('value', 'CUSTOM', 'NOT_APPLICABLE', 'widgets'),
           ],
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -360,11 +373,11 @@ describe('MetricsNode', () => {
     });
 
     it('should clear previous validation errors on success', () => {
-      const node = new MetricsNode(makeState());
+      const node = new MetricsNode(makeState(), {});
 
       // First validation should fail (no input)
       expect(node.validate()).toBe(false);
-      expect(node.state.issues?.queryError).toBeDefined();
+      expect(node.context.issues?.queryError).toBeDefined();
 
       // Add valid input and validate again
       const inputCols = [createColumnInfo('value', 'int')];
@@ -372,7 +385,7 @@ describe('MetricsNode', () => {
       connectNodes(inputNode, node);
 
       expect(node.validate()).toBe(true);
-      expect(node.state.issues?.queryError).toBeUndefined();
+      expect(node.context.issues?.queryError).toBeUndefined();
     });
   });
 
@@ -385,13 +398,13 @@ describe('MetricsNode', () => {
       ];
       const inputNode = createMockNode({columns: inputCols});
 
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
-      expect(node.state.availableColumns.length).toBe(3);
-      expect(node.state.availableColumns.map((c) => c.name)).toEqual([
+      expect(node.availableColumns.length).toBe(3);
+      expect(node.availableColumns.map((c) => c.name)).toEqual([
         'id',
         'name',
         'value',
@@ -404,13 +417,14 @@ describe('MetricsNode', () => {
 
       const node = new MetricsNode(
         makeState({valueColumns: [makeValueCol('old_value')]}),
+        {},
       );
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
       // 'old_value' is gone, so it should be removed from valueColumns
-      expect(node.state.valueColumns).toHaveLength(0);
+      expect(node.attrs.valueColumns).toHaveLength(0);
     });
 
     it('should remove value column entry if it becomes non-numeric', () => {
@@ -419,13 +433,14 @@ describe('MetricsNode', () => {
 
       const node = new MetricsNode(
         makeState({valueColumns: [makeValueCol('value')]}),
+        {},
       );
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
       // 'value' is now string, so it should be removed
-      expect(node.state.valueColumns).toHaveLength(0);
+      expect(node.attrs.valueColumns).toHaveLength(0);
     });
 
     it('should preserve value column if it still exists and is numeric', () => {
@@ -434,13 +449,14 @@ describe('MetricsNode', () => {
 
       const node = new MetricsNode(
         makeState({valueColumns: [makeValueCol('value')]}),
+        {},
       );
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
-      expect(node.state.valueColumns).toHaveLength(1);
-      expect(node.state.valueColumns[0].column).toBe('value');
+      expect(node.attrs.valueColumns).toHaveLength(1);
+      expect(node.attrs.valueColumns[0].column).toBe('value');
     });
 
     it('should selectively remove only stale value columns from multi-value', () => {
@@ -457,32 +473,34 @@ describe('MetricsNode', () => {
             makeValueCol('stale_col'), // no longer exists
           ],
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
       node.onPrevNodesUpdated();
 
-      expect(node.state.valueColumns).toHaveLength(1);
-      expect(node.state.valueColumns[0].column).toBe('cpu');
+      expect(node.attrs.valueColumns).toHaveLength(1);
+      expect(node.attrs.valueColumns[0].column).toBe('cpu');
     });
 
     it('should do nothing when no primary input', () => {
       const node = new MetricsNode(
         makeState({valueColumns: [makeValueCol('value')]}),
+        {},
       );
 
       // Should not throw
       node.onPrevNodesUpdated();
 
       // State should remain unchanged
-      expect(node.state.valueColumns).toHaveLength(1);
-      expect(node.state.valueColumns[0].column).toBe('value');
+      expect(node.attrs.valueColumns).toHaveLength(1);
+      expect(node.attrs.valueColumns[0].column).toBe('value');
     });
   });
 
   describe('getStructuredQuery', () => {
     it('should return undefined when validation fails', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       expect(node.getStructuredQuery()).toBeUndefined();
     });
@@ -494,7 +512,7 @@ describe('MetricsNode', () => {
         getStructuredQuery: () => undefined,
       });
 
-      const node = new MetricsNode(makeState());
+      const node = new MetricsNode(makeState(), {});
       connectNodes(inputNode, node);
 
       expect(node.getStructuredQuery()).toBeUndefined();
@@ -504,7 +522,7 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode(makeState());
+      const node = new MetricsNode(makeState(), {});
       connectNodes(inputNode, node);
 
       const sq = node.getStructuredQuery();
@@ -517,7 +535,7 @@ describe('MetricsNode', () => {
 
   describe('getMetricTemplateSpec', () => {
     it('should return undefined when validation fails', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       expect(node.getMetricTemplateSpec()).toBeUndefined();
     });
@@ -531,6 +549,7 @@ describe('MetricsNode', () => {
           metricIdPrefix: 'my_metric_prefix',
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -553,6 +572,7 @@ describe('MetricsNode', () => {
           valueColumns: [makeValueCol('value1')],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -583,6 +603,7 @@ describe('MetricsNode', () => {
           valueColumns: [makeValueCol('cpu'), makeValueCol('mem')],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -612,6 +633,7 @@ describe('MetricsNode', () => {
           },
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -655,6 +677,7 @@ describe('MetricsNode', () => {
           ],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -675,6 +698,7 @@ describe('MetricsNode', () => {
           valueColumns: [makeValueCol('value')],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -702,6 +726,7 @@ describe('MetricsNode', () => {
           ],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -724,6 +749,7 @@ describe('MetricsNode', () => {
 
       const node = new MetricsNode(
         makeState({dimensionUniqueness: 'UNIQUE', availableColumns: inputCols}),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -743,6 +769,7 @@ describe('MetricsNode', () => {
           dimensionUniqueness: 'NOT_UNIQUE',
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -764,6 +791,7 @@ describe('MetricsNode', () => {
           ],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -781,6 +809,7 @@ describe('MetricsNode', () => {
           valueColumns: [makeValueCol('value', 'COUNT', 'LOWER_IS_BETTER')],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -795,7 +824,10 @@ describe('MetricsNode', () => {
       const inputCols = [createColumnInfo('value', 'int')];
       const inputNode = createMockNodeWithStructuredQuery('input', inputCols);
 
-      const node = new MetricsNode(makeState({availableColumns: inputCols}));
+      const node = new MetricsNode(
+        makeState({availableColumns: inputCols}),
+        {},
+      );
       connectNodes(inputNode, node);
 
       const spec = node.getMetricTemplateSpec();
@@ -805,8 +837,8 @@ describe('MetricsNode', () => {
     });
   });
 
-  describe('serializeState', () => {
-    it('should serialize all state properties including valueColumns array', () => {
+  describe('attrs serialization', () => {
+    it('should have all state properties in attrs', () => {
       const inputNode = createMockNode({columns: []});
 
       const node = new MetricsNode(
@@ -815,20 +847,19 @@ describe('MetricsNode', () => {
           valueColumns: [makeValueCol('value1', 'BYTES', 'HIGHER_IS_BETTER')],
           dimensionUniqueness: 'UNIQUE',
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
-      const serialized = node.serializeState();
-
-      expect(serialized.metricIdPrefix).toBe('my_metric');
-      expect(serialized.valueColumns).toHaveLength(1);
-      expect(serialized.valueColumns?.[0].column).toBe('value1');
-      expect(serialized.valueColumns?.[0].unit).toBe('BYTES');
-      expect(serialized.valueColumns?.[0].polarity).toBe('HIGHER_IS_BETTER');
-      expect(serialized.dimensionUniqueness).toBe('UNIQUE');
+      expect(node.attrs.metricIdPrefix).toBe('my_metric');
+      expect(node.attrs.valueColumns).toHaveLength(1);
+      expect(node.attrs.valueColumns[0].column).toBe('value1');
+      expect(node.attrs.valueColumns[0].unit).toBe('BYTES');
+      expect(node.attrs.valueColumns[0].polarity).toBe('HIGHER_IS_BETTER');
+      expect(node.attrs.dimensionUniqueness).toBe('UNIQUE');
     });
 
-    it('should serialize multiple value columns', () => {
+    it('should have multiple value columns in attrs', () => {
       const node = new MetricsNode(
         makeState({
           valueColumns: [
@@ -836,23 +867,23 @@ describe('MetricsNode', () => {
             makeValueCol('mem', 'BYTES', 'LOWER_IS_BETTER'),
           ],
         }),
+        {},
       );
 
-      const serialized = node.serializeState();
-
-      expect(serialized.valueColumns).toHaveLength(2);
-      expect(serialized.valueColumns?.[0].column).toBe('cpu');
-      expect(serialized.valueColumns?.[1].column).toBe('mem');
+      expect(node.attrs.valueColumns).toHaveLength(2);
+      expect(node.attrs.valueColumns[0].column).toBe('cpu');
+      expect(node.attrs.valueColumns[1].column).toBe('mem');
     });
   });
 
   describe('deserializeState', () => {
     it('should deserialize new-format valueColumns array', () => {
-      const serialized: MetricsSerializedState = {
+      const serialized: MetricsNodeAttrs = {
         metricIdPrefix: 'restored_metric',
         valueColumns: [
           {column: 'value1', unit: 'MEGABYTES', polarity: 'LOWER_IS_BETTER'},
         ],
+        dimensionConfigs: {},
         dimensionUniqueness: 'UNIQUE',
       };
 
@@ -864,16 +895,16 @@ describe('MetricsNode', () => {
       expect(state.valueColumns[0].unit).toBe('MEGABYTES');
       expect(state.valueColumns[0].polarity).toBe('LOWER_IS_BETTER');
       expect(state.dimensionUniqueness).toBe('UNIQUE');
-      expect(state.availableColumns).toEqual([]);
     });
 
     it('should deserialize multiple value columns', () => {
-      const serialized: MetricsSerializedState = {
+      const serialized: MetricsNodeAttrs = {
         metricIdPrefix: 'multi',
         valueColumns: [
           {column: 'cpu', unit: 'TIME_NANOS', polarity: 'LOWER_IS_BETTER'},
           {column: 'mem', unit: 'BYTES', polarity: 'LOWER_IS_BETTER'},
         ],
+        dimensionConfigs: {},
         dimensionUniqueness: 'NOT_UNIQUE',
       };
 
@@ -885,7 +916,9 @@ describe('MetricsNode', () => {
     });
 
     it('should provide defaults for missing properties', () => {
-      const state = MetricsNode.deserializeState({} as MetricsSerializedState);
+      const state = MetricsNode.deserializeState(
+        {} as unknown as MetricsNodeAttrs,
+      );
 
       expect(state.metricIdPrefix).toBe('');
       expect(state.valueColumns).toEqual([]);
@@ -900,7 +933,7 @@ describe('MetricsNode', () => {
         customUnit: undefined,
         polarity: 'HIGHER_IS_BETTER',
         dimensionUniqueness: 'NOT_UNIQUE',
-      } as unknown as MetricsSerializedState;
+      } as unknown as MetricsNodeAttrs;
 
       const state = MetricsNode.deserializeState(oldFormat);
 
@@ -919,7 +952,7 @@ describe('MetricsNode', () => {
         customUnit: 'widgets',
         polarity: 'NOT_APPLICABLE',
         dimensionUniqueness: 'NOT_UNIQUE',
-      } as unknown as MetricsSerializedState;
+      } as unknown as MetricsNodeAttrs;
 
       const state = MetricsNode.deserializeState(oldFormat);
 
@@ -946,7 +979,7 @@ describe('MetricsNode', () => {
           },
         ],
         dimensionUniqueness: 'UNIQUE',
-      } as unknown as MetricsSerializedState;
+      } as unknown as MetricsNodeAttrs;
 
       const state = MetricsNode.deserializeState(oldFormat);
 
@@ -963,7 +996,7 @@ describe('MetricsNode', () => {
           {column: 'val', unit: 'COUNT', polarity: 'NOT_APPLICABLE'},
         ],
         dimensionUniqueness: 'NOT_UNIQUE',
-      } as unknown as MetricsSerializedState;
+      } as unknown as MetricsNodeAttrs;
 
       const state = MetricsNode.deserializeState(oldFormat);
 
@@ -980,17 +1013,18 @@ describe('MetricsNode', () => {
           dimensionUniqueness: 'UNIQUE',
           availableColumns: [createColumnInfo('value1', 'int')],
         }),
+        {},
       );
 
       const cloned = node.clone() as MetricsNode;
 
       expect(cloned).toBeInstanceOf(MetricsNode);
       expect(cloned.nodeId).not.toBe(node.nodeId);
-      expect(cloned.state.metricIdPrefix).toBe('test');
-      expect(cloned.state.valueColumns).toHaveLength(1);
-      expect(cloned.state.valueColumns[0].column).toBe('value1');
-      expect(cloned.state.valueColumns[0].unit).toBe('BYTES');
-      expect(cloned.state.dimensionUniqueness).toBe('UNIQUE');
+      expect(cloned.attrs.metricIdPrefix).toBe('test');
+      expect(cloned.attrs.valueColumns).toHaveLength(1);
+      expect(cloned.attrs.valueColumns[0].column).toBe('value1');
+      expect(cloned.attrs.valueColumns[0].unit).toBe('BYTES');
+      expect(cloned.attrs.dimensionUniqueness).toBe('UNIQUE');
     });
 
     it('should deep-copy valueColumns array so mutation does not affect original', () => {
@@ -998,44 +1032,42 @@ describe('MetricsNode', () => {
         makeState({
           valueColumns: [makeValueCol('cpu'), makeValueCol('mem')],
         }),
+        {},
       );
 
       const cloned = node.clone() as MetricsNode;
 
       // Mutate clone
-      cloned.state.valueColumns[0].unit = 'BYTES';
-      cloned.state.valueColumns.push(makeValueCol('extra'));
+      cloned.attrs.valueColumns[0].unit = 'BYTES';
+      cloned.attrs.valueColumns.push(makeValueCol('extra'));
 
       // Original should be unaffected
-      expect(node.state.valueColumns[0].unit).toBe('COUNT');
-      expect(node.state.valueColumns).toHaveLength(2);
+      expect(node.attrs.valueColumns[0].unit).toBe('COUNT');
+      expect(node.attrs.valueColumns).toHaveLength(2);
     });
 
     it('should preserve onchange callback', () => {
       const onchange = jest.fn();
-      const node = new MetricsNode({
-        ...makeState(),
-        onchange,
-      });
+      const node = new MetricsNode(makeState(), {onchange});
 
       const cloned = node.clone() as MetricsNode;
 
-      expect(cloned.state.onchange).toBe(onchange);
+      expect(cloned.context.onchange).toBe(onchange);
     });
 
     it('should not copy issues to the clone', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
       node.validate(); // Triggers issues creation
 
       const cloned = node.clone() as MetricsNode;
 
-      expect(cloned.state.issues).toBeUndefined();
+      expect(cloned.context.issues).toBeUndefined();
     });
   });
 
   describe('getTitle', () => {
     it('should return correct title', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       expect(node.getTitle()).toBe('Metrics');
     });
@@ -1043,7 +1075,7 @@ describe('MetricsNode', () => {
 
   describe('nodeDetails', () => {
     it('should always include title', () => {
-      const node = new MetricsNode({} as MetricsNodeState);
+      const node = new MetricsNode({} as unknown as MetricsNodeAttrs, {});
 
       const details = node.nodeDetails();
 
@@ -1051,7 +1083,7 @@ describe('MetricsNode', () => {
     });
 
     it('should show invalid state when metric ID prefix is empty', () => {
-      const node = new MetricsNode(makeState({metricIdPrefix: ''}));
+      const node = new MetricsNode(makeState({metricIdPrefix: ''}), {});
 
       const details = node.nodeDetails();
 
@@ -1061,6 +1093,7 @@ describe('MetricsNode', () => {
     it('should show metric ID prefix when configured', () => {
       const node = new MetricsNode(
         makeState({metricIdPrefix: 'my_metric', valueColumns: []}),
+        {},
       );
 
       const details = node.nodeDetails();
@@ -1073,6 +1106,7 @@ describe('MetricsNode', () => {
         makeState({
           valueColumns: [makeValueCol('cpu'), makeValueCol('mem')],
         }),
+        {},
       );
 
       const details = node.nodeDetails();
@@ -1090,6 +1124,7 @@ describe('MetricsNode', () => {
             createColumnInfo('dim2', 'int'),
           ],
         }),
+        {},
       );
 
       const details = node.nodeDetails();
@@ -1108,6 +1143,7 @@ describe('MetricsNode', () => {
             createColumnInfo('name', 'string'),
           ],
         }),
+        {},
       );
 
       const modify = node.nodeSpecificModify();
@@ -1140,6 +1176,7 @@ describe('MetricsNode', () => {
           ],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -1177,6 +1214,7 @@ describe('MetricsNode', () => {
           ],
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
@@ -1204,25 +1242,22 @@ describe('MetricsNode', () => {
           dimensionUniqueness: 'UNIQUE',
           availableColumns: inputCols,
         }),
+        {},
       );
       connectNodes(inputNode, node);
 
-      const serialized = node.serializeState();
+      const restoredState = MetricsNode.deserializeState(node.attrs);
 
-      const restoredState = MetricsNode.deserializeState(
-        serialized as MetricsSerializedState,
-      );
+      const restoredNode = new MetricsNode(restoredState, {});
 
-      const restoredNode = new MetricsNode(restoredState);
-
-      expect(restoredNode.state.metricIdPrefix).toBe('original_metric');
-      expect(restoredNode.state.valueColumns).toHaveLength(1);
-      expect(restoredNode.state.valueColumns[0].column).toBe('value1');
-      expect(restoredNode.state.valueColumns[0].unit).toBe('PERCENTAGE');
-      expect(restoredNode.state.valueColumns[0].polarity).toBe(
+      expect(restoredNode.attrs.metricIdPrefix).toBe('original_metric');
+      expect(restoredNode.attrs.valueColumns).toHaveLength(1);
+      expect(restoredNode.attrs.valueColumns[0].column).toBe('value1');
+      expect(restoredNode.attrs.valueColumns[0].unit).toBe('PERCENTAGE');
+      expect(restoredNode.attrs.valueColumns[0].polarity).toBe(
         'HIGHER_IS_BETTER',
       );
-      expect(restoredNode.state.dimensionUniqueness).toBe('UNIQUE');
+      expect(restoredNode.attrs.dimensionUniqueness).toBe('UNIQUE');
     });
 
     it('should handle multi-value serialization round-trip', () => {
@@ -1235,16 +1270,14 @@ describe('MetricsNode', () => {
             makeValueCol('score', 'CUSTOM', 'HIGHER_IS_BETTER', 'pts'),
           ],
         }),
+        {},
       );
 
-      const serialized = node.serializeState();
-      const restored = MetricsNode.deserializeState(
-        serialized as MetricsSerializedState,
-      );
-      const restoredNode = new MetricsNode(restored);
+      const restored = MetricsNode.deserializeState(node.attrs);
+      const restoredNode = new MetricsNode(restored, {});
 
-      expect(restoredNode.state.valueColumns).toHaveLength(3);
-      expect(restoredNode.state.valueColumns[2].customUnit).toBe('pts');
+      expect(restoredNode.attrs.valueColumns).toHaveLength(3);
+      expect(restoredNode.attrs.valueColumns[2].customUnit).toBe('pts');
     });
 
     it('should preserve value columns after deserialization and reconnection', () => {
@@ -1260,20 +1293,20 @@ describe('MetricsNode', () => {
         valueColumns: [
           {column: 'metric_value', unit: 'BYTES', polarity: 'LOWER_IS_BETTER'},
         ],
+        dimensionConfigs: {},
         dimensionUniqueness: 'NOT_UNIQUE',
       });
 
-      expect(deserializedState.availableColumns).toEqual([]);
-
-      const restoredNode = new MetricsNode(deserializedState);
-      expect(restoredNode.state.valueColumns).toHaveLength(1);
+      const restoredNode = new MetricsNode(deserializedState, {});
+      expect(restoredNode.availableColumns).toEqual([]);
+      expect(restoredNode.attrs.valueColumns).toHaveLength(1);
 
       connectNodes(inputNode, restoredNode);
       restoredNode.onPrevNodesUpdated();
 
-      expect(restoredNode.state.availableColumns.length).toBe(3);
-      expect(restoredNode.state.valueColumns).toHaveLength(1);
-      expect(restoredNode.state.valueColumns[0].column).toBe('metric_value');
+      expect(restoredNode.availableColumns.length).toBe(3);
+      expect(restoredNode.attrs.valueColumns).toHaveLength(1);
+      expect(restoredNode.attrs.valueColumns[0].column).toBe('metric_value');
       expect(restoredNode.getDimensions()).toEqual(['id', 'category']);
       expect(restoredNode.validate()).toBe(true);
     });
@@ -1295,13 +1328,14 @@ describe('MetricsNode', () => {
           },
         ],
         dimensionUniqueness: 'NOT_UNIQUE',
+        dimensionConfigs: {},
       });
 
-      const restoredNode = new MetricsNode(deserializedState);
+      const restoredNode = new MetricsNode(deserializedState, {});
       connectNodes(inputNode, restoredNode);
       restoredNode.onPrevNodesUpdated();
 
-      expect(restoredNode.state.valueColumns).toHaveLength(0);
+      expect(restoredNode.attrs.valueColumns).toHaveLength(0);
     });
 
     it('should clear value columns that become non-numeric after reconnection', () => {
@@ -1317,13 +1351,14 @@ describe('MetricsNode', () => {
           {column: 'metric_value', unit: 'COUNT', polarity: 'NOT_APPLICABLE'},
         ],
         dimensionUniqueness: 'NOT_UNIQUE',
+        dimensionConfigs: {},
       });
 
-      const restoredNode = new MetricsNode(deserializedState);
+      const restoredNode = new MetricsNode(deserializedState, {});
       connectNodes(inputNode, restoredNode);
       restoredNode.onPrevNodesUpdated();
 
-      expect(restoredNode.state.valueColumns).toHaveLength(0);
+      expect(restoredNode.attrs.valueColumns).toHaveLength(0);
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
@@ -13,18 +13,9 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import {TextInput} from '../../../../widgets/text_input';
-import {
-  ColumnInfo,
-  legacyDeserializeType,
-  newColumnInfoList,
-} from '../column_info';
+import {ColumnInfo, legacyDeserializeType} from '../column_info';
 import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 import {NodeIssues} from '../node_issues';
@@ -38,21 +29,9 @@ import {
 } from '../node_styling_widgets';
 import {loadNodeDoc} from '../node_doc_loader';
 import {renderTypeSelector} from './modify_columns_utils';
-import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
 
-export interface ModifyColumnsSerializedState {
-  primaryInputId?: string;
-  selectedColumns: {
-    name: string;
-    type?: PerfettoSqlType;
-    checked: boolean;
-    alias?: string;
-    typeUserModified?: boolean;
-  }[];
-  comment?: string;
-}
-
-export interface ModifyColumnsState extends QueryNodeState {
+// Serializable node configuration.
+export interface ModifyColumnsNodeAttrs {
   selectedColumns: ColumnInfo[];
 }
 
@@ -61,112 +40,78 @@ export class ModifyColumnsNode implements QueryNode {
   readonly type = NodeType.kModifyColumns;
   primaryInput?: QueryNode;
   nextNodes: QueryNode[];
-  readonly state: ModifyColumnsState;
+  readonly attrs: ModifyColumnsNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: ModifyColumnsState) {
+  constructor(attrs: ModifyColumnsNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
     this.nextNodes = [];
 
-    this.state = {
-      ...state,
-      selectedColumns: state.selectedColumns ?? [],
+    this.attrs = {
+      ...attrs,
+      selectedColumns: attrs.selectedColumns ?? [],
     };
+    this.context = context;
   }
 
   get finalCols(): ColumnInfo[] {
-    return this.computeFinalCols();
-  }
-
-  private computeFinalCols(): ColumnInfo[] {
-    const finalCols = newColumnInfoList(
-      this.state.selectedColumns.filter((col) => col.checked),
-    );
-    return finalCols;
+    return this.attrs.selectedColumns
+      .filter((col) => col.checked)
+      .map((col) => {
+        const finalName = col.alias ?? col.name;
+        return {
+          name: finalName,
+          checked: true,
+          type: col.type,
+          alias: undefined,
+          typeUserModified: col.typeUserModified,
+        };
+      });
   }
 
   onPrevNodesUpdated() {
-    // This node assumes it has only one previous node.
     if (this.primaryInput === undefined) {
       return;
     }
 
     const sourceCols = this.primaryInput.finalCols;
 
-    const newSelectedColumns = newColumnInfoList(sourceCols);
-
-    // Preserve checked status and aliases for columns that still exist.
-    // Types are only preserved if the user explicitly modified them.
-    for (const oldCol of this.state.selectedColumns) {
-      const newCol = newSelectedColumns.find(
-        (c) => c.column.name === oldCol.column.name,
+    const newSelectedColumns: ColumnInfo[] = sourceCols.map((col) => {
+      const oldCol = this.attrs.selectedColumns.find(
+        (c) => c.name === col.name,
       );
-      if (newCol) {
-        newCol.checked = oldCol.checked;
-        newCol.alias = oldCol.alias;
-        // Only preserve type if user explicitly modified it
-        if (oldCol.typeUserModified) {
-          newCol.column = {
-            ...newCol.column,
-            type: oldCol.column.type,
-          };
-          newCol.typeUserModified = true;
-        }
-      }
-    }
+      return {
+        name: col.name,
+        type: oldCol?.typeUserModified ? oldCol.type : col.type,
+        checked: oldCol?.checked ?? true,
+        alias: oldCol?.alias,
+        typeUserModified: oldCol?.typeUserModified,
+      };
+    });
 
-    this.state.selectedColumns = newSelectedColumns;
-
-    // Trigger downstream update (handled by builder's onchange callback)
-    this.state.onchange?.();
+    this.attrs.selectedColumns = newSelectedColumns;
+    this.context.onchange?.();
   }
 
   static deserializeState(
-    sqlModules: SqlModules,
-    serializedState: ModifyColumnsSerializedState,
-  ): ModifyColumnsState {
+    state: ModifyColumnsNodeAttrs,
+  ): ModifyColumnsNodeAttrs {
     return {
-      ...serializedState,
-      sqlModules,
-      selectedColumns: serializedState.selectedColumns.map((c) => ({
-        name: c.name,
-        checked: c.checked,
-        column: {name: c.name, type: legacyDeserializeType(c.type)},
-        alias: c.alias,
-        typeUserModified: c.typeUserModified,
+      selectedColumns: state.selectedColumns.map((c) => ({
+        ...c,
+        // Handle legacy string types (e.g. 'INT' → {kind: 'int'})
+        type: legacyDeserializeType(
+          c.type as unknown as PerfettoSqlType | string | undefined,
+        ),
       })),
     };
   }
 
-  resolveColumns() {
-    // Recover full column information from primaryInput
-    // Note: We preserve user-modified types and only recover the base column object
-    if (this.primaryInput === undefined) {
-      return;
-    }
-
-    const sourceCols = this.primaryInput.finalCols ?? [];
-    this.state.selectedColumns.forEach((c) => {
-      const sourceCol = sourceCols.find((s) => s.name === c.name);
-      if (sourceCol) {
-        // Only update the column reference, NOT the type
-        // The type may have been modified by the user and is preserved in serialization
-        c.column = {
-          ...sourceCol.column,
-          // Keep the user-modified type if it exists
-          type: c.column.type ?? sourceCol.column.type,
-        };
-        // Do NOT update c.type - it's already set from deserialization
-      }
-    });
-  }
-
   validate(): boolean {
-    // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
-    // Check if primary input exists and is valid
     if (this.primaryInput === undefined) {
       this.setValidationError('No input node connected');
       return false;
@@ -177,10 +122,9 @@ export class ModifyColumnsNode implements QueryNode {
     }
 
     const colNames = new Set<string>();
-    for (const col of this.state.selectedColumns) {
+    for (const col of this.attrs.selectedColumns) {
       if (!col.checked) continue;
-      // Empty aliases are allowed - they just mean use the original column name
-      const name = col.alias ? col.alias.trim() : col.column.name;
+      const name = col.alias ? col.alias.trim() : col.name;
       if (colNames.has(name)) {
         this.setValidationError('Duplicate column names');
         return false;
@@ -188,7 +132,6 @@ export class ModifyColumnsNode implements QueryNode {
       colNames.add(name);
     }
 
-    // Check if there are no columns selected
     if (colNames.size === 0) {
       this.setValidationError(
         'No columns selected. Select at least one column.',
@@ -200,10 +143,10 @@ export class ModifyColumnsNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -211,37 +154,32 @@ export class ModifyColumnsNode implements QueryNode {
   }
 
   nodeDetails(): NodeDetailsAttrs {
-    const selectedCols = this.state.selectedColumns.filter((c) => c.checked);
-    const totalCols = this.state.selectedColumns.length;
+    const selectedCols = this.attrs.selectedColumns.filter((c) => c.checked);
+    const totalCols = this.attrs.selectedColumns.length;
 
-    // If all columns have been deselected, show a specific message.
     if (selectedCols.length === 0) {
       return {
         content: NodeDetailsMessage('All columns deselected'),
       };
     }
 
-    // Determine the state of modifications.
-    const hasUnselected = this.state.selectedColumns.some((c) => !c.checked);
-    const hasAlias = this.state.selectedColumns.some((c) => c.alias);
+    const hasUnselected = this.attrs.selectedColumns.some((c) => !c.checked);
+    const hasAlias = this.attrs.selectedColumns.some((c) => c.alias);
     if (!hasUnselected && !hasAlias) {
       return {
         content: NodeDetailsMessage('Select all columns'),
       };
     }
 
-    // If there are too many selected columns, show a summary.
     const maxColumnsToShow = 5;
     if (selectedCols.length > maxColumnsToShow) {
       const renamedCols = selectedCols.filter((c) => c.alias);
       const allSelected = selectedCols.length === totalCols;
 
-      // Show up to 3 renamed columns explicitly even in summary mode.
       if (renamedCols.length > 0 && renamedCols.length <= 3) {
         const renamedItems = renamedCols.map((c) =>
-          m('div', ColumnName(c.column.name), ' AS ', ColumnName(c.alias!)),
+          m('div', ColumnName(c.name), ' AS ', ColumnName(c.alias!)),
         );
-        // Only show the count if not all columns are selected
         if (allSelected) {
           return {
             content: m('div', ...renamedItems),
@@ -257,7 +195,6 @@ export class ModifyColumnsNode implements QueryNode {
           ),
         };
       } else {
-        // If all columns are selected, don't show the redundant "X of X" message
         if (allSelected) {
           return {
             content: NodeDetailsMessage('Select all'),
@@ -270,12 +207,11 @@ export class ModifyColumnsNode implements QueryNode {
       }
     }
 
-    // Otherwise, list all selected columns.
     const selectedItems = selectedCols.map((c) => {
       if (c.alias) {
-        return m('div', ColumnName(c.column.name), ' AS ', ColumnName(c.alias));
+        return m('div', ColumnName(c.name), ' AS ', ColumnName(c.alias));
       } else {
-        return m('div', ColumnName(c.column.name));
+        return m('div', ColumnName(c.name));
       }
     });
     return {
@@ -284,20 +220,36 @@ export class ModifyColumnsNode implements QueryNode {
   }
 
   nodeSpecificModify(): NodeModifyAttrs {
-    const selectedCount = this.state.selectedColumns.filter(
+    const selectedCount = this.attrs.selectedColumns.filter(
       (col) => col.checked,
     ).length;
-    const totalCount = this.state.selectedColumns.length;
+    const totalCount = this.attrs.selectedColumns.length;
 
-    // Build sections
+    // Convert descriptors to ColumnInfo for the ColumnSelector widget.
+    const columnsForWidget: ColumnInfo[] = this.attrs.selectedColumns.map(
+      (d) => ({
+        name: d.name,
+        checked: d.checked,
+        type: d.type,
+        alias: d.alias,
+        typeUserModified: d.typeUserModified,
+      }),
+    );
+
     const sections: NodeModifyAttrs['sections'] = [
       {
         title: `Select and Rename Columns (${selectedCount} / ${totalCount} selected)`,
         content: m(ColumnSelector, {
-          columns: this.state.selectedColumns,
+          columns: columnsForWidget,
           onColumnsChange: (columns) => {
-            this.state.selectedColumns = columns;
-            this.state.onchange?.();
+            this.attrs.selectedColumns = columns.map((c) => ({
+              name: c.name,
+              type: c.type,
+              checked: c.checked,
+              alias: c.alias,
+              typeUserModified: c.typeUserModified,
+            }));
+            this.context.onchange?.();
           },
           helpText:
             'Check columns to include, add aliases to rename, and drag to reorder',
@@ -307,30 +259,27 @@ export class ModifyColumnsNode implements QueryNode {
               idx: number,
               newType: PerfettoSqlType,
             ) => {
-              const newSelectedColumns = [...this.state.selectedColumns];
+              const newSelectedColumns = [...this.attrs.selectedColumns];
               newSelectedColumns[idx] = {
                 ...newSelectedColumns[idx],
-                column: {
-                  ...newSelectedColumns[idx].column,
-                  type: newType,
-                },
+                type: newType,
                 typeUserModified: true,
               };
-              this.state.selectedColumns = newSelectedColumns;
-              this.state.onchange?.();
+              this.attrs.selectedColumns = newSelectedColumns;
+              this.context.onchange?.();
             };
 
             return [
               m(TextInput, {
                 oninput: (e: Event) => {
-                  const newSelectedColumns = [...this.state.selectedColumns];
+                  const newSelectedColumns = [...this.attrs.selectedColumns];
                   const inputValue = (e.target as HTMLInputElement).value;
                   newSelectedColumns[index] = {
                     ...newSelectedColumns[index],
                     alias: inputValue.trim() === '' ? undefined : inputValue,
                   };
-                  this.state.selectedColumns = newSelectedColumns;
-                  this.state.onchange?.();
+                  this.attrs.selectedColumns = newSelectedColumns;
+                  this.context.onchange?.();
                 },
                 placeholder: 'alias',
                 value: col.alias ? col.alias : '',
@@ -338,7 +287,7 @@ export class ModifyColumnsNode implements QueryNode {
               renderTypeSelector(
                 col,
                 index,
-                this.state.sqlModules,
+                this.context.sqlModules,
                 handleTypeChange,
               ),
             ];
@@ -358,70 +307,38 @@ export class ModifyColumnsNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    // Deep copy selectedColumns preserving exact state (including aliases)
-    // Do NOT use newColumnInfoList here - that transforms columns for downstream
-    // propagation (applying aliases as new names), but cloning needs exact copy.
-    const clonedColumns: ColumnInfo[] = this.state.selectedColumns.map(
-      (col) => ({
-        ...col,
-        column: {...col.column},
-      }),
+    return new ModifyColumnsNode(
+      {selectedColumns: this.attrs.selectedColumns.map((c) => ({...c}))},
+      this.context,
     );
-
-    const stateCopy: ModifyColumnsState = {
-      selectedColumns: clonedColumns,
-      filters: this.state.filters?.map((f) => ({...f})),
-      filterOperator: this.state.filterOperator,
-      onchange: this.state.onchange,
-      sqlModules: this.state.sqlModules,
-    };
-    return new ModifyColumnsNode(stateCopy);
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (this.primaryInput === undefined) return undefined;
 
-    // Check if any modification is needed:
-    // - A column is unchecked (hidden)
-    // - A column has an alias (renamed)
-    const hasModification = this.state.selectedColumns.some(
+    const hasModification = this.attrs.selectedColumns.some(
       (col) => !col.checked || (col.alias && col.alias.trim() !== ''),
     );
 
-    // If no modification, return passthrough to maintain reference chain
     if (!hasModification) {
       return StructuredQueryBuilder.passthrough(this.primaryInput, this.nodeId);
     }
 
-    // Build column specifications
     const columns: ColumnSpec[] = [];
 
-    for (const col of this.state.selectedColumns) {
+    for (const col of this.attrs.selectedColumns) {
       if (!col.checked) continue;
       columns.push({
-        columnNameOrExpression: col.column.name,
+        columnNameOrExpression: col.name,
         alias: col.alias,
       });
     }
 
-    // Apply column selection
     return StructuredQueryBuilder.withSelectColumns(
       this.primaryInput,
       columns,
       undefined,
       this.nodeId,
     );
-  }
-
-  serializeState(): ModifyColumnsSerializedState {
-    return {
-      selectedColumns: this.state.selectedColumns.map((c) => ({
-        name: c.name,
-        type: c.column.type,
-        checked: c.checked,
-        alias: c.alias,
-        typeUserModified: c.typeUserModified,
-      })),
-    };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  ModifyColumnsNode,
-  ModifyColumnsSerializedState,
-  ModifyColumnsState,
-} from './modify_columns_node';
+import {ModifyColumnsNode, ModifyColumnsNodeAttrs} from './modify_columns_node';
 import {QueryNode} from '../../query_node';
 import {
   createMockNode,
@@ -24,7 +20,6 @@ import {
   connectNodes,
 } from '../testing/test_utils';
 import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
-import {SqlModules} from '../../../dev.perfetto.SqlModules/sql_modules';
 
 describe('ModifyColumnsNode', () => {
   function createMockPrevNode(): QueryNode {
@@ -39,10 +34,10 @@ describe('ModifyColumnsNode', () => {
   }
 
   function createModifyColumnsNodeWithInput(
-    state: ModifyColumnsState,
+    state: ModifyColumnsNodeAttrs,
     inputNode?: QueryNode,
   ): ModifyColumnsNode {
-    const node = new ModifyColumnsNode(state);
+    const node = new ModifyColumnsNode(state, {});
     if (inputNode) {
       // Directly set the connection without triggering onPrevNodesUpdated
       // to preserve the test's explicitly provided selectedColumns
@@ -72,7 +67,7 @@ describe('ModifyColumnsNode', () => {
       );
 
       // Uncheck all auto-populated columns
-      node.state.selectedColumns.forEach((col) => {
+      node.attrs.selectedColumns.forEach((col) => {
         col.checked = false;
       });
 
@@ -127,76 +122,66 @@ describe('ModifyColumnsNode', () => {
       const node = createModifyColumnsNodeWithInput(
         {
           selectedColumns: [
-            createColumnInfo('id', 'int'),
-            createColumnInfo('status', 'string'),
+            {name: 'id', checked: true},
+            {name: 'status', checked: true},
           ],
         },
         createMockPrevNode(),
       );
 
-      const serialized = node.serializeState();
-
-      expect(serialized.selectedColumns).toBeDefined();
-      expect(serialized.selectedColumns.length).toBe(2);
-      expect(serialized.selectedColumns[0].name).toBe('id');
-      expect(serialized.selectedColumns[1].name).toBe('status');
+      expect(node.attrs.selectedColumns).toBeDefined();
+      expect(node.attrs.selectedColumns.length).toBe(2);
+      expect(node.attrs.selectedColumns[0].name).toBe('id');
+      expect(node.attrs.selectedColumns[1].name).toBe('status');
     });
 
     it('should serialize column aliases correctly', () => {
-      const col1 = createColumnInfo('id', 'int');
-      const col2 = createColumnInfo('status', 'string', {
-        alias: 'status_renamed',
-      });
       const node = createModifyColumnsNodeWithInput(
         {
-          selectedColumns: [col1, col2],
+          selectedColumns: [
+            {name: 'id', checked: true},
+            {name: 'status', checked: true, alias: 'status_renamed'},
+          ],
         },
         createMockPrevNode(),
       );
 
-      const serialized = node.serializeState();
-
-      expect(serialized.selectedColumns[0].alias).toBeUndefined();
-      expect(serialized.selectedColumns[1].alias).toBe('status_renamed');
+      expect(node.attrs.selectedColumns[0].alias).toBeUndefined();
+      expect(node.attrs.selectedColumns[1].alias).toBe('status_renamed');
     });
 
     it('should serialize checked status correctly', () => {
-      const col1 = createColumnInfo('id', 'int');
-      const col2 = createColumnInfo('status', 'string', {checked: false});
       const node = createModifyColumnsNodeWithInput(
         {
-          selectedColumns: [col1, col2],
+          selectedColumns: [
+            {name: 'id', checked: true},
+            {name: 'status', checked: false},
+          ],
         },
         createMockPrevNode(),
       );
 
-      const serialized = node.serializeState();
-
-      expect(serialized.selectedColumns[0].checked).toBe(true);
-      expect(serialized.selectedColumns[1].checked).toBe(false);
+      expect(node.attrs.selectedColumns[0].checked).toBe(true);
+      expect(node.attrs.selectedColumns[1].checked).toBe(false);
     });
 
     it('should serialize column types as PerfettoSqlType objects', () => {
-      const col1 = createColumnInfo('id', 'int');
-      const col2 = createColumnInfo('ts', 'timestamp');
       const node = createModifyColumnsNodeWithInput(
-        {selectedColumns: [col1, col2]},
+        {
+          selectedColumns: [
+            {name: 'id', type: {kind: 'int'}, checked: true},
+            {name: 'ts', type: {kind: 'timestamp'}, checked: true},
+          ],
+        },
         createMockPrevNode(),
       );
 
-      const serialized = node.serializeState();
-
-      expect(serialized.selectedColumns[0].type).toEqual({kind: 'int'});
-      expect(serialized.selectedColumns[1].type).toEqual({kind: 'timestamp'});
+      expect(node.attrs.selectedColumns[0].type).toEqual({kind: 'int'});
+      expect(node.attrs.selectedColumns[1].type).toEqual({kind: 'timestamp'});
     });
   });
 
   describe('legacy deserialization', () => {
-    const mockSqlModules = {
-      listTables: () => [],
-      listModules: () => [],
-    } as unknown as SqlModules;
-
     it('should deserialize legacy string types into PerfettoSqlType', () => {
       // Simulate old serialized state where type was a string like "INT"
       const legacyState = {
@@ -205,69 +190,47 @@ describe('ModifyColumnsNode', () => {
           {name: 'name', type: 'STRING', checked: true},
           {name: 'ts', type: 'TIMESTAMP', checked: false},
         ],
-      } as unknown as ModifyColumnsSerializedState;
+      } as unknown as ModifyColumnsNodeAttrs;
 
-      const state = ModifyColumnsNode.deserializeState(
-        mockSqlModules,
-        legacyState,
-      );
+      const state = ModifyColumnsNode.deserializeState(legacyState);
 
-      expect(state.selectedColumns[0].column.type).toEqual(
-        PerfettoSqlTypes.INT,
-      );
-      expect(state.selectedColumns[1].column.type).toEqual(
-        PerfettoSqlTypes.STRING,
-      );
-      expect(state.selectedColumns[2].column.type).toEqual(
-        PerfettoSqlTypes.TIMESTAMP,
-      );
+      expect(state.selectedColumns[0].type).toEqual(PerfettoSqlTypes.INT);
+      expect(state.selectedColumns[1].type).toEqual(PerfettoSqlTypes.STRING);
+      expect(state.selectedColumns[2].type).toEqual(PerfettoSqlTypes.TIMESTAMP);
     });
 
     it('should deserialize new PerfettoSqlType objects correctly', () => {
-      const newState: ModifyColumnsSerializedState = {
+      const newState: ModifyColumnsNodeAttrs = {
         selectedColumns: [
           {name: 'id', type: {kind: 'int'}, checked: true},
           {name: 'dur', type: {kind: 'duration'}, checked: true},
         ],
       };
 
-      const state = ModifyColumnsNode.deserializeState(
-        mockSqlModules,
-        newState,
-      );
+      const state = ModifyColumnsNode.deserializeState(newState);
 
-      expect(state.selectedColumns[0].column.type).toEqual(
-        PerfettoSqlTypes.INT,
-      );
-      expect(state.selectedColumns[1].column.type).toEqual(
-        PerfettoSqlTypes.DURATION,
-      );
+      expect(state.selectedColumns[0].type).toEqual(PerfettoSqlTypes.INT);
+      expect(state.selectedColumns[1].type).toEqual(PerfettoSqlTypes.DURATION);
     });
 
     it('should handle undefined types gracefully', () => {
       const stateWithNoTypes = {
         selectedColumns: [{name: 'col1', checked: true}],
-      } as unknown as ModifyColumnsSerializedState;
+      } as unknown as ModifyColumnsNodeAttrs;
 
-      const state = ModifyColumnsNode.deserializeState(
-        mockSqlModules,
-        stateWithNoTypes,
-      );
+      const state = ModifyColumnsNode.deserializeState(stateWithNoTypes);
 
-      expect(state.selectedColumns[0].column.type).toBeUndefined();
+      expect(state.selectedColumns[0].type).toBeUndefined();
     });
 
     it('should handle unrecognized legacy string types', () => {
       const stateWithUnknown = {
         selectedColumns: [{name: 'col1', type: 'NA', checked: true}],
-      } as unknown as ModifyColumnsSerializedState;
+      } as unknown as ModifyColumnsNodeAttrs;
 
-      const state = ModifyColumnsNode.deserializeState(
-        mockSqlModules,
-        stateWithUnknown,
-      );
+      const state = ModifyColumnsNode.deserializeState(stateWithUnknown);
 
-      expect(state.selectedColumns[0].column.type).toBeUndefined();
+      expect(state.selectedColumns[0].type).toBeUndefined();
     });
   });
 
@@ -319,30 +282,28 @@ describe('ModifyColumnsNode', () => {
       });
 
       // Create modify columns node and connect it
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       connectNodes(sourceNode, modifyNode);
 
       // Initialize the node to populate columns from source
       modifyNode.onPrevNodesUpdated();
 
       // Verify initial state - all columns should be from source
-      expect(modifyNode.state.selectedColumns.length).toBe(3);
-      expect(modifyNode.state.selectedColumns[2].name).toBe('value');
-      expect(modifyNode.state.selectedColumns[2].column.type).toEqual(
+      expect(modifyNode.attrs.selectedColumns.length).toBe(3);
+      expect(modifyNode.attrs.selectedColumns[2].name).toBe('value');
+      expect(modifyNode.attrs.selectedColumns[2].type).toEqual(
         PerfettoSqlTypes.INT,
       );
 
       // User modifies the type of 'value' column to 'duration'
-      modifyNode.state.selectedColumns[2].column = {
-        ...modifyNode.state.selectedColumns[2].column,
+      modifyNode.attrs.selectedColumns[2] = {
+        ...modifyNode.attrs.selectedColumns[2],
         type: {kind: 'duration'},
+        typeUserModified: true,
       };
-      modifyNode.state.selectedColumns[2].typeUserModified = true;
 
       // Verify the type was modified
-      expect(modifyNode.state.selectedColumns[2].column.type).toEqual(
+      expect(modifyNode.attrs.selectedColumns[2].type).toEqual(
         PerfettoSqlTypes.DURATION,
       );
 
@@ -366,8 +327,8 @@ describe('ModifyColumnsNode', () => {
       modifyNode.onPrevNodesUpdated();
 
       // The modified type should be preserved!
-      expect(modifyNode.state.selectedColumns[2].name).toBe('value');
-      expect(modifyNode.state.selectedColumns[2].column.type).toEqual(
+      expect(modifyNode.attrs.selectedColumns[2].name).toBe('value');
+      expect(modifyNode.attrs.selectedColumns[2].type).toEqual(
         PerfettoSqlTypes.DURATION,
       );
     });
@@ -382,15 +343,13 @@ describe('ModifyColumnsNode', () => {
         ],
       });
 
-      const modifyNode = new ModifyColumnsNode({
-        selectedColumns: [],
-      });
+      const modifyNode = new ModifyColumnsNode({selectedColumns: []}, {});
       connectNodes(sourceNode, modifyNode);
       modifyNode.onPrevNodesUpdated();
 
       // User customizes the node
-      modifyNode.state.selectedColumns[0].checked = false; // Uncheck 'id'
-      modifyNode.state.selectedColumns[1].alias = 'full_name'; // Rename 'name'
+      modifyNode.attrs.selectedColumns[0].checked = false; // Uncheck 'id'
+      modifyNode.attrs.selectedColumns[1].alias = 'full_name'; // Rename 'name'
 
       // Insert intermediate node
       const intermediateNode = createMockNode({
@@ -406,8 +365,8 @@ describe('ModifyColumnsNode', () => {
       modifyNode.onPrevNodesUpdated();
 
       // Customizations should be preserved
-      expect(modifyNode.state.selectedColumns[0].checked).toBe(false);
-      expect(modifyNode.state.selectedColumns[1].alias).toBe('full_name');
+      expect(modifyNode.attrs.selectedColumns[0].checked).toBe(false);
+      expect(modifyNode.attrs.selectedColumns[1].alias).toBe('full_name');
     });
   });
 
@@ -426,9 +385,9 @@ describe('ModifyColumnsNode', () => {
       const clonedNode = node.clone() as ModifyColumnsNode;
 
       // Aliases should be preserved in the cloned node
-      expect(clonedNode.state.selectedColumns[0].alias).toBeUndefined();
-      expect(clonedNode.state.selectedColumns[1].alias).toBe('full_name');
-      expect(clonedNode.state.selectedColumns[2].alias).toBe('amount');
+      expect(clonedNode.attrs.selectedColumns[0].alias).toBeUndefined();
+      expect(clonedNode.attrs.selectedColumns[1].alias).toBe('full_name');
+      expect(clonedNode.attrs.selectedColumns[2].alias).toBe('amount');
     });
 
     it('should preserve checked status when cloning', () => {
@@ -444,18 +403,17 @@ describe('ModifyColumnsNode', () => {
 
       const clonedNode = node.clone() as ModifyColumnsNode;
 
-      expect(clonedNode.state.selectedColumns[0].checked).toBe(true);
-      expect(clonedNode.state.selectedColumns[1].checked).toBe(false);
-      expect(clonedNode.state.selectedColumns[2].checked).toBe(true);
+      expect(clonedNode.attrs.selectedColumns[0].checked).toBe(true);
+      expect(clonedNode.attrs.selectedColumns[1].checked).toBe(false);
+      expect(clonedNode.attrs.selectedColumns[2].checked).toBe(true);
     });
 
     it('should preserve original column names when cloning with aliases', () => {
       // This is a regression test: cloning should NOT apply aliases as new
       // column names. The clone should preserve the exact internal state.
-      const col = createColumnInfo('id', 'int', {alias: 'identifier'});
       const node = createModifyColumnsNodeWithInput(
         {
-          selectedColumns: [col],
+          selectedColumns: [{name: 'id', checked: true, alias: 'identifier'}],
         },
         createMockPrevNode(),
       );
@@ -463,27 +421,31 @@ describe('ModifyColumnsNode', () => {
       const clonedNode = node.clone() as ModifyColumnsNode;
 
       // The original column name should be preserved, NOT the alias
-      expect(clonedNode.state.selectedColumns[0].column.name).toBe('id');
-      expect(clonedNode.state.selectedColumns[0].alias).toBe('identifier');
+      expect(clonedNode.attrs.selectedColumns[0].name).toBe('id');
+      expect(clonedNode.attrs.selectedColumns[0].alias).toBe('identifier');
     });
 
     it('should preserve typeUserModified flag when cloning', () => {
-      const col = createColumnInfo('value', 'int');
-      col.column = {...col.column, type: PerfettoSqlTypes.DURATION};
-      col.typeUserModified = true;
       const node = createModifyColumnsNodeWithInput(
         {
-          selectedColumns: [col],
+          selectedColumns: [
+            {
+              name: 'value',
+              type: PerfettoSqlTypes.DURATION,
+              checked: true,
+              typeUserModified: true,
+            },
+          ],
         },
         createMockPrevNode(),
       );
 
       const clonedNode = node.clone() as ModifyColumnsNode;
 
-      expect(clonedNode.state.selectedColumns[0].column.type).toEqual(
+      expect(clonedNode.attrs.selectedColumns[0].type).toEqual(
         PerfettoSqlTypes.DURATION,
       );
-      expect(clonedNode.state.selectedColumns[0].typeUserModified).toBe(true);
+      expect(clonedNode.attrs.selectedColumns[0].typeUserModified).toBe(true);
     });
 
     it('should create independent copies (mutations do not affect original)', () => {
@@ -498,12 +460,12 @@ describe('ModifyColumnsNode', () => {
       const clonedNode = node.clone() as ModifyColumnsNode;
 
       // Modify the cloned node
-      clonedNode.state.selectedColumns[0].alias = 'modified_alias';
-      clonedNode.state.selectedColumns[0].checked = false;
+      clonedNode.attrs.selectedColumns[0].alias = 'modified_alias';
+      clonedNode.attrs.selectedColumns[0].checked = false;
 
       // Original should be unchanged
-      expect(node.state.selectedColumns[0].alias).toBe('original_alias');
-      expect(node.state.selectedColumns[0].checked).toBe(true);
+      expect(node.attrs.selectedColumns[0].alias).toBe('original_alias');
+      expect(node.attrs.selectedColumns[0].checked).toBe(true);
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_utils.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_utils.ts
@@ -68,9 +68,9 @@ export function renderTypeSelector(
     return null;
   }
 
-  const currentType = col.column.type;
+  const currentType = col.type;
   const currentTypeStr = perfettoSqlTypeToString(currentType);
-  const originalType = col.column.type;
+  const originalType = col.type;
 
   // Build the list of menu items
   const menuItems: m.Child[] = [];

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sort_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sort_node.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, NodeContext, nextNodeId, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
 import {Button} from '../../../../widgets/button';
@@ -44,7 +39,9 @@ export interface SortCriterion {
   direction: 'ASC' | 'DESC';
 }
 
-export interface SortNodeState extends QueryNodeState {
+// Serializable node configuration. This IS the serialized format —
+// no separate serializeState()/deserializeState() needed.
+export interface SortNodeAttrs {
   sortCriteria?: SortCriterion[];
 }
 
@@ -53,22 +50,25 @@ export class SortNode implements QueryNode {
   readonly type = NodeType.kSort;
   primaryInput?: QueryNode;
   nextNodes: QueryNode[];
-  readonly state: SortNodeState;
+  readonly attrs: SortNodeAttrs;
+  readonly context: NodeContext;
 
-  constructor(state: SortNodeState) {
+  constructor(attrs: SortNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = state;
+    this.attrs = {
+      ...attrs,
+      sortCriteria: attrs.sortCriteria ?? [],
+    };
+    this.context = context;
     this.nextNodes = [];
-
-    this.state.sortCriteria = this.state.sortCriteria ?? [];
   }
 
   get sortCols(): ColumnInfo[] {
-    if (!this.state.sortCriteria) {
+    if (!this.attrs.sortCriteria) {
       return [];
     }
     const sourceCols = this.sourceCols;
-    return this.state.sortCriteria
+    return this.attrs.sortCriteria
       .map((criterion) => sourceCols.find((c) => c.name === criterion.colName))
       .filter((c): c is ColumnInfo => c !== undefined);
   }
@@ -86,13 +86,13 @@ export class SortNode implements QueryNode {
   }
 
   nodeDetails(): NodeDetailsAttrs {
-    if (!this.state.sortCriteria || this.state.sortCriteria.length === 0) {
+    if (!this.attrs.sortCriteria || this.attrs.sortCriteria.length === 0) {
       return {
         content: NodeDetailsMessage('No sort columns'),
       };
     }
 
-    const label = this.state.sortCriteria
+    const label = this.attrs.sortCriteria
       .map((c) =>
         c.direction === 'DESC' ? `${c.colName} ↓` : `${c.colName} ↑`,
       )
@@ -104,8 +104,8 @@ export class SortNode implements QueryNode {
   }
 
   nodeSpecificModify(): NodeModifyAttrs {
-    if (!this.state.sortCriteria) {
-      this.state.sortCriteria = [];
+    if (!this.attrs.sortCriteria) {
+      this.attrs.sortCriteria = [];
     }
 
     const sections: NodeModifyAttrs['sections'] = [
@@ -129,7 +129,7 @@ export class SortNode implements QueryNode {
   }
 
   private renderColumnSelector(): m.Child {
-    const sortCriteria = this.state.sortCriteria ?? [];
+    const sortCriteria = this.attrs.sortCriteria ?? [];
 
     const sortOptions: MultiSelectOption[] = this.sourceCols.map((col) => ({
       id: col.name,
@@ -156,45 +156,45 @@ export class SortNode implements QueryNode {
         options: sortOptions,
         showNumSelected: false,
         onChange: (diffs: MultiSelectDiff[]) => {
-          if (!this.state.sortCriteria) {
-            this.state.sortCriteria = [];
+          if (!this.attrs.sortCriteria) {
+            this.attrs.sortCriteria = [];
           }
           for (const diff of diffs) {
             if (diff.checked) {
               // Add column if not already present
-              if (!this.state.sortCriteria.some((c) => c.colName === diff.id)) {
-                this.state.sortCriteria.push({
+              if (!this.attrs.sortCriteria.some((c) => c.colName === diff.id)) {
+                this.attrs.sortCriteria.push({
                   colName: diff.id,
                   direction: 'ASC',
                 });
               }
             } else {
               // Remove column
-              this.state.sortCriteria = this.state.sortCriteria.filter(
+              this.attrs.sortCriteria = this.attrs.sortCriteria.filter(
                 (c) => c.colName !== diff.id,
               );
             }
           }
-          this.state.onchange?.();
+          this.context.onchange?.();
         },
       }),
     );
   }
 
   private renderSortCriteriaList(): m.Child {
-    const sortCriteria = this.state.sortCriteria ?? [];
+    const sortCriteria = this.attrs.sortCriteria ?? [];
 
     if (sortCriteria.length === 0) {
       return null;
     }
 
     const handleReorder = (from: number, to: number) => {
-      if (!this.state.sortCriteria) return;
-      const newSortCriteria = [...this.state.sortCriteria];
+      if (!this.attrs.sortCriteria) return;
+      const newSortCriteria = [...this.attrs.sortCriteria];
       const [removed] = newSortCriteria.splice(from, 1);
       newSortCriteria.splice(to, 0, removed);
-      this.state.sortCriteria = newSortCriteria;
-      this.state.onchange?.();
+      this.attrs.sortCriteria = newSortCriteria;
+      this.context.onchange?.();
       m.redraw();
     };
 
@@ -211,10 +211,10 @@ export class SortNode implements QueryNode {
           m(Button, {
             label: criterion.direction,
             onclick: () => {
-              if (this.state.sortCriteria) {
-                this.state.sortCriteria[index].direction =
+              if (this.attrs.sortCriteria) {
+                this.attrs.sortCriteria[index].direction =
                   criterion.direction === 'ASC' ? 'DESC' : 'ASC';
-                this.state.onchange?.();
+                this.context.onchange?.();
                 m.redraw();
               }
             },
@@ -230,22 +230,22 @@ export class SortNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
-      setValidationError(this.state, 'No input node connected');
+      setValidationError(this.context, 'No input node connected');
       return false;
     }
 
     if (!this.primaryInput.validate()) {
-      setValidationError(this.state, 'Previous node is invalid');
+      setValidationError(this.context, 'Previous node is invalid');
       return false;
     }
 
     if (this.sortCols === undefined || this.sortCols.length === 0) {
-      setValidationError(this.state, 'No sort columns selected');
+      setValidationError(this.context, 'No sort columns selected');
       return false;
     }
 
@@ -253,13 +253,10 @@ export class SortNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: SortNodeState = {
-      sortCriteria: this.state.sortCriteria?.map((c) => ({...c})),
-      filters: this.state.filters?.map((f) => ({...f})),
-      filterOperator: this.state.filterOperator,
-      onchange: this.state.onchange,
-    };
-    return new SortNode(stateCopy);
+    return new SortNode(
+      {sortCriteria: this.attrs.sortCriteria?.map((c) => ({...c}))},
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -271,14 +268,12 @@ export class SortNode implements QueryNode {
     }
 
     const criteria: BuilderSortCriterion[] = [];
-    for (const criterion of this.state.sortCriteria ?? []) {
-      const col = this.sortCols.find(
-        (c) => c.column.name === criterion.colName,
-      );
+    for (const criterion of this.attrs.sortCriteria ?? []) {
+      const col = this.sortCols.find((c) => c.name === criterion.colName);
       if (!col) continue;
 
       criteria.push({
-        columnName: col.column.name,
+        columnName: col.name,
         direction: criterion.direction,
       });
     }
@@ -293,17 +288,5 @@ export class SortNode implements QueryNode {
       criteria,
       this.nodeId,
     );
-  }
-
-  serializeState(): object {
-    // Only return serializable fields, excluding callbacks and objects
-    // that might contain circular references
-    return {
-      sortCriteria: this.state.sortCriteria,
-    };
-  }
-
-  static deserializeState(state: SortNodeState): SortNodeState {
-    return {...state};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/slices_source.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/slices_source.ts
@@ -15,14 +15,14 @@
 import m from 'mithril';
 import {
   QueryNode,
-  QueryNodeState,
   NodeType,
   nextNodeId,
+  NodeContext,
 } from '../../../query_node';
 import {
   ColumnInfo,
   columnInfoFromSqlColumn,
-  newColumnInfoList,
+  newColumnInfo,
 } from '../../column_info';
 import protos from '../../../../../protos';
 import {SqlColumn} from '../../../../dev.perfetto.SqlModules/sql_modules';
@@ -31,25 +31,23 @@ import {NodeDetailsAttrs} from '../../../node_types';
 import {loadNodeDoc} from '../../node_doc_loader';
 import {NodeTitle} from '../../node_styling_widgets';
 
-export interface SlicesSourceSerializedState {
-  comment?: string;
-}
-
-export interface SlicesSourceState extends QueryNodeState {
-  onchange?: () => void;
-}
+// Serializable node configuration (slices source has no config fields).
+export interface SlicesSourceNodeAttrs {}
 
 export class SlicesSourceNode implements QueryNode {
   readonly nodeId: string;
-  readonly state: SlicesSourceState;
+  readonly attrs: SlicesSourceNodeAttrs;
+  readonly context: NodeContext;
   readonly finalCols: ColumnInfo[];
   nextNodes: QueryNode[];
 
-  constructor(attrs: SlicesSourceState) {
+  constructor(attrs: SlicesSourceNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = attrs;
-    this.state.onchange = attrs.onchange;
-    this.finalCols = newColumnInfoList(slicesSourceNodeColumns(true), true);
+    this.attrs = attrs;
+    this.context = context;
+    this.finalCols = slicesSourceNodeColumns(true).map((col) =>
+      newColumnInfo(col, true),
+    );
     this.nextNodes = [];
   }
 
@@ -62,11 +60,7 @@ export class SlicesSourceNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: SlicesSourceState = {
-      onchange: this.state.onchange,
-      trace: this.state.trace,
-    };
-    return new SlicesSourceNode(stateCopy);
+    return new SlicesSourceNode(this.attrs, this.context);
   }
 
   getTitle(): string {
@@ -77,10 +71,6 @@ export class SlicesSourceNode implements QueryNode {
     return {
       content: NodeTitle(this.getTitle()),
     };
-  }
-
-  serializeState(): SlicesSourceSerializedState {
-    return {};
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/sql_source.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/sql_source.ts
@@ -15,35 +15,27 @@
 import m from 'mithril';
 import {
   QueryNode,
-  QueryNodeState,
   NodeType,
   nextNodeId,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../../query_node';
 import {notifyNextNodes} from '../../graph_utils';
-import {columnInfoFromName, newColumnInfoList} from '../../column_info';
 import protos from '../../../../../protos';
 import {Editor} from '../../../../../widgets/editor';
 import {
   StructuredQueryBuilder,
   SqlDependency,
 } from '../../structured_query_builder';
-import {Trace} from '../../../../../public/trace';
-
 import {ColumnInfo} from '../../column_info';
 import {setValidationError} from '../../node_issues';
 import {NodeDetailsAttrs} from '../../../node_types';
 import {loadNodeDoc} from '../../node_doc_loader';
 import {NodeTitle} from '../../node_styling_widgets';
 
-export interface SqlSourceSerializedState {
+// Serializable node configuration.
+export interface SqlSourceNodeAttrs {
   sql?: string;
-  comment?: string;
-}
-
-export interface SqlSourceState extends QueryNodeState {
-  sql?: string;
-  trace: Trace;
 }
 
 interface SqlEditorAttrs {
@@ -140,17 +132,19 @@ function validateStatementStructure(sql: string): string | undefined {
 
 export class SqlSourceNode implements QueryNode {
   readonly nodeId: string;
-  readonly state: SqlSourceState;
+  readonly attrs: SqlSourceNodeAttrs;
+  readonly context: NodeContext;
   finalCols: ColumnInfo[];
   nextNodes: QueryNode[];
   secondaryInputs: SecondaryInputSpec;
 
-  constructor(attrs: SqlSourceState) {
+  constructor(attrs: SqlSourceNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...attrs,
+    this.attrs = attrs;
+    this.context = {
+      ...context,
       // SQL source nodes require manual execution since users write SQL
-      autoExecute: attrs.autoExecute ?? false,
+      autoExecute: context.autoExecute ?? false,
     };
     this.finalCols = [];
     this.nextNodes = [];
@@ -168,10 +162,7 @@ export class SqlSourceNode implements QueryNode {
   }
 
   setSourceColumns(columns: string[]) {
-    this.finalCols = newColumnInfoList(
-      columns.map((c) => columnInfoFromName(c)),
-      true,
-    );
+    this.finalCols = columns.map((c) => ({name: c, checked: true}));
     m.redraw();
   }
 
@@ -193,28 +184,23 @@ export class SqlSourceNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: SqlSourceState = {
-      sql: this.state.sql,
-      issues: this.state.issues,
-      trace: this.state.trace,
-    };
-    return new SqlSourceNode(stateCopy);
+    return new SqlSourceNode({sql: this.attrs.sql}, this.context);
   }
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
-    if (this.state.sql === undefined || this.state.sql.trim() === '') {
-      setValidationError(this.state, 'SQL query is empty');
+    if (this.attrs.sql === undefined || this.attrs.sql.trim() === '') {
+      setValidationError(this.context, 'SQL query is empty');
       return false;
     }
 
-    const structureError = validateStatementStructure(this.state.sql);
+    const structureError = validateStatementStructure(this.attrs.sql);
     if (structureError !== undefined) {
-      setValidationError(this.state, structureError);
+      setValidationError(this.context, structureError);
       return false;
     }
 
@@ -228,12 +214,6 @@ export class SqlSourceNode implements QueryNode {
   nodeDetails(): NodeDetailsAttrs {
     return {
       content: NodeTitle(this.getTitle()),
-    };
-  }
-
-  serializeState(): SqlSourceSerializedState {
-    return {
-      sql: this.state.sql,
     };
   }
 
@@ -257,10 +237,10 @@ export class SqlSourceNode implements QueryNode {
     // Use columns from the last successful execution. These are populated
     // by onQueryExecuted() and are cleared when SQL changes (to prevent
     // stale columns from being used with a different query).
-    const columnNames: string[] = this.finalCols.map((c) => c.column.name);
+    const columnNames: string[] = this.finalCols.map((c) => c.name);
 
     const sq = StructuredQueryBuilder.fromSql(
-      this.state.sql || '',
+      this.attrs.sql || '',
       dependencies,
       columnNames,
       this.nodeId,
@@ -272,24 +252,24 @@ export class SqlSourceNode implements QueryNode {
 
   nodeSpecificModify(): m.Child {
     return m(SqlEditor, {
-      sql: this.state.sql ?? '',
+      sql: this.attrs.sql ?? '',
       onUpdate: (text: string) => {
-        if (this.state.sql === text) {
+        if (this.attrs.sql === text) {
           return;
         }
-        this.state.sql = text;
+        this.attrs.sql = text;
         // Clear columns when SQL changes to prevent stale column usage
         this.finalCols = [];
         // Notify that the query has changed so stale results are cleared
-        this.state.onchange?.();
+        this.context.onchange?.();
         m.redraw();
       },
       onExecute: (text: string) => {
-        this.state.sql = text.trim();
+        this.attrs.sql = text.trim();
         // Clear columns when SQL changes to prevent stale column usage
         this.finalCols = [];
         // Notify that the query has changed so stale results are cleared
-        this.state.onchange?.();
+        this.context.onchange?.();
         m.redraw();
       },
     });
@@ -303,9 +283,8 @@ export class SqlSourceNode implements QueryNode {
     const regex = /\$([A-Za-z0-9_]*)/g;
     let match: RegExpExecArray | null;
     const dependencies: string[] = [];
-    const node = this;
-    if (node.state.sql) {
-      while ((match = regex.exec(node.state.sql)) !== null) {
+    if (this.attrs.sql) {
+      while ((match = regex.exec(this.attrs.sql)) !== null) {
         dependencies.push(match[1]);
       }
     }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/sql_source_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/sql_source_unittest.ts
@@ -39,22 +39,22 @@ describe('SqlSourceNode', () => {
 
   describe('constructor', () => {
     it('should initialize with default values', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
-      expect(node.state.sql).toBe('SELECT * FROM slice');
-      expect(node.state.autoExecute).toBe(false);
+      expect(node.attrs.sql).toBe('SELECT * FROM slice');
+      expect(node.context.autoExecute).toBe(false);
       expect(node.finalCols).toEqual([]);
       expect(node.nextNodes).toEqual([]);
     });
 
     it('should initialize secondaryInputs with correct configuration', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM $input_0',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM $input_0'},
+        {trace: mockTrace},
+      );
 
       expect(node.secondaryInputs).toBeDefined();
       expect(node.secondaryInputs.min).toBe(0);
@@ -63,10 +63,7 @@ describe('SqlSourceNode', () => {
     });
 
     it('should have port names following $input_N pattern', () => {
-      const node = new SqlSourceNode({
-        sql: '',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode({sql: ''}, {trace: mockTrace});
 
       const portNames = node.secondaryInputs.portNames;
       expect(typeof portNames).toBe('function');
@@ -80,19 +77,16 @@ describe('SqlSourceNode', () => {
 
   describe('inputNodesList', () => {
     it('should return empty array when no inputs connected', () => {
-      const node = new SqlSourceNode({
-        sql: '',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode({sql: ''}, {trace: mockTrace});
 
       expect(node.inputNodesList).toEqual([]);
     });
 
     it('should return connected nodes sorted by port index', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM $input_0 JOIN $input_1',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM $input_0 JOIN $input_1'},
+        {trace: mockTrace},
+      );
 
       const input0 = createMockNodeWithSq('node0', []);
       const input1 = createMockNodeWithSq('node1', []);
@@ -113,10 +107,10 @@ describe('SqlSourceNode', () => {
 
   describe('getStructuredQuery', () => {
     it('should return structured query without dependencies when no inputs', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
       const sq = node.getStructuredQuery();
       expect(sq).toBeDefined();
@@ -124,10 +118,10 @@ describe('SqlSourceNode', () => {
     });
 
     it('should include dependencies for connected inputs', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM $input_0',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM $input_0'},
+        {trace: mockTrace},
+      );
 
       const input0 = createMockNodeWithSq('node0', [
         createColumnInfo('id', 'int'),
@@ -141,10 +135,10 @@ describe('SqlSourceNode', () => {
     });
 
     it('should include multiple dependencies with correct aliases', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT a.*, b.* FROM $input_0 a JOIN $input_1 b ON a.id = b.id',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT a.*, b.* FROM $input_0 a JOIN $input_1 b ON a.id = b.id'},
+        {trace: mockTrace},
+      );
 
       const input0 = createMockNodeWithSq('node0', [
         createColumnInfo('id', 'int'),
@@ -167,10 +161,10 @@ describe('SqlSourceNode', () => {
     });
 
     it('should return undefined when any input has invalid query', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM $input_0',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM $input_0'},
+        {trace: mockTrace},
+      );
 
       // Create a mock node that returns undefined for getStructuredQuery
       const invalidInput = createMockNode({
@@ -188,29 +182,26 @@ describe('SqlSourceNode', () => {
 
   describe('validate', () => {
     it('should fail validation with empty SQL', () => {
-      const node = new SqlSourceNode({
-        sql: '',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode({sql: ''}, {trace: mockTrace});
 
       // Empty SQL fails validation
       expect(node.validate()).toBe(false);
     });
 
     it('should pass validation with valid SQL', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
       expect(node.validate()).toBe(true);
     });
 
     it('should pass validation with connected inputs', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM $input_0',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM $input_0'},
+        {trace: mockTrace},
+      );
 
       const input0 = createMockNodeWithSq('node0', [
         createColumnInfo('id', 'int'),
@@ -222,176 +213,180 @@ describe('SqlSourceNode', () => {
 
     describe('statement structure validation', () => {
       it('should reject statements that do not start with SELECT', () => {
-        const node = new SqlSourceNode({
-          sql: 'CREATE TABLE foo AS SELECT * FROM slice',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'CREATE TABLE foo AS SELECT * FROM slice'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(false);
-        expect(node.state.issues?.queryError?.message).toContain('SELECT');
+        expect(node.context.issues?.queryError?.message).toContain('SELECT');
       });
 
       it('should reject multiple SELECT statements', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT * FROM slice; SELECT * FROM thread',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT * FROM slice; SELECT * FROM thread'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(false);
-        expect(node.state.issues?.queryError?.message).toContain(
+        expect(node.context.issues?.queryError?.message).toContain(
           'INCLUDE PERFETTO MODULE',
         );
       });
 
       it('should allow subqueries', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT * FROM (SELECT * FROM slice) AS sub',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT * FROM (SELECT * FROM slice) AS sub'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow CTEs', () => {
-        const node = new SqlSourceNode({
-          sql: 'WITH cte AS (SELECT * FROM slice) SELECT * FROM cte',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'WITH cte AS (SELECT * FROM slice) SELECT * FROM cte'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow nested subqueries', () => {
-        const node = new SqlSourceNode({
-          sql: `SELECT * FROM (
+        const node = new SqlSourceNode(
+          {
+            sql: `SELECT * FROM (
             SELECT id FROM (
               SELECT id FROM slice
             ) AS inner_sub
           ) AS outer_sub`,
-          trace: mockTrace,
-        });
+          },
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow SELECT in WHERE subquery', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT * FROM slice WHERE id IN (SELECT id FROM thread)',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT * FROM slice WHERE id IN (SELECT id FROM thread)'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow SELECT in comments', () => {
-        const node = new SqlSourceNode({
-          sql: '-- SELECT * FROM thread\nSELECT * FROM slice',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: '-- SELECT * FROM thread\nSELECT * FROM slice'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow SELECT in string literals', () => {
-        const node = new SqlSourceNode({
-          sql: "SELECT 'SELECT * FROM thread' AS query FROM slice",
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: "SELECT 'SELECT * FROM thread' AS query FROM slice"},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow SELECT in multi-line comments', () => {
-        const node = new SqlSourceNode({
-          sql: '/* SELECT * FROM thread */ SELECT * FROM slice',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: '/* SELECT * FROM thread */ SELECT * FROM slice'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow UNION queries', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT * FROM slice UNION SELECT * FROM thread',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT * FROM slice UNION SELECT * FROM thread'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow UNION ALL queries', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT * FROM slice UNION ALL SELECT * FROM thread',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT * FROM slice UNION ALL SELECT * FROM thread'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow INTERSECT queries', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT id FROM slice INTERSECT SELECT id FROM thread',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT id FROM slice INTERSECT SELECT id FROM thread'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow EXCEPT queries', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT id FROM slice EXCEPT SELECT id FROM thread',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT id FROM slice EXCEPT SELECT id FROM thread'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow INCLUDE PERFETTO MODULE before SELECT', () => {
-        const node = new SqlSourceNode({
-          sql: 'INCLUDE PERFETTO MODULE slices.slices; SELECT * FROM slice',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'INCLUDE PERFETTO MODULE slices.slices; SELECT * FROM slice'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow multiple INCLUDE PERFETTO MODULE before SELECT', () => {
-        const node = new SqlSourceNode({
-          sql: `INCLUDE PERFETTO MODULE slices.slices;
+        const node = new SqlSourceNode(
+          {
+            sql: `INCLUDE PERFETTO MODULE slices.slices;
                 INCLUDE PERFETTO MODULE android.startup;
                 SELECT * FROM slice`,
-          trace: mockTrace,
-        });
+          },
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should reject non-INCLUDE statements before SELECT', () => {
-        const node = new SqlSourceNode({
-          sql: 'DROP TABLE foo; SELECT * FROM slice',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'DROP TABLE foo; SELECT * FROM slice'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(false);
-        expect(node.state.issues?.queryError?.message).toContain(
+        expect(node.context.issues?.queryError?.message).toContain(
           'INCLUDE PERFETTO MODULE',
         );
       });
 
       it('should reject INCLUDE PERFETTO MODULE after SELECT', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT * FROM slice; INCLUDE PERFETTO MODULE slices.slices',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT * FROM slice; INCLUDE PERFETTO MODULE slices.slices'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(false);
       });
 
       it('should reject query without SELECT', () => {
-        const node = new SqlSourceNode({
-          sql: 'INCLUDE PERFETTO MODULE slices.slices',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'INCLUDE PERFETTO MODULE slices.slices'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(false);
-        expect(node.state.issues?.queryError?.message).toContain('SELECT');
+        expect(node.context.issues?.queryError?.message).toContain('SELECT');
       });
 
       it('should allow trailing semicolon', () => {
-        const node = new SqlSourceNode({
-          sql: 'SELECT * FROM slice;',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'SELECT * FROM slice;'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
 
       it('should allow INCLUDE with trailing semicolon', () => {
-        const node = new SqlSourceNode({
-          sql: 'INCLUDE PERFETTO MODULE foo; SELECT * FROM slice;',
-          trace: mockTrace,
-        });
+        const node = new SqlSourceNode(
+          {sql: 'INCLUDE PERFETTO MODULE foo; SELECT * FROM slice;'},
+          {trace: mockTrace},
+        );
         expect(node.validate()).toBe(true);
       });
     });
@@ -399,10 +394,10 @@ describe('SqlSourceNode', () => {
 
   describe('getTitle', () => {
     it('should return "Sql source" as title', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
       expect(node.getTitle()).toBe('Sql source');
     });
@@ -410,39 +405,39 @@ describe('SqlSourceNode', () => {
 
   describe('clone', () => {
     it('should create a new node with same SQL', () => {
-      const original = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const original = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
       const cloned = original.clone() as SqlSourceNode;
 
       expect(cloned).not.toBe(original);
-      expect(cloned.state.sql).toBe(original.state.sql);
+      expect(cloned.attrs.sql).toBe(original.attrs.sql);
       expect(cloned.nodeId).not.toBe(original.nodeId);
     });
 
     it('should not share state with original', () => {
-      const original = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const original = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
       const cloned = original.clone() as SqlSourceNode;
-      cloned.state.sql = 'SELECT * FROM thread';
+      cloned.attrs.sql = 'SELECT * FROM thread';
 
-      expect(original.state.sql).toBe('SELECT * FROM slice');
+      expect(original.attrs.sql).toBe('SELECT * FROM slice');
     });
   });
 
   describe('serializeState', () => {
     it('should serialize SQL', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
-      const serialized = node.serializeState();
+      const serialized = node.attrs;
 
       expect(serialized.sql).toBe('SELECT * FROM slice');
     });
@@ -450,10 +445,10 @@ describe('SqlSourceNode', () => {
 
   describe('nodeSpecificModify', () => {
     it('should render SQL editor component', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: mockTrace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: mockTrace},
+      );
 
       const result = node.nodeSpecificModify();
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/table_source.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/table_source.ts
@@ -19,18 +19,17 @@ import {
 } from '../../../../dev.perfetto.SqlModules/sql_modules';
 import {
   QueryNode,
-  QueryNodeState,
   NodeType,
   nextNodeId,
+  NodeContext,
 } from '../../../query_node';
 import {StructuredQueryBuilder} from '../../structured_query_builder';
 import {
   ColumnInfo,
   columnInfoFromSqlColumn,
-  newColumnInfoList,
+  newColumnInfo,
 } from '../../column_info';
 import protos from '../../../../../protos';
-import {Trace} from '../../../../../public/trace';
 import {closeModal, showModal} from '../../../../../widgets/modal';
 import {TableList} from '../../table_list';
 import {redrawModal} from '../../../../../widgets/modal';
@@ -40,16 +39,9 @@ import {NodeDetailsAttrs} from '../../../node_types';
 import {loadNodeDoc} from '../../node_doc_loader';
 import {NodeTitle} from '../../node_styling_widgets';
 
-export interface TableSourceSerializedState {
+// Serializable node configuration.
+export interface TableSourceNodeAttrs {
   sqlTable?: string;
-  comment?: string;
-}
-
-export interface TableSourceState extends QueryNodeState {
-  readonly trace: Trace;
-
-  sqlTable?: SqlTable;
-  onchange?: () => void;
 }
 
 interface TableSelectionResult {
@@ -153,20 +145,24 @@ export function modalForTableSelection(
 
 export class TableSourceNode implements QueryNode {
   readonly nodeId: string;
-  readonly state: TableSourceState;
+  readonly attrs: TableSourceNodeAttrs;
+  readonly context: NodeContext;
+  // Runtime-resolved SqlTable object (not serializable).
+  readonly sqlTable?: SqlTable;
   readonly finalCols: ColumnInfo[];
   nextNodes: QueryNode[];
 
-  constructor(attrs: TableSourceState) {
+  constructor(attrs: TableSourceNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = attrs;
-    this.state.onchange = attrs.onchange;
-    this.finalCols = newColumnInfoList(
-      this.state.sqlTable?.columns.map((c) =>
-        columnInfoFromSqlColumn(c, true),
-      ) ?? [],
-      true,
-    );
+    this.attrs = attrs;
+    this.context = context;
+    // Resolve sqlTable from sqlModules using the table name string.
+    this.sqlTable = attrs.sqlTable
+      ? context.sqlModules?.getTable(attrs.sqlTable)
+      : undefined;
+    this.finalCols = (
+      this.sqlTable?.columns.map((c) => columnInfoFromSqlColumn(c, true)) ?? []
+    ).map((col) => newColumnInfo(col, true));
     this.nextNodes = [];
   }
 
@@ -175,12 +171,7 @@ export class TableSourceNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: TableSourceState = {
-      trace: this.state.trace,
-      sqlTable: this.state.sqlTable,
-      onchange: this.state.onchange,
-    };
-    return new TableSourceNode(stateCopy);
+    return new TableSourceNode(this.attrs, this.context);
   }
 
   nodeSpecificModify(): m.Child {
@@ -189,12 +180,12 @@ export class TableSourceNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
-    if (this.state.sqlTable === undefined) {
-      setValidationError(this.state, 'No table selected');
+    if (this.sqlTable === undefined) {
+      setValidationError(this.context, 'No table selected');
       return false;
     }
 
@@ -202,26 +193,26 @@ export class TableSourceNode implements QueryNode {
   }
 
   getTitle(): string {
-    return `${this.state.sqlTable?.name}`;
+    return `${this.sqlTable?.name}`;
   }
 
   nodeDetails(): NodeDetailsAttrs {
     return {
-      content: NodeTitle('Table ' + (this.state.sqlTable?.name ?? '')),
+      content: NodeTitle('Table ' + (this.sqlTable?.name ?? '')),
     };
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     if (!this.validate()) return;
-    if (!this.state.sqlTable) return;
+    if (!this.sqlTable) return;
 
     const columnNames = this.finalCols
       .filter((c) => c.checked)
-      .map((c) => c.column.name);
+      .map((c) => c.name);
 
     const sq = StructuredQueryBuilder.fromTable(
-      this.state.sqlTable.name,
-      this.state.sqlTable.includeKey || undefined,
+      this.sqlTable.name,
+      this.sqlTable.includeKey || undefined,
       columnNames,
       this.nodeId,
     );
@@ -230,44 +221,23 @@ export class TableSourceNode implements QueryNode {
     return sq;
   }
 
-  serializeState(): TableSourceSerializedState {
-    return {
-      sqlTable: this.state.sqlTable?.name,
-    };
-  }
-
   nodeInfo(): m.Children {
     // Show general documentation
     const docContent = loadNodeDoc('table_source');
 
     // If a table is selected, also show table-specific information
-    if (this.state.sqlTable != null) {
+    if (this.sqlTable != null) {
       return m(
         'div',
         docContent,
         m(
           '.pf-table-source-selected',
           m('h2', 'Selected Table'),
-          m(TableDescription, {table: this.state.sqlTable}),
+          m(TableDescription, {table: this.sqlTable}),
         ),
       );
     }
 
     return docContent;
-  }
-
-  static deserializeState(
-    trace: Trace,
-    sqlModules: SqlModules,
-    state: TableSourceSerializedState,
-  ): TableSourceState {
-    const sqlTable = state.sqlTable
-      ? sqlModules.getTable(state.sqlTable)
-      : undefined;
-    return {
-      ...state,
-      trace,
-      sqlTable,
-    };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source.ts
@@ -15,18 +15,13 @@
 import m from 'mithril';
 import {
   QueryNode,
-  QueryNodeState,
   NodeType,
   nextNodeId,
+  NodeContext,
 } from '../../../query_node';
-import {
-  ColumnInfo,
-  columnInfoFromSqlColumn,
-  newColumnInfoList,
-} from '../../column_info';
+import {ColumnInfo, columnInfoFromSqlColumn} from '../../column_info';
 import {time, TimeSpan, Time} from '../../../../../base/time';
 import {PerfettoSqlTypes} from '../../../../../trace_processor/perfetto_sql_type';
-import {Trace} from '../../../../../public/trace';
 import {Button, ButtonVariant} from '../../../../../widgets/button';
 import {Switch} from '../../../../../widgets/switch';
 import {Anchor} from '../../../../../widgets/anchor';
@@ -42,48 +37,53 @@ import {NodeTitle} from '../../node_styling_widgets';
 // Poll interval for dynamic mode selection updates (in milliseconds)
 const SELECTION_POLL_INTERVAL_MS = 200;
 
-export interface TimeRangeSourceSerializedState {
+// Serializable node configuration.
+export interface TimeRangeSourceNodeAttrs {
   start?: string;
   end?: string;
   isDynamic?: boolean;
-  comment?: string;
-}
-
-export interface TimeRangeSourceState extends QueryNodeState {
-  start?: time;
-  end?: time;
-  isDynamic?: boolean;
-  trace: Trace;
-  onchange?: () => void;
 }
 
 export class TimeRangeSourceNode implements QueryNode {
   readonly nodeId: string;
-  readonly state: TimeRangeSourceState;
+  readonly attrs: TimeRangeSourceNodeAttrs;
+  readonly context: NodeContext;
+  // Runtime state for resolved time values (not serializable as-is).
+  start?: time;
+  end?: time;
+  isDynamic: boolean;
   readonly finalCols: ColumnInfo[];
   nextNodes: QueryNode[] = [];
   private selectionCheckInterval?: number;
 
-  constructor(attrs: TimeRangeSourceState) {
+  constructor(attrs: TimeRangeSourceNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...attrs,
-      isDynamic: attrs.isDynamic ?? false,
-    };
+    this.attrs = attrs;
+    this.context = context;
+    // Resolve BigInt start/end from serialized string form.
+    this.start = attrs.start ? Time.fromRaw(BigInt(attrs.start)) : undefined;
+    this.end = attrs.end ? Time.fromRaw(BigInt(attrs.end)) : undefined;
+    this.isDynamic = attrs.isDynamic ?? false;
 
     // Initialize columns: id, ts, dur
-    this.finalCols = newColumnInfoList(
-      [
-        columnInfoFromSqlColumn({name: 'id', type: PerfettoSqlTypes.INT}),
-        columnInfoFromSqlColumn({name: 'ts', type: PerfettoSqlTypes.TIMESTAMP}),
-        columnInfoFromSqlColumn({name: 'dur', type: PerfettoSqlTypes.DURATION}),
-      ],
-      true,
-    );
+    this.finalCols = [
+      columnInfoFromSqlColumn({name: 'id', type: PerfettoSqlTypes.INT}, true),
+      columnInfoFromSqlColumn(
+        {name: 'ts', type: PerfettoSqlTypes.TIMESTAMP},
+        true,
+      ),
+      columnInfoFromSqlColumn(
+        {name: 'dur', type: PerfettoSqlTypes.DURATION},
+        true,
+      ),
+    ];
 
     // If dynamic mode is enabled, subscribe to selection changes and
-    // immediately populate from current selection
-    if (this.state.isDynamic) {
+    // immediately populate from current selection.
+    // Clear persisted timestamps — dynamic mode re-syncs from selection.
+    if (this.isDynamic) {
+      this.attrs.start = undefined;
+      this.attrs.end = undefined;
       this.subscribeToSelectionChanges();
       this.updateFromSelection();
     }
@@ -95,20 +95,20 @@ export class TimeRangeSourceNode implements QueryNode {
 
   validate(): boolean {
     // Initialize issues if not present
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = undefined;
+    this.context.issues.queryError = undefined;
 
-    if (this.state.start === undefined || this.state.end === undefined) {
-      this.state.issues.queryError = new Error(
+    if (this.start === undefined || this.end === undefined) {
+      this.context.issues.queryError = new Error(
         'Time range not set. Use "Update from Timeline" or enable Dynamic mode to sync with timeline selection.',
       );
       return false;
     }
 
-    if (this.state.end < this.state.start) {
-      this.state.issues.queryError = new Error(
+    if (this.end < this.start) {
+      this.context.issues.queryError = new Error(
         'End time must be greater than or equal to start time.',
       );
       return false;
@@ -118,18 +118,18 @@ export class TimeRangeSourceNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: TimeRangeSourceState = {
-      start: this.state.start,
-      end: this.state.end,
-      isDynamic: false, // Clone always creates a static snapshot
-      trace: this.state.trace,
-      onchange: this.state.onchange,
-    };
-    return new TimeRangeSourceNode(stateCopy);
+    return new TimeRangeSourceNode(
+      {
+        start: this.start?.toString(),
+        end: this.end?.toString(),
+        isDynamic: false, // Clone always creates a static snapshot
+      },
+      this.context,
+    );
   }
 
   getTitle(): string {
-    return this.state.isDynamic ? 'Current time range' : 'Time range';
+    return this.isDynamic ? 'Current time range' : 'Time range';
   }
 
   nodeDetails(): NodeDetailsAttrs {
@@ -138,41 +138,12 @@ export class TimeRangeSourceNode implements QueryNode {
     };
   }
 
-  serializeState(): TimeRangeSourceSerializedState {
-    // Don't serialize start/end for dynamic mode - they'll be populated
-    // from the current selection when deserialized
-    if (this.state.isDynamic) {
-      return {
-        isDynamic: true,
-      };
-    }
-    return {
-      start: this.state.start?.toString(),
-      end: this.state.end?.toString(),
-      isDynamic: false,
-    };
-  }
-
-  static deserializeState(
-    trace: Trace,
-    serialized: TimeRangeSourceSerializedState,
-  ): TimeRangeSourceState {
-    return {
-      trace,
-      start: serialized.start
-        ? Time.fromRaw(BigInt(serialized.start))
-        : undefined,
-      end: serialized.end ? Time.fromRaw(BigInt(serialized.end)) : undefined,
-      isDynamic: serialized.isDynamic ?? false,
-    };
-  }
-
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
     // For dynamic nodes without start/end set, we can still generate a query
     // that uses trace_start() and trace_end() - the backend handles this.
     // Only validate for static nodes or when we have explicit values.
-    const start = this.state.start;
-    const end = this.state.end;
+    const start = this.start;
+    const end = this.end;
 
     // If both are set, calculate duration
     if (start !== undefined && end !== undefined) {
@@ -210,8 +181,8 @@ export class TimeRangeSourceNode implements QueryNode {
     if (!this.validate()) {
       return undefined;
     }
-    const start = this.state.start;
-    const end = this.state.end;
+    const start = this.start;
+    const end = this.end;
     if (start === undefined || end === undefined) {
       return undefined;
     }
@@ -232,52 +203,61 @@ export class TimeRangeSourceNode implements QueryNode {
   }
 
   private updateFromSelection() {
+    if (!this.context.trace) return;
     // Get selection time span, or fall back to full trace if no selection
-    let timeSpan = this.state.trace.selection.getTimeSpanOfSelection();
+    let timeSpan = this.context.trace.selection.getTimeSpanOfSelection();
     if (!timeSpan) {
       // No selection - use full trace
       timeSpan = new TimeSpan(
-        this.state.trace.traceInfo.start,
-        this.state.trace.traceInfo.end,
+        this.context.trace.traceInfo.start,
+        this.context.trace.traceInfo.end,
       );
     }
 
     // Only update if the values have actually changed to avoid unnecessary redraws
-    if (
-      this.state.start === timeSpan.start &&
-      this.state.end === timeSpan.end
-    ) {
+    if (this.start === timeSpan.start && this.end === timeSpan.end) {
       return; // No change needed
     }
 
-    this.state.start = timeSpan.start;
-    this.state.end = timeSpan.end;
-    this.state.onchange?.();
+    this.start = timeSpan.start;
+    this.end = timeSpan.end;
+    if (!this.isDynamic) {
+      this.attrs.start = timeSpan.start.toString();
+      this.attrs.end = timeSpan.end.toString();
+    }
+    this.context.onchange?.();
     m.redraw();
   }
 
   private toggleDynamicMode() {
-    this.state.isDynamic = !this.state.isDynamic;
+    this.isDynamic = !this.isDynamic;
+    this.attrs.isDynamic = this.isDynamic;
 
-    if (this.state.isDynamic) {
+    if (this.isDynamic) {
+      // Clear persisted timestamps — dynamic mode re-syncs from selection.
+      this.attrs.start = undefined;
+      this.attrs.end = undefined;
       this.subscribeToSelectionChanges();
       this.updateFromSelection(); // Immediately sync with current selection
     } else {
       this.unsubscribeFromSelectionChanges();
+      // Capture current runtime values into attrs.
+      this.attrs.start = this.start?.toString();
+      this.attrs.end = this.end?.toString();
     }
 
-    this.state.onchange?.();
+    this.context.onchange?.();
     m.redraw();
   }
 
   nodeSpecificModify(): NodeModifyAttrs {
-    const isDynamic = this.state.isDynamic ?? false;
+    const isDynamic = this.isDynamic ?? false;
     const isValid = this.validate();
     const dur =
-      isValid && this.state.start !== undefined && this.state.end !== undefined
-        ? this.state.end - this.state.start
+      isValid && this.start !== undefined && this.end !== undefined
+        ? this.end - this.start
         : 0n;
-    const error = this.state.issues?.queryError;
+    const error = this.context.issues?.queryError;
 
     const sections: NodeModifyAttrs['sections'] = [];
 
@@ -313,7 +293,7 @@ export class TimeRangeSourceNode implements QueryNode {
         m(InlineField, {
           label: 'Start (ns)',
           icon: 'start',
-          value: this.state.start?.toString() ?? 'Not set',
+          value: this.start?.toString() ?? 'Not set',
           editable: !isDynamic,
           placeholder: 'Start timestamp (ns)',
           type: 'number',
@@ -330,17 +310,18 @@ export class TimeRangeSourceNode implements QueryNode {
           onchange: (value: string) => {
             try {
               const parsed = BigInt(value.trim());
-              this.state.start = Time.fromRaw(parsed);
+              this.start = Time.fromRaw(parsed);
+              this.attrs.start = value.trim();
             } catch (e) {
               // Keep current value if invalid
             }
-            this.state.onchange?.();
+            this.context.onchange?.();
           },
         }),
         m(InlineField, {
           label: 'End (ns)',
           icon: 'stop',
-          value: this.state.end?.toString() ?? 'Not set',
+          value: this.end?.toString() ?? 'Not set',
           editable: !isDynamic,
           placeholder: 'End timestamp (ns)',
           type: 'number',
@@ -357,11 +338,12 @@ export class TimeRangeSourceNode implements QueryNode {
           onchange: (value: string) => {
             try {
               const parsed = BigInt(value.trim());
-              this.state.end = Time.fromRaw(parsed);
+              this.end = Time.fromRaw(parsed);
+              this.attrs.end = value.trim();
             } catch (e) {
               // Keep current value if invalid
             }
-            this.state.onchange?.();
+            this.context.onchange?.();
           },
         }),
         isValid &&
@@ -384,14 +366,15 @@ export class TimeRangeSourceNode implements QueryNode {
             onchange: (value: string) => {
               try {
                 const parsed = BigInt(value.trim());
-                if (this.state.start !== undefined) {
+                if (this.start !== undefined) {
                   // Keep start fixed, update end based on duration
-                  this.state.end = Time.fromRaw(this.state.start + parsed);
+                  this.end = Time.fromRaw(this.start + parsed);
+                  this.attrs.end = this.end.toString();
                 }
               } catch (e) {
                 // Keep current value if invalid
               }
-              this.state.onchange?.();
+              this.context.onchange?.();
             },
           }),
       ),
@@ -422,11 +405,11 @@ export class TimeRangeSourceNode implements QueryNode {
 
     // If valid, also show current time range data
     if (this.validate()) {
-      const start = this.state.start;
-      const end = this.state.end;
+      const start = this.start;
+      const end = this.end;
       if (start !== undefined && end !== undefined) {
         const dur = end - start;
-        const isDynamic = this.state.isDynamic ?? false;
+        const isDynamic = this.isDynamic ?? false;
         const title = isDynamic ? 'Current time selection' : 'Time selection';
 
         return m(

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/sources/timerange_source_unittest.ts
@@ -14,8 +14,7 @@
 
 import {
   TimeRangeSourceNode,
-  TimeRangeSourceState,
-  TimeRangeSourceSerializedState,
+  TimeRangeSourceNodeAttrs,
 } from './timerange_source';
 import {Trace} from '../../../../../public/trace';
 import {Time, TimeSpan} from '../../../../../base/time';
@@ -35,120 +34,103 @@ describe('TimeRangeSourceNode', () => {
 
   describe('constructor', () => {
     it('should create node with start and end', () => {
-      const state: TimeRangeSourceState = {
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      };
+      const node = new TimeRangeSourceNode(
+        {
+          start: '100',
+          end: '500',
+          isDynamic: false,
+        },
+        {trace: createMockTrace()},
+      );
 
-      const node = new TimeRangeSourceNode(state);
-
-      expect(node.state.start).toEqual(Time.fromRaw(100n));
-      expect(node.state.end).toEqual(Time.fromRaw(500n));
-      expect(node.state.isDynamic).toBe(false);
+      expect(node.start).toEqual(Time.fromRaw(100n));
+      expect(node.end).toEqual(Time.fromRaw(500n));
+      expect(node.isDynamic).toBe(false);
     });
 
     it('should create node with undefined start/end', () => {
-      const state: TimeRangeSourceState = {
-        trace: createMockTrace(),
-        isDynamic: false,
-      };
+      const node = new TimeRangeSourceNode(
+        {isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
-      const node = new TimeRangeSourceNode(state);
-
-      expect(node.state.start).toBeUndefined();
-      expect(node.state.end).toBeUndefined();
+      expect(node.start).toBeUndefined();
+      expect(node.end).toBeUndefined();
     });
 
     it('should default isDynamic to false', () => {
-      const state: TimeRangeSourceState = {
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-      };
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500'},
+        {trace: createMockTrace()},
+      );
 
-      const node = new TimeRangeSourceNode(state);
-
-      expect(node.state.isDynamic).toBe(false);
+      expect(node.isDynamic).toBe(false);
     });
 
     it('should create node in dynamic mode and update from selection', () => {
-      const state: TimeRangeSourceState = {
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: true,
-      };
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: true},
+        {trace: createMockTrace()},
+      );
 
-      const node = new TimeRangeSourceNode(state);
-
-      expect(node.state.isDynamic).toBe(true);
+      expect(node.isDynamic).toBe(true);
       // Dynamic mode immediately updates from selection (falls back to full trace)
-      expect(node.state.start).toEqual(Time.fromRaw(0n));
-      expect(node.state.end).toEqual(Time.fromRaw(1000000n));
+      expect(node.start).toEqual(Time.fromRaw(0n));
+      expect(node.end).toEqual(Time.fromRaw(1000000n));
     });
   });
 
   describe('validation', () => {
     it('should validate when start and end are set', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(true);
     });
 
     it('should invalidate when start is missing', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(false);
     });
 
     it('should invalidate when end is missing', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(false);
     });
 
     it('should invalidate when both start and end are missing', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(false);
     });
 
     it('should invalidate when end is before start', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(500n),
-        end: Time.fromRaw(100n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '500', end: '100', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(false);
     });
 
     it('should validate when end equals start (zero duration)', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(100n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '100', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(true);
     });
@@ -156,12 +138,10 @@ describe('TimeRangeSourceNode', () => {
 
   describe('getTimeRange', () => {
     it('should return TimeSpan when valid', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       const timeRange = node.getTimeRange();
 
@@ -171,10 +151,10 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should return undefined when invalid', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       const timeRange = node.getTimeRange();
 
@@ -184,12 +164,10 @@ describe('TimeRangeSourceNode', () => {
 
   describe('getStructuredQuery', () => {
     it('should generate SQL with single row for valid time range', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       const query = node.getStructuredQuery();
 
@@ -201,10 +179,10 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should return query with unset ts/dur for node without start/end', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       const query = node.getStructuredQuery();
 
@@ -215,12 +193,10 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should handle zero duration', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(100n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '100', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       const query = node.getStructuredQuery();
 
@@ -231,11 +207,10 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should return undefined when only end is set without start', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       const query = node.getStructuredQuery();
 
@@ -245,182 +220,158 @@ describe('TimeRangeSourceNode', () => {
   });
 
   describe('serialization', () => {
-    it('should serialize static node with start and end', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+    it('should have start and end in attrs for static node', () => {
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
-      const serialized = node.serializeState();
-
-      expect(serialized.start).toBe('100');
-      expect(serialized.end).toBe('500');
-      expect(serialized.isDynamic).toBe(false);
+      expect(node.attrs.start).toBe('100');
+      expect(node.attrs.end).toBe('500');
+      expect(node.attrs.isDynamic).toBe(false);
     });
 
-    it('should serialize dynamic node without start/end', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(200n),
-        end: Time.fromRaw(800n),
-        isDynamic: true,
-      });
+    it('should not have start/end in attrs for dynamic node', () => {
+      const node = new TimeRangeSourceNode(
+        {start: '200', end: '800', isDynamic: true},
+        {trace: createMockTrace()},
+      );
 
-      const serialized = node.serializeState();
-
-      // Dynamic nodes don't serialize start/end - they're populated from selection on load
-      expect(serialized.start).toBeUndefined();
-      expect(serialized.end).toBeUndefined();
-      expect(serialized.isDynamic).toBe(true);
+      // Dynamic nodes don't persist start/end - they're populated from selection on load
+      expect(node.attrs.start).toBeUndefined();
+      expect(node.attrs.end).toBeUndefined();
+      expect(node.attrs.isDynamic).toBe(true);
     });
 
-    it('should serialize node with undefined start/end', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        isDynamic: false,
-      });
+    it('should have undefined start/end in attrs when not set', () => {
+      const node = new TimeRangeSourceNode(
+        {isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
-      const serialized = node.serializeState();
-
-      expect(serialized.start).toBeUndefined();
-      expect(serialized.end).toBeUndefined();
-      expect(serialized.isDynamic).toBe(false);
+      expect(node.attrs.start).toBeUndefined();
+      expect(node.attrs.end).toBeUndefined();
+      expect(node.attrs.isDynamic).toBe(false);
     });
 
-    it('should serialize state', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+    it('attrs should be defined', () => {
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
-      const serialized = node.serializeState();
-      expect(serialized).toBeDefined();
+      expect(node.attrs).toBeDefined();
     });
   });
 
   describe('deserialization', () => {
     it('should deserialize static node with start and end', () => {
-      const serialized: TimeRangeSourceSerializedState = {
+      const serialized: TimeRangeSourceNodeAttrs = {
         start: '100',
         end: '500',
         isDynamic: false,
       };
 
-      const state = TimeRangeSourceNode.deserializeState(
-        createMockTrace(),
-        serialized,
-      );
+      const node = new TimeRangeSourceNode(serialized, {
+        trace: createMockTrace(),
+      });
 
-      expect(state.start).toEqual(Time.fromRaw(100n));
-      expect(state.end).toEqual(Time.fromRaw(500n));
-      expect(state.isDynamic).toBe(false);
+      expect(node.start).toEqual(Time.fromRaw(100n));
+      expect(node.end).toEqual(Time.fromRaw(500n));
+      expect(node.isDynamic).toBe(false);
     });
 
     it('should deserialize dynamic node without start/end', () => {
       // Dynamic nodes are serialized without start/end
-      const serialized: TimeRangeSourceSerializedState = {
+      const serialized: TimeRangeSourceNodeAttrs = {
         isDynamic: true,
       };
 
-      const state = TimeRangeSourceNode.deserializeState(
-        createMockTrace(),
-        serialized,
-      );
+      const node = new TimeRangeSourceNode(serialized, {
+        trace: createMockTrace(),
+      });
 
-      // Deserialize returns state with undefined start/end - constructor will populate
-      expect(state.start).toBeUndefined();
-      expect(state.end).toBeUndefined();
-      expect(state.isDynamic).toBe(true);
+      // Dynamic node populates from selection/trace on construction
+      expect(node.isDynamic).toBe(true);
     });
 
     it('should deserialize with undefined start/end', () => {
-      const serialized: TimeRangeSourceSerializedState = {
+      const serialized: TimeRangeSourceNodeAttrs = {
         isDynamic: false,
       };
 
-      const state = TimeRangeSourceNode.deserializeState(
-        createMockTrace(),
-        serialized,
-      );
+      const node = new TimeRangeSourceNode(serialized, {
+        trace: createMockTrace(),
+      });
 
-      expect(state.start).toBeUndefined();
-      expect(state.end).toBeUndefined();
-      expect(state.isDynamic).toBe(false);
+      expect(node.start).toBeUndefined();
+      expect(node.end).toBeUndefined();
+      expect(node.isDynamic).toBe(false);
     });
 
     it('should default isDynamic to false when undefined', () => {
-      const serialized: TimeRangeSourceSerializedState = {
+      const serialized: TimeRangeSourceNodeAttrs = {
         start: '100',
         end: '500',
       };
 
-      const state = TimeRangeSourceNode.deserializeState(
-        createMockTrace(),
-        serialized,
-      );
+      const node = new TimeRangeSourceNode(serialized, {
+        trace: createMockTrace(),
+      });
 
-      expect(state.isDynamic).toBe(false);
+      expect(node.isDynamic).toBe(false);
     });
 
     it('should deserialize state', () => {
-      const serialized: TimeRangeSourceSerializedState = {
+      const serialized: TimeRangeSourceNodeAttrs = {
         start: '100',
         end: '500',
         isDynamic: false,
       };
 
-      const state = TimeRangeSourceNode.deserializeState(
-        createMockTrace(),
-        serialized,
-      );
-      expect(state).toBeDefined();
+      const node = new TimeRangeSourceNode(serialized, {
+        trace: createMockTrace(),
+      });
+      expect(node).toBeDefined();
     });
 
     it('should preserve trace reference', () => {
       const mockTrace = createMockTrace();
-      const serialized: TimeRangeSourceSerializedState = {
+      const serialized: TimeRangeSourceNodeAttrs = {
         start: '100',
         end: '500',
         isDynamic: false,
       };
 
-      const state = TimeRangeSourceNode.deserializeState(mockTrace, serialized);
+      const node = new TimeRangeSourceNode(serialized, {trace: mockTrace});
 
-      expect(state.trace).toBe(mockTrace);
+      expect(node.context.trace).toBe(mockTrace);
     });
   });
 
   describe('clone', () => {
     it('should clone node as static snapshot', () => {
-      const originalNode = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: true, // Original is dynamic
-      });
+      const originalNode = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: true},
+        {trace: createMockTrace()},
+      );
 
       const clonedNode = originalNode.clone() as TimeRangeSourceNode;
 
       // Dynamic node's start/end are updated to trace range (0/1000000) on construction
-      expect(clonedNode.state.start).toEqual(originalNode.state.start);
-      expect(clonedNode.state.end).toEqual(originalNode.state.end);
-      expect(clonedNode.state.start).toEqual(Time.fromRaw(0n));
-      expect(clonedNode.state.end).toEqual(Time.fromRaw(1000000n));
-      expect(clonedNode.state.isDynamic).toBe(false); // Clone is always static
+      expect(clonedNode.start).toEqual(originalNode.start);
+      expect(clonedNode.end).toEqual(originalNode.end);
+      expect(clonedNode.start).toEqual(Time.fromRaw(0n));
+      expect(clonedNode.end).toEqual(Time.fromRaw(1000000n));
+      expect(clonedNode.isDynamic).toBe(false); // Clone is always static
       expect(clonedNode.nodeId).not.toBe(originalNode.nodeId);
     });
 
     it('should clone successfully', () => {
-      const originalNode = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const originalNode = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       const clonedNode = originalNode.clone() as TimeRangeSourceNode;
       expect(clonedNode).toBeDefined();
@@ -429,21 +380,19 @@ describe('TimeRangeSourceNode', () => {
 
   describe('getTitle', () => {
     it('should return "Time range" for static mode', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.getTitle()).toBe('Time range');
     });
 
     it('should return "Current time range" for dynamic mode', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        isDynamic: true,
-      });
+      const node = new TimeRangeSourceNode(
+        {isDynamic: true},
+        {trace: createMockTrace()},
+      );
 
       expect(node.getTitle()).toBe('Current time range');
     });
@@ -451,12 +400,10 @@ describe('TimeRangeSourceNode', () => {
 
   describe('finalCols', () => {
     it('should have id, ts, and dur columns', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.finalCols.length).toBe(3);
       expect(node.finalCols[0].name).toBe('id');
@@ -465,48 +412,41 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should have correct column types', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.finalCols.length).toBe(3);
       expect(node.finalCols[0].name).toBe('id');
-      expect(node.finalCols[0].column.type).toEqual({kind: 'int'});
+      expect(node.finalCols[0].type).toEqual({kind: 'int'});
       expect(node.finalCols[1].name).toBe('ts');
-      expect(node.finalCols[1].column.type).toEqual({kind: 'timestamp'});
+      expect(node.finalCols[1].type).toEqual({kind: 'timestamp'});
       expect(node.finalCols[2].name).toBe('dur');
-      expect(node.finalCols[2].column.type).toEqual({kind: 'duration'});
+      expect(node.finalCols[2].type).toEqual({kind: 'duration'});
     });
   });
 
   describe('edge cases', () => {
     it('should handle very large timestamps', () => {
-      const largeStart = Time.fromRaw(9223372036854775000n);
-      const largeEnd = Time.fromRaw(9223372036854775807n); // Near max int64
+      const largeStart = '9223372036854775000';
+      const largeEnd = '9223372036854775807'; // Near max int64
 
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: largeStart,
-        end: largeEnd,
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: largeStart, end: largeEnd, isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(true);
-      const serialized = node.serializeState();
-      expect(serialized.start).toBe('9223372036854775000');
-      expect(serialized.end).toBe('9223372036854775807');
+      expect(node.attrs.start).toBe('9223372036854775000');
+      expect(node.attrs.end).toBe('9223372036854775807');
     });
 
     it('should handle timestamp at zero', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(0n),
-        end: Time.fromRaw(1000n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '0', end: '1000', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(node.validate()).toBe(true);
       const query = node.getStructuredQuery();
@@ -515,42 +455,34 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should serialize and deserialize round-trip correctly for static node', () => {
-      const originalNode = new TimeRangeSourceNode({
+      const originalNode = new TimeRangeSourceNode(
+        {start: '12345', end: '67890', isDynamic: false},
+        {trace: createMockTrace()},
+      );
+
+      const newNode = new TimeRangeSourceNode(originalNode.attrs, {
         trace: createMockTrace(),
-        start: Time.fromRaw(12345n),
-        end: Time.fromRaw(67890n),
-        isDynamic: false,
       });
 
-      const serialized = originalNode.serializeState();
-      const deserializedState = TimeRangeSourceNode.deserializeState(
-        createMockTrace(),
-        serialized,
-      );
-      const newNode = new TimeRangeSourceNode(deserializedState);
-
-      expect(newNode.state.start).toEqual(originalNode.state.start);
-      expect(newNode.state.end).toEqual(originalNode.state.end);
-      expect(newNode.state.isDynamic).toBe(originalNode.state.isDynamic);
+      expect(newNode.start).toEqual(originalNode.start);
+      expect(newNode.end).toEqual(originalNode.end);
+      expect(newNode.isDynamic).toBe(originalNode.isDynamic);
     });
 
     it('should serialize and deserialize round-trip for dynamic node', () => {
-      const originalNode = new TimeRangeSourceNode({
+      const originalNode = new TimeRangeSourceNode(
+        {isDynamic: true},
+        {trace: createMockTrace()},
+      );
+
+      const newNode = new TimeRangeSourceNode(originalNode.attrs, {
         trace: createMockTrace(),
-        isDynamic: true,
       });
 
-      const serialized = originalNode.serializeState();
-      const deserializedState = TimeRangeSourceNode.deserializeState(
-        createMockTrace(),
-        serialized,
-      );
-      const newNode = new TimeRangeSourceNode(deserializedState);
-
       // Dynamic nodes get their start/end from trace selection, not serialized state
-      expect(newNode.state.start).toEqual(originalNode.state.start);
-      expect(newNode.state.end).toEqual(originalNode.state.end);
-      expect(newNode.state.isDynamic).toBe(true);
+      expect(newNode.start).toEqual(originalNode.start);
+      expect(newNode.end).toEqual(originalNode.end);
+      expect(newNode.isDynamic).toBe(true);
     });
   });
 
@@ -564,12 +496,10 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should clean up interval when dispose is called on dynamic node', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: true,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: true},
+        {trace: createMockTrace()},
+      );
 
       // Verify interval is set up
       expect(jest.getTimerCount()).toBeGreaterThan(0);
@@ -581,23 +511,19 @@ describe('TimeRangeSourceNode', () => {
     });
 
     it('should not throw when dispose is called on static node', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: false},
+        {trace: createMockTrace()},
+      );
 
       expect(() => node.dispose()).not.toThrow();
     });
 
     it('should allow multiple calls to dispose', () => {
-      const node = new TimeRangeSourceNode({
-        trace: createMockTrace(),
-        start: Time.fromRaw(100n),
-        end: Time.fromRaw(500n),
-        isDynamic: true,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '100', end: '500', isDynamic: true},
+        {trace: createMockTrace()},
+      );
 
       node.dispose();
       expect(() => node.dispose()).not.toThrow();
@@ -612,10 +538,10 @@ describe('TimeRangeSourceNode', () => {
         return undefined;
       });
 
-      const node = new TimeRangeSourceNode({
-        trace: mockTrace,
-        isDynamic: true,
-      });
+      const node = new TimeRangeSourceNode(
+        {isDynamic: true},
+        {trace: mockTrace},
+      );
 
       // Advance time to trigger some polls (1 initial call + 3 from interval)
       jest.advanceTimersByTime(600);
@@ -648,14 +574,14 @@ describe('TimeRangeSourceNode', () => {
         );
       });
 
-      const node = new TimeRangeSourceNode({
-        trace: mockTrace,
-        isDynamic: true,
-      });
+      const node = new TimeRangeSourceNode(
+        {isDynamic: true},
+        {trace: mockTrace},
+      );
 
       // Values should be updated immediately on construction
-      expect(node.state.start).toEqual(Time.fromRaw(100n));
-      expect(node.state.end).toEqual(Time.fromRaw(500n));
+      expect(node.start).toEqual(Time.fromRaw(100n));
+      expect(node.end).toEqual(Time.fromRaw(500n));
 
       // Change the selection
       currentTime = 200n;
@@ -664,8 +590,8 @@ describe('TimeRangeSourceNode', () => {
       jest.advanceTimersByTime(200);
 
       // Values should be updated
-      expect(node.state.start).toEqual(Time.fromRaw(200n));
-      expect(node.state.end).toEqual(Time.fromRaw(600n));
+      expect(node.start).toEqual(Time.fromRaw(200n));
+      expect(node.end).toEqual(Time.fromRaw(600n));
 
       node.dispose();
     });
@@ -680,16 +606,14 @@ describe('TimeRangeSourceNode', () => {
         );
       });
 
-      const node = new TimeRangeSourceNode({
-        trace: mockTrace,
-        start: Time.fromRaw(50n),
-        end: Time.fromRaw(150n),
-        isDynamic: false,
-      });
+      const node = new TimeRangeSourceNode(
+        {start: '50', end: '150', isDynamic: false},
+        {trace: mockTrace},
+      );
 
       // Values should remain unchanged
-      expect(node.state.start).toEqual(Time.fromRaw(50n));
-      expect(node.state.end).toEqual(Time.fromRaw(150n));
+      expect(node.start).toEqual(Time.fromRaw(50n));
+      expect(node.end).toEqual(Time.fromRaw(150n));
 
       // Change the selection
       currentTime = 200n;
@@ -698,22 +622,22 @@ describe('TimeRangeSourceNode', () => {
       jest.advanceTimersByTime(1000);
 
       // Values should still be unchanged
-      expect(node.state.start).toEqual(Time.fromRaw(50n));
-      expect(node.state.end).toEqual(Time.fromRaw(150n));
+      expect(node.start).toEqual(Time.fromRaw(50n));
+      expect(node.end).toEqual(Time.fromRaw(150n));
     });
 
     it('should use full trace range when no selection exists in dynamic mode', () => {
       const mockTrace = createMockTrace();
       mockTrace.selection.getTimeSpanOfSelection = jest.fn(() => undefined);
 
-      const node = new TimeRangeSourceNode({
-        trace: mockTrace,
-        isDynamic: true,
-      });
+      const node = new TimeRangeSourceNode(
+        {isDynamic: true},
+        {trace: mockTrace},
+      );
 
       // Should fall back to full trace range immediately on construction
-      expect(node.state.start).toEqual(mockTrace.traceInfo.start);
-      expect(node.state.end).toEqual(mockTrace.traceInfo.end);
+      expect(node.start).toEqual(mockTrace.traceInfo.start);
+      expect(node.end).toEqual(mockTrace.traceInfo.end);
 
       node.dispose();
     });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_node.ts
@@ -16,10 +16,10 @@ import m from 'mithril';
 import protos from '../../../../protos';
 import {
   QueryNode,
-  QueryNodeState,
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import {NodeIssues} from '../node_issues';
@@ -42,24 +42,25 @@ import {
   buildEmbeddedQueryTree,
 } from '../query_builder_utils';
 
-export interface TraceSummarySerializedState {}
-
-export interface TraceSummaryNodeState extends QueryNodeState {}
+// Serializable node configuration (empty for TraceSummary).
+export interface TraceSummaryNodeAttrs {}
 
 export class TraceSummaryNode implements QueryNode {
   readonly nodeId: string;
   readonly type = NodeType.kTraceSummary;
   nextNodes: QueryNode[];
-  readonly state: TraceSummaryNodeState;
+  readonly attrs: TraceSummaryNodeAttrs;
+  readonly context: NodeContext;
   secondaryInputs: SecondaryInputSpec;
 
   get finalCols(): ColumnInfo[] {
     return [];
   }
 
-  constructor(state: TraceSummaryNodeState) {
+  constructor(attrs: TraceSummaryNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {...state};
+    this.attrs = {...attrs};
+    this.context = context;
     this.nextNodes = [];
     this.secondaryInputs = {
       connections: new Map(),
@@ -85,8 +86,8 @@ export class TraceSummaryNode implements QueryNode {
   }
 
   validate(): boolean {
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     // Validate all inputs are Metrics nodes.
@@ -107,7 +108,7 @@ export class TraceSummaryNode implements QueryNode {
     // Validate metric ID prefixes are unique.
     const seenPrefixes = new Set<string>();
     for (const metricsNode of metricsNodes) {
-      const prefix = metricsNode.state.metricIdPrefix;
+      const prefix = metricsNode.attrs.metricIdPrefix;
       if (prefix && seenPrefixes.has(prefix)) {
         this.setValidationError(
           `Duplicate metric ID prefix '${prefix}'. Each metric must have a unique prefix.`,
@@ -122,7 +123,7 @@ export class TraceSummaryNode implements QueryNode {
     for (const metricsNode of metricsNodes) {
       if (!metricsNode.validate()) {
         this.setValidationError(
-          `Metrics node '${metricsNode.state.metricIdPrefix || '(unnamed)'}' is invalid`,
+          `Metrics node '${metricsNode.attrs.metricIdPrefix || '(unnamed)'}' is invalid`,
         );
         return false;
       }
@@ -132,10 +133,10 @@ export class TraceSummaryNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -158,7 +159,7 @@ export class TraceSummaryNode implements QueryNode {
         'div',
         `${metricsNodes.length} metric${metricsNodes.length !== 1 ? 's' : ''}: `,
         metricsNodes.map((mn, i) => [
-          ColumnName(mn.state.metricIdPrefix || '(unnamed)'),
+          ColumnName(mn.attrs.metricIdPrefix || '(unnamed)'),
           i < metricsNodes.length - 1 ? ', ' : '',
         ]),
       ),
@@ -196,7 +197,8 @@ export class TraceSummaryNode implements QueryNode {
       });
     }
 
-    const canExport = this.validate() && this.state.trace?.engine !== undefined;
+    const canExport =
+      this.validate() && this.context.trace?.engine !== undefined;
 
     return {
       info: 'Bundle multiple metrics into a single trace summary. Connect Metrics nodes as inputs to include them in the summary.',
@@ -213,8 +215,8 @@ export class TraceSummaryNode implements QueryNode {
   }
 
   private renderMetricHeader(mn: MetricsNode): m.Children {
-    const prefix = mn.state.metricIdPrefix || '(unnamed)';
-    const valueCount = mn.state.valueColumns.length;
+    const prefix = mn.attrs.metricIdPrefix || '(unnamed)';
+    const valueCount = mn.attrs.valueColumns.length;
     return m('.pf-trace-summary-metric-header', [
       ColumnName(prefix),
       m(
@@ -248,7 +250,7 @@ export class TraceSummaryNode implements QueryNode {
       m('.pf-trace-summary-detail-row', [
         m('span.pf-trace-summary-detail-label', 'Values'),
       ]),
-      ...mn.state.valueColumns.map((vc) =>
+      ...mn.attrs.valueColumns.map((vc) =>
         m('.pf-trace-summary-value-item', [
           ColumnName(vc.column),
           m(
@@ -271,7 +273,7 @@ export class TraceSummaryNode implements QueryNode {
     // Embed query trees for self-contained export.
     for (const templateSpec of spec.metricTemplateSpec) {
       const metricsNode = this.getAllMetricsNodes().find(
-        (mn) => mn.state.metricIdPrefix === templateSpec.idPrefix,
+        (mn) => mn.attrs.metricIdPrefix === templateSpec.idPrefix,
       );
       if (metricsNode?.primaryInput !== undefined) {
         const allQueries = getStructuredQueries(metricsNode.primaryInput);
@@ -307,9 +309,7 @@ export class TraceSummaryNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    return new TraceSummaryNode({
-      onchange: this.state.onchange,
-    });
+    return new TraceSummaryNode({}, this.context);
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -317,12 +317,12 @@ export class TraceSummaryNode implements QueryNode {
   }
 
   customResultsPanel(): m.Children {
-    const trace = this.state.trace;
+    const trace = this.context.trace;
     if (trace === undefined) return undefined;
     return m(TraceSummaryResultsPanel, {
       node: this,
       trace,
-      onchange: () => this.state.onchange?.(),
+      onchange: () => this.context.onchange?.(),
     });
   }
 
@@ -347,15 +347,5 @@ export class TraceSummaryNode implements QueryNode {
     const spec = new protos.TraceSummarySpec();
     spec.metricTemplateSpec = templateSpecs;
     return spec;
-  }
-
-  serializeState(): TraceSummarySerializedState {
-    return {};
-  }
-
-  static deserializeState(
-    _state: TraceSummarySerializedState,
-  ): TraceSummaryNodeState {
-    return {};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_node_unittest.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {TraceSummaryNode} from './trace_summary_node';
-import {MetricsNode, MetricsNodeState} from './metrics_node';
+import {MetricsNode, MetricsNodeAttrs} from './metrics_node';
 import {NodeType} from '../../query_node';
 import {
   createMockNode,
@@ -26,22 +26,23 @@ import {
 } from '../testing/test_utils';
 
 function makeMetricsNode(
-  overrides: Partial<MetricsNodeState> = {},
+  overrides: Partial<MetricsNodeAttrs> = {},
 ): MetricsNode {
-  const state: MetricsNodeState = {
+  const attrs: MetricsNodeAttrs = {
     metricIdPrefix: 'test_metric',
     valueColumns: [
       {column: 'value', unit: 'COUNT', polarity: 'NOT_APPLICABLE'},
     ],
     dimensionConfigs: {},
     dimensionUniqueness: 'NOT_UNIQUE',
-    availableColumns: [
-      createColumnInfo('name', 'string'),
-      createColumnInfo('value', 'int'),
-    ],
     ...overrides,
   };
-  return new MetricsNode(state);
+  const node = new MetricsNode(attrs, {});
+  node.availableColumns = [
+    createColumnInfo('name', 'string'),
+    createColumnInfo('value', 'int'),
+  ];
+  return node;
 }
 
 function makeConnectedMetricsNode(prefix = 'test_metric'): {
@@ -61,38 +62,38 @@ function makeConnectedMetricsNode(prefix = 'test_metric'): {
 describe('TraceSummaryNode', () => {
   describe('basic properties', () => {
     test('type is kTraceSummary', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expect(node.type).toBe(NodeType.kTraceSummary);
     });
 
     test('has unique nodeId', () => {
-      const node1 = new TraceSummaryNode({});
-      const node2 = new TraceSummaryNode({});
+      const node1 = new TraceSummaryNode({}, {});
+      const node2 = new TraceSummaryNode({}, {});
       expect(node1.nodeId).not.toBe(node2.nodeId);
     });
 
     test('finalCols is always empty', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expect(node.finalCols).toEqual([]);
     });
 
     test('getTitle returns Trace Summary', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expect(node.getTitle()).toBe('Trace Summary');
     });
 
     test('nextNodes is empty', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expect(node.nextNodes).toEqual([]);
     });
 
     test('getStructuredQuery returns undefined', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expect(node.getStructuredQuery()).toBeUndefined();
     });
 
     test('secondaryInputs requires min 1', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expect(node.secondaryInputs.min).toBe(1);
       expect(node.secondaryInputs.max).toBe('unbounded');
     });
@@ -100,13 +101,13 @@ describe('TraceSummaryNode', () => {
 
   describe('validation', () => {
     test('fails with no inputs', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expectValidationError(node, 'At least one Metrics node is required');
     });
 
     test('fails when input is not a Metrics node', () => {
       const nonMetrics = createMockNode({nodeId: 'non-metrics'});
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(nonMetrics, node, 0);
       expectValidationError(node, 'All inputs must be Metrics nodes');
     });
@@ -114,7 +115,7 @@ describe('TraceSummaryNode', () => {
     test('fails when one of multiple inputs is not a Metrics node', () => {
       const {metrics} = makeConnectedMetricsNode();
       const nonMetrics = createMockNode({nodeId: 'non-metrics'});
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics, node, 0);
       connectSecondary(nonMetrics, node, 1);
       expectValidationError(node, 'All inputs must be Metrics nodes');
@@ -132,7 +133,7 @@ describe('TraceSummaryNode', () => {
       connectNodes(source, metrics);
       metrics.onPrevNodesUpdated();
 
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics, node, 0);
 
       expect(node.validate()).toBe(false);
@@ -140,7 +141,7 @@ describe('TraceSummaryNode', () => {
 
     test('succeeds with one valid Metrics node', () => {
       const {metrics} = makeConnectedMetricsNode();
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics, node, 0);
       expectValidationSuccess(node);
     });
@@ -148,7 +149,7 @@ describe('TraceSummaryNode', () => {
     test('succeeds with multiple Metrics nodes', () => {
       const {metrics: metrics1} = makeConnectedMetricsNode('metric_a');
       const {metrics: metrics2} = makeConnectedMetricsNode('metric_b');
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics1, node, 0);
       connectSecondary(metrics2, node, 1);
       expectValidationSuccess(node);
@@ -157,13 +158,13 @@ describe('TraceSummaryNode', () => {
 
   describe('getTraceSummarySpec', () => {
     test('returns undefined when invalid', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       expect(node.getTraceSummarySpec()).toBeUndefined();
     });
 
     test('bundles single Metrics node', () => {
       const {metrics} = makeConnectedMetricsNode('my_metric');
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics, node, 0);
 
       const spec = node.getTraceSummarySpec();
@@ -175,7 +176,7 @@ describe('TraceSummaryNode', () => {
     test('bundles multiple Metrics nodes', () => {
       const {metrics: metrics1} = makeConnectedMetricsNode('cpu_metric');
       const {metrics: metrics2} = makeConnectedMetricsNode('mem_metric');
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics1, node, 0);
       connectSecondary(metrics2, node, 1);
 
@@ -190,7 +191,7 @@ describe('TraceSummaryNode', () => {
     test('preserves port order in the spec', () => {
       const {metrics: metrics1} = makeConnectedMetricsNode('first_metric');
       const {metrics: metrics2} = makeConnectedMetricsNode('second_metric');
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics1, node, 0);
       connectSecondary(metrics2, node, 1);
 
@@ -202,20 +203,20 @@ describe('TraceSummaryNode', () => {
 
   describe('serialization', () => {
     test('serializeState returns empty object', () => {
-      const node = new TraceSummaryNode({});
-      const serialized = node.serializeState();
+      const node = new TraceSummaryNode({}, {});
+      const serialized = node.attrs;
       expect(serialized).toEqual({});
     });
 
-    test('deserializeState returns empty state', () => {
-      const state = TraceSummaryNode.deserializeState({});
-      expect(state).toEqual({});
+    test('constructor accepts empty attrs', () => {
+      const node = new TraceSummaryNode({}, {});
+      expect(node.attrs).toEqual({});
     });
   });
 
   describe('clone', () => {
     test('creates a new node with different ID', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       const cloned = node.clone();
       expect(cloned.nodeId).not.toBe(node.nodeId);
       expect(cloned.type).toBe(NodeType.kTraceSummary);
@@ -224,7 +225,7 @@ describe('TraceSummaryNode', () => {
 
   describe('nodeDetails', () => {
     test('shows message when no metrics connected', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       const details = node.nodeDetails();
       expect(details.content).toBeDefined();
     });
@@ -232,7 +233,7 @@ describe('TraceSummaryNode', () => {
     test('shows connected metrics count', () => {
       const {metrics: metrics1} = makeConnectedMetricsNode('cpu');
       const {metrics: metrics2} = makeConnectedMetricsNode('mem');
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       connectSecondary(metrics1, node, 0);
       connectSecondary(metrics2, node, 1);
 
@@ -243,7 +244,7 @@ describe('TraceSummaryNode', () => {
 
   describe('nodeSpecificModify', () => {
     test('returns NodeModifyAttrs with info', () => {
-      const node = new TraceSummaryNode({});
+      const node = new TraceSummaryNode({}, {});
       const result = node.nodeSpecificModify();
       expect(result).toHaveProperty('info');
       expect(result).toHaveProperty('sections');

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/trace_summary_results_panel.ts
@@ -177,7 +177,7 @@ export class TraceSummaryResultsPanel
 
   view({attrs}: m.CVnode<TraceSummaryResultsPanelAttrs>) {
     const {node} = attrs;
-    const autoExecute = node.state.autoExecute ?? true;
+    const autoExecute = node.context.autoExecute ?? true;
 
     // Auto-execute when spec changes.
     if (autoExecute && node.validate()) {
@@ -202,17 +202,17 @@ export class TraceSummaryResultsPanel
   private computeSpecHash(node: TraceSummaryNode): string {
     const metricsNodes = node.getAllMetricsNodes();
     const parts = metricsNodes.map((mn) => {
-      const values = mn.state.valueColumns
+      const values = mn.attrs.valueColumns
         .map((v) => `${v.column}/${v.unit}/${v.customUnit ?? ''}/${v.polarity}`)
         .join(',');
       const dims = mn.getDimensions().join(',');
-      return `${mn.nodeId}:${mn.state.metricIdPrefix}:${mn.state.dimensionUniqueness}:${dims}:${values}`;
+      return `${mn.nodeId}:${mn.attrs.metricIdPrefix}:${mn.attrs.dimensionUniqueness}:${dims}:${values}`;
     });
     return parts.join('|');
   }
 
   private renderMenu(attrs: TraceSummaryResultsPanelAttrs): m.Children {
-    const autoExecute = attrs.node.state.autoExecute ?? true;
+    const autoExecute = attrs.node.context.autoExecute ?? true;
     const isLoading = this.executionState.kind === 'loading';
     const isStale = this.prevSpecHash !== this.computeSpecHash(attrs.node);
 
@@ -238,7 +238,7 @@ export class TraceSummaryResultsPanel
       checked: autoExecute,
       onchange: (e: Event) => {
         const target = e.target as HTMLInputElement;
-        attrs.node.state.autoExecute = target.checked;
+        attrs.node.context.autoExecute = target.checked;
         attrs.onchange?.();
         if (target.checked && attrs.node.validate()) {
           this.prevSpecHash = this.computeSpecHash(attrs.node);
@@ -285,7 +285,7 @@ export class TraceSummaryResultsPanel
       return m(ResultsPanelEmptyState, {
         icon: 'warning',
         title:
-          attrs.node.state.issues?.queryError?.message ??
+          attrs.node.context.issues?.queryError?.message ??
           'Node validation failed',
       });
     }
@@ -347,7 +347,7 @@ export class TraceSummaryResultsPanel
     // Guard against concurrent executions (e.g. re-renders during loading).
     if (this.executionState.kind === 'loading') return;
 
-    const engine = node.state.trace?.engine;
+    const engine = node.context.trace?.engine;
     if (engine === undefined) {
       this.executionState = {
         kind: 'error',

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/union_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/union_node.ts
@@ -15,14 +15,14 @@
 import m from 'mithril';
 import {
   QueryNode,
-  QueryNodeState,
   nextNodeId,
   NodeType,
   SecondaryInputSpec,
+  NodeContext,
 } from '../../query_node';
 import {notifyNextNodes} from '../graph_utils';
 import protos from '../../../../protos';
-import {ColumnInfo, newColumnInfoList} from '../column_info';
+import {ColumnInfo, newColumnInfo} from '../column_info';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
 import {StructuredQueryBuilder, ColumnSpec} from '../structured_query_builder';
@@ -36,13 +36,8 @@ import {
   ColumnName,
 } from '../node_styling_widgets';
 
-export interface UnionSerializedState {
-  selectedColumns: ColumnInfo[];
-  comment?: string;
-}
-
-export interface UnionNodeState extends QueryNodeState {
-  inputNodes: QueryNode[];
+// Serializable node configuration.
+export interface UnionNodeAttrs {
   selectedColumns: ColumnInfo[];
 }
 
@@ -51,8 +46,8 @@ export class UnionNode implements QueryNode {
   readonly type = NodeType.kUnion;
   secondaryInputs: SecondaryInputSpec;
   nextNodes: QueryNode[];
-  readonly state: UnionNodeState;
-  comment?: string;
+  readonly attrs: UnionNodeAttrs;
+  readonly context: NodeContext;
 
   get inputNodesList(): QueryNode[] {
     return [...this.secondaryInputs.connections.entries()]
@@ -61,29 +56,33 @@ export class UnionNode implements QueryNode {
   }
 
   get finalCols(): ColumnInfo[] {
-    return this.state.selectedColumns.filter((col) => col.checked);
+    return this.attrs.selectedColumns.filter((col) => col.checked);
   }
 
-  constructor(state: UnionNodeState) {
+  constructor(
+    attrs: UnionNodeAttrs & {inputNodes?: QueryNode[]},
+    context: NodeContext,
+  ) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...state,
-      autoExecute: state.autoExecute ?? false,
-    };
+    const {inputNodes, ...rest} = attrs;
+    this.attrs = rest as UnionNodeAttrs;
+    this.context = context;
     this.secondaryInputs = {
       connections: new Map(),
       min: 2,
       max: 'unbounded',
       portNames: (portIndex: number) => `Input ${portIndex}`,
     };
-    // Initialize connections from state.inputNodes
-    for (let i = 0; i < state.inputNodes.length; i++) {
-      this.secondaryInputs.connections.set(i, state.inputNodes[i]);
+    // Initialize connections from inputNodes
+    if (inputNodes) {
+      for (let i = 0; i < inputNodes.length; i++) {
+        this.secondaryInputs.connections.set(i, inputNodes[i]);
+      }
     }
     this.nextNodes = [];
 
-    const userOnChange = this.state.onchange;
-    this.state.onchange = () => {
+    const userOnChange = this.context.onchange;
+    this.context.onchange = () => {
       notifyNextNodes(this);
       userOnChange?.();
     };
@@ -93,16 +92,14 @@ export class UnionNode implements QueryNode {
     const newCommonColumns = this.getCommonColumns();
 
     // Preserve checked status for columns that still exist.
-    for (const oldCol of this.state.selectedColumns ?? []) {
-      const newCol = newCommonColumns.find(
-        (c) => c.column.name === oldCol.column.name,
-      );
+    for (const oldCol of this.attrs.selectedColumns ?? []) {
+      const newCol = newCommonColumns.find((c) => c.name === oldCol.name);
       if (newCol) {
         newCol.checked = oldCol.checked;
       }
     }
 
-    this.state.selectedColumns = newCommonColumns;
+    this.attrs.selectedColumns = newCommonColumns;
   }
 
   private getCommonColumns(): ColumnInfo[] {
@@ -116,13 +113,14 @@ export class UnionNode implements QueryNode {
     if (validPrevNodes.length === 0) {
       return [];
     }
-    let commonCols = newColumnInfoList(validPrevNodes[0].finalCols, true);
+    let commonCols = validPrevNodes[0].finalCols.map((col) =>
+      newColumnInfo(col, true),
+    );
     for (let i = 1; i < validPrevNodes.length; i++) {
       const currentNodeCols = validPrevNodes[i].finalCols;
       commonCols = commonCols.filter((commonCol) =>
         currentNodeCols.some(
-          (currentNodeCol) =>
-            currentNodeCol.column.name === commonCol.column.name,
+          (currentNodeCol) => currentNodeCol.name === commonCol.name,
         ),
       );
     }
@@ -131,8 +129,8 @@ export class UnionNode implements QueryNode {
 
   validate(): boolean {
     // Clear any previous errors at the start of validation
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     // Check for undefined entries (disconnected inputs)
@@ -165,7 +163,7 @@ export class UnionNode implements QueryNode {
 
       if (!inputNode.validate()) {
         this.setValidationError(
-          inputNode.state.issues?.queryError?.message ??
+          inputNode.context.issues?.queryError?.message ??
             `Input node '${inputNode.getTitle()}' is invalid`,
         );
         return false;
@@ -176,10 +174,10 @@ export class UnionNode implements QueryNode {
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   getTitle(): string {
@@ -191,7 +189,7 @@ export class UnionNode implements QueryNode {
   }
 
   nodeDetails(): NodeDetailsAttrs {
-    const selectedCols = this.state.selectedColumns.filter((c) => c.checked);
+    const selectedCols = this.attrs.selectedColumns.filter((c) => c.checked);
     let message: m.Child;
 
     if (selectedCols.length === 0) {
@@ -202,7 +200,7 @@ export class UnionNode implements QueryNode {
     } else {
       // Show individual column names
       const selectedItems = selectedCols.map((c) =>
-        m('div', ColumnName(c.column.name)),
+        m('div', ColumnName(c.name)),
       );
       message = m('div', ...selectedItems);
     }
@@ -213,12 +211,12 @@ export class UnionNode implements QueryNode {
 
   nodeSpecificModify(): NodeModifyAttrs {
     this.validate();
-    const error = this.state.issues?.queryError;
+    const error = this.context.issues?.queryError;
 
-    const selectedCount = this.state.selectedColumns.filter(
+    const selectedCount = this.attrs.selectedColumns.filter(
       (col) => col.checked,
     ).length;
-    const totalCount = this.state.selectedColumns.length;
+    const totalCount = this.attrs.selectedColumns.length;
 
     const sections: NodeModifyAttrs['sections'] = [];
 
@@ -243,10 +241,10 @@ export class UnionNode implements QueryNode {
       sections.push({
         title: `Select Common Columns (${selectedCount} / ${totalCount} selected)`,
         content: m(ColumnSelector, {
-          columns: this.state.selectedColumns,
+          columns: this.attrs.selectedColumns,
           onColumnsChange: (columns) => {
-            this.state.selectedColumns = columns;
-            this.state.onchange?.();
+            this.attrs.selectedColumns = columns;
+            this.context.onchange?.();
           },
           helpText: 'Select which common columns to include in the union',
           draggable: true,
@@ -261,13 +259,10 @@ export class UnionNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: UnionNodeState = {
-      inputNodes: [...this.state.inputNodes],
-      selectedColumns: this.state.selectedColumns.map((c) => ({...c})),
-    };
-    const clone = new UnionNode(stateCopy);
-    clone.comment = this.comment;
-    return clone;
+    return new UnionNode(
+      {selectedColumns: this.attrs.selectedColumns.map((c) => ({...c}))},
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -279,12 +274,12 @@ export class UnionNode implements QueryNode {
     }
 
     // Get the list of checked common columns
-    const selectedColumns = this.state.selectedColumns.filter((c) => c.checked);
+    const selectedColumns = this.attrs.selectedColumns.filter((c) => c.checked);
     if (selectedColumns.length === 0) return undefined;
 
     // Build column specifications for the SELECT
     const columnSpecs: ColumnSpec[] = selectedColumns.map((col) => ({
-      columnNameOrExpression: col.column.name,
+      columnNameOrExpression: col.name,
     }));
 
     // Create wrapper queries for each input that selects only the common columns
@@ -302,19 +297,5 @@ export class UnionNode implements QueryNode {
 
     // Create the union from the wrapped queries
     return StructuredQueryBuilder.withUnion(wrappedQueries, true, this.nodeId);
-  }
-
-  serializeState(): UnionSerializedState {
-    return {
-      selectedColumns: this.state.selectedColumns,
-      comment: this.comment,
-    };
-  }
-
-  static deserializeState(state: UnionSerializedState): UnionNodeState {
-    return {
-      inputNodes: [],
-      selectedColumns: state.selectedColumns,
-    };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/union_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/union_node_unittest.ts
@@ -43,16 +43,19 @@ describe('UnionNode', () => {
         createColumnInfo('name', 'string'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string'),
-        ],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string'),
+          ],
+        },
+        {},
+      );
 
-      expect(unionNode.state.autoExecute).toBe(false);
-      expect(unionNode.state.selectedColumns.length).toBe(2);
+      expect(unionNode.context.autoExecute).toBeUndefined();
+      expect(unionNode.attrs.selectedColumns.length).toBe(2);
       expect(unionNode.secondaryInputs.min).toBe(2);
       expect(unionNode.secondaryInputs.max).toBe('unbounded');
     });
@@ -62,10 +65,13 @@ describe('UnionNode', () => {
       const node2 = createMockNodeWithSq('node2', []);
       const node3 = createMockNodeWithSq('node3', []);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2, node3],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2, node3],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       expect(unionNode.secondaryInputs.connections.size).toBe(3);
       expect(unionNode.secondaryInputs.connections.get(0)).toBe(node1);
@@ -76,10 +82,13 @@ describe('UnionNode', () => {
 
   describe('getCommonColumns', () => {
     it('should return empty array when there are no input nodes', () => {
-      const unionNode = new UnionNode({
-        inputNodes: [],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       expect(unionNode['getCommonColumns']()).toEqual([]);
     });
@@ -90,14 +99,17 @@ describe('UnionNode', () => {
         createColumnInfo('name', 'string'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       const commonCols = unionNode['getCommonColumns']();
       expect(commonCols.length).toBe(2);
-      expect(commonCols.map((c) => c.column.name)).toEqual(['id', 'name']);
+      expect(commonCols.map((c) => c.name)).toEqual(['id', 'name']);
     });
 
     it('should return only common columns between two inputs', () => {
@@ -112,14 +124,17 @@ describe('UnionNode', () => {
         createColumnInfo('value', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       const commonCols = unionNode['getCommonColumns']();
       expect(commonCols.length).toBe(2);
-      expect(commonCols.map((c) => c.column.name)).toEqual(['id', 'name']);
+      expect(commonCols.map((c) => c.name)).toEqual(['id', 'name']);
     });
 
     it('should return only columns present in all inputs', () => {
@@ -138,14 +153,17 @@ describe('UnionNode', () => {
         createColumnInfo('other', 'string'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2, node3],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2, node3],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       const commonCols = unionNode['getCommonColumns']();
       expect(commonCols.length).toBe(1);
-      expect(commonCols.map((c) => c.column.name)).toEqual(['id']);
+      expect(commonCols.map((c) => c.name)).toEqual(['id']);
     });
 
     it('should return empty array when there are no common columns', () => {
@@ -158,10 +176,13 @@ describe('UnionNode', () => {
         createColumnInfo('ts', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       const commonCols = unionNode['getCommonColumns']();
       expect(commonCols.length).toBe(0);
@@ -177,10 +198,13 @@ describe('UnionNode', () => {
         createColumnInfo('name', 'string'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       const commonCols = unionNode['getCommonColumns']();
       expect(commonCols.every((c) => c.checked === true)).toBe(true);
@@ -198,17 +222,20 @@ describe('UnionNode', () => {
         createColumnInfo('name', 'string'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          {...createColumnInfo('name', 'string'), checked: false},
-        ],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            {...createColumnInfo('name', 'string'), checked: false},
+          ],
+        },
+        {},
+      );
 
       const finalCols = unionNode.finalCols;
       expect(finalCols.length).toBe(1);
-      expect(finalCols[0].column.name).toBe('id');
+      expect(finalCols[0].name).toBe('id');
     });
 
     it('should return empty array when no columns are checked', () => {
@@ -219,10 +246,13 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [{...createColumnInfo('id', 'int'), checked: false}],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [{...createColumnInfo('id', 'int'), checked: false}],
+        },
+        {},
+      );
 
       expect(unionNode.finalCols).toEqual([]);
     });
@@ -239,13 +269,16 @@ describe('UnionNode', () => {
         createColumnInfo('name', 'string'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          {...createColumnInfo('name', 'string'), checked: false},
-        ],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            {...createColumnInfo('name', 'string'), checked: false},
+          ],
+        },
+        {},
+      );
 
       // Update node2 to remove 'name'
       const updatedNode2 = createMockNodeWithSq('node2', [
@@ -257,10 +290,10 @@ describe('UnionNode', () => {
       unionNode.onPrevNodesUpdated();
 
       // Only 'id' should remain as it's the only common column
-      expect(unionNode.state.selectedColumns.length).toBe(1);
-      expect(unionNode.state.selectedColumns[0].column.name).toBe('id');
+      expect(unionNode.attrs.selectedColumns.length).toBe(1);
+      expect(unionNode.attrs.selectedColumns[0].name).toBe('id');
       // 'id' should preserve its checked status (true)
-      expect(unionNode.state.selectedColumns[0].checked).toBe(true);
+      expect(unionNode.attrs.selectedColumns[0].checked).toBe(true);
     });
 
     it('should preserve checked status for columns that still exist', () => {
@@ -275,29 +308,32 @@ describe('UnionNode', () => {
         createColumnInfo('ts', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          {...createColumnInfo('name', 'string'), checked: false},
-          createColumnInfo('ts', 'int'),
-        ],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            {...createColumnInfo('name', 'string'), checked: false},
+            createColumnInfo('ts', 'int'),
+          ],
+        },
+        {},
+      );
 
       unionNode.onPrevNodesUpdated();
 
       // All columns should still exist
-      expect(unionNode.state.selectedColumns.length).toBe(3);
+      expect(unionNode.attrs.selectedColumns.length).toBe(3);
 
       // Check that checked status is preserved
-      const idCol = unionNode.state.selectedColumns.find(
-        (c) => c.column.name === 'id',
+      const idCol = unionNode.attrs.selectedColumns.find(
+        (c) => c.name === 'id',
       );
-      const nameCol = unionNode.state.selectedColumns.find(
-        (c) => c.column.name === 'name',
+      const nameCol = unionNode.attrs.selectedColumns.find(
+        (c) => c.name === 'name',
       );
-      const tsCol = unionNode.state.selectedColumns.find(
-        (c) => c.column.name === 'ts',
+      const tsCol = unionNode.attrs.selectedColumns.find(
+        (c) => c.name === 'ts',
       );
 
       expect(idCol?.checked).toBe(true);
@@ -312,13 +348,16 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       expect(unionNode.validate()).toBe(false);
-      expect(unionNode.state.issues?.queryError?.message).toContain(
+      expect(unionNode.context.issues?.queryError?.message).toContain(
         'at least two sources',
       );
     });
@@ -331,13 +370,16 @@ describe('UnionNode', () => {
         createColumnInfo('value', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       expect(unionNode.validate()).toBe(false);
-      expect(unionNode.state.issues?.queryError?.message).toContain(
+      expect(unionNode.context.issues?.queryError?.message).toContain(
         'common columns',
       );
     });
@@ -347,10 +389,13 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       // Manually add undefined to connections
       unionNode.secondaryInputs.connections.set(
@@ -359,7 +404,7 @@ describe('UnionNode', () => {
       );
 
       expect(unionNode.validate()).toBe(false);
-      expect(unionNode.state.issues?.queryError?.message).toContain(
+      expect(unionNode.context.issues?.queryError?.message).toContain(
         'disconnected inputs',
       );
     });
@@ -374,13 +419,16 @@ describe('UnionNode', () => {
         createColumnInfo('name', 'string'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string'),
-        ],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string'),
+          ],
+        },
+        {},
+      );
 
       expect(unionNode.validate()).toBe(true);
     });
@@ -393,30 +441,36 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [createColumnInfo('id', 'int')],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [createColumnInfo('id', 'int')],
+        },
+        {},
+      );
 
       // First validate with error
       unionNode.secondaryInputs.connections.clear();
       expect(unionNode.validate()).toBe(false);
-      expect(unionNode.state.issues?.queryError).toBeDefined();
+      expect(unionNode.context.issues?.queryError).toBeDefined();
 
       // Restore connections and validate again
       unionNode.secondaryInputs.connections.set(0, node1);
       unionNode.secondaryInputs.connections.set(1, node2);
       expect(unionNode.validate()).toBe(true);
-      expect(unionNode.state.issues?.queryError).toBeUndefined();
+      expect(unionNode.context.issues?.queryError).toBeUndefined();
     });
   });
 
   describe('getTitle', () => {
     it('should return "Union"', () => {
-      const unionNode = new UnionNode({
-        inputNodes: [],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       expect(unionNode.getTitle()).toBe('Union');
     });
@@ -431,18 +485,18 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [createColumnInfo('id', 'int')],
-      });
-      unionNode.comment = 'test comment';
-
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [createColumnInfo('id', 'int')],
+        },
+        {},
+      );
       const cloned = unionNode.clone() as UnionNode;
 
       expect(cloned).not.toBe(unionNode);
-      expect(cloned.state.inputNodes).toEqual(unionNode.state.inputNodes);
-      expect(cloned.state.selectedColumns.length).toBe(1);
-      expect(cloned.comment).toBe('test comment');
+      // Clone doesn't copy input connections (those are graph topology)
+      expect((cloned as UnionNode).attrs.selectedColumns.length).toBe(1);
     });
 
     it('should not share state with original', () => {
@@ -453,18 +507,21 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [createColumnInfo('id', 'int')],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [createColumnInfo('id', 'int')],
+        },
+        {},
+      );
 
       const cloned = unionNode.clone() as UnionNode;
 
       // Modify the cloned state
-      cloned.state.selectedColumns[0].checked = false;
+      (cloned as UnionNode).attrs.selectedColumns[0].checked = false;
 
       // Original should not be affected
-      expect(unionNode.state.selectedColumns[0].checked).toBe(true);
+      expect(unionNode.attrs.selectedColumns[0].checked).toBe(true);
     });
   });
 
@@ -474,10 +531,13 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1],
-        selectedColumns: [],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1],
+          selectedColumns: [],
+        },
+        {},
+      );
 
       expect(unionNode.getStructuredQuery()).toBeUndefined();
     });
@@ -490,10 +550,13 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [{...createColumnInfo('id', 'int'), checked: false}],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [{...createColumnInfo('id', 'int'), checked: false}],
+        },
+        {},
+      );
 
       expect(unionNode.getStructuredQuery()).toBeUndefined();
     });
@@ -503,10 +566,13 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1],
-        selectedColumns: [createColumnInfo('id', 'int')],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1],
+          selectedColumns: [createColumnInfo('id', 'int')],
+        },
+        {},
+      );
 
       unionNode.secondaryInputs.connections.set(
         1,
@@ -528,13 +594,16 @@ describe('UnionNode', () => {
         createColumnInfo('value', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          createColumnInfo('name', 'string'),
-        ],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            createColumnInfo('name', 'string'),
+          ],
+        },
+        {},
+      );
 
       const sq = unionNode.getStructuredQuery();
 
@@ -556,14 +625,17 @@ describe('UnionNode', () => {
         createColumnInfo('ts', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [
-          createColumnInfo('id', 'int'),
-          {...createColumnInfo('name', 'string'), checked: false}, // unchecked
-          createColumnInfo('ts', 'int'),
-        ],
-      });
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [
+            createColumnInfo('id', 'int'),
+            {...createColumnInfo('name', 'string'), checked: false}, // unchecked
+            createColumnInfo('ts', 'int'),
+          ],
+        },
+        {},
+      );
 
       const sq = unionNode.getStructuredQuery();
 
@@ -599,32 +671,27 @@ describe('UnionNode', () => {
         createColumnInfo('id', 'int'),
       ]);
 
-      const unionNode = new UnionNode({
-        inputNodes: [node1, node2],
-        selectedColumns: [createColumnInfo('id', 'int')],
-      });
-      unionNode.comment = 'test comment';
-
-      const serialized = unionNode.serializeState();
-
-      expect(serialized.selectedColumns.length).toBe(1);
-      expect(serialized.selectedColumns[0].column.name).toBe('id');
-      expect(serialized.comment).toBe('test comment');
+      const unionNode = new UnionNode(
+        {
+          inputNodes: [node1, node2],
+          selectedColumns: [createColumnInfo('id', 'int')],
+        },
+        {},
+      );
+      expect(unionNode.attrs.selectedColumns.length).toBe(1);
+      expect(unionNode.attrs.selectedColumns[0].name).toBe('id');
     });
   });
 
-  describe('deserializeState', () => {
-    it('should deserialize state correctly', () => {
-      const serialized = {
-        selectedColumns: [createColumnInfo('id', 'int')],
-        comment: 'test comment',
-      };
+  describe('deserialize', () => {
+    it('should restore state via constructor', () => {
+      const node = new UnionNode(
+        {selectedColumns: [createColumnInfo('id', 'int')]},
+        {},
+      );
 
-      const state = UnionNode.deserializeState(serialized);
-
-      expect(state.inputNodes).toEqual([]);
-      expect(state.selectedColumns.length).toBe(1);
-      expect(state.selectedColumns[0].column.name).toBe('id');
+      expect(node.attrs.selectedColumns.length).toBe(1);
+      expect(node.attrs.selectedColumns[0].name).toBe('id');
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/visualisation_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/visualisation_node.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {
-  QueryNode,
-  QueryNodeState,
-  nextNodeId,
-  NodeType,
-} from '../../query_node';
+import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import {ColumnInfo} from '../column_info';
 import protos from '../../../../protos';
 import {isQuantitativeType} from '../../../../trace_processor/perfetto_sql_type';
@@ -187,7 +182,8 @@ export function getDefaultChartLabel(config: ChartConfig): string {
   }
 }
 
-export interface VisualisationNodeState extends QueryNodeState {
+// Serializable node configuration.
+export interface VisualisationNodeAttrs {
   /** Array of chart configurations - multiple charts per node */
   chartConfigs: ChartConfig[];
   /** Shared filters applied to all charts */
@@ -200,20 +196,36 @@ export class VisualisationNode implements QueryNode {
   primaryInput?: QueryNode;
   secondaryInputs?: undefined;
   nextNodes: QueryNode[];
-  readonly state: VisualisationNodeState;
+  readonly attrs: VisualisationNodeAttrs;
+  readonly context: NodeContext;
 
   // UI-only state for tracking collapsed charts (not persisted)
   private collapsedCharts: Set<string> = new Set();
   // UI-only state for tracking which chart title is being edited
   private editingChartId?: string;
 
-  constructor(state: Partial<VisualisationNodeState>) {
+  constructor(attrs: VisualisationNodeAttrs, context: NodeContext) {
     this.nodeId = nextNodeId();
-    this.state = {
-      ...state,
-      chartConfigs: state.chartConfigs ?? [],
-      chartFilters: state.chartFilters ?? [],
+    // Migrate filter values from strings back to numbers when appropriate.
+    // JSON serialization converts BigInt to string, and we need numeric
+    // values for proper filtering (same logic as FilterNode).
+    const chartFilters = attrs.chartFilters?.map((f): Partial<UIFilter> => {
+      if ('value' in f && typeof f.value === 'string') {
+        if (!Array.isArray(f.value)) {
+          const parsed = parseFilterValue(f.value);
+          if (parsed !== undefined && parsed !== f.value) {
+            return {...f, value: parsed} as Partial<UIFilter>;
+          }
+        }
+      }
+      return f;
+    });
+    this.attrs = {
+      ...attrs,
+      chartConfigs: attrs.chartConfigs ?? [],
+      chartFilters: chartFilters ?? [],
     };
+    this.context = context;
     this.nextNodes = [];
   }
 
@@ -239,7 +251,7 @@ export class VisualisationNode implements QueryNode {
       chartType === 'cdf'
     ) {
       return this.sourceCols.filter((col) => {
-        const type = col.column.type;
+        const type = col.type;
         return type !== undefined && isQuantitativeType(type);
       });
     }
@@ -265,21 +277,21 @@ export class VisualisationNode implements QueryNode {
 
   /** Number of charts that have a column selected. */
   private configuredChartCount(): number {
-    return this.state.chartConfigs.filter((c) => c.column).length;
+    return this.attrs.chartConfigs.filter((c) => c.column).length;
   }
 
   private setValidationError(message: string): void {
-    if (!this.state.issues) {
-      this.state.issues = new NodeIssues();
+    if (!this.context.issues) {
+      this.context.issues = new NodeIssues();
     }
-    this.state.issues.queryError = new Error(message);
+    this.context.issues.queryError = new Error(message);
   }
 
   nodeDetails(): NodeDetailsAttrs {
     this.validate();
 
     const validFilters =
-      this.state.chartFilters?.filter((f) => this.isFilterValid(f)) ?? [];
+      this.attrs.chartFilters?.filter((f) => this.isFilterValid(f)) ?? [];
 
     const configuredCount = this.configuredChartCount();
     if (configuredCount === 0) {
@@ -324,13 +336,13 @@ export class VisualisationNode implements QueryNode {
     const sections: NodeModifyAttrs['sections'] = [];
 
     // Chart cards container
-    const chartCards = this.state.chartConfigs.map((config) => {
+    const chartCards = this.attrs.chartConfigs.map((config) => {
       const chartTypeIcon =
         config.chartType === 'bar' ? 'bar_chart' : 'ssid_chart';
       const defaultLabel = getDefaultChartLabel(config);
 
       // Filters matching this chart's column
-      const chartFilters = (this.state.chartFilters?.filter(
+      const chartFilters = (this.attrs.chartFilters?.filter(
         (f) => this.isFilterValid(f) && f.column === config.column,
       ) ?? []) as UIFilter[];
       const hasFilters = chartFilters.length > 0;
@@ -429,7 +441,7 @@ export class VisualisationNode implements QueryNode {
                         onclick: (e: Event) => {
                           e.stopPropagation();
                           this.clearChartFiltersForColumn(config.column);
-                          this.state.onchange?.();
+                          this.context.onchange?.();
                         },
                         title: 'Clear filters for this chart',
                       },
@@ -438,7 +450,7 @@ export class VisualisationNode implements QueryNode {
                   ],
                 ),
               // Remove button (only show if more than one chart)
-              this.state.chartConfigs.length > 1 &&
+              this.attrs.chartConfigs.length > 1 &&
                 m(Button, {
                   icon: 'close',
                   compact: true,
@@ -471,7 +483,7 @@ export class VisualisationNode implements QueryNode {
                     onRemove: () => {
                       // Find the index in the full filters array
                       const fullIndex =
-                        this.state.chartFilters?.indexOf(filter) ?? -1;
+                        this.attrs.chartFilters?.indexOf(filter) ?? -1;
                       if (fullIndex >= 0) {
                         this.removeChartFilter(fullIndex);
                       }
@@ -540,7 +552,7 @@ export class VisualisationNode implements QueryNode {
   addChart(chartType: ChartType = 'bar'): void {
     // Get columns already used by existing charts
     const usedColumns = new Set(
-      this.state.chartConfigs.map((c) => c.column).filter(Boolean),
+      this.attrs.chartConfigs.map((c) => c.column).filter(Boolean),
     );
 
     // Find a good default column:
@@ -553,7 +565,7 @@ export class VisualisationNode implements QueryNode {
 
     // Prefer string/categorical columns for aggregation charts
     const stringCol = colsToCheck.find(
-      (c) => c.column.type === undefined || !isQuantitativeType(c.column.type),
+      (c) => c.type === undefined || !isQuantitativeType(c.type),
     );
     const defaultColumn = stringCol?.name ?? colsToCheck[0]?.name ?? '';
 
@@ -562,8 +574,8 @@ export class VisualisationNode implements QueryNode {
       column: defaultColumn,
       chartType,
     };
-    this.state.chartConfigs.push(newChart);
-    this.state.onchange?.();
+    this.attrs.chartConfigs.push(newChart);
+    this.context.onchange?.();
   }
 
   /**
@@ -573,27 +585,27 @@ export class VisualisationNode implements QueryNode {
     chartId: string,
     updates: Partial<Omit<ChartConfig, 'id'>>,
   ): void {
-    const chartIndex = this.state.chartConfigs.findIndex(
+    const chartIndex = this.attrs.chartConfigs.findIndex(
       (c) => c.id === chartId,
     );
     if (chartIndex === -1) return;
 
-    const config = this.state.chartConfigs[chartIndex];
-    this.state.chartConfigs[chartIndex] = {
+    const config = this.attrs.chartConfigs[chartIndex];
+    this.attrs.chartConfigs[chartIndex] = {
       ...config,
       ...updates,
     };
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   /**
    * Remove a chart configuration by ID.
    */
   removeChart(chartId: string): void {
-    this.state.chartConfigs = this.state.chartConfigs.filter(
+    this.attrs.chartConfigs = this.attrs.chartConfigs.filter(
       (c) => c.id !== chartId,
     );
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   /**
@@ -601,12 +613,12 @@ export class VisualisationNode implements QueryNode {
    * Creates a copy with a new ID placed after the original.
    */
   duplicateChart(chartId: string): void {
-    const chartIndex = this.state.chartConfigs.findIndex(
+    const chartIndex = this.attrs.chartConfigs.findIndex(
       (c) => c.id === chartId,
     );
     if (chartIndex === -1) return;
 
-    const original = this.state.chartConfigs[chartIndex];
+    const original = this.attrs.chartConfigs[chartIndex];
     const duplicate: ChartConfig = {
       ...original,
       id: generateChartId(),
@@ -614,8 +626,8 @@ export class VisualisationNode implements QueryNode {
     };
 
     // Insert after the original
-    this.state.chartConfigs.splice(chartIndex + 1, 0, duplicate);
-    this.state.onchange?.();
+    this.attrs.chartConfigs.splice(chartIndex + 1, 0, duplicate);
+    this.context.onchange?.();
   }
 
   /**
@@ -624,7 +636,7 @@ export class VisualisationNode implements QueryNode {
    * @param targetId The ID of the chart to drop before
    */
   reorderChart(draggedId: string, targetId: string): void {
-    const configs = this.state.chartConfigs;
+    const configs = this.attrs.chartConfigs;
     const draggedIndex = configs.findIndex((c) => c.id === draggedId);
     const targetIndex = configs.findIndex((c) => c.id === targetId);
 
@@ -641,7 +653,7 @@ export class VisualisationNode implements QueryNode {
     // Insert at new position
     configs.splice(newTargetIndex, 0, draggedItem);
 
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   nodeInfo(): m.Children {
@@ -649,8 +661,8 @@ export class VisualisationNode implements QueryNode {
   }
 
   validate(): boolean {
-    if (this.state.issues) {
-      this.state.issues.clear();
+    if (this.context.issues) {
+      this.context.issues.clear();
     }
 
     if (this.primaryInput === undefined) {
@@ -674,12 +686,13 @@ export class VisualisationNode implements QueryNode {
   }
 
   clone(): QueryNode {
-    const stateCopy: Partial<VisualisationNodeState> = {
-      chartConfigs: this.state.chartConfigs.map((c) => ({...c})),
-      chartFilters: this.state.chartFilters?.map((f) => ({...f})),
-      onchange: this.state.onchange,
-    };
-    return new VisualisationNode(stateCopy);
+    return new VisualisationNode(
+      {
+        chartConfigs: this.attrs.chartConfigs.map((c) => ({...c})),
+        chartFilters: this.attrs.chartFilters?.map((f) => ({...f})),
+      },
+      this.context,
+    );
   }
 
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined {
@@ -687,7 +700,7 @@ export class VisualisationNode implements QueryNode {
 
     // Get valid filters
     const validFilters =
-      this.state.chartFilters?.filter((f) => this.isFilterValid(f)) ?? [];
+      this.attrs.chartFilters?.filter((f) => this.isFilterValid(f)) ?? [];
 
     if (validFilters.length === 0) {
       // No filters - return passthrough
@@ -715,11 +728,11 @@ export class VisualisationNode implements QueryNode {
    * This is called by the chart component when a user clicks on a bar/bin.
    */
   addChartFilter(filter: UIFilter): void {
-    if (!this.state.chartFilters) {
-      this.state.chartFilters = [];
+    if (!this.attrs.chartFilters) {
+      this.attrs.chartFilters = [];
     }
-    this.state.chartFilters.push({...filter, enabled: true});
-    this.state.onchange?.();
+    this.attrs.chartFilters.push({...filter, enabled: true});
+    this.context.onchange?.();
   }
 
   /**
@@ -727,32 +740,32 @@ export class VisualisationNode implements QueryNode {
    * Creates two filters: column >= min AND column < max
    */
   addRangeFilter(column: string, min: number, max: number): void {
-    if (!this.state.chartFilters) {
-      this.state.chartFilters = [];
+    if (!this.attrs.chartFilters) {
+      this.attrs.chartFilters = [];
     }
     // Add >= min filter
-    this.state.chartFilters.push({
+    this.attrs.chartFilters.push({
       column,
       op: '>=',
       value: min,
       enabled: true,
     });
     // Add < max filter
-    this.state.chartFilters.push({
+    this.attrs.chartFilters.push({
       column,
       op: '<',
       value: max,
       enabled: true,
     });
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   /**
    * Clear all chart filters.
    */
   clearChartFilters(): void {
-    this.state.chartFilters = [];
-    this.state.onchange?.();
+    this.attrs.chartFilters = [];
+    this.context.onchange?.();
   }
 
   /**
@@ -762,12 +775,12 @@ export class VisualisationNode implements QueryNode {
    * Does NOT call `onchange`. Use this when immediately followed by a method
    * that adds replacement filters and calls `onchange` (e.g. `setBrushSelection`,
    * `addRangeFilter`). If clearing filters is the final operation, callers must
-   * call `this.state.onchange?.()` themselves — or use `clearChartFilters()`
+   * call `this.context.onchange?.()` themselves — or use `clearChartFilters()`
    * which handles it automatically.
    */
   clearChartFiltersForColumn(column: string): void {
-    if (!this.state.chartFilters) return;
-    this.state.chartFilters = this.state.chartFilters.filter(
+    if (!this.attrs.chartFilters) return;
+    this.attrs.chartFilters = this.attrs.chartFilters.filter(
       (f) => f.column !== column,
     );
   }
@@ -777,15 +790,15 @@ export class VisualisationNode implements QueryNode {
    * Calls onchange to rebuild query so child nodes see filtered data.
    */
   toggleChartFilter(index: number): void {
-    if (!this.state.chartFilters || index >= this.state.chartFilters.length) {
+    if (!this.attrs.chartFilters || index >= this.attrs.chartFilters.length) {
       return;
     }
-    const filter = this.state.chartFilters[index];
-    this.state.chartFilters[index] = {
+    const filter = this.attrs.chartFilters[index];
+    this.attrs.chartFilters[index] = {
       ...filter,
       enabled: !(filter.enabled ?? true),
     };
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   /**
@@ -793,13 +806,13 @@ export class VisualisationNode implements QueryNode {
    * Calls onchange to rebuild query so child nodes see filtered data.
    */
   removeChartFilter(index: number): void {
-    if (!this.state.chartFilters || index >= this.state.chartFilters.length) {
+    if (!this.attrs.chartFilters || index >= this.attrs.chartFilters.length) {
       return;
     }
-    this.state.chartFilters = this.state.chartFilters.filter(
+    this.attrs.chartFilters = this.attrs.chartFilters.filter(
       (_, i) => i !== index,
     );
-    this.state.onchange?.();
+    this.context.onchange?.();
   }
 
   /**
@@ -808,18 +821,18 @@ export class VisualisationNode implements QueryNode {
    * Note: Caller should call clearChartFiltersForColumn() first if needed.
    */
   setBrushSelection(column: string, values: SqlValue[]): void {
-    if (!this.state.chartFilters) {
-      this.state.chartFilters = [];
+    if (!this.attrs.chartFilters) {
+      this.attrs.chartFilters = [];
     }
     for (const value of values) {
       if (value === null) {
-        this.state.chartFilters.push({
+        this.attrs.chartFilters.push({
           column,
           op: 'is null',
           enabled: true,
         });
       } else {
-        this.state.chartFilters.push({
+        this.attrs.chartFilters.push({
           column,
           op: '=',
           value,
@@ -828,65 +841,6 @@ export class VisualisationNode implements QueryNode {
       }
     }
 
-    this.state.onchange?.();
-  }
-
-  serializeState(): object {
-    return {
-      chartConfigs: this.state.chartConfigs.map((c) => ({
-        id: c.id,
-        name: c.name,
-        column: c.column,
-        chartType: c.chartType,
-        binCount: c.binCount,
-        orientation: c.orientation,
-        widthPx: c.widthPx,
-        aggregation: c.aggregation,
-        measureColumn: c.measureColumn,
-        yColumn: c.yColumn,
-        groupColumn: c.groupColumn,
-        sizeColumn: c.sizeColumn,
-      })),
-      chartFilters: this.state.chartFilters?.map((f) => {
-        if ('value' in f) {
-          return {
-            column: f.column,
-            op: f.op,
-            value: f.value,
-            enabled: f.enabled,
-          };
-        } else {
-          return {
-            column: f.column,
-            op: f.op,
-            enabled: f.enabled,
-          };
-        }
-      }),
-    };
-  }
-
-  static deserializeState(
-    state: Partial<VisualisationNodeState>,
-  ): Partial<VisualisationNodeState> {
-    // Convert filter values from strings back to numbers when appropriate.
-    // JSON serialization converts BigInt to string, and we need numeric
-    // values for proper filtering (same logic as FilterNode).
-    const chartFilters = state.chartFilters?.map((f): Partial<UIFilter> => {
-      if ('value' in f && typeof f.value === 'string') {
-        if (!Array.isArray(f.value)) {
-          const parsed = parseFilterValue(f.value);
-          if (parsed !== undefined && parsed !== f.value) {
-            return {...f, value: parsed} as Partial<UIFilter>;
-          }
-        }
-      }
-      return {...f};
-    });
-    return {
-      ...state,
-      chartConfigs: state.chartConfigs?.map((c) => ({...c})) ?? [],
-      chartFilters,
-    };
+    this.context.onchange?.();
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter.ts
@@ -412,7 +412,7 @@ function partitionValuesByType(
     if (typeof value === 'string') {
       stringValues.push(value);
     } else if (typeof value === 'number' || typeof value === 'bigint') {
-      if (column?.column.type?.kind === 'int') {
+      if (column?.type?.kind === 'int') {
         int64Values.push(Number(value));
       } else {
         doubleValues.push(Number(value));
@@ -498,7 +498,7 @@ export function createFiltersProto(
           if (typeof value === 'string') {
             result.stringRhs = [value];
           } else if (typeof value === 'number' || typeof value === 'bigint') {
-            if (col?.column.type?.kind === 'int') {
+            if (col?.type?.kind === 'int') {
               result.int64Rhs = [Number(value)];
             } else {
               result.doubleRhs = [Number(value)];

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/operations/filter_unittest.ts
@@ -39,22 +39,22 @@ describe('filter operations', () => {
       {
         name: 'id',
         checked: false,
-        column: {name: 'id', type: {kind: 'int'}},
+        type: {kind: 'int'},
       },
       {
         name: 'name',
         checked: false,
-        column: {name: 'name', type: {kind: 'string'}},
+        type: {kind: 'string'},
       },
       {
         name: 'age',
         checked: false,
-        column: {name: 'age', type: {kind: 'int'}},
+        type: {kind: 'int'},
       },
       {
         name: 'status',
         checked: false,
-        column: {name: 'status', type: {kind: 'string'}},
+        type: {kind: 'string'},
       },
     ];
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/query_builder_utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/query_builder_utils_unittest.ts
@@ -32,7 +32,8 @@ describe('query_builder_utils', () => {
       type: NodeType.kTable,
       nextNodes: [],
       finalCols: [],
-      state: {},
+      attrs: {},
+      context: {},
       validate: () => true,
       getTitle: () => 'Test',
       nodeSpecificModify: () => null,
@@ -40,7 +41,6 @@ describe('query_builder_utils', () => {
       nodeInfo: () => null,
       clone: () => createMockNode(nodeId),
       getStructuredQuery: () => undefined,
-      serializeState: () => ({}),
     } as QueryNode;
   }
 
@@ -196,10 +196,10 @@ describe('query_builder_utils', () => {
     });
 
     it('should warn for SqlSourceNode with non-module statements', () => {
-      const node = new SqlSourceNode({
-        sql: 'CREATE VIEW test AS SELECT 1; SELECT * FROM test',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'CREATE VIEW test AS SELECT 1; SELECT * FROM test'},
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query: 'CREATE VIEW test AS SELECT 1; SELECT * FROM test',
         statementCount: 2,
@@ -215,10 +215,10 @@ describe('query_builder_utils', () => {
     });
 
     it('should not warn for SqlSourceNode with only module includes', () => {
-      const node = new SqlSourceNode({
-        sql: 'INCLUDE PERFETTO MODULE android.slices; SELECT * FROM slice',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'INCLUDE PERFETTO MODULE android.slices; SELECT * FROM slice'},
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query: 'INCLUDE PERFETTO MODULE android.slices; SELECT * FROM slice',
         statementCount: 2,
@@ -232,10 +232,12 @@ describe('query_builder_utils', () => {
     });
 
     it('should handle multiple module includes correctly', () => {
-      const node = new SqlSourceNode({
-        sql: 'INCLUDE PERFETTO MODULE android.slices; INCLUDE PERFETTO MODULE android.frames; SELECT * FROM slice',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {
+          sql: 'INCLUDE PERFETTO MODULE android.slices; INCLUDE PERFETTO MODULE android.frames; SELECT * FROM slice',
+        },
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query:
           'INCLUDE PERFETTO MODULE android.slices; INCLUDE PERFETTO MODULE android.frames; SELECT * FROM slice',
@@ -250,10 +252,10 @@ describe('query_builder_utils', () => {
     });
 
     it('should handle case-insensitive INCLUDE PERFETTO MODULE', () => {
-      const node = new SqlSourceNode({
-        sql: 'include perfetto module android.slices; SELECT * FROM slice',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'include perfetto module android.slices; SELECT * FROM slice'},
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query: 'include perfetto module android.slices; SELECT * FROM slice',
         statementCount: 2,
@@ -267,10 +269,10 @@ describe('query_builder_utils', () => {
     });
 
     it('should not warn for single statement SqlSourceNode', () => {
-      const node = new SqlSourceNode({
-        sql: 'SELECT * FROM slice',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'SELECT * FROM slice'},
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query: 'SELECT * FROM slice',
         statementCount: 1,
@@ -298,10 +300,10 @@ describe('query_builder_utils', () => {
     });
 
     it('should handle empty statements in query split', () => {
-      const node = new SqlSourceNode({
-        sql: 'CREATE VIEW test AS SELECT 1;; SELECT * FROM test',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'CREATE VIEW test AS SELECT 1;; SELECT * FROM test'},
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query: 'CREATE VIEW test AS SELECT 1;; SELECT * FROM test',
         statementCount: 2,
@@ -316,10 +318,12 @@ describe('query_builder_utils', () => {
     });
 
     it('should handle statements with whitespace', () => {
-      const node = new SqlSourceNode({
-        sql: '   INCLUDE PERFETTO MODULE android.slices   ;   SELECT * FROM slice   ',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {
+          sql: '   INCLUDE PERFETTO MODULE android.slices   ;   SELECT * FROM slice   ',
+        },
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query:
           '   INCLUDE PERFETTO MODULE android.slices   ;   SELECT * FROM slice   ',
@@ -334,10 +338,12 @@ describe('query_builder_utils', () => {
     });
 
     it('should detect non-module statements mixed with modules', () => {
-      const node = new SqlSourceNode({
-        sql: 'INCLUDE PERFETTO MODULE android.slices; CREATE VIEW test AS SELECT 1; SELECT * FROM test',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {
+          sql: 'INCLUDE PERFETTO MODULE android.slices; CREATE VIEW test AS SELECT 1; SELECT * FROM test',
+        },
+        {trace: {} as Trace},
+      );
       const response = createMockQueryResponse({
         query:
           'INCLUDE PERFETTO MODULE android.slices; CREATE VIEW test AS SELECT 1; SELECT * FROM test',
@@ -355,10 +361,10 @@ describe('query_builder_utils', () => {
 
   describe('integration tests', () => {
     it('should correctly identify error vs warning scenarios', () => {
-      const node = new SqlSourceNode({
-        sql: 'CREATE VIEW test AS SELECT 1; SELECT * FROM test',
-        trace: {} as Trace,
-      });
+      const node = new SqlSourceNode(
+        {sql: 'CREATE VIEW test AS SELECT 1; SELECT * FROM test'},
+        {trace: {} as Trace},
+      );
 
       // Scenario 1: No issues
       const response1 = createMockQueryResponse({
@@ -447,8 +453,8 @@ describe('query_builder_utils', () => {
         finalCols: [],
         getTitle: () => 'Test Node',
         validate: () => true,
-        state: {},
-        serializeState: () => ({}),
+        context: {},
+        attrs: {},
         nodeSpecificModify: () => null,
         nodeDetails: () => ({content: null, message: ''}),
         nodeInfo: () => null,

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/query_execution_service.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/query_execution_service.ts
@@ -324,7 +324,7 @@ export class QueryExecutionService {
     // Store allNodes for use by buildAllStructuredQueries()
     this.allNodes = allNodes;
 
-    const autoExecute = node.state.autoExecute ?? true;
+    const autoExecute = node.context.autoExecute ?? true;
 
     // For autoExecute=false and not manual: either handle locally (skip path)
     // or perform the initial TP sync (first time this node is selected).

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/query_execution_service_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/query_execution_service_unittest.ts
@@ -52,10 +52,10 @@ describe('QueryExecutionService', () => {
   });
 
   function createTestNode(id: string): QueryNode {
-    const node = new TableSourceNode({
-      trace: mockTrace,
-      sqlModules: mockSqlModules,
-    }) as QueryNode;
+    const node = new TableSourceNode(
+      {},
+      {trace: mockTrace, sqlModules: mockSqlModules},
+    ) as QueryNode;
     // Override nodeId for testing
     Object.defineProperty(node, 'nodeId', {value: id, writable: true});
     return node;
@@ -372,7 +372,7 @@ describe('QueryExecutionService', () => {
 
     it('fires onAnalysisStart on initial load and on user edits, but NOT on column discovery', async () => {
       const node = createTestNode('node1');
-      node.state.autoExecute = false;
+      node.context.autoExecute = false;
       mockInitialLoad('node1');
 
       const analysisStartCalls: number[] = [];
@@ -397,7 +397,7 @@ describe('QueryExecutionService', () => {
 
     it('fires onAnalysisComplete(undefined) on user edit in skip path', async () => {
       const node = createTestNode('node1');
-      node.state.autoExecute = false;
+      node.context.autoExecute = false;
       mockInitialLoad('node1');
 
       // Initialize the node
@@ -419,7 +419,7 @@ describe('QueryExecutionService', () => {
 
     it('fires no callbacks on column discovery in skip path', async () => {
       const node = createTestNode('node1');
-      node.state.autoExecute = false;
+      node.context.autoExecute = false;
       // Successful manual execution populates justExecutedNodes and initializedNodes
       mockSuccessfulExecution('node1');
 
@@ -441,7 +441,7 @@ describe('QueryExecutionService', () => {
 
     it('resetNode forces the next processNode call to re-run initial load', async () => {
       const node = createTestNode('node1');
-      node.state.autoExecute = false;
+      node.context.autoExecute = false;
       // Fresh mock: initial load retrieves existing result, populating
       // justExecutedNodes so the second call is column discovery (no callbacks).
       mockFreshNode('node1');

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/results_panel.ts
@@ -25,6 +25,7 @@ import {Button, ButtonVariant} from '../../../widgets/button';
 import {Spinner} from '../../../widgets/spinner';
 import {Switch} from '../../../widgets/switch';
 import {Query, QueryNode} from '../query_node';
+import {FilterNode} from './nodes/filter_node';
 import {Intent} from '../../../widgets/common';
 import {Icons} from '../../../base/semantic_icons';
 import {MenuItem, PopupMenu} from '../../../widgets/menu';
@@ -187,7 +188,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
   }
 
   private renderMenu(attrs: ResultsPanelAttrs): m.Children {
-    const autoExecute = attrs.node.state.autoExecute ?? true;
+    const autoExecute = attrs.node.context.autoExecute ?? true;
 
     // Only show "Run Query" button when autoExecute is off AND node is stale
     const runButton =
@@ -216,7 +217,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
       checked: autoExecute,
       onchange: (e: Event) => {
         const target = e.target as HTMLInputElement;
-        attrs.node.state.autoExecute = target.checked;
+        attrs.node.context.autoExecute = target.checked;
         attrs.onchange?.();
         // Execute the query when auto-execute is toggled on
         // Analysis will happen automatically in node_panel when autoExecute becomes true
@@ -317,20 +318,20 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
     // Show validation errors first (queryError is set by validate() methods).
     // Validation errors take priority over execution errors because if validation
     // fails, we should not execute the query at all.
-    if (!attrs.node.validate() && attrs.node.state.issues?.queryError) {
+    if (!attrs.node.validate() && attrs.node.context.issues?.queryError) {
       // Clear any stale execution error when validation fails
-      attrs.node.state.issues.clearExecutionError();
+      attrs.node.context.issues.clearExecutionError();
       return m(ResultsPanelEmptyState, {
         icon: 'warning',
         variant: 'warning',
-        title: attrs.node.state.issues.queryError.message,
+        title: attrs.node.context.issues.queryError.message,
       });
     }
 
     // Show execution errors (e.g., when materialization fails due to
     // invalid column names). These are stored separately from validation errors
     // so they survive validate() calls during rendering.
-    if (attrs.node.state.issues?.executionError) {
+    if (attrs.node.context.issues?.executionError) {
       // Get the SQL that caused the error (query is preserved during error)
       const failingSql = isAQuery(attrs.query) ? attrs.query.sql : undefined;
 
@@ -339,7 +340,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
         {
           icon: 'warning',
           variant: 'warning',
-          title: attrs.node.state.issues.executionError.message,
+          title: attrs.node.context.issues.executionError.message,
         },
         [
           // Show the failing SQL if available
@@ -364,7 +365,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
             intent: Intent.Primary,
             onclick: () => {
               // Clear the execution error and re-run the query
-              attrs.node.state.issues?.clearExecutionError();
+              attrs.node.context.issues?.clearExecutionError();
               attrs.onExecute();
             },
           }),
@@ -382,20 +383,20 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
     }
 
     // Show response warnings with centered warning icon
-    if (attrs.node.state.issues?.responseError) {
+    if (attrs.node.context.issues?.responseError) {
       return m(ResultsPanelEmptyState, {
         icon: 'warning',
         variant: 'warning',
-        title: attrs.node.state.issues.responseError.message,
+        title: attrs.node.context.issues.responseError.message,
       });
     }
 
     // Show data errors (like "no rows returned") with centered warning icon
-    if (attrs.node.state.issues?.dataError) {
+    if (attrs.node.context.issues?.dataError) {
       return m(ResultsPanelEmptyState, {
         icon: 'warning',
         variant: 'warning',
-        title: attrs.node.state.issues.dataError.message,
+        title: attrs.node.context.issues.dataError.message,
       });
     }
 
@@ -449,27 +450,27 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
         const columnInfo = getColumnInfo(attrs.node, c);
         if (columnInfo) {
           // Set columnType based on the SQL type
-          if (columnInfo.column.type) {
-            columnType = getColumnType(columnInfo.column.type);
+          if (columnInfo.type) {
+            columnType = getColumnType(columnInfo.type);
           }
 
           // Check if this is a timestamp column
-          if (columnInfo.column.type?.kind === 'timestamp') {
+          if (columnInfo.type?.kind === 'timestamp') {
             cellRenderer = createTimestampCellRenderer(attrs.trace);
           }
           // Check if this is a duration column
-          else if (columnInfo.column.type?.kind === 'duration') {
+          else if (columnInfo.type?.kind === 'duration') {
             cellRenderer = createDurationCellRenderer(attrs.trace);
           }
           // Check if this is an ID column that links to a navigable table
           else if (
-            columnInfo.column.type !== undefined &&
-            isIdType(columnInfo.column.type) &&
-            NAVIGABLE_TABLES.has(columnInfo.column.type.source.table)
+            columnInfo.type !== undefined &&
+            isIdType(columnInfo.type) &&
+            NAVIGABLE_TABLES.has(columnInfo.type.source.table)
           ) {
             cellRenderer = createIdCellRenderer(
               attrs.trace,
-              columnInfo.column.type.source.table,
+              columnInfo.type.source.table,
               c,
             );
           }
@@ -495,8 +496,8 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
 
         for (const c of responseColumns) {
           const columnInfo = getColumnInfo(attrs.node, c);
-          if (columnInfo?.column.type?.kind === 'joinid') {
-            const targetTableName = columnInfo.column.type.source.table;
+          if (columnInfo?.type?.kind === 'joinid') {
+            const targetTableName = columnInfo.type.source.table;
             if (!tableToJoinidColumns.has(targetTableName)) {
               tableToJoinidColumns.set(targetTableName, []);
             }
@@ -622,13 +623,14 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
                 operator,
               );
             } else {
-              // Legacy: add filters directly to node state
-              attrs.node.state.filters = [
-                ...(attrs.node.state.filters ?? []),
+              // Legacy: add filters directly to node attrs
+              const filterNode = attrs.node as FilterNode;
+              filterNode.attrs.filters = [
+                ...(filterNode.attrs.filters ?? []),
                 ...normalizedFilters,
               ];
               if (normalizedFilters.length > 1) {
-                attrs.node.state.filterOperator =
+                filterNode.attrs.filterOperator =
                   filter.op === 'not in' ? 'AND' : 'OR';
               }
             }
@@ -650,7 +652,7 @@ export class ResultsPanel implements m.ClassComponent<ResultsPanelAttrs> {
     }
 
     // Show a prominent execute button when autoExecute is false and node is stale
-    const autoExecute = attrs.node.state.autoExecute ?? true;
+    const autoExecute = attrs.node.context.autoExecute ?? true;
     if (
       !autoExecute &&
       attrs.isStale &&

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder.ts
@@ -203,7 +203,7 @@ export class StructuredQueryBuilder {
       .filter((c) => c.checked !== false)
       .map((c) => {
         const col = new protos.PerfettoSqlStructuredQuery.SelectColumn();
-        col.columnName = c.column.name;
+        col.columnName = c.name;
         if (c.alias) col.alias = c.alias;
         return col;
       });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/structured_query_builder_unittest.ts
@@ -29,7 +29,8 @@ describe('StructuredQueryBuilder', () => {
         type: NodeType.kTable,
         nextNodes: [],
         finalCols: columns,
-        state: {},
+        attrs: {},
+        context: {},
         validate: () => true,
         getTitle: () => 'Test',
         nodeSpecificModify: () => null,
@@ -37,7 +38,6 @@ describe('StructuredQueryBuilder', () => {
         nodeInfo: () => null,
         clone: () => createMockNode(columns),
         getStructuredQuery: () => undefined,
-        serializeState: () => ({}),
       } as QueryNode;
     }
 
@@ -50,12 +50,12 @@ describe('StructuredQueryBuilder', () => {
         {
           name: 'id',
           checked: true,
-          column: {name: 'id', type: intType},
+          type: intType,
         },
         {
           name: 'name',
           checked: true,
-          column: {name: 'name', type: stringType},
+          type: stringType,
         },
       ];
       const node = createMockNode(columns);
@@ -71,17 +71,17 @@ describe('StructuredQueryBuilder', () => {
         {
           name: 'id',
           checked: true,
-          column: {name: 'id', type: intType},
+          type: intType,
         },
         {
           name: 'name',
           checked: false,
-          column: {name: 'name', type: stringType},
+          type: stringType,
         },
         {
           name: 'age',
           checked: true,
-          column: {name: 'age', type: intType},
+          type: intType,
         },
       ];
       const node = createMockNode(columns);
@@ -99,13 +99,13 @@ describe('StructuredQueryBuilder', () => {
         {
           name: 'id',
           checked: true,
-          column: {name: 'id', type: intType},
+          type: intType,
           alias: 'identifier',
         },
         {
           name: 'name',
           checked: false,
-          column: {name: 'name', type: stringType},
+          type: stringType,
         },
       ];
       const node = createMockNode(columns);
@@ -133,12 +133,12 @@ describe('StructuredQueryBuilder', () => {
         {
           name: 'id',
           checked: false,
-          column: {name: 'id', type: intType},
+          type: intType,
         },
         {
           name: 'name',
           checked: false,
-          column: {name: 'name', type: stringType},
+          type: stringType,
         },
       ];
       const node = createMockNode(columns);

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/testing/test_utils.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/testing/test_utils.ts
@@ -50,10 +50,10 @@ export interface MockNodeOptions {
   getTitle?: () => string;
   /** Custom getStructuredQuery function (default: returns undefined) */
   getStructuredQuery?: () => protos.PerfettoSqlStructuredQuery | undefined;
-  /** Custom state to merge with default state */
-  state?: Partial<QueryNode['state']>;
   /** Secondary inputs spec (default: undefined) */
   secondaryInputs?: SecondaryInputSpec;
+  /** Custom context to merge with default context */
+  context?: Partial<QueryNode['context']>;
 }
 
 /** Options for creating a column info */
@@ -103,8 +103,8 @@ export function createMockNode(options: MockNodeOptions = {}): QueryNode {
     validate = () => true,
     getTitle = () => 'Mock Node',
     getStructuredQuery = () => undefined,
-    state = {},
     secondaryInputs,
+    context = {},
   } = options;
 
   const node: QueryNode = {
@@ -112,16 +112,16 @@ export function createMockNode(options: MockNodeOptions = {}): QueryNode {
     type,
     nextNodes: [],
     finalCols: columns,
-    state: {...state},
     secondaryInputs,
+    context: {...context},
     validate,
     getTitle,
+    attrs: {},
     nodeSpecificModify: () => null,
     nodeDetails: (): NodeDetailsAttrs => ({content: null}),
     nodeInfo: () => null,
     clone: () => createMockNode(options),
     getStructuredQuery,
-    serializeState: () => ({}),
   };
 
   return node;
@@ -188,7 +188,7 @@ export function createColumnInfo(
   return {
     name,
     checked,
-    column: {name, type: sqlType},
+    type: sqlType,
     alias,
   };
 }
@@ -212,8 +212,8 @@ export function createColumnInfoWithType(
 
   return {
     name,
+    type,
     checked,
-    column: {name, type},
     alias,
   };
 }
@@ -390,7 +390,7 @@ export function expectValidationError(
   expectedMessage: string,
 ): void {
   expect(node.validate()).toBe(false);
-  expect(node.state.issues?.queryError?.message).toContain(expectedMessage);
+  expect(node.context.issues?.queryError?.message).toContain(expectedMessage);
 }
 
 /**
@@ -403,7 +403,7 @@ export function expectValidationError(
  */
 export function expectValidationSuccess(node: QueryNode): void {
   expect(node.validate()).toBe(true);
-  expect(node.state.issues?.hasIssues() ?? false).toBe(false);
+  expect(node.context.issues?.hasIssues() ?? false).toBe(false);
 }
 
 /**
@@ -412,7 +412,7 @@ export function expectValidationSuccess(node: QueryNode): void {
  * @param node - The node to check
  */
 export function expectNoIssues(node: QueryNode): void {
-  expect(node.state.issues?.hasIssues() ?? false).toBe(false);
+  expect(node.context.issues?.hasIssues() ?? false).toBe(false);
 }
 
 // ============================================================================

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils.ts
@@ -50,18 +50,19 @@ export function isStringType(type?: PerfettoSqlType): boolean {
 /**
  * Checks if a column is compatible with a specific aggregation operation.
  *
- * @param col The column to check
+ * @param col The column to check (must have an optional `type` field)
+ * @param col.type The SQL type of the column
  * @param op The aggregation operation (e.g., 'SUM', 'COUNT', 'MEAN', etc.)
  * @returns true if the column is compatible with the operation
  */
 export function isColumnValidForAggregation(
-  col: ColumnInfo,
+  col: {type?: PerfettoSqlType},
   op?: string,
 ): boolean {
   if (!op) return true;
 
-  const isNumeric = isNumericType(col.column.type);
-  const isString = isStringType(col.column.type);
+  const isNumeric = isNumericType(col.type);
+  const isString = isStringType(col.type);
 
   switch (op) {
     case 'MEAN':
@@ -146,17 +147,13 @@ export function getCommonColumns(
   const firstArray = columnArrays[0];
   const commonColumns = new Set(
     firstArray
-      .filter(
-        (c) => !excludedColumns.has(c.name) && !isTypeExcluded(c.column.type),
-      )
+      .filter((c) => !excludedColumns.has(c.name) && !isTypeExcluded(c.type))
       .map((c) => c.name),
   );
 
   // Intersect with columns from remaining arrays
   for (let i = 1; i < columnArrays.length; i++) {
-    const colsMap = new Map(
-      columnArrays[i].map((c) => [c.name, c.column.type]),
-    );
+    const colsMap = new Map(columnArrays[i].map((c) => [c.name, c.type]));
     for (const col of commonColumns) {
       const colType = colsMap.get(col);
       if (colType === undefined || isTypeExcluded(colType)) {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/utils_unittest.ts
@@ -18,7 +18,6 @@ import {
   isColumnValidForAggregation,
   getAggregationTypeRequirements,
 } from './utils';
-import {ColumnInfo} from './column_info';
 import {
   PerfettoSqlType,
   PerfettoSqlTypes,
@@ -102,15 +101,8 @@ describe('utils', () => {
     function createColumnInfo(
       name: string,
       type?: PerfettoSqlType,
-    ): ColumnInfo {
-      return {
-        name,
-        checked: false,
-        column: {
-          name,
-          type,
-        },
-      };
+    ): {name: string; type?: PerfettoSqlType} {
+      return {name, type};
     }
 
     describe('MEAN operation', () => {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/widgets.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/widgets.ts
@@ -347,18 +347,18 @@ export class InfoBox implements m.ClassComponent {
 }
 
 /**
- * Automatically creates error/warning sections from node.state.issues
+ * Automatically creates error/warning sections from node.context.issues
  * Returns sections to prepend to the node's modify view
  */
 export function createErrorSections(node: QueryNode): NodeModifySection[] {
   const sections: NodeModifySection[] = [];
 
-  if (node.state.issues?.queryError) {
+  if (node.context.issues?.queryError) {
     sections.push({
       content: m(
         Callout,
         {icon: 'error'},
-        node.state.issues.queryError.message,
+        node.context.issues.queryError.message,
       ),
     });
   }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_node.ts
@@ -14,9 +14,8 @@
 
 import protos from '../../protos';
 import m from 'mithril';
-import {SqlModules, SqlTable} from '../dev.perfetto.SqlModules/sql_modules';
+import {SqlModules} from '../dev.perfetto.SqlModules/sql_modules';
 import {ColumnInfo} from './query_builder/column_info';
-import {UIFilter} from './query_builder/operations/filter';
 import {NodeIssues} from './query_builder/node_issues';
 import {Trace} from '../../public/trace';
 import {NodeDetailsAttrs} from './node_types';
@@ -109,6 +108,20 @@ export interface NodeActions {
   onInsertCounterToIntervalsNode?: (portIndex: number) => void;
 }
 
+// Runtime dependencies shared across nodes. Never serialized.
+// Injected by the parent component (DataExplorer) after node creation.
+export interface NodeContext {
+  trace?: Trace;
+  sqlModules?: SqlModules;
+  onchange?: () => void;
+  actions?: NodeActions;
+  issues?: NodeIssues;
+  getTableNameForNode?: (nodeId: string) => Promise<string | undefined>;
+  requestNodeExecution?: (nodeId: string) => Promise<void>;
+  hasOperationChanged?: boolean;
+  autoExecute?: boolean;
+}
+
 // Specification for secondary inputs with clear cardinality requirements
 export interface SecondaryInputSpec {
   // The actual connections (no undefined holes - indexed by port number)
@@ -123,41 +136,6 @@ export interface SecondaryInputSpec {
   readonly portNames: string[] | ((portIndex: number) => string);
 }
 
-// All information required to create a new node.
-export interface QueryNodeState {
-  trace?: Trace;
-  sqlModules?: SqlModules;
-  sqlTable?: SqlTable;
-
-  // Operations
-  // Filters can be partial during editing (similar to how Aggregation works)
-  filters?: Partial<UIFilter>[];
-  filterOperator?: 'AND' | 'OR'; // How to combine filters (default: AND)
-
-  issues?: NodeIssues;
-
-  onchange?: () => void;
-
-  // Actions that can be performed on the parent graph
-  actions?: NodeActions;
-
-  // Returns the materialized table name for a given node ID.
-  // Set by the parent component using the QueryExecutionService.
-  getTableNameForNode?: (nodeId: string) => Promise<string | undefined>;
-
-  // Triggers execution (sync + materialize) of a node by ID.
-  // Used by dashboard nodes to force-execute their source nodes.
-  requestNodeExecution?: (nodeId: string) => Promise<void>;
-
-  // Caching
-  hasOperationChanged?: boolean;
-
-  // Whether queries should automatically execute when this node changes.
-  // If false, the user must manually click "Run" to execute queries.
-  // Set by the node registry when the node is created.
-  autoExecute?: boolean;
-}
-
 export interface QueryNode {
   readonly nodeId: string;
   readonly type: NodeType;
@@ -166,30 +144,29 @@ export interface QueryNode {
   // Columns that are available after applying all operations.
   readonly finalCols: ColumnInfo[];
 
-  // State of the node. This is used to store the user's input and can be used
-  // to fully recover the node.
-  readonly state: QueryNodeState;
+  // Serializable node configuration. Always JSON-serializable.
+  readonly attrs: object;
+
+  // Runtime context (trace, callbacks, issues). Never serialized.
+  readonly context: NodeContext;
 
   // Primary input from above (data flows vertically down)
-  // Used by single-input operations (Filter, Sort, Aggregation, etc.)
   primaryInput?: QueryNode;
 
   // Secondary inputs from the side (horizontal connections)
-  // Used by multi-input operations (Union, Join, IntervalIntersect) and
-  // for side joins (AddColumns)
   secondaryInputs?: SecondaryInputSpec;
+
+  // Inner nodes encapsulated by this node (e.g. GroupNode).
+  innerNodes?: QueryNode[];
 
   validate(): boolean;
   getTitle(): string;
   // Returns either NodeModifyAttrs (new structured pattern) or m.Child (legacy pattern)
-  // NodeModifyAttrs allows nodes to declaratively specify sections and corner buttons,
-  // while m.Child allows direct rendering for backwards compatibility
   nodeSpecificModify(): unknown;
   nodeDetails(): NodeDetailsAttrs;
   nodeInfo(): m.Children;
   clone(): QueryNode;
   getStructuredQuery(): protos.PerfettoSqlStructuredQuery | undefined;
-  serializeState(): object;
   onPrevNodesUpdated?(): void;
 
   // Optional custom results panel for the bottom drawer panel.

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_node_unittest.ts
@@ -18,15 +18,9 @@ import {
   singleNodeOperation,
   Query,
   QueryNode,
-  QueryNodeState,
 } from './query_node';
 import {queryToRun, isAQuery} from './query_builder/query_builder_utils';
 import {notifyNextNodes} from './query_builder/graph_utils';
-import {ColumnInfo, newColumnInfoList} from './query_builder/column_info';
-import {
-  PerfettoSqlType,
-  PerfettoSqlTypes,
-} from '../../trace_processor/perfetto_sql_type';
 
 describe('query_node utilities', () => {
   describe('nextNodeId', () => {
@@ -65,49 +59,6 @@ describe('query_node utilities', () => {
     });
   });
 
-  describe('createFinalColumns', () => {
-    const stringType: PerfettoSqlType = {kind: 'string'};
-
-    it('should create final columns with all checked', () => {
-      const sourceCols: ColumnInfo[] = [
-        {
-          name: 'id',
-          checked: false,
-          column: {name: 'id', type: stringType},
-        },
-        {
-          name: 'name',
-          checked: false,
-          column: {name: 'name', type: stringType},
-        },
-      ];
-
-      const result = newColumnInfoList(sourceCols, true);
-
-      expect(result.length).toBe(2);
-      expect(result[0].checked).toBe(true);
-      expect(result[1].checked).toBe(true);
-    });
-
-    it('should preserve column information', () => {
-      const sourceCols: ColumnInfo[] = [
-        {
-          name: 'id',
-          checked: false,
-          column: {name: 'id', type: stringType},
-          alias: 'identifier',
-        },
-      ];
-
-      const result = newColumnInfoList(sourceCols, true);
-
-      expect(result[0].name).toBe('identifier');
-      expect(result[0].column.type).toEqual(PerfettoSqlTypes.STRING);
-      // column.name should also be replaced with the alias so child nodes see the aliased name
-      expect(result[0].column.name).toBe('identifier');
-    });
-  });
-
   describe('queryToRun', () => {
     it('should handle undefined query', () => {
       const result = queryToRun(undefined);
@@ -125,65 +76,60 @@ describe('query_node utilities', () => {
   });
 
   describe('setOperationChanged', () => {
-    function createMockNode(
-      nodeId: string,
-      state: QueryNodeState = {},
-    ): QueryNode {
+    function createMockNode(nodeId: string): QueryNode {
       return {
         nodeId,
         type: NodeType.kTable,
         nextNodes: [],
         finalCols: [],
-        state,
+        context: {},
         validate: () => true,
         getTitle: () => 'Test',
         nodeSpecificModify: () => null,
         nodeDetails: () => ({content: null}),
         nodeInfo: () => null,
-        clone: () => createMockNode(nodeId, state),
+        clone: () => createMockNode(nodeId),
         getStructuredQuery: () => undefined,
-        serializeState: () => ({}),
+        attrs: {},
       } as QueryNode;
     }
 
     it('should mark node as changed', () => {
-      const state: QueryNodeState = {hasOperationChanged: false};
-      const node = createMockNode('node1', state);
+      const node = createMockNode('node1');
+      node.context.hasOperationChanged = false;
 
-      node.state.hasOperationChanged = true;
+      node.context.hasOperationChanged = true;
 
-      expect(state.hasOperationChanged).toBe(true);
+      expect(node.context.hasOperationChanged).toBe(true);
     });
 
     it('should mark node as changed', () => {
-      const state1: QueryNodeState = {hasOperationChanged: false};
-      const state2: QueryNodeState = {hasOperationChanged: false};
-      const state3: QueryNodeState = {hasOperationChanged: false};
-
-      const node1 = createMockNode('node1', state1);
-      const node2 = createMockNode('node2', state2);
-      const node3 = createMockNode('node3', state3);
+      const node1 = createMockNode('node1');
+      const node2 = createMockNode('node2');
+      const node3 = createMockNode('node3');
+      node1.context.hasOperationChanged = false;
+      node2.context.hasOperationChanged = false;
+      node3.context.hasOperationChanged = false;
 
       node1.nextNodes = [node2];
       node2.nextNodes = [node3];
 
-      node1.state.hasOperationChanged = true;
+      node1.context.hasOperationChanged = true;
 
       // Only the node itself should be marked, not children
       // (propagation is handled by QueryExecutionService.invalidateNode)
-      expect(state1.hasOperationChanged).toBe(true);
-      expect(state2.hasOperationChanged).toBe(false);
-      expect(state3.hasOperationChanged).toBe(false);
+      expect(node1.context.hasOperationChanged).toBe(true);
+      expect(node2.context.hasOperationChanged).toBe(false);
+      expect(node3.context.hasOperationChanged).toBe(false);
     });
 
     it('should mark node as changed even if already changed', () => {
-      const state1: QueryNodeState = {hasOperationChanged: true};
+      const node1 = createMockNode('node1');
+      node1.context.hasOperationChanged = true;
 
-      const node1 = createMockNode('node1', state1);
+      node1.context.hasOperationChanged = true;
 
-      node1.state.hasOperationChanged = true;
-
-      expect(state1.hasOperationChanged).toBe(true);
+      expect(node1.context.hasOperationChanged).toBe(true);
     });
   });
 
@@ -225,7 +171,8 @@ describe('query_node utilities', () => {
         type: NodeType.kTable,
         nextNodes: [],
         finalCols: [],
-        state: {},
+        attrs: {},
+        context: {},
         validate: () => true,
         getTitle: () => 'Test',
         nodeSpecificModify: () => null,
@@ -233,7 +180,6 @@ describe('query_node utilities', () => {
         nodeInfo: () => null,
         clone: () => createPartialNode(nodeId, onPrevNodesUpdated),
         getStructuredQuery: () => undefined,
-        serializeState: () => ({}),
         onPrevNodesUpdated,
       } as QueryNode;
     }
@@ -250,7 +196,8 @@ describe('query_node utilities', () => {
           createPartialNode('node3', mockCallback2),
         ],
         finalCols: [],
-        state: {},
+        attrs: {},
+        context: {},
         validate: () => true,
         getTitle: () => 'Test',
         nodeSpecificModify: () => null,
@@ -258,7 +205,6 @@ describe('query_node utilities', () => {
         nodeInfo: () => null,
         clone: () => node,
         getStructuredQuery: () => undefined,
-        serializeState: () => ({}),
       } as QueryNode;
 
       notifyNextNodes(node);
@@ -273,7 +219,8 @@ describe('query_node utilities', () => {
         type: NodeType.kTable,
         nextNodes: [createPartialNode('node2')],
         finalCols: [],
-        state: {},
+        attrs: {},
+        context: {},
         validate: () => true,
         getTitle: () => 'Test',
         nodeSpecificModify: () => null,
@@ -281,7 +228,6 @@ describe('query_node utilities', () => {
         nodeInfo: () => null,
         clone: () => node,
         getStructuredQuery: () => undefined,
-        serializeState: () => ({}),
       } as QueryNode;
 
       expect(() => notifyNextNodes(node)).not.toThrow();
@@ -293,7 +239,8 @@ describe('query_node utilities', () => {
         type: NodeType.kTable,
         nextNodes: [],
         finalCols: [],
-        state: {},
+        attrs: {},
+        context: {},
         validate: () => true,
         getTitle: () => 'Test',
         nodeSpecificModify: () => null,
@@ -301,7 +248,6 @@ describe('query_node utilities', () => {
         nodeInfo: () => null,
         clone: () => node,
         getStructuredQuery: () => undefined,
-        serializeState: () => ({}),
       } as QueryNode;
 
       expect(() => notifyNextNodes(node)).not.toThrow();


### PR DESCRIPTION
Continues the serialization simplification started in #5346. The goal is to make `QueryNode.attrs` the single source of truth for node config — always JSON-serializable, no overrides needed.

- Removes `serializeState?()` from the `QueryNode` interface. All nodes now serialize via `attrs` directly.
- Lifts `innerNodeIds` (GroupNode's inner subgraph membership) to the `SerializedNode` graph level, alongside the existing `primaryInputId` and `secondaryInputIds`. This is the last case where a node needed to override serialization to capture derived state.
- Backward compatibility: old saved graphs that stored `innerNodeIds` inside the node state blob are still deserialized correctly.