### PR TITLE
perfetto: add extra_asmflags for cross-compile

### DIFF
--- a/gn/standalone/toolchain/BUILD.gn
+++ b/gn/standalone/toolchain/BUILD.gn
@@ -302,7 +302,14 @@ template("gcc_like_toolchain") {
       } else {
         depfile_args = "-MMD -MF $depfile"
       }
-      command = "$cc_wrapper $cc $depfile_args {{defines}} {{include_dirs}} {{asmflags}} -c {{source}} -o {{output}}"
+
+      # Propagate ${external_cflags} (where extra_cflags + extra_target_cflags
+      # land, including -target for cross-compile) to the assembler. Without
+      # this the cc/cxx tools cross-compile correctly but the asm tool
+      # defaults to the build host's arch, which breaks .S files like
+      # buildtools/android-unwinding/libunwindstack/AsmGetRegsX86_64.S
+      # when cross-compiling Linux x64 from e.g. a macOS arm64 host.
+      command = "$cc_wrapper $cc $depfile_args {{defines}} {{include_dirs}} {{asmflags}} ${external_cflags} -c {{source}} -o {{output}}"
       depsformat = "gcc"
       outputs =
           [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]

--- a/gn/standalone/toolchain/BUILD.gn
+++ b/gn/standalone/toolchain/BUILD.gn
@@ -31,16 +31,19 @@ declare_args() {
   # These apply to both target and host toolchains.
   extra_cflags = ""
   extra_cxxflags = ""
+  extra_asmflags = ""
   extra_ldflags = ""
 
   # These apply only to the target toolchain.
   extra_target_cflags = ""
   extra_target_cxxflags = ""
+  extra_target_asmflags = ""
   extra_target_ldflags = ""
 
   # These apply only to the host toolchain.
   extra_host_cflags = ""
   extra_host_cxxflags = ""
+  extra_host_asmflags = ""
   extra_host_ldflags = ""
 }
 
@@ -238,6 +241,7 @@ template("gcc_like_toolchain") {
     ld_arg = ""
     external_cflags = ""
     external_cxxflags = ""
+    external_asmflags = ""
     external_ldflags = ""
     strip = ""
     if (defined(invoker.linker) && invoker.linker != "") {
@@ -259,6 +263,9 @@ template("gcc_like_toolchain") {
     }
     if (defined(invoker.external_cxxflags)) {
       external_cxxflags = invoker.external_cxxflags
+    }
+    if (defined(invoker.external_asmflags)) {
+      external_asmflags = invoker.external_asmflags
     }
     if (defined(invoker.external_ldflags)) {
       external_ldflags = invoker.external_ldflags
@@ -302,7 +309,7 @@ template("gcc_like_toolchain") {
       } else {
         depfile_args = "-MMD -MF $depfile"
       }
-      command = "$cc_wrapper $cc $depfile_args {{defines}} {{include_dirs}} {{asmflags}} ${external_cflags} -c {{source}} -o {{output}}"
+      command = "$cc_wrapper $cc $depfile_args {{defines}} {{include_dirs}} {{asmflags}} ${external_asmflags} -c {{source}} -o {{output}}"
       depsformat = "gcc"
       outputs =
           [ "{{source_out_dir}}/{{target_output_name}}.{{source_name_part}}.o" ]
@@ -398,6 +405,11 @@ gcc_like_toolchain("gcc_like") {
                                     extra_cxxflags,
                                     extra_target_cxxflags,
                                   ])
+  external_asmflags = string_join(" ",
+                                  [
+                                    extra_asmflags,
+                                    extra_target_asmflags,
+                                  ])
   external_ldflags = string_join(" ",
                                  [
                                    extra_ldflags,
@@ -424,6 +436,11 @@ gcc_like_toolchain("gcc_like_host") {
                                   [
                                     extra_cxxflags,
                                     extra_host_cxxflags,
+                                  ])
+  external_asmflags = string_join(" ",
+                                  [
+                                    extra_asmflags,
+                                    extra_host_asmflags,
                                   ])
   external_ldflags = string_join(" ",
                                  [

--- a/gn/standalone/toolchain/BUILD.gn
+++ b/gn/standalone/toolchain/BUILD.gn
@@ -302,13 +302,6 @@ template("gcc_like_toolchain") {
       } else {
         depfile_args = "-MMD -MF $depfile"
       }
-
-      # Propagate ${external_cflags} (where extra_cflags + extra_target_cflags
-      # land, including -target for cross-compile) to the assembler. Without
-      # this the cc/cxx tools cross-compile correctly but the asm tool
-      # defaults to the build host's arch, which breaks .S files like
-      # buildtools/android-unwinding/libunwindstack/AsmGetRegsX86_64.S
-      # when cross-compiling Linux x64 from e.g. a macOS arm64 host.
       command = "$cc_wrapper $cc $depfile_args {{defines}} {{include_dirs}} {{asmflags}} ${external_cflags} -c {{source}} -o {{output}}"
       depsformat = "gcc"
       outputs =


### PR DESCRIPTION
The standalone gcc-like toolchain template forwards `${external_cflags}` (which accumulates `-target` for cross-compile) to the cc and cxx tools but not to the asm tool. Cross-compiling from a different host arch then breaks at the `.S` files under `buildtools/android-unwinding/libunwindstack/AsmGetRegs*.S` because the assembler defaults to the host arch.

Adds a dedicated `extra_asmflags` (plus `extra_target_asmflags` / `extra_host_asmflags`) and wires `${external_asmflags}` into the asm tool, mirroring how cflags / cxxflags / ldflags are plumbed.