### PR TITLE
protovm: extend merge operation with del_if_src_empty

### DIFF
--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -304,6 +304,15 @@ message VmOpMerge {
   // the deepest submessages first, then moving up to the parent
   // message and merging it with skip_submessages = true.
   optional bool skip_submessages = 1;
+
+  // When true, the merge operation will remove the dst field if the src field
+  // is empty.
+  //
+  // This can be used to replicate the removal of a subobject within the
+  // producer's state. E.g.
+  //  This event on the producer side: mProducerState.mSubobject = nullptr
+  //  can be represented by this patch: { producer_state { subobject {} }}
+  optional bool del_if_src_empty = 2;
 }
 
 // Copies SRC into DST. If a message, replaces the DST node, discarding any

--- a/protos/perfetto/config/perfetto_config.proto
+++ b/protos/perfetto/config/perfetto_config.proto
@@ -310,8 +310,8 @@ message VmOpMerge {
   //
   // This can be used to replicate the removal of a subobject within the
   // producer's state. E.g.
-  //  This event on the producer side: mProducerState.mSubobject = nullptr
-  //  can be represented by this patch: { producer_state { subobject {} }}
+  // This event on the producer side: mProducerState.mSubobject = nullptr
+  // can be represented by this patch: { producer_state { subobject {} }}
   optional bool del_if_src_empty = 2;
 }
 
@@ -418,6 +418,19 @@ message TracingServiceState {
     // Returns true if the process appears to be frozen (Android only).
     // Introduced in Perfetto V49 / Android 24Q4.
     optional bool frozen = 6;
+
+    // Identifies the machine this producer is connected from in multi-machine
+    // tracing setups (e.g. when going through traced_relay). Unset (or zero)
+    // means the producer is connected from the local/host machine where the
+    // tracing service is running.
+    // Introduced in Perfetto V56 / Android 26Q3.
+    optional uint32 machine_id = 7;
+
+    // Human-readable name of the machine, as advertised by the relay (usually
+    // the value of PERFETTO_MACHINE_NAME on the remote, falling back to the
+    // remote's `uname -s`). Only set when machine_id is non-zero.
+    // Introduced in Perfetto V56 / Android 26Q3.
+    optional string machine_name = 8;
   }
 
   // Describes a data source registered by a producer. Data sources are listed

--- a/protos/perfetto/protovm/vm_program.proto
+++ b/protos/perfetto/protovm/vm_program.proto
@@ -125,6 +125,15 @@ message VmOpMerge {
   // the deepest submessages first, then moving up to the parent
   // message and merging it with skip_submessages = true.
   optional bool skip_submessages = 1;
+
+  // When true, the merge operation will remove the dst field if the src field
+  // is empty.
+  //
+  // This can be used to replicate the removal of a subobject within the
+  // producer's state. E.g.
+  //  This event on the producer side: mProducerState.mSubobject = nullptr
+  //  can be represented by this patch: { producer_state { subobject {} }}
+  optional bool del_if_src_empty = 2;
 }
 
 // Copies SRC into DST. If a message, replaces the DST node, discarding any

--- a/protos/perfetto/protovm/vm_program.proto
+++ b/protos/perfetto/protovm/vm_program.proto
@@ -131,8 +131,8 @@ message VmOpMerge {
   //
   // This can be used to replicate the removal of a subobject within the
   // producer's state. E.g.
-  //  This event on the producer side: mProducerState.mSubobject = nullptr
-  //  can be represented by this patch: { producer_state { subobject {} }}
+  // This event on the producer side: mProducerState.mSubobject = nullptr
+  // can be represented by this patch: { producer_state { subobject {} }}
   optional bool del_if_src_empty = 2;
 }
 

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -304,6 +304,15 @@ message VmOpMerge {
   // the deepest submessages first, then moving up to the parent
   // message and merging it with skip_submessages = true.
   optional bool skip_submessages = 1;
+
+  // When true, the merge operation will remove the dst field if the src field
+  // is empty.
+  //
+  // This can be used to replicate the removal of a subobject within the
+  // producer's state. E.g.
+  //  This event on the producer side: mProducerState.mSubobject = nullptr
+  //  can be represented by this patch: { producer_state { subobject {} }}
+  optional bool del_if_src_empty = 2;
 }
 
 // Copies SRC into DST. If a message, replaces the DST node, discarding any

--- a/protos/perfetto/trace/perfetto_trace.proto
+++ b/protos/perfetto/trace/perfetto_trace.proto
@@ -310,8 +310,8 @@ message VmOpMerge {
   //
   // This can be used to replicate the removal of a subobject within the
   // producer's state. E.g.
-  //  This event on the producer side: mProducerState.mSubobject = nullptr
-  //  can be represented by this patch: { producer_state { subobject {} }}
+  // This event on the producer side: mProducerState.mSubobject = nullptr
+  // can be represented by this patch: { producer_state { subobject {} }}
   optional bool del_if_src_empty = 2;
 }
 
@@ -418,6 +418,19 @@ message TracingServiceState {
     // Returns true if the process appears to be frozen (Android only).
     // Introduced in Perfetto V49 / Android 24Q4.
     optional bool frozen = 6;
+
+    // Identifies the machine this producer is connected from in multi-machine
+    // tracing setups (e.g. when going through traced_relay). Unset (or zero)
+    // means the producer is connected from the local/host machine where the
+    // tracing service is running.
+    // Introduced in Perfetto V56 / Android 26Q3.
+    optional uint32 machine_id = 7;
+
+    // Human-readable name of the machine, as advertised by the relay (usually
+    // the value of PERFETTO_MACHINE_NAME on the remote, falling back to the
+    // remote's `uname -s`). Only set when machine_id is non-zero.
+    // Introduced in Perfetto V56 / Android 26Q3.
+    optional string machine_name = 8;
   }
 
   // Describes a data source registered by a producer. Data sources are listed

--- a/src/protovm/executor.cc
+++ b/src/protovm/executor.cc
@@ -105,14 +105,17 @@ StatusOr<void> Executor::Delete(RwProto::Cursor* dst) const {
   return dst->Delete();
 }
 
-StatusOr<void> Executor::Merge(Cursors* cursors, bool skip_submessages) const {
+StatusOr<void> Executor::Merge(Cursors* cursors,
+                               bool skip_submessages,
+                               bool del_if_src_empty) const {
   if (!cursors->src.IsBytes()) {
     PROTOVM_ABORT(
         "Attempted MERGE operation but src cursor has incompatible data "
         "type");
   }
 
-  return cursors->dst.Merge(*cursors->src.GetBytes(), skip_submessages);
+  return cursors->dst.Merge(*cursors->src.GetBytes(), skip_submessages,
+                            del_if_src_empty);
 }
 
 StatusOr<void> Executor::Set(Cursors* cursors) const {

--- a/src/protovm/executor.cc
+++ b/src/protovm/executor.cc
@@ -105,17 +105,14 @@ StatusOr<void> Executor::Delete(RwProto::Cursor* dst) const {
   return dst->Delete();
 }
 
-StatusOr<void> Executor::Merge(Cursors* cursors,
-                               bool skip_submessages,
-                               bool del_if_src_empty) const {
+StatusOr<void> Executor::Merge(Cursors* cursors, uint32_t flags) const {
   if (!cursors->src.IsBytes()) {
     PROTOVM_ABORT(
         "Attempted MERGE operation but src cursor has incompatible data "
         "type");
   }
 
-  return cursors->dst.Merge(*cursors->src.GetBytes(), skip_submessages,
-                            del_if_src_empty);
+  return cursors->dst.Merge(*cursors->src.GetBytes(), flags);
 }
 
 StatusOr<void> Executor::Set(Cursors* cursors) const {

--- a/src/protovm/executor.h
+++ b/src/protovm/executor.h
@@ -59,7 +59,9 @@ class Executor {
   virtual StatusOr<uint64_t> ReadRegister(uint8_t reg_id) const;
   virtual StatusOr<void> WriteRegister(const Cursors& cursors, uint8_t reg_id);
   virtual StatusOr<void> Delete(RwProto::Cursor* dst) const;
-  virtual StatusOr<void> Merge(Cursors* cursors, bool skip_submessages) const;
+  virtual StatusOr<void> Merge(Cursors* cursors,
+                               bool skip_submessages,
+                               bool del_if_src_empty) const;
   virtual StatusOr<void> Set(Cursors* cursors) const;
 
  private:

--- a/src/protovm/executor.h
+++ b/src/protovm/executor.h
@@ -41,6 +41,8 @@ struct Cursors {
 // Executor's methods are virtual to be overridden in tests
 class Executor {
  public:
+  using MergeFlags = RwProto::Cursor::MergeFlags;
+
   virtual ~Executor();
   virtual StatusOr<void> EnterField(Cursors* cursors, uint32_t field_id) const;
   virtual StatusOr<void> EnterRepeatedFieldAt(Cursors* cursors,
@@ -59,9 +61,7 @@ class Executor {
   virtual StatusOr<uint64_t> ReadRegister(uint8_t reg_id) const;
   virtual StatusOr<void> WriteRegister(const Cursors& cursors, uint8_t reg_id);
   virtual StatusOr<void> Delete(RwProto::Cursor* dst) const;
-  virtual StatusOr<void> Merge(Cursors* cursors,
-                               bool skip_submessages,
-                               bool del_if_src_empty) const;
+  virtual StatusOr<void> Merge(Cursors* cursors, uint32_t flags) const;
   virtual StatusOr<void> Set(Cursors* cursors) const;
 
  private:

--- a/src/protovm/parser.cc
+++ b/src/protovm/parser.cc
@@ -93,7 +93,8 @@ StatusOr<void> Parser::ParseInstruction(
 StatusOr<void> Parser::ParseMerge(
     const protos::pbzero::VmInstruction::Decoder& instruction) {
   protos::pbzero::VmOpMerge::Decoder merge(instruction.merge());
-  auto status = executor_->Merge(&cursors_, merge.skip_submessages());
+  auto status = executor_->Merge(&cursors_, merge.skip_submessages(),
+                                 merge.del_if_src_empty());
   PROTOVM_RETURN_IF_NOT_OK(status);
   return status;
 }

--- a/src/protovm/parser.cc
+++ b/src/protovm/parser.cc
@@ -93,8 +93,12 @@ StatusOr<void> Parser::ParseInstruction(
 StatusOr<void> Parser::ParseMerge(
     const protos::pbzero::VmInstruction::Decoder& instruction) {
   protos::pbzero::VmOpMerge::Decoder merge(instruction.merge());
-  auto status = executor_->Merge(&cursors_, merge.skip_submessages(),
-                                 merge.del_if_src_empty());
+  uint32_t flags = Executor::MergeFlags::kNone;
+  if (merge.skip_submessages())
+    flags |= Executor::MergeFlags::kSkipSubmessages;
+  if (merge.del_if_src_empty())
+    flags |= Executor::MergeFlags::kDelIfSrcEmpty;
+  auto status = executor_->Merge(&cursors_, flags);
   PROTOVM_RETURN_IF_NOT_OK(status);
   return status;
 }

--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -81,8 +81,8 @@ StatusOr<void> RwProtoCursor::EnterField(uint32_t field_id) {
         field_id);
   }
 
-  holding_map_and_node_ = {&node_->GetIf<Node::Message>()->field_id_to_node,
-                           std::addressof(*it)};
+  parent_link_ = {node_, &node_->GetIf<Node::Message>()->field_id_to_node,
+                  std::addressof(*it)};
   node_ = it->value.get();
   return StatusOr<void>::Ok();
 }
@@ -103,7 +103,8 @@ StatusOr<void> RwProtoCursor::EnterRepeatedFieldAt(uint32_t field_id,
       FindOrCreateIndexedRepeatedField(message_field->value.get(), index);
   PROTOVM_RETURN_IF_NOT_OK(status_or_repeated_field);
 
-  holding_map_and_node_ = {
+  parent_link_ = {
+      message_field->value.get(),
       &message_field->value->GetIf<Node::IndexedRepeatedField>()->index_to_node,
       std::addressof(**status_or_repeated_field)};
   node_ = (*status_or_repeated_field)->value.get();
@@ -152,7 +153,8 @@ StatusOr<void> RwProtoCursor::EnterRepeatedFieldByKey(uint32_t field_id,
       FindOrCreateMappedRepeatedField(message_field->value.get(), key);
   PROTOVM_RETURN_IF_NOT_OK(status_or_repeated_field);
 
-  holding_map_and_node_ = {
+  parent_link_ = {
+      message_field->value.get(),
       &message_field->value->GetIf<Node::MappedRepeatedField>()->key_to_node,
       std::addressof(**status_or_repeated_field)};
   node_ = (*status_or_repeated_field)->value.get();
@@ -290,21 +292,31 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
 StatusOr<void> RwProtoCursor::Delete() {
   PERFETTO_DCHECK(node_);
 
-  bool is_root_node = !holding_map_and_node_.first;
+  bool is_root_node = !parent_link_.node;
   if (is_root_node) {
     node_->value = Node::Empty{};
     return StatusOr<void>::Ok();
   }
 
-  auto [holding_map, map_node] = holding_map_and_node_;
-  PERFETTO_DCHECK(holding_map);
-  PERFETTO_DCHECK(map_node);
-  holding_map->Remove(*map_node);
-  allocator_->Delete(&GetOuterNode(*map_node));
+  PERFETTO_DCHECK(parent_link_.node);
+  PERFETTO_DCHECK(parent_link_.map);
+  PERFETTO_DCHECK(parent_link_.map_node);
+
+  parent_link_.map->Remove(*parent_link_.map_node);
+  allocator_->Delete(&GetOuterNode(*parent_link_.map_node));
 
   node_ = nullptr;  // Delete operation invalidates cursor
 
   return StatusOr<void>::Ok();
+}
+
+bool RwProtoCursor::IsRepeated() const {
+  auto* parent_node = parent_link_.node;
+  if (!parent_node) {
+    return false;
+  }
+  return parent_node->GetIf<Node::IndexedRepeatedField>() ||
+         parent_node->GetIf<Node::MappedRepeatedField>();
 }
 
 StatusOr<void> RwProtoCursor::ConvertToMessageIfNeeded(Node* node) {

--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -208,7 +208,8 @@ StatusOr<void> RwProtoCursor::SetScalar(Scalar scalar) {
 }
 
 StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
-                                    bool skip_submessages) {
+                                    bool skip_submessages,
+                                    bool del_if_src_empty) {
   PERFETTO_DCHECK(node_);
 
   if (bool is_compatible = node_->GetIf<Node::Empty>() ||
@@ -231,16 +232,27 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
 
   for (auto field = decoder.ReadField(); field.valid();
        field = decoder.ReadField()) {
-    auto status_or_map_value = CreateNodeFromField(field);
-    PROTOVM_RETURN_IF_NOT_OK(status_or_map_value);
-
     auto it = message->field_id_to_node.Find(field.id());
+
     if (skip_submessages && it && it->value->GetIf<Node::Message>()) {
-      // Skip this node if it was merged by a previous operation and the flag is
-      // set
-      allocator_->Delete(status_or_map_value->release());
+      // Implements deep merge semantics: skip this message that was already
+      // merged by a previous operation
       continue;
     }
+
+    if (it && del_if_src_empty &&
+        field.type() ==
+            protozero::proto_utils::ProtoWireType::kLengthDelimited &&
+        field.size() == 0) {
+      // Implements remove submessage semantics: empty src field means delete
+      // the dst field
+      message->field_id_to_node.Remove(*it);
+      allocator_->Delete(&GetOuterNode(*it));
+      continue;
+    }
+
+    auto status_or_map_value = CreateNodeFromField(field);
+    PROTOVM_RETURN_IF_NOT_OK(status_or_map_value);
 
     if (!it) {
       auto status_or_it = MapInsert(&message->field_id_to_node, field.id(),
@@ -308,15 +320,6 @@ StatusOr<void> RwProtoCursor::Delete() {
   node_ = nullptr;  // Delete operation invalidates cursor
 
   return StatusOr<void>::Ok();
-}
-
-bool RwProtoCursor::IsRepeated() const {
-  auto* parent_node = parent_link_.node;
-  if (!parent_node) {
-    return false;
-  }
-  return parent_node->GetIf<Node::IndexedRepeatedField>() ||
-         parent_node->GetIf<Node::MappedRepeatedField>();
 }
 
 StatusOr<void> RwProtoCursor::ConvertToMessageIfNeeded(Node* node) {

--- a/src/protovm/rw_proto_cursor.cc
+++ b/src/protovm/rw_proto_cursor.cc
@@ -208,8 +208,7 @@ StatusOr<void> RwProtoCursor::SetScalar(Scalar scalar) {
 }
 
 StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
-                                    bool skip_submessages,
-                                    bool del_if_src_empty) {
+                                    uint32_t flags) {
   PERFETTO_DCHECK(node_);
 
   if (bool is_compatible = node_->GetIf<Node::Empty>() ||
@@ -234,12 +233,14 @@ StatusOr<void> RwProtoCursor::Merge(protozero::ConstBytes data,
        field = decoder.ReadField()) {
     auto it = message->field_id_to_node.Find(field.id());
 
+    bool skip_submessages = (flags & kSkipSubmessages) != 0;
     if (skip_submessages && it && it->value->GetIf<Node::Message>()) {
       // Implements deep merge semantics: skip this message that was already
       // merged by a previous operation
       continue;
     }
 
+    bool del_if_src_empty = (flags & kDelIfSrcEmpty) != 0;
     if (it && del_if_src_empty &&
         field.type() ==
             protozero::proto_utils::ProtoWireType::kLengthDelimited &&

--- a/src/protovm/rw_proto_cursor.h
+++ b/src/protovm/rw_proto_cursor.h
@@ -28,6 +28,12 @@ namespace protovm {
 
 class RwProtoCursor {
  public:
+  enum MergeFlags : uint32_t {
+    kNone = 0,
+    kSkipSubmessages = 1 << 0,
+    kDelIfSrcEmpty = 1 << 1,
+  };
+
   class RepeatedFieldIterator {
    public:
     RepeatedFieldIterator();
@@ -91,9 +97,7 @@ class RwProtoCursor {
   // from 'data'. Fields present in 'data' but not in the cursor's message are
   // added/created. If skip_submessages is set to true, any message node already
   // resolved in the dst are skipped, thus not overwritten by the parent merge.
-  StatusOr<void> Merge(protozero::ConstBytes data,
-                       bool skip_submessages,
-                       bool del_if_src_empty);
+  StatusOr<void> Merge(protozero::ConstBytes data, uint32_t flags);
 
   StatusOr<void> Delete();
 

--- a/src/protovm/rw_proto_cursor.h
+++ b/src/protovm/rw_proto_cursor.h
@@ -95,7 +95,15 @@ class RwProtoCursor {
 
   StatusOr<void> Delete();
 
+  bool IsRepeated() const;
+
  private:
+  struct ParentLink {
+    Node* node;
+    IntrusiveMap* map;
+    Node::MapNode* map_node;
+  };
+
   StatusOr<void> ConvertToMessageIfNeeded(Node* node);
   StatusOr<OwnedPtr<Node>> CreateNodeFromField(protozero::Field field);
   StatusOr<void> ConvertToMappedRepeatedFieldIfNeeded(
@@ -116,7 +124,7 @@ class RwProtoCursor {
   StatusOr<uint64_t> ReadScalarField(const Node& node, uint32_t field_id);
 
   Node* node_ = nullptr;
-  std::pair<IntrusiveMap*, Node::MapNode*> holding_map_and_node_ = {};
+  ParentLink parent_link_ = {};
   Allocator* allocator_ = nullptr;
 };
 

--- a/src/protovm/rw_proto_cursor.h
+++ b/src/protovm/rw_proto_cursor.h
@@ -91,11 +91,11 @@ class RwProtoCursor {
   // from 'data'. Fields present in 'data' but not in the cursor's message are
   // added/created. If skip_submessages is set to true, any message node already
   // resolved in the dst are skipped, thus not overwritten by the parent merge.
-  StatusOr<void> Merge(protozero::ConstBytes data, bool skip_submessages);
+  StatusOr<void> Merge(protozero::ConstBytes data,
+                       bool skip_submessages,
+                       bool del_if_src_empty);
 
   StatusOr<void> Delete();
-
-  bool IsRepeated() const;
 
  private:
   struct ParentLink {

--- a/src/protovm/test/mock_executor.h
+++ b/src/protovm/test/mock_executor.h
@@ -53,8 +53,10 @@ class MockExecutor : public Executor {
   MOCK_METHOD2(WriteRegister,
                StatusOr<void>(const Cursors& cursors, uint8_t reg_id));
   MOCK_CONST_METHOD1(Delete, StatusOr<void>(RwProto::Cursor* dst));
-  MOCK_CONST_METHOD2(Merge,
-                     StatusOr<void>(Cursors* cursors, bool skip_submessages));
+  MOCK_CONST_METHOD3(Merge,
+                     StatusOr<void>(Cursors* cursors,
+                                    bool skip_submessages,
+                                    bool del_if_src_empty));
   MOCK_CONST_METHOD1(Set, StatusOr<void>(Cursors* cursors));
 };
 

--- a/src/protovm/test/mock_executor.h
+++ b/src/protovm/test/mock_executor.h
@@ -53,10 +53,7 @@ class MockExecutor : public Executor {
   MOCK_METHOD2(WriteRegister,
                StatusOr<void>(const Cursors& cursors, uint8_t reg_id));
   MOCK_CONST_METHOD1(Delete, StatusOr<void>(RwProto::Cursor* dst));
-  MOCK_CONST_METHOD3(Merge,
-                     StatusOr<void>(Cursors* cursors,
-                                    bool skip_submessages,
-                                    bool del_if_src_empty));
+  MOCK_CONST_METHOD2(Merge, StatusOr<void>(Cursors* cursors, uint32_t flags));
   MOCK_CONST_METHOD1(Set, StatusOr<void>(Cursors* cursors));
 };
 

--- a/src/protovm/test/parser_unittest.cc
+++ b/src/protovm/test/parser_unittest.cc
@@ -75,10 +75,19 @@ TEST_F(ParserTest, Del) {
 }
 
 TEST_F(ParserTest, Merge) {
-  EXPECT_CALL(executor_, Merge(testing::_, testing::_))
+  EXPECT_CALL(executor_, Merge(testing::_, false, false))
       .WillOnce(testing::Return(testing::ByMove(StatusOr<void>::Ok())));
 
   auto program = SamplePrograms::Merge().SerializeAsString();
+  Parser parser(AsConstBytes(program), &executor_);
+  ASSERT_TRUE(parser.Run(RoCursor{}, RwProto::Cursor{}).IsOk());
+}
+
+TEST_F(ParserTest, Merge_DelIfSrcEmpty) {
+  EXPECT_CALL(executor_, Merge(testing::_, false, true))
+      .WillOnce(testing::Return(testing::ByMove(StatusOr<void>::Ok())));
+
+  auto program = SamplePrograms::Merge_DelIfSrcEmpty().SerializeAsString();
   Parser parser(AsConstBytes(program), &executor_);
   ASSERT_TRUE(parser.Run(RoCursor{}, RwProto::Cursor{}).IsOk());
 }

--- a/src/protovm/test/parser_unittest.cc
+++ b/src/protovm/test/parser_unittest.cc
@@ -75,7 +75,7 @@ TEST_F(ParserTest, Del) {
 }
 
 TEST_F(ParserTest, Merge) {
-  EXPECT_CALL(executor_, Merge(testing::_, false, false))
+  EXPECT_CALL(executor_, Merge(testing::_, Executor::MergeFlags::kNone))
       .WillOnce(testing::Return(testing::ByMove(StatusOr<void>::Ok())));
 
   auto program = SamplePrograms::Merge().SerializeAsString();
@@ -84,7 +84,8 @@ TEST_F(ParserTest, Merge) {
 }
 
 TEST_F(ParserTest, Merge_DelIfSrcEmpty) {
-  EXPECT_CALL(executor_, Merge(testing::_, false, true))
+  EXPECT_CALL(executor_,
+              Merge(testing::_, Executor::MergeFlags::kDelIfSrcEmpty))
       .WillOnce(testing::Return(testing::ByMove(StatusOr<void>::Ok())));
 
   auto program = SamplePrograms::Merge_DelIfSrcEmpty().SerializeAsString();

--- a/src/protovm/test/rw_proto_unittest.cc
+++ b/src/protovm/test/rw_proto_unittest.cc
@@ -693,13 +693,13 @@ TEST_F(RwProtoTest, Merge_IncompatibleWireType) {
   auto cursor = data_trace_entry_with_two_elements_.GetRoot();
   cursor.EnterRepeatedFieldAt(protos::TraceEntry::kElementsFieldNumber, 0);
   cursor.EnterField(protos::Element::kIdFieldNumber);
-  ASSERT_TRUE(cursor.Merge(bytes_empty_, false).IsAbort());
+  ASSERT_TRUE(cursor.Merge(bytes_empty_, false, false).IsAbort());
 }
 
 TEST_F(RwProtoTest, Merge_EmptySrc) {
   auto cursor = data_trace_entry_with_two_elements_.GetRoot();
   cursor.EnterRepeatedFieldAt(protos::TraceEntry::kElementsFieldNumber, 0);
-  ASSERT_TRUE(cursor.Merge(bytes_empty_, false).IsOk());
+  ASSERT_TRUE(cursor.Merge(bytes_empty_, false, false).IsOk());
   CheckProtoWithTwoElements(
       SerializeAsString(data_trace_entry_with_two_elements_));
 }
@@ -712,7 +712,7 @@ TEST_F(RwProtoTest, Merge_EmptyDst) {
   element.set_id(1);
   element.set_value(11);
   auto proto = element.SerializeAsString();
-  ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false).IsOk());
+  ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false, false).IsOk());
 
   protos::TraceEntry entry;
   entry.ParseFromString(SerializeAsString(data_empty_));
@@ -730,7 +730,7 @@ TEST_F(RwProtoTest, Merge_FieldsUnion) {
     protos::Element element;
     element.set_id(1);
     auto proto = element.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false).IsOk());
+    ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false, false).IsOk());
   }
 
   // merge with element = {value: 11}
@@ -738,7 +738,7 @@ TEST_F(RwProtoTest, Merge_FieldsUnion) {
     protos::Element element;
     element.set_value(11);
     auto proto = element.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false).IsOk());
+    ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false, false).IsOk());
   }
 
   protos::TraceEntry entry;
@@ -767,7 +767,7 @@ TEST_F(RwProtoTest, Merge_FieldsReplacement) {
     element.set_id(1);
     element.set_value(11);
     auto bytes = element.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false).IsOk());
+    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false, false).IsOk());
   }
 
   protos::TraceEntry entry;
@@ -806,7 +806,7 @@ TEST_F(RwProtoTest, Merge_RepeatedField) {
     element1->set_value(20);
 
     auto bytes = entry.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false).IsOk());
+    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false, false).IsOk());
   }
 
   // check
@@ -830,7 +830,7 @@ TEST_F(RwProtoTest, Merge_RepeatedField) {
     element0->set_value(1);
 
     auto bytes = entry.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false).IsOk());
+    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false, false).IsOk());
   }
 
   // check
@@ -878,8 +878,10 @@ TEST_F(RwProtoTest, Merge_SkipSubmessages) {
   }
 
   // merge root with skip_submessages = true
-  ASSERT_TRUE(
-      cursor.Merge(AsConstBytes(root_patch.SerializeAsString()), true).IsOk());
+  ASSERT_TRUE(cursor
+                  .Merge(AsConstBytes(root_patch.SerializeAsString()),
+                         /* skip_submessages */ true, false)
+                  .IsOk());
 
   protos::TraceEntry entry;
   entry.ParseFromString(SerializeAsString(data_empty_));
@@ -888,6 +890,49 @@ TEST_F(RwProtoTest, Merge_SkipSubmessages) {
   ASSERT_EQ(entry.single_element().value(), 10);  // not updated
   ASSERT_TRUE(entry.has_id());
   ASSERT_EQ(entry.id(), 200);  // updated
+}
+
+TEST_F(RwProtoTest, Merge_DelIfSrcEmpty_SingleField) {
+  auto root = data_empty_.GetRoot();
+
+  // root = { single_element { id: 10 }}
+  {
+    auto cursor = root;
+    cursor.EnterField(protos::TraceEntry::kSingleElementFieldNumber);
+    cursor.EnterField(protos::Element::kIdFieldNumber);
+    cursor.SetScalar(Scalar::VarInt(10));
+  }
+
+  // patch = { single_element {} }
+  protos::TraceEntry patch;
+  patch.mutable_single_element();
+
+  // Merge
+  ASSERT_TRUE(root.Merge(AsConstBytes(patch.SerializeAsString()), false,
+                         /*del_if_src_empty*/ true)
+                  .IsOk());
+
+  // Check root = {}
+  protos::TraceEntry entry;
+  entry.ParseFromString(SerializeAsString(data_empty_));
+  ASSERT_FALSE(entry.has_single_element());
+}
+
+TEST_F(RwProtoTest, Merge_DelIfSrcEmpty_RepeatedField) {
+  // root = { element {...} element {...} }
+  auto root = data_trace_entry_with_two_elements_.GetRoot();
+
+  // patch = { element {} }
+  protos::TraceEntry patch;
+  patch.add_elements();
+
+  root.Merge(AsConstBytes(patch.SerializeAsString()), false,
+             /* del_if_src_empty */ true);
+
+  // Check root = {}
+  protos::TraceEntry entry;
+  entry.ParseFromString(SerializeAsString(data_trace_entry_with_two_elements_));
+  ASSERT_EQ(entry.elements_size(), 0);
 }
 
 TEST_F(RwProtoTest, SetBytes_IncompatibleWireType) {

--- a/src/protovm/test/rw_proto_unittest.cc
+++ b/src/protovm/test/rw_proto_unittest.cc
@@ -693,13 +693,13 @@ TEST_F(RwProtoTest, Merge_IncompatibleWireType) {
   auto cursor = data_trace_entry_with_two_elements_.GetRoot();
   cursor.EnterRepeatedFieldAt(protos::TraceEntry::kElementsFieldNumber, 0);
   cursor.EnterField(protos::Element::kIdFieldNumber);
-  ASSERT_TRUE(cursor.Merge(bytes_empty_, false, false).IsAbort());
+  ASSERT_TRUE(cursor.Merge(bytes_empty_, RwProto::Cursor::kNone).IsAbort());
 }
 
 TEST_F(RwProtoTest, Merge_EmptySrc) {
   auto cursor = data_trace_entry_with_two_elements_.GetRoot();
   cursor.EnterRepeatedFieldAt(protos::TraceEntry::kElementsFieldNumber, 0);
-  ASSERT_TRUE(cursor.Merge(bytes_empty_, false, false).IsOk());
+  ASSERT_TRUE(cursor.Merge(bytes_empty_, RwProto::Cursor::kNone).IsOk());
   CheckProtoWithTwoElements(
       SerializeAsString(data_trace_entry_with_two_elements_));
 }
@@ -712,7 +712,7 @@ TEST_F(RwProtoTest, Merge_EmptyDst) {
   element.set_id(1);
   element.set_value(11);
   auto proto = element.SerializeAsString();
-  ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false, false).IsOk());
+  ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), RwProto::Cursor::kNone).IsOk());
 
   protos::TraceEntry entry;
   entry.ParseFromString(SerializeAsString(data_empty_));
@@ -730,7 +730,8 @@ TEST_F(RwProtoTest, Merge_FieldsUnion) {
     protos::Element element;
     element.set_id(1);
     auto proto = element.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false, false).IsOk());
+    ASSERT_TRUE(
+        cursor.Merge(AsConstBytes(proto), RwProto::Cursor::kNone).IsOk());
   }
 
   // merge with element = {value: 11}
@@ -738,7 +739,8 @@ TEST_F(RwProtoTest, Merge_FieldsUnion) {
     protos::Element element;
     element.set_value(11);
     auto proto = element.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(proto), false, false).IsOk());
+    ASSERT_TRUE(
+        cursor.Merge(AsConstBytes(proto), RwProto::Cursor::kNone).IsOk());
   }
 
   protos::TraceEntry entry;
@@ -767,7 +769,8 @@ TEST_F(RwProtoTest, Merge_FieldsReplacement) {
     element.set_id(1);
     element.set_value(11);
     auto bytes = element.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false, false).IsOk());
+    ASSERT_TRUE(
+        cursor.Merge(AsConstBytes(bytes), RwProto::Cursor::kNone).IsOk());
   }
 
   protos::TraceEntry entry;
@@ -806,7 +809,8 @@ TEST_F(RwProtoTest, Merge_RepeatedField) {
     element1->set_value(20);
 
     auto bytes = entry.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false, false).IsOk());
+    ASSERT_TRUE(
+        cursor.Merge(AsConstBytes(bytes), RwProto::Cursor::kNone).IsOk());
   }
 
   // check
@@ -830,7 +834,8 @@ TEST_F(RwProtoTest, Merge_RepeatedField) {
     element0->set_value(1);
 
     auto bytes = entry.SerializeAsString();
-    ASSERT_TRUE(cursor.Merge(AsConstBytes(bytes), false, false).IsOk());
+    ASSERT_TRUE(
+        cursor.Merge(AsConstBytes(bytes), RwProto::Cursor::kNone).IsOk());
   }
 
   // check
@@ -880,7 +885,7 @@ TEST_F(RwProtoTest, Merge_SkipSubmessages) {
   // merge root with skip_submessages = true
   ASSERT_TRUE(cursor
                   .Merge(AsConstBytes(root_patch.SerializeAsString()),
-                         /* skip_submessages */ true, false)
+                         RwProto::Cursor::kSkipSubmessages)
                   .IsOk());
 
   protos::TraceEntry entry;
@@ -908,8 +913,8 @@ TEST_F(RwProtoTest, Merge_DelIfSrcEmpty_SingleField) {
   patch.mutable_single_element();
 
   // Merge
-  ASSERT_TRUE(root.Merge(AsConstBytes(patch.SerializeAsString()), false,
-                         /*del_if_src_empty*/ true)
+  ASSERT_TRUE(root.Merge(AsConstBytes(patch.SerializeAsString()),
+                         RwProto::Cursor::kDelIfSrcEmpty)
                   .IsOk());
 
   // Check root = {}
@@ -926,8 +931,8 @@ TEST_F(RwProtoTest, Merge_DelIfSrcEmpty_RepeatedField) {
   protos::TraceEntry patch;
   patch.add_elements();
 
-  root.Merge(AsConstBytes(patch.SerializeAsString()), false,
-             /* del_if_src_empty */ true);
+  root.Merge(AsConstBytes(patch.SerializeAsString()),
+             RwProto::Cursor::kDelIfSrcEmpty);
 
   // Check root = {}
   protos::TraceEntry entry;

--- a/src/protovm/test/sample_programs.h
+++ b/src/protovm/test/sample_programs.h
@@ -258,6 +258,14 @@ class SamplePrograms {
     return program;
   }
 
+  static perfetto::protos::VmProgram Merge_DelIfSrcEmpty() {
+    perfetto::protos::VmProgram program;
+    auto* instruction = program.add_instructions();
+    auto* merge = instruction->mutable_merge();
+    merge->set_del_if_src_empty(true);
+    return program;
+  }
+
   static perfetto::protos::VmProgram Set() {
     perfetto::protos::VmProgram program;
     program.add_instructions()->mutable_set();


### PR DESCRIPTION
This change implements the "delete submessage" semantics during
merge operations: when the flag delete_if_src_empty is set, an empty
src field means "delete the corresponding dst field".

This functionality is required to replicate in the ProtoVM the removal
of a subobject within the producer's state.

E.g.:
This event on the producer side: mProducerState.mSubobject = nullptr
can be represented with this patch: { producer_state { subobject {} }}