### PR TITLE
tp: scope gpu_counter custom-groups cache to per-sequence state

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -16056,6 +16056,7 @@ filegroup {
         "src/trace_processor/importers/proto/deobfuscation_module.cc",
         "src/trace_processor/importers/proto/deobfuscation_tracker.cc",
         "src/trace_processor/importers/proto/frame_timeline_event_parser.cc",
+        "src/trace_processor/importers/proto/gpu_counter_sequence_state.cc",
         "src/trace_processor/importers/proto/gpu_event_parser.cc",
         "src/trace_processor/importers/proto/graphics_event_module.cc",
         "src/trace_processor/importers/proto/graphics_frame_event_parser.cc",

--- a/BUILD
+++ b/BUILD
@@ -2860,6 +2860,8 @@ perfetto_filegroup(
         "src/trace_processor/importers/proto/deobfuscation_tracker.h",
         "src/trace_processor/importers/proto/frame_timeline_event_parser.cc",
         "src/trace_processor/importers/proto/frame_timeline_event_parser.h",
+        "src/trace_processor/importers/proto/gpu_counter_sequence_state.cc",
+        "src/trace_processor/importers/proto/gpu_counter_sequence_state.h",
         "src/trace_processor/importers/proto/gpu_event_parser.cc",
         "src/trace_processor/importers/proto/gpu_event_parser.h",
         "src/trace_processor/importers/proto/graphics_event_module.cc",

--- a/src/trace_processor/importers/proto/BUILD.gn
+++ b/src/trace_processor/importers/proto/BUILD.gn
@@ -152,6 +152,8 @@ source_set("full") {
     "deobfuscation_tracker.h",
     "frame_timeline_event_parser.cc",
     "frame_timeline_event_parser.h",
+    "gpu_counter_sequence_state.cc",
+    "gpu_counter_sequence_state.h",
     "gpu_event_parser.cc",
     "gpu_event_parser.h",
     "graphics_event_module.cc",

--- a/src/trace_processor/importers/proto/gpu_counter_sequence_state.cc
+++ b/src/trace_processor/importers/proto/gpu_counter_sequence_state.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/importers/proto/gpu_counter_sequence_state.h"
+#include "src/trace_processor/types/trace_processor_context.h"
+
+namespace perfetto::trace_processor {
+
+GpuCounterSequenceState::GpuCounterSequenceState(TraceProcessorContext*) {}
+
+GpuCounterSequenceState::~GpuCounterSequenceState() = default;
+
+}  // namespace perfetto::trace_processor

--- a/src/trace_processor/importers/proto/gpu_counter_sequence_state.h
+++ b/src/trace_processor/importers/proto/gpu_counter_sequence_state.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_GPU_COUNTER_SEQUENCE_STATE_H_
+#define SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_GPU_COUNTER_SEQUENCE_STATE_H_
+
+#include <cstdint>
+
+#include "perfetto/ext/base/flat_hash_map.h"
+#include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
+
+namespace perfetto::trace_processor {
+
+class TraceProcessorContext;
+
+// Per-incremental-state cache of which interned counter descriptors have
+// already had their custom counter groups inserted. Lives on
+// `IncrementalState` so it shares scope with the interned-data table that
+// the descriptors themselves are looked up from — keying by iid alone is
+// safe here because two distinct producers necessarily live on distinct
+// packet sequences (and therefore distinct IncrementalStates), so they each
+// get their own cache.
+struct GpuCounterSequenceState : PacketSequenceStateGeneration::CustomState {
+  explicit GpuCounterSequenceState(TraceProcessorContext*);
+  ~GpuCounterSequenceState() override;
+
+  base::FlatHashMap<uint64_t, bool> custom_groups_inserted;
+};
+
+}  // namespace perfetto::trace_processor
+
+#endif  // SRC_TRACE_PROCESSOR_IMPORTERS_PROTO_GPU_COUNTER_SEQUENCE_STATE_H_

--- a/src/trace_processor/importers/proto/gpu_event_parser.cc
+++ b/src/trace_processor/importers/proto/gpu_event_parser.cc
@@ -40,6 +40,7 @@
 #include "src/trace_processor/importers/common/track_tracker.h"
 #include "src/trace_processor/importers/common/tracks.h"
 #include "src/trace_processor/importers/common/tracks_common.h"
+#include "src/trace_processor/importers/proto/gpu_counter_sequence_state.h"
 #include "src/trace_processor/importers/proto/packet_sequence_state_generation.h"
 #include "src/trace_processor/importers/proto/vulkan_memory_tracker.h"
 #include "src/trace_processor/storage/stats.h"
@@ -491,10 +492,15 @@ void GpuEventParser::ParseGpuCounterEvent(
       }
     }
 
-    // Insert custom counter groups once per interned descriptor.
+    // Insert custom counter groups once per interned descriptor. The cache
+    // lives on the sequence's IncrementalState (alongside the interned-data
+    // table the descriptor was looked up from), so two producers picking the
+    // same iid on different sequences each get their own cache.
     auto iid = event.counter_descriptor_iid();
-    if (!gpu_custom_groups_inserted_.Find(iid)) {
-      gpu_custom_groups_inserted_.Insert(iid, true);
+    auto* gpu_counter_state =
+        sequence_state->GetCustomState<GpuCounterSequenceState>();
+    if (!gpu_counter_state->custom_groups_inserted.Find(iid)) {
+      gpu_counter_state->custom_groups_inserted.Insert(iid, true);
       base::FlatHashMap<uint32_t, TrackId> counter_id_to_track;
       for (auto spec_it = desc.specs(); spec_it; ++spec_it) {
         GpuCounterDescriptor::GpuCounterSpec::Decoder spec(*spec_it);

--- a/src/trace_processor/importers/proto/gpu_event_parser.h
+++ b/src/trace_processor/importers/proto/gpu_event_parser.h
@@ -155,10 +155,6 @@ class GpuEventParser {
   base::FlatHashMap<TrackId, std::optional<tables::CounterTable::Id>>
       gpu_counter_last_id_;
 
-  // Tracks which interned counter descriptors have had their custom groups
-  // inserted, to avoid duplicates. Key: counter_descriptor_iid.
-  base::FlatHashMap<uint64_t, bool> gpu_custom_groups_inserted_;
-
   // For GpuRenderStageEvent
   struct HwQueueInfo {
     StringId name;

--- a/src/trace_processor/importers/proto/incremental_state.h
+++ b/src/trace_processor/importers/proto/incremental_state.h
@@ -48,13 +48,15 @@ class V8SequenceState;
 struct AndroidKernelWakelockState;
 struct AndroidCpuPerUidState;
 class TrackEventSequenceState;
+struct GpuCounterSequenceState;
 
 using CustomStateClasses = std::tuple<StackProfileSequenceState,
                                       ProfilePacketSequenceState,
                                       V8SequenceState,
                                       AndroidKernelWakelockState,
                                       AndroidCpuPerUidState,
-                                      TrackEventSequenceState>;
+                                      TrackEventSequenceState,
+                                      GpuCounterSequenceState>;
 
 // Defines an optional dependency for a `CustomState` class, which will be
 // passed as an argument to its constructor. The default leaves `Tracker` as


### PR DESCRIPTION
gpu_custom_groups_inserted_ in GpuEventParser was a global FlatHashMap<uint64_t, bool> keyed solely by counter_descriptor_iid, used to dedupe GpuCounterBlock insertions for the interned descriptor path. Interned ids are scoped to a packet sequence's incremental-state interval, not global, so two producers that legitimately share an iid on different packet sequences collide: whichever arrives first flips the cache, and the second producer's InsertCustomCounterGroups call is silently short-circuited. If the first producer's descriptor has no counter_groups, the second producer's blocks never reach gpu_counter_group_table and the UI renders those counters flat instead of grouped.

Move the cache into a new GpuCounterSequenceState : CustomState on PacketSequenceStateGeneration, alongside the interned-data table the descriptor was looked up from. Cache key stays plain counter_descriptor_iid; correctness comes from CustomState being intrinsically per-sequence per-incremental-state-interval, matching where the iids are valid. Same pattern as AndroidKernelWakelockState.