### PR TITLE
tp: Add gpu_api arg for tagging track events with GPU API type

### DIFF
--- a/protos/perfetto/trace/gpu/gpu_track_event.proto
+++ b/protos/perfetto/trace/gpu/gpu_track_event.proto
@@ -18,6 +18,18 @@ package perfetto.protos;
 
 import public "protos/perfetto/trace/track_event/track_event.proto";
 
+// GPU API type for tagging track events.
+// Values intentionally match InternedGraphicsContext.Api in
+// gpu_render_stage_event.proto.
+enum GpuApi {
+  GPU_API_UNDEFINED = 0;
+  GPU_API_OPEN_GL = 1;
+  GPU_API_VULKAN = 2;
+  GPU_API_OPEN_CL = 3;
+  GPU_API_CUDA = 4;
+  GPU_API_HIP = 5;
+}
+
 // Correlates a track event with GPU render stage events.
 message GpuCorrelation {
   // Event IDs of GpuRenderStageEvents that this track event submitted.
@@ -32,5 +44,8 @@ message GpuTrackEvent {
   extend TrackEvent {
     // Correlates this track event with GPU render stage events.
     optional GpuCorrelation gpu_correlation = 3000;
+
+    // GPU API that this track event represents a call to.
+    optional GpuApi gpu_api = 3001;
   }
 }

--- a/test/trace_processor/diff_tests/parser/graphics/gpu_api_slice.textproto
+++ b/test/trace_processor/diff_tests/parser/graphics/gpu_api_slice.textproto
@@ -1,0 +1,62 @@
+# Test gpu_api_call table populated from GpuTrackEvent.gpu_api extension.
+
+# Interned data for track event sequences.
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 0
+  interned_data {
+    event_categories { iid: 1 name: "gpu" }
+    event_names { iid: 1 name: "cuLaunchKernel" }
+    event_names { iid: 2 name: "vkCmdDispatch" }
+  }
+  sequence_flags: 1  # SEQ_INCREMENTAL_STATE_CLEARED
+}
+
+# CUDA API call slice.
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 100
+  track_event {
+    type: TYPE_SLICE_BEGIN
+    category_iids: 1
+    name_iid: 1
+    [perfetto.protos.GpuTrackEvent.gpu_api]: GPU_API_CUDA
+  }
+  sequence_flags: 2  # SEQ_NEEDS_INCREMENTAL_STATE
+}
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 200
+  track_event {
+    type: TYPE_SLICE_END
+    category_iids: 1
+  }
+  sequence_flags: 2
+}
+
+# Vulkan API call slice.
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 300
+  track_event {
+    type: TYPE_SLICE_BEGIN
+    category_iids: 1
+    name_iid: 2
+    [perfetto.protos.GpuTrackEvent.gpu_api]: GPU_API_VULKAN
+  }
+  sequence_flags: 2
+}
+packet {
+  trusted_uid: 9999
+  trusted_packet_sequence_id: 1
+  timestamp: 400
+  track_event {
+    type: TYPE_SLICE_END
+    category_iids: 1
+  }
+  sequence_flags: 2
+}

--- a/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
+++ b/test/trace_processor/diff_tests/parser/graphics/tests_gpu_trace.py
@@ -579,3 +579,20 @@ class GraphicsGpuTrace(TestSuite):
           "softmax","cudaEventWait"
           "softmax","matmul"
         '''))
+
+  def test_gpu_api_arg(self):
+    return DiffTestBlueprint(
+        trace=Path('gpu_api_slice.textproto'),
+        query='''
+          SELECT
+            s.name AS slice_name,
+            extract_arg(s.arg_set_id, 'gpu_api') AS gpu_api
+          FROM slice s
+          WHERE extract_arg(s.arg_set_id, 'gpu_api') IS NOT NULL
+          ORDER BY s.ts;
+        ''',
+        out=Csv('''
+          "slice_name","gpu_api"
+          "cuLaunchKernel","GPU_API_CUDA"
+          "vkCmdDispatch","GPU_API_VULKAN"
+        '''))


### PR DESCRIPTION
Add a GpuApi enum to gpu_track_event.proto that allows producers to
tag host-side API call slices with the GPU API they represent (e.g.
CUDA, Vulkan, OpenGL).

The gpu_api extension field (3001) on GpuTrackEvent is automatically
parsed into the args table by the trace processor's proto reflection
system via the registered gpu_track_event.descriptor. No custom
importer code is needed.

Example query:
  SELECT s.name
  FROM args a
  JOIN slice s ON s.arg_set_id = a.arg_set_id
  WHERE a.key = 'gpu_api' AND a.string_value = 'GPU_API_CUDA'

Related: https://github.com/google/perfetto/issues/5097