### PR TITLE
perfetto: fix ScrapeEmulatedSharedMemoryBuffer never committing

### DIFF
--- a/src/tracing/core/shared_memory_arbiter_impl.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl.cc
@@ -974,7 +974,7 @@ void SharedMemoryArbiterImpl::ScrapeEmulatedSharedMemoryBuffer(
     if (writer == buffer_for_writers.end())
       return;
     BufferID target_buffer_id = writer->second;
-    auto* ctm = commit_data_req_->add_chunks_to_move();
+    auto* ctm = commit_req.add_chunks_to_move();
     auto page_and_chunk = shmem_abi_.GetPageAndChunkIndex(*chunk);
     ctm->set_page(static_cast<uint32_t>(page_and_chunk.first));
     ctm->set_chunk(static_cast<uint32_t>(page_and_chunk.second));

--- a/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
+++ b/src/tracing/core/shared_memory_arbiter_impl_unittest.cc
@@ -267,6 +267,62 @@ TEST_P(SharedMemoryArbiterImplTest, UseShmemEmulation) {
       arbiter_->shmem_abi_for_testing()->GetChunkState(page_idx, chunk_idx));
 }
 
+// Verifies that ScrapeEmulatedSharedMemoryBuffer commits the scraped chunks
+// via the producer endpoint and leaves the chunk state untouched (the writer
+// still owns it).
+TEST_P(SharedMemoryArbiterImplTest, ScrapeEmulatedSharedMemoryBuffer) {
+  arbiter_.reset(new SharedMemoryArbiterImpl(
+      buf(), buf_size(), ShmemMode::kShmemEmulation, page_size(),
+      &mock_producer_endpoint_, task_runner_.get()));
+
+  SharedMemoryArbiterImpl::set_default_layout_for_testing(
+      SharedMemoryABI::PageLayout::kPageDiv1);
+
+  constexpr WriterID kWriterId = 7;
+  constexpr BufferID kTargetBuffer = 42;
+
+  size_t page_idx;
+  size_t chunk_idx;
+  auto* abi = arbiter_->shmem_abi_for_testing();
+
+  // Acquire a chunk and leave it in kChunkBeingWritten state with at least 2
+  // packets, so that ForEachScrapableChunk() picks it up as scrapable.
+  SharedMemoryABI::ChunkHeader header = {};
+  header.writer_id.store(kWriterId, std::memory_order_relaxed);
+  header.chunk_id.store(0, std::memory_order_relaxed);
+  header.packets.store({}, std::memory_order_relaxed);
+  SharedMemoryABI::Chunk chunk =
+      arbiter_->GetNewChunk(header, BufferExhaustedPolicy::kStall);
+  std::tie(page_idx, chunk_idx) = abi->GetPageAndChunkIndex(chunk);
+  ASSERT_TRUE(chunk.is_valid());
+  chunk.IncrementPacketCount();
+  chunk.IncrementPacketCount();
+
+  EXPECT_CALL(mock_producer_endpoint_, CommitData(_, _))
+      .WillOnce([&](const CommitDataRequest& req,
+                    MockProducerEndpoint::CommitDataCallback) {
+        ASSERT_EQ(1, req.chunks_to_move_size());
+
+        ASSERT_EQ(page_idx, req.chunks_to_move()[0].page());
+        ASSERT_EQ(chunk_idx, req.chunks_to_move()[0].chunk());
+        ASSERT_EQ(kTargetBuffer, req.chunks_to_move()[0].target_buffer());
+
+        // The chunk is still being written, so it must be flagged as
+        // incomplete and the data must be inlined in the request.
+        ASSERT_TRUE(req.chunks_to_move()[0].chunk_incomplete());
+        ASSERT_TRUE(req.chunks_to_move()[0].has_data());
+      });
+
+  std::map<WriterID, BufferID> buffer_for_writers = {
+      {kWriterId, kTargetBuffer}};
+  arbiter_->ScrapeEmulatedSharedMemoryBuffer(buffer_for_writers);
+  ASSERT_TRUE(Mock::VerifyAndClearExpectations(&mock_producer_endpoint_));
+
+  // Scraping must not disturb the chunk: the writer still owns it.
+  ASSERT_EQ(SharedMemoryABI::kChunkBeingWritten,
+            abi->GetChunkState(page_idx, chunk_idx));
+}
+
 // Check that we can create up to many TraceWriter(s).
 TEST_P(SharedMemoryArbiterImplTest, WriterIDsAllocation) {
   constexpr size_t kBigWriterCount = (1 << 12);


### PR DESCRIPTION
ScrapeEmulatedSharedMemoryBuffer declared a local CommitDataRequest named |commit_req|, but the lambda passed to ForEachScrapableChunk appended scrape entries to the member |commit_data_req_| instead of the local. 


As a result:
- |commit_req.chunks_to_move_size()| was always zero, so the function always returned early without ever calling |producer_endpoint_->CommitData|. Producer-side SMB scraping for remote (emulated SMB) producers was therefore a silent no-op.
- The scrape entries were instead leaked onto the pending |commit_data_req_|, where the FlushPendingCommitDataRequests drain treats them as arbiter-owned chunks and would ReleaseChunkAsComplete + ReleaseChunkAsFree them while their writers were still mid-write, corrupting the SMB.

Adds a unit test (ScrapeEmulatedSharedMemoryBuffer) that drives the emulated-SMB scrape path with a chunk in kChunkBeingWritten state and asserts that CommitData is invoked with the scraped chunk and that the chunk is left in kChunkBeingWritten afterwards.
