### PR TITLE
ui: restructure flamegraph with three perf wins

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
@@ -183,13 +183,19 @@ AS (
 CREATE PERFETTO MACRO _viz_flamegraph_s_prefix(col ColumnName)
 RETURNS Expr AS s.$col;
 
--- Propogates the cumulative value of the pivot nodes to the roots
--- and computes the "fingerprint" of the path.
+-- Propagates the cumulative value of the pivot nodes to the roots and
+-- computes the "fingerprint" of the path. Output is intentionally narrow:
+-- it omits name and the |grouping| columns. Those are recovered later in
+-- _viz_flamegraph_resolve_groups via a single per-merged-row JOIN against
+-- |source|, which is far cheaper than the per-walk-row JOIN we'd pay if
+-- we pulled them in here (the walk produces ~4x more rows than the merged
+-- table). |grouped| columns ARE pulled in here because they're aggregated
+-- across the whole hash group and would otherwise need a second source
+-- JOIN over all walk rows just to sum them.
 CREATE PERFETTO MACRO _viz_flamegraph_upwards_hash(
   source TableOrSubquery,
   filtered TableOrSubquery,
   accumulated TableOrSubquery,
-  grouping ColumnNameList,
   grouped ColumnNameList
 )
 RETURNS TableOrSubquery
@@ -216,8 +222,6 @@ AS (
     g.hash,
     g.parentHash,
     g.depth,
-    s.name,
-    __intrinsic_token_apply!(_viz_flamegraph_s_prefix, $grouping),
     __intrinsic_token_apply!(_viz_flamegraph_s_prefix, $grouped),
     f.value,
     g.cumulativeValue
@@ -240,13 +244,13 @@ AS (
   JOIN $filtered f USING (id)
 );
 
--- Computes the "fingerprint" of the path by walking from the laves
--- to the root.
+-- Computes the "fingerprint" of the path by walking from the roots to
+-- the leaves. Output mirrors _viz_flamegraph_upwards_hash (skinny - no
+-- name or |grouping| columns) for the same performance reasons.
 CREATE PERFETTO MACRO _viz_flamegraph_downwards_hash(
   source TableOrSubquery,
   filtered TableOrSubquery,
   accumulated TableOrSubquery,
-  grouping ColumnNameList,
   grouped ColumnNameList,
   showDownward Expr
 )
@@ -273,8 +277,6 @@ AS (
     g.hash,
     g.parentHash,
     g.depth,
-    s.name,
-    __intrinsic_token_apply!(_viz_flamegraph_s_prefix, $grouping),
     __intrinsic_token_apply!(_viz_flamegraph_s_prefix, $grouped),
     f.value,
     a.cumulativeValue
@@ -295,7 +297,6 @@ AS (
   JOIN $source s USING (id)
   JOIN $filtered f USING (id)
   JOIN $accumulated a USING (id)
-  ORDER BY hash
 );
 
 CREATE PERFETTO MACRO _col_list_id(a ColumnName)
@@ -304,35 +305,72 @@ RETURNS Expr AS $a;
 CREATE PERFETTO MACRO _col_list_null(a ColumnName)
 RETURNS _ProjectionFragment AS NULL AS $a;
 
--- Converts a table of hashes and paretn hashes into ids and parent
--- ids, grouping all hashes together.
-CREATE PERFETTO MACRO _viz_flamegraph_merge_hashes(
+CREATE PERFETTO MACRO _viz_flamegraph_g_prefix(col ColumnName)
+RETURNS Expr AS g.$col;
+
+-- Groups the hash table by hash, summing values and aggregating any
+-- |grouped_agged_exprs| (e.g. GROUP_CONCAT) across all walk rows in the
+-- group. Records MIN(c.id) as |rep_id| - any id with this hash will
+-- have the same |grouping| columns in source, so a single representative
+-- is sufficient for the _resolve_groups JOIN.
+--
+-- Caller MUST materialize this into a Perfetto table with an index on
+-- |hash| - _viz_flamegraph_resolve_groups self-joins on hash to compute
+-- parentId and that lookup must be O(log N).
+CREATE PERFETTO MACRO _viz_flamegraph_group_hashes(
   hashed TableOrSubquery,
-  grouping ColumnNameList,
   grouped_agged_exprs ColumnNameList
 )
 RETURNS TableOrSubquery
 AS (
   SELECT
     _auto_id AS id,
-    (
-      SELECT p._auto_id
-      FROM $hashed p
-      WHERE p.hash = c.parentHash
-      LIMIT 1
-    ) AS parentId,
-    depth,
-    name,
-    -- The grouping columns should be passed through as-is because the
-    -- hash took them into account: we would not merged any nodes where
-    -- the grouping columns were different.
-    __intrinsic_token_apply!(_col_list_id, $grouping),
+    MIN(c.id) AS rep_id,
+    c.hash,
+    MIN(c.parentHash) AS parentHash,
+    c.depth,
     __intrinsic_token_apply!(_col_list_id, $grouped_agged_exprs),
-    SUM(value) AS value,
-    SUM(cumulativeValue) AS cumulativeValue,
-    FALSE AS isPlaceholder
+    SUM(c.value) AS value,
+    SUM(c.cumulativeValue) AS cumulativeValue
   FROM $hashed c
-  GROUP BY hash
+  GROUP BY c.hash
+);
+
+-- Resolves a |grouped| table (output of _viz_flamegraph_group_hashes) into
+-- the merged tree. Self-joins on hash to compute parentId, and joins
+-- |source| on rep_id to recover name and the |grouping| columns. This
+-- replaces the per-walk-row source JOIN that the old single-pass
+-- _merge_hashes did - 4x fewer JOIN rows, since |grouped| has one row
+-- per unique hash rather than one per walk visit.
+--
+-- |grouped_cols| are pass-through references to the columns that were
+-- aggregated by _viz_flamegraph_group_hashes (their names, not the agg
+-- expressions).
+CREATE PERFETTO MACRO _viz_flamegraph_resolve_groups(
+  grouped TableOrSubquery,
+  source TableOrSubquery,
+  grouping ColumnNameList,
+  grouped_cols ColumnNameList
+)
+RETURNS TableOrSubquery
+AS (
+  SELECT
+    g.id,
+    p.id AS parentId,
+    g.depth,
+    s.name,
+    __intrinsic_token_apply!(_viz_flamegraph_s_prefix, $grouping),
+    __intrinsic_token_apply!(_viz_flamegraph_g_prefix, $grouped_cols),
+    g.value,
+    g.cumulativeValue,
+    FALSE AS isPlaceholder
+  FROM $grouped g
+  LEFT JOIN $grouped p ON p.hash = g.parentHash
+  JOIN $source s ON s.id = g.rep_id
+  -- Order by id so the resulting Perfetto table is dense in id-order;
+  -- downstream graph_aggregating_scan over (parentId, id) is sensitive
+  -- to non-sequential id storage (~5x slower without).
+  ORDER BY g.id
 );
 
 -- Per-node propagation pass for the trim. For each node in |merged| emits:

--- a/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
@@ -343,6 +343,11 @@ AS (
 -- _merge_hashes did - 4x fewer JOIN rows, since |grouped| has one row
 -- per unique hash rather than one per walk visit.
 --
+-- The parent's cumulativeValue is also carried through as
+-- |parentCumulativeValue|. It piggybacks on the LEFT JOIN already used
+-- for parentId, so it's essentially free here and lets
+-- _viz_flamegraph_global_layout avoid a LEFT JOIN of its own.
+--
 -- |grouped_cols| are pass-through references to the columns that were
 -- aggregated by _viz_flamegraph_group_hashes (their names, not the agg
 -- expressions).
@@ -363,6 +368,7 @@ AS (
     __intrinsic_token_apply!(_viz_flamegraph_g_prefix, $grouped_cols),
     g.value,
     g.cumulativeValue,
+    p.cumulativeValue AS parentCumulativeValue,
     FALSE AS isPlaceholder
   FROM $grouped g
   LEFT JOIN $grouped p ON p.hash = g.parentHash
@@ -373,16 +379,19 @@ AS (
   ORDER BY g.id
 );
 
--- Per-node propagation pass for the trim. For each node in |merged| emits:
---   alive       - whether the node itself survives the join thresholds.
+-- Per-node propagation pass for the trim. For each node visited, emits:
+--   alive       - whether the node survives the join thresholds.
 --   requiredCum - the cumulativeValue this node's CHILDREN must clear.
--- Roots are always alive and emit requiredCum = 0. A node that itself
--- failed the thresholds emits requiredCum = +inf, which kills its whole
--- subtree on the next step (no cumulativeValue can be >= +inf).
+-- Roots are always alive (seeded with requiredCum = 0). A node whose
+-- cumulativeValue < parent's requiredCum emits requiredCum = +inf, which
+-- kills its whole subtree on the next step.
 --
--- Computing |alive| inside the scan rather than via a downstream JOIN of
--- merged with propagated avoids an N x N pass over the merged tree, which
--- on WASM-sized inputs (millions of rows) was the dominant cost.
+-- The floor threshold |min_value| is applied by pre-filtering scan
+-- edges: only dest nodes whose cumulativeValue clears the floor are
+-- propagated. Sub-floor subtrees are naturally dead because scan
+-- output excludes unreachable nodes, which is what alive_set reads.
+-- This is ~12x faster than keeping the floor check inside the scan on
+-- large trees because the scan input shrinks proportionally.
 --
 -- Caller should materialize the result into a Perfetto table with an
 -- index on |id|, since _viz_flamegraph_trim_with_placeholder looks up
@@ -396,11 +405,16 @@ RETURNS TableOrSubquery
 AS (
   SELECT id, requiredCum, alive
   FROM _graph_aggregating_scan!(
+    -- Edge filter is the floor: exclude dest rows below min_value.
+    -- The scan can never reach them, so they end up implicitly dead.
     (
       SELECT m.parentId AS source_node_id, m.id AS dest_node_id
       FROM $merged m
       WHERE m.parentId IS NOT NULL
+        AND m.cumulativeValue >= $min_value
     ),
+    -- Roots stay alive regardless of floor (matches the prior semantic
+    -- where the init always seeded TRUE).
     (
       SELECT id, 0.0 AS requiredCum, TRUE AS alive
       FROM $merged WHERE parentId IS NULL
@@ -410,13 +424,11 @@ AS (
       SELECT
         x.id,
         IIF(
-          t.cumulativeValue >= x.incoming
-            AND t.cumulativeValue >= $min_value,
+          t.cumulativeValue >= x.incoming,
           $ratio * t.cumulativeValue,
           1e308
         ) AS requiredCum,
-        (t.cumulativeValue >= x.incoming
-            AND t.cumulativeValue >= $min_value) AS alive
+        (t.cumulativeValue >= x.incoming) AS alive
       FROM (
         SELECT id, MIN(requiredCum) AS incoming
         FROM $table
@@ -454,38 +466,47 @@ RETURNS TableOrSubquery
 AS (
   WITH _max_id AS (
     SELECT COALESCE(MAX(id), 0) AS v FROM $merged
+  ),
+  _unsorted AS (
+    SELECT
+      m.id, m.parentId, m.depth, m.name,
+      __intrinsic_token_apply!(_col_list_id, $grouping),
+      __intrinsic_token_apply!(_col_list_id, $grouped),
+      m.value, m.cumulativeValue, m.parentCumulativeValue,
+      FALSE AS isPlaceholder
+    FROM $merged m
+    JOIN $alive a USING (id)
+    UNION ALL
+    SELECT
+      (SELECT v FROM _max_id)
+        + ROW_NUMBER() OVER (ORDER BY d.parentId, (d.depth > 0)) AS id,
+      d.parentId,
+      -- All dropped children of one parent on one side of the root share
+      -- the same depth in a tree, so MIN/MAX/ANY are equivalent.
+      MIN(d.depth) AS depth,
+      '(merged)' AS name,
+      __intrinsic_token_apply!(_col_list_null, $grouping),
+      __intrinsic_token_apply!(_col_list_null, $grouped),
+      SUM(d.value) AS value,
+      SUM(d.cumulativeValue) AS cumulativeValue,
+      -- All dropped children of one parent share the same parent, so
+      -- MIN is just "any" here - we use it to stay inside GROUP BY.
+      MIN(d.parentCumulativeValue) AS parentCumulativeValue,
+      TRUE AS isPlaceholder
+    FROM $merged d
+    LEFT JOIN $alive a ON a.id = d.id
+    WHERE
+      a.id IS NULL
+      AND d.parentId IS NOT NULL
+      AND d.parentId IN (SELECT id FROM $alive)
+    -- A root node can have both upward and downward dropped subtrees;
+    -- keep them as separate placeholders since they sit on opposite sides.
+    GROUP BY d.parentId, (d.depth > 0)
   )
-  SELECT
-    m.id, m.parentId, m.depth, m.name,
-    __intrinsic_token_apply!(_col_list_id, $grouping),
-    __intrinsic_token_apply!(_col_list_id, $grouped),
-    m.value, m.cumulativeValue,
-    FALSE AS isPlaceholder
-  FROM $merged m
-  JOIN $alive a USING (id)
-  UNION ALL
-  SELECT
-    (SELECT v FROM _max_id)
-      + ROW_NUMBER() OVER (ORDER BY d.parentId, (d.depth > 0)) AS id,
-    d.parentId,
-    -- All dropped children of one parent on one side of the root share
-    -- the same depth in a tree, so MIN/MAX/ANY are equivalent.
-    MIN(d.depth) AS depth,
-    '(merged)' AS name,
-    __intrinsic_token_apply!(_col_list_null, $grouping),
-    __intrinsic_token_apply!(_col_list_null, $grouped),
-    SUM(d.value) AS value,
-    SUM(d.cumulativeValue) AS cumulativeValue,
-    TRUE AS isPlaceholder
-  FROM $merged d
-  LEFT JOIN $alive a ON a.id = d.id
-  WHERE
-    a.id IS NULL
-    AND d.parentId IS NOT NULL
-    AND d.parentId IN (SELECT id FROM $alive)
-  -- A root node can have both upward and downward dropped subtrees;
-  -- keep them as separate placeholders since they sit on opposite sides.
-  GROUP BY d.parentId, (d.depth > 0)
+  -- Order by id so the resulting Perfetto table is dense in id-order;
+  -- _viz_flamegraph_global_layout's graph_scan over (parentId, id) is
+  -- sensitive to non-sequential id storage (~5x slower without).
+  SELECT * FROM _unsorted ORDER BY id
 );
 
 -- Performs a "layout" of nodes in the flamegraph relative to their
@@ -542,7 +563,7 @@ AS (
     __intrinsic_token_apply!(_viz_flamegraph_s_prefix, $grouped),
     s.value AS selfValue,
     s.cumulativeValue,
-    p.cumulativeValue AS parentCumulativeValue,
+    s.parentCumulativeValue,
     s.depth,
     g.xStart,
     g.xEnd,
@@ -562,6 +583,5 @@ AS (
     )
   ) g
   JOIN $merged s USING (id)
-  LEFT JOIN $merged p ON s.parentId = p.id
   ORDER BY rootDistance, xStart
 );

--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -436,6 +436,11 @@ async function computeFlamegraphTree(
       `,
     }),
   );
+  // The hash macros now emit a skinny output (no name / |grouping|
+  // columns). Those are filled in later in resolve_groups against the
+  // per-merged-row representative, which is ~4x cheaper than joining at
+  // every walk row. We deliberately skip ORDER BY here - the grouping
+  // step uses a hash index instead.
   disposable.use(
     await createPerfettoTable({
       engine,
@@ -446,7 +451,6 @@ async function computeFlamegraphTree(
           _flamegraph_source_${uuid},
           _flamegraph_filtered_${uuid},
           _flamegraph_accumulated_${uuid},
-          ${groupingColumns},
           ${groupedColumns},
           ${view.kind === 'BOTTOM_UP' ? 'FALSE' : 'TRUE'}
         )
@@ -456,11 +460,38 @@ async function computeFlamegraphTree(
           _flamegraph_source_${uuid},
           _flamegraph_filtered_${uuid},
           _flamegraph_accumulated_${uuid},
-          ${groupingColumns},
           ${groupedColumns}
         )
-        order by hash
       `,
+    }),
+  );
+  disposable.use(
+    await createPerfettoIndex({
+      engine,
+      name: `_flamegraph_hash_${uuid}_index`,
+      on: `_flamegraph_hash_${uuid}(hash)`,
+    }),
+  );
+  // Group hashes into one row per unique hash. Index on hash so that
+  // resolve_groups can self-join in O(N log N) for parentId resolution.
+  disposable.use(
+    await createPerfettoTable({
+      engine,
+      name: `_flamegraph_grouped_${uuid}`,
+      as: `
+        select *
+        from _viz_flamegraph_group_hashes!(
+          _flamegraph_hash_${uuid},
+          ${computeGroupedAggExprs(agg)}
+        )
+      `,
+    }),
+  );
+  disposable.use(
+    await createPerfettoIndex({
+      engine,
+      name: `_flamegraph_grouped_${uuid}_index`,
+      on: `_flamegraph_grouped_${uuid}(hash)`,
     }),
   );
   disposable.use(
@@ -469,10 +500,11 @@ async function computeFlamegraphTree(
       name: `_flamegraph_merged_${uuid}`,
       as: `
         select *
-        from _viz_flamegraph_merge_hashes!(
-          _flamegraph_hash_${uuid},
+        from _viz_flamegraph_resolve_groups!(
+          _flamegraph_grouped_${uuid},
+          _flamegraph_source_${uuid},
           ${groupingColumns},
-          ${computeGroupedAggExprs(agg)}
+          ${groupedColumns}
         )
       `,
     }),

--- a/ui/src/components/query_flamegraph.ts
+++ b/ui/src/components/query_flamegraph.ts
@@ -441,20 +441,16 @@ async function computeFlamegraphTree(
   // per-merged-row representative, which is ~4x cheaper than joining at
   // every walk row. We deliberately skip ORDER BY here - the grouping
   // step uses a hash index instead.
-  disposable.use(
-    await createPerfettoTable({
-      engine,
-      name: `_flamegraph_hash_${uuid}`,
-      as: `
-        select *
-        from _viz_flamegraph_downwards_hash!(
-          _flamegraph_source_${uuid},
-          _flamegraph_filtered_${uuid},
-          _flamegraph_accumulated_${uuid},
-          ${groupedColumns},
-          ${view.kind === 'BOTTOM_UP' ? 'FALSE' : 'TRUE'}
-        )
-        union all
+  //
+  // Only one of upwards/downwards is non-empty for a given view:
+  //   BOTTOM_UP: upwards_hash has pivot-seeded inits, downwards_hash
+  //              is empty (showDownward=FALSE).
+  //   TOP_DOWN:  downwards_hash has root-seeded inits, upwards_hash is
+  //              empty (no rows match the pivot filter).
+  // So we skip the empty side entirely to avoid its graph_scan setup.
+  const hashWalkSql =
+    view.kind === 'BOTTOM_UP'
+      ? `
         select *
         from _viz_flamegraph_upwards_hash!(
           _flamegraph_source_${uuid},
@@ -462,7 +458,22 @@ async function computeFlamegraphTree(
           _flamegraph_accumulated_${uuid},
           ${groupedColumns}
         )
-      `,
+      `
+      : `
+        select *
+        from _viz_flamegraph_downwards_hash!(
+          _flamegraph_source_${uuid},
+          _flamegraph_filtered_${uuid},
+          _flamegraph_accumulated_${uuid},
+          ${groupedColumns},
+          TRUE
+        )
+      `;
+  disposable.use(
+    await createPerfettoTable({
+      engine,
+      name: `_flamegraph_hash_${uuid}`,
+      as: hashWalkSql,
     }),
   );
   disposable.use(


### PR DESCRIPTION
## Summary

Stacks two flamegraph perf commits on top of #5568 (trim + alive-fold):

1. **Restructure flamegraph hash + merge for ~22% speedup on bottom-up** (7faf26cb85) — skinny hash walk + materialized grouped + self-JOIN for parentId. -15s on the hash step, small positive on merged, bit-identical output.
2. **Three more wins: skip empty walk, pre-floor trim, parentCum** (3da067ae39) — skip the no-op UNION side in the hash walk for single-direction views, apply the trim floor as a scan edge filter (8.4M -> 108K rows, propagation 12.6s -> 1.0s), and precompute parentCumulativeValue through merged so global_layout reads it directly (13.2s -> 1.0s).

Combined on a large heap-graph trace: ~25s saved native, ~75-100s saved WASM, all three bit-identical to baseline. Full rationale + per-step measurements in the commit messages and in /tmp/claude/flamegraph_perf_journal.md.

## Test plan

- [x] `tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell` (1356 tests pass)
- [x] A/B on full bottom-up pipeline on the real heap-graph trace: bit-identical output, -25s total
- [ ] CI green

Stacked on #5568 — merge that first.