### PR TITLE
profiling: guard end_to_end_tests inside enable_perfetto_integration_tests

### DIFF
--- a/src/profiling/memory/BUILD.gn
+++ b/src/profiling/memory/BUILD.gn
@@ -358,33 +358,35 @@ perfetto_unittest_source_set("unittests") {
   }
 }
 
-source_set("end_to_end_tests") {
-  testonly = true
-  deps = [
-    ":client",
-    ":daemon",
-    ":wire_protocol",
-    "../../../gn:default_deps",
-    "../../../gn:gtest_and_gmock",
-    "../../../gn:libunwindstack",
-    "../../../protos/perfetto/config/profiling:cpp",
-    "../../../protos/perfetto/trace/interned_data:cpp",
-    "../../../protos/perfetto/trace/profiling:cpp",
-    "../../../test:integrationtest_initializer",
-    "../../../test:test_helper",
-    "../../base",
-    "../../base:test_support",
-    "../../trace_processor:lib",
-    "../../tracing/test:test_support",
-  ]
-  sources = [
-    "heapprofd_end_to_end_test.cc",
-    "heapprofd_producer_integrationtest.cc",
-  ]
-  if (perfetto_build_with_android) {
-    deps += [ ":heapprofd_client_api" ]
-  } else {
-    deps += [ ":heapprofd_standalone_client" ]
+if (enable_perfetto_integration_tests) {
+  source_set("end_to_end_tests") {
+    testonly = true
+    deps = [
+      ":client",
+      ":daemon",
+      ":wire_protocol",
+      "../../../gn:default_deps",
+      "../../../gn:gtest_and_gmock",
+      "../../../gn:libunwindstack",
+      "../../../protos/perfetto/config/profiling:cpp",
+      "../../../protos/perfetto/trace/interned_data:cpp",
+      "../../../protos/perfetto/trace/profiling:cpp",
+      "../../../test:integrationtest_initializer",
+      "../../../test:test_helper",
+      "../../base",
+      "../../base:test_support",
+      "../../trace_processor:lib",
+      "../../tracing/test:test_support",
+    ]
+    sources = [
+      "heapprofd_end_to_end_test.cc",
+      "heapprofd_producer_integrationtest.cc",
+    ]
+    if (perfetto_build_with_android) {
+      deps += [ ":heapprofd_client_api" ]
+    } else {
+      deps += [ ":heapprofd_standalone_client" ]
+    }
   }
 }
 


### PR DESCRIPTION
This fixes the build with enable_perfetto_integration_tests=false and enable_perfetto_heapprofd=true.