### PR TITLE
Update references to old windows toolchain

### DIFF
--- a/infra/luci/recipe_modules/windows_sdk/__init__.py
+++ b/infra/luci/recipe_modules/windows_sdk/__init__.py
@@ -35,7 +35,7 @@ PROPERTIES = {
                 sdk_version=Single(str)),
             default={
                 'sdk_package': 'chrome_internal/third_party/sdk/windows',
-                'sdk_version': 'uploaded:2024-01-11'
+                'sdk_version': 'uploaded:2026-05-06'
             },
         )
 }

--- a/infra/luci/recipe_modules/windows_sdk/examples/full.expected/win.json
+++ b/infra/luci/recipe_modules/windows_sdk/examples/full.expected/win.json
@@ -6,7 +6,7 @@
       "-root",
       "[CACHE]\\windows_sdk",
       "-ensure-file",
-      "chrome_internal/third_party/sdk/windows uploaded:2024-01-11",
+      "chrome_internal/third_party/sdk/windows uploaded:2026-05-06",
       "-max-threads",
       "0",
       "-json-output",

--- a/infra/luci/recipes/perfetto.expected/ci_win.json
+++ b/infra/luci/recipes/perfetto.expected/ci_win.json
@@ -164,7 +164,7 @@
       "-root",
       "[CACHE]\\windows_sdk",
       "-ensure-file",
-      "chrome_internal/third_party/sdk/windows uploaded:2024-01-11",
+      "chrome_internal/third_party/sdk/windows uploaded:2026-05-06",
       "-max-threads",
       "0",
       "-json-output",


### PR DESCRIPTION
The windows toolchain CIPD package was updated following http://go/windows-sdk-cipd-update (sorry, Googlers only). I'm not entirely sure if perfetto still relies on it, but in doubt, update the reference to the most recent version.