### PR TITLE
sdk: Guard activateTrigger in Java on sdk registration

### DIFF
--- a/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
+++ b/src/android_sdk/java/main/dev/perfetto/sdk/PerfettoTrace.java
@@ -46,6 +46,7 @@ public final class PerfettoTrace {
   private static final PerfettoNativeMemoryCleaner sNativeMemoryCleaner =
       new PerfettoNativeMemoryCleaner();
 
+  private static final AtomicBoolean sAttemptedRegistration = new AtomicBoolean(false);
   private static final AtomicBoolean sAttemptedSystemRegistration = new AtomicBoolean(false);
 
   /** For fetching the next flow event id in a process. */
@@ -302,17 +303,26 @@ public final class PerfettoTrace {
     return native_get_thread_track_uuid(tid);
   }
 
-  /** Activates a trigger by name {@code triggerName} with expiry in {@code ttlMs}. */
-  public static void activateTrigger(String triggerName, int ttlMs) {
+  /**
+   * Activates a trigger by name {@code triggerName} with expiry in {@code ttlMs}. Returns
+   * {@code true} iff the trigger was forwarded to the system backend; on {@code false} the
+   * caller should fall back to {@code trigger_perfetto}.
+   */
+  public static boolean activateTrigger(String triggerName, int ttlMs) {
+    if (!sAttemptedRegistration.get()) {
+      return false;
+    }
     native_activate_trigger(triggerName, ttlMs);
+    return sAttemptedSystemRegistration.get();
   }
 
   /** Registers the process with Perfetto. */
   public static void register(boolean isBackendInProcess) {
+    native_register(isBackendInProcess);
+    sAttemptedRegistration.set(true);
     if (!isBackendInProcess) {
         sAttemptedSystemRegistration.set(true);
     }
-    native_register(isBackendInProcess);
   }
 
   /** Registers the process with Perfetto and enable additional debug checks on the Java side. */

--- a/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
+++ b/src/android_sdk/java/test/dev/perfetto/sdk/test/PerfettoTraceTest.java
@@ -729,29 +729,27 @@ public class PerfettoTraceTest {
   @Test
   public void testActivateTrigger() throws Exception {
     TraceConfig traceConfig = getTriggerTraceConfig(FOO, FOO);
-
     PerfettoTrace.Session session = new PerfettoTrace.Session(true, traceConfig.toByteArray());
 
     PerfettoTrace.instant(FOO_CATEGORY, "event_trigger").emit();
 
-    PerfettoTrace.activateTrigger(FOO, 1000);
+    // setUp() registered with isBackendInProcess=true: the trigger fires against
+    // the in-process session but the return is false (system not registered).
+    assertThat(PerfettoTrace.activateTrigger(FOO, 1000)).isFalse();
 
     byte[] traceBytes = session.close();
 
     Trace trace = Trace.parseFrom(traceBytes);
 
-    boolean hasTrackEvent = false;
-    boolean hasChromeLatencyInfo = false;
-
+    boolean hasTrigger = false;
     for (TracePacket packet : trace.getPacketList()) {
-      TrackEvent event;
-      if (packet.hasTrackEvent()) {
-        hasTrackEvent = true;
+      if (packet.hasTrigger() && FOO.equals(packet.getTrigger().getTriggerName())) {
+        hasTrigger = true;
       }
-
       collectInternedData(packet);
     }
 
+    assertThat(hasTrigger).isTrue();
     assertThat(mCategoryNames).contains(FOO);
   }
 


### PR DESCRIPTION
Calling activateTrigger before register() SIGTRAPs in TracingMuxerFake. Callers worked around this by pre-checking getAttempedSystemRegistration(), but that check was stricter than it needed to be and silently dropped triggers against in-process registrations, which the native muxer handles safely.

Move the guard inside activateTrigger and key it on any register() call. The return value now tells the caller whether the trigger reaches the system backend, so callers can skip the pre-check and only fall back to trigger_perfetto when it returns false.