### PR TITLE
ui: add external_embedder.ts override point for third-party deployments

### DIFF
--- a/ui/src/core/embedder/create_embedder.ts
+++ b/ui/src/core/embedder/create_embedder.ts
@@ -15,13 +15,19 @@
 import {Embedder} from './embedder';
 import {DefaultEmbedder} from './default_embedder';
 import {PerfettoUiEmbedder} from './perfetto_ui_embedder';
+import {EXTERNAL_EMBEDDER} from './external_embedder';
 
 /**
- * Returns the appropriate Embedder based on the current origin.
- * Uses PerfettoUiEmbedder when running on ui.perfetto.dev or localhost,
- * and DefaultEmbedder otherwise.
+ * Returns the appropriate Embedder. A deployment-supplied external
+ * embedder (provided by overriding the contents of external_embedder.ts)
+ * is used unconditionally when present. Otherwise selects between
+ * PerfettoUiEmbedder for ui.perfetto.dev / localhost and
+ * DefaultEmbedder for everything else.
  */
 export function createEmbedder(): Embedder {
+  if (EXTERNAL_EMBEDDER !== undefined) {
+    return EXTERNAL_EMBEDDER;
+  }
   const origin = self.location?.origin ?? '';
   if (
     origin.endsWith('.perfetto.dev') ||

--- a/ui/src/core/embedder/external_embedder.ts
+++ b/ui/src/core/embedder/external_embedder.ts
@@ -1,0 +1,31 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Embedder} from './embedder';
+
+// External embedder override point. The default file ships
+// EXTERNAL_EMBEDDER = undefined; create_embedder.ts falls through to the
+// built-in PerfettoUiEmbedder / DefaultEmbedder ladder.
+//
+// Deployments that want to plug in a custom Embedder replace this file's
+// contents — e.g. via a fork commit on a vendored copy of perfetto, or a
+// setup-time symlink to a deployment-side file. When non-undefined, the
+// exported value is used unconditionally regardless of the current
+// origin. Example override:
+//
+//   import {Embedder} from './embedder';
+//   import {MyEmbedder} from './my_embedder';
+//
+//   export const EXTERNAL_EMBEDDER: Embedder = new MyEmbedder();
+export const EXTERNAL_EMBEDDER: Embedder | undefined = undefined;


### PR DESCRIPTION
Adds a tracked override point for deployments that want to plug in a custom Embedder without patching upstream code.

`ui/src/core/embedder/external_embedder.ts` ships with `EXTERNAL_EMBEDDER = undefined`. `create_embedder.ts` consults it first; when non-undefined, the exported value is used unconditionally regardless of origin. Otherwise the existing `PerfettoUiEmbedder` (for `*.perfetto.dev` / localhost) and `DefaultEmbedder` ladder applies as before.

Deployments override by replacing the file's contents — via a fork commit on a vendored copy of perfetto, or via a setup-time symlink/copy to a deployment-side file.

*Stacked on [#5712](https://github.com/google/perfetto/pull/5712)*