### PR TITLE
tp: stdlib: Fix lock_name in android_monitor_contention

### DIFF
--- a/src/trace_processor/perfetto_sql/stdlib/android/monitor_contention.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/monitor_contention.sql
@@ -205,7 +205,8 @@ WITH
       s.ts,
       s.name,
       lag(s.name) OVER (PARTITION BY s.track_id ORDER BY s.ts) AS prev_name,
-      lead(s.name) OVER (PARTITION BY s.track_id ORDER BY s.ts) AS next_name
+      lead(s.name, 1) OVER (PARTITION BY s.track_id ORDER BY s.ts) AS next_name_1,
+      lead(s.name, 2) OVER (PARTITION BY s.track_id ORDER BY s.ts) AS next_name_2
     FROM slice AS s
     WHERE
       s.track_id IN (
@@ -224,9 +225,16 @@ WITH
     SELECT
       id,
       CASE
-        WHEN prev_name GLOB '*_lock_acquire'
-        AND next_name GLOB '*_lock_held'
-        AND replace(prev_name, '_lock_acquire', '') = replace(next_name, '_lock_held', '')
+        -- Scenario A: Immediate adjacency
+        WHEN substr(next_name_1, -10) = '_lock_held'
+        AND substr(prev_name, -13) = '_lock_acquire'
+        AND replace(prev_name, '_lock_acquire', '') = replace(next_name_1, '_lock_held', '')
+        THEN replace(prev_name, '_lock_acquire', '')
+        -- Scenario B: Child 'Lock contention' slice exists (check next_name_2)
+        WHEN substr(next_name_1, 1, 15) = 'Lock contention'
+        AND substr(next_name_2, -10) = '_lock_held'
+        AND substr(prev_name, -13) = '_lock_acquire'
+        AND replace(prev_name, '_lock_acquire', '') = replace(next_name_2, '_lock_held', '')
         THEN replace(prev_name, '_lock_acquire', '')
         ELSE NULL
       END AS lock_name


### PR DESCRIPTION
Previously, `monitor contention*` events with a child `Lock contention*` slice were not properly showing a `lock_name` in `android_monitor_contention` as the query uses lag and lead to look for `*_lock_acquire` and `*_lock_held` slices respectively. This meant that the leading slice would be seen to be the child `Lock contention*` as opposed to the adjacent `*_lock_held`.

This PR changes the logic to fetch both the next two slice names with an extra LEAD() statement, and uses CASE to account for both scenarios.

Bug: 507922080