### PR TITLE
gn: add -Wpedantic warning suppression on new clang version

### DIFF
--- a/gn/standalone/BUILD.gn
+++ b/gn/standalone/BUILD.gn
@@ -87,6 +87,7 @@ config("extra_warnings") {
     cflags += [
       "-Wno-c++98-compat-pedantic",
       "-Wno-c++98-compat",
+      "-Wno-c2y-extensions",
       "-Wno-disabled-macro-expansion",
       "-Wno-documentation-unknown-command",
       "-Wno-gnu-include-next",


### PR DESCRIPTION
Upreved to new version of clang on MacOS, getting the error:
```
FAILED: obj/src/trace_processor/lib.trace_processor_impl.o
../../src/trace_processor/trace_processor_impl.cc:768:3: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
```

Supresss the failure as the use of this macro is very intentional and
also necessary.
