### PR TITLE
perfetto: document trace_processor & traceconv on Windows

### DIFF
--- a/docs/analysis/trace-processor.md
+++ b/docs/analysis/trace-processor.md
@@ -16,22 +16,50 @@ library, providing a convenient way to interactively analyze traces.
 
 ### Downloading the shell
 
-The shell can be downloaded from the Perfetto website:
+The shell can be downloaded from the Perfetto website. The download is a thin
+Python wrapper that fetches and caches the correct native binary for your
+platform (including `trace_processor_shell.exe` on Windows) under
+`~/.local/share/perfetto/prebuilts` on first use.
+
+<?tabs>
+
+TAB: Linux / macOS
 
 ```bash
-# Download prebuilts (Linux and Mac only)
 curl -LO https://get.perfetto.dev/trace_processor
 chmod +x ./trace_processor
 ```
+
+TAB: Windows
+
+```powershell
+curl.exe -LO https://get.perfetto.dev/trace_processor
+```
+
+Python 3 is required to run the wrapper script. `curl` ships with Windows 10
+and later.
+
+</tabs?>
 
 ### Running the shell
 
 Once downloaded, you can immediately use it to open a trace file:
 
+<?tabs>
+
+TAB: Linux / macOS
+
 ```bash
-# Start the interactive shell
 ./trace_processor trace.perfetto-trace
 ```
+
+TAB: Windows
+
+```powershell
+python trace_processor trace.perfetto-trace
+```
+
+</tabs?>
 
 This will open an interactive SQL shell where you can query the trace. For
 more information on how to write queries, see the

--- a/docs/quickstart/traceconv.md
+++ b/docs/quickstart/traceconv.md
@@ -30,18 +30,24 @@ utilities.
 
 To use the latest binaries:
 
+<?tabs>
+
+TAB: Linux / macOS
+
 ```bash
-# Linux / macOS
 curl -LO https://get.perfetto.dev/traceconv
 chmod +x traceconv
 ./traceconv MODE [OPTIONS] [input_file] [output_file]
 ```
 
+TAB: Windows
+
 ```powershell
-# Windows
 curl.exe -LO https://get.perfetto.dev/traceconv
 python traceconv MODE [OPTIONS] [input_file] [output_file]
 ```
+
+</tabs?>
 
 The `traceconv` script is a thin Python wrapper that downloads and caches
 the correct native binary for your platform (including `traceconv.exe` on


### PR DESCRIPTION
The trace_processor download instructions used to claim "Linux and Mac
only", but the Python wrapper at get.perfetto.dev/trace_processor in
fact fetches trace_processor_shell.exe on Windows just fine. Replace
the misleading note with proper OS tabs (mirroring traceconv) so the
Windows command is documented alongside Linux/macOS.

Also wrap the existing Linux/macOS and Windows code blocks in the
traceconv quickstart with the same <?tabs> markup used elsewhere in
the docs, instead of stacking them as separate code blocks.
