### PR TITLE
tp: stop mutating PacketSequenceStateGeneration on packet loss

### DIFF
--- a/src/trace_processor/importers/proto/packet_sequence_state_generation.cc
+++ b/src/trace_processor/importers/proto/packet_sequence_state_generation.cc
@@ -39,7 +39,7 @@ PacketSequenceStateGeneration::PacketSequenceStateGeneration(
     InternedFieldMap interned_data,
     TrackEventSequenceState track_event_sequence_state,
     CustomStateArray custom_state,
-    TraceBlobView trace_packet_defaults,
+    std::optional<InternedMessageView> trace_packet_defaults,
     bool is_incremental_state_valid)
     : context_(context),
       interned_data_(std::move(interned_data)),
@@ -56,15 +56,18 @@ PacketSequenceStateGeneration::PacketSequenceStateGeneration(
 
 RefPtr<PacketSequenceStateGeneration>
 PacketSequenceStateGeneration::OnPacketLoss() {
-  // No need to increment the generation. If any future packet depends on
-  // previous messages to update the incremental state its packet (if the
-  // DataSource is behaving correctly) would have the
-  // SEQ_NEEDS_INCREMENTAL_STATE bit set and such a packet will be dropped by
-  // the ProtoTraceReader and never make it far enough to update any incremental
-  // state.
-  track_event_sequence_state_.OnPacketLoss();
-  is_incremental_state_valid_ = false;
-  return RefPtr<PacketSequenceStateGeneration>(this);
+  // Don't mutate `this`: it may be held by the TraceSorter for buffered
+  // packets that were tokenized while the sequence was valid. Mutating in
+  // place would retroactively flip their view on those buffered packets.
+  // Instead, return a new generation that shares the per-interval state
+  // (interned data, custom state, persistent thread descriptor) but resets
+  // delta-encoded track-event state, since incremental values cannot be
+  // safely carried across the lost run of packets.
+  return RefPtr<PacketSequenceStateGeneration>(
+      new PacketSequenceStateGeneration(
+          context_, interned_data_, track_event_sequence_state_.OnPacketLoss(),
+          custom_state_, trace_packet_defaults_,
+          /* is_incremental_state_valid */ false));
 }
 
 RefPtr<PacketSequenceStateGeneration>
@@ -82,7 +85,7 @@ PacketSequenceStateGeneration::OnNewTracePacketDefaults(
       new PacketSequenceStateGeneration(
           context_, interned_data_,
           track_event_sequence_state_.OnIncrementalStateCleared(),
-          custom_state_, std::move(trace_packet_defaults),
+          custom_state_, InternedMessageView(std::move(trace_packet_defaults)),
           is_incremental_state_valid_));
 }
 

--- a/src/trace_processor/importers/proto/packet_sequence_state_generation.h
+++ b/src/trace_processor/importers/proto/packet_sequence_state_generation.h
@@ -288,7 +288,7 @@ class PacketSequenceStateGeneration : public RefCounted {
       InternedFieldMap interned_data,
       TrackEventSequenceState track_event_sequence_state,
       CustomStateArray custom_state,
-      TraceBlobView trace_packet_defaults,
+      std::optional<InternedMessageView> trace_packet_defaults,
       bool is_incremental_state_valid);
 
   // Add an interned message to this incremental state view. This can only be

--- a/src/trace_processor/importers/proto/track_event_sequence_state.h
+++ b/src/trace_processor/importers/proto/track_event_sequence_state.h
@@ -32,11 +32,17 @@ class TrackEventSequenceState {
     return TrackEventSequenceState(PersistentState());
   }
 
-  TrackEventSequenceState OnIncrementalStateCleared() {
+  // Returns a successor for use after packet loss. Persistent state (pid/tid)
+  // is preserved; delta-encoded state (running reference timestamps,
+  // incremental counter values, the timestamps_valid flag) is reset because
+  // those values are tied to the run of packets that we just lost.
+  TrackEventSequenceState OnPacketLoss() const {
     return TrackEventSequenceState(persistent_state_);
   }
 
-  void OnPacketLoss() { timestamps_valid_ = false; }
+  TrackEventSequenceState OnIncrementalStateCleared() const {
+    return TrackEventSequenceState(persistent_state_);
+  }
 
   bool pid_and_tid_valid() const { return persistent_state_.pid_and_tid_valid; }
 


### PR DESCRIPTION
`PacketSequenceStateGeneration::OnPacketLoss()` previously mutated `this` (flipping `is_incremental_state_valid_` and the track-event delta state's `timestamps_valid_`) and returned `RefPtr(this)`. The TraceSorter holds RefPtrs to the same generation for buffered packets that were tokenized while the sequence was valid, so the in-place flip was retroactively visible from those RefPtrs. No current reader observes the mutation through a buffered RefPtr, but that is incidental — anything added in the future that consults the generation's validity from the parser side would see a stale, retroactively-invalidated view.

Make `OnPacketLoss()` return a new generation instead, sharing the per-interval state (interned data, custom states, persistent thread descriptor) with the previous one but with the validity bits cleared and delta-encoded track-event state reset. Buffered packets retain the view they had at tokenization time; the Builder swaps its current generation to the new instance so subsequent tokenizations see the cleared state.

To support this, replace `TrackEventSequenceState::OnPacketLoss()` (which mutated `timestamps_valid_` in place) with a value-returning form that produces a fresh successor with persistent state preserved and delta state reset. Incremental counter values and running reference timestamps cannot be carried across the lost run of packets, so they are dropped along with `timestamps_valid_`.

The full PSSG constructor's `trace_packet_defaults` parameter changes from `TraceBlobView` to `std::optional<InternedMessageView>` so OnPacketLoss can pass the existing defaults through without having to reach inside the optional and reconstruct the view.

---

**Stack:**
- **#5588 — tp: stop mutating PacketSequenceStateGeneration on packet loss** (this PR)
- #5590 — tp: split TrackEventSequenceState into descriptor + delta state
- #5593 — tp: extract IncrementalState to fix CustomState UAF
