### PR TITLE
ui: Show tooltips on the HeapDumpExplorer columns

### DIFF
--- a/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/components.ts
@@ -22,6 +22,8 @@ import type {Engine} from '../../trace_processor/engine';
 import type {InstanceRow, PathEntry, PrimOrRef} from './types';
 import {fmtSize} from './format';
 import type {NavState} from './nav_state';
+import {Tooltip} from '../../widgets/tooltip';
+import {Icon} from '../../widgets/icon';
 
 export type NavFn = (
   view: NavState['view'],
@@ -185,6 +187,50 @@ export function shortClassName(full: string): string {
     return dot >= 0 ? tok.slice(dot + 1) : tok;
   });
   return short + suffix;
+}
+
+// Hover-help text for size/count columns, shared across HDE views.
+export const COL_INFO = {
+  shallow:
+    'Java memory used by this object alone, excluding referenced objects.',
+  shallowNative:
+    'Native memory attributed to this object alone (e.g. a Bitmap pixel ' +
+    'buffer). Zero for most plain Java objects.',
+  retained:
+    'Java size of every object exclusively held by this one (dominator ' +
+    'subtree, self inclusive). If something is reachable from multiple ' +
+    'paths, it is not retained here — it is retained higher up at the ' +
+    'common ancestor.',
+  retainedNative:
+    'Native size of every object exclusively held by this one (dominator ' +
+    'subtree, self inclusive). Often zero in multi-rooted graphs where ' +
+    'native-bearing objects (e.g. Bitmaps) are reachable via multiple ' +
+    'paths — try Reachable Native if you expected a non-zero value.',
+  retainedCount:
+    'Number of objects exclusively held by this one (dominator subtree, ' +
+    'self inclusive).',
+  reachable:
+    'Java size of every object reachable from this one along the heap ' +
+    "graph's BFS shortest-path tree. Includes objects also reachable via " +
+    'other paths. Matches the flamegraph "Object Size" cumulative.',
+  reachableNative:
+    'Native size of every object reachable from this one (BFS tree). ' +
+    'Includes objects also reachable via other paths.',
+  reachableCount: 'Count of objects reachable from this one (BFS tree).',
+} as const;
+
+// Label + info icon for DataGrid column titles.
+export function colHeader(label: string, info: m.Children): m.Children {
+  return m(
+    'span',
+    {class: 'ah-col-header'},
+    label,
+    m(
+      Tooltip,
+      {trigger: m(Icon, {className: 'ah-col-header__info', icon: 'info'})},
+      info,
+    ),
+  );
 }
 
 /** SQL preamble that includes dominator tree and object tree modules. */

--- a/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/heap_dump_page.ts
@@ -115,7 +115,11 @@ function buildTabs(
     {
       key: 'overview',
       title: 'Overview',
-      content: m(OverviewView, {overview, navigate: navigateWithTabs}),
+      content: m(OverviewView, {
+        overview,
+        activeDump,
+        navigate: navigateWithTabs,
+      }),
     },
     {
       key: 'flamegraph',

--- a/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/queries.ts
@@ -244,11 +244,22 @@ export async function getOverview(
   activeDump: HeapDump,
 ): Promise<OverviewData> {
   const dumpFilter = dumpFilterSql(activeDump, 'o');
-  const countRes = await engine.query(
-    `SELECT count(*) as cnt FROM heap_graph_object o
-     WHERE o.reachable != 0 AND ${dumpFilter}`,
-  );
-  const instanceCount = countRes.iter({cnt: NUM}).cnt;
+  const countRes = await engine.query(`
+    SELECT
+      sum(iif(o.reachable, 1, 0)) AS reachable,
+      sum(iif(NOT o.reachable, 1, 0)) AS unreachable,
+      count(DISTINCT o.type_id) AS classes
+    FROM heap_graph_object o
+    WHERE ${dumpFilter}
+  `);
+  const countIt = countRes.iter({
+    reachable: NUM,
+    unreachable: NUM,
+    classes: NUM,
+  });
+  const reachableInstanceCount = countIt.reachable;
+  const unreachableInstanceCount = countIt.unreachable;
+  const classCount = countIt.classes;
 
   const heapRes = await engine.query(`
     SELECT
@@ -452,7 +463,9 @@ export async function getOverview(
   }
 
   return {
-    instanceCount,
+    reachableInstanceCount,
+    unreachableInstanceCount,
+    classCount,
     heaps,
     duplicateBitmaps:
       duplicateBitmaps.length > 0 ? duplicateBitmaps : undefined,

--- a/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/styles.scss
@@ -427,3 +427,25 @@
 .ah-mt-4 {
   margin-top: 1rem;
 }
+
+.ah-col-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.ah-col-header__info {
+  color: var(--pf-color-fg-muted, #888);
+  font-size: 14px;
+  cursor: help;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.ah-col-header:hover .ah-col-header__info {
+  opacity: 1;
+}
+
+.ah-col-header__info:hover {
+  color: var(--pf-color-fg, #333);
+}

--- a/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/types.ts
@@ -44,7 +44,9 @@ export interface DuplicateArrayGroup {
 }
 
 export interface OverviewData {
-  instanceCount: number;
+  reachableInstanceCount: number;
+  unreachableInstanceCount: number;
+  classCount: number;
   heaps: HeapInfo[];
   duplicateBitmaps?: DuplicateBitmapGroup[];
   duplicateStrings?: DuplicateStringGroup[];

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/all_objects_view.ts
@@ -28,6 +28,8 @@ import {
   shortClassName,
   SQL_PREAMBLE,
   RowCounter,
+  COL_INFO,
+  colHeader,
 } from '../components';
 import {dumpFilterSql, type HeapDump} from '../queries';
 
@@ -100,42 +102,50 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
         },
       },
       self_size: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       native_size: {
-        title: 'Native',
+        title: colHeader('Native', COL_INFO.shallowNative),
+        titleString: 'Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_native: {
-        title: 'Retained Native',
+        title: colHeader('Retained Native', COL_INFO.retainedNative),
+        titleString: 'Retained Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_count: {
-        title: 'Retained #',
+        title: colHeader('Retained #', COL_INFO.retainedCount),
+        titleString: 'Retained #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },
       reachable_size: {
-        title: 'Reachable',
+        title: colHeader('Reachable', COL_INFO.reachable),
+        titleString: 'Reachable',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_native: {
-        title: 'Reachable Native',
+        title: colHeader('Reachable Native', COL_INFO.reachableNative),
+        titleString: 'Reachable Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_count: {
-        title: 'Reachable #',
+        title: colHeader('Reachable #', COL_INFO.reachableCount),
+        titleString: 'Reachable #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/arrays_view.ts
@@ -28,6 +28,8 @@ import {
   countRenderer,
   shortClassName,
   RowCounter,
+  COL_INFO,
+  colHeader,
 } from '../components';
 import {dumpFilterSql, type HeapDump} from '../queries';
 
@@ -75,12 +77,14 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
         columnType: 'text',
       },
       self_size: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       native_size: {
-        title: 'Native',
+        title: colHeader('Native', COL_INFO.shallowNative),
+        titleString: 'Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/classes_view.ts
@@ -25,6 +25,8 @@ import {
   sizeRenderer,
   countRenderer,
   RowCounter,
+  COL_INFO,
+  colHeader,
 } from '../components';
 import * as queries from '../queries';
 import {dumpFilterSql, type HeapDump} from '../queries';
@@ -77,27 +79,32 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
         cellRenderer: countRenderer,
       },
       shallow: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       native_shallow: {
-        title: 'Shallow Native',
+        title: colHeader('Shallow Native', COL_INFO.shallowNative),
+        titleString: 'Shallow Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_native: {
-        title: 'Retained Native',
+        title: colHeader('Retained Native', COL_INFO.retainedNative),
+        titleString: 'Retained Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_count: {
-        title: 'Retained #',
+        title: colHeader('Retained #', COL_INFO.retainedCount),
+        titleString: 'Retained #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/dominators_view.ts
@@ -27,6 +27,8 @@ import {
   shortClassName,
   SQL_PREAMBLE,
   RowCounter,
+  COL_INFO,
+  colHeader,
 } from '../components';
 import {dumpFilterSql, type HeapDump} from '../queries';
 
@@ -81,42 +83,50 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
         },
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_native: {
-        title: 'Retained Native',
+        title: colHeader('Retained Native', COL_INFO.retainedNative),
+        titleString: 'Retained Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       self_size: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       native_size: {
-        title: 'Shallow Native',
+        title: colHeader('Shallow Native', COL_INFO.shallowNative),
+        titleString: 'Shallow Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_count: {
-        title: 'Retained Count',
+        title: colHeader('Retained Count', COL_INFO.retainedCount),
+        titleString: 'Retained Count',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },
       reachable_size: {
-        title: 'Reachable',
+        title: colHeader('Reachable', COL_INFO.reachable),
+        titleString: 'Reachable',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_native: {
-        title: 'Reachable Native',
+        title: colHeader('Reachable Native', COL_INFO.reachableNative),
+        titleString: 'Reachable Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_count: {
-        title: 'Reachable Count',
+        title: colHeader('Reachable Count', COL_INFO.reachableCount),
+        titleString: 'Reachable Count',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_objects_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/flamegraph_objects_view.ts
@@ -27,6 +27,8 @@ import {
   shortClassName,
   SQL_PREAMBLE,
   RowCounter,
+  COL_INFO,
+  colHeader,
 } from '../components';
 
 interface FlamegraphObjectsViewAttrs {
@@ -106,42 +108,50 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
         },
       },
       self_size: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       native_size: {
-        title: 'Native',
+        title: colHeader('Native', COL_INFO.shallowNative),
+        titleString: 'Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_native: {
-        title: 'Retained Native',
+        title: colHeader('Retained Native', COL_INFO.retainedNative),
+        titleString: 'Retained Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_count: {
-        title: 'Retained #',
+        title: colHeader('Retained #', COL_INFO.retainedCount),
+        titleString: 'Retained #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },
       reachable_size: {
-        title: 'Reachable',
+        title: colHeader('Reachable', COL_INFO.reachable),
+        titleString: 'Reachable',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_native: {
-        title: 'Reachable Native',
+        title: colHeader('Reachable Native', COL_INFO.reachableNative),
+        titleString: 'Reachable Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_count: {
-        title: 'Reachable #',
+        title: colHeader('Reachable #', COL_INFO.reachableCount),
+        titleString: 'Reachable #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/object_view.ts
@@ -37,6 +37,8 @@ import {
   Section,
   PrimOrRefCell,
   BitmapImage,
+  COL_INFO,
+  colHeader,
 } from '../components';
 import * as queries from '../queries';
 import type {HeapDump} from '../queries';
@@ -183,11 +185,28 @@ function nullableSizeRenderer(value: SqlValue): CellRenderResult {
   };
 }
 
+// Per-row info for the Object Size grid; the row label carries the metric.
+const METRIC_INFO: Record<string, string> = {
+  Shallow: 'Memory used by this object alone, excluding referenced objects.',
+  Retained:
+    'Memory exclusively held by this object (dominator subtree, self ' +
+    'inclusive). The Native column is often zero in multi-rooted graphs ' +
+    'where Bitmaps are reachable via multiple paths — see Reachable below.',
+  Reachable:
+    "Memory reachable from this object along the heap graph's BFS " +
+    'shortest-path tree. Includes objects also reachable via other paths.',
+};
+
 const SIZE_SCHEMA: SchemaRegistry = {
   query: {
     metric: {
       title: 'Metric',
       columnType: 'text',
+      cellRenderer: (value: SqlValue): CellRenderResult => {
+        const label = String(value ?? '');
+        const info = METRIC_INFO[label];
+        return {content: info ? colHeader(label, info) : label};
+      },
     },
     java: {
       title: 'Java',
@@ -254,42 +273,50 @@ function makeInstanceSchema(navigate: NavFn): SchemaRegistry {
         },
       },
       self_size: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       native_size: {
-        title: 'Shallow Native',
+        title: colHeader('Shallow Native', COL_INFO.shallowNative),
+        titleString: 'Shallow Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_native: {
-        title: 'Retained Native',
+        title: colHeader('Retained Native', COL_INFO.retainedNative),
+        titleString: 'Retained Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_count: {
-        title: 'Retained #',
+        title: colHeader('Retained #', COL_INFO.retainedCount),
+        titleString: 'Retained #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },
       reachable_size: {
-        title: 'Reachable',
+        title: colHeader('Reachable', COL_INFO.reachable),
+        titleString: 'Reachable',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_native: {
-        title: 'Reachable Native',
+        title: colHeader('Reachable Native', COL_INFO.reachableNative),
+        titleString: 'Reachable Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_count: {
-        title: 'Reachable #',
+        title: colHeader('Reachable #', COL_INFO.reachableCount),
+        titleString: 'Reachable #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },
@@ -356,37 +383,44 @@ function makeFieldSchema(navigate: NavFn): SchemaRegistry {
         },
       },
       shallow: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       shallow_native: {
-        title: 'Shallow Native',
+        title: colHeader('Shallow Native', COL_INFO.shallowNative),
+        titleString: 'Shallow Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_native: {
-        title: 'Retained Native',
+        title: colHeader('Retained Native', COL_INFO.retainedNative),
+        titleString: 'Retained Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable: {
-        title: 'Reachable',
+        title: colHeader('Reachable', COL_INFO.reachable),
+        titleString: 'Reachable',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_native: {
-        title: 'Reachable Native',
+        title: colHeader('Reachable Native', COL_INFO.reachableNative),
+        titleString: 'Reachable Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_count: {
-        title: 'Reachable #',
+        title: colHeader('Reachable #', COL_INFO.reachableCount),
+        titleString: 'Reachable #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },
@@ -439,37 +473,44 @@ function makeArraySchema(
         },
       },
       shallow: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       shallow_native: {
-        title: 'Shallow Native',
+        title: colHeader('Shallow Native', COL_INFO.shallowNative),
+        titleString: 'Shallow Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       retained_native: {
-        title: 'Retained Native',
+        title: colHeader('Retained Native', COL_INFO.retainedNative),
+        titleString: 'Retained Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable: {
-        title: 'Reachable',
+        title: colHeader('Reachable', COL_INFO.reachable),
+        titleString: 'Reachable',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_native: {
-        title: 'Reachable Native',
+        title: colHeader('Reachable Native', COL_INFO.reachableNative),
+        titleString: 'Reachable Native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_count: {
-        title: 'Reachable #',
+        title: colHeader('Reachable #', COL_INFO.reachableCount),
+        titleString: 'Reachable #',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/overview_view.ts
@@ -20,6 +20,7 @@ import type {OverviewData} from '../types';
 import {fmtSize} from '../format';
 import type {NavState} from '../nav_state';
 import {type NavFn, sizeRenderer} from '../components';
+import type {HeapDump} from '../queries';
 
 const HEAP_SCHEMA: SchemaRegistry = {
   query: {
@@ -238,12 +239,13 @@ function renderDuplicateSection(
 
 interface OverviewViewAttrs {
   readonly overview: OverviewData;
+  readonly activeDump: HeapDump;
   readonly navigate: NavFn;
 }
 function OverviewView(): m.Component<OverviewViewAttrs> {
   return {
     view(vnode) {
-      const {overview, navigate} = vnode.attrs;
+      const {overview, activeDump, navigate} = vnode.attrs;
       const heapIndices: number[] = [];
       for (let i = 0; i < overview.heaps.length; i++) {
         const h = overview.heaps[i];
@@ -270,12 +272,20 @@ function OverviewView(): m.Component<OverviewViewAttrs> {
         })),
       ];
 
+      const processLabel =
+        (activeDump.processName ?? '<unknown>') +
+        (activeDump.pid ? ` (pid ${activeDump.pid})` : '');
       const infoRows: Row[] = [
+        {property: 'Process', value: processLabel},
+        {property: 'Classes', value: overview.classCount.toLocaleString()},
         {
-          property: 'Instances',
-          value: overview.instanceCount.toLocaleString(),
+          property: 'Reachable instances',
+          value: overview.reachableInstanceCount.toLocaleString(),
         },
-        {property: 'Heaps', value: heaps.map((h) => h.name).join(', ')},
+        {
+          property: 'Unreachable instances',
+          value: overview.unreachableInstanceCount.toLocaleString(),
+        },
       ];
 
       return m('div', {class: 'ah-view-scroll'}, [

--- a/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
+++ b/ui/src/plugins/com.android.HeapDumpExplorer/views/strings_view.ts
@@ -30,6 +30,8 @@ import {
   countRenderer,
   SQL_PREAMBLE,
   RowCounter,
+  COL_INFO,
+  colHeader,
 } from '../components';
 import * as queries from '../queries';
 import {dumpFilterSql, type HeapDump} from '../queries';
@@ -100,7 +102,8 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
         },
       },
       retained: {
-        title: 'Retained',
+        title: colHeader('Retained', COL_INFO.retained),
+        titleString: 'Retained',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
@@ -118,22 +121,26 @@ function makeUiSchema(navigate: NavFn): SchemaRegistry {
         columnType: 'text',
       },
       self_size: {
-        title: 'Shallow',
+        title: colHeader('Shallow', COL_INFO.shallow),
+        titleString: 'Shallow',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_size: {
-        title: 'Reachable',
+        title: colHeader('Reachable', COL_INFO.reachable),
+        titleString: 'Reachable',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_native: {
-        title: 'Reachable native',
+        title: colHeader('Reachable native', COL_INFO.reachableNative),
+        titleString: 'Reachable native',
         columnType: 'quantitative',
         cellRenderer: sizeRenderer,
       },
       reachable_count: {
-        title: 'Reachable count',
+        title: colHeader('Reachable count', COL_INFO.reachableCount),
+        titleString: 'Reachable count',
         columnType: 'quantitative',
         cellRenderer: countRenderer,
       },


### PR DESCRIPTION
Added hover info icons on the size/count columns across HDE views to surface the dominator-vs-BFS distinction.

Also cleaned up the general information card with more useful info like process name and class counts.