### PR TITLE
ui: search and highlight chip text in omnibox commands

### DIFF
--- a/ui/src/assets/topbar.scss
+++ b/ui/src/assets/topbar.scss
@@ -210,6 +210,14 @@
       &.pf-highlighted {
         background-color: var(--pf-color-primary);
         color: var(--pf-color-text-on-primary);
+
+        // Intent-coloured chips would otherwise blend into the primary bg;
+        // re-derive their colours from the row's text colour so they stay
+        // visible against the highlight.
+        .pf-chip {
+          color: currentColor;
+          background: color-mix(in srgb, currentColor 15%, transparent);
+        }
       }
     }
   }

--- a/ui/src/base/fuzzy.ts
+++ b/ui/src/base/fuzzy.ts
@@ -96,7 +96,10 @@ function camelCaseTokenize(text: string): string[] {
 // Given a query (possibly multi-word) and candidate text, compute highlight
 // segments. Each query token is first tried as a substring match, then falls
 // back to sequential character matching.
-function computeHighlightSegments(query: string, text: string): FuzzySegment[] {
+export function computeHighlightSegments(
+  query: string,
+  text: string,
+): FuzzySegment[] {
   const tokens = query.split(/\s+/).filter(Boolean);
   const lowerText = text.toLowerCase();
   const highlightedIndices: number[] = [];

--- a/ui/src/base/fuzzy.ts
+++ b/ui/src/base/fuzzy.ts
@@ -60,10 +60,10 @@ export class FuzzyFinder<T> {
   find(searchTerm: string): FuzzyResult<T>[] {
     if (searchTerm === '') {
       return this.items.map((item) => {
-        const text = this.keyLookup(item);
+        const normalisedTerm = this.keyLookup(item);
         return {
           item,
-          segments: [{matching: false, value: text}],
+          segments: [{matching: false, value: normalisedTerm}],
         };
       });
     }
@@ -96,10 +96,7 @@ function camelCaseTokenize(text: string): string[] {
 // Given a query (possibly multi-word) and candidate text, compute highlight
 // segments. Each query token is first tried as a substring match, then falls
 // back to sequential character matching.
-export function computeHighlightSegments(
-  query: string,
-  text: string,
-): FuzzySegment[] {
+function computeHighlightSegments(query: string, text: string): FuzzySegment[] {
   const tokens = query.split(/\s+/).filter(Boolean);
   const lowerText = text.toLowerCase();
   const highlightedIndices: number[] = [];

--- a/ui/src/base/fuzzy.ts
+++ b/ui/src/base/fuzzy.ts
@@ -60,10 +60,10 @@ export class FuzzyFinder<T> {
   find(searchTerm: string): FuzzyResult<T>[] {
     if (searchTerm === '') {
       return this.items.map((item) => {
-        const normalisedTerm = this.keyLookup(item);
+        const text = this.keyLookup(item);
         return {
           item,
-          segments: [{matching: false, value: normalisedTerm}],
+          segments: [{matching: false, value: text}],
         };
       });
     }
@@ -96,7 +96,10 @@ function camelCaseTokenize(text: string): string[] {
 // Given a query (possibly multi-word) and candidate text, compute highlight
 // segments. Each query token is first tried as a substring match, then falls
 // back to sequential character matching.
-function computeHighlightSegments(query: string, text: string): FuzzySegment[] {
+export function computeHighlightSegments(
+  query: string,
+  text: string,
+): FuzzySegment[] {
   const tokens = query.split(/\s+/).filter(Boolean);
   const lowerText = text.toLowerCase();
   const highlightedIndices: number[] = [];

--- a/ui/src/frontend/omnibox.ts
+++ b/ui/src/frontend/omnibox.ts
@@ -15,7 +15,11 @@
 import m from 'mithril';
 import {classNames} from '../base/classnames';
 import {findRef} from '../base/dom_utils';
-import {FuzzyFinder, FuzzySegment} from '../base/fuzzy';
+import {
+  FuzzyFinder,
+  FuzzySegment,
+  computeHighlightSegments,
+} from '../base/fuzzy';
 import {assertExists, assertUnreachable} from '../base/assert';
 import {isString} from '../base/object_utils';
 import {exists} from '../base/utils';
@@ -124,9 +128,17 @@ export class Omnibox implements m.ClassComponent<OmniboxAttrs> {
   private fuzzyFilterCommands(searchTerm: string): CommandWithMatchInfo[] {
     const app = AppImpl.instance;
     const allCommands = app.commands.getCommands();
-    const finder = new FuzzyFinder(allCommands, ({name}) => name);
+    // Index name + source so users can filter by either. Highlight segments
+    // are recomputed per-field at render time so each piece (title chip /
+    // source chip) gets its own match highlighting.
+    const finder = new FuzzyFinder(allCommands, ({name, source}) =>
+      source ? `${source} ${name}` : name,
+    );
     return finder.find(searchTerm).map((result) => {
-      return {segments: result.segments, ...result.item};
+      return {
+        segments: computeHighlightSegments(searchTerm, result.item.name),
+        ...result.item,
+      };
     });
   }
 
@@ -160,7 +172,10 @@ export class Omnibox implements m.ClassComponent<OmniboxAttrs> {
         key: id,
         displayName: segments,
         tag: recentsIndex !== -1 ? 'recently used' : undefined,
-        source,
+        source:
+          source !== undefined
+            ? computeHighlightSegments(omnibox.text, source)
+            : undefined,
         rightContent: defaultHotkey && m(HotkeyGlyphs, {hotkey: defaultHotkey}),
       };
     });
@@ -371,7 +386,8 @@ interface OmniboxOptionRowAttrs extends HTMLAttrs {
   readonly label?: string;
 
   // Source label to show as a left-side chip (e.g. extension module name).
-  readonly source?: string;
+  // Either a plain string or fuzzy segments to enable match highlighting.
+  readonly source?: FuzzySegment[] | string;
 }
 
 class OmniboxOptionRow implements m.ClassComponent<OmniboxOptionRowAttrs> {
@@ -392,25 +408,25 @@ class OmniboxOptionRow implements m.ClassComponent<OmniboxOptionRowAttrs> {
         class: classNames(highlighted && 'pf-highlighted'),
         ...htmlAttrs,
       },
-      source &&
+      exists(source) &&
         m(Chip, {
           className: 'pf-omnibox__source',
-          label: source,
+          label: this.renderSegments(source),
           rounded: true,
           compact: true,
           intent: Intent.Primary,
         }),
-      m('span.pf-title', this.renderTitle(displayName)),
+      m('span.pf-title', this.renderSegments(displayName)),
       label && m(Chip, {className: 'pf-omnibox__tag', label, rounded: true}),
       rightContent,
     );
   }
 
-  private renderTitle(title: FuzzySegment[] | string): m.Children {
-    if (isString(title)) {
-      return title;
+  private renderSegments(text: FuzzySegment[] | string): m.Children {
+    if (isString(text)) {
+      return text;
     } else {
-      return title.map(({matching, value}) => {
+      return text.map(({matching, value}) => {
         return matching ? m('b', value) : value;
       });
     }
@@ -439,7 +455,8 @@ interface OmniboxOption {
   readonly tag?: string;
 
   // Source label to show as a left-side chip (e.g. extension module name).
-  readonly source?: string;
+  // Either a plain string or fuzzy segments to enable match highlighting.
+  readonly source?: FuzzySegment[] | string;
 
   // Arbitrary components to put on the right hand side of the option.
   readonly rightContent?: m.Children;


### PR DESCRIPTION
The command omnibox shows a "source" chip (e.g. plugin name) on the
left of each result but neither searched nor highlighted it. Index
both name + source so users can filter by either, compute fuzzy
highlight segments for the chip, and invert chip colours on the
highlighted row so the primary-intent chip stays visible against the
primary-coloured selection background.

FuzzyFinder grows an optional displayLookup so a caller can index
combined fields while restricting highlight segments to one of them.
