### PR TITLE
ui: Trim flamegraph rows in trace_processor with placeholder rectangles

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
@@ -301,6 +301,9 @@ AS (
 CREATE PERFETTO MACRO _col_list_id(a ColumnName)
 RETURNS Expr AS $a;
 
+CREATE PERFETTO MACRO _col_list_null(a ColumnName)
+RETURNS _ProjectionFragment AS NULL AS $a;
+
 -- Converts a table of hashes and paretn hashes into ids and parent
 -- ids, grouping all hashes together.
 CREATE PERFETTO MACRO _viz_flamegraph_merge_hashes(
@@ -326,9 +329,133 @@ AS (
     __intrinsic_token_apply!(_col_list_id, $grouping),
     __intrinsic_token_apply!(_col_list_id, $grouped_agged_exprs),
     SUM(value) AS value,
-    SUM(cumulativeValue) AS cumulativeValue
+    SUM(cumulativeValue) AS cumulativeValue,
+    FALSE AS isPlaceholder
   FROM $hashed c
   GROUP BY hash
+);
+
+-- Per-node propagation pass for the trim. For each node in |merged|,
+-- emits |requiredCum|: the cumulativeValue that this node's CHILDREN must
+-- clear in order to be kept. Roots emit 0. A node propagates +inf if it
+-- itself failed the join thresholds (which kills its whole subtree, since
+-- nothing is >= +inf).
+--
+-- Caller should materialize the result into a Perfetto table with an
+-- index on |id|, since _viz_flamegraph_alive_set looks up parentId →
+-- requiredCum once per merged row.
+CREATE PERFETTO MACRO _viz_flamegraph_trim_propagation(
+  merged TableOrSubquery,
+  ratio Expr,
+  min_value Expr
+)
+RETURNS TableOrSubquery
+AS (
+  SELECT id, requiredCum
+  FROM _graph_aggregating_scan!(
+    (
+      SELECT m.parentId AS source_node_id, m.id AS dest_node_id
+      FROM $merged m
+      WHERE m.parentId IS NOT NULL
+    ),
+    (SELECT id, 0.0 AS requiredCum FROM $merged WHERE parentId IS NULL),
+    (requiredCum),
+    (
+      SELECT
+        x.id,
+        IIF(
+          t.cumulativeValue >= x.incoming
+            AND t.cumulativeValue >= $min_value,
+          $ratio * t.cumulativeValue,
+          1e308
+        ) AS requiredCum
+      FROM (
+        SELECT id, MIN(requiredCum) AS incoming
+        FROM $table
+        GROUP BY id
+      ) x
+      JOIN $merged t USING (id)
+    )
+  )
+);
+
+-- Given |merged| and the materialized + id-indexed |propagated| table from
+-- _viz_flamegraph_trim_propagation, emits the ids of nodes that survive a
+-- per-parent + absolute floor trim. A node is "alive" iff it is reachable
+-- from a root through edges where every step satisfies BOTH:
+--   child.cumulativeValue >= |ratio| * parent.cumulativeValue   (encoded
+--                          in propagated[parent].requiredCum)
+--   child.cumulativeValue >= |min_value|
+-- Roots are always kept.
+--
+-- Caller should materialize the result with an index on |id| since
+-- _viz_flamegraph_trim_with_placeholder looks it up three times.
+CREATE PERFETTO MACRO _viz_flamegraph_alive_set(
+  merged TableOrSubquery,
+  propagated TableOrSubquery,
+  min_value Expr
+)
+RETURNS TableOrSubquery
+AS (
+  SELECT m.id
+  FROM $merged m
+  LEFT JOIN $propagated pp ON pp.id = m.parentId
+  WHERE m.parentId IS NULL
+     OR (m.cumulativeValue >= pp.requiredCum
+         AND m.cumulativeValue >= $min_value)
+);
+
+-- Emits the trimmed flamegraph: kept rows from |merged| pass through, plus
+-- one synthetic '(merged)' placeholder per kept parent that has any
+-- dropped direct children (split by depth-sign so a root with both
+-- upward and downward dropped subtrees gets one placeholder per side).
+--
+-- |alive| must be a Perfetto table containing the kept ids (the output of
+-- _viz_flamegraph_alive_set materialized with an index on id). Caller is
+-- responsible for that materialization so the three references to |alive|
+-- below all hit an indexed lookup.
+CREATE PERFETTO MACRO _viz_flamegraph_trim_with_placeholder(
+  merged TableOrSubquery,
+  alive TableOrSubquery,
+  grouping ColumnNameList,
+  grouped ColumnNameList
+)
+RETURNS TableOrSubquery
+AS (
+  WITH _max_id AS (
+    SELECT COALESCE(MAX(id), 0) AS v FROM $merged
+  )
+  SELECT
+    m.id, m.parentId, m.depth, m.name,
+    __intrinsic_token_apply!(_col_list_id, $grouping),
+    __intrinsic_token_apply!(_col_list_id, $grouped),
+    m.value, m.cumulativeValue,
+    FALSE AS isPlaceholder
+  FROM $merged m
+  JOIN $alive a USING (id)
+  UNION ALL
+  SELECT
+    (SELECT v FROM _max_id)
+      + ROW_NUMBER() OVER (ORDER BY d.parentId, (d.depth > 0)) AS id,
+    d.parentId,
+    -- All dropped children of one parent on one side of the root share
+    -- the same depth in a tree, so MIN/MAX/ANY are equivalent.
+    MIN(d.depth) AS depth,
+    '(merged)' AS name,
+    __intrinsic_token_apply!(_col_list_null, $grouping),
+    __intrinsic_token_apply!(_col_list_null, $grouped),
+    SUM(d.value) AS value,
+    SUM(d.cumulativeValue) AS cumulativeValue,
+    TRUE AS isPlaceholder
+  FROM $merged d
+  LEFT JOIN $alive a ON a.id = d.id
+  WHERE
+    a.id IS NULL
+    AND d.parentId IS NOT NULL
+    AND d.parentId IN (SELECT id FROM $alive)
+  -- A root node can have both upward and downward dropped subtrees;
+  -- keep them as separate placeholders since they sit on opposite sides.
+  GROUP BY d.parentId, (d.depth > 0)
 );
 
 -- Performs a "layout" of nodes in the flamegraph relative to their
@@ -388,7 +515,8 @@ AS (
     p.cumulativeValue AS parentCumulativeValue,
     s.depth,
     g.xStart,
-    g.xEnd
+    g.xEnd,
+    s.isPlaceholder
   FROM _graph_scan!(
     edges,
     inits,

--- a/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
@@ -335,15 +335,20 @@ AS (
   GROUP BY hash
 );
 
--- Per-node propagation pass for the trim. For each node in |merged|,
--- emits |requiredCum|: the cumulativeValue that this node's CHILDREN must
--- clear in order to be kept. Roots emit 0. A node propagates +inf if it
--- itself failed the join thresholds (which kills its whole subtree, since
--- nothing is >= +inf).
+-- Per-node propagation pass for the trim. For each node in |merged| emits:
+--   alive       - whether the node itself survives the join thresholds.
+--   requiredCum - the cumulativeValue this node's CHILDREN must clear.
+-- Roots are always alive and emit requiredCum = 0. A node that itself
+-- failed the thresholds emits requiredCum = +inf, which kills its whole
+-- subtree on the next step (no cumulativeValue can be >= +inf).
+--
+-- Computing |alive| inside the scan rather than via a downstream JOIN of
+-- merged with propagated avoids an N x N pass over the merged tree, which
+-- on WASM-sized inputs (millions of rows) was the dominant cost.
 --
 -- Caller should materialize the result into a Perfetto table with an
--- index on |id|, since _viz_flamegraph_alive_set looks up parentId →
--- requiredCum once per merged row.
+-- index on |id|, since _viz_flamegraph_trim_with_placeholder looks up
+-- parentId -> alive while emitting placeholders.
 CREATE PERFETTO MACRO _viz_flamegraph_trim_propagation(
   merged TableOrSubquery,
   ratio Expr,
@@ -351,15 +356,18 @@ CREATE PERFETTO MACRO _viz_flamegraph_trim_propagation(
 )
 RETURNS TableOrSubquery
 AS (
-  SELECT id, requiredCum
+  SELECT id, requiredCum, alive
   FROM _graph_aggregating_scan!(
     (
       SELECT m.parentId AS source_node_id, m.id AS dest_node_id
       FROM $merged m
       WHERE m.parentId IS NOT NULL
     ),
-    (SELECT id, 0.0 AS requiredCum FROM $merged WHERE parentId IS NULL),
-    (requiredCum),
+    (
+      SELECT id, 0.0 AS requiredCum, TRUE AS alive
+      FROM $merged WHERE parentId IS NULL
+    ),
+    (requiredCum, alive),
     (
       SELECT
         x.id,
@@ -368,7 +376,9 @@ AS (
             AND t.cumulativeValue >= $min_value,
           $ratio * t.cumulativeValue,
           1e308
-        ) AS requiredCum
+        ) AS requiredCum,
+        (t.cumulativeValue >= x.incoming
+            AND t.cumulativeValue >= $min_value) AS alive
       FROM (
         SELECT id, MIN(requiredCum) AS incoming
         FROM $table
@@ -379,31 +389,13 @@ AS (
   )
 );
 
--- Given |merged| and the materialized + id-indexed |propagated| table from
--- _viz_flamegraph_trim_propagation, emits the ids of nodes that survive a
--- per-parent + absolute floor trim. A node is "alive" iff it is reachable
--- from a root through edges where every step satisfies BOTH:
---   child.cumulativeValue >= |ratio| * parent.cumulativeValue   (encoded
---                          in propagated[parent].requiredCum)
---   child.cumulativeValue >= |min_value|
--- Roots are always kept.
---
--- Caller should materialize the result with an index on |id| since
--- _viz_flamegraph_trim_with_placeholder looks it up three times.
+-- Returns the ids of nodes that survive the trim. Just a thin filter over
+-- |propagated| now that |alive| is computed inside the propagation scan.
 CREATE PERFETTO MACRO _viz_flamegraph_alive_set(
-  merged TableOrSubquery,
-  propagated TableOrSubquery,
-  min_value Expr
+  propagated TableOrSubquery
 )
 RETURNS TableOrSubquery
-AS (
-  SELECT m.id
-  FROM $merged m
-  LEFT JOIN $propagated pp ON pp.id = m.parentId
-  WHERE m.parentId IS NULL
-     OR (m.cumulativeValue >= pp.requiredCum
-         AND m.cumulativeValue >= $min_value)
-);
+AS (SELECT id FROM $propagated WHERE alive);
 
 -- Emits the trimmed flamegraph: kept rows from |merged| pass through, plus
 -- one synthetic '(merged)' placeholder per kept parent that has any

--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -484,6 +484,89 @@ async function computeFlamegraphTree(
       on: `_flamegraph_merged_${uuid}(parentId)`,
     }),
   );
+  // Trim sub-threshold subtrees, replacing them with a single '(merged)'
+  // placeholder per kept parent. Two thresholds are applied jointly via a
+  // single downward graph scan:
+  //   * a per-parent ratio (TRIM_RATIO_DENOMINATOR) bounds the fan-out a
+  //     subtree can show, preserving zoom-time resolution under any parent.
+  //   * an absolute floor derived from the root total (TRIM_FLOOR_DENOMINATOR)
+  //     prunes long invisible chain tails - critical for chain-shaped data
+  //     where the per-parent ratio alone cannot reduce row count.
+  // The pipeline is split into three materialized perfetto tables so
+  // each lookup hits an indexed table instead of an unindexed CTE.
+  const TRIM_RATIO_DENOMINATOR = 100;
+  const TRIM_FLOOR_DENOMINATOR = 10000;
+  const totalRow = await engine.query(`
+    select sum(cumulativeValue) as v
+    from _flamegraph_merged_${uuid}
+    where parentId is null
+  `);
+  const totalCumulativeValue = totalRow.firstRow({v: NUM_NULL}).v ?? 0;
+  const trimMinValue = totalCumulativeValue / TRIM_FLOOR_DENOMINATOR;
+  disposable.use(
+    await createPerfettoTable({
+      engine,
+      name: `_flamegraph_propagated_${uuid}`,
+      as: `
+        select *
+        from _viz_flamegraph_trim_propagation!(
+          _flamegraph_merged_${uuid},
+          (1.0 / ${TRIM_RATIO_DENOMINATOR}),
+          ${trimMinValue}
+        )
+      `,
+    }),
+  );
+  disposable.use(
+    await createPerfettoIndex({
+      engine,
+      name: `_flamegraph_propagated_${uuid}_index`,
+      on: `_flamegraph_propagated_${uuid}(id)`,
+    }),
+  );
+  disposable.use(
+    await createPerfettoTable({
+      engine,
+      name: `_flamegraph_alive_${uuid}`,
+      as: `
+        select *
+        from _viz_flamegraph_alive_set!(
+          _flamegraph_merged_${uuid},
+          _flamegraph_propagated_${uuid},
+          ${trimMinValue}
+        )
+      `,
+    }),
+  );
+  disposable.use(
+    await createPerfettoIndex({
+      engine,
+      name: `_flamegraph_alive_${uuid}_index`,
+      on: `_flamegraph_alive_${uuid}(id)`,
+    }),
+  );
+  disposable.use(
+    await createPerfettoTable({
+      engine,
+      name: `_flamegraph_trimmed_${uuid}`,
+      as: `
+        select *
+        from _viz_flamegraph_trim_with_placeholder!(
+          _flamegraph_merged_${uuid},
+          _flamegraph_alive_${uuid},
+          ${groupingColumns},
+          ${groupedColumns}
+        )
+      `,
+    }),
+  );
+  disposable.use(
+    await createPerfettoIndex({
+      engine,
+      name: `_flamegraph_trimmed_${uuid}_index`,
+      on: `_flamegraph_trimmed_${uuid}(parentId)`,
+    }),
+  );
   disposable.use(
     await createPerfettoTable({
       engine,
@@ -491,7 +574,7 @@ async function computeFlamegraphTree(
       as: `
         select *
         from _viz_flamegraph_local_layout!(
-          _flamegraph_merged_${uuid}
+          _flamegraph_trimmed_${uuid}
         );
       `,
     }),
@@ -499,7 +582,7 @@ async function computeFlamegraphTree(
   const res = await engine.query(`
     select *
     from _viz_flamegraph_global_layout!(
-      _flamegraph_merged_${uuid},
+      _flamegraph_trimmed_${uuid},
       _flamegraph_layout_${uuid},
       ${groupingColumns},
       ${groupedColumns}
@@ -516,6 +599,7 @@ async function computeFlamegraphTree(
     parentCumulativeValue: NUM_NULL,
     xStart: NUM,
     xEnd: NUM,
+    isPlaceholder: NUM,
     ...Object.fromEntries(unaggCols.map((m) => [m, STR_NULL])),
     ...Object.fromEntries(aggCols.map((m) => [m, UNKNOWN])),
   });
@@ -572,6 +656,7 @@ async function computeFlamegraphTree(
       parentCumulativeValue: it.parentCumulativeValue ?? undefined,
       xStart: it.xStart,
       xEnd: it.xEnd,
+      isPlaceholder: it.isPlaceholder !== 0,
       properties,
       marker,
     });

--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -492,8 +492,10 @@ async function computeFlamegraphTree(
   //   * an absolute floor derived from the root total (TRIM_FLOOR_DENOMINATOR)
   //     prunes long invisible chain tails - critical for chain-shaped data
   //     where the per-parent ratio alone cannot reduce row count.
-  // The pipeline is split into three materialized perfetto tables so
-  // each lookup hits an indexed table instead of an unindexed CTE.
+  // The propagation scan emits an `alive` flag per node so the alive set
+  // is a direct WHERE on propagated rather than a costly LEFT JOIN of the
+  // full merged table - this is the dominant cost on WASM for large
+  // bottom-up trees.
   const TRIM_RATIO_DENOMINATOR = 100;
   const TRIM_FLOOR_DENOMINATOR = 10000;
   const totalRow = await engine.query(`
@@ -518,22 +520,13 @@ async function computeFlamegraphTree(
     }),
   );
   disposable.use(
-    await createPerfettoIndex({
-      engine,
-      name: `_flamegraph_propagated_${uuid}_index`,
-      on: `_flamegraph_propagated_${uuid}(id)`,
-    }),
-  );
-  disposable.use(
     await createPerfettoTable({
       engine,
       name: `_flamegraph_alive_${uuid}`,
       as: `
         select *
         from _viz_flamegraph_alive_set!(
-          _flamegraph_merged_${uuid},
-          _flamegraph_propagated_${uuid},
-          ${trimMinValue}
+          _flamegraph_propagated_${uuid}
         )
       `,
     }),

--- a/ui/src/widgets/flamegraph.ts
+++ b/ui/src/widgets/flamegraph.ts
@@ -112,6 +112,10 @@ export interface FlamegraphNode {
   readonly marker?: string;
   readonly xStart: number;
   readonly xEnd: number;
+  // True when the node was emitted by trace_processor as a synthetic
+  // '(merged)' bucket absorbing a sub-threshold subtree. The render path
+  // treats these identically to UI-time merged rectangles (kind: 'MERGED').
+  readonly isPlaceholder?: boolean;
 }
 
 export interface FlamegraphQueryData {
@@ -1276,7 +1280,14 @@ function computeRenderNodes(
 
   const zoomQueryWidth = zoomRegion.queryXEnd - zoomRegion.queryXStart;
   for (let i = 0; i < nodes.length; i++) {
-    const {id, parentId, depth, xStart: qXStart, xEnd: qXEnd} = nodes[i];
+    const {
+      id,
+      parentId,
+      depth,
+      xStart: qXStart,
+      xEnd: qXEnd,
+      isPlaceholder,
+    } = nodes[i];
     assertTrue(depth !== 0);
 
     const depthMatchingZoom = isDepthMatchingZoom(depth, zoomRegion);
@@ -1304,7 +1315,7 @@ function computeRenderNodes(
       : relativeWidth / queryXPerPx;
     const state = computeState(qXStart, qXEnd, zoomRegion, depthMatchingZoom);
 
-    if (width < MIN_PIXEL_DISPLAYED) {
+    if (width < MIN_PIXEL_DISPLAYED || isPlaceholder) {
       // Check if parent was merged - if so, use x-position-based key so that
       // children of different parents that were merged together also merge.
       // This enables recursive merging: if parents A and B merged into the


### PR DESCRIPTION
The bottom-up flamegraph for traces with many distinct upward stacks can
produce millions of merged rows where the vast majority represent
sub-pixel rectangles that the UI cannot render meaningfully. The
existing render-time merge in computeRenderNodes still has to walk
every row, so a 2.5M-row response can crash the tab.

Push the same per-parent merge concept down into trace_processor so
that the wire payload itself is bounded:

- _viz_flamegraph_trim_propagation: a single downward
  _graph_aggregating_scan computes the cumulativeValue threshold each
  node imposes on its children. Roots emit 0; nodes that fail their
  own threshold emit +inf so the whole subtree below is killed.
  Combines a per-parent ratio (preserves zoom-time fan-out
  resolution) with an absolute floor (prunes long invisible chain
  tails - critical for chain-shaped data where the per-parent ratio
  alone cannot reduce row count).

- _viz_flamegraph_alive_set: derives kept ids from merged +
  propagated.

- _viz_flamegraph_trim_with_placeholder: passes kept rows through
  and emits one synthetic '(merged)' row per (kept_parent,
  depth_sign) summing the dropped subtree. Cumulative value is
  conserved.

The pipeline is split into three macros so the UI can materialize
each into a Perfetto table with an index on id - the per-row parent
lookup needed by the alive derivation must hit an indexed table, not
an unindexed CTE.

In the UI:
- query_flamegraph.ts wires the three new macros between the existing
  merged and layout steps. min_value is derived from a quick scalar
  query on the root total (1/10000 of total kept).
- A new isPlaceholder boolean is plumbed from the SQL through to
  FlamegraphNode.
- computeRenderNodes routes any node with isPlaceholder through the
  same kind: 'MERGED' branch that already handles sub-pixel siblings,
  so the placeholder gets the existing color, '(merged)' label,
  tooltip, and zoom-disable behaviour with no further changes.

Verified end-to-end on a 2.5M-row bottom-up flamegraph: shrinks to
~138K rows (18x reduction) with cumulative value conserved. Top-down
works identically (272K -> 40K on the same trace).

Bug: b/505843952