### PR TITLE
perfetto: add multi-machine information to --query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,16 @@
+Unreleased:
+  Tracing service and probes:
+    * Added `machine_id` and `machine_name` fields to `TracingServiceState`,
+      exposing the originating machine for producers connected via
+      `traced_relay`. `perfetto --query` and `--query-raw` surface these in a
+      new `MACHINE` column when more than one machine is involved.
+  Trace Processor:
+   *
+  UI:
+   *
+  SDK:
+   *
+
 v55.0 - 2026-04-29:
   Tracing service and probes:
     * Breaking change: Renamed the `TraceMetadata` proto to `TraceAttributes`.

--- a/protos/perfetto/common/tracing_service_state.proto
+++ b/protos/perfetto/common/tracing_service_state.proto
@@ -48,6 +48,19 @@ message TracingServiceState {
     // Returns true if the process appears to be frozen (Android only).
     // Introduced in Perfetto V49 / Android 24Q4.
     optional bool frozen = 6;
+
+    // Identifies the machine this producer is connected from in multi-machine
+    // tracing setups (e.g. when going through traced_relay). Unset (or zero)
+    // means the producer is connected from the local/host machine where the
+    // tracing service is running.
+    // Introduced in Perfetto V56 / Android 26Q3.
+    optional uint32 machine_id = 7;
+
+    // Human-readable name of the machine, as advertised by the relay (usually
+    // the value of PERFETTO_MACHINE_NAME on the remote, falling back to the
+    // remote's `uname -s`). Only set when machine_id is non-zero.
+    // Introduced in Perfetto V56 / Android 26Q3.
+    optional string machine_name = 8;
   }
 
   // Describes a data source registered by a producer. Data sources are listed

--- a/src/perfetto_cmd/perfetto_cmd.cc
+++ b/src/perfetto_cmd/perfetto_cmd.cc
@@ -1486,40 +1486,100 @@ void PerfettoCmd::PrintServiceState(bool success,
       svc_state.tracing_service_version().c_str(), svc_state.num_sessions(),
       svc_state.num_sessions_started());
 
+  // Whether any producer is connected from a non-default machine (i.e. via
+  // traced_relay). We hide the MACHINE column entirely when there is none, to
+  // keep the output identical for the typical single-machine case.
+  bool has_non_default_machine = false;
+  for (const auto& producer : svc_state.producers()) {
+    if (producer.machine_id() != 0) {
+      has_non_default_machine = true;
+      break;
+    }
+  }
+
+  // Returns a human-readable label for the machine a producer is connected
+  // from. Empty for producers connected from the host machine.
+  auto machine_label = [](const auto& producer) -> std::string {
+    if (producer.machine_id() == 0)
+      return {};
+    if (!producer.machine_name().empty())
+      return producer.machine_name();
+    base::StackString<16> id("0x%x", producer.machine_id());
+    return id.ToStdString();
+  };
+
   printf(R"(
 
 PRODUCER PROCESSES CONNECTED:
 
-ID     PID      UID      FLAGS  NAME                                       SDK
-==     ===      ===      =====  ====                                       ===
 )");
+  if (has_non_default_machine) {
+    printf(
+        "ID     PID      UID      FLAGS  MACHINE              "
+        "NAME                                       SDK\n"
+        "==     ===      ===      =====  =======              "
+        "====                                       ===\n");
+  } else {
+    printf(
+        "ID     PID      UID      FLAGS  "
+        "NAME                                       SDK\n"
+        "==     ===      ===      =====  "
+        "====                                       ===\n");
+  }
   for (const auto& producer : svc_state.producers()) {
     base::StackString<8> status("%s", producer.frozen() ? "F" : "");
-    printf("%-6d %-8d %-8d %-6s %-42s %s\n", producer.id(), producer.pid(),
-           producer.uid(), status.c_str(), producer.name().c_str(),
-           producer.sdk_version().c_str());
+    if (has_non_default_machine) {
+      std::string m = machine_label(producer);
+      printf("%-6d %-8d %-8d %-6s %-20s %-42s %s\n", producer.id(),
+             producer.pid(), producer.uid(), status.c_str(),
+             m.empty() ? "(host)" : m.c_str(), producer.name().c_str(),
+             producer.sdk_version().c_str());
+    } else {
+      printf("%-6d %-8d %-8d %-6s %-42s %s\n", producer.id(), producer.pid(),
+             producer.uid(), status.c_str(), producer.name().c_str(),
+             producer.sdk_version().c_str());
+    }
   }
 
   printf(R"(
 
 DATA SOURCES REGISTERED:
 
-NAME                                     PRODUCER                     DETAILS
-===                                      ========                     ========
 )");
+  if (has_non_default_machine) {
+    printf(
+        "NAME                                     PRODUCER                     "
+        "MACHINE              DETAILS\n"
+        "===                                      ========                     "
+        "=======              ========\n");
+  } else {
+    printf(
+        "NAME                                     PRODUCER                     "
+        "DETAILS\n"
+        "===                                      ========                     "
+        "========\n");
+  }
   for (const auto& ds : svc_state.data_sources()) {
     char producer_id_and_name[128]{};
+    std::string ds_machine;
     const int ds_producer_id = ds.producer_id();
     for (const auto& producer : svc_state.producers()) {
       if (producer.id() == ds_producer_id) {
         base::SprintfTrunc(producer_id_and_name, sizeof(producer_id_and_name),
                            "%s (%d)", producer.name().c_str(), ds_producer_id);
+        ds_machine = machine_label(producer);
         break;
       }
     }
 
-    printf("%-40s %-28s ", ds.ds_descriptor().name().c_str(),
-           producer_id_and_name);
+    if (has_non_default_machine) {
+      printf("%-40s %-28s %-20s ", ds.ds_descriptor().name().c_str(),
+             producer_id_and_name,
+             ds_machine.empty() ? "(host)" : ds_machine.c_str());
+    } else {
+      printf("%-40s %-28s ", ds.ds_descriptor().name().c_str(),
+             producer_id_and_name);
+    }
     // Print the category names for clients using the track event SDK.
     std::string cats;
     if (!ds.ds_descriptor().track_event_descriptor_raw().empty()) {

--- a/src/tracing/service/tracing_service_endpoints_impl.cc
+++ b/src/tracing/service/tracing_service_endpoints_impl.cc
@@ -313,6 +313,16 @@ void ConsumerEndpointImpl::QueryServiceState(
     producer->set_uid(static_cast<int32_t>(kv.second->uid()));
     producer->set_pid(static_cast<int32_t>(kv.second->pid()));
     producer->set_frozen(kv.second->IsAndroidProcessFrozen());
+    // We only surface machine info for non-host producers (those connected
+    // through traced_relay). The IPC layer fills in machine_name with the
+    // host's sysname for every locally-connected producer too, so guarding on
+    // machine_id is what tells host vs. relay apart.
+    if (kv.second->client_identity().has_non_default_machine_id()) {
+      producer->set_machine_id(kv.second->client_identity().machine_id());
+      if (!kv.second->machine_name_.empty()) {
+        producer->set_machine_name(kv.second->machine_name_);
+      }
+    }
   }
 
   for (const auto& kv : service_->data_sources_) {

--- a/src/tracing/service/tracing_service_impl_unittest.cc
+++ b/src/tracing/service/tracing_service_impl_unittest.cc
@@ -423,6 +423,34 @@ TEST_F(TracingServiceImplTest, RegisterAndUnregister) {
   ASSERT_EQ(svc_state.producers_size(), 0);
 }
 
+TEST_F(TracingServiceImplTest, QueryServiceStateReportsMachine) {
+  std::unique_ptr<MockProducer> host_producer = CreateMockProducer();
+  std::unique_ptr<MockProducer> guest_producer = CreateMockProducer();
+
+  host_producer->Connect(svc.get(), "host_producer", /*uid=*/123, /*pid=*/100);
+  guest_producer->Connect(svc.get(), "guest_producer", /*uid=*/42, /*pid=*/1025,
+                          /*machine_id=*/1234, "guest_machine");
+
+  std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
+  consumer->Connect(svc.get());
+
+  TracingServiceState svc_state = consumer->QueryServiceState();
+  ASSERT_EQ(svc_state.producers_size(), 2);
+
+  // The host producer must report no machine_id and no machine_name (so callers
+  // can distinguish host from relay-connected producers without parsing
+  // strings).
+  const auto& host = svc_state.producers().at(0);
+  EXPECT_EQ(host.name(), "host_producer");
+  EXPECT_FALSE(host.has_machine_id());
+  EXPECT_FALSE(host.has_machine_name());
+
+  const auto& guest = svc_state.producers().at(1);
+  EXPECT_EQ(guest.name(), "guest_producer");
+  EXPECT_EQ(guest.machine_id(), 1234u);
+  EXPECT_EQ(guest.machine_name(), "guest_machine");
+}
+
 TEST_F(TracingServiceImplTest, EnableAndDisableTracing) {
   std::unique_ptr<MockConsumer> consumer = CreateMockConsumer();
   consumer->Connect(svc.get());


### PR DESCRIPTION
When multiple machines are connected (e.g. using traced_relay), add
support in --query and --query-raw to indicate which machine the source
came from. This is backwards compatible as host-only traces are left
completely unchanged (i.e. we don't pollute the output of --query
unnecessarily).

Fixes the follow-up raised in #5760.

**Output**

Multi-machine `--query`:

```
PRODUCER PROCESSES CONNECTED:

ID     PID      UID      FLAGS  MACHINE              NAME                                       SDK
==     ===      ===      =====  =======              ====                                       ===
1      0        501             guest-B              example_system_wide                        Perfetto v55.0
2      0        501             guest-A              example_system_wide                        Perfetto v55.0
3      -1       0               (host)               example_system_wide                        Perfetto v55.0


DATA SOURCES REGISTERED:

NAME                                     PRODUCER                     MACHINE              DETAILS
===                                      ========                     =======              ========
track_event                              example_system_wide (1)      guest-B              ...
track_event                              example_system_wide (2)      guest-A              ...
track_event                              example_system_wide (3)      (host)               ...
```

Host-only `--query` output is byte-identical to before.