### PR TITLE
ui: Add 'Name tab' command to command palette

### DIFF
--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index.ts
@@ -168,6 +168,17 @@ export default class CoreCommands implements PerfettoPlugin {
       });
     }
 
+    ctx.commands.registerCommand({
+      id: 'dev.perfetto.NameTab',
+      name: 'Rename current browser tab',
+      callback: async () => {
+        const name = await ctx.omnibox.prompt('Enter new window title...');
+        if (name !== undefined && name !== '') {
+          document.title = name;
+        }
+      },
+    });
+
     // Register the new macros setting (array format)
     const macroSettingsEditor = new JsonSettingsEditor<MacrosConfig>({
       schema: macrosConfigSchema,

--- a/ui/src/core_plugins/dev.perfetto.CoreCommands/index_unittest.ts
+++ b/ui/src/core_plugins/dev.perfetto.CoreCommands/index_unittest.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import {legacyMacrosConfigSchema} from './index';
+import CoreCommands from './index';
+import {AppImpl} from '../../core/app_impl';
 
 describe('legacyMacrosConfigSchema', () => {
   it('parses a valid legacy macros config', () => {
@@ -62,5 +64,80 @@ describe('legacyMacrosConfigSchema', () => {
     };
 
     expect(() => legacyMacrosConfigSchema.parse(input)).toThrow();
+  });
+});
+
+describe('CoreCommands', () => {
+  it('registers NameTab command', () => {
+    const mockRegisterCommand = jest.fn();
+    const mockPrompt = jest.fn();
+
+    const mockCtx = {
+      commands: {
+        registerCommand: mockRegisterCommand,
+      },
+      omnibox: {
+        prompt: mockPrompt,
+      },
+      sidebar: {
+        enabled: false,
+        addMenuItem: jest.fn(),
+      },
+      settings: {
+        register: jest.fn().mockReturnValue({
+          get: jest.fn().mockReturnValue([]),
+          set: jest.fn(),
+        }),
+      },
+    };
+
+    CoreCommands.onActivate(mockCtx as unknown as AppImpl);
+
+    const nameTabCall = mockRegisterCommand.mock.calls.find(
+      (call) => call[0].id === 'dev.perfetto.NameTab',
+    );
+
+    expect(nameTabCall).toBeTruthy();
+    expect(nameTabCall[0].name).toBe('Rename current browser tab');
+  });
+
+  it('NameTab command updates document title', async () => {
+    const mockRegisterCommand = jest.fn();
+    const mockPrompt = jest.fn().mockResolvedValue('New Title');
+
+    const mockCtx = {
+      commands: {
+        registerCommand: mockRegisterCommand,
+      },
+      omnibox: {
+        prompt: mockPrompt,
+      },
+      sidebar: {
+        enabled: false,
+        addMenuItem: jest.fn(),
+      },
+      settings: {
+        register: jest.fn().mockReturnValue({
+          get: jest.fn().mockReturnValue([]),
+          set: jest.fn(),
+        }),
+      },
+    };
+
+    CoreCommands.onActivate(mockCtx as unknown as AppImpl);
+
+    const nameTabCall = mockRegisterCommand.mock.calls.find(
+      (call) => call[0].id === 'dev.perfetto.NameTab',
+    );
+
+    const callback = nameTabCall[0].callback;
+
+    const oldTitle = document.title;
+    await callback();
+
+    expect(mockPrompt).toHaveBeenCalledWith('Enter new window title...');
+    expect(document.title).toBe('New Title');
+
+    document.title = oldTitle;
   });
 });


### PR DESCRIPTION
This feature adds a new command "Name tab" to the Perfetto UI command palette. When invoked, it prompts the user for a new window title and updates `document.title` with the provided value.

This allows users to distinguish between multiple Perfetto UI tabs by giving them custom names.

Added unit tests to verify command registration and behavior.