### PR TITLE
ui: allow 'data:' URIs in ?url=

### DIFF
--- a/ui/src/core/trace_stream.ts
+++ b/ui/src/core/trace_stream.ts
@@ -108,7 +108,7 @@ export class TraceHttpStream implements TraceStream {
   private httpStream?: ReadableStreamDefaultReader<Uint8Array>;
 
   constructor(uri: string) {
-    assertTrue(uri.startsWith('http://') || uri.startsWith('https://'));
+    assertTrue(uri.startsWith('http://') || uri.startsWith('https://') || uri.startsWith('data:'));
     this.uri = uri;
   }
 

--- a/ui/src/core/trace_stream.ts
+++ b/ui/src/core/trace_stream.ts
@@ -108,7 +108,11 @@ export class TraceHttpStream implements TraceStream {
   private httpStream?: ReadableStreamDefaultReader<Uint8Array>;
 
   constructor(uri: string) {
-    assertTrue(uri.startsWith('http://') || uri.startsWith('https://') || uri.startsWith('data:'));
+    assertTrue(
+      uri.startsWith('http://') ||
+        uri.startsWith('https://') ||
+        uri.startsWith('data:'),
+    );
     this.uri = uri;
   }
 

--- a/ui/src/frontend/post_message_handler.ts
+++ b/ui/src/frontend/post_message_handler.ts
@@ -103,7 +103,7 @@ function isUserTrustedOrigin(hostname: string): boolean {
 // Saves the given hostname as a trusted origin.
 // This is used for user convenience: if it fails for any reason, it's not a
 // big deal.
-function saveUserTrustedOrigin(hostname: string) {
+export function saveUserTrustedOrigin(hostname: string) {
   const s = window.localStorage.getItem(TRUSTED_ORIGINS_KEY);
   let origins: string[];
   try {

--- a/ui/src/frontend/trace_url_handler.ts
+++ b/ui/src/frontend/trace_url_handler.ts
@@ -20,6 +20,7 @@ import {loadAndroidBugToolInfo} from './android_bug_tool';
 import {Route, Router} from '../core/router';
 import {taskTracker} from './task_tracker';
 import {AppImpl} from '../core/app_impl';
+import {isTrustedOrigin, saveUserTrustedOrigin} from './post_message_handler';
 
 function getCurrentTraceUrl(): undefined | string {
   const source = AppImpl.instance.trace?.traceInfo.source;
@@ -244,7 +245,17 @@ function loadTraceFromUrl(url: string) {
 
 function promptDataUrlTrust(url: string) {
   const origin = document.referrer ? new URL(document.referrer).origin : 'null';
-  const originTxt = origin === 'null' ? 'An unknown origin' : origin;
+  const open = () => {
+    AppImpl.instance.openTraceFromUrl(url);
+  };
+
+  if (isTrustedOrigin(origin)) {
+    open();
+    return;
+  }
+
+  const originUnknown = origin === 'null';
+  const originTxt = originUnknown ? 'An unknown origin' : origin;
   showModal({
     title: 'Open trace?',
     content: m(
@@ -254,14 +265,19 @@ function promptDataUrlTrust(url: string) {
     ),
     buttons: [
       {text: 'No', primary: true},
-      {
-        text: 'Yes',
-        primary: false,
-        action: () => {
-          AppImpl.instance.openTraceFromUrl(url);
-        },
-      },
-    ],
+      {text: 'Yes', primary: false, action: open},
+    ].concat(
+      originUnknown
+        ? []
+        : {
+            text: 'Always trust',
+            primary: false,
+            action: () => {
+              saveUserTrustedOrigin(origin);
+              open();
+            },
+          },
+    ),
   });
 }
 

--- a/ui/src/frontend/trace_url_handler.ts
+++ b/ui/src/frontend/trace_url_handler.ts
@@ -215,6 +215,13 @@ async function maybeOpenCachedTrace(traceUuid: string) {
 }
 
 function loadTraceFromUrl(url: string) {
+  if (url.startsWith('data:')) {
+    // Gate behind a trust prompt: window.open(...?url=data:...) would
+    // otherwise silently load attacker-controlled bytes.
+    promptDataUrlTrust(url);
+    return;
+  }
+
   const isLocalhostTraceUrl = ['127.0.0.1', 'localhost'].includes(
     new URL(url).hostname,
   );
@@ -233,6 +240,29 @@ function loadTraceFromUrl(url: string) {
   } else {
     AppImpl.instance.openTraceFromUrl(url);
   }
+}
+
+function promptDataUrlTrust(url: string) {
+  const origin = document.referrer ? new URL(document.referrer).origin : 'null';
+  const originTxt = origin === 'null' ? 'An unknown origin' : origin;
+  showModal({
+    title: 'Open trace?',
+    content: m(
+      'div',
+      m('div', `${originTxt} is trying to open an embedded trace.`),
+      m('div', 'Only continue if you trust this URL.'),
+    ),
+    buttons: [
+      {text: 'No', primary: true},
+      {
+        text: 'Yes',
+        primary: false,
+        action: () => {
+          AppImpl.instance.openTraceFromUrl(url);
+        },
+      },
+    ],
+  });
 }
 
 function openTraceFromAndroidBugTool() {


### PR DESCRIPTION
Allows embedding trace bytes (e.g. a small pprof) directly in the URL as base64, instead of hosting the file. fetch() already supports data: URIs; only the protocol assertion in TraceHttpStream blocked them.
