### PR TITLE
ui: generalize Embedder hooks for third-party deployments

### DIFF
--- a/tools/gen_ui_imports
+++ b/tools/gen_ui_imports
@@ -59,9 +59,23 @@ def plugin_has_css(dir):
   return os.path.isdir(dir) and os.path.exists(os.path.join(dir, 'styles.scss'))
 
 
-def gen_imports(input_dir, output_path):
+def parse_include_list(path):
+  """Reads a plugin allowlist file. One basename per line; blank lines and
+  lines starting with '#' are ignored. Returns the set of allowed names."""
+  allowed = set()
+  with open(path, 'r') as f:
+    for line in f:
+      stripped = line.split('#', 1)[0].strip()
+      if stripped:
+        allowed.add(stripped)
+  return allowed
+
+
+def gen_imports(input_dir, output_path, include_list=None):
   paths = [os.path.join(input_dir, p) for p in os.listdir(input_dir)]
   paths = [p for p in paths if is_plugin_dir(p)]
+  if include_list is not None:
+    paths = [p for p in paths if os.path.basename(p) in include_list]
   paths.sort()
 
   output_dir = os.path.dirname(output_path)
@@ -88,9 +102,11 @@ def gen_imports(input_dir, output_path):
   return True
 
 
-def gen_css_import(input_dir, output_path):
+def gen_css_import(input_dir, output_path, include_list=None):
   paths = [os.path.join(input_dir, p) for p in os.listdir(input_dir)]
   paths = [p for p in paths if plugin_has_css(p)]
+  if include_list is not None:
+    paths = [p for p in paths if os.path.basename(p) in include_list]
   paths.sort()
 
   output_dir = os.path.dirname(output_path)
@@ -112,9 +128,18 @@ def main():
       description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
   parser.add_argument('INPUT')
   parser.add_argument('--out', required=True)
+  parser.add_argument(
+      '--include-list',
+      help='Path to a file listing plugin directory basenames to include '
+      '(one per line; blank lines and # comments allowed). Plugins not '
+      'in the list are silently dropped, so callers must validate the '
+      'list contents themselves.')
   args = parser.parse_args()
   input_dir = args.INPUT
   output_path = args.out
+  include_list = (
+      parse_include_list(args.include_list)
+      if args.include_list is not None else None)
 
   if not os.path.isdir(input_dir):
     print(f'INPUT argument {input_dir} must be a directory')
@@ -128,8 +153,8 @@ def main():
     print(f'--out ({output_path}) should not be a directory')
     exit(1)
 
-  success = gen_imports(input_dir, output_path)
-  success = success | gen_css_import(input_dir, output_path)
+  success = gen_imports(input_dir, output_path, include_list)
+  success = success | gen_css_import(input_dir, output_path, include_list)
   return 0 if success else 1
 
 

--- a/ui/build.js
+++ b/ui/build.js
@@ -77,6 +77,13 @@ const pjoin = path.join;
 const ROOT_DIR = path.dirname(__dirname);  // The repo root.
 const VERSION_SCRIPT = pjoin(ROOT_DIR, 'tools/write_version_header.py');
 const GEN_IMPORTS_SCRIPT = pjoin(ROOT_DIR, 'tools/gen_ui_imports');
+const DEFAULT_CONFIG_PATH = pjoin(ROOT_DIR, 'ui/config/default.json');
+const CONFIG_KEYS = new Set([
+  'appTitle',
+  'errorMessage',
+  'faviconPath',
+  'includePlugins',
+]);
 const DEFAULT_PORT = 10000;
 
 const cfg = {
@@ -117,6 +124,8 @@ const cfg = {
   outBigtraceDistDir: '',
   outOpenPerfettoTraceDistDir: '',
   lockFile: '',
+  config: null,
+  configPath: '',
 };
 
 const RULES = [
@@ -166,6 +175,70 @@ function loadDevServerEnvFile() {
     const key = trimmed.slice(0, eqIdx).trim();
     const value = trimmed.slice(eqIdx + 1).trim();
     if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+// Reads a deployment config JSON, validates that only known keys are used, and
+// fills in defaults from ui/config/default.json. Embedders point --config at
+// their own JSON; missing keys fall back to the defaults so the file only
+// needs to override what the deployment actually changes.
+function loadDeploymentConfig(configPath) {
+  const defaults = JSON.parse(fs.readFileSync(DEFAULT_CONFIG_PATH, 'utf8'));
+  let overrides = {};
+  if (configPath !== DEFAULT_CONFIG_PATH) {
+    if (!fs.existsSync(configPath)) {
+      console.error(`--config: file not found: ${configPath}`);
+      process.exit(1);
+    }
+    overrides = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  }
+  for (const key of Object.keys(overrides)) {
+    if (!CONFIG_KEYS.has(key)) {
+      console.error(`--config: unknown key '${key}' in ${configPath}`);
+      process.exit(1);
+    }
+  }
+  const merged = {...defaults, ...overrides};
+
+  // Resolve includePlugins (if set) against the config-file directory so
+  // embedder configs can reference allowlists with relative paths.
+  if (merged.includePlugins !== null && merged.includePlugins !== undefined) {
+    const resolved = path.resolve(path.dirname(configPath), merged.includePlugins);
+    if (!fs.existsSync(resolved)) {
+      console.error(`--config: includePlugins file not found: ${resolved}`);
+      process.exit(1);
+    }
+    merged.includePluginsPath = resolved;
+    validateIncludePluginsList(resolved);
+  } else {
+    merged.includePluginsPath = null;
+  }
+  return merged;
+}
+
+// Cross-checks every basename listed in the include-list against the union
+// of //ui/src/plugins and //ui/src/core_plugins, so a typo can't silently
+// drop a plugin from the bundle.
+function validateIncludePluginsList(listPath) {
+  const requested = new Set();
+  for (const raw of fs.readFileSync(listPath, 'utf8').split('\n')) {
+    const stripped = raw.split('#', 1)[0].trim();
+    if (stripped) requested.add(stripped);
+  }
+  const available = new Set();
+  for (const dir of ['ui/src/plugins', 'ui/src/core_plugins']) {
+    const abs = pjoin(ROOT_DIR, dir);
+    for (const entry of fs.readdirSync(abs)) {
+      const indexPath = pjoin(abs, entry, 'index.ts');
+      if (fs.existsSync(indexPath)) available.add(entry);
+    }
+  }
+  const missing = [...requested].filter((n) => !available.has(n)).sort();
+  if (missing.length > 0) {
+    console.error(
+        `--config: includePlugins entries do not match any plugin in ` +
+        `ui/src/plugins or ui/src/core_plugins: ${missing.join(', ')}`);
+    process.exit(1);
   }
 }
 
@@ -230,6 +303,9 @@ Env-var overrides:
   });
   parser.add_argument('--title', {
     help: 'Override the page title (useful for distinguishing multiple instances)',
+  });
+  parser.add_argument('--config', {
+    help: 'Path to a JSON deployment config (defaults to ui/config/default.json)',
   });
 
   // Load ~/.config/perfetto/ui-dev-server.env defaults, then map any
@@ -309,6 +385,8 @@ Env-var overrides:
   cfg.check = !!args.typecheck;
   cfg.onlyWasmMemory64 = !!args.only_wasm_memory64;
   cfg.titleOverride = args.title || '';
+  cfg.configPath = path.resolve(args.config || DEFAULT_CONFIG_PATH);
+  cfg.config = loadDeploymentConfig(cfg.configPath);
   cfg.wasmModules = ['traceconv', 'proto_utils', 'trace_processor_memory64'];
   if (!cfg.onlyWasmMemory64) {
     cfg.wasmModules.push('trace_processor');
@@ -485,8 +563,17 @@ function runTests(cfgFile) {
   }
 }
 
-function cpHtml(src, filename) {
+function cpHtml(src, filename, substitutions) {
   let html = fs.readFileSync(src).toString();
+  // Apply deployment-config placeholder substitutions (only for files that
+  // contain the placeholders). Done before the version-map patch so the
+  // archived /v1.2.3/ copy and the live root copy stay in sync.
+  if (substitutions) {
+    for (const [placeholder, value] of Object.entries(substitutions)) {
+      html = html.split(placeholder).join(value);
+    }
+  }
+
   // First copy the html as-is into the dist/v1.2.3/ directory. This is
   // only used for archival purporses, so one can open
   // ui.perfetto.dev/v1.2.3/ to skip the auto-update and channel logic.
@@ -511,7 +598,11 @@ function cpHtml(src, filename) {
 }
 
 function copyIndexHtml(src) {
-  addTask(cpHtml, [src, 'index.html']);
+  addTask(cpHtml, [src, 'index.html', {
+    '__APP_TITLE__': cfg.config.appTitle,
+    '__ERROR_MESSAGE__': cfg.config.errorMessage,
+    '__FAVICON_PATH__': cfg.config.faviconPath,
+  }]);
 }
 
 function copyBigtraceHtml(src) {
@@ -605,6 +696,9 @@ function generateImports(dir, name) {
   const dstTs = pjoin(ROOT_DIR, 'ui/src/gen', name);
   const inputDir = pjoin(ROOT_DIR, dir);
   const args = [GEN_IMPORTS_SCRIPT, inputDir, '--out', dstTs];
+  if (cfg.config.includePluginsPath) {
+    args.push('--include-list', cfg.config.includePluginsPath);
+  }
   addTask(exec, ['python3', args]);
 }
 

--- a/ui/config/default.json
+++ b/ui/config/default.json
@@ -1,0 +1,6 @@
+{
+  "appTitle": "Perfetto UI",
+  "errorMessage": "Perfetto UI - An unrecoverable problem occurred",
+  "faviconPath": "data:image/png;base64,iVBORw0KGgo=",
+  "includePlugins": null
+}

--- a/ui/src/assets/index.html
+++ b/ui/src/assets/index.html
@@ -2,9 +2,9 @@
 <html lang="en-us">
 <head>
   <meta charset="utf-8">
-  <title>Perfetto UI</title>
+  <title>__APP_TITLE__</title>
   <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" name="viewport" />
-  <link rel="shortcut icon" id="favicon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
+  <link rel="shortcut icon" id="favicon" type="image/png" href="__FAVICON_PATH__">
 </head>
 <body data-perfetto_version='{"filled_by_build_js":"."}'>
   <!--
@@ -25,7 +25,7 @@
   <div id="app_load"><div id="app_load_spinner"></div></div>
   <div id="app_load_failure">
 <pre>
-<span>Perfetto UI - An unrecoverable problem occurred</span>
+<span>__ERROR_MESSAGE__</span>
 
 If you are seeing this message, something went wrong while loading the UI.
 In most cases this is due to very slow or flaky network and it goes away by

--- a/ui/src/core/embedder/default_embedder.ts
+++ b/ui/src/core/embedder/default_embedder.ts
@@ -21,4 +21,6 @@ export class DefaultEmbedder implements Embedder {
   readonly extensionServer = undefined;
   readonly brandingBadge = undefined;
   readonly defaultPlugins = defaultPlugins;
+  readonly homePage = undefined;
+  readonly brandLogo = undefined;
 }

--- a/ui/src/core/embedder/embedder.ts
+++ b/ui/src/core/embedder/embedder.ts
@@ -12,6 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import m from 'mithril';
+import {App} from '../../public/app';
+
+/**
+ * Attrs passed to an embedder-supplied home-page component. Carrying the
+ * `App` instance via Mithril attrs lets embedders use commands/settings
+ * without importing `AppImpl`, which would form a circular import (the
+ * embedder is referenced from `AppImpl` via `createEmbedder`).
+ */
+export interface HomePageAttrs {
+  readonly app: App;
+}
+
 /**
  * Configuration for an embedder-provided default extension server.
  */
@@ -62,4 +75,14 @@ export interface Embedder {
 
   // Returns the list of plugin IDs that should be enabled by default.
   readonly defaultPlugins: ReadonlyArray<string>;
+
+  // Mithril component rendered at route '/'. Receives the running App via
+  // attrs so embedder-supplied components can reach commands/settings/the
+  // router without importing AppImpl. Undefined falls back to the
+  // built-in HomePage.
+  readonly homePage: m.ComponentTypes<HomePageAttrs> | undefined;
+
+  // Sidebar wordmark image. Undefined falls back to the bundled Perfetto
+  // wordmark; embedders override to swap it out.
+  readonly brandLogo: {readonly src: string; readonly alt?: string} | undefined;
 }

--- a/ui/src/core/embedder/perfetto_ui_embedder.ts
+++ b/ui/src/core/embedder/perfetto_ui_embedder.ts
@@ -24,4 +24,6 @@ export class PerfettoUiEmbedder implements Embedder {
   };
   readonly brandingBadge = undefined;
   readonly defaultPlugins = defaultPlugins;
+  readonly homePage = undefined;
+  readonly brandLogo = undefined;
 }

--- a/ui/src/frontend/index.ts
+++ b/ui/src/frontend/index.ts
@@ -358,7 +358,11 @@ function onCssLoaded(app: AppImpl) {
   document.body.innerHTML = '';
 
   const pages = app.pages;
-  pages.registerPage({route: '/', render: () => m(HomePage)});
+  const homePage = app.embedder.homePage;
+  pages.registerPage({
+    route: '/',
+    render: () => (homePage ? m(homePage, {app}) : m(HomePage)),
+  });
   const router = new Router();
   router.onRouteChanged = routeChange;
 

--- a/ui/src/frontend/ui_main.ts
+++ b/ui/src/frontend/ui_main.ts
@@ -67,7 +67,7 @@ export class UiMain implements m.ClassComponent {
         state: isSomethingLoading ? 'indeterminate' : 'none',
       }),
       m('.pf-ui-main__page-container', app.pages.renderPageForCurrentRoute()),
-      m(CookieConsent),
+      app.embedder.analyticsId !== undefined && m(CookieConsent),
       maybeRenderFullscreenModalDialog(),
       showStatusBarFlag.get() && renderStatusBar(app),
       app.perfDebugging.renderPerfStats(),

--- a/ui/src/frontend/views/sidebar.ts
+++ b/ui/src/frontend/views/sidebar.ts
@@ -80,7 +80,7 @@ export class Sidebar implements m.ClassComponent<SidebarAttrs> {
       {
         className: `pf-sidebar__header--${getCurrentChannel()}`,
       },
-      m(`img[src=${assetSrc('assets/brand.png')}].pf-sidebar__brand`),
+      this.renderBrandLogo(app),
       app.embedder.brandingBadge &&
         m(
           'span.pf-sidebar__branding-badge',
@@ -105,6 +105,14 @@ export class Sidebar implements m.ClassComponent<SidebarAttrs> {
         m(Icon, {icon: 'menu'}),
       ),
     );
+  }
+
+  private renderBrandLogo(app: AppImpl): m.Children {
+    const logo = app.embedder.brandLogo;
+    if (logo === undefined) {
+      return m(`img[src=${assetSrc('assets/brand.png')}].pf-sidebar__brand`);
+    }
+    return m('img.pf-sidebar__brand', {src: logo.src, alt: logo.alt});
   }
 
   private renderSidebarContent(app: AppImpl) {


### PR DESCRIPTION
Carve out the build-time and runtime surfaces that branding-customising
embedders previously had to fork-patch:

Build-time (new ui/config/default.json + --config flag on build.js):
  appTitle, errorMessage, faviconPath are substituted into index.html;
  includePlugins points to an allowlist file forwarded to
  tools/gen_ui_imports via the new --include-list flag. build.js
  cross-checks the allowlist against the union of //ui/src/plugins and
  //ui/src/core_plugins so a typo cannot silently drop a plugin.

Runtime (Embedder interface):
  - homePage replaces the route '/' component when set.
  - brandLogo swaps the sidebar wordmark; undefined keeps the bundled
    Perfetto brand asset so default deployments are unchanged.
  - CookieConsent is now mounted only when embedder.analyticsId is
    defined, so non-analytics deployments never instantiate it.
