### PR TITLE
ui: Disable chart tooltip transitions

### DIFF
--- a/ui/src/components/widgets/charts/chart_option_builder.ts
+++ b/ui/src/components/widgets/charts/chart_option_builder.ts
@@ -136,6 +136,8 @@ export function buildTooltipOption(
   extra?: Record<string, unknown>,
 ): Record<string, unknown> {
   return {
+    showDelay: 0,
+    transitionDuration: 0,
     ...extra,
   };
 }


### PR DESCRIPTION
Echart's tooltip transitions (the feature where the tooltip lags behind the mouse cursor when mousing over charts) appear to make echart's series level highlight feature rather flakey. This patch simply disables all transitions. Tooltips appear immediately and stay directly under the mouse cursor.