### PR TITLE
perfetto: fix false data_loss on re-admit in TraceBufferV2

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -289,9 +289,18 @@ ChunkSeqReader::ChunkSeqReader(TraceBufferV2* buf,
                            : 0,
                        iter_->chunk_id, end_->chunk_id);
 
-  if (seq_->last_chunk_consumed.has_value() &&
-      iter_->chunk_id != seq_->last_chunk_consumed->chunk_id + 1) {
-    seq_->data_loss = true;
+  if (seq_->last_chunk_consumed.has_value()) {
+    const auto& last = *seq_->last_chunk_consumed;
+    // Re-admit: an incomplete chunk that was evicted has been re-committed
+    // with strictly more payload. The chunk_id is unchanged, so the +1
+    // successor check below would fire spuriously even though the re-admit
+    // recovered the deferred fragments without losing data. Keep this
+    // predicate in sync with the re-admit acceptance check in
+    // TraceBufferV2::CopyChunkUntrusted.
+    bool readmit = last.was_incomplete && iter_->chunk_id == last.chunk_id;
+    if (!readmit && iter_->chunk_id != last.chunk_id + 1) {
+      seq_->data_loss = true;
+    }
   }
 }
 
@@ -754,7 +763,8 @@ void TraceBufferV2::CopyChunkUntrusted(
   // Don't allow re-commit of chunks that have been consumed already, unless
   // the chunk was evicted while incomplete (scraped) and the new commit has
   // strictly more payload. In that case we re-admit it so the previously-
-  // dropped fragments can be recovered.
+  // dropped fragments can be recovered. Keep this acceptance condition in
+  // sync with the re-admit branch of the gap check in ChunkSeqReader's ctor.
   //
   // When re-admitting, |previously_consumed_payload| records how many payload
   // bytes were already consumed before eviction, so we can skip them below.

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -2441,13 +2441,20 @@ TEST_F(TraceBufferV2Test, RescrapeAfterEviction_FullyRead) {
       .PadTo(512)
       .CopyIntoTraceBuffer(/*chunk_complete=*/false);
 
-  // Drain and verify: 'b' recovered, 'a' not duplicated.
+  // Drain and verify: 'b' recovered, 'a' not duplicated. The recovered 'b'
+  // must not be flagged with previous_packet_dropped — the re-admit landed
+  // on the same chunk_id as last_consumed, and the gap check in
+  // ChunkSeqReader must treat that as gapless rather than firing spuriously.
   trace_buffer()->BeginRead();
   std::vector<std::vector<FakePacketFragment>> packets;
+  bool b_dropped = false;
   for (;;) {
-    auto p = ReadPacket();
+    bool dropped = false;
+    auto p = ReadPacket(/*sequence_properties=*/nullptr, &dropped);
     if (p.empty())
       break;
+    if (p.size() == 1 && p[0] == FakePacketFragment(30, 'b'))
+      b_dropped = dropped;
     packets.push_back(std::move(p));
   }
 
@@ -2461,6 +2468,8 @@ TEST_F(TraceBufferV2Test, RescrapeAfterEviction_FullyRead) {
       found_c = true;
   }
   EXPECT_TRUE(found_b) << "Packet 'b' not found after rescrape re-admission";
+  EXPECT_FALSE(b_dropped) << "Re-admitted 'b' falsely flagged as dropped — "
+                             "ChunkSeqReader gap check fired on re-admit.";
   EXPECT_FALSE(found_a) << "Packet 'a' duplicated after rescrape re-admission";
   EXPECT_FALSE(found_c)
       << "Packet 'c' should still be dropped (chunk incomplete)";


### PR DESCRIPTION
ChunkSeqReader's ctor checks iter_->chunk_id against
last_chunk_consumed.chunk_id + 1 to detect a gap in the sequence. But
when a previously-evicted incomplete chunk is re-admitted via the
re-admit path in CopyChunkUntrusted (same chunk_id, was_incomplete=true,
strictly more payload), the new iter_ lands on the same chunk_id as
last_consumed — so the +1 check fires spuriously and seq.data_loss is
set even though the re-admit recovered the deferred fragments without
losing any data.

The next packet delivered for that sequence then carries
previous_packet_dropped=true, which trace_processor surfaces as
traced_buf_sequence_packet_loss. This bites real traces with heavy
scraping/recommit traffic (chunks_rewritten dominated) and can show up
as nonzero packet loss even on under-utilized buffers with no
trace_writer_packet_loss and no overwrites.

Mirror the re-admit acceptance condition in the gap check: skip data
loss when iter_->chunk_id == last.chunk_id and last.was_incomplete.
This is the symmetric counterpart of the re-admit path; any other
equality case is impossible because CopyChunkUntrusted would have
discarded the chunk before it reached the buffer.

Adds RescrapeAfterEviction_NoFalseDataLoss alongside the existing
rescrape tests, which exercised the same path but didn't assert on
previous_packet_dropped.
