### PR TITLE
ui: Fixed class hierarchy in object view in Heap Dump Explorer

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
@@ -334,7 +334,7 @@ export function renderPath(path: PathEntry[], navigate: NavFn): m.Children {
         {
           key: i,
           class: `ah-path-entry${pe.isDominator ? ' ah-semibold' : ''}`,
-          style: {paddingLeft: Math.min(i, 20) * 12},
+          style: {'--ah-depth': String(i)},
         },
         [
           m('span', {class: 'ah-path-arrow'}, i === 0 ? '' : '\u2192'),

--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -238,7 +238,12 @@ function buildTabs(
     {
       key: 'classes',
       title: 'Classes',
-      content: m(ClassesView, {engine, navigate: navigateWithTabs}),
+      content: m(ClassesView, {
+        engine,
+        navigate: navigateWithTabs,
+        initialRootClass:
+          state.view === 'classes' ? state.params.rootClass : undefined,
+      }),
     },
     {
       key: 'objects',

--- a/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
@@ -18,7 +18,7 @@ import m from 'mithril';
 
 export type NavState =
   | {view: 'overview'; params: Record<string, never>}
-  | {view: 'classes'; params: Record<string, never>}
+  | {view: 'classes'; params: {rootClass?: string}}
   | {view: 'dominators'; params: Record<string, never>}
   | {view: 'objects'; params: {cls?: string}}
   | {view: 'object'; params: {id: number; label?: string}}
@@ -31,8 +31,10 @@ export function stateToSubpage(state: NavState): string {
   switch (state.view) {
     case 'overview':
       return '';
-    case 'classes':
-      return 'classes';
+    case 'classes': {
+      const root = state.params.rootClass;
+      return root ? `classes?root=${encodeURIComponent(root)}` : 'classes';
+    }
     case 'dominators':
       return 'dominators';
     case 'objects': {
@@ -88,8 +90,10 @@ export function subpageToState(subpage: string | undefined): NavState {
     case '':
     case 'overview':
       return {view: 'overview', params: {}};
-    case 'classes':
-      return {view: 'classes', params: {}};
+    case 'classes': {
+      const root = sp.get('root') ?? undefined;
+      return {view: 'classes', params: root ? {rootClass: root} : {}};
+    }
     case 'dominators':
       return {view: 'dominators', params: {}};
     case 'objects': {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -816,10 +816,10 @@ export async function getInstance(
   const objRes = await engine.query(`
     SELECT
       o.id,
+      o.type_id,
       c.name AS cls,
       c.deobfuscated_name AS deob,
       c.kind AS class_kind,
-      sc.name AS super_cls,
       o.self_size,
       o.native_size,
       o.heap_type,
@@ -834,7 +834,6 @@ export async function getInstance(
       d.dominated_obj_count
     FROM heap_graph_object o
     JOIN heap_graph_class c ON o.type_id = c.id
-    LEFT JOIN heap_graph_class sc ON c.superclass_id = sc.id
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE o.id = ${id}
@@ -842,10 +841,10 @@ export async function getInstance(
 
   const oit = objRes.iter({
     id: NUM,
+    type_id: NUM,
     cls: STR,
     deob: STR_NULL,
     class_kind: STR,
-    super_cls: STR_NULL,
     self_size: NUM,
     native_size: NUM,
     heap_type: STR_NULL,
@@ -863,7 +862,7 @@ export async function getInstance(
 
   const fullClassName = className(oit.cls, oit.deob);
   const classKind = oit.class_kind;
-  const superClassName = oit.super_cls;
+  const typeId = oit.type_id;
   const refSetId = oit.reference_set_id;
   const fieldSetId = oit.field_set_id;
   const arrayDataId = oit.array_data_id;
@@ -1084,31 +1083,7 @@ export async function getInstance(
     }
   }
 
-  // Resolve superclass object id (the java.lang.Class<Super> heap object).
-  let superClassObjId: number | null = null;
-  if (superClassName !== null) {
-    const superObjName = `java.lang.Class<${superClassName}>`.replace(
-      /'/g,
-      "''",
-    );
-    const superRes = await engine.query(`
-      SELECT o.id
-      FROM heap_graph_object o
-      JOIN heap_graph_class c ON o.type_id = c.id
-      WHERE (c.name = '${superObjName}'
-        OR c.deobfuscated_name = '${superObjName}')
-
-    `);
-    const sit = superRes.iter({id: NUM});
-    if (sit.valid()) superClassObjId = sit.id;
-  }
-
-  // Extract forClassName for class objects: "java.lang.Class<Foo>" → "Foo"
-  let forClassName: string | null = null;
-  if (isClassObj) {
-    const match = fullClassName.match(/^java\.lang\.Class<(.+)>$/);
-    forClassName = match ? match[1] : fullClassName;
-  }
+  const classHierarchy = await getClassHierarchy(engine, typeId);
 
   return {
     row,
@@ -1116,9 +1091,8 @@ export async function getInstance(
     isArrayInstance,
     isClassInstance: !isClassObj && !isArrayInstance,
     classObjRow,
-    forClassName,
-    superClassObjId,
     instanceSize: row.shallowJava,
+    classHierarchy,
     staticFields,
     instanceFields,
     elemTypeName,
@@ -1129,6 +1103,88 @@ export async function getInstance(
     dominated,
     pathFromRoot,
   };
+}
+
+/**
+ * Superclass chain of `startClassId`, ordered starting-class first. The DFS
+ * over `id → superclass_id` is a linear chain under single inheritance, so
+ * we walk it by following each row's `parent_node_id` (the DFS predecessor,
+ * i.e. the subclass that discovered this ancestor).
+ */
+export async function getClassHierarchy(
+  engine: Engine,
+  startClassId: number,
+): Promise<string[]> {
+  const res = await engine.query(`
+    INCLUDE PERFETTO MODULE graphs.search;
+
+    SELECT
+      dfs.node_id AS class_id,
+      dfs.parent_node_id AS child_class_id,
+      coalesce(c.deobfuscated_name, c.name) AS name
+    FROM graph_reachable_dfs!(
+      (SELECT id AS source_node_id, superclass_id AS dest_node_id
+       FROM heap_graph_class WHERE superclass_id IS NOT NULL),
+      (SELECT ${startClassId} AS node_id)
+    ) AS dfs
+    JOIN heap_graph_class c ON c.id = dfs.node_id
+  `);
+
+  type Row = {classId: number; childClassId: number | null; className: string};
+  const rows: Row[] = [];
+  for (
+    const it = res.iter({
+      class_id: NUM,
+      child_class_id: NUM_NULL,
+      name: STR,
+    });
+    it.valid();
+    it.next()
+  ) {
+    rows.push({
+      classId: it.class_id,
+      childClassId: it.child_class_id,
+      className: it.name,
+    });
+  }
+
+  const byChildId = new Map<number, Row>();
+  let start: Row | undefined;
+  for (const r of rows) {
+    if (r.classId === startClassId) start = r;
+    else if (r.childClassId !== null) byChildId.set(r.childClassId, r);
+  }
+
+  const chain: string[] = [];
+  for (let cur = start; cur !== undefined; cur = byChildId.get(cur.classId)) {
+    chain.push(cur.className);
+  }
+  return chain;
+}
+
+/** Transitive subclass names of `rootName` (including the root itself). */
+export async function getSubclassNames(
+  engine: Engine,
+  rootName: string,
+): Promise<string[]> {
+  const res = await engine.query(`
+    INCLUDE PERFETTO MODULE graphs.search;
+
+    SELECT coalesce(c.deobfuscated_name, c.name) AS name
+    FROM graph_reachable_dfs!(
+      (SELECT superclass_id AS source_node_id, id AS dest_node_id
+       FROM heap_graph_class WHERE superclass_id IS NOT NULL),
+      (SELECT id AS node_id FROM heap_graph_class
+       WHERE coalesce(deobfuscated_name, name) = '${sqlEsc(rootName)}'
+       LIMIT 1)
+    ) AS dfs
+    JOIN heap_graph_class c ON c.id = dfs.node_id
+  `);
+  const names: string[] = [];
+  for (const it = res.iter({name: STR}); it.valid(); it.next()) {
+    names.push(it.name);
+  }
+  return names;
 }
 
 export async function getRawArrayBlob(

--- a/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
@@ -338,6 +338,7 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  padding-left: calc(min(var(--ah-depth, 0), 20) * 0.75rem);
 }
 
 .ah-dup-grid-container {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
@@ -102,9 +102,9 @@ export interface InstanceDetail {
   isArrayInstance: boolean;
   isClassInstance: boolean;
   classObjRow: InstanceRow | null;
-  forClassName: string | null;
-  superClassObjId: number | null;
   instanceSize: number;
+  /** Superclass chain ordered starting-class first. */
+  classHierarchy: string[];
   staticFields: {name: string; typeName: string; value: PrimOrRef}[];
   instanceFields: {name: string; typeName: string; value: PrimOrRef}[];
   elemTypeName: string | null;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
@@ -19,16 +19,20 @@ import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import {SQLDataSource} from '../../../components/widgets/datagrid/sql_data_source';
 import {createSimpleSchema} from '../../../components/widgets/datagrid/sql_schema';
 import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
+import type {Filter} from '../../../components/widgets/datagrid/model';
 import {
   type NavFn,
   sizeRenderer,
   countRenderer,
   RowCounter,
 } from '../components';
+import {clearNavParam} from '../nav_state';
+import * as queries from '../queries';
 
 interface ClassesViewAttrs {
   readonly engine: Engine;
   readonly navigate: NavFn;
+  readonly initialRootClass?: string;
 }
 
 const PREAMBLE =
@@ -100,6 +104,17 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
 function ClassesView(): m.Component<ClassesViewAttrs> {
   let dataSource: SQLDataSource | null = null;
   const counter = new RowCounter();
+  let filters: Filter[] = [];
+
+  async function applyNavFilter(engine: Engine, root: string | undefined) {
+    if (!root) return;
+    clearNavParam('rootClass');
+    const names = await queries.getSubclassNames(engine, root);
+    if (names.length === 0) return;
+    filters = [{field: 'cls', op: 'in' as const, value: names}];
+    counter.onFiltersChanged(filters);
+    m.redraw();
+  }
 
   return {
     oninit(vnode) {
@@ -111,6 +126,12 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
         preamble: PREAMBLE,
       });
       counter.init(engine, QUERY, PREAMBLE);
+      applyNavFilter(engine, vnode.attrs.initialRootClass).catch(console.error);
+    },
+    onupdate(vnode) {
+      applyNavFilter(vnode.attrs.engine, vnode.attrs.initialRootClass).catch(
+        console.error,
+      );
     },
     view(vnode) {
       const {navigate} = vnode.attrs;
@@ -133,8 +154,12 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
             {id: 'retained_native', field: 'retained_native'},
             {id: 'retained_count', field: 'retained_count'},
           ],
+          filters,
           showExportButton: true,
-          onFiltersChanged: counter.onFiltersChanged,
+          onFiltersChanged: (f) => {
+            filters = [...f];
+            counter.onFiltersChanged(f);
+          },
         }),
       ]);
     },

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -626,7 +626,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
                     {
                       key: i,
                       class: `ah-path-entry${pe.isDominator ? ' ah-semibold' : ''}`,
-                      style: {paddingLeft: Math.min(i, 20) * 12},
+                      style: {'--ah-depth': String(i)},
                     },
                     [
                       m(
@@ -715,23 +715,18 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
         detail.isClassObj
           ? m(Section, {title: 'Class Info'}, [
               m('div', {class: 'ah-info-grid ah-mb-3'}, [
-                m('span', {class: 'ah-info-grid__label'}, 'Super Class:'),
-                m(
-                  'span',
-                  detail.superClassObjId != null
-                    ? m(InstanceLink, {
-                        row: {
-                          id: detail.superClassObjId,
-                          display: fmtHex(detail.superClassObjId),
-                        },
-                        navigate,
-                      })
-                    : 'none',
-                ),
                 m('span', {class: 'ah-info-grid__label'}, 'Instance Size:'),
                 m('span', {class: 'ah-mono'}, String(detail.instanceSize)),
               ]),
             ])
+          : null,
+
+        detail.classHierarchy.length > 0
+          ? m(
+              Section,
+              {title: 'Class Hierarchy'},
+              renderClassHierarchy(detail.classHierarchy, navigate),
+            )
           : null,
 
         detail.isClassObj
@@ -934,6 +929,54 @@ function renderArrayGrid(
       showExportButton: true,
     }),
   ]);
+}
+
+// `java.lang.Class<Foo>` has no useful subclasses in heap_graph_class; the
+// meaningful filter target is `Foo`.
+const CLASS_OBJ_PREFIX = 'java.lang.Class<';
+function subclassFilterTarget(className: string): string {
+  if (className.startsWith(CLASS_OBJ_PREFIX) && className.endsWith('>')) {
+    return className.slice(CLASS_OBJ_PREFIX.length, -1);
+  }
+  return className;
+}
+
+function classFilterLink(className: string, navigate: NavFn): m.Child {
+  return m(
+    'button',
+    {
+      class: 'ah-link',
+      title: 'Open subclasses of this class',
+      onclick: () =>
+        navigate('classes', {rootClass: subclassFilterTarget(className)}),
+    },
+    className,
+  );
+}
+
+function renderClassHierarchy(
+  hierarchy: string[],
+  navigate: NavFn,
+): m.Children {
+  const topDown = hierarchy.slice().reverse();
+  return m(
+    'div',
+    {class: 'ah-view-stack--tight'},
+    topDown.map((className, i) =>
+      m(
+        'div',
+        {
+          key: className,
+          class: `ah-path-entry${i === topDown.length - 1 ? ' ah-semibold' : ''}`,
+          style: {'--ah-depth': String(i)},
+        },
+        [
+          m('span', {class: 'ah-path-arrow'}, i === 0 ? '' : '→'),
+          classFilterLink(className, navigate),
+        ],
+      ),
+    ),
+  );
 }
 
 export default ObjectView;


### PR DESCRIPTION
"Super Class" always showed "none" because the lookup read superclass_id from the wrapper type java.lang.Class<Foo> instead of from Foo's own class row.

Now replaced it with a "Class Hierarchy" section showing the full inheritance chain. The chain is resolved with graph_reachable_dfs! over id -> superclass_id.

Clicking any class in the hierarchy opens the Classes tab filtered to that class and its transitive subclasses.