### PR TITLE
Avoid dangling pointers from SizeProfileComputer::Field to ProtoDescr…

### DIFF
--- a/src/trace_processor/util/proto_profiler.cc
+++ b/src/trace_processor/util/proto_profiler.cc
@@ -55,25 +55,13 @@ std::string GetLeafTypeName(uint32_t type_id) {
 }  // namespace
 
 SizeProfileComputer::Field::Field(uint32_t field_idx_in,
-                                  const FieldDescriptor* field_descriptor_in,
-                                  uint32_t type_in,
-                                  const ProtoDescriptor* proto_descriptor_in)
+                                  std::string field_name,
+                                  std::string type_name)
     : field_idx(field_idx_in),
-      type(type_in),
-      field_descriptor(field_descriptor_in),
-      proto_descriptor(proto_descriptor_in) {}
-
-std::string SizeProfileComputer::Field::field_name() const {
-  if (field_descriptor)
-    return "#" + field_descriptor->name();
-  return "#unknown";
-}
-
-std::string SizeProfileComputer::Field::type_name() const {
-  if (proto_descriptor)
-    return GetFieldTypeName(proto_descriptor->full_name());
-  return GetLeafTypeName(type);
-}
+      field_name_(field_idx == 0
+                      ? ""
+                      : (field_name.empty() ? "#unknown" : "#" + field_name)),
+      type_name_(std::move(type_name)) {}
 
 SizeProfileComputer::SizeProfileComputer(DescriptorPool* pool,
                                          const std::string& message_type)
@@ -92,7 +80,8 @@ void SizeProfileComputer::Reset(const uint8_t* ptr, size_t size) {
   protozero::ProtoDecoder decoder(ptr, size);
   const ProtoDescriptor* descriptor = &pool_->descriptors()[root_message_idx_];
   state_stack_.push_back(State{descriptor, decoder, size, 0});
-  field_path_.fields.emplace_back(0, nullptr, root_message_idx_, descriptor);
+  field_path_.fields.emplace_back(0, /* field_name= */ "",
+                                  GetFieldTypeName(descriptor->full_name()));
 }
 
 std::optional<size_t> SizeProfileComputer::GetNext() {
@@ -144,18 +133,20 @@ std::optional<size_t> SizeProfileComputer::GetNext() {
 
       protozero::ProtoDecoder decoder(field.data(), field.size());
       const ProtoDescriptor* descriptor = &pool_->descriptors()[*message_idx];
-      field_path_.fields.emplace_back(field.id(), field_descriptor,
-                                      *message_idx, descriptor);
+      field_path_.fields.emplace_back(
+          field.id(), field_descriptor->name(),
+          GetFieldTypeName(descriptor->full_name()));
       state_stack_.push_back(State{descriptor, decoder, field.size(), 0U});
       return GetNext();
     }
-    field_path_.fields.emplace_back(field.id(), field_descriptor,
-                                    field_descriptor->type(), nullptr);
+    field_path_.fields.emplace_back(field.id(), field_descriptor->name(),
+                                    GetLeafTypeName(field_descriptor->type()));
     result.emplace(field_size);
     return result;
   }
   if (state.unknown) {
-    field_path_.fields.emplace_back(uint32_t(-1), nullptr, 0U, nullptr);
+    field_path_.fields.emplace_back(uint32_t(-1), /* field_name= */ "",
+                                    /* type_name= */ "");
     result.emplace(state.unknown);
     state.unknown = 0;
     return result;

--- a/src/trace_processor/util/proto_profiler.h
+++ b/src/trace_processor/util/proto_profiler.h
@@ -34,31 +34,27 @@ namespace perfetto::trace_processor::util {
 class SizeProfileComputer {
  public:
   struct Field {
-    Field(uint32_t field_idx_in,
-          const FieldDescriptor* field_descriptor_in,
-          uint32_t type_in,
-          const ProtoDescriptor* proto_descriptor_in);
+    Field(uint32_t field_idx_in, std::string field_name, std::string type_name);
 
     bool has_field_name() const {
-      return field_descriptor || field_idx == static_cast<uint32_t>(-1);
+      return !field_name_.empty() || field_idx == static_cast<uint32_t>(-1);
     }
 
-    std::string field_name() const;
-    std::string type_name() const;
+    const std::string& field_name() const { return field_name_; }
+    const std::string& type_name() const { return type_name_; }
 
     bool operator==(const Field& other) const {
-      return field_idx == other.field_idx && type == other.type;
+      return field_idx == other.field_idx && type_name_ == other.type_name_;
     }
 
     template <typename H>
     friend H PerfettoHashValue(H hasher, const Field& f) {
-      return H::Combine(std::move(hasher), f.field_idx, f.type);
+      return H::Combine(std::move(hasher), f.field_idx, f.type_name_);
     }
 
     uint32_t field_idx;
-    uint32_t type;
-    const FieldDescriptor* field_descriptor;
-    const ProtoDescriptor* proto_descriptor;
+    std::string field_name_;
+    std::string type_name_;
   };
 
   struct FieldPath {

--- a/src/trace_processor/util/proto_profiler_unittest.cc
+++ b/src/trace_processor/util/proto_profiler_unittest.cc
@@ -76,5 +76,56 @@ TEST(ProtoProfiler, TestMessage) {
   EXPECT_THAT(got, UnorderedElementsAreArray(expected));
 }
 
+TEST(ProtoProfiler, TestMessageSurvivesPoolDestruction) {
+  protozero::HeapBuffered<protozero::test::protos::pbzero::NestedA> message;
+  message->add_repeated_a()->set_value_b()->set_value_c(1);
+  message->add_repeated_a()->set_value_b()->set_value_c(2);
+  message->set_super_nested()->set_value_c(3);
+  const std::vector<uint8_t> bytes = message.SerializeAsArray();
+
+  std::vector<std::pair<SizeProfileComputer::FieldPath, size_t>> samples;
+  {
+    DescriptorPool pool;
+    pool.AddFromFileDescriptorSet(kTestMessagesDescriptor.data(),
+                                  kTestMessagesDescriptor.size());
+    SizeProfileComputer computer(&pool, ".protozero.test.protos.NestedA");
+    computer.Reset(bytes.data(), bytes.size());
+
+    for (auto sample = computer.GetNext(); sample;
+         sample = computer.GetNext()) {
+      samples.push_back({computer.GetPath(), *sample});
+    }
+  }
+
+  // Convert to vector for test matcher *after* pool destruction.
+  using Item = std::pair<std::vector<std::string>, size_t>;
+  std::vector<Item> got;
+  for (const auto& [sample_path, sample_size] : samples) {
+    std::vector<std::string> path;
+    for (const auto& field : sample_path.fields) {
+      if (field.has_field_name())
+        path.push_back(field.field_name());
+      path.push_back(field.type_name());
+    }
+    got.emplace_back(path, sample_size);
+  }
+  std::vector<Item> expected{
+      {{"NestedA"}, 6},
+      {{"NestedA", "#repeated_a", "NestedB"}, 2},
+      {{"NestedA", "#repeated_a", "NestedB"}, 2},
+      {{"NestedA", "#repeated_a", "NestedB", "#value_b", "NestedC"}, 1},
+      {{"NestedA", "#repeated_a", "NestedB", "#value_b", "NestedC"}, 1},
+      {{"NestedA", "#repeated_a", "NestedB", "#value_b", "NestedC", "#value_c",
+        "int32"},
+       1},
+      {{"NestedA", "#repeated_a", "NestedB", "#value_b", "NestedC", "#value_c",
+        "int32"},
+       1},
+      {{"NestedA", "#super_nested", "NestedC"}, 1},
+      {{"NestedA", "#super_nested", "NestedC", "#value_c", "int32"}, 1}};
+
+  EXPECT_THAT(got, UnorderedElementsAreArray(expected));
+}
+
 }  // namespace
 }  // namespace perfetto::trace_processor::util


### PR DESCRIPTION
This change fixes a bug where `SizeProfileComputer::Field::proto_descriptor` might end up holding a dangling pointer to a `ProtoDescriptor` or a `FieldDescriptor`.

Bug: https://crbug.com/507066166
