### PR TITLE
ui: Disambiguate multi-dump traces in the Heap Dump Explorer

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -15,18 +15,20 @@
 import m from 'mithril';
 import type {Engine} from '../../trace_processor/engine';
 import type {Trace} from '../../public/trace';
+import {Time} from '../../base/time';
 import {Spinner} from '../../widgets/spinner';
 import {EmptyState} from '../../widgets/empty_state';
+import {Button, ButtonVariant} from '../../widgets/button';
+import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {Tabs} from '../../widgets/tabs';
 import type {TabsTab} from '../../widgets/tabs';
-interface HeapdumpSelection {
-  pathHashes: string;
-  isDominator: boolean;
-}
+import {formatDuration} from '../../components/time_utils';
+import {NUM} from '../../trace_processor/query_result';
 import type {NavState} from './nav_state';
 import type {OverviewData} from './types';
 import {nav, navigate, syncFromSubpage, setNavigateCallback} from './nav_state';
 import * as queries from './queries';
+import {SQL_PREAMBLE} from './components';
 import OverviewView from './views/overview_view';
 import DominatorsView from './views/dominators_view';
 import ObjectView from './views/object_view';
@@ -38,10 +40,12 @@ import ArraysView from './views/arrays_view';
 import FlamegraphObjectsView, {
   flamegraphQuery,
 } from './views/flamegraph_objects_view';
-import {SQL_PREAMBLE} from './components';
-import {NUM} from '../../trace_processor/query_result';
 
-// Each "Open in Heapdump Explorer" creates a closable flamegraph tab.
+interface HeapdumpSelection {
+  pathHashes: string;
+  isDominator: boolean;
+}
+
 let nextFgId = 0;
 const flamegraphTabs: Array<
   {id: number; count: number | null} & HeapdumpSelection
@@ -83,10 +87,19 @@ export function resetFlamegraphSelection(): void {
 let cachedOverview: OverviewData | null = null;
 let overviewLoading = false;
 
-/** Reset cached overview on trace change. */
 export function resetCachedOverview(): void {
   cachedOverview = null;
   overviewLoading = false;
+}
+
+function onDumpChanged(): void {
+  resetCachedOverview();
+  resetFlamegraphSelection();
+  resetInstanceTabs();
+  queries.resetBitmapDumpDataCache();
+  if (nav.view === 'object' || nav.view === 'flamegraph-objects') {
+    navigate('overview');
+  }
 }
 
 // Closable object tabs — clicking an object anywhere opens a new tab.
@@ -332,6 +345,49 @@ function buildTabs(
   return tabs;
 }
 
+function processLabel(d: queries.HeapDump): string {
+  return d.processName !== null
+    ? `${d.processName} (pid ${d.pid})`
+    : `pid ${d.pid}`;
+}
+
+function renderDumpSelector(): m.Children {
+  const trace = HeapDumpPage.trace;
+  if (!trace) return null;
+  const allDumps = queries.getDumps();
+  const active = queries.getActiveDump();
+  if (allDumps.length <= 1 || active === null) return null;
+
+  return m(
+    'div',
+    {class: 'ah-dump-selector'},
+    m('span', {class: 'ah-dump-selector__label'}, 'Heap dump:'),
+    m(
+      PopupMenu,
+      {
+        trigger: m(Button, {
+          label: processLabel(active),
+          icon: 'memory',
+          rightIcon: 'arrow_drop_down',
+          variant: ButtonVariant.Outlined,
+          compact: true,
+        }),
+      },
+      allDumps.map((d) => {
+        const offset = Time.diff(Time.fromRaw(d.ts), trace.traceInfo.start);
+        return m(MenuItem, {
+          label: `${processLabel(d)} — ${formatDuration(trace, offset)}`,
+          active: d === active,
+          onclick: () => {
+            queries.setActiveDump(d);
+            onDumpChanged();
+          },
+        });
+      }),
+    ),
+  );
+}
+
 interface HeapDumpPageAttrs {
   readonly subpage: string | undefined;
 }
@@ -384,20 +440,30 @@ export class HeapDumpPage implements m.ClassComponent<HeapDumpPageAttrs> {
     }
 
     if (!cachedOverview) {
+      if (!overviewLoading) {
+        this.loadOverview();
+      }
       return m(
         'div',
         {class: 'ah-page'},
+        renderDumpSelector(),
         m('div', {class: 'ah-loading'}, m(Spinner, {easing: true})),
       );
     }
 
+    // Keyed so Mithril remounts views (and their SQLDataSources) on dump switch.
+    const active = queries.getActiveDump();
+    const tabsKey = active ? `${active.upid}:${active.ts}` : 'none';
+
     return m(
       'div',
       {class: 'ah-page'},
+      renderDumpSelector(),
       m(
         'main',
         {class: 'ah-main'},
         m(Tabs, {
+          key: tabsKey,
           tabs: buildTabs(nav, HeapDumpPage.engine, cachedOverview),
           activeTabKey: getActiveTabKey(),
           onTabChange: handleTabChange,

--- a/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
@@ -25,7 +25,7 @@ import {
   resetInstanceTabs,
   resetCachedOverview,
 } from './heap_dump_page';
-import {resetBitmapDumpDataCache} from './queries';
+import {resetBitmapDumpDataCache, loadDumps, resetDumps} from './queries';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'com.android.HeapDumpExplorer';
@@ -52,6 +52,9 @@ export default class implements PerfettoPlugin {
     resetFlamegraphSelection();
     resetInstanceTabs();
     resetCachedOverview();
+
+    resetDumps();
+    await loadDumps(ctx.engine);
 
     ctx.plugins
       .getPlugin(HeapProfilePlugin)

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
 import {Engine} from '../../trace_processor/engine';
 import {
   BLOB_NULL,
+  LONG,
   LONG_NULL,
   NUM,
   NUM_NULL,
@@ -38,6 +40,82 @@ import type {
 } from './types';
 import {fmtHex} from './format';
 import {shortClassName, SQL_PREAMBLE} from './components';
+
+export interface HeapDump {
+  readonly upid: number;
+  readonly ts: bigint;
+  readonly processName: string | null;
+  readonly pid: number;
+}
+
+let dumps: ReadonlyArray<HeapDump> = [];
+let activeDump: HeapDump | null = null;
+
+export function getDumps(): ReadonlyArray<HeapDump> {
+  return dumps;
+}
+
+export function getActiveDump(): HeapDump | null {
+  return activeDump;
+}
+
+export function setDumps(newDumps: ReadonlyArray<HeapDump>): void {
+  dumps = newDumps;
+  activeDump = newDumps.length > 0 ? newDumps[0] : null;
+  m.redraw();
+}
+
+export function setActiveDump(d: HeapDump): void {
+  if (activeDump === d) return;
+  activeDump = d;
+  m.redraw();
+}
+
+export function resetDumps(): void {
+  dumps = [];
+  activeDump = null;
+}
+
+export async function loadDumps(engine: Engine): Promise<void> {
+  const res = await engine.query(`
+    SELECT
+      o.upid AS upid,
+      o.graph_sample_ts AS ts,
+      coalesce(p.cmdline, p.name) AS pname,
+      p.pid AS pid
+    FROM heap_graph_object o
+    JOIN process p USING (upid)
+    GROUP BY o.upid, o.graph_sample_ts
+    ORDER BY o.graph_sample_ts ASC
+  `);
+  const result: HeapDump[] = [];
+  for (
+    const it = res.iter({
+      upid: NUM,
+      ts: LONG,
+      pname: STR_NULL,
+      pid: NUM_NULL,
+    });
+    it.valid();
+    it.next()
+  ) {
+    result.push({
+      upid: it.upid,
+      ts: it.ts,
+      processName: it.pname,
+      pid: it.pid ?? 0,
+    });
+  }
+  setDumps(result);
+}
+
+export function dumpFilterSql(alias: string = 'o'): string {
+  if (!activeDump) return '1=1';
+  return (
+    `${alias}.upid = ${activeDump.upid} ` +
+    `AND ${alias}.graph_sample_ts = ${activeDump.ts}`
+  );
+}
 
 async function requireDominatorTree(engine: Engine): Promise<void> {
   await engine.query(SQL_PREAMBLE);
@@ -191,18 +269,20 @@ async function batchBitmapBufferHashes(
 }
 
 export async function getOverview(engine: Engine): Promise<OverviewData> {
+  const dumpFilter = dumpFilterSql('o');
   const countRes = await engine.query(
-    `SELECT count(*) as cnt FROM heap_graph_object WHERE reachable != 0`,
+    `SELECT count(*) as cnt FROM heap_graph_object o
+     WHERE o.reachable != 0 AND ${dumpFilter}`,
   );
   const instanceCount = countRes.iter({cnt: NUM}).cnt;
 
   const heapRes = await engine.query(`
     SELECT
-      ifnull(heap_type, 'default') AS heap,
-      SUM(self_size) AS java,
-      SUM(native_size) AS native_
-    FROM heap_graph_object
-    WHERE reachable != 0
+      ifnull(o.heap_type, 'default') AS heap,
+      SUM(o.self_size) AS java,
+      SUM(o.native_size) AS native_
+    FROM heap_graph_object o
+    WHERE o.reachable != 0 AND ${dumpFilter}
     GROUP BY heap
     ORDER BY heap
   `);
@@ -236,6 +316,7 @@ export async function getOverview(engine: Engine): Promise<OverviewData> {
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     LEFT JOIN heap_graph_primitive f ON f.field_set_id = od.field_set_id
     WHERE o.reachable != 0
+      AND ${dumpFilter}
       AND (c.name = 'android.graphics.Bitmap'
         OR c.deobfuscated_name = 'android.graphics.Bitmap')
     GROUP BY o.id
@@ -331,6 +412,7 @@ export async function getOverview(engine: Engine): Promise<OverviewData> {
       JOIN heap_graph_class c ON o.type_id = c.id
       LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
       WHERE o.reachable != 0
+        AND ${dumpFilter}
         AND od.value_string IS NOT NULL
         AND (c.name = 'java.lang.String'
           OR c.deobfuscated_name = 'java.lang.String')
@@ -369,6 +451,7 @@ export async function getOverview(engine: Engine): Promise<OverviewData> {
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE o.reachable != 0
+      AND ${dumpFilter}
       AND od.array_data_hash IS NOT NULL
     GROUP BY o.type_id, od.array_data_hash
     HAVING cnt > 1
@@ -427,6 +510,7 @@ export async function getAllocations(
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     WHERE o.reachable != 0
+      AND ${dumpFilterSql('o')}
       ${hf}
     GROUP BY cls, heap
     ORDER BY retained DESC
@@ -472,6 +556,7 @@ export async function getRooted(engine: Engine): Promise<InstanceRow[]> {
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE d.idom_id IS NULL
+      AND ${dumpFilterSql('o')}
     ORDER BY d.dominated_size_bytes + d.dominated_native_size_bytes DESC
   `);
   return collectRows(res);
@@ -1014,9 +1099,9 @@ export async function getInstance(
       JOIN heap_graph_class c ON o.type_id = c.id
       LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
       LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
-      WHERE (c.name = '${classObjName}'
-        OR c.deobfuscated_name = '${classObjName}')
-
+      WHERE ${dumpFilterSql('o')}
+        AND (c.name = '${classObjName}'
+          OR c.deobfuscated_name = '${classObjName}')
     `);
     const rows = collectRows(cRes);
     if (rows.length > 0) classObjRow = rows[0];
@@ -1355,14 +1440,13 @@ async function loadBitmapDumpData(
 ): Promise<BitmapDumpData | null> {
   if (cachedDumpData !== undefined) return cachedDumpData;
 
-  // Step 1: Find the Bitmap class object.
   const classObjRes = await engine.query(`
     SELECT o.reference_set_id
     FROM heap_graph_object o
     JOIN heap_graph_class c ON o.type_id = c.id
-    WHERE (c.name LIKE '%Class<android.graphics.Bitmap>'
-      OR c.deobfuscated_name LIKE '%Class<android.graphics.Bitmap>')
-
+    WHERE ${dumpFilterSql('o')}
+      AND (c.name LIKE '%Class<android.graphics.Bitmap>'
+        OR c.deobfuscated_name LIKE '%Class<android.graphics.Bitmap>')
   `);
   const classIt = classObjRes.iter({reference_set_id: NUM_NULL});
   if (!classIt.valid() || classIt.reference_set_id === null) {
@@ -1569,6 +1653,7 @@ export async function search(
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE o.reachable != 0
+      AND ${dumpFilterSql('o')}
       AND (c.name LIKE '%${escaped}%' ESCAPE '\\'
         OR c.deobfuscated_name LIKE '%${escaped}%' ESCAPE '\\')
     ORDER BY (ifnull(d.dominated_size_bytes, 0)
@@ -1592,6 +1677,7 @@ export async function getObjects(
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE o.reachable != 0
+      AND ${dumpFilterSql('o')}
       AND (c.name = '${escaped}' OR c.deobfuscated_name = '${escaped}')
       ${hf}
     ORDER BY o.self_size + o.native_size DESC
@@ -1646,6 +1732,7 @@ export async function getStringList(engine: Engine): Promise<StringListRow[]> {
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     WHERE o.reachable != 0
+      AND ${dumpFilterSql('o')}
       AND od.value_string IS NOT NULL
       AND (c.name = 'java.lang.String'
         OR c.deobfuscated_name = 'java.lang.String')
@@ -1715,6 +1802,7 @@ export async function getBitmapList(engine: Engine): Promise<BitmapListRow[]> {
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_primitive f ON f.field_set_id = od.field_set_id
     WHERE o.reachable != 0
+      AND ${dumpFilterSql('o')}
       AND (c.name = 'android.graphics.Bitmap'
         OR c.deobfuscated_name = 'android.graphics.Bitmap')
     GROUP BY o.id

--- a/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
@@ -106,6 +106,21 @@
   flex: 1;
 }
 
+.ah-dump-selector {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--pf-color-background);
+  border-bottom: 1px solid var(--pf-color-border);
+  font-size: 0.875rem;
+}
+
+.ah-dump-selector__label {
+  color: var(--pf-color-text-hint);
+}
+
 .ah-error-text {
   color: var(--pf-color-danger);
   padding: 1rem;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
@@ -30,6 +30,7 @@ import {
   RowCounter,
 } from '../components';
 import {clearNavParam} from '../nav_state';
+import {dumpFilterSql} from '../queries';
 
 interface AllObjectsViewAttrs {
   readonly engine: Engine;
@@ -37,31 +38,34 @@ interface AllObjectsViewAttrs {
   readonly initialClass?: string;
 }
 
-const QUERY = `
-  SELECT
-    base.*,
-    a.cumulative_size AS reachable_size,
-    a.cumulative_native_size AS reachable_native,
-    a.cumulative_count AS reachable_count
-  FROM (
+function buildQuery(): string {
+  return `
     SELECT
-      o.id,
-      ifnull(c.deobfuscated_name, c.name) AS cls,
-      o.self_size,
-      o.native_size,
-      ifnull(d.dominated_size_bytes, o.self_size) AS retained,
-      ifnull(d.dominated_native_size_bytes, o.native_size) AS retained_native,
-      ifnull(d.dominated_obj_count, 1) AS retained_count,
-      ifnull(o.heap_type, 'default') AS heap,
-      od.value_string AS str
-    FROM heap_graph_object o
-    JOIN heap_graph_class c ON o.type_id = c.id
-    LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
-    LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
-    WHERE o.reachable != 0
-  ) base
-  LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = base.id
-`;
+      base.*,
+      a.cumulative_size AS reachable_size,
+      a.cumulative_native_size AS reachable_native,
+      a.cumulative_count AS reachable_count
+    FROM (
+      SELECT
+        o.id,
+        ifnull(c.deobfuscated_name, c.name) AS cls,
+        o.self_size,
+        o.native_size,
+        ifnull(d.dominated_size_bytes, o.self_size) AS retained,
+        ifnull(d.dominated_native_size_bytes, o.native_size) AS retained_native,
+        ifnull(d.dominated_obj_count, 1) AS retained_count,
+        ifnull(o.heap_type, 'default') AS heap,
+        od.value_string AS str
+      FROM heap_graph_object o
+      JOIN heap_graph_class c ON o.type_id = c.id
+      LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
+      LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
+      WHERE o.reachable != 0
+        AND ${dumpFilterSql('o')}
+    ) base
+    LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = base.id
+  `;
+}
 
 function makeUiSchema(navigate: NavFn): SchemaRegistry {
   return {
@@ -165,13 +169,14 @@ function AllObjectsView(): m.Component<AllObjectsViewAttrs> {
   return {
     oninit(vnode) {
       const {engine} = vnode.attrs;
+      const query = buildQuery();
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(QUERY),
+        sqlSchema: createSimpleSchema(query),
         rootSchemaName: 'query',
         preamble: SQL_PREAMBLE,
       });
-      counter.init(engine, QUERY, SQL_PREAMBLE);
+      counter.init(engine, query, SQL_PREAMBLE);
       applyNavFilter(vnode.attrs.initialClass);
     },
     onupdate(vnode) {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
@@ -30,22 +30,26 @@ import {
   RowCounter,
 } from '../components';
 import {clearNavParam} from '../nav_state';
+import {dumpFilterSql} from '../queries';
 
-const QUERY = `
-  SELECT
-    o.id,
-    ifnull(c.deobfuscated_name, c.name) AS cls,
-    o.self_size,
-    o.native_size,
-    od.array_element_count AS element_count,
-    ifnull(o.heap_type, 'default') AS heap,
-    CAST(od.array_data_hash AS TEXT) AS array_hash
-  FROM heap_graph_object o
-  JOIN heap_graph_class c ON o.type_id = c.id
-  LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
-  WHERE o.reachable != 0
-    AND od.array_data_hash IS NOT NULL
-`;
+function buildQuery(): string {
+  return `
+    SELECT
+      o.id,
+      ifnull(c.deobfuscated_name, c.name) AS cls,
+      o.self_size,
+      o.native_size,
+      od.array_element_count AS element_count,
+      ifnull(o.heap_type, 'default') AS heap,
+      CAST(od.array_data_hash AS TEXT) AS array_hash
+    FROM heap_graph_object o
+    JOIN heap_graph_class c ON o.type_id = c.id
+    LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
+    WHERE o.reachable != 0
+      AND ${dumpFilterSql('o')}
+      AND od.array_data_hash IS NOT NULL
+  `;
+}
 
 function makeUiSchema(navigate: NavFn): SchemaRegistry {
   return {
@@ -120,12 +124,13 @@ function ArraysView(): m.Component<ArraysViewAttrs> {
   return {
     oninit(vnode) {
       const {engine} = vnode.attrs;
+      const query = buildQuery();
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(QUERY),
+        sqlSchema: createSimpleSchema(query),
         rootSchemaName: 'query',
       });
-      counter.init(engine, QUERY);
+      counter.init(engine, query);
       applyNavFilter(vnode.attrs.initialArrayHash);
     },
     onupdate(vnode) {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
@@ -28,6 +28,7 @@ import {
 } from '../components';
 import {clearNavParam} from '../nav_state';
 import * as queries from '../queries';
+import {dumpFilterSql} from '../queries';
 
 interface ClassesViewAttrs {
   readonly engine: Engine;
@@ -38,18 +39,20 @@ interface ClassesViewAttrs {
 const PREAMBLE =
   'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_class_aggregation';
 
-const QUERY = `
-  SELECT
-    type_name AS cls,
-    reachable_obj_count AS cnt,
-    reachable_size_bytes AS shallow,
-    reachable_native_size_bytes AS native_shallow,
-    dominated_size_bytes AS retained,
-    dominated_native_size_bytes AS retained_native,
-    dominated_obj_count AS retained_count
-  FROM android_heap_graph_class_aggregation
-  WHERE reachable_obj_count > 0
-`;
+function buildQuery(): string {
+  return `
+    SELECT
+      type_name AS cls,
+      reachable_obj_count AS cnt,
+      reachable_size_bytes AS shallow,
+      reachable_native_size_bytes AS native_shallow,
+      dominated_size_bytes AS retained,
+      dominated_native_size_bytes AS retained_native,
+      dominated_obj_count AS retained_count
+    FROM android_heap_graph_class_aggregation a
+    WHERE a.reachable_obj_count > 0 AND ${dumpFilterSql('a')}
+  `;
+}
 
 function makeUiSchema(navigate: NavFn): SchemaRegistry {
   return {
@@ -119,13 +122,14 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
   return {
     oninit(vnode) {
       const {engine} = vnode.attrs;
+      const query = buildQuery();
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(QUERY),
+        sqlSchema: createSimpleSchema(query),
         rootSchemaName: 'query',
         preamble: PREAMBLE,
       });
-      counter.init(engine, QUERY, PREAMBLE);
+      counter.init(engine, query, PREAMBLE);
       applyNavFilter(engine, vnode.attrs.initialRootClass).catch(console.error);
     },
     onupdate(vnode) {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
@@ -28,32 +28,36 @@ import {
   SQL_PREAMBLE,
   RowCounter,
 } from '../components';
+import {dumpFilterSql} from '../queries';
 
 interface DominatorsViewAttrs {
   readonly engine: Engine;
   readonly navigate: NavFn;
 }
 
-const QUERY = `
-  SELECT
-    o.id,
-    ifnull(c.deobfuscated_name, c.name) AS cls,
-    o.self_size,
-    o.native_size,
-    ifnull(d.dominated_size_bytes, o.self_size) AS retained,
-    ifnull(d.dominated_native_size_bytes, o.native_size) AS retained_native,
-    d.dominated_obj_count AS retained_count,
-    ifnull(o.heap_type, 'default') AS heap,
-    o.root_type,
-    a.cumulative_size AS reachable_size,
-    a.cumulative_native_size AS reachable_native,
-    a.cumulative_count AS reachable_count
-  FROM heap_graph_dominator_tree d
-  JOIN heap_graph_object o ON d.id = o.id
-  JOIN heap_graph_class c ON o.type_id = c.id
-  LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = o.id
-  WHERE d.idom_id IS NULL
-`;
+function buildQuery(): string {
+  return `
+    SELECT
+      o.id,
+      ifnull(c.deobfuscated_name, c.name) AS cls,
+      o.self_size,
+      o.native_size,
+      ifnull(d.dominated_size_bytes, o.self_size) AS retained,
+      ifnull(d.dominated_native_size_bytes, o.native_size) AS retained_native,
+      d.dominated_obj_count AS retained_count,
+      ifnull(o.heap_type, 'default') AS heap,
+      o.root_type,
+      a.cumulative_size AS reachable_size,
+      a.cumulative_native_size AS reachable_native,
+      a.cumulative_count AS reachable_count
+    FROM heap_graph_dominator_tree d
+    JOIN heap_graph_object o ON d.id = o.id
+    JOIN heap_graph_class c ON o.type_id = c.id
+    LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = o.id
+    WHERE d.idom_id IS NULL
+      AND ${dumpFilterSql('o')}
+  `;
+}
 
 function makeUiSchema(navigate: NavFn): SchemaRegistry {
   return {
@@ -138,13 +142,14 @@ function DominatorsView(): m.Component<DominatorsViewAttrs> {
   return {
     oninit(vnode) {
       const {engine} = vnode.attrs;
+      const query = buildQuery();
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(QUERY),
+        sqlSchema: createSimpleSchema(query),
         rootSchemaName: 'query',
         preamble: SQL_PREAMBLE,
       });
-      counter.init(engine, QUERY, SQL_PREAMBLE);
+      counter.init(engine, query, SQL_PREAMBLE);
     },
     view(vnode) {
       const {navigate} = vnode.attrs;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
@@ -33,32 +33,36 @@ import {
 } from '../components';
 import {clearNavParam} from '../nav_state';
 import * as queries from '../queries';
+import {dumpFilterSql} from '../queries';
 
-const QUERY = `
-  SELECT base.*,
-    a.cumulative_size AS reachable_size,
-    a.cumulative_native_size AS reachable_native,
-    a.cumulative_count AS reachable_count
-  FROM (
-    SELECT
-      o.id,
-      od.value_string AS value,
-      LENGTH(od.value_string) AS len,
-      o.self_size,
-      ifnull(d.dominated_size_bytes, o.self_size)
-        + ifnull(d.dominated_native_size_bytes, o.native_size) AS retained,
-      ifnull(o.heap_type, 'default') AS heap
-    FROM heap_graph_object o
-    JOIN heap_graph_class c ON o.type_id = c.id
-    LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
-    LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
-    WHERE o.reachable != 0
-      AND od.value_string IS NOT NULL
-      AND (c.name = 'java.lang.String'
-        OR c.deobfuscated_name = 'java.lang.String')
-  ) base
-  LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = base.id
-`;
+function buildQuery(): string {
+  return `
+    SELECT base.*,
+      a.cumulative_size AS reachable_size,
+      a.cumulative_native_size AS reachable_native,
+      a.cumulative_count AS reachable_count
+    FROM (
+      SELECT
+        o.id,
+        od.value_string AS value,
+        LENGTH(od.value_string) AS len,
+        o.self_size,
+        ifnull(d.dominated_size_bytes, o.self_size)
+          + ifnull(d.dominated_native_size_bytes, o.native_size) AS retained,
+        ifnull(o.heap_type, 'default') AS heap
+      FROM heap_graph_object o
+      JOIN heap_graph_class c ON o.type_id = c.id
+      LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
+      LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
+      WHERE o.reachable != 0
+        AND ${dumpFilterSql('o')}
+        AND od.value_string IS NOT NULL
+        AND (c.name = 'java.lang.String'
+          OR c.deobfuscated_name = 'java.lang.String')
+    ) base
+    LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = base.id
+  `;
+}
 
 function makeUiSchema(navigate: NavFn): SchemaRegistry {
   return {
@@ -171,13 +175,14 @@ function StringsView(): m.Component<StringsViewAttrs> {
   return {
     oninit(vnode) {
       const {engine} = vnode.attrs;
+      const query = buildQuery();
       dataSource = new SQLDataSource({
         engine,
-        sqlSchema: createSimpleSchema(QUERY),
+        sqlSchema: createSimpleSchema(query),
         rootSchemaName: 'query',
         preamble: SQL_PREAMBLE,
       });
-      counter.init(engine, QUERY, SQL_PREAMBLE);
+      counter.init(engine, query, SQL_PREAMBLE);
       applyNavFilter(vnode.attrs.initialQuery);
       queries
         .getStringList(vnode.attrs.engine)


### PR DESCRIPTION
Add a dump selector so traces with multiple heap dumps filter all views to a single (upid, ts) pair instead of silently summing across dumps.

