### PR TITLE
ui: surface blocked/failed startup commands in a dialog

### DIFF
--- a/ui/src/core/command_manager.ts
+++ b/ui/src/core/command_manager.ts
@@ -62,6 +62,21 @@ export const macroSchema = z.object({
 export type Macro = z.infer<typeof macroSchema>;
 
 /**
+ * Thrown by runCommand() when a command is rejected because it's not on the
+ * startup allowlist and the command manager is currently running startup
+ * commands. Callers driving the startup loop catch this to collect the set
+ * of blocked IDs.
+ */
+export class StartupCommandNotAllowedError extends Error {
+  constructor(readonly commandId: string) {
+    super(
+      `Startup command "${commandId}" is not on the allowlist and was blocked`,
+    );
+    this.name = 'StartupCommandNotAllowedError';
+  }
+}
+
+/**
  * Parses URL commands parameter from route args.
  * @param commandsParam URL commands parameter (JSON-encoded string)
  * @returns Parsed commands array or undefined if parsing fails
@@ -110,8 +125,7 @@ export class CommandManagerImpl implements CommandManager {
 
   runCommand(id: string, ...args: unknown[]): unknown {
     if (this.isExecutingStartupCommands && !this.isStartupCommandAllowed(id)) {
-      console.warn(`Command ${id} is not allowed in current execution context`);
-      return;
+      throw new StartupCommandNotAllowedError(id);
     }
     const cmd = this.registry.get(id);
     const res = cmd.callback(...args);

--- a/ui/src/core/load_trace.ts
+++ b/ui/src/core/load_trace.ts
@@ -48,9 +48,14 @@ import {TraceSource} from './trace_source';
 import {Router} from '../core/router';
 import {TraceInfoImpl} from './trace_info_impl';
 import {base64Decode} from '../base/string_utils';
-import {parseUrlCommands} from './command_manager';
+import {
+  parseUrlCommands,
+  StartupCommandNotAllowedError,
+} from './command_manager';
 import {HighPrecisionTimeSpan} from '../base/high_precision_time_span';
 import {sha1} from '../base/hash';
+import {showModal} from '../widgets/modal';
+import m from 'mithril';
 
 const ENABLE_CHROME_RELIABLE_RANGE_ZOOM_FLAG = featureFlags.register({
   id: 'enableChromeReliableRangeZoom',
@@ -328,6 +333,8 @@ async function loadTraceIntoEngine(
       app.commands.setExecutingStartupCommands(true);
     }
 
+    const blocked: string[] = [];
+    const failed: Array<{id: string; error: unknown}> = [];
     try {
       for (const command of allStartupCommands) {
         try {
@@ -335,20 +342,64 @@ async function loadTraceIntoEngine(
           // commands.
           await app.commands.runCommand(command.id, ...command.args);
         } catch (error) {
-          // TODO(stevegolton): Add a mechanism to notify users of startup
-          // command errors. This will involve creating a notification UX
-          // similar to VSCode where there are popups on the bottom right
-          // of the UI.
-          console.warn(`Startup command ${command.id} failed:`, error);
+          if (error instanceof StartupCommandNotAllowedError) {
+            blocked.push(error.commandId);
+          } else {
+            failed.push({id: command.id, error});
+          }
         }
       }
     } finally {
       // Always restore default (allow all) behavior when done
       app.commands.setExecutingStartupCommands(false);
     }
+
+    if (blocked.length > 0 || failed.length > 0) {
+      showStartupCommandIssuesDialog(blocked, failed);
+    }
   }
 
   return trace;
+}
+
+function showStartupCommandIssuesDialog(
+  blocked: ReadonlyArray<string>,
+  failed: ReadonlyArray<{id: string; error: unknown}>,
+) {
+  const uniqueBlocked = Array.from(new Set(blocked));
+  showModal({
+    title: 'Some startup commands did not run',
+    content: () =>
+      m(
+        '.pf-startup-command-issues',
+        uniqueBlocked.length > 0 &&
+          m(
+            'section',
+            m(
+              'p',
+              'These commands were blocked because they are not on the ',
+              "allowlist. Disable 'Enforce startup command allowlist' in ",
+              'settings to run them anyway.',
+            ),
+            m(
+              'ul',
+              uniqueBlocked.map((id) => m('li', m('code', id))),
+            ),
+          ),
+        failed.length > 0 &&
+          m(
+            'section',
+            m('p', 'These commands threw an error while executing:'),
+            m(
+              'ul',
+              failed.map(({id, error}) =>
+                m('li', m('code', id), ': ', String(error)),
+              ),
+            ),
+          ),
+      ),
+    buttons: [{text: 'Dismiss', primary: true}],
+  });
 }
 
 function decideTabs(trace: TraceImpl) {


### PR DESCRIPTION
Startup commands that aren't on the allowlist were previously dropped
silently with only a console.warn. Make CommandManagerImpl.runCommand
throw a typed StartupCommandNotAllowedError when blocked, and have the
load_trace startup loop catch both that error and any other exceptions
to accumulate per-command results. After the loop, if anything was
blocked or failed, show a single modal dialog listing the offending
command IDs (and the error text for failures). This replaces the
TODO about needing a notification UX for startup-command errors.
