### PR TITLE
tp: fix stack OOB write in ParseChromeEvents Chrome metadata key

### DIFF
--- a/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
+++ b/src/trace_processor/importers/proto/proto_trace_parser_impl.cc
@@ -175,18 +175,18 @@ void ProtoTraceParserImpl::ParseChromeEvents(int64_t ts, ConstBytes blob) {
       StringId name_id = storage->InternString(metadata.name());
       args.AddArgsTo(id).AddArg(name_id, value);
 
-      char buffer[2048];
-      base::FixedStringWriter writer(buffer, sizeof(buffer));
-      writer.AppendString("cr-");
+      // metadata.name() comes from the trace and is untrusted/unbounded,
+      // so we build the key on the heap rather than a fixed stack buffer.
+      std::string key = "cr-";
       // If we have data from multiple Chrome instances, append a suffix
       // to differentiate them.
       if (bundle_index > 1) {
-        writer.AppendUnsignedInt(bundle_index);
-        writer.AppendChar('-');
+        key += std::to_string(bundle_index);
+        key += '-';
       }
-      writer.AppendString(metadata.name());
+      key.append(metadata.name().data, metadata.name().size);
 
-      auto metadata_id = storage->InternString(writer.GetStringView());
+      auto metadata_id = storage->InternString(base::StringView(key));
       context_->metadata_tracker->SetDynamicMetadata(metadata_id, value);
     }
   }


### PR DESCRIPTION
ParseChromeEvents built a "cr-[<index>-]<name>" key for each
ChromeMetadata entry into a fixed 2048-byte stack buffer via
FixedStringWriter, whose only bounds check is PERFETTO_DCHECK (a no-op
in release). Since metadata.name() can theoretically be arbitrary size,
an oversized name causes an out-of-bounds memcpy past
the buffer, corrupting adjacent stack state (e.g. the ArgsTracker
declared earlier in the function) before the stack canary is checked.

Build the key into a std::string instead. Not a hot path (a handful of
metadata entries per trace), so the heap allocation is negligible.
