### PR TITLE
ui: AndroidBinderViz fix empty string quoting in BreakdownTracks SQL

### DIFF
--- a/ui/src/components/tracks/breakdown_tracks.ts
+++ b/ui/src/components/tracks/breakdown_tracks.ts
@@ -518,7 +518,7 @@ function filterToSql(filter: Filter) {
 }
 
 function toSqlValue(input: string | undefined): string | number | bigint {
-  if (input === undefined || !input.trim()) {
+  if (input === undefined) {
     return '';
   }
 


### PR DESCRIPTION
Updates BreakdownTracks in ui/src/components/tracks/breakdown_tracks.ts to correctly single-quote empty strings within the SQL queries it generates. This prevents syntax issues when empty values are encountered.

Bug: b/505652376
