### PR TITLE
perfetto: allow overriding write_version_header SCM revision via env

### DIFF
--- a/tools/write_version_header.py
+++ b/tools/write_version_header.py
@@ -57,6 +57,12 @@ def get_latest_release(changelog_path):
 
 def get_git_sha1(commitish):
   """Returns the SHA1 of the provided commit-ish"""
+  # Embedders / forks can override the SCM revision via env var so the
+  # version string baked into the build identifies their checkout
+  # instead of perfetto's git HEAD.
+  override = os.environ.get('PERFETTO_VERSION_HEADER_OVERRIDE_SCM_REVISION')
+  if override:
+    return override
   commit_sha1 = SCM_REV_NOT_AVAILABLE
   git_dir = os.path.join(PROJECT_ROOT, '.git')
   if os.path.exists(git_dir):


### PR DESCRIPTION
Add \`PERFETTO_VERSION_HEADER_OVERRIDE_SCM_REVISION\` as an env-var override for the SHA1 baked into \`perfetto_version{.gen.h,.ts}\`. Embedders and forks that build the UI as part of a larger product want the version footer (and the C++ macro) to identify their own checkout's commit instead of perfetto's HEAD; today the only options are post-processing the generated file or maintaining a local patch on \`tools/write_version_header.py\`. An env var keeps the override out of the build graph and inert for anyone who doesn't set it.

The override applies for any commit-ish passed to \`get_git_sha1\`, but in practice the function is only invoked with \`HEAD\`. When the env var is unset, behavior is unchanged.