### PR TITLE
ui: Tabs widget - Add optional rightContent slot

### DIFF
--- a/ui/src/assets/widgets/tabs.scss
+++ b/ui/src/assets/widgets/tabs.scss
@@ -118,6 +118,12 @@
     margin-left: 2px;
   }
 
+  &__right-content {
+    margin-left: auto;
+    display: flex;
+    align-items: baseline;
+  }
+
   &__content {
     flex: 1;
     overflow: auto;

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/tabs_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/tabs_demo.ts
@@ -15,6 +15,7 @@
 import m from 'mithril';
 import {Icons} from '../../../base/semantic_icons';
 import {Tabs, TabsTab} from '../../../widgets/tabs';
+import {Button} from '../../../widgets/button';
 import {MenuItem} from '../../../widgets/menu';
 import {renderWidgetShowcase} from '../widgets_page_utils';
 import {shortUuid} from '../../../base/uuid';
@@ -159,6 +160,9 @@ export function renderTabs(): m.Children {
                   activeTabKey = id;
                 }
               : undefined,
+            rightContent: opts.rightButton
+              ? m(Button, {icon: Icons.Filter, label: 'Filter'})
+              : undefined,
           }),
         );
       },
@@ -169,6 +173,7 @@ export function renderTabs(): m.Children {
         renamable: true,
         reorderable: true,
         menuItems: true,
+        rightButton: false,
       },
     }),
   ];

--- a/ui/src/widgets/tabs.ts
+++ b/ui/src/widgets/tabs.ts
@@ -14,7 +14,7 @@
 
 import m from 'mithril';
 import {classNames} from '../base/classnames';
-import {Gate} from '../base/mithril_utils';
+import {Gate, isEmptyVnodes} from '../base/mithril_utils';
 import {Button} from './button';
 import {Icon} from './icon';
 import {Icons} from '../base/semantic_icons';
@@ -64,6 +64,8 @@ export interface TabsAttrs {
   // Custom content to render in place of the default "+" button. When set,
   // onNewTab is ignored and this content is rendered instead.
   readonly newTabContent?: m.Children;
+  // Content to render on the right side of the tab bar.
+  readonly rightContent?: m.Children;
   // Additional class name for the container.
   readonly className?: string;
 }
@@ -247,6 +249,7 @@ export class Tabs implements m.ClassComponent<TabsAttrs> {
       onTabReorder,
       onNewTab,
       newTabContent,
+      rightContent,
       className,
     } = attrs;
 
@@ -381,6 +384,8 @@ export class Tabs implements m.ClassComponent<TabsAttrs> {
               className: 'pf-tabs__new-tab-btn',
               onclick: () => onNewTab(),
             })),
+        !isEmptyVnodes(rightContent) &&
+          m('.pf-tabs__right-content', rightContent),
       ),
       m(
         '.pf-tabs__content',


### PR DESCRIPTION
This allows putting content to the right of the tab strip in a Tabs widget.