### PR TITLE
traced_probes: add wdog handler to finalize the trace gracefully

### DIFF
--- a/include/perfetto/ext/base/metatrace_events.h
+++ b/include/perfetto/ext/base/metatrace_events.h
@@ -87,6 +87,9 @@ enum Tags : uint32_t {
 //   tracing_service_impl.cc for the format.
 // * PROFILER_UNWIND_CURRENT_PID represents the PID that is being unwound.
 // * WATCHDOG_CRASH_REASON represents the base::WatchdogCrashReason enum.
+// * WATCHDOG_CRASH_TIME_BOOT_MS The time in ms since boot when the watchdog
+//   timeout alarm triggered (i.e. when it would have caused a crash, without
+//   counting for the optional handler time).
 // * WATCHDOG_CRASH_ACTUAL_{MONO,BOOT,CPU} are the elapsed seconds (since the
 //   offending fatal timer was created) sampled from CLOCK_MONOTONIC,
 //   CLOCK_BOOTTIME and CLOCK_PROCESS_CPUTIME_ID respectively.
@@ -99,6 +102,7 @@ enum Tags : uint32_t {
   F(PROFILER_UNWIND_QUEUE_SZ), \
   F(PROFILER_UNWIND_CURRENT_PID), \
   F(WATCHDOG_CRASH_REASON), \
+  F(WATCHDOG_CRASH_TIME_BOOT_MS), \
   F(WATCHDOG_CRASH_ACTUAL_MONO), \
   F(WATCHDOG_CRASH_ACTUAL_BOOT), \
   F(WATCHDOG_CRASH_ACTUAL_CPU), \

--- a/include/perfetto/ext/base/metatrace_events.h
+++ b/include/perfetto/ext/base/metatrace_events.h
@@ -86,6 +86,10 @@ enum Tags : uint32_t {
 // * FTRACE_SERVICE_COMMIT_DATA is a bit-packed representation of an event, see
 //   tracing_service_impl.cc for the format.
 // * PROFILER_UNWIND_CURRENT_PID represents the PID that is being unwound.
+// * WATCHDOG_CRASH_REASON represents the base::WatchdogCrashReason enum.
+// * WATCHDOG_CRASH_ACTUAL_{MONO,BOOT,CPU} are the elapsed seconds (since the
+//   offending fatal timer was created) sampled from CLOCK_MONOTONIC,
+//   CLOCK_BOOTTIME and CLOCK_PROCESS_CPUTIME_ID respectively.
 //
 #define PERFETTO_METATRACE_COUNTERS(F) \
   F(COUNTER_ZERO_UNUSED),\
@@ -93,7 +97,12 @@ enum Tags : uint32_t {
   F(PS_PIDS_SCANNED), \
   F(TRACE_SERVICE_COMMIT_DATA), \
   F(PROFILER_UNWIND_QUEUE_SZ), \
-  F(PROFILER_UNWIND_CURRENT_PID)
+  F(PROFILER_UNWIND_CURRENT_PID), \
+  F(WATCHDOG_CRASH_REASON), \
+  F(WATCHDOG_CRASH_ACTUAL_MONO), \
+  F(WATCHDOG_CRASH_ACTUAL_BOOT), \
+  F(WATCHDOG_CRASH_ACTUAL_CPU), \
+  F(FTRACE_SESSIONS)
 
 // clang-format on
 

--- a/include/perfetto/ext/base/watchdog.h
+++ b/include/perfetto/ext/base/watchdog.h
@@ -41,6 +41,28 @@ enum class WatchdogCrashReason {
   kTraceDidntStop = 4,
 };
 
+// Information about an imminent watchdog-triggered crash. Passed to the fatal
+// handler installed via Watchdog::Start() so embedders can record it (e.g. via
+// metatrace counters) before the process is force-killed.
+struct WatchdogCrashInfo {
+  int thread_id = 0;
+  WatchdogCrashReason reason = WatchdogCrashReason::kUnspecified;
+
+  // The time in CLOCK_BOOTTIME when the watchdog triggered.
+  int64_t alarm_time_ms = 0;
+
+  // The initial timeout passed to CreateFatalTimer.
+  int timeout_s = 0;
+
+  // Elapsed seconds, since the offending fatal timer was created, sampled
+  // from CLOCK_MONOTONIC, CLOCK_BOOTTIME and CLOCK_PROCESS_CPUTIME_ID
+  // respectively. These mirror the wdog_actual_{mono,boot,cpu} crash keys.
+  // They are 0 for cpu/memory guardrail crashes (no associated timer).
+  int actual_mono_s = 0;
+  int actual_boot_s = 0;
+  int actual_cpu_s = 0;
+};
+
 // Make the limits more relaxed on desktop, where multi-GB traces are likely.
 // Multi-GB traces can take bursts of cpu time to write into disk at the end of
 // the trace.

--- a/include/perfetto/ext/base/watchdog_noop.h
+++ b/include/perfetto/ext/base/watchdog_noop.h
@@ -19,10 +19,15 @@
 
 #include <stdint.h>
 
+#include <functional>
+
 namespace perfetto {
 namespace base {
 
+class TaskRunner;
+
 enum class WatchdogCrashReason;  // Defined in watchdog.h.
+struct WatchdogCrashInfo;        // Defined in watchdog.h.
 
 class Watchdog {
  public:
@@ -40,7 +45,8 @@ class Watchdog {
   Timer CreateFatalTimer(uint32_t /*ms*/, WatchdogCrashReason) {
     return Timer();
   }
-  void Start() {}
+  void Start(TaskRunner* /*task_runner*/ = nullptr,
+             std::function<void(WatchdogCrashInfo)> /*handler*/ = {}) {}
   void SetMemoryLimit(uint64_t /*bytes*/, uint32_t /*window_ms*/) {}
   void SetCpuLimit(uint32_t /*percentage*/, uint32_t /*window_ms*/) {}
 };

--- a/include/perfetto/ext/base/watchdog_posix.h
+++ b/include/perfetto/ext/base/watchdog_posix.h
@@ -102,13 +102,10 @@ class Watchdog {
   // If |fatal_handler| is non-empty, it will be invoked on |task_runner|
   // before the watchdog force-kills the process due to a fatal timer expiry
   // (CreateFatalTimer) or a cpu/memory guardrail violation. The handler gets
-  // a kFatalHandlerGraceMs (30s) grace period to crash the process on its
+  // a kFatalHandlerGraceMs (60s) grace period to crash the process on its
   // own (e.g. via PERFETTO_FATAL); if it doesn't, the watchdog force-kills.
   // |task_runner| must outlive the watchdog (typically the main task runner
   // of a process-singleton).
-  // The handler is intentionally captured here (one-shot, before the watchdog
-  // thread is started) so that the watchdog thread can read it without
-  // locking.
   void Start(TaskRunner* task_runner = nullptr,
              std::function<void(WatchdogCrashInfo)> fatal_handler = {});
 

--- a/include/perfetto/ext/base/watchdog_posix.h
+++ b/include/perfetto/ext/base/watchdog_posix.h
@@ -22,6 +22,7 @@
 #include "perfetto/ext/base/scoped_file.h"
 
 #include <atomic>
+#include <functional>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -29,7 +30,10 @@
 namespace perfetto {
 namespace base {
 
+class TaskRunner;
+
 enum class WatchdogCrashReason;  // Defined in watchdog.h.
+struct WatchdogCrashInfo;        // Defined in watchdog.h.
 
 struct ProcStat {
   unsigned long int utime = 0l;
@@ -95,7 +99,18 @@ class Watchdog {
 
   // Starts the watchdog thread which monitors the memory and CPU usage
   // of the program.
-  void Start();
+  // If |fatal_handler| is non-empty, it will be invoked on |task_runner|
+  // before the watchdog force-kills the process due to a fatal timer expiry
+  // (CreateFatalTimer) or a cpu/memory guardrail violation. The handler gets
+  // a kFatalHandlerGraceMs (30s) grace period to crash the process on its
+  // own (e.g. via PERFETTO_FATAL); if it doesn't, the watchdog force-kills.
+  // |task_runner| must outlive the watchdog (typically the main task runner
+  // of a process-singleton).
+  // The handler is intentionally captured here (one-shot, before the watchdog
+  // thread is started) so that the watchdog thread can read it without
+  // locking.
+  void Start(TaskRunner* task_runner = nullptr,
+             std::function<void(WatchdogCrashInfo)> fatal_handler = {});
 
   // Sets a limit on the memory (defined as the RSS) used by the program
   // averaged over the last |window_ms| milliseconds. If |kb| is 0, any
@@ -168,7 +183,7 @@ class Watchdog {
   void AddFatalTimer(TimerData);
   void RemoveFatalTimer(TimerData);
   void RearmTimerFd_Locked() PERFETTO_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
-  void SerializeLogsAndKillThread(int tid, WatchdogCrashReason);
+  void SerializeLogsAndKillThread(int tid, const WatchdogCrashInfo&);
 
   // Computes the time interval spanned by a given ring buffer with respect
   // to |polling_interval_ms_|.
@@ -193,6 +208,13 @@ class Watchdog {
   // All the timers in the list share the same |timer_fd_|, which is keeped
   // armed on the min(timers_) through RearmTimerFd_Locked().
   std::vector<TimerData> timers_ PERFETTO_GUARDED_BY(mutex_);
+
+  // See Start(). Set once in Start() before the watchdog thread is created.
+  // After Start() returns these are only ever accessed by the watchdog
+  // thread, which clears them after invoking the handler so subsequent
+  // expirations during the grace period don't re-post it. No locking needed.
+  TaskRunner* fatal_handler_task_runner_ = nullptr;
+  std::function<void(WatchdogCrashInfo)> fatal_handler_;
 
  protected:
   // Protected for testing.

--- a/src/base/watchdog_posix.cc
+++ b/src/base/watchdog_posix.cc
@@ -36,6 +36,7 @@
 
 #include "perfetto/base/build_config.h"
 #include "perfetto/base/logging.h"
+#include "perfetto/base/task_runner.h"
 #include "perfetto/base/thread_utils.h"
 #include "perfetto/base/time.h"
 #include "perfetto/ext/base/crash_keys.h"
@@ -49,6 +50,10 @@ namespace base {
 namespace {
 
 constexpr uint32_t kDefaultPollingInterval = 30 * 1000;
+
+// Grace period given to a fatal handler installed via SetFatalHandler() to
+// crash the process on its own before the watchdog force-kills it.
+constexpr uint32_t kFatalHandlerGraceMs = 60 * 1000;
 
 base::CrashKey g_crash_key_reason("wdog_reason");
 base::CrashKey g_crash_key_timeout("wdog_timeout");
@@ -168,12 +173,19 @@ void Watchdog::RearmTimerFd_Locked() {
   PERFETTO_DCHECK(res == 0);
 }
 
-void Watchdog::Start() {
+void Watchdog::Start(TaskRunner* task_runner,
+                     std::function<void(WatchdogCrashInfo)> fatal_handler) {
   std::lock_guard<std::mutex> guard(mutex_);
   if (thread_.joinable()) {
     PERFETTO_DCHECK(enabled_);
   } else {
     PERFETTO_DCHECK(!enabled_);
+
+    // |fatal_handler_*| are written here, before the watchdog thread is
+    // created. The watchdog thread is the only reader, so no locking is
+    // needed when accessing them from ThreadMain().
+    fatal_handler_task_runner_ = task_runner;
+    fatal_handler_ = std::move(fatal_handler);
 
 #if PERFETTO_BUILDFLAG(PERFETTO_OS_LINUX) || \
     PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
@@ -262,39 +274,41 @@ void Watchdog::ThreadMain() {
     auto res = PERFETTO_EINTR(read(*timer_fd_, &expired, sizeof(expired)));
     PERFETTO_DCHECK((res < 0 && (errno == EAGAIN)) ||
                     (res == sizeof(expired) && expired > 0));
-    const auto now = GetWallTimeMs();
+    const TimeMillis now_mono_ms = GetWallTimeMs();
 
     // Check if any of the timers expired.
-    TimerData timer{};
+    WatchdogCrashInfo info{};
     {
       std::lock_guard<std::mutex> guard(mutex_);
-      for (const auto& t : timers_) {
-        if (now >= t.deadline) {
-          timer = t;
+      for (const auto& timer : timers_) {
+        if (now_mono_ms >= timer.deadline) {
+          info.thread_id = timer.thread_id;
+          info.reason = timer.crash_reason;
+          const TimeMillis now_boot_ms = GetBootTimeMs();
+          info.alarm_time_ms = now_boot_ms.count();
+          info.timeout_s =
+              static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                                   timer.deadline - timer.ctime_mono)
+                                   .count());
+          info.actual_mono_s =
+              static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                                   now_mono_ms - timer.ctime_mono)
+                                   .count());
+          info.actual_boot_s =
+              static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                                   now_boot_ms - timer.ctime_boot)
+                                   .count());
+          info.actual_cpu_s =
+              static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
+                                   GetProcessCPUTimeNs() - timer.ctime_cpu)
+                                   .count());
           break;
         }
       }
     }
 
-    if (timer.thread_id) {
-      g_crash_key_timeout.Set(
-          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
-                               timer.deadline - timer.ctime_mono)
-                               .count()));
-      g_crash_key_actual_mono.Set(
-          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
-                               GetWallTimeMs() - timer.ctime_mono)
-                               .count()));
-      g_crash_key_actual_boot.Set(
-          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
-                               GetBootTimeMs() - timer.ctime_boot)
-                               .count()));
-      g_crash_key_actual_cpu.Set(
-          static_cast<int>(std::chrono::duration_cast<TimeSeconds>(
-                               GetProcessCPUTimeNs() - timer.ctime_cpu)
-                               .count()));
-
-      SerializeLogsAndKillThread(timer.thread_id, timer.crash_reason);
+    if (info.thread_id) {
+      SerializeLogsAndKillThread(info.thread_id, info);
     }
 
     // Check CPU and memory guardrails (if enabled).
@@ -319,14 +333,40 @@ void Watchdog::ThreadMain() {
       }
     }
 
-    if (threshold_exceeded)
-      SerializeLogsAndKillThread(getpid(), crash_reason);
+    if (threshold_exceeded) {
+      info.reason = crash_reason;
+      // No associated timer: info.actual_*_s remain 0.
+      SerializeLogsAndKillThread(getpid(), info);
+    }
   }
 }
 
 void Watchdog::SerializeLogsAndKillThread(int tid,
-                                          WatchdogCrashReason crash_reason) {
-  g_crash_key_reason.Set(static_cast<int>(crash_reason));
+                                          const WatchdogCrashInfo& info) {
+  g_crash_key_timeout.Set(info.timeout_s);
+  g_crash_key_actual_mono.Set(info.actual_mono_s);
+  g_crash_key_actual_boot.Set(info.actual_boot_s);
+  g_crash_key_actual_cpu.Set(info.actual_cpu_s);
+  g_crash_key_reason.Set(static_cast<int>(info.reason));
+
+  // If the embedder installed a fatal handler, give it a chance to run (e.g.
+  // to flush in-flight state) before we force-kill the process. The handler
+  // is expected to crash the process on its own (e.g. via PERFETTO_FATAL once
+  // it's done). If it doesn't crash within |kFatalHandlerGraceMs|, we proceed
+  // and force-kill from here.
+  // |fatal_handler_*| are set in Start() before the watchdog thread is
+  // created, so no locking is needed. Clearing them after invocation prevents
+  // re-posting if the same expired condition is observed again.
+  if (fatal_handler_ && fatal_handler_task_runner_) {
+    fatal_handler_task_runner_->PostTask(
+        [h = std::move(fatal_handler_), info] { h(info); });
+    fatal_handler_ = nullptr;
+    fatal_handler_task_runner_ = nullptr;
+    if (!disable_kill_failsafe_for_testing_) {
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(kFatalHandlerGraceMs));
+    }
+  }
 
   // We are about to die. Serialize the logs into the crash buffer so the
   // debuggerd crash handler picks them up and attaches to the bugreport.

--- a/src/base/watchdog_posix.cc
+++ b/src/base/watchdog_posix.cc
@@ -51,7 +51,7 @@ namespace {
 
 constexpr uint32_t kDefaultPollingInterval = 30 * 1000;
 
-// Grace period given to a fatal handler installed via SetFatalHandler() to
+// Grace period given to a fatal handler (passed to Start()) to
 // crash the process on its own before the watchdog force-kills it.
 constexpr uint32_t kFatalHandlerGraceMs = 60 * 1000;
 

--- a/src/base/watchdog_unittest.cc
+++ b/src/base/watchdog_unittest.cc
@@ -17,6 +17,7 @@
 #include "perfetto/ext/base/watchdog.h"
 
 #include "perfetto/base/logging.h"
+#include "perfetto/base/task_runner.h"
 #include "perfetto/base/thread_utils.h"
 #include "perfetto/ext/base/paged_memory.h"
 #include "perfetto/ext/base/scoped_file.h"
@@ -171,6 +172,80 @@ TEST(WatchdogTest, TimerCrashDeliveredToCallerThread) {
     thread.join();
 
   EXPECT_EQ(g_aborted_thread, expected_tid);
+}
+
+// Minimal TaskRunner stub that captures whatever is posted via PostTask().
+// Sufficient for the FatalHandler test below; other methods are unused.
+class CapturingTaskRunner : public TaskRunner {
+ public:
+  void PostTask(std::function<void()> t) override {
+    std::lock_guard<std::mutex> lock(mu);
+    posted_tasks.emplace_back(std::move(t));
+    cv.notify_all();
+  }
+  void PostDelayedTask(std::function<void()>, uint32_t) override {}
+  void AddFileDescriptorWatch(PlatformHandle, std::function<void()>) override {}
+  void RemoveFileDescriptorWatch(PlatformHandle) override {}
+  bool RunsTasksOnCurrentThread() const override { return true; }
+
+  std::mutex mu;
+  std::condition_variable cv;
+  std::vector<std::function<void()>> posted_tasks;
+};
+
+TEST(WatchdogTest, FatalHandlerRunsBeforeKill) {
+  // Absorb SIGABRT so the kill-via-tgkill path inside the watchdog doesn't
+  // actually crash the test process.
+  struct sigaction oldact;
+  struct sigaction newact = {};
+  newact.sa_handler = SIGABRTHandler;
+  ASSERT_EQ(sigaction(SIGABRT, &newact, &oldact), 0);
+  base::ScopedResource<const struct sigaction*, RestoreSIGABRT, nullptr>
+      auto_restore(&oldact);
+  g_aborted_thread = 0;
+
+  CapturingTaskRunner runner;
+  std::atomic<int> handler_calls{0};
+  WatchdogCrashInfo captured_info{};
+  std::mutex captured_mu;
+
+  TestWatchdog watchdog(100);
+  watchdog.Start(&runner, [&](WatchdogCrashInfo info) {
+    std::lock_guard<std::mutex> lock(captured_mu);
+    captured_info = info;
+    handler_calls.fetch_add(1);
+  });
+
+  auto handle =
+      watchdog.CreateFatalTimer(20, WatchdogCrashReason::kTaskRunnerHung);
+
+  // The watchdog thread should observe the expired timer and PostTask the
+  // handler. The polling interval is 100ms, so allow up to 10s for slow CI.
+  {
+    std::unique_lock<std::mutex> lock(runner.mu);
+    ASSERT_TRUE(runner.cv.wait_for(lock, std::chrono::seconds(10), [&] {
+      return !runner.posted_tasks.empty();
+    })) << "watchdog did not post the fatal handler";
+  }
+
+  // Run the captured task as the embedder's task runner would.
+  runner.posted_tasks.front()();
+  EXPECT_EQ(handler_calls.load(), 1);
+  {
+    std::lock_guard<std::mutex> lock(captured_mu);
+    EXPECT_EQ(captured_info.reason, WatchdogCrashReason::kTaskRunnerHung);
+  }
+
+  // Even if the watchdog thread observes the same expired timer again on
+  // subsequent iterations, the handler must not be re-posted (it was moved
+  // out and the task_runner pointer cleared after the first invocation).
+  // Wait at least one more polling interval and then make sure we still
+  // have only the single posted task captured initially.
+  usleep(300 * 1000);
+  {
+    std::lock_guard<std::mutex> lock(runner.mu);
+    EXPECT_EQ(runner.posted_tasks.size(), 1u);
+  }
 }
 
 }  // namespace

--- a/src/traced/probes/probes.cc
+++ b/src/traced/probes/probes.cc
@@ -21,6 +21,7 @@
 
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/flags.h"
 #include "perfetto/ext/base/getopt.h"
 #include "perfetto/ext/base/lock_free_task_runner.h"
 #include "perfetto/ext/base/utils.h"
@@ -91,15 +92,6 @@ int PERFETTO_EXPORT_ENTRYPOINT ProbesMain(int argc, char** argv) {
     base::Daemonize([] { return 0; });
   }
 
-  base::Watchdog* watchdog = base::Watchdog::GetInstance();
-  // The memory watchdog will be updated soon after connect, once the shmem
-  // buffer size is known, in ProbesProducer::OnTracingSetup().
-  watchdog->SetMemoryLimit(base::kWatchdogDefaultMemorySlack,
-                           base::kWatchdogDefaultMemoryWindow);
-  watchdog->SetCpuLimit(base::kWatchdogDefaultCpuLimit,
-                        base::kWatchdogDefaultCpuWindow);
-  watchdog->Start();
-
   PERFETTO_LOG("Starting %s service", argv[0]);
 
   // This environment variable is set by Android's init to a fd to /dev/kmsg
@@ -116,6 +108,26 @@ int PERFETTO_EXPORT_ENTRYPOINT ProbesMain(int argc, char** argv) {
 
   base::MaybeLockFreeTaskRunner task_runner;
   ProbesProducer producer;
+
+  base::Watchdog* watchdog = base::Watchdog::GetInstance();
+  // The memory watchdog will be updated soon after connect, once the shmem
+  // buffer size is known, in ProbesProducer::OnTracingSetup().
+  watchdog->SetMemoryLimit(base::kWatchdogDefaultMemorySlack,
+                           base::kWatchdogDefaultMemoryWindow);
+  watchdog->SetCpuLimit(base::kWatchdogDefaultCpuLimit,
+                        base::kWatchdogDefaultCpuWindow);
+  // Give us a chance to flush ftrace data before the watchdog force-crashes
+  // the process, to better debug traced_probes wdog crashes.
+  if constexpr (PERFETTO_FLAGS(TRIGGER_PERFETTO_ON_TRACED_PROBES_DISCONNECT)) {
+    watchdog->Start(&task_runner, [](base::WatchdogCrashInfo info) {
+      auto* probes_producer = ProbesProducer::GetInstance();
+      if (probes_producer)
+        probes_producer->FlushForWatchdogAndCrash(info);
+    });
+  } else {
+    watchdog->Start(&task_runner);
+  }
+
   // If the TRACED_PROBES_NOTIFY_FD env var is set, write 1 and close the FD,
   // when all data sources have been registered. This is used for //src/tracebox
   // --background-wait, to make sure that the data sources are registered before

--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -703,6 +703,8 @@ void ProbesProducer::FlushForWatchdogAndCrash(base::WatchdogCrashInfo info) {
                              info.actual_boot_s);
   PERFETTO_METATRACE_COUNTER(TAG_PRODUCER, WATCHDOG_CRASH_ACTUAL_CPU,
                              info.actual_cpu_s);
+  PERFETTO_METATRACE_COUNTER(TAG_PRODUCER, WATCHDOG_CRASH_TIME_BOOT_MS,
+                             info.alarm_time_ms);
 
   std::vector<ProbesDataSource*> ds_to_flush;
 
@@ -737,7 +739,7 @@ void ProbesProducer::FlushForWatchdogAndCrash(base::WatchdogCrashInfo info) {
   };
 
   for (ProbesDataSource* ds : ds_to_flush) {
-    const FlushRequestID kFlushId = UINT64_MAX;
+    constexpr FlushRequestID kFlushId = UINT64_MAX;
     ds->Flush(kFlushId, flush_callback);
   }
 }

--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -18,12 +18,16 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
+#include "perfetto/base/flat_set.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/crash_keys.h"
 #include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/metatrace.h"
+#include "perfetto/ext/base/metatrace_events.h"
 #include "perfetto/ext/base/unix_socket.h"
 #include "perfetto/ext/base/utils.h"
 #include "perfetto/ext/base/watchdog.h"
@@ -686,6 +690,57 @@ void ProbesProducer::OnFlushTimeout(FlushRequestID flush_request_id) {
   PERFETTO_ELOG("Flush(%" PRIu64 ") timed out", flush_request_id);
   pending_flushes_.erase(flush_request_id);
   endpoint_->NotifyFlushComplete(flush_request_id);
+}
+
+// Called when the watchdgog is about to kill us. This is to better debug
+// traced_probes' wdog crashes. This function has nothing to do with
+// protocol-level flushes.
+void ProbesProducer::FlushForWatchdogAndCrash(base::WatchdogCrashInfo info) {
+  PERFETTO_METATRACE_COUNTER(TAG_PRODUCER, WATCHDOG_CRASH_REASON,
+                             static_cast<int32_t>(info.reason));
+  PERFETTO_METATRACE_COUNTER(TAG_PRODUCER, WATCHDOG_CRASH_ACTUAL_MONO,
+                             info.actual_mono_s);
+  PERFETTO_METATRACE_COUNTER(TAG_PRODUCER, WATCHDOG_CRASH_ACTUAL_BOOT,
+                             info.actual_boot_s);
+  PERFETTO_METATRACE_COUNTER(TAG_PRODUCER, WATCHDOG_CRASH_ACTUAL_CPU,
+                             info.actual_cpu_s);
+
+  // shared_ptr as this is passed around the various callbacks to tell when
+  // we are done.
+  auto ds_to_flush = std::make_shared<base::FlatSet<ProbesDataSource*>>();
+
+  // We are only interested in ftrace data sources. Trying to flush other data
+  // sources might cause cascading problems.
+  int ftrace_sessions = 0;
+  for (auto& kv : data_sources_) {
+    ProbesDataSource* ds = kv.second.get();
+    if (!ds || !ds->started ||
+        (ds->descriptor != &FtraceDataSource::descriptor &&
+         ds->descriptor != &MetatraceDataSource::descriptor)) {
+      continue;
+    }
+    ds_to_flush->insert(ds);
+    ftrace_sessions += ds->descriptor == &FtraceDataSource::descriptor ? 1 : 0;
+  }
+  PERFETTO_METATRACE_COUNTER(TAG_FTRACE, FTRACE_SESSIONS, ftrace_sessions);
+
+  if (ds_to_flush->empty()) {
+    PERFETTO_FATAL("No active data sources found. Crashing now.");
+  }
+
+  PERFETTO_LOG("FlushWatchdogAndCrash(): Flushing %zu ftrace data sources",
+               ds_to_flush->size());
+  auto flush_callback = [ds_to_flush](ProbesDataSource* ds) {
+    ds_to_flush->erase(ds);
+    if (ds_to_flush->empty()) {
+      PERFETTO_FATAL("Done flushing data sources. Crashing now.");
+    }
+  };
+
+  for (ProbesDataSource* ds : *ds_to_flush) {
+    const FlushRequestID kFlushId = UINT64_MAX;
+    ds->Flush(kFlushId, std::bind(flush_callback, ds));
+  }
 }
 
 void ProbesProducer::ClearIncrementalState(

--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -22,7 +22,6 @@
 #include <memory>
 #include <string>
 
-#include "perfetto/base/flat_set.h"
 #include "perfetto/base/logging.h"
 #include "perfetto/ext/base/crash_keys.h"
 #include "perfetto/ext/base/file_utils.h"
@@ -705,9 +704,7 @@ void ProbesProducer::FlushForWatchdogAndCrash(base::WatchdogCrashInfo info) {
   PERFETTO_METATRACE_COUNTER(TAG_PRODUCER, WATCHDOG_CRASH_ACTUAL_CPU,
                              info.actual_cpu_s);
 
-  // shared_ptr as this is passed around the various callbacks to tell when
-  // we are done.
-  auto ds_to_flush = std::make_shared<base::FlatSet<ProbesDataSource*>>();
+  std::vector<ProbesDataSource*> ds_to_flush;
 
   // We are only interested in ftrace data sources. Trying to flush other data
   // sources might cause cascading problems.
@@ -719,27 +716,29 @@ void ProbesProducer::FlushForWatchdogAndCrash(base::WatchdogCrashInfo info) {
          ds->descriptor != &MetatraceDataSource::descriptor)) {
       continue;
     }
-    ds_to_flush->insert(ds);
+    ds_to_flush.emplace_back(ds);
     ftrace_sessions += ds->descriptor == &FtraceDataSource::descriptor ? 1 : 0;
   }
+
   PERFETTO_METATRACE_COUNTER(TAG_FTRACE, FTRACE_SESSIONS, ftrace_sessions);
 
-  if (ds_to_flush->empty()) {
+  if (ds_to_flush.empty()) {
     PERFETTO_FATAL("No active data sources found. Crashing now.");
   }
 
   PERFETTO_LOG("FlushWatchdogAndCrash(): Flushing %zu ftrace data sources",
-               ds_to_flush->size());
-  auto flush_callback = [ds_to_flush](ProbesDataSource* ds) {
-    ds_to_flush->erase(ds);
-    if (ds_to_flush->empty()) {
+               ds_to_flush.size());
+  // shared_ptr as this is passed around the various callbacks.
+  auto flushes_pending = std::make_shared<size_t>(ds_to_flush.size());
+  auto flush_callback = [flushes_pending]() {
+    if (--*(flushes_pending) == 0) {
       PERFETTO_FATAL("Done flushing data sources. Crashing now.");
     }
   };
 
-  for (ProbesDataSource* ds : *ds_to_flush) {
+  for (ProbesDataSource* ds : ds_to_flush) {
     const FlushRequestID kFlushId = UINT64_MAX;
-    ds->Flush(kFlushId, std::bind(flush_callback, ds));
+    ds->Flush(kFlushId, flush_callback);
   }
 }
 

--- a/src/traced/probes/probes_producer.cc
+++ b/src/traced/probes/probes_producer.cc
@@ -692,7 +692,7 @@ void ProbesProducer::OnFlushTimeout(FlushRequestID flush_request_id) {
   endpoint_->NotifyFlushComplete(flush_request_id);
 }
 
-// Called when the watchdgog is about to kill us. This is to better debug
+// Called when the watchdog is about to kill us. This is to better debug
 // traced_probes' wdog crashes. This function has nothing to do with
 // protocol-level flushes.
 void ProbesProducer::FlushForWatchdogAndCrash(base::WatchdogCrashInfo info) {

--- a/src/traced/probes/probes_producer.h
+++ b/src/traced/probes/probes_producer.h
@@ -83,6 +83,12 @@ class ProbesProducer : public Producer, public FtraceController::Observer {
     all_data_sources_registered_cb_ = std::move(cb);
   }
 
+  // Wired up to base::Watchdog as the fatal handler: when the watchdog is
+  // about to crash the process, this is called (on the producer's task runner)
+  // so we can flush ftrace data before the actual crash, to better debug
+  // traced_probes' wdog crashes.
+  void FlushForWatchdogAndCrash(base::WatchdogCrashInfo);
+
  private:
   static ProbesProducer* instance_;
 

--- a/src/tracing/service/metatrace_writer.cc
+++ b/src/tracing/service/metatrace_writer.cc
@@ -97,9 +97,9 @@ void MetatraceWriter::WriteAllAvailableEvents() {
 void MetatraceWriter::WriteAllAndFlushTraceWriter(
     std::function<void()> callback) {
   PERFETTO_DCHECK_THREAD(thread_checker_);
-  if (!started_)
-    return;
-  WriteAllAvailableEvents();
+  if (started_) {
+    WriteAllAvailableEvents();
+  }
   trace_writer_->Flush(std::move(callback));
 }
 


### PR DESCRIPTION
This change introduces an option to install a watchdog handler.
Rather than killing the process directly, it allows the process
to gracefully handle the wathdog for up to 60 seconds.
We need this in traced_probes to give us a chance to serialize the
trace which will be picked up by traced to better debug these
watchdog failures.

Bug: b/496506220
Flag: trigger_perfetto_on_traced_probes_disconnect
