### PR TITLE
ui: signifcantly improve performance for incomplete slice fetch

### DIFF
--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -749,17 +749,16 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       ))`,
     });
 
-    // Pre-compute incomplete slices with LEAD() to find next_ts
-    // We compute LEAD over ALL slices first, then filter to incomplete ones
-    // This ensures next_ts is the next slice at the same depth (complete or incomplete)
     const incompleteSlicesTable = await createPerfettoTable({
       engine,
       as: `
-        SELECT id, ts, depth, next_ts
-        FROM (
-          SELECT id, ts, dur, depth, LEAD(ts) OVER (PARTITION BY depth ORDER BY ts) as next_ts
-          FROM (${sqlSource})
-        )
+        SELECT id, ts, depth, (
+          SELECT inner.ts
+          FROM (${sqlSource}) inner
+          WHERE inner.ts > outer.ts AND outer.depth = inner.depth
+          LIMIT 1
+        ) AS Nexft_ts
+        FROM (${sqlSource}) outer
         WHERE dur = -1
       `,
     });

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -756,8 +756,9 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
           SELECT inner.ts
           FROM (${sqlSource}) inner
           WHERE inner.ts > outer.ts AND outer.depth = inner.depth
+          ORDER BY inner.ts
           LIMIT 1
-        ) AS Nexft_ts
+        ) AS next_ts
         FROM (${sqlSource}) outer
         WHERE dur = -1
       `,

--- a/ui/src/components/tracks/slice_track.ts
+++ b/ui/src/components/tracks/slice_track.ts
@@ -753,13 +753,13 @@ export class SliceTrack<T extends RowSchema> implements TrackRenderer {
       engine,
       as: `
         SELECT id, ts, depth, (
-          SELECT inner.ts
-          FROM (${sqlSource}) inner
-          WHERE inner.ts > outer.ts AND outer.depth = inner.depth
-          ORDER BY inner.ts
+          SELECT i.ts
+          FROM (${sqlSource}) i
+          WHERE i.ts > o.ts AND o.depth = i.depth
+          ORDER BY i.ts
           LIMIT 1
         ) AS next_ts
-        FROM (${sqlSource}) outer
+        FROM (${sqlSource}) o
         WHERE dur = -1
       `,
     });


### PR DESCRIPTION
Doing a window function is highly inefficient as you pay the cost
for O(n) slices instead of O(m) incomplete slices with a nested
subquery fetching the next entry instead.

Cuts the time taken on large traces without incomplete events from
~2s to 8ms
