### PR TITLE
tp: per-level critical-path drill-down

### DIFF
--- a/src/trace_processor/perfetto_sql/intrinsics/functions/critical_path.cc
+++ b/src/trace_processor/perfetto_sql/intrinsics/functions/critical_path.cc
@@ -96,11 +96,11 @@ struct WakeupGraphAgg : public sqlite::AggregateFunction<WakeupGraphAgg> {
 };
 
 // Attribute time during `[window_start, window_end)` using `node_id`
-// at chain `depth` from the root. `parent_node_id` is the layer one
-// level above this frame in the attribution hierarchy (the root for
-// depth-0 frames) and propagates into every emitted row's `parent_id`
-// so `_intervals_flatten` can collapse overlapping layers to the
-// deepest active blocker per `(root, ts)`.
+// at chain `depth` from the root. `parent_node_id` is the
+// wakeup-graph node id of the depth-(N-1) thread that descended into
+// this frame; at depth 0 it equals the root id (self-reference).
+// Propagated into every emitted row's `parent_id` so callers can
+// drill the chain by following the (parent_id -> node_id) edge.
 struct Frame {
   uint32_t node_id;
   int64_t window_start;
@@ -158,10 +158,9 @@ void WalkOneRoot(const WakeupGraph& graph,
       continue;
     }
 
-    // Idle portion of the effective window. With no `waker_id` (IRQ
-    // context, no thread chain to walk) the woken thread is in kernel
-    // and self-attributes; otherwise descend into `waker_id` at
-    // depth+1 to chain through the cross-thread waker.
+    // Idle portion. With no `waker_id` (IRQ context) the woken
+    // thread self-attributes in kernel; otherwise descend into the
+    // waker at depth+1.
     int64_t idle_clip_start = eff_start;
     int64_t idle_clip_end = std::min(eff_end, n.ts);
     if (idle_clip_start < idle_clip_end) {
@@ -176,8 +175,10 @@ void WalkOneRoot(const WakeupGraph& graph,
         row.parent_id = f.parent_node_id;
         out.Insert(row);
       } else if (n.waker_id) {
+        // Cross-thread descent: this frame becomes the parent of the
+        // pushed one so per-hop lineage is preserved.
         stack.push_back({*n.waker_id, idle_clip_start, idle_clip_end,
-                         f.depth + 1, f.parent_node_id});
+                         f.depth + 1, f.node_id});
       }
     }
 
@@ -197,9 +198,11 @@ void WalkOneRoot(const WakeupGraph& graph,
   }
 }
 
-// Args, in order: WakeupGraph* (from `__intrinsic_wakeup_graph_agg`),
-// IntArray* of root ids (from `__intrinsic_array_agg`). Returns a
-// `Dataframe*` tagged "TABLE", consumed via `__intrinsic_table_ptr`.
+// Args, in order:
+//   WakeupGraph* (from `__intrinsic_wakeup_graph_agg`),
+//   IntArray*    (from `__intrinsic_array_agg`, root ids).
+// Returns a `Dataframe*` tagged "TABLE", consumed via
+// `__intrinsic_table_ptr`.
 struct CriticalPathWalk : public sqlite::AggregateFunction<CriticalPathWalk> {
   static constexpr char kName[] = "__intrinsic_critical_path_walk";
   static constexpr int kArgCount = 2;

--- a/src/trace_processor/perfetto_sql/stdlib/sched/thread_executing_span.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/sched/thread_executing_span.sql
@@ -383,13 +383,13 @@ RETURNS TableOrSubQuery AS
     AND _interval_to_root_nodes.utid = _bound.utid
 );
 
--- Critical path for the given roots with the chain depth retained.
--- One row per `(root_id, depth, ts, dur, id, parent_id)` blocker
--- frame: `id` is the on-CPU blocker at this depth, `parent_id` is
--- the blocker one level up (the root at depth 0). At a self-wake the
--- woken thread is the depth-N fallback (it is in kernel) and the
--- waker chain layers at depth N+1. `_critical_path_by_roots`
--- collapses these depths to one blocker per `(root_id, ts)`.
+-- All viable critical-path frames for the given roots. One row per
+-- `(root_id, depth, ts, dur, id, blocker_utid, parent_id)` where
+-- `id` is the on-CPU thread node at this depth, `blocker_utid` its
+-- utid, and `parent_id` the frame one level above (root at depth 0).
+-- Multiple rows may cover the same `(root_id, ts)`; pair with
+-- `_critical_path_flatten!` to collapse to one blocker per
+-- `(root_id, ts)`.
 CREATE PERFETTO MACRO _critical_path_with_depth_by_roots(
     _roots_table TableOrSubQuery,
     _node_table TableOrSubQuery
@@ -402,6 +402,7 @@ RETURNS TableOrSubQuery AS
     c2 AS ts,
     c3 AS dur,
     c4 AS id,
+    c5 AS blocker_utid,
     c6 AS parent_id
   FROM __intrinsic_table_ptr(
     __intrinsic_critical_path_walk(
@@ -427,13 +428,11 @@ RETURNS TableOrSubQuery AS
     AND __intrinsic_table_ptr_bind(c6, 'parent_id')
 );
 
--- Critical path for the given roots, one blocker per `(root_id, ts)`.
--- Pair with `_intervals_to_roots` to compute the path over a sparse
--- time region (e.g. binder transactions) without walking the whole
--- trace.
-CREATE PERFETTO MACRO _critical_path_by_roots(
-    _roots_table TableOrSubQuery,
-    _node_table TableOrSubQuery
+-- Collapses with-depth critical-path frames to one blocker per
+-- `(root_id, ts)`: deeper frames win where they have coverage,
+-- shallower frames fill the gaps.
+CREATE PERFETTO MACRO _critical_path_flatten(
+    _frames_table TableOrSubQuery
 )
 RETURNS TableOrSubQuery AS
 (
@@ -441,7 +440,7 @@ RETURNS TableOrSubQuery AS
     _frames AS (
       SELECT
         *
-      FROM _critical_path_with_depth_by_roots!($_roots_table, $_node_table)
+      FROM $_frames_table
     ),
     _root_spans AS (
       SELECT
@@ -476,6 +475,27 @@ RETURNS TableOrSubQuery AS
   GROUP BY
     flat.root_id,
     flat.ts
+);
+
+-- Critical path for the given roots, one blocker per `(root_id, ts)`.
+-- Pair with `_intervals_to_roots` to compute the path over a sparse
+-- time region (e.g. binder transactions) without walking the whole
+-- trace.
+CREATE PERFETTO MACRO _critical_path_by_roots(
+    _roots_table TableOrSubQuery,
+    _node_table TableOrSubQuery
+)
+RETURNS TableOrSubQuery AS
+(
+  WITH
+    _cp_frames AS (
+      SELECT
+        *
+      FROM _critical_path_with_depth_by_roots!($_roots_table, $_node_table)
+    )
+  SELECT
+    *
+  FROM _critical_path_flatten!(_cp_frames)
 );
 
 -- Generates the critical path for only the time intervals for the utids given.
@@ -542,6 +562,159 @@ RETURNS TableOrSubQuery AS
     ON _span.id = ii.id_0
   JOIN _intervals
     ON _intervals.id = ii.id_1
+);
+
+-- With-depth critical-path frames clipped to the supplied user intervals.
+-- Same shape as `_critical_path_with_depth_by_roots!`, with `(ts, dur)`
+-- intersected against the input intervals and one canonical row per
+-- `(utid, depth, ts, dur)` (smallest `root_id` wins). `root_id` is
+-- kept in the output so callers can join `(root_id, parent_id)` of
+-- depth-(N+1) rows to `(root_id, id)` of depth-N rows within the
+-- same chain; aliasing across chains would otherwise occur.
+CREATE PERFETTO MACRO _critical_path_with_depth_by_intervals(
+    _intervals_table TableOrSubQuery,
+    _node_table TableOrSubQuery
+)
+RETURNS TableOrSubQuery AS
+(
+  WITH
+    _nodes AS (
+      SELECT
+        *
+      FROM $_node_table
+    ),
+    _raw_intervals AS (
+      SELECT
+        ts,
+        dur,
+        utid
+      FROM $_intervals_table
+    ),
+    _intervals AS (
+      SELECT
+        row_number() OVER (ORDER BY ts) AS id,
+        ts,
+        dur,
+        utid AS root_utid
+      FROM _raw_intervals
+    ),
+    _frames AS (
+      SELECT
+        row_number() OVER (ORDER BY ts) AS id,
+        root_id,
+        depth,
+        parent_id,
+        id AS cr_id,
+        ts,
+        dur
+      FROM _critical_path_with_depth_by_roots!(
+        _intervals_to_roots!(_raw_intervals, _nodes), _nodes)
+    ),
+    _span AS (
+      SELECT
+        _root_nodes.utid AS root_utid,
+        _nodes.utid,
+        cr.root_id,
+        cr.depth,
+        cr.parent_id,
+        cr.cr_id,
+        cr.id,
+        cr.ts,
+        cr.dur
+      FROM _frames AS cr
+      JOIN _nodes AS _root_nodes
+        ON _root_nodes.id = cr.root_id
+      JOIN _nodes
+        ON _nodes.id = cr.cr_id
+    ),
+    _intersected AS (
+      SELECT
+        _span.root_utid,
+        _span.root_id,
+        _span.utid,
+        _span.depth,
+        _span.cr_id AS id,
+        _span.parent_id,
+        ii.ts,
+        ii.dur
+      FROM _interval_intersect!((_span, _intervals), (root_utid)) AS ii
+      JOIN _span
+        ON _span.id = ii.id_0
+    ),
+    -- Multiple roots can cover the same frame after interval
+    -- intersection; rank by root_id within each frame group so the
+    -- outer SELECT keeps one row per frame (smallest root_id wins).
+    _dedup_ranked AS (
+      SELECT
+        root_utid,
+        root_id,
+        utid,
+        depth,
+        id,
+        parent_id,
+        ts,
+        dur,
+        row_number() OVER (PARTITION BY root_utid, utid, depth, ts, dur ORDER BY root_id) AS rn
+      FROM _intersected
+    )
+  SELECT
+    root_utid,
+    root_id,
+    utid,
+    depth,
+    id,
+    parent_id,
+    ts,
+    dur
+  FROM _dedup_ranked
+  WHERE
+    rn = 1
+);
+
+-- Given a with-depth critical-path output and a set of anchor row ids,
+-- returns the depth-(N+1) frames whose `(root_id, parent_node_id)`
+-- matches an anchor's `(root_id, node_id)` — the per-anchor "next
+-- blocker" frames.
+--
+-- The `_frames` argument must expose:
+--   id LONG (unique per row),
+--   root_id LONG, node_id LONG, parent_node_id LONG,
+--   depth LONG, ts TIMESTAMP, dur DURATION, utid JOINID(thread.id).
+-- The `_anchors` argument must expose `id` matching `_frames.id`.
+CREATE PERFETTO MACRO _critical_path_next_blockers(
+    _frames TableOrSubQuery,
+    _anchors TableOrSubQuery
+)
+RETURNS TableOrSubQuery AS
+(
+  WITH
+    _anchor_keys AS (
+      SELECT DISTINCT
+        depth + 1 AS child_depth,
+        root_id,
+        node_id
+      FROM $_frames
+      WHERE
+        id IN (
+          SELECT
+            id
+          FROM $_anchors
+        )
+    )
+  SELECT
+    frames.id,
+    frames.root_id,
+    frames.node_id,
+    frames.parent_node_id,
+    frames.depth,
+    frames.ts,
+    frames.dur,
+    frames.utid
+  FROM $_frames AS frames
+  JOIN _anchor_keys AS k
+    ON frames.depth = k.child_depth
+    AND frames.root_id = k.root_id
+    AND frames.parent_node_id = k.node_id
 );
 
 -- Generates the critical path for a given utid over the <ts, dur> interval.

--- a/test/trace_processor/diff_tests/tables/tests_sched.py
+++ b/test/trace_processor/diff_tests/tables/tests_sched.py
@@ -353,6 +353,117 @@ class TablesSched(TestSuite):
         12521,1477,12521,1737407641875,1830015,1477
         """))
 
+  # parent_id on each with-depth frame is the wakeup-graph node id of the
+  # depth-(N-1) thread that descended into this frame via waker_id.
+  # Validates that every depth-N row's parent_id resolves to a row at
+  # depth N-1 within the same root_id — i.e. (id, parent_id) forms a
+  # proper tree the UI can drill by `WHERE parent_id IN (...)`. At
+  # depth 0 parent_id == id (self-reference).
+  def test_thread_executing_span_critical_path_parent_id_tree(self):
+    return DiffTestBlueprint(
+        trace=DataPath('sched_wakeup_trace.atr'),
+        query="""
+        INCLUDE PERFETTO MODULE sched.thread_executing_span;
+        WITH cp AS (
+          SELECT
+            root_id,
+            depth,
+            id,
+            parent_id
+          FROM _critical_path_with_depth_by_roots!(
+            (SELECT id AS root_node_id FROM _wakeup_graph LIMIT 200),
+            _wakeup_graph)
+        ),
+        joined AS (
+          SELECT
+            a.depth AS depth,
+            (SELECT b.depth FROM cp b
+             WHERE b.id = a.parent_id AND b.root_id = a.root_id LIMIT 1) AS parent_depth,
+            (a.depth = 0 AND a.parent_id = a.id) AS depth0_self,
+            (a.depth > 0 AND a.parent_id != a.id) AS deeper_real_parent
+          FROM cp a
+        )
+        SELECT
+          depth,
+          COUNT(*) AS rows_at_depth,
+          SUM(CASE WHEN depth = 0 THEN depth0_self ELSE deeper_real_parent END) AS rows_with_valid_link,
+          SUM(CASE WHEN depth > 0 AND parent_depth = depth - 1 THEN 1 ELSE 0 END) AS rows_with_parent_one_shallower
+        FROM joined
+        GROUP BY depth
+        ORDER BY depth
+        """,
+        out=Csv("""
+        "depth","rows_at_depth","rows_with_valid_link","rows_with_parent_one_shallower"
+        0,224,224,0
+        1,159,159,159
+        2,99,99,99
+        3,34,34,34
+        4,10,10,10
+        """))
+
+  # `_critical_path_next_blockers!` is the per-track drill query the
+  # UI emits: given the with-depth critical-path output and a set of
+  # anchor row ids, return the depth-(N+1) frames that immediately
+  # block the anchor frames within the same chain. The track label
+  # is the anchor (blocked) thread; the slices come from this macro.
+  #
+  # This test mirrors the UI's exact SQL shape — build the with-depth frames
+  # perfetto table the same way, anchor on the root utid's depth-0
+  # frames, then call _critical_path_next_blockers! and join thread.
+  def test_critical_path_next_blockers(self):
+    return DiffTestBlueprint(
+        trace=DataPath('sched_wakeup_trace.atr'),
+        query="""
+        INCLUDE PERFETTO MODULE sched.thread_executing_span;
+
+        CREATE PERFETTO TABLE _frames AS
+        SELECT
+          row_number() OVER (ORDER BY cr.depth, cr.ts) AS id,
+          cr.root_id AS root_id,
+          cr.id AS node_id,
+          cr.parent_id AS parent_node_id,
+          cr.depth AS depth,
+          cr.ts AS ts,
+          ifnull(CAST(cr.dur AS INT), -1) AS dur,
+          cr.utid AS utid
+        FROM _critical_path_with_depth_by_intervals!(
+               (SELECT
+                  (SELECT utid FROM thread WHERE tid = 3487) AS utid,
+                  start_ts AS ts,
+                  end_ts - start_ts AS dur
+                FROM trace_bounds),
+               _wakeup_graph) AS cr;
+
+        WITH anchors AS (
+          SELECT id FROM _frames
+          WHERE depth = 0
+            AND utid = (SELECT utid FROM thread WHERE tid = 3487)
+        )
+        SELECT
+          blocker.depth,
+          blocker.ts,
+          blocker.dur,
+          blocker.utid,
+          thread.name AS thread_name
+        FROM _critical_path_next_blockers!(_frames, anchors) AS blocker
+        JOIN thread USING (utid)
+        ORDER BY blocker.ts, blocker.utid
+        LIMIT 10
+        """,
+        out=Csv("""
+        "depth","ts","dur","utid","thread_name"
+        1,1737357107000,547583,1480,"Signal Catcher"
+        1,1737366085345,50400,91,"servicemanager"
+        1,1737372771672,12594070,1488,"binder:3487_1"
+        1,1737385365742,204244,1488,"binder:3487_1"
+        1,1737407400608,241267,91,"servicemanager"
+        1,1737409471890,68590,91,"servicemanager"
+        1,1737461767363,436324,649,"binder:642_E"
+        1,1737462291210,245422,649,"binder:642_E"
+        1,1737463573333,393487,649,"binder:642_E"
+        1,1737464047330,251025,649,"binder:642_E"
+        """))
+
   def test_thread_executing_span_critical_path_stack(self):
     return DiffTestBlueprint(
         trace=DataPath('sched_wakeup_trace.atr'),

--- a/ui/src/plugins/dev.perfetto.CriticalPath/critical_path_tree.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/critical_path_tree.ts
@@ -67,6 +67,7 @@ export class CriticalPathTreePin {
     private readonly rootName: string,
     private readonly windowTs: bigint,
     private readonly windowDur: bigint,
+    private readonly parentTrackUri: string,
   ) {}
 
   async pin(): Promise<void> {
@@ -99,8 +100,11 @@ export class CriticalPathTreePin {
       });
     }
 
+    const parent = this.ctx.currentWorkspace.getTrackByUri(this.parentTrackUri);
+    if (parent === undefined) return;
     const rootNode = await this.makeRootNode(rootAnchors);
-    this.ctx.currentWorkspace.pinnedTracksNode.addChildLast(rootNode);
+    parent.addChildLast(rootNode);
+    parent.expand();
   }
 
   // One row per chain frame: each `(depth, utid)` frame in the
@@ -401,7 +405,7 @@ export class CriticalPathTreePin {
   private async makeRootNode(rootAnchors: number[]): Promise<TrackNode> {
     return this.makeThreadTrack(
       0,
-      this.rootName,
+      `Critical path of ${this.rootName}`,
       rootAnchors,
       /* removable=*/ true,
     );

--- a/ui/src/plugins/dev.perfetto.CriticalPath/critical_path_tree.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/critical_path_tree.ts
@@ -1,0 +1,409 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {SliceTrack} from '../../components/tracks/slice_track';
+import {getColorForSlice} from '../../components/colorizer';
+import {Trace} from '../../public/trace';
+import {TrackNode} from '../../public/workspace';
+import {showModal} from '../../widgets/modal';
+import {LONG, NUM, STR, STR_NULL} from '../../trace_processor/query_result';
+import {SourceDataset} from '../../trace_processor/dataset';
+import {DebugSliceTrackDetailsPanel} from '../../components/tracks/debug_slice_track_details_panel';
+import {createPerfettoTable} from '../../trace_processor/sql_utils';
+
+type ChildThread = {
+  utid: number;
+  name: string | null;
+  rowIds: number[];
+  firstTs: bigint;
+};
+
+const PER_TRACK_SLICE_SCHEMA = {
+  id: NUM,
+  ts: LONG,
+  dur: LONG,
+  name: STR,
+  // raw_* expose the thread_state row backing each slice so the
+  // details panel can jump to it.
+  raw_id: NUM,
+  raw_table_name: STR,
+  raw_utid: NUM,
+};
+
+// Pins one critical-path drill-down tree for a (root utid, window).
+// Each instance owns a per-invocation set of perfetto tables and a
+// track URI namespace, so concurrent pins don't collide.
+//
+// A track at depth N for thread U shows full coverage of U's
+// chain: own frames (depth N) named after U, and every deeper
+// frame attributed to its depth-(N+1) ancestor in the chain
+// (named after that ancestor's thread = the immediate blocker).
+// The depth-N and depth-(N+1) ancestor maps are built once via
+// `_graph_aggregating_scan!` over a dense renumbering of chain
+// nodes (graphs.scan requires dense ids).
+export class CriticalPathTreePin {
+  private framesTable = '';
+  private denseNodesTable = '';
+  private denseEdgesTable = '';
+  private hasChildrenTable = '';
+  private baseUri = '';
+  private readonly builtAncDepths = new Set<number>();
+  private nextTrackId = 0;
+
+  constructor(
+    private readonly ctx: Trace,
+    private readonly rootUtid: number,
+    private readonly rootName: string,
+    private readonly windowTs: bigint,
+    private readonly windowDur: bigint,
+  ) {}
+
+  async pin(): Promise<void> {
+    await this.ctx.engine.query(
+      `INCLUDE PERFETTO MODULE sched.thread_executing_span;`,
+    );
+    await this.ctx.engine.query(`INCLUDE PERFETTO MODULE graphs.scan;`);
+    await this.createFrames();
+    if (await this.isFramesEmpty()) {
+      return showModal({
+        title: 'Critical path: no chain found',
+        content:
+          'No wakeup-graph attribution for this thread over this ' +
+          'window. Trace may be missing sched_switch / sched_waking, ' +
+          'or this thread never slept with a recorded waker.',
+      });
+    }
+    await this.createDenseNodes();
+    await this.createDenseEdges();
+    await this.createHasChildren();
+
+    const rootAnchors = await this.fetchRootAnchors();
+    if (rootAnchors.length === 0) {
+      return showModal({
+        title: 'Critical path: root has no on-CPU contribution',
+        content:
+          'The root thread does not appear at depth 0 in the chain ' +
+          'frames for this window — the chain may be entirely from ' +
+          'wakers with no self-runs in this range.',
+      });
+    }
+
+    const rootNode = await this.makeRootNode(rootAnchors);
+    this.ctx.currentWorkspace.pinnedTracksNode.addChildLast(rootNode);
+  }
+
+  // One row per chain frame: each `(depth, utid)` frame in the
+  // critical path of `rootUtid` over the window.
+  private async createFrames(): Promise<void> {
+    const t = await createPerfettoTable({
+      engine: this.ctx.engine,
+      as: `
+        SELECT
+          row_number() OVER (ORDER BY cr.depth, cr.ts) AS id,
+          cr.root_id AS root_id,
+          cr.id AS node_id,
+          cr.parent_id AS parent_node_id,
+          cr.depth AS depth,
+          cr.ts AS ts,
+          ifnull(CAST(cr.dur AS INT), -1) AS dur,
+          cr.utid AS utid,
+          thread.name AS thread_name
+        FROM _critical_path_with_depth_by_intervals!(
+               (SELECT ${this.rootUtid} AS utid,
+                       ${this.windowTs.toString()} AS ts,
+                       ${this.windowDur.toString()} AS dur),
+               _wakeup_graph) AS cr
+        JOIN thread USING (utid)
+      `,
+    });
+    this.framesTable = t.name;
+    this.baseUri = `dev.perfetto.CriticalPathTree.${this.framesTable}`;
+    await this.ctx.engine.query(`
+      CREATE PERFETTO INDEX ${this.framesTable}_child_idx
+        ON ${this.framesTable}(depth, root_id, parent_node_id)
+    `);
+  }
+
+  private async isFramesEmpty(): Promise<boolean> {
+    const r = await this.ctx.engine.query(
+      `SELECT COUNT(*) AS n FROM ${this.framesTable}`,
+    );
+    return r.firstRow({n: NUM}).n === 0;
+  }
+
+  // Dense [1..N] renumbering of (root_id, node_id) — graphs.scan
+  // requires dense node ids; wakeup-graph node_ids are sparse.
+  private async createDenseNodes(): Promise<void> {
+    const t = await createPerfettoTable({
+      engine: this.ctx.engine,
+      as: `
+        SELECT row_number() OVER (ORDER BY root_id, node_id) AS dense_id,
+               root_id, node_id,
+               MAX(parent_node_id) AS parent_node_id,
+               MAX(depth) AS depth, MAX(utid) AS utid
+        FROM ${this.framesTable}
+        GROUP BY root_id, node_id
+      `,
+    });
+    this.denseNodesTable = t.name;
+    await this.ctx.engine.query(`
+      CREATE PERFETTO INDEX ${this.denseNodesTable}_lookup
+        ON ${this.denseNodesTable}(root_id, node_id)
+    `);
+    await this.ctx.engine.query(`
+      CREATE PERFETTO INDEX ${this.denseNodesTable}_id
+        ON ${this.denseNodesTable}(dense_id)
+    `);
+  }
+
+  // (parent dense_id -> child dense_id) within each chain. The
+  // with-depth macro emits parent_node_id = node_id for depth-0
+  // rows; that self-loop must be filtered, graphs.scan requires a
+  // DAG.
+  private async createDenseEdges(): Promise<void> {
+    const t = await createPerfettoTable({
+      engine: this.ctx.engine,
+      as: `
+        SELECT p.dense_id AS source_node_id, c.dense_id AS dest_node_id
+        FROM ${this.denseNodesTable} c
+        JOIN ${this.denseNodesTable} p
+          ON p.root_id = c.root_id AND p.node_id = c.parent_node_id
+        WHERE c.parent_node_id IS NOT NULL
+          AND c.parent_node_id <> c.node_id
+      `,
+    });
+    this.denseEdgesTable = t.name;
+  }
+
+  // Frame ids that have at least one direct child; used to suppress
+  // the expand arrow on terminal tracks.
+  private async createHasChildren(): Promise<void> {
+    const t = await createPerfettoTable({
+      engine: this.ctx.engine,
+      as: `
+        SELECT DISTINCT p.id AS row_id
+        FROM ${this.framesTable} p
+        JOIN ${this.framesTable} c
+          ON c.root_id = p.root_id
+         AND c.parent_node_id = p.node_id
+         AND c.depth = p.depth + 1
+      `,
+    });
+    this.hasChildrenTable = t.name;
+  }
+
+  private async anyAnchorHasChildren(
+    rowIds: ReadonlyArray<number>,
+  ): Promise<boolean> {
+    if (rowIds.length === 0) return false;
+    const r = await this.ctx.engine.query(`
+      SELECT COUNT(*) AS n FROM ${this.hasChildrenTable}
+      WHERE row_id IN (${rowIds.join(',')})
+    `);
+    return r.firstRow({n: NUM}).n > 0;
+  }
+
+  // Per-depth ancestor map (dense_id -> depth-D ancestor),
+  // memoised across sibling tracks.
+  private ancTableForDepth(d: number): string {
+    return `${this.framesTable}_anc_d${d}`;
+  }
+
+  private async ensureAncTable(d: number): Promise<void> {
+    if (this.builtAncDepths.has(d)) return;
+    this.builtAncDepths.add(d);
+    const t = this.ancTableForDepth(d);
+    await this.ctx.engine.query(`
+      CREATE PERFETTO TABLE ${t} AS
+      SELECT id AS dense_id, anc_id
+      FROM _graph_aggregating_scan!(
+        ${this.denseEdgesTable},
+        (SELECT dense_id AS id, dense_id AS anc_id
+         FROM ${this.denseNodesTable} WHERE depth = ${d}),
+        (anc_id),
+        (SELECT id, MIN(anc_id) AS anc_id FROM $table GROUP BY id))
+    `);
+    await this.ctx.engine.query(`
+      CREATE PERFETTO INDEX ${t}_idx ON ${t}(dense_id)
+    `);
+  }
+
+  // For a track at depth N for thread U:
+  //   * Frames at any depth M >= N whose depth-N ancestor is one of
+  //     our anchors are in our chain.
+  //   * Slice name & raw_id come from the depth-(N+1) ancestor (the
+  //     immediate blocker); when M = N (own on-CPU frame) the name
+  //     comes from the frame itself.
+  private async registerTrack(
+    depth: number,
+    rowIds: ReadonlyArray<number>,
+  ): Promise<string> {
+    const uri = `${this.baseUri}.t${this.nextTrackId++}`;
+    const anchorIdsCsv = rowIds.join(',');
+    await this.ensureAncTable(depth);
+    await this.ensureAncTable(depth + 1);
+    const ancTable = this.ancTableForDepth(depth);
+    const blkTable = this.ancTableForDepth(depth + 1);
+    let materializedTableName = '';
+    const renderer = await SliceTrack.createMaterialized({
+      trace: this.ctx,
+      uri,
+      dataset: new SourceDataset({
+        schema: PER_TRACK_SLICE_SCHEMA,
+        src: `WITH anchors_dense AS (
+                SELECT DISTINCT dn.dense_id
+                FROM ${this.framesTable} f
+                JOIN ${this.denseNodesTable} dn
+                  ON dn.root_id = f.root_id AND dn.node_id = f.node_id
+                WHERE f.id IN (${anchorIdsCsv})
+              ),
+              picked AS (
+                SELECT
+                  f.ts, f.dur, f.depth,
+                  CASE WHEN f.depth = ${depth}
+                       THEN f.utid ELSE blk.utid END AS slice_utid,
+                  CASE WHEN f.depth = ${depth}
+                       THEN f.node_id ELSE blk.node_id END AS slice_node_id
+                FROM ${this.framesTable} f
+                JOIN ${this.denseNodesTable} dn
+                  ON dn.root_id = f.root_id AND dn.node_id = f.node_id
+                JOIN ${ancTable} ad ON ad.dense_id = dn.dense_id
+                JOIN anchors_dense ax ON ax.dense_id = ad.anc_id
+                LEFT JOIN ${blkTable} bd ON bd.dense_id = dn.dense_id
+                LEFT JOIN ${this.denseNodesTable} blk
+                  ON blk.dense_id = bd.anc_id
+                WHERE f.depth >= ${depth}
+              )
+              SELECT
+                row_number() OVER (ORDER BY p.ts) AS id,
+                p.ts, p.dur,
+                coalesce(thread.name, 'utid ' || p.slice_utid) AS name,
+                p.slice_node_id AS raw_id,
+                'thread_state' AS raw_table_name,
+                p.slice_utid AS raw_utid
+              FROM picked p
+              JOIN thread ON thread.utid = p.slice_utid`,
+      }),
+      colorizer: (row) => getColorForSlice(row.name),
+      detailsPanel: (row) =>
+        new DebugSliceTrackDetailsPanel(
+          this.ctx,
+          materializedTableName,
+          row.id,
+        ),
+    });
+    materializedTableName = renderer.getDataset()?.src ?? '';
+    this.ctx.tracks.registerTrack({uri, renderer});
+    return uri;
+  }
+
+  // Returns the depth-(N+1) child threads of the given anchors,
+  // ordered by first appearance.
+  private async queryChildren(
+    parentAnchorRowIds: ReadonlyArray<number>,
+  ): Promise<ChildThread[]> {
+    if (parentAnchorRowIds.length === 0) return [];
+    const res = await this.ctx.engine.query(`
+      SELECT c.id AS row_id, c.utid, c.ts, c.thread_name AS tname
+      FROM ${this.framesTable} p
+      JOIN ${this.framesTable} c
+        ON c.root_id = p.root_id
+       AND c.parent_node_id = p.node_id
+       AND c.depth = p.depth + 1
+      WHERE p.id IN (${parentAnchorRowIds.join(',')})
+      ORDER BY c.ts
+    `);
+    const it = res.iter({
+      row_id: NUM,
+      utid: NUM,
+      ts: LONG,
+      tname: STR_NULL,
+    });
+    const byUtid = new Map<number, ChildThread>();
+    for (; it.valid(); it.next()) {
+      let th = byUtid.get(it.utid);
+      if (!th) {
+        th = {utid: it.utid, name: it.tname, rowIds: [], firstTs: it.ts};
+        byUtid.set(it.utid, th);
+      }
+      th.rowIds.push(it.row_id);
+      if (it.ts < th.firstTs) th.firstTs = it.ts;
+    }
+    return Array.from(byUtid.values()).sort((a, b) =>
+      a.firstTs < b.firstTs ? -1 : a.firstTs > b.firstTs ? 1 : 0,
+    );
+  }
+
+  // Thread track at the given depth; depth-(N+1) child threads (if
+  // any) are queried and minted on first expand.
+  private async makeThreadTrack(
+    depth: number,
+    label: string,
+    rowIds: ReadonlyArray<number>,
+    removable = false,
+  ): Promise<TrackNode> {
+    const uri = await this.registerTrack(depth, rowIds);
+    if (!(await this.anyAnchorHasChildren(rowIds))) {
+      return new TrackNode({uri, name: label, removable});
+    }
+    let opened = false;
+    const node = new TrackNode({
+      uri,
+      name: label,
+      removable,
+      onExpand: () => {
+        if (opened) return;
+        opened = true;
+        void (async () => {
+          const children = await this.queryChildren(rowIds);
+          const childNodes = await Promise.all(
+            children.map((c) =>
+              this.makeThreadTrack(
+                depth + 1,
+                c.name ?? `<utid ${c.utid}>`,
+                c.rowIds,
+              ),
+            ),
+          );
+          for (const c of [...node.children]) node.removeChild(c);
+          for (const c of childNodes) node.addChildLast(c);
+        })();
+      },
+    });
+    // Empty placeholder so the parent shows an expand arrow before
+    // its real children are loaded; replaced on first expand.
+    node.addChildLast(new TrackNode({name: '', headless: true}));
+    return node;
+  }
+
+  private async fetchRootAnchors(): Promise<number[]> {
+    const r = await this.ctx.engine.query(`
+      SELECT id FROM ${this.framesTable}
+      WHERE depth = 0 AND utid = ${this.rootUtid}
+      ORDER BY ts
+    `);
+    const out: number[] = [];
+    for (const it = r.iter({id: NUM}); it.valid(); it.next()) out.push(it.id);
+    return out;
+  }
+
+  private async makeRootNode(rootAnchors: number[]): Promise<TrackNode> {
+    return this.makeThreadTrack(
+      0,
+      this.rootName,
+      rootAnchors,
+      /* removable=*/ true,
+    );
+  }
+}

--- a/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
@@ -25,7 +25,8 @@ import {
   CRITICAL_PATH_LITE_CMD,
 } from '../../public/exposed_commands';
 import {getTimeSpanOfSelectionOrVisibleWindow} from '../../public/utils';
-import {NUM} from '../../trace_processor/query_result';
+import {LONG, NUM} from '../../trace_processor/query_result';
+import {CriticalPathTreePin} from './critical_path_tree';
 
 const criticalPathSliceColumns = {
   ts: 'ts',
@@ -39,22 +40,6 @@ const criticalPathsliceColumnNames = [
   'ts',
   'dur',
   'name',
-  'table_name',
-];
-
-const criticalPathsliceLiteColumns = {
-  ts: 'ts',
-  dur: 'dur',
-  name: 'thread_name',
-};
-
-const criticalPathsliceLiteColumnNames = [
-  'id',
-  'utid',
-  'ts',
-  'dur',
-  'thread_name',
-  'process_name',
   'table_name',
 ];
 
@@ -155,12 +140,9 @@ export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.CriticalPath';
   static readonly dependencies = [QueryPagePlugin];
   async onTraceLoad(ctx: Trace): Promise<void> {
-    // The 3 commands below are used in two contextes:
-    // 1. By clicking a slice and using the command palette. In this case the
-    //    utid argument is undefined and we need to look at the selection.
-    // 2. Invoked via runCommand(...) by thread_state_tab.ts when the user
-    //    clicks on the buttons in the details panel. In this case the details
-    //    panel passes the utid explicitly.
+    // Each command is invoked either from the command palette (utid
+    // resolved from the current selection) or via runCommand(utid)
+    // from the thread-state details panel.
     ctx.commands.registerCommand({
       id: CRITICAL_PATH_LITE_CMD,
       name: 'Critical path lite (selected thread state slice)',
@@ -169,43 +151,121 @@ export default class implements PerfettoPlugin {
         if (thdInfo === undefined) {
           return showModalErrorThreadStateRequired();
         }
-        ctx.engine
-          .query(`INCLUDE PERFETTO MODULE sched.thread_executing_span;`)
-          .then(() =>
-            addDebugSliceTrack({
-              trace: ctx,
-              data: {
-                sqlSource: `
-                SELECT
-                  cr.id,
-                  cr.utid,
-                  cr.ts,
-                  cr.dur,
-                  thread.name AS thread_name,
-                  process.name AS process_name,
-                  'thread_state' AS table_name
-                FROM
-                  _thread_executing_span_critical_path(
-                    ${thdInfo.utid},
-                    trace_bounds.start_ts,
-                    trace_bounds.end_ts - trace_bounds.start_ts) cr,
-                  trace_bounds
-                JOIN thread USING(utid)
-                LEFT JOIN process USING(upid)
-              `,
-                columns: sliceLiteColumnNames,
-              },
-              title: `${thdInfo.name}`,
-              columns: sliceLiteColumns,
-              rawColumns: sliceLiteColumnNames,
-            }),
-          );
+        await ctx.engine.query(
+          `INCLUDE PERFETTO MODULE sched.thread_executing_span;`,
+        );
+        await addDebugSliceTrack({
+          trace: ctx,
+          data: {
+            sqlSource: `
+              SELECT
+                cr.id,
+                cr.utid,
+                cr.ts,
+                cr.dur,
+                thread.name AS thread_name,
+                process.name AS process_name,
+                'thread_state' AS table_name
+              FROM
+                _thread_executing_span_critical_path(
+                  ${thdInfo.utid},
+                  trace_bounds.start_ts,
+                  trace_bounds.end_ts - trace_bounds.start_ts) cr,
+                trace_bounds
+              JOIN thread USING (utid)
+              LEFT JOIN process USING (upid)
+            `,
+            columns: sliceLiteColumnNames,
+          },
+          title: `${thdInfo.name}`,
+          columns: sliceLiteColumns,
+          rawColumns: sliceLiteColumnNames,
+        });
+      },
+    });
+
+    ctx.commands.registerCommand({
+      id: 'dev.perfetto.CriticalPathLite_AreaSelection',
+      name: 'Critical path lite (over area selection)',
+      callback: async () => {
+        const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
+        const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
+        if (trackUtid === 0) return showModalErrorAreaSelectionRequired();
+        await ctx.engine.query(
+          `INCLUDE PERFETTO MODULE sched.thread_executing_span;`,
+        );
+        await addDebugSliceTrack({
+          trace: ctx,
+          data: {
+            sqlSource: `
+              SELECT
+                cr.id,
+                cr.utid,
+                cr.ts,
+                cr.dur,
+                thread.name AS thread_name,
+                process.name AS process_name,
+                'thread_state' AS table_name
+              FROM
+                _thread_executing_span_critical_path(
+                  ${trackUtid},
+                  ${window.start},
+                  ${window.end} - ${window.start}) cr
+              JOIN thread USING (utid)
+              LEFT JOIN process USING (upid)
+            `,
+            columns: sliceLiteColumnNames,
+          },
+          title:
+            (await getThreadInfo(ctx.engine, trackUtid as Utid)).name ??
+            '<thread name>',
+          columns: sliceLiteColumns,
+          rawColumns: sliceLiteColumnNames,
+        });
+      },
+    });
+
+    ctx.commands.registerCommand({
+      id: 'dev.perfetto.CriticalPathTree',
+      name: 'Critical path tree (selected thread state slice)',
+      callback: async (utidArg) => {
+        const thdInfo = await getThreadInfoForUtidOrSelection(ctx, utidArg);
+        if (thdInfo === undefined) return showModalErrorThreadStateRequired();
+        const tb = await ctx.engine.query(
+          `SELECT start_ts AS s, end_ts AS e FROM trace_bounds`,
+        );
+        const tbRow = tb.firstRow({s: LONG, e: LONG});
+        await new CriticalPathTreePin(
+          ctx,
+          thdInfo.utid,
+          thdInfo.name ?? `utid ${thdInfo.utid}`,
+          tbRow.s,
+          tbRow.e - tbRow.s,
+        ).pin();
+      },
+    });
+
+    ctx.commands.registerCommand({
+      id: 'dev.perfetto.CriticalPathTree_AreaSelection',
+      name: 'Critical path tree (over area selection)',
+      callback: async () => {
+        const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
+        const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
+        if (trackUtid === 0) return showModalErrorAreaSelectionRequired();
+        const thdInfo = await getThreadInfo(ctx.engine, trackUtid as Utid);
+        await new CriticalPathTreePin(
+          ctx,
+          trackUtid,
+          thdInfo.name ?? `utid ${trackUtid}`,
+          window.start,
+          window.end - window.start,
+        ).pin();
       },
     });
 
     ctx.commands.registerCommand({
       id: CRITICAL_PATH_CMD,
-      name: 'Critical path (selected thread state slice)',
+      name: 'Critical path stacks (selected thread state slice)',
       callback: async (utidArg) => {
         const thdInfo = await getThreadInfoForUtidOrSelection(ctx, utidArg);
         if (thdInfo === undefined) {
@@ -239,51 +299,8 @@ export default class implements PerfettoPlugin {
     });
 
     ctx.commands.registerCommand({
-      id: 'dev.perfetto.CriticalPathLite_AreaSelection',
-      name: 'Critical path lite (over area selection)',
-      callback: async () => {
-        const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
-        const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
-        if (trackUtid === 0) {
-          return showModalErrorAreaSelectionRequired();
-        }
-        await ctx.engine.query(
-          `INCLUDE PERFETTO MODULE sched.thread_executing_span;`,
-        );
-        await addDebugSliceTrack({
-          trace: ctx,
-          data: {
-            sqlSource: `
-                SELECT
-                  cr.id,
-                  cr.utid,
-                  cr.ts,
-                  cr.dur,
-                  thread.name AS thread_name,
-                  process.name AS process_name,
-                  'thread_state' AS table_name
-                FROM
-                  _thread_executing_span_critical_path(
-                      ${trackUtid},
-                      ${window.start},
-                      ${window.end} - ${window.start}) cr
-                JOIN thread USING(utid)
-                LEFT JOIN process USING(upid)
-                `,
-            columns: criticalPathsliceLiteColumnNames,
-          },
-          title:
-            (await getThreadInfo(ctx.engine, trackUtid as Utid)).name ??
-            '<thread name>',
-          columns: criticalPathsliceLiteColumns,
-          rawColumns: criticalPathsliceLiteColumnNames,
-        });
-      },
-    });
-
-    ctx.commands.registerCommand({
       id: 'dev.perfetto.CriticalPath_AreaSelection',
-      name: 'Critical path  (over area selection)',
+      name: 'Critical path stacks (over area selection)',
       callback: async () => {
         const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
         const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);

--- a/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
+++ b/ui/src/plugins/dev.perfetto.CriticalPath/index.ts
@@ -19,6 +19,7 @@ import {THREAD_STATE_TRACK_KIND} from '../../public/track_kinds';
 import {PerfettoPlugin} from '../../public/plugin';
 import {asUtid, Utid} from '../../components/sql_utils/core_types';
 import QueryPagePlugin from '../dev.perfetto.QueryPage';
+import SchedPlugin from '../dev.perfetto.Sched';
 import {showModal} from '../../widgets/modal';
 import {
   CRITICAL_PATH_CMD,
@@ -60,19 +61,24 @@ const sliceColumns = {ts: 'ts', dur: 'dur', name: 'name'};
 const sliceColumnNames = ['id', 'utid', 'ts', 'dur', 'name', 'table_name'];
 
 function getFirstUtidOfSelectionOrVisibleWindow(trace: Trace): number {
+  return getThreadStateTracksInArea(trace)[0]?.utid ?? 0;
+}
+
+function getThreadStateTracksInArea(
+  trace: Trace,
+): ReadonlyArray<{utid: number; uri: string}> {
   const selection = trace.selection.selection;
-  if (selection.kind === 'area') {
-    for (const trackDesc of selection.tracks) {
-      if (
-        trackDesc?.tags?.kinds?.includes(THREAD_STATE_TRACK_KIND) &&
-        trackDesc?.tags?.utid !== undefined
-      ) {
-        return trackDesc.tags.utid;
-      }
+  if (selection.kind !== 'area') return [];
+  const out: {utid: number; uri: string}[] = [];
+  for (const trackDesc of selection.tracks) {
+    if (
+      trackDesc?.tags?.kinds?.includes(THREAD_STATE_TRACK_KIND) &&
+      trackDesc?.tags?.utid !== undefined
+    ) {
+      out.push({utid: trackDesc.tags.utid, uri: trackDesc.uri});
     }
   }
-
-  return 0;
+  return out;
 }
 
 function showModalErrorAreaSelectionRequired() {
@@ -88,6 +94,15 @@ function showModalErrorThreadStateRequired() {
     title: 'Error: thread state selection required',
     content: 'This command requires a thread state slice to be selected.',
   });
+}
+
+// URI of the thread state track currently holding the selected slice.
+function getSelectedThreadStateTrackUri(trace: Trace): string | undefined {
+  const selection = trace.selection.selection;
+  if (selection.kind !== 'track_event') return undefined;
+  const track = trace.tracks.getTrack(selection.trackUri);
+  if (!track?.tags?.kinds?.includes(THREAD_STATE_TRACK_KIND)) return undefined;
+  return selection.trackUri;
 }
 
 // If utid is undefined, returns the utid for the selected thread state track,
@@ -138,7 +153,7 @@ async function getUtid(trace: Trace): Promise<Utid | undefined> {
 
 export default class implements PerfettoPlugin {
   static readonly id = 'dev.perfetto.CriticalPath';
-  static readonly dependencies = [QueryPagePlugin];
+  static readonly dependencies = [QueryPagePlugin, SchedPlugin];
   async onTraceLoad(ctx: Trace): Promise<void> {
     // Each command is invoked either from the command palette (utid
     // resolved from the current selection) or via runCommand(utid)
@@ -231,6 +246,8 @@ export default class implements PerfettoPlugin {
       callback: async (utidArg) => {
         const thdInfo = await getThreadInfoForUtidOrSelection(ctx, utidArg);
         if (thdInfo === undefined) return showModalErrorThreadStateRequired();
+        const parentUri = getSelectedThreadStateTrackUri(ctx);
+        if (parentUri === undefined) return showModalErrorThreadStateRequired();
         const tb = await ctx.engine.query(
           `SELECT start_ts AS s, end_ts AS e FROM trace_bounds`,
         );
@@ -241,6 +258,7 @@ export default class implements PerfettoPlugin {
           thdInfo.name ?? `utid ${thdInfo.utid}`,
           tbRow.s,
           tbRow.e - tbRow.s,
+          parentUri,
         ).pin();
       },
     });
@@ -249,17 +267,20 @@ export default class implements PerfettoPlugin {
       id: 'dev.perfetto.CriticalPathTree_AreaSelection',
       name: 'Critical path tree (over area selection)',
       callback: async () => {
-        const trackUtid = getFirstUtidOfSelectionOrVisibleWindow(ctx);
+        const parents = getThreadStateTracksInArea(ctx);
+        if (parents.length === 0) return showModalErrorAreaSelectionRequired();
         const window = await getTimeSpanOfSelectionOrVisibleWindow(ctx);
-        if (trackUtid === 0) return showModalErrorAreaSelectionRequired();
-        const thdInfo = await getThreadInfo(ctx.engine, trackUtid as Utid);
-        await new CriticalPathTreePin(
-          ctx,
-          trackUtid,
-          thdInfo.name ?? `utid ${trackUtid}`,
-          window.start,
-          window.end - window.start,
-        ).pin();
+        for (const parent of parents) {
+          const thdInfo = await getThreadInfo(ctx.engine, parent.utid as Utid);
+          await new CriticalPathTreePin(
+            ctx,
+            parent.utid,
+            thdInfo.name ?? `utid ${parent.utid}`,
+            window.start,
+            window.end - window.start,
+            parent.uri,
+          ).pin();
+        }
       },
     });
 


### PR DESCRIPTION
Adds a critical-path tree command that pins the root thread as a slice track and expands per-thread blocker sub-tracks one hop per click.