### PR TITLE
ui: Add shortest path from GC root to heap dump explorer

### DIFF
--- a/docs/visualization/heap-dump-explorer.md
+++ b/docs/visualization/heap-dump-explorer.md
@@ -243,10 +243,12 @@ instance of a data class holding the largest subgraph.
 
 ## Inspecting a single object
 
-**The _Sample Path from GC Root_ and _Objects with References to this
-Object_ are the two sections that resolve most investigations.** The
-path from GC root shows who is keeping the object alive; the reverse
-references list every object holding a field pointer to it.
+**The _Shortest Path from GC Root_, _Dominator Tree Path_ and _Objects
+with References to this Object_ are the key sections for most
+investigations.** The shortest path shows the fewest reference hops
+keeping the object alive; the dominator tree path shows the chain of
+objects that exclusively retain it; the reverse references list every
+object holding a field pointer to it.
 
 Clicking any object in any tab opens a closable tab for that instance.
 Multiple object tabs can be open at once.
@@ -256,10 +258,10 @@ The object tab contains everything known about the instance:
 - **Header** with the object id, plus an _Open in Classes_ shortcut
   when the object is itself a `Class`.
 - **Bitmap preview** for bitmap instances, with a download button.
-- **Reference path from GC root** — the chain of references keeping
-  this object alive, one step per row with the holder and the field
-  name. Dominator hops along the path are bold. If the object is
-  unreachable, a sample path is shown instead.
+- **Shortest Path from GC Root** — the shortest chain of references
+  from a GC root to this object.
+- **Dominator Tree Path** — the chain of dominators keeping this
+  object alive, one step per row with the holder and the field name.
 - **Object info** — class, heap, root type.
 - **Object size** — shallow, retained and reachable sizes split by
   Java / native / count.

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -589,10 +589,10 @@ async function fetchFieldValues(
 }
 
 /** Fetch dominator-tree path from GC root to the given object. */
-export async function fetchPathFromRoot(
+export async function fetchDominatorPath(
   engine: Engine,
   id: number,
-): Promise<InstanceDetail['pathFromRoot']> {
+): Promise<InstanceDetail['dominatorPath']> {
   const pathRes = await engine.query(`
     WITH RECURSIVE path(obj_id, depth) AS (
       SELECT ${id}, 0
@@ -640,7 +640,7 @@ export async function fetchPathFromRoot(
     entries.push({row: rowFromIter(pit), objId: pit.id});
   }
 
-  const result: NonNullable<InstanceDetail['pathFromRoot']> = [];
+  const result: NonNullable<InstanceDetail['dominatorPath']> = [];
   for (let i = 0; i < entries.length; i++) {
     let field = '';
     if (i < entries.length - 1) {
@@ -667,8 +667,122 @@ export async function fetchPathFromRoot(
   return result.length > 0 ? result : null;
 }
 
+/**
+ * Fetch shortest reference path from a GC root to the given object,
+ * using the BFS-based min-depth tree from the stdlib.
+ */
+export async function fetchShortestPathFromRoot(
+  engine: Engine,
+  id: number,
+): Promise<InstanceDetail['shortestPath']> {
+  const pathRes = await engine.query(`
+    INCLUDE PERFETTO MODULE graphs.hierarchy;
+
+    SELECT
+      o.id, t.parent_id,
+      c.name AS cls, c.deobfuscated_name AS deob,
+      o.self_size, o.native_size, o.heap_type, o.root_type,
+      dt.dominated_size_bytes AS dominated_size,
+      dt.dominated_native_size_bytes AS dominated_native,
+      dt.dominated_obj_count,
+      od.value_string, c.kind AS class_kind
+    FROM _tree_reachable_ancestors_or_self!(
+      _heap_graph_object_min_depth_tree,
+      (SELECT ${id} AS id)
+    ) a
+    JOIN _heap_graph_object_min_depth_tree t ON t.id = a.id
+    JOIN heap_graph_object o ON o.id = a.id
+    JOIN heap_graph_class c ON o.type_id = c.id
+    LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
+    LEFT JOIN heap_graph_dominator_tree dt ON dt.id = o.id
+  `);
+
+  // Collect unordered entries keyed by id.
+  const byId = new Map<
+    number,
+    {row: InstanceRow; objId: number; parentId: number | null}
+  >();
+  const parentToChild = new Map<number, number>();
+  let rootId: number | null = null;
+
+  for (
+    const pit = pathRes.iter({
+      id: NUM,
+      parent_id: NUM_NULL,
+      cls: STR,
+      deob: STR_NULL,
+      self_size: NUM,
+      native_size: NUM,
+      heap_type: STR_NULL,
+      root_type: STR_NULL,
+      dominated_size: NUM_NULL,
+      dominated_native: NUM_NULL,
+      dominated_obj_count: NUM_NULL,
+      value_string: STR_NULL,
+      class_kind: STR,
+    });
+    pit.valid();
+    pit.next()
+  ) {
+    byId.set(pit.id, {
+      row: rowFromIter(pit),
+      objId: pit.id,
+      parentId: pit.parent_id,
+    });
+  }
+  if (byId.size === 0) return null;
+
+  // Build parent→child map and find the root (parent outside the set).
+  for (const [objId, entry] of byId) {
+    if (entry.parentId === null || !byId.has(entry.parentId)) {
+      rootId = objId;
+    } else {
+      parentToChild.set(entry.parentId, objId);
+    }
+  }
+
+  // Walk root → target.
+  const entries: {row: InstanceRow; objId: number}[] = [];
+  for (
+    let cur: number | null = rootId;
+    cur !== null;
+    cur = parentToChild.get(cur) ?? null
+  ) {
+    const e = byId.get(cur);
+    if (!e) break;
+    entries.push({row: e.row, objId: e.objId});
+  }
+
+  // Resolve field names between consecutive entries.
+  const result: NonNullable<InstanceDetail['shortestPath']> = [];
+  for (let i = 0; i < entries.length; i++) {
+    let field = '';
+    if (i < entries.length - 1) {
+      const parentId = entries[i].objId;
+      const childId = entries[i + 1].objId;
+      const fRes = await engine.query(`
+        SELECT ifnull(r.deobfuscated_field_name, r.field_name) AS fname
+        FROM heap_graph_reference r
+        JOIN heap_graph_object o ON r.reference_set_id = o.reference_set_id
+        WHERE o.id = ${parentId} AND r.owned_id = ${childId}
+        LIMIT 1
+      `);
+      const fit = fRes.iter({fname: STR});
+      if (fit.valid()) {
+        field = '.' + fit.fname;
+      }
+    }
+    result.push({
+      row: entries[i].row,
+      field,
+      isDominator: false,
+    });
+  }
+  return result.length > 0 ? result : null;
+}
+
 /** Batch-fetch dominator-tree paths for multiple objects. */
-export async function fetchPathsFromRoot(
+export async function fetchDominatorPaths(
   engine: Engine,
   ids: number[],
 ): Promise<Map<number, PathEntry[]>> {
@@ -1066,7 +1180,8 @@ export async function getInstance(
   `);
   const dominated = collectRows(domRes);
 
-  const pathFromRoot = await fetchPathFromRoot(engine, id);
+  const dominatorPath = await fetchDominatorPath(engine, id);
+  const shortestPath = await fetchShortestPathFromRoot(engine, id);
 
   const staticFields = isClassObj
     ? await fetchFieldValues(engine, refSetId, fieldSetId)
@@ -1101,7 +1216,8 @@ export async function getInstance(
     bitmap,
     reverseRefs,
     dominated,
-    pathFromRoot,
+    dominatorPath,
+    shortestPath,
   };
 }
 

--- a/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
@@ -118,8 +118,8 @@ export interface InstanceDetail {
   } | null;
   reverseRefs: InstanceRow[];
   dominated: InstanceRow[];
-  pathFromRoot: PathEntry[] | null;
-  isUnreachablePath?: boolean;
+  dominatorPath: PathEntry[] | null;
+  shortestPath: PathEntry[] | null;
 }
 
 export interface ClassRow {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -303,7 +303,7 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
     const ids = bitmaps.map((b) => b.row.id);
     if (ids.length === 0) return;
     queries
-      .fetchPathsFromRoot(engine, ids)
+      .fetchDominatorPaths(engine, ids)
       .then((paths) => {
         if (!alive) return;
         for (const id of ids) {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -611,16 +611,46 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
 
         m(
           Section,
-          {
-            title: detail.isUnreachablePath
-              ? 'Sample Path'
-              : 'Sample Path from GC Root',
-          },
-          detail.pathFromRoot
+          {title: 'Shortest Path from GC Root'},
+          detail.shortestPath
             ? m(
                 'div',
                 {class: 'ah-view-stack--tight'},
-                detail.pathFromRoot.map((pe, i) =>
+                detail.shortestPath.map((pe, i) =>
+                  m(
+                    'div',
+                    {
+                      key: i,
+                      class: 'ah-path-entry',
+                      style: {'--ah-depth': String(i)},
+                    },
+                    [
+                      m(
+                        'span',
+                        {class: 'ah-path-arrow'},
+                        i === 0 ? '' : '\u2192',
+                      ),
+                      m(InstanceLink, {row: pe.row, navigate}),
+                      pe.field
+                        ? m('span', {class: 'ah-path-field'}, pe.field)
+                        : null,
+                    ],
+                  ),
+                ),
+              )
+            : m('p', {class: 'ah-muted'}, 'No path to GC root.'),
+        ),
+
+        m(
+          Section,
+          {
+            title: 'Dominator Tree Path',
+          },
+          detail.dominatorPath
+            ? m(
+                'div',
+                {class: 'ah-view-stack--tight'},
+                detail.dominatorPath.map((pe, i) =>
                   m(
                     'div',
                     {


### PR DESCRIPTION
The existing "Sample Path from GC Root" section was walking the dominator tree, not actual references. Renamed it to "Dominator Tree Path" to reflect what it actually shows.

Added a new "Shortest Path from GC Root" section that walks the BFS min-depth reference tree (_heap_graph_object_min_depth_tree) from the stdlib, showing the fewest reference hops from a GC root to the selected object.

Both paths are shown in the object tab: shortest path first (most useful for understanding reachability), dominator tree path second (most useful for understanding retained memory).