### PR TITLE
tbV2: fix silent packet duplication on same-call eviction of recommit chunk

### DIFF
--- a/src/tracing/service/trace_buffer_v2.cc
+++ b/src/tracing/service/trace_buffer_v2.cc
@@ -731,6 +731,7 @@ void TraceBufferV2::CopyChunkUntrusted(
   bool trace_writer_data_drop = frag_iter.trace_writer_data_drop();
 
   PERFETTO_CHECK(all_frags_size <= src_size);
+  const uint16_t all_frags_size_u16 = static_cast<uint16_t>(all_frags_size);
 
   // Make space in the buffer for the chunk we are about to copy.
 
@@ -788,51 +789,40 @@ void TraceBufferV2::CopyChunkUntrusted(
     }
   }
 
-  // If there isn't enough room from the given write position: write a padding
-  // record to clear the end of the buffer, wrap and start at offset 0.
-  const size_t cached_size_to_end = size_to_end();
-  if (PERFETTO_UNLIKELY(tbchunk_outer_size > cached_size_to_end)) {
-    // If we reached the end of the buffer and we are using discard policy,
-    // this is where we stop. This buffer will no longer accept data.
-    if (overwrite_policy_ == kDiscard)
-      return DiscardWrite();
-
-    // Skip the tail cleanup if the previous write landed exactly at the end
-    // of the buffer (|wr_| == |size_|): there is no leftover tail to clear.
-    if (cached_size_to_end > 0)
-      DeleteNextChunksFor(cached_size_to_end);
-
-    wr_ = 0;
-    stats_.set_write_wrap_count(stats_.write_wrap_count() + 1);
-    PERFETTO_DCHECK(size_to_end() >= tbchunk_outer_size);
-  }
-
-  // Deletes all chunks from |wptr_| to |wptr_| + |record_size|.
-  DeleteNextChunksFor(tbchunk_outer_size);
-
   // Find the insert position in the SequenceState's chunk list. We iterate the
   // list in reverse order as in the majority of cases chunks arrive naturally
   // in order. SMB scraping is really the only thing that might commit chunks
   // slightly out of order.
+  //
+  // This search runs BEFORE the wrap path / DeleteNextChunksFor below: a
+  // re-commit must be handled in place, and the eviction below could
+  // otherwise destroy the chunk we'd want to rewrite (silent duplication
+  // when the consumer has already drained an incomplete copy).
   auto& chunk_list = seq.chunks;
-  auto insert_pos = chunk_list.rbegin();
-  TBChunk* recommit_chunk = nullptr;
-  for (; insert_pos != chunk_list.rend(); ++insert_pos) {
-    TBChunk* other_chunk = GetTBChunkAt(*insert_pos);
-    int cmp = ChunkIdCompare(chunk_id, other_chunk->chunk_id);
-    if (cmp > 0)
-      break;
-    if (cmp == 0) {
-      // The producer is trying to re-commit a previously copied chunk. This
-      // can happen when the service does SMB scraping (the same chunk could
-      // be scraped more than once), and later the producer does a commit.
-      // We allow recommit only if the new chunk is larger than the existing.
-      recommit_chunk = other_chunk;
-      break;
-    }
-  }
+  size_t chunk_list_size_before_remove = chunk_list.size();
 
-  const uint16_t all_frags_size_u16 = static_cast<uint16_t>(all_frags_size);
+  using InsIter = base::CircularQueue<size_t>::ReverseIterator;
+  auto compute_insert_position = [&]() -> std::pair<InsIter, TBChunk*> const {
+    TBChunk* _recommit_chunk = nullptr;
+    auto _insert_pos = chunk_list.rbegin();
+    for (; _insert_pos != chunk_list.rend(); ++_insert_pos) {
+      TBChunk* other_chunk = GetTBChunkAt(*_insert_pos);
+      int cmp = ChunkIdCompare(chunk_id, other_chunk->chunk_id);
+      if (cmp > 0)
+        break;
+      if (cmp == 0) {
+        // The producer is trying to re-commit a previously copied chunk. This
+        // can happen when the service does SMB scraping (the same chunk could
+        // be scraped more than once), and later the producer does a commit.
+        // We allow recommit only if the new chunk is larger than the existing.
+        _recommit_chunk = other_chunk;
+        break;
+      }
+    }
+    return std::make_pair(_insert_pos, _recommit_chunk);
+  };
+
+  auto [insert_pos, recommit_chunk] = compute_insert_position();
 
   // In the case of a re-commit we don't need to create a new chunk, we just
   // want to overwrite the existing one.
@@ -864,6 +854,37 @@ void TraceBufferV2::CopyChunkUntrusted(
     recommit_chunk->flags |= chunk_flags;
     stats_.set_chunks_rewritten(stats_.chunks_rewritten() + 1);
     return;
+  }
+
+  // If there isn't enough room from the given write position: write a padding
+  // record to clear the end of the buffer, wrap and start at offset 0.
+  const size_t cached_size_to_end = size_to_end();
+  if (PERFETTO_UNLIKELY(tbchunk_outer_size > cached_size_to_end)) {
+    // If we reached the end of the buffer and we are using discard policy,
+    // this is where we stop. This buffer will no longer accept data.
+    if (overwrite_policy_ == kDiscard)
+      return DiscardWrite();
+
+    // Skip the tail cleanup if the previous write landed exactly at the end
+    // of the buffer (|wr_| == |size_|): there is no leftover tail to clear.
+    if (cached_size_to_end > 0)
+      DeleteNextChunksFor(cached_size_to_end);
+
+    wr_ = 0;
+    stats_.set_write_wrap_count(stats_.write_wrap_count() + 1);
+    PERFETTO_DCHECK(size_to_end() >= tbchunk_outer_size);
+  }
+
+  // Deletes all chunks from |wptr_| to |wptr_| + |record_size|.
+  DeleteNextChunksFor(tbchunk_outer_size);
+
+  // If the DeleteNextChunksFor happens to delete a chunk in the same sequence,
+  // the insert_pos becomes invalid and we need to recompute that.
+  // Why don't we compute the insert_pos here? Because we also need to check
+  // for re-commits (which are rare, but possible) and don't want to iterate
+  // over the chunk list twice in most cases.
+  if (PERFETTO_UNLIKELY(chunk_list.size() != chunk_list_size_before_remove)) {
+    std::tie(insert_pos, std::ignore) = compute_insert_position();
   }
 
   TBChunk* tbchunk = CreateTBChunk(wr_, tbchunk_size);

--- a/src/tracing/service/trace_buffer_v2_unittest.cc
+++ b/src/tracing/service/trace_buffer_v2_unittest.cc
@@ -2378,22 +2378,29 @@ TEST_F(TraceBufferV2Test, SequenceGaps_DetectionWithChunkIdWrap) {
 TEST_F(TraceBufferV2Test, Overwrite_SizeDiffLessThanChunkHeader) {
   ResetBuffer(4096);
 
-  size_t c1_size = 36;
-  ASSERT_EQ(c1_size, CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
-                         .AddPacket(c1_size - 16, 'a')
+  size_t c0_size = 36;
+  ASSERT_EQ(c0_size, CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+                         .AddPacket(c0_size - 16, 'a')
                          .CopyIntoTraceBuffer());
-  size_t pad_size = 4096 - internal::TBChunk::OuterSize(c1_size - 16);
+  size_t pad_size = 4096 - internal::TBChunk::OuterSize(c0_size - 16);
   ASSERT_EQ(pad_size, CreateChunk(ProducerID(1), WriterID(1), ChunkID(1))
                           .AddPacket(pad_size - 16, 'b')
                           .CopyIntoTraceBuffer());
   ASSERT_EQ(0u, size_to_end());
 
-  ASSERT_EQ(32u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+  // The third commit uses a fresh chunk_id so the wrap path overwrites c0
+  // ('a') with c2 ('c'). This exercises the case where the leftover space
+  // after the new chunk is exactly sizeof(TBChunk) (= 16B) — a header-only
+  // padding chunk.
+  ASSERT_EQ(32u, CreateChunk(ProducerID(1), WriterID(1), ChunkID(2))
                      .AddPacket(32 - 16, 'c')
                      .CopyIntoTraceBuffer());
 
   trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(),
+              ElementsAre(FakePacketFragment(pad_size - 16, 'b')));
   ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(32 - 16, 'c')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 
 // -------------------------------------------
@@ -2903,6 +2910,68 @@ TEST_F(TraceBufferV2Test, NoOverwriteCountIfReaderCatchesUp) {
   ASSERT_THAT(ReadPacket(nullptr, &dropped),
               ElementsAre(FakePacketFragment(2000, 'c')));
   EXPECT_FALSE(dropped);
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+}
+
+// Scrape → read → recommit when the buffer is full. The producer's complete
+// commit arrives when wr_ has reached size_, so cached_size_to_end is 0 and
+// the wrap path would otherwise evict the same kChunkIncomplete chunk we are
+// about to recommit. The recommit must rewrite the chunk in place: the
+// consumer must see only the new packets ('b' and 'c'), not the previously-
+// drained 'a' a second time.
+TEST_F(TraceBufferV2Test, Override_ReCommitIncompleteOnFullBuffer) {
+  ResetBuffer(4096);
+
+  // Scrape chunk 0: [Whole 'a'] [kFragBegin 'b'] padded to 1024 bytes. The
+  // last fragment is dropped; only 'a' is visible. The full 1024-byte slot
+  // is reserved so the producer can later grow into it.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(10, 'b', kContOnNextChunk)
+      .PadTo(1024)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/false);
+
+  // Read 'a'. payload_avail → 0 but kChunkIncomplete + kReadMode keeps the
+  // chunk in seq.chunks (no EraseCurrentChunk).
+  trace_buffer()->BeginRead();
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(20, 'a')));
+  ASSERT_THAT(ReadPacket(), IsEmpty());
+
+  // Fill the rest of the buffer with chunks on a different sequence. wr_
+  // ends at 4096 (== size_).
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(1))
+      .AddPacket(1024 - 16, 'x')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(2))
+      .AddPacket(1024 - 16, 'y')
+      .CopyIntoTraceBuffer();
+  CreateChunk(ProducerID(2), WriterID(1), ChunkID(3))
+      .AddPacket(1024 - 16, 'z')
+      .CopyIntoTraceBuffer();
+
+  // Producer commits chunk 0 with the final payload from the same SMB slot.
+  // Bytes 0..21 are still 'a' (an SMB invariant: producers never rewrite
+  // already-written bytes). The recommit must be detected and written in
+  // place — not turned into a fresh write that would re-emit 'a'.
+  CreateChunk(ProducerID(1), WriterID(1), ChunkID(0))
+      .AddPacket(20, 'a')
+      .AddPacket(10, 'b')
+      .AddPacket(100, 'c')
+      .PadTo(1024)
+      .CopyIntoTraceBuffer(/*chunk_complete=*/true);
+
+  // Expected: 'a' is not delivered again; 'b' and 'c' are the newly-recovered
+  // packets; 'x', 'y', 'z' from the filler sequence follow. No data loss is
+  // signalled.
+  trace_buffer()->BeginRead();
+  bool dropped = false;
+  ASSERT_THAT(ReadPacket(nullptr, &dropped),
+              ElementsAre(FakePacketFragment(10, 'b')));
+  EXPECT_FALSE(dropped);
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(100, 'c')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'x')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'y')));
+  ASSERT_THAT(ReadPacket(), ElementsAre(FakePacketFragment(1024 - 16, 'z')));
   ASSERT_THAT(ReadPacket(), IsEmpty());
 }
 


### PR DESCRIPTION
CopyChunkUntrusted previously ran the wrap path + DeleteNextChunksFor before searching seq.chunks for an existing chunk with the same chunk_id. When the producer re-committed a kChunkIncomplete chunk that the consumer had fully drained (kChunkIncomplete + kReadMode in ReadNextPacketInSeqOrder skips EraseCurrentChunk to keep the chunk alive for future scrapes/finalizations), and the same call's DeleteNextChunksFor evicted that chunk:

- The linear search for recommit_chunk found nothing (the chunk had just been popped from seq.chunks by EraseCurrentChunk).
- The fresh-write path ran with previously_consumed_payload = 0 and re-emitted the bytes the consumer had already received via the scrape read, including the packet header.
- The gap check in ChunkSeqReader's ctor saw iter_->chunk_id == last.chunk_id with was_incomplete=true, classified the new chunk as a re-admit and suppressed seq.data_loss, so the consumer received the duplicated packet with previous_packet_dropped=false. Silent duplication.

Adds Override_ReCommitIncompleteOnFullBuffer to cover the fix.