### PR TITLE
rust-sdk: Add tracing-perfetto-sdk crate

### DIFF
--- a/contrib/rust-sdk/Cargo.lock
+++ b/contrib/rust-sdk/Cargo.lock
@@ -344,7 +344,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perfetto-sdk"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bitflags",
  "paste",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-derive"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "perfetto-sdk",
  "proc-macro2",
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-protos-gpu"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "paste",
  "perfetto-sdk",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-protos-trace-processor"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "paste",
  "perfetto-sdk",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-sys"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/contrib/rust-sdk/Cargo.lock
+++ b/contrib/rust-sdk/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-protos-gpu"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "paste",
  "perfetto-sdk",

--- a/contrib/rust-sdk/Cargo.lock
+++ b/contrib/rust-sdk/Cargo.lock
@@ -265,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +392,12 @@ dependencies = [
  "bindgen",
  "cc",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
@@ -538,6 +550,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +647,46 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-perfetto-sdk"
+version = "0.3.0"
+dependencies = [
+ "perfetto-sdk",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/contrib/rust-sdk/Cargo.lock
+++ b/contrib/rust-sdk/Cargo.lock
@@ -350,7 +350,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perfetto-sdk"
-version = "0.3.3"
+version = "1.0.0"
 dependencies = [
  "bitflags",
  "paste",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-derive"
-version = "0.3.1"
+version = "1.0.0"
 dependencies = [
  "perfetto-sdk",
  "proc-macro2",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-protos-gpu"
-version = "0.3.10"
+version = "1.0.0"
 dependencies = [
  "paste",
  "perfetto-sdk",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-protos-trace-processor"
-version = "0.3.1"
+version = "1.0.0"
 dependencies = [
  "paste",
  "perfetto-sdk",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "perfetto-sdk-sys"
-version = "0.3.1"
+version = "1.0.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-perfetto-sdk"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "perfetto-sdk",
  "tracing",

--- a/contrib/rust-sdk/Cargo.toml
+++ b/contrib/rust-sdk/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["perfetto", "perfetto-derive", "perfetto-protos-gpu", "perfetto-protos-trace-processor", "perfetto-sys"]
+members = ["perfetto", "perfetto-derive", "perfetto-protos-gpu", "perfetto-protos-trace-processor", "perfetto-sys", "tracing-perfetto"]

--- a/contrib/rust-sdk/perfetto-derive/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-derive"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Procedural macros for Perfetto"
 readme = "README.md"
@@ -22,7 +22,7 @@ default = ["vendored"]
 vendored = ["perfetto-sdk/vendored"]
 
 [dependencies]
-perfetto-sdk = { path = "../perfetto", version = "0.3", default-features = false }
+perfetto-sdk = { path = "../perfetto", version = "1", default-features = false }
 syn = { version = "2", features = ["full"] }
 quote = "1.0.8"
 proc-macro2 = "1.0"

--- a/contrib/rust-sdk/perfetto-derive/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-derive"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Procedural macros for Perfetto"
 readme = "README.md"

--- a/contrib/rust-sdk/perfetto-derive/README.md
+++ b/contrib/rust-sdk/perfetto-derive/README.md
@@ -1,1 +1,33 @@
-../perfetto/README.md
+# perfetto-sdk-derive
+
+Procedural macros for the [Perfetto](https://perfetto.dev) Rust SDK.
+
+This crate provides the `#[tracefn]` attribute macro for automatically
+instrumenting functions with Perfetto track events. When applied to a
+function, it emits a trace event spanning the function's execution and
+optionally captures input parameters as event arguments.
+
+## Usage
+
+```rust,ignore
+use perfetto_sdk::track_event::*;
+
+perfetto_sdk::track_event_categories! {
+    pub mod my_categories {
+        ("rendering", "Rendering events", []),
+    }
+}
+use my_categories as perfetto_te_ns;
+
+#[perfetto_sdk_derive::tracefn("rendering")]
+fn draw_frame(width: u32, height: u32) {
+    // A "draw_frame" trace event is emitted automatically,
+    // capturing width and height as arguments.
+}
+```
+
+## Related crates
+
+| Crate | Description |
+|-------|-------------|
+| [`perfetto-sdk`](https://crates.io/crates/perfetto-sdk) | Main SDK with tracing session and track event APIs |

--- a/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-protos-gpu"
-version = "0.3.10"
+version = "1.0.0"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Extra protobuf bindings for GPU events"
 readme = "README.md"
@@ -19,7 +19,7 @@ default = ["vendored"]
 vendored = ["perfetto-sdk/vendored"]
 
 [dependencies]
-perfetto-sdk = { path = "../perfetto", version = "0.3", default-features = false }
+perfetto-sdk = { path = "../perfetto", version = "1", default-features = false }
 paste = "1"
 
 [[example]]

--- a/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-protos-gpu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-protos-gpu"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Extra protobuf bindings for GPU events"
 readme = "README.md"

--- a/contrib/rust-sdk/perfetto-protos-gpu/README.md
+++ b/contrib/rust-sdk/perfetto-protos-gpu/README.md
@@ -1,1 +1,34 @@
-../perfetto/README.md
+# perfetto-sdk-protos-gpu
+
+GPU event protobuf bindings for the [Perfetto](https://perfetto.dev) Rust SDK.
+
+This crate provides auto-generated Rust types for GPU-related Perfetto
+protobuf messages, including GPU render stage events, GPU counters, GPU
+frequency events, GPU memory events, Vulkan events, and GPU track event
+extensions.
+
+It extends `TracePacket` from `perfetto-sdk` with GPU-specific fields so
+trace producers can emit GPU events alongside standard track events.
+
+## Usage
+
+```rust,no_run
+use perfetto_sdk_protos_gpu::protos::trace::trace_packet::prelude::*;
+use perfetto_sdk_protos_gpu::protos::trace::gpu::gpu_counter_event::*;
+
+fn write_gpu_counter(packet: &mut perfetto_sdk::protos::trace::trace_packet::TracePacket) {
+    packet.set_gpu_counter_event(|event: &mut GpuCounterEvent| {
+        event.set_counters(|counter: &mut GpuCounterEventGpuCounter| {
+            counter.set_counter_id(1);
+            counter.set_double_value(42.0);
+        });
+    });
+}
+```
+
+## Related crates
+
+| Crate | Description |
+|-------|-------------|
+| [`perfetto-sdk`](https://crates.io/crates/perfetto-sdk) | Main SDK with tracing session and track event APIs |
+| [`perfetto-sdk-protos-trace-processor`](https://crates.io/crates/perfetto-sdk-protos-trace-processor) | Trace processor protobuf bindings |

--- a/contrib/rust-sdk/perfetto-protos-gpu/src/lib.rs
+++ b/contrib/rust-sdk/perfetto-protos-gpu/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![doc = include_str!("../README.md")]
+
 /// Re-export pb_msg macro from this crate.
 pub use perfetto_sdk::pb_msg;
 

--- a/contrib/rust-sdk/perfetto-protos-trace-processor/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-protos-trace-processor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-protos-trace-processor"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Extra protobuf bindings for trace processor"
 readme = "README.md"
@@ -19,7 +19,7 @@ default = ["vendored"]
 vendored = ["perfetto-sdk/vendored"]
 
 [dependencies]
-perfetto-sdk = { path = "../perfetto", version = "0.3", default-features = false }
+perfetto-sdk = { path = "../perfetto", version = "1", default-features = false }
 paste = "1"
 
 [dev-dependencies]

--- a/contrib/rust-sdk/perfetto-protos-trace-processor/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-protos-trace-processor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-protos-trace-processor"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Extra protobuf bindings for trace processor"
 readme = "README.md"

--- a/contrib/rust-sdk/perfetto-protos-trace-processor/README.md
+++ b/contrib/rust-sdk/perfetto-protos-trace-processor/README.md
@@ -1,1 +1,37 @@
-../perfetto/README.md
+# perfetto-sdk-protos-trace-processor
+
+Trace processor protobuf bindings for the [Perfetto](https://perfetto.dev)
+Rust SDK.
+
+This crate provides auto-generated Rust types for Perfetto trace processor
+protobuf messages, enabling communication with
+`trace_processor_shell serve http` via its HTTP+protobuf RPC interface.
+
+## Usage
+
+```rust,no_run
+use perfetto_sdk::heap_buffer::HeapBuffer;
+use perfetto_sdk::pb_msg::{PbMsg, PbMsgWriter};
+use perfetto_sdk_protos_trace_processor::protos::trace_processor
+    ::trace_processor::QueryArgsFieldNumber;
+
+/// Encode a SQL query as a QueryArgs protobuf message.
+fn encode_query(sql: &str) -> Vec<u8> {
+    let writer = PbMsgWriter::new();
+    let hb = HeapBuffer::new(writer.stream_writer());
+    let mut msg = PbMsg::new(&writer).unwrap();
+    msg.append_cstr_field(QueryArgsFieldNumber::SqlQuery as u32, sql);
+    msg.finalize();
+    let size = writer.stream_writer().get_written_size();
+    let mut buffer = vec![0u8; size];
+    hb.copy_into(&mut buffer);
+    buffer
+}
+```
+
+## Related crates
+
+| Crate | Description |
+|-------|-------------|
+| [`perfetto-sdk`](https://crates.io/crates/perfetto-sdk) | Main SDK with tracing session and track event APIs |
+| [`perfetto-sdk-protos-gpu`](https://crates.io/crates/perfetto-sdk-protos-gpu) | GPU event protobuf bindings |

--- a/contrib/rust-sdk/perfetto-protos-trace-processor/src/lib.rs
+++ b/contrib/rust-sdk/perfetto-protos-trace-processor/src/lib.rs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Perfetto trace processor protobuf bindings.
-//!
-//! This crate provides Rust bindings for Perfetto trace processor protos,
-//! enabling communication with `trace_processor_shell -D` via HTTP.
-
+#![doc = include_str!("../README.md")]
 #![allow(clippy::module_inception)]
 
 /// Re-export pb_msg macro from this crate.

--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["David Reveman <reveman@meta.com>"]
 build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"

--- a/contrib/rust-sdk/perfetto-sys/Cargo.toml
+++ b/contrib/rust-sdk/perfetto-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk-sys"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["David Reveman <reveman@meta.com>"]
 build = "build.rs"
 description = "Low-level FFI bindings for Perfetto"

--- a/contrib/rust-sdk/perfetto-sys/README.md
+++ b/contrib/rust-sdk/perfetto-sys/README.md
@@ -1,27 +1,30 @@
 # perfetto-sdk-sys
 
-Low-level FFI bindings for Perfetto.
+Low-level FFI bindings for [Perfetto](https://perfetto.dev).
 
-## Features
+This crate provides raw Rust bindings to the Perfetto C API (`perfetto_c`).
+It is used internally by `perfetto-sdk` and should not normally be used
+directly.
 
-### `vendored` (default)
+## Crate features
 
-Compiles the Perfetto C library from the included amalgamated source. This is
-the default and recommended option for most users.
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `vendored` | yes | Compiles and statically links the bundled Perfetto C library |
+| `bindgen` | no | Regenerates Rust bindings from C headers at build time using bindgen (requires `libclang`) |
 
-### `bindgen`
+### Linking against an external library
 
-Regenerates the Rust bindings from the C headers at build time using
-[bindgen](https://github.com/rust-lang/rust-bindgen). This requires `libclang`
-to be installed on the system.
-
-By default, pre-generated bindings are used, which avoids the `libclang`
-dependency and speeds up build times. Enable this feature when:
-
-- You've modified the C headers and need updated bindings
-- You're targeting a platform where the pre-generated bindings don't work
-- You want to ensure bindings match your specific `libclang` version
+To link against a system-installed Perfetto C library instead of the
+vendored one:
 
 ```bash
-cargo build --features bindgen
+export PERFETTO_SYS_LIB_DIR=/path/to/lib
+cargo build -p perfetto-sdk-sys --no-default-features
 ```
+
+## Related crates
+
+| Crate | Description |
+|-------|-------------|
+| [`perfetto-sdk`](https://crates.io/crates/perfetto-sdk) | Safe wrapper around these bindings |

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Bindings for the Perfetto tracing framework"
 readme = "README.md"

--- a/contrib/rust-sdk/perfetto/Cargo.toml
+++ b/contrib/rust-sdk/perfetto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "perfetto-sdk"
-version = "0.3.3"
+version = "1.0.0"
 authors = ["David Reveman <reveman@meta.com>"]
 description = "Bindings for the Perfetto tracing framework"
 readme = "README.md"
@@ -20,7 +20,7 @@ intrinsics = []
 vendored = ["perfetto-sdk-sys/vendored"]
 
 [dependencies]
-perfetto-sdk-sys = { path = "../perfetto-sys", version = "0.3", default-features = false }
+perfetto-sdk-sys = { path = "../perfetto-sys", version = "1", default-features = false }
 bitflags = "2"
 paste = "1"
 thiserror = "1"

--- a/contrib/rust-sdk/perfetto/README.md
+++ b/contrib/rust-sdk/perfetto/README.md
@@ -1,3 +1,46 @@
 # perfetto-sdk
 
-Perfetto bindings for the Rust programming language.
+Safe and ergonomic Rust bindings for the
+[Perfetto](https://perfetto.dev) tracing framework.
+
+This crate provides the main API for recording trace data from Rust
+applications. It wraps the Perfetto C API with safe Rust abstractions for
+tracing sessions, data sources, and track events.
+
+## Quick start
+
+```rust,no_run
+use perfetto_sdk::track_event::*;
+
+perfetto_sdk::track_event_categories! {
+    pub mod my_categories {
+        ("rendering", "Rendering events", []),
+        ("input", "Input events", []),
+    }
+}
+use my_categories as perfetto_te_ns;
+
+perfetto_sdk::track_event_instant!("rendering", "DrawFrame");
+```
+
+## Features
+
+- **Track events** with categories, names, and typed arguments
+- **Data sources** for custom trace data
+- **Protozero encoding** in pure Rust for minimal overhead
+- **Tracing sessions** for programmatic trace collection
+
+## Crate features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `vendored` | yes | Statically links the bundled Perfetto C library |
+| `intrinsics` | no | Enables branch-prediction hints to reduce trace overhead |
+
+## Related crates
+
+| Crate | Description |
+|-------|-------------|
+| [`perfetto-sdk-sys`](https://crates.io/crates/perfetto-sdk-sys) | Low-level FFI bindings |
+| [`perfetto-sdk-derive`](https://crates.io/crates/perfetto-sdk-derive) | Proc macros for function tracing |
+| [`perfetto-sdk-protos-gpu`](https://crates.io/crates/perfetto-sdk-protos-gpu) | GPU event protobuf bindings |

--- a/contrib/rust-sdk/perfetto/src/lib.rs
+++ b/contrib/rust-sdk/perfetto/src/lib.rs
@@ -12,15 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! # perfetto
-//!
-//! This crate provides Rust bindings for Perfetto.
-//!
-//! It is uses the public ABI under the hood and has been designed for safe
-//! and efficient usage in Rust projects. Performance critical operations
-//! such as checking if a track event category is enabled is done in Rust
-//! code as well as encoding of proto messages.
-
+#![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![cfg_attr(

--- a/contrib/rust-sdk/tracing-perfetto/Cargo.toml
+++ b/contrib/rust-sdk/tracing-perfetto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-perfetto-sdk"
-version = "0.3.0"
+version = "1.0.0"
 authors = ["David Reveman <reveman@meta.com>"]
 edition = "2024"
 description = "tracing-subscriber Layer for Perfetto SDK"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-perfetto-sdk = { path = "../perfetto", version = "0.3", default-features = false }
+perfetto-sdk = { path = "../perfetto", version = "1", default-features = false }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 tracing-core = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }

--- a/contrib/rust-sdk/tracing-perfetto/Cargo.toml
+++ b/contrib/rust-sdk/tracing-perfetto/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tracing-perfetto-sdk"
+version = "0.3.0"
+authors = ["David Reveman <reveman@meta.com>"]
+edition = "2024"
+description = "tracing-subscriber Layer for Perfetto SDK"
+license = "Apache-2.0"
+readme = "README.md"
+
+[dependencies]
+perfetto-sdk = { path = "../perfetto", version = "0.3", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-core = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+
+[[example]]
+name = "tracing"
+path = "examples/tracing.rs"
+
+[features]
+default = ["vendored"]
+vendored = ["perfetto-sdk/vendored"]
+intrinsics = ["perfetto-sdk/intrinsics"]

--- a/contrib/rust-sdk/tracing-perfetto/README.md
+++ b/contrib/rust-sdk/tracing-perfetto/README.md
@@ -1,0 +1,46 @@
+# tracing-perfetto-sdk
+
+A [`tracing-subscriber`](https://docs.rs/tracing-subscriber) `Layer` that
+emits [Perfetto](https://perfetto.dev) track events via the
+[`perfetto-sdk`](https://crates.io/crates/perfetto-sdk) crate.
+
+This bridges the Rust `tracing` ecosystem with Perfetto's native tracing
+infrastructure. Spans become duration slices and events become instant
+events, with full support for debug annotations, source locations, and
+integration with the Perfetto tracing service.
+
+## Quick start
+
+```rust,no_run
+use tracing_subscriber::prelude::*;
+
+tracing_perfetto_sdk::init();
+tracing_subscriber::registry()
+    .with(tracing_perfetto_sdk::PerfettoLayer::new())
+    .init();
+
+let span = tracing::info_span!("my_function", arg = 42);
+let _guard = span.enter();
+tracing::info!("hello from Perfetto");
+```
+
+## Features
+
+- **Zero-cost when disabled** — category enable check is a single atomic load
+- **Debug annotations** — span and event fields are captured as Perfetto debug annotations
+- **Source locations** — file and line number are attached to every event
+- **Service integration** — works with both in-process tracing and the system tracing service
+
+## Crate features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `vendored` | yes | Statically links the bundled Perfetto C library |
+
+## Related crates
+
+| Crate | Description |
+|-------|-------------|
+| [`perfetto-sdk`](https://crates.io/crates/perfetto-sdk) | The underlying Perfetto SDK bindings |
+| [`tracing`](https://crates.io/crates/tracing) | The Rust tracing facade |
+| [`tracing-subscriber`](https://crates.io/crates/tracing-subscriber) | Composable tracing subscriber layers |

--- a/contrib/rust-sdk/tracing-perfetto/examples/tracing.rs
+++ b/contrib/rust-sdk/tracing-perfetto/examples/tracing.rs
@@ -1,0 +1,151 @@
+// Copyright (C) 2025 Rivos Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Example demonstrating the tracing-perfetto-sdk layer.
+//!
+//! This shows how to use Rust's `tracing` crate with Perfetto as a
+//! backend. Spans become duration slices and events become instants
+//! in the Perfetto trace.
+//!
+//! ## In-process mode (default)
+//!
+//! Collects a trace to a file without needing a tracing service:
+//! ```sh
+//! cargo run --example tracing
+//! ```
+//! Then open `/tmp/trace.pftrace` in <https://ui.perfetto.dev>.
+//!
+//! ## System mode
+//!
+//! Connects to a running Perfetto tracing service:
+//! ```sh
+//! perfetto -o /tmp/trace.pftrace -c - --txt <<EOF
+//!   buffers { size_kb: 65536 }
+//!   data_sources { config { name: "track_event" } }
+//!   duration_ms: 5000
+//! EOF
+//!
+//! cargo run --example tracing -- --system
+//! ```
+
+use std::thread;
+use std::time::Duration;
+
+use tracing::{info, info_span, warn};
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    let system_mode = std::env::args().any(|arg| arg == "--system");
+
+    if system_mode {
+        tracing_perfetto_sdk::init_system();
+    } else {
+        tracing_perfetto_sdk::init_in_process();
+    }
+
+    tracing_subscriber::registry()
+        .with(tracing_perfetto_sdk::PerfettoLayer::new())
+        .init();
+
+    // For in-process mode, start a tracing session.
+    let mut session = if !system_mode {
+        let mut session =
+            perfetto_sdk::tracing_session::TracingSession::in_process().expect("session");
+        // Build a minimal trace config enabling track_event.
+        let config = build_trace_config();
+        session.setup(&config);
+        session.start_blocking();
+        Some(session)
+    } else {
+        eprintln!("System mode: waiting for external trace session...");
+        None
+    };
+
+    // Run the workload.
+    info!("application started");
+    for i in 0..3 {
+        let _span = info_span!("iteration", i).entered();
+        do_work(i);
+    }
+    info!("application finished");
+
+    // For in-process mode, stop and write the trace.
+    if let Some(ref mut session) = session {
+        session.flush_blocking(Duration::from_secs(5));
+        session.stop_blocking();
+        let trace_data = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let trace_data_clone = trace_data.clone();
+        session.read_trace_blocking(move |data, _has_more| {
+            trace_data_clone.lock().unwrap().extend_from_slice(data);
+        });
+        let trace_data = std::sync::Arc::try_unwrap(trace_data)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+        std::fs::write("/tmp/trace.pftrace", &trace_data).expect("write trace");
+        eprintln!(
+            "Trace written to /tmp/trace.pftrace ({} bytes)",
+            trace_data.len()
+        );
+    }
+}
+
+fn do_work(iteration: u32) {
+    let _span = info_span!("do_work", iteration).entered();
+
+    info!(iteration, "starting work");
+    thread::sleep(Duration::from_millis(10));
+
+    {
+        let _inner = info_span!("inner_task", iteration).entered();
+        thread::sleep(Duration::from_millis(5));
+        warn!("something happened");
+    }
+
+    info!("work complete");
+}
+
+/// Build a minimal TraceConfig enabling the track_event data source.
+fn build_trace_config() -> Vec<u8> {
+    use perfetto_sdk::heap_buffer::HeapBuffer;
+    use perfetto_sdk::pb_msg::{PbMsg, PbMsgWriter};
+    use perfetto_sdk::protos::config::{
+        data_source_config::DataSourceConfig,
+        trace_config::{TraceConfig, TraceConfigBufferConfig, TraceConfigDataSource},
+        track_event::track_event_config::TrackEventConfig,
+    };
+
+    let writer = PbMsgWriter::new();
+    let hb = HeapBuffer::new(writer.stream_writer());
+    let mut msg = PbMsg::new(&writer).unwrap();
+    {
+        let mut cfg = TraceConfig { msg: &mut msg };
+        cfg.set_buffers(|buf_cfg: &mut TraceConfigBufferConfig| {
+            buf_cfg.set_size_kb(4096);
+        });
+        cfg.set_data_sources(|data_sources: &mut TraceConfigDataSource| {
+            data_sources.set_config(|ds_cfg: &mut DataSourceConfig| {
+                ds_cfg.set_name("track_event");
+                ds_cfg.set_track_event_config(|te_cfg: &mut TrackEventConfig| {
+                    te_cfg.set_enabled_categories("tracing");
+                });
+            });
+        });
+    }
+    msg.finalize();
+    let cfg_size = writer.stream_writer().get_written_size();
+    let mut cfg_buffer = vec![0u8; cfg_size];
+    hb.copy_into(&mut cfg_buffer);
+    cfg_buffer
+}

--- a/contrib/rust-sdk/tracing-perfetto/src/lib.rs
+++ b/contrib/rust-sdk/tracing-perfetto/src/lib.rs
@@ -1,0 +1,369 @@
+// Copyright (C) 2025 Rivos Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![doc = include_str!("../README.md")]
+#![cfg_attr(
+    feature = "intrinsics",
+    allow(internal_features),
+    feature(core_intrinsics)
+)]
+
+use std::ffi::CString;
+
+use perfetto_sdk::producer::{Backends, Producer, ProducerInitArgsBuilder};
+use perfetto_sdk::track_event::{EventContext, TrackEvent, TrackEventDebugArg, TrackEventType};
+use tracing_core::span;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+perfetto_sdk::track_event_categories! {
+    pub mod perfetto_te_ns {
+        ("tracing", "Events from the Rust tracing crate", []),
+    }
+}
+
+/// Initialize the Perfetto producer and track event system with both
+/// in-process and system backends enabled.
+///
+/// Call this once before installing the layer.
+pub fn init() {
+    init_with_backends(Backends::IN_PROCESS | Backends::SYSTEM);
+}
+
+/// Initialize with only the in-process backend.
+///
+/// Use this when collecting traces programmatically via
+/// [`perfetto_sdk::tracing_session::TracingSession`] without a system
+/// tracing service.
+pub fn init_in_process() {
+    init_with_backends(Backends::IN_PROCESS);
+}
+
+/// Initialize with only the system backend.
+///
+/// Use this when connecting to a running Perfetto tracing service
+/// (e.g. `traced`).
+pub fn init_system() {
+    init_with_backends(Backends::SYSTEM);
+}
+
+fn init_with_backends(backends: Backends) {
+    Producer::init(ProducerInitArgsBuilder::new().backends(backends).build());
+    TrackEvent::init();
+    perfetto_te_ns::register().ok();
+}
+
+/// Per-span data stored in tracing-subscriber's Extensions.
+struct SpanData {
+    name: CString,
+    fields: Vec<(&'static str, FieldValue)>,
+}
+
+enum FieldValue {
+    Bool(bool),
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    Str(String),
+}
+
+/// A `tracing_subscriber::Layer` that emits Perfetto track events.
+///
+/// Spans become duration slices (begin/end) and events become instant
+/// events, all routed through the Perfetto SDK's track event system.
+pub struct PerfettoLayer {
+    debug_annotations: bool,
+}
+
+impl PerfettoLayer {
+    /// Create a new layer with debug annotations enabled.
+    pub fn new() -> Self {
+        Self {
+            debug_annotations: true,
+        }
+    }
+
+    /// Create a new layer without debug annotations.
+    ///
+    /// Fields on spans and events will not be captured, reducing
+    /// overhead.
+    pub fn without_debug_annotations() -> Self {
+        Self {
+            debug_annotations: false,
+        }
+    }
+}
+
+impl Default for PerfettoLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn add_debug_args(ctx: &mut EventContext, fields: &[(&'static str, FieldValue)]) {
+    for (name, value) in fields {
+        let arg = match value {
+            FieldValue::Bool(v) => TrackEventDebugArg::Bool(*v),
+            FieldValue::I64(v) => TrackEventDebugArg::Int64(*v),
+            FieldValue::U64(v) => TrackEventDebugArg::Uint64(*v),
+            FieldValue::F64(v) => TrackEventDebugArg::Double(*v),
+            FieldValue::Str(v) => TrackEventDebugArg::String(v),
+        };
+        ctx.add_debug_arg(name, arg);
+    }
+}
+
+fn add_source_location(ctx: &mut EventContext, meta: &tracing_core::Metadata<'_>) {
+    use perfetto_sdk::protos::trace::track_event::source_location::SourceLocationFieldNumber;
+    use perfetto_sdk::protos::trace::track_event::track_event::TrackEventFieldNumber;
+    use perfetto_sdk::track_event::{TrackEventProtoField, TrackEventProtoFields};
+
+    let file = meta.file().unwrap_or("");
+    let line = meta.line().unwrap_or(0);
+
+    ctx.set_proto_fields(&TrackEventProtoFields {
+        fields: &[TrackEventProtoField::Nested(
+            TrackEventFieldNumber::SourceLocation as u32,
+            &[
+                TrackEventProtoField::Cstr(SourceLocationFieldNumber::FileName as u32, file),
+                TrackEventProtoField::VarInt(
+                    SourceLocationFieldNumber::LineNumber as u32,
+                    line as u64,
+                ),
+            ],
+        )],
+    });
+}
+
+struct FieldVisitor {
+    fields: Vec<(&'static str, FieldValue)>,
+}
+
+impl FieldVisitor {
+    fn new() -> Self {
+        Self { fields: Vec::new() }
+    }
+}
+
+impl tracing::field::Visit for FieldVisitor {
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields.push((field.name(), FieldValue::Bool(value)));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields.push((field.name(), FieldValue::I64(value)));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields.push((field.name(), FieldValue::U64(value)));
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.fields.push((field.name(), FieldValue::F64(value)));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields
+            .push((field.name(), FieldValue::Str(value.to_string())));
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .push((field.name(), FieldValue::Str(format!("{value:?}"))));
+    }
+}
+
+impl<S> Layer<S> for PerfettoLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("span not found");
+        let name = CString::new(attrs.metadata().name()).unwrap_or_default();
+
+        let fields = if self.debug_annotations {
+            let mut visitor = FieldVisitor::new();
+            attrs.values().record(&mut visitor);
+            visitor.fields
+        } else {
+            Vec::new()
+        };
+
+        span.extensions_mut().insert(SpanData { name, fields });
+    }
+
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        if !self.debug_annotations {
+            return;
+        }
+        let span = ctx.span(id).expect("span not found");
+        let mut extensions = span.extensions_mut();
+        if let Some(data) = extensions.get_mut::<SpanData>() {
+            let mut visitor = FieldVisitor::new();
+            values.record(&mut visitor);
+            data.fields.extend(visitor.fields);
+        }
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("span not found");
+        let extensions = span.extensions();
+        let Some(data) = extensions.get::<SpanData>() else {
+            return;
+        };
+        let name_ptr = data.name.as_ptr();
+        let fields = &data.fields;
+        let meta = span.metadata();
+        let debug_annotations = self.debug_annotations;
+        perfetto_sdk::track_event!(
+            "tracing",
+            TrackEventType::SliceBegin(name_ptr),
+            |ctx: &mut EventContext| {
+                add_source_location(ctx, meta);
+                if debug_annotations && !fields.is_empty() {
+                    add_debug_args(ctx, fields);
+                }
+            }
+        );
+    }
+
+    fn on_exit(&self, _id: &span::Id, _ctx: Context<'_, S>) {
+        perfetto_sdk::track_event!("tracing", TrackEventType::SliceEnd);
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let meta = event.metadata();
+        let name = CString::new(meta.name()).unwrap_or_default();
+        let name_ptr = name.as_ptr();
+
+        let fields = if self.debug_annotations {
+            let mut visitor = FieldVisitor::new();
+            event.record(&mut visitor);
+            visitor.fields
+        } else {
+            Vec::new()
+        };
+
+        perfetto_sdk::track_event!(
+            "tracing",
+            TrackEventType::Instant(name_ptr),
+            |ctx: &mut EventContext| {
+                add_source_location(ctx, meta);
+                if !fields.is_empty() {
+                    add_debug_args(ctx, &fields);
+                }
+            }
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::prelude::*;
+
+    #[test]
+    fn layer_can_be_installed() {
+        init();
+        let _subscriber = tracing_subscriber::registry().with(PerfettoLayer::new());
+    }
+
+    #[test]
+    fn layer_without_debug_annotations() {
+        init();
+        let _subscriber =
+            tracing_subscriber::registry().with(PerfettoLayer::without_debug_annotations());
+    }
+
+    #[test]
+    fn default_layer() {
+        init();
+        let layer = PerfettoLayer::default();
+        assert!(layer.debug_annotations);
+    }
+
+    #[test]
+    fn span_enter_exit() {
+        init();
+        let subscriber = tracing_subscriber::registry().with(PerfettoLayer::new());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("test_span", x = 42);
+            let _guard = span.enter();
+        });
+    }
+
+    #[test]
+    fn nested_spans() {
+        init();
+        let subscriber = tracing_subscriber::registry().with(PerfettoLayer::new());
+        tracing::subscriber::with_default(subscriber, || {
+            let outer = tracing::info_span!("outer").entered();
+            {
+                let _inner = tracing::info_span!("inner", value = "hello").entered();
+            }
+            drop(outer);
+        });
+    }
+
+    #[test]
+    fn instant_event() {
+        init();
+        let subscriber = tracing_subscriber::registry().with(PerfettoLayer::new());
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("test event");
+        });
+    }
+
+    #[test]
+    fn event_with_fields() {
+        init();
+        let subscriber = tracing_subscriber::registry().with(PerfettoLayer::new());
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(count = 42, name = "test", enabled = true, "an event");
+        });
+    }
+
+    #[test]
+    fn event_inside_span() {
+        init();
+        let subscriber = tracing_subscriber::registry().with(PerfettoLayer::new());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!("parent").entered();
+            tracing::warn!("warning inside span");
+        });
+    }
+
+    #[test]
+    fn span_record_late_fields() {
+        init();
+        let subscriber = tracing_subscriber::registry().with(PerfettoLayer::new());
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("span", answer = tracing::field::Empty);
+            span.record("answer", 42);
+            let _guard = span.enter();
+        });
+    }
+
+    #[test]
+    fn no_annotations_mode() {
+        init();
+        let subscriber =
+            tracing_subscriber::registry().with(PerfettoLayer::without_debug_annotations());
+        tracing::subscriber::with_default(subscriber, || {
+            let _span = tracing::info_span!("span", field = "ignored").entered();
+            tracing::info!(also = "ignored", "event");
+        });
+    }
+}


### PR DESCRIPTION
Add a tracing-subscriber Layer that bridges the Rust tracing
ecosystem to Perfetto via the perfetto-sdk crate. Spans become
duration slices (begin/end) and events become instant events,
with debug annotations for fields and source locations.

Uses the SDK's track event macros for proper interning,
incremental state, and integration with both in-process tracing
and the system tracing service.

Also replace symlinks to the main crate README with dedicated
README files for each crate. Each README describes the crate's
purpose, basic usage, and links to related crates.