### PR TITLE
tp: rename LegacyV8CpuProfileTracker to V8CpuProfileTracker

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -15721,7 +15721,6 @@ filegroup {
         "src/trace_processor/importers/common/gpu_tracker.cc",
         "src/trace_processor/importers/common/import_logs_tracker.cc",
         "src/trace_processor/importers/common/jit_cache.cc",
-        "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc",
         "src/trace_processor/importers/common/machine_tracker.cc",
         "src/trace_processor/importers/common/mapping_tracker.cc",
         "src/trace_processor/importers/common/metadata_tracker.cc",
@@ -15738,6 +15737,7 @@ filegroup {
         "src/trace_processor/importers/common/trace_file_tracker.cc",
         "src/trace_processor/importers/common/track_compressor.cc",
         "src/trace_processor/importers/common/track_tracker.cc",
+        "src/trace_processor/importers/common/v8_cpu_profile_tracker.cc",
         "src/trace_processor/importers/common/virtual_memory_mapping.cc",
     ],
 }

--- a/BUILD
+++ b/BUILD
@@ -4862,7 +4862,6 @@ perfetto_cc_library(
         "src/trace_processor/importers/common/gpu_tracker.cc",
         "src/trace_processor/importers/common/import_logs_tracker.cc",
         "src/trace_processor/importers/common/jit_cache.cc",
-        "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.cc",
         "src/trace_processor/importers/common/machine_tracker.cc",
         "src/trace_processor/importers/common/mapping_tracker.cc",
         "src/trace_processor/importers/common/metadata_tracker.cc",
@@ -4879,6 +4878,7 @@ perfetto_cc_library(
         "src/trace_processor/importers/common/trace_file_tracker.cc",
         "src/trace_processor/importers/common/track_compressor.cc",
         "src/trace_processor/importers/common/track_tracker.cc",
+        "src/trace_processor/importers/common/v8_cpu_profile_tracker.cc",
         "src/trace_processor/importers/common/virtual_memory_mapping.cc",
     ],
     hdrs = [
@@ -4898,7 +4898,6 @@ perfetto_cc_library(
         "src/trace_processor/importers/common/gpu_tracker.h",
         "src/trace_processor/importers/common/import_logs_tracker.h",
         "src/trace_processor/importers/common/jit_cache.h",
-        "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h",
         "src/trace_processor/importers/common/machine_tracker.h",
         "src/trace_processor/importers/common/mapping_tracker.h",
         "src/trace_processor/importers/common/metadata_tracker.h",
@@ -4919,6 +4918,7 @@ perfetto_cc_library(
         "src/trace_processor/importers/common/tracks.h",
         "src/trace_processor/importers/common/tracks_common.h",
         "src/trace_processor/importers/common/tracks_internal.h",
+        "src/trace_processor/importers/common/v8_cpu_profile_tracker.h",
         "src/trace_processor/importers/common/virtual_memory_mapping.h",
     ],
     deps = [

--- a/src/trace_processor/importers/common/BUILD.gn
+++ b/src/trace_processor/importers/common/BUILD.gn
@@ -45,8 +45,6 @@ source_set("common") {
     "import_logs_tracker.h",
     "jit_cache.cc",
     "jit_cache.h",
-    "legacy_v8_cpu_profile_tracker.cc",
-    "legacy_v8_cpu_profile_tracker.h",
     "machine_tracker.cc",
     "machine_tracker.h",
     "mapping_tracker.cc",
@@ -83,6 +81,8 @@ source_set("common") {
     "tracks.h",
     "tracks_common.h",
     "tracks_internal.h",
+    "v8_cpu_profile_tracker.cc",
+    "v8_cpu_profile_tracker.h",
     "virtual_memory_mapping.cc",
     "virtual_memory_mapping.h",
   ]

--- a/src/trace_processor/importers/common/v8_cpu_profile_tracker.cc
+++ b/src/trace_processor/importers/common/v8_cpu_profile_tracker.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h"
+#include "src/trace_processor/importers/common/v8_cpu_profile_tracker.h"
 
 #include <cstdint>
 #include <optional>
@@ -38,14 +38,14 @@
 
 namespace perfetto::trace_processor {
 
-LegacyV8CpuProfileTracker::LegacyV8CpuProfileTracker(
+V8CpuProfileTracker::V8CpuProfileTracker(
     TraceProcessorContext* context)
     : context_(context) {}
 
-LegacyV8CpuProfileTracker::~LegacyV8CpuProfileTracker() = default;
+V8CpuProfileTracker::~V8CpuProfileTracker() = default;
 
-void LegacyV8CpuProfileTracker::Parse(int64_t ts,
-                                      LegacyV8CpuProfileEvent event) {
+void V8CpuProfileTracker::Parse(int64_t ts,
+                                LegacyV8CpuProfileEvent event) {
   base::Status status =
       AddSample(ts, event.session_id, event.pid, event.tid, event.callsite_id);
   if (!status.ok()) {
@@ -54,9 +54,9 @@ void LegacyV8CpuProfileTracker::Parse(int64_t ts,
   }
 }
 
-void LegacyV8CpuProfileTracker::SetStartTsForSessionAndPid(uint64_t session_id,
-                                                           uint32_t pid,
-                                                           int64_t ts) {
+void V8CpuProfileTracker::SetStartTsForSessionAndPid(uint64_t session_id,
+                                                     uint32_t pid,
+                                                     int64_t ts) {
   auto [it, inserted] = state_by_session_and_pid_.Insert(
       std::make_pair(session_id, pid),
       State{ts, base::FlatHashMap<uint32_t, CallsiteId>(),
@@ -67,7 +67,7 @@ void LegacyV8CpuProfileTracker::SetStartTsForSessionAndPid(uint64_t session_id,
   }
 }
 
-base::Status LegacyV8CpuProfileTracker::AddCallsite(
+base::Status V8CpuProfileTracker::AddCallsite(
     uint64_t session_id,
     uint32_t pid,
     uint32_t raw_callsite_id,
@@ -158,7 +158,7 @@ base::Status LegacyV8CpuProfileTracker::AddCallsite(
   return base::OkStatus();
 }
 
-base::StatusOr<int64_t> LegacyV8CpuProfileTracker::AddDeltaAndGetTs(
+base::StatusOr<int64_t> V8CpuProfileTracker::AddDeltaAndGetTs(
     uint64_t session_id,
     uint32_t pid,
     int64_t delta_ts) {
@@ -171,11 +171,11 @@ base::StatusOr<int64_t> LegacyV8CpuProfileTracker::AddDeltaAndGetTs(
   return state->ts;
 }
 
-base::Status LegacyV8CpuProfileTracker::AddSample(int64_t ts,
-                                                  uint64_t session_id,
-                                                  uint32_t pid,
-                                                  uint32_t tid,
-                                                  uint32_t raw_callsite_id) {
+base::Status V8CpuProfileTracker::AddSample(int64_t ts,
+                                            uint64_t session_id,
+                                            uint32_t pid,
+                                            uint32_t tid,
+                                            uint32_t raw_callsite_id) {
   auto* state = state_by_session_and_pid_.Find(std::make_pair(session_id, pid));
   if (!state) {
     return base::ErrStatus("v8 callsite id does not exist: cannot add sample");

--- a/src/trace_processor/importers/common/v8_cpu_profile_tracker.h
+++ b/src/trace_processor/importers/common/v8_cpu_profile_tracker.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_LEGACY_V8_CPU_PROFILE_TRACKER_H_
-#define SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_LEGACY_V8_CPU_PROFILE_TRACKER_H_
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_V8_CPU_PROFILE_TRACKER_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_V8_CPU_PROFILE_TRACKER_H_
 
 #include <cstdint>
 #include <optional>
@@ -36,12 +36,12 @@
 namespace perfetto::trace_processor {
 
 // Stores interned callsites for given pid for legacy v8 samples.
-class LegacyV8CpuProfileTracker
+class V8CpuProfileTracker
     : public TraceSorter::Sink<LegacyV8CpuProfileEvent,
-                               LegacyV8CpuProfileTracker> {
+                               V8CpuProfileTracker> {
  public:
-  explicit LegacyV8CpuProfileTracker(TraceProcessorContext*);
-  ~LegacyV8CpuProfileTracker() override;
+  explicit V8CpuProfileTracker(TraceProcessorContext*);
+  ~V8CpuProfileTracker() override;
 
   void Parse(int64_t ts, LegacyV8CpuProfileEvent);
 
@@ -92,4 +92,4 @@ class LegacyV8CpuProfileTracker
 
 }  // namespace perfetto::trace_processor
 
-#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_LEGACY_V8_CPU_PROFILE_TRACKER_H_
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_COMMON_V8_CPU_PROFILE_TRACKER_H_

--- a/src/trace_processor/importers/json/json_trace_parser.cc
+++ b/src/trace_processor/importers/json/json_trace_parser.cc
@@ -34,7 +34,6 @@
 #include "src/trace_processor/importers/common/cpu_tracker.h"
 #include "src/trace_processor/importers/common/event_tracker.h"
 #include "src/trace_processor/importers/common/flow_tracker.h"
-#include "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
 #include "src/trace_processor/importers/common/slice_tracker.h"

--- a/src/trace_processor/importers/json/json_trace_tokenizer.cc
+++ b/src/trace_processor/importers/json/json_trace_tokenizer.cc
@@ -41,7 +41,6 @@
 #include "perfetto/trace_processor/trace_blob_view.h"
 #include "src/trace_processor/containers/string_pool.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
-#include "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/v8_profile_parser.h"
 #include "src/trace_processor/importers/json/json_trace_parser.h"
@@ -378,13 +377,13 @@ class SystraceSink : public TraceSorter::Sink<SystraceLine, SystraceSink> {
 };
 class V8Sink : public TraceSorter::Sink<LegacyV8CpuProfileEvent, V8Sink> {
  public:
-  explicit V8Sink(LegacyV8CpuProfileTracker* tracker) : tracker_(tracker) {}
+  explicit V8Sink(V8CpuProfileTracker* tracker) : tracker_(tracker) {}
   void Parse(int64_t ts, LegacyV8CpuProfileEvent data) {
     tracker_->Parse(ts, data);
   }
 
  private:
-  LegacyV8CpuProfileTracker* tracker_;
+  V8CpuProfileTracker* tracker_;
 };
 
 }  // namespace
@@ -484,7 +483,7 @@ ReadSystemLineRes ReadOneSystemTraceLine(const char* start,
 JsonTraceTokenizer::JsonTraceTokenizer(TraceProcessorContext* ctx)
     : context_(ctx),
       parser_(ctx),
-      v8_tracker_(std::make_unique<LegacyV8CpuProfileTracker>(ctx)),
+      v8_tracker_(std::make_unique<V8CpuProfileTracker>(ctx)),
       json_stream_(
           context_->sorter->CreateStream(std::make_unique<JsonSink>(&parser_))),
       systrace_stream_(context_->sorter->CreateStream(

--- a/src/trace_processor/importers/json/json_trace_tokenizer.h
+++ b/src/trace_processor/importers/json/json_trace_tokenizer.h
@@ -26,8 +26,8 @@
 #include "perfetto/base/status.h"
 #include "src/trace_processor/importers/common/chunked_trace_reader.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
-#include "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/common/v8_cpu_profile_tracker.h"
 #include "src/trace_processor/importers/json/json_trace_parser.h"
 #include "src/trace_processor/importers/systrace/systrace_line.h"
 #include "src/trace_processor/importers/systrace/systrace_line_tokenizer.h"
@@ -134,7 +134,7 @@ class JsonTraceTokenizer : public ChunkedTraceReader {
   TraceProcessorContext* const context_;
 
   JsonTraceParser parser_;
-  std::unique_ptr<LegacyV8CpuProfileTracker> v8_tracker_;
+  std::unique_ptr<V8CpuProfileTracker> v8_tracker_;
   std::unique_ptr<TraceSorter::Stream<JsonEvent>> json_stream_;
   std::unique_ptr<TraceSorter::Stream<SystraceLine>> systrace_stream_;
   std::unique_ptr<TraceSorter::Stream<LegacyV8CpuProfileEvent>> v8_stream_;

--- a/src/trace_processor/importers/proto/track_event_tokenizer.cc
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.cc
@@ -37,7 +37,6 @@
 #include "src/trace_processor/importers/common/args_tracker.h"
 #include "src/trace_processor/importers/common/clock_tracker.h"
 #include "src/trace_processor/importers/common/import_logs_tracker.h"
-#include "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h"
 #include "src/trace_processor/importers/common/metadata_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
 #include "src/trace_processor/importers/common/process_tracker.h"
@@ -70,13 +69,13 @@ using protos::pbzero::CounterDescriptor;
 
 class V8Sink : public TraceSorter::Sink<LegacyV8CpuProfileEvent, V8Sink> {
  public:
-  explicit V8Sink(LegacyV8CpuProfileTracker* tracker) : tracker_(tracker) {}
+  explicit V8Sink(V8CpuProfileTracker* tracker) : tracker_(tracker) {}
   void Parse(int64_t ts, LegacyV8CpuProfileEvent data) {
     tracker_->Parse(ts, data);
   }
 
  private:
-  LegacyV8CpuProfileTracker* tracker_;
+  V8CpuProfileTracker* tracker_;
 };
 
 }  // namespace
@@ -88,7 +87,7 @@ TrackEventTokenizer::TrackEventTokenizer(
     : context_(context),
       track_event_tracker_(track_event_tracker),
       module_context_(module_context),
-      v8_tracker_(std::make_unique<LegacyV8CpuProfileTracker>(context)),
+      v8_tracker_(std::make_unique<V8CpuProfileTracker>(context)),
       v8_stream_(context->sorter->CreateStream(
           std::make_unique<V8Sink>(v8_tracker_.get()))),
       counter_name_thread_time_id_(

--- a/src/trace_processor/importers/proto/track_event_tokenizer.h
+++ b/src/trace_processor/importers/proto/track_event_tokenizer.h
@@ -25,8 +25,8 @@
 #include "perfetto/base/status.h"
 #include "perfetto/protozero/proto_decoder.h"
 #include "perfetto/trace_processor/ref_counted.h"
-#include "src/trace_processor/importers/common/legacy_v8_cpu_profile_tracker.h"
 #include "src/trace_processor/importers/common/parser_types.h"
+#include "src/trace_processor/importers/common/v8_cpu_profile_tracker.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/proto_importer_module.h"
 #include "src/trace_processor/sorter/trace_sorter.h"
@@ -110,7 +110,7 @@ class TrackEventTokenizer {
   TrackEventTracker* const track_event_tracker_;
   ProtoImporterModuleContext* const module_context_;
 
-  std::unique_ptr<LegacyV8CpuProfileTracker> v8_tracker_;
+  std::unique_ptr<V8CpuProfileTracker> v8_tracker_;
   std::unique_ptr<TraceSorter::Stream<LegacyV8CpuProfileEvent>> v8_stream_;
 
   const StringId counter_name_thread_time_id_;


### PR DESCRIPTION
**Part (1/6) in the series**

Mechanical rename in preparation for unifying the legacy JSON v8 CPU profile import path and the new `V8CpuProfileChunk` proto import path on a single tracker.

No behaviour change.

Refs https://github.com/google/perfetto/issues/5673
