### PR TITLE
ui: fix histogram SQL when bucketSize is fractional

### DIFF
--- a/ui/src/components/widgets/charts/chart_sql_source.ts
+++ b/ui/src/components/widgets/charts/chart_sql_source.ts
@@ -528,7 +528,7 @@ SELECT
   ${min} AS _min,
   ${max} AS _max,
   (SELECT COUNT(*) FROM _data) AS _total,
-  MIN(${bucketCount - 1}, MAX(0, CAST((_value - ${min}) / ${size}.0 AS INT))) AS _bucket_idx,
+  MIN(${bucketCount - 1}, MAX(0, CAST((_value - ${min}) / CAST(${size} AS REAL) AS INT))) AS _bucket_idx,
   COUNT(*) AS _count
 FROM _data
 GROUP BY _bucket_idx


### PR DESCRIPTION
The fixed-bucketization branch in ChartSource appended ".0" to
${size} to force float division, assuming size was always an
integer. With a single slice, computeNiceBuckets produces a
fractional bucketSize (e.g. 0.02), which interpolated as the
malformed literal "0.02.0" and crashed the slice distribution
panel with a syntax error.

Use CAST(${size} AS REAL) instead so division stays float
regardless of the runtime value's form.
