### PR TITLE
Monitor Render Thread blocking calls during Android CUJs

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16979,6 +16979,7 @@ filegroup {
         "src/trace_processor/perfetto_sql/stdlib/android/oom_adjuster.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/process_metadata.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/render_thread.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/screenshots.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/services.sql",

--- a/BUILD
+++ b/BUILD
@@ -3872,6 +3872,7 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/stdlib/android/oom_adjuster.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/power_rails.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/process_metadata.sql",
+        "src/trace_processor/perfetto_sql/stdlib/android/render_thread.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/screen_state.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/screenshots.sql",
         "src/trace_processor/perfetto_sql/stdlib/android/services.sql",

--- a/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_metric.sql
+++ b/src/trace_processor/metrics/sql/android/android_blocking_calls_cuj_metric.sql
@@ -18,6 +18,7 @@ SELECT RUN_METRIC('android/process_metadata.sql');
 INCLUDE PERFETTO MODULE android.slices;
 INCLUDE PERFETTO MODULE android.binder;
 INCLUDE PERFETTO MODULE android.critical_blocking_calls;
+INCLUDE PERFETTO MODULE android.render_thread;
 INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
 
 -- We have:
@@ -29,8 +30,8 @@ INCLUDE PERFETTO MODULE android.cujs.sysui_cujs;
 --      slice, there needs to be 2 entries for that slice, one for each cuj id.
 --  (2) each slice needs to be trimmed to be fully inside the cuj associated
 --      (as we don't care about what's outside cujs)
-DROP TABLE IF EXISTS main_thread_slices_scoped_to_cujs;
-CREATE PERFETTO TABLE main_thread_slices_scoped_to_cujs AS
+DROP TABLE IF EXISTS blocking_call_slices_scoped_to_cujs;
+CREATE PERFETTO TABLE blocking_call_slices_scoped_to_cujs AS
 SELECT
     s.id,
     s.id AS slice_id,
@@ -49,8 +50,9 @@ FROM _android_critical_blocking_calls s
     ON s.ts + s.dur > cuj.ts AND s.ts < cuj.ts_end
         -- and are from the same process
         AND s.upid = cuj.upid
-        -- from the CUJ ui thread only
-        AND s.utid = cuj.ui_thread;
+    LEFT JOIN _render_thread_per_process rt
+        ON rt.upid = cuj.upid
+    WHERE s.utid = cuj.ui_thread OR s.utid = rt.render_thread_utid;
 
 
 DROP TABLE IF EXISTS android_blocking_calls_cuj_calls;
@@ -66,7 +68,7 @@ SELECT
     cuj_name,
     process_name
 FROM
-    main_thread_slices_scoped_to_cujs
+    blocking_call_slices_scoped_to_cujs
 GROUP BY name, upid, cuj_id, cuj_name, process_name
 ORDER BY cuj_id;
 

--- a/src/trace_processor/perfetto_sql/stdlib/android/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/android/BUILD.gn
@@ -56,6 +56,7 @@ perfetto_sql_source_set("android") {
     "oom_adjuster.sql",
     "power_rails.sql",
     "process_metadata.sql",
+    "render_thread.sql",
     "screen_state.sql",
     "screenshots.sql",
     "services.sql",

--- a/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/critical_blocking_calls.sql
@@ -48,6 +48,7 @@ SELECT
   OR $name GLOB 'Recomposer:*'
   OR $name GLOB 'Compose:*'
   OR $name GLOB 'draw-VRI*'
+  OR $name = 'CreateGraphicsPipeline'
   OR (
     NOT $name GLOB '*Choreographer*'
     AND NOT $name GLOB '*Input*'

--- a/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/cujs/base.sql
@@ -151,7 +151,8 @@ SELECT
   (
     frame.ts + frame.dur
   ) AS ts_end,
-  ui_thread_utid
+  ui_thread_utid,
+  frame.render_thread_utid
 FROM android_frames_layers AS frame
 JOIN _cuj_instant_events AS cie
   ON frame.ui_thread_utid = cie.ui_thread AND frame.layer_id IS NOT NULL
@@ -200,6 +201,7 @@ SELECT
   expected_frame_timeline_id,
   cuj_id,
   ui_thread_utid,
+  render_thread_utid,
   -- In case of multiple frames for a frame_id, consider the min start timestamp.
   min(frame_ts) AS frame_ts,
   -- In case of multiple frames for a frame_id, consider the max end timestamp.
@@ -232,6 +234,7 @@ SELECT
   expected_frame_timeline_id,
   cuj_id,
   ui_thread_utid,
+  render_thread_utid,
   frame_ts,
   ts_end,
   dur

--- a/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/frame_blocking_calls/blocking_calls_aggregation.sql
@@ -41,6 +41,7 @@ WITH
       fr.frame_id,
       fr.frame_ts AS ts,
       fr.ui_thread_utid,
+      fr.render_thread_utid,
       fr.cuj_id,
       fr.cuj_name,
       fr.layer_id,
@@ -59,6 +60,7 @@ WITH
 SELECT
   ts,
   ui_thread_utid,
+  render_thread_utid,
   frame_id,
   layer_id,
   cuj_id,
@@ -90,7 +92,9 @@ SELECT
   cuj_name
 FROM _android_critical_blocking_calls AS bc
 JOIN _extended_frame_boundary AS frame
-  ON bc.utid = frame.ui_thread_utid
+  ON (
+    bc.utid = frame.ui_thread_utid OR bc.utid = frame.render_thread_utid
+  )
 -- The following condition to accommodate blocking call crossing frame boundary. The blocking
 -- call starts in a frame or ends in a frame. It can either be the same frame or a different
 -- frame.

--- a/src/trace_processor/perfetto_sql/stdlib/android/render_thread.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/render_thread.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright 2026 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+CREATE PERFETTO TABLE _render_thread_per_process (
+  upid JOINID(process.id),
+  render_thread_utid JOINID(thread.id)
+) AS
+SELECT
+  upid,
+  utid AS render_thread_utid
+FROM thread
+WHERE
+  thread.name = 'RenderThread';

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_metric.out
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_metric.out
@@ -12,6 +12,16 @@ android_blocking_calls_cuj_metric {
     ts: 2000000
     dur: 15000000
     blocking_calls {
+      name: "CreateGraphicsPipeline"
+      cnt: 1
+      total_dur_ms: 1
+      max_dur_ms: 1
+      min_dur_ms: 1
+      total_dur_ns: 1000000
+      max_dur_ns: 1000000
+      min_dur_ns: 1000000
+    }
+    blocking_calls {
       name: "binder transaction"
       cnt: 4
       total_dur_ms: 6
@@ -34,6 +44,16 @@ android_blocking_calls_cuj_metric {
     }
     ts: 2000000
     dur: 15000000
+    blocking_calls {
+      name: "CreateGraphicsPipeline"
+      cnt: 1
+      total_dur_ms: 1
+      max_dur_ms: 1
+      min_dur_ms: 1
+      total_dur_ns: 1000000
+      max_dur_ns: 1000000
+      min_dur_ns: 1000000
+    }
     blocking_calls {
       name: "binder transaction"
       cnt: 4

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_metric.py
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_metric.py
@@ -18,14 +18,28 @@ import synth_common
 
 # com.android.systemui
 SYSUI_PID = 1000
+SYSUI_RTID = 1500
 # com.google.android.apps.nexuslauncher
 LAUNCHER_PID = 2000
+LAUNCHER_RTID = 2500
 
 THIRD_PROCESS_PID = 3000
+THIRD_PROCESS_RTID = 3500
 
 TOP_LEVEL_SLICES_PID = 4000
+TOP_LEVEL_SLICES_RTID = 4500
+
+RTID_MAP = {
+    SYSUI_PID: SYSUI_RTID,
+    LAUNCHER_PID: LAUNCHER_RTID,
+    THIRD_PROCESS_PID: THIRD_PROCESS_RTID,
+    TOP_LEVEL_SLICES_PID: TOP_LEVEL_SLICES_RTID,
+}
 
 NESTED_HANDLER_PID = 5000
+NESTED_HANDLER_RTID = 5500
+
+RTID_MAP[NESTED_HANDLER_PID] = NESTED_HANDLER_RTID
 
 # List of blocking calls
 blocking_call_names = [
@@ -153,6 +167,15 @@ def add_cuj_with_blocking_calls(trace, cuj_name, pid):
       buf=blocking_call_name,
       tid=pid,
       pid=pid)
+
+  # render thread blocking call completely inside
+  if pid in RTID_MAP:
+    trace.add_atrace_for_thread(
+        ts=cuj_begin + 8_000_000,
+        ts_end=cuj_begin + 9_000_000,
+        buf="CreateGraphicsPipeline",
+        tid=RTID_MAP[pid],
+        pid=pid)
 
 
 def add_cuj_with_top_level_slices(trace, cuj_name, pid):
@@ -525,6 +548,10 @@ def setup_trace():
       package_name="com.google.android.nested.handlers",
       uid=10005,
       pid=NESTED_HANDLER_PID)
+
+  for p, rt in RTID_MAP.items():
+    trace.add_thread(
+        tid=rt, tgid=p, cmdline="RenderThread", name="RenderThread")
   trace.add_ftrace_packet(cpu=0)
 
   trace.add_async_atrace_for_thread(

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.out
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.out
@@ -4,9 +4,18 @@ android_blocking_calls_cuj_per_frame_metric {
     process {
       name: "com.android.systemui"
       uid: 10001
-      pid: 5000
       android_user_id: 0
+      pid: 5000
       is_kernel_task: false
+    }
+    blocking_calls {
+      name: "CreateGraphicsPipeline"
+      max_dur_per_frame_ms: 0
+      max_dur_per_frame_ns: 800000
+      mean_dur_per_frame_ms: 0
+      mean_dur_per_frame_ns: 200000
+      max_cnt_per_frame: 1
+      mean_cnt_per_frame: 0.250000
     }
     blocking_calls {
       name: "animation"
@@ -15,7 +24,7 @@ android_blocking_calls_cuj_per_frame_metric {
       mean_dur_per_frame_ms: 1
       mean_dur_per_frame_ns: 1000000
       max_cnt_per_frame: 1
-      mean_cnt_per_frame: 0.5
+      mean_cnt_per_frame: 0.500000
     }
     blocking_calls {
       name: "binder transaction"
@@ -24,7 +33,7 @@ android_blocking_calls_cuj_per_frame_metric {
       mean_dur_per_frame_ms: 1
       mean_dur_per_frame_ns: 1375000
       max_cnt_per_frame: 2
-      mean_cnt_per_frame: 0.75
+      mean_cnt_per_frame: 0.750000
     }
   }
   cuj {
@@ -32,8 +41,8 @@ android_blocking_calls_cuj_per_frame_metric {
     process {
       name: "com.google.android.apps.nexuslauncher"
       uid: 10002
-      pid: 6000
       android_user_id: 0
+      pid: 6000
       is_kernel_task: false
     }
     blocking_calls {
@@ -43,7 +52,7 @@ android_blocking_calls_cuj_per_frame_metric {
       mean_dur_per_frame_ms: 5
       mean_dur_per_frame_ns: 5500000
       max_cnt_per_frame: 1
-      mean_cnt_per_frame: 0.5
+      mean_cnt_per_frame: 0.500000
     }
   }
 }

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.py
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_cuj_per_frame_metric.py
@@ -231,6 +231,13 @@ def add_blocking_calls_per_frame_multiple_cuj_instance(trace, cuj_name):
       ts=86_000_000, buf="binder transaction", tid=SYSUI_UI_TID, pid=SYSUI_PID)
   trace.add_atrace_end(ts=88_500_000, tid=SYSUI_UI_TID, pid=SYSUI_PID)
 
+  trace.add_atrace_begin(
+      ts=27_100_000,
+      buf="CreateGraphicsPipeline",
+      tid=SYSUI_RTID,
+      pid=SYSUI_PID)
+  trace.add_atrace_end(ts=27_900_000, tid=SYSUI_RTID, pid=SYSUI_PID)
+
   # Add expected and actual frames.
   add_expected_surface_frame_events(
       ts=10_000_000, dur=16_000_000, token=15, pid=SYSUI_PID)
@@ -444,6 +451,16 @@ def setup_trace():
       tgid=SYSUI_PID,
       cmdline="BackPanelUiThre",
       name="BackPanelUiThre")
+  trace.add_thread(
+      tid=SYSUI_RTID,
+      tgid=SYSUI_PID,
+      cmdline="RenderThread",
+      name="RenderThread")
+  trace.add_thread(
+      tid=LAUNCHER_RTID,
+      tgid=LAUNCHER_PID,
+      cmdline="RenderThread",
+      name="RenderThread")
 
   trace.add_ftrace_packet(cpu=0)
   return trace

--- a/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_unagg.out
+++ b/test/trace_processor/diff_tests/metrics/android/android_blocking_calls_unagg.out
@@ -43,6 +43,18 @@ android_blocking_calls_unagg {
       max_dur_ns: 10000000
       min_dur_ns: 10000000
     }
+    blocking_calls {
+      name: "CreateGraphicsPipeline"
+      cnt: 1
+      avg_dur_ms: 1
+      total_dur_ms: 1
+      max_dur_ms: 1
+      min_dur_ms: 1
+      avg_dur_ns: 1000000
+      total_dur_ns: 1000000
+      max_dur_ns: 1000000
+      min_dur_ns: 1000000
+    }
   }
   process_with_blocking_calls {
     process {
@@ -62,6 +74,18 @@ android_blocking_calls_unagg {
       avg_dur_ns: 1666666
       total_dur_ns: 10000000
       max_dur_ns: 3000000
+      min_dur_ns: 1000000
+    }
+    blocking_calls {
+      name: "CreateGraphicsPipeline"
+      cnt: 1
+      avg_dur_ms: 1
+      total_dur_ms: 1
+      max_dur_ms: 1
+      min_dur_ms: 1
+      avg_dur_ns: 1000000
+      total_dur_ns: 1000000
+      max_dur_ns: 1000000
       min_dur_ns: 1000000
     }
   }

--- a/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
+++ b/test/trace_processor/diff_tests/stdlib/android/sysui_cujs_test.py
@@ -34,8 +34,8 @@ class SystemUICujs(TestSuite):
         out=Csv("""
         "cuj_id","upid","process_name","cuj_slice_name","cuj_name","slice_id","ts","ts_end","dur","state","ui_thread","layer_id","begin_vsync","end_vsync"
         1,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",4,27000000,65000000,38000000,"completed",3,0,20,30
-        2,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",25,85000000,89000000,4000000,"completed",3,2,60,70
-        3,2,"com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",39,121000000,143000000,22000000,"completed",5,1,80,90
+        2,1,"com.android.systemui","J<BACK_PANEL_ARROW>","BACK_PANEL_ARROW",26,85000000,89000000,4000000,"completed",3,2,60,70
+        3,2,"com.google.android.apps.nexuslauncher","J<CUJ_NAME>","CUJ_NAME",40,121000000,143000000,22000000,"completed",6,1,80,90
         """))
 
   def test_android_sysui_latency_cujs(self):
@@ -50,8 +50,8 @@ class SystemUICujs(TestSuite):
         """,
         out=Csv("""
         "cuj_id","upid","process_name","cuj_slice_name","cuj_name","slice_id","ts","ts_end","dur","state"
-        1,1,"com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",53,150000000,155000000,5000000,"completed"
-        2,1,"com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",58,156000000,160000000,4000000,"completed"
+        1,1,"com.android.systemui","L<IGNORED_CUJ_1>","IGNORED_CUJ_1",54,150000000,155000000,5000000,"completed"
+        2,1,"com.android.systemui","L<IGNORED_CUJ_2>","IGNORED_CUJ_2",59,156000000,160000000,4000000,"completed"
         """))
 
   def test_android_sysui_latency_cujs_state(self):


### PR DESCRIPTION
Until now the blocking calls were only considering what was happening in the ui thread associated with the CUJ. After this change, we're also considering the render thread of the process reporting the CUJ.

The render thread is a single one for each process, and is identified with the thread name.

CUJ boundaries considered are left unchanged.

bug:
Change-Id: I1d68bb712eb8860436c330b4db28d2e91d0a8710
