### PR TITLE
ui: show slice arguments before flows

### DIFF
--- a/ui/src/components/details/thread_slice_details_tab.ts
+++ b/ui/src/components/details/thread_slice_details_tab.ts
@@ -323,9 +323,9 @@ export class ThreadSliceDetailsPanel implements TrackEventDetailsPanel {
     ) {
       return m(
         GridLayoutColumn,
+        args,
         precFlows,
         followingFlows,
-        args,
         distribution,
         additionalSections,
       );


### PR DESCRIPTION
### Details
Perfetto UI's slice details panel currently renders Preceding Flows and Following Flows before the Arguments section. For slices with many preceding/following flows, this pushes arguments and debug annotations below the fold and makes the common inspection path require scrolling.

This changes the slice details panel ordering so Arguments appears before the flow sections.

This is a UI-only change, and does not change trace proto, trace processor behavior, or how arguments/flows are emitted.

### Tested
  - Manual: opened an example Perfetto trace and verified Arguments appears above Preceding/Following Flows
  - `eslint src/components/details/thread_slice_details_tab.ts`
  - `prettier --check src/components/details/thread_slice_details_tab.ts`
  - `git diff --check`

### Screenshot (After PR)
<img width="559" height="225" alt="image" src="https://github.com/user-attachments/assets/bc152eb3-5b11-4d49-a51a-0f2b9df52b9e" />
