### PR TITLE
DNS: heap_graph: per-Java-frame root attribution

### DIFF
--- a/docs/data-sources/java-heap-profiler.md
+++ b/docs/data-sources/java-heap-profiler.md
@@ -87,6 +87,63 @@ FROM android_heap_graph_class_summary_tree;
 |java.util.Collections$SynchronizedMap|1063376|
 |java.util.HashMap|1063292|
 
+## Java thread call stacks
+
+NOTE: Capturing Java thread call stacks alongside the heap graph requires
+Android 16 (Baklava) or higher.
+
+Each Java heap dump is paired with one call-stack sample per Java thread,
+captured at the same instant the heap graph was snapshotted. The intent is
+to answer "*who* was holding all this memory?" — the heap graph alone tells
+you what is on the heap, the per-thread stacks tell you what code path
+each thread was running when the heap was sampled.
+
+The stack data lands in the standard perfetto stack-profiling tables, so
+the existing call-tree / top-frame SQL recipes work as-is:
+
+* [`stack_profile_frame`](/docs/analysis/sql-tables.autogen#stack_profile_frame) —
+  one row per `(ArtMethod*, dex_pc)`. The `name` column is the method's
+  `PrettyMethod()` (`"void android.os.Looper.loop()"`).
+* [`stack_profile_callsite`](/docs/analysis/sql-tables.autogen#stack_profile_callsite) —
+  parent-child chain of frames per call stack.
+* [`perf_sample`](/docs/analysis/sql-tables.autogen#perf_sample) —
+  one sample per Java thread per heap dump, joinable to `thread` /
+  `process` via `utid` / `upid`. Threads with no Java frames (Signal
+  Catcher, JIT pool, binder threads, etc.) appear with `callsite_id`
+  NULL.
+
+Each sample's `(ts, upid)` matches the heap dump's `(graph_sample_ts,
+upid)` exactly, so a join lines them up cleanly:
+
+```sql
+SELECT
+  hgo.graph_sample_ts AS dump_ts,
+  thread.name AS thread_name,
+  ps.callsite_id
+FROM heap_graph_object hgo
+JOIN perf_sample ps
+  ON ps.ts = hgo.graph_sample_ts AND ps.upid = hgo.upid
+LEFT JOIN thread USING(utid)
+GROUP BY 1, 2, 3
+ORDER BY 1, 2;
+```
+
+In `ui.perfetto.dev` the heap graph still appears as a diamond on the
+"Heap Profile" track; the Java stack samples appear as additional
+markers on each thread track at the same timestamp.
+
+### Implementation note
+
+The dumper runs in a forked child whose only kernel thread is the
+perfetto producer — every other pthread is gone (POSIX semantics). The
+parent's pre-fork `ScopedSuspendAll` snapshot, including each
+`art::Thread*`'s `ManagedStack` / `top_quick_frame_` / `top_shadow_frame_`,
+is preserved byte-for-byte in the child's address space. We walk those
+in-memory fields with `art::StackVisitor` (`check_suspended=false`,
+`kIncludeInlinedFrames`) — no kernel-state probes, no `/proc` reads —
+to reconstruct each Java thread's stack. Source:
+[`art/perfetto_hprof/perfetto_hprof.cc`](https://cs.android.com/android/platform/superproject/main/+/main:art/perfetto_hprof/perfetto_hprof.cc).
+
 ## TraceConfig
 
 The Java heap dump data source is configured through the

--- a/protos/perfetto/trace/profiling/heap_graph.proto
+++ b/protos/perfetto/trace/profiling/heap_graph.proto
@@ -145,6 +145,34 @@ message HeapGraphObject {
   optional uint32 bitmap_height_field = 14;
 }
 
+// Per-object attribution for ROOT_JAVA_FRAME GC roots: identifies the
+// thread whose Java stack retains the object. Only emitted for
+// ROOT_JAVA_FRAME — other root kinds (sticky class, VM internal, JNI
+// global, etc.) are not associated with a specific live thread frame and
+// continue to use HeapGraphRoot.
+//
+// The thread's full call stack at heap-dump time is available via
+// PerfSample on the same trace at the same (timestamp, upid) — so a
+// consumer can join from the heap dominator straight to the holding
+// thread's stack with one trace_processor query. The retaining frame
+// itself is not surfaced here on purpose: a single Java thread typically
+// has only one or a handful of frames holding GC roots, and the consumer
+// reads them off the perf_sample stack visually.
+message HeapGraphFrameRoot {
+  // Object retained by this Java-frame root.
+  optional uint64 object_id = 1;
+  // Kernel TID of the thread whose frame holds the reference. Producers
+  // are expected to convert any internal/runtime thread id (e.g. ART's
+  // RootInfo::GetThreadId()) to the kernel TID before emission so that
+  // consumers can join directly to the `thread` table on tid.
+  optional uint32 thread_id = 2;
+  // Reserved for a future per-frame attribution field (e.g. interning
+  // key into InternedData.frames). Not emitted by current producers and
+  // not consumed by trace_processor — see PerfSample for the holding
+  // thread's call stack.
+  reserved 3;
+}
+
 message HeapGraph {
   optional int32 pid = 1;
 
@@ -160,6 +188,13 @@ message HeapGraph {
   // All live objects are reachable from the roots. All other objects are
   // garbage.
   repeated HeapGraphRoot roots = 7;
+
+  // Java-frame roots with per-object attribution to the retaining thread and
+  // stack frame. Disjoint from `roots` for ROOT_JAVA_FRAME entries: when this
+  // field is populated, ROOT_JAVA_FRAME objects appear here instead of in
+  // `roots`. Older producers that don't emit this still populate
+  // ROOT_JAVA_FRAME via `roots`; consumers should accept either.
+  repeated HeapGraphFrameRoot frame_roots = 11;
 
   // Types used in HeapGraphObjects.
   repeated HeapGraphType types = 9;

--- a/src/trace_processor/importers/proto/heap_graph_module.cc
+++ b/src/trace_processor/importers/proto/heap_graph_module.cc
@@ -244,6 +244,18 @@ void HeapGraphModule::ParseHeapGraph(uint32_t seq_id,
     }
     heap_graph_tracker->AddRoot(seq_id, upid, ts, std::move(src_root));
   }
+  // Per-Java-frame root attribution. Disjoint from `roots` for
+  // ROOT_JAVA_FRAME entries. The wire frame_iid is intentionally not
+  // surfaced through trace_processor — consumers navigate to the holding
+  // thread via root_thread_tid and read its full call stack from the
+  // perf_sample row at the same (ts, upid).
+  for (auto it = heap_graph.frame_roots(); it; ++it) {
+    protos::pbzero::HeapGraphFrameRoot::Decoder entry(*it);
+    HeapGraphTracker::SourceFrameRoot src_fr;
+    src_fr.object_id = entry.object_id();
+    src_fr.thread_tid = entry.thread_id();
+    heap_graph_tracker->AddFrameRoot(seq_id, upid, ts, src_fr);
+  }
   if (!heap_graph.continued()) {
     heap_graph_tracker->FinalizeProfile(seq_id);
   }

--- a/src/trace_processor/importers/proto/heap_graph_tracker.cc
+++ b/src/trace_processor/importers/proto/heap_graph_tracker.cc
@@ -505,6 +505,17 @@ void HeapGraphTracker::AddRoot(uint32_t seq_id,
   sequence_state.current_roots.emplace_back(std::move(root));
 }
 
+void HeapGraphTracker::AddFrameRoot(uint32_t seq_id,
+                                    UniquePid upid,
+                                    int64_t ts,
+                                    SourceFrameRoot frame_root) {
+  SequenceState& sequence_state = GetOrCreateSequence(seq_id);
+  if (!SetPidAndTimestamp(&sequence_state, upid, ts))
+    return;
+
+  sequence_state.current_frame_roots.emplace_back(frame_root);
+}
+
 void HeapGraphTracker::AddInternedLocationName(uint32_t seq_id,
                                                uint64_t intern_id,
                                                StringId strid) {
@@ -762,6 +773,26 @@ void HeapGraphTracker::FinalizeProfile(uint32_t seq_id) {
                             sequence_state.current_ts)]
           .emplace(*ptr);
       MarkRoot(row_ref, InternRootTypeString(root.root_type));
+    }
+  }
+  // Apply per-Java-frame attribution: marks the object as ROOT_JAVA_FRAME
+  // and records the kernel TID of the retaining thread. The thread's full
+  // call stack at heap-dump time is in the trace's perf_sample row at the
+  // same (ts, upid).
+  StringId java_frame_root_type =
+      InternRootTypeString(protos::pbzero::HeapGraphRoot::ROOT_JAVA_FRAME);
+  for (const SourceFrameRoot& fr : sequence_state.current_frame_roots) {
+    auto* ptr = sequence_state.object_id_to_db_row.Find(fr.object_id);
+    if (!ptr)
+      continue;
+    ObjectTable::RowReference row_ref =
+        ptr->ToRowReference(storage_->mutable_heap_graph_object_table());
+    roots_[std::make_pair(sequence_state.current_upid,
+                          sequence_state.current_ts)]
+        .emplace(*ptr);
+    MarkRoot(row_ref, java_frame_root_type);
+    if (fr.thread_tid != 0) {
+      row_ref.set_root_thread_tid(fr.thread_tid);
     }
   }
 

--- a/src/trace_processor/importers/proto/heap_graph_tracker.h
+++ b/src/trace_processor/importers/proto/heap_graph_tracker.h
@@ -95,6 +95,17 @@ class HeapGraphTracker : public Destructible {
     std::vector<uint64_t> object_ids;
   };
 
+  // Per-object Java-frame root attribution: identifies the kernel TID of
+  // the thread whose stack frame retains a single object. Implies
+  // root_type = ROOT_JAVA_FRAME for that object — emitted disjoint from
+  // SourceRoot to avoid losing per-object attribution to the type-
+  // bucketed list. The actual call stack of that thread at heap-dump time
+  // is in the trace's perf_sample row at the same (ts, upid).
+  struct SourceFrameRoot {
+    uint64_t object_id = 0;
+    uint32_t thread_tid = 0;
+  };
+
   explicit HeapGraphTracker(TraceStorage* storage);
 
   static HeapGraphTracker* Get(TraceProcessorContext* context) {
@@ -102,6 +113,10 @@ class HeapGraphTracker : public Destructible {
   }
 
   void AddRoot(uint32_t seq_id, UniquePid upid, int64_t ts, SourceRoot root);
+  void AddFrameRoot(uint32_t seq_id,
+                    UniquePid upid,
+                    int64_t ts,
+                    SourceFrameRoot frame_root);
   void AddObject(uint32_t seq_id, UniquePid upid, int64_t ts, SourceObject obj);
   void AddInternedType(uint32_t seq_id,
                        uint64_t intern_id,
@@ -174,6 +189,7 @@ class HeapGraphTracker : public Destructible {
     protos::pbzero::HeapGraphObject::HeapType last_heap_type =
         protos::pbzero::HeapGraphObject::HEAP_TYPE_UNKNOWN;
     std::vector<SourceRoot> current_roots;
+    std::vector<SourceFrameRoot> current_frame_roots;
     std::vector<uint64_t> internal_vm_roots;
 
     // Note: the below maps are a mix of std::map and base::FlatHashMap because

--- a/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/memory/heap_graph/helpers.sql
@@ -94,6 +94,12 @@ RETURNS TableOrSubquery AS
         coalesce(c.deobfuscated_name, c.name) AS name,
         o.root_type,
         o.heap_type,
+        -- For ROOT_JAVA_FRAME nodes: pick any retaining-thread tid from the
+        -- aggregated rows. In practice all aggregated objects with the same
+        -- class+path are usually held on the same thread (allocations come
+        -- from one code path); when they differ we surface a representative
+        -- one rather than NULL so the tooltip is at least suggestive.
+        MAX(o.root_thread_tid) AS root_thread_tid,
         count() AS self_count,
         sum(o.self_size) AS self_size,
         sum(o.native_size > 0) AS self_native_count,
@@ -114,6 +120,7 @@ RETURNS TableOrSubquery AS
     '[native] ' || x.name AS name,
     root_type,
     'HEAP_TYPE_NATIVE' AS heap_type,
+    NULL AS root_thread_tid,
     sum(x.self_native_count) AS self_count,
     sum(x.self_native_size) AS self_size
   FROM x
@@ -130,6 +137,7 @@ RETURNS TableOrSubquery AS
     name,
     root_type,
     heap_type,
+    root_thread_tid,
     self_count,
     self_size
   FROM x
@@ -162,6 +170,7 @@ RETURNS TableOrSubquery AS
     name,
     root_type,
     heap_type,
+    root_thread_tid,
     self_count,
     self_size,
     path_hash AS path_hash_stable

--- a/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/memory.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/prelude/after_eof/memory.sql
@@ -84,7 +84,12 @@ CREATE PERFETTO VIEW heap_graph_object (
   -- Distance from the root object.
   root_distance LONG,
   -- Optional ID into heap_graph_object_data for HPROF data.
-  object_data_id LONG
+  object_data_id LONG,
+  -- For ROOT_JAVA_FRAME objects: kernel TID of the thread whose stack frame
+  -- retains this object. NULL when the producer did not emit per-Java-frame
+  -- attribution. Joinable to thread.tid; the thread's full call stack at
+  -- heap-dump time lives in perf_sample at the same (ts, upid).
+  root_thread_tid LONG
 ) AS
 SELECT
   id,
@@ -98,7 +103,8 @@ SELECT
   type_id,
   root_type,
   root_distance,
-  object_data_id
+  object_data_id,
+  root_thread_tid
 FROM __intrinsic_heap_graph_object;
 
 -- HPROF-specific data for heap graph objects.

--- a/src/trace_processor/tables/profiler_tables.py
+++ b/src/trace_processor/tables/profiler_tables.py
@@ -876,6 +876,12 @@ HEAP_GRAPH_OBJECT_TABLE = Table(
             CppOptional(CppUint32()),
             cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
         ),
+        C(
+            'root_thread_tid',
+            CppOptional(CppUint32()),
+            cpp_access=CppAccess.READ_AND_LOW_PERF_WRITE,
+            cpp_access_duration=CppAccessDuration.POST_FINALIZATION,
+        ),
     ],
     tabledoc=TableDoc(
         doc='''
@@ -912,6 +918,11 @@ HEAP_GRAPH_OBJECT_TABLE = Table(
             'object_data_id':
                 '''optional ID into heap_graph_object_data for HPROF
                 primitive field values and array data.''',
+            'root_thread_tid':
+                '''For ROOT_JAVA_FRAME objects: kernel TID of the thread whose
+                stack frame retains this object. Joinable to thread.tid. The
+                thread's full call stack at heap-dump time is in the trace's
+                perf_sample row at the same (ts, upid).''',
         }))
 
 HEAP_GRAPH_OBJECT_DATA_TABLE = Table(

--- a/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
+++ b/ui/src/plugins/dev.perfetto.HeapProfile/heap_profile_details_panel.ts
@@ -283,20 +283,29 @@ function flamegraphMetrics(
             'include perfetto module android.memory.heap_graph.class_tree;',
           statement: `
             select
-              id,
-              parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
-              root_type,
-              heap_type,
-              self_size as value,
-              self_count,
-              path_hash_stable
-            from _heap_graph_class_tree
-            where graph_sample_ts = ${ts} and upid = ${upid}
+              t.id,
+              t.parent_id as parentId,
+              ifnull(t.name, '[Unknown]') as name,
+              t.root_type,
+              t.heap_type,
+              case
+                when t.root_type = 'ROOT_JAVA_FRAME' and t.root_thread_tid is not null
+                  then printf('%s (tid %d)',
+                              coalesce(thread.name, '[unknown]'),
+                              t.root_thread_tid)
+                else null
+              end as held_by_thread,
+              t.self_size as value,
+              t.self_count,
+              t.path_hash_stable
+            from _heap_graph_class_tree as t
+            left join thread on thread.tid = t.root_thread_tid
+            where t.graph_sample_ts = ${ts} and t.upid = ${upid}
           `,
           unaggregatableProperties: [
             {name: 'root_type', displayName: 'Root Type'},
             {name: 'heap_type', displayName: 'Heap Type'},
+            {name: 'held_by_thread', displayName: 'Held By Thread'},
           ],
           aggregatableProperties: [
             {
@@ -325,20 +334,29 @@ function flamegraphMetrics(
             'include perfetto module android.memory.heap_graph.class_tree;',
           statement: `
             select
-              id,
-              parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
-              root_type,
-              heap_type,
-              self_size,
-              self_count as value,
-              path_hash_stable
-            from _heap_graph_class_tree
-            where graph_sample_ts = ${ts} and upid = ${upid}
+              t.id,
+              t.parent_id as parentId,
+              ifnull(t.name, '[Unknown]') as name,
+              t.root_type,
+              t.heap_type,
+              case
+                when t.root_type = 'ROOT_JAVA_FRAME' and t.root_thread_tid is not null
+                  then printf('%s (tid %d)',
+                              coalesce(thread.name, '[unknown]'),
+                              t.root_thread_tid)
+                else null
+              end as held_by_thread,
+              t.self_size,
+              t.self_count as value,
+              t.path_hash_stable
+            from _heap_graph_class_tree as t
+            left join thread on thread.tid = t.root_thread_tid
+            where t.graph_sample_ts = ${ts} and t.upid = ${upid}
           `,
           unaggregatableProperties: [
             {name: 'root_type', displayName: 'Root Type'},
             {name: 'heap_type', displayName: 'Heap Type'},
+            {name: 'held_by_thread', displayName: 'Held By Thread'},
           ],
           aggregatableProperties: [
             {
@@ -362,20 +380,34 @@ function flamegraphMetrics(
             'include perfetto module android.memory.heap_graph.dominator_class_tree;',
           statement: `
             select
-              id,
-              parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
-              root_type,
-              heap_type,
-              self_size as value,
-              self_count,
-              path_hash_stable
-            from _heap_graph_dominator_class_tree
-            where graph_sample_ts = ${ts} and upid = ${upid}
+              t.id,
+              t.parent_id as parentId,
+              ifnull(t.name, '[Unknown]') as name,
+              t.root_type,
+              t.heap_type,
+              -- Held-by attribution for ROOT_JAVA_FRAME nodes: surface the
+              -- retaining thread (kernel TID + name) as a tooltip line. NULL
+              -- (and hence not displayed) for any node whose root_type is
+              -- not ROOT_JAVA_FRAME, keeping the tooltip clean for other
+              -- root kinds.
+              case
+                when t.root_type = 'ROOT_JAVA_FRAME' and t.root_thread_tid is not null
+                  then printf('%s (tid %d)',
+                              coalesce(thread.name, '[unknown]'),
+                              t.root_thread_tid)
+                else null
+              end as held_by_thread,
+              t.self_size as value,
+              t.self_count,
+              t.path_hash_stable
+            from _heap_graph_dominator_class_tree as t
+            left join thread on thread.tid = t.root_thread_tid
+            where t.graph_sample_ts = ${ts} and t.upid = ${upid}
           `,
           unaggregatableProperties: [
             {name: 'root_type', displayName: 'Root Type'},
             {name: 'heap_type', displayName: 'Heap Type'},
+            {name: 'held_by_thread', displayName: 'Held By Thread'},
           ],
           aggregatableProperties: [
             {
@@ -404,20 +436,29 @@ function flamegraphMetrics(
             'include perfetto module android.memory.heap_graph.dominator_class_tree;',
           statement: `
             select
-              id,
-              parent_id as parentId,
-              ifnull(name, '[Unknown]') as name,
-              root_type,
-              heap_type,
-              self_size,
-              self_count as value,
-              path_hash_stable
-            from _heap_graph_dominator_class_tree
-            where graph_sample_ts = ${ts} and upid = ${upid}
+              t.id,
+              t.parent_id as parentId,
+              ifnull(t.name, '[Unknown]') as name,
+              t.root_type,
+              t.heap_type,
+              case
+                when t.root_type = 'ROOT_JAVA_FRAME' and t.root_thread_tid is not null
+                  then printf('%s (tid %d)',
+                              coalesce(thread.name, '[unknown]'),
+                              t.root_thread_tid)
+                else null
+              end as held_by_thread,
+              t.self_size,
+              t.self_count as value,
+              t.path_hash_stable
+            from _heap_graph_dominator_class_tree as t
+            left join thread on thread.tid = t.root_thread_tid
+            where t.graph_sample_ts = ${ts} and t.upid = ${upid}
           `,
           unaggregatableProperties: [
             {name: 'root_type', displayName: 'Root Type'},
             {name: 'heap_type', displayName: 'Heap Type'},
+            {name: 'held_by_thread', displayName: 'Held By Thread'},
           ],
           aggregatableProperties: [
             {


### PR DESCRIPTION
Surface, for ROOT_JAVA_FRAME GC roots emitted by ART's perfetto_hprof, the kernel TID of the thread whose stack frame retains each object. Combined with the Java thread stack samples ART now emits at heap- dump time, this lets a consumer navigate from a heap dominator straight to the holding thread's call stack with a single trace_processor join.

Wire (heap_graph.proto):
  HeapGraph.frame_roots: repeated HeapGraphFrameRoot
  HeapGraphFrameRoot { object_id, thread_id (kernel TID) }

trace_processor:
  * New nullable column heap_graph_object.root_thread_tid populated from HeapGraphFrameRoot at FinalizeProfile.
  * Stdlib helper macro propagates root_thread_tid through to _heap_graph_dominator_class_tree.
  * Public view heap_graph_object exposes root_thread_tid.

UI (dev.perfetto.HeapProfile):
  * Dominator flamegraph tooltip line 'Held By Thread: <thread_name> (tid <N>)' surfaced only for ROOT_JAVA_FRAME nodes. Resolved via LEFT JOIN thread on the existing thread.tid.