### PR TITLE
ui: Add optional actions buttons to grid cells

### DIFF
--- a/ui/src/assets/widgets/grid.scss
+++ b/ui/src/assets/widgets/grid.scss
@@ -88,9 +88,14 @@ $indent-guide-offset: 12px;
   --pf-cell-padding-inline: 0;
   --pf-grid-cell-indent: 0;
 
-  &__menu-button {
+  &__actions {
     // Eliminate the extra space between the menu button and the cell content added by the content padding.
     margin-left: calc(-1 * var(--pf-cell-padding-inline));
+    display: flex;
+    align-items: baseline;
+    gap: 2px;
+    flex-wrap: nowrap;
+    flex-shrink: 0;
   }
 
   &__indent {
@@ -161,6 +166,10 @@ $indent-guide-offset: 12px;
 
   .pf-visible-on-hover {
     display: none;
+
+    &:has(.pf-active) {
+      display: block;
+    }
 
     &.pf-active {
       display: block;

--- a/ui/src/components/widgets/datagrid/datagrid.ts
+++ b/ui/src/components/widgets/datagrid/datagrid.ts
@@ -1631,6 +1631,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
           return m(
             GridCell,
             {
+              actionButtons: colInfo?.actions?.(value, row),
               align: isRich ? rendered.align ?? 'left' : getAligment(value),
               nullish: isRich
                 ? rendered.nullish ?? value === null
@@ -2300,7 +2301,7 @@ export class DataGrid implements m.ClassComponent<DataGridAttrs> {
   }
 }
 
-export function renderCell(value: SqlValue, columnName: string) {
+export function renderCell(value: SqlValue, columnName?: string) {
   if (value === undefined) {
     return '';
   } else if (value instanceof Uint8Array) {
@@ -2310,7 +2311,7 @@ export function renderCell(value: SqlValue, columnName: string) {
         icon: Icons.Download,
         onclick: () =>
           download({
-            fileName: `${columnName}.blob`,
+            fileName: `${columnName ?? 'untitled'}.bin`,
             content: value,
           }),
       },

--- a/ui/src/components/widgets/datagrid/datagrid_schema.ts
+++ b/ui/src/components/widgets/datagrid/datagrid_schema.ts
@@ -96,6 +96,9 @@ export interface ColumnDef {
 
   // Optional value formatter for this column, used when exporting data.
   readonly cellFormatter?: CellFormatter;
+
+  // Additional actions displayed to the right of the cell dropdown menu.
+  readonly actions?: (value: SqlValue, row: Row) => m.Children;
 }
 
 /**
@@ -202,6 +205,9 @@ export interface ColumnInfo {
   readonly columnType?: ColumnType;
   readonly cellRenderer?: CellRenderer;
   readonly cellFormatter?: CellFormatter;
+
+  // Additional actions displayed to the right of the cell dropdown menu.
+  readonly actions?: (value: SqlValue, row: Row) => m.Children;
 }
 
 /**
@@ -284,6 +290,7 @@ export function getColumnInfo(
           columnType: entry.columnType,
           cellRenderer: entry.cellRenderer,
           cellFormatter: entry.cellFormatter,
+          actions: entry.actions,
         };
       }
       // Trying to navigate deeper into a leaf column - invalid

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/grid_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/grid_demo.ts
@@ -19,6 +19,9 @@ import {renderWidgetShowcase} from '../widgets_page_utils';
 import {languages} from '../sample_data';
 import {Anchor} from '../../../widgets/anchor';
 import {CodeSnippet} from '../../../widgets/code_snippet';
+import {Button, ButtonVariant} from '../../../widgets/button';
+import {Intent} from '../../../widgets/common';
+import {Icons} from '../../../base/semantic_icons';
 
 export function renderGrid(): m.Children {
   return [
@@ -483,7 +486,21 @@ function renderSimpleGridDemo(
         m(GridCell, {wrap, align: 'right', menuItems}, row.id),
         m(GridCell, {wrap, menuItems}, renderValue(row.name)),
         m(GridCell, {wrap, align: 'right', menuItems}, renderValue(row.score)),
-        m(GridCell, {wrap, menuItems}, renderValue(row.notes)),
+        m(
+          GridCell,
+          {
+            wrap,
+            menuItems,
+            actionButtons: m(Button, {
+              label: 'Edit',
+              rounded: true,
+              intent: Intent.Primary,
+              icon: Icons.Edit,
+              variant: ButtonVariant.Filled,
+            }),
+          },
+          renderValue(row.notes),
+        ),
         m(GridCell, {wrap, menuItems}, renderValue(row.status)),
       ];
     }),

--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -171,6 +171,7 @@ export interface GridCellAttrs extends HTMLAttrs {
   readonly indent?: number;
   readonly chevron?: 'expanded' | 'collapsed' | 'leaf';
   readonly onChevronClick?: () => void;
+  readonly actionButtons?: m.Children;
 }
 
 export class GridCell implements m.ClassComponent<GridCellAttrs> {
@@ -185,6 +186,7 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
       indent,
       chevron,
       onChevronClick,
+      actionButtons,
       ...htmlAttrs
     } = attrs;
 
@@ -221,6 +223,22 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
       });
     };
 
+    const cellMenu =
+      !isEmptyVnodes(menuItems) &&
+      m(
+        PopupMenu,
+        {
+          trigger: m(Button, {
+            className: 'pf-visible-on-hover',
+            icon: Icons.ContextMenuAlt,
+            rounded: true,
+            ariaLabel: 'Cell menu',
+          }),
+          position: PopupPosition.Bottom,
+        },
+        menuItems,
+      );
+
     return m(
       '.pf-grid-cell',
       {
@@ -237,20 +255,7 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
       renderIndent(),
       renderChevron(),
       m('.pf-grid-cell__content', children),
-      !isEmptyVnodes(menuItems) &&
-        m(
-          PopupMenu,
-          {
-            trigger: m(Button, {
-              className: 'pf-visible-on-hover pf-grid-cell__menu-button',
-              icon: Icons.ContextMenuAlt,
-              rounded: true,
-              ariaLabel: 'Cell menu',
-            }),
-            position: PopupPosition.Bottom,
-          },
-          menuItems,
-        ),
+      m('.pf-grid-cell__actions.pf-visible-on-hover', actionButtons, cellMenu),
     );
   }
 }

--- a/ui/src/widgets/grid.ts
+++ b/ui/src/widgets/grid.ts
@@ -239,6 +239,8 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
         menuItems,
       );
 
+    const cellActions = [actionButtons, cellMenu];
+
     return m(
       '.pf-grid-cell',
       {
@@ -255,7 +257,8 @@ export class GridCell implements m.ClassComponent<GridCellAttrs> {
       renderIndent(),
       renderChevron(),
       m('.pf-grid-cell__content', children),
-      m('.pf-grid-cell__actions.pf-visible-on-hover', actionButtons, cellMenu),
+      !isEmptyVnodes(cellActions) &&
+        m('.pf-grid-cell__actions.pf-visible-on-hover', cellActions),
     );
   }
 }


### PR DESCRIPTION
Adds an optional 'actions' slot for injecting buttons and other such entities into grid cells in both the Grid and DataGrid widgets.

For example - a primary rounded button:
<img width="417" height="144" alt="image" src="https://github.com/user-attachments/assets/508ee30e-ce25-4176-88da-c82f2a2349f9" />
