### PR TITLE
watchdog: Report actual boot/mono/cpu time

### DIFF
--- a/include/perfetto/base/time.h
+++ b/include/perfetto/base/time.h
@@ -62,6 +62,7 @@ void InitializeTime();
 
 TimeNanos GetWallTimeNs();
 TimeNanos GetThreadCPUTimeNs();
+TimeNanos GetProcessCPUTimeNs();
 inline TimeNanos GetWallTimeRawNs() {
   return GetWallTimeNs();
 }
@@ -139,10 +140,49 @@ inline TimeNanos GetThreadCPUTimeNs() {
                    info.system_time.seconds * 1000000000LL +
                    info.system_time.microseconds * 1000LL);
 }
+
+inline TimeNanos GetProcessCPUTimeNs() {
+  // task_basic_info gives CPU time accumulated by terminated threads only.
+  // task_thread_times_info gives CPU time of currently-live threads. The sum
+  // of the two is the equivalent of CLOCK_PROCESS_CPUTIME_ID.
+  task_basic_info_data_t past_threads{};
+  mach_msg_type_number_t basic_count = TASK_BASIC_INFO_COUNT;
+  kern_return_t kr =
+      task_info(mach_task_self(), TASK_BASIC_INFO,
+                reinterpret_cast<task_info_t>(&past_threads), &basic_count);
+  if (kr != KERN_SUCCESS) {
+    PERFETTO_DFATAL("Failed to get process CPU time (basic).");
+    return TimeNanos(0);
+  }
+
+  task_thread_times_info_data_t cur_threads{};
+  mach_msg_type_number_t times_count = TASK_THREAD_TIMES_INFO_COUNT;
+  kr = task_info(mach_task_self(), TASK_THREAD_TIMES_INFO,
+                 reinterpret_cast<task_info_t>(&cur_threads), &times_count);
+  if (kr != KERN_SUCCESS) {
+    PERFETTO_DFATAL("Failed to get process CPU time (thread times).");
+    return TimeNanos(0);
+  }
+
+  return TimeNanos(past_threads.user_time.seconds * 1000000000LL +
+                   past_threads.user_time.microseconds * 1000LL +
+                   past_threads.system_time.seconds * 1000000000LL +
+                   past_threads.system_time.microseconds * 1000LL +
+                   cur_threads.user_time.seconds * 1000000000LL +
+                   cur_threads.user_time.microseconds * 1000LL +
+                   cur_threads.system_time.seconds * 1000000000LL +
+                   cur_threads.system_time.microseconds * 1000LL);
+}
 #else
 inline TimeNanos GetThreadCPUTimeNs() {
   struct timespec ts = {};
   PERFETTO_CHECK(clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0);
+  return FromPosixTimespec(ts);
+}
+
+inline TimeNanos GetProcessCPUTimeNs() {
+  struct timespec ts = {};
+  PERFETTO_CHECK(clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &ts) == 0);
   return FromPosixTimespec(ts);
 }
 #endif
@@ -158,6 +198,10 @@ inline TimeNanos GetWallTimeRawNs() {
 }
 
 inline TimeNanos GetThreadCPUTimeNs() {
+  return TimeNanos(0);
+}
+
+inline TimeNanos GetProcessCPUTimeNs() {
   return TimeNanos(0);
 }
 
@@ -181,6 +225,10 @@ inline TimeNanos GetWallTimeRawNs() {
 }
 
 inline TimeNanos GetThreadCPUTimeNs() {
+  return TimeNanos(0);
+}
+
+inline TimeNanos GetProcessCPUTimeNs() {
   return TimeNanos(0);
 }
 
@@ -208,6 +256,10 @@ inline TimeNanos GetWallTimeRawNs() {
 
 inline TimeNanos GetThreadCPUTimeNs() {
   return GetTimeInternalNs(CLOCK_THREAD_CPUTIME_ID);
+}
+
+inline TimeNanos GetProcessCPUTimeNs() {
+  return GetTimeInternalNs(CLOCK_PROCESS_CPUTIME_ID);
 }
 
 // TODO: Clock that counts time during suspend is not implemented on QNX.
@@ -254,6 +306,10 @@ inline TimeNanos GetWallTimeRawNs() {
 
 inline TimeNanos GetThreadCPUTimeNs() {
   return GetTimeInternalNs(CLOCK_THREAD_CPUTIME_ID);
+}
+
+inline TimeNanos GetProcessCPUTimeNs() {
+  return GetTimeInternalNs(CLOCK_PROCESS_CPUTIME_ID);
 }
 #endif
 

--- a/include/perfetto/ext/base/watchdog_posix.h
+++ b/include/perfetto/ext/base/watchdog_posix.h
@@ -45,10 +45,14 @@ bool ReadProcStat(int fd, ProcStat* out);
 class Watchdog {
  public:
   struct TimerData {
-    TimeMillis deadline{};     // Absolute deadline, CLOCK_MONOTONIC.
-    uint32_t duration_ms = 0;  // Relative deadline in ms (for debugging only).
-    int thread_id = 0;         // The tid we'll send a SIGABRT to on expiry.
+    TimeMillis deadline{};  // Absolute deadline, CLOCK_MONOTONIC.
+    int thread_id = 0;      // The tid we'll send a SIGABRT to on expiry.
     WatchdogCrashReason crash_reason{};  // Becomes a crash key.
+
+    // The fields below are for debugging / logging purposes only.
+    TimeMillis ctime_mono{};  // Creation time in CLOCK_MONOTONIC.
+    TimeMillis ctime_boot{};  // Creation time in CLOCK_BOOTTIME.
+    TimeMillis ctime_cpu{};   // Creation time in CLOCK_PROCESS_CPUTIME_ID.
 
     TimerData() = default;
     TimerData(TimeMillis d, int t) : deadline(d), thread_id(t) {}

--- a/src/base/watchdog_posix.cc
+++ b/src/base/watchdog_posix.cc
@@ -15,6 +15,7 @@
  */
 
 #include "perfetto/ext/base/platform.h"
+#include "perfetto/ext/base/string_utils.h"
 #include "perfetto/ext/base/watchdog.h"
 
 #if PERFETTO_BUILDFLAG(PERFETTO_WATCHDOG)
@@ -50,7 +51,10 @@ namespace {
 constexpr uint32_t kDefaultPollingInterval = 30 * 1000;
 
 base::CrashKey g_crash_key_reason("wdog_reason");
-base::CrashKey g_crash_key_timer_ms("wdog_ms");
+base::CrashKey g_crash_key_timeout("wdog_timeout");
+base::CrashKey g_crash_key_actual_mono("wdog_actual_mono");
+base::CrashKey g_crash_key_actual_boot("wdog_actual_boot");
+base::CrashKey g_crash_key_actual_cpu("wdog_actual_cpu");
 
 bool IsMultipleOf(uint32_t number, uint32_t divisor) {
   return number >= divisor && number % divisor == 0;
@@ -102,11 +106,10 @@ Watchdog::~Watchdog() {
   }
   PERFETTO_DCHECK(enabled_);
   enabled_ = false;
-
   // Rearm the timer to 1ns from now. This will cause the watchdog thread to
   // wakeup from the poll() and see |enabled_| == false.
-  // This code path is used only in tests. In production code the watchdog is
-  // a singleton and is never destroyed.
+  // This code path is used only in tests. In production code the watchdog
+  // is a singleton and is never destroyed.
   struct itimerspec ts{};
   ts.it_value.tv_sec = 0;
   ts.it_value.tv_nsec = 1;
@@ -215,7 +218,10 @@ void Watchdog::SetCpuLimit(uint32_t percentage, uint32_t window_ms) {
 void Watchdog::ThreadMain() {
   // Register crash keys explicitly to avoid running out of slots at crash time.
   g_crash_key_reason.Register();
-  g_crash_key_timer_ms.Register();
+  g_crash_key_timeout.Register();
+  g_crash_key_actual_boot.Register();
+  g_crash_key_actual_mono.Register();
+  g_crash_key_actual_cpu.Register();
 
   base::ScopedFile stat_fd(base::OpenFile("/proc/self/stat", O_RDONLY));
   if (!stat_fd) {
@@ -259,24 +265,36 @@ void Watchdog::ThreadMain() {
     const auto now = GetWallTimeMs();
 
     // Check if any of the timers expired.
-    int tid_to_kill = 0;
-    uint32_t wdog_timer_ms = 0;
-    WatchdogCrashReason crash_reason{};
+    TimerData timer{};
     {
       std::lock_guard<std::mutex> guard(mutex_);
-      for (const auto& timer : timers_) {
-        if (now >= timer.deadline) {
-          tid_to_kill = timer.thread_id;
-          crash_reason = timer.crash_reason;
-          wdog_timer_ms = timer.duration_ms;
+      for (const auto& t : timers_) {
+        if (now >= t.deadline) {
+          timer = t;
           break;
         }
       }
     }
 
-    if (tid_to_kill) {
-      g_crash_key_timer_ms.Set(static_cast<int>(wdog_timer_ms));
-      SerializeLogsAndKillThread(tid_to_kill, crash_reason);
+    if (timer.thread_id) {
+      g_crash_key_timeout.Set(
+          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                               timer.deadline - timer.ctime_mono)
+                               .count()));
+      g_crash_key_actual_mono.Set(
+          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                               GetWallTimeMs() - timer.ctime_mono)
+                               .count()));
+      g_crash_key_actual_boot.Set(
+          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                               GetBootTimeMs() - timer.ctime_boot)
+                               .count()));
+      g_crash_key_actual_cpu.Set(
+          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                               GetProcessCPUTimeNs() - timer.ctime_cpu)
+                               .count()));
+
+      SerializeLogsAndKillThread(timer.thread_id, timer.crash_reason);
     }
 
     // Check CPU and memory guardrails (if enabled).
@@ -289,6 +307,7 @@ void Watchdog::ThreadMain() {
         static_cast<uint64_t>(stat.rss_pages) * base::GetSysPageSize();
 
     bool threshold_exceeded = false;
+    WatchdogCrashReason crash_reason{};
     {
       std::lock_guard<std::mutex> guard(mutex_);
       if (CheckMemory_Locked(rss_bytes) && !IsSyncMemoryTaggingEnabled()) {
@@ -419,8 +438,13 @@ Watchdog::Timer::Timer(Watchdog* watchdog,
     : watchdog_(watchdog) {
   if (!ms)
     return;  // No-op timer created when the watchdog is disabled.
-  timer_data_.deadline = GetWallTimeMs() + std::chrono::milliseconds(ms);
-  timer_data_.duration_ms = ms;
+
+  TimeMillis now_mono = GetWallTimeMs();
+  timer_data_.deadline = now_mono + std::chrono::milliseconds(ms);
+  timer_data_.ctime_mono = now_mono;
+  timer_data_.ctime_boot = GetBootTimeMs();
+  timer_data_.ctime_cpu =
+      std::chrono::duration_cast<TimeMillis>(GetProcessCPUTimeNs());
   timer_data_.thread_id = GetThreadId();
   timer_data_.crash_reason = crash_reason;
   PERFETTO_DCHECK(watchdog_);


### PR DESCRIPTION
Improve debuggability of watchdog by adding:
- Actual elapsed boot time
- Actual elapsed mono time
- Actual elapses cpu time (which gives a sense of whether we
  did too much CPU work or never got CPU bandwidth)
- Also rename the recently introduced crash key to timeout and
  make everything seconds based. 

Bug: b/496506220