### PR TITLE
docs: Add Rust SDK getting started guide

### DIFF
--- a/contrib/rust-sdk/Cargo.lock
+++ b/contrib/rust-sdk/Cargo.lock
@@ -369,6 +369,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "perfetto-sdk-docs-tests"
+version = "0.0.0"
+dependencies = [
+ "perfetto-sdk",
+ "perfetto-sdk-derive",
+ "perfetto-sdk-protos-gpu",
+ "tracing",
+ "tracing-perfetto-sdk",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "perfetto-sdk-protos-gpu"
 version = "1.0.0"
 dependencies = [

--- a/contrib/rust-sdk/Cargo.toml
+++ b/contrib/rust-sdk/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["perfetto", "perfetto-derive", "perfetto-protos-gpu", "perfetto-protos-trace-processor", "perfetto-sys", "tracing-perfetto"]
+members = ["docs-tests", "perfetto", "perfetto-derive", "perfetto-protos-gpu", "perfetto-protos-trace-processor", "perfetto-sys", "tracing-perfetto"]

--- a/contrib/rust-sdk/docs-tests/Cargo.toml
+++ b/contrib/rust-sdk/docs-tests/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "perfetto-sdk-docs-tests"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+perfetto-sdk = { path = "../perfetto", version = "1" }
+perfetto-sdk-derive = { path = "../perfetto-derive", version = "1" }
+perfetto-sdk-protos-gpu = { path = "../perfetto-protos-gpu", version = "1" }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+tracing-perfetto-sdk = { path = "../tracing-perfetto", version = "1" }

--- a/contrib/rust-sdk/docs-tests/src/lib.rs
+++ b/contrib/rust-sdk/docs-tests/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright (C) 2025 Rivos Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compile-tests for documentation code examples.
+//!
+//! This crate exists solely to verify that code blocks in Perfetto
+//! documentation files compile correctly. It is not published.
+
+#![doc = include_str!("../../../../docs/getting-started/rust-sdk.md")]

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,8 @@ It consists of:
   many processes on a single machine into a unified trace file for offline
   analysis and visualization.
 - **Low-overhead tracing SDK** for direct userspace-to-userspace tracing of
-  timings and state changes of your C/C++ code.
+  timings and state changes of your C/C++ code. A community-maintained
+  [Rust SDK](/docs/getting-started/rust-sdk.md) is also available.
 - **Extensive OS-level probes on Android and Linux** for capturing wider system
   level (e.g. scheduling states, CPU frequencies, memory profiling, callstack
   sampling) context during the trace.
@@ -57,8 +58,8 @@ reduced level of support.
 Other usecases Perfetto is commonly used for include:
 
 - **Collecting, analysing and visualizing in-app traces** to debug functional
-  and performance issues in C/C++ apps and libraries on Windows, macOS and
-  Linux-based embedded systems.
+  and performance issues in C/C++ and Rust apps and libraries on Windows,
+  macOS and Linux-based embedded systems.
 - **Collecting, analysing and visualizing heap profiles on Linux** to debug high
   memory usage of C/C++/Rust apps and libraries.
 - **Analysing and visualizing CPU profiles (Linux perf profiles) on Linux** to

--- a/docs/contributing/build-instructions.md
+++ b/docs/contributing/build-instructions.md
@@ -31,7 +31,7 @@ git clone https://github.com/google/perfetto
 #### Pull dependent libraries and toolchains
 
 ```bash
-tools/install-build-deps [--android] [--ui] [--linux-arm]
+tools/install-build-deps [--android] [--ui] [--linux-arm] [--rust]
 ```
 
 `--android` will pull the Android NDK, emulator and other deps required
@@ -41,6 +41,11 @@ to build for `target_os = "android"`.
 Web UI. See the [UI Development](/docs/contributing/ui-getting-started.md) section below for more.
 
 `--linux-arm` will pull the sysroots for cross-compiling for Linux ARM/64.
+
+`--rust` will pull the Rust toolchain required to build the
+[Rust SDK](/docs/getting-started/rust-sdk.md). The Rust SDK can also
+be built using a system Rust toolchain (1.85+) via Cargo without this
+flag.
 
 WARNING: Note that if you're using an M1 or any later ARM Mac, your Python
 version should be at least 3.9.1 to work around

--- a/docs/getting-started/rust-sdk.md
+++ b/docs/getting-started/rust-sdk.md
@@ -1,0 +1,265 @@
+# Recording Traces with the Rust SDK
+
+In this guide, you'll learn how to:
+
+- Use the Perfetto Rust SDK to add trace points to a Rust application.
+- Record a trace containing your custom events.
+- Use the `#[tracefn]` attribute macro for automatic function tracing.
+- Use the `tracing` crate with Perfetto as a backend.
+- Extend `TracePacket` with GPU event protos.
+
+NOTE: The Rust SDK is a community-maintained project. It may not have
+the same level of support, stability, or feature coverage as the
+official C++ SDK.
+
+The Perfetto Rust SDK provides safe and ergonomic bindings for the
+Perfetto tracing framework. It wraps the Perfetto C API with Rust
+abstractions for tracing sessions, data sources, and track events.
+
+## Crates
+
+The SDK is split into several crates:
+
+| Crate | Description |
+|-------|-------------|
+| `perfetto-sdk` | Core SDK with tracing sessions, data sources, and track events |
+| `perfetto-sdk-sys` | Low-level FFI bindings to the Perfetto C API |
+| `perfetto-sdk-derive` | `#[tracefn]` proc macro for automatic function instrumentation |
+| `perfetto-sdk-protos-gpu` | GPU event protobuf bindings extending `TracePacket` |
+| `perfetto-sdk-protos-trace-processor` | Trace processor protobuf bindings |
+| `tracing-perfetto-sdk` | `tracing-subscriber` Layer for Perfetto |
+
+## Setup
+
+Add the SDK to your `Cargo.toml`:
+
+```toml
+[dependencies]
+perfetto-sdk = "1"
+```
+
+By default, this compiles and statically links the bundled Perfetto C
+library. No external dependencies are required.
+
+## Track events
+
+Initialize Perfetto and define your tracing categories:
+
+```rust
+use perfetto_sdk::producer::*;
+use perfetto_sdk::track_event::*;
+use perfetto_sdk::{scoped_track_event, track_event_begin, track_event_end, track_event_instant};
+
+// Define tracing categories. Each category can be independently
+// enabled or disabled in the trace configuration.
+perfetto_sdk::track_event_categories! {
+    pub mod my_categories {
+        ("rendering", "Events from the graphics subsystem", []),
+        ("network", "Network upload and download statistics", []),
+    }
+}
+use my_categories as perfetto_te_ns;
+
+fn main() {
+    Producer::init(
+        ProducerInitArgsBuilder::new()
+            .backends(Backends::IN_PROCESS)
+            .build(),
+    );
+    TrackEvent::init();
+    my_categories::register().unwrap();
+
+    // Scoped event — ends when the scope exits.
+    scoped_track_event!("rendering", "DrawPlayer",
+        |ctx: &mut EventContext| {
+            ctx.add_debug_arg("player_number",
+                TrackEventDebugArg::Uint64(1));
+        },
+        |_| {}
+    );
+
+    // Manual begin/end events.
+    track_event_begin!("rendering", "DrawGame");
+    track_event_end!("rendering");
+
+    // Instant event.
+    track_event_instant!("rendering", "VSync");
+}
+```
+
+## Collecting traces
+
+### In-process tracing
+
+For self-contained trace collection without a tracing service, create
+a `TracingSession` with the in-process backend. See
+`contrib/rust-sdk/perfetto/examples/tracing_session.rs` for a
+complete working example.
+
+### System tracing
+
+To connect to a running Perfetto tracing service (`traced`), use the
+system backend instead:
+
+```rust
+use perfetto_sdk::producer::*;
+
+Producer::init(
+    ProducerInitArgsBuilder::new()
+        .backends(Backends::SYSTEM)
+        .build(),
+);
+```
+
+Your application acts as a producer, and the system tracing service
+controls when tracing starts and stops. Record a trace using the
+[system tracing](/docs/getting-started/system-tracing.md) tools.
+
+## Automatic function tracing with `#[tracefn]`
+
+The `perfetto-sdk-derive` crate provides a proc macro that
+automatically instruments a function with a track event. It captures
+all input parameters as debug annotations.
+
+```toml
+[dependencies]
+perfetto-sdk = "1"
+perfetto-sdk-derive = "1"
+```
+
+Then annotate functions with `#[tracefn]`:
+
+```rust
+// Assuming categories are defined as in the example above.
+use perfetto_sdk::producer::*;
+use perfetto_sdk::track_event::*;
+perfetto_sdk::track_event_categories! {
+    pub mod my_categories {
+        ("rendering", "Events from the graphics subsystem", []),
+    }
+}
+use my_categories as perfetto_te_ns;
+use perfetto_sdk_derive::tracefn;
+
+#[tracefn("rendering")]
+fn draw_player(player_number: u32, x: f64, y: f64) {
+    // A "draw_player" track event is emitted automatically.
+    // player_number, x, and y are captured as debug annotations.
+}
+```
+
+The macro wraps the function body in a `scoped_track_event!` so the
+event spans the full function execution. The category name is passed
+as the macro argument.
+
+## Using the `tracing` crate
+
+If your application uses the Rust
+[`tracing`](https://crates.io/crates/tracing) crate, you can use
+`tracing-perfetto-sdk` to send events to Perfetto without changing
+your existing instrumentation:
+
+```toml
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-perfetto-sdk = "1"
+```
+
+Initialize and install the layer:
+
+```rust
+use tracing_subscriber::prelude::*;
+
+tracing_perfetto_sdk::init();
+tracing_subscriber::registry()
+    .with(tracing_perfetto_sdk::PerfettoLayer::new())
+    .init();
+
+// Standard tracing macros emit Perfetto events.
+let _span = tracing::info_span!("DrawGame").entered();
+tracing::info!(player = 1, "drawing player");
+```
+
+Spans become duration slices and events become instant events, with
+fields captured as debug annotations and source locations attached
+automatically.
+
+## GPU event protos
+
+The `perfetto-sdk-protos-gpu` crate extends `TracePacket` with
+GPU-specific fields for emitting GPU counter events, render stage
+events, Vulkan events, and more.
+
+```toml
+[dependencies]
+perfetto-sdk = "1"
+perfetto-sdk-protos-gpu = "1"
+```
+
+Import the `TracePacketExt` trait to access the GPU fields:
+
+```rust
+use perfetto_sdk_protos_gpu::protos::trace::trace_packet::prelude::*;
+use perfetto_sdk_protos_gpu::protos::trace::gpu::gpu_counter_event::*;
+
+fn emit_gpu_counter(packet: &mut perfetto_sdk::protos::trace::trace_packet::TracePacket) {
+    packet.set_gpu_counter_event(|event: &mut GpuCounterEvent| {
+        event.set_counters(|counter: &mut GpuCounterEventGpuCounter| {
+            counter.set_counter_id(1);
+            counter.set_double_value(42.0);
+        });
+    });
+}
+```
+
+This is typically used inside a custom data source's trace callback.
+See `contrib/rust-sdk/perfetto-protos-gpu/examples/gpu_counters.rs`
+for a complete example.
+
+## Track event extensions
+
+Track events can be extended with custom protobuf fields using the
+extension mechanism. The `perfetto-sdk-protos-gpu` crate defines GPU
+extensions such as `gpu_api` that tag track events with the GPU API
+type.
+
+Use `set_proto_fields` on `EventContext` to add extension fields:
+
+```rust
+// Assuming categories are defined as in the example above.
+use perfetto_sdk::producer::*;
+use perfetto_sdk::track_event::*;
+use perfetto_sdk::track_event_instant;
+perfetto_sdk::track_event_categories! {
+    pub mod my_categories {
+        ("rendering", "Events from the graphics subsystem", []),
+    }
+}
+use my_categories as perfetto_te_ns;
+use perfetto_sdk_protos_gpu::protos::trace::gpu::gpu_track_event::{
+    GpuApi, TrackEventExtFieldNumber,
+};
+
+track_event_instant!("rendering", "cuLaunchKernel", |ctx: &mut EventContext| {
+    ctx.set_proto_fields(&TrackEventProtoFields {
+        fields: &[TrackEventProtoField::VarInt(
+            TrackEventExtFieldNumber::GpuApi as u32,
+            GpuApi::GpuApiCuda as u64,
+        )],
+    });
+});
+```
+
+The extension field appears in the trace as `gpu_api: GPU_API_CUDA`
+on the track event, which the trace processor decodes into the
+`gpu_api` column of the `slice` table args.
+
+## Next steps
+
+- **[Track Events](/docs/instrumentation/track-events.md)**: Learn more
+  about the different types of track events.
+- **[Rust SDK examples](https://github.com/google/perfetto/tree/main/contrib/rust-sdk/perfetto/examples)**:
+  Working examples of data sources, track events, and tracing sessions.
+- **[GPU counter example](https://github.com/google/perfetto/tree/main/contrib/rust-sdk/perfetto-protos-gpu/examples)**:
+  Example of a GPU counter data source.

--- a/docs/getting-started/start-using-perfetto.md
+++ b/docs/getting-started/start-using-perfetto.md
@@ -36,6 +36,7 @@ graph TD
     B --> C["<a href='#android-developers'>Android App/Platform Developer</a>"];
     B --> D["<a href='#linux-kernel-developers'>Linux Kernel Developer</a>"];
     B --> E["<a href='#c-cpp-developers'>C/C++ Developer (non-Android)</a>"];
+    B --> E2["<a href='#rust-developers'>Rust Developer</a>"];
     B --> F["<a href='#chromium-developers'>Chromium Developer</a>"];
     B --> G["<a href='#trace-like-data'>I have trace-like data</a>"];
     B --> H["<a href='#not-listed'>None of the above</a>"];
@@ -363,6 +364,24 @@ Here’s how Perfetto can help:
     [Recording Memory Profiles (Native Heap Profiling)](/docs/getting-started/memory-profiling.md)
   - **Reference**:
     [Native Heap Profiler Data Source](/docs/data-sources/native-heap-profiler.md)
+
+## {#rust-developers} Rust Developers
+
+If you're developing Rust applications, the community-maintained Perfetto
+Rust SDK allows you to instrument your code with trace points, record
+traces, and integrate with the Perfetto tracing service. It supports the
+standard Rust `tracing` crate as well as direct Perfetto track event
+macros.
+
+- **How can I add Perfetto tracing to my Rust application?** The Rust SDK
+  provides track event macros, a `#[tracefn]` proc macro for automatic
+  function instrumentation, and a `tracing-subscriber` Layer for bridging
+  the Rust `tracing` ecosystem to Perfetto.
+
+  - **Tutorial**:
+    [Recording Traces with the Rust SDK](/docs/getting-started/rust-sdk.md)
+  - **Reference**:
+    [Rust SDK on crates.io](https://crates.io/crates/perfetto-sdk)
 
 ## {#chromium-developers} Chromium Developers
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -9,7 +9,8 @@
   - [Tutorials](#)
 
     - [System Tracing](getting-started/system-tracing.md) {.tag-android .tag-linux}
-    - [In-App Tracing](getting-started/in-app-tracing.md) {.tag-cpp}
+    - [In-App Tracing](getting-started/in-app-tracing.md) {.tag-cpp-rust}
+    - [Rust SDK](getting-started/rust-sdk.md) {.tag-cpp-rust}
     - [Memory Profiling](getting-started/memory-profiling.md) {.tag-android .tag-linux}
     - [CPU Profiling](getting-started/cpu-profiling.md) {.tag-android .tag-linux}
     - [Instrumenting with atrace](getting-started/atrace.md) {.tag-android}
@@ -39,11 +40,11 @@
 
   - [Concepts](#)
 
-    - [Service Model](concepts/service-model.md) {.tag-android .tag-linux .tag-cpp}
-    - [Buffers and Dataflow](concepts/buffers.md) {.tag-android .tag-linux .tag-cpp .tag-chrome}
-    - [Trace Configuration](concepts/config.md) {.tag-android .tag-linux .tag-cpp .tag-chrome}
-    - [Clock Synchronization](concepts/clock-sync.md) {.tag-android .tag-linux .tag-cpp .tag-chrome}
-    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) {.tag-android .tag-linux .tag-cpp}
+    - [Service Model](concepts/service-model.md) {.tag-android .tag-linux .tag-cpp-rust}
+    - [Buffers and Dataflow](concepts/buffers.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
+    - [Trace Configuration](concepts/config.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
+    - [Clock Synchronization](concepts/clock-sync.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
+    - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) {.tag-android .tag-linux .tag-cpp-rust}
 
   - [Recording](#)
 
@@ -51,8 +52,8 @@
     - [Advanced Android Tracing](learning-more/android.md) {.tag-android}
     - [Symbolization and Deobfuscation](learning-more/symbolization.md) {.tag-android .tag-linux}
     - [Tracing across Reboots](data-sources/previous-boot-trace.md) {.tag-android .tag-linux}
-    - [Custom Proto Extensions](instrumentation/extensions.md) {.tag-cpp .tag-android .tag-perf}
-    - [heapprofd API](instrumentation/heapprofd-api.md) {.tag-cpp}
+    - [Custom Proto Extensions](instrumentation/extensions.md) {.tag-cpp-rust .tag-android .tag-perf}
+    - [heapprofd API](instrumentation/heapprofd-api.md) {.tag-cpp-rust}
 
   - [Data Sources](#)
 
@@ -80,47 +81,47 @@
 
   - [Tracing SDK](#)
 
-    - [Tracing SDK](instrumentation/tracing-sdk.md) {.tag-cpp}
-    - [Track Events](instrumentation/track-events.md) {.tag-cpp}
+    - [Tracing SDK](instrumentation/tracing-sdk.md) {.tag-cpp-rust}
+    - [Track Events](instrumentation/track-events.md) {.tag-cpp-rust}
 
   - [Visualization](#)
 
-    - [Perfetto UI](visualization/perfetto-ui.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-    - [Data Explorer](visualization/data-explorer.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-    - [Opening Large Traces](visualization/large-traces.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-    - [Debug Tracks](analysis/debug-tracks.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Perfetto UI](visualization/perfetto-ui.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Data Explorer](visualization/data-explorer.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Opening Large Traces](visualization/large-traces.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Deep Linking](visualization/deep-linking-to-perfetto-ui.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Debug Tracks](analysis/debug-tracks.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Heap Dump Explorer](visualization/heap-dump-explorer.md) {.tag-android}
 
     - [Extending the UI](#)
 
-      - [Overview](visualization/extending-the-ui.md) {.tag-android .tag-linux .tag-cpp .tag-perf}
-      - [UI Automation](visualization/ui-automation.md) {.tag-android .tag-linux .tag-cpp .tag-perf}
-      - [Commands Reference](visualization/commands-automation-reference.md) {.tag-android .tag-linux .tag-cpp .tag-perf}
-      - [Extension Servers](visualization/extension-servers.md) {.tag-android .tag-linux .tag-cpp .tag-perf}
+      - [Overview](visualization/extending-the-ui.md) {.tag-android .tag-linux .tag-cpp-rust .tag-perf}
+      - [UI Automation](visualization/ui-automation.md) {.tag-android .tag-linux .tag-cpp-rust .tag-perf}
+      - [Commands Reference](visualization/commands-automation-reference.md) {.tag-android .tag-linux .tag-cpp-rust .tag-perf}
+      - [Extension Servers](visualization/extension-servers.md) {.tag-android .tag-linux .tag-cpp-rust .tag-perf}
 
   - [Trace Analysis](#)
 
-    - [Getting Started](analysis/getting-started.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Getting Started](analysis/getting-started.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
     - [PerfettoSQL](#)
 
-      - [Getting Started](analysis/perfetto-sql-getting-started.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Syntax](analysis/perfetto-sql-syntax.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Standard Library](analysis/stdlib-docs.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Style Guide](analysis/style-guide.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+      - [Getting Started](analysis/perfetto-sql-getting-started.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Syntax](analysis/perfetto-sql-syntax.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Standard Library](analysis/stdlib-docs.autogen) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Style Guide](analysis/style-guide.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Backwards Compatibility](analysis/perfetto-sql-backcompat.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
     - [Trace Processor](#)
 
-      - [C++ Library](analysis/trace-processor.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Python Library](analysis/trace-processor-python.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Batch Trace Processor](analysis/batch-trace-processor.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+      - [C++ Library](analysis/trace-processor.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Python Library](analysis/trace-processor-python.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Batch Trace Processor](analysis/batch-trace-processor.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
-    - [Trace Summarization](analysis/trace-summary.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-    - [Converting from Perfetto](quickstart/traceconv.md) {.tag-android .tag-linux .tag-cpp .tag-chrome}
+    - [Trace Summarization](analysis/trace-summary.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+    - [Converting from Perfetto](quickstart/traceconv.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
 
-  - [FAQ](faq.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+  - [FAQ](faq.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
 - [Diving Deep](#)
 
@@ -136,24 +137,24 @@
 
     - [Protos](#)
 
-      - [Trace Config](reference/trace-config-proto.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome}
-      - [Trace Packet](reference/trace-packet-proto.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+      - [Trace Config](reference/trace-config-proto.autogen) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
+      - [Trace Packet](reference/trace-packet-proto.autogen) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
     - [PerfettoSQL](#)
 
-      - [Prelude Tables](analysis/sql-tables.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Built-in Functions](analysis/builtin.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
-      - [Stats Table](analysis/sql-stats.autogen) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+      - [Prelude Tables](analysis/sql-tables.autogen) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Built-in Functions](analysis/builtin.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+      - [Stats Table](analysis/sql-stats.autogen) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
 
     - [Synthetic Track Events](reference/synthetic-track-event.md) {.tag-perf}
     - [Kernel Track Events](reference/kernel-track-event.md) {.tag-android .tag-linux}
-    - [Extension Server Protocol](visualization/extension-server-protocol.md) {.tag-android .tag-linux .tag-cpp .tag-chrome .tag-perf}
+    - [Extension Server Protocol](visualization/extension-server-protocol.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
     - [Android Version Notes](reference/android-version-notes.md) {.tag-android}
 
   - [Advanced Topics](#)
 
     - [Detached Mode](concepts/detached-mode.md) {.tag-android}
-    - [Interceptors](instrumentation/interceptors.md) {.tag-cpp}
+    - [Interceptors](instrumentation/interceptors.md) {.tag-cpp-rust}
     - [Legacy (v1) Metrics](analysis/metrics.md) {.tag-android}
     - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md) {.tag-android .tag-perf}
     - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md) {.tag-android .tag-perf}

--- a/infra/perfetto.dev/src/assets/script.js
+++ b/infra/perfetto.dev/src/assets/script.js
@@ -142,7 +142,7 @@ function scrollIntoViewIfNeeded(element, container, margin = 100) {
 }
 
 const TAG_PREFIX = 'tag-';
-const TAG_LABELS = {cpp: 'C++'};
+const TAG_LABELS = {'cpp-rust': 'C++/Rust'};
 const NAV_DEFAULT_TAG = 'android';
 
 function tagLabel(tag) {


### PR DESCRIPTION
Add docs/getting-started/rust-sdk.md with a step-by-step guide covering SDK setup, category definition, track event macros, in-process trace collection, the tracing crate integration via tracing-perfetto-sdk, trace visualization, SQL queries, and combined in-app + system tracing.