### PR TITLE
perfetto: tbv2: fix bytes_overwritten over-counting consumed chunks

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -442,12 +442,17 @@ void ChunkSeqReader::ConsumeFragment(TBChunk* chunk, Frag* frag) {
 
   PERFETTO_DCHECK(chunk->payload_avail >= frag->size_with_header());
   chunk->payload_avail -= frag->size_with_header();
+
   if (chunk->payload_avail == 0) {
     TRACE_BUFFER_V2_DLOG("  Fully consumed chunk @ %zu", buf_->OffsetOf(chunk));
+    auto& stats = buf_->stats_;
     if (mode_ == kReadMode) {
-      auto& stats = buf_->stats_;
       stats.set_chunks_read(stats.chunks_read() + 1);
       stats.set_bytes_read(stats.bytes_read() + chunk->outer_size());
+    } else if (mode_ == kEraseMode) {
+      stats.set_chunks_overwritten(stats.chunks_overwritten() + 1);
+      stats.set_bytes_overwritten(stats.bytes_overwritten() +
+                                  chunk->outer_size());
     }
   }
 }
@@ -459,24 +464,22 @@ ChunkSeqReader::FragReassemblyResult ChunkSeqReader::ReassembleFragmentedPacket(
     TracePacket* out_packet,
     Frag* initial_frag) {
   PERFETTO_DCHECK(initial_frag->type == Frag::kFragBegin);
-
   TBChunk* initial_chunk = seq_iter_.chunk();
-  if (initial_chunk->flags & kChunkNeedsPatch)
-    return FragReassemblyResult::kNotEnoughData;
 
   struct FragAndChunk {
     FragAndChunk(Frag f, TBChunk* c) : frag(std::move(f)), chunk(c) {}
     Frag frag;
     TBChunk* chunk;
   };
-
   base::SmallVector<FragAndChunk, 8> frags;
   frags.emplace_back(*initial_frag, initial_chunk);
   ChunkSeqIterator chunk_iter = seq_iter_;  // Make copy.
 
-  // Iterate over chunks using the linked list.
-  FragReassemblyResult res;
-  for (;;) {
+  // Iterate over chunks using the linked list, unless the chunk needs patching
+  // in which case we skip down with res = kNotEnoughData.
+  FragReassemblyResult res = FragReassemblyResult::kNotEnoughData;
+  const bool chunk_needs_patching = initial_chunk->flags & kChunkNeedsPatch;
+  while (!chunk_needs_patching) {
     PERFETTO_DCHECK((chunk_iter.valid()));
     TBChunk* next_chunk = chunk_iter.NextChunkInSequence();
     if (!next_chunk || next_chunk->flags & kChunkNeedsPatch) {
@@ -537,7 +540,8 @@ ChunkSeqReader::FragReassemblyResult ChunkSeqReader::ReassembleFragmentedPacket(
         out_packet->AddSlice(f.begin, f.size);
     }
     if (res == FragReassemblyResult::kSuccess ||
-        res == FragReassemblyResult::kDataLoss) {
+        res == FragReassemblyResult::kDataLoss ||
+        (res == FragReassemblyResult::kNotEnoughData && mode_ == kEraseMode)) {
       ConsumeFragment(fc.chunk, &f);
     }
   }
@@ -980,9 +984,6 @@ void TraceBufferV2::DeleteNextChunksFor(size_t bytes_to_clear) {
     // ChunkSeqReader(kEraseMode) must delete the chunk once
     // ReadNextPacketInSeqOrder() returns false.
     PERFETTO_DCHECK(chunk->is_padding());
-
-    stats_.set_chunks_overwritten(stats_.chunks_overwritten() + 1);
-    stats_.set_bytes_overwritten(stats_.bytes_overwritten() + chunk_outer_size);
   }
 
   // Having consumed the packets above, this loop wipes out the contents of the

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -2666,4 +2666,235 @@ TEST_F(TraceBufferV2Test, ScrapeRecommitPreservesIncomplete) {
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 
+// Whole-packet path: the consumer reads the only packet of a chunk, returns,
+// and pauses (mimicking the kApproxBytesPerTask=32KB break taken by
+// ReadBuffersIntoConsumer in tracing_service_impl.cc). The chunk's
+// payload_avail is now 0 but it has not been erased to padding yet. A
+// concurrent producer wrap then incorrectly counts it in bytes_overwritten.
+TEST_F(TraceBufferV2Test, BytesOverwritten_ConsumedWholePacketCountedAsLost) {
+  ResetBuffer(4096);
+
+  // chunkX: a single whole packet on sequence {1,1}.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(512 - 16, 'a')
+      .CopyIntoTraceBuffer();
+
+  // Read the packet but do NOT call ReadNextTracePacket again. After the call
+  // ChunkSeqReader::ConsumeFragment has set payload_avail=0 on chunkX, but
+  // EraseCurrentChunk has not run, so chunkX is still a non-padding chunk
+  // sitting in seq.chunks.
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(512 - 16, 'a')));
+
+  // Sanity: the chunk has been credited as bytes_read; nothing overwritten
+  // yet.
+  EXPECT_EQ(512u, trace_buffer()->stats().bytes_read());
+  EXPECT_EQ(0u, trace_buffer()->stats().bytes_overwritten());
+  EXPECT_EQ(0u, trace_buffer()->stats().chunks_overwritten());
+
+  // Fill the buffer with chunks the consumer never reads, then write a chunk
+  // that wraps and clobbers chunkX along with the new fillers.
+  // wr_ goes 512 -> 1536 -> 2560 -> wraps to 0 to fit the 2048B chunk.
+  CreateChunk(ProducerID(1), WriterID(2), ChunkID(0))
+      .AddPacket(1024 - 16, 'b')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(2), ChunkID(1))
+      .AddPacket(1024 - 16, 'c')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(3), ChunkID(0))
+      .AddPacket(2048 - 16, 'd')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+
+  // chunkX (offset 0, 512B) had no unread data when overwritten, so it must
+  // not contribute to bytes_overwritten or chunks_overwritten. Only chunkY
+  // and chunkZ (1024B each, never read) legitimately carry data loss.
+  EXPECT_EQ(2u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(2048u, trace_buffer()->stats().bytes_overwritten());
+}
+
+// Reassembly path: a fragmented packet split across N chunks. After
+// ReassembleFragmentedPacket succeeds, ConsumeFragment runs on every chunk
+// (payload_avail -> 0 on each), but ChunkSeqReader's seq_iter_ is still on
+// the kFragBegin chunk. A producer wrap before the consumer next iterates
+// counts ALL N chunks as overwritten, even though no data was lost.
+TEST_F(TraceBufferV2Test,
+       BytesOverwritten_ConsumedFragmentedPacketCountedAsLost) {
+  ResetBuffer(4096);
+
+  // A fragmented packet split across 3 chunks of 512B each.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(512 - 16, 'a', kContOnNextChunk)
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(512 - 16, 'b', kContFromPrevChunk | kContOnNextChunk)
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
+      .AddPacket(512 - 16, 'c', kContFromPrevChunk)
+      .CopyIntoTraceBuffer();
+
+  // Reassemble + read the packet. All 3 chunks have payload_avail=0 after
+  // this, but none have been erased into padding chunks.
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(512 - 16, 'a'),
+                                        FakePacketFragment(512 - 16, 'b'),
+                                        FakePacketFragment(512 - 16, 'c')));
+
+  EXPECT_EQ(3u * 512u, trace_buffer()->stats().bytes_read());
+  EXPECT_EQ(0u, trace_buffer()->stats().bytes_overwritten());
+  EXPECT_EQ(0u, trace_buffer()->stats().chunks_overwritten());
+
+  // Add one big chunk to take used_size_ near the end, then a chunk that
+  // forces a wrap and lands on chunks A, B, C.
+  CreateChunk(ProducerID(1), WriterID(2), ChunkID(0))
+      .AddPacket(2048 - 16, 'd')
+      .CopyIntoTraceBuffer();  // wr_=3584
+  CreateChunk(ProducerID(1), WriterID(3), ChunkID(0))
+      .AddPacket(1536 - 16, 'e')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+
+  // None of A, B, C had unread data when they were overwritten (the consumer
+  // already read the reassembled packet). Hence no chunks should be reported
+  // as overwritten and bytes_overwritten should be 0.
+  EXPECT_EQ(0u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(0u, trace_buffer()->stats().bytes_overwritten());
+}
+
+// Same bug as ConsumedWholePacketCountedAsLost, but the cleanup gap stretches
+// across a BeginRead() boundary — mimicking the consumer flow where
+// ReadBuffersIntoConsumer (tracing_service_impl.cc:2507) yields after
+// ~kApproxBytesPerTask=32KB of packet bytes and the next IPC task starts a
+// fresh BeginRead. BeginRead does chunk_seq_reader_.reset(), so the
+// "consumed-but-not-padded" chunk survives across reads until the new
+// buffer-order walk happens to step on it again. If a producer wraps in
+// between, bytes_overwritten still counts the chunk.
+TEST_F(TraceBufferV2Test,
+       BytesOverwritten_ConsumedChunkSurvivesBeginReadBoundary) {
+  ResetBuffer(4096);
+
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(512 - 16, 'a')
+      .CopyIntoTraceBuffer();
+
+  // First read cycle: reads the packet, then the consumer stops.
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(512 - 16, 'a')));
+
+  // Second BeginRead before any cleanup happens. This resets
+  // chunk_seq_reader_ — the previously consumed chunkX is left in the
+  // buffer with payload_avail=0 and is_padding()==false, but no read
+  // iterator is keeping track of it.
+  trace_buffer()->BeginRead();
+
+  // Now a producer wrap arrives before the consumer's new walk reaches
+  // chunkX. Same arithmetic as the simple test: 512 + 1024 + 1024 = 2560,
+  // then a 2048B wrap clobbers the head.
+  CreateChunk(ProducerID(1), WriterID(2), ChunkID(0))
+      .AddPacket(1024 - 16, 'b')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(2), ChunkID(1))
+      .AddPacket(1024 - 16, 'c')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(3), ChunkID(0))
+      .AddPacket(2048 - 16, 'd')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+
+  // chunkX was already drained before the BeginRead boundary. Only chunkY
+  // and chunkZ legitimately had unread data.
+  EXPECT_EQ(2u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(2048u, trace_buffer()->stats().bytes_overwritten());
+}
+
+// A kFragBegin chunk pending a patch (kChunkNeedsPatching) whose patch never
+// arrives gets evicted by a subsequent wrap. ReassembleFragmentedPacket
+// returns kNotEnoughData on this chain and — unlike the kDataLoss branch —
+// does NOT call ConsumeFragment on the frags it walked. As a result the
+// kFragBegin chunk's data loss is not credited in bytes_overwritten /
+// chunks_overwritten. The continuation chunkB is still credited because the
+// outer DeleteNextChunksFor loop reaches it and the kFragEnd switch case in
+// ReadNextPacketInSeqOrder calls ConsumeFragment directly.
+TEST_F(TraceBufferV2Test,
+       BytesOverwritten_PendingPatchChunkOverwrittenIsCounted) {
+  ResetBuffer(4096);
+
+  // chunkA: kFragBegin + kChunkNeedsPatching. Continuation chunkB exists, but
+  // the patch never arrives, so the consumer can't reassemble the packet.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(1024 - 16, 'a', kContOnNextChunk | kChunkNeedsPatching)
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(1024 - 16, 'b', kContFromPrevChunk)
+      .CopyIntoTraceBuffer();
+
+  // The reader can't deliver this fragmented packet because A needs a patch.
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+
+  // Wrap so chunkA and chunkB get evicted before the patch arrives.
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(0))
+      .AddPacket(2048 - 16, 'c')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(3), WriterID(1), ChunkID(0))
+      .AddPacket(2048 - 16, 'd')
+      .CopyIntoTraceBuffer();
+  EXPECT_EQ(1u, trace_buffer()->stats().write_wrap_count());
+
+  // Both chunkA (kFragBegin pending patch) and chunkB (kFragEnd nobody read)
+  // carried unread data when overwritten. Both should be counted.
+  EXPECT_EQ(2u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(2048u, trace_buffer()->stats().bytes_overwritten());
+}
+
+// chunks_overwritten / bytes_overwritten must not be incremented for a chunk
+// that the reader already drained but hadn't yet "stepped past". The
+// kFragWholePacket branch in ReadNextPacketInSeqOrder() decrements
+// payload_avail to 0 and returns the packet to the consumer without erasing
+// the chunk; the chunk only becomes a padding chunk on the next read call,
+// when NextFragmentInChunk() returns nullopt and EraseCurrentChunk() runs.
+// If a write forces a wrap in that gap, DeleteNextChunksFor() encounters a
+// non-padding chunk and (incorrectly) bumps the overwrite counters, even
+// though there is nothing left to lose. Mirrors NoDataLossIfReaderCatchesUp
+// above, which exercises the same pattern but doesn't assert on the stats.
+TEST_F(TraceBufferV2Test, NoOverwriteCountIfReaderCatchesUp) {
+  ResetBuffer(4096);
+
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(2000, 'a')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
+      .AddPacket(1000, 'b')
+      .CopyIntoTraceBuffer();
+
+  // Read 'a' with a single ReadPacket(). Crucially, do not call ReadPacket()
+  // again — that follow-up call is what would turn ChunkID(0) into a padding
+  // chunk via EraseCurrentChunk().
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(2000, 'a')));
+
+  // ChunkID(2) doesn't fit in the tail, so wr_ wraps to 0 and
+  // DeleteNextChunksFor() walks ChunkID(0). ChunkID(0) has no unread bytes,
+  // so this is not an overwrite.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
+      .AddPacket(2000, 'c')
+      .CopyIntoTraceBuffer();
+
+  EXPECT_EQ(0u, trace_buffer()->stats().chunks_overwritten());
+  EXPECT_EQ(0u, trace_buffer()->stats().bytes_overwritten());
+
+  // Sanity check: the surviving packets are still readable and the consumer
+  // is not signalled any data loss — confirming that the increment above (if
+  // it fires) is bogus rather than a real overwrite reported elsewhere.
+  trace_buffer()->BeginRead();
+  bool dropped = false;
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(1000, 'b')));
+  EXPECT_FALSE(dropped);
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(2000, 'c')));
+  EXPECT_FALSE(dropped);
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+}
+
 }  // namespace perfetto


### PR DESCRIPTION
TraceBufferV2's bytes_overwritten / chunks_overwritten were incremented
unconditionally for every non-padding chunk encountered in
DeleteNextChunksFor. The intent was that fully-consumed chunks would
have already been turned into padding by ChunkSeqReader::
EraseCurrentChunk before any overwrite reached them, but that
invariant doesn't hold:

- ConsumeFragment decrements payload_avail to 0 on the last fragment
  of a chunk and returns true to the caller. EraseCurrentChunk only
  runs lazily on the next ReadNextPacketInSeqOrder iteration when
  NextFragmentInChunk returns nullopt. Between those two points the
  chunk has payload_avail == 0 and is_padding() == false.
- For reassembled fragmented packets, ConsumeFragment runs on every
  chunk in the chain (kFragBegin, kFragContinue, kFragEnd) but only
  the kFragBegin chunk is on seq_iter_; the rest are stranded in the
  same consumed-but-not-padded state until the consumer's iterator
  walks over each one in subsequent reads.
- BeginRead resets chunk_seq_reader_, so these chunks survive across
  IPC task boundaries (ReadBuffersIntoConsumer yields every ~32KB)
  until the next buffer-order walk reaches them.

A producer wrap during any of these gaps walked the chunk in
DeleteNextChunksFor and credited bytes_overwritten with the full outer
size, even though no data was lost. With ~8-25 active sequences the
phantom over-count lands in the 30-100KB range, matching the symptom
that surfaced in production.

Move the counter increment into ConsumeFragment, gated on mode_ ==
kEraseMode, mirroring how bytes_read / chunks_read already work in
kReadMode. The counter now fires from the canonical "the last byte of
this chunk's payload was just consumed (or evicted)" point. Chunks
that enter DeleteNextChunksFor with payload_avail already at 0 are
walked, erased, and not credited — matching V1's "had unread
fragments" semantics.

ReassembleFragmentedPacket previously skipped its consumption loop on
kNotEnoughData, which produced a symmetrical under-count for
kFragBegin chunks pending a patch that never arrives: the chunk had
unread data but ConsumeFragment never ran, so neither V1- nor old-V2-
equivalent accounting fired. Treat kEraseMode + kNotEnoughData like
kDataLoss for consumption purposes (the chain is about to be evicted
either way), and restructure the early-return on kChunkNeedsPatch on
the initial chunk so it falls through to the consumption loop.