### PR TITLE
ui: Move command fuzzy out of CommandManager

### DIFF
--- a/ui/src/core/command_manager.ts
+++ b/ui/src/core/command_manager.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {z} from 'zod';
-import {FuzzyFinder, FuzzySegment} from '../base/fuzzy';
 import {Registry} from '../base/registry';
 import {Command, CommandManager} from '../public/command';
 import {raf} from './raf_scheduler';
@@ -81,10 +80,6 @@ export function parseUrlCommands(
   }
 }
 
-export interface CommandWithMatchInfo extends Command {
-  segments: FuzzySegment[];
-}
-
 export class CommandManagerImpl implements CommandManager {
   private readonly registry = new Registry<Command>((cmd) => cmd.id);
   private readonly macros = new Registry<string>((macroId) => macroId);
@@ -139,16 +134,6 @@ export class CommandManagerImpl implements CommandManager {
       }),
     );
     return stack;
-  }
-
-  // Returns a list of commands that match the search term, along with a list
-  // of segments which describe which parts of the command name match and
-  // which don't.
-  fuzzyFilterCommands(searchTerm: string): CommandWithMatchInfo[] {
-    const finder = new FuzzyFinder(this.commands, ({name}) => name);
-    return finder.find(searchTerm).map((result) => {
-      return {segments: result.segments, ...result.item};
-    });
   }
 
   setExecutingStartupCommands(isExecuting: boolean) {

--- a/ui/src/frontend/omnibox.ts
+++ b/ui/src/frontend/omnibox.ts
@@ -30,6 +30,7 @@ import {EmptyState} from '../widgets/empty_state';
 import {HotkeyGlyphs, KeycapGlyph} from '../widgets/hotkey_glyphs';
 import {Popup} from '../widgets/popup';
 import {Spinner} from '../widgets/spinner';
+import {Command} from '../public/command';
 
 const OMNIBOX_INPUT_REF = 'omnibox';
 const RECENT_COMMANDS_LIMIT = 6;
@@ -37,6 +38,10 @@ const RECENT_COMMANDS_LIMIT = 6;
 // Omnibox attrs - simplified to just what's needed from outside
 export interface OmniboxAttrs {
   readonly trace?: TraceImpl;
+}
+
+interface CommandWithMatchInfo extends Command {
+  readonly segments: FuzzySegment[];
 }
 
 // Omnibox: Smart component that contains all omnibox business logic
@@ -116,10 +121,20 @@ export class Omnibox implements m.ClassComponent<OmniboxAttrs> {
     });
   }
 
+  private fuzzyFilterCommands(searchTerm: string): CommandWithMatchInfo[] {
+    const app = AppImpl.instance;
+    const allCommands = app.commands.commands;
+
+    const finder = new FuzzyFinder(allCommands, ({name}) => name);
+    return finder.find(searchTerm).map((result) => {
+      return {segments: result.segments, ...result.item};
+    });
+  }
+
   private renderCommandOmnibox(): m.Children {
     // Fuzzy-filter commands by the filter string.
     const {commands, omnibox} = AppImpl.instance;
-    const filteredCmds = commands.fuzzyFilterCommands(omnibox.text);
+    const filteredCmds = this.fuzzyFilterCommands(omnibox.text);
 
     // Create an array of commands with attached heuristics from the recent
     // command register.


### PR DESCRIPTION
The function `fuzzyFindCommands()` currently lives on the command manager and pulled fuzzy find interfaces into everything that depends on commands. The command manger should arguably have nothing to do with how commands are projected, and only know how to provide a simple registry of commands.

This patch inlines the command fuzzy finding logic into the omnibox component.

This is a pure refactor - no functional changes.