### PR TITLE
ui: Charts: Add bottom aligned legends

### DIFF
--- a/ui/src/components/widgets/charts/bar_chart.ts
+++ b/ui/src/components/widgets/charts/bar_chart.ts
@@ -21,6 +21,7 @@ import {
   percentile,
 } from './chart_utils';
 import {EChartView, EChartEventHandler} from './echart_view';
+import type {LegendPosition} from './common';
 import {
   buildAxisOption,
   buildGridOption,
@@ -154,6 +155,12 @@ export interface BarChartAttrs {
    * this state — typically by feeding the `onBrush` output back in.
    */
   readonly selection?: ReadonlyArray<string | number>;
+
+  /**
+   * Where the legend sits relative to the chart (stacked charts only).
+   * Defaults to 'top'.
+   */
+  readonly legendPosition?: LegendPosition;
 }
 
 export class BarChart implements m.ClassComponent<BarChartAttrs> {
@@ -261,7 +268,7 @@ function buildBarOption(
     }),
     xAxis: horizontal ? valueAxis : categoryAxis,
     yAxis: horizontal ? categoryAxis : valueAxis,
-    legend: isStacked ? buildLegendOption() : {show: false},
+    legend: isStacked ? buildLegendOption(attrs.legendPosition) : {show: false},
     series: echartsSeries,
   };
 

--- a/ui/src/components/widgets/charts/chart_option_builder.ts
+++ b/ui/src/components/widgets/charts/chart_option_builder.ts
@@ -21,6 +21,8 @@
  */
 
 import type {EChartsCoreOption} from 'echarts/core';
+import {assertUnreachable} from '../../../base/assert';
+import type {LegendPosition} from './common';
 
 /** Font size used for axis tick labels across all charts. */
 export const AXIS_LABEL_FONT_SIZE = 10;
@@ -164,31 +166,43 @@ export function buildBrushOption(config: BrushConfig): Record<string, unknown> {
  * Theme colors are applied by EChartView.
  */
 export function buildLegendOption(
-  position: 'top' | 'right' = 'top',
+  position: LegendPosition = 'bottom',
 ): Record<string, unknown> {
-  if (position === 'right') {
-    return {
-      show: true,
-      type: 'scroll',
-      orient: 'vertical',
-      right: 0,
-      top: 20,
-      bottom: 20,
-      textStyle: {
-        fontSize: 10,
-        width: 120,
-        overflow: 'truncate',
-        ellipsis: '\u2026',
-      },
-      tooltip: {show: true},
-      pageButtonPosition: 'end',
-    };
+  switch (position) {
+    case 'top':
+      return {
+        show: true,
+        type: 'scroll',
+        top: 0,
+        textStyle: {fontSize: 10},
+      };
+    case 'bottom':
+      return {
+        show: true,
+        type: 'scroll',
+        bottom: 0,
+        textStyle: {fontSize: 10},
+      };
+    case 'right':
+      return {
+        show: true,
+        type: 'scroll',
+        orient: 'vertical',
+        right: 0,
+        top: 20,
+        bottom: 20,
+        textStyle: {
+          fontSize: 10,
+          width: 120,
+          overflow: 'truncate',
+          ellipsis: '\u2026',
+        },
+        tooltip: {show: true},
+        pageButtonPosition: 'end',
+      };
+    default:
+      assertUnreachable(position);
   }
-  return {
-    show: true,
-    top: 0,
-    textStyle: {fontSize: 10},
-  };
 }
 
 /**

--- a/ui/src/components/widgets/charts/common.ts
+++ b/ui/src/components/widgets/charts/common.ts
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export type LegendPosition = 'top' | 'right' | 'bottom';

--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -156,6 +156,10 @@ const GRID_LEFT_INNER_PAD = 6; // Padding between axis line and grid edge.
 // Bottom spacing (grid.bottom) default when the X-axis has a name.
 const X_AXIS_NAME_BOTTOM = 30;
 
+// Right spacing (grid.right) reserved for a vertical (right-side) legend.
+// Matches the legend's truncation width plus padding for the colour swatch.
+const RIGHT_LEGEND_WIDTH = 140;
+
 const AXIS_LABEL_FONT = `${AXIS_LABEL_FONT_SIZE}px sans-serif`;
 
 // Minimal shape we rely on from a CanvasRenderingContext2D-like object, so we
@@ -211,16 +215,30 @@ function autoAdjustGridSpacing(
   const legend = opt.legend as Record<string, unknown> | undefined;
   let yAxisPatch: Record<string, unknown> | undefined;
 
+  const hasLegend = legend !== undefined && legend.show !== false;
+  // Horizontal legends (top/bottom) have no `orient: 'vertical'`; we
+  // distinguish top vs bottom by which edge the legend is anchored to.
+  const legendAtRight = hasLegend && legend?.orient === 'vertical';
+  const isHorizontalLegend = hasLegend && !legendAtRight;
+  const legendAtBottom = isHorizontalLegend && legend?.bottom !== undefined;
+  const legendAtTop = isHorizontalLegend && !legendAtBottom;
+
   if (grid.top === undefined) {
-    const hasLegend = legend !== undefined && legend.show !== false;
-    grid.top = hasLegend ? LEGEND_TOP : TICK_LABEL_TOP;
+    grid.top = legendAtTop ? LEGEND_TOP : TICK_LABEL_TOP;
   }
 
   if (grid.bottom === undefined) {
     const xAxisName = xAxis?.name as string | undefined;
-    if (xAxisName !== undefined && xAxisName !== '') {
+    const hasXAxisName = xAxisName !== undefined && xAxisName !== '';
+    if (legendAtBottom) {
+      grid.bottom = hasXAxisName ? X_AXIS_NAME_BOTTOM + LEGEND_TOP : LEGEND_TOP;
+    } else if (hasXAxisName) {
       grid.bottom = X_AXIS_NAME_BOTTOM;
     }
+  }
+
+  if (grid.right === undefined && legendAtRight) {
+    grid.right = RIGHT_LEGEND_WIDTH;
   }
 
   if (yAxis !== undefined) {

--- a/ui/src/components/widgets/charts/line_chart.ts
+++ b/ui/src/components/widgets/charts/line_chart.ts
@@ -16,6 +16,7 @@ import m from 'mithril';
 import type {EChartsCoreOption} from 'echarts/core';
 import {extractBrushRange, formatNumber} from './chart_utils';
 import {EChartView, EChartEventHandler} from './echart_view';
+import type {LegendPosition} from './common';
 import {
   buildChartOption,
   buildLegendOption,
@@ -126,6 +127,11 @@ export interface LineChartAttrs {
    * Show legend. Defaults to true when multiple series.
    */
   readonly showLegend?: boolean;
+
+  /**
+   * Where the legend sits relative to the chart. Defaults to 'top'.
+   */
+  readonly legendPosition?: LegendPosition;
 
   /**
    * Show data points as circles. Defaults to true.
@@ -287,7 +293,9 @@ function buildLineOption(
       },
     },
     brush: attrs.onBrush ? {xAxisIndex: 0, brushType: 'lineX'} : undefined,
-    legend: displayLegend ? buildLegendOption() : {show: false},
+    legend: displayLegend
+      ? buildLegendOption(attrs.legendPosition)
+      : {show: false},
   });
 
   (option as Record<string, unknown>).series = series;

--- a/ui/src/components/widgets/charts/pie_chart.ts
+++ b/ui/src/components/widgets/charts/pie_chart.ts
@@ -17,6 +17,7 @@ import type {EChartsCoreOption} from 'echarts/core';
 import {formatNumber} from './chart_utils';
 import {EChartView, EChartEventHandler, EChartClickParams} from './echart_view';
 import {buildLegendOption, buildTooltipOption} from './chart_option_builder';
+import type {LegendPosition} from './common';
 
 /**
  * A single slice in the pie chart.
@@ -71,6 +72,11 @@ export interface PieChartAttrs {
   readonly showLegend?: boolean;
 
   /**
+   * Where the legend sits relative to the chart. Defaults to 'right'.
+   */
+  readonly legendPosition?: LegendPosition;
+
+  /**
    * Show percentage labels on slices. Defaults to false.
    */
   readonly showLabels?: boolean;
@@ -114,9 +120,11 @@ function buildPieOption(
   const {
     formatValue = (v: number) => formatNumber(v),
     showLegend = true,
+    legendPosition = 'right',
     showLabels = false,
     innerRadiusRatio = 0,
   } = attrs;
+  const legendOnRight = showLegend && legendPosition === 'right';
 
   const pieData = slices.map((s) => ({
     name: s.label,
@@ -124,7 +132,7 @@ function buildPieOption(
     itemStyle: s.color !== undefined ? {color: s.color} : undefined,
   }));
 
-  const outerPct = showLegend ? 65 : 75;
+  const outerPct = legendOnRight ? 65 : 75;
   const outerRadius = `${outerPct}%`;
   const innerRadius = `${Math.round(outerPct * innerRadiusRatio)}%`;
 
@@ -143,12 +151,12 @@ function buildPieOption(
         return [name, `Value: ${formatValue(value)}`, `${pct}%`].join('<br>');
       },
     }),
-    legend: showLegend ? buildLegendOption('right') : {show: false},
+    legend: showLegend ? buildLegendOption(legendPosition) : {show: false},
     series: [
       {
         type: 'pie',
         radius: [innerRadius, outerRadius],
-        center: showLegend ? ['35%', '50%'] : ['50%', '50%'],
+        center: legendOnRight ? ['35%', '50%'] : ['50%', '50%'],
         data: pieData,
         label: {
           show: showLabels,

--- a/ui/src/components/widgets/charts/scatterplot.ts
+++ b/ui/src/components/widgets/charts/scatterplot.ts
@@ -16,6 +16,7 @@ import m from 'mithril';
 import type {EChartsCoreOption} from 'echarts/core';
 import {extractBrushRect, formatNumber} from './chart_utils';
 import {EChartView, EChartEventHandler} from './echart_view';
+import type {LegendPosition} from './common';
 import {
   buildChartOption,
   buildLegendOption,
@@ -137,6 +138,11 @@ export interface ScatterChartAttrs {
    * Show legend. Defaults to true when multiple series.
    */
   readonly showLegend?: boolean;
+
+  /**
+   * Where the legend sits relative to the chart. Defaults to 'top'.
+   */
+  readonly legendPosition?: LegendPosition;
 
   /**
    * Default symbol size for points without explicit size.
@@ -327,7 +333,9 @@ function buildScatterOption(
     brush: attrs.onBrush
       ? {xAxisIndex: 0, yAxisIndex: 0, brushType: 'rect' as const}
       : undefined,
-    legend: displayLegend ? buildLegendOption() : {show: false},
+    legend: displayLegend
+      ? buildLegendOption(attrs.legendPosition)
+      : {show: false},
   });
 
   (option as Record<string, unknown>).series = series;

--- a/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
+++ b/ui/src/plugins/dev.perfetto.WidgetsPage/demos/charts_demo.ts
@@ -27,6 +27,7 @@ import {
   BarChartLoaderConfig,
 } from '../../../components/widgets/charts/bar_chart_loader';
 import {Histogram} from '../../../components/widgets/charts/histogram';
+import type {LegendPosition} from '../../../components/widgets/charts/common';
 import {
   InMemoryHistogramLoader,
   SQLHistogramLoader,
@@ -167,6 +168,7 @@ export function renderCharts(app: App): m.Children {
           multiSeries: opts.multiSeries,
           stacked: opts.stacked,
           gridLines: opts.gridLines,
+          legendPosition: opts.legendPosition,
         });
       },
       initialOpts: {
@@ -186,6 +188,11 @@ export function renderCharts(app: App): m.Children {
           'vertical',
           'both',
         ] as const),
+        legendPosition: new EnumOption('top', [
+          'top',
+          'right',
+          'bottom',
+        ] as const),
       },
     }),
 
@@ -198,6 +205,7 @@ export function renderCharts(app: App): m.Children {
           showLabels: opts.showLabels,
           showLegend: opts.showLegend,
           donut: opts.donut,
+          legendPosition: opts.legendPosition,
         });
       },
       initialOpts: {
@@ -205,6 +213,11 @@ export function renderCharts(app: App): m.Children {
         showLabels: false,
         showLegend: true,
         donut: false,
+        legendPosition: new EnumOption('right', [
+          'top',
+          'right',
+          'bottom',
+        ] as const),
       },
     }),
 
@@ -282,6 +295,7 @@ export function renderCharts(app: App): m.Children {
           scaleAxes: opts.scaleAxes,
           brushMode: opts.brushMode,
           gridLines: opts.gridLines,
+          legendPosition: opts.legendPosition,
         });
       },
       initialOpts: {
@@ -299,6 +313,11 @@ export function renderCharts(app: App): m.Children {
           'horizontal',
           'vertical',
           'both',
+        ] as const),
+        legendPosition: new EnumOption('top', [
+          'top',
+          'right',
+          'bottom',
         ] as const),
       },
     }),
@@ -1316,6 +1335,7 @@ function LineChartDemo(): m.Component<{
   multiSeries: boolean;
   stacked: boolean;
   gridLines: string;
+  legendPosition: LegendPosition;
 }> {
   let brushRange: {start: number; end: number} | undefined;
 
@@ -1407,6 +1427,7 @@ function LineChartDemo(): m.Component<{
           xAxisMax: isFilter ? range?.end : undefined,
           stacked: attrs.stacked,
           gridLines: toGridLines(attrs.gridLines),
+          legendPosition: attrs.legendPosition,
           onBrush:
             attrs.brushMode !== 'off'
               ? (newRange) => {
@@ -1467,6 +1488,7 @@ function PieChartDemo(): m.Component<{
   showLabels: boolean;
   showLegend: boolean;
   donut: boolean;
+  legendPosition: LegendPosition;
 }> {
   let clickedSlice: string | undefined;
 
@@ -1478,6 +1500,7 @@ function PieChartDemo(): m.Component<{
           height: attrs.height,
           showLabels: attrs.showLabels,
           showLegend: attrs.showLegend,
+          legendPosition: attrs.legendPosition,
           innerRadiusRatio: attrs.donut ? 0.5 : 0,
           onSliceClick: (slice) => {
             clickedSlice = slice.label;
@@ -1569,6 +1592,7 @@ function ScatterChartDemo(): m.Component<{
   scaleAxes: boolean;
   brushMode: 'off' | 'filter' | 'select';
   gridLines: string;
+  legendPosition: LegendPosition;
 }> {
   let brushRange:
     | {xMin: number; xMax: number; yMin: number; yMax: number}
@@ -1606,6 +1630,7 @@ function ScatterChartDemo(): m.Component<{
           xAxisLabel: 'X Value',
           yAxisLabel: 'Y Value',
           showLegend: attrs.showLegend,
+          legendPosition: attrs.legendPosition,
           scaleAxes: attrs.scaleAxes,
           gridLines: toGridLines(attrs.gridLines),
           onBrush:


### PR DESCRIPTION
- Add option to show the legent at the bottom of the chart, in addition to the top or right.
- Adjust chart margin when right or bottom legend mode is used to avoid overlapping the chart content.

<img width="581" height="277" alt="image" src="https://github.com/user-attachments/assets/62292a39-4a15-4266-876a-b7acd321268c" />

