### PR TITLE
docs: add docs for multi-machine tracing

### DIFF
--- a/docs/data-sources/gpu.md
+++ b/docs/data-sources/gpu.md
@@ -37,9 +37,11 @@ data_sources: {
 ```
 
 Traces include a `gpu_id` field to distinguish between GPUs and a `machine_id`
-field to distinguish between machines in multi-machine setups. GPU hardware
-metadata (name, vendor, architecture, UUID, PCI BDF) is recorded via the
-[GpuInfo](/protos/perfetto/trace/system_info/gpu_info.proto) trace packet.
+field to distinguish between machines in
+[multi-machine setups](/docs/deployment/multi-machine-architecture.md).
+GPU hardware metadata (name, vendor, architecture, UUID, PCI BDF) is recorded
+via the [GpuInfo](/protos/perfetto/trace/system_info/gpu_info.proto) trace
+packet.
 
 ## Android
 

--- a/docs/deployment/multi-machine-architecture.md
+++ b/docs/deployment/multi-machine-architecture.md
@@ -1,0 +1,157 @@
+# Multi-machine architecture
+
+Perfetto can record a single trace that spans more than one operating system
+image — for example, a host and one or more virtual-machine guests, an SoC
+and a companion processor, or a fleet of test machines driving a shared
+workload. The result is one timeline in which causality across machines is
+visible and queryable, instead of one trace per machine that has to be
+correlated by hand.
+
+This page explains *what* multi-machine tracing is and *how* the pieces fit
+together. For the step-by-step setup, see
+[Multi-machine recording](/docs/learning-more/multi-machine-tracing.md).
+
+## Problem statement
+
+The standard [service model](/docs/concepts/service-model.md) assumes that
+all producers, the `traced` service, and the consumer share one OS image:
+they reach `traced` through a local UNIX socket, agree on PIDs, and observe
+the same `CLOCK_BOOTTIME`.
+
+That assumption breaks as soon as a producer lives on a different kernel.
+There is no shared filesystem socket. PID namespaces are independent. Boot
+clocks start at different points and drift independently of each other.
+Running a separate `traced` on every machine and stitching the resulting
+traces together after the fact is possible but fragile, especially for
+anything timing-sensitive (e.g. cross-machine scheduling or RPC latency).
+
+Multi-machine tracing solves this without duplicating buffers or consumer
+machinery on every machine.
+
+## Architecture
+
+Exactly one machine in the setup runs `traced` (the "host"). Every other
+machine runs `traced_relay`, which forwards the producer-side IPC to the
+host:
+
+```
+   Remote machine                            Host machine
+  ┌────────────────────────┐               ┌────────────────────────────┐
+  │ traced_probes          │               │  traced --enable-relay-    │
+  │ + other producers      │               │          endpoint          │
+  │        │               │               │           ▲                │
+  │        ▼ (local IPC)   │   TCP/vsock   │           │ (local IPC)    │
+  │  traced_relay  ────────┼──────────────►│  relay endpoint            │
+  └────────────────────────┘               │           ▲                │
+                                           │           │                │
+                                           │   traced_probes / other    │
+                                           │   local producers          │
+                                           │           ▲                │
+                                           │           │ (consumer IPC) │
+                                           │      perfetto cmdline      │
+                                           └────────────────────────────┘
+```
+
+`traced_relay` is intentionally thin: it accepts producer connections on the
+local producer socket, exchanges a small amount of metadata with the host
+(see below), and then proxies producer IPC frames over TCP or vsock. It does
+not buffer trace data, does not parse trace packets, and does not implement
+any consumer-side functionality.
+
+The consumer (`perfetto` cmdline or the UI's WebSocket bridge) only ever
+talks to the host's `traced`. Trace configuration, buffer ownership, and
+final read-back stay on a single machine.
+
+## Machine identity
+
+When `traced_relay` first connects to the host it sends a `SetPeerIdentity`
+message containing a `machine_id_hint` — on Linux this is derived from
+`/proc/sys/kernel/random/boot_id` when available, or a hash of `uname(2)`
+plus a bootup-timestamp source as a fallback. The hint is stable across
+reconnects of the same kernel, but distinct between different kernels.
+
+The host's `traced` maps each unique hint to a small integer `MachineId`
+and stamps every `TracePacket` arriving from that relay with it (the
+`machine_id` field on `TracePacket`). At import time, [Trace Processor]
+materialises one row per machine in the `machine` table:
+
+| Column | Description |
+| ------ | ----------- |
+| `id` | Trace-Processor-assigned machine ID. Always `0` for the host. |
+| `raw_id` | The raw machine identifier from the trace packet (`0` for the host, non-zero for remote machines). |
+| `sysname`, `release`, `version`, `arch` | `uname(2)` fields for the machine. |
+| `num_cpus` | CPU count visible to that kernel. |
+| `system_ram_bytes`, `system_ram_gb` | Total RAM. |
+| `android_build_fingerprint`, `android_device_manufacturer`, `android_sdk_version` | Populated only for Android machines. |
+
+Tables that have a per-CPU or per-thread dimension (`thread`, `cpu`,
+`gpu_counter_track`, etc.) carry a nullable `machine_id` so cross-machine
+data can be sliced by SQL. UI support for per-machine tracks is still
+maturing, so `machine_id` joins remain the most reliable way to answer
+cross-machine questions today.
+
+## Clock synchronisation across machines
+
+Each remote machine has its own `CLOCK_BOOTTIME`, so timestamps written by
+its producers cannot be compared directly to host timestamps. `traced_relay`
+runs a lightweight ping protocol against the host's relay endpoint, sending
+and receiving timestamped messages to estimate the per-machine clock offset
+and round-trip time. The host periodically emits the resulting offsets as
+`ClockSnapshot` packets in the trace.
+
+From there everything reuses the existing single-machine machinery
+described in [Clock Synchronization](/docs/concepts/clock-sync.md): Trace
+Processor folds the cross-machine offsets into the same clock graph it
+already builds for `CLOCK_REALTIME`, `CLOCK_MONOTONIC`, etc., and resolves
+every event to a single global trace clock at import. There is nothing
+extra a data source has to do.
+
+## {#data-source-dispatch} Data source dispatch
+
+By default `traced` only dispatches data sources to producers on the host
+machine. To collect data from remote machines, the consumer's
+`TraceConfig` must opt in, either globally with `trace_all_machines: true`
+or per-data-source with `DataSource.machine_name_filter`. Without one of
+these, `traced_probes` on the remote machine still registers and shows up
+as a row in the `machine` table, but is never assigned the requested data
+sources, so no events flow from it.
+
+`trace_all_machines` was introduced in v54; earlier versions matched all
+machines by default. The remote-side machine name comes from the
+`PERFETTO_MACHINE_NAME` env var when `traced_relay` is started, falling
+back to `uname -s`. The literal name `"host"` is a synonym for the
+machine running `traced`.
+
+Producers on a single kernel cannot stand in for "two machines" even for
+testing. The two `traced_probes` instances would race over the same
+`/sys/kernel/tracing/` ring buffers, and per-CPU events would be
+partitioned arbitrarily between the two `machine_id`s — the trace looks
+valid but is silently torn. Multi-machine setups need two kernels (two
+machines, host plus a VM, separate containers with their own kernel
+namespaces, etc.).
+
+## Limitations and constraints
+
+* `traced_relay` cannot run on the same machine as `traced` — both bind the
+  local producer socket. Each machine in the setup runs *either* `traced`
+  (the host) *or* `traced_relay` (every other machine).
+* Every remote machine must have a network path to the host's relay
+  endpoint, on TCP or vsock.
+* Cross-machine clock alignment is only as good as the ping protocol's
+  measurement of the offset; a roughly-aligned wall clock (NTP or
+  similar) helps the first snapshots but is not strictly required.
+* UI per-machine track rendering is still maturing. SQL on the `machine`
+  table and `machine_id` columns is the authoritative way to slice
+  cross-machine data today.
+
+## Next steps
+
+* [Multi-machine recording](/docs/learning-more/multi-machine-tracing.md) —
+  step-by-step walk-through of recording a multi-machine trace between two
+  Linux hosts.
+* [Clock Synchronization](/docs/concepts/clock-sync.md) — the single-machine
+  clock-sync graph that the cross-machine offsets fold into at import.
+* [`machine` table reference](/docs/analysis/sql-tables.autogen#machine) —
+  full schema of the table populated from `SetPeerIdentity`.
+
+[Trace Processor]: /docs/analysis/trace-processor.md

--- a/docs/learning-more/multi-machine-tracing.md
+++ b/docs/learning-more/multi-machine-tracing.md
@@ -1,0 +1,199 @@
+# Multi-machine recording
+
+This document describes how to record a single Perfetto trace that captures
+events from two Linux machines simultaneously. It uses `traced_relay` on
+the second machine to forward producer IPC to a `traced` running on the
+first machine.
+
+For background on what multi-machine tracing is and how it works under the
+hood, see
+[Multi-machine architecture](/docs/deployment/multi-machine-architecture.md).
+
+## Use case
+
+You have a workload split across two Linux machines — e.g. a client on
+machine A driving a server on machine B, or a host running a Linux VM —
+and you want a single trace covering both, so cross-machine causality is
+visible in one timeline and queryable in one trace file.
+
+In the rest of this guide, `host` is the machine that will run `traced`
+and own the trace buffers, and `guest` is the second machine whose
+producers feed into the same trace via `traced_relay`. Substitute
+`<host-ip>` with the IP address (or hostname) of `host` as reachable from
+`guest`.
+
+## Prerequisites
+
+* `tracebox` available on both machines. See
+  [Start Using Perfetto](/docs/getting-started/start-using-perfetto.md) for
+  how to obtain a binary.
+* A network path from `guest` to `host` on a chosen TCP port (e.g. port
+  `20001`). If there's a firewall between them, open the port.
+* No `traced` already running on either machine. On the `guest`, `traced`
+  and `traced_relay` would contest the same local producer socket; on the
+  `host` you want the `traced` you start below, not a system one.
+* `host` and `guest` are separate OS images — two machines, a host plus a
+  VM, etc. Pointing both producers at the same kernel does not work.
+
+NOTE: This guide records ftrace events for the example, which on Linux
+typically requires running the producer commands as root (or with
+`CAP_SYS_ADMIN`). The IPC commands themselves do not require root.
+
+## Usage
+
+### Step 1: Start `traced` on the host, listening on TCP
+
+On `host`:
+
+```bash
+PERFETTO_PRODUCER_SOCK_NAME=0.0.0.0:20001 \
+  tracebox traced --enable-relay-endpoint
+```
+
+`PERFETTO_PRODUCER_SOCK_NAME` rebinds the producer socket from the default
+UNIX path to a TCP listener that remote machines can reach.
+`--enable-relay-endpoint` makes that socket accept `traced_relay`
+connections in addition to ordinary local producers.
+
+Leave this process running.
+
+### Step 2: Start `traced_probes` on the host
+
+In a second shell on `host`:
+
+```bash
+PERFETTO_PRODUCER_SOCK_NAME=127.0.0.1:20001 \
+  sudo -E tracebox traced_probes
+```
+
+The same env var that rebound `traced`'s listener also tells local
+producers where to connect — without it, `traced_probes` would still try
+the default UNIX socket and fail. `sudo -E` preserves the env var across
+the privilege escalation needed for ftrace.
+
+### Step 3: Start `traced_relay` on the guest
+
+On `guest`:
+
+```bash
+PERFETTO_RELAY_SOCK_NAME=<host-ip>:20001 \
+  tracebox traced_relay
+```
+
+`traced_relay` opens the standard local producer socket on `guest` and
+forwards every producer IPC frame to the host's relay endpoint. You should
+see a startup line of the form:
+
+```
+Started traced_relay, listening on /tmp/perfetto-producer, forwarding to <host-ip>:20001
+```
+
+(The listening path may instead be `/run/perfetto/traced-producer.sock` if
+that directory exists — both are valid Linux defaults.)
+
+Leave this process running.
+
+### Step 4: Start `traced_probes` on the guest
+
+In a second shell on `guest`:
+
+```bash
+sudo tracebox traced_probes
+```
+
+No env var is needed: with `PERFETTO_PRODUCER_SOCK_NAME` unset,
+`traced_probes` connects to the default Linux producer socket — which is
+exactly the path `traced_relay` is listening on — so the two find each
+other automatically.
+
+### Step 5: Record a trace from the host
+
+Multi-machine tracing requires an explicit `TraceConfig` — the
+`tracebox perfetto -t 10s ... sched/sched_switch` shorthand records on
+the host machine only (see
+[Multi-machine architecture](/docs/deployment/multi-machine-architecture.md#data-source-dispatch)).
+
+On `host`, write a config file:
+
+```bash
+cat > config.pbtx <<'EOF'
+buffers {
+  size_kb: 32768
+  fill_policy: RING_BUFFER
+}
+trace_all_machines: true
+data_sources {
+  config {
+    name: "linux.ftrace"
+    ftrace_config {
+      ftrace_events: "sched/sched_switch"
+    }
+  }
+}
+duration_ms: 10000
+EOF
+```
+
+Then record:
+
+```bash
+tracebox perfetto --txt -c config.pbtx -o trace.pftrace
+```
+
+### Step 6: Verify both machines are in the trace
+
+Open `trace.pftrace` at <https://ui.perfetto.dev>. In the SQL query view,
+run:
+
+```sql
+SELECT id, raw_id, sysname, release, arch, num_cpus FROM machine;
+```
+
+Expect two rows. `id = 0` is always the host; remote machines have a
+non-zero `raw_id`. See the [`machine` table reference][machine-table] for
+the full set of columns.
+
+To confirm that events from both machines made it into the trace, group
+ftrace events by machine. `ftrace_event` does not carry `machine_id`
+directly — each row references a `cpu` (via `ucpu`), and `cpu` carries
+the `machine_id`:
+
+```sql
+SELECT cpu.machine_id, COUNT(*) AS num_events
+FROM ftrace_event
+JOIN cpu USING (ucpu)
+GROUP BY cpu.machine_id;
+```
+
+You should see one row per machine, each with a non-zero count. The same
+join pattern works against the `thread` or `process` tables to slice by
+machine through different dimensions.
+
+## Troubleshooting
+
+* **Only one row in `machine`.** Connectivity problem. Check that
+  `<host-ip>:20001` is reachable from `guest` (e.g. with `nc -zv`), that
+  the firewall is open, and that `traced` on the host bound `0.0.0.0`
+  (not `127.0.0.1`).
+* **`traced_relay` exits immediately and prints usage.**
+  `PERFETTO_RELAY_SOCK_NAME` is unset or empty — `traced_relay` has no
+  host to forward to.
+* **`traced_probes` on the guest fails with a connect error.** Make sure
+  `traced_relay` is running on the guest (Step 3) and that no stale
+  `traced` is also running there contesting the producer socket.
+* **Producers on the host fail to connect.** Confirm `traced` started
+  with `PERFETTO_PRODUCER_SOCK_NAME=0.0.0.0:20001` (Step 1) and that the
+  producers are pointed at the same address (Step 2).
+
+## Next steps
+
+* [Multi-machine architecture](/docs/deployment/multi-machine-architecture.md) —
+  the why: how `traced_relay`, machine identity, and cross-kernel clock
+  sync fit together.
+* [PerfettoSQL: Getting Started](/docs/analysis/perfetto-sql-getting-started.md) —
+  for slicing the resulting trace by `machine_id` across `cpu`, `thread`,
+  and `process`.
+* [Trace Processor](/docs/analysis/trace-processor.md) — embed analysis
+  in scripts or pipelines once the recording is repeatable.
+
+[machine-table]: /docs/analysis/sql-tables.autogen#machine

--- a/docs/reference/tracebox.md
+++ b/docs/reference/tracebox.md
@@ -88,7 +88,12 @@ The following applets are available:
 :    Probes for system-wide tracing (ftrace, /proc pollers).
 
 `traced_relay`
-:    Relays trace data to a remote tracing service.
+:    Relays trace data to a remote tracing service. Used to extend a tracing
+     session across machines; see
+     [Multi-machine architecture](/docs/deployment/multi-machine-architecture.md)
+     for the design and
+     [Multi-machine recording](/docs/learning-more/multi-machine-tracing.md)
+     for setup.
 
 `traced_perf`
 :    Perf-based CPU profiling data source.

--- a/docs/reference/traced.md
+++ b/docs/reference/traced.md
@@ -83,8 +83,11 @@ Entities interact with `traced` primarily through two channels:
     <prod_group>:<prod_mode>:<cons_group>:<cons_mode>`: Sets the group ownership
     and permission mode for the producer and consumer sockets. This is important
     for controlling which users and processes can connect to `traced`.
-*   `--enable-relay-endpoint`: Enables an endpoint for multi-machine tracing via
-    `traced_relay`.
+*   `--enable-relay-endpoint`: Enables an endpoint for
+    [multi-machine tracing](/docs/deployment/multi-machine-architecture.md) via
+    `traced_relay`. See
+    [Multi-machine recording](/docs/learning-more/multi-machine-tracing.md)
+    for the host-side setup.
 
 ## Built-in Producer
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -54,6 +54,7 @@
     - [Tracing across Reboots](data-sources/previous-boot-trace.md) {.tag-android .tag-linux}
     - [Custom Proto Extensions](instrumentation/extensions.md) {.tag-cpp-rust .tag-android .tag-perf}
     - [heapprofd API](instrumentation/heapprofd-api.md) {.tag-cpp-rust}
+    - [Multi-machine recording](learning-more/multi-machine-tracing.md) {.tag-android .tag-linux}
 
   - [Data Sources](#)
 
@@ -156,6 +157,7 @@
     - [Detached Mode](concepts/detached-mode.md) {.tag-android}
     - [Interceptors](instrumentation/interceptors.md) {.tag-cpp-rust}
     - [Legacy (v1) Metrics](analysis/metrics.md) {.tag-android}
+    - [Multi-machine architecture](deployment/multi-machine-architecture.md) {.tag-android .tag-linux}
     - [BigTrace (Single Machine)](deployment/deploying-bigtrace-on-a-single-machine.md) {.tag-android .tag-perf}
     - [BigTrace on Kubernetes](deployment/deploying-bigtrace-on-kubernetes.md) {.tag-android .tag-perf}
 


### PR DESCRIPTION
This change adds two docs for multi-machine tracing, one how-to guide, one explanation of
how multi-machine works. Tested manually myself with QEMU debian on bare metal debian to
make sure that it all works E2E.

Fixes: https://github.com/google/perfetto/issues/5760