### PR TITLE
ui: Embed flamegraph viewer in Heap Dump Explorer

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
@@ -95,6 +95,9 @@ export function InstanceLink(): m.Component<InstanceLinkAttrs> {
 interface SectionAttrs {
   readonly title: string;
   readonly defaultOpen?: boolean;
+  // Optional inline actions rendered to the right of the title. Action
+  // clicks are isolated from the section toggle.
+  readonly actions?: m.Children;
 }
 export function Section(): m.Component<SectionAttrs> {
   let open = true;
@@ -107,28 +110,42 @@ export function Section(): m.Component<SectionAttrs> {
         'div',
         {class: 'ah-section'},
         m(
-          'button',
-          {
-            'class': 'ah-section__toggle',
-            'onclick': () => {
-              open = !open;
-            },
-            'aria-expanded': open,
-          },
-          m('span', {class: 'ah-section__title'}, vnode.attrs.title),
+          'div',
+          {class: 'ah-section__header'},
           m(
-            'svg',
+            'button',
             {
-              class: `ah-section__chevron${open ? ' ah-section__chevron--open' : ''}`,
-              viewBox: '0 0 20 20',
-              fill: 'currentColor',
+              'class': 'ah-section__toggle',
+              'onclick': () => {
+                open = !open;
+              },
+              'aria-expanded': open,
             },
-            m('path', {
-              'fill-rule': 'evenodd',
-              'd': 'M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z',
-              'clip-rule': 'evenodd',
-            }),
+            m('span', {class: 'ah-section__title'}, vnode.attrs.title),
+            m(
+              'svg',
+              {
+                class: `ah-section__chevron${open ? ' ah-section__chevron--open' : ''}`,
+                viewBox: '0 0 20 20',
+                fill: 'currentColor',
+              },
+              m('path', {
+                'fill-rule': 'evenodd',
+                'd': 'M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z',
+                'clip-rule': 'evenodd',
+              }),
+            ),
           ),
+          vnode.attrs.actions !== undefined
+            ? m(
+                'div',
+                {
+                  class: 'ah-section__actions',
+                  onclick: (e: Event) => e.stopPropagation(),
+                },
+                vnode.attrs.actions,
+              )
+            : null,
         ),
         open ? m('div', {class: 'ah-section__body'}, vnode.children) : null,
       );

--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -32,6 +32,7 @@ import ClassesView from './views/classes_view';
 import StringsView from './views/strings_view';
 import ArraysView from './views/arrays_view';
 import FlamegraphObjectsView from './views/flamegraph_objects_view';
+import FlamegraphView from './views/flamegraph_view';
 import type {HeapDumpExplorerSession} from './session';
 
 interface HeapDumpPageAttrs {
@@ -117,6 +118,24 @@ function buildTabs(
       content: m(OverviewView, {overview, navigate: navigateWithTabs}),
     },
     {
+      key: 'flamegraph',
+      title: 'Flamegraph',
+      content: m(FlamegraphView, {
+        trace,
+        upid: activeDump.upid,
+        ts: Time.fromRaw(activeDump.ts),
+        state: session.flamegraphPanelState,
+        onStateChange: session.setFlamegraphPanelState,
+        onShowObjects: (pathHashes, isDominator) =>
+          session.openFlamegraph({
+            pathHashes,
+            isDominator,
+            upid: activeDump.upid,
+            ts: activeDump.ts,
+          }),
+      }),
+    },
+    {
       key: 'classes',
       title: 'Classes',
       content: m(ClassesView, {
@@ -193,8 +212,8 @@ function buildTabs(
       key: fgTabKey(fg.id),
       title:
         fg.count !== null
-          ? `Flamegraph (${fg.count.toLocaleString()})`
-          : 'Flamegraph',
+          ? `Flamegraph objects (${fg.count.toLocaleString()})`
+          : 'Flamegraph objects',
       closeButton: true,
       content: m(FlamegraphObjectsView, {
         engine,
@@ -216,6 +235,7 @@ function buildTabs(
         activeDump,
         heaps: overview.heaps,
         navigate: navigateWithTabs,
+        openFlamegraphPivotedAt: session.openFlamegraphPivotedAt,
         params: {id: obj.objId},
       }),
     });

--- a/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/nav_state.ts
@@ -21,7 +21,8 @@ export type NavState =
   | {view: 'bitmaps'; params: {id?: number; filterKey?: string}}
   | {view: 'strings'; params: {q?: string}}
   | {view: 'arrays'; params: {arrayHash?: string}}
-  | {view: 'flamegraph-objects'; params: {name?: string}};
+  | {view: 'flamegraph-objects'; params: {name?: string}}
+  | {view: 'flamegraph'; params: Record<string, never>};
 
 export type NavView = NavState['view'];
 
@@ -62,6 +63,8 @@ export function stateToSubpage(state: NavState): string {
         ? `flamegraph_objects_${encodeURIComponent(n)}`
         : 'flamegraph_objects';
     }
+    case 'flamegraph':
+      return 'flamegraph';
   }
 }
 
@@ -129,6 +132,8 @@ export function subpageToState(subpage: string | undefined): NavState {
       const n = param ? decodeURIComponent(param) : undefined;
       return {view: 'flamegraph-objects', params: n ? {name: n} : {}};
     }
+    case 'flamegraph':
+      return {view: 'flamegraph', params: {}};
     default:
       return {view: 'overview', params: {}};
   }

--- a/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/session.ts
@@ -27,6 +27,11 @@ import {
   subpageToState,
 } from './nav_state';
 import type {OverviewData} from './types';
+import type {FlamegraphState} from '../../widgets/flamegraph';
+import {
+  METRIC_DOMINATED_OBJECT_SIZE,
+  METRIC_OBJECT_SIZE,
+} from './views/flamegraph_view';
 
 interface FlamegraphSelection {
   readonly pathHashes: string;
@@ -73,6 +78,10 @@ export class HeapDumpExplorerSession {
   private _activeInstanceId: number | null = null;
 
   private _overview: OverviewData | null = null;
+
+  // Persists across tab switches; reset on dump change so a new dump
+  // opens with defaults instead of the prior dump's filters.
+  private _flamegraphPanelState: FlamegraphState | undefined;
 
   constructor(
     readonly trace: Trace,
@@ -282,11 +291,42 @@ export class HeapDumpExplorerSession {
     this._instanceTabs.length = 0;
     this._nextInstanceId = 0;
     this._activeInstanceId = null;
+    this._flamegraphPanelState = undefined;
   }
 
   get cachedOverview(): OverviewData | null {
     return this._overview;
   }
+
+  get flamegraphPanelState(): FlamegraphState | undefined {
+    return this._flamegraphPanelState;
+  }
+
+  readonly setFlamegraphPanelState = (s: FlamegraphState): void => {
+    this._flamegraphPanelState = s;
+  };
+
+  // Open the flamegraph pivoted at `pathHash`. The metric is chosen to
+  // match the tree the hash came from. The chip displays
+  // `<label> (this instance)` since the raw hash regex is unreadable.
+  readonly openFlamegraphPivotedAt = (
+    pathHash: string,
+    label: string,
+    isDominator: boolean,
+  ): void => {
+    this._flamegraphPanelState = {
+      selectedMetricName: isDominator
+        ? METRIC_DOMINATED_OBJECT_SIZE
+        : METRIC_OBJECT_SIZE,
+      filters: [],
+      view: {
+        kind: 'PIVOT',
+        pivot: `^${pathHash}$`,
+        displayLabel: `${label} (this instance)`,
+      },
+    };
+    this.navigate('flamegraph');
+  };
 
   // Pins the dump at fetch start; if the user switches dumps before
   // the result arrives, the result is dropped instead of briefly

--- a/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
@@ -223,8 +223,13 @@
   border: 1px solid var(--pf-color-border);
 }
 
+.ah-section__header {
+  display: flex;
+  align-items: stretch;
+}
+
 .ah-section__toggle {
-  width: 100%;
+  flex: 1;
   padding: 0.5rem 1rem;
   display: flex;
   justify-content: space-between;
@@ -233,6 +238,14 @@
   &:hover {
     background: var(--pf-color-background-secondary);
   }
+}
+
+.ah-section__actions {
+  display: flex;
+  align-items: center;
+  padding: 0 1rem;
+  gap: 0.5rem;
+  border-left: 1px solid var(--pf-color-border-secondary);
 }
 
 .ah-section__title {

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_view.ts
@@ -1,0 +1,205 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import m from 'mithril';
+import type {Trace} from '../../../public/trace';
+import {time} from '../../../base/time';
+import {QueryFlamegraphMetric} from '../../../components/query_flamegraph';
+import {FlamegraphPanel} from '../../../components/flamegraph_panel';
+import {
+  Flamegraph,
+  FlamegraphState,
+  FlamegraphOptionalAction,
+} from '../../../widgets/flamegraph';
+
+// Referenced by session.openFlamegraphPivotedAt.
+export const METRIC_OBJECT_SIZE = 'Object Size';
+export const METRIC_DOMINATED_OBJECT_SIZE = 'Dominated Object Size';
+
+interface FlamegraphViewAttrs {
+  readonly trace: Trace;
+  readonly upid: number;
+  readonly ts: time;
+  readonly state: FlamegraphState | undefined;
+  readonly onStateChange: (state: FlamegraphState) => void;
+  // Open the flamegraph-objects tab for `pathHashes` (CSV).
+  readonly onShowObjects: (pathHashes: string, isDominator: boolean) => void;
+}
+
+// path_hash_stable is exposed unaggregatable (and CAST to TEXT in SQL,
+// since the stdlib emits it as INT64 and the flamegraph reads
+// unaggregatable columns as STR_NULL) so it lands in `matchingColumns`
+// — that's what lets a PIVOT filter target a specific node by its hash.
+// Hidden from the tooltip via `isVisible: false`.
+const UNAGG_PROPS = [
+  {name: 'root_type', displayName: 'Root Type'},
+  {name: 'heap_type', displayName: 'Heap Type'},
+  {
+    name: 'path_hash_stable',
+    displayName: 'Path Hash',
+    isVisible: () => false,
+  },
+];
+
+const SELF_COUNT_AGG_PROP = {
+  name: 'self_count',
+  displayName: 'Self Count',
+  mergeAggregation: 'SUM' as const,
+};
+
+// Build a JAVA_HEAP_GRAPH metric for the BFS or dominator class tree,
+// projecting `valueColumn` as `value` and the other column for tooltips.
+function buildMetric(
+  upid: number,
+  ts: time,
+  name: string,
+  unit: string,
+  valueColumn: 'self_size' | 'self_count',
+  isDominator: boolean,
+  showObjectsAction: FlamegraphOptionalAction,
+): QueryFlamegraphMetric {
+  const tree = isDominator
+    ? '_heap_graph_dominator_class_tree'
+    : '_heap_graph_class_tree';
+  const dependencyModule = isDominator
+    ? 'android.memory.heap_graph.dominator_class_tree'
+    : 'android.memory.heap_graph.class_tree';
+  const otherCol = valueColumn === 'self_size' ? 'self_count' : 'self_size';
+  return {
+    name,
+    unit,
+    dependencySql: `include perfetto module ${dependencyModule};`,
+    statement: `
+      select
+        id,
+        parent_id as parentId,
+        ifnull(name, '[Unknown]') as name,
+        root_type,
+        heap_type,
+        ${valueColumn} as value,
+        ${otherCol},
+        CAST(path_hash_stable AS TEXT) AS path_hash_stable
+      from ${tree}
+      where graph_sample_ts = ${ts} and upid = ${upid}
+    `,
+    unaggregatableProperties: UNAGG_PROPS,
+    aggregatableProperties:
+      valueColumn === 'self_size' ? [SELF_COUNT_AGG_PROP] : [],
+    optionalNodeActions: [showObjectsAction],
+  };
+}
+
+interface MetricSpec {
+  readonly name: string;
+  readonly unit: string;
+  readonly valueColumn: 'self_size' | 'self_count';
+  readonly isDominator: boolean;
+}
+
+const METRIC_SPECS: ReadonlyArray<MetricSpec> = [
+  {
+    name: METRIC_OBJECT_SIZE,
+    unit: 'B',
+    valueColumn: 'self_size',
+    isDominator: false,
+  },
+  {
+    name: 'Object Count',
+    unit: '',
+    valueColumn: 'self_count',
+    isDominator: false,
+  },
+  {
+    name: METRIC_DOMINATED_OBJECT_SIZE,
+    unit: 'B',
+    valueColumn: 'self_size',
+    isDominator: true,
+  },
+  {
+    name: 'Dominated Object Count',
+    unit: '',
+    valueColumn: 'self_count',
+    isDominator: true,
+  },
+];
+
+function buildHeapGraphMetrics(
+  upid: number,
+  ts: time,
+  onShowObjects: (pathHashes: string, isDominator: boolean) => void,
+): ReadonlyArray<QueryFlamegraphMetric> {
+  const showObjectsAction = (
+    isDominator: boolean,
+  ): FlamegraphOptionalAction => ({
+    name: 'Show objects from this class',
+    execute: async ({properties}) => {
+      const pathHashes = properties.get('path_hash_stable');
+      if (pathHashes === undefined) return;
+      onShowObjects(pathHashes, isDominator);
+    },
+  });
+  return METRIC_SPECS.map((s) =>
+    buildMetric(
+      upid,
+      ts,
+      s.name,
+      s.unit,
+      s.valueColumn,
+      s.isDominator,
+      showObjectsAction(s.isDominator),
+    ),
+  );
+}
+
+const FlamegraphView: m.ClosureComponent<FlamegraphViewAttrs> = () => {
+  let cachedMetrics: ReadonlyArray<QueryFlamegraphMetric> | undefined;
+  let cachedKey: string | undefined;
+
+  return {
+    view({attrs}) {
+      const key = `${attrs.upid}:${attrs.ts}`;
+      if (cachedMetrics === undefined || key !== cachedKey) {
+        cachedMetrics = buildHeapGraphMetrics(
+          attrs.upid,
+          attrs.ts,
+          attrs.onShowObjects,
+        );
+        cachedKey = key;
+      }
+      const metrics = cachedMetrics;
+
+      // First render or after a dump-change reset: create a default
+      // state so the panel renders meaningfully on the same frame.
+
+      let state = attrs.state;
+      if (state === undefined) {
+        state = Flamegraph.createDefaultState(metrics);
+        attrs.onStateChange(state);
+      }
+
+      return m(
+        'div',
+        {class: 'ah-view-content ah-flamegraph-view'},
+        m(FlamegraphPanel, {
+          trace: attrs.trace,
+          metrics,
+          state,
+          onStateChange: attrs.onStateChange,
+        }),
+      );
+    },
+  };
+};
+
+export default FlamegraphView;

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -14,8 +14,11 @@
 
 import m from 'mithril';
 import type {Engine} from '../../../trace_processor/engine';
-import type {SqlValue} from '../../../trace_processor/query_result';
-import type {Row} from '../../../trace_processor/query_result';
+import {
+  STR,
+  type Row,
+  type SqlValue,
+} from '../../../trace_processor/query_result';
 import {Spinner} from '../../../widgets/spinner';
 import {DataGrid} from '../../../components/widgets/datagrid/datagrid';
 import type {
@@ -42,11 +45,20 @@ export interface ObjectParams {
   readonly id: number;
 }
 
+// Open the flamegraph pivoted at the given path. Routed through the
+// session so flamegraph state has a single owner.
+export type OpenFlamegraphPivotedAt = (
+  pathHash: string,
+  label: string,
+  isDominator: boolean,
+) => void;
+
 interface ObjectViewAttrs {
   readonly engine: Engine;
   readonly activeDump: HeapDump;
   readonly heaps: ReadonlyArray<HeapInfo>;
   readonly navigate: NavFn;
+  readonly openFlamegraphPivotedAt: OpenFlamegraphPivotedAt;
   readonly params: ObjectParams;
 }
 
@@ -556,6 +568,28 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
 
       const {row} = detail;
 
+      const flamegraphAction = (isDominator: boolean) =>
+        row.className
+          ? m(
+              'button',
+              {
+                class: 'ah-link',
+                title: isDominator
+                  ? 'Open in Flamegraph pivoted on this dominator path'
+                  : 'Open in Flamegraph pivoted on this shortest path',
+                onclick: () =>
+                  openInFlamegraph(
+                    vnode.attrs.engine,
+                    row.id,
+                    row.className,
+                    isDominator,
+                    vnode.attrs.openFlamegraphPivotedAt,
+                  ),
+              },
+              'View in Flamegraph',
+            )
+          : null;
+
       return m('div', {class: 'ah-view-scroll ah-view-stack'}, [
         m('div', [
           m(
@@ -613,7 +647,10 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
 
         m(
           Section,
-          {title: 'Shortest Path from GC Root'},
+          {
+            title: 'Shortest Path from GC Root',
+            actions: detail.shortestPath ? flamegraphAction(false) : null,
+          },
           detail.shortestPath
             ? m(
                 'div',
@@ -647,6 +684,7 @@ function ObjectView(): m.Component<ObjectViewAttrs> {
           Section,
           {
             title: 'Dominator Tree Path',
+            actions: detail.dominatorPath ? flamegraphAction(true) : null,
           },
           detail.dominatorPath
             ? m(
@@ -961,6 +999,33 @@ function renderArrayGrid(
       showExportButton: true,
     }),
   ]);
+}
+
+// Look up the object's path_hash in the chosen tree (BFS or dominator)
+// and open the flamegraph pivoted on it with the matching metric. The
+// hash is tree-specific so the tree dictates both. No-op if the object
+// has no entry (e.g. unreachable garbage).
+async function openInFlamegraph(
+  engine: Engine,
+  id: number,
+  cls: string,
+  isDominator: boolean,
+  openFlamegraphPivotedAt: OpenFlamegraphPivotedAt,
+): Promise<void> {
+  const moduleName = isDominator
+    ? 'android.memory.heap_graph.dominator_class_tree'
+    : 'android.memory.heap_graph.class_tree';
+  const table = isDominator
+    ? '_heap_graph_dominator_path_hashes'
+    : '_heap_graph_path_hashes';
+  await engine.query(`INCLUDE PERFETTO MODULE ${moduleName};`);
+  const res = await engine.query(
+    `SELECT CAST(path_hash AS TEXT) AS path_hash
+       FROM ${table} WHERE id = ${id} LIMIT 1`,
+  );
+  const it = res.iter({path_hash: STR});
+  if (!it.valid()) return;
+  openFlamegraphPivotedAt(it.path_hash, shortClassName(cls), isDominator);
 }
 
 // `java.lang.Class<Foo>` has no useful subclasses in heap_graph_class; the


### PR DESCRIPTION
Added a Flamegraph tab using FlamegraphPanel and Bidirectional navigation between object info and the flamegraph.

A "Show objects from this class" node action opens the flamegraph-objects tab, and each retention-path section in the object view ("Shortest Path", "Dominator Tree Path") gets a "View in Flamegraph" button that pivots the flamegraph at the object's path.
