### PR TITLE
ui: Support release-branch deploys that skip the index update

### DIFF
--- a/infra/ui.perfetto.dev/README.md
+++ b/infra/ui.perfetto.dev/README.md
@@ -14,7 +14,8 @@ Three channels are served from `gs://ui.perfetto.dev/`:
 | stable   | `stable`      | push to `stable`           |
 
 Each Cloud Build trigger invokes `ui_builder_entrypoint.sh` with the
-channel name as `$1`. The entrypoint runs `ui/release/build_channel.py
+branch name as `$1`. The entrypoint maps `autopush`/`canary`/`stable` to
+the channel of the same name and runs `ui/release/build_channel.py
 --channel=<name> --upload`, which builds the UI from the branch HEAD
 and uploads `/v<version>/**` to GCS.
 
@@ -28,6 +29,16 @@ The stable channel additionally owns the HTML body itself (it is the
 only channel that overwrites the body) and the shared `/service_worker.*`
 files. Canary and autopush never write the body or service_worker, so
 canary instability cannot break stable users.
+
+### Release branches
+
+Pushes to long-lived release branches (anything other than
+`main`/`canary`/`stable`) are wired to the same `cloudbuild_release.yaml`
+trigger, which passes `$BRANCH_NAME`. The entrypoint normalises any such
+branch to `--channel=release`. The release mode uploads `/v<version>/`
+only and does NOT modify the root index.html map or `/service_worker.*`,
+so the build is reachable by direct URL but no channel points to it until
+the branch is eventually merged into `stable`.
 
 ## /appengine : GAE <> GCS proxy
 

--- a/infra/ui.perfetto.dev/builder/ui_builder_entrypoint.sh
+++ b/infra/ui.perfetto.dev/builder/ui_builder_entrypoint.sh
@@ -16,10 +16,14 @@
 # ENTRYPOINT for the perfetto-ui-builder Docker image, invoked from
 # infra/ui.perfetto.dev/cloudbuild*.yaml.
 #
-# $1 must be the channel name to build: autopush | canary | stable.
-# Cloud Build has already placed us on the SHA that fired the trigger
-# (main HEAD for autopush, canary HEAD for canary, stable HEAD for
-# stable), so we build from HEAD without any explicit checkout.
+# $1 is the branch name (or 'autopush' literal from cloudbuild.yaml).
+# Cloud Build has already placed us on the SHA that fired the trigger,
+# so we build from HEAD without any explicit checkout.
+#
+# Branches autopush/canary/stable map 1:1 to channels of the same name.
+# Any other branch (i.e. a release branch) maps to the 'release' mode,
+# which uploads /v<version>/ only and does NOT touch the shared root
+# index.html or service_worker.
 #
 # See go/perfetto-ui-autopush for end-to-end docs.
 
@@ -31,5 +35,8 @@ git config --global init.defaultBranch main
 git fetch --unshallow
 git rev-parse HEAD
 
-CHANNEL="$1"
+case "$1" in
+  autopush|canary|stable) CHANNEL="$1" ;;
+  *)                      CHANNEL="release" ;;
+esac
 python3 -u ui/release/build_channel.py --channel="$CHANNEL" --upload

--- a/infra/ui.perfetto.dev/cloudbuild_release.yaml
+++ b/infra/ui.perfetto.dev/cloudbuild_release.yaml
@@ -3,9 +3,11 @@
 # for the project "perfetto-ui" (zone: europe-west2).
 #
 # This config is wired to the triggers that fire on pushes to the
-# long-lived `canary` and `stable` branches. The branch name is passed
-# as the channel name to the entrypoint, so a push to `canary` builds
-# the canary channel and a push to `stable` builds the stable channel.
+# long-lived `canary` / `stable` branches and to release branches. The
+# branch name is passed to the entrypoint, which maps canary/stable to
+# the channel of the same name and any other branch (i.e. a release
+# branch) to the 'release' mode -- uploads /v<version>/ only, no index
+# or service_worker mutation.
 steps:
 - name: europe-docker.pkg.dev/perfetto-ui/builder/perfetto-ui-builder
   args:

--- a/ui/release/build_channel.py
+++ b/ui/release/build_channel.py
@@ -29,6 +29,13 @@ channels' map entries) and uploads the shared /service_worker.* files.
 Canary and autopush never write the HTML body or service_worker --
 preserves the invariant that canary instability cannot break stable users.
 
+There is also a fourth mode, 'release', used for pushes to long-lived
+release branches. It builds and uploads the /v<version>/ artifacts so
+the version is reachable by direct URL, but it does NOT touch the root
+index.html map or any shared loose files. No channel points to it
+until someone explicitly promotes the version (typically by merging
+into the stable branch, which then runs this script in stable mode).
+
 See go/perfetto-ui-autopush for end-to-end docs.
 """
 
@@ -46,7 +53,11 @@ from os.path import dirname
 pjoin = os.path.join
 
 BUCKET_NAME = 'ui.perfetto.dev'
-CHANNELS = ('autopush', 'canary', 'stable')
+# Channels that own a slot in the root /index.html data-perfetto_version map.
+INDEX_CHANNELS = ('autopush', 'canary', 'stable')
+# 'release' uploads /v<version>/ only and never touches the index / service
+# worker, so it is valid as a --channel value but does not appear in the map.
+CHANNELS = INDEX_CHANNELS + ('release',)
 CUR_DIR = dirname(os.path.abspath(__file__))
 ROOT_DIR = dirname(dirname(CUR_DIR))
 CAS_MAX_RETRIES = 10
@@ -241,8 +252,15 @@ def make_other_channel_updater(channel, new_version):
 
 def upload_loose_files(channel, version, dist_dir):
   """Iterate the loose files in dist_dir (HTML files + service_worker.*).
-  HTML files get CAS-updated by every channel. Non-HTML files are uploaded
-  plain by the stable channel only and ignored by other channels."""
+  HTML files get CAS-updated by every index channel. Non-HTML files are
+  uploaded plain by the stable channel only and ignored by other index
+  channels. The 'release' mode skips loose files entirely -- a release-branch
+  deploy publishes only the /v<version>/ artifacts and must not mutate any
+  shared state."""
+  if channel == 'release':
+    print('Skipping loose-file upload for release mode (index / '
+          'service_worker are left untouched).')
+    return
   for fname in sorted(os.listdir(dist_dir)):
     fpath = pjoin(dist_dir, fname)
     if not os.path.isfile(fpath):


### PR DESCRIPTION
Pushes that come from a long-lived release branch (not main, canary,
or stable) now build and upload the /v<version>/ artifacts to GCS but
leave the root index.html map and /service_worker.* untouched. The
versioned build is reachable by direct URL, but no channel points to
it until it is eventually promoted by merging into stable.

- build_channel.py: 'release' is now a valid --channel value. In that
  mode upload_loose_files returns early, so only the versioned dir
  goes up and the shared root state is not mutated.
- ui_builder_entrypoint.sh: treats $1 as the branch name and maps
  autopush/canary/stable to the channel of the same name; any other
  branch (i.e. a release branch) maps to 'release'. This lets the
  existing cloudbuild_release.yaml trigger be reused verbatim once
  the trigger glob is widened to cover release branches.
- README.md / cloudbuild_release.yaml: docs refreshed accordingly.
