### PR TITLE
Clarify memory profiling features

### DIFF
--- a/docs/data-sources/java-heap-profiler.md
+++ b/docs/data-sources/java-heap-profiler.md
@@ -1,21 +1,26 @@
-# Memory: Java heap dumps
+# Memory: ART Heap Dumps for Java/Kotlin Heap
 
-NOTE: Capturing Java heap dumps requires Android 11 or higher
+NOTE: Capturing Heap dumps requires Android 11 or higher
+
+NOTE: Perfetto ART Heap Dumps are distinct from standard JVM / HPROF heap
+dumps. Unlike HPROF dumps, these only contain the reference graph - not the
+data within objects.
 
 See the [Memory Guide](/docs/case-studies/memory.md#java-hprof) for getting
-started with Java heap dumps.
+started with ART (Android RunTime) heap dumps.
 
-Conversely from [Native heap profiles](native-heap-profiler.md), Java heap dumps
-report full retention graphs of managed objects but not call-stacks. The
-information recorded in a Java heap dump is of the form: _Object X retains
+Conversely from [heap profiles](native-heap-profiler.md), heap dumps report
+full retention graphs of Java objects but not call-stacks. The information
+recorded in a heap dump is of the form: _Object X retains
 object Y, which is N bytes large, through its class member named Z_.
 
-Java heap dumps are not to be confused with profiles taken by the
-[Java heap sampler](native-heap-profiler.md#java-heap-sampling)
+Heap dumps are not to be confused with profiles taken by the
+[Java Allocation Profiling](native-heap-profiler.md#java-heap-sampling), which
+records allocation events / call stacks.
 
 ## UI
 
-Heap graph dumps are shown as flamegraphs in the UI after clicking on the
+Heap dumps are shown as flamegraphs in the UI after clicking on the
 diamond in the _"Heap Profile"_ track of a process. Each diamond corresponds to
 a heap dump.
 

--- a/docs/data-sources/native-heap-profiler.md
+++ b/docs/data-sources/native-heap-profiler.md
@@ -1,4 +1,4 @@
-# Heap profiler
+# Memory: Callstack-based Allocation Profiling
 
 NOTE: **heapprofd requires Android 10 or higher**
 
@@ -254,11 +254,11 @@ the `<application>` section of the app manifest.
 </manifest>
 ```
 
-## {#java-heap-sampling} Java heap sampling
+## {#java-heap-sampling} Java Allocation Profiling (Churn Profiling)
 
-NOTE: **Java heap sampling is available on Android 12 or higher**
+NOTE: **Java allocation profiling is available on Android 12 or higher**
 
-NOTE: **Java heap sampling is not to be confused with [Java heap
+NOTE: **Java allocation profiling is not to be confused with [Heap
 dumps](/docs/data-sources/java-heap-profiler.md)**
 
 Heapprofd can be configured to track Java allocations instead of native ones.

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -66,8 +66,8 @@
     - [Memory](#)
 
       - [Memory Counters](data-sources/memory-counters.md) {.tag-android .tag-linux}
-      - [Native Heap Profiler](data-sources/native-heap-profiler.md) {.tag-android .tag-linux}
-      - [Java Heap Dumps](data-sources/java-heap-profiler.md) {.tag-android}
+      - [Allocation Profiler](data-sources/native-heap-profiler.md) {.tag-android .tag-linux}
+      - [ART Heap Dumps](data-sources/java-heap-profiler.md) {.tag-android}
 
     - [Android](#)
 


### PR DESCRIPTION
* Retitle Java Heap Dumps -> ART Heap Dumps, and more clearly differentiate these from .hprof files

* Retitle native heap profiling -> Allocation Profiling, since allocation is the important term here to explain what it does, and it's not native specific

* Leave filenames and links working

* Update TOC

