### PR TITLE
ui: Tidy up the public CommandManager interface

### DIFF
--- a/ui/src/core/command_manager.ts
+++ b/ui/src/core/command_manager.ts
@@ -14,7 +14,7 @@
 
 import {z} from 'zod';
 import {Registry} from '../base/registry';
-import {Command, CommandManager} from '../public/command';
+import {Command, CommandManager} from '../public/commands';
 import {raf} from './raf_scheduler';
 import {OmniboxManagerImpl} from './omnibox_manager';
 import {STARTUP_COMMAND_ALLOWLIST_SET} from './startup_command_allowlist';
@@ -87,16 +87,16 @@ export class CommandManagerImpl implements CommandManager {
 
   constructor(private omnibox: OmniboxManagerImpl) {}
 
-  getCommand(commandId: string): Command {
-    return this.registry.get(commandId);
+  getCommand(commandId: string): Command | undefined {
+    return this.registry.tryGet(commandId);
   }
 
   hasCommand(commandId: string): boolean {
     return this.registry.has(commandId);
   }
 
-  get commands(): Command[] {
-    return Array.from(this.registry.values());
+  getCommands(): readonly Command[] {
+    return this.registry.valuesAsArray();
   }
 
   registerCommand(cmd: Command): Disposable {
@@ -113,6 +113,8 @@ export class CommandManagerImpl implements CommandManager {
     Promise.resolve(res).finally(() => raf.scheduleFullRedraw());
     return res;
   }
+
+  // Internal API: not part of the public CommandManager interface.
 
   registerMacro({id, name, run}: Macro, source?: string) {
     const stack = new DisposableStack();

--- a/ui/src/core/trace_impl.ts
+++ b/ui/src/core/trace_impl.ts
@@ -15,7 +15,7 @@
 import {DisposableStack} from '../base/disposable_stack';
 import {createStore, Migrate, Store} from '../base/store';
 import {TimelineImpl} from './timeline';
-import {Command} from '../public/command';
+import {Command} from '../public/commands';
 import {Trace} from '../public/trace';
 import {ScrollToArgs} from '../public/scroll_helper';
 import {Engine, EngineBase} from '../trace_processor/engine';

--- a/ui/src/frontend/help_modal.ts
+++ b/ui/src/frontend/help_modal.ts
@@ -157,7 +157,8 @@ class KeyMappingsHelp implements m.ClassComponent {
       m('h2', 'Command Hotkeys'),
       m(
         'table',
-        AppImpl.instance.commands.commands
+        AppImpl.instance.commands
+          .getCommands()
           .filter(({defaultHotkey}) => defaultHotkey)
           .sort((a, b) => a.name.localeCompare(b.name))
           .map(({defaultHotkey, name}) => {

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -389,7 +389,7 @@ function onCssLoaded(app: AppImpl) {
     view: () => {
       const commands = app.commands;
       const hotkeys: HotkeyConfig[] = [];
-      for (const {id, defaultHotkey} of commands.commands) {
+      for (const {id, defaultHotkey} of commands.getCommands()) {
         if (defaultHotkey) {
           hotkeys.push({
             callback: () => commands.runCommand(id),

--- a/ui/src/frontend/omnibox.ts
+++ b/ui/src/frontend/omnibox.ts
@@ -30,7 +30,7 @@ import {EmptyState} from '../widgets/empty_state';
 import {HotkeyGlyphs, KeycapGlyph} from '../widgets/hotkey_glyphs';
 import {Popup} from '../widgets/popup';
 import {Spinner} from '../widgets/spinner';
-import {Command} from '../public/command';
+import {Command} from '../public/commands';
 
 const OMNIBOX_INPUT_REF = 'omnibox';
 const RECENT_COMMANDS_LIMIT = 6;
@@ -123,8 +123,7 @@ export class Omnibox implements m.ClassComponent<OmniboxAttrs> {
 
   private fuzzyFilterCommands(searchTerm: string): CommandWithMatchInfo[] {
     const app = AppImpl.instance;
-    const allCommands = app.commands.commands;
-
+    const allCommands = app.commands.getCommands();
     const finder = new FuzzyFinder(allCommands, ({name}) => name);
     return finder.find(searchTerm).map((result) => {
       return {segments: result.segments, ...result.item};

--- a/ui/src/frontend/sidebar.ts
+++ b/ui/src/frontend/sidebar.ts
@@ -26,7 +26,7 @@ import {Router} from '../core/router';
 import {SidebarMenuItemInternal} from '../core/sidebar_manager';
 import {OptionalTraceImplAttrs, TraceImpl} from '../core/trace_impl';
 import {SCM_REVISION, VERSION} from '../gen/perfetto_version';
-import {Command} from '../public/command';
+import {Command} from '../public/commands';
 import {SIDEBAR_SECTIONS, SidebarSections} from '../public/sidebar';
 import {EngineMode} from '../trace_processor/engine';
 import {Icon} from '../widgets/icon';

--- a/ui/src/public/app.ts
+++ b/ui/src/public/app.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {RouteArgs} from './route_schema';
-import {CommandManager} from './command';
+import {CommandManager} from './commands';
 import {OmniboxManager} from './omnibox';
 import {SidebarManager} from './sidebar';
 import {Analytics} from './analytics';

--- a/ui/src/public/commands.ts
+++ b/ui/src/public/commands.ts
@@ -14,14 +14,6 @@
 
 import {Hotkey} from '../base/hotkeys';
 
-export interface CommandManager {
-  registerCommand(command: Command): void;
-
-  hasCommand(commandId: string): boolean;
-
-  runCommand(id: string, ...args: unknown[]): unknown;
-}
-
 export interface Command {
   // A unique id for this command.
   id: string;
@@ -40,4 +32,20 @@ export interface Command {
   // A human-readable label shown as a left-side chip in the command palette,
   // indicating where this command came from (e.g. extension module name).
   source?: string;
+}
+
+export interface CommandManager {
+  // Register a command. Throws if a command with the same id already exists.
+  // Dispose the returned handle to unregister.
+  registerCommand(command: Command): Disposable;
+  // Returns true if a command with the given id is registered.
+  hasCommand(commandId: string): boolean;
+  // Look up a registered command by id. Returns the command, or undefined if
+  // not found.
+  getCommand(commandId: string): Command | undefined;
+  // Returns all registered commands.
+  getCommands(): readonly Command[];
+  // Invoke a registered command by id, forwarding any extra args to its
+  // callback. Returns whatever the callback returns.
+  runCommand(id: string, ...args: unknown[]): unknown;
 }


### PR DESCRIPTION
- Add comments.
- Add `getCommand(id)`.
- Add `getCommands()` (renamed from just `get commands`).
- Fix all `getCommands()` callsites.

Refactor only - no functional changes.