### PR TITLE
tracing: fix MSVC LNK2019 in DataSourceHelper::type() (#5591)

### DIFF
--- a/include/perfetto/tracing/data_source.h
+++ b/include/perfetto/tracing/data_source.h
@@ -237,21 +237,29 @@ struct DefaultDataSourceTraits {
   static bool ClearIncrementalState(IncrementalStateType*) { return false; }
 };
 
-// Holds the type for a DataSource. Accessed by the static Trace() method
-// fastpaths. This allows redefinitions under a component where a component
-// specific export macro is used.
-// Due to C2086 (redefinition) error on MSVC/clang-cl, internal::DataSourceType
-// can't be a static data member. To avoid explicit specialization after
-// instantiation error, type() needs to be in a template helper class that's
-// instantiated independently from DataSource. See b/280777748.
+// Holds the DataSourceType for a DataSource, accessed by Trace()'s fastpaths.
+// Lives on a separate helper (not as a static member on DataSource) so
+// per-component export macros can redefine it, and because MSVC/clang-cl reject
+// the static-data-member design with a redefinition error (C2086) and an
+// explicit-specialization-after-instantiation error. See b/280777748.
+//
+// type() must be defined out-of-line: defining it in the class body makes it
+// implicitly inline ([dcl.inline]/4), which MSVC then propagates to every
+// explicit specialization from PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS and
+// silently drops the body (C4506), so callers fail to link with an unresolved
+// external symbol (LNK2019). GCC/Clang are unaffected.
 template <typename DerivedDataSource,
           typename DataSourceTraits = DefaultDataSourceTraits>
 struct DataSourceHelper {
-  static internal::DataSourceType& type() {
-    static perfetto::internal::DataSourceType type_;
-    return type_;
-  }
+  static internal::DataSourceType& type();
 };
+
+template <typename DerivedDataSource, typename DataSourceTraits>
+internal::DataSourceType&
+DataSourceHelper<DerivedDataSource, DataSourceTraits>::type() {
+  static perfetto::internal::DataSourceType type_;
+  return type_;
+}
 
 // Templated base class meant to be derived by embedders to create a custom data
 // source. DerivedDataSource must be the type of the derived class itself, e.g.:


### PR DESCRIPTION
Move the primary-template definition of `DataSourceHelper::type()` out of
the class body so it is not implicitly inline.

`DataSourceHelper::type()` was added in 06486b8b6010 ("Fix component build
for client library on Windows", 2023-05-05) as a workaround for an MSVC
C2086 redefinition bug affecting an earlier static-data-member design.
That commit defined `type()` inline inside the class body
([dcl.fct.spec]/4 then makes it implicitly inline). MSVC propagates that
inline attribute to every explicit specialization of `type()` defined
out-of-line by `PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS` in a `.cc`,
emits a C4506 ("no definition for inline function"), and silently drops
the specialization body. Any TU that does not see the body but calls
`Helper::type()` -- transitively via `DataSource<...>::Register<>()`,
`Trace()`, etc. -- is then left with an unresolved external symbol.

The bug stayed dormant until a5f062d78a60 ("[API] Single data source for
all track events", 2025-06-24, in v52.0+) made `TrackEventDataSource`
a concrete class with a `PERFETTO_DECLARE_DATA_SOURCE_STATIC_MEMBERS`
visible in the public header, so user TUs that invoke
`PERFETTO_TRACK_EVENT_STATIC_STORAGE()` started instantiating
`Register<>` and producing LNK2019:

```
  example.cc.obj : error LNK2019: unresolved external symbol
  "public: static class perfetto::internal::DataSourceType & __cdecl
   perfetto::DataSourceHelper<class perfetto::internal::TrackEventDataSource,
                              struct perfetto::internal::TrackEventDataSourceTraits>::type(void)"
  referenced in function "perfetto::DataSource<...>::Register<>(...)".
```

GCC and Clang are unaffected: they treat the out-of-line explicit
specialization as a regular non-inline function and emit it normally.

Fix: declare `type()` in the class body and define it out-of-line. The
primary template's member is then a non-inline function template, and
explicit specializations are unambiguously non-inline regular functions
on every compiler. No call sites change; the only file touched is
`include/perfetto/tracing/data_source.h`.

Verified on Windows / MSVC v143 (14.50.35717) for x64 Debug and Release
builds of `examples/sdk` and the v54.0 amalgamated SDK. GCC/Clang
unaffected because the change is a no-op semantic refactor for them.

Bug: #5591
