### PR TITLE
tp: emit cc_library for source_sets in gen_bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7142,6 +7142,7 @@ perfetto_cc_library(
         ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
     ],
     linkstatic = True,
+    alwayslink = True,
 )
 
 # GN target: //src/android_sdk/nativehelper:nativehelper

--- a/BUILD
+++ b/BUILD
@@ -7143,6 +7143,9 @@ perfetto_cc_library(
     ],
     linkstatic = True,
     alwayslink = True,
+    target_compatible_with = [
+        "@platforms//os:android",
+    ],
 )
 
 # GN target: //src/android_sdk/nativehelper:nativehelper
@@ -7159,6 +7162,9 @@ perfetto_cc_library(
         "src/android_sdk/nativehelper/utils.h",
     ],
     linkstatic = True,
+    target_compatible_with = [
+        "@platforms//os:android",
+    ],
 )
 
 # GN target: //src/android_sdk/perfetto_sdk_for_jni:perfetto_sdk_for_jni
@@ -7173,6 +7179,9 @@ perfetto_cc_library(
         ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
     ],
     linkstatic = True,
+    target_compatible_with = [
+        "@platforms//os:android",
+    ],
 )
 
 # GN target: //src/android_sdk/perfetto_sdk_for_jni:perfetto_sdk_for_jni_public
@@ -7182,6 +7191,9 @@ perfetto_cc_library(
         "src/android_sdk/perfetto_sdk_for_jni/tracing_sdk.h",
     ],
     linkstatic = True,
+    target_compatible_with = [
+        "@platforms//os:android",
+    ],
 )
 
 # GN target: //src/java_sdk/main/cpp:perfetto_example_jni_lib

--- a/BUILD
+++ b/BUILD
@@ -62,11 +62,8 @@ perfetto_cc_library(
     srcs = [
         "src/base/default_platform.cc",
     ],
-    hdrs = [
-        ":include_perfetto_base_base",
+    deps = [
         ":include_perfetto_ext_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
     ],
     linkstatic = True,
 )
@@ -85,24 +82,10 @@ perfetto_cc_binary(
 # GN target: //src/ipc:perfetto_ipc
 perfetto_cc_library(
     name = "perfetto_ipc",
-    srcs = [
+    deps = [
         ":src_ipc_client",
         ":src_ipc_common",
         ":src_ipc_host",
-    ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_ipc_ipc",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-    ],
-    deps = [
-        ":protos_perfetto_ipc_wire_protocol_cpp",
-        ":src_base_base",
-        ":src_base_unix_socket",
     ],
     linkstatic = True,
 )
@@ -145,14 +128,9 @@ perfetto_cc_library(
         "src/protozero/static_buffer.cc",
         "src/protozero/virtual_destructors.cc",
     ],
-    hdrs = [
+    deps = [
         ":include_perfetto_base_base",
         ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-    ],
-    deps = [
         ":src_base_base",
     ],
     linkstatic = True,
@@ -161,121 +139,10 @@ perfetto_cc_library(
 # GN target: //src/shared_lib:libperfetto_c
 perfetto_cc_library(
     name = "libperfetto_c",
-    srcs = [
-        ":src_android_stats_android_stats",
-        ":src_android_stats_perfetto_atoms",
-        ":src_protozero_filtering_bytecode_common",
-        ":src_protozero_filtering_bytecode_parser",
-        ":src_protozero_filtering_message_filter",
-        ":src_protozero_filtering_message_filter_config",
-        ":src_protozero_filtering_string_filter",
-        ":src_shared_lib_for_testing",
-        ":src_shared_lib_shared_lib",
-        ":src_shared_lib_track_event_intern_map",
-        ":src_shared_lib_track_event_track_event",
-        ":src_tracing_client_api_without_backends",
-        ":src_tracing_common",
-        ":src_tracing_core_core",
-        ":src_tracing_in_process_backend",
-        ":src_tracing_ipc_common",
-        ":src_tracing_ipc_consumer_consumer",
-        ":src_tracing_ipc_default_socket",
-        ":src_tracing_ipc_producer_producer",
-        ":src_tracing_ipc_service_service",
-        ":src_tracing_service_service",
-        ":src_tracing_system_backend",
-    ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_ipc_ipc",
-        ":include_perfetto_ext_tracing_core_core",
-        ":include_perfetto_ext_tracing_ipc_ipc",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_abi_public",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protos_protos",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_public_public",
-        ":include_perfetto_tracing_core_core",
-        ":include_perfetto_tracing_core_forward_decls",
-        ":include_perfetto_tracing_tracing",
-    ],
-    defines = [
-        "PERFETTO_SHLIB_SDK_IMPLEMENTATION",
-    ],
     visibility = PERFETTO_CONFIG.public_visibility,
     deps = [
-        ":perfetto_ipc",
-        ":protos_perfetto_common_cpp",
-        ":protos_perfetto_common_semantic_type_cpp",
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_cpp",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_cpp",
-        ":protos_perfetto_config_ftrace_cpp",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_cpp",
-        ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_cpp",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_cpp",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_cpp",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_cpp",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_cpp",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_cpp",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_cpp",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_cpp",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_cpp",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_cpp",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_cpp",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_cpp",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_ipc_cpp",
-        ":protos_perfetto_ipc_ipc",
-        ":protos_perfetto_protovm_cpp",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
-        ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
-        ":protos_perfetto_trace_minimal_zero",
-        ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_cpp",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
-        ":protozero",
-        ":src_base_base",
-        ":src_base_clock_snapshots",
-        ":src_base_regex_regex",
-        ":src_base_version",
-        ":src_protovm_protovm",
+        ":include_perfetto_public_public",
+        ":src_shared_lib_shared_lib",
     ],
     linkstatic = True,
 )
@@ -284,49 +151,18 @@ perfetto_cc_library(
 perfetto_cc_binary(
     name = "proto_filter",
     srcs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":src_proto_utils_txt_to_pb",
-        ":src_protozero_filtering_bytecode_common",
-        ":src_protozero_filtering_bytecode_generator",
-        ":src_protozero_filtering_bytecode_parser",
-        ":src_protozero_filtering_filter_util",
-        ":src_protozero_filtering_message_filter",
-        ":src_protozero_filtering_string_filter",
-        ":src_protozero_multifile_error_collector",
-        ":src_protozero_text_to_proto_text_to_proto",
         "src/tools/proto_filter/proto_filter.cc",
     ],
     deps = [
-        ":protos_perfetto_common_cpp",
-        ":protos_perfetto_common_semantic_type_cpp",
-        ":protos_perfetto_common_semantic_type_lite",
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_config_android_cpp",
         ":protos_perfetto_config_cpp",
-        ":protos_perfetto_config_ftrace_cpp",
-        ":protos_perfetto_config_gpu_cpp",
-        ":protos_perfetto_config_inode_file_cpp",
-        ":protos_perfetto_config_interceptors_cpp",
-        ":protos_perfetto_config_power_cpp",
-        ":protos_perfetto_config_priority_boost_cpp",
-        ":protos_perfetto_config_process_stats_cpp",
-        ":protos_perfetto_config_profiling_cpp",
-        ":protos_perfetto_config_protovm_cpp",
-        ":protos_perfetto_config_qnx_cpp",
-        ":protos_perfetto_config_statsd_cpp",
-        ":protos_perfetto_config_sys_stats_cpp",
-        ":protos_perfetto_config_system_info_cpp",
-        ":protos_perfetto_config_track_event_cpp",
-        ":protos_perfetto_proto_filtering_lite",
-        ":protos_perfetto_protovm_cpp",
         ":protozero",
         ":src_base_base",
-        ":src_base_regex_regex",
         ":src_base_version",
-        ":src_proto_utils_gen_cc_config_descriptor",
-        ":src_proto_utils_gen_cc_trace_summary_descriptor",
+        ":src_proto_utils_txt_to_pb",
+        ":src_protozero_filtering_bytecode_generator",
+        ":src_protozero_filtering_filter_util",
+        ":src_protozero_filtering_message_filter",
+        ":src_protozero_filtering_string_filter",
     ] + PERFETTO_CONFIG.deps.protobuf_full,
 )
 
@@ -334,7 +170,6 @@ perfetto_cc_binary(
 perfetto_cc_binary(
     name = "proto_merger",
     srcs = [
-        ":src_protozero_multifile_error_collector",
         "src/tools/proto_merger/allowlist.cc",
         "src/tools/proto_merger/allowlist.h",
         "src/tools/proto_merger/main.cc",
@@ -348,551 +183,55 @@ perfetto_cc_binary(
     deps = [
         ":src_base_base",
         ":src_base_version",
+        ":src_protozero_multifile_error_collector",
     ] + PERFETTO_CONFIG.deps.protobuf_full,
 )
 
 # GN target: //src/trace_processor/rpc:trace_processor_rpc
 perfetto_cc_library(
     name = "trace_processor_rpc",
-    srcs = [
-        ":src_kernel_utils_kernel_wakelock_errors",
-        ":src_kernel_utils_syscall_table",
-        ":src_protozero_proto_ring_buffer",
-        ":src_protozero_text_to_proto_text_to_proto",
-        ":src_trace_processor_core_common_common",
-        ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_interpreter_interpreter",
-        ":src_trace_processor_core_plugin_plugin",
-        ":src_trace_processor_core_tree_tree",
-        ":src_trace_processor_core_util_util",
-        ":src_trace_processor_export_json",
-        ":src_trace_processor_importers_android_bugreport_android_bugreport",
-        ":src_trace_processor_importers_android_bugreport_android_dumpstate_event",
-        ":src_trace_processor_importers_android_bugreport_android_log_event",
-        ":src_trace_processor_importers_archive_archive",
-        ":src_trace_processor_importers_art_hprof_art_hprof",
-        ":src_trace_processor_importers_art_method_art_method",
-        ":src_trace_processor_importers_art_method_art_method_event",
-        ":src_trace_processor_importers_collapsed_stack_collapsed_stack",
-        ":src_trace_processor_importers_common_common",
-        ":src_trace_processor_importers_common_parser_types",
-        ":src_trace_processor_importers_common_synthetic_tid_hdr",
-        ":src_trace_processor_importers_common_v8_profile_parser",
-        ":src_trace_processor_importers_etw_full",
-        ":src_trace_processor_importers_etw_minimal",
-        ":src_trace_processor_importers_ftrace_ftrace_descriptors",
-        ":src_trace_processor_importers_ftrace_full",
-        ":src_trace_processor_importers_ftrace_minimal",
-        ":src_trace_processor_importers_fuchsia_fuchsia_record",
-        ":src_trace_processor_importers_fuchsia_full",
-        ":src_trace_processor_importers_fuchsia_minimal",
-        ":src_trace_processor_importers_gecko_gecko",
-        ":src_trace_processor_importers_gecko_gecko_event",
-        ":src_trace_processor_importers_generic_kernel_full",
-        ":src_trace_processor_importers_i2c_full",
-        ":src_trace_processor_importers_json_json",
-        ":src_trace_processor_importers_memory_tracker_graph_processor",
-        ":src_trace_processor_importers_ninja_ninja",
-        ":src_trace_processor_importers_perf_perf",
-        ":src_trace_processor_importers_perf_record",
-        ":src_trace_processor_importers_perf_text_perf_text",
-        ":src_trace_processor_importers_perf_text_perf_text_event",
-        ":src_trace_processor_importers_perf_text_perf_text_sample_line_parser",
-        ":src_trace_processor_importers_pprof_pprof",
-        ":src_trace_processor_importers_primes_primes",
-        ":src_trace_processor_importers_proto_full",
-        ":src_trace_processor_importers_proto_minimal",
-        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
-        ":src_trace_processor_importers_proto_proto_importer_module",
-        ":src_trace_processor_importers_proto_winscope_full",
-        ":src_trace_processor_importers_simpleperf_proto_simpleperf_proto",
-        ":src_trace_processor_importers_syscalls_full",
-        ":src_trace_processor_importers_systrace_full",
-        ":src_trace_processor_importers_systrace_systrace_line",
-        ":src_trace_processor_importers_systrace_systrace_parser",
-        ":src_trace_processor_lib",
-        ":src_trace_processor_metatrace",
-        ":src_trace_processor_metrics_metrics",
-        ":src_trace_processor_perfetto_sql_engine_engine",
-        ":src_trace_processor_perfetto_sql_generator_generator",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_trees_trees",
-        ":src_trace_processor_perfetto_sql_intrinsics_operators_operators",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_types_types",
-        ":src_trace_processor_perfetto_sql_parser_parser",
-        ":src_trace_processor_perfetto_sql_preprocessor_grammar",
-        ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
-        ":src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
-        ":src_trace_processor_perfetto_sql_tokenizer_tokenizer",
-        ":src_trace_processor_plugins_wattson_wattson",
-        ":src_trace_processor_rpc_rpc",
-        ":src_trace_processor_sorter_sorter",
-        ":src_trace_processor_sqlite_bindings_bindings",
-        ":src_trace_processor_sqlite_sqlite",
-        ":src_trace_processor_storage_minimal",
-        ":src_trace_processor_storage_storage",
-        ":src_trace_processor_tables_tables",
-        ":src_trace_processor_tables_tables_python",
-        ":src_trace_processor_trace_summary_trace_summary",
-        ":src_trace_processor_types_types",
-        ":src_trace_processor_util_args_utils",
-        ":src_trace_processor_util_blob",
-        ":src_trace_processor_util_bump_allocator",
-        ":src_trace_processor_util_clock",
-        ":src_trace_processor_util_descriptors",
-        ":src_trace_processor_util_elf_elf",
-        ":src_trace_processor_util_galloping_search",
-        ":src_trace_processor_util_glob",
-        ":src_trace_processor_util_gzip",
-        ":src_trace_processor_util_interned_message_view",
-        ":src_trace_processor_util_json_args",
-        ":src_trace_processor_util_json_parser",
-        ":src_trace_processor_util_json_serializer",
-        ":src_trace_processor_util_json_value",
-        ":src_trace_processor_util_profile_builder",
-        ":src_trace_processor_util_profiler_util",
-        ":src_trace_processor_util_proto_profiler",
-        ":src_trace_processor_util_proto_to_args_parser",
-        ":src_trace_processor_util_protozero_to_json",
-        ":src_trace_processor_util_protozero_to_text",
-        ":src_trace_processor_util_simple_json_parser",
-        ":src_trace_processor_util_simple_json_serializer",
-        ":src_trace_processor_util_sql_argument",
-        ":src_trace_processor_util_sql_bundle",
-        ":src_trace_processor_util_stdlib",
-        ":src_trace_processor_util_trace_blob_view_reader",
-        ":src_trace_processor_util_trace_type",
-        ":src_trace_processor_util_winscope_proto_mapping",
-        ":src_trace_processor_util_zip_reader",
-    ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_protozero_protozero",
-        ":include_perfetto_ext_trace_processor_demangle",
-        ":include_perfetto_ext_trace_processor_export_json",
-        ":include_perfetto_ext_trace_processor_importers_memory_tracker_memory_tracker",
-        ":include_perfetto_ext_trace_processor_rpc_query_result_serializer",
-        ":include_perfetto_ext_traced_sys_stats_counters",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_trace_processor_basic_types",
-        ":include_perfetto_trace_processor_storage",
-        ":include_perfetto_trace_processor_trace_processor",
-        ":include_perfetto_trace_processor_util",
-    ],
     deps = [
-               ":protos_perfetto_common_cpp",
-               ":protos_perfetto_common_semantic_type_zero",
-               ":protos_perfetto_common_zero",
-               ":protos_perfetto_config_android_zero",
-               ":protos_perfetto_config_ftrace_zero",
-               ":protos_perfetto_config_gpu_zero",
-               ":protos_perfetto_config_inode_file_zero",
-               ":protos_perfetto_config_interceptors_zero",
-               ":protos_perfetto_config_power_zero",
-               ":protos_perfetto_config_priority_boost_zero",
-               ":protos_perfetto_config_process_stats_zero",
-               ":protos_perfetto_config_profiling_zero",
-               ":protos_perfetto_config_protovm_zero",
-               ":protos_perfetto_config_qnx_zero",
-               ":protos_perfetto_config_statsd_zero",
-               ":protos_perfetto_config_sys_stats_zero",
-               ":protos_perfetto_config_system_info_zero",
-               ":protos_perfetto_config_track_event_zero",
-               ":protos_perfetto_config_zero",
-               ":protos_perfetto_perfetto_sql_zero",
-               ":protos_perfetto_protovm_cpp",
-               ":protos_perfetto_protovm_zero",
-               ":protos_perfetto_trace_android_winscope_common_zero",
-               ":protos_perfetto_trace_android_winscope_extensions_zero",
-               ":protos_perfetto_trace_android_winscope_regular_zero",
-               ":protos_perfetto_trace_android_zero",
-               ":protos_perfetto_trace_chrome_zero",
-               ":protos_perfetto_trace_etw_zero",
-               ":protos_perfetto_trace_filesystem_zero",
-               ":protos_perfetto_trace_ftrace_zero",
-               ":protos_perfetto_trace_generic_kernel_zero",
-               ":protos_perfetto_trace_gpu_gpu_interned_data_zero",
-               ":protos_perfetto_trace_gpu_gpu_track_event_zero",
-               ":protos_perfetto_trace_gpu_zero",
-               ":protos_perfetto_trace_interned_data_zero",
-               ":protos_perfetto_trace_minimal_zero",
-               ":protos_perfetto_trace_non_minimal_zero",
-               ":protos_perfetto_trace_perfetto_zero",
-               ":protos_perfetto_trace_power_zero",
-               ":protos_perfetto_trace_processor_metrics_impl_zero",
-               ":protos_perfetto_trace_processor_zero",
-               ":protos_perfetto_trace_profiling_zero",
-               ":protos_perfetto_trace_ps_zero",
-               ":protos_perfetto_trace_statsd_zero",
-               ":protos_perfetto_trace_summary_zero",
-               ":protos_perfetto_trace_sys_stats_zero",
-               ":protos_perfetto_trace_system_info_zero",
-               ":protos_perfetto_trace_track_event_zero",
-               ":protos_perfetto_trace_translation_zero",
-               ":protos_third_party_chromium_zero",
-               ":protos_third_party_pprof_zero",
-               ":protos_third_party_primes_cpp",
-               ":protos_third_party_primes_zero",
-               ":protos_third_party_simpleperf_zero",
-               ":protozero",
-               ":src_base_base",
-               ":src_base_clock_snapshots",
-               ":src_base_regex_regex",
-               ":src_base_version",
-               ":src_protovm_protovm",
-               ":src_trace_processor_containers_containers",
-               ":src_trace_processor_importers_proto_gen_cc_android_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_chrome_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_interned_data_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_statsd_atoms_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_trace_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
-               ":src_trace_processor_importers_proto_winscope_gen_cc_winscope_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_chrome_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_webview_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_metrics_descriptor",
-               ":src_trace_processor_metrics_sql_gen_amalgamated_sql_metrics",
-               ":src_trace_processor_perfetto_sql_stdlib_stdlib",
-               ":src_trace_processor_plugins_wattson_gen_cpu_1d_curves",
-               ":src_trace_processor_plugins_wattson_gen_cpu_2d_curves",
-               ":src_trace_processor_plugins_wattson_gen_gpu_curves",
-               ":src_trace_processor_plugins_wattson_gen_l3_curves",
-               ":src_trace_processor_plugins_wattson_gen_tpu_curves",
-               ":src_trace_processor_trace_summary_gen_cc_trace_summary_descriptor",
-               ":src_trace_processor_util_build_id",
-           ] + PERFETTO_CONFIG.deps.sqlite +
-           PERFETTO_CONFIG.deps.sqlite_ext_percentile +
-           PERFETTO_CONFIG.deps.zlib +
-           PERFETTO_CONFIG.deps.demangle_wrapper,
+        ":src_trace_processor_rpc_rpc",
+    ],
     linkstatic = True,
-    alwayslink = True,
 )
 
 # GN target: //src/trace_processor:trace_processor_shell_lib
 perfetto_cc_library(
     name = "trace_processor_shell_lib",
     srcs = [
-        ":src_kernel_utils_kernel_wakelock_errors",
-        ":src_kernel_utils_syscall_table",
-        ":src_protozero_proto_ring_buffer",
-        ":src_protozero_text_to_proto_text_to_proto",
-        ":src_trace_processor_core_common_common",
-        ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_interpreter_interpreter",
-        ":src_trace_processor_core_plugin_plugin",
-        ":src_trace_processor_core_tree_tree",
-        ":src_trace_processor_core_util_util",
-        ":src_trace_processor_export_json",
-        ":src_trace_processor_importers_android_bugreport_android_bugreport",
-        ":src_trace_processor_importers_android_bugreport_android_dumpstate_event",
-        ":src_trace_processor_importers_android_bugreport_android_log_event",
-        ":src_trace_processor_importers_archive_archive",
-        ":src_trace_processor_importers_art_hprof_art_hprof",
-        ":src_trace_processor_importers_art_method_art_method",
-        ":src_trace_processor_importers_art_method_art_method_event",
-        ":src_trace_processor_importers_collapsed_stack_collapsed_stack",
-        ":src_trace_processor_importers_common_common",
-        ":src_trace_processor_importers_common_parser_types",
-        ":src_trace_processor_importers_common_synthetic_tid_hdr",
-        ":src_trace_processor_importers_common_v8_profile_parser",
-        ":src_trace_processor_importers_etw_full",
-        ":src_trace_processor_importers_etw_minimal",
-        ":src_trace_processor_importers_ftrace_ftrace_descriptors",
-        ":src_trace_processor_importers_ftrace_full",
-        ":src_trace_processor_importers_ftrace_minimal",
-        ":src_trace_processor_importers_fuchsia_fuchsia_record",
-        ":src_trace_processor_importers_fuchsia_full",
-        ":src_trace_processor_importers_fuchsia_minimal",
-        ":src_trace_processor_importers_gecko_gecko",
-        ":src_trace_processor_importers_gecko_gecko_event",
-        ":src_trace_processor_importers_generic_kernel_full",
-        ":src_trace_processor_importers_i2c_full",
-        ":src_trace_processor_importers_json_json",
-        ":src_trace_processor_importers_memory_tracker_graph_processor",
-        ":src_trace_processor_importers_ninja_ninja",
-        ":src_trace_processor_importers_perf_perf",
-        ":src_trace_processor_importers_perf_record",
-        ":src_trace_processor_importers_perf_text_perf_text",
-        ":src_trace_processor_importers_perf_text_perf_text_event",
-        ":src_trace_processor_importers_perf_text_perf_text_sample_line_parser",
-        ":src_trace_processor_importers_pprof_pprof",
-        ":src_trace_processor_importers_primes_primes",
-        ":src_trace_processor_importers_proto_full",
-        ":src_trace_processor_importers_proto_minimal",
-        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
-        ":src_trace_processor_importers_proto_proto_importer_module",
-        ":src_trace_processor_importers_proto_winscope_full",
-        ":src_trace_processor_importers_simpleperf_proto_simpleperf_proto",
-        ":src_trace_processor_importers_syscalls_full",
-        ":src_trace_processor_importers_systrace_full",
-        ":src_trace_processor_importers_systrace_systrace_line",
-        ":src_trace_processor_importers_systrace_systrace_parser",
+        "src/trace_processor/trace_processor_shell.cc",
+    ],
+    deps = [
+        ":include_perfetto_ext_trace_processor_trace_processor_shell",
+        ":protos_perfetto_trace_processor_zero",
+        ":src_base_base",
+        ":src_base_version",
         ":src_trace_processor_lib",
-        ":src_trace_processor_metatrace",
         ":src_trace_processor_metrics_metrics",
-        ":src_trace_processor_perfetto_sql_engine_engine",
         ":src_trace_processor_perfetto_sql_generator_generator",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_trees_trees",
-        ":src_trace_processor_perfetto_sql_intrinsics_operators_operators",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_types_types",
-        ":src_trace_processor_perfetto_sql_parser_parser",
-        ":src_trace_processor_perfetto_sql_preprocessor_grammar",
-        ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
-        ":src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
-        ":src_trace_processor_perfetto_sql_tokenizer_tokenizer",
-        ":src_trace_processor_plugins_wattson_wattson",
         ":src_trace_processor_rpc_httpd",
         ":src_trace_processor_rpc_rpc",
         ":src_trace_processor_rpc_stdiod",
         ":src_trace_processor_shell_shell",
         ":src_trace_processor_shell_subcommands",
-        ":src_trace_processor_sorter_sorter",
-        ":src_trace_processor_sqlite_bindings_bindings",
         ":src_trace_processor_sqlite_sqlite",
-        ":src_trace_processor_storage_minimal",
-        ":src_trace_processor_storage_storage",
-        ":src_trace_processor_tables_tables",
-        ":src_trace_processor_tables_tables_python",
         ":src_trace_processor_trace_summary_trace_summary",
-        ":src_trace_processor_types_types",
-        ":src_trace_processor_util_args_utils",
-        ":src_trace_processor_util_blob",
-        ":src_trace_processor_util_bump_allocator",
-        ":src_trace_processor_util_clock",
-        ":src_trace_processor_util_descriptors",
-        ":src_trace_processor_util_elf_elf",
-        ":src_trace_processor_util_galloping_search",
-        ":src_trace_processor_util_glob",
-        ":src_trace_processor_util_gzip",
-        ":src_trace_processor_util_interned_message_view",
-        ":src_trace_processor_util_json_args",
-        ":src_trace_processor_util_json_parser",
-        ":src_trace_processor_util_json_serializer",
-        ":src_trace_processor_util_json_value",
-        ":src_trace_processor_util_profile_builder",
-        ":src_trace_processor_util_profiler_util",
-        ":src_trace_processor_util_proto_profiler",
-        ":src_trace_processor_util_proto_to_args_parser",
-        ":src_trace_processor_util_protozero_to_json",
-        ":src_trace_processor_util_protozero_to_text",
-        ":src_trace_processor_util_simple_json_parser",
-        ":src_trace_processor_util_simple_json_serializer",
-        ":src_trace_processor_util_sql_argument",
-        ":src_trace_processor_util_sql_bundle",
+        ":src_trace_processor_util_deobfuscation_deobfuscator",
         ":src_trace_processor_util_stdlib",
-        ":src_trace_processor_util_tar_writer",
-        ":src_trace_processor_util_trace_blob_view_reader",
-        ":src_trace_processor_util_trace_enrichment_trace_enrichment",
-        ":src_trace_processor_util_trace_type",
-        ":src_trace_processor_util_winscope_proto_mapping",
-        ":src_trace_processor_util_zip_reader",
-        ":src_traceconv_lib",
-        ":src_traceconv_pprofbuilder",
-        ":src_traceconv_traceconv_lib",
-        ":src_traceconv_utils",
-        "src/trace_processor/trace_processor_shell.cc",
-    ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_protozero_protozero",
-        ":include_perfetto_ext_trace_processor_demangle",
-        ":include_perfetto_ext_trace_processor_export_json",
-        ":include_perfetto_ext_trace_processor_importers_memory_tracker_memory_tracker",
-        ":include_perfetto_ext_trace_processor_rpc_query_result_serializer",
-        ":include_perfetto_ext_trace_processor_trace_processor_shell",
-        ":include_perfetto_ext_traceconv_traceconv",
-        ":include_perfetto_ext_traced_sys_stats_counters",
-        ":include_perfetto_profiling_pprof_builder",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_trace_processor_basic_types",
-        ":include_perfetto_trace_processor_storage",
-        ":include_perfetto_trace_processor_trace_processor",
-        ":include_perfetto_trace_processor_util",
-    ],
-    deps = [
-               ":protos_perfetto_common_cpp",
-               ":protos_perfetto_common_semantic_type_zero",
-               ":protos_perfetto_common_zero",
-               ":protos_perfetto_config_android_zero",
-               ":protos_perfetto_config_ftrace_zero",
-               ":protos_perfetto_config_gpu_zero",
-               ":protos_perfetto_config_inode_file_zero",
-               ":protos_perfetto_config_interceptors_zero",
-               ":protos_perfetto_config_power_zero",
-               ":protos_perfetto_config_priority_boost_zero",
-               ":protos_perfetto_config_process_stats_zero",
-               ":protos_perfetto_config_profiling_zero",
-               ":protos_perfetto_config_protovm_zero",
-               ":protos_perfetto_config_qnx_zero",
-               ":protos_perfetto_config_statsd_zero",
-               ":protos_perfetto_config_sys_stats_zero",
-               ":protos_perfetto_config_system_info_zero",
-               ":protos_perfetto_config_track_event_zero",
-               ":protos_perfetto_config_zero",
-               ":protos_perfetto_perfetto_sql_zero",
-               ":protos_perfetto_protovm_cpp",
-               ":protos_perfetto_protovm_zero",
-               ":protos_perfetto_trace_android_winscope_common_zero",
-               ":protos_perfetto_trace_android_winscope_extensions_zero",
-               ":protos_perfetto_trace_android_winscope_regular_zero",
-               ":protos_perfetto_trace_android_zero",
-               ":protos_perfetto_trace_chrome_zero",
-               ":protos_perfetto_trace_etw_zero",
-               ":protos_perfetto_trace_filesystem_zero",
-               ":protos_perfetto_trace_ftrace_zero",
-               ":protos_perfetto_trace_generic_kernel_zero",
-               ":protos_perfetto_trace_gpu_gpu_interned_data_zero",
-               ":protos_perfetto_trace_gpu_gpu_track_event_zero",
-               ":protos_perfetto_trace_gpu_zero",
-               ":protos_perfetto_trace_interned_data_zero",
-               ":protos_perfetto_trace_minimal_zero",
-               ":protos_perfetto_trace_non_minimal_zero",
-               ":protos_perfetto_trace_perfetto_zero",
-               ":protos_perfetto_trace_power_zero",
-               ":protos_perfetto_trace_processor_metrics_impl_zero",
-               ":protos_perfetto_trace_processor_zero",
-               ":protos_perfetto_trace_profiling_zero",
-               ":protos_perfetto_trace_ps_zero",
-               ":protos_perfetto_trace_statsd_zero",
-               ":protos_perfetto_trace_summary_zero",
-               ":protos_perfetto_trace_sys_stats_zero",
-               ":protos_perfetto_trace_system_info_zero",
-               ":protos_perfetto_trace_track_event_zero",
-               ":protos_perfetto_trace_translation_zero",
-               ":protos_third_party_chromium_zero",
-               ":protos_third_party_pprof_zero",
-               ":protos_third_party_primes_cpp",
-               ":protos_third_party_primes_zero",
-               ":protos_third_party_simpleperf_zero",
-               ":protozero",
-               ":src_base_base",
-               ":src_base_clock_snapshots",
-               ":src_base_http_http",
-               ":src_base_regex_regex",
-               ":src_base_version",
-               ":src_protovm_protovm",
-               ":src_trace_processor_containers_containers",
-               ":src_trace_processor_importers_proto_gen_cc_android_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_chrome_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_interned_data_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_statsd_atoms_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_trace_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
-               ":src_trace_processor_importers_proto_winscope_gen_cc_winscope_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_chrome_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_webview_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_metrics_descriptor",
-               ":src_trace_processor_metrics_sql_gen_amalgamated_sql_metrics",
-               ":src_trace_processor_perfetto_sql_stdlib_stdlib",
-               ":src_trace_processor_plugins_wattson_gen_cpu_1d_curves",
-               ":src_trace_processor_plugins_wattson_gen_cpu_2d_curves",
-               ":src_trace_processor_plugins_wattson_gen_gpu_curves",
-               ":src_trace_processor_plugins_wattson_gen_l3_curves",
-               ":src_trace_processor_plugins_wattson_gen_tpu_curves",
-               ":src_trace_processor_trace_summary_gen_cc_trace_summary_descriptor",
-               ":src_trace_processor_util_build_id",
-               ":src_trace_processor_util_deobfuscation_deobfuscator",
-               ":src_trace_processor_util_symbolizer_symbolize_database",
-               ":src_trace_processor_util_symbolizer_symbolizer",
-               ":src_traceconv_gen_cc_trace_descriptor",
-               ":src_traceconv_gen_cc_winscope_descriptor",
-           ] + PERFETTO_CONFIG.deps.linenoise +
-           PERFETTO_CONFIG.deps.protobuf_full +
-           PERFETTO_CONFIG.deps.sqlite +
-           PERFETTO_CONFIG.deps.sqlite_ext_percentile +
-           PERFETTO_CONFIG.deps.zlib +
-           PERFETTO_CONFIG.deps.demangle_wrapper,
+        ":src_trace_processor_util_symbolizer_symbolize_database",
+        ":src_trace_processor_util_symbolizer_symbolizer",
+    ] + PERFETTO_CONFIG.deps.protobuf_full,
     linkstatic = True,
-    alwayslink = True,
 )
 
 # GN target: //src/traceconv:libpprofbuilder
 perfetto_cc_library(
     name = "libpprofbuilder",
-    srcs = [
-        ":src_traceconv_pprofbuilder",
-        ":src_traceconv_utils",
-    ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_profiling_pprof_builder",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_trace_processor_basic_types",
-        ":include_perfetto_trace_processor_storage",
-        ":include_perfetto_trace_processor_trace_processor",
-        ":include_perfetto_trace_processor_util",
-    ],
     visibility = PERFETTO_CONFIG.public_visibility,
     deps = [
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
-        ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
-        ":protos_perfetto_trace_minimal_zero",
-        ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
-        ":protos_third_party_pprof_zero",
-        ":src_trace_processor_containers_containers",
-        ":src_trace_processor_util_deobfuscation_deobfuscator",
-        ":src_trace_processor_util_symbolizer_symbolize_database",
-        ":src_trace_processor_util_symbolizer_symbolizer",
-    ] + PERFETTO_CONFIG.deps.zlib,
+        ":src_traceconv_pprofbuilder",
+    ],
     linkstatic = True,
 )
 
@@ -900,233 +239,32 @@ perfetto_cc_library(
 perfetto_cc_binary(
     name = "client_api_example",
     srcs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_tracing_core_forward_decls",
-        ":include_perfetto_tracing_tracing",
         "test/client_api_example.cc",
     ],
     deps = [
+        ":include_perfetto_tracing_tracing",
         ":libperfetto_client_experimental",
-        ":protos_perfetto_common_cpp",
-        ":protos_perfetto_common_semantic_type_cpp",
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_cpp",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_cpp",
-        ":protos_perfetto_config_ftrace_cpp",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_cpp",
         ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_cpp",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_cpp",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_cpp",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_cpp",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_cpp",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_cpp",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_cpp",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_cpp",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_cpp",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_cpp",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_cpp",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_cpp",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_protovm_cpp",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
         ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
         ":protos_perfetto_trace_minimal_zero",
         ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_cpp",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
     ],
 )
 
 # GN target: //:libperfetto
 perfetto_cc_library(
     name = "libperfetto",
-    srcs = [
-        ":src_android_stats_android_stats",
-        ":src_android_stats_perfetto_atoms",
-        ":src_protozero_filtering_bytecode_common",
-        ":src_protozero_filtering_bytecode_parser",
-        ":src_protozero_filtering_message_filter",
-        ":src_protozero_filtering_message_filter_config",
-        ":src_protozero_filtering_string_filter",
-        ":src_traced_service_builtin_producer",
-        ":src_traced_service_service",
-        ":src_tracing_common",
-        ":src_tracing_core_core",
-        ":src_tracing_ipc_common",
-        ":src_tracing_ipc_default_socket",
-        ":src_tracing_ipc_service_service",
-        ":src_tracing_service_service",
-        ":src_tracing_service_zlib_compressor",
-    ] + select({
-        "@platforms//os:windows": [],
-        "//conditions:default": [
-            ":src_android_internal_headers",
-            ":src_android_internal_lazy_library_loader",
-            ":src_kallsyms_kallsyms",
-            ":src_kernel_utils_kernel_wakelock_errors",
-            ":src_kernel_utils_syscall_table",
-            ":src_protozero_proto_ring_buffer",
-            ":src_traced_probes_android_aflags_android_aflags",
-            ":src_traced_probes_android_cpu_per_uid_android_cpu_per_uid",
-            ":src_traced_probes_android_game_intervention_list_android_game_intervention_list",
-            ":src_traced_probes_android_kernel_wakelocks_android_kernel_wakelocks",
-            ":src_traced_probes_android_log_android_log",
-            ":src_traced_probes_android_system_property_android_system_property",
-            ":src_traced_probes_common_common",
-            ":src_traced_probes_data_source",
-            ":src_traced_probes_filesystem_filesystem",
-            ":src_traced_probes_ftrace_format_parser_format_parser",
-            ":src_traced_probes_ftrace_ftrace",
-            ":src_traced_probes_ftrace_tracefs",
-            ":src_traced_probes_initial_display_state_initial_display_state",
-            ":src_traced_probes_metatrace_metatrace",
-            ":src_traced_probes_packages_list_packages_list",
-            ":src_traced_probes_packages_list_packages_list_parser",
-            ":src_traced_probes_power_power",
-            ":src_traced_probes_probes",
-            ":src_traced_probes_probes_src",
-            ":src_traced_probes_ps_ps",
-            ":src_traced_probes_statsd_client_statsd_client",
-            ":src_traced_probes_sys_stats_sys_stats",
-            ":src_traced_probes_system_info_system_info",
-            ":src_traced_probes_user_list_user_list",
-            ":src_tracing_ipc_producer_producer",
-        ],
-    }),
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_ipc_ipc",
-        ":include_perfetto_ext_protozero_protozero",
-        ":include_perfetto_ext_traced_sys_stats_counters",
-        ":include_perfetto_ext_traced_traced",
-        ":include_perfetto_ext_tracing_core_core",
-        ":include_perfetto_ext_tracing_ipc_ipc",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_tracing_core_core",
-        ":include_perfetto_tracing_core_forward_decls",
-        ":include_perfetto_tracing_tracing",
-    ],
     deps = [
-        ":perfetto_ipc",
-        ":protos_perfetto_common_cpp",
-        ":protos_perfetto_common_semantic_type_cpp",
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_cpp",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_cpp",
-        ":protos_perfetto_config_ftrace_cpp",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_cpp",
-        ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_cpp",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_cpp",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_cpp",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_cpp",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_cpp",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_cpp",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_cpp",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_cpp",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_cpp",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_cpp",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_cpp",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_cpp",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_ipc_cpp",
-        ":protos_perfetto_ipc_ipc",
-        ":protos_perfetto_protovm_cpp",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
-        ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
-        ":protos_perfetto_trace_minimal_zero",
-        ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_cpp",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_cpp",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
-        ":protos_third_party_statsd_config_zero",
-        ":protozero",
-        ":src_base_base",
-        ":src_base_clock_snapshots",
-        ":src_base_regex_regex",
-        ":src_base_version",
-        ":src_protovm_protovm",
-    ] + PERFETTO_CONFIG.deps.zlib,
+        ":src_traced_probes_probes",
+        ":src_traced_service_service",
+    ],
     linkstatic = True,
 )
 
 # GN target: //include/perfetto/base:base
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_base_base",
-    srcs = [
+    hdrs = [
         "include/perfetto/base/build_config.h",
         "include/perfetto/base/compiler.h",
         "include/perfetto/base/export.h",
@@ -1141,21 +279,29 @@ perfetto_filegroup(
         "include/perfetto/base/thread_utils.h",
         "include/perfetto/base/time.h",
     ],
+    deps = [
+        ":include_perfetto_public_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/base/http:http
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_base_http_http",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/base/http/http_server.h",
         "include/perfetto/ext/base/http/sha1.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/base:base
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_base_base",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/base/android_utils.h",
         "include/perfetto/ext/base/base64.h",
         "include/perfetto/ext/base/bits.h",
@@ -1220,28 +366,34 @@ perfetto_filegroup(
         "include/perfetto/ext/base/weak_ptr.h",
         "include/perfetto/ext/base/weak_runner.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/base:regex
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_base_regex",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/base/regex.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/base:version
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_base_version",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/base/version.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/ipc:ipc
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_ipc_ipc",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/ipc/async_result.h",
         "include/perfetto/ext/ipc/basic_types.h",
         "include/perfetto/ext/ipc/client.h",
@@ -1253,20 +405,29 @@ perfetto_filegroup(
         "include/perfetto/ext/ipc/service_descriptor.h",
         "include/perfetto/ext/ipc/service_proxy.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_protozero_protozero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/protozero:protozero
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_protozero_protozero",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/protozero/proto_ring_buffer.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/trace_processor/importers/memory_tracker:memory_tracker
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_trace_processor_importers_memory_tracker_memory_tracker",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/trace_processor/importers/memory_tracker/graph.h",
         "include/perfetto/ext/trace_processor/importers/memory_tracker/graph_processor.h",
         "include/perfetto/ext/trace_processor/importers/memory_tracker/memory_allocator_node_id.h",
@@ -1274,69 +435,85 @@ perfetto_filegroup(
         "include/perfetto/ext/trace_processor/importers/memory_tracker/raw_memory_graph_node.h",
         "include/perfetto/ext/trace_processor/importers/memory_tracker/raw_process_memory_node.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/trace_processor/rpc:query_result_serializer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_trace_processor_rpc_query_result_serializer",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/trace_processor/rpc/query_result_serializer.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/trace_processor:demangle
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_trace_processor_demangle",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/trace_processor/demangle.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/trace_processor:export_json
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_trace_processor_export_json",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/trace_processor/export_json.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/trace_processor:trace_processor_shell
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_trace_processor_trace_processor_shell",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/trace_processor/trace_processor_shell.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/traceconv:traceconv
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_traceconv_traceconv",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/traceconv/traceconv.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/traced:sys_stats_counters
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_traced_sys_stats_counters",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/traced/sys_stats_counters.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":protos_perfetto_common_zero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/traced:traced
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_traced_traced",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/traced/data_source_types.h",
         "include/perfetto/ext/traced/traced.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/tracing/core:core
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_tracing_core_core",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/tracing/core/basic_types.h",
         "include/perfetto/ext/tracing/core/client_identity.h",
         "include/perfetto/ext/tracing/core/commit_data_request.h",
@@ -1353,30 +530,43 @@ perfetto_filegroup(
         "include/perfetto/ext/tracing/core/trace_writer.h",
         "include/perfetto/ext/tracing/core/tracing_service.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_tracing_core_core",
+        ":protos_perfetto_common_cpp",
+        ":protos_perfetto_config_priority_boost_cpp",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/ext/tracing/ipc:ipc
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_ext_tracing_ipc_ipc",
-    srcs = [
+    hdrs = [
         "include/perfetto/ext/tracing/ipc/consumer_ipc_client.h",
         "include/perfetto/ext/tracing/ipc/producer_ipc_client.h",
         "include/perfetto/ext/tracing/ipc/service_ipc_host.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_ext_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/profiling:pprof_builder
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_profiling_pprof_builder",
-    srcs = [
+    hdrs = [
         "include/perfetto/profiling/pprof_builder.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/protozero:protozero
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_protozero_protozero",
-    srcs = [
+    hdrs = [
         "include/perfetto/protozero/contiguous_memory_range.h",
         "include/perfetto/protozero/copyable_ptr.h",
         "include/perfetto/protozero/cpp_message_obj.h",
@@ -1395,21 +585,27 @@ perfetto_filegroup(
         "include/perfetto/protozero/scattered_stream_writer.h",
         "include/perfetto/protozero/static_buffer.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_public_protozero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/public/abi:base
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_public_abi_base",
-    srcs = [
+    hdrs = [
         "include/perfetto/public/abi/atomic.h",
         "include/perfetto/public/abi/export.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/public/abi:public
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_public_abi_public",
-    srcs = [
+    hdrs = [
         "include/perfetto/public/abi/backend_type.h",
         "include/perfetto/public/abi/data_source_abi.h",
         "include/perfetto/public/abi/heap_buffer.h",
@@ -1422,12 +618,16 @@ perfetto_filegroup(
         "include/perfetto/public/abi/track_event_hl_abi.h",
         "include/perfetto/public/abi/track_event_ll_abi.h",
     ],
+    deps = [
+        ":include_perfetto_public_abi_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/public/protos:protos
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_public_protos_protos",
-    srcs = [
+    hdrs = [
         "include/perfetto/public/protos/common/builtin_clock.pzc.h",
         "include/perfetto/public/protos/common/data_source_descriptor.pzc.h",
         "include/perfetto/public/protos/common/semantic_type.pzc.h",
@@ -1444,28 +644,34 @@ perfetto_filegroup(
         "include/perfetto/public/protos/trace/track_event/track_event.pzc.h",
         "include/perfetto/public/protos/trace/trigger.pzc.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/public:base
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_public_base",
-    srcs = [
+    hdrs = [
         "include/perfetto/public/compiler.h",
     ],
+    deps = [
+        ":include_perfetto_public_abi_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/public:protozero
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_public_protozero",
-    srcs = [
+    hdrs = [
         "include/perfetto/public/pb_utils.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/public:public
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_public_public",
-    srcs = [
+    hdrs = [
         "include/perfetto/public/data_source.h",
         "include/perfetto/public/fnv1a.h",
         "include/perfetto/public/pb_decoder.h",
@@ -1480,51 +686,76 @@ perfetto_filegroup(
         "include/perfetto/public/tracing_session.h",
         "include/perfetto/public/track_event.h",
     ],
+    deps = [
+        ":include_perfetto_public_abi_public",
+        ":include_perfetto_public_base",
+        ":include_perfetto_public_protos_protos",
+        ":include_perfetto_public_protozero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/trace_processor:basic_types
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_trace_processor_basic_types",
-    srcs = [
+    hdrs = [
         "include/perfetto/trace_processor/basic_types.h",
         "include/perfetto/trace_processor/status.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/trace_processor:storage
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_trace_processor_storage",
-    srcs = [
+    hdrs = [
         "include/perfetto/trace_processor/trace_processor_storage.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":include_perfetto_trace_processor_util",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/trace_processor:trace_processor
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_trace_processor_trace_processor",
-    srcs = [
+    hdrs = [
         "include/perfetto/trace_processor/iterator.h",
         "include/perfetto/trace_processor/metatrace_config.h",
         "include/perfetto/trace_processor/read_trace.h",
         "include/perfetto/trace_processor/summarizer.h",
         "include/perfetto/trace_processor/trace_processor.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":include_perfetto_trace_processor_storage",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/trace_processor:util
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_trace_processor_util",
-    srcs = [
+    hdrs = [
         "include/perfetto/trace_processor/ref_counted.h",
         "include/perfetto/trace_processor/trace_blob.h",
         "include/perfetto/trace_processor/trace_blob_view.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/tracing/core:core
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_tracing_core_core",
-    srcs = [
+    hdrs = [
         "include/perfetto/tracing/core/chrome_config.h",
         "include/perfetto/tracing/core/data_source_config.h",
         "include/perfetto/tracing/core/data_source_descriptor.h",
@@ -1533,20 +764,27 @@ perfetto_filegroup(
         "include/perfetto/tracing/core/tracing_service_capabilities.h",
         "include/perfetto/tracing/core/tracing_service_state.h",
     ],
+    deps = [
+        ":include_perfetto_tracing_core_forward_decls",
+        ":protos_perfetto_common_cpp",
+        ":protos_perfetto_config_cpp",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/tracing/core:forward_decls
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_tracing_core_forward_decls",
-    srcs = [
+    hdrs = [
         "include/perfetto/tracing/core/forward_decls.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //include/perfetto/tracing:tracing
-perfetto_filegroup(
+perfetto_cc_library(
     name = "include_perfetto_tracing_tracing",
-    srcs = [
+    hdrs = [
         "include/perfetto/tracing/backend_type.h",
         "include/perfetto/tracing/buffer_exhausted_policy.h",
         "include/perfetto/tracing/console_interceptor.h",
@@ -1590,6 +828,21 @@ perfetto_filegroup(
         "include/perfetto/tracing/track_event_legacy.h",
         "include/perfetto/tracing/track_event_state_tracker.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_protozero_protozero",
+        ":include_perfetto_tracing_core_forward_decls",
+        ":protos_perfetto_common_cpp",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_cpp",
+        ":protos_perfetto_config_track_event_cpp",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_track_event_cpp",
+        ":protos_perfetto_trace_track_event_zero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //protos/third_party/chromium:extension_descriptor
@@ -1603,9 +856,9 @@ perfetto_protozero_descriptor_diff(
 )
 
 # GN target: //src/android_internal:headers
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_internal_headers",
-    srcs = [
+    hdrs = [
         "src/android_internal/atrace_hal.h",
         "src/android_internal/cpu_time_in_state.h",
         "src/android_internal/health_hal.h",
@@ -1616,32 +869,51 @@ perfetto_filegroup(
         "src/android_internal/suspend_control_service.h",
         "src/android_internal/tracing_service_proxy.h",
     ],
+    deps = [
+        ":src_android_stats_perfetto_atoms",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/android_internal:lazy_library_loader
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_internal_lazy_library_loader",
     srcs = [
         "src/android_internal/lazy_library_loader.cc",
+    ],
+    hdrs = [
         "src/android_internal/lazy_library_loader.h",
     ],
+    deps = [
+        ":src_android_internal_headers",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/android_stats:android_stats
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_stats_android_stats",
     srcs = [
         "src/android_stats/statsd_logging_helper.cc",
+    ],
+    hdrs = [
         "src/android_stats/statsd_logging_helper.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":src_android_stats_perfetto_atoms",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/android_stats:perfetto_atoms
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_stats_perfetto_atoms",
-    srcs = [
+    hdrs = [
         "src/android_stats/perfetto_atoms.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/base/http:http
@@ -1651,14 +923,9 @@ perfetto_cc_library(
         "src/base/http/http_server.cc",
         "src/base/http/sha1.cc",
     ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_base_http_http",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-    ],
     deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_http_http",
         ":src_base_base",
         ":src_base_unix_socket",
     ],
@@ -1672,15 +939,13 @@ perfetto_cc_library(
         "src/base/regex/regex.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_base_regex",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
         "src/base/regex/regex_re2.h",
         "src/base/regex/regex_std.h",
     ],
     deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_ext_base_regex",
     ] + PERFETTO_CONFIG.deps.re2,
     linkstatic = True,
 )
@@ -1731,13 +996,11 @@ perfetto_cc_library(
         "src/base/weak_runner.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
         "src/base/log_ring_buffer.h",
     ],
     deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
     ] + PERFETTO_CONFIG.deps.base_platform,
     linkstatic = True,
 )
@@ -1748,15 +1011,9 @@ perfetto_cc_library(
     srcs = [
         "src/base/clock_snapshots.cc",
     ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-    ],
     deps = [
+        ":include_perfetto_ext_base_base",
         ":protos_perfetto_common_zero",
-        ":protos_perfetto_protovm_zero",
     ],
     linkstatic = True,
 )
@@ -1768,11 +1025,10 @@ perfetto_cc_library(
         "src/base/unix_socket.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
         "src/base/vm_sockets.h",
+    ],
+    deps = [
+        ":include_perfetto_ext_base_base",
     ],
     linkstatic = True,
 )
@@ -1783,10 +1039,8 @@ perfetto_cc_library(
     srcs = [
         "src/base/version.cc",
     ],
-    hdrs = [
-        ":include_perfetto_ext_base_version",
-    ],
     deps = [
+        ":include_perfetto_ext_base_version",
         ":src_base_base",
     ] + PERFETTO_CONFIG.deps.version_header,
     linkstatic = True,
@@ -1807,92 +1061,165 @@ perfetto_genrule(
 )
 
 # GN target: //src/ipc:client
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_ipc_client",
     srcs = [
         "src/ipc/client_impl.cc",
-        "src/ipc/client_impl.h",
         "src/ipc/service_proxy.cc",
     ],
+    hdrs = [
+        "src/ipc/client_impl.h",
+    ],
+    deps = [
+        ":include_perfetto_ext_ipc_ipc",
+        ":protos_perfetto_ipc_wire_protocol_cpp",
+        ":src_base_base",
+        ":src_base_unix_socket",
+        ":src_ipc_common",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/ipc:common
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_ipc_common",
     srcs = [
         "src/ipc/buffered_frame_deserializer.cc",
-        "src/ipc/buffered_frame_deserializer.h",
         "src/ipc/deferred.cc",
         "src/ipc/virtual_destructors.cc",
     ],
+    hdrs = [
+        "src/ipc/buffered_frame_deserializer.h",
+    ],
+    deps = [
+        ":include_perfetto_ext_ipc_ipc",
+        ":protos_perfetto_ipc_wire_protocol_cpp",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/ipc:host
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_ipc_host",
     srcs = [
         "src/ipc/host_impl.cc",
+    ],
+    hdrs = [
         "src/ipc/host_impl.h",
     ],
+    deps = [
+        ":include_perfetto_ext_ipc_ipc",
+        ":protos_perfetto_ipc_wire_protocol_cpp",
+        ":src_base_base",
+        ":src_base_unix_socket",
+        ":src_ipc_common",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/kallsyms:kallsyms
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_kallsyms_kallsyms",
     srcs = [
         "src/kallsyms/kernel_symbol_map.cc",
-        "src/kallsyms/kernel_symbol_map.h",
         "src/kallsyms/lazy_kernel_symbolizer.cc",
+    ],
+    hdrs = [
+        "src/kallsyms/kernel_symbol_map.h",
         "src/kallsyms/lazy_kernel_symbolizer.h",
     ],
+    deps = [
+        ":include_perfetto_protozero_protozero",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/kernel_utils:kernel_wakelock_errors
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_kernel_utils_kernel_wakelock_errors",
-    srcs = [
+    hdrs = [
         "src/kernel_utils/kernel_wakelock_errors.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/kernel_utils:syscall_table
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_kernel_utils_syscall_table",
     srcs = [
         "src/kernel_utils/syscall_table.cc",
+    ],
+    hdrs = [
         "src/kernel_utils/syscall_table.h",
         "src/kernel_utils/syscall_table_generated.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/perfetto_cmd:bugreport_path
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_perfetto_cmd_bugreport_path",
-    srcs = [
+    hdrs = [
         "src/perfetto_cmd/bugreport_path.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/perfetto_cmd:perfetto_cmd
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_perfetto_cmd_perfetto_cmd",
     srcs = [
         "src/perfetto_cmd/config.cc",
-        "src/perfetto_cmd/config.h",
         "src/perfetto_cmd/packet_writer.cc",
-        "src/perfetto_cmd/packet_writer.h",
         "src/perfetto_cmd/perfetto_cmd.cc",
+    ],
+    hdrs = [
+        "src/perfetto_cmd/config.h",
+        "src/perfetto_cmd/packet_writer.h",
         "src/perfetto_cmd/perfetto_cmd.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_cpp",
+        ":protos_perfetto_config_cpp",
+        ":protos_perfetto_config_ftrace_cpp",
+        ":protos_perfetto_config_sys_stats_cpp",
+        ":protozero",
+        ":src_android_stats_android_stats",
+        ":src_base_base",
+        ":src_base_version",
+        ":src_perfetto_cmd_bugreport_path",
+        ":src_perfetto_cmd_protos_cpp",
+        ":src_perfetto_cmd_trigger_producer",
+        ":src_proto_utils_txt_to_pb",
+        ":src_tracing_ipc_consumer_consumer",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/perfetto_cmd:trigger_producer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_perfetto_cmd_trigger_producer",
     srcs = [
         "src/perfetto_cmd/trigger_producer.cc",
+    ],
+    hdrs = [
         "src/perfetto_cmd/trigger_producer.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_tracing_ipc_producer_producer",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/proto_utils:gen_cc_config_descriptor
@@ -1934,12 +1261,22 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/proto_utils:txt_to_pb
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_proto_utils_txt_to_pb",
     srcs = [
         "src/proto_utils/txt_to_pb.cc",
+    ],
+    hdrs = [
         "src/proto_utils/txt_to_pb.h",
     ],
+    deps = [
+        ":protozero",
+        ":src_base_base",
+        ":src_proto_utils_gen_cc_config_descriptor",
+        ":src_proto_utils_gen_cc_trace_summary_descriptor",
+        ":src_protozero_text_to_proto_text_to_proto",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protovm:protovm
@@ -1979,158 +1316,264 @@ perfetto_cc_library(
 )
 
 # GN target: //src/protozero/descriptor_diff:lib
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_descriptor_diff_lib",
     srcs = [
         "src/protozero/descriptor_diff/descriptor_diff.cc",
+    ],
+    hdrs = [
         "src/protozero/descriptor_diff/descriptor_diff.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protozero",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/descriptor_diff:protozero_descriptor_diff
 perfetto_cc_binary(
     name = "src_protozero_descriptor_diff_protozero_descriptor_diff",
     srcs = [
-        ":src_protozero_descriptor_diff_lib",
         "src/protozero/descriptor_diff/main.cc",
     ],
     deps = [
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_protovm_zero",
-        ":protozero",
         ":src_base_base",
         ":src_base_version",
+        ":src_protozero_descriptor_diff_lib",
     ],
 )
 
 # GN target: //src/protozero/filtering:bytecode_common
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_filtering_bytecode_common",
-    srcs = [
+    hdrs = [
         "src/protozero/filtering/filter_bytecode_common.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/filtering:bytecode_generator
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_filtering_bytecode_generator",
     srcs = [
         "src/protozero/filtering/filter_bytecode_generator.cc",
+    ],
+    hdrs = [
         "src/protozero/filtering/filter_bytecode_generator.h",
     ],
+    deps = [
+        ":protozero",
+        ":src_base_base",
+        ":src_protozero_filtering_bytecode_common",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/filtering:bytecode_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_filtering_bytecode_parser",
     srcs = [
         "src/protozero/filtering/filter_bytecode_parser.cc",
+    ],
+    hdrs = [
         "src/protozero/filtering/filter_bytecode_parser.h",
     ],
+    deps = [
+        ":protozero",
+        ":src_base_base",
+        ":src_protozero_filtering_bytecode_common",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/filtering:filter_util
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_filtering_filter_util",
     srcs = [
         "src/protozero/filtering/filter_util.cc",
+    ],
+    hdrs = [
         "src/protozero/filtering/filter_util.h",
     ],
+    deps = [
+        ":protos_perfetto_common_semantic_type_zero",
+        ":protos_perfetto_proto_filtering_lite",
+        ":protozero",
+        ":src_base_base",
+        ":src_protozero_filtering_bytecode_generator",
+        ":src_protozero_filtering_bytecode_parser",
+        ":src_protozero_multifile_error_collector",
+    ] + PERFETTO_CONFIG.deps.protobuf_full,
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/filtering:message_filter
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_filtering_message_filter",
     srcs = [
         "src/protozero/filtering/message_filter.cc",
+    ],
+    hdrs = [
         "src/protozero/filtering/message_filter.h",
         "src/protozero/filtering/message_tokenizer.h",
     ],
+    deps = [
+        ":protozero",
+        ":src_base_base",
+        ":src_protozero_filtering_bytecode_parser",
+        ":src_protozero_filtering_string_filter",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/filtering:message_filter_config
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_filtering_message_filter_config",
     srcs = [
         "src/protozero/filtering/message_filter_config.cc",
+    ],
+    hdrs = [
         "src/protozero/filtering/message_filter_config.h",
     ],
+    deps = [
+        ":protos_perfetto_config_cpp",
+        ":src_base_base",
+        ":src_protozero_filtering_message_filter",
+        ":src_protozero_filtering_string_filter",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/filtering:string_filter
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_filtering_string_filter",
     srcs = [
         "src/protozero/filtering/string_filter.cc",
+    ],
+    hdrs = [
         "src/protozero/filtering/string_filter.h",
     ],
+    deps = [
+        ":protozero",
+        ":src_base_base",
+        ":src_base_regex_regex",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero/text_to_proto:text_to_proto
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_text_to_proto_text_to_proto",
     srcs = [
         "src/protozero/text_to_proto/text_to_proto.cc",
+    ],
+    hdrs = [
         "src/protozero/text_to_proto/text_to_proto.h",
     ],
+    deps = [
+        ":protos_perfetto_common_cpp",
+        ":protozero",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/protozero:multifile_error_collector
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_multifile_error_collector",
     srcs = [
         "src/protozero/multifile_error_collector.cc",
+    ],
+    hdrs = [
         "src/protozero/multifile_error_collector.h",
     ],
+    deps = [
+        ":src_base_base",
+    ] + PERFETTO_CONFIG.deps.protobuf_full,
+    linkstatic = True,
 )
 
 # GN target: //src/protozero:proto_ring_buffer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_protozero_proto_ring_buffer",
     srcs = [
         "src/protozero/proto_ring_buffer.cc",
     ],
+    deps = [
+        ":include_perfetto_ext_protozero_protozero",
+        ":protozero",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/shared_lib/track_event:intern_map
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_shared_lib_track_event_intern_map",
     srcs = [
         "src/shared_lib/track_event/intern_map.cc",
+    ],
+    hdrs = [
         "src/shared_lib/track_event/intern_map.h",
     ],
+    deps = [
+        ":include_perfetto_public_public",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/shared_lib/track_event:track_event
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_shared_lib_track_event_track_event",
     srcs = [
         "src/shared_lib/track_event/category_impl.cc",
-        "src/shared_lib/track_event/category_impl.h",
         "src/shared_lib/track_event/category_utils.cc",
-        "src/shared_lib/track_event/category_utils.h",
         "src/shared_lib/track_event/ds.cc",
-        "src/shared_lib/track_event/ds.h",
         "src/shared_lib/track_event/global_state.cc",
-        "src/shared_lib/track_event/global_state.h",
         "src/shared_lib/track_event/hl.cc",
         "src/shared_lib/track_event/ll.cc",
         "src/shared_lib/track_event/serialization.cc",
-        "src/shared_lib/track_event/serialization.h",
         "src/shared_lib/track_event/track_event.cc",
     ],
+    hdrs = [
+        "src/shared_lib/track_event/category_impl.h",
+        "src/shared_lib/track_event/category_utils.h",
+        "src/shared_lib/track_event/ds.h",
+        "src/shared_lib/track_event/global_state.h",
+        "src/shared_lib/track_event/serialization.h",
+    ],
+    deps = [
+        ":include_perfetto_protozero_protozero",
+        ":include_perfetto_public_public",
+        ":include_perfetto_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":src_base_base",
+        ":src_shared_lib_for_testing",
+        ":src_shared_lib_track_event_intern_map",
+        ":src_tracing_client_api_without_backends",
+        ":src_tracing_in_process_backend",
+        ":src_tracing_system_backend",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/shared_lib:for_testing
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_shared_lib_for_testing",
-    srcs = [
+    hdrs = [
         "src/shared_lib/reset_for_testing.h",
     ],
+    deps = [
+        ":include_perfetto_public_public",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/shared_lib:shared_lib
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_shared_lib_shared_lib",
     srcs = [
         "src/shared_lib/data_source.cc",
@@ -2138,10 +1581,25 @@ perfetto_filegroup(
         "src/shared_lib/pb_decoder.cc",
         "src/shared_lib/producer.cc",
         "src/shared_lib/stream_writer.cc",
-        "src/shared_lib/stream_writer.h",
         "src/shared_lib/thread_utils.cc",
         "src/shared_lib/tracing_session.cc",
     ],
+    hdrs = [
+        "src/shared_lib/stream_writer.h",
+    ],
+    deps = [
+        ":include_perfetto_protozero_protozero",
+        ":include_perfetto_public_public",
+        ":include_perfetto_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":src_base_base",
+        ":src_shared_lib_for_testing",
+        ":src_shared_lib_track_event_track_event",
+        ":src_tracing_client_api_without_backends",
+        ":src_tracing_in_process_backend",
+        ":src_tracing_system_backend",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/containers:containers
@@ -2151,11 +1609,6 @@ perfetto_cc_library(
         "src/trace_processor/containers/string_pool.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
         "src/trace_processor/containers/implicit_segment_forest.h",
         "src/trace_processor/containers/interval_intersector.h",
         "src/trace_processor/containers/interval_tree.h",
@@ -2163,20 +1616,17 @@ perfetto_cc_library(
         "src/trace_processor/containers/string_pool.h",
     ],
     deps = [
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_perfetto_sql_zero",
-        ":protos_perfetto_protovm_zero",
+        ":include_perfetto_protozero_protozero",
         ":protos_perfetto_trace_processor_zero",
-        ":protos_perfetto_trace_summary_zero",
         ":src_base_base",
     ],
     linkstatic = True,
 )
 
 # GN target: //src/trace_processor/core/common:common
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_core_common_common",
-    srcs = [
+    hdrs = [
         "src/trace_processor/core/common/duplicate_types.h",
         "src/trace_processor/core/common/null_types.h",
         "src/trace_processor/core/common/op_types.h",
@@ -2185,76 +1635,126 @@ perfetto_filegroup(
         "src/trace_processor/core/common/tree_types.h",
         "src/trace_processor/core/common/value_fetcher.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_util_util",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/core/dataframe:dataframe
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_core_dataframe_dataframe",
     srcs = [
         "src/trace_processor/core/dataframe/adhoc_dataframe_builder.cc",
+        "src/trace_processor/core/dataframe/dataframe.cc",
+        "src/trace_processor/core/dataframe/query_plan.cc",
+        "src/trace_processor/core/dataframe/typed_cursor.cc",
+    ],
+    hdrs = [
         "src/trace_processor/core/dataframe/adhoc_dataframe_builder.h",
         "src/trace_processor/core/dataframe/cursor.h",
         "src/trace_processor/core/dataframe/cursor_impl.h",
-        "src/trace_processor/core/dataframe/dataframe.cc",
         "src/trace_processor/core/dataframe/dataframe.h",
         "src/trace_processor/core/dataframe/dataframe_register_cache.h",
-        "src/trace_processor/core/dataframe/query_plan.cc",
         "src/trace_processor/core/dataframe/query_plan.h",
         "src/trace_processor/core/dataframe/runtime_dataframe_builder.h",
         "src/trace_processor/core/dataframe/specs.h",
-        "src/trace_processor/core/dataframe/typed_cursor.cc",
         "src/trace_processor/core/dataframe/typed_cursor.h",
         "src/trace_processor/core/dataframe/types.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_base_regex_regex",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_common_common",
+        ":src_trace_processor_core_interpreter_interpreter",
+        ":src_trace_processor_core_util_util",
+        ":src_trace_processor_util_glob",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/core/interpreter:interpreter
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_core_interpreter_interpreter",
     srcs = [
         "src/trace_processor/core/interpreter/bytecode_builder.cc",
+        "src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc",
+        "src/trace_processor/core/interpreter/bytecode_to_string.cc",
+    ],
+    hdrs = [
         "src/trace_processor/core/interpreter/bytecode_builder.h",
         "src/trace_processor/core/interpreter/bytecode_core.h",
         "src/trace_processor/core/interpreter/bytecode_instruction_macros.h",
         "src/trace_processor/core/interpreter/bytecode_instructions.h",
         "src/trace_processor/core/interpreter/bytecode_interpreter.h",
-        "src/trace_processor/core/interpreter/bytecode_interpreter_impl.cc",
         "src/trace_processor/core/interpreter/bytecode_interpreter_impl.h",
         "src/trace_processor/core/interpreter/bytecode_interpreter_state.h",
         "src/trace_processor/core/interpreter/bytecode_registers.h",
-        "src/trace_processor/core/interpreter/bytecode_to_string.cc",
         "src/trace_processor/core/interpreter/bytecode_to_string.h",
         "src/trace_processor/core/interpreter/interpreter_types.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_base_regex_regex",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_common_common",
+        ":src_trace_processor_core_util_util",
+        ":src_trace_processor_util_glob",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/core/plugin:plugin
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_core_plugin_plugin",
     srcs = [
         "src/trace_processor/core/plugin/plugin.cc",
+    ],
+    hdrs = [
         "src/trace_processor/core/plugin/plugin.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_util_util",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/core/tree:tree
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_core_tree_tree",
     srcs = [
         "src/trace_processor/core/tree/propagate_spec.cc",
+        "src/trace_processor/core/tree/tree_columns_builder.cc",
+        "src/trace_processor/core/tree/tree_transformer.cc",
+    ],
+    hdrs = [
         "src/trace_processor/core/tree/propagate_spec.h",
         "src/trace_processor/core/tree/tree_columns.h",
-        "src/trace_processor/core/tree/tree_columns_builder.cc",
         "src/trace_processor/core/tree/tree_columns_builder.h",
-        "src/trace_processor/core/tree/tree_transformer.cc",
         "src/trace_processor/core/tree/tree_transformer.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_common_common",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_core_interpreter_interpreter",
+        ":src_trace_processor_core_util_util",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/core/util:util
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_core_util_util",
-    srcs = [
+    hdrs = [
         "src/trace_processor/core/util/bit_vector.h",
         "src/trace_processor/core/util/flex_vector.h",
         "src/trace_processor/core/util/range.h",
@@ -2263,375 +1763,682 @@ perfetto_filegroup(
         "src/trace_processor/core/util/span.h",
         "src/trace_processor/core/util/type_set.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/android_bugreport:android_bugreport
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_android_bugreport_android_bugreport",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/importers/android_bugreport/android_battery_stats_history_string_tracker.cc",
-        "src/trace_processor/importers/android_bugreport/android_battery_stats_history_string_tracker.h",
         "src/trace_processor/importers/android_bugreport/android_battery_stats_reader.cc",
-        "src/trace_processor/importers/android_bugreport/android_battery_stats_reader.h",
         "src/trace_processor/importers/android_bugreport/android_bugreport_reader.cc",
-        "src/trace_processor/importers/android_bugreport/android_bugreport_reader.h",
         "src/trace_processor/importers/android_bugreport/android_dumpstate_event_parser.cc",
-        "src/trace_processor/importers/android_bugreport/android_dumpstate_event_parser.h",
         "src/trace_processor/importers/android_bugreport/android_dumpstate_reader.cc",
-        "src/trace_processor/importers/android_bugreport/android_dumpstate_reader.h",
         "src/trace_processor/importers/android_bugreport/android_log_event_parser.cc",
-        "src/trace_processor/importers/android_bugreport/android_log_event_parser.h",
         "src/trace_processor/importers/android_bugreport/android_log_reader.cc",
-        "src/trace_processor/importers/android_bugreport/android_log_reader.h",
         "src/trace_processor/importers/android_bugreport/chunked_line_reader.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/android_bugreport/android_battery_stats_history_string_tracker.h",
+        "src/trace_processor/importers/android_bugreport/android_battery_stats_reader.h",
+        "src/trace_processor/importers/android_bugreport/android_bugreport_reader.h",
+        "src/trace_processor/importers/android_bugreport/android_dumpstate_event_parser.h",
+        "src/trace_processor/importers/android_bugreport/android_dumpstate_reader.h",
+        "src/trace_processor/importers/android_bugreport/android_log_event_parser.h",
+        "src/trace_processor/importers/android_bugreport/android_log_reader.h",
         "src/trace_processor/importers/android_bugreport/chunked_line_reader.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_trace_processor_importers_android_bugreport_android_dumpstate_event",
+        ":src_trace_processor_importers_android_bugreport_android_log_event",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_type",
+        ":src_trace_processor_util_zip_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/android_bugreport:android_dumpstate_event
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_android_bugreport_android_dumpstate_event",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/android_bugreport/android_dumpstate_event.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/android_bugreport:android_log_event
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_android_bugreport_android_log_event",
     srcs = [
         "src/trace_processor/importers/android_bugreport/android_log_event.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/android_bugreport/android_log_event.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/archive:archive
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_archive_archive",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/importers/archive/archive_entry.cc",
-        "src/trace_processor/importers/archive/archive_entry.h",
         "src/trace_processor/importers/archive/gzip_trace_parser.cc",
-        "src/trace_processor/importers/archive/gzip_trace_parser.h",
         "src/trace_processor/importers/archive/tar_trace_reader.cc",
-        "src/trace_processor/importers/archive/tar_trace_reader.h",
         "src/trace_processor/importers/archive/zip_trace_reader.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/archive/archive_entry.h",
+        "src/trace_processor/importers/archive/gzip_trace_parser.h",
+        "src/trace_processor/importers/archive/tar_trace_reader.h",
         "src/trace_processor/importers/archive/zip_trace_reader.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":src_base_base",
+        ":src_trace_processor_importers_android_bugreport_android_bugreport",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_storage_minimal",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_gzip",
+        ":src_trace_processor_util_trace_blob_view_reader",
+        ":src_trace_processor_util_trace_type",
+        ":src_trace_processor_util_zip_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/art_hprof:art_hprof
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_art_hprof_art_hprof",
     srcs = [
-        "src/trace_processor/importers/art_hprof/art_heap_graph.h",
         "src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc",
-        "src/trace_processor/importers/art_hprof/art_heap_graph_builder.h",
         "src/trace_processor/importers/art_hprof/art_heap_graph_resolver.cc",
-        "src/trace_processor/importers/art_hprof/art_hprof_model.h",
         "src/trace_processor/importers/art_hprof/art_hprof_parser.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/art_hprof/art_heap_graph.h",
+        "src/trace_processor/importers/art_hprof/art_heap_graph_builder.h",
+        "src/trace_processor/importers/art_hprof/art_hprof_model.h",
         "src/trace_processor/importers/art_hprof/art_hprof_parser.h",
         "src/trace_processor/importers/art_hprof/art_hprof_types.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/art_method:art_method
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_art_method_art_method",
     srcs = [
         "src/trace_processor/importers/art_method/art_method_parser.cc",
-        "src/trace_processor/importers/art_method/art_method_parser.h",
         "src/trace_processor/importers/art_method/art_method_tokenizer.cc",
-        "src/trace_processor/importers/art_method/art_method_tokenizer.h",
         "src/trace_processor/importers/art_method/art_method_v2_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/art_method/art_method_parser.h",
+        "src/trace_processor/importers/art_method/art_method_tokenizer.h",
         "src/trace_processor/importers/art_method/art_method_v2_tokenizer.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_art_method_art_method_event",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/art_method:art_method_event
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_art_method_art_method_event",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/art_method/art_method_event.h",
     ],
+    deps = [
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/collapsed_stack:collapsed_stack
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_collapsed_stack_collapsed_stack",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/importers/collapsed_stack/collapsed_stack_trace_reader.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/collapsed_stack/collapsed_stack_trace_reader.h",
     ],
+    deps = [
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/common:common
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_common_common",
     srcs = [
-        "src/trace_processor/importers/common/address_range.h",
         "src/trace_processor/importers/common/args_tracker.cc",
-        "src/trace_processor/importers/common/args_tracker.h",
         "src/trace_processor/importers/common/args_translation_table.cc",
+        "src/trace_processor/importers/common/clock_converter.cc",
+        "src/trace_processor/importers/common/clock_tracker.cc",
+        "src/trace_processor/importers/common/cpu_tracker.cc",
+        "src/trace_processor/importers/common/deobfuscation_mapping_table.cc",
+        "src/trace_processor/importers/common/event_tracker.cc",
+        "src/trace_processor/importers/common/flow_tracker.cc",
+        "src/trace_processor/importers/common/global_args_tracker.cc",
+        "src/trace_processor/importers/common/global_metadata_tracker.cc",
+        "src/trace_processor/importers/common/gpu_tracker.cc",
+        "src/trace_processor/importers/common/import_logs_tracker.cc",
+        "src/trace_processor/importers/common/jit_cache.cc",
+        "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc",
+        "src/trace_processor/importers/common/machine_tracker.cc",
+        "src/trace_processor/importers/common/mapping_tracker.cc",
+        "src/trace_processor/importers/common/metadata_tracker.cc",
+        "src/trace_processor/importers/common/process_track_translation_table.cc",
+        "src/trace_processor/importers/common/process_tracker.cc",
+        "src/trace_processor/importers/common/registered_file_tracker.cc",
+        "src/trace_processor/importers/common/sched_event_tracker.cc",
+        "src/trace_processor/importers/common/slice_tracker.cc",
+        "src/trace_processor/importers/common/slice_translation_table.cc",
+        "src/trace_processor/importers/common/stack_profile_tracker.cc",
+        "src/trace_processor/importers/common/symbol_tracker.cc",
+        "src/trace_processor/importers/common/system_info_tracker.cc",
+        "src/trace_processor/importers/common/thread_state_tracker.cc",
+        "src/trace_processor/importers/common/trace_file_tracker.cc",
+        "src/trace_processor/importers/common/track_compressor.cc",
+        "src/trace_processor/importers/common/track_tracker.cc",
+        "src/trace_processor/importers/common/virtual_memory_mapping.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/common/address_range.h",
+        "src/trace_processor/importers/common/args_tracker.h",
         "src/trace_processor/importers/common/args_translation_table.h",
         "src/trace_processor/importers/common/chunked_trace_reader.h",
-        "src/trace_processor/importers/common/clock_converter.cc",
         "src/trace_processor/importers/common/clock_converter.h",
-        "src/trace_processor/importers/common/clock_tracker.cc",
         "src/trace_processor/importers/common/clock_tracker.h",
-        "src/trace_processor/importers/common/cpu_tracker.cc",
         "src/trace_processor/importers/common/cpu_tracker.h",
         "src/trace_processor/importers/common/create_mapping_params.h",
-        "src/trace_processor/importers/common/deobfuscation_mapping_table.cc",
         "src/trace_processor/importers/common/deobfuscation_mapping_table.h",
-        "src/trace_processor/importers/common/event_tracker.cc",
         "src/trace_processor/importers/common/event_tracker.h",
-        "src/trace_processor/importers/common/flow_tracker.cc",
         "src/trace_processor/importers/common/flow_tracker.h",
-        "src/trace_processor/importers/common/global_args_tracker.cc",
         "src/trace_processor/importers/common/global_args_tracker.h",
-        "src/trace_processor/importers/common/global_metadata_tracker.cc",
         "src/trace_processor/importers/common/global_metadata_tracker.h",
-        "src/trace_processor/importers/common/gpu_tracker.cc",
         "src/trace_processor/importers/common/gpu_tracker.h",
-        "src/trace_processor/importers/common/import_logs_tracker.cc",
         "src/trace_processor/importers/common/import_logs_tracker.h",
-        "src/trace_processor/importers/common/jit_cache.cc",
         "src/trace_processor/importers/common/jit_cache.h",
-        "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc",
         "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h",
-        "src/trace_processor/importers/common/machine_tracker.cc",
         "src/trace_processor/importers/common/machine_tracker.h",
-        "src/trace_processor/importers/common/mapping_tracker.cc",
         "src/trace_processor/importers/common/mapping_tracker.h",
-        "src/trace_processor/importers/common/metadata_tracker.cc",
         "src/trace_processor/importers/common/metadata_tracker.h",
-        "src/trace_processor/importers/common/process_track_translation_table.cc",
         "src/trace_processor/importers/common/process_track_translation_table.h",
-        "src/trace_processor/importers/common/process_tracker.cc",
         "src/trace_processor/importers/common/process_tracker.h",
-        "src/trace_processor/importers/common/registered_file_tracker.cc",
         "src/trace_processor/importers/common/registered_file_tracker.h",
         "src/trace_processor/importers/common/sched_event_state.h",
-        "src/trace_processor/importers/common/sched_event_tracker.cc",
         "src/trace_processor/importers/common/sched_event_tracker.h",
-        "src/trace_processor/importers/common/slice_tracker.cc",
         "src/trace_processor/importers/common/slice_tracker.h",
-        "src/trace_processor/importers/common/slice_translation_table.cc",
         "src/trace_processor/importers/common/slice_translation_table.h",
-        "src/trace_processor/importers/common/stack_profile_tracker.cc",
         "src/trace_processor/importers/common/stack_profile_tracker.h",
-        "src/trace_processor/importers/common/symbol_tracker.cc",
         "src/trace_processor/importers/common/symbol_tracker.h",
-        "src/trace_processor/importers/common/system_info_tracker.cc",
         "src/trace_processor/importers/common/system_info_tracker.h",
-        "src/trace_processor/importers/common/thread_state_tracker.cc",
         "src/trace_processor/importers/common/thread_state_tracker.h",
-        "src/trace_processor/importers/common/trace_file_tracker.cc",
         "src/trace_processor/importers/common/trace_file_tracker.h",
-        "src/trace_processor/importers/common/track_compressor.cc",
         "src/trace_processor/importers/common/track_compressor.h",
-        "src/trace_processor/importers/common/track_tracker.cc",
         "src/trace_processor/importers/common/track_tracker.h",
         "src/trace_processor/importers/common/tracks.h",
         "src/trace_processor/importers/common/tracks_common.h",
         "src/trace_processor/importers/common/tracks_internal.h",
-        "src/trace_processor/importers/common/virtual_memory_mapping.cc",
         "src/trace_processor/importers/common/virtual_memory_mapping.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_common_synthetic_tid_hdr",
+        ":src_trace_processor_importers_fuchsia_fuchsia_record",
+        ":src_trace_processor_importers_systrace_systrace_line",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_build_id",
+        ":src_trace_processor_util_clock",
+        ":src_trace_processor_util_elf_elf",
+        ":src_trace_processor_util_profiler_util",
+        ":src_trace_processor_util_proto_to_args_parser",
+        ":src_trace_processor_util_protozero_to_text",
+        ":src_trace_processor_util_trace_type",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/common:parser_types
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_common_parser_types",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/common/parser_types.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_storage",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/common:synthetic_tid_hdr
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_common_synthetic_tid_hdr",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/common/synthetic_tid.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/common:v8_profile_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_common_v8_profile_parser",
     srcs = [
         "src/trace_processor/importers/common/v8_profile_parser.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/common/v8_profile_parser.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_simple_json_parser",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/etw:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_etw_full",
     srcs = [
         "src/trace_processor/importers/etw/etw_module_impl.cc",
-        "src/trace_processor/importers/etw/etw_module_impl.h",
         "src/trace_processor/importers/etw/etw_parser.cc",
-        "src/trace_processor/importers/etw/etw_parser.h",
         "src/trace_processor/importers/etw/etw_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/etw/etw_module_impl.h",
+        "src/trace_processor/importers/etw/etw_parser.h",
         "src/trace_processor/importers/etw/etw_tokenizer.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_etw_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protozero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_etw_minimal",
+        ":src_trace_processor_importers_i2c_full",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
+        ":src_trace_processor_importers_syscalls_full",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/etw:minimal
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_etw_minimal",
     srcs = [
         "src/trace_processor/importers/etw/etw_module.cc",
-        "src/trace_processor/importers/etw/etw_module.h",
         "src/trace_processor/importers/etw/file_io_tracker.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/etw/etw_module.h",
         "src/trace_processor/importers/etw/file_io_tracker.h",
     ],
+    deps = [
+        ":protos_perfetto_trace_etw_zero",
+        ":protozero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_proto_proto_importer_module",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/ftrace:ftrace_descriptors
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_ftrace_ftrace_descriptors",
     srcs = [
         "src/trace_processor/importers/ftrace/ftrace_descriptors.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/ftrace/ftrace_descriptors.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":protozero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/ftrace:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_ftrace_full",
     srcs = [
         "src/trace_processor/importers/ftrace/binder_tracker.cc",
-        "src/trace_processor/importers/ftrace/binder_tracker.h",
         "src/trace_processor/importers/ftrace/drm_tracker.cc",
-        "src/trace_processor/importers/ftrace/drm_tracker.h",
         "src/trace_processor/importers/ftrace/ftrace_module_impl.cc",
-        "src/trace_processor/importers/ftrace/ftrace_module_impl.h",
         "src/trace_processor/importers/ftrace/ftrace_parser.cc",
-        "src/trace_processor/importers/ftrace/ftrace_parser.h",
         "src/trace_processor/importers/ftrace/ftrace_sched_event_tracker.cc",
-        "src/trace_processor/importers/ftrace/ftrace_sched_event_tracker.h",
         "src/trace_processor/importers/ftrace/ftrace_tokenizer.cc",
-        "src/trace_processor/importers/ftrace/ftrace_tokenizer.h",
         "src/trace_processor/importers/ftrace/generic_ftrace_tracker.cc",
-        "src/trace_processor/importers/ftrace/generic_ftrace_tracker.h",
         "src/trace_processor/importers/ftrace/gpu_work_period_tracker.cc",
-        "src/trace_processor/importers/ftrace/gpu_work_period_tracker.h",
         "src/trace_processor/importers/ftrace/iostat_tracker.cc",
-        "src/trace_processor/importers/ftrace/iostat_tracker.h",
         "src/trace_processor/importers/ftrace/mali_gpu_event_tracker.cc",
-        "src/trace_processor/importers/ftrace/mali_gpu_event_tracker.h",
         "src/trace_processor/importers/ftrace/pixel_display_tracker.cc",
-        "src/trace_processor/importers/ftrace/pixel_display_tracker.h",
         "src/trace_processor/importers/ftrace/pixel_mm_kswapd_event_tracker.cc",
-        "src/trace_processor/importers/ftrace/pixel_mm_kswapd_event_tracker.h",
         "src/trace_processor/importers/ftrace/pkvm_hyp_cpu_tracker.cc",
-        "src/trace_processor/importers/ftrace/pkvm_hyp_cpu_tracker.h",
         "src/trace_processor/importers/ftrace/rss_stat_tracker.cc",
-        "src/trace_processor/importers/ftrace/rss_stat_tracker.h",
         "src/trace_processor/importers/ftrace/thermal_tracker.cc",
-        "src/trace_processor/importers/ftrace/thermal_tracker.h",
         "src/trace_processor/importers/ftrace/v4l2_tracker.cc",
-        "src/trace_processor/importers/ftrace/v4l2_tracker.h",
         "src/trace_processor/importers/ftrace/virtio_gpu_tracker.cc",
-        "src/trace_processor/importers/ftrace/virtio_gpu_tracker.h",
         "src/trace_processor/importers/ftrace/virtio_video_tracker.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/ftrace/binder_tracker.h",
+        "src/trace_processor/importers/ftrace/drm_tracker.h",
+        "src/trace_processor/importers/ftrace/ftrace_module_impl.h",
+        "src/trace_processor/importers/ftrace/ftrace_parser.h",
+        "src/trace_processor/importers/ftrace/ftrace_sched_event_tracker.h",
+        "src/trace_processor/importers/ftrace/ftrace_tokenizer.h",
+        "src/trace_processor/importers/ftrace/generic_ftrace_tracker.h",
+        "src/trace_processor/importers/ftrace/gpu_work_period_tracker.h",
+        "src/trace_processor/importers/ftrace/iostat_tracker.h",
+        "src/trace_processor/importers/ftrace/mali_gpu_event_tracker.h",
+        "src/trace_processor/importers/ftrace/pixel_display_tracker.h",
+        "src/trace_processor/importers/ftrace/pixel_mm_kswapd_event_tracker.h",
+        "src/trace_processor/importers/ftrace/pkvm_hyp_cpu_tracker.h",
+        "src/trace_processor/importers/ftrace/rss_stat_tracker.h",
+        "src/trace_processor/importers/ftrace/thermal_tracker.h",
+        "src/trace_processor/importers/ftrace/v4l2_tracker.h",
+        "src/trace_processor/importers/ftrace/virtio_gpu_tracker.h",
         "src/trace_processor/importers/ftrace/virtio_video_tracker.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_ftrace_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protozero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_ftrace_ftrace_descriptors",
+        ":src_trace_processor_importers_ftrace_minimal",
+        ":src_trace_processor_importers_i2c_full",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
+        ":src_trace_processor_importers_syscalls_full",
+        ":src_trace_processor_importers_systrace_systrace_parser",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/ftrace:minimal
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_ftrace_minimal",
     srcs = [
         "src/trace_processor/importers/ftrace/ftrace_module.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/ftrace/ftrace_module.h",
     ],
+    deps = [
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_proto_proto_importer_module",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/fuchsia:fuchsia_record
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_fuchsia_fuchsia_record",
     srcs = [
         "src/trace_processor/importers/fuchsia/fuchsia_record.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/fuchsia/fuchsia_record.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_storage",
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/fuchsia:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_fuchsia_full",
     srcs = [
         "src/trace_processor/importers/fuchsia/fuchsia_trace_parser.cc",
-        "src/trace_processor/importers/fuchsia/fuchsia_trace_parser.h",
         "src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.cc",
-        "src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.h",
         "src/trace_processor/importers/fuchsia/fuchsia_trace_utils.cc",
     ],
+    hdrs = [
+        "src/trace_processor/importers/fuchsia/fuchsia_trace_parser.h",
+        "src/trace_processor/importers/fuchsia/fuchsia_trace_tokenizer.h",
+    ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_fuchsia_fuchsia_record",
+        ":src_trace_processor_importers_fuchsia_minimal",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_type",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/fuchsia:minimal
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_fuchsia_minimal",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/fuchsia/fuchsia_trace_utils.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_storage",
+        ":src_base_base",
+        ":src_trace_processor_importers_fuchsia_fuchsia_record",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/gecko:gecko
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_gecko_gecko",
     srcs = [
         "src/trace_processor/importers/gecko/gecko_trace_parser.cc",
-        "src/trace_processor/importers/gecko/gecko_trace_parser.h",
         "src/trace_processor/importers/gecko/gecko_trace_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/gecko/gecko_trace_parser.h",
         "src/trace_processor/importers/gecko/gecko_trace_tokenizer.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_storage",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_gecko_gecko_event",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_simple_json_parser",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/gecko:gecko_event
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_gecko_gecko_event",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/gecko/gecko_event.h",
     ],
+    deps = [
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_tables_tables",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/generic_kernel:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_generic_kernel_full",
     srcs = [
         "src/trace_processor/importers/generic_kernel/generic_kernel_module.cc",
-        "src/trace_processor/importers/generic_kernel/generic_kernel_module.h",
         "src/trace_processor/importers/generic_kernel/generic_kernel_parser.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/generic_kernel/generic_kernel_module.h",
         "src/trace_processor/importers/generic_kernel/generic_kernel_parser.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_generic_kernel_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protozero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_proto_proto_importer_module",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/i2c:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_i2c_full",
     srcs = [
         "src/trace_processor/importers/i2c/i2c_tracker.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/i2c/i2c_tracker.h",
     ],
+    deps = [
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/json:json
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_json_json",
     srcs = [
         "src/trace_processor/importers/json/json_trace_parser.cc",
-        "src/trace_processor/importers/json/json_trace_parser.h",
         "src/trace_processor/importers/json/json_trace_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/json/json_trace_parser.h",
         "src/trace_processor/importers/json/json_trace_tokenizer.h",
     ],
+    deps = [
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_common_v8_profile_parser",
+        ":src_trace_processor_importers_systrace_full",
+        ":src_trace_processor_importers_systrace_systrace_line",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_json_args",
+        ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_simple_json_parser",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/memory_tracker:graph_processor
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_memory_tracker_graph_processor",
     srcs = [
         "src/trace_processor/importers/memory_tracker/graph.cc",
@@ -2640,175 +2447,305 @@ perfetto_filegroup(
         "src/trace_processor/importers/memory_tracker/raw_memory_graph_node.cc",
         "src/trace_processor/importers/memory_tracker/raw_process_memory_node.cc",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_ext_trace_processor_importers_memory_tracker_memory_tracker",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/ninja:ninja
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_ninja_ninja",
     srcs = [
         "src/trace_processor/importers/ninja/ninja_log_parser.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/ninja/ninja_log_parser.h",
     ],
+    deps = [
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/perf:perf
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_perf_perf",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/importers/perf/attrs_section_reader.cc",
-        "src/trace_processor/importers/perf/attrs_section_reader.h",
         "src/trace_processor/importers/perf/aux_data_tokenizer.cc",
-        "src/trace_processor/importers/perf/aux_data_tokenizer.h",
         "src/trace_processor/importers/perf/aux_record.cc",
-        "src/trace_processor/importers/perf/aux_record.h",
         "src/trace_processor/importers/perf/aux_stream_manager.cc",
-        "src/trace_processor/importers/perf/aux_stream_manager.h",
         "src/trace_processor/importers/perf/auxtrace_info_record.cc",
-        "src/trace_processor/importers/perf/auxtrace_info_record.h",
         "src/trace_processor/importers/perf/auxtrace_record.cc",
-        "src/trace_processor/importers/perf/auxtrace_record.h",
         "src/trace_processor/importers/perf/features.cc",
-        "src/trace_processor/importers/perf/features.h",
         "src/trace_processor/importers/perf/itrace_start_record.cc",
-        "src/trace_processor/importers/perf/itrace_start_record.h",
         "src/trace_processor/importers/perf/mmap_record.cc",
-        "src/trace_processor/importers/perf/mmap_record.h",
         "src/trace_processor/importers/perf/perf_data_tokenizer.cc",
+        "src/trace_processor/importers/perf/perf_tracker.cc",
+        "src/trace_processor/importers/perf/record_parser.cc",
+        "src/trace_processor/importers/perf/sample.cc",
+        "src/trace_processor/importers/perf/sample_id.cc",
+        "src/trace_processor/importers/perf/spe_record_parser.cc",
+        "src/trace_processor/importers/perf/spe_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/perf/attrs_section_reader.h",
+        "src/trace_processor/importers/perf/aux_data_tokenizer.h",
+        "src/trace_processor/importers/perf/aux_record.h",
+        "src/trace_processor/importers/perf/aux_stream_manager.h",
+        "src/trace_processor/importers/perf/auxtrace_info_record.h",
+        "src/trace_processor/importers/perf/auxtrace_record.h",
+        "src/trace_processor/importers/perf/features.h",
+        "src/trace_processor/importers/perf/itrace_start_record.h",
+        "src/trace_processor/importers/perf/mmap_record.h",
         "src/trace_processor/importers/perf/perf_data_tokenizer.h",
         "src/trace_processor/importers/perf/perf_file.h",
-        "src/trace_processor/importers/perf/perf_tracker.cc",
         "src/trace_processor/importers/perf/perf_tracker.h",
-        "src/trace_processor/importers/perf/record_parser.cc",
         "src/trace_processor/importers/perf/record_parser.h",
-        "src/trace_processor/importers/perf/sample.cc",
         "src/trace_processor/importers/perf/sample.h",
-        "src/trace_processor/importers/perf/sample_id.cc",
         "src/trace_processor/importers/perf/sample_id.h",
         "src/trace_processor/importers/perf/spe.h",
-        "src/trace_processor/importers/perf/spe_record_parser.cc",
         "src/trace_processor/importers/perf/spe_record_parser.h",
-        "src/trace_processor/importers/perf/spe_tokenizer.cc",
         "src/trace_processor/importers/perf/spe_tokenizer.h",
         "src/trace_processor/importers/perf/time_conv_record.h",
         "src/trace_processor/importers/perf/util.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protos_third_party_simpleperf_zero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_perf_record",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_build_id",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/perf:record
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_perf_record",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/importers/perf/perf_counter.cc",
+        "src/trace_processor/importers/perf/perf_event_attr.cc",
+        "src/trace_processor/importers/perf/perf_invocation.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/perf/perf_counter.h",
         "src/trace_processor/importers/perf/perf_event.h",
-        "src/trace_processor/importers/perf/perf_event_attr.cc",
         "src/trace_processor/importers/perf/perf_event_attr.h",
-        "src/trace_processor/importers/perf/perf_invocation.cc",
         "src/trace_processor/importers/perf/perf_invocation.h",
         "src/trace_processor/importers/perf/reader.h",
         "src/trace_processor/importers/perf/record.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_build_id",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/perf_text:perf_text
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_perf_text_perf_text",
     srcs = [
         "src/trace_processor/importers/perf_text/perf_text_trace_parser.cc",
-        "src/trace_processor/importers/perf_text/perf_text_trace_parser.h",
         "src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/perf_text/perf_text_trace_parser.h",
         "src/trace_processor/importers/perf_text/perf_text_trace_tokenizer.h",
     ],
+    deps = [
+        ":protos_perfetto_trace_minimal_zero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_perf_text_perf_text_event",
+        ":src_trace_processor_importers_perf_text_perf_text_sample_line_parser",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/perf_text:perf_text_event
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_perf_text_perf_text_event",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/perf_text/perf_text_event.h",
     ],
+    deps = [
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_tables_tables",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/perf_text:perf_text_sample_line_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_perf_text_perf_text_sample_line_parser",
     srcs = [
         "src/trace_processor/importers/perf_text/perf_text_sample_line_parser.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/perf_text/perf_text_sample_line_parser.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/pprof:pprof
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_pprof_pprof",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/importers/pprof/pprof_trace_reader.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/pprof/pprof_trace_reader.h",
     ],
+    deps = [
+        ":protos_third_party_pprof_zero",
+        ":protozero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_build_id",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/primes:primes
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_primes_primes",
     srcs = [
         "src/trace_processor/importers/primes/primes_trace_parser.cc",
-        "src/trace_processor/importers/primes/primes_trace_parser.h",
         "src/trace_processor/importers/primes/primes_trace_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/primes/primes_trace_parser.h",
         "src/trace_processor/importers/primes/primes_trace_tokenizer.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_protozero_protozero",
+        ":protos_perfetto_common_zero",
+        ":protos_third_party_primes_cpp",
+        ":protos_third_party_primes_zero",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/proto/winscope:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_proto_winscope_full",
     srcs = [
         "src/trace_processor/importers/proto/winscope/android_input_event_parser.cc",
-        "src/trace_processor/importers/proto/winscope/android_input_event_parser.h",
         "src/trace_processor/importers/proto/winscope/protolog_message_decoder.cc",
-        "src/trace_processor/importers/proto/winscope/protolog_message_decoder.h",
         "src/trace_processor/importers/proto/winscope/protolog_parser.cc",
-        "src/trace_processor/importers/proto/winscope/protolog_parser.h",
         "src/trace_processor/importers/proto/winscope/shell_transitions_parser.cc",
-        "src/trace_processor/importers/proto/winscope/shell_transitions_parser.h",
         "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.cc",
-        "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor.cc",
-        "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor.h",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc",
-        "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.h",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_rect_computation.cc",
+        "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation.cc",
+        "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc",
+        "src/trace_processor/importers/proto/winscope/viewcapture_visibility_computation.cc",
+        "src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.cc",
+        "src/trace_processor/importers/proto/winscope/windowmanager_parser.cc",
+        "src/trace_processor/importers/proto/winscope/windowmanager_proto_clone.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_geometry.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_module.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc",
+        "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/proto/winscope/android_input_event_parser.h",
+        "src/trace_processor/importers/proto/winscope/protolog_message_decoder.h",
+        "src/trace_processor/importers/proto/winscope/protolog_parser.h",
+        "src/trace_processor/importers/proto/winscope/shell_transitions_parser.h",
+        "src/trace_processor/importers/proto/winscope/shell_transitions_tracker.h",
+        "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_extractor.h",
+        "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.h",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_rect_computation.h",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h",
-        "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation.cc",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation.h",
-        "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.cc",
         "src/trace_processor/importers/proto/winscope/surfaceflinger_transactions_parser.h",
-        "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_args_parser.h",
-        "src/trace_processor/importers/proto/winscope/viewcapture_parser.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_parser.h",
-        "src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_rect_computation.h",
-        "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_views_extractor.h",
-        "src/trace_processor/importers/proto/winscope/viewcapture_visibility_computation.cc",
         "src/trace_processor/importers/proto/winscope/viewcapture_visibility_computation.h",
-        "src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.cc",
         "src/trace_processor/importers/proto/winscope/windowmanager_hierarchy_walker.h",
-        "src/trace_processor/importers/proto/winscope/windowmanager_parser.cc",
         "src/trace_processor/importers/proto/winscope/windowmanager_parser.h",
-        "src/trace_processor/importers/proto/winscope/windowmanager_proto_clone.cc",
         "src/trace_processor/importers/proto/winscope/windowmanager_proto_clone.h",
         "src/trace_processor/importers/proto/winscope/winscope_context.h",
-        "src/trace_processor/importers/proto/winscope/winscope_geometry.cc",
         "src/trace_processor/importers/proto/winscope/winscope_geometry.h",
-        "src/trace_processor/importers/proto/winscope/winscope_module.cc",
         "src/trace_processor/importers/proto/winscope/winscope_module.h",
-        "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.cc",
         "src/trace_processor/importers/proto/winscope/winscope_rect_tracker.h",
-        "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.cc",
         "src/trace_processor/importers/proto/winscope/winscope_transform_tracker.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_android_winscope_common_zero",
+        ":protos_perfetto_trace_android_winscope_extensions_zero",
+        ":protos_perfetto_trace_android_winscope_regular_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protozero",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
+        ":src_trace_processor_importers_proto_proto_importer_module",
+        ":src_trace_processor_importers_proto_winscope_gen_cc_winscope_descriptor",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_winscope_proto_mapping",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/proto/winscope:gen_cc_winscope_descriptor
@@ -2831,76 +2768,127 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/trace_processor/importers/proto:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_proto_full",
     srcs = [
         "src/trace_processor/importers/proto/additional_modules.cc",
-        "src/trace_processor/importers/proto/additional_modules.h",
         "src/trace_processor/importers/proto/android_camera_event_module.cc",
-        "src/trace_processor/importers/proto/android_camera_event_module.h",
         "src/trace_processor/importers/proto/android_cpu_per_uid_module.cc",
-        "src/trace_processor/importers/proto/android_cpu_per_uid_module.h",
         "src/trace_processor/importers/proto/android_cpu_per_uid_state.cc",
-        "src/trace_processor/importers/proto/android_cpu_per_uid_state.h",
         "src/trace_processor/importers/proto/android_kernel_wakelocks_module.cc",
-        "src/trace_processor/importers/proto/android_kernel_wakelocks_module.h",
         "src/trace_processor/importers/proto/android_kernel_wakelocks_state.cc",
-        "src/trace_processor/importers/proto/android_kernel_wakelocks_state.h",
         "src/trace_processor/importers/proto/android_probes_module.cc",
-        "src/trace_processor/importers/proto/android_probes_module.h",
         "src/trace_processor/importers/proto/android_probes_parser.cc",
-        "src/trace_processor/importers/proto/android_probes_parser.h",
         "src/trace_processor/importers/proto/android_probes_tracker.cc",
-        "src/trace_processor/importers/proto/android_probes_tracker.h",
         "src/trace_processor/importers/proto/content_analyzer.cc",
-        "src/trace_processor/importers/proto/content_analyzer.h",
         "src/trace_processor/importers/proto/deobfuscation_module.cc",
-        "src/trace_processor/importers/proto/deobfuscation_module.h",
         "src/trace_processor/importers/proto/deobfuscation_tracker.cc",
-        "src/trace_processor/importers/proto/deobfuscation_tracker.h",
         "src/trace_processor/importers/proto/frame_timeline_event_parser.cc",
-        "src/trace_processor/importers/proto/frame_timeline_event_parser.h",
         "src/trace_processor/importers/proto/gpu_event_parser.cc",
-        "src/trace_processor/importers/proto/gpu_event_parser.h",
         "src/trace_processor/importers/proto/graphics_event_module.cc",
-        "src/trace_processor/importers/proto/graphics_event_module.h",
         "src/trace_processor/importers/proto/graphics_frame_event_parser.cc",
-        "src/trace_processor/importers/proto/graphics_frame_event_parser.h",
         "src/trace_processor/importers/proto/heap_graph_module.cc",
-        "src/trace_processor/importers/proto/heap_graph_module.h",
         "src/trace_processor/importers/proto/heap_graph_tracker.cc",
-        "src/trace_processor/importers/proto/heap_graph_tracker.h",
         "src/trace_processor/importers/proto/jit_tracker.cc",
-        "src/trace_processor/importers/proto/jit_tracker.h",
         "src/trace_processor/importers/proto/metadata_module.cc",
-        "src/trace_processor/importers/proto/metadata_module.h",
         "src/trace_processor/importers/proto/pigweed_detokenizer.cc",
-        "src/trace_processor/importers/proto/pigweed_detokenizer.h",
         "src/trace_processor/importers/proto/pixel_modem_module.cc",
-        "src/trace_processor/importers/proto/pixel_modem_module.h",
         "src/trace_processor/importers/proto/pixel_modem_parser.cc",
-        "src/trace_processor/importers/proto/pixel_modem_parser.h",
         "src/trace_processor/importers/proto/profile_module.cc",
-        "src/trace_processor/importers/proto/profile_module.h",
         "src/trace_processor/importers/proto/statsd_module.cc",
-        "src/trace_processor/importers/proto/statsd_module.h",
         "src/trace_processor/importers/proto/string_encoding_utils.cc",
-        "src/trace_processor/importers/proto/string_encoding_utils.h",
         "src/trace_processor/importers/proto/system_probes_module.cc",
-        "src/trace_processor/importers/proto/system_probes_module.h",
         "src/trace_processor/importers/proto/system_probes_parser.cc",
-        "src/trace_processor/importers/proto/system_probes_parser.h",
         "src/trace_processor/importers/proto/translation_table_module.cc",
-        "src/trace_processor/importers/proto/translation_table_module.h",
         "src/trace_processor/importers/proto/v8_module.cc",
-        "src/trace_processor/importers/proto/v8_module.h",
         "src/trace_processor/importers/proto/v8_sequence_state.cc",
-        "src/trace_processor/importers/proto/v8_sequence_state.h",
         "src/trace_processor/importers/proto/v8_tracker.cc",
-        "src/trace_processor/importers/proto/v8_tracker.h",
         "src/trace_processor/importers/proto/vulkan_memory_tracker.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/proto/additional_modules.h",
+        "src/trace_processor/importers/proto/android_camera_event_module.h",
+        "src/trace_processor/importers/proto/android_cpu_per_uid_module.h",
+        "src/trace_processor/importers/proto/android_cpu_per_uid_state.h",
+        "src/trace_processor/importers/proto/android_kernel_wakelocks_module.h",
+        "src/trace_processor/importers/proto/android_kernel_wakelocks_state.h",
+        "src/trace_processor/importers/proto/android_probes_module.h",
+        "src/trace_processor/importers/proto/android_probes_parser.h",
+        "src/trace_processor/importers/proto/android_probes_tracker.h",
+        "src/trace_processor/importers/proto/content_analyzer.h",
+        "src/trace_processor/importers/proto/deobfuscation_module.h",
+        "src/trace_processor/importers/proto/deobfuscation_tracker.h",
+        "src/trace_processor/importers/proto/frame_timeline_event_parser.h",
+        "src/trace_processor/importers/proto/gpu_event_parser.h",
+        "src/trace_processor/importers/proto/graphics_event_module.h",
+        "src/trace_processor/importers/proto/graphics_frame_event_parser.h",
+        "src/trace_processor/importers/proto/heap_graph_module.h",
+        "src/trace_processor/importers/proto/heap_graph_tracker.h",
+        "src/trace_processor/importers/proto/jit_tracker.h",
+        "src/trace_processor/importers/proto/metadata_module.h",
+        "src/trace_processor/importers/proto/pigweed_detokenizer.h",
+        "src/trace_processor/importers/proto/pixel_modem_module.h",
+        "src/trace_processor/importers/proto/pixel_modem_parser.h",
+        "src/trace_processor/importers/proto/profile_module.h",
+        "src/trace_processor/importers/proto/statsd_module.h",
+        "src/trace_processor/importers/proto/string_encoding_utils.h",
+        "src/trace_processor/importers/proto/system_probes_module.h",
+        "src/trace_processor/importers/proto/system_probes_parser.h",
+        "src/trace_processor/importers/proto/translation_table_module.h",
+        "src/trace_processor/importers/proto/v8_module.h",
+        "src/trace_processor/importers/proto/v8_sequence_state.h",
+        "src/trace_processor/importers/proto/v8_tracker.h",
         "src/trace_processor/importers/proto/vulkan_memory_tracker.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_sys_stats_counters",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_chrome_zero",
+        ":protos_perfetto_trace_gpu_gpu_interned_data_zero",
+        ":protos_perfetto_trace_gpu_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_power_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protos_perfetto_trace_ps_zero",
+        ":protos_perfetto_trace_statsd_zero",
+        ":protos_perfetto_trace_sys_stats_zero",
+        ":protos_perfetto_trace_system_info_zero",
+        ":protos_perfetto_trace_translation_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_kernel_utils_kernel_wakelock_errors",
+        ":src_kernel_utils_syscall_table",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_etw_full",
+        ":src_trace_processor_importers_etw_minimal",
+        ":src_trace_processor_importers_ftrace_full",
+        ":src_trace_processor_importers_ftrace_minimal",
+        ":src_trace_processor_importers_generic_kernel_full",
+        ":src_trace_processor_importers_proto_gen_cc_gpu_interned_data_descriptor",
+        ":src_trace_processor_importers_proto_gen_cc_statsd_atoms_descriptor",
+        ":src_trace_processor_importers_proto_gen_cc_trace_descriptor",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
+        ":src_trace_processor_importers_proto_winscope_full",
+        ":src_trace_processor_importers_syscalls_full",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_build_id",
+        ":src_trace_processor_util_descriptors",
+        ":src_trace_processor_util_profiler_util",
+        ":src_trace_processor_util_proto_profiler",
+        ":src_trace_processor_util_proto_to_args_parser",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/proto:gen_cc_android_track_event_descriptor
@@ -3037,138 +3025,265 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/trace_processor/importers/proto:minimal
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_proto_minimal",
     srcs = [
         "src/trace_processor/importers/proto/active_chrome_processes_tracker.cc",
-        "src/trace_processor/importers/proto/active_chrome_processes_tracker.h",
         "src/trace_processor/importers/proto/app_wakelock_module.cc",
-        "src/trace_processor/importers/proto/app_wakelock_module.h",
         "src/trace_processor/importers/proto/args_parser.cc",
-        "src/trace_processor/importers/proto/args_parser.h",
         "src/trace_processor/importers/proto/blob_packet_writer.cc",
-        "src/trace_processor/importers/proto/blob_packet_writer.h",
         "src/trace_processor/importers/proto/chrome_string_lookup.cc",
-        "src/trace_processor/importers/proto/chrome_string_lookup.h",
         "src/trace_processor/importers/proto/chrome_system_probes_module.cc",
-        "src/trace_processor/importers/proto/chrome_system_probes_module.h",
         "src/trace_processor/importers/proto/chrome_system_probes_parser.cc",
-        "src/trace_processor/importers/proto/chrome_system_probes_parser.h",
         "src/trace_processor/importers/proto/default_modules.cc",
-        "src/trace_processor/importers/proto/default_modules.h",
         "src/trace_processor/importers/proto/incremental_state.cc",
         "src/trace_processor/importers/proto/memory_tracker_snapshot_module.cc",
-        "src/trace_processor/importers/proto/memory_tracker_snapshot_module.h",
         "src/trace_processor/importers/proto/memory_tracker_snapshot_parser.cc",
-        "src/trace_processor/importers/proto/memory_tracker_snapshot_parser.h",
         "src/trace_processor/importers/proto/metadata_minimal_module.cc",
-        "src/trace_processor/importers/proto/metadata_minimal_module.h",
         "src/trace_processor/importers/proto/network_trace_module.cc",
-        "src/trace_processor/importers/proto/network_trace_module.h",
         "src/trace_processor/importers/proto/packet_analyzer.cc",
-        "src/trace_processor/importers/proto/packet_analyzer.h",
-        "src/trace_processor/importers/proto/packet_sequence_state_builder.h",
         "src/trace_processor/importers/proto/packet_sequence_state_generation.cc",
         "src/trace_processor/importers/proto/perf_sample_tracker.cc",
-        "src/trace_processor/importers/proto/perf_sample_tracker.h",
         "src/trace_processor/importers/proto/profile_packet_sequence_state.cc",
-        "src/trace_processor/importers/proto/profile_packet_sequence_state.h",
         "src/trace_processor/importers/proto/profile_packet_utils.cc",
-        "src/trace_processor/importers/proto/profile_packet_utils.h",
         "src/trace_processor/importers/proto/proto_trace_parser_impl.cc",
-        "src/trace_processor/importers/proto/proto_trace_parser_impl.h",
         "src/trace_processor/importers/proto/proto_trace_reader.cc",
-        "src/trace_processor/importers/proto/proto_trace_reader.h",
         "src/trace_processor/importers/proto/proto_trace_tokenizer.cc",
-        "src/trace_processor/importers/proto/proto_trace_tokenizer.h",
         "src/trace_processor/importers/proto/protovm_incremental_tracing.cc",
-        "src/trace_processor/importers/proto/protovm_incremental_tracing.h",
         "src/trace_processor/importers/proto/stack_profile_sequence_state.cc",
-        "src/trace_processor/importers/proto/stack_profile_sequence_state.h",
-        "src/trace_processor/importers/proto/track_event_event_importer.h",
         "src/trace_processor/importers/proto/track_event_module.cc",
-        "src/trace_processor/importers/proto/track_event_module.h",
         "src/trace_processor/importers/proto/track_event_parser.cc",
-        "src/trace_processor/importers/proto/track_event_parser.h",
         "src/trace_processor/importers/proto/track_event_sequence_state.cc",
         "src/trace_processor/importers/proto/track_event_tokenizer.cc",
-        "src/trace_processor/importers/proto/track_event_tokenizer.h",
         "src/trace_processor/importers/proto/track_event_tracker.cc",
-        "src/trace_processor/importers/proto/track_event_tracker.h",
         "src/trace_processor/importers/proto/user_tracker.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/proto/active_chrome_processes_tracker.h",
+        "src/trace_processor/importers/proto/app_wakelock_module.h",
+        "src/trace_processor/importers/proto/args_parser.h",
+        "src/trace_processor/importers/proto/blob_packet_writer.h",
+        "src/trace_processor/importers/proto/chrome_string_lookup.h",
+        "src/trace_processor/importers/proto/chrome_system_probes_module.h",
+        "src/trace_processor/importers/proto/chrome_system_probes_parser.h",
+        "src/trace_processor/importers/proto/default_modules.h",
+        "src/trace_processor/importers/proto/memory_tracker_snapshot_module.h",
+        "src/trace_processor/importers/proto/memory_tracker_snapshot_parser.h",
+        "src/trace_processor/importers/proto/metadata_minimal_module.h",
+        "src/trace_processor/importers/proto/network_trace_module.h",
+        "src/trace_processor/importers/proto/packet_analyzer.h",
+        "src/trace_processor/importers/proto/packet_sequence_state_builder.h",
+        "src/trace_processor/importers/proto/perf_sample_tracker.h",
+        "src/trace_processor/importers/proto/profile_packet_sequence_state.h",
+        "src/trace_processor/importers/proto/profile_packet_utils.h",
+        "src/trace_processor/importers/proto/proto_trace_parser_impl.h",
+        "src/trace_processor/importers/proto/proto_trace_reader.h",
+        "src/trace_processor/importers/proto/proto_trace_tokenizer.h",
+        "src/trace_processor/importers/proto/protovm_incremental_tracing.h",
+        "src/trace_processor/importers/proto/stack_profile_sequence_state.h",
+        "src/trace_processor/importers/proto/track_event_event_importer.h",
+        "src/trace_processor/importers/proto/track_event_module.h",
+        "src/trace_processor/importers/proto/track_event_parser.h",
+        "src/trace_processor/importers/proto/track_event_tokenizer.h",
+        "src/trace_processor/importers/proto/track_event_tracker.h",
         "src/trace_processor/importers/proto/user_tracker.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_chrome_zero",
+        ":protos_perfetto_trace_etw_zero",
+        ":protos_perfetto_trace_ftrace_zero",
+        ":protos_perfetto_trace_gpu_gpu_track_event_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_perfetto_zero",
+        ":protos_perfetto_trace_power_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protos_perfetto_trace_ps_zero",
+        ":protos_perfetto_trace_sys_stats_zero",
+        ":protos_perfetto_trace_system_info_zero",
+        ":protos_perfetto_trace_track_event_zero",
+        ":protos_perfetto_trace_translation_zero",
+        ":protos_third_party_chromium_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_protovm_protovm",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_common_v8_profile_parser",
+        ":src_trace_processor_importers_etw_minimal",
+        ":src_trace_processor_importers_ftrace_minimal",
+        ":src_trace_processor_importers_memory_tracker_graph_processor",
+        ":src_trace_processor_importers_proto_gen_cc_android_track_event_descriptor",
+        ":src_trace_processor_importers_proto_gen_cc_chrome_track_event_descriptor",
+        ":src_trace_processor_importers_proto_gen_cc_gpu_track_event_descriptor",
+        ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
+        ":src_trace_processor_importers_proto_proto_importer_module",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_build_id",
+        ":src_trace_processor_util_gzip",
+        ":src_trace_processor_util_json_args",
+        ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_profiler_util",
+        ":src_trace_processor_util_simple_json_parser",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/proto:packet_sequence_state_generation_hdr
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/proto/incremental_state.h",
         "src/trace_processor/importers/proto/packet_sequence_state_generation.h",
         "src/trace_processor/importers/proto/track_event_sequence_state.h",
         "src/trace_processor/importers/proto/track_event_thread_descriptor.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_track_event_zero",
+        ":src_trace_processor_importers_common_synthetic_tid_hdr",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_interned_message_view",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/proto:proto_importer_module
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_proto_proto_importer_module",
     srcs = [
         "src/trace_processor/importers/proto/proto_importer_module.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/proto/proto_importer_module.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_trace_processor",
+        ":src_base_base",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/simpleperf_proto:simpleperf_proto
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_simpleperf_proto_simpleperf_proto",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.cc",
-        "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.h",
         "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_tokenizer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_parser.h",
         "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_tokenizer.h",
         "src/trace_processor/importers/simpleperf_proto/simpleperf_proto_tracker.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_protozero_protozero",
+        ":protos_perfetto_common_zero",
+        ":protos_third_party_simpleperf_zero",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/syscalls:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_syscalls_full",
     srcs = [
         "src/trace_processor/importers/syscalls/syscall_tracker.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/syscalls/syscall_tracker.h",
     ],
+    deps = [
+        ":src_kernel_utils_syscall_table",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/systrace:full
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_systrace_full",
     srcs = [
         "src/trace_processor/importers/systrace/systrace_line_parser.cc",
-        "src/trace_processor/importers/systrace/systrace_line_parser.h",
         "src/trace_processor/importers/systrace/systrace_line_tokenizer.cc",
-        "src/trace_processor/importers/systrace/systrace_line_tokenizer.h",
         "src/trace_processor/importers/systrace/systrace_trace_parser.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/importers/systrace/systrace_line_parser.h",
+        "src/trace_processor/importers/systrace/systrace_line_tokenizer.h",
         "src/trace_processor/importers/systrace/systrace_trace_parser.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":src_base_regex_regex",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_ftrace_full",
+        ":src_trace_processor_importers_systrace_systrace_line",
+        ":src_trace_processor_importers_systrace_systrace_parser",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_minimal",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_trace_type",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/systrace:systrace_line
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_systrace_systrace_line",
-    srcs = [
+    hdrs = [
         "src/trace_processor/importers/systrace/systrace_line.h",
     ],
+    deps = [
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/importers/systrace:systrace_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_importers_systrace_systrace_parser",
     srcs = [
         "src/trace_processor/importers/systrace/systrace_parser.cc",
+    ],
+    hdrs = [
         "src/trace_processor/importers/systrace/systrace_parser.h",
     ],
+    deps = [
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/metrics/sql/android:android
@@ -3451,113 +3566,215 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/trace_processor/metrics:metrics
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_metrics_metrics",
     srcs = [
         "src/trace_processor/metrics/metrics.cc",
+    ],
+    hdrs = [
         "src/trace_processor/metrics/metrics.h",
     ],
+    deps = [
+               ":include_perfetto_trace_processor_trace_processor",
+               ":protos_perfetto_common_zero",
+               ":protos_perfetto_trace_processor_metrics_impl_zero",
+               ":protos_perfetto_trace_processor_zero",
+               ":protozero",
+               ":src_base_base",
+               ":src_base_regex_regex",
+               ":src_trace_processor_metatrace",
+               ":src_trace_processor_metrics_gen_cc_all_chrome_metrics_descriptor",
+               ":src_trace_processor_metrics_gen_cc_all_webview_metrics_descriptor",
+               ":src_trace_processor_metrics_gen_cc_metrics_descriptor",
+               ":src_trace_processor_metrics_sql_gen_amalgamated_sql_metrics",
+               ":src_trace_processor_perfetto_sql_engine_engine",
+               ":src_trace_processor_perfetto_sql_intrinsics_functions_functions",
+               ":src_trace_processor_sqlite_sqlite",
+               ":src_trace_processor_util_descriptors",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/engine:engine
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_engine_engine",
     srcs = [
         "src/trace_processor/perfetto_sql/engine/created_function.cc",
-        "src/trace_processor/perfetto_sql/engine/created_function.h",
         "src/trace_processor/perfetto_sql/engine/dataframe_module.cc",
-        "src/trace_processor/perfetto_sql/engine/dataframe_module.h",
         "src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.cc",
-        "src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.h",
         "src/trace_processor/perfetto_sql/engine/runtime_table_function.cc",
-        "src/trace_processor/perfetto_sql/engine/runtime_table_function.h",
         "src/trace_processor/perfetto_sql/engine/static_table_function_module.cc",
-        "src/trace_processor/perfetto_sql/engine/static_table_function_module.h",
         "src/trace_processor/perfetto_sql/engine/table_pointer_module.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/perfetto_sql/engine/created_function.h",
+        "src/trace_processor/perfetto_sql/engine/dataframe_module.h",
+        "src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.h",
+        "src/trace_processor/perfetto_sql/engine/runtime_table_function.h",
+        "src/trace_processor/perfetto_sql/engine/static_table_function_module.h",
         "src/trace_processor/perfetto_sql/engine/table_pointer_module.h",
     ],
+    deps = [
+               ":include_perfetto_trace_processor_basic_types",
+               ":protos_perfetto_trace_processor_zero",
+               ":src_base_base",
+               ":src_trace_processor_containers_containers",
+               ":src_trace_processor_core_dataframe_dataframe",
+               ":src_trace_processor_metatrace",
+               ":src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
+               ":src_trace_processor_perfetto_sql_parser_parser",
+               ":src_trace_processor_perfetto_sql_tokenizer_tokenizer",
+               ":src_trace_processor_sqlite_sqlite",
+               ":src_trace_processor_types_types",
+               ":src_trace_processor_util_sql_argument",
+               ":src_trace_processor_util_stdlib",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/generator:generator
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_generator_generator",
     srcs = [
         "src/trace_processor/perfetto_sql/generator/structured_query_generator.cc",
+    ],
+    hdrs = [
         "src/trace_processor/perfetto_sql/generator/structured_query_generator.h",
     ],
+    deps = [
+        ":protos_perfetto_perfetto_sql_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_perfetto_sql_tokenizer_tokenizer",
+        ":src_trace_processor_sqlite_sqlite",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/functions/trees:trees
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_intrinsics_functions_trees_trees",
     srcs = [
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_conversion.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_conversion.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_filter.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_filter.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_conversion.h",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_filter.h",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_functions.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/trees/tree_propagate.h",
     ],
+    deps = [
+               ":include_perfetto_trace_processor_basic_types",
+               ":src_base_base",
+               ":src_trace_processor_containers_containers",
+               ":src_trace_processor_core_common_common",
+               ":src_trace_processor_core_dataframe_dataframe",
+               ":src_trace_processor_core_tree_tree",
+               ":src_trace_processor_perfetto_sql_engine_engine",
+               ":src_trace_processor_sqlite_sqlite",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/functions:functions
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_intrinsics_functions_functions",
     srcs = [
+        ":src_trace_processor_perfetto_sql_intrinsics_functions_tables",
         "src/trace_processor/perfetto_sql/intrinsics/functions/args.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/args.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/art_heap_graph_functions.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/art_heap_graph_functions.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/base64.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/counter_intervals.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/create_function.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/create_intervals.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/create_view_function.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/dominator_tree.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/graph_scan.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/graph_traversal.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/import.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/interval_intersect.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/layout_functions.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/math.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/metadata.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/package_lookup.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/perf_counter.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/pprof_functions.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/sqlite3_str_split.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/stack_functions.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/structural_tree_partition.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/to_ftrace.cc",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/perfetto_sql/intrinsics/functions/args.h",
+        "src/trace_processor/perfetto_sql/intrinsics/functions/art_heap_graph_functions.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/base64.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/clock_functions.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/counter_intervals.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/counter_intervals.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/create_function.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/create_function.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/create_intervals.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/create_intervals.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/create_view_function.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/create_view_function.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/dominator_tree.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/dominator_tree.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/graph_scan.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/graph_scan.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/graph_traversal.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/graph_traversal.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/import.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/import.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/interval_intersect.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/interval_intersect.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/layout_functions.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/layout_functions.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/math.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/math.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/metadata.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/metadata.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/package_lookup.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/package_lookup.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/perf_counter.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/perf_counter.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/pprof_functions.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/pprof_functions.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/replace_numbers_function.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/sqlite3_str_split.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/sqlite3_str_split.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/stack_functions.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/stack_functions.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/structural_tree_partition.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/structural_tree_partition.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/to_ftrace.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/to_ftrace.h",
-        "src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.cc",
         "src/trace_processor/perfetto_sql/intrinsics/functions/type_builders.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/utils.h",
         "src/trace_processor/perfetto_sql/intrinsics/functions/window_functions.h",
     ],
+    deps = [
+               ":include_perfetto_protozero_protozero",
+               ":protos_perfetto_common_zero",
+               ":protos_perfetto_trace_ftrace_zero",
+               ":protos_perfetto_trace_minimal_zero",
+               ":protos_perfetto_trace_non_minimal_zero",
+               ":protos_perfetto_trace_processor_zero",
+               ":src_base_base",
+               ":src_base_regex_regex",
+               ":src_trace_processor_containers_containers",
+               ":src_trace_processor_core_dataframe_dataframe",
+               ":src_trace_processor_export_json",
+               ":src_trace_processor_importers_common_common",
+               ":src_trace_processor_importers_ftrace_ftrace_descriptors",
+               ":src_trace_processor_metatrace",
+               ":src_trace_processor_perfetto_sql_engine_engine",
+               ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
+               ":src_trace_processor_perfetto_sql_intrinsics_types_types",
+               ":src_trace_processor_perfetto_sql_parser_parser",
+               ":src_trace_processor_sqlite_sqlite",
+               ":src_trace_processor_storage_storage",
+               ":src_trace_processor_tables_tables",
+               ":src_trace_processor_types_types",
+               ":src_trace_processor_util_args_utils",
+               ":src_trace_processor_util_glob",
+               ":src_trace_processor_util_json_serializer",
+               ":src_trace_processor_util_profile_builder",
+               ":src_trace_processor_util_simple_json_serializer",
+               ":src_trace_processor_util_sql_argument",
+               ":src_trace_processor_util_stdlib",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile +
+           PERFETTO_CONFIG.deps.demangle_wrapper,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/functions:tables
@@ -3574,60 +3791,108 @@ perfetto_cc_tp_tables(
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/operators:operators
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_intrinsics_operators_operators",
     srcs = [
         "src/trace_processor/perfetto_sql/intrinsics/operators/counter_mipmap_operator.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/operators/counter_mipmap_operator.h",
         "src/trace_processor/perfetto_sql/intrinsics/operators/slice_mipmap_operator.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/operators/slice_mipmap_operator.h",
         "src/trace_processor/perfetto_sql/intrinsics/operators/span_join_operator.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/operators/span_join_operator.h",
         "src/trace_processor/perfetto_sql/intrinsics/operators/window_operator.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/perfetto_sql/intrinsics/operators/counter_mipmap_operator.h",
+        "src/trace_processor/perfetto_sql/intrinsics/operators/slice_mipmap_operator.h",
+        "src/trace_processor/perfetto_sql/intrinsics/operators/span_join_operator.h",
         "src/trace_processor/perfetto_sql/intrinsics/operators/window_operator.h",
     ],
+    deps = [
+               ":include_perfetto_trace_processor_trace_processor",
+               ":protos_perfetto_trace_processor_zero",
+               ":src_base_base",
+               ":src_trace_processor_containers_containers",
+               ":src_trace_processor_metatrace",
+               ":src_trace_processor_perfetto_sql_engine_engine",
+               ":src_trace_processor_sqlite_sqlite",
+               ":src_trace_processor_util_galloping_search",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/table_functions:interface
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
     srcs = [
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/static_table_function.cc",
+    ],
+    hdrs = [
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/static_table_function.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":src_base_base",
+        ":src_trace_processor_core_dataframe_dataframe",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/table_functions:table_functions
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
     srcs = [
+        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/ancestor.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/ancestor.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/connected_flow.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/connected_flow.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/dataframe_query_plan_decoder.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/dataframe_query_plan_decoder.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/descendant.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/descendant.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/dfs_weight_bounded.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/dfs_weight_bounded.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_annotated_stack.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_annotated_stack.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flamegraph.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flamegraph.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flat_slice.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flat_slice.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_slice_layout.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_slice_layout.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/flamegraph_construction_algorithms.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/flamegraph_construction_algorithms.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/table_info.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/table_info.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_proto_to_args_with_defaults.cc",
-        "src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_proto_to_args_with_defaults.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_surfaceflinger_hierarchy_paths.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/ancestor.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/connected_flow.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/dataframe_query_plan_decoder.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/descendant.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/dfs_weight_bounded.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_annotated_stack.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flamegraph.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_flat_slice.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/experimental_slice_layout.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/flamegraph_construction_algorithms.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/table_info.h",
+        "src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_proto_to_args_with_defaults.h",
         "src/trace_processor/perfetto_sql/intrinsics/table_functions/winscope_surfaceflinger_hierarchy_paths.h",
     ],
+    deps = [
+               ":include_perfetto_trace_processor_basic_types",
+               ":protos_perfetto_trace_android_winscope_regular_zero",
+               ":protos_perfetto_trace_processor_metrics_impl_zero",
+               ":protozero",
+               ":src_base_base",
+               ":src_trace_processor_containers_containers",
+               ":src_trace_processor_core_dataframe_dataframe",
+               ":src_trace_processor_importers_proto_full",
+               ":src_trace_processor_importers_proto_minimal",
+               ":src_trace_processor_importers_proto_winscope_full",
+               ":src_trace_processor_perfetto_sql_engine_engine",
+               ":src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
+               ":src_trace_processor_sqlite_sqlite",
+               ":src_trace_processor_storage_storage",
+               ":src_trace_processor_tables_tables",
+               ":src_trace_processor_types_types",
+               ":src_trace_processor_util_descriptors",
+               ":src_trace_processor_util_proto_to_args_parser",
+               ":src_trace_processor_util_winscope_proto_mapping",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/table_functions:tables
@@ -3647,9 +3912,9 @@ perfetto_cc_tp_tables(
 )
 
 # GN target: //src/trace_processor/perfetto_sql/intrinsics/types:types
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_intrinsics_types_types",
-    srcs = [
+    hdrs = [
         "src/trace_processor/perfetto_sql/intrinsics/types/array.h",
         "src/trace_processor/perfetto_sql/intrinsics/types/counter.h",
         "src/trace_processor/perfetto_sql/intrinsics/types/node.h",
@@ -3659,38 +3924,68 @@ perfetto_filegroup(
         "src/trace_processor/perfetto_sql/intrinsics/types/struct.h",
         "src/trace_processor/perfetto_sql/intrinsics/types/value.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_basic_types",
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/parser:parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_parser_parser",
     srcs = [
         "src/trace_processor/perfetto_sql/parser/function_util.cc",
-        "src/trace_processor/perfetto_sql/parser/function_util.h",
         "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.cc",
-        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.h",
         "src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/perfetto_sql/parser/function_util.h",
+        "src/trace_processor/perfetto_sql/parser/intrinsic_macro_expansion.h",
         "src/trace_processor/perfetto_sql/parser/perfetto_sql_parser.h",
     ],
+    deps = [
+               ":src_base_base",
+               ":src_trace_processor_metatrace",
+               ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
+               ":src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
+               ":src_trace_processor_sqlite_sqlite",
+               ":src_trace_processor_util_sql_argument",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/preprocessor:grammar
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_preprocessor_grammar",
     srcs = [
         "src/trace_processor/perfetto_sql/preprocessor/preprocessor_grammar.c",
+    ],
+    hdrs = [
         "src/trace_processor/perfetto_sql/preprocessor/preprocessor_grammar.h",
         "src/trace_processor/perfetto_sql/preprocessor/preprocessor_grammar_interface.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/preprocessor:preprocessor
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_preprocessor_preprocessor",
     srcs = [
         "src/trace_processor/perfetto_sql/preprocessor/perfetto_sql_preprocessor.cc",
+    ],
+    hdrs = [
         "src/trace_processor/perfetto_sql/preprocessor/perfetto_sql_preprocessor.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_trace_processor_perfetto_sql_preprocessor_grammar",
+        ":src_trace_processor_perfetto_sql_tokenizer_tokenizer",
+        ":src_trace_processor_sqlite_sqlite",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/stdlib/android/auto:auto
@@ -4290,21 +4585,32 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/trace_processor/perfetto_sql/syntaqlite:syntaqlite
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
     srcs = [
         "src/trace_processor/perfetto_sql/syntaqlite/syntaqlite_perfetto.c",
+    ],
+    hdrs = [
         "src/trace_processor/perfetto_sql/syntaqlite/syntaqlite_perfetto.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/perfetto_sql/tokenizer:tokenizer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_perfetto_sql_tokenizer_tokenizer",
     srcs = [
         "src/trace_processor/perfetto_sql/tokenizer/sqlite_tokenizer.cc",
+    ],
+    hdrs = [
         "src/trace_processor/perfetto_sql/tokenizer/sqlite_tokenizer.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
+        ":src_trace_processor_sqlite_sqlite",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/plugins/wattson:gen_cpu_1d_curves
@@ -4416,102 +4722,200 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/trace_processor/plugins/wattson:wattson
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_plugins_wattson_wattson",
     srcs = [
         "src/trace_processor/plugins/wattson/plugin.cc",
         "src/trace_processor/plugins/wattson/table_function.cc",
+    ],
+    hdrs = [
         "src/trace_processor/plugins/wattson/table_function.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_core_plugin_plugin",
+        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
+        ":src_trace_processor_plugins_wattson_gen_cpu_1d_curves",
+        ":src_trace_processor_plugins_wattson_gen_cpu_2d_curves",
+        ":src_trace_processor_plugins_wattson_gen_gpu_curves",
+        ":src_trace_processor_plugins_wattson_gen_l3_curves",
+        ":src_trace_processor_plugins_wattson_gen_tpu_curves",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_gzip",
+    ],
+    linkstatic = True,
+    alwayslink = True,
 )
 
 # GN target: //src/trace_processor/rpc:httpd
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_rpc_httpd",
     srcs = [
         "src/trace_processor/rpc/httpd.cc",
+    ],
+    hdrs = [
         "src/trace_processor/rpc/httpd.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_trace_processor_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_base_http_http",
+        ":src_trace_processor_rpc_rpc",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/rpc:rpc
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_rpc_rpc",
     srcs = [
         "src/trace_processor/rpc/query_result_serializer.cc",
         "src/trace_processor/rpc/rpc.cc",
+    ],
+    hdrs = [
         "src/trace_processor/rpc/rpc.h",
     ],
+    deps = [
+        ":include_perfetto_ext_trace_processor_rpc_query_result_serializer",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_trace_processor_zero",
+        ":protos_perfetto_trace_summary_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_base_version",
+        ":src_protozero_proto_ring_buffer",
+        ":src_trace_processor_lib",
+        ":src_trace_processor_metatrace",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/rpc:stdiod
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_rpc_stdiod",
     srcs = [
         "src/trace_processor/rpc/stdiod.cc",
+    ],
+    hdrs = [
         "src/trace_processor/rpc/stdiod.h",
     ],
+    deps = [
+        ":src_base_base",
+        ":src_trace_processor_lib",
+        ":src_trace_processor_rpc_rpc",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/shell:shell
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_shell_shell",
     srcs = [
         "src/trace_processor/shell/common_flags.cc",
-        "src/trace_processor/shell/common_flags.h",
         "src/trace_processor/shell/convert_subcommand.cc",
-        "src/trace_processor/shell/convert_subcommand.h",
         "src/trace_processor/shell/export_subcommand.cc",
-        "src/trace_processor/shell/export_subcommand.h",
         "src/trace_processor/shell/interactive.cc",
-        "src/trace_processor/shell/interactive.h",
         "src/trace_processor/shell/interactive_subcommand.cc",
-        "src/trace_processor/shell/interactive_subcommand.h",
         "src/trace_processor/shell/metatrace.cc",
-        "src/trace_processor/shell/metatrace.h",
         "src/trace_processor/shell/metrics.cc",
-        "src/trace_processor/shell/metrics.h",
         "src/trace_processor/shell/metrics_subcommand.cc",
-        "src/trace_processor/shell/metrics_subcommand.h",
         "src/trace_processor/shell/query.cc",
-        "src/trace_processor/shell/query.h",
         "src/trace_processor/shell/query_subcommand.cc",
-        "src/trace_processor/shell/query_subcommand.h",
         "src/trace_processor/shell/server_subcommand.cc",
-        "src/trace_processor/shell/server_subcommand.h",
         "src/trace_processor/shell/shell_utils.cc",
-        "src/trace_processor/shell/shell_utils.h",
         "src/trace_processor/shell/sql_packages.cc",
-        "src/trace_processor/shell/sql_packages.h",
         "src/trace_processor/shell/summarize_subcommand.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/shell/common_flags.h",
+        "src/trace_processor/shell/convert_subcommand.h",
+        "src/trace_processor/shell/export_subcommand.h",
+        "src/trace_processor/shell/interactive.h",
+        "src/trace_processor/shell/interactive_subcommand.h",
+        "src/trace_processor/shell/metatrace.h",
+        "src/trace_processor/shell/metrics.h",
+        "src/trace_processor/shell/metrics_subcommand.h",
+        "src/trace_processor/shell/query.h",
+        "src/trace_processor/shell/query_subcommand.h",
+        "src/trace_processor/shell/server_subcommand.h",
+        "src/trace_processor/shell/shell_utils.h",
+        "src/trace_processor/shell/sql_packages.h",
         "src/trace_processor/shell/summarize_subcommand.h",
     ],
+    deps = [
+               ":include_perfetto_ext_trace_processor_trace_processor_shell",
+               ":include_perfetto_trace_processor_trace_processor",
+               ":protos_perfetto_trace_processor_zero",
+               ":src_base_base",
+               ":src_base_version",
+               ":src_protozero_text_to_proto_text_to_proto",
+               ":src_trace_processor_metrics_metrics",
+               ":src_trace_processor_rpc_httpd",
+               ":src_trace_processor_rpc_rpc",
+               ":src_trace_processor_rpc_stdiod",
+               ":src_trace_processor_shell_subcommands",
+               ":src_trace_processor_trace_summary_gen_cc_trace_summary_descriptor",
+               ":src_trace_processor_trace_summary_trace_summary",
+               ":src_trace_processor_util_deobfuscation_deobfuscator",
+               ":src_trace_processor_util_stdlib",
+               ":src_trace_processor_util_symbolizer_symbolize_database",
+               ":src_trace_processor_util_symbolizer_symbolizer",
+               ":src_traceconv_traceconv_lib",
+           ] + PERFETTO_CONFIG.deps.linenoise +
+           PERFETTO_CONFIG.deps.protobuf_full,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/shell:subcommands
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_shell_subcommands",
     srcs = [
         "src/trace_processor/shell/subcommand.cc",
+    ],
+    hdrs = [
         "src/trace_processor/shell/subcommand.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/sorter:sorter
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_sorter_sorter",
     srcs = [
         "src/trace_processor/sorter/trace_sorter.cc",
-        "src/trace_processor/sorter/trace_sorter.h",
         "src/trace_processor/sorter/trace_token_buffer.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/sorter/trace_sorter.h",
         "src/trace_processor/sorter/trace_token_buffer.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_storage",
+        ":src_base_base",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
+        ":src_trace_processor_importers_systrace_systrace_line",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_bump_allocator",
+        ":src_trace_processor_util_trace_type",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/sqlite/bindings:bindings
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_sqlite_bindings_bindings",
-    srcs = [
+    hdrs = [
         "src/trace_processor/sqlite/bindings/sqlite_aggregate_function.h",
         "src/trace_processor/sqlite/bindings/sqlite_bind.h",
         "src/trace_processor/sqlite/bindings/sqlite_column.h",
@@ -4523,45 +4927,88 @@ perfetto_filegroup(
         "src/trace_processor/sqlite/bindings/sqlite_value.h",
         "src/trace_processor/sqlite/bindings/sqlite_window_function.h",
     ],
+    deps = [
+               ":src_base_base",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/sqlite:sqlite
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_sqlite_sqlite",
     srcs = [
         "src/trace_processor/sqlite/module_state_manager.cc",
+        "src/trace_processor/sqlite/sql_source.cc",
+        "src/trace_processor/sqlite/sql_stats_table.cc",
+        "src/trace_processor/sqlite/sqlite_engine.cc",
+        "src/trace_processor/sqlite/sqlite_utils.cc",
+        "src/trace_processor/sqlite/stats_table.cc",
+    ],
+    hdrs = [
         "src/trace_processor/sqlite/module_state_manager.h",
         "src/trace_processor/sqlite/scoped_db.h",
-        "src/trace_processor/sqlite/sql_source.cc",
         "src/trace_processor/sqlite/sql_source.h",
-        "src/trace_processor/sqlite/sql_stats_table.cc",
         "src/trace_processor/sqlite/sql_stats_table.h",
-        "src/trace_processor/sqlite/sqlite_engine.cc",
         "src/trace_processor/sqlite/sqlite_engine.h",
-        "src/trace_processor/sqlite/sqlite_utils.cc",
         "src/trace_processor/sqlite/sqlite_utils.h",
-        "src/trace_processor/sqlite/stats_table.cc",
         "src/trace_processor/sqlite/stats_table.h",
     ],
+    deps = [
+               ":include_perfetto_trace_processor_basic_types",
+               ":include_perfetto_trace_processor_trace_processor",
+               ":protos_perfetto_trace_ftrace_zero",
+               ":protos_perfetto_trace_processor_zero",
+               ":src_base_base",
+               ":src_trace_processor_containers_containers",
+               ":src_trace_processor_importers_common_common",
+               ":src_trace_processor_importers_ftrace_ftrace_descriptors",
+               ":src_trace_processor_metatrace",
+               ":src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
+               ":src_trace_processor_sqlite_bindings_bindings",
+               ":src_trace_processor_storage_storage",
+               ":src_trace_processor_types_types",
+               ":src_trace_processor_util_profile_builder",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/storage:storage
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_storage_storage",
     srcs = [
+        "src/trace_processor/storage/trace_storage.cc",
+    ],
+    hdrs = [
         "src/trace_processor/storage/metadata.h",
         "src/trace_processor/storage/stats.h",
-        "src/trace_processor/storage/trace_storage.cc",
         "src/trace_processor/storage/trace_storage.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/tables:tables
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_tables_tables",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
+    ],
+    hdrs = [
         "src/trace_processor/tables/macros_internal.h",
     ],
+    deps = [
+        ":src_trace_processor_core_dataframe_dataframe",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/tables:tables_python
@@ -4639,26 +5086,45 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/trace_processor/trace_summary:trace_summary
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_trace_summary_trace_summary",
     srcs = [
         "src/trace_processor/trace_summary/summarizer.cc",
-        "src/trace_processor/trace_summary/summarizer.h",
         "src/trace_processor/trace_summary/summary.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/trace_summary/summarizer.h",
         "src/trace_processor/trace_summary/summary.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_basic_types",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_perfetto_sql_zero",
+        ":protos_perfetto_trace_summary_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_protozero_text_to_proto_text_to_proto",
+        ":src_trace_processor_perfetto_sql_generator_generator",
+        ":src_trace_processor_trace_summary_gen_cc_trace_summary_descriptor",
+        ":src_trace_processor_util_descriptors",
+        ":src_trace_processor_util_protozero_to_text",
+    ] + PERFETTO_CONFIG.deps.zlib,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/types:types
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_types_types",
     srcs = [
+        ":src_trace_processor_tables_tables_python",
         "src/trace_processor/types/destructible.cc",
-        "src/trace_processor/types/destructible.h",
         "src/trace_processor/types/gfp_flags.cc",
+        "src/trace_processor/types/task_state.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/types/destructible.h",
         "src/trace_processor/types/gfp_flags.h",
         "src/trace_processor/types/softirq_action.h",
-        "src/trace_processor/types/task_state.cc",
         "src/trace_processor/types/task_state.h",
         "src/trace_processor/types/tcp_state.h",
         "src/trace_processor/types/trace_processor_context.h",
@@ -4666,6 +5132,13 @@ perfetto_filegroup(
         "src/trace_processor/types/variadic.h",
         "src/trace_processor/types/version_number.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_util_trace_type",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util/deobfuscation:deobfuscator
@@ -4675,66 +5148,33 @@ perfetto_cc_library(
         "src/trace_processor/util/deobfuscation/deobfuscator.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
         "src/trace_processor/util/deobfuscation/deobfuscator.h",
     ],
     deps = [
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
-        ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
+        ":include_perfetto_ext_base_base",
         ":protos_perfetto_trace_minimal_zero",
         ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
         ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
         ":protozero",
     ],
     linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util/elf:elf
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_elf_elf",
     srcs = [
         "src/trace_processor/util/elf/binary_info.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/elf/binary_info.h",
         "src/trace_processor/util/elf/elf.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util/symbolizer:symbolize_database
@@ -4744,59 +5184,15 @@ perfetto_cc_library(
         "src/trace_processor/util/symbolizer/symbolize_database.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_trace_processor_basic_types",
-        ":include_perfetto_trace_processor_storage",
-        ":include_perfetto_trace_processor_trace_processor",
-        ":include_perfetto_trace_processor_util",
         "src/trace_processor/util/symbolizer/symbolize_database.h",
     ],
     deps = [
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
-        ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_protozero_protozero",
+        ":include_perfetto_trace_processor_trace_processor",
         ":protos_perfetto_trace_minimal_zero",
         ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
         ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
         ":src_trace_processor_util_build_id",
         ":src_trace_processor_util_symbolizer_symbolizer",
     ],
@@ -4817,10 +5213,6 @@ perfetto_cc_library(
         "src/trace_processor/util/symbolizer/symbolizer.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
         "src/trace_processor/util/symbolizer/breakpad_parser.h",
         "src/trace_processor/util/symbolizer/breakpad_symbolizer.h",
         "src/trace_processor/util/symbolizer/elf.h",
@@ -4829,33 +5221,64 @@ perfetto_cc_library(
         "src/trace_processor/util/symbolizer/subprocess.h",
         "src/trace_processor/util/symbolizer/symbolizer.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+    ],
     linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util/trace_enrichment:trace_enrichment
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_trace_enrichment_trace_enrichment",
     srcs = [
         "src/trace_processor/util/trace_enrichment/trace_enrichment.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/trace_enrichment/trace_enrichment.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":src_trace_processor_util_deobfuscation_deobfuscator",
+        ":src_trace_processor_util_symbolizer_symbolize_database",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:args_utils
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_args_utils",
     srcs = [
         "src/trace_processor/util/args_utils.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/args_utils.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:blob
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_blob",
     srcs = [
         "src/trace_processor/util/trace_blob.cc",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_basic_types",
+        ":include_perfetto_trace_processor_util",
+        ":protos_perfetto_common_zero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:build_id
@@ -4865,253 +5288,465 @@ perfetto_cc_library(
         "src/trace_processor/util/build_id.cc",
     ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
         "src/trace_processor/util/build_id.h",
+    ],
+    deps = [
+        ":include_perfetto_ext_base_base",
     ],
     linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:bump_allocator
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_bump_allocator",
     srcs = [
         "src/trace_processor/util/bump_allocator.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/bump_allocator.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:clock
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_clock",
     srcs = [
         "src/trace_processor/util/clock_synchronizer.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/clock_synchronizer.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":protos_perfetto_common_zero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:descriptors
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_descriptors",
     srcs = [
         "src/trace_processor/util/descriptors.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/descriptors.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_processor_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:galloping_search
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_galloping_search",
-    srcs = [
+    hdrs = [
         "src/trace_processor/util/galloping_search.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:glob
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_glob",
     srcs = [
         "src/trace_processor/util/glob.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/glob.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:gzip
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_gzip",
     srcs = [
         "src/trace_processor/util/gzip_utils.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/gzip_utils.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+    ] + PERFETTO_CONFIG.deps.zlib,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:interned_message_view
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_interned_message_view",
-    srcs = [
+    hdrs = [
         "src/trace_processor/util/interned_message_view.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_trace_processor",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:json_args
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_json_args",
     srcs = [
         "src/trace_processor/util/json_args.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/json_args.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_simple_json_parser",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:json_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_json_parser",
-    srcs = [
+    hdrs = [
         "src/trace_processor/util/json_parser.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:json_serializer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_json_serializer",
-    srcs = [
+    hdrs = [
         "src/trace_processor/util/json_serializer.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:json_value
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_json_value",
     srcs = [
         "src/trace_processor/util/json_value.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/json_value.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_util_json_parser",
+        ":src_trace_processor_util_json_serializer",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:profile_builder
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_profile_builder",
     srcs = [
         "src/trace_processor/util/annotated_callsites.cc",
-        "src/trace_processor/util/annotated_callsites.h",
         "src/trace_processor/util/profile_builder.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/util/annotated_callsites.h",
         "src/trace_processor/util/profile_builder.h",
     ],
+    deps = [
+        ":include_perfetto_ext_trace_processor_demangle",
+        ":include_perfetto_protozero_protozero",
+        ":protos_perfetto_trace_processor_zero",
+        ":protos_third_party_pprof_zero",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:profiler_util
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_profiler_util",
     srcs = [
         "src/trace_processor/util/profiler_util.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/profiler_util.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":protos_perfetto_trace_profiling_zero",
+        ":src_trace_processor_storage_storage",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:proto_profiler
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_proto_profiler",
     srcs = [
         "src/trace_processor/util/proto_profiler.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/proto_profiler.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_third_party_pprof_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_util_descriptors",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:proto_to_args_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_proto_to_args_parser",
     srcs = [
         "src/trace_processor/util/proto_to_args_parser.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/proto_to_args_parser.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_processor_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protos_perfetto_trace_track_event_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
+        ":src_trace_processor_util_descriptors",
+        ":src_trace_processor_util_interned_message_view",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:protozero_to_json
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_protozero_to_json",
     srcs = [
         "src/trace_processor/util/protozero_to_json.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/protozero_to_json.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_track_event_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
+        ":src_trace_processor_util_descriptors",
+        ":src_trace_processor_util_json_serializer",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:protozero_to_text
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_protozero_to_text",
     srcs = [
         "src/trace_processor/util/protozero_to_text.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/protozero_to_text.h",
     ],
+    deps = [
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_trace_track_event_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_util_descriptors",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:simple_json_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_simple_json_parser",
     srcs = [
         "src/trace_processor/util/simple_json_parser.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/simple_json_parser.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_util_json_parser",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:simple_json_serializer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_simple_json_serializer",
     srcs = [
         "src/trace_processor/util/simple_json_serializer.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/simple_json_serializer.h",
     ],
+    deps = [
+        ":src_trace_processor_util_json_serializer",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:sql_argument
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_sql_argument",
     srcs = [
         "src/trace_processor/util/sql_argument.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/sql_argument.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":src_trace_processor_containers_containers",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:sql_bundle
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_sql_bundle",
-    srcs = [
+    hdrs = [
         "src/trace_processor/util/sql_bundle.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:stdlib
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_stdlib",
-    srcs = [
+    hdrs = [
         "src/trace_processor/util/sql_modules.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:tar_writer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_tar_writer",
     srcs = [
         "src/trace_processor/util/tar_writer.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/tar_writer.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:trace_blob_view_reader
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_trace_blob_view_reader",
     srcs = [
         "src/trace_processor/util/trace_blob_view_reader.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/trace_blob_view_reader.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_storage",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:trace_type
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_trace_type",
     srcs = [
         "src/trace_processor/util/trace_type.cc",
+    ],
+    hdrs = [
         "src/trace_processor/util/trace_type.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_third_party_pprof_zero",
+        ":protozero",
+        ":src_trace_processor_importers_android_bugreport_android_dumpstate_event",
+        ":src_trace_processor_importers_android_bugreport_android_log_event",
+        ":src_trace_processor_importers_perf_text_perf_text_sample_line_parser",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:winscope_proto_mapping
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_winscope_proto_mapping",
-    srcs = [
+    hdrs = [
         "src/trace_processor/util/winscope_proto_mapping.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_core_dataframe_dataframe",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor/util:zip_reader
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_util_zip_reader",
     srcs = [
         "src/trace_processor/util/streaming_line_reader.cc",
-        "src/trace_processor/util/streaming_line_reader.h",
         "src/trace_processor/util/zip_reader.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/util/streaming_line_reader.h",
         "src/trace_processor/util/zip_reader.h",
     ],
+    deps = [
+        ":include_perfetto_trace_processor_storage",
+        ":src_base_base",
+        ":src_trace_processor_util_gzip",
+        ":src_trace_processor_util_trace_blob_view_reader",
+    ] + PERFETTO_CONFIG.deps.zlib,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor:demangle
@@ -5120,65 +5755,176 @@ perfetto_cc_library(
     srcs = [
         "src/trace_processor/demangle.cc",
     ],
-    hdrs = [
+    deps = [
         ":include_perfetto_base_base",
         ":include_perfetto_ext_base_base",
         ":include_perfetto_ext_trace_processor_demangle",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-    ],
-    deps = [
     ] + PERFETTO_CONFIG.deps.llvm_demangle,
     linkstatic = True,
 )
 
 # GN target: //src/trace_processor:export_json
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_export_json",
     srcs = [
         "src/trace_processor/export_json.cc",
+    ],
+    hdrs = [
         "src/trace_processor/export_json.h",
     ],
+    deps = [
+        ":include_perfetto_ext_trace_processor_export_json",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_storage_minimal",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_args_utils",
+        ":src_trace_processor_util_json_value",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor:lib
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_lib",
     srcs = [
         "src/trace_processor/iterator_impl.cc",
-        "src/trace_processor/iterator_impl.h",
         "src/trace_processor/read_trace.cc",
         "src/trace_processor/read_trace_internal.cc",
-        "src/trace_processor/read_trace_internal.h",
         "src/trace_processor/trace_processor.cc",
         "src/trace_processor/trace_processor_impl.cc",
+    ],
+    hdrs = [
+        "src/trace_processor/iterator_impl.h",
+        "src/trace_processor/read_trace_internal.h",
         "src/trace_processor/trace_processor_impl.h",
     ],
+    deps = [
+               ":include_perfetto_trace_processor_trace_processor",
+               ":protos_perfetto_common_zero",
+               ":protos_perfetto_trace_minimal_zero",
+               ":protos_perfetto_trace_non_minimal_zero",
+               ":protos_perfetto_trace_perfetto_zero",
+               ":protos_perfetto_trace_processor_zero",
+               ":protos_perfetto_trace_summary_zero",
+               ":protozero",
+               ":src_base_base",
+               ":src_base_clock_snapshots",
+               ":src_trace_processor_core_dataframe_dataframe",
+               ":src_trace_processor_core_plugin_plugin",
+               ":src_trace_processor_importers_android_bugreport_android_bugreport",
+               ":src_trace_processor_importers_archive_archive",
+               ":src_trace_processor_importers_art_hprof_art_hprof",
+               ":src_trace_processor_importers_art_method_art_method",
+               ":src_trace_processor_importers_collapsed_stack_collapsed_stack",
+               ":src_trace_processor_importers_common_common",
+               ":src_trace_processor_importers_etw_full",
+               ":src_trace_processor_importers_ftrace_full",
+               ":src_trace_processor_importers_fuchsia_full",
+               ":src_trace_processor_importers_gecko_gecko",
+               ":src_trace_processor_importers_json_json",
+               ":src_trace_processor_importers_ninja_ninja",
+               ":src_trace_processor_importers_perf_perf",
+               ":src_trace_processor_importers_perf_text_perf_text",
+               ":src_trace_processor_importers_pprof_pprof",
+               ":src_trace_processor_importers_primes_primes",
+               ":src_trace_processor_importers_proto_full",
+               ":src_trace_processor_importers_proto_minimal",
+               ":src_trace_processor_importers_simpleperf_proto_simpleperf_proto",
+               ":src_trace_processor_importers_systrace_full",
+               ":src_trace_processor_metatrace",
+               ":src_trace_processor_metrics_metrics",
+               ":src_trace_processor_perfetto_sql_engine_engine",
+               ":src_trace_processor_perfetto_sql_generator_generator",
+               ":src_trace_processor_perfetto_sql_intrinsics_functions_functions",
+               ":src_trace_processor_perfetto_sql_intrinsics_functions_trees_trees",
+               ":src_trace_processor_perfetto_sql_intrinsics_operators_operators",
+               ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
+               ":src_trace_processor_perfetto_sql_stdlib_stdlib",
+               ":src_trace_processor_plugins_wattson_wattson",
+               ":src_trace_processor_sqlite_sqlite",
+               ":src_trace_processor_storage_minimal",
+               ":src_trace_processor_storage_storage",
+               ":src_trace_processor_tables_tables",
+               ":src_trace_processor_trace_summary_gen_cc_trace_summary_descriptor",
+               ":src_trace_processor_trace_summary_trace_summary",
+               ":src_trace_processor_types_types",
+               ":src_trace_processor_util_clock",
+               ":src_trace_processor_util_gzip",
+               ":src_trace_processor_util_json_parser",
+               ":src_trace_processor_util_protozero_to_json",
+               ":src_trace_processor_util_protozero_to_text",
+               ":src_trace_processor_util_simple_json_parser",
+               ":src_trace_processor_util_sql_bundle",
+               ":src_trace_processor_util_stdlib",
+               ":src_trace_processor_util_trace_type",
+           ] + PERFETTO_CONFIG.deps.sqlite +
+           PERFETTO_CONFIG.deps.sqlite_ext_percentile,
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor:metatrace
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_metatrace",
     srcs = [
         "src/trace_processor/tp_metatrace.cc",
+    ],
+    hdrs = [
         "src/trace_processor/tp_metatrace.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_trace_processor_zero",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/trace_processor:storage_minimal
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_trace_processor_storage_minimal",
     srcs = [
         "src/trace_processor/forwarding_trace_parser.cc",
-        "src/trace_processor/forwarding_trace_parser.h",
         "src/trace_processor/trace_processor_context.cc",
         "src/trace_processor/trace_processor_storage.cc",
         "src/trace_processor/trace_processor_storage_impl.cc",
-        "src/trace_processor/trace_processor_storage_impl.h",
         "src/trace_processor/trace_reader_registry.cc",
-        "src/trace_processor/trace_reader_registry.h",
         "src/trace_processor/virtual_destructors.cc",
     ],
+    hdrs = [
+        "src/trace_processor/forwarding_trace_parser.h",
+        "src/trace_processor/trace_processor_storage_impl.h",
+        "src/trace_processor/trace_reader_registry.h",
+    ],
+    deps = [
+        ":include_perfetto_trace_processor_storage",
+        ":protos_perfetto_common_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_importers_common_common",
+        ":src_trace_processor_importers_common_parser_types",
+        ":src_trace_processor_importers_etw_minimal",
+        ":src_trace_processor_importers_ftrace_minimal",
+        ":src_trace_processor_importers_fuchsia_fuchsia_record",
+        ":src_trace_processor_importers_memory_tracker_graph_processor",
+        ":src_trace_processor_importers_proto_minimal",
+        ":src_trace_processor_importers_systrace_systrace_line",
+        ":src_trace_processor_sorter_sorter",
+        ":src_trace_processor_storage_storage",
+        ":src_trace_processor_tables_tables",
+        ":src_trace_processor_types_types",
+        ":src_trace_processor_util_blob",
+        ":src_trace_processor_util_clock",
+        ":src_trace_processor_util_descriptors",
+        ":src_trace_processor_util_gzip",
+        ":src_trace_processor_util_proto_to_args_parser",
+        ":src_trace_processor_util_trace_type",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traceconv:gen_cc_trace_descriptor
@@ -5220,463 +5966,990 @@ perfetto_cpp_blob_header(
 )
 
 # GN target: //src/traceconv:lib
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traceconv_lib",
     srcs = [
         "src/traceconv/deobfuscate_profile.cc",
-        "src/traceconv/deobfuscate_profile.h",
         "src/traceconv/symbolize_profile.cc",
-        "src/traceconv/symbolize_profile.h",
         "src/traceconv/trace_to_bundle.cc",
-        "src/traceconv/trace_to_bundle.h",
         "src/traceconv/trace_to_firefox.cc",
-        "src/traceconv/trace_to_firefox.h",
         "src/traceconv/trace_to_json.cc",
-        "src/traceconv/trace_to_json.h",
         "src/traceconv/trace_to_profile.cc",
-        "src/traceconv/trace_to_profile.h",
         "src/traceconv/trace_to_systrace.cc",
-        "src/traceconv/trace_to_systrace.h",
         "src/traceconv/trace_to_text.cc",
-        "src/traceconv/trace_to_text.h",
         "src/traceconv/trace_unpack.cc",
+    ],
+    hdrs = [
+        "src/traceconv/deobfuscate_profile.h",
+        "src/traceconv/symbolize_profile.h",
+        "src/traceconv/trace_to_bundle.h",
+        "src/traceconv/trace_to_firefox.h",
+        "src/traceconv/trace_to_json.h",
+        "src/traceconv/trace_to_profile.h",
+        "src/traceconv/trace_to_systrace.h",
+        "src/traceconv/trace_to_text.h",
         "src/traceconv/trace_unpack.h",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_ext_traced_sys_stats_counters",
+        ":include_perfetto_protozero_protozero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_protozero_proto_ring_buffer",
+        ":src_trace_processor_lib",
+        ":src_trace_processor_storage_minimal",
+        ":src_trace_processor_util_deobfuscation_deobfuscator",
+        ":src_trace_processor_util_descriptors",
+        ":src_trace_processor_util_gzip",
+        ":src_trace_processor_util_protozero_to_text",
+        ":src_trace_processor_util_symbolizer_symbolize_database",
+        ":src_trace_processor_util_symbolizer_symbolizer",
+        ":src_trace_processor_util_tar_writer",
+        ":src_trace_processor_util_trace_enrichment_trace_enrichment",
+        ":src_trace_processor_util_trace_type",
+        ":src_traceconv_gen_cc_trace_descriptor",
+        ":src_traceconv_gen_cc_winscope_descriptor",
+        ":src_traceconv_pprofbuilder",
+        ":src_traceconv_utils",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traceconv:main
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traceconv_main",
     srcs = [
         "src/traceconv/main.cc",
     ],
+    deps = [
+        ":src_traceconv_traceconv_lib",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traceconv:pprofbuilder
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traceconv_pprofbuilder",
     srcs = [
         "src/traceconv/pprof_builder.cc",
     ],
+    deps = [
+        ":include_perfetto_base_base",
+        ":include_perfetto_profiling_pprof_builder",
+        ":include_perfetto_protozero_protozero",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protos_third_party_pprof_zero",
+        ":src_trace_processor_containers_containers",
+        ":src_trace_processor_util_symbolizer_symbolize_database",
+        ":src_trace_processor_util_symbolizer_symbolizer",
+        ":src_traceconv_utils",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traceconv:traceconv_lib
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traceconv_traceconv_lib",
     srcs = [
         "src/traceconv/traceconv.cc",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_ext_traceconv_traceconv",
+        ":src_base_version",
+        ":src_protozero_text_to_proto_text_to_proto",
+        ":src_traceconv_gen_cc_trace_descriptor",
+        ":src_traceconv_lib",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traceconv:utils
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traceconv_utils",
     srcs = [
         "src/traceconv/utils.cc",
+    ],
+    hdrs = [
         "src/traceconv/utils.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_protozero_protozero",
+        ":include_perfetto_trace_processor_trace_processor",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":src_trace_processor_util_deobfuscation_deobfuscator",
+        ":src_trace_processor_util_symbolizer_symbolize_database",
+        ":src_trace_processor_util_symbolizer_symbolizer",
+    ] + PERFETTO_CONFIG.deps.zlib,
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/android_aflags:android_aflags
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_android_aflags_android_aflags",
     srcs = [
         "src/traced/probes/android_aflags/android_aflags_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/android_aflags/android_aflags_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/android_cpu_per_uid:android_cpu_per_uid
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_android_cpu_per_uid_android_cpu_per_uid",
     srcs = [
         "src/traced/probes/android_cpu_per_uid/android_cpu_per_uid_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/android_cpu_per_uid/android_cpu_per_uid_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_android_internal_lazy_library_loader",
+        ":src_base_base",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/android_game_intervention_list:android_game_intervention_list
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_android_game_intervention_list_android_game_intervention_list",
     srcs = [
         "src/traced/probes/android_game_intervention_list/android_game_intervention_list_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/android_game_intervention_list/android_game_intervention_list_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/android_kernel_wakelocks:android_kernel_wakelocks
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_android_kernel_wakelocks_android_kernel_wakelocks",
     srcs = [
         "src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/android_kernel_wakelocks/android_kernel_wakelocks_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_android_internal_lazy_library_loader",
+        ":src_base_base",
+        ":src_kernel_utils_kernel_wakelock_errors",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/android_log:android_log
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_android_log_android_log",
     srcs = [
         "src/traced/probes/android_log/android_log_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/android_log/android_log_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/android_system_property:android_system_property
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_android_system_property_android_system_property",
     srcs = [
         "src/traced/probes/android_system_property/android_system_property_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/android_system_property/android_system_property_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/common:common
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_common_common",
     srcs = [
         "src/traced/probes/common/android_cpu_per_uid_poller.cc",
-        "src/traced/probes/common/android_cpu_per_uid_poller.h",
         "src/traced/probes/common/cpu_freq_info.cc",
+    ],
+    hdrs = [
+        "src/traced/probes/common/android_cpu_per_uid_poller.h",
         "src/traced/probes/common/cpu_freq_info.h",
     ],
+    deps = [
+        ":src_android_internal_lazy_library_loader",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/filesystem:filesystem
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_filesystem_filesystem",
     srcs = [
         "src/traced/probes/filesystem/file_scanner.cc",
-        "src/traced/probes/filesystem/file_scanner.h",
         "src/traced/probes/filesystem/fs_mount.cc",
-        "src/traced/probes/filesystem/fs_mount.h",
         "src/traced/probes/filesystem/inode_file_data_source.cc",
-        "src/traced/probes/filesystem/inode_file_data_source.h",
         "src/traced/probes/filesystem/lru_inode_cache.cc",
-        "src/traced/probes/filesystem/lru_inode_cache.h",
         "src/traced/probes/filesystem/prefix_finder.cc",
-        "src/traced/probes/filesystem/prefix_finder.h",
         "src/traced/probes/filesystem/range_tree.cc",
+    ],
+    hdrs = [
+        "src/traced/probes/filesystem/file_scanner.h",
+        "src/traced/probes/filesystem/fs_mount.h",
+        "src/traced/probes/filesystem/inode_file_data_source.h",
+        "src/traced/probes/filesystem/lru_inode_cache.h",
+        "src/traced/probes/filesystem/prefix_finder.h",
         "src/traced/probes/filesystem/range_tree.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_config_inode_file_zero",
+        ":protos_perfetto_trace_filesystem_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/ftrace/format_parser:format_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_ftrace_format_parser_format_parser",
     srcs = [
         "src/traced/probes/ftrace/format_parser/format_parser.cc",
+    ],
+    hdrs = [
         "src/traced/probes/ftrace/format_parser/format_parser.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/ftrace:ftrace
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_ftrace_ftrace",
     srcs = [
         "src/traced/probes/ftrace/atrace_hal_wrapper.cc",
-        "src/traced/probes/ftrace/atrace_hal_wrapper.h",
         "src/traced/probes/ftrace/atrace_wrapper.cc",
-        "src/traced/probes/ftrace/atrace_wrapper.h",
         "src/traced/probes/ftrace/compact_sched.cc",
-        "src/traced/probes/ftrace/compact_sched.h",
         "src/traced/probes/ftrace/cpu_reader.cc",
-        "src/traced/probes/ftrace/cpu_reader.h",
         "src/traced/probes/ftrace/cpu_stats_parser.cc",
-        "src/traced/probes/ftrace/cpu_stats_parser.h",
         "src/traced/probes/ftrace/event_info.cc",
-        "src/traced/probes/ftrace/event_info.h",
         "src/traced/probes/ftrace/event_info_constants.cc",
-        "src/traced/probes/ftrace/event_info_constants.h",
         "src/traced/probes/ftrace/frozen_ftrace_data_source.cc",
-        "src/traced/probes/ftrace/frozen_ftrace_data_source.h",
         "src/traced/probes/ftrace/ftrace_config_muxer.cc",
-        "src/traced/probes/ftrace/ftrace_config_muxer.h",
         "src/traced/probes/ftrace/ftrace_config_utils.cc",
-        "src/traced/probes/ftrace/ftrace_config_utils.h",
         "src/traced/probes/ftrace/ftrace_controller.cc",
-        "src/traced/probes/ftrace/ftrace_controller.h",
         "src/traced/probes/ftrace/ftrace_data_source.cc",
+        "src/traced/probes/ftrace/ftrace_print_filter.cc",
+        "src/traced/probes/ftrace/ftrace_stats.cc",
+        "src/traced/probes/ftrace/predefined_tracepoints.cc",
+        "src/traced/probes/ftrace/printk_formats_parser.cc",
+        "src/traced/probes/ftrace/proto_translation_table.cc",
+        "src/traced/probes/ftrace/vendor_tracepoints.cc",
+    ],
+    hdrs = [
+        "src/traced/probes/ftrace/atrace_hal_wrapper.h",
+        "src/traced/probes/ftrace/atrace_wrapper.h",
+        "src/traced/probes/ftrace/compact_sched.h",
+        "src/traced/probes/ftrace/cpu_reader.h",
+        "src/traced/probes/ftrace/cpu_stats_parser.h",
+        "src/traced/probes/ftrace/event_info.h",
+        "src/traced/probes/ftrace/event_info_constants.h",
+        "src/traced/probes/ftrace/frozen_ftrace_data_source.h",
+        "src/traced/probes/ftrace/ftrace_config_muxer.h",
+        "src/traced/probes/ftrace/ftrace_config_utils.h",
+        "src/traced/probes/ftrace/ftrace_controller.h",
         "src/traced/probes/ftrace/ftrace_data_source.h",
         "src/traced/probes/ftrace/ftrace_metadata.h",
-        "src/traced/probes/ftrace/ftrace_print_filter.cc",
         "src/traced/probes/ftrace/ftrace_print_filter.h",
-        "src/traced/probes/ftrace/ftrace_stats.cc",
         "src/traced/probes/ftrace/ftrace_stats.h",
-        "src/traced/probes/ftrace/predefined_tracepoints.cc",
         "src/traced/probes/ftrace/predefined_tracepoints.h",
-        "src/traced/probes/ftrace/printk_formats_parser.cc",
         "src/traced/probes/ftrace/printk_formats_parser.h",
-        "src/traced/probes/ftrace/proto_translation_table.cc",
         "src/traced/probes/ftrace/proto_translation_table.h",
-        "src/traced/probes/ftrace/vendor_tracepoints.cc",
         "src/traced/probes/ftrace/vendor_tracepoints.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_ftrace_cpp",
+        ":protos_perfetto_trace_ftrace_zero",
+        ":protos_perfetto_trace_interned_data_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_profiling_zero",
+        ":protozero",
+        ":src_android_internal_lazy_library_loader",
+        ":src_base_base",
+        ":src_kallsyms_kallsyms",
+        ":src_kernel_utils_syscall_table",
+        ":src_traced_probes_data_source",
+        ":src_traced_probes_ftrace_format_parser_format_parser",
+        ":src_traced_probes_ftrace_tracefs",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/ftrace:tracefs
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_ftrace_tracefs",
     srcs = [
         "src/traced/probes/ftrace/tracefs.cc",
+    ],
+    hdrs = [
         "src/traced/probes/ftrace/tracefs.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/initial_display_state:initial_display_state
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_initial_display_state_initial_display_state",
     srcs = [
         "src/traced/probes/initial_display_state/initial_display_state_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/initial_display_state/initial_display_state_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/metatrace:metatrace
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_metatrace_metatrace",
     srcs = [
         "src/traced/probes/metatrace/metatrace_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/metatrace/metatrace_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_perfetto_zero",
+        ":src_base_base",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+        ":src_tracing_service_service",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/packages_list:packages_list
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_packages_list_packages_list",
     srcs = [
         "src/traced/probes/packages_list/packages_list_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/packages_list/packages_list_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_base_regex_regex",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_traced_probes_packages_list_packages_list_parser",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/packages_list:packages_list_parser
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_packages_list_packages_list_parser",
     srcs = [
         "src/traced/probes/packages_list/packages_list_parser.cc",
+    ],
+    hdrs = [
         "src/traced/probes/packages_list/packages_list_parser.h",
     ],
+    deps = [
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/power:power
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_power_power",
     srcs = [
         "src/traced/probes/power/android_power_data_source.cc",
-        "src/traced/probes/power/android_power_data_source.h",
         "src/traced/probes/power/linux_power_sysfs_data_source.cc",
+    ],
+    hdrs = [
+        "src/traced/probes/power/android_power_data_source.h",
         "src/traced/probes/power/linux_power_sysfs_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_power_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_power_zero",
+        ":src_android_internal_lazy_library_loader",
+        ":src_base_base",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/ps:ps
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_ps_ps",
     srcs = [
         "src/traced/probes/ps/process_stats_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/ps/process_stats_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_config_process_stats_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_ps_zero",
+        ":src_base_base",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/statsd_client:statsd_client
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_statsd_client_statsd_client",
     srcs = [
         "src/traced/probes/statsd_client/common.cc",
-        "src/traced/probes/statsd_client/common.h",
         "src/traced/probes/statsd_client/statsd_binder_data_source.cc",
+    ],
+    hdrs = [
+        "src/traced/probes/statsd_client/common.h",
         "src/traced/probes/statsd_client/statsd_binder_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_config_statsd_cpp",
+        ":protos_perfetto_config_statsd_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_statsd_cpp",
+        ":protos_perfetto_trace_statsd_zero",
+        ":protos_third_party_statsd_config_zero",
+        ":src_android_internal_headers",
+        ":src_android_internal_lazy_library_loader",
+        ":src_base_base",
+        ":src_protozero_proto_ring_buffer",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/sys_stats:sys_stats
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_sys_stats_sys_stats",
     srcs = [
         "src/traced/probes/sys_stats/sys_stats_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/sys_stats/sys_stats_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_sys_stats_counters",
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_sys_stats_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_sys_stats_zero",
+        ":src_base_base",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/system_info:system_info
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_system_info_system_info",
     srcs = [
         "src/traced/probes/system_info/system_info_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/system_info/system_info_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_system_info_zero",
+        ":src_base_base",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes/user_list:user_list
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_user_list_user_list",
     srcs = [
         "src/traced/probes/user_list/user_list_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/user_list/user_list_data_source.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_android_zero",
+        ":protos_perfetto_trace_android_zero",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":src_base_base",
+        ":src_traced_probes_data_source",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes:data_source
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_data_source",
     srcs = [
         "src/traced/probes/probes_data_source.cc",
+    ],
+    hdrs = [
         "src/traced/probes/probes_data_source.h",
     ],
+    deps = [
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes:probes
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_probes",
     srcs = [
         "src/traced/probes/probes.cc",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":src_base_version",
+        ":src_traced_probes_probes_src",
+        ":src_tracing_ipc_producer_producer",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/probes:probes_src
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_probes_probes_src",
     srcs = [
         "src/traced/probes/probes_producer.cc",
+    ],
+    hdrs = [
         "src/traced/probes/probes_producer.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":protos_perfetto_config_ftrace_cpp",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_ps_zero",
+        ":src_android_stats_android_stats",
+        ":src_base_base",
+        ":src_kernel_utils_syscall_table",
+        ":src_traced_probes_android_aflags_android_aflags",
+        ":src_traced_probes_android_cpu_per_uid_android_cpu_per_uid",
+        ":src_traced_probes_android_game_intervention_list_android_game_intervention_list",
+        ":src_traced_probes_android_kernel_wakelocks_android_kernel_wakelocks",
+        ":src_traced_probes_android_log_android_log",
+        ":src_traced_probes_android_system_property_android_system_property",
+        ":src_traced_probes_common_common",
+        ":src_traced_probes_data_source",
+        ":src_traced_probes_filesystem_filesystem",
+        ":src_traced_probes_ftrace_ftrace",
+        ":src_traced_probes_ftrace_tracefs",
+        ":src_traced_probes_initial_display_state_initial_display_state",
+        ":src_traced_probes_metatrace_metatrace",
+        ":src_traced_probes_packages_list_packages_list",
+        ":src_traced_probes_power_power",
+        ":src_traced_probes_ps_ps",
+        ":src_traced_probes_statsd_client_statsd_client",
+        ":src_traced_probes_sys_stats_sys_stats",
+        ":src_traced_probes_system_info_system_info",
+        ":src_traced_probes_user_list_user_list",
+        ":src_tracing_core_core",
+        ":src_tracing_ipc_producer_producer",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/service:builtin_producer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_service_builtin_producer",
     srcs = [
         "src/traced/service/builtin_producer.cc",
+    ],
+    hdrs = [
         "src/traced/service/builtin_producer.h",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":include_perfetto_tracing_tracing",
+        ":protos_perfetto_config_android_zero",
+        ":src_base_base",
+        ":src_tracing_core_core",
+        ":src_tracing_service_service",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/traced/service:service
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_traced_service_service",
     srcs = [
         "src/traced/service/service.cc",
     ],
+    deps = [
+        ":include_perfetto_ext_traced_traced",
+        ":include_perfetto_tracing_tracing",
+        ":src_base_base",
+        ":src_base_version",
+        ":src_traced_service_builtin_producer",
+        ":src_tracing_core_core",
+        ":src_tracing_ipc_service_service",
+        ":src_tracing_service_service",
+        ":src_tracing_service_zlib_compressor",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/core:core
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_core_core",
     srcs = [
         "src/tracing/core/id_allocator.cc",
-        "src/tracing/core/id_allocator.h",
         "src/tracing/core/in_process_shared_memory.cc",
-        "src/tracing/core/in_process_shared_memory.h",
         "src/tracing/core/null_trace_writer.cc",
-        "src/tracing/core/null_trace_writer.h",
-        "src/tracing/core/patch_list.h",
         "src/tracing/core/shared_memory_abi.cc",
         "src/tracing/core/shared_memory_arbiter_impl.cc",
-        "src/tracing/core/shared_memory_arbiter_impl.h",
         "src/tracing/core/trace_packet.cc",
         "src/tracing/core/trace_writer_impl.cc",
-        "src/tracing/core/trace_writer_impl.h",
         "src/tracing/core/virtual_destructors.cc",
     ],
+    hdrs = [
+        "src/tracing/core/id_allocator.h",
+        "src/tracing/core/in_process_shared_memory.h",
+        "src/tracing/core/null_trace_writer.h",
+        "src/tracing/core/patch_list.h",
+        "src/tracing/core/shared_memory_arbiter_impl.h",
+        "src/tracing/core/trace_writer_impl.h",
+    ],
+    deps = [
+        ":include_perfetto_ext_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protozero",
+        ":src_base_base",
+        ":src_tracing_common",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/ipc/consumer:consumer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_ipc_consumer_consumer",
     srcs = [
         "src/tracing/ipc/consumer/consumer_ipc_client_impl.cc",
+    ],
+    hdrs = [
         "src/tracing/ipc/consumer/consumer_ipc_client_impl.h",
     ],
+    deps = [
+        ":include_perfetto_ext_tracing_core_core",
+        ":include_perfetto_ext_tracing_ipc_ipc",
+        ":include_perfetto_tracing_tracing",
+        ":perfetto_ipc",
+        ":protos_perfetto_ipc_ipc",
+        ":src_base_base",
+        ":src_tracing_ipc_common",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/ipc/producer:producer
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_ipc_producer_producer",
     srcs = [
         "src/tracing/ipc/producer/producer_ipc_client_impl.cc",
+    ],
+    hdrs = [
         "src/tracing/ipc/producer/producer_ipc_client_impl.h",
     ],
+    deps = [
+        ":include_perfetto_ext_tracing_core_core",
+        ":include_perfetto_ext_tracing_ipc_ipc",
+        ":include_perfetto_tracing_tracing",
+        ":perfetto_ipc",
+        ":protos_perfetto_ipc_ipc",
+        ":src_base_base",
+        ":src_base_version",
+        ":src_tracing_core_core",
+        ":src_tracing_ipc_common",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/ipc/service:service
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_ipc_service_service",
     srcs = [
         "src/tracing/ipc/service/consumer_ipc_service.cc",
-        "src/tracing/ipc/service/consumer_ipc_service.h",
         "src/tracing/ipc/service/producer_ipc_service.cc",
-        "src/tracing/ipc/service/producer_ipc_service.h",
         "src/tracing/ipc/service/relay_ipc_service.cc",
-        "src/tracing/ipc/service/relay_ipc_service.h",
         "src/tracing/ipc/service/service_ipc_host_impl.cc",
+    ],
+    hdrs = [
+        "src/tracing/ipc/service/consumer_ipc_service.h",
+        "src/tracing/ipc/service/producer_ipc_service.h",
+        "src/tracing/ipc/service/relay_ipc_service.h",
         "src/tracing/ipc/service/service_ipc_host_impl.h",
     ],
+    deps = [
+        ":include_perfetto_ext_tracing_core_core",
+        ":include_perfetto_ext_tracing_ipc_ipc",
+        ":include_perfetto_tracing_tracing",
+        ":perfetto_ipc",
+        ":protos_perfetto_ipc_ipc",
+        ":src_base_base",
+        ":src_tracing_core_core",
+        ":src_tracing_ipc_common",
+        ":src_tracing_service_service",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/ipc:common
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_ipc_common",
     srcs = [
         "src/tracing/ipc/memfd.cc",
-        "src/tracing/ipc/memfd.h",
         "src/tracing/ipc/posix_shared_memory.cc",
-        "src/tracing/ipc/posix_shared_memory.h",
         "src/tracing/ipc/shared_memory_windows.cc",
+    ],
+    hdrs = [
+        "src/tracing/ipc/memfd.h",
+        "src/tracing/ipc/posix_shared_memory.h",
         "src/tracing/ipc/shared_memory_windows.h",
     ],
+    deps = [
+        ":include_perfetto_ext_ipc_ipc",
+        ":include_perfetto_ext_tracing_core_core",
+        ":include_perfetto_ext_tracing_ipc_ipc",
+        ":src_base_base",
+        ":src_tracing_core_core",
+        ":src_tracing_ipc_default_socket",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/ipc:default_socket
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_ipc_default_socket",
     srcs = [
         "src/tracing/ipc/default_socket.cc",
     ],
+    deps = [
+        ":include_perfetto_ext_ipc_ipc",
+        ":include_perfetto_ext_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":src_base_base",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/service:service
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_service_service",
     srcs = [
         "src/tracing/service/clock.cc",
+        "src/tracing/service/metatrace_writer.cc",
+        "src/tracing/service/packet_stream_validator.cc",
+        "src/tracing/service/random.cc",
+        "src/tracing/service/trace_buffer_v1.cc",
+        "src/tracing/service/trace_buffer_v1_with_v2_shadow.cc",
+        "src/tracing/service/trace_buffer_v2.cc",
+        "src/tracing/service/tracing_service_endpoints_impl.cc",
+        "src/tracing/service/tracing_service_impl.cc",
+        "src/tracing/service/tracing_service_session.cc",
+    ],
+    hdrs = [
         "src/tracing/service/clock.h",
         "src/tracing/service/dependencies.h",
         "src/tracing/service/histogram.h",
-        "src/tracing/service/metatrace_writer.cc",
         "src/tracing/service/metatrace_writer.h",
-        "src/tracing/service/packet_stream_validator.cc",
         "src/tracing/service/packet_stream_validator.h",
-        "src/tracing/service/random.cc",
         "src/tracing/service/random.h",
         "src/tracing/service/trace_buffer.h",
-        "src/tracing/service/trace_buffer_v1.cc",
         "src/tracing/service/trace_buffer_v1.h",
-        "src/tracing/service/trace_buffer_v1_with_v2_shadow.cc",
         "src/tracing/service/trace_buffer_v1_with_v2_shadow.h",
-        "src/tracing/service/trace_buffer_v2.cc",
         "src/tracing/service/trace_buffer_v2.h",
-        "src/tracing/service/tracing_service_endpoints_impl.cc",
         "src/tracing/service/tracing_service_endpoints_impl.h",
-        "src/tracing/service/tracing_service_impl.cc",
         "src/tracing/service/tracing_service_impl.h",
-        "src/tracing/service/tracing_service_session.cc",
         "src/tracing/service/tracing_service_session.h",
         "src/tracing/service/tracing_service_structs.h",
     ],
+    deps = [
+        ":include_perfetto_ext_base_base",
+        ":include_perfetto_ext_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_protovm_cpp",
+        ":protos_perfetto_config_zero",
+        ":protos_perfetto_protovm_cpp",
+        ":protos_perfetto_trace_minimal_zero",
+        ":protos_perfetto_trace_non_minimal_zero",
+        ":protos_perfetto_trace_perfetto_zero",
+        ":src_android_stats_android_stats",
+        ":src_base_base",
+        ":src_base_clock_snapshots",
+        ":src_base_regex_regex",
+        ":src_base_version",
+        ":src_protovm_protovm",
+        ":src_protozero_filtering_message_filter",
+        ":src_protozero_filtering_message_filter_config",
+        ":src_protozero_filtering_string_filter",
+        ":src_tracing_common",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing/service:zlib_compressor
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_service_zlib_compressor",
     srcs = [
         "src/tracing/service/zlib_compressor.cc",
+    ],
+    hdrs = [
         "src/tracing/service/zlib_compressor.h",
     ],
+    deps = [
+        ":include_perfetto_tracing_tracing",
+        ":src_tracing_core_core",
+    ] + PERFETTO_CONFIG.deps.zlib,
+    linkstatic = True,
 )
 
 # GN target: //src/tracing:client_api_without_backends
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_client_api_without_backends",
     srcs = [
         "src/tracing/console_interceptor.cc",
@@ -5688,9 +6961,7 @@ perfetto_filegroup(
         "src/tracing/internal/interceptor_trace_writer.cc",
         "src/tracing/internal/tracing_backend_fake.cc",
         "src/tracing/internal/tracing_muxer_fake.cc",
-        "src/tracing/internal/tracing_muxer_fake.h",
         "src/tracing/internal/tracing_muxer_impl.cc",
-        "src/tracing/internal/tracing_muxer_impl.h",
         "src/tracing/internal/track_event_internal.cc",
         "src/tracing/internal/track_event_interned_fields.cc",
         "src/tracing/platform.cc",
@@ -5705,30 +6976,69 @@ perfetto_filegroup(
         "src/tracing/track_event_state_tracker.cc",
         "src/tracing/virtual_destructors.cc",
     ],
+    hdrs = [
+        "src/tracing/internal/tracing_muxer_fake.h",
+        "src/tracing/internal/tracing_muxer_impl.h",
+    ],
+    deps = [
+        ":include_perfetto_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":protos_perfetto_common_zero",
+        ":protos_perfetto_config_cpp",
+        ":protos_perfetto_config_interceptors_cpp",
+        ":protos_perfetto_config_track_event_cpp",
+        ":src_base_base",
+        ":src_tracing_core_core",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing:common
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_common",
     srcs = [
         "src/tracing/trace_writer_base.cc",
     ],
+    deps = [
+        ":include_perfetto_tracing_tracing",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing:in_process_backend
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_in_process_backend",
     srcs = [
         "src/tracing/internal/in_process_tracing_backend.cc",
     ],
+    deps = [
+        ":include_perfetto_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":src_base_base",
+        ":src_tracing_client_api_without_backends",
+        ":src_tracing_core_core",
+        ":src_tracing_service_service",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/tracing:system_backend
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_tracing_system_backend",
     srcs = [
         "src/tracing/internal/system_tracing_backend.cc",
     ],
+    deps = [
+        ":include_perfetto_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":src_base_base",
+        ":src_tracing_client_api_without_backends",
+        ":src_tracing_ipc_common",
+        ":src_tracing_ipc_consumer_consumer",
+        ":src_tracing_ipc_producer_producer",
+        ":src_tracing_ipc_service_service",
+    ],
+    linkstatic = True,
 )
 
 # ##############################################################################
@@ -5801,26 +7111,13 @@ perfetto_android_library(
 # GN target: //src/android_sdk/jni:libperfetto_jni
 perfetto_android_jni_library(
     name = "src_android_sdk_jni_libperfetto_jni",
-    srcs = [
-        ":src_android_sdk_jni_libperfetto_jni_src",
-        ":src_android_sdk_nativehelper_nativehelper",
-        ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
-        ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
-    ],
     binary_name = "libperfetto_jni.so",
     linkopts = [
         "-llog",
     ],
-    hdrs = [
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_abi_public",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protos_protos",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_public_public",
-    ],
     deps = [
         ":libperfetto_c",
+        ":src_android_sdk_jni_libperfetto_jni_src",
     ],
     tags = [
         "notap",
@@ -5828,22 +7125,29 @@ perfetto_android_jni_library(
 )
 
 # GN target: //src/android_sdk/jni:libperfetto_jni_src
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_sdk_jni_libperfetto_jni_src",
     srcs = [
         "src/android_sdk/jni/dev_perfetto_sdk_PerfettoNativeMemoryCleaner.cc",
-        "src/android_sdk/jni/dev_perfetto_sdk_PerfettoNativeMemoryCleaner.h",
         "src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrace.cc",
         "src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.cc",
+    ],
+    hdrs = [
+        "src/android_sdk/jni/dev_perfetto_sdk_PerfettoNativeMemoryCleaner.h",
         "src/android_sdk/jni/dev_perfetto_sdk_PerfettoTrackEventExtra.h",
         "src/android_sdk/jni/macros.h",
     ],
+    deps = [
+        ":src_android_sdk_nativehelper_nativehelper",
+        ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/android_sdk/nativehelper:nativehelper
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_sdk_nativehelper_nativehelper",
-    srcs = [
+    hdrs = [
         "src/android_sdk/nativehelper/JNIHelp.h",
         "src/android_sdk/nativehelper/nativehelper_utils.h",
         "src/android_sdk/nativehelper/scoped_local_frame.h",
@@ -5853,22 +7157,30 @@ perfetto_filegroup(
         "src/android_sdk/nativehelper/scoped_utf_chars.h",
         "src/android_sdk/nativehelper/utils.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/android_sdk/perfetto_sdk_for_jni:perfetto_sdk_for_jni
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni",
     srcs = [
         "src/android_sdk/perfetto_sdk_for_jni/tracing_sdk.cc",
     ],
+    deps = [
+        ":include_perfetto_public_abi_public",
+        ":include_perfetto_public_public",
+        ":src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
+    ],
+    linkstatic = True,
 )
 
 # GN target: //src/android_sdk/perfetto_sdk_for_jni:perfetto_sdk_for_jni_public
-perfetto_filegroup(
+perfetto_cc_library(
     name = "src_android_sdk_perfetto_sdk_for_jni_perfetto_sdk_for_jni_public",
-    srcs = [
+    hdrs = [
         "src/android_sdk/perfetto_sdk_for_jni/tracing_sdk.h",
     ],
+    linkstatic = True,
 )
 
 # GN target: //src/java_sdk/main/cpp:perfetto_example_jni_lib
@@ -9026,114 +10338,18 @@ perfetto_proto_library(
 # GN target: //:libperfetto_client_experimental
 perfetto_cc_library(
     name = "libperfetto_client_experimental",
-    srcs = [
-        ":src_android_stats_android_stats",
-        ":src_android_stats_perfetto_atoms",
-        ":src_protozero_filtering_bytecode_common",
-        ":src_protozero_filtering_bytecode_parser",
-        ":src_protozero_filtering_message_filter",
-        ":src_protozero_filtering_message_filter_config",
-        ":src_protozero_filtering_string_filter",
-        ":src_tracing_client_api_without_backends",
-        ":src_tracing_common",
-        ":src_tracing_core_core",
-        ":src_tracing_in_process_backend",
-        ":src_tracing_ipc_common",
-        ":src_tracing_ipc_consumer_consumer",
-        ":src_tracing_ipc_default_socket",
-        ":src_tracing_ipc_producer_producer",
-        ":src_tracing_ipc_service_service",
-        ":src_tracing_service_service",
-        ":src_tracing_system_backend",
-    ],
     hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_ipc_ipc",
-        ":include_perfetto_ext_tracing_core_core",
-        ":include_perfetto_ext_tracing_ipc_ipc",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_tracing_core_core",
-        ":include_perfetto_tracing_core_forward_decls",
-        ":include_perfetto_tracing_tracing",
         "include/perfetto/tracing.h",
     ],
     visibility = [
         "//visibility:public",
     ],
     deps = [
-        ":perfetto_ipc",
-        ":protos_perfetto_common_cpp",
-        ":protos_perfetto_common_semantic_type_cpp",
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_cpp",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_cpp",
-        ":protos_perfetto_config_ftrace_cpp",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_cpp",
-        ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_cpp",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_cpp",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_cpp",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_cpp",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_cpp",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_cpp",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_cpp",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_cpp",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_cpp",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_cpp",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_cpp",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_cpp",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_ipc_cpp",
-        ":protos_perfetto_ipc_ipc",
-        ":protos_perfetto_protovm_cpp",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
-        ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
-        ":protos_perfetto_trace_minimal_zero",
-        ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_cpp",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
-        ":protozero",
-        ":src_base_base",
-        ":src_base_clock_snapshots",
-        ":src_base_regex_regex",
-        ":src_base_version",
-        ":src_protovm_protovm",
+        ":include_perfetto_tracing_core_core",
+        ":include_perfetto_tracing_tracing",
+        ":src_tracing_client_api_without_backends",
+        ":src_tracing_in_process_backend",
+        ":src_tracing_system_backend",
     ],
     linkstatic = True,
 )
@@ -9142,332 +10358,26 @@ perfetto_cc_library(
 perfetto_cc_binary(
     name = "perfetto",
     srcs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_ipc_ipc",
-        ":include_perfetto_ext_traced_traced",
-        ":include_perfetto_ext_tracing_core_core",
-        ":include_perfetto_ext_tracing_ipc_ipc",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_tracing_core_core",
-        ":include_perfetto_tracing_core_forward_decls",
-        ":include_perfetto_tracing_tracing",
-        ":src_android_stats_android_stats",
-        ":src_android_stats_perfetto_atoms",
-        ":src_perfetto_cmd_bugreport_path",
-        ":src_perfetto_cmd_perfetto_cmd",
-        ":src_perfetto_cmd_trigger_producer",
-        ":src_proto_utils_txt_to_pb",
-        ":src_protozero_text_to_proto_text_to_proto",
-        ":src_tracing_common",
-        ":src_tracing_core_core",
-        ":src_tracing_ipc_common",
-        ":src_tracing_ipc_consumer_consumer",
-        ":src_tracing_ipc_default_socket",
-        ":src_tracing_ipc_producer_producer",
         "src/perfetto_cmd/main.cc",
     ],
     visibility = [
         "//visibility:public",
     ],
     deps = [
-        ":perfetto_ipc",
-        ":protos_perfetto_common_cpp",
-        ":protos_perfetto_common_semantic_type_cpp",
-        ":protos_perfetto_common_semantic_type_zero",
-        ":protos_perfetto_common_zero",
-        ":protos_perfetto_config_android_cpp",
-        ":protos_perfetto_config_android_zero",
-        ":protos_perfetto_config_cpp",
-        ":protos_perfetto_config_ftrace_cpp",
-        ":protos_perfetto_config_ftrace_zero",
-        ":protos_perfetto_config_gpu_cpp",
-        ":protos_perfetto_config_gpu_zero",
-        ":protos_perfetto_config_inode_file_cpp",
-        ":protos_perfetto_config_inode_file_zero",
-        ":protos_perfetto_config_interceptors_cpp",
-        ":protos_perfetto_config_interceptors_zero",
-        ":protos_perfetto_config_power_cpp",
-        ":protos_perfetto_config_power_zero",
-        ":protos_perfetto_config_priority_boost_cpp",
-        ":protos_perfetto_config_priority_boost_zero",
-        ":protos_perfetto_config_process_stats_cpp",
-        ":protos_perfetto_config_process_stats_zero",
-        ":protos_perfetto_config_profiling_cpp",
-        ":protos_perfetto_config_profiling_zero",
-        ":protos_perfetto_config_protovm_cpp",
-        ":protos_perfetto_config_protovm_zero",
-        ":protos_perfetto_config_qnx_cpp",
-        ":protos_perfetto_config_qnx_zero",
-        ":protos_perfetto_config_statsd_cpp",
-        ":protos_perfetto_config_statsd_zero",
-        ":protos_perfetto_config_sys_stats_cpp",
-        ":protos_perfetto_config_sys_stats_zero",
-        ":protos_perfetto_config_system_info_cpp",
-        ":protos_perfetto_config_system_info_zero",
-        ":protos_perfetto_config_track_event_cpp",
-        ":protos_perfetto_config_track_event_zero",
-        ":protos_perfetto_config_zero",
-        ":protos_perfetto_ipc_cpp",
-        ":protos_perfetto_ipc_ipc",
-        ":protos_perfetto_protovm_cpp",
-        ":protos_perfetto_protovm_zero",
-        ":protos_perfetto_trace_android_winscope_common_zero",
-        ":protos_perfetto_trace_android_winscope_regular_zero",
-        ":protos_perfetto_trace_android_zero",
-        ":protos_perfetto_trace_chrome_zero",
-        ":protos_perfetto_trace_etw_zero",
-        ":protos_perfetto_trace_filesystem_zero",
-        ":protos_perfetto_trace_ftrace_zero",
-        ":protos_perfetto_trace_generic_kernel_zero",
-        ":protos_perfetto_trace_gpu_zero",
-        ":protos_perfetto_trace_interned_data_zero",
-        ":protos_perfetto_trace_minimal_zero",
-        ":protos_perfetto_trace_non_minimal_zero",
-        ":protos_perfetto_trace_perfetto_zero",
-        ":protos_perfetto_trace_power_zero",
-        ":protos_perfetto_trace_profiling_zero",
-        ":protos_perfetto_trace_ps_zero",
-        ":protos_perfetto_trace_statsd_zero",
-        ":protos_perfetto_trace_sys_stats_zero",
-        ":protos_perfetto_trace_system_info_zero",
-        ":protos_perfetto_trace_track_event_cpp",
-        ":protos_perfetto_trace_track_event_zero",
-        ":protos_perfetto_trace_translation_zero",
-        ":protozero",
-        ":src_base_base",
-        ":src_base_version",
-        ":src_perfetto_cmd_protos_cpp",
-        ":src_proto_utils_gen_cc_config_descriptor",
-        ":src_proto_utils_gen_cc_trace_summary_descriptor",
+        ":src_perfetto_cmd_perfetto_cmd",
     ],
 )
 
 # GN target: //src/trace_processor:trace_processor
 perfetto_cc_library(
     name = "trace_processor",
-    srcs = [
-        ":src_kernel_utils_kernel_wakelock_errors",
-        ":src_kernel_utils_syscall_table",
-        ":src_protozero_text_to_proto_text_to_proto",
-        ":src_trace_processor_core_common_common",
-        ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_interpreter_interpreter",
-        ":src_trace_processor_core_plugin_plugin",
-        ":src_trace_processor_core_tree_tree",
-        ":src_trace_processor_core_util_util",
-        ":src_trace_processor_export_json",
-        ":src_trace_processor_importers_android_bugreport_android_bugreport",
-        ":src_trace_processor_importers_android_bugreport_android_dumpstate_event",
-        ":src_trace_processor_importers_android_bugreport_android_log_event",
-        ":src_trace_processor_importers_archive_archive",
-        ":src_trace_processor_importers_art_hprof_art_hprof",
-        ":src_trace_processor_importers_art_method_art_method",
-        ":src_trace_processor_importers_art_method_art_method_event",
-        ":src_trace_processor_importers_collapsed_stack_collapsed_stack",
-        ":src_trace_processor_importers_common_common",
-        ":src_trace_processor_importers_common_parser_types",
-        ":src_trace_processor_importers_common_synthetic_tid_hdr",
-        ":src_trace_processor_importers_common_v8_profile_parser",
-        ":src_trace_processor_importers_etw_full",
-        ":src_trace_processor_importers_etw_minimal",
-        ":src_trace_processor_importers_ftrace_ftrace_descriptors",
-        ":src_trace_processor_importers_ftrace_full",
-        ":src_trace_processor_importers_ftrace_minimal",
-        ":src_trace_processor_importers_fuchsia_fuchsia_record",
-        ":src_trace_processor_importers_fuchsia_full",
-        ":src_trace_processor_importers_fuchsia_minimal",
-        ":src_trace_processor_importers_gecko_gecko",
-        ":src_trace_processor_importers_gecko_gecko_event",
-        ":src_trace_processor_importers_generic_kernel_full",
-        ":src_trace_processor_importers_i2c_full",
-        ":src_trace_processor_importers_json_json",
-        ":src_trace_processor_importers_memory_tracker_graph_processor",
-        ":src_trace_processor_importers_ninja_ninja",
-        ":src_trace_processor_importers_perf_perf",
-        ":src_trace_processor_importers_perf_record",
-        ":src_trace_processor_importers_perf_text_perf_text",
-        ":src_trace_processor_importers_perf_text_perf_text_event",
-        ":src_trace_processor_importers_perf_text_perf_text_sample_line_parser",
-        ":src_trace_processor_importers_pprof_pprof",
-        ":src_trace_processor_importers_primes_primes",
-        ":src_trace_processor_importers_proto_full",
-        ":src_trace_processor_importers_proto_minimal",
-        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
-        ":src_trace_processor_importers_proto_proto_importer_module",
-        ":src_trace_processor_importers_proto_winscope_full",
-        ":src_trace_processor_importers_simpleperf_proto_simpleperf_proto",
-        ":src_trace_processor_importers_syscalls_full",
-        ":src_trace_processor_importers_systrace_full",
-        ":src_trace_processor_importers_systrace_systrace_line",
-        ":src_trace_processor_importers_systrace_systrace_parser",
-        ":src_trace_processor_lib",
-        ":src_trace_processor_metatrace",
-        ":src_trace_processor_metrics_metrics",
-        ":src_trace_processor_perfetto_sql_engine_engine",
-        ":src_trace_processor_perfetto_sql_generator_generator",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_trees_trees",
-        ":src_trace_processor_perfetto_sql_intrinsics_operators_operators",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_types_types",
-        ":src_trace_processor_perfetto_sql_parser_parser",
-        ":src_trace_processor_perfetto_sql_preprocessor_grammar",
-        ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
-        ":src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
-        ":src_trace_processor_perfetto_sql_tokenizer_tokenizer",
-        ":src_trace_processor_plugins_wattson_wattson",
-        ":src_trace_processor_sorter_sorter",
-        ":src_trace_processor_sqlite_bindings_bindings",
-        ":src_trace_processor_sqlite_sqlite",
-        ":src_trace_processor_storage_minimal",
-        ":src_trace_processor_storage_storage",
-        ":src_trace_processor_tables_tables",
-        ":src_trace_processor_tables_tables_python",
-        ":src_trace_processor_trace_summary_trace_summary",
-        ":src_trace_processor_types_types",
-        ":src_trace_processor_util_args_utils",
-        ":src_trace_processor_util_blob",
-        ":src_trace_processor_util_bump_allocator",
-        ":src_trace_processor_util_clock",
-        ":src_trace_processor_util_descriptors",
-        ":src_trace_processor_util_elf_elf",
-        ":src_trace_processor_util_galloping_search",
-        ":src_trace_processor_util_glob",
-        ":src_trace_processor_util_gzip",
-        ":src_trace_processor_util_interned_message_view",
-        ":src_trace_processor_util_json_args",
-        ":src_trace_processor_util_json_parser",
-        ":src_trace_processor_util_json_serializer",
-        ":src_trace_processor_util_json_value",
-        ":src_trace_processor_util_profile_builder",
-        ":src_trace_processor_util_profiler_util",
-        ":src_trace_processor_util_proto_profiler",
-        ":src_trace_processor_util_proto_to_args_parser",
-        ":src_trace_processor_util_protozero_to_json",
-        ":src_trace_processor_util_protozero_to_text",
-        ":src_trace_processor_util_simple_json_parser",
-        ":src_trace_processor_util_simple_json_serializer",
-        ":src_trace_processor_util_sql_argument",
-        ":src_trace_processor_util_sql_bundle",
-        ":src_trace_processor_util_stdlib",
-        ":src_trace_processor_util_trace_blob_view_reader",
-        ":src_trace_processor_util_trace_type",
-        ":src_trace_processor_util_winscope_proto_mapping",
-        ":src_trace_processor_util_zip_reader",
-    ],
-    hdrs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_trace_processor_demangle",
-        ":include_perfetto_ext_trace_processor_export_json",
-        ":include_perfetto_ext_trace_processor_importers_memory_tracker_memory_tracker",
-        ":include_perfetto_ext_traced_sys_stats_counters",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_trace_processor_basic_types",
-        ":include_perfetto_trace_processor_storage",
-        ":include_perfetto_trace_processor_trace_processor",
-        ":include_perfetto_trace_processor_util",
-    ],
     visibility = [
         "//visibility:public",
     ],
     deps = [
-               ":protos_perfetto_common_cpp",
-               ":protos_perfetto_common_semantic_type_zero",
-               ":protos_perfetto_common_zero",
-               ":protos_perfetto_config_android_zero",
-               ":protos_perfetto_config_ftrace_zero",
-               ":protos_perfetto_config_gpu_zero",
-               ":protos_perfetto_config_inode_file_zero",
-               ":protos_perfetto_config_interceptors_zero",
-               ":protos_perfetto_config_power_zero",
-               ":protos_perfetto_config_priority_boost_zero",
-               ":protos_perfetto_config_process_stats_zero",
-               ":protos_perfetto_config_profiling_zero",
-               ":protos_perfetto_config_protovm_zero",
-               ":protos_perfetto_config_qnx_zero",
-               ":protos_perfetto_config_statsd_zero",
-               ":protos_perfetto_config_sys_stats_zero",
-               ":protos_perfetto_config_system_info_zero",
-               ":protos_perfetto_config_track_event_zero",
-               ":protos_perfetto_config_zero",
-               ":protos_perfetto_perfetto_sql_zero",
-               ":protos_perfetto_protovm_cpp",
-               ":protos_perfetto_protovm_zero",
-               ":protos_perfetto_trace_android_winscope_common_zero",
-               ":protos_perfetto_trace_android_winscope_extensions_zero",
-               ":protos_perfetto_trace_android_winscope_regular_zero",
-               ":protos_perfetto_trace_android_zero",
-               ":protos_perfetto_trace_chrome_zero",
-               ":protos_perfetto_trace_etw_zero",
-               ":protos_perfetto_trace_filesystem_zero",
-               ":protos_perfetto_trace_ftrace_zero",
-               ":protos_perfetto_trace_generic_kernel_zero",
-               ":protos_perfetto_trace_gpu_gpu_interned_data_zero",
-               ":protos_perfetto_trace_gpu_gpu_track_event_zero",
-               ":protos_perfetto_trace_gpu_zero",
-               ":protos_perfetto_trace_interned_data_zero",
-               ":protos_perfetto_trace_minimal_zero",
-               ":protos_perfetto_trace_non_minimal_zero",
-               ":protos_perfetto_trace_perfetto_zero",
-               ":protos_perfetto_trace_power_zero",
-               ":protos_perfetto_trace_processor_metrics_impl_zero",
-               ":protos_perfetto_trace_processor_zero",
-               ":protos_perfetto_trace_profiling_zero",
-               ":protos_perfetto_trace_ps_zero",
-               ":protos_perfetto_trace_statsd_zero",
-               ":protos_perfetto_trace_summary_zero",
-               ":protos_perfetto_trace_sys_stats_zero",
-               ":protos_perfetto_trace_system_info_zero",
-               ":protos_perfetto_trace_track_event_zero",
-               ":protos_perfetto_trace_translation_zero",
-               ":protos_third_party_chromium_zero",
-               ":protos_third_party_pprof_zero",
-               ":protos_third_party_primes_cpp",
-               ":protos_third_party_primes_zero",
-               ":protos_third_party_simpleperf_zero",
-               ":protozero",
-               ":src_base_base",
-               ":src_base_clock_snapshots",
-               ":src_base_regex_regex",
-               ":src_protovm_protovm",
-               ":src_trace_processor_containers_containers",
-               ":src_trace_processor_importers_proto_gen_cc_android_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_chrome_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_interned_data_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_statsd_atoms_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_trace_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
-               ":src_trace_processor_importers_proto_winscope_gen_cc_winscope_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_chrome_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_webview_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_metrics_descriptor",
-               ":src_trace_processor_metrics_sql_gen_amalgamated_sql_metrics",
-               ":src_trace_processor_perfetto_sql_stdlib_stdlib",
-               ":src_trace_processor_plugins_wattson_gen_cpu_1d_curves",
-               ":src_trace_processor_plugins_wattson_gen_cpu_2d_curves",
-               ":src_trace_processor_plugins_wattson_gen_gpu_curves",
-               ":src_trace_processor_plugins_wattson_gen_l3_curves",
-               ":src_trace_processor_plugins_wattson_gen_tpu_curves",
-               ":src_trace_processor_trace_summary_gen_cc_trace_summary_descriptor",
-               ":src_trace_processor_util_build_id",
-           ] + PERFETTO_CONFIG.deps.sqlite +
-           PERFETTO_CONFIG.deps.sqlite_ext_percentile +
-           PERFETTO_CONFIG.deps.zlib +
-           PERFETTO_CONFIG.deps.demangle_wrapper,
+        ":src_trace_processor_lib",
+    ],
     linkstatic = True,
-    alwayslink = True,
 )
 
 # GN target: //src/trace_processor:trace_processor_shell
@@ -9487,251 +10397,25 @@ perfetto_cc_binary(
 # GN target: //src/traceconv:traceconv
 perfetto_cc_binary(
     name = "traceconv",
-    srcs = [
-        ":include_perfetto_base_base",
-        ":include_perfetto_ext_base_base",
-        ":include_perfetto_ext_protozero_protozero",
-        ":include_perfetto_ext_trace_processor_demangle",
-        ":include_perfetto_ext_trace_processor_export_json",
-        ":include_perfetto_ext_trace_processor_importers_memory_tracker_memory_tracker",
-        ":include_perfetto_ext_traceconv_traceconv",
-        ":include_perfetto_ext_traced_sys_stats_counters",
-        ":include_perfetto_profiling_pprof_builder",
-        ":include_perfetto_protozero_protozero",
-        ":include_perfetto_public_abi_base",
-        ":include_perfetto_public_base",
-        ":include_perfetto_public_protozero",
-        ":include_perfetto_trace_processor_basic_types",
-        ":include_perfetto_trace_processor_storage",
-        ":include_perfetto_trace_processor_trace_processor",
-        ":include_perfetto_trace_processor_util",
-        ":src_kernel_utils_kernel_wakelock_errors",
-        ":src_kernel_utils_syscall_table",
-        ":src_protozero_proto_ring_buffer",
-        ":src_protozero_text_to_proto_text_to_proto",
-        ":src_trace_processor_core_common_common",
-        ":src_trace_processor_core_dataframe_dataframe",
-        ":src_trace_processor_core_interpreter_interpreter",
-        ":src_trace_processor_core_plugin_plugin",
-        ":src_trace_processor_core_tree_tree",
-        ":src_trace_processor_core_util_util",
-        ":src_trace_processor_export_json",
-        ":src_trace_processor_importers_android_bugreport_android_bugreport",
-        ":src_trace_processor_importers_android_bugreport_android_dumpstate_event",
-        ":src_trace_processor_importers_android_bugreport_android_log_event",
-        ":src_trace_processor_importers_archive_archive",
-        ":src_trace_processor_importers_art_hprof_art_hprof",
-        ":src_trace_processor_importers_art_method_art_method",
-        ":src_trace_processor_importers_art_method_art_method_event",
-        ":src_trace_processor_importers_collapsed_stack_collapsed_stack",
-        ":src_trace_processor_importers_common_common",
-        ":src_trace_processor_importers_common_parser_types",
-        ":src_trace_processor_importers_common_synthetic_tid_hdr",
-        ":src_trace_processor_importers_common_v8_profile_parser",
-        ":src_trace_processor_importers_etw_full",
-        ":src_trace_processor_importers_etw_minimal",
-        ":src_trace_processor_importers_ftrace_ftrace_descriptors",
-        ":src_trace_processor_importers_ftrace_full",
-        ":src_trace_processor_importers_ftrace_minimal",
-        ":src_trace_processor_importers_fuchsia_fuchsia_record",
-        ":src_trace_processor_importers_fuchsia_full",
-        ":src_trace_processor_importers_fuchsia_minimal",
-        ":src_trace_processor_importers_gecko_gecko",
-        ":src_trace_processor_importers_gecko_gecko_event",
-        ":src_trace_processor_importers_generic_kernel_full",
-        ":src_trace_processor_importers_i2c_full",
-        ":src_trace_processor_importers_json_json",
-        ":src_trace_processor_importers_memory_tracker_graph_processor",
-        ":src_trace_processor_importers_ninja_ninja",
-        ":src_trace_processor_importers_perf_perf",
-        ":src_trace_processor_importers_perf_record",
-        ":src_trace_processor_importers_perf_text_perf_text",
-        ":src_trace_processor_importers_perf_text_perf_text_event",
-        ":src_trace_processor_importers_perf_text_perf_text_sample_line_parser",
-        ":src_trace_processor_importers_pprof_pprof",
-        ":src_trace_processor_importers_primes_primes",
-        ":src_trace_processor_importers_proto_full",
-        ":src_trace_processor_importers_proto_minimal",
-        ":src_trace_processor_importers_proto_packet_sequence_state_generation_hdr",
-        ":src_trace_processor_importers_proto_proto_importer_module",
-        ":src_trace_processor_importers_proto_winscope_full",
-        ":src_trace_processor_importers_simpleperf_proto_simpleperf_proto",
-        ":src_trace_processor_importers_syscalls_full",
-        ":src_trace_processor_importers_systrace_full",
-        ":src_trace_processor_importers_systrace_systrace_line",
-        ":src_trace_processor_importers_systrace_systrace_parser",
-        ":src_trace_processor_lib",
-        ":src_trace_processor_metatrace",
-        ":src_trace_processor_metrics_metrics",
-        ":src_trace_processor_perfetto_sql_engine_engine",
-        ":src_trace_processor_perfetto_sql_generator_generator",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_functions_trees_trees",
-        ":src_trace_processor_perfetto_sql_intrinsics_operators_operators",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_interface",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_table_functions",
-        ":src_trace_processor_perfetto_sql_intrinsics_table_functions_tables",
-        ":src_trace_processor_perfetto_sql_intrinsics_types_types",
-        ":src_trace_processor_perfetto_sql_parser_parser",
-        ":src_trace_processor_perfetto_sql_preprocessor_grammar",
-        ":src_trace_processor_perfetto_sql_preprocessor_preprocessor",
-        ":src_trace_processor_perfetto_sql_syntaqlite_syntaqlite",
-        ":src_trace_processor_perfetto_sql_tokenizer_tokenizer",
-        ":src_trace_processor_plugins_wattson_wattson",
-        ":src_trace_processor_sorter_sorter",
-        ":src_trace_processor_sqlite_bindings_bindings",
-        ":src_trace_processor_sqlite_sqlite",
-        ":src_trace_processor_storage_minimal",
-        ":src_trace_processor_storage_storage",
-        ":src_trace_processor_tables_tables",
-        ":src_trace_processor_tables_tables_python",
-        ":src_trace_processor_trace_summary_trace_summary",
-        ":src_trace_processor_types_types",
-        ":src_trace_processor_util_args_utils",
-        ":src_trace_processor_util_blob",
-        ":src_trace_processor_util_bump_allocator",
-        ":src_trace_processor_util_clock",
-        ":src_trace_processor_util_descriptors",
-        ":src_trace_processor_util_elf_elf",
-        ":src_trace_processor_util_galloping_search",
-        ":src_trace_processor_util_glob",
-        ":src_trace_processor_util_gzip",
-        ":src_trace_processor_util_interned_message_view",
-        ":src_trace_processor_util_json_args",
-        ":src_trace_processor_util_json_parser",
-        ":src_trace_processor_util_json_serializer",
-        ":src_trace_processor_util_json_value",
-        ":src_trace_processor_util_profile_builder",
-        ":src_trace_processor_util_profiler_util",
-        ":src_trace_processor_util_proto_profiler",
-        ":src_trace_processor_util_proto_to_args_parser",
-        ":src_trace_processor_util_protozero_to_json",
-        ":src_trace_processor_util_protozero_to_text",
-        ":src_trace_processor_util_simple_json_parser",
-        ":src_trace_processor_util_simple_json_serializer",
-        ":src_trace_processor_util_sql_argument",
-        ":src_trace_processor_util_sql_bundle",
-        ":src_trace_processor_util_stdlib",
-        ":src_trace_processor_util_tar_writer",
-        ":src_trace_processor_util_trace_blob_view_reader",
-        ":src_trace_processor_util_trace_enrichment_trace_enrichment",
-        ":src_trace_processor_util_trace_type",
-        ":src_trace_processor_util_winscope_proto_mapping",
-        ":src_trace_processor_util_zip_reader",
-        ":src_traceconv_lib",
-        ":src_traceconv_main",
-        ":src_traceconv_pprofbuilder",
-        ":src_traceconv_traceconv_lib",
-        ":src_traceconv_utils",
-    ],
     visibility = [
         "//visibility:public",
     ],
     deps = [
-               ":protos_perfetto_common_cpp",
-               ":protos_perfetto_common_semantic_type_zero",
-               ":protos_perfetto_common_zero",
-               ":protos_perfetto_config_android_zero",
-               ":protos_perfetto_config_ftrace_zero",
-               ":protos_perfetto_config_gpu_zero",
-               ":protos_perfetto_config_inode_file_zero",
-               ":protos_perfetto_config_interceptors_zero",
-               ":protos_perfetto_config_power_zero",
-               ":protos_perfetto_config_priority_boost_zero",
-               ":protos_perfetto_config_process_stats_zero",
-               ":protos_perfetto_config_profiling_zero",
-               ":protos_perfetto_config_protovm_zero",
-               ":protos_perfetto_config_qnx_zero",
-               ":protos_perfetto_config_statsd_zero",
-               ":protos_perfetto_config_sys_stats_zero",
-               ":protos_perfetto_config_system_info_zero",
-               ":protos_perfetto_config_track_event_zero",
-               ":protos_perfetto_config_zero",
-               ":protos_perfetto_perfetto_sql_zero",
-               ":protos_perfetto_protovm_cpp",
-               ":protos_perfetto_protovm_zero",
-               ":protos_perfetto_trace_android_winscope_common_zero",
-               ":protos_perfetto_trace_android_winscope_extensions_zero",
-               ":protos_perfetto_trace_android_winscope_regular_zero",
-               ":protos_perfetto_trace_android_zero",
-               ":protos_perfetto_trace_chrome_zero",
-               ":protos_perfetto_trace_etw_zero",
-               ":protos_perfetto_trace_filesystem_zero",
-               ":protos_perfetto_trace_ftrace_zero",
-               ":protos_perfetto_trace_generic_kernel_zero",
-               ":protos_perfetto_trace_gpu_gpu_interned_data_zero",
-               ":protos_perfetto_trace_gpu_gpu_track_event_zero",
-               ":protos_perfetto_trace_gpu_zero",
-               ":protos_perfetto_trace_interned_data_zero",
-               ":protos_perfetto_trace_minimal_zero",
-               ":protos_perfetto_trace_non_minimal_zero",
-               ":protos_perfetto_trace_perfetto_zero",
-               ":protos_perfetto_trace_power_zero",
-               ":protos_perfetto_trace_processor_metrics_impl_zero",
-               ":protos_perfetto_trace_processor_zero",
-               ":protos_perfetto_trace_profiling_zero",
-               ":protos_perfetto_trace_ps_zero",
-               ":protos_perfetto_trace_statsd_zero",
-               ":protos_perfetto_trace_summary_zero",
-               ":protos_perfetto_trace_sys_stats_zero",
-               ":protos_perfetto_trace_system_info_zero",
-               ":protos_perfetto_trace_track_event_zero",
-               ":protos_perfetto_trace_translation_zero",
-               ":protos_third_party_chromium_zero",
-               ":protos_third_party_pprof_zero",
-               ":protos_third_party_primes_cpp",
-               ":protos_third_party_primes_zero",
-               ":protos_third_party_simpleperf_zero",
-               ":protozero",
-               ":src_base_base",
-               ":src_base_clock_snapshots",
-               ":src_base_regex_regex",
-               ":src_base_version",
-               ":src_protovm_protovm",
-               ":src_trace_processor_containers_containers",
-               ":src_trace_processor_importers_proto_gen_cc_android_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_chrome_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_interned_data_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_gpu_track_event_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_statsd_atoms_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_trace_descriptor",
-               ":src_trace_processor_importers_proto_gen_cc_track_event_descriptor",
-               ":src_trace_processor_importers_proto_winscope_gen_cc_winscope_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_chrome_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_all_webview_metrics_descriptor",
-               ":src_trace_processor_metrics_gen_cc_metrics_descriptor",
-               ":src_trace_processor_metrics_sql_gen_amalgamated_sql_metrics",
-               ":src_trace_processor_perfetto_sql_stdlib_stdlib",
-               ":src_trace_processor_plugins_wattson_gen_cpu_1d_curves",
-               ":src_trace_processor_plugins_wattson_gen_cpu_2d_curves",
-               ":src_trace_processor_plugins_wattson_gen_gpu_curves",
-               ":src_trace_processor_plugins_wattson_gen_l3_curves",
-               ":src_trace_processor_plugins_wattson_gen_tpu_curves",
-               ":src_trace_processor_trace_summary_gen_cc_trace_summary_descriptor",
-               ":src_trace_processor_util_build_id",
-               ":src_trace_processor_util_deobfuscation_deobfuscator",
-               ":src_trace_processor_util_symbolizer_symbolize_database",
-               ":src_trace_processor_util_symbolizer_symbolizer",
-               ":src_traceconv_gen_cc_trace_descriptor",
-               ":src_traceconv_gen_cc_winscope_descriptor",
-           ] + PERFETTO_CONFIG.deps.sqlite +
-           PERFETTO_CONFIG.deps.sqlite_ext_percentile +
-           PERFETTO_CONFIG.deps.zlib +
-           PERFETTO_CONFIG.deps.demangle_wrapper,
+        ":src_traceconv_main",
+    ],
 )
 
 # GN target: //src/traced/probes:traced_probes
 perfetto_cc_binary(
     name = "traced_probes",
     srcs = [
-        ":include_perfetto_ext_traced_traced",
         "src/traced/probes/main.cc",
     ],
     visibility = [
         "//visibility:public",
     ],
     deps = [
+        ":include_perfetto_ext_traced_traced",
         ":libperfetto",
     ],
 )
@@ -9740,13 +10424,13 @@ perfetto_cc_binary(
 perfetto_cc_binary(
     name = "traced",
     srcs = [
-        ":include_perfetto_ext_traced_traced",
         "src/traced/service/main.cc",
     ],
     visibility = [
         "//visibility:public",
     ],
     deps = [
+        ":include_perfetto_ext_traced_traced",
         ":libperfetto",
     ],
 )

--- a/src/android_sdk/jni/BUILD.gn
+++ b/src/android_sdk/jni/BUILD.gn
@@ -19,15 +19,27 @@ SOURCE_SET_DEPS = [
   "../perfetto_sdk_for_jni:perfetto_sdk_for_jni",
 ]
 
+# JNI_OnLoad and the Java_* native methods are looked up by the JVM via
+# dlsym(), so they have no in-binary references. When this source_set is
+# absorbed into a final link as a static archive (Bazel cc_library /
+# Soong cc_library_static), the linker dead-strips those .o files. The
+# `perfetto_force_alwayslink` metadata tells generators to mark the
+# library so its objects survive the link.
+SOURCE_SET_METADATA = {
+  perfetto_force_alwayslink = [ true ]
+}
+
 source_set("libperfetto_jni_src") {
   sources = SOURCE_SET_SOURCES
   deps = SOURCE_SET_DEPS
+  metadata = SOURCE_SET_METADATA
 }
 
 source_set("libperfetto_framework_jni_src") {
   sources = SOURCE_SET_SOURCES
   deps = SOURCE_SET_DEPS
   cflags = [ "-DPERFETTO_JNI_JARJAR_PREFIX=com/android/internal/" ]
+  metadata = SOURCE_SET_METADATA
 }
 
 perfetto_android_jni_library("libperfetto_jni") {

--- a/src/base/BUILD.gn
+++ b/src/base/BUILD.gn
@@ -23,7 +23,7 @@ import("../../gn/wasm.gni")
 _subprocess_supported =
     is_linux || is_chromeos || is_android || is_mac || is_win || is_freebsd
 
-perfetto_component("base") {
+source_set("base") {
   deps = [
     "../../gn:base_platform",
     "../../gn:default_deps",

--- a/src/base/regex/BUILD.gn
+++ b/src/base/regex/BUILD.gn
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import("../../../gn/perfetto.gni")
-import("../../../gn/perfetto_component.gni")
 
-perfetto_component("regex") {
+source_set("regex") {
   sources = [
     "regex.cc",
     "regex_std.h",

--- a/src/protovm/BUILD.gn
+++ b/src/protovm/BUILD.gn
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import("../../gn/fuzzer.gni")
-import("../../gn/perfetto_component.gni")
 import("../../gn/perfetto_host_executable.gni")
 import("../../gn/proto_library.gni")
 import("../../gn/test.gni")
 
-perfetto_component("protovm") {
+source_set("protovm") {
   sources = [
     "allocator.cc",
     "allocator.h",

--- a/src/trace_processor/containers/BUILD.gn
+++ b/src/trace_processor/containers/BUILD.gn
@@ -12,14 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("../../../gn/perfetto_component.gni")
 import("../../../gn/test.gni")
 
-# Used by two static libs - trace_processor and libpprofbuilder, hence using
-# perfetto_component to turn this into a cc_library in bazel builds.
-# The 'public' section gets converted to 'hdrs', and is necessary for the bazel
-# build to pass strict header checks.
-perfetto_component("containers") {
+source_set("containers") {
   public = [
     "implicit_segment_forest.h",
     "interval_intersector.h",

--- a/src/trace_processor/util/BUILD.gn
+++ b/src/trace_processor/util/BUILD.gn
@@ -14,7 +14,6 @@
 
 import("../../../gn/perfetto.gni")
 import("../../../gn/perfetto_cc_proto_descriptor.gni")
-import("../../../gn/perfetto_component.gni")
 
 # Track event args parsing logic here is tentatitively planned to eventually
 # move to src/util and will be used to implement writing typed args in console
@@ -62,7 +61,7 @@ source_set("gzip") {
   }
 }
 
-perfetto_component("build_id") {
+source_set("build_id") {
   sources = [
     "build_id.cc",
     "build_id.h",

--- a/src/trace_processor/util/deobfuscation/BUILD.gn
+++ b/src/trace_processor/util/deobfuscation/BUILD.gn
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import("../../../../gn/perfetto.gni")
-import("../../../../gn/perfetto_component.gni")
 import("../../../../gn/test.gni")
 
-perfetto_component("deobfuscator") {
+source_set("deobfuscator") {
   sources = [
     "deobfuscator.cc",
     "deobfuscator.h",

--- a/src/trace_processor/util/symbolizer/BUILD.gn
+++ b/src/trace_processor/util/symbolizer/BUILD.gn
@@ -13,10 +13,9 @@
 # limitations under the License.
 
 import("../../../../gn/perfetto.gni")
-import("../../../../gn/perfetto_component.gni")
 import("../../../../gn/test.gni")
 
-perfetto_component("symbolizer") {
+source_set("symbolizer") {
   public_deps = [ "../../../../include/perfetto/ext/base" ]
   deps = [ "../../../../gn:default_deps" ]
   sources = [
@@ -39,7 +38,7 @@ perfetto_component("symbolizer") {
 }
 
 if (enable_perfetto_trace_processor) {
-  perfetto_component("symbolize_database") {
+  source_set("symbolize_database") {
     public_deps = [
       ":symbolizer",
       "../../../../include/perfetto/ext/base",

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -445,6 +445,7 @@ class BazelLabel(object):
     self.testonly: Optional[bool] = None
     self.script: Optional[str] = None
     self.args: List[str] = []
+    self.target_compatible_with: List[str] = []
 
   def __lt__(self, other):
     if isinstance(other, self.__class__):
@@ -847,7 +848,8 @@ def gen_protozero_descriptor_diff(target: GnParser.Target):
 
 
 def gen_target_helper(gn_target: GnParser.Target,
-                      win_target: GnParser.Target = None):
+                      win_target: GnParser.Target = None,
+                      android_only: bool = False):
   if gn_target.type == 'proto_library':
     return [gen_proto_label(gn_target)]
   elif gn_target.type == 'action':
@@ -941,6 +943,13 @@ def gen_target_helper(gn_target: GnParser.Target,
     label.binary_name = gn_target.binary_name()
     label.linkopts = gn_target.linkopts()
 
+  # Targets that only exist in the Android GN description (e.g. JNI source
+  # sets behind enable_perfetto_android_java_sdk) need to be marked as
+  # Android-only in Bazel; otherwise `bazel build //...` on a Linux host
+  # tries to compile them and fails on missing `<jni.h>` / `<android/log.h>`.
+  if android_only and bazel_type == 'perfetto_cc_library':
+    label.target_compatible_with = ['@platforms//os:android']
+
   if (gn_target.type in gn_utils.LINKER_UNIT_TYPES or
       gn_target.type == 'source_set'):
     # source_sets are now cc_library targets, so each cc_library only needs
@@ -1011,8 +1020,10 @@ def gen_protozero_group_target(gn: GnParser):
   return [label]
 
 
-def gen_target(gn_target: GnParser.Target, win_target: GnParser.Target = None):
-  targets = gen_target_helper(gn_target, win_target)
+def gen_target(gn_target: GnParser.Target,
+               win_target: GnParser.Target = None,
+               android_only: bool = False):
+  targets = gen_target_helper(gn_target, win_target, android_only)
   if gn_target.name not in target_overrides:
     return targets
   for target in targets:
@@ -1021,8 +1032,11 @@ def gen_target(gn_target: GnParser.Target, win_target: GnParser.Target = None):
   return targets
 
 
-def gen_target_str(gn_target, win_target: GnParser.Target = None):
-  return ''.join(str(x) for x in gen_target(gn_target, win_target))
+def gen_target_str(gn_target,
+                   win_target: GnParser.Target = None,
+                   android_only: bool = False):
+  return ''.join(
+      str(x) for x in gen_target(gn_target, win_target, android_only))
 
 
 def generate_build(gn_desc, gn_desc_win, gn_desc_android, targets, extras):
@@ -1134,7 +1148,7 @@ exports_files(["NOTICE"])
   android_str = ''
   for target_name in sorted(android_only_targets):
     target = gn_android.get_target(target_name)
-    android_str += gen_target_str(target)
+    android_str += gen_target_str(target, android_only=True)
 
   res += android_str
 

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -877,7 +877,7 @@ def gen_target_helper(gn_target: GnParser.Target,
   elif gn_target.type == 'static_library':
     bazel_type = 'perfetto_cc_library'
   elif gn_target.type == 'source_set':
-    bazel_type = 'perfetto_filegroup'
+    bazel_type = 'perfetto_cc_library'
   elif gn_target.type == 'generated_file':
     return []
   else:
@@ -928,11 +928,7 @@ def gen_target_helper(gn_target: GnParser.Target,
   else:
     label.srcs = raw_srcs
 
-  # `alwayslink` is a cc_library attribute in Bazel and is not valid on
-  # filegroups. The flag propagates to cc_library consumers below: if any
-  # transitive source_set dep is force_alwayslink, the cc_library that
-  # absorbs it inherits the flag.
-  if gn_target.force_alwayslink and bazel_type != 'perfetto_filegroup':
+  if gn_target.force_alwayslink:
     label.alwayslink = True
 
   if win_target:
@@ -945,59 +941,37 @@ def gen_target_helper(gn_target: GnParser.Target,
     label.binary_name = gn_target.binary_name()
     label.linkopts = gn_target.linkopts()
 
-  if gn_target.type in gn_utils.LINKER_UNIT_TYPES:
-    # |source_sets| contains the transitive set of source_set deps.
-    for trans_dep in gn_target.transitive_source_set_deps():
-      name = ':' + get_bazel_label_name(trans_dep.name)
-      if name.startswith(
-          ':include_perfetto_') and gn_target.type != 'executable':
-        label.hdrs += [name]
-      else:
-        if win_target:
-          win_target_names = [
-              target.name for target in win_target.transitive_source_set_deps()
-          ]
-          if trans_dep.name in win_target_names:
-            label.win_srcs += [name]
-
-        label.srcs += [name]
-
-      # Add defines from all transitive dependencies.
-      label.defines += trans_dep.defines
-
-      # A force_alwayslink source_set becomes a filegroup whose srcs are
-      # inlined here; without alwayslink on this cc_library the linker drops
-      # the .o files that exist solely for global-ctor side effects (e.g.
-      # self-registering plugins). cc_binary has no `alwayslink` attribute,
-      # so only set it on cc_library targets.
-      if trans_dep.force_alwayslink and bazel_type == 'perfetto_cc_library':
-        label.alwayslink = True
-
-    for dep in sorted(gn_target.non_proto_or_source_set_deps()):
+  if (gn_target.type in gn_utils.LINKER_UNIT_TYPES or
+      gn_target.type == 'source_set'):
+    # source_sets are now cc_library targets, so each cc_library only needs
+    # to declare its immediate GN deps and let Bazel resolve the graph
+    # transitively.
+    for dep in sorted(gn_target.immediate_deps):
       dep_name = dep.name
+      # source_set / descriptor proto plugins don't emit cc artifacts; they
+      # are pure proto aggregators, so cc consumers must skip them.
+      if dep.type == 'proto_library' and dep.proto_plugin in ('source_set',
+                                                              'descriptor'):
+        continue
       if dep_name.startswith('//gn:'):
         assert (dep_name in external_deps), dep
+      if dep_name in external_deps:
+        assert (isinstance(external_deps[dep_name], list))
+        label.external_deps += external_deps[dep_name]
+        continue
 
       # tp_tables produces a filegroup not a cc_library so should end up srcs
       # not deps.
       if dep.custom_action_type == 'tp_tables':
         label_name = ':' + get_bazel_label_name(dep_name)
-        win_target_names = [
-            target.name for target in win_target.non_proto_or_source_set_deps()
-        ]
-        if win_target and dep_name in win_target_names:
-          label.win_srcs += [label_name]
+        if win_target:
+          win_target_names = [t.name for t in win_target.immediate_deps]
+          if dep_name in win_target_names:
+            label.win_srcs += [label_name]
         label.srcs += [label_name]
-      elif dep_name in external_deps:
-        assert (isinstance(external_deps[dep_name], list))
-        label.external_deps += external_deps[dep_name]
-      else:
-        label.deps += [':' + get_bazel_label_name(dep_name)]
+        continue
 
-    label.deps += [
-        ':' + get_bazel_label_name(x.name)
-        for x in gn_target.transitive_cpp_proto_deps()
-    ]
+      label.deps += [':' + get_bazel_label_name(dep_name)]
 
   # All items starting with : need to be sorted to the end of the list.
   # However, Python makes specifying a comparator function hard so cheat
@@ -1201,10 +1175,6 @@ exports_files(["NOTICE"])
   res += public_str
   res += '# Content from BUILD.extras\n\n'
   res += extras
-
-  # Check for ODR violations
-  for target_name in default_targets:
-    checker = gn_utils.ODRChecker(gn, target_name)
 
   return res
 

--- a/tools/gn_utils.py
+++ b/tools/gn_utils.py
@@ -453,6 +453,11 @@ class GnParser(object):
       self.defines = set()
       self.deps: Set[GnParser.Target] = set()
       self.transitive_deps: Set[GnParser.Target] = set()
+      # Direct GN deps as written in BUILD.gn, before any bubbling-up from
+      # source_set or group deps. Generators that emit cc_library-style
+      # rules (where the build system resolves transitivity) should prefer
+      # these over `deps`.
+      self.immediate_deps: Set[GnParser.Target] = set()
       self.libs = set()
       self.include_dirs = set()
       self.ldflags = set()
@@ -668,10 +673,14 @@ class GnParser(object):
         continue
 
       # Non-third party groups are only used for bubbling cflags etc so don't
-      # add a dep.
+      # add a dep. Their direct deps surface to consumers as if they were
+      # direct deps of the consumer.
       if dep.type == 'group' and not dep.is_third_party_dep_:
         target.update(dep)  # Bubble up groups's cflags/ldflags etc.
+        target.immediate_deps.update(dep.immediate_deps)
         continue
+
+      target.immediate_deps.add(dep)
 
       # Linker units act as a hard boundary making all their internal deps
       # opaque to the outside world. For this reason, do not propogate deps


### PR DESCRIPTION
Map GN source_sets to perfetto_cc_library instead of perfetto_filegroup,
so each one is its own bazel target with its own srcs, hdrs and deps,
and Bazel resolves the graph transitively. This drops the awkward
"inline transitive_source_set_deps as srcs" model that gen_bazel used
to work around the lack of source_set in Bazel.

Track the direct GN deps (before bubbling up from source_sets/groups)
in `immediate_deps` and use them when emitting cc_library deps, so the
generated BUILD only lists each target's actual immediate dependencies.

Drop the gen_bazel ODRChecker call: it was guarding against same-file
duplication caused by inlining a source_set into multiple linker units,
which can't happen now that each source_set is its own cc_library.

The previous force_alwayslink propagation in gen_bazel becomes a no-op:
`alwayslink = True` lands directly on the source_set's cc_library and
Bazel propagates it to dependents.
