### PR TITLE
de: Centralize legacy type migration in the deserialization layer

### DIFF
--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler.ts
@@ -19,6 +19,11 @@ import {Trace} from '../../public/trace';
 import {SqlModules} from '../../plugins/dev.perfetto.SqlModules/sql_modules';
 import {nodeRegistry} from './query_builder/node_registry';
 import {restoreLegacySecondaryInputs} from './query_builder/legacy_connections';
+import {
+  PerfettoSqlType,
+  parsePerfettoSqlTypeFromString,
+} from '../../trace_processor/perfetto_sql_type';
+import {ColumnInfo} from './query_builder/column_info';
 
 // Interfaces for the serialized JSON structure
 export interface SerializedNode {
@@ -213,6 +218,105 @@ export function exportStateAsJson(
   downloadJsonFile(json, `${traceName}-graph-${date}.json`);
 }
 
+// Translate a legacy string type (e.g. 'INT') to the current PerfettoSqlType
+// object form (e.g. {kind: 'int'}). Returns undefined for unrecognised strings.
+function legacyDeserializeType(
+  type: PerfettoSqlType | string | undefined,
+): PerfettoSqlType | undefined {
+  if (type === undefined) return undefined;
+  if (typeof type === 'string') {
+    const parsed = parsePerfettoSqlTypeFromString({type});
+    return parsed.ok ? parsed.value : undefined;
+  }
+  if (type.kind !== undefined) return type;
+  return undefined;
+}
+
+function migrateColumnList(
+  cols: unknown[] | undefined,
+): ColumnInfo[] | undefined {
+  if (!cols) return undefined;
+  return cols.map((c) => {
+    const col = c as {
+      columnName?: string;
+      name?: string;
+      type?: PerfettoSqlType | string;
+      checked?: boolean;
+      alias?: string;
+      typeUserModified?: boolean;
+    };
+    return {
+      name: col.columnName ?? col.name ?? '',
+      type: legacyDeserializeType(col.type),
+      checked: col.checked ?? false,
+      alias: col.alias,
+      typeUserModified: col.typeUserModified,
+    };
+  });
+}
+
+// Apply legacy type migrations to a node's raw serialized state before it
+// reaches the node constructor. Each node type only handles what it needs.
+function migrateNodeState(type: NodeType, state: unknown): unknown {
+  const s = state as Record<string, unknown>;
+  switch (type) {
+    case NodeType.kJoin:
+      return {
+        ...s,
+        conditionType: (s.conditionType as string | undefined) ?? 'equality',
+        joinType: (s.joinType as string | undefined) ?? 'INNER',
+        leftColumn: (s.leftColumn as string | undefined) ?? '',
+        rightColumn: (s.rightColumn as string | undefined) ?? '',
+        sqlExpression: (s.sqlExpression as string | undefined) ?? '',
+        leftColumns: migrateColumnList(s.leftColumns as unknown[]),
+        rightColumns: migrateColumnList(s.rightColumns as unknown[]),
+      };
+    case NodeType.kModifyColumns:
+      return {
+        ...s,
+        selectedColumns:
+          migrateColumnList(s.selectedColumns as unknown[]) ?? [],
+      };
+    case NodeType.kUnion:
+      return {
+        ...s,
+        selectedColumns:
+          migrateColumnList(s.selectedColumns as unknown[]) ?? [],
+      };
+    case NodeType.kAggregation: {
+      type RawAgg = {column?: {name?: string; type?: PerfettoSqlType | string}};
+      const aggregations = s.aggregations as RawAgg[] | undefined;
+      return {
+        ...s,
+        groupByColumns: migrateColumnList(s.groupByColumns as unknown[]) ?? [],
+        aggregations: aggregations?.map((agg) => ({
+          ...agg,
+          column: agg.column
+            ? {...agg.column, type: legacyDeserializeType(agg.column.type)}
+            : undefined,
+        })),
+      };
+    }
+    case NodeType.kAddColumns: {
+      const columnTypes = s.columnTypes as
+        | Record<string, PerfettoSqlType | string>
+        | undefined;
+      if (!columnTypes) return s;
+      return {
+        ...s,
+        columnTypes: Object.fromEntries(
+          Object.entries(columnTypes)
+            .map(([k, v]) => [k, legacyDeserializeType(v)] as const)
+            .filter((e): e is [string, PerfettoSqlType] => e[1] !== undefined),
+        ),
+      };
+    }
+    default:
+      // Unknown node types pass through unchanged for forward-compatibility.
+      return state;
+  }
+}
+
 function createNodeInstance(
   serializedNode: SerializedNode,
   trace: Trace,
@@ -222,7 +326,11 @@ function createNodeInstance(
   if (!descriptor) {
     throw new Error(`Unknown node type: ${serializedNode.type}`);
   }
-  return descriptor.deserialize(serializedNode.state, trace, sqlModules);
+  const migratedState = migrateNodeState(
+    serializedNode.type,
+    serializedNode.state,
+  );
+  return descriptor.deserialize(migratedState as object, trace, sqlModules);
 }
 
 export function deserializeState(

--- a/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/json_handler_unittest.ts
@@ -31,7 +31,10 @@ import {SortNode} from './query_builder/nodes/sort_node';
 import {FilterNode} from './query_builder/nodes/filter_node';
 import {JoinNode} from './query_builder/nodes/join_node';
 import {UnionNode} from './query_builder/nodes/union_node';
-import {PerfettoSqlType} from '../../trace_processor/perfetto_sql_type';
+import {
+  PerfettoSqlType,
+  PerfettoSqlTypes,
+} from '../../trace_processor/perfetto_sql_type';
 import {NodeType} from './query_node';
 import {
   addConnection,
@@ -3092,5 +3095,255 @@ describe('JSON serialization/deserialization', () => {
     ) as FilterNode;
     expect(deserializedFilter).toBeDefined();
     expect(deserializedFilter.primaryInput).toBeDefined();
+  });
+
+  describe('legacy string type migration', () => {
+    function deserializeRaw(serializedGraph: object): DataExplorerState {
+      return deserializeState(
+        JSON.stringify(serializedGraph),
+        trace,
+        sqlModules,
+      );
+    }
+
+    it('migrates legacy columnName field in JoinNode columns, preserving checked state', () => {
+      // columnName→name migration matters because buildDescriptors() looks up
+      // existing columns by name to preserve user customizations (checked, alias).
+      // Without migration, the lookup fails and checked resets to false.
+      //
+      // The test uses connected TableSourceNodes (slice table: name, ts, dur)
+      // so that postDeserializeLate/updateColumnArrays() can actually run.
+      const graph = {
+        nodes: [
+          {
+            nodeId: 'src1',
+            type: NodeType.kTable,
+            nextNodes: ['join1'],
+            state: {sqlTable: 'slice'},
+          },
+          {
+            nodeId: 'src2',
+            type: NodeType.kTable,
+            nextNodes: ['join1'],
+            state: {sqlTable: 'slice'},
+          },
+          {
+            nodeId: 'join1',
+            type: NodeType.kJoin,
+            nextNodes: [],
+            secondaryInputIds: {'0': 'src1', '1': 'src2'},
+            state: {
+              leftQueryAlias: 'left',
+              rightQueryAlias: 'right',
+              conditionType: 'equality',
+              joinType: 'INNER',
+              leftColumn: 'name',
+              rightColumn: 'name',
+              sqlExpression: '',
+              // Legacy format: 'columnName' instead of 'name'. After migration,
+              // buildDescriptors can match this to the 'name' column from src1
+              // and preserve checked: true.
+              leftColumns: [
+                {columnName: 'name', type: {kind: 'string'}, checked: true},
+              ],
+              rightColumns: [],
+            },
+          },
+        ],
+        rootNodeIds: ['src1', 'src2'],
+        nodeLayouts: {},
+        labels: [],
+      };
+      const state = deserializeRaw(graph);
+      const src1 = state.rootNodes[0];
+      const joinNode = src1.nextNodes[0] as JoinNode;
+      // After migration, 'name' column should be found and checked: true preserved.
+      const nameCol = joinNode.attrs.leftColumns?.find(
+        (c) => c.name === 'name',
+      );
+      expect(nameCol).toBeDefined();
+      expect(nameCol?.checked).toBe(true);
+    });
+
+    it('applies JoinNode defaults for absent conditionType/joinType/column/sqlExpression fields', () => {
+      const graph = {
+        nodes: [
+          {
+            nodeId: 'join1',
+            type: NodeType.kJoin,
+            nextNodes: [],
+            state: {
+              leftQueryAlias: 'left',
+              rightQueryAlias: 'right',
+              // conditionType, joinType, leftColumn, rightColumn, sqlExpression
+              // are all absent — must default to their canonical values.
+            },
+          },
+        ],
+        rootNodeIds: ['join1'],
+        nodeLayouts: {},
+        labels: [],
+      };
+      const state = deserializeRaw(graph);
+      const joinNode = state.rootNodes[0] as JoinNode;
+      expect(joinNode.attrs.conditionType).toBe('equality');
+      expect(joinNode.attrs.joinType).toBe('INNER');
+      expect(joinNode.attrs.leftColumn).toBe('');
+      expect(joinNode.attrs.rightColumn).toBe('');
+      expect(joinNode.attrs.sqlExpression).toBe('');
+    });
+
+    it('migrates legacy string types in ModifyColumnsNode selectedColumns', () => {
+      const graph = {
+        nodes: [
+          {
+            nodeId: 'mod1',
+            type: NodeType.kModifyColumns,
+            nextNodes: [],
+            state: {
+              selectedColumns: [
+                {name: 'id', type: 'INT', checked: true},
+                {name: 'name', type: 'STRING', checked: true},
+                {name: 'ts', type: 'UNKNOWN_LEGACY', checked: false},
+              ],
+            },
+          },
+        ],
+        rootNodeIds: ['mod1'],
+        nodeLayouts: {},
+        labels: [],
+      };
+      const state = deserializeRaw(graph);
+      const modNode = state.rootNodes[0] as ModifyColumnsNode;
+      expect(modNode.attrs.selectedColumns[0].type).toEqual(
+        PerfettoSqlTypes.INT,
+      );
+      expect(modNode.attrs.selectedColumns[1].type).toEqual(
+        PerfettoSqlTypes.STRING,
+      );
+      expect(modNode.attrs.selectedColumns[2].type).toBeUndefined();
+    });
+
+    it('migrates legacy string types in AggregationNode groupByColumns', () => {
+      // groupByColumns flow directly into finalCols, so unmigrated string types
+      // would crash downstream nodes (e.g. renderTypeSelector).
+      const graph = {
+        nodes: [
+          {
+            nodeId: 'agg1',
+            type: NodeType.kAggregation,
+            nextNodes: [],
+            state: {
+              groupByColumns: [
+                {name: 'ts', type: 'TIMESTAMP', checked: true},
+                {name: 'name', type: 'STRING', checked: true},
+              ],
+              aggregations: [],
+            },
+          },
+        ],
+        rootNodeIds: ['agg1'],
+        nodeLayouts: {},
+        labels: [],
+      };
+      const state = deserializeRaw(graph);
+      const aggNode = state.rootNodes[0] as AggregationNode;
+      expect(aggNode.attrs.groupByColumns[0].type).toEqual(
+        PerfettoSqlTypes.TIMESTAMP,
+      );
+      expect(aggNode.attrs.groupByColumns[1].type).toEqual(
+        PerfettoSqlTypes.STRING,
+      );
+    });
+
+    it('migrates legacy string types in AggregationNode aggregations[].column.type', () => {
+      // aggregations[].column.type flows into finalCols via getAggregationResultType
+      // for SUM/MIN/MAX ops, so a string type there would crash renderTypeSelector.
+      const graph = {
+        nodes: [
+          {
+            nodeId: 'agg1',
+            type: NodeType.kAggregation,
+            nextNodes: [],
+            state: {
+              groupByColumns: [],
+              aggregations: [
+                {
+                  column: {name: 'dur', type: 'DURATION'},
+                  aggregationOp: 'SUM',
+                  newColumnName: 'total_dur',
+                },
+              ],
+            },
+          },
+        ],
+        rootNodeIds: ['agg1'],
+        nodeLayouts: {},
+        labels: [],
+      };
+      const state = deserializeRaw(graph);
+      const aggNode = state.rootNodes[0] as AggregationNode;
+      expect(aggNode.attrs.aggregations[0].column?.type).toEqual(
+        PerfettoSqlTypes.DURATION,
+      );
+    });
+
+    it('migrates legacy string types in UnionNode selectedColumns', () => {
+      // selectedColumns flow directly into finalCols, so unmigrated string types
+      // would crash downstream nodes (e.g. renderTypeSelector).
+      const graph = {
+        nodes: [
+          {
+            nodeId: 'union1',
+            type: NodeType.kUnion,
+            nextNodes: [],
+            state: {
+              selectedColumns: [
+                {name: 'id', type: 'INT', checked: true},
+                {name: 'ts', type: 'TIMESTAMP', checked: true},
+              ],
+            },
+          },
+        ],
+        rootNodeIds: ['union1'],
+        nodeLayouts: {},
+        labels: [],
+      };
+      const state = deserializeRaw(graph);
+      const unionNode = state.rootNodes[0] as UnionNode;
+      expect(unionNode.attrs.selectedColumns[0].type).toEqual(
+        PerfettoSqlTypes.INT,
+      );
+      expect(unionNode.attrs.selectedColumns[1].type).toEqual(
+        PerfettoSqlTypes.TIMESTAMP,
+      );
+    });
+
+    it('migrates legacy string types in AddColumnsNode columnTypes', () => {
+      const graph = {
+        nodes: [
+          {
+            nodeId: 'add1',
+            type: NodeType.kAddColumns,
+            nextNodes: [],
+            state: {
+              sql: 'SELECT 1 AS val',
+              columnTypes: {val: 'DOUBLE', count: 'INT'},
+            },
+          },
+        ],
+        rootNodeIds: ['add1'],
+        nodeLayouts: {},
+        labels: [],
+      };
+      const state = deserializeRaw(graph);
+      const addNode = state.rootNodes[0] as AddColumnsNode;
+      expect(addNode.attrs.columnTypes?.['val']).toEqual(
+        PerfettoSqlTypes.DOUBLE,
+      );
+      expect(addNode.attrs.columnTypes?.['count']).toEqual(
+        PerfettoSqlTypes.INT,
+      );
+    });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info.ts
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  PerfettoSqlType,
-  parsePerfettoSqlTypeFromString,
-} from '../../../trace_processor/perfetto_sql_type';
+import {PerfettoSqlType} from '../../../trace_processor/perfetto_sql_type';
 import {SqlColumn} from '../../dev.perfetto.SqlModules/sql_modules';
 
 export interface ColumnInfo {
@@ -54,19 +51,4 @@ export function newColumnInfo(
     checked: checked ?? col.checked,
     typeUserModified: col.typeUserModified,
   };
-}
-
-// Handle legacy serialized state where type was a string (e.g. "INT")
-// instead of a PerfettoSqlType object (e.g. {kind: 'int'}).
-export function legacyDeserializeType(
-  type: PerfettoSqlType | string | undefined,
-): PerfettoSqlType | undefined {
-  if (type === undefined) return undefined;
-  if (typeof type === 'string') {
-    const parsed = parsePerfettoSqlTypeFromString({type});
-    return parsed.ok ? parsed.value : undefined;
-  }
-  // Already a proper PerfettoSqlType object
-  if (type.kind !== undefined) return type;
-  return undefined;
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/column_info_unittest.ts
@@ -15,7 +15,6 @@
 import {
   ColumnInfo,
   columnInfoFromSqlColumn,
-  legacyDeserializeType,
   newColumnInfo,
 } from './column_info';
 import {SqlColumn} from '../../dev.perfetto.SqlModules/sql_modules';
@@ -161,85 +160,6 @@ describe('column_info utilities', () => {
       const result = newColumnInfo(original);
 
       expect(result.alias).toBeUndefined();
-    });
-  });
-
-  describe('legacyDeserializeType', () => {
-    it('should return undefined for undefined input', () => {
-      expect(legacyDeserializeType(undefined)).toBeUndefined();
-    });
-
-    it('should pass through valid PerfettoSqlType objects', () => {
-      expect(legacyDeserializeType(intType)).toEqual(intType);
-      expect(legacyDeserializeType(stringType)).toEqual(stringType);
-      expect(legacyDeserializeType(timestampType)).toEqual(timestampType);
-    });
-
-    it('should pass through ID types', () => {
-      const idType: PerfettoSqlType = {
-        kind: 'id',
-        source: {table: 'thread', column: 'id'},
-      };
-      expect(legacyDeserializeType(idType)).toEqual(idType);
-    });
-
-    it('should pass through JOINID types', () => {
-      const joinidType: PerfettoSqlType = {
-        kind: 'joinid',
-        source: {table: 'thread', column: 'id'},
-      };
-      expect(legacyDeserializeType(joinidType)).toEqual(joinidType);
-    });
-
-    it('should convert legacy string types to PerfettoSqlType', () => {
-      expect(
-        legacyDeserializeType('INT' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'int'});
-      expect(
-        legacyDeserializeType('STRING' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'string'});
-      expect(
-        legacyDeserializeType('TIMESTAMP' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'timestamp'});
-      expect(
-        legacyDeserializeType('DURATION' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'duration'});
-      expect(
-        legacyDeserializeType('DOUBLE' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'double'});
-      expect(
-        legacyDeserializeType('BOOLEAN' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'boolean'});
-      expect(
-        legacyDeserializeType('BYTES' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'bytes'});
-      expect(
-        legacyDeserializeType('ARG_SET_ID' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'arg_set_id'});
-    });
-
-    it('should handle lowercase legacy string types', () => {
-      expect(
-        legacyDeserializeType('int' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'int'});
-      expect(
-        legacyDeserializeType('string' as unknown as PerfettoSqlType),
-      ).toEqual({kind: 'string'});
-    });
-
-    it('should return undefined for unrecognized legacy strings', () => {
-      expect(
-        legacyDeserializeType('UNKNOWN' as unknown as PerfettoSqlType),
-      ).toBeUndefined();
-      expect(
-        legacyDeserializeType('NA' as unknown as PerfettoSqlType),
-      ).toBeUndefined();
-    });
-
-    it('should return undefined for objects without kind', () => {
-      expect(
-        legacyDeserializeType({} as unknown as PerfettoSqlType),
-      ).toBeUndefined();
     });
   });
 });

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/core_nodes.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/core_nodes.ts
@@ -236,10 +236,7 @@ export function registerCoreNodes() {
         factoryCtx?.context ?? {},
       ),
     deserialize: (_attrs, trace, sqlModules) =>
-      new AddColumnsNode(
-        AddColumnsNode.deserializeState(_attrs as AddColumnsNodeAttrs),
-        {trace, sqlModules},
-      ),
+      new AddColumnsNode(_attrs as AddColumnsNodeAttrs, {trace, sqlModules}),
   });
 
   nodeRegistry.register('modify_columns', {
@@ -252,10 +249,7 @@ export function registerCoreNodes() {
     factory: (_attrs) =>
       new ModifyColumnsNode(_attrs as unknown as ModifyColumnsNodeAttrs, {}),
     deserialize: (_attrs, _trace, _sqlModules) =>
-      new ModifyColumnsNode(
-        ModifyColumnsNode.deserializeState(_attrs as ModifyColumnsNodeAttrs),
-        {},
-      ),
+      new ModifyColumnsNode(_attrs as ModifyColumnsNodeAttrs, {}),
   });
 
   nodeRegistry.register('aggregation', {
@@ -351,9 +345,7 @@ export function registerCoreNodes() {
       return new JoinNode(attrs, factoryCtx?.context ?? {});
     },
     deserialize: (_attrs, _trace, sqlModules) =>
-      new JoinNode(JoinNode.deserializeState(_attrs as JoinNodeAttrs), {
-        sqlModules,
-      }),
+      new JoinNode(_attrs as JoinNodeAttrs, {sqlModules}),
     postDeserializeLate: (node) => {
       const joinNode = node as JoinNode;
       joinNode.onPrevNodesUpdated();

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/add_columns_node.ts
@@ -20,11 +20,7 @@ import {
   NodeContext,
 } from '../../query_node';
 import {getSecondaryInput} from '../graph_utils';
-import {
-  ColumnInfo,
-  columnInfoFromSqlColumn,
-  legacyDeserializeType,
-} from '../column_info';
+import {ColumnInfo, columnInfoFromSqlColumn} from '../column_info';
 import {
   PerfettoSqlType,
   PerfettoSqlTypes,
@@ -1674,19 +1670,5 @@ export class AddColumnsNode implements QueryNode {
         : undefined,
       this.nodeId,
     );
-  }
-
-  static deserializeState(
-    serializedState: AddColumnsNodeAttrs,
-  ): AddColumnsNodeAttrs {
-    // Migrate columnTypes: apply legacyDeserializeType to each value.
-    const columnTypes = serializedState.columnTypes
-      ? Object.fromEntries(
-          Object.entries(serializedState.columnTypes)
-            .map(([k, v]) => [k, legacyDeserializeType(v)] as const)
-            .filter((e): e is [string, PerfettoSqlType] => e[1] !== undefined),
-        )
-      : undefined;
-    return {...serializedState, columnTypes};
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node.ts
@@ -22,7 +22,7 @@ import {
 } from '../../query_node';
 import {getSecondaryInput} from '../graph_utils';
 import protos from '../../../../protos';
-import {ColumnInfo, legacyDeserializeType} from '../column_info';
+import {ColumnInfo} from '../column_info';
 import {Callout} from '../../../../widgets/callout';
 import {NodeIssues} from '../node_issues';
 import {Switch} from '../../../../widgets/switch';
@@ -438,34 +438,5 @@ export class JoinNode implements QueryNode {
     });
 
     return sq;
-  }
-
-  static deserializeState(attrs: JoinNodeAttrs): JoinNodeAttrs {
-    // Migrate legacy columnName field and string types
-    const migrateColumns = (
-      cols?: (ColumnInfo & {columnName?: string})[],
-    ): ColumnInfo[] =>
-      (cols ?? []).map((c) => ({
-        name: c.columnName ?? c.name,
-        type: legacyDeserializeType(c.type),
-        checked: c.checked,
-        alias: c.alias,
-        typeUserModified: c.typeUserModified,
-      }));
-
-    return {
-      ...attrs,
-      conditionType: attrs.conditionType ?? 'equality',
-      joinType: attrs.joinType ?? 'INNER',
-      leftColumn: attrs.leftColumn ?? '',
-      rightColumn: attrs.rightColumn ?? '',
-      sqlExpression: attrs.sqlExpression ?? '',
-      leftColumns: migrateColumns(
-        attrs.leftColumns as (ColumnInfo & {columnName?: string})[],
-      ),
-      rightColumns: migrateColumns(
-        attrs.rightColumns as (ColumnInfo & {columnName?: string})[],
-      ),
-    };
   }
 }

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/join_node_unittest.ts
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {JoinNode, JoinNodeAttrs} from './join_node';
+import {JoinNode} from './join_node';
 import {QueryNode, NodeType} from '../../query_node';
 import {ColumnInfo} from '../column_info';
-import {PerfettoSqlTypes} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 
 describe('JoinNode', () => {
@@ -1030,72 +1029,6 @@ describe('JoinNode', () => {
     });
   });
 
-  describe('deserializeState', () => {
-    it('should deserialize state correctly', () => {
-      const serialized = {
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality' as const,
-        joinType: 'INNER' as const,
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: undefined,
-        rightColumns: undefined,
-      };
-
-      const state = JoinNode.deserializeState(serialized);
-
-      expect(state.leftQueryAlias).toBe('left');
-      expect(state.rightQueryAlias).toBe('right');
-      expect(state.conditionType).toBe('equality');
-      expect(state.leftColumn).toBe('id');
-      expect(state.rightColumn).toBe('id');
-    });
-
-    it('should deserialize legacy string types into PerfettoSqlType', () => {
-      const legacySerialized = {
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality' as const,
-        leftColumn: 'id',
-        rightColumn: 'id',
-        leftColumns: [
-          {name: 'id', type: 'INT', checked: true, columnName: 'id'},
-          {name: 'ts', type: 'TIMESTAMP', checked: false, columnName: 'ts'},
-        ],
-        rightColumns: [
-          {name: 'val', type: 'DOUBLE', checked: true, columnName: 'val'},
-        ],
-      } as unknown as JoinNodeAttrs;
-
-      const state = JoinNode.deserializeState(legacySerialized);
-
-      expect(state.leftColumns?.[0].type).toEqual(PerfettoSqlTypes.INT);
-      expect(state.leftColumns?.[1].type).toEqual(PerfettoSqlTypes.TIMESTAMP);
-      expect(state.rightColumns?.[0].type).toEqual(PerfettoSqlTypes.DOUBLE);
-    });
-
-    it('should deserialize new PerfettoSqlType objects correctly', () => {
-      const newSerialized: JoinNodeAttrs = {
-        leftQueryAlias: 'left',
-        rightQueryAlias: 'right',
-        conditionType: 'equality',
-        joinType: 'INNER',
-        leftColumn: 'id',
-        rightColumn: 'id',
-        sqlExpression: '',
-        leftColumns: [{name: 'id', type: {kind: 'int'}, checked: true}],
-        rightColumns: [{name: 'dur', type: {kind: 'duration'}, checked: true}],
-      };
-
-      const state = JoinNode.deserializeState(newSerialized);
-
-      expect(state.leftColumns?.[0].type).toEqual(PerfettoSqlTypes.INT);
-      expect(state.rightColumns?.[0].type).toEqual(PerfettoSqlTypes.DURATION);
-    });
-  });
-
   describe('serialize/deserialize round-trip', () => {
     it('should preserve checked columns after serialization and deserialization', () => {
       // Create mock source nodes with columns
@@ -1138,15 +1071,12 @@ describe('JoinNode', () => {
       // Serialize the state via attrs
       const serialized = joinNode.attrs;
 
-      // Deserialize the state
-      const deserializedState = JoinNode.deserializeState(serialized);
-
-      // Create a new join node from deserialized state
-      // Connections are now restored at the graph level by json_handler
+      // Create a new join node from serialized state (connections restored at
+      // the graph level by json_handler; constructor handles defaults).
       const restoredNode = createJoinNodeWithInputs(
         node1,
         node2,
-        {...deserializedState},
+        {...serialized},
         {},
       );
 
@@ -1203,15 +1133,11 @@ describe('JoinNode', () => {
       // Serialize the state via attrs
       const serialized = joinNode.attrs;
 
-      // Deserialize the state
-      const deserializedState = JoinNode.deserializeState(serialized);
-
-      // Create a new join node from deserialized state
-      // Connections are now restored at the graph level by json_handler
+      // Create a new join node from serialized state.
       const restoredNode = createJoinNodeWithInputs(
         node1,
         node2,
-        {...deserializedState},
+        {...serialized},
         {},
       );
 

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node.ts
@@ -15,7 +15,7 @@
 import m from 'mithril';
 import {QueryNode, nextNodeId, NodeType, NodeContext} from '../../query_node';
 import {TextInput} from '../../../../widgets/text_input';
-import {ColumnInfo, legacyDeserializeType} from '../column_info';
+import {ColumnInfo} from '../column_info';
 import {PerfettoSqlType} from '../../../../trace_processor/perfetto_sql_type';
 import protos from '../../../../protos';
 import {NodeIssues} from '../node_issues';
@@ -91,20 +91,6 @@ export class ModifyColumnsNode implements QueryNode {
 
     this.attrs.selectedColumns = newSelectedColumns;
     this.context.onchange?.();
-  }
-
-  static deserializeState(
-    state: ModifyColumnsNodeAttrs,
-  ): ModifyColumnsNodeAttrs {
-    return {
-      selectedColumns: state.selectedColumns.map((c) => ({
-        ...c,
-        // Handle legacy string types (e.g. 'INT' → {kind: 'int'})
-        type: legacyDeserializeType(
-          c.type as unknown as PerfettoSqlType | string | undefined,
-        ),
-      })),
-    };
   }
 
   validate(): boolean {

--- a/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
+++ b/ui/src/plugins/dev.perfetto.DataExplorer/query_builder/nodes/modify_columns_node_unittest.ts
@@ -181,59 +181,6 @@ describe('ModifyColumnsNode', () => {
     });
   });
 
-  describe('legacy deserialization', () => {
-    it('should deserialize legacy string types into PerfettoSqlType', () => {
-      // Simulate old serialized state where type was a string like "INT"
-      const legacyState = {
-        selectedColumns: [
-          {name: 'id', type: 'INT', checked: true},
-          {name: 'name', type: 'STRING', checked: true},
-          {name: 'ts', type: 'TIMESTAMP', checked: false},
-        ],
-      } as unknown as ModifyColumnsNodeAttrs;
-
-      const state = ModifyColumnsNode.deserializeState(legacyState);
-
-      expect(state.selectedColumns[0].type).toEqual(PerfettoSqlTypes.INT);
-      expect(state.selectedColumns[1].type).toEqual(PerfettoSqlTypes.STRING);
-      expect(state.selectedColumns[2].type).toEqual(PerfettoSqlTypes.TIMESTAMP);
-    });
-
-    it('should deserialize new PerfettoSqlType objects correctly', () => {
-      const newState: ModifyColumnsNodeAttrs = {
-        selectedColumns: [
-          {name: 'id', type: {kind: 'int'}, checked: true},
-          {name: 'dur', type: {kind: 'duration'}, checked: true},
-        ],
-      };
-
-      const state = ModifyColumnsNode.deserializeState(newState);
-
-      expect(state.selectedColumns[0].type).toEqual(PerfettoSqlTypes.INT);
-      expect(state.selectedColumns[1].type).toEqual(PerfettoSqlTypes.DURATION);
-    });
-
-    it('should handle undefined types gracefully', () => {
-      const stateWithNoTypes = {
-        selectedColumns: [{name: 'col1', checked: true}],
-      } as unknown as ModifyColumnsNodeAttrs;
-
-      const state = ModifyColumnsNode.deserializeState(stateWithNoTypes);
-
-      expect(state.selectedColumns[0].type).toBeUndefined();
-    });
-
-    it('should handle unrecognized legacy string types', () => {
-      const stateWithUnknown = {
-        selectedColumns: [{name: 'col1', type: 'NA', checked: true}],
-      } as unknown as ModifyColumnsNodeAttrs;
-
-      const state = ModifyColumnsNode.deserializeState(stateWithUnknown);
-
-      expect(state.selectedColumns[0].type).toBeUndefined();
-    });
-  });
-
   describe('finalCols computation', () => {
     it('should include only checked columns', () => {
       const col1 = createColumnInfo('id', 'int');


### PR DESCRIPTION
Moves all serialized-format migration logic (string types, legacy field names) out of individual node classes and into a single `migrateNodeState()` function in `json_handler.ts`. This runs before node construction, so nodes no longer need to know about or handle legacy formats