### PR TITLE
ui: Encapsulate plugin state in HeapDumpExplorerSession

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -13,22 +13,16 @@
 // limitations under the License.
 
 import m from 'mithril';
-import type {Engine} from '../../trace_processor/engine';
-import type {Trace} from '../../public/trace';
 import {Time} from '../../base/time';
 import {Spinner} from '../../widgets/spinner';
-import {EmptyState} from '../../widgets/empty_state';
 import {Button, ButtonVariant} from '../../widgets/button';
 import {MenuItem, PopupMenu} from '../../widgets/menu';
 import {Tabs} from '../../widgets/tabs';
 import type {TabsTab} from '../../widgets/tabs';
 import {formatDuration} from '../../components/time_utils';
-import {NUM} from '../../trace_processor/query_result';
-import type {NavState} from './nav_state';
+import type {NavState, NavView} from './nav_state';
 import type {OverviewData} from './types';
-import {nav, navigate, syncFromSubpage, setNavigateCallback} from './nav_state';
 import * as queries from './queries';
-import {SQL_PREAMBLE} from './components';
 import OverviewView from './views/overview_view';
 import DominatorsView from './views/dominators_view';
 import ObjectView from './views/object_view';
@@ -37,225 +31,85 @@ import BitmapGalleryView from './views/bitmap_gallery_view';
 import ClassesView from './views/classes_view';
 import StringsView from './views/strings_view';
 import ArraysView from './views/arrays_view';
-import FlamegraphObjectsView, {
-  flamegraphQuery,
-} from './views/flamegraph_objects_view';
+import FlamegraphObjectsView from './views/flamegraph_objects_view';
+import type {HeapDumpExplorerSession} from './session';
 
-interface HeapdumpSelection {
-  pathHashes: string;
-  isDominator: boolean;
-  upid: number;
-  ts: bigint;
+interface HeapDumpPageAttrs {
+  readonly session: HeapDumpExplorerSession;
+  readonly subpage: string | undefined;
 }
 
-let nextFgId = 0;
-const flamegraphTabs: Array<
-  {id: number; count: number | null} & HeapdumpSelection
-> = [];
-let activeFgId = -1;
-
-export function setFlamegraphSelection(
-  sel: HeapdumpSelection,
-  engine: Engine,
-): void {
-  const target = queries
-    .getDumps()
-    .find((d) => d.upid === sel.upid && d.ts === sel.ts);
-  if (target && target !== queries.getActiveDump()) {
-    queries.setActiveDump(target);
-    resetDumpScopedState();
-  }
-  const existing = flamegraphTabs.find(
-    (t) => t.pathHashes === sel.pathHashes && t.isDominator === sel.isDominator,
-  );
-  if (existing) {
-    activeFgId = existing.id;
-    navigate('flamegraph-objects');
-    return;
-  }
-  const id = nextFgId++;
-  const tab = {id, count: null as number | null, ...sel};
-  flamegraphTabs.push(tab);
-  activeFgId = id;
-  navigate('flamegraph-objects');
-  const q = flamegraphQuery(sel.pathHashes, sel.isDominator);
-  engine
-    .query(`${SQL_PREAMBLE}; SELECT COUNT(*) AS c FROM (${q})`)
-    .then((r) => {
-      tab.count = Number(r.firstRow({c: NUM}).c);
-      m.redraw();
-    });
-}
-
-export function resetFlamegraphSelection(): void {
-  flamegraphTabs.length = 0;
-  nextFgId = 0;
-  activeFgId = -1;
-}
-
-// Module-level overview cache. Survives component remounts (e.g. theme toggle).
-let cachedOverview: OverviewData | null = null;
-let overviewLoading = false;
-
-export function resetCachedOverview(): void {
-  cachedOverview = null;
-  overviewLoading = false;
-}
-
-function resetDumpScopedState(): void {
-  resetCachedOverview();
-  resetFlamegraphSelection();
-  resetInstanceTabs();
-  queries.resetBitmapDumpDataCache();
-}
-
-function onDumpChanged(): void {
-  resetDumpScopedState();
-  if (nav.view === 'object' || nav.view === 'flamegraph-objects') {
-    navigate('overview');
-  }
-}
-
-// Closable object tabs — clicking an object anywhere opens a new tab.
-interface InstanceTab {
-  id: number;
-  objId: number;
-  label: string;
-}
-
-let nextInstanceTabId = 0;
-const instanceTabs: InstanceTab[] = [];
-let activeInstanceTabId = -1;
-
-function instanceTabKey(id: number): string {
-  return `inst-${id}`;
-}
-
-export function resetInstanceTabs(): void {
-  instanceTabs.length = 0;
-  nextInstanceTabId = 0;
-  activeInstanceTabId = -1;
-}
-
-function openInstanceTab(objId: number, label?: string): void {
-  const existing = instanceTabs.find((t) => t.objId === objId);
-  if (existing) {
-    activeInstanceTabId = existing.id;
-    return;
-  }
-  const displayLabel = label ?? 'Instance';
-  const tab: InstanceTab = {
-    id: nextInstanceTabId++,
-    objId,
-    label:
-      displayLabel.length > 30
-        ? displayLabel.slice(0, 30) + '\u2026'
-        : displayLabel,
-  };
-  instanceTabs.push(tab);
-  activeInstanceTabId = tab.id;
-}
-
-// Navigate wrapper: intercepts 'object' to open closable instance tabs.
-function navigateWithTabs(
-  view: NavState['view'],
-  params?: Record<string, unknown>,
-): void {
-  if (view === 'object') {
-    openInstanceTab(params?.id as number, params?.label as string | undefined);
-    navigate(view, params);
-    return;
-  }
-  activeInstanceTabId = -1;
-  navigate(view, params);
-}
-
-// When nav state points to 'object' (e.g. after browser back), ensure
-// the matching instance tab exists and is active. When nav moves away
-// from 'object', clear the active instance tab so fixed tabs are shown.
-function syncInstanceTabFromNav(): void {
-  if (nav.view !== 'object') {
-    activeInstanceTabId = -1;
-    return;
-  }
-  const objId = nav.params.id;
-  const existing = instanceTabs.find((t) => t.objId === objId);
-  if (existing) {
-    activeInstanceTabId = existing.id;
-  } else {
-    openInstanceTab(objId, nav.params.label);
-  }
-}
+const FG_KEY_PREFIX = 'fg-';
+const INSTANCE_KEY_PREFIX = 'inst-';
 
 function fgTabKey(id: number): string {
-  return `fg-${id}`;
+  return `${FG_KEY_PREFIX}${id}`;
+}
+
+function instanceTabKey(id: number): string {
+  return `${INSTANCE_KEY_PREFIX}${id}`;
 }
 
 function parseFgTabKey(key: string): number | undefined {
-  if (!key.startsWith('fg-')) return undefined;
-  return parseInt(key.slice(3), 10);
+  if (!key.startsWith(FG_KEY_PREFIX)) return undefined;
+  return parseInt(key.slice(FG_KEY_PREFIX.length), 10);
 }
 
-function getActiveTabKey(): string {
-  if (nav.view === 'flamegraph-objects' && flamegraphTabs.length > 0) {
-    const tab = flamegraphTabs.find((t) => t.id === activeFgId);
-    return fgTabKey(
-      tab ? tab.id : flamegraphTabs[flamegraphTabs.length - 1].id,
-    );
-  }
-  if (activeInstanceTabId >= 0) {
-    return instanceTabKey(activeInstanceTabId);
-  }
-  return nav.view;
+function parseInstanceTabKey(key: string): number | undefined {
+  if (!key.startsWith(INSTANCE_KEY_PREFIX)) return undefined;
+  return parseInt(key.slice(INSTANCE_KEY_PREFIX.length), 10);
 }
 
-function handleTabChange(key: string): void {
+function activeTabKey(session: HeapDumpExplorerSession): string {
+  const tabs = session.flamegraphTabs;
+  if (session.nav.view === 'flamegraph-objects' && tabs.length > 0) {
+    const active = tabs.find((t) => t.id === session.activeFlamegraphId);
+    return fgTabKey(active ? active.id : tabs[tabs.length - 1].id);
+  }
+  if (session.activeInstanceId !== null) {
+    return instanceTabKey(session.activeInstanceId);
+  }
+  return session.nav.view;
+}
+
+function handleTabChange(session: HeapDumpExplorerSession, key: string): void {
   const fgId = parseFgTabKey(key);
   if (fgId !== undefined) {
-    activeFgId = fgId;
-    navigate('flamegraph-objects');
-  } else if (key.startsWith('inst-')) {
-    activeInstanceTabId = parseInt(key.slice(5), 10);
-    const tab = instanceTabs.find((t) => t.id === activeInstanceTabId);
-    if (tab) {
-      navigate('object', {id: tab.objId});
-    }
-  } else {
-    activeFgId = -1;
-    activeInstanceTabId = -1;
-    navigate(key as NavState['view']);
-  }
-}
-
-function handleTabClose(key: string): void {
-  const fgId = parseFgTabKey(key);
-  if (fgId !== undefined) {
-    const idx = flamegraphTabs.findIndex((t) => t.id === fgId);
-    if (idx === -1) return;
-    flamegraphTabs.splice(idx, 1);
-    if (activeFgId === fgId) {
-      activeFgId = -1;
-      navigate('overview');
-    }
+    session.setActiveFlamegraphTab(fgId);
+    session.navigate('flamegraph-objects');
     return;
   }
-  if (!key.startsWith('inst-')) return;
-  const id = parseInt(key.slice(5), 10);
-  const idx = instanceTabs.findIndex((t) => t.id === id);
-  if (idx === -1) return;
-  instanceTabs.splice(idx, 1);
-  if (activeInstanceTabId === id) {
-    activeInstanceTabId = -1;
-    navigate('overview');
+  const instId = parseInstanceTabKey(key);
+  if (instId !== undefined) {
+    session.setActiveInstanceTab(instId);
+    const tab = session.instanceTabs.find((t) => t.id === instId);
+    if (tab) session.navigate('object', {id: tab.objId});
+    return;
+  }
+  session.clearActiveFlamegraphTab();
+  session.clearActiveInstanceTab();
+  session.navigate(key as NavView);
+}
+
+function handleTabClose(session: HeapDumpExplorerSession, key: string): void {
+  const fgId = parseFgTabKey(key);
+  if (fgId !== undefined) {
+    session.closeFlamegraph(fgId);
+    return;
+  }
+  const instId = parseInstanceTabKey(key);
+  if (instId !== undefined) {
+    session.closeInstanceTab(instId);
   }
 }
 
 function buildTabs(
+  session: HeapDumpExplorerSession,
+  activeDump: queries.HeapDump,
   state: NavState,
-  engine: Engine,
   overview: OverviewData,
 ): TabsTab[] {
-  const trace = HeapDumpPage.trace;
+  const {engine, trace, navigateWithTabs, clearNavParam} = session;
   const tabs: TabsTab[] = [
     {
       key: 'overview',
@@ -267,7 +121,9 @@ function buildTabs(
       title: 'Classes',
       content: m(ClassesView, {
         engine,
+        activeDump,
         navigate: navigateWithTabs,
+        clearNavParam,
         initialRootClass:
           state.view === 'classes' ? state.params.rootClass : undefined,
       }),
@@ -277,21 +133,29 @@ function buildTabs(
       title: 'Objects',
       content: m(AllObjectsView, {
         engine,
+        activeDump,
         navigate: navigateWithTabs,
+        clearNavParam,
         initialClass: state.view === 'objects' ? state.params.cls : undefined,
       }),
     },
     {
       key: 'dominators',
       title: 'Dominators',
-      content: m(DominatorsView, {engine, navigate: navigateWithTabs}),
+      content: m(DominatorsView, {
+        engine,
+        activeDump,
+        navigate: navigateWithTabs,
+      }),
     },
     {
       key: 'bitmaps',
       title: 'Bitmaps',
       content: m(BitmapGalleryView, {
         engine,
+        activeDump,
         navigate: navigateWithTabs,
+        clearNavParam,
         hasFieldValues: overview.hasFieldValues,
         filterKey:
           state.view === 'bitmaps' ? state.params.filterKey : undefined,
@@ -302,7 +166,9 @@ function buildTabs(
       title: 'Strings',
       content: m(StringsView, {
         engine,
+        activeDump,
         navigate: navigateWithTabs,
+        clearNavParam,
         initialQuery: state.view === 'strings' ? state.params.q : undefined,
         hasFieldValues: overview.hasFieldValues,
       }),
@@ -312,7 +178,9 @@ function buildTabs(
       title: 'Arrays',
       content: m(ArraysView, {
         engine,
+        activeDump,
         navigate: navigateWithTabs,
+        clearNavParam,
         initialArrayHash:
           state.view === 'arrays' ? state.params.arrayHash : undefined,
         hasFieldValues: overview.hasFieldValues,
@@ -320,8 +188,7 @@ function buildTabs(
     },
   ];
 
-  // Append closable flamegraph tabs.
-  for (const fg of flamegraphTabs) {
+  for (const fg of session.flamegraphTabs) {
     tabs.push({
       key: fgTabKey(fg.id),
       title:
@@ -334,21 +201,19 @@ function buildTabs(
         navigate: navigateWithTabs,
         pathHashes: fg.pathHashes,
         isDominator: fg.isDominator,
-        onBackToTimeline: () => {
-          if (trace) trace.navigate('#!/viewer');
-        },
+        onBackToTimeline: () => trace.navigate('#!/viewer'),
       }),
     });
   }
 
-  // Append closable object instance tabs.
-  for (const obj of instanceTabs) {
+  for (const obj of session.instanceTabs) {
     tabs.push({
       key: instanceTabKey(obj.id),
       title: obj.label,
       closeButton: true,
       content: m(ObjectView, {
         engine,
+        activeDump,
         heaps: overview.heaps,
         navigate: navigateWithTabs,
         params: {id: obj.objId},
@@ -365,11 +230,9 @@ function processLabel(d: queries.HeapDump): string {
     : `pid ${d.pid}`;
 }
 
-function renderDumpSelector(): m.Children {
-  const trace = HeapDumpPage.trace;
-  if (!trace) return null;
-  const allDumps = queries.getDumps();
-  const active = queries.getActiveDump();
+function renderDumpSelector(session: HeapDumpExplorerSession): m.Children {
+  const allDumps = session.dumps;
+  const active = session.activeDump;
   if (allDumps.length <= 1 || active === null) return null;
 
   return m(
@@ -388,100 +251,65 @@ function renderDumpSelector(): m.Children {
         }),
       },
       allDumps.map((d) => {
-        const offset = Time.diff(Time.fromRaw(d.ts), trace.traceInfo.start);
+        const offset = Time.diff(
+          Time.fromRaw(d.ts),
+          session.trace.traceInfo.start,
+        );
         return m(MenuItem, {
-          label: `${processLabel(d)} — ${formatDuration(trace, offset)}`,
+          label: `${processLabel(d)} — ${formatDuration(session.trace, offset)}`,
           active: d === active,
-          onclick: () => {
-            queries.setActiveDump(d);
-            onDumpChanged();
-          },
+          onclick: () => session.selectDump(d),
         });
       }),
     ),
   );
 }
 
-interface HeapDumpPageAttrs {
-  readonly subpage: string | undefined;
-}
-
 export class HeapDumpPage implements m.ClassComponent<HeapDumpPageAttrs> {
-  static engine: Engine | null = null;
-  static trace: Trace | null = null;
-  static hasHeapData = false;
-
-  oncreate(vnode: m.VnodeDOM<HeapDumpPageAttrs>) {
-    setNavigateCallback((subpage) => {
-      const href = `#!/heapdump${subpage ? '/' + subpage : ''}`;
-      window.location.hash = href.slice(1);
+  oncreate({attrs}: m.VnodeDOM<HeapDumpPageAttrs>) {
+    attrs.session.setNavigateCallback((sub) => {
+      window.location.hash = `!/heapdump${sub ? '/' + sub : ''}`;
     });
-    syncFromSubpage(vnode.attrs.subpage);
-    this.loadOverview();
+    void attrs.session.loadOverview();
   }
 
-  onremove() {
-    setNavigateCallback(undefined);
+  onremove({attrs}: m.VnodeDOM<HeapDumpPageAttrs>) {
+    attrs.session.setNavigateCallback(undefined);
   }
 
-  private async loadOverview() {
-    if (!HeapDumpPage.engine || overviewLoading || cachedOverview) return;
-    overviewLoading = true;
-    try {
-      cachedOverview = await queries.getOverview(HeapDumpPage.engine);
-    } catch (err) {
-      console.error('Failed to load overview:', err);
-    } finally {
-      overviewLoading = false;
-      m.redraw();
-    }
-  }
+  view({attrs}: m.Vnode<HeapDumpPageAttrs>) {
+    const {session, subpage} = attrs;
+    session.syncFromSubpage(subpage);
+    session.syncInstanceTabFromNav();
 
-  view(vnode: m.Vnode<HeapDumpPageAttrs>) {
-    syncFromSubpage(vnode.attrs.subpage);
-    syncInstanceTabFromNav();
-
-    if (!HeapDumpPage.engine || !HeapDumpPage.hasHeapData) {
+    const active = session.activeDump;
+    const overview = session.cachedOverview;
+    if (active === null || overview === null) {
       return m(
         'div',
         {class: 'ah-page'},
-        m(EmptyState, {
-          icon: 'memory',
-          title: 'No heap graph data in this trace',
-          fillHeight: true,
-        }),
-      );
-    }
-
-    if (!cachedOverview) {
-      if (!overviewLoading) {
-        this.loadOverview();
-      }
-      return m(
-        'div',
-        {class: 'ah-page'},
-        renderDumpSelector(),
+        renderDumpSelector(session),
         m('div', {class: 'ah-loading'}, m(Spinner, {easing: true})),
       );
     }
 
-    // Keyed so Mithril remounts views (and their SQLDataSources) on dump switch.
-    const active = queries.getActiveDump();
-    const tabsKey = active ? `${active.upid}:${active.ts}` : 'none';
+    // Keyed so Mithril remounts views (and their SQLDataSources) on
+    // dump switch.
+    const tabsKey = `${active.upid}:${active.ts}`;
 
     return m(
       'div',
       {class: 'ah-page'},
-      renderDumpSelector(),
+      renderDumpSelector(session),
       m(
         'main',
         {class: 'ah-main'},
         m(Tabs, {
           key: tabsKey,
-          tabs: buildTabs(nav, HeapDumpPage.engine, cachedOverview),
-          activeTabKey: getActiveTabKey(),
-          onTabChange: handleTabChange,
-          onTabClose: handleTabClose,
+          tabs: buildTabs(session, active, session.nav, overview),
+          activeTabKey: activeTabKey(session),
+          onTabChange: (key: string) => handleTabChange(session, key),
+          onTabClose: (key: string) => handleTabClose(session, key),
         }),
       ),
     );

--- a/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/index.ts
@@ -15,51 +15,33 @@
 import m from 'mithril';
 import {PerfettoPlugin} from '../../public/plugin';
 import {Trace} from '../../public/trace';
-import {App} from '../../public/app';
 import {NUM} from '../../trace_processor/query_result';
 import HeapProfilePlugin from '../dev.perfetto.HeapProfile';
-import {
-  HeapDumpPage,
-  setFlamegraphSelection,
-  resetFlamegraphSelection,
-  resetInstanceTabs,
-  resetCachedOverview,
-} from './heap_dump_page';
-import {resetBitmapDumpDataCache, loadDumps, resetDumps} from './queries';
+import {HeapDumpPage} from './heap_dump_page';
+import {HeapDumpExplorerSession} from './session';
 
 export default class implements PerfettoPlugin {
   static readonly id = 'com.android.HeapDumpExplorer';
   static readonly dependencies = [HeapProfilePlugin];
 
-  static onActivate(app: App): void {
-    app.pages.registerPage({
-      route: '/heapdump',
-      render: (subpage) => m(HeapDumpPage, {subpage}),
-    });
-  }
-
   async onTraceLoad(ctx: Trace): Promise<void> {
     const res = await ctx.engine.query(
       'SELECT count(*) AS cnt FROM heap_graph_object LIMIT 1',
     );
-    const cnt = res.iter({cnt: NUM}).cnt;
-    if (cnt === 0) return;
+    if (res.iter({cnt: NUM}).cnt === 0) return;
 
-    HeapDumpPage.engine = ctx.engine;
-    HeapDumpPage.trace = ctx;
-    HeapDumpPage.hasHeapData = true;
-    resetBitmapDumpDataCache();
-    resetFlamegraphSelection();
-    resetInstanceTabs();
-    resetCachedOverview();
+    const session = new HeapDumpExplorerSession(ctx, ctx.engine);
+    await session.loadDumps();
 
-    resetDumps();
-    await loadDumps(ctx.engine);
+    ctx.pages.registerPage({
+      route: '/heapdump',
+      render: (subpage) => m(HeapDumpPage, {session, subpage}),
+    });
 
     ctx.plugins
       .getPlugin(HeapProfilePlugin)
       .registerOnNodeSelectedListener(({pathHashes, isDominator, upid, ts}) =>
-        setFlamegraphSelection({pathHashes, isDominator, upid, ts}, ctx.engine),
+        session.openFlamegraph({pathHashes, isDominator, upid, ts}),
       );
 
     ctx.sidebar.addMenuItem({

--- a/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Internal navigation state for the Heapdump Explorer plugin.
-
-import m from 'mithril';
-
 export type NavState =
   | {view: 'overview'; params: Record<string, never>}
   | {view: 'classes'; params: {rootClass?: string}}
@@ -26,6 +22,8 @@ export type NavState =
   | {view: 'strings'; params: {q?: string}}
   | {view: 'arrays'; params: {arrayHash?: string}}
   | {view: 'flamegraph-objects'; params: {name?: string}};
+
+export type NavView = NavState['view'];
 
 export function stateToSubpage(state: NavState): string {
   switch (state.view) {
@@ -134,49 +132,4 @@ export function subpageToState(subpage: string | undefined): NavState {
     default:
       return {view: 'overview', params: {}};
   }
-}
-
-export let nav: NavState = {view: 'overview', params: {}};
-
-let navigateCallback: ((subpage: string) => void) | undefined;
-
-export function setNavigateCallback(
-  cb: ((subpage: string) => void) | undefined,
-): void {
-  navigateCallback = cb;
-}
-
-export function navigate(
-  v: NavState['view'],
-  p: Record<string, unknown> = {},
-): void {
-  const state = {view: v, params: p} as NavState;
-  nav = state;
-  navigateCallback?.(stateToSubpage(state));
-  m.redraw();
-}
-
-// Clear a single nav param without pushing a history entry.
-// Used after consuming a one-shot param (e.g. a filter from overview).
-export function clearNavParam(key: string): void {
-  const params = {...(nav.params as Record<string, unknown>)};
-  delete params[key];
-  nav = {view: nav.view, params} as NavState;
-}
-
-export function syncFromSubpage(subpage: string | undefined): void {
-  if (subpage?.startsWith('/')) subpage = subpage.slice(1);
-  // Compare path-only: Perfetto's router strips query params from subpage.
-  const currentSubpage = stateToSubpage(nav);
-  const currentPath = currentSubpage.split('?')[0];
-  const incomingPath = (subpage ?? '').split('?')[0];
-  if (incomingPath !== currentPath) {
-    nav = subpageToState(subpage);
-  }
-}
-
-// Shared flag for sidebar sub-item visibility (readable by sidebar callbacks).
-export let hasReadyHprofSession = false;
-export function setHasReadyHprofSession(v: boolean): void {
-  hasReadyHprofSession = v;
 }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import m from 'mithril';
 import {Engine} from '../../trace_processor/engine';
 import {
   BLOB_NULL,
@@ -48,35 +47,7 @@ export interface HeapDump {
   readonly pid: number;
 }
 
-let dumps: ReadonlyArray<HeapDump> = [];
-let activeDump: HeapDump | null = null;
-
-export function getDumps(): ReadonlyArray<HeapDump> {
-  return dumps;
-}
-
-export function getActiveDump(): HeapDump | null {
-  return activeDump;
-}
-
-export function setDumps(newDumps: ReadonlyArray<HeapDump>): void {
-  dumps = newDumps;
-  activeDump = newDumps.length > 0 ? newDumps[0] : null;
-  m.redraw();
-}
-
-export function setActiveDump(d: HeapDump): void {
-  if (activeDump === d) return;
-  activeDump = d;
-  m.redraw();
-}
-
-export function resetDumps(): void {
-  dumps = [];
-  activeDump = null;
-}
-
-export async function loadDumps(engine: Engine): Promise<void> {
+export async function loadDumpsList(engine: Engine): Promise<HeapDump[]> {
   const res = await engine.query(`
     SELECT
       o.upid AS upid,
@@ -106,14 +77,13 @@ export async function loadDumps(engine: Engine): Promise<void> {
       pid: it.pid ?? 0,
     });
   }
-  setDumps(result);
+  return result;
 }
 
-export function dumpFilterSql(alias: string = 'o'): string {
-  if (!activeDump) return '1=1';
+export function dumpFilterSql(dump: HeapDump, alias: string = 'o'): string {
   return (
-    `${alias}.upid = ${activeDump.upid} ` +
-    `AND ${alias}.graph_sample_ts = ${activeDump.ts}`
+    `${alias}.upid = ${dump.upid} ` +
+    `AND ${alias}.graph_sample_ts = ${dump.ts}`
   );
 }
 
@@ -223,10 +193,11 @@ function collectRows(res: QueryResult): InstanceRow[] {
  */
 async function batchBitmapBufferHashes(
   engine: Engine,
+  activeDump: HeapDump,
   bitmaps: Array<{objectId: number; nativePtr: bigint}>,
 ): Promise<Map<number, string>> {
   const result = new Map<number, string>();
-  const dumpData = await loadBitmapDumpData(engine);
+  const dumpData = await loadBitmapDumpData(engine, activeDump);
   if (!dumpData) return result;
 
   // Build bufferObjId → [bitmapObjectId, ...] mapping.
@@ -268,8 +239,11 @@ async function batchBitmapBufferHashes(
   return result;
 }
 
-export async function getOverview(engine: Engine): Promise<OverviewData> {
-  const dumpFilter = dumpFilterSql('o');
+export async function getOverview(
+  engine: Engine,
+  activeDump: HeapDump,
+): Promise<OverviewData> {
+  const dumpFilter = dumpFilterSql(activeDump, 'o');
   const countRes = await engine.query(
     `SELECT count(*) as cnt FROM heap_graph_object o
      WHERE o.reachable != 0 AND ${dumpFilter}`,
@@ -359,7 +333,7 @@ export async function getOverview(engine: Engine): Promise<OverviewData> {
     .map((b) => ({objectId: b.id, nativePtr: b.nativePtr!}));
   const hashes =
     hashInputs.length > 0
-      ? await batchBitmapBufferHashes(engine, hashInputs)
+      ? await batchBitmapBufferHashes(engine, activeDump, hashInputs)
       : new Map<number, string>();
 
   const hashGroups = new Map<
@@ -491,6 +465,7 @@ export async function getOverview(engine: Engine): Promise<OverviewData> {
 
 export async function getAllocations(
   engine: Engine,
+  activeDump: HeapDump,
   heap: string | null,
 ): Promise<ClassRow[]> {
   await requireDominatorTree(engine);
@@ -510,7 +485,7 @@ export async function getAllocations(
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     WHERE o.reachable != 0
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
       ${hf}
     GROUP BY cls, heap
     ORDER BY retained DESC
@@ -547,7 +522,10 @@ export async function getAllocations(
   return rows;
 }
 
-export async function getRooted(engine: Engine): Promise<InstanceRow[]> {
+export async function getRooted(
+  engine: Engine,
+  activeDump: HeapDump,
+): Promise<InstanceRow[]> {
   await requireDominatorTree(engine);
   const res = await engine.query(`
     SELECT ${INSTANCE_COLS}
@@ -556,7 +534,7 @@ export async function getRooted(engine: Engine): Promise<InstanceRow[]> {
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE d.idom_id IS NULL
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
     ORDER BY d.dominated_size_bytes + d.dominated_native_size_bytes DESC
   `);
   return collectRows(res);
@@ -567,6 +545,7 @@ type FieldEntry = {name: string; typeName: string; value: PrimOrRef};
 /** Fetch primitive and reference field values for an object. */
 async function fetchFieldValues(
   engine: Engine,
+  activeDump: HeapDump,
   refSetId: number | null,
   fieldSetId: number | null,
 ): Promise<FieldEntry[]> {
@@ -613,7 +592,7 @@ async function fetchFieldValues(
         SELECT c.name, MIN(c.deobfuscated_name) AS deobfuscated_name
         FROM heap_graph_class c
         JOIN heap_graph_object o ON o.type_id = c.id
-        WHERE ${dumpFilterSql('o')}
+        WHERE ${dumpFilterSql(activeDump, 'o')}
         GROUP BY c.name
       )
       SELECT
@@ -985,6 +964,7 @@ export async function fetchDominatorPaths(
 
 export async function getInstance(
   engine: Engine,
+  activeDump: HeapDump,
   id: number,
 ): Promise<InstanceDetail | null> {
   await requireDominatorTree(engine);
@@ -1108,7 +1088,7 @@ export async function getInstance(
       JOIN heap_graph_class c ON o.type_id = c.id
       LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
       LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
-      WHERE ${dumpFilterSql('o')}
+      WHERE ${dumpFilterSql(activeDump, 'o')}
         AND (c.name = '${classObjName}'
           OR c.deobfuscated_name = '${classObjName}')
     `);
@@ -1118,7 +1098,7 @@ export async function getInstance(
 
   const instanceFields =
     !isArrayInstance && !isClassObj
-      ? await fetchFieldValues(engine, refSetId, fieldSetId)
+      ? await fetchFieldValues(engine, activeDump, refSetId, fieldSetId)
       : [];
 
   let arrayLength = 0;
@@ -1245,17 +1225,17 @@ export async function getInstance(
   const shortestPath = await fetchShortestPathFromRoot(engine, id);
 
   const staticFields = isClassObj
-    ? await fetchFieldValues(engine, refSetId, fieldSetId)
+    ? await fetchFieldValues(engine, activeDump, refSetId, fieldSetId)
     : [];
 
   let bitmap: InstanceDetail['bitmap'] = null;
   if (fullClassName === 'android.graphics.Bitmap') {
-    bitmap = await extractBitmapPixels(engine, fieldSetId);
+    bitmap = await extractBitmapPixels(engine, activeDump, fieldSetId);
   }
   if (bitmap === null) {
     const deobName = className(oit.cls, oit.deob);
     if (deobName === 'android.graphics.Bitmap') {
-      bitmap = await extractBitmapPixels(engine, fieldSetId);
+      bitmap = await extractBitmapPixels(engine, activeDump, fieldSetId);
     }
   }
 
@@ -1342,9 +1322,9 @@ export async function getClassHierarchy(
 /** Transitive subclass names of `rootName` (including the root itself). */
 export async function getSubclassNames(
   engine: Engine,
+  activeDump: HeapDump,
   rootName: string,
 ): Promise<string[]> {
-  // Scope to the active dump so we don't walk another dump's class hierarchy.
   const res = await engine.query(`
     INCLUDE PERFETTO MODULE graphs.search;
 
@@ -1352,7 +1332,7 @@ export async function getSubclassNames(
       SELECT DISTINCT c.id, c.name, c.deobfuscated_name, c.superclass_id
       FROM heap_graph_class c
       JOIN heap_graph_object o ON o.type_id = c.id
-      WHERE ${dumpFilterSql('o')}
+      WHERE ${dumpFilterSql(activeDump, 'o')}
     )
     SELECT coalesce(c.deobfuscated_name, c.name) AS name
     FROM graph_reachable_dfs!(
@@ -1388,9 +1368,9 @@ export async function getRawArrayBlob(
 
 export async function getRawBitmapBlob(
   engine: Engine,
+  activeDump: HeapDump,
   objectId: number,
 ): Promise<{data: Uint8Array; format: string} | null> {
-  // Read mNativePtr from the Bitmap instance fields.
   const fieldRes = await engine.query(`
     SELECT f.long_value
     FROM heap_graph_object o
@@ -1403,7 +1383,7 @@ export async function getRawBitmapBlob(
   if (!fit.valid() || fit.long_value === null) return null;
   const nativePtr = fit.long_value;
 
-  const dumpData = await loadBitmapDumpData(engine);
+  const dumpData = await loadBitmapDumpData(engine, activeDump);
   if (!dumpData) return null;
   const bufferObjId = dumpData.bufferMap.get(nativePtr);
   if (bufferObjId === undefined) return null;
@@ -1445,30 +1425,36 @@ interface BitmapDumpData {
   bufferMap: Map<bigint, number>;
 }
 
-let cachedDumpData: BitmapDumpData | null | undefined;
+const bitmapDumpDataByDump = new WeakMap<
+  HeapDump,
+  Promise<BitmapDumpData | null>
+>();
 
-export function resetBitmapDumpDataCache(): void {
-  cachedDumpData = undefined;
+function loadBitmapDumpData(
+  engine: Engine,
+  activeDump: HeapDump,
+): Promise<BitmapDumpData | null> {
+  const cached = bitmapDumpDataByDump.get(activeDump);
+  if (cached !== undefined) return cached;
+  const promise = computeBitmapDumpData(engine, activeDump);
+  bitmapDumpDataByDump.set(activeDump, promise);
+  return promise;
 }
 
-async function loadBitmapDumpData(
+async function computeBitmapDumpData(
   engine: Engine,
+  activeDump: HeapDump,
 ): Promise<BitmapDumpData | null> {
-  if (cachedDumpData !== undefined) return cachedDumpData;
-
   const classObjRes = await engine.query(`
     SELECT o.reference_set_id
     FROM heap_graph_object o
     JOIN heap_graph_class c ON o.type_id = c.id
-    WHERE ${dumpFilterSql('o')}
+    WHERE ${dumpFilterSql(activeDump, 'o')}
       AND (c.name LIKE '%Class<android.graphics.Bitmap>'
         OR c.deobfuscated_name LIKE '%Class<android.graphics.Bitmap>')
   `);
   const classIt = classObjRes.iter({reference_set_id: NUM_NULL});
-  if (!classIt.valid() || classIt.reference_set_id === null) {
-    cachedDumpData = null;
-    return null;
-  }
+  if (!classIt.valid() || classIt.reference_set_id === null) return null;
 
   // Step 2: Follow dumpData reference from the class object.
   const ddRes = await engine.query(`
@@ -1479,10 +1465,7 @@ async function loadBitmapDumpData(
 
   `);
   const ddIt = ddRes.iter({dump_data_id: NUM_NULL});
-  if (!ddIt.valid() || ddIt.dump_data_id === null) {
-    cachedDumpData = null;
-    return null;
-  }
+  if (!ddIt.valid() || ddIt.dump_data_id === null) return null;
   const dumpDataId = ddIt.dump_data_id;
 
   // Step 3: Read format from DumpData's fields.
@@ -1516,10 +1499,7 @@ async function loadBitmapDumpData(
     if (it.field_name.endsWith('natives')) nativesObjId = it.owned_id;
     if (it.field_name.endsWith('buffers')) buffersObjId = it.owned_id;
   }
-  if (nativesObjId === null || buffersObjId === null) {
-    cachedDumpData = null;
-    return null;
-  }
+  if (nativesObjId === null || buffersObjId === null) return null;
 
   // Step 5: Decode natives long[] via JSON.
   const nativesRes = await engine.query(`
@@ -1529,10 +1509,7 @@ async function loadBitmapDumpData(
     WHERE o.id = ${nativesObjId}
   `);
   const nativesIt = nativesRes.iter({data: STR_NULL});
-  if (!nativesIt.valid() || nativesIt.data === null) {
-    cachedDumpData = null;
-    return null;
-  }
+  if (!nativesIt.valid() || nativesIt.data === null) return null;
   // Native pointers need BigInt for 64-bit precision in Map lookups.
   const nativesPtrs = (JSON.parse(nativesIt.data) as string[]).map(BigInt);
 
@@ -1563,8 +1540,7 @@ async function loadBitmapDumpData(
     }
   }
 
-  cachedDumpData = {format, bufferMap};
-  return cachedDumpData;
+  return {format, bufferMap};
 }
 
 const DUMP_DATA_FORMAT_NAMES: Record<number, string> = {
@@ -1577,6 +1553,7 @@ const DUMP_DATA_FORMAT_NAMES: Record<number, string> = {
 
 async function extractBitmapPixels(
   engine: Engine,
+  activeDump: HeapDump,
   fieldSetId: number | null,
 ): Promise<InstanceDetail['bitmap']> {
   if (fieldSetId === null) return null;
@@ -1608,7 +1585,7 @@ async function extractBitmapPixels(
   }
   if (width <= 0 || height <= 0 || nativePtr === 0n) return null;
 
-  const dumpData = await loadBitmapDumpData(engine);
+  const dumpData = await loadBitmapDumpData(engine, activeDump);
   if (dumpData === null) return null;
 
   const bufferObjId = dumpData.bufferMap.get(nativePtr);
@@ -1629,6 +1606,7 @@ async function extractBitmapPixels(
 
 export async function getBitmapPixels(
   engine: Engine,
+  activeDump: HeapDump,
   objectId: number,
 ): Promise<InstanceDetail['bitmap']> {
   const res = await engine.query(`
@@ -1638,11 +1616,12 @@ export async function getBitmapPixels(
     WHERE o.id = ${objectId}
 `);
   const row = res.maybeFirstRow({field_set_id: NUM_NULL});
-  return extractBitmapPixels(engine, row?.field_set_id ?? null);
+  return extractBitmapPixels(engine, activeDump, row?.field_set_id ?? null);
 }
 
 export async function search(
   engine: Engine,
+  activeDump: HeapDump,
   query: string,
 ): Promise<InstanceRow[]> {
   await requireDominatorTree(engine);
@@ -1669,7 +1648,7 @@ export async function search(
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE o.reachable != 0
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
       AND (c.name LIKE '%${escaped}%' ESCAPE '\\'
         OR c.deobfuscated_name LIKE '%${escaped}%' ESCAPE '\\')
     ORDER BY (ifnull(d.dominated_size_bytes, 0)
@@ -1680,6 +1659,7 @@ export async function search(
 
 export async function getObjects(
   engine: Engine,
+  activeDump: HeapDump,
   cls: string,
   heap: string | null,
 ): Promise<InstanceRow[]> {
@@ -1693,7 +1673,7 @@ export async function getObjects(
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE o.reachable != 0
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
       AND (c.name = '${escaped}' OR c.deobfuscated_name = '${escaped}')
       ${hf}
     ORDER BY o.self_size + o.native_size DESC
@@ -1730,7 +1710,10 @@ export async function getObjectsByFlamegraphSelection(
   return collectRows(res);
 }
 
-export async function getStringList(engine: Engine): Promise<StringListRow[]> {
+export async function getStringList(
+  engine: Engine,
+  activeDump: HeapDump,
+): Promise<StringListRow[]> {
   await requireDominatorTree(engine);
   const res = await engine.query(`
     SELECT
@@ -1748,7 +1731,7 @@ export async function getStringList(engine: Engine): Promise<StringListRow[]> {
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     WHERE o.reachable != 0
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
       AND od.value_string IS NOT NULL
       AND (c.name = 'java.lang.String'
         OR c.deobfuscated_name = 'java.lang.String')
@@ -1791,9 +1774,12 @@ export async function getStringList(engine: Engine): Promise<StringListRow[]> {
   return rows;
 }
 
-export async function getBitmapList(engine: Engine): Promise<BitmapListRow[]> {
+export async function getBitmapList(
+  engine: Engine,
+  activeDump: HeapDump,
+): Promise<BitmapListRow[]> {
   await requireDominatorTree(engine);
-  const dumpData = await loadBitmapDumpData(engine);
+  const dumpData = await loadBitmapDumpData(engine, activeDump);
   const res = await engine.query(`
     SELECT
       o.id,
@@ -1818,7 +1804,7 @@ export async function getBitmapList(engine: Engine): Promise<BitmapListRow[]> {
     LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
     LEFT JOIN heap_graph_primitive f ON f.field_set_id = od.field_set_id
     WHERE o.reachable != 0
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
       AND (c.name = 'android.graphics.Bitmap'
         OR c.deobfuscated_name = 'android.graphics.Bitmap')
     GROUP BY o.id
@@ -1880,7 +1866,7 @@ export async function getBitmapList(engine: Engine): Promise<BitmapListRow[]> {
   // Look up pre-computed content hashes for bitmaps with pixel data.
   const hashes =
     hashInputs.length > 0
-      ? await batchBitmapBufferHashes(engine, hashInputs)
+      ? await batchBitmapBufferHashes(engine, activeDump, hashInputs)
       : new Map<number, string>();
 
   const rows: BitmapListRow[] = rawRows.map((r) => ({

--- a/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
@@ -1,0 +1,307 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {Engine} from '../../trace_processor/engine';
+import type {Trace} from '../../public/trace';
+import {NUM} from '../../trace_processor/query_result';
+
+import {SQL_PREAMBLE} from './components';
+import {flamegraphQuery} from './views/flamegraph_objects_view';
+import * as queries from './queries';
+import {
+  type NavState,
+  type NavView,
+  stateToSubpage,
+  subpageToState,
+} from './nav_state';
+import type {OverviewData} from './types';
+
+interface FlamegraphSelection {
+  readonly pathHashes: string;
+  readonly isDominator: boolean;
+  readonly upid: number;
+  readonly ts: bigint;
+}
+
+interface FlamegraphTab extends FlamegraphSelection {
+  readonly id: number;
+  count: number | null;
+}
+
+interface InstanceTab {
+  readonly id: number;
+  readonly objId: number;
+  readonly label: string;
+}
+
+const INSTANCE_LABEL_MAX = 30;
+
+function truncateInstanceLabel(label: string): string {
+  return label.length > INSTANCE_LABEL_MAX
+    ? label.slice(0, INSTANCE_LABEL_MAX) + '…'
+    : label;
+}
+
+// Created per onTraceLoad and replaced on the next one, so per-trace
+// state disappears together. Dump switching within a trace keeps the
+// session but drops per-dump caches.
+export class HeapDumpExplorerSession {
+  private _nav: NavState = {view: 'overview', params: {}};
+  private _navigateCallback?: (subpage: string) => void;
+
+  private _dumps: ReadonlyArray<queries.HeapDump> = [];
+  private _activeDump: queries.HeapDump | null = null;
+
+  private readonly _flamegraphTabs: FlamegraphTab[] = [];
+  private _nextFlamegraphId = 0;
+  private _activeFlamegraphId: number | null = null;
+
+  private readonly _instanceTabs: InstanceTab[] = [];
+  private _nextInstanceId = 0;
+  private _activeInstanceId: number | null = null;
+
+  private _overview: OverviewData | null = null;
+
+  constructor(
+    readonly trace: Trace,
+    readonly engine: Engine,
+  ) {}
+
+  get dumps(): ReadonlyArray<queries.HeapDump> {
+    return this._dumps;
+  }
+
+  get activeDump(): queries.HeapDump | null {
+    return this._activeDump;
+  }
+
+  async loadDumps(): Promise<void> {
+    this._dumps = await queries.loadDumpsList(this.engine);
+    this._activeDump = this._dumps.length > 0 ? this._dumps[0] : null;
+  }
+
+  selectDump(d: queries.HeapDump): void {
+    if (this._activeDump === d) return;
+    this.switchToDump(d);
+    if (
+      this._nav.view === 'object' ||
+      this._nav.view === 'flamegraph-objects'
+    ) {
+      this.navigate('overview');
+    }
+    m.redraw();
+  }
+
+  private switchToDump(d: queries.HeapDump): void {
+    this._activeDump = d;
+    this.resetDumpScopedState();
+    void this.loadOverview();
+  }
+
+  get nav(): NavState {
+    return this._nav;
+  }
+
+  setNavigateCallback(cb: ((subpage: string) => void) | undefined): void {
+    this._navigateCallback = cb;
+  }
+
+  navigate(view: NavView, params: Record<string, unknown> = {}): void {
+    this._nav = {view, params} as NavState;
+    this._navigateCallback?.(stateToSubpage(this._nav));
+    m.redraw();
+  }
+
+  // Arrow property: passed by reference into Mithril attrs.
+  readonly navigateWithTabs = (
+    view: NavView,
+    params?: Record<string, unknown>,
+  ): void => {
+    if (view === 'object') {
+      this.openInstanceTab(
+        params?.id as number,
+        params?.label as string | undefined,
+      );
+      this.navigate(view, params);
+      return;
+    }
+    this._activeInstanceId = null;
+    this.navigate(view, params);
+  };
+
+  readonly clearNavParam = (key: string): void => {
+    delete (this._nav.params as Record<string, unknown>)[key];
+  };
+
+  syncFromSubpage(subpage: string | undefined): void {
+    const sub = subpage?.startsWith('/') ? subpage.slice(1) : subpage;
+    // The router strips query params from `subpage`; compare path-only.
+    const currentPath = stateToSubpage(this._nav).split('?')[0];
+    const incomingPath = (sub ?? '').split('?')[0];
+    if (incomingPath !== currentPath) {
+      this._nav = subpageToState(sub);
+    }
+  }
+
+  get flamegraphTabs(): ReadonlyArray<FlamegraphTab> {
+    return this._flamegraphTabs;
+  }
+
+  get activeFlamegraphId(): number | null {
+    return this._activeFlamegraphId;
+  }
+
+  setActiveFlamegraphTab(id: number): void {
+    this._activeFlamegraphId = id;
+  }
+
+  clearActiveFlamegraphTab(): void {
+    this._activeFlamegraphId = null;
+  }
+
+  openFlamegraph(sel: FlamegraphSelection): void {
+    const target = this._dumps.find(
+      (d) => d.upid === sel.upid && d.ts === sel.ts,
+    );
+    if (target && target !== this._activeDump) {
+      this.switchToDump(target);
+    }
+    const existing = this._flamegraphTabs.find(
+      (t) =>
+        t.pathHashes === sel.pathHashes && t.isDominator === sel.isDominator,
+    );
+    if (existing) {
+      this._activeFlamegraphId = existing.id;
+      this.navigate('flamegraph-objects');
+      return;
+    }
+    const tab: FlamegraphTab = {
+      id: this._nextFlamegraphId++,
+      count: null,
+      pathHashes: sel.pathHashes,
+      isDominator: sel.isDominator,
+      upid: sel.upid,
+      ts: sel.ts,
+    };
+    this._flamegraphTabs.push(tab);
+    this._activeFlamegraphId = tab.id;
+    this.navigate('flamegraph-objects');
+
+    const q = flamegraphQuery(sel.pathHashes, sel.isDominator);
+    this.engine
+      .query(`${SQL_PREAMBLE}; SELECT COUNT(*) AS c FROM (${q})`)
+      .then((r) => {
+        tab.count = Number(r.firstRow({c: NUM}).c);
+        m.redraw();
+      })
+      .catch(console.error);
+  }
+
+  closeFlamegraph(id: number): void {
+    const idx = this._flamegraphTabs.findIndex((t) => t.id === id);
+    if (idx === -1) return;
+    this._flamegraphTabs.splice(idx, 1);
+    if (this._activeFlamegraphId === id) {
+      this._activeFlamegraphId = null;
+      this.navigate('overview');
+    }
+  }
+
+  get instanceTabs(): ReadonlyArray<InstanceTab> {
+    return this._instanceTabs;
+  }
+
+  get activeInstanceId(): number | null {
+    return this._activeInstanceId;
+  }
+
+  setActiveInstanceTab(id: number): void {
+    this._activeInstanceId = id;
+  }
+
+  clearActiveInstanceTab(): void {
+    this._activeInstanceId = null;
+  }
+
+  private openInstanceTab(objId: number, label?: string): void {
+    const existing = this._instanceTabs.find((t) => t.objId === objId);
+    if (existing) {
+      this._activeInstanceId = existing.id;
+      return;
+    }
+    const tab: InstanceTab = {
+      id: this._nextInstanceId++,
+      objId,
+      label: truncateInstanceLabel(label ?? 'Instance'),
+    };
+    this._instanceTabs.push(tab);
+    this._activeInstanceId = tab.id;
+  }
+
+  closeInstanceTab(id: number): void {
+    const idx = this._instanceTabs.findIndex((t) => t.id === id);
+    if (idx === -1) return;
+    this._instanceTabs.splice(idx, 1);
+    if (this._activeInstanceId === id) {
+      this._activeInstanceId = null;
+      this.navigate('overview');
+    }
+  }
+
+  syncInstanceTabFromNav(): void {
+    if (this._nav.view !== 'object') {
+      this._activeInstanceId = null;
+      return;
+    }
+    const {id, label} = this._nav.params;
+    const existing = this._instanceTabs.find((t) => t.objId === id);
+    if (existing) {
+      this._activeInstanceId = existing.id;
+    } else {
+      this.openInstanceTab(id, label);
+    }
+  }
+
+  private resetDumpScopedState(): void {
+    this._overview = null;
+    this._flamegraphTabs.length = 0;
+    this._nextFlamegraphId = 0;
+    this._activeFlamegraphId = null;
+    this._instanceTabs.length = 0;
+    this._nextInstanceId = 0;
+    this._activeInstanceId = null;
+  }
+
+  get cachedOverview(): OverviewData | null {
+    return this._overview;
+  }
+
+  // Pins the dump at fetch start; if the user switches dumps before
+  // the result arrives, the result is dropped instead of briefly
+  // displaying the wrong dump's overview.
+  async loadOverview(): Promise<void> {
+    if (this._overview !== null) return;
+    const dump = this._activeDump;
+    if (dump === null) return;
+    try {
+      const data = await queries.getOverview(this.engine, dump);
+      if (this._activeDump === dump) this._overview = data;
+    } catch (err) {
+      console.error('Failed to load overview:', err);
+    } finally {
+      m.redraw();
+    }
+  }
+}

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
@@ -29,16 +29,17 @@ import {
   SQL_PREAMBLE,
   RowCounter,
 } from '../components';
-import {clearNavParam} from '../nav_state';
-import {dumpFilterSql} from '../queries';
+import {dumpFilterSql, type HeapDump} from '../queries';
 
 interface AllObjectsViewAttrs {
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
+  readonly clearNavParam: (key: string) => void;
   readonly initialClass?: string;
 }
 
-function buildQuery(): string {
+function buildQuery(activeDump: HeapDump): string {
   return `
     SELECT
       base.*,
@@ -61,7 +62,7 @@ function buildQuery(): string {
       LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
       LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
       WHERE o.reachable != 0
-        AND ${dumpFilterSql('o')}
+        AND ${dumpFilterSql(activeDump, 'o')}
     ) base
     LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = base.id
   `;
@@ -159,7 +160,10 @@ function AllObjectsView(): m.Component<AllObjectsViewAttrs> {
   const counter = new RowCounter();
   let filters: Filter[] = [];
 
-  function applyNavFilter(cls: string | undefined) {
+  function applyNavFilter(
+    cls: string | undefined,
+    clearNavParam: (key: string) => void,
+  ) {
     if (!cls) return;
     filters = [{field: 'cls', op: '=' as const, value: cls}];
     counter.onFiltersChanged(filters);
@@ -168,8 +172,8 @@ function AllObjectsView(): m.Component<AllObjectsViewAttrs> {
 
   return {
     oninit(vnode) {
-      const {engine} = vnode.attrs;
-      const query = buildQuery();
+      const {engine, activeDump} = vnode.attrs;
+      const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
         sqlSchema: createSimpleSchema(query),
@@ -177,10 +181,10 @@ function AllObjectsView(): m.Component<AllObjectsViewAttrs> {
         preamble: SQL_PREAMBLE,
       });
       counter.init(engine, query, SQL_PREAMBLE);
-      applyNavFilter(vnode.attrs.initialClass);
+      applyNavFilter(vnode.attrs.initialClass, vnode.attrs.clearNavParam);
     },
     onupdate(vnode) {
-      applyNavFilter(vnode.attrs.initialClass);
+      applyNavFilter(vnode.attrs.initialClass, vnode.attrs.clearNavParam);
     },
     view(vnode) {
       const {navigate} = vnode.attrs;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
@@ -29,10 +29,9 @@ import {
   shortClassName,
   RowCounter,
 } from '../components';
-import {clearNavParam} from '../nav_state';
-import {dumpFilterSql} from '../queries';
+import {dumpFilterSql, type HeapDump} from '../queries';
 
-function buildQuery(): string {
+function buildQuery(activeDump: HeapDump): string {
   return `
     SELECT
       o.id,
@@ -46,7 +45,7 @@ function buildQuery(): string {
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
     WHERE o.reachable != 0
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
       AND od.array_data_hash IS NOT NULL
   `;
 }
@@ -104,7 +103,9 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
 
 interface ArraysViewAttrs {
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
+  readonly clearNavParam: (key: string) => void;
   readonly initialArrayHash?: string;
   readonly hasFieldValues?: boolean;
 }
@@ -114,7 +115,10 @@ function ArraysView(): m.Component<ArraysViewAttrs> {
   const counter = new RowCounter();
   let filters: Filter[] = [];
 
-  function applyNavFilter(ah: string | undefined) {
+  function applyNavFilter(
+    ah: string | undefined,
+    clearNavParam: (key: string) => void,
+  ) {
     if (!ah) return;
     filters = [{field: 'array_hash', op: '=' as const, value: ah}];
     counter.onFiltersChanged(filters);
@@ -123,18 +127,18 @@ function ArraysView(): m.Component<ArraysViewAttrs> {
 
   return {
     oninit(vnode) {
-      const {engine} = vnode.attrs;
-      const query = buildQuery();
+      const {engine, activeDump} = vnode.attrs;
+      const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
         sqlSchema: createSimpleSchema(query),
         rootSchemaName: 'query',
       });
       counter.init(engine, query);
-      applyNavFilter(vnode.attrs.initialArrayHash);
+      applyNavFilter(vnode.attrs.initialArrayHash, vnode.attrs.clearNavParam);
     },
     onupdate(vnode) {
-      applyNavFilter(vnode.attrs.initialArrayHash);
+      applyNavFilter(vnode.attrs.initialArrayHash, vnode.attrs.clearNavParam);
     },
     view(vnode) {
       const {navigate} = vnode.attrs;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/bitmap_gallery_view.ts
@@ -33,8 +33,8 @@ import {
   renderPath,
 } from '../components';
 import type {PathEntry} from '../types';
-import {clearNavParam} from '../nav_state';
 import * as queries from '../queries';
+import type {HeapDump} from '../queries';
 
 const SUMMARY_SCHEMA: SchemaRegistry = {
   query: {
@@ -164,6 +164,7 @@ const PATH_HEADING: Record<Exclude<PathMode, 'none'>, string> = {
 interface BitmapCardAttrs {
   readonly row: BitmapListRow;
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
   readonly pathMode: PathMode;
   readonly pathData?: PathEntry[] | null;
@@ -173,11 +174,11 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
   let obs: IntersectionObserver | null = null;
   let bitmap: InstanceDetail['bitmap'] | null | 'loading' | 'error' = null;
 
-  function load(engine: Engine, id: number) {
+  function load(engine: Engine, activeDump: HeapDump, id: number) {
     if (bitmap !== null) return;
     bitmap = 'loading';
     queries
-      .getBitmapPixels(engine, id)
+      .getBitmapPixels(engine, activeDump, id)
       .then((result) => {
         bitmap = result ?? 'error';
         m.redraw();
@@ -194,7 +195,11 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
       obs = new IntersectionObserver(
         ([entry]) => {
           if (entry.isIntersecting) {
-            load(vnode.attrs.engine, vnode.attrs.row.row.id);
+            load(
+              vnode.attrs.engine,
+              vnode.attrs.activeDump,
+              vnode.attrs.row.row.id,
+            );
             obs!.disconnect();
           }
         },
@@ -302,7 +307,9 @@ function BitmapCard(): m.Component<BitmapCardAttrs> {
 
 interface BitmapGalleryViewAttrs {
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
+  readonly clearNavParam: (key: string) => void;
   readonly hasFieldValues?: boolean;
   readonly filterKey?: string;
 }
@@ -347,7 +354,10 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
       .catch(console.error);
   }
 
-  function applyNavFilter(fk: string | undefined) {
+  function applyNavFilter(
+    fk: string | undefined,
+    clearNavParam: (key: string) => void,
+  ) {
     if (!fk) return;
     filters = [{field: 'buffer_hash', op: '=' as const, value: fk}];
     clearNavParam('filterKey');
@@ -355,9 +365,9 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
 
   return {
     oninit(vnode) {
-      applyNavFilter(vnode.attrs.filterKey);
+      applyNavFilter(vnode.attrs.filterKey, vnode.attrs.clearNavParam);
       queries
-        .getBitmapList(vnode.attrs.engine)
+        .getBitmapList(vnode.attrs.engine, vnode.attrs.activeDump)
         .then((r) => {
           if (!alive) return;
           rows = r;
@@ -376,13 +386,13 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
         .catch(console.error);
     },
     onupdate(vnode) {
-      applyNavFilter(vnode.attrs.filterKey);
+      applyNavFilter(vnode.attrs.filterKey, vnode.attrs.clearNavParam);
     },
     onremove() {
       alive = false;
     },
     view(vnode) {
-      const {engine, navigate} = vnode.attrs;
+      const {engine, activeDump, navigate} = vnode.attrs;
 
       if (!rows) {
         return m('div', {class: 'ah-loading'}, m(Spinner, {easing: true}));
@@ -499,6 +509,7 @@ function BitmapGalleryView(): m.Component<BitmapGalleryViewAttrs> {
                   key: r.row.id,
                   row: r,
                   engine,
+                  activeDump,
                   navigate,
                   pathMode,
                   pathData:

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
@@ -26,20 +26,21 @@ import {
   countRenderer,
   RowCounter,
 } from '../components';
-import {clearNavParam} from '../nav_state';
 import * as queries from '../queries';
-import {dumpFilterSql} from '../queries';
+import {dumpFilterSql, type HeapDump} from '../queries';
 
 interface ClassesViewAttrs {
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
+  readonly clearNavParam: (key: string) => void;
   readonly initialRootClass?: string;
 }
 
 const PREAMBLE =
   'INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_class_aggregation';
 
-function buildQuery(): string {
+function buildQuery(activeDump: HeapDump): string {
   return `
     SELECT
       type_name AS cls,
@@ -50,7 +51,7 @@ function buildQuery(): string {
       dominated_native_size_bytes AS retained_native,
       dominated_obj_count AS retained_count
     FROM android_heap_graph_class_aggregation a
-    WHERE a.reachable_obj_count > 0 AND ${dumpFilterSql('a')}
+    WHERE a.reachable_obj_count > 0 AND ${dumpFilterSql(activeDump, 'a')}
   `;
 }
 
@@ -106,14 +107,20 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
 
 function ClassesView(): m.Component<ClassesViewAttrs> {
   let dataSource: SQLDataSource | null = null;
+  let alive = true;
   const counter = new RowCounter();
   let filters: Filter[] = [];
 
-  async function applyNavFilter(engine: Engine, root: string | undefined) {
+  async function applyNavFilter(
+    engine: Engine,
+    activeDump: HeapDump,
+    root: string | undefined,
+    clearNavParam: (key: string) => void,
+  ) {
     if (!root) return;
     clearNavParam('rootClass');
-    const names = await queries.getSubclassNames(engine, root);
-    if (names.length === 0) return;
+    const names = await queries.getSubclassNames(engine, activeDump, root);
+    if (!alive || names.length === 0) return;
     filters = [{field: 'cls', op: 'in' as const, value: names}];
     counter.onFiltersChanged(filters);
     m.redraw();
@@ -121,8 +128,8 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
 
   return {
     oninit(vnode) {
-      const {engine} = vnode.attrs;
-      const query = buildQuery();
+      const {engine, activeDump} = vnode.attrs;
+      const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
         sqlSchema: createSimpleSchema(query),
@@ -130,12 +137,23 @@ function ClassesView(): m.Component<ClassesViewAttrs> {
         preamble: PREAMBLE,
       });
       counter.init(engine, query, PREAMBLE);
-      applyNavFilter(engine, vnode.attrs.initialRootClass).catch(console.error);
+      applyNavFilter(
+        engine,
+        activeDump,
+        vnode.attrs.initialRootClass,
+        vnode.attrs.clearNavParam,
+      ).catch(console.error);
     },
     onupdate(vnode) {
-      applyNavFilter(vnode.attrs.engine, vnode.attrs.initialRootClass).catch(
-        console.error,
-      );
+      applyNavFilter(
+        vnode.attrs.engine,
+        vnode.attrs.activeDump,
+        vnode.attrs.initialRootClass,
+        vnode.attrs.clearNavParam,
+      ).catch(console.error);
+    },
+    onremove() {
+      alive = false;
     },
     view(vnode) {
       const {navigate} = vnode.attrs;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
@@ -28,14 +28,15 @@ import {
   SQL_PREAMBLE,
   RowCounter,
 } from '../components';
-import {dumpFilterSql} from '../queries';
+import {dumpFilterSql, type HeapDump} from '../queries';
 
 interface DominatorsViewAttrs {
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
 }
 
-function buildQuery(): string {
+function buildQuery(activeDump: HeapDump): string {
   return `
     SELECT
       o.id,
@@ -55,7 +56,7 @@ function buildQuery(): string {
     JOIN heap_graph_class c ON o.type_id = c.id
     LEFT JOIN _heap_graph_object_tree_aggregation a ON a.id = o.id
     WHERE d.idom_id IS NULL
-      AND ${dumpFilterSql('o')}
+      AND ${dumpFilterSql(activeDump, 'o')}
   `;
 }
 
@@ -141,8 +142,8 @@ function DominatorsView(): m.Component<DominatorsViewAttrs> {
 
   return {
     oninit(vnode) {
-      const {engine} = vnode.attrs;
-      const query = buildQuery();
+      const {engine, activeDump} = vnode.attrs;
+      const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
         sqlSchema: createSimpleSchema(query),

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -36,6 +36,7 @@ import {
   BitmapImage,
 } from '../components';
 import * as queries from '../queries';
+import type {HeapDump} from '../queries';
 
 export interface ObjectParams {
   readonly id: number;
@@ -43,6 +44,7 @@ export interface ObjectParams {
 
 interface ObjectViewAttrs {
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly heaps: ReadonlyArray<HeapInfo>;
   readonly navigate: NavFn;
   readonly params: ObjectParams;
@@ -486,7 +488,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
     prevId = attrs.params.id;
     const seq = ++fetchSeq;
     queries
-      .getInstance(attrs.engine, attrs.params.id)
+      .getInstance(attrs.engine, attrs.activeDump, attrs.params.id)
       .then((d) => {
         if (!alive || seq !== fetchSeq) return;
         detail = d;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
@@ -31,11 +31,10 @@ import {
   SQL_PREAMBLE,
   RowCounter,
 } from '../components';
-import {clearNavParam} from '../nav_state';
 import * as queries from '../queries';
-import {dumpFilterSql} from '../queries';
+import {dumpFilterSql, type HeapDump} from '../queries';
 
-function buildQuery(): string {
+function buildQuery(activeDump: HeapDump): string {
   return `
     SELECT base.*,
       a.cumulative_size AS reachable_size,
@@ -55,7 +54,7 @@ function buildQuery(): string {
       LEFT JOIN heap_graph_object_data od ON o.object_data_id = od.id
       LEFT JOIN heap_graph_dominator_tree d ON d.id = o.id
       WHERE o.reachable != 0
-        AND ${dumpFilterSql('o')}
+        AND ${dumpFilterSql(activeDump, 'o')}
         AND od.value_string IS NOT NULL
         AND (c.name = 'java.lang.String'
           OR c.deobfuscated_name = 'java.lang.String')
@@ -153,7 +152,9 @@ const SUMMARY_SCHEMA: SchemaRegistry = {
 
 interface StringsViewAttrs {
   readonly engine: Engine;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
+  readonly clearNavParam: (key: string) => void;
   readonly initialQuery?: string;
   readonly hasFieldValues?: boolean;
 }
@@ -165,7 +166,10 @@ function StringsView(): m.Component<StringsViewAttrs> {
   const counter = new RowCounter();
   let filters: Filter[] = [];
 
-  function applyNavFilter(q: string | undefined) {
+  function applyNavFilter(
+    q: string | undefined,
+    clearNavParam: (key: string) => void,
+  ) {
     if (!q) return;
     filters = [{field: 'value', op: '=' as const, value: q}];
     counter.onFiltersChanged(filters);
@@ -174,8 +178,8 @@ function StringsView(): m.Component<StringsViewAttrs> {
 
   return {
     oninit(vnode) {
-      const {engine} = vnode.attrs;
-      const query = buildQuery();
+      const {engine, activeDump} = vnode.attrs;
+      const query = buildQuery(activeDump);
       dataSource = new SQLDataSource({
         engine,
         sqlSchema: createSimpleSchema(query),
@@ -183,9 +187,9 @@ function StringsView(): m.Component<StringsViewAttrs> {
         preamble: SQL_PREAMBLE,
       });
       counter.init(engine, query, SQL_PREAMBLE);
-      applyNavFilter(vnode.attrs.initialQuery);
+      applyNavFilter(vnode.attrs.initialQuery, vnode.attrs.clearNavParam);
       queries
-        .getStringList(vnode.attrs.engine)
+        .getStringList(engine, activeDump)
         .then((r) => {
           if (!alive) return;
           allRows = r;
@@ -194,7 +198,7 @@ function StringsView(): m.Component<StringsViewAttrs> {
         .catch(console.error);
     },
     onupdate(vnode) {
-      applyNavFilter(vnode.attrs.initialQuery);
+      applyNavFilter(vnode.attrs.initialQuery, vnode.attrs.clearNavParam);
     },
     onremove() {
       alive = false;


### PR DESCRIPTION
The plugin's mutable state was scattered across module-level let/const variables, static fields on HeapDumpPage, and the dumps/activeDump/bitmap-cache globals in queries.ts, with implicit reset semantics.

Concentrate it on a session class constructed per onTraceLoad: the session owns nav, dumps, tabs, and the cached overview, and is registered with the page via ctx.pages.registerPage so it's captured by closure and disposed with the trace.