### PR TITLE
tp: don't abort hprof parse when a sub-record spans segment boundaries

### DIFF
--- a/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
+++ b/src/trace_processor/importers/art_hprof/art_heap_graph_builder.cc
@@ -250,23 +250,23 @@ bool HeapGraphBuilder::ParseClassDefinition() {
 bool HeapGraphBuilder::ParseHeapDump(size_t length) {
   size_t end_position = iterator_->GetPosition() + length;
 
-  // Parse heap dump records until we reach the end of the segment
+  // Parse heap dump records until we reach the end of the segment.
+  //
+  // Note: a single sub-record (e.g. CLASS_DUMP) is allowed to extend past
+  // the declared segment end. AHAT (the reference parser) reads sub-records
+  // by their own internal length and does not enforce the segment boundary,
+  // and some producers split segments at arbitrary byte boundaries that
+  // bisect a sub-record. We mirror that lenient behavior here.
   while (iterator_->GetPosition() < end_position) {
     if (!ParseHeapDumpRecord()) {
       return false;
     }
   }
 
-  // Ensure we're at the exact end position
-  if (iterator_->GetPosition() != end_position) {
-    size_t current = iterator_->GetPosition();
-    if (current < end_position) {
-      // Skip any remaining bytes
-      iterator_->SkipBytes(end_position - current);
-    } else {
-      // We went too far, which is an error
-      return false;
-    }
+  if (iterator_->GetPosition() < end_position) {
+    iterator_->SkipBytes(end_position - iterator_->GetPosition());
+  } else if (iterator_->GetPosition() > end_position) {
+    context_->storage->IncrementStats(stats::hprof_segment_overshoot_counter);
   }
 
   return true;

--- a/src/trace_processor/storage/stats.h
+++ b/src/trace_processor/storage/stats.h
@@ -591,6 +591,11 @@ namespace perfetto::trace_processor::stats {
         "Number of references encountered."),                                  \
   F(hprof_record_counter,                  kSingle,  kInfo,   kAnalysis,       \
         "Total number of records parsed."),                                    \
+  F(hprof_segment_overshoot_counter,       kSingle,  kInfo,   kAnalysis,       \
+        "Number of HEAP_DUMP_SEGMENTs whose last sub-record extended past "    \
+        "the declared segment end. Benign: the sub-record's own length is "    \
+        "authoritative and the parser keeps going. Reported for visibility "   \
+        "into how a producer framed the dump."),                               \
   F(hprof_field_value_errors,              kSingle,  kError,   kAnalysis,      \
       "Number of field value parsing errors. This indicates a malformed "      \
       "hprof file. Check if the hprof opens correctly in a tool like "         \


### PR DESCRIPTION
ParseHeapDump returned false when a sub-record's bytes ran past the declared HEAP_DUMP_SEGMENT end, aborting the entire parse. AHAT reads each sub-record by its own internal length and treats the segment boundary as advisory; some files split segments at offsets that bisect a CLASS_DUMP. Those loaded with empty heap_graph_object / _reference tables.

Drop the strict overshoot check; skip leftover bytes only on undershoot. Track overshoots in hprof_segment_overshoot_counter (kInfo) so the signal stays visible without flagging valid files as malformed.