### PR TITLE
ui: Add startDragGesture helper

### DIFF
--- a/ui/src/base/mithril_utils.ts
+++ b/ui/src/base/mithril_utils.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import m from 'mithril';
+import {assertIsInstance} from './assert';
 
 // Check if a mithril component vnode has children
 export function hasChildren<T>({children}: m.Vnode<T>): boolean {
@@ -276,4 +277,168 @@ export function createContext<T>(initialValue?: T): {
       },
     },
   };
+}
+
+/**
+ * Options for {@link startDragGesture}.
+ */
+export interface DragOptions {
+  // The pointerdown event that initiates the drag. Its `currentTarget` must
+  // be an HTMLElement and is the element that captures the pointer for the
+  // duration of the gesture.
+  readonly e: PointerEvent;
+
+  // The distance in pixels the pointer must move from its initial position
+  // before the drag is considered started. Defaults to 0px (i.e. dragging
+  // starts immediately on pointerdown).
+  readonly deadzonePx?: number;
+
+  // Called once when the pointer first moves beyond `deadzonePx`. May
+  // return per-gesture handlers that take precedence over the top-level
+  // `onDrag`/`onDragEnd` for the rest of this gesture — useful when the
+  // drag needs to capture state at the moment it starts. If you don't need
+  // to initialize anything, omit this and use `onDrag`/`onDragEnd` directly.
+  readonly onDragStart?: (e: PointerEvent) => {
+    readonly onDrag?: (e: PointerEvent) => void;
+    readonly onDragEnd?: (e: PointerEvent) => void;
+  } | void;
+
+  // Called for each pointermove after the deadzone is crossed. Ignored for
+  // a given gesture if `onDragStart` returned its own `onDrag`.
+  readonly onDrag?: (e: PointerEvent) => void;
+
+  // Called when the gesture ends (pointerup/pointercancel) after the
+  // deadzone was crossed. Ignored for a given gesture if `onDragStart`
+  // returned its own `onDragEnd`.
+  readonly onDragEnd?: (e: PointerEvent) => void;
+
+  // Called if the pointer is released before crossing the deadzone — i.e.
+  // the gesture turned out to be a click rather than a drag. `onDragStart`
+  // will not have been invoked when this fires.
+  readonly onDragFailed?: (e: PointerEvent) => void;
+}
+
+/**
+ * Turns a pointerdown event into a deadzone-gated drag gesture.
+ *
+ * Captures the pointer on `e.currentTarget`, then waits for movement to
+ * exceed `deadzonePx` before invoking `onDragStart`. Subsequent pointermove
+ * events are routed to `onDrag`; pointerup/pointercancel ends the
+ * gesture and invokes `onDragEnd`. If the pointer is released before the
+ * deadzone is crossed, `onDragFailed` is invoked instead — useful for
+ * distinguishing clicks from drags on the same element.
+ *
+ * Pointer capture is released and all listeners are removed automatically
+ * when the gesture ends, regardless of how it ends.
+ *
+ * @example
+ * m('.draggable', {
+ *   onpointerdown: (e: PointerEvent) => {
+ *     startDragGesture({
+ *       e,
+ *       deadzonePx: 5,
+ *       onDrag: (ev) => console.log('moved to', ev.clientX, ev.clientY),
+ *       onDragEnd: () => console.log('drag ended'),
+ *       onDragFailed: () => console.log('was a click, not a drag'),
+ *     });
+ *   },
+ * });
+ *
+ * Use `onDragStart` instead when the gesture needs to capture state at the
+ * moment dragging actually begins (e.g. clone a node):
+ *
+ * @example
+ * startDragGesture({
+ *   e,
+ *   deadzonePx: 5,
+ *   onDragStart: (ev) => {
+ *     const cloned = element.cloneNode();
+ *     return {
+ *       onDrag: (e2) => cloned.style.transform = `translate(...)`,
+ *       onDragEnd: () => cloned.remove(),
+ *     };
+ *   },
+ * });
+ */
+export function startDragGesture(options: DragOptions): void {
+  const {
+    e,
+    deadzonePx = 0,
+    onDragStart,
+    onDragFailed,
+    onDrag,
+    onDragEnd,
+  } = options;
+  const el = assertIsInstance(e.currentTarget, HTMLElement);
+  const startX = e.clientX;
+  const startY = e.clientY;
+  el.setPointerCapture(e.pointerId);
+
+  let started = false;
+  let handlers: {
+    onDrag?: (e: PointerEvent) => void;
+    onDragEnd?: (e: PointerEvent) => void;
+  } = {};
+
+  function teardown() {
+    el.removeEventListener('pointermove', onPointerMove);
+    el.removeEventListener('pointerup', onPointerUp);
+    el.removeEventListener('pointercancel', onPointerUp);
+    el.removeEventListener('contextmenu', onContextMenu);
+    if (el.hasPointerCapture(e.pointerId)) {
+      el.releasePointerCapture(e.pointerId);
+    }
+  }
+
+  // Suppress the context menu for the duration of the gesture. Right-click
+  // drags otherwise pop up the browser menu over the dragged element. We
+  // also can't rely on the menu cleaning up our state for us: Chrome does
+  // not fire `pointercancel` (or `lostpointercapture` until the next pointer
+  // move after the menu closes) when a native context menu opens over a
+  // captured pointer, so a drag started with the right button can be left
+  // stuck if we don't preventDefault here. See w3c/pointerevents#408.
+  function onContextMenu(ev: Event) {
+    ev.preventDefault();
+    ev.stopPropagation();
+  }
+
+  function start(ev: PointerEvent) {
+    started = true;
+    const perGesture = onDragStart?.(ev);
+    handlers = {
+      onDrag: perGesture?.onDrag ?? onDrag,
+      onDragEnd: perGesture?.onDragEnd ?? onDragEnd,
+    };
+  }
+
+  function onPointerMove(ev: PointerEvent) {
+    m.redraw();
+    if (!started) {
+      const dx = ev.clientX - startX;
+      const dy = ev.clientY - startY;
+      if (Math.hypot(dx, dy) < deadzonePx) return;
+      start(ev);
+    } else {
+      handlers.onDrag?.(ev);
+    }
+  }
+
+  function onPointerUp(ev: PointerEvent) {
+    m.redraw();
+    teardown();
+    if (started) {
+      handlers.onDragEnd?.(ev);
+    } else {
+      onDragFailed?.(ev);
+    }
+  }
+
+  el.addEventListener('pointermove', onPointerMove);
+  el.addEventListener('pointerup', onPointerUp);
+  el.addEventListener('pointercancel', onPointerUp);
+  el.addEventListener('contextmenu', onContextMenu);
+
+  // With a zero deadzone the gesture starts immediately on pointerdown, so
+  // even a click-without-moving counts as a drag (no `onDragFailed` path).
+  if (deadzonePx === 0) start(e);
 }

--- a/ui/src/base/mithril_utils_unittest.ts
+++ b/ui/src/base/mithril_utils_unittest.ts
@@ -13,7 +13,226 @@
 // limitations under the License.
 
 import m from 'mithril';
-import {createContext} from './mithril_utils';
+import {createContext, startDragGesture} from './mithril_utils';
+
+// jsdom doesn't implement PointerEvent. Build a minimal stand-in by
+// extending MouseEvent with a pointerId — sufficient for startDragGesture,
+// which only reads clientX/clientY and pointerId.
+function makePointerEvent(
+  type: string,
+  init: {clientX?: number; clientY?: number; pointerId?: number} = {},
+): PointerEvent {
+  const ev = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  }) as MouseEvent & {pointerId: number};
+  ev.pointerId = init.pointerId ?? 1;
+  return ev as unknown as PointerEvent;
+}
+
+function makeTarget(): HTMLElement {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  // jsdom lacks pointer-capture; stub the methods startDragGesture calls.
+  el.setPointerCapture = () => {};
+  el.releasePointerCapture = () => {};
+  el.hasPointerCapture = () => false;
+  return el;
+}
+
+describe('startDragGesture', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('invokes onDragFailed when released inside deadzone', () => {
+    const el = makeTarget();
+    const onDrag = jest.fn();
+    const onDragEnd = jest.fn();
+    const onDragFailed = jest.fn();
+
+    const down = makePointerEvent('pointerdown', {clientX: 100, clientY: 100});
+    Object.defineProperty(down, 'currentTarget', {value: el});
+    startDragGesture({e: down, deadzonePx: 5, onDrag, onDragEnd, onDragFailed});
+
+    el.dispatchEvent(
+      makePointerEvent('pointerup', {clientX: 101, clientY: 101}),
+    );
+
+    expect(onDrag).not.toHaveBeenCalled();
+    expect(onDragEnd).not.toHaveBeenCalled();
+    expect(onDragFailed).toHaveBeenCalledTimes(1);
+  });
+
+  test('top-level onDrag/onDragEnd fire after deadzone is crossed', () => {
+    const el = makeTarget();
+    const onDrag = jest.fn();
+    const onDragEnd = jest.fn();
+    const onDragFailed = jest.fn();
+    const onDragStart = jest.fn();
+
+    const down = makePointerEvent('pointerdown', {clientX: 0, clientY: 0});
+    Object.defineProperty(down, 'currentTarget', {value: el});
+    startDragGesture({
+      e: down,
+      deadzonePx: 5,
+      onDragStart,
+      onDrag,
+      onDragEnd,
+      onDragFailed,
+    });
+
+    // Inside deadzone — nothing fires.
+    el.dispatchEvent(makePointerEvent('pointermove', {clientX: 2, clientY: 2}));
+    expect(onDragStart).not.toHaveBeenCalled();
+    expect(onDrag).not.toHaveBeenCalled();
+
+    // Crosses deadzone — onDragStart fires, but this move is consumed by it.
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 10, clientY: 0}),
+    );
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+    expect(onDrag).not.toHaveBeenCalled();
+
+    // Subsequent moves go to the top-level onDrag.
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 20, clientY: 0}),
+    );
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 30, clientY: 0}),
+    );
+    expect(onDrag).toHaveBeenCalledTimes(2);
+
+    el.dispatchEvent(makePointerEvent('pointerup', {clientX: 30, clientY: 0}));
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+    expect(onDragFailed).not.toHaveBeenCalled();
+  });
+
+  test('works with no onDragStart at all (direct mode)', () => {
+    const el = makeTarget();
+    const onDrag = jest.fn();
+    const onDragEnd = jest.fn();
+
+    const down = makePointerEvent('pointerdown');
+    Object.defineProperty(down, 'currentTarget', {value: el});
+    startDragGesture({e: down, onDrag, onDragEnd});
+
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 50, clientY: 0}),
+    );
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 60, clientY: 0}),
+    );
+    el.dispatchEvent(makePointerEvent('pointerup', {clientX: 60, clientY: 0}));
+
+    expect(onDrag).toHaveBeenCalledTimes(2);
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+  });
+
+  test('per-gesture handlers from onDragStart override top-level ones', () => {
+    const el = makeTarget();
+    const topOnDrag = jest.fn();
+    const topOnDragEnd = jest.fn();
+    const perOnDrag = jest.fn();
+    const perOnDragEnd = jest.fn();
+
+    const down = makePointerEvent('pointerdown');
+    Object.defineProperty(down, 'currentTarget', {value: el});
+    startDragGesture({
+      e: down,
+      onDragStart: () => ({onDrag: perOnDrag, onDragEnd: perOnDragEnd}),
+      onDrag: topOnDrag,
+      onDragEnd: topOnDragEnd,
+    });
+
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 50, clientY: 0}),
+    );
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 60, clientY: 0}),
+    );
+    el.dispatchEvent(makePointerEvent('pointerup', {clientX: 60, clientY: 0}));
+
+    expect(perOnDrag).toHaveBeenCalledTimes(2);
+    expect(perOnDragEnd).toHaveBeenCalledTimes(1);
+    expect(topOnDrag).not.toHaveBeenCalled();
+    expect(topOnDragEnd).not.toHaveBeenCalled();
+  });
+
+  test('listeners are removed after gesture ends', () => {
+    const el = makeTarget();
+    const onDrag = jest.fn();
+    const onDragEnd = jest.fn();
+
+    const down = makePointerEvent('pointerdown');
+    Object.defineProperty(down, 'currentTarget', {value: el});
+    startDragGesture({e: down, onDrag, onDragEnd});
+
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 50, clientY: 0}),
+    );
+    el.dispatchEvent(makePointerEvent('pointerup', {clientX: 50, clientY: 0}));
+
+    onDrag.mockClear();
+    onDragEnd.mockClear();
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 100, clientY: 0}),
+    );
+    el.dispatchEvent(makePointerEvent('pointerup', {clientX: 100, clientY: 0}));
+
+    expect(onDrag).not.toHaveBeenCalled();
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+
+  test('deadzonePx: 0 starts the drag immediately on pointerdown', () => {
+    const el = makeTarget();
+    const onDragStart = jest.fn();
+    const onDrag = jest.fn();
+    const onDragEnd = jest.fn();
+    const onDragFailed = jest.fn();
+
+    const down = makePointerEvent('pointerdown', {clientX: 10, clientY: 10});
+    Object.defineProperty(down, 'currentTarget', {value: el});
+    startDragGesture({
+      e: down,
+      deadzonePx: 0,
+      onDragStart,
+      onDrag,
+      onDragEnd,
+      onDragFailed,
+    });
+
+    // onDragStart fires synchronously, before any pointermove.
+    expect(onDragStart).toHaveBeenCalledTimes(1);
+
+    // A release without moving counts as drag end, not drag failed.
+    el.dispatchEvent(makePointerEvent('pointerup', {clientX: 10, clientY: 10}));
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+    expect(onDragFailed).not.toHaveBeenCalled();
+  });
+
+  test('pointercancel ends the gesture like pointerup', () => {
+    const el = makeTarget();
+    const onDragEnd = jest.fn();
+    const onDragFailed = jest.fn();
+
+    const down = makePointerEvent('pointerdown');
+    Object.defineProperty(down, 'currentTarget', {value: el});
+    startDragGesture({e: down, onDragEnd, onDragFailed});
+
+    el.dispatchEvent(
+      makePointerEvent('pointermove', {clientX: 50, clientY: 0}),
+    );
+    el.dispatchEvent(
+      makePointerEvent('pointercancel', {clientX: 50, clientY: 0}),
+    );
+
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+    expect(onDragFailed).not.toHaveBeenCalled();
+  });
+});
 
 describe('createContext', () => {
   test('provides default value to consumers', () => {

--- a/ui/src/core_plugins/dev.perfetto.Timeline/minimap.ts
+++ b/ui/src/core_plugins/dev.perfetto.Timeline/minimap.ts
@@ -22,7 +22,11 @@ import {colorForCpu} from '../../components/colorizer';
 import {TraceImpl} from '../../core/trace_impl';
 import {TimestampFormat} from '../../public/timeline';
 import {VirtualOverlayCanvas} from '../../widgets/virtual_overlay_canvas';
-import {COLOR_TEXT_MUTED, FONT_COMPACT, COLOR_BORDER} from '../../frontend/css_constants';
+import {
+  COLOR_TEXT_MUTED,
+  FONT_COMPACT,
+  COLOR_BORDER,
+} from '../../frontend/css_constants';
 import {
   generateTicks,
   getMaxMajorTicks,
@@ -30,6 +34,7 @@ import {
   TickType,
 } from './gridline_helper';
 import {findRef} from '../../base/dom_utils';
+import {startDragGesture} from '../../base/mithril_utils';
 
 const HEADER_HEIGHT_PX = 20;
 const HANDLE_SIZE_PX = 5;
@@ -269,58 +274,39 @@ interface SelectionAreaAttrs extends m.Attributes {
 }
 
 function SelectionArea(): m.Component<SelectionAreaAttrs> {
-  let dragStartX: number | undefined;
-
   return {
     view({attrs}: m.Vnode<SelectionAreaAttrs>) {
       return m('div', {
-        onpointerdown: (e: PointerEvent) => {
-          const target = e.target as HTMLElement;
-          target.setPointerCapture(e.pointerId);
-          const rect = target.getBoundingClientRect();
-          dragStartX = e.clientX - rect.left;
-        },
-        onpointerup: (e: PointerEvent) => {
-          const target = e.target as HTMLElement;
-          target.releasePointerCapture(e.pointerId);
-          dragStartX = undefined;
-        },
-        onpointermove: (e: PointerEvent) => {
-          if (dragStartX !== undefined) {
-            const target = e.target as HTMLElement;
-            const rect = target.getBoundingClientRect();
-            const currentX = e.clientX - rect.left;
-            attrs.onDrag(dragStartX, currentX);
-          }
-        },
         class: 'pf-minimap__selection-area',
+        onpointerdown: (e: PointerEvent) => {
+          const target = e.currentTarget as HTMLElement;
+          const rect = target.getBoundingClientRect();
+          const dragStartX = e.clientX - rect.left;
+          startDragGesture({
+            e,
+            onDrag: (ev) => {
+              attrs.onDrag(dragStartX, ev.clientX - rect.left);
+            },
+          });
+        },
       });
     },
   };
 }
 
 function DragHandle(): m.Component<DragHandleAttrs> {
-  let lastClientX: number | undefined;
-
   return {
     view({attrs}: m.Vnode<DragHandleAttrs>) {
       return m('span.pf-minimap__drag-handle', {
         onpointerdown: (e: PointerEvent) => {
-          const target = e.target as HTMLElement;
-          target.setPointerCapture(e.pointerId);
-          lastClientX = e.clientX;
-        },
-        onpointerup: (e: PointerEvent) => {
-          const target = e.target as HTMLElement;
-          target.releasePointerCapture(e.pointerId);
-          lastClientX = undefined;
-        },
-        onpointermove: (e: PointerEvent) => {
-          if (lastClientX !== undefined) {
-            const deltaX = e.clientX - lastClientX;
-            lastClientX = e.clientX;
-            attrs.onDrag(deltaX);
-          }
+          let lastClientX = e.clientX;
+          startDragGesture({
+            e,
+            onDrag: (ev) => {
+              attrs.onDrag(ev.clientX - lastClientX);
+              lastClientX = ev.clientX;
+            },
+          });
         },
         style: {
           position: 'absolute',
@@ -335,34 +321,25 @@ function DragHandle(): m.Component<DragHandleAttrs> {
 }
 
 function Brush(): m.Component<BrushAttrs> {
-  let dragging = false;
-
   return {
     view({attrs}: m.Vnode<BrushAttrs>) {
       return m(
         '.pf-minimap__brush',
         {
           onpointerdown: (e: PointerEvent) => {
-            const target = e.currentTarget as HTMLElement;
-            target.setPointerCapture(e.pointerId);
-            dragging = true;
-          },
-          onpointerup: (e: PointerEvent) => {
-            const target = e.currentTarget as HTMLElement;
-            target.releasePointerCapture(e.pointerId);
-            dragging = false;
-          },
-          onpointermove: (e: PointerEvent) => {
-            if (dragging) {
-              const brushElement = e.currentTarget as HTMLElement;
-              const parentRect =
-                brushElement.offsetParent!.getBoundingClientRect();
-              const x = Math.max(
-                attrs.minX,
-                Math.min(attrs.maxX, e.clientX - parentRect.left),
-              );
-              attrs.onDrag(x);
-            }
+            const brushElement = e.currentTarget as HTMLElement;
+            const parentRect =
+              brushElement.offsetParent!.getBoundingClientRect();
+            startDragGesture({
+              e,
+              onDrag: (ev) => {
+                const x = Math.max(
+                  attrs.minX,
+                  Math.min(attrs.maxX, ev.clientX - parentRect.left),
+                );
+                attrs.onDrag(x);
+              },
+            });
           },
           style: {
             position: 'absolute',


### PR DESCRIPTION
Factors out the pointerdown/move/up/capture/teardown boilerplate that several minimap components were each reimplementing. Callers pass an onDrag (and optionally onDragEnd / onDragFailed); an optional onDragStart is available when the gesture needs to capture state at the moment it actually begins.

A configurable deadzone distinguishes clicks from drags - set to 0 (the default) to start the drag immediately on pointerdown.

Also handles a Chrome quirk where right-click drags can leave pointer capture stuck if the context menu opens (w3c/pointerevents#408).

Before:

```ts
let lastClientX: number | undefined;
return {
  view: () => m('.handle', {
    onpointerdown: (e) => {
      e.currentTarget.setPointerCapture(e.pointerId);
      lastClientX = e.clientX;
    },
    onpointerup: (e) => {
      e.currentTarget.releasePointerCapture(e.pointerId);
      lastClientX = undefined;
    },
    onpointermove: (e) => {
      if (lastClientX === undefined) return;
      attrs.onDrag(e.clientX - lastClientX);
      lastClientX = e.clientX;
    },
  }),
};
```

After:

```ts
view: () => m('.handle', {
  onpointerdown: (e) => {
    let lastClientX = e.clientX;
    startDragGesture({
      e,
      onDrag: (ev) => {
        attrs.onDrag(ev.clientX - lastClientX);
        lastClientX = ev.clientX;
      },
    });
  },
}),
```