### PR TITLE
perfetto: attempt to fix MSVC link error for TrackEventDataSource

### DIFF
--- a/src/tracing/internal/track_event_internal.cc
+++ b/src/tracing/internal/track_event_internal.cc
@@ -649,10 +649,12 @@ void TrackEventDataSource::OnStart(const DataSourceBase::StartArgs& args) {
 }
 
 }  // namespace internal
+}  // namespace perfetto
 
+// Must be at global scope to match the matching DECLARE in
+// track_event_data_source.h. MSVC otherwise fails to link the explicit
+// specialization (issue #5591).
 PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS_WITH_ATTRS(
     PERFETTO_EXPORT_COMPONENT,
     perfetto::internal::TrackEventDataSource,
     perfetto::internal::TrackEventDataSourceTraits);
-
-}  // namespace perfetto


### PR DESCRIPTION
Move the explicit-specialization definition of DataSourceHelper<TrackEventDataSource, ...>::type() to global scope
so it matches the scope of the corresponding DECLARE in track_event_data_source.h.

I've not actually confirmed that this fixes the issue but it does seem suspicious given that Clang/GCC don't complain about this and, in general, MSVC is a lot more picky about linking than them.

Fixes #5591.
