### PR TITLE
tp: fix OOB read in DebugAnnotationParser DICT parsing

### DIFF
--- a/src/trace_processor/util/debug_annotation_parser.cc
+++ b/src/trace_processor/util/debug_annotation_parser.cc
@@ -304,13 +304,18 @@ DebugAnnotationParser::ParseResult DebugAnnotationParser::ParseNestedValueArgs(
           uint32_t count = 0;
           auto keys = item.decoder.dict_keys();
           auto values = item.decoder.dict_values();
-          for (; keys; ++keys, ++values, ++count) {
-            PERFETTO_DCHECK(values);
+          for (; keys && values; ++keys, ++values, ++count) {
             protozero::ConstChars k = *keys;
             nested_storage.emplace_back(NestedItem{
                 SanitizeDebugAnnotationName(k.ToStdStringView()),
                 *values,
             });
+          }
+          if (keys || values) {
+            return {
+                base::ErrStatus("Nested debug annotation DICT has mismatched "
+                                "dict_keys and dict_values counts"),
+                added_entry};
           }
           item.nested_count = count;
           item.first_pass_done = true;

--- a/src/trace_processor/util/debug_annotation_parser_unittest.cc
+++ b/src/trace_processor/util/debug_annotation_parser_unittest.cc
@@ -302,6 +302,66 @@ TEST_F(DebugAnnotationParserTest, TypedMessageInsideUntyped) {
                           "root.field_string root.field_string value"));
 }
 
+TEST_F(DebugAnnotationParserTest, NestedValueDictMismatchedKeysAndValues) {
+  protozero::HeapBuffered<protos::pbzero::DebugAnnotation> msg;
+  msg->set_name("root");
+  auto* nested = msg->set_nested_value();
+  nested->set_nested_type(protos::pbzero::DebugAnnotation::NestedValue::DICT);
+  nested->add_dict_keys("k1");
+  nested->add_dict_keys("k2");
+  nested->add_dict_keys("k3");
+  auto* v1 = nested->add_dict_values();
+  v1->set_int_value(1);
+
+  DescriptorPool pool;
+  ProtoToArgsParser args_parser(pool);
+  DebugAnnotationParser parser(args_parser);
+
+  base::Status status = ParseDebugAnnotation(parser, msg, *this);
+  EXPECT_FALSE(status.ok());
+}
+
+TEST_F(DebugAnnotationParserTest, NestedValueDictMoreValuesThanKeys) {
+  protozero::HeapBuffered<protos::pbzero::DebugAnnotation> msg;
+  msg->set_name("root");
+  auto* nested = msg->set_nested_value();
+  nested->set_nested_type(protos::pbzero::DebugAnnotation::NestedValue::DICT);
+  nested->add_dict_keys("k1");
+  auto* v1 = nested->add_dict_values();
+  v1->set_int_value(1);
+  auto* v2 = nested->add_dict_values();
+  v2->set_int_value(2);
+
+  DescriptorPool pool;
+  ProtoToArgsParser args_parser(pool);
+  DebugAnnotationParser parser(args_parser);
+
+  base::Status status = ParseDebugAnnotation(parser, msg, *this);
+  EXPECT_FALSE(status.ok());
+}
+
+TEST_F(DebugAnnotationParserTest, NestedValueDictMatchedKeysAndValues) {
+  protozero::HeapBuffered<protos::pbzero::DebugAnnotation> msg;
+  msg->set_name("root");
+  auto* nested = msg->set_nested_value();
+  nested->set_nested_type(protos::pbzero::DebugAnnotation::NestedValue::DICT);
+  nested->add_dict_keys("k1");
+  nested->add_dict_keys("k2");
+  auto* v1 = nested->add_dict_values();
+  v1->set_int_value(1);
+  auto* v2 = nested->add_dict_values();
+  v2->set_int_value(2);
+
+  DescriptorPool pool;
+  ProtoToArgsParser args_parser(pool);
+  DebugAnnotationParser parser(args_parser);
+
+  base::Status status = ParseDebugAnnotation(parser, msg, *this);
+  EXPECT_TRUE(status.ok()) << status.message();
+  EXPECT_THAT(args(),
+              testing::ElementsAre("root.k1 root.k1 1", "root.k2 root.k2 2"));
+}
+
 TEST_F(DebugAnnotationParserTest, InternedString) {
   protozero::HeapBuffered<protos::pbzero::DebugAnnotation> msg;
   msg->set_name("root");


### PR DESCRIPTION
ParseNestedValueArgs iterated dict_keys and dict_values in lockstep
but only checked the keys iterator in the loop condition. A malformed
NestedValue with more keys than values caused the values iterator to
be advanced past end_, after which the next dereference triggered an
unbounded memory scan in RepeatedFieldIterator::FindNextMatchingId.

Gate the loop on both iterators and return an error if the two
repeated fields end up with mismatched lengths, so a malformed packet
is rejected rather than silently truncated or, worse, parsed past the
end of the field storage.
