### PR TITLE
perfetto: seed ai/skills/ for RFC-0025

### DIFF
--- a/ai/skills/README.md
+++ b/ai/skills/README.md
@@ -1,0 +1,105 @@
+# Perfetto Skills
+
+This directory holds **skills**: self-contained, model-agnostic
+instructions that teach an AI agent how to do something useful with
+Perfetto. Skills are how Perfetto and the teams that use it encode
+the knowledge an expert would share when sitting next to a colleague
+— what to look at, which tables to query, what good queries look
+like, and how to interpret the results.
+
+The format follows the [Agent Skills](https://agentskills.io)
+convention: each skill is a directory containing a `SKILL.md` with
+YAML frontmatter (`name`, `description`) and a markdown body. Any
+tool that implements the
+convention — Claude Code, Gemini CLI, OpenAI Codex — can load them.
+
+This is the **seed** of a much larger skill ecosystem described in
+[RFC-0025: AI in Perfetto](https://github.com/google/perfetto/discussions/5763).
+External teams will eventually contribute their own skills, either
+checked in here or served from extension servers.
+
+## Skills are designed to be copied
+
+A skill is portable. It will be vendored into agent contexts (e.g.
+`~/.claude/skills/`), pasted into other repos, and read by tools
+running without access to the Perfetto source tree. So:
+
+- **Never use repo-relative paths** like `src/trace_processor/...`
+  or `docs/analysis/...` — they don't resolve outside this checkout.
+  Link to [perfetto.dev](https://perfetto.dev/docs) instead.
+- **Don't refer to "this repo" or `tools/...` scripts** — assume
+  the reader only has a Perfetto build (`trace_processor`) and the
+  trace.
+- **Keep the skill self-sufficient.** If a skill needs a SQL helper
+  or example, ship it inside the skill directory next to `SKILL.md`.
+
+## Layout
+
+The directory is **flat**: every skill is a direct child of
+`ai/skills/`. This matches the discovery rules of every supported
+agent (`<root>/<slug>/SKILL.md`), so the same tree drops into
+`~/.claude/skills/`, `~/.gemini/skills/`, or `~/.agents/skills/`
+without any flattening step.
+
+```
+ai/skills/
+├── README.md
+├── perfetto-infra-querying-traces/
+│   └── SKILL.md
+├── perfetto-infra-getting-trace-processor/
+│   └── SKILL.md
+└── perfetto-workflow-android-heap-dump/
+    └── SKILL.md
+```
+
+The slug doubles as the taxonomy: `perfetto-` is the vendor prefix
+(so Perfetto skills don't collide with anything else the user has
+installed), then a category, then any sub-categories, then the
+skill name. Two categories today:
+
+- **`perfetto-infra-*`** — domain-agnostic mechanics of working with
+  Perfetto: how to query a trace, how to install the binary, etc.
+- **`perfetto-workflow-<domain>-*`** — domain-specific
+  investigation workflows: how to investigate a heap dump on
+  Android, jank on Chrome, etc.
+
+A workflow skill *uses* infra skills — it tells the agent "you'll
+need to query the trace; here's the bit specific to this problem."
+
+## Authoring a skill
+
+Create a directory under `ai/skills/` whose name follows the
+`perfetto-<category>-<name>` pattern, with a `SKILL.md` inside:
+
+```markdown
+---
+name: perfetto-infra-querying-traces
+description: Use when the user wants to load a Perfetto trace, run
+  a SQL query against it, or discover which tables and columns are
+  available. Covers trace_processor invocation and the PerfettoSQL
+  standard library.
+---
+
+# Body of the skill, written for an AI agent to follow.
+```
+
+Guidelines:
+
+- **`name`** must equal the directory slug. Agents key off the
+  frontmatter name and discovery is a single level deep.
+- **`description`** must clearly state *when* the skill should be
+  invoked. The agent uses this line to decide whether the skill is
+  relevant, so be specific about the trigger conditions, not just
+  the topic.
+- The body is regular markdown. Write it in the imperative ("run X",
+  "check Y"), the same way you would write a runbook.
+- **Always link to absolute URLs on
+  [perfetto.dev/docs](https://perfetto.dev/docs)**, not
+  repo-relative paths.
+- **Test your skill against a real trace** before checking it in.
+  Skills that have never been run end up with broken syntax and
+  wrong column names.
+- A skill directory can contain additional files (example scripts,
+  reference SQL). Reference them from `SKILL.md` by relative path.
+- Keep the body focused. If a skill grows past a couple of pages,
+  split it.

--- a/ai/skills/perfetto-infra-getting-trace-processor/SKILL.md
+++ b/ai/skills/perfetto-infra-getting-trace-processor/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: perfetto-infra-getting-trace-processor
+description: Use when the user does not yet have `trace_processor`
+  installed, or has not set up the Python `perfetto` client used to
+  drive the long-running RPC mode. Covers fetching the prebuilt binary
+  and an opinionated venv-based install for the Python client. This is
+  the OSS / public path; teams in restricted environments may have
+  their own version of this skill that overrides it.
+---
+
+# Getting `trace_processor` and the Python client
+
+This skill is one *answer* to the question "where does `trace_processor`
+come from?". It is intentionally **orthogonal** to the
+`querying-traces` skill: that one teaches what to do once you have a
+working `trace_processor`; this one teaches how to obtain it.
+
+There are many possible answers depending on the environment — Google
+internal users, OEM build environments, CI images, and other teams
+typically have their own preferred or mandatory path. **If the user is
+in such an environment, prefer their team-specific version of this
+skill.** Use this one when nothing more specific is available.
+
+## Part 1 — The `trace_processor` binary
+
+Fetch the official prebuilt binary. This is what 99% of users should
+do — a build from source is only needed when developing Perfetto
+itself.
+
+```sh
+curl -LO https://get.perfetto.dev/trace_processor
+chmod +x trace_processor
+./trace_processor --version    # smoke test
+```
+
+`get.perfetto.dev/trace_processor` is a small wrapper script that picks
+the right prebuilt binary for the host platform (Linux x86_64 / arm64,
+macOS, Windows) and caches it. Re-running the `curl -LO` (or just
+re-invoking `./trace_processor`) is the recommended way to stay
+current — the script is hash-idempotent, so it only re-downloads when
+the upstream binary actually changes. **Don't move it onto `PATH`** as
+a one-shot install: doing so encourages users to keep running a stale
+binary indefinitely.
+
+If a Perfetto source checkout *is* available, `tools/trace_processor`
+inside that checkout does the same fetch under the hood and
+additionally supports `--build` for a from-source build.
+
+## Part 2 — The Python client (for long-running RPC mode)
+
+The `querying-traces` skill recommends starting `trace_processor server
+http TRACE_FILE` once and connecting from Python so iteration doesn't
+re-parse the trace on every query. That requires the `perfetto` Python
+package (and `protobuf`).
+
+### Default: an isolated venv
+
+Modern macOS / Debian / Ubuntu Python installs (PEP 668) refuse global
+`pip install` by default, and even where they don't, mixing the
+Perfetto client into the system interpreter is a recipe for version
+conflicts. The opinionated path is a dedicated venv:
+
+```sh
+python3 -m venv ~/.venv/perfetto
+~/.venv/perfetto/bin/pip install -U perfetto protobuf
+# Optional: pandas, only if you want .as_pandas_dataframe() to work.
+~/.venv/perfetto/bin/pip install -U pandas
+
+# Sanity check.
+~/.venv/perfetto/bin/python -c \
+  "from perfetto.trace_processor import TraceProcessor; print('ok')"
+```
+
+Then invoke Python from the querying skill as
+`~/.venv/perfetto/bin/python`, or `source ~/.venv/perfetto/bin/activate`
+once per shell and use plain `python`.
+
+### When to override the default
+
+- **The user already has an environment manager** (`uv`, `pipx`,
+  `conda`, `poetry`, an existing project venv): install `perfetto` and
+  `protobuf` into that environment instead of creating a fresh
+  `~/.venv/perfetto`.
+- **The user explicitly wants a global install**: `pip install
+  --break-system-packages perfetto protobuf` is the escape hatch on
+  PEP-668 distros. Don't reach for it on the user's behalf — only
+  when they ask.
+- **The environment has its own packaging story** (Google internal,
+  CI images with pre-baked deps, locked-down corporate Python): defer
+  to that. This skill is the OSS default, not a mandate.
+
+## Verifying the full setup
+
+A one-shot end-to-end check that the binary and the client agree:
+
+```sh
+# Start the server on a small trace in the background, on a random port
+# to avoid clashing with any other trace_processor server / the UI.
+PORT=$((9100 + RANDOM % 900))
+trace_processor server http --port $PORT /path/to/some_trace.pftrace &
+SERVER_PID=$!
+sleep 1
+
+# Query via the Python client.
+~/.venv/perfetto/bin/python - "$PORT" <<'PY'
+import sys
+from perfetto.trace_processor import TraceProcessor
+tp = TraceProcessor(addr=f'127.0.0.1:{sys.argv[1]}')
+print(next(iter(tp.query('SELECT count(*) AS c FROM slice'))).c)
+tp.close()
+PY
+
+kill $SERVER_PID
+```
+
+If this prints a non-zero count and exits cleanly, the user is ready to
+follow the `querying-traces` skill.

--- a/ai/skills/perfetto-infra-querying-traces/SKILL.md
+++ b/ai/skills/perfetto-infra-querying-traces/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: perfetto-infra-querying-traces
+description: Use when the user wants to load a Perfetto trace, run a
+  PerfettoSQL query against it, or discover which tables, views, columns,
+  or stdlib modules are available. Covers trace_processor invocation, the
+  long-running RPC mode, and how to compose stdlib modules into a query.
+---
+
+# Querying Perfetto traces
+
+This skill teaches you how to extract data from a Perfetto trace file
+(`.pftrace`, `.perfetto-trace`, `.pb`) using `trace_processor` and
+PerfettoSQL.
+
+The `trace_processor` binary is what every other Perfetto analysis tool
+runs on top of, including the Perfetto UI. Reference docs:
+<https://perfetto.dev/docs/analysis/trace-processor>.
+
+> **Prerequisite — getting `trace_processor`.** This skill assumes
+> `trace_processor` is already on `PATH` (and, for the long-running RPC
+> mode below, that the Python client is installed). If neither is set
+> up, follow whatever skill the user's environment provides for
+> acquisition — typically `perfetto-infra-getting-trace-processor` for the
+> open-source path, or a team-specific variant inside Google or other
+> restricted environments. The rest of this skill is intentionally
+> orthogonal to *how* you got `trace_processor`.
+
+## Quickstart
+
+To run a single query and exit:
+
+```sh
+trace_processor query TRACE_FILE "SELECT ts, dur FROM slice LIMIT 10"
+```
+
+Multiple statements separated by `;` are supported in one invocation.
+
+## Long-running mode (preferred for iteration)
+
+Reparsing a trace on every query is slow — for a multi-GB trace it's tens
+of seconds, every time. When you expect to run more than a couple of
+queries, start the shell once as an HTTP RPC server and drive it from
+the Python client. (If the Python client is not installed yet, see the
+`getting-trace-processor` skill or the team-specific equivalent.)
+
+```sh
+# Terminal A: pick a random high port and start the server on it.
+# Always pass --port explicitly: the default (9001) is also used by
+# the Perfetto UI, and a fixed port collides with any other agent
+# already running a trace_processor server.
+PORT=$((9100 + RANDOM % 900))
+trace_processor server http --port $PORT TRACE_FILE
+```
+
+```python
+# Terminal B (or any Python process): connect to the running server.
+# PORT is the value chosen in Terminal A.
+from perfetto.trace_processor import TraceProcessor
+
+tp = TraceProcessor(addr='127.0.0.1:PORT')
+for row in tp.query('SELECT ts, dur, name FROM slice WHERE dur > 5e8 LIMIT 5'):
+    print(row.dur, row.name)
+
+# Pandas is also supported if the dependency is installed:
+df = tp.query('SELECT ts, dur, name FROM slice LIMIT 100').as_pandas_dataframe()
+
+tp.close()
+```
+
+The server keeps the trace parsed in memory; each `tp.query()` call is
+just a query against the existing session. This is the same RPC channel
+`ui.perfetto.dev` uses when you load a trace there.
+
+Notes:
+
+- Use `'127.0.0.1:PORT'`, not `'localhost:PORT'`. The server binds on
+  IPv4/IPv6 explicitly and `localhost` resolution can pick an interface
+  that isn't bound on macOS.
+- A quick liveness check from the shell:
+  `curl http://127.0.0.1:PORT/status` returns plain JSON-ish status
+  (loaded path, version) and is the fastest way to confirm the server
+  is up.
+- The on-the-wire `/query`, `/parse`, `/rpc` endpoints take protobuf-
+  encoded `QueryArgs`/`TraceProcessorRpc` payloads. **Do not hand-craft
+  HTTP calls with `curl`** — use the Python client (or the WASM
+  client embedded in the UI). Hand-crafted calls work for `/status` only.
+- If you want to stay in the C++ shell instead of Python, a one-shot
+  `trace_processor query TRACE_FILE "..."` is fine for a handful of
+  queries; the server is the right answer the moment iteration starts.
+
+## Discovering what's in the trace
+
+PerfettoSQL ships with **intrinsic table-functions** for browsing the
+loaded standard library — modules, tables/views, functions, macros. Use
+these to find what's available; use a plain `LIMIT 0` query to read the
+column schema of any specific table, view, or query result.
+
+> **Intrinsic surface — not stable API.** The `__intrinsic_*` names below
+> are an implementation detail of trace processor. They're fair game for
+> an agent to use during a session because this skill is loaded, but
+> **don't bake `__intrinsic_*` names into committed scripts, dashboards,
+> or stdlib modules** — they can change without notice.
+
+```sql
+-- 1. List every stdlib module currently available.
+SELECT package, module FROM __intrinsic_stdlib_modules ORDER BY 1, 2;
+
+-- 2. List the tables/views a specific module exposes
+--    (after INCLUDE PERFETTO MODULE).
+INCLUDE PERFETTO MODULE slices.with_context;
+SELECT name, type, exposed, description
+FROM __intrinsic_stdlib_tables('slices.with_context');
+
+-- 3. List functions / macros a module exposes.
+SELECT name, return_type, args
+FROM __intrinsic_stdlib_functions('slices.with_context');
+SELECT name, return_type, args
+FROM __intrinsic_stdlib_macros('android.memory.heap_graph.helpers');
+
+-- 4. Read the column schema of any table, view, or query.
+--    LIMIT 0 returns the result header with no row scan; trace_processor
+--    prints "column N = <name>" lines for each column.
+SELECT * FROM slice LIMIT 0;
+SELECT * FROM thread_or_process_slice LIMIT 0;
+SELECT * FROM (SELECT ts, dur, name FROM slice WHERE dur > 0) LIMIT 0;
+```
+
+Useful starting points for any trace:
+
+| View           | What's in it                                                    |
+| -------------- | --------------------------------------------------------------- |
+| `slice`        | Atrace slices, async slices, anything with a duration on a track |
+| `thread`       | One row per thread                                              |
+| `process`      | One row per process                                             |
+| `thread_state` | Scheduling state transitions (Running, Runnable, Sleeping, …)   |
+| `sched_slice`  | When threads were on-CPU                                        |
+| `counter`      | Time-series counter samples                                     |
+| `track`        | Every track in the trace; join on `track_id` to most other tables |
+
+Static reference for the public surface (does not require a running
+trace_processor): <https://perfetto.dev/docs/analysis/sql-tables>.
+
+## Using the standard library
+
+Most useful queries are *much* shorter when you build on stdlib modules
+instead of joining raw tables yourself. Generated stdlib reference:
+<https://perfetto.dev/docs/analysis/stdlib-docs>.
+
+Include a module before referencing the views, tables or macros it
+defines:
+
+```sql
+INCLUDE PERFETTO MODULE slices.with_context;
+
+SELECT name, dur, thread_name, process_name
+FROM thread_or_process_slice
+WHERE dur > 1e9                     -- slices longer than 1s
+ORDER BY dur DESC
+LIMIT 20;
+```
+
+A few commonly used modules to know:
+
+- `slices.with_context` — slice rows joined with their thread / process.
+- `sched.with_context` — `sched_slice` joined with thread / process.
+- `android.startup.startups` — one row per app startup.
+- `stacks.cpu_profiling` — flat samples and call-graph helpers.
+- `android.memory.heap_graph.dominator_tree` — retained-size analysis for
+  Java heap dumps (see the `perfetto-workflow-android-heap-dump`
+  skill for usage).
+
+The module name maps directly to the file path under the stdlib root:
+`foo.bar` lives at `foo/bar.sql`. Browse the full list at the stdlib
+reference linked above.
+
+## Tips for writing good PerfettoSQL
+
+- **Reach for stdlib first.** If you find yourself joining `slice` to
+  `thread_track` to `thread` to `process`, there is almost certainly a
+  stdlib module that already does it. Check the stdlib reference before
+  writing the join.
+- **Filter on `dur > 0` carefully.** Some slices have `dur = -1` (still
+  open at trace end) and some have `dur = 0` (instant events). Be explicit
+  about which you mean.
+- **Avoid `SELECT *` in saved queries.** Trace processor table schemas can
+  gain columns; pin the columns you actually use.
+- **Don't expose raw IDs in summaries.** Columns like `id`, `utid`, `upid`,
+  `track_id` are not stable across traces or even runs of trace_processor
+  on the same trace. They are fine to use *inside* a query as join keys,
+  but join out to a stable name (`thread.name`, `process.name`,
+  `slice.name`) before reporting results to the user.
+- **Use `EXPLAIN QUERY PLAN` if a query is slow.** It shows whether SQLite
+  is using indexes. Counter and slice tables have built-in indexes on `ts`
+  and `track_id`; queries that don't filter on either will scan the whole
+  table.
+- **Materialise expensive intermediate results.** `CREATE PERFETTO TABLE
+  foo AS SELECT ...` caches the result so subsequent queries don't redo
+  the work. Use `CREATE PERFETTO VIEW` if you want lazy evaluation.
+
+## Where to look for more
+
+- Language tour:
+  <https://perfetto.dev/docs/analysis/perfetto-sql-getting-started>
+- Trace processor reference:
+  <https://perfetto.dev/docs/analysis/trace-processor>
+- Generated table reference:
+  <https://perfetto.dev/docs/analysis/sql-tables>
+- Generated stdlib reference:
+  <https://perfetto.dev/docs/analysis/stdlib-docs>

--- a/ai/skills/perfetto-workflow-android-heap-dump/SKILL.md
+++ b/ai/skills/perfetto-workflow-android-heap-dump/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: perfetto-workflow-android-heap-dump
+description: Use when the user has an Android trace containing a Java heap
+  graph (heap dump) and wants to investigate memory usage, find leaks, or
+  understand what is retaining memory. Walks through a guided workflow
+  built on the heap_graph_* tables and the android.memory.heap_graph
+  stdlib.
+---
+
+# Investigating an Android Java heap dump
+
+This skill is the recommended first pass when the user asks "what's wrong
+with this heap dump?", "why is this process using so much memory?", or
+"what's leaking?". It assumes the trace was recorded with the ART perfetto
+data source and contains at least one Java heap graph.
+
+If the user has not yet loaded a trace into `trace_processor`, follow
+the `perfetto-infra-querying-traces` skill first, then come back here.
+Recording-side reference for heap dumps:
+<https://perfetto.dev/docs/data-sources/java-heap-profiler>.
+
+> All queries below use `$upid` and `$ts` as placeholders. Substitute the
+> values you picked in step 1 — `trace_processor` does not interpret `$`
+> variables.
+
+## Mental model
+
+A heap dump is a snapshot of every Java object alive in a process at a
+moment in time, plus the references between them. To find a leak you
+generally want to answer two questions:
+
+1. **What is taking up the most memory?** — sum object sizes by class or
+   by *retained* (dominated) size, not just by `self_size`. Retained size
+   is the memory that would be freed if the object went away.
+2. **Why isn't it getting GC'd?** — walk the dominator tree (or the
+   shortest path from a GC root) to find the chain of references keeping
+   it alive.
+
+The Perfetto stdlib has prebuilt views for both. Reach for those before
+joining `heap_graph_object` and `heap_graph_reference` by hand. Browse the
+modules under `android.memory.heap_graph.*` in the stdlib reference:
+<https://perfetto.dev/docs/analysis/stdlib-docs>.
+
+## Step 1 — Confirm the trace has a heap graph and orient
+
+```sql
+INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;
+
+SELECT
+  upid,
+  graph_sample_ts,
+  total_heap_size,
+  reachable_heap_size,
+  total_obj_count,
+  reachable_obj_count,
+  anon_rss_and_swap_size,
+  oom_score_adj
+FROM android_heap_graph_stats
+ORDER BY graph_sample_ts;
+```
+
+Sanity checks at this point:
+
+- Did any rows come back? If not, the trace doesn't contain a heap graph
+  and you should stop and tell the user.
+- Is `reachable_heap_size` close to `total_heap_size`? A big gap means a
+  lot of memory is unreachable but not yet collected — interesting on its
+  own but not the typical "leak" pattern.
+- How does `total_heap_size` compare to `anon_rss_and_swap_size`? If RSS
+  is much larger than the Java heap, the bloat is probably not Java —
+  consider native allocations instead.
+- Pick the `upid` and `graph_sample_ts` you'll focus on for the rest of
+  the investigation. If there are multiple dumps, the earliest one
+  usually shows the steady state; later dumps show growth.
+
+Join with `process` to turn `upid` into a process name when reporting back
+to the user — never expose raw `upid` values.
+
+## Step 2 — Find the classes dominating retained size
+
+The `android_heap_graph_class_summary_tree` view aggregates the heap by
+the shortest-path tree from GC roots, grouped by class name. It's the
+fastest way to spot "this one class is holding most of the heap":
+
+```sql
+INCLUDE PERFETTO MODULE android.memory.heap_graph.class_summary_tree;
+
+SELECT
+  name AS class_name,
+  root_type,
+  self_count,
+  self_size,
+  cumulative_count,
+  cumulative_size
+FROM android_heap_graph_class_summary_tree
+WHERE upid = $upid AND graph_sample_ts = $ts
+ORDER BY cumulative_size DESC
+LIMIT 30;
+```
+
+`cumulative_size` is the size of all objects of this class plus everything
+they retain — this is what to sort by to find the dominant retainer.
+`self_size` only counts the objects of the class itself.
+
+Patterns that are usually worth flagging to the user:
+
+- A single class with a `cumulative_size` that's a large fraction of
+  `reachable_heap_size`.
+- An unexpectedly large `self_count` for a class that "should" only have
+  a handful of instances (Activities, Fragments, application singletons).
+- A `root_type` of `ROOT_JAVA_FRAME` or `ROOT_JNI_GLOBAL` retaining a lot
+  — these often indicate a native or JNI leak.
+
+## Step 3 — Use the dominator tree to find the retention chain
+
+Once a suspicious class is identified, the dominator tree tells you what
+is *uniquely* keeping its instances alive. An object's immediate
+dominator is the closest ancestor that *every* path from a GC root must
+pass through.
+
+```sql
+INCLUDE PERFETTO MODULE android.memory.heap_graph.dominator_tree;
+
+WITH suspect_objects AS (
+  SELECT o.id
+  FROM heap_graph_object o
+  JOIN heap_graph_class c ON o.type_id = c.id
+  WHERE o.upid = $upid
+    AND o.graph_sample_ts = $ts
+    AND c.name = 'com.example.LeakySingleton'
+)
+SELECT
+  d.id,
+  d.idom_id,
+  d.dominated_obj_count,
+  d.dominated_size_bytes,
+  d.depth
+FROM heap_graph_dominator_tree d
+JOIN suspect_objects s USING (id)
+ORDER BY dominated_size_bytes DESC;
+```
+
+To walk *up* from a leaked object to its GC root, follow `idom_id`
+recursively (it's NULL once you hit the super-root). Join each step
+through `heap_graph_object.type_id` → `heap_graph_class.name` to get a
+human-readable retention path.
+
+For a per-class rollup of the dominator tree (often easier to read than
+per-object), use `android.memory.heap_graph.dominator_class_tree`
+instead.
+
+## Step 4 — Inspect specific references when needed
+
+The dominator tree shows *one* retaining edge per object (the dominator).
+If you need the full set of incoming/outgoing references — e.g. to
+explain why an object can't be collected even though the dominator looks
+benign — query `heap_graph_reference` directly. Note that
+`heap_graph_reference.owner_id` is the source object id; you do not need
+to join through `reference_set_id`.
+
+```sql
+-- Outgoing references from a specific object.
+SELECT
+  r.field_name,
+  r.field_type_name,
+  oc.name AS owner_class,
+  r.owned_id AS referent_id,
+  rc.name AS referent_class,
+  ro.self_size AS referent_self_size
+FROM heap_graph_reference r
+JOIN heap_graph_object oo ON r.owner_id = oo.id
+JOIN heap_graph_class oc ON oo.type_id = oc.id
+LEFT JOIN heap_graph_object ro ON r.owned_id = ro.id
+LEFT JOIN heap_graph_class rc ON ro.type_id = rc.id
+WHERE r.owner_id = $object_id;
+```
+
+Common things to look for here:
+
+- An `ArrayList` / `HashMap` / `ConcurrentHashMap` whose internal array
+  has thousands of slots — the leaked container is the suspect.
+- A `WeakReference` or `SoftReference` chain that turns out not to be
+  weak in practice (a strong reference is also held).
+- An inner class (`Outer$Inner`) with a `this$0` field pinning an
+  Activity or Fragment — classic Android leak.
+
+## What to report back
+
+A good summary for the user contains:
+
+1. The process name and the timestamp of the heap dump.
+2. Total reachable heap size and the top retainers by `cumulative_size`,
+   with class names, not raw IDs.
+3. For the dominant retainer, the chain from a GC root to one example
+   object, expressed as `Class -> field -> Class -> field -> …`.
+4. A hypothesis stated as a hypothesis, not a fact ("this looks like a
+   leaked Activity retained via the inner Listener; the next step is to
+   confirm by …").
+
+Always keep the underlying SQL and object IDs available so the user can
+audit. Do not make claims about what the code is doing without inspecting
+the references.
+
+## Reference
+
+- Java heap profiler (recording side):
+  <https://perfetto.dev/docs/data-sources/java-heap-profiler>
+- PerfettoSQL language tour (with a heap-graph example):
+  <https://perfetto.dev/docs/analysis/perfetto-sql-getting-started>
+- Generated stdlib reference (browse `android.memory.heap_graph.*`):
+  <https://perfetto.dev/docs/analysis/stdlib-docs>


### PR DESCRIPTION
Bootstrap the AI skills directory called out in
[RFC-0025](https://github.com/google/perfetto/discussions/5763). Lives
at the top level (not under `src/`) because skills are shipped
artifacts, not source code: an `ai/` tree gives future AI-related
material (skill bundles, MCP configs, agent prompts, etc.) a natural
home.

The directory is flat, matching the discovery contract every
supported coding agent shares (Claude Code, Gemini CLI, OpenAI
Codex): one level of `<slug>/SKILL.md` directly under the skills
root. The slug carries the taxonomy as a `perfetto-<category>-...`
prefix:

- `perfetto-infra-*` — domain-agnostic mechanics of working with
  Perfetto (how to query a trace, how to install the binary, …).
- `perfetto-workflow-<domain>-*` — domain-specific investigation
  workflows (heap dumps on Android, jank on Chrome, …).

Because the on-disk layout matches what the agents look for, the
tree drops into `~/.claude/skills/`, `~/.gemini/skills/`, or
`~/.agents/skills/` with a plain `cp -r ai/skills/* <root>/`. No
flattening step is required at install time.

Skills follow the [agentskills.io](https://agentskills.io) `SKILL.md`
frontmatter convention so they are portable into agent contexts
outside the tree. All doc references are absolute `perfetto.dev`
URLs because skills get vendored.

## Three starter skills

- `perfetto-infra-querying-traces`: pure querying skill —
  `trace_processor` invocation, the long-running HTTP RPC mode,
  stdlib discovery via the new `__intrinsic_stdlib_*` table
  functions plus `LIMIT 0` for column schemas. Validated end-to-end
  against a real trace.
- `perfetto-infra-getting-trace-processor`: the OSS acquisition
  path (curl-bash binary fetch + venv-based Python client install).
  Designed to be swappable: teams in restricted environments (e.g.
  Google internal) can override this skill with their own without
  touching `perfetto-infra-querying-traces`. The two skills are
  intentionally orthogonal.
- `perfetto-workflow-android-heap-dump`: 4-step workflow over
  `android_heap_graph_stats`, `class_summary_tree`, `dominator_tree`,
  and `heap_graph_reference`.

The user-facing docs landing page (and the `trace_processor ai
install-skills` subcommand for installing the bundle without `cp`)
follow in the dependent change.