### PR TITLE
ui: GpuCompute plugin: performance improvements and bug fixes

### DIFF
--- a/ui/src/plugins/com.meta.GpuCompute/details.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/details.ts
@@ -262,8 +262,12 @@ function kernelQueryBody(ctx: GpuComputeContext): string {
     FROM gpu_slice s
     INNER JOIN gpu_track tr ON tr.id = s.track_id
     LEFT JOIN counter c ON c.ts >= s.ts AND c.ts < s.ts + s.dur
+      AND c.track_id IN (
+        SELECT gc_tc.id FROM gpu_counter_track gc_tc
+        INNER JOIN gpu_counter_group gc ON gc.track_id = gc_tc.id
+          AND gc.group_id = ${COMPUTE_COUNTER_GROUP_ID}
+      )
     LEFT JOIN gpu_counter_track tc ON tc.id = c.track_id
-    LEFT JOIN gpu_counter_group gc ON gc.track_id = tc.id AND gc.group_id = ${COMPUTE_COUNTER_GROUP_ID}
   `;
 }
 
@@ -275,7 +279,6 @@ export function buildKernelQuery(
   const whereFilter = `
     WHERE s.render_stage_category = ${COMPUTE_RENDER_STAGE_CATEGORY}
       AND s.id = ${sliceIdFilter}
-      AND (gc.group_id IS NOT NULL OR c.id IS NULL)
     GROUP BY kernel_id, metric_label
   `;
 
@@ -810,8 +813,11 @@ function loadMetricData(
       FROM gpu_slice s
       INNER JOIN gpu_track tr ON tr.id = s.track_id
       INNER JOIN counter c ON c.ts >= s.ts AND c.ts < s.ts + s.dur
-      INNER JOIN gpu_counter_track tc ON tc.id = c.track_id
-      INNER JOIN gpu_counter_group gc ON gc.track_id = tc.id AND gc.group_id = ${COMPUTE_COUNTER_GROUP_ID}
+        AND c.track_id IN (
+          SELECT gc_tc.id FROM gpu_counter_track gc_tc
+          INNER JOIN gpu_counter_group gc ON gc.track_id = gc_tc.id
+            AND gc.group_id = ${COMPUTE_COUNTER_GROUP_ID}
+        )
       WHERE s.render_stage_category = ${COMPUTE_RENDER_STAGE_CATEGORY}
       LIMIT 1;
     `;
@@ -899,10 +905,11 @@ export const KernelMetricsSection: m.Component<
           baselineLookup,
         });
 
-      // Built-in sections are always registered, so this should never
-      // be empty. Assert rather than showing a placeholder.
       if (kernel.sections.length === 0) {
-        throw new Error('GpuCompute: no sections registered');
+        return m(
+          '.pf-gpu-compute__pad',
+          m('p', 'No detailed metrics available for this kernel.'),
+        );
       }
 
       return (

--- a/ui/src/plugins/com.meta.GpuCompute/details.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/details.ts
@@ -21,7 +21,6 @@
 // optional baseline comparison and per-section analysis.
 //
 // Key exports:
-// - {@link fetchKernelLaunchList} — populates the toolbar's Results dropdown
 // - {@link fetchSelectedKernelMetricData} — loads full metric data for a slice
 // - {@link KernelMetricsSection} — top-level Mithril component for the tab
 // - {@link renderPercentBar}, {@link renderMetricResultTable},
@@ -292,37 +291,6 @@ export function buildKernelQuery(
 // =============================================================================
 // Data fetching
 // =============================================================================
-
-// Fetches the list of compute kernel launches for the Results dropdown.
-// Returns one entry per launch, ordered by timestamp.
-export async function fetchKernelLaunchList(
-  engine: QueryCapable,
-): Promise<KernelLaunchOption[]> {
-  const sql = `
-    SELECT
-      s.id AS id,
-      COALESCE(
-        EXTRACT_ARG(s.arg_set_id, 'kernel_demangled_name'),
-        EXTRACT_ARG(s.arg_set_id, 'kernel_name'),
-        s.name
-      ) AS kname
-    FROM gpu_slice s
-    INNER JOIN gpu_track tr ON tr.id = s.track_id
-    WHERE s.render_stage_category = ${COMPUTE_RENDER_STAGE_CATEGORY}
-    ORDER BY s.ts ASC;
-  `;
-  const result = await engine.query(sql);
-  const iter = result.iter({});
-  const list: KernelLaunchOption[] = [];
-  while (iter.valid()) {
-    list.push({
-      id: Number(iter.get('id')),
-      label: String(iter.get('kname')),
-    });
-    iter.next();
-  }
-  return list;
-}
 
 // =============================================================================
 // Row reduction — SQL iterator → KernelGroup map

--- a/ui/src/plugins/com.meta.GpuCompute/index.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/index.ts
@@ -76,6 +76,7 @@ class Compute {
   private sliceId: number | undefined = -1;
   private options: KernelLaunchOption[] = [];
   private summaryRows: SummaryRow[] = [];
+  private knownKernelIds = new Set<number>();
 
   // Selection-driven metric fetching via QuerySlot. Selection changes
   // trigger mithril redraws; render() reads the current selection and
@@ -141,6 +142,7 @@ class Compute {
   public async setSliceId(sliceId: number, suppressAutoDetails = false) {
     const firstId = this.options[0]?.id ?? -1;
     this.sliceId = sliceId !== -1 ? sliceId : firstId;
+    const requestedSliceId = this.sliceId;
 
     if (this.sliceId === -1) {
       this.setToolbarInfo(undefined);
@@ -154,6 +156,9 @@ class Compute {
         this.engine,
         this.sliceId,
       );
+      // Guard against stale async completions: if the sliceId changed
+      // while the query was in flight, discard the result.
+      if (this.sliceId !== requestedSliceId) return;
       const hasMetrics = Array.isArray(data) && data.length > 0;
       this.setToolbarInfo(hasMetrics ? data[0].toolbar : undefined);
       if (!hasMetrics) {
@@ -220,6 +225,7 @@ class Compute {
   // Updates the "Results" dropdown with new launch options
   public setOptions(opts: KernelLaunchOption[]) {
     this.options = opts;
+    this.knownKernelIds = new Set(opts.map((o) => o.id));
   }
 
   public setSummaryRows(rows: SummaryRow[]) {
@@ -256,6 +262,17 @@ class Compute {
     if (selSliceId !== undefined) {
       this.hadSelection = true;
       const id = selSliceId;
+      const isKnownKernel = this.knownKernelIds.has(id);
+
+      // Show the tab immediately for known kernels so the user doesn't
+      // see a flicker to the "Current Selection" tab while the async
+      // metric query is in flight.
+      if (isKnownKernel && this.appliedSelectionSliceId !== selSliceId) {
+        this.sliceId = selSliceId;
+        this.ctx.activeInfoTab = 'details';
+        this.trace.tabs.showTab(this.tabUri);
+      }
+
       const result = this.selectionSlot.use({
         key: {sliceId: id},
         queryFn: async () => {
@@ -277,9 +294,7 @@ class Compute {
         if (result.data.hasMetrics) {
           this.sliceId = selSliceId;
           this.setToolbarInfo(result.data.toolbar);
-          this.ctx.activeInfoTab = 'details';
-          this.trace.tabs.showTab(this.tabUri);
-        } else {
+        } else if (!isKnownKernel) {
           this.sliceId = this.options[0]?.id ?? -1;
           this.setToolbarInfo(undefined);
           this.ctx.activeInfoTab = 'summary';
@@ -288,9 +303,6 @@ class Compute {
     } else if (this.hadSelection) {
       this.hadSelection = false;
       this.appliedSelectionSliceId = undefined;
-      this.sliceId = this.options[0]?.id ?? -1;
-      this.setToolbarInfo(undefined);
-      this.ctx.activeInfoTab = 'summary';
     }
 
     const toolbar = renderToolbar({
@@ -339,7 +351,6 @@ class Compute {
       });
     }
 
-    // Rendering view
     return m('div', [toolbar, body]);
   }
 }

--- a/ui/src/plugins/com.meta.GpuCompute/index.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/index.ts
@@ -16,11 +16,7 @@ import m from 'mithril';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
 import {Engine} from '../../trace_processor/engine';
-import {
-  KernelMetricsSection,
-  fetchKernelLaunchList,
-  fetchSelectedKernelMetricData,
-} from './details';
+import {KernelMetricsSection, fetchSelectedKernelMetricData} from './details';
 import {TrackEventSelection} from '../../public/selection';
 import {renderToolbar} from './toolbar';
 import type {InfoTab} from './toolbar';
@@ -29,7 +25,8 @@ import type {
   KernelMetricData,
   ToolbarInfo,
 } from './details';
-import {KernelSummarySection} from './summary';
+import {KernelSummarySection, fetchKernelSummaryRows} from './summary';
+import type {SummaryRow} from './summary';
 import {registerSpeedOfLightSection} from './section/speed_of_light';
 import {registerLaunchStatisticsSection} from './section/launch_statistics';
 import {registerOccupancySection} from './section/occupancy';
@@ -78,6 +75,7 @@ class Compute {
 
   private sliceId: number | undefined = -1;
   private options: KernelLaunchOption[] = [];
+  private summaryRows: SummaryRow[] = [];
 
   // Selection-driven metric fetching via QuerySlot. Selection changes
   // trigger mithril redraws; render() reads the current selection and
@@ -224,6 +222,10 @@ class Compute {
     this.options = opts;
   }
 
+  public setSummaryRows(rows: SummaryRow[]) {
+    this.summaryRows = rows;
+  }
+
   // Populating the toolbar with the correct kernel's launch info
   private toolbarInfo?: ToolbarInfo;
   public setToolbarInfo(info?: ToolbarInfo) {
@@ -314,6 +316,7 @@ class Compute {
         engine: this.engine,
         sliceId: effectiveSliceId,
         openSliceInDetail: (id: number) => this.setSliceId(id),
+        prefetchedRows: this.summaryRows,
       });
     } else if (this.ctx.activeInfoTab === 'analysis') {
       const provider = this.ctx.analysisProviderHolder.get();
@@ -403,9 +406,13 @@ export default class GpuComputePlugin implements PerfettoPlugin {
     });
 
     try {
-      const list = await fetchKernelLaunchList(trace.engine);
-      content.setOptions(list);
-      if (list.length > 0) {
+      const rows = await fetchKernelSummaryRows(
+        this.getContext(),
+        trace.engine,
+      );
+      content.setSummaryRows(rows);
+      content.setOptions(rows.map((r) => ({id: r.id, label: r.demangledName})));
+      if (rows.length > 0) {
         trace.tabs.showTab(tabUri);
       }
     } catch (e) {

--- a/ui/src/plugins/com.meta.GpuCompute/summary.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/summary.ts
@@ -33,7 +33,7 @@ import type {GpuComputeContext} from './index';
 import {adjustSeconds} from './humanize';
 
 // Per-kernel row returned by {@link fetchKernelSummaryRows}.
-type SummaryRow = {
+export type SummaryRow = {
   id: number;
   demangledName: string;
   durationNSecNum: number | string | null;
@@ -178,6 +178,7 @@ export interface SummarySectionAttrs extends m.Attributes {
   engine: Engine;
   sliceId?: number;
   openSliceInDetail?: (sliceId: number) => void;
+  prefetchedRows?: SummaryRow[];
 }
 
 // Column keys that the table can be sorted by.
@@ -266,7 +267,9 @@ export const KernelSummarySection: m.Component<
     state.sortDescending = false;
     state.pageOffset = 0;
 
-    const rows = await fetchKernelSummaryRows(attrs.ctx, attrs.engine);
+    const rows =
+      attrs.prefetchedRows ??
+      (await fetchKernelSummaryRows(attrs.ctx, attrs.engine));
 
     // Build launch-order map so the ID column shows 0, 1, 2, …
     rows.forEach((opt, zeroBasedIndex) =>

--- a/ui/src/plugins/com.meta.GpuCompute/summary.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/summary.ts
@@ -300,8 +300,6 @@ export const KernelSummarySection: m.Component<
       rows.map((r) => Number(r.registersPerThread)),
     );
     state.maxGridSize = finiteMax(rows.map((r) => Number(r.gridSize)));
-
-    m.redraw();
   },
 
   view({state, attrs}) {
@@ -355,7 +353,6 @@ export const KernelSummarySection: m.Component<
         state.sortDescending = true;
       }
       state.pageOffset = 0;
-      m.redraw();
     };
 
     // Up/down arrow indicator for the active sort column
@@ -491,8 +488,6 @@ export const KernelSummarySection: m.Component<
             disabled: state.pageOffset === 0,
             onclick: () => {
               state.pageOffset = Math.max(0, state.pageOffset - PAGE_SIZE);
-
-              m.redraw();
             },
           }),
           m(
@@ -507,8 +502,6 @@ export const KernelSummarySection: m.Component<
                 state.pageOffset + PAGE_SIZE,
                 sortedRows.length - PAGE_SIZE,
               );
-
-              m.redraw();
             },
           }),
         ]),

--- a/ui/src/plugins/com.meta.GpuCompute/summary.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/summary.ts
@@ -27,6 +27,7 @@ import {
   COMPUTE_RENDER_STAGE_CATEGORY,
 } from './details';
 import {Icons} from '../../base/semantic_icons';
+import {Button} from '../../widgets/button';
 import {Icon} from '../../widgets/icon';
 import type {GpuComputeContext} from './index';
 import {adjustSeconds} from './humanize';
@@ -42,6 +43,8 @@ type SummaryRow = {
   gridSize: number | string | null;
 };
 
+const PAGE_SIZE = 100;
+
 // Component state holding the fetched rows and per-column max values.
 type SummaryState = {
   rows?: SummaryRow[];
@@ -53,6 +56,7 @@ type SummaryState = {
   launchIndexBySliceId: Map<number, number>;
   sortKey: SortKey | null;
   sortDescending: boolean;
+  pageOffset: number;
 };
 
 // Renders a bar whose width is proportional to `val / max`.
@@ -260,6 +264,7 @@ export const KernelSummarySection: m.Component<
     state.launchIndexBySliceId = new Map();
     state.sortKey = 'id';
     state.sortDescending = false;
+    state.pageOffset = 0;
 
     const rows = await fetchKernelSummaryRows(attrs.ctx, attrs.engine);
 
@@ -346,6 +351,7 @@ export const KernelSummarySection: m.Component<
         state.sortKey = key;
         state.sortDescending = true;
       }
+      state.pageOffset = 0;
       m.redraw();
     };
 
@@ -412,67 +418,97 @@ export const KernelSummarySection: m.Component<
 
         m(
           'tbody',
-          sortedRows.map((r) =>
-            m(
-              'tr.pf-gpu-compute__summary-row',
-              {
-                ondblclick: () => attrs.openSliceInDetail?.(r.id),
-              },
-              [
-                m(
-                  'td.pf-gpu-compute__summary-td',
-                  String(launchIndexBySliceId.get(r.id) ?? r.id),
-                ),
-                m(
-                  'td.pf-gpu-compute__summary-td.pf-gpu-compute__summary-td--name',
-                  {title: r.demangledName},
-                  r.demangledName,
-                ),
-                m(
-                  'td.pf-gpu-compute__summary-td',
-                  renderRelPercentBar(
-                    Number(r.durationNSecNum),
-                    state.maxDurationNSec,
-                    label(Number(r.durationNSecNum), 'nsecond'),
+          sortedRows
+            .slice(state.pageOffset, state.pageOffset + PAGE_SIZE)
+            .map((r) =>
+              m(
+                'tr.pf-gpu-compute__summary-row',
+                {
+                  ondblclick: () => attrs.openSliceInDetail?.(r.id),
+                },
+                [
+                  m(
+                    'td.pf-gpu-compute__summary-td',
+                    String(launchIndexBySliceId.get(r.id) ?? r.id),
                   ),
-                ),
-                m(
-                  'td.pf-gpu-compute__summary-td',
-                  renderRelPercentBar(
-                    Number(r.computePct),
-                    state.maxComputePct,
-                    label(r.computePct),
+                  m(
+                    'td.pf-gpu-compute__summary-td.pf-gpu-compute__summary-td--name',
+                    {title: r.demangledName},
+                    r.demangledName,
                   ),
-                ),
-                m(
-                  'td.pf-gpu-compute__summary-td',
-                  renderRelPercentBar(
-                    Number(r.memoryPct),
-                    state.maxMemoryPct,
-                    label(r.memoryPct),
+                  m(
+                    'td.pf-gpu-compute__summary-td',
+                    renderRelPercentBar(
+                      Number(r.durationNSecNum),
+                      state.maxDurationNSec,
+                      label(Number(r.durationNSecNum), 'nsecond'),
+                    ),
                   ),
-                ),
-                m(
-                  'td.pf-gpu-compute__summary-td',
-                  renderRelPercentBar(
-                    Number(r.registersPerThread),
-                    state.maxRegisters,
-                    label(r.registersPerThread),
+                  m(
+                    'td.pf-gpu-compute__summary-td',
+                    renderRelPercentBar(
+                      Number(r.computePct),
+                      state.maxComputePct,
+                      label(r.computePct),
+                    ),
                   ),
-                ),
-                m(
-                  'td.pf-gpu-compute__summary-td',
-                  renderRelPercentBar(
-                    Number(r.gridSize),
-                    state.maxGridSize,
-                    label(r.gridSize),
+                  m(
+                    'td.pf-gpu-compute__summary-td',
+                    renderRelPercentBar(
+                      Number(r.memoryPct),
+                      state.maxMemoryPct,
+                      label(r.memoryPct),
+                    ),
                   ),
-                ),
-              ],
+                  m(
+                    'td.pf-gpu-compute__summary-td',
+                    renderRelPercentBar(
+                      Number(r.registersPerThread),
+                      state.maxRegisters,
+                      label(r.registersPerThread),
+                    ),
+                  ),
+                  m(
+                    'td.pf-gpu-compute__summary-td',
+                    renderRelPercentBar(
+                      Number(r.gridSize),
+                      state.maxGridSize,
+                      label(r.gridSize),
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
         ),
       ]),
+      sortedRows.length > PAGE_SIZE &&
+        m('.pf-gpu-compute__summary-pagination', [
+          m(Button, {
+            icon: Icons.PrevPage,
+            disabled: state.pageOffset === 0,
+            onclick: () => {
+              state.pageOffset = Math.max(0, state.pageOffset - PAGE_SIZE);
+
+              m.redraw();
+            },
+          }),
+          m(
+            'span',
+            `${state.pageOffset + 1}–${Math.min(state.pageOffset + PAGE_SIZE, sortedRows.length)} of ${sortedRows.length}`,
+          ),
+          m(Button, {
+            icon: Icons.NextPage,
+            disabled: state.pageOffset + PAGE_SIZE >= sortedRows.length,
+            onclick: () => {
+              state.pageOffset = Math.min(
+                state.pageOffset + PAGE_SIZE,
+                sortedRows.length - PAGE_SIZE,
+              );
+
+              m.redraw();
+            },
+          }),
+        ]),
     );
   },
 };

--- a/ui/src/plugins/com.meta.GpuCompute/toolbar.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/toolbar.ts
@@ -156,12 +156,8 @@ export function renderToolbar(opts: {
             },
           },
           [
-            ...opts.options.map((o) =>
-              m(
-                'option',
-                {value: String(o.id)},
-                `${opts.options.indexOf(o)} - ${trunc(o.label)}`,
-              ),
+            ...opts.options.map((o, i) =>
+              m('option', {value: String(o.id)}, `${i} - ${trunc(o.label)}`),
             ),
           ],
         ),

--- a/ui/src/plugins/com.meta.GpuCompute/toolbar.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/toolbar.ts
@@ -28,6 +28,43 @@ import {Switch} from '../../widgets/switch';
 import type {GpuComputeContext} from './index';
 import {Select} from '../../widgets/select';
 
+// Memoized kernel selector that skips vdom diffing when the options
+// list and selected value haven't changed. Without this, mithril
+// rebuilds and diffs thousands of <option> vnodes on every redraw.
+interface KernelSelectAttrs {
+  readonly options: readonly KernelLaunchOption[];
+  readonly value: string;
+  onChange: (id: number | undefined) => void;
+}
+
+class KernelSelect implements m.ClassComponent<KernelSelectAttrs> {
+  onbeforeupdate(
+    {attrs}: m.CVnode<KernelSelectAttrs>,
+    old: m.CVnode<KernelSelectAttrs>,
+  ): boolean {
+    return (
+      attrs.value !== old.attrs.value || attrs.options !== old.attrs.options
+    );
+  }
+
+  view({attrs}: m.CVnode<KernelSelectAttrs>): m.Children {
+    return m(
+      Select,
+      {
+        value: attrs.value,
+        className: 'pf-gpu-compute__toolbar-kernel-select',
+        onchange: (e: Event) => {
+          const v = (e.target as HTMLSelectElement).value;
+          attrs.onChange(v === '' ? undefined : Number(v));
+        },
+      },
+      attrs.options.map((o, i) =>
+        m('option', {value: String(o.id)}, `${i} - ${trunc(o.label)}`),
+      ),
+    );
+  }
+}
+
 // Maximum label length before truncation.
 const MAX_LABEL_LENGTH = 50;
 
@@ -145,22 +182,11 @@ export function renderToolbar(opts: {
           ),
           m('span', 'Current'),
         ]),
-        m(
-          Select,
-          {
-            value,
-            className: 'pf-gpu-compute__toolbar-kernel-select',
-            onchange: (e: Event) => {
-              const value = (e.target as HTMLSelectElement).value;
-              opts.onChange(value === '' ? undefined : Number(value));
-            },
-          },
-          [
-            ...opts.options.map((o, i) =>
-              m('option', {value: String(o.id)}, `${i} - ${trunc(o.label)}`),
-            ),
-          ],
-        ),
+        m(KernelSelect, {
+          options: opts.options,
+          value,
+          onChange: opts.onChange,
+        }),
         m(
           'span.pf-gpu-compute__toolbar-size',
           opts.toolbarInfo?.sizeText ?? '—',

--- a/ui/src/plugins/com.meta.GpuCompute/toolbar.ts
+++ b/ui/src/plugins/com.meta.GpuCompute/toolbar.ts
@@ -235,7 +235,6 @@ export function renderToolbar(opts: {
         currentTabKey: ctx.activeInfoTab,
         onTabChange: (key: string) => {
           ctx.activeInfoTab = key as InfoTab;
-          m.redraw();
         },
       }),
 
@@ -252,7 +251,6 @@ export function renderToolbar(opts: {
           // Auto focusing to 'Details' tab
           if (enable) {
             ctx.activeInfoTab = 'details';
-            m.redraw();
           }
         },
       }),
@@ -279,7 +277,6 @@ export function renderToolbar(opts: {
               checked: ctx.humanizeMetrics,
               onchange: (e: Event) => {
                 ctx.humanizeMetrics = (e.target as HTMLInputElement).checked;
-                m.redraw();
                 opts.onHumanizeChanged?.();
               },
             }),
@@ -296,7 +293,6 @@ export function renderToolbar(opts: {
                 onchange: (e: Event) => {
                   ctx.terminologyId = (e.target as HTMLSelectElement).value;
                   opts.onTerminologyChanged?.();
-                  m.redraw();
                 },
                 className: 'pf-gpu-compute__toolbar-terminology-select',
               },


### PR DESCRIPTION
This PR addresses rendering performance issues and correctness bugs in the GPU Compute plugin that become apparent with large traces containing many kernel launches (10s of thousands).

  Performance fixes

  - Fix O(n²) rendering in toolbar dropdown — The kernel selector rebuilt thousands of <option> vnodes on every Mithril redraw. Memoize the component to skip vdom diffing
  when the options list and selected value haven't changed.
  - Memoize kernel selector to skip unchanged redraws — Further reduces unnecessary vdom work in the toolbar by tracking previous state and short-circuiting onbeforeupdate.
  - Skip summary table redraw when nothing changed — Add a dirty flag to KernelSummarySection so the table skips vdom diffing unless data or sort state actually changed.
  - Paginate summary table — Limit the summary table to 100 rows per page with prev/next navigation, preventing the browser from rendering thousands of table rows at once.
  - Deduplicate kernel list and summary queries — fetchKernelLaunchList and fetchKernelSummaryRows both scanned all compute slices. The launch list was a strict subset.
  Remove it and call fetchKernelSummaryRows once at trace load, deriving the dropdown options from the result and passing pre-fetched rows to the summary component.

  Bug fixes

  - Fix details tab for kernels without compute counters — The details query filtered counters through gpu_counter_group.group_id = 6 in the WHERE clause, which discarded
  the entire row when non-compute counters (e.g. Power, Temperature) overlapped in time with a kernel slice. This left the query with zero rows, making the kernel appear to
   have no data. Move the compute counter group filter into the LEFT JOIN condition so non-compute counters simply don't match the join, preserving launch args for the
  Launch Statistics section. Also replace the throw when no metric sections are visible with a user-facing message.
  - Eliminate tab flicker when selecting compute kernels — Three issues caused visible flicker: (1) the tab switch waited for an async metric query before calling
  showTab(), letting the Current Selection tab appear; (2) the async result could fall back to summary for known kernels without compute counters; (3) render() is called
  multiple times per Mithril redraw cycle and the deselection block briefly set activeInfoTab to summary between calls. Fix by using the known kernel ID set for synchronous
   tab switching, guarding the summary fallback, removing the eager summary switch from deselection, and guarding setSliceId() against stale async completions.