### PR TITLE
ui: Fix theme colors for time-based line and sankey charts

### DIFF
--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -136,6 +136,13 @@ function buildEChartsTheme(colors: ChartThemeColors): Record<string, unknown> {
       splitLine: {lineStyle: {color: colors.borderColor}},
       nameTextStyle: {color: colors.textColor},
     },
+    timeAxis: {
+      axisLine: {lineStyle: {color: colors.borderColor}},
+      axisTick: {lineStyle: {color: colors.borderColor}},
+      axisLabel: {color: colors.textColor},
+      splitLine: {lineStyle: {color: colors.borderColor}},
+      nameTextStyle: {color: colors.textColor},
+    },
     visualMap: {
       textStyle: {color: colors.textColor},
       inRange: {

--- a/ui/src/components/widgets/charts/sankey.ts
+++ b/ui/src/components/widgets/charts/sankey.ts
@@ -15,7 +15,12 @@
 import m from 'mithril';
 import type {EChartsCoreOption} from 'echarts/core';
 import {formatNumber} from './chart_utils';
-import {EChartView, EChartEventHandler, EChartClickParams} from './echart_view';
+import {
+  type ThemeColors,
+  EChartView,
+  EChartEventHandler,
+  EChartClickParams,
+} from './echart_view';
 import {buildTooltipOption} from './chart_option_builder';
 
 export interface SankeyNode {
@@ -63,6 +68,7 @@ export class Sankey implements m.ClassComponent<SankeyChartAttrs> {
       className,
       empty: isEmpty,
       eventHandlers: buildSankeyEventHandlers(attrs, data),
+      resolveOption: applySankeyTheme,
     });
   }
 }
@@ -131,6 +137,7 @@ function buildSankeyOption(
         emphasis: {
           focus: 'adjacency',
         },
+        draggable: false,
         nodeWidth: 24,
         nodeGap: 16,
         layoutIterations: 0,
@@ -141,6 +148,28 @@ function buildSankeyOption(
       },
     ],
   };
+}
+
+interface SankeySeries {
+  type?: string;
+  label?: {color?: unknown};
+}
+
+function applySankeyTheme(
+  option: EChartsCoreOption,
+  colors: ThemeColors,
+): EChartsCoreOption {
+  const series = (option as {series?: unknown[]}).series;
+  if (!Array.isArray(series) || series.length === 0) return option;
+
+  const sankey = series[0] as SankeySeries;
+  if (sankey.type !== 'sankey') return option;
+
+  if (sankey.label) {
+    sankey.label.color = colors.textColor;
+  }
+
+  return option;
 }
 
 function buildSankeyEventHandlers(


### PR DESCRIPTION
Theme colors were previously not being applied properly for the following charts:
- Line chart using time as the x-axis (hack, but requirement for multi series line charts).
- Sankey charts.

This patch fixes this by wiring up the themes properly.