### PR TITLE
ui: Switch active heap dump on 'Open in Heapdump Explorer'

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -44,6 +44,8 @@ import FlamegraphObjectsView, {
 interface HeapdumpSelection {
   pathHashes: string;
   isDominator: boolean;
+  upid: number;
+  ts: bigint;
 }
 
 let nextFgId = 0;
@@ -56,6 +58,13 @@ export function setFlamegraphSelection(
   sel: HeapdumpSelection,
   engine: Engine,
 ): void {
+  const target = queries
+    .getDumps()
+    .find((d) => d.upid === sel.upid && d.ts === sel.ts);
+  if (target && target !== queries.getActiveDump()) {
+    queries.setActiveDump(target);
+    resetDumpScopedState();
+  }
   const existing = flamegraphTabs.find(
     (t) => t.pathHashes === sel.pathHashes && t.isDominator === sel.isDominator,
   );
@@ -68,6 +77,7 @@ export function setFlamegraphSelection(
   const tab = {id, count: null as number | null, ...sel};
   flamegraphTabs.push(tab);
   activeFgId = id;
+  navigate('flamegraph-objects');
   const q = flamegraphQuery(sel.pathHashes, sel.isDominator);
   engine
     .query(`${SQL_PREAMBLE}; SELECT COUNT(*) AS c FROM (${q})`)
@@ -92,11 +102,15 @@ export function resetCachedOverview(): void {
   overviewLoading = false;
 }
 
-function onDumpChanged(): void {
+function resetDumpScopedState(): void {
   resetCachedOverview();
   resetFlamegraphSelection();
   resetInstanceTabs();
   queries.resetBitmapDumpDataCache();
+}
+
+function onDumpChanged(): void {
+  resetDumpScopedState();
   if (nav.view === 'object' || nav.view === 'flamegraph-objects') {
     navigate('overview');
   }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
@@ -58,8 +58,8 @@ export default class implements PerfettoPlugin {
 
     ctx.plugins
       .getPlugin(HeapProfilePlugin)
-      .registerOnNodeSelectedListener(({pathHashes, isDominator}) =>
-        setFlamegraphSelection({pathHashes, isDominator}, ctx.engine),
+      .registerOnNodeSelectedListener(({pathHashes, isDominator, upid, ts}) =>
+        setFlamegraphSelection({pathHashes, isDominator, upid, ts}, ctx.engine),
       );
 
     ctx.sidebar.addMenuItem({

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -606,7 +606,16 @@ async function fetchFieldValues(
   }
 
   if (refSetId !== null) {
+    // heap_graph_class is not dump-scoped; restrict and dedup by name to
+    // avoid cross-dump row multiplication when deobfuscating field_type_name.
     const rRes = await engine.query(`
+      WITH class_in_dump AS (
+        SELECT c.name, MIN(c.deobfuscated_name) AS deobfuscated_name
+        FROM heap_graph_class c
+        JOIN heap_graph_object o ON o.type_id = c.id
+        WHERE ${dumpFilterSql('o')}
+        GROUP BY c.name
+      )
       SELECT
         ifnull(r.deobfuscated_field_name, r.field_name) AS fname,
         ifnull(ct.deobfuscated_name, r.field_type_name) AS ftype,
@@ -619,7 +628,7 @@ async function fetchFieldValues(
         d2.dominated_size_bytes AS ref_dominated_size,
         d2.dominated_native_size_bytes AS ref_dominated_native
       FROM heap_graph_reference r
-      LEFT JOIN heap_graph_class ct ON r.field_type_name = ct.name
+      LEFT JOIN class_in_dump ct ON r.field_type_name = ct.name
       LEFT JOIN heap_graph_object o2 ON r.owned_id = o2.id
       LEFT JOIN heap_graph_class c2 ON o2.type_id = c2.id
       LEFT JOIN heap_graph_object_data od2 ON o2.object_data_id = od2.id
@@ -1335,18 +1344,25 @@ export async function getSubclassNames(
   engine: Engine,
   rootName: string,
 ): Promise<string[]> {
+  // Scope to the active dump so we don't walk another dump's class hierarchy.
   const res = await engine.query(`
     INCLUDE PERFETTO MODULE graphs.search;
 
+    WITH dump_classes AS (
+      SELECT DISTINCT c.id, c.name, c.deobfuscated_name, c.superclass_id
+      FROM heap_graph_class c
+      JOIN heap_graph_object o ON o.type_id = c.id
+      WHERE ${dumpFilterSql('o')}
+    )
     SELECT coalesce(c.deobfuscated_name, c.name) AS name
     FROM graph_reachable_dfs!(
       (SELECT superclass_id AS source_node_id, id AS dest_node_id
-       FROM heap_graph_class WHERE superclass_id IS NOT NULL),
-      (SELECT id AS node_id FROM heap_graph_class
+       FROM dump_classes WHERE superclass_id IS NOT NULL),
+      (SELECT id AS node_id FROM dump_classes
        WHERE coalesce(deobfuscated_name, name) = '${sqlEsc(rootName)}'
        LIMIT 1)
     ) AS dfs
-    JOIN heap_graph_class c ON c.id = dfs.node_id
+    JOIN dump_classes c ON c.id = dfs.node_id
   `);
   const names: string[] = [];
   for (const it = res.iter({name: STR}); it.valid(); it.next()) {
@@ -1925,27 +1941,16 @@ function primFieldValue(it: {
 // The _heap_graph_object_tree_aggregation table computes cumulative reachable
 // sizes via a BFS tree.  The table materialisation is expensive on first access,
 // so we load it asynchronously and fill in reachable columns after the initial
-// render.  The module INCLUDE is cached per-engine via a WeakMap.
-
-const objectTreeReady = new WeakMap<Engine, Promise<void>>();
-
-function ensureObjectTree(engine: Engine): Promise<void> {
-  let p = objectTreeReady.get(engine);
-  if (!p) {
-    p = engine
-      .query(`INCLUDE PERFETTO MODULE android.memory.heap_graph.object_tree`)
-      .then(() => {});
-    objectTreeReady.set(engine, p);
-  }
-  return p;
-}
+// render.
 
 /** Fetch reachable (cumulative) sizes for a set of object IDs. */
 async function getReachableSizes(
   engine: Engine,
   ids: number[],
 ): Promise<Map<number, {size: number; native: number; count: number}>> {
-  await ensureObjectTree(engine);
+  await engine.query(
+    `INCLUDE PERFETTO MODULE android.memory.heap_graph.object_tree`,
+  );
   if (ids.length === 0) return new Map();
   const res = await engine.query(`
     SELECT id,
@@ -1983,59 +1988,6 @@ export async function enrichWithReachable(
     row.reachableSize = s?.size ?? 0;
     row.reachableNative = s?.native ?? 0;
     row.reachableCount = s?.count ?? 0;
-  }
-}
-
-/**
- * Enrich ClassRow[] with reachable sizes (summed per class+heap group).
- */
-export async function enrichClassRowsWithReachable(
-  engine: Engine,
-  rows: ClassRow[],
-  heap: string | null,
-): Promise<void> {
-  await ensureObjectTree(engine);
-  const hf = heapFilter(heap);
-  const res = await engine.query(`
-    SELECT
-      ifnull(c.deobfuscated_name, c.name) AS cls,
-      SUM(a.cumulative_size) AS reachable,
-      SUM(a.cumulative_native_size) AS reachable_native,
-      SUM(a.cumulative_count) AS reachable_count,
-      ifnull(o.heap_type, 'default') AS heap
-    FROM heap_graph_object o
-    JOIN heap_graph_class c ON o.type_id = c.id
-    JOIN _heap_graph_object_tree_aggregation a ON a.id = o.id
-    WHERE o.reachable != 0
-      ${hf}
-    GROUP BY cls, heap
-  `);
-  const map = new Map<
-    string,
-    {reachable: number; reachableNative: number; reachableCount: number}
-  >();
-  for (
-    const it = res.iter({
-      cls: STR,
-      reachable: NUM,
-      reachable_native: NUM,
-      reachable_count: NUM,
-      heap: STR,
-    });
-    it.valid();
-    it.next()
-  ) {
-    map.set(`${it.cls}\0${it.heap}`, {
-      reachable: it.reachable,
-      reachableNative: it.reachable_native,
-      reachableCount: it.reachable_count,
-    });
-  }
-  for (const row of rows) {
-    const s = map.get(`${row.className}\0${row.heap}`);
-    row.reachableSize = s?.reachable ?? 0;
-    row.reachableNativeSize = s?.reachableNative ?? 0;
-    row.reachableCount = s?.reachableCount ?? 0;
   }
 }
 

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -77,10 +77,12 @@ export class HeapProfileFlamegraphDetailsPanel
     private readonly tsEnd: time,
     private state: FlamegraphState | undefined,
     private readonly onStateChange: (state: FlamegraphState) => void,
-    private readonly onNodeSelected?: (
-      pathHashes: string,
-      isDominator: boolean,
-    ) => void,
+    onNodeSelected?: (args: {
+      pathHashes: string;
+      isDominator: boolean;
+      upid: number;
+      ts: time;
+    }) => void,
   ) {
     this.props = {ts, type: profileDescriptor.type};
     this.flamegraph = new QueryFlamegraph(trace);
@@ -90,7 +92,10 @@ export class HeapProfileFlamegraphDetailsPanel
       this.ts,
       this.tsEnd,
       this.upid,
-      this.onNodeSelected,
+      onNodeSelected
+        ? (pathHashes, isDominator) =>
+            onNodeSelected({pathHashes, isDominator, upid, ts})
+        : undefined,
     );
     if (this.state === undefined) {
       this.state = Flamegraph.createDefaultState(this.metrics);

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_track.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import {materialColorScheme} from '../../components/colorizer';
-import {Time} from '../../base/time';
+import {Time, time} from '../../base/time';
 import {SliceTrack} from '../../components/tracks/slice_track';
 import {Trace} from '../../public/trace';
 import {SourceDataset} from '../../trace_processor/dataset';
@@ -30,7 +30,12 @@ export function createHeapProfileTrack(
   heapProfileIsIncomplete: boolean,
   detailsPanelState: FlamegraphState | undefined,
   onDetailsPanelStateChange: (state: FlamegraphState) => void,
-  onNodeSelected?: (pathHashes: string, isDominator: boolean) => void,
+  onNodeSelected?: (args: {
+    pathHashes: string;
+    isDominator: boolean;
+    upid: number;
+    ts: time;
+  }) => void,
 ) {
   return SliceTrack.create({
     trace,

--- a/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/index.ts
@@ -14,6 +14,7 @@
 
 import {Trace} from '../../public/trace';
 import {PerfettoPlugin} from '../../public/plugin';
+import {time} from '../../base/time';
 import {NUM, STR} from '../../trace_processor/query_result';
 import {createHeapProfileTrack} from './heap_profile_track';
 import {TrackNode} from '../../public/workspace';
@@ -67,10 +68,17 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
   private readonly nodeSelectedEvt = new EvtSource<{
     pathHashes: string;
     isDominator: boolean;
+    upid: number;
+    ts: time;
   }>();
 
   registerOnNodeSelectedListener(
-    cb: (args: {pathHashes: string; isDominator: boolean}) => void,
+    cb: (args: {
+      pathHashes: string;
+      isDominator: boolean;
+      upid: number;
+      ts: time;
+    }) => void,
   ): Disposable {
     return this.nodeSelectedEvt.addListener(cb);
   }
@@ -228,8 +236,7 @@ export default class HeapProfilePlugin implements PerfettoPlugin {
               });
             },
             heapType === 'java_heap_graph'
-              ? (pathHashes, isDominator) =>
-                  this.nodeSelectedEvt.notify({pathHashes, isDominator})
+              ? (args) => this.nodeSelectedEvt.notify(args)
               : undefined,
           ),
         };


### PR DESCRIPTION
When clicking "Open in Heapdump Explorer" on a flamegraph node in a multi-dump trace, the Heapdump Explorer now switches its active dump to match the flamegraph node.

Small fix for limiting field name queries to specific dump
