### PR TITLE
tp: adjust SF transform matrix construction for layers.

### DIFF
--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_parser.cc
@@ -301,9 +301,7 @@ SurfaceFlingerLayersParser::InsertDisplayRectRow(
   geometry::Rect rect =
       surfaceflinger_layers::display::MakeLayerStackSpaceRect(display_decoder);
 
-  if (display_decoder.has_layer_stack()) {
-    displays_by_layer_stack[display_decoder.layer_stack()] = rect;
-  }
+  displays_by_layer_stack[display_decoder.layer_stack()] = rect;
 
   if (rect.IsEmpty()) {
     const auto& size =

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_rect_computation.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_rect_computation.cc
@@ -80,26 +80,7 @@ ExtractDisplayTransforms(const SnapshotDecoder& snapshot_decoder) {
 
   for (auto it = snapshot_decoder.displays(); it; ++it) {
     protos::pbzero::DisplayProto::Decoder display(*it);
-    auto matrix = display.has_layer_stack()
-                      ? display::GetTransformMatrix(display)
-                      : geometry::TransformMatrix{};
-
-    protos::pbzero::TransformProto::Decoder transform(display.transform());
-
-    if (transform.has_type() && display.has_layer_stack_space_rect()) {
-      const auto& layer_stack_space_rect =
-          display::MakeLayerStackSpaceRect(display);
-      auto transform_type = transform.type();
-
-      if (transform::IsRotated180(transform_type)) {
-        matrix.tx = layer_stack_space_rect.w;
-        matrix.ty = layer_stack_space_rect.h;
-      } else if (transform::IsRotated270(transform_type)) {
-        matrix.tx = layer_stack_space_rect.w;
-      } else if (transform::IsRotated90(transform_type)) {
-        matrix.ty = layer_stack_space_rect.h;
-      }
-    }
+    auto matrix = display::GetTransformMatrix(display);
     transforms[display.layer_stack()] = matrix;
   }
 
@@ -287,11 +268,9 @@ std::optional<TraceRectTableId> RectComputation::TryInsertInputRect(
   auto layer_transform = layer::GetTransformMatrix(layer);
   auto inverse_layer_transform = layer_transform.Inverse();
   std::optional<geometry::TransformMatrix> display_transform;
-  if (layer.has_layer_stack()) {
-    auto pos = display_transforms.find(layer.layer_stack());
-    if (pos != display_transforms.end()) {
-      display_transform = pos->second;
-    }
+  auto pos = display_transforms.find(layer.layer_stack());
+  if (pos != display_transforms.end()) {
+    display_transform = pos->second;
   }
 
   auto frame_rect = MakeFrameRect(input_window_info, display_transform,
@@ -302,20 +281,18 @@ std::optional<TraceRectTableId> RectComputation::TryInsertInputRect(
   bool should_crop_to_display = false;
   std::optional<geometry::Rect> display;
 
-  if (layer.has_layer_stack()) {
-    auto display_pos = displays_by_layer_stack_.find(layer.layer_stack());
-    if (display_pos != displays_by_layer_stack_.end()) {
-      display = display_pos->second;
-      should_crop_to_display =
-          frame_rect.IsEmpty() ||
-          (input_config & InputConfig::IS_WALLPAPER) != 0 ||
-          std::find_if(invalid_bounds.begin(), invalid_bounds.end(),
-                       [&](const geometry::Rect& bounds) {
-                         return frame_rect.IsAlmostEqual(bounds);
-                       }) != invalid_bounds.end();
-      if (should_crop_to_display) {
-        frame_rect = frame_rect.CropRect(display.value());
-      }
+  auto display_pos = displays_by_layer_stack_.find(layer.layer_stack());
+  if (display_pos != displays_by_layer_stack_.end()) {
+    display = display_pos->second;
+    should_crop_to_display =
+        frame_rect.IsEmpty() ||
+        (input_config & InputConfig::IS_WALLPAPER) != 0 ||
+        std::find_if(invalid_bounds.begin(), invalid_bounds.end(),
+                     [&](const geometry::Rect& bounds) {
+                       return frame_rect.IsAlmostEqual(bounds);
+                     }) != invalid_bounds.end();
+    if (should_crop_to_display) {
+      frame_rect = frame_rect.CropRect(display.value());
     }
   }
 

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_utils.h
@@ -172,10 +172,13 @@ inline TransformMatrix GetTransformMatrix(const LayerDecoder& layer_decoder) {
     if (transform::IsSimpleTransform(type)) {
       matrix = transform::GetTransformMatrix(type, matrix.tx, matrix.ty);
     } else {
+      // Adjust transform matrix to correct for layer transforms incorrectly
+      // written to proto using LayerProtoHelper#writeToProtoDeprecated. See
+      // frameworks/native/services/surfaceflinger/LayerProtoHelper.cpp.
       matrix.dsdx = static_cast<double>(transform.dsdx());
-      matrix.dtdx = static_cast<double>(transform.dtdx());
+      matrix.dtdx = static_cast<double>(transform.dsdy());
       matrix.dsdy = static_cast<double>(transform.dtdy());
-      matrix.dtdy = static_cast<double>(transform.dsdy());
+      matrix.dtdy = static_cast<double>(transform.dtdx());
     }
   }
   return matrix;
@@ -249,8 +252,25 @@ inline TransformMatrix GetTransformMatrix(
     } else {
       matrix.dsdx = static_cast<double>(transform.dsdx());
       matrix.dtdx = static_cast<double>(transform.dtdx());
-      matrix.dsdy = static_cast<double>(transform.dtdy());
-      matrix.dtdy = static_cast<double>(transform.dsdy());
+      matrix.dsdy = static_cast<double>(transform.dsdy());
+      matrix.dtdy = static_cast<double>(transform.dtdy());
+    }
+
+    // Apply translation according to Transform::set, used in platform to
+    // reconstruct display transforms from type, width, and height. See
+    // frameworks/native/libs/ui/Transform.cpp.
+    if (transform.has_type() && display_decoder.has_layer_stack_space_rect()) {
+      const auto& layer_stack_space_rect =
+          display::MakeLayerStackSpaceRect(display_decoder);
+
+      if (transform::IsRotated180(type)) {
+        matrix.tx = layer_stack_space_rect.w;
+        matrix.ty = layer_stack_space_rect.h;
+      } else if (transform::IsRotated270(type)) {
+        matrix.tx = layer_stack_space_rect.w;
+      } else if (transform::IsRotated90(type)) {
+        matrix.ty = layer_stack_space_rect.h;
+      }
     }
   }
 

--- a/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation.cc
+++ b/src/trace_processor/importers/proto/winscope/surfaceflinger_layers_visibility_computation.cc
@@ -166,13 +166,10 @@ geometry::Rect GetDisplayCrop(
     const LayerDecoder& layer,
     const protos::pbzero::LayersSnapshotProto::Decoder& snapshot_decoder) {
   geometry::Rect display_crop = geometry::Rect();
-  if (!layer.has_layer_stack()) {
-    return display_crop;
-  }
   auto layer_stack = layer.layer_stack();
   for (auto it = snapshot_decoder.displays(); it; ++it) {
     protos::pbzero::DisplayProto::Decoder display(*it);
-    if (!display.has_layer_stack() || display.layer_stack() != layer_stack) {
+    if (display.layer_stack() != layer_stack) {
       continue;
     }
     if (!display.has_layer_stack_space_rect()) {
@@ -236,9 +233,6 @@ VisibilityProperties VisibilityComputation::IsLayerVisible(
   if (res.is_visible) {
     for (const auto opaque_layer_id : opaque_layer_ids) {
       const auto& opaque_layer = layers_by_id_.at(opaque_layer_id);
-      if (opaque_layer.has_layer_stack() != layer.has_layer_stack()) {
-        continue;
-      }
       if (opaque_layer.layer_stack() != layer.layer_stack()) {
         continue;
       }
@@ -261,9 +255,6 @@ VisibilityProperties VisibilityComputation::IsLayerVisible(
 
     for (const auto translucent_layer_id : translucent_layer_ids) {
       const auto& translucent_layer = layers_by_id_.at(translucent_layer_id);
-      if (translucent_layer.has_layer_stack() != layer.has_layer_stack()) {
-        continue;
-      }
       if (translucent_layer.layer_stack() != layer.layer_stack()) {
         continue;
       }


### PR DESCRIPTION
Account for wrongly written layer transforms. Display transforms are written correctly and do not need adjustment.

Remove checks for `has_layer_stack` before layer stack-related logic - a default (zero) value for layer stack does not mean that this logic should not be carried out.

Move final display matrix reconstruction logic into the display::GetTransformMatrix function for clarity.

Bug: 507393011
Test: tools/ninja -C out/linux_clang_debug perfetto_unittests && out/linux_clang_debug/perfetto_unittests --gtest_filter=SurfaceFlinger*
Test: tools/diff_test_trace_processor.py out/linux_clang_release/trace_processor_shell --name-filter="SurfaceFlinger|PerfettoTable:winscope"