### PR TITLE
perfetto: fix bogus chunks_overwritten in TraceBufferV2

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -971,18 +971,21 @@ void TraceBufferV2::DeleteNextChunksFor(size_t bytes_to_clear) {
       has_cleared_unconsumed_fragments = true;
     }
 
-    // In future this branch should become "&& !protovm_has_consumed_packet"
-    // We shouldn't report a data loss if ProtoVM merged the outgoing packet.
-    if (has_cleared_unconsumed_fragments) {
-      csr.seq()->data_loss = true;
-    }
-
     // ChunkSeqReader(kEraseMode) must delete the chunk once
     // ReadNextPacketInSeqOrder() returns false.
     PERFETTO_DCHECK(chunk->is_padding());
 
-    stats_.set_chunks_overwritten(stats_.chunks_overwritten() + 1);
-    stats_.set_bytes_overwritten(stats_.bytes_overwritten() + chunk_outer_size);
+    // A chunk that the reader already drained but hadn't yet "stepped past"
+    // is still non-padding until the next ReadNextTracePacket() call would
+    // erase it; clearing it here is not a real overwrite.
+    // In future this branch should become "&& !protovm_has_consumed_packet"
+    // We shouldn't report a data loss if ProtoVM merged the outgoing packet.
+    if (has_cleared_unconsumed_fragments) {
+      csr.seq()->data_loss = true;
+      stats_.set_chunks_overwritten(stats_.chunks_overwritten() + 1);
+      stats_.set_bytes_overwritten(stats_.bytes_overwritten() +
+                                   chunk_outer_size);
+    }
   }
 
   // Having consumed the packets above, this loop wipes out the contents of the

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -1691,6 +1691,56 @@ TEST_F(TraceBufferV2Test, NoDataLossIfReaderCatchesUp) {
   }
 }
 
+// chunks_overwritten / bytes_overwritten must not be incremented for a chunk
+// that the reader already drained but hadn't yet "stepped past". The
+// kFragWholePacket branch in ReadNextPacketInSeqOrder() decrements
+// payload_avail to 0 and returns the packet to the consumer without erasing
+// the chunk; the chunk only becomes a padding chunk on the next read call,
+// when NextFragmentInChunk() returns nullopt and EraseCurrentChunk() runs.
+// If a write forces a wrap in that gap, DeleteNextChunksFor() encounters a
+// non-padding chunk and (incorrectly) bumps the overwrite counters, even
+// though there is nothing left to lose. Mirrors NoDataLossIfReaderCatchesUp
+// above, which exercises the same pattern but doesn't assert on the stats.
+TEST_F(TraceBufferV2Test, NoOverwriteCountIfReaderCatchesUp) {
+  ResetBuffer(4096);
+
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(2000, 'a')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(1000, 'b')
+      .CopyIntoTraceBuffer();
+
+  // Read 'a' with a single ReadPacket(). Crucially, do not call ReadPacket()
+  // again — that follow-up call is what would turn ChunkID(0) into a padding
+  // chunk via EraseCurrentChunk().
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(2000, 'a')));
+
+  // ChunkID(2) doesn't fit in the tail, so wr_ wraps to 0 and
+  // DeleteNextChunksFor() walks ChunkID(0). ChunkID(0) has no unread bytes,
+  // so this is not an overwrite.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
+      .AddPacket(2000, 'c')
+      .CopyIntoTraceBuffer();
+
+  EXPECT_EQ(0u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(0u, trace_buffer()->stats().bytes_overwritten());
+
+  // Sanity check: the surviving packets are still readable and the consumer
+  // is not signalled any data loss — confirming that the increment above (if
+  // it fires) is bogus rather than a real overwrite reported elsewhere.
+  trace_buffer()->BeginRead();
+  bool dropped = false;
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(1000, 'b')));
+  EXPECT_FALSE(dropped);
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(2000, 'c')));
+  EXPECT_FALSE(dropped);
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+}
+
 TEST_F(TraceBufferV2Test, PacketDropOnOverwrite) {
   ResetBuffer(4096);
   SuppressClientDchecksForTesting();


### PR DESCRIPTION
DeleteNextChunksFor() unconditionally bumped chunks_overwritten /
bytes_overwritten for any non-padding chunk it walked, while data_loss
was correctly gated on has_cleared_unconsumed_fragments. The two should
move together: a chunk that the reader already drained (payload_avail
== 0) but hadn't yet "stepped past" via the follow-up
ReadNextTracePacket() call is still non-padding, and clearing it on a
subsequent wrap is not a real overwrite.

Move the stat increments inside the same gate as data_loss so they
only fire when there were actually unread fragments at clear time.
This matches v1 (trace_buffer_v1.cc only counts when num_fragments_read
< num_fragments).

Also adds NoOverwriteCountIfReaderCatchesUp, which mirrors the
existing NoDataLossIfReaderCatchesUp pattern but asserts on the stats
the latter never checked.
