### PR TITLE
perfetto: reserve TracePacket.service_event in SMB validator

### DIFF
--- a/src/tracing/service/packet_stream_validator.cc
+++ b/src/tracing/service/packet_stream_validator.cc
@@ -41,6 +41,7 @@ const uint32_t kReservedFieldIds[] = {
     protos::pbzero::TracePacket::kSynchronizationMarkerFieldNumber,
     protos::pbzero::TracePacket::kTrustedPidFieldNumber,
     protos::pbzero::TracePacket::kMachineIdFieldNumber,
+    protos::pbzero::TracePacket::kServiceEventFieldNumber,
 };
 
 // This translation unit is quite subtle and perf-sensitive. Remember to check

--- a/src/tracing/service/packet_stream_validator_unittest.cc
+++ b/src/tracing/service/packet_stream_validator_unittest.cc
@@ -21,6 +21,7 @@
 #include "protos/perfetto/trace/ftrace/ftrace_event.gen.h"
 #include "protos/perfetto/trace/ftrace/ftrace_event_bundle.gen.h"
 #include "protos/perfetto/trace/ftrace/sched.gen.h"
+#include "protos/perfetto/trace/perfetto/tracing_service_event.gen.h"
 #include "protos/perfetto/trace/test_event.gen.h"
 #include "protos/perfetto/trace/trace_packet.gen.h"
 #include "test/gtest_and_gmock.h"
@@ -194,6 +195,16 @@ TEST(PacketStreamValidatorTest, SimplePacketWithMachineID) {
 TEST(PacketStreamValidatorTest, SimplePacketWithZeroMachineID) {
   protos::gen::TracePacket proto;
   proto.set_machine_id(0);
+  std::string ser_buf = proto.SerializeAsString();
+
+  Slices seq;
+  seq.emplace_back(&ser_buf[0], ser_buf.size());
+  EXPECT_FALSE(PacketStreamValidator::Validate(seq));
+}
+
+TEST(PacketStreamValidatorTest, SimplePacketWithServiceEvent) {
+  protos::gen::TracePacket proto;
+  proto.mutable_service_event()->set_flush_started(true);
   std::string ser_buf = proto.SerializeAsString();
 
   Slices seq;


### PR DESCRIPTION
Add TracePacket::kServiceEventFieldNumber (= 69) to the
PacketStreamValidator's reserved field list so a compromised producer
cannot forge tracing service events (flush_started,
read_tracing_buffers_completed, all_data_sources_flushed, etc.) into
the SMB. The service synthesizes these packets by writing directly
into the trace buffer and bypasses this validator, so the change is
purely additive.

This does not replace downstream defenses against adversarial bytes
in offline traces or other ingestion paths, but it removes the
in-process attack surface from untrusted producers.
