### PR TITLE
ui: Add shortest-path option to heap dump explorer bitmap tab

### DIFF
--- a/docs/visualization/heap-dump-explorer.md
+++ b/docs/visualization/heap-dump-explorer.md
@@ -319,8 +319,10 @@ retained memory and a _Details_ button that opens the object tab.
 Pixel buffers may be RGBA, PNG, JPEG or WebP depending on how they
 were stored.
 
-The _Show Paths_ toggle adds the reference path from the GC root to
-each card — the fastest way to spot an `Activity`, `Fragment` or
+The path dropdown above the gallery picks which reference path to
+overlay on each card: _Shortest path_ (fewest edges from a GC root),
+_Dominator path_ (the chain of dominators), or _No path_. Showing a
+path is the fastest way to spot an `Activity`, `Fragment` or
 `Handler` holding leaked bitmaps.
 
 ![Bitmaps gallery with "Show Paths" enabled; the reference chain below each card runs `Class<FeedAdapter>.cache → ArrayList → Bitmap`, showing the single static holder.](../images/heap_docs/09-bitmaps-show-paths.png)
@@ -586,8 +588,9 @@ render as cards:
 
 ![Bitmaps gallery filtered to the 128×128 group. Twelve copies at 64.2 KiB each, 971.2 KiB retained across the tab.](../images/heap_docs/08-bitmaps-gallery.png)
 
-**Find the holder.** Toggle _Show Paths_. The reference chain below
-each card is the fields keeping that bitmap alive:
+**Find the holder.** Set the path dropdown to _Shortest path_. The
+reference chain below each card is the fields keeping that bitmap
+alive:
 
 ![Bitmaps gallery with Show Paths on. Every card's chain reads Class&lt;FeedAdapter&gt;.cache → ArrayList → Bitmap — the companion-object list is the single holder.](../images/heap_docs/09-bitmaps-show-paths.png)
 

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -593,122 +593,101 @@ export async function fetchDominatorPath(
   engine: Engine,
   id: number,
 ): Promise<InstanceDetail['dominatorPath']> {
-  const pathRes = await engine.query(`
-    WITH RECURSIVE path(obj_id, depth) AS (
-      SELECT ${id}, 0
-      UNION ALL
-      SELECT d.idom_id, p.depth + 1
-      FROM path p
-      JOIN heap_graph_dominator_tree d ON d.id = p.obj_id
-      WHERE d.idom_id IS NOT NULL AND p.depth < 100
-    )
-    SELECT
-      p.obj_id AS id, p.depth,
-      c.name AS cls, c.deobfuscated_name AS deob,
-      o.self_size, o.native_size, o.heap_type, o.root_type,
-      dt.dominated_size_bytes AS dominated_size,
-      dt.dominated_native_size_bytes AS dominated_native,
-      dt.dominated_obj_count,
-      od.value_string, c.kind AS class_kind
-    FROM path p
-    JOIN heap_graph_object o ON o.id = p.obj_id
-    JOIN heap_graph_class c ON o.type_id = c.id
-    LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
-    LEFT JOIN heap_graph_dominator_tree dt ON dt.id = o.id
-    ORDER BY p.depth DESC
-  `);
-  const entries: {row: InstanceRow; objId: number}[] = [];
-  for (
-    const pit = pathRes.iter({
-      id: NUM,
-      depth: NUM,
-      cls: STR,
-      deob: STR_NULL,
-      self_size: NUM,
-      native_size: NUM,
-      heap_type: STR_NULL,
-      root_type: STR_NULL,
-      dominated_size: NUM_NULL,
-      dominated_native: NUM_NULL,
-      dominated_obj_count: NUM_NULL,
-      value_string: STR_NULL,
-      class_kind: STR,
-    });
-    pit.valid();
-    pit.next()
-  ) {
-    entries.push({row: rowFromIter(pit), objId: pit.id});
-  }
-
-  const result: NonNullable<InstanceDetail['dominatorPath']> = [];
-  for (let i = 0; i < entries.length; i++) {
-    let field = '';
-    if (i < entries.length - 1) {
-      const parentId = entries[i].objId;
-      const childId = entries[i + 1].objId;
-      const fRes = await engine.query(`
-        SELECT ifnull(r.deobfuscated_field_name, r.field_name) AS fname
-        FROM heap_graph_reference r
-        JOIN heap_graph_object o ON r.reference_set_id = o.reference_set_id
-        WHERE o.id = ${parentId} AND r.owned_id = ${childId}
-        LIMIT 1
-      `);
-      const fit = fRes.iter({fname: STR});
-      if (fit.valid()) {
-        field = '.' + fit.fname;
-      }
-    }
-    result.push({
-      row: entries[i].row,
-      field,
-      isDominator: true,
-    });
-  }
-  return result.length > 0 ? result : null;
+  return (await fetchDominatorPaths(engine, [id])).get(id) ?? null;
 }
 
-/**
- * Fetch shortest reference path from a GC root to the given object,
- * using the BFS-based min-depth tree from the stdlib.
- */
+/** Fetch shortest reference path from a GC root to the given object. */
 export async function fetchShortestPathFromRoot(
   engine: Engine,
   id: number,
 ): Promise<InstanceDetail['shortestPath']> {
-  const pathRes = await engine.query(`
-    INCLUDE PERFETTO MODULE graphs.hierarchy;
+  return (await fetchShortestPaths(engine, [id])).get(id) ?? null;
+}
 
+/** Batch-fetch shortest reference paths for multiple objects. */
+export async function fetchShortestPaths(
+  engine: Engine,
+  ids: number[],
+): Promise<Map<number, PathEntry[]>> {
+  const result = new Map<number, PathEntry[]>();
+  if (ids.length === 0) return result;
+
+  await requireDominatorTree(engine);
+
+  // Walk UP the BFS tree (id→parent_id) from each target.
+  const seeds = ids
+    .map((id) => `SELECT ${id} AS root_node_id, 1 AS root_target_weight`)
+    .join(' UNION ALL ');
+  const dfsRes = await engine.query(`
+    INCLUDE PERFETTO MODULE graphs.search;
+    SELECT root_node_id, node_id
+    FROM graph_reachable_weight_bounded_dfs!(
+      (
+        SELECT id AS source_node_id, parent_id AS dest_node_id,
+          0 AS edge_weight
+        FROM _heap_graph_object_min_depth_tree
+        WHERE parent_id IS NOT NULL
+      ),
+      (${seeds}),
+      1
+    )
+  `);
+
+  const allNodeIds = new Set<number>();
+  for (const it = dfsRes.iter({node_id: NUM}); it.valid(); it.next()) {
+    allNodeIds.add(it.node_id);
+  }
+  if (allNodeIds.size === 0) return result;
+
+  // Fetch parent_id links to reconstruct ordered chains.
+  const parentRes = await engine.query(`
+    SELECT id, parent_id
+    FROM _heap_graph_object_min_depth_tree
+    WHERE id IN (${Array.from(allNodeIds).join(',')})
+  `);
+  const parentMap = new Map<number, number | null>();
+  for (
+    const it = parentRes.iter({id: NUM, parent_id: NUM_NULL});
+    it.valid();
+    it.next()
+  ) {
+    parentMap.set(it.id, it.parent_id ?? null);
+  }
+
+  // Reconstruct ordered chains: walk parent_id from each target up, reverse.
+  const pathChains = new Map<number, number[]>();
+  for (const id of ids) {
+    const chain: number[] = [];
+    let cur: number | null = id;
+    while (cur !== null && parentMap.has(cur)) {
+      chain.push(cur);
+      cur = parentMap.get(cur) ?? null;
+    }
+    if (chain.length === 0) continue;
+    chain.reverse();
+    pathChains.set(id, chain);
+  }
+  if (pathChains.size === 0) return result;
+
+  // Batch-fetch node metadata.
+  const nodeRes = await engine.query(`
     SELECT
-      o.id, t.parent_id,
-      c.name AS cls, c.deobfuscated_name AS deob,
+      o.id, c.name AS cls, c.deobfuscated_name AS deob,
       o.self_size, o.native_size, o.heap_type, o.root_type,
       dt.dominated_size_bytes AS dominated_size,
       dt.dominated_native_size_bytes AS dominated_native,
       dt.dominated_obj_count,
       od.value_string, c.kind AS class_kind
-    FROM _tree_reachable_ancestors_or_self!(
-      _heap_graph_object_min_depth_tree,
-      (SELECT ${id} AS id)
-    ) a
-    JOIN _heap_graph_object_min_depth_tree t ON t.id = a.id
-    JOIN heap_graph_object o ON o.id = a.id
+    FROM heap_graph_object o
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     LEFT JOIN heap_graph_dominator_tree dt ON dt.id = o.id
+    WHERE o.id IN (${Array.from(allNodeIds).join(',')})
   `);
-
-  // Collect unordered entries keyed by id.
-  const byId = new Map<
-    number,
-    {row: InstanceRow; objId: number; parentId: number | null}
-  >();
-  const parentToChild = new Map<number, number>();
-  let rootId: number | null = null;
-
+  const nodeMap = new Map<number, InstanceRow>();
   for (
-    const pit = pathRes.iter({
+    const it = nodeRes.iter({
       id: NUM,
-      parent_id: NUM_NULL,
       cls: STR,
       deob: STR_NULL,
       self_size: NUM,
@@ -721,64 +700,52 @@ export async function fetchShortestPathFromRoot(
       value_string: STR_NULL,
       class_kind: STR,
     });
-    pit.valid();
-    pit.next()
+    it.valid();
+    it.next()
   ) {
-    byId.set(pit.id, {
-      row: rowFromIter(pit),
-      objId: pit.id,
-      parentId: pit.parent_id,
-    });
+    nodeMap.set(it.id, rowFromIter(it));
   }
-  if (byId.size === 0) return null;
 
-  // Build parent→child map and find the root (parent outside the set).
-  for (const [objId, entry] of byId) {
-    if (entry.parentId === null || !byId.has(entry.parentId)) {
-      rootId = objId;
-    } else {
-      parentToChild.set(entry.parentId, objId);
+  // Batch-resolve field names for all parent→child edges.
+  const edgePairs: string[] = [];
+  for (const chain of pathChains.values()) {
+    for (let i = 0; i < chain.length - 1; i++) {
+      edgePairs.push(`SELECT ${chain[i]} AS pid, ${chain[i + 1]} AS cid`);
+    }
+  }
+  const fieldMap = new Map<string, string>();
+  if (edgePairs.length > 0) {
+    const fRes = await engine.query(`
+      SELECT e.pid, e.cid,
+        ifnull(r.deobfuscated_field_name, r.field_name) AS fname
+      FROM (${edgePairs.join(' UNION ALL ')}) e
+      JOIN heap_graph_object o ON o.id = e.pid
+      JOIN heap_graph_reference r
+        ON r.reference_set_id = o.reference_set_id AND r.owned_id = e.cid
+    `);
+    for (
+      const it = fRes.iter({pid: NUM, cid: NUM, fname: STR});
+      it.valid();
+      it.next()
+    ) {
+      fieldMap.set(`${it.pid}:${it.cid}`, '.' + it.fname);
     }
   }
 
-  // Walk root → target.
-  const entries: {row: InstanceRow; objId: number}[] = [];
-  for (
-    let cur: number | null = rootId;
-    cur !== null;
-    cur = parentToChild.get(cur) ?? null
-  ) {
-    const e = byId.get(cur);
-    if (!e) break;
-    entries.push({row: e.row, objId: e.objId});
-  }
-
-  // Resolve field names between consecutive entries.
-  const result: NonNullable<InstanceDetail['shortestPath']> = [];
-  for (let i = 0; i < entries.length; i++) {
-    let field = '';
-    if (i < entries.length - 1) {
-      const parentId = entries[i].objId;
-      const childId = entries[i + 1].objId;
-      const fRes = await engine.query(`
-        SELECT ifnull(r.deobfuscated_field_name, r.field_name) AS fname
-        FROM heap_graph_reference r
-        JOIN heap_graph_object o ON r.reference_set_id = o.reference_set_id
-        WHERE o.id = ${parentId} AND r.owned_id = ${childId}
-        LIMIT 1
-      `);
-      const fit = fRes.iter({fname: STR});
-      if (fit.valid()) {
-        field = '.' + fit.fname;
-      }
+  for (const [targetId, chain] of pathChains) {
+    const path: PathEntry[] = [];
+    for (let i = 0; i < chain.length; i++) {
+      const row = nodeMap.get(chain[i]);
+      if (!row) continue;
+      const field =
+        i < chain.length - 1
+          ? fieldMap.get(`${chain[i]}:${chain[i + 1]}`) ?? ''
+          : '';
+      path.push({row, field, isDominator: false});
     }
-    result.push({
-      row: entries[i].row,
-      field,
-      isDominator: false,
-    });
+    if (path.length > 0) result.set(targetId, path);
   }
-  return result.length > 0 ? result : null;
+  return result;
 }
 
 /** Batch-fetch dominator-tree paths for multiple objects. */

--- a/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
@@ -68,6 +68,20 @@
   }
 }
 
+// Inline label+control (e.g. "Path: <select>") sitting at the right edge
+// of an .ah-heading-row.
+.ah-heading-control {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+
+  &__label {
+    color: var(--pf-color-text-hint);
+  }
+}
+
 // Flex-growing wrapper for view content with a DataGrid that fills height.
 .ah-view-content {
   flex: 1;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -18,6 +18,7 @@ import type {SqlValue} from '../../../trace_processor/query_result';
 import type {Row} from '../../../trace_processor/query_result';
 import {Spinner} from '../../../widgets/spinner';
 import {EmptyState} from '../../../widgets/empty_state';
+import {Select} from '../../../widgets/select';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import type {SchemaRegistry} from '../../../components/widgets/datagrid/datagrid_schema';
 import type {Filter} from '../../../components/widgets/datagrid/model';
@@ -153,10 +154,18 @@ function makeBitmapListSchema(navigate: NavFn): SchemaRegistry {
   };
 }
 
+type PathMode = 'none' | 'shortest' | 'dominator';
+
+const PATH_HEADING: Record<Exclude<PathMode, 'none'>, string> = {
+  shortest: 'Shortest Path',
+  dominator: 'Dominator Path',
+};
+
 interface BitmapCardAttrs {
   readonly row: BitmapListRow;
   readonly engine: Engine;
   readonly navigate: NavFn;
+  readonly pathMode: PathMode;
   readonly pathData?: PathEntry[] | null;
 }
 
@@ -270,10 +279,17 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
             'Details',
           ),
         ),
-        vnode.attrs.pathData !== undefined && vnode.attrs.pathData !== null
+        vnode.attrs.pathMode !== 'none' &&
+        vnode.attrs.pathData !== undefined &&
+        vnode.attrs.pathData !== null
           ? m(
               'div',
               {class: 'ah-bitmap-card__path'},
+              m(
+                'div',
+                {class: 'ah-muted-heading'},
+                PATH_HEADING[vnode.attrs.pathMode],
+              ),
               vnode.attrs.pathData.length > 0
                 ? renderPath(vnode.attrs.pathData, navigate)
                 : m('span', {class: 'ah-muted'}, 'No path to GC root.'),
@@ -294,22 +310,34 @@ interface BitmapGalleryViewAttrs {
 function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
   let rows: BitmapListRow[] | null = null;
   let alive = true;
-  let showPaths = false;
-  let pathsFetched = false;
-  const pathMap = new Map<number, PathEntry[]>();
+  let pathMode: PathMode = 'none';
+  const pathsFetched: Record<Exclude<PathMode, 'none'>, boolean> = {
+    shortest: false,
+    dominator: false,
+  };
+  const pathMaps: Record<Exclude<PathMode, 'none'>, Map<number, PathEntry[]>> =
+    {
+      shortest: new Map(),
+      dominator: new Map(),
+    };
   let filters: Filter[] = [];
 
-  function fetchAllPaths(engine: Engine, bitmaps: BitmapListRow[]) {
+  function fetchPaths(
+    engine: Engine,
+    bitmaps: BitmapListRow[],
+    mode: Exclude<PathMode, 'none'>,
+  ) {
     const ids = bitmaps.map((b) => b.row.id);
     if (ids.length === 0) return;
-    queries
-      .fetchDominatorPaths(engine, ids)
+    const fetcher =
+      mode === 'shortest' ? queries.fetchShortestPaths : queries.fetchDominatorPaths;
+    fetcher(engine, ids)
       .then((paths) => {
         if (!alive) return;
         for (const id of ids) {
-          pathMap.set(id, paths.get(id) ?? []);
+          pathMaps[mode].set(id, paths.get(id) ?? []);
         }
-        pathsFetched = true;
+        pathsFetched[mode] = true;
         m.redraw();
       })
       .catch(console.error);
@@ -401,17 +429,39 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
             `Bitmaps (${rows.length.toLocaleString()})`,
           ),
           m(
-            'button',
-            {
-              class: 'ah-link--alt',
-              onclick: () => {
-                showPaths = !showPaths;
-                if (showPaths && !pathsFetched) {
-                  fetchAllPaths(engine, rows!);
-                }
+            'label',
+            {class: 'ah-heading-control'},
+            m('span', {class: 'ah-heading-control__label'}, 'Path'),
+            m(
+              Select,
+              {
+                onchange: (e: Event) => {
+                  const value = (e.target as HTMLSelectElement)
+                    .value as PathMode;
+                  pathMode = value;
+                  if (value !== 'none' && !pathsFetched[value]) {
+                    fetchPaths(engine, rows!, value);
+                  }
+                },
               },
-            },
-            showPaths ? 'Hide Paths' : 'Show Paths',
+              [
+                m(
+                  'option',
+                  {value: 'none', selected: pathMode === 'none'},
+                  'None',
+                ),
+                m(
+                  'option',
+                  {value: 'shortest', selected: pathMode === 'shortest'},
+                  'Shortest path',
+                ),
+                m(
+                  'option',
+                  {value: 'dominator', selected: pathMode === 'dominator'},
+                  'Dominator path',
+                ),
+              ],
+            ),
           ),
         ]),
         m('div', {class: 'ah-card ah-mb-4'}, [
@@ -446,7 +496,11 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
                   row: r,
                   engine,
                   navigate,
-                  pathData: showPaths ? pathMap.get(r.row.id) ?? null : null,
+                  pathMode,
+                  pathData:
+                    pathMode === 'none'
+                      ? undefined
+                      : pathMaps[pathMode].get(r.row.id) ?? null,
                 }),
               ),
             )

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -280,8 +280,8 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
           ),
         ),
         vnode.attrs.pathMode !== 'none' &&
-        vnode.attrs.pathData !== undefined &&
-        vnode.attrs.pathData !== null
+          vnode.attrs.pathData !== undefined &&
+          vnode.attrs.pathData !== null
           ? m(
               'div',
               {class: 'ah-bitmap-card__path'},
@@ -315,11 +315,13 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
     shortest: false,
     dominator: false,
   };
-  const pathMaps: Record<Exclude<PathMode, 'none'>, Map<number, PathEntry[]>> =
-    {
-      shortest: new Map(),
-      dominator: new Map(),
-    };
+  const pathMaps: Record<
+    Exclude<PathMode, 'none'>,
+    Map<number, PathEntry[]>
+  > = {
+    shortest: new Map(),
+    dominator: new Map(),
+  };
   let filters: Filter[] = [];
 
   function fetchPaths(
@@ -330,7 +332,9 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
     const ids = bitmaps.map((b) => b.row.id);
     if (ids.length === 0) return;
     const fetcher =
-      mode === 'shortest' ? queries.fetchShortestPaths : queries.fetchDominatorPaths;
+      mode === 'shortest'
+        ? queries.fetchShortestPaths
+        : queries.fetchDominatorPaths;
     fetcher(engine, ids)
       .then((paths) => {
         if (!alive) return;


### PR DESCRIPTION
Replaced the 'Show Paths' button (dominator-only) in the bitmap tab with a Path dropdown (None / Shortest / Dominator) so shortest-path overlays are also available.

Also collapsed the single-id path fetchers into thin wrappers around the batch versions.