### PR TITLE
tests: guard remaining integrationtests inside enable_perfetto_integration_tests

### DIFF
--- a/src/trace_processor/BUILD.gn
+++ b/src/trace_processor/BUILD.gn
@@ -396,27 +396,29 @@ perfetto_cc_proto_descriptor("gen_cc_test_messages_descriptor") {
   descriptor_target = "../protozero:testing_messages_descriptor"
 }
 
-source_set("integrationtests") {
-  testonly = true
-  sources = []
-  deps = []
-  if (enable_perfetto_trace_processor_sqlite) {
-    sources += [
-      "read_trace_integrationtest.cc",
-      "trace_database_integrationtest.cc",
-    ]
-    deps += [
-      ":lib",
-      "../../gn:default_deps",
-      "../../gn:gtest_and_gmock",
-      "../../protos/perfetto/common:zero",
-      "../../protos/perfetto/trace:zero",
-      "../../protos/perfetto/trace_processor:zero",
-      "../base",
-      "../base:test_support",
-      "sqlite",
-      "trace_summary:integrationtests",
-    ]
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    sources = []
+    deps = []
+    if (enable_perfetto_trace_processor_sqlite) {
+      sources += [
+        "read_trace_integrationtest.cc",
+        "trace_database_integrationtest.cc",
+      ]
+      deps += [
+        ":lib",
+        "../../gn:default_deps",
+        "../../gn:gtest_and_gmock",
+        "../../protos/perfetto/common:zero",
+        "../../protos/perfetto/trace:zero",
+        "../../protos/perfetto/trace_processor:zero",
+        "../base",
+        "../base:test_support",
+        "sqlite",
+        "trace_summary:integrationtests",
+      ]
+    }
   }
 }
 

--- a/src/trace_processor/trace_summary/BUILD.gn
+++ b/src/trace_processor/trace_summary/BUILD.gn
@@ -66,21 +66,23 @@ source_set("unittests") {
   ]
 }
 
-source_set("integrationtests") {
-  testonly = true
-  sources = [ "summary_integrationtest.cc" ]
-  deps = [
-    ":gen_cc_trace_summary_descriptor",
-    ":trace_summary",
-    "../../../gn:default_deps",
-    "../../../gn:gtest_and_gmock",
-    "../../../include/perfetto/trace_processor",
-    "../../base",
-    "../../base:test_support",
-    "../util:descriptors",
-  ]
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    sources = [ "summary_integrationtest.cc" ]
+    deps = [
+      ":gen_cc_trace_summary_descriptor",
+      ":trace_summary",
+      "../../../gn:default_deps",
+      "../../../gn:gtest_and_gmock",
+      "../../../include/perfetto/trace_processor",
+      "../../base",
+      "../../base:test_support",
+      "../util:descriptors",
+    ]
 
-  if (enable_perfetto_zlib) {
-    deps += [ "../../../gn:zlib" ]
+    if (enable_perfetto_zlib) {
+      deps += [ "../../../gn:zlib" ]
+    }
   }
 }

--- a/src/trace_redaction/BUILD.gn
+++ b/src/trace_redaction/BUILD.gn
@@ -96,37 +96,39 @@ source_set("trace_redaction") {
   ]
 }
 
-source_set("integrationtests") {
-  testonly = true
-  sources = [
-    "boardphase_packet_filter_integrationtest.cc",
-    "collect_frame_cookies_integrationtest.cc",
-    "filter_sched_waking_events_integrationtest.cc",
-    "filter_task_rename_integrationtest.cc",
-    "process_thread_timeline_integrationtest.cc",
-    "prune_package_list_integrationtest.cc",
-    "prune_perf_events_integrationtest.cc",
-    "redact_sched_events_integrationtest.cc",
-    "reduce_threads_in_process_trees_integrationtest.cc",
-    "scrub_process_stats_integrationtest.cc",
-    "trace_processor_integrationtest.cc",
-    "trace_redaction_integration_fixture.cc",
-    "trace_redaction_integration_fixture.h",
-  ]
-  deps = [
-    ":trace_redaction",
-    "../../gn:default_deps",
-    "../../gn:gtest_and_gmock",
-    "../../include/perfetto/trace_processor:trace_processor",
-    "../../protos/perfetto/trace:non_minimal_cpp",
-    "../../protos/perfetto/trace:non_minimal_zero",
-    "../../protos/perfetto/trace/android:cpp",
-    "../../protos/perfetto/trace/android:zero",
-    "../../protos/perfetto/trace/ftrace:zero",
-    "../../protos/perfetto/trace/ps:zero",
-    "../base",
-    "../base:test_support",
-  ]
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    sources = [
+      "boardphase_packet_filter_integrationtest.cc",
+      "collect_frame_cookies_integrationtest.cc",
+      "filter_sched_waking_events_integrationtest.cc",
+      "filter_task_rename_integrationtest.cc",
+      "process_thread_timeline_integrationtest.cc",
+      "prune_package_list_integrationtest.cc",
+      "prune_perf_events_integrationtest.cc",
+      "redact_sched_events_integrationtest.cc",
+      "reduce_threads_in_process_trees_integrationtest.cc",
+      "scrub_process_stats_integrationtest.cc",
+      "trace_processor_integrationtest.cc",
+      "trace_redaction_integration_fixture.cc",
+      "trace_redaction_integration_fixture.h",
+    ]
+    deps = [
+      ":trace_redaction",
+      "../../gn:default_deps",
+      "../../gn:gtest_and_gmock",
+      "../../include/perfetto/trace_processor:trace_processor",
+      "../../protos/perfetto/trace:non_minimal_cpp",
+      "../../protos/perfetto/trace:non_minimal_zero",
+      "../../protos/perfetto/trace/android:cpp",
+      "../../protos/perfetto/trace/android:zero",
+      "../../protos/perfetto/trace/ftrace:zero",
+      "../../protos/perfetto/trace/ps:zero",
+      "../base",
+      "../base:test_support",
+    ]
+  }
 }
 
 perfetto_unittest_source_set("unittests") {

--- a/src/traceconv/BUILD.gn
+++ b/src/traceconv/BUILD.gn
@@ -159,26 +159,28 @@ perfetto_cc_proto_descriptor("gen_cc_winscope_descriptor") {
   descriptor_target = "../../protos/perfetto/trace/android:winscope_descriptor"
 }
 
-source_set("integrationtests") {
-  testonly = true
-  deps = [
-    ":lib",
-    ":traceconv_lib",
-    "../../gn:default_deps",
-    "../../gn:gtest_and_gmock",
-    "../../include/perfetto/base",
-    "../../include/perfetto/ext/base:base",
-    "../../protos/perfetto/trace:cpp",
-    "../../protos/perfetto/trace/profiling:cpp",
-    "../../protos/third_party/pprof:cpp",
-    "../../protos/third_party/pprof:zero",
-    "../../src/base:test_support",
-  ]
-  sources = [
-    "pprof_reader.cc",
-    "pprof_reader.h",
-    "trace_to_pprof_integrationtest.cc",
-    "trace_to_text_integrationtest.cc",
-    "traceconv_bundle_integrationtest.cc",
-  ]
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    deps = [
+      ":lib",
+      ":traceconv_lib",
+      "../../gn:default_deps",
+      "../../gn:gtest_and_gmock",
+      "../../include/perfetto/base",
+      "../../include/perfetto/ext/base:base",
+      "../../protos/perfetto/trace:cpp",
+      "../../protos/perfetto/trace/profiling:cpp",
+      "../../protos/third_party/pprof:cpp",
+      "../../protos/third_party/pprof:zero",
+      "../../src/base:test_support",
+    ]
+    sources = [
+      "pprof_reader.cc",
+      "pprof_reader.h",
+      "trace_to_pprof_integrationtest.cc",
+      "trace_to_text_integrationtest.cc",
+      "traceconv_bundle_integrationtest.cc",
+    ]
+  }
 }

--- a/src/traced/probes/ftrace/BUILD.gn
+++ b/src/traced/probes/ftrace/BUILD.gn
@@ -89,18 +89,20 @@ perfetto_proto_library("test_messages_@TYPE@") {
 
 # These tests require access to a real ftrace implementation and must
 # run with sudo.
-source_set("integrationtests") {
-  testonly = true
-  deps = [
-    ":ftrace",
-    ":test_support",
-    ":tracefs",
-    "../../../../gn:default_deps",
-    "../../../../gn:gtest_and_gmock",
-    "../../../base",
-    "../../../tracing/core",
-  ]
-  sources = [ "tracefs_integrationtest.cc" ]
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    deps = [
+      ":ftrace",
+      ":test_support",
+      ":tracefs",
+      "../../../../gn:default_deps",
+      "../../../../gn:gtest_and_gmock",
+      "../../../base",
+      "../../../tracing/core",
+    ]
+    sources = [ "tracefs_integrationtest.cc" ]
+  }
 }
 
 source_set("ftrace") {

--- a/src/traced_relay/BUILD.gn
+++ b/src/traced_relay/BUILD.gn
@@ -65,15 +65,17 @@ perfetto_unittest_source_set("unittests") {
   ]
 }
 
-source_set("integrationtests") {
-  testonly = true
-  deps = [
-    ":lib",
-    "../../gn:default_deps",
-    "../../gn:gtest_and_gmock",
-    "../../test:test_helper",
-    "../base",
-    "../base:test_support",
-  ]
-  sources = [ "relay_service_integrationtest.cc" ]
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    deps = [
+      ":lib",
+      "../../gn:default_deps",
+      "../../gn:gtest_and_gmock",
+      "../../test:test_helper",
+      "../base",
+      "../base:test_support",
+    ]
+    sources = [ "relay_service_integrationtest.cc" ]
+  }
 }

--- a/src/tracing/BUILD.gn
+++ b/src/tracing/BUILD.gn
@@ -120,18 +120,20 @@ source_set("client_api_without_backends") {
 }
 
 # Separate target because the embedder might not want this.
-source_set("integrationtests") {
-  testonly = true
-  deps = [
-    "../../gn:default_deps",
-    "../../gn:gtest_and_gmock",
-    "../../include/perfetto/ext/tracing/ipc",
-    "../../include/perfetto/tracing",
-    "../../protos/perfetto/trace:cpp",
-    "../base",
-    "../base:test_support",
-  ]
-  sources = [ "internal/tracing_muxer_impl_integrationtest.cc" ]
+if (enable_perfetto_integration_tests) {
+  source_set("integrationtests") {
+    testonly = true
+    deps = [
+      "../../gn:default_deps",
+      "../../gn:gtest_and_gmock",
+      "../../include/perfetto/ext/tracing/ipc",
+      "../../include/perfetto/tracing",
+      "../../protos/perfetto/trace:cpp",
+      "../base",
+      "../base:test_support",
+    ]
+    sources = [ "internal/tracing_muxer_impl_integrationtest.cc" ]
+  }
 }
 
 perfetto_unittest_source_set("unittests") {


### PR DESCRIPTION
This fixes the standalone build with enable_perfetto_integration_tests=false due to test_helper.