### PR TITLE
perfetto: fix UAF race in LockFreeTaskRunner::PostTask

### DIFF
--- a/src/base/lock_free_task_runner.cc
+++ b/src/base/lock_free_task_runner.cc
@@ -89,6 +89,17 @@ void LockFreeTaskRunner::PostTask(std::function<void()> closure) {
     Slab* slab = tail_.load();
     PERFETTO_DCHECK(slab);  // The tail_ must be always valid.
     ScopedRefcount scoped_refcount(this, slab);
+    // After incrementing the refcount, re-verify that `slab` is still the
+    // current tail. If it isn't, the slab might have been deleted between
+    // our tail_.load() above and the refcount inc (the reader's check on
+    // refcount==0 may have happened before our inc). Retry with the new tail.
+    // If the second tail.load() returns the same slab, in seq_cst order
+    // any subsequent CAS that replaces tail_ comes after this load, hence
+    // any reader's later refcount check is also after our inc and will
+    // observe refcount > 0.
+    if (PERFETTO_UNLIKELY(tail_.load() != slab)) {
+      continue;
+    }
 
     // Now that we have a slab, try appending a task to it (if there is space).
     // We have 3 cases:


### PR DESCRIPTION
PostTask reads `tail_` before incrementing the per-slab refcount:

    Slab* slab = tail_.load();                      // (1)
    ScopedRefcount scoped_refcount(this, slab);     // (2)
    slab->next_task_slot.fetch_add(1);              // (3)

If a writer is preempted between (1) and (2), other writers can fill
the slab and CAS in a new tail. The reader then walks back from the
new tail, finds the now-non-tail slab, sees refcount[bucket] == 0
(the preempted writer hasn't incremented yet), and calls DeleteSlab.
When DeleteSlab can't park the slab in free_slab_ it `delete`s it,
freeing the memory. The preempted writer eventually wakes up,
increments the refcount, and dereferences freed memory in (3).

This is exactly the race the design doc tried to mitigate, but the
seq_cst argument there requires the refcount inc to happen *before*
the tail load. The actual code does it the other way around, which
breaks the proof: a writer that observed the old tail before the CAS
but hasn't incremented the refcount yet is invisible to the reader's
refcount==0 check.

In production this manifested as a SIGSEGV in PopTaskRecursive
reading slab->prev with a wild pointer (0x8000000000000008,
consistent with allocator metadata in a freed/poisoned chunk on
Android Scudo) — the reader-side cascade of the writer's UAF.

Fix: re-verify tail after taking the refcount. If the second
tail_.load() returns the same slab, then in seq_cst order any
subsequent CAS that replaces tail_ is ordered after this load, hence
after our refcount inc — so the reader's later refcount check
observes refcount > 0 and skips the delete. If the second load
returns a different slab we retry; we never touch the original
(potentially freed) slab pointer.

Verified with a deterministic repro (yield inserted between (1) and
(2)): without the fix, ASan reports heap-use-after-free in PostTask's
fetch_add, freed by Run -> PopTaskRecursive -> DeleteSlab. With the
fix, the repro and all existing LockFreeTaskRunner tests pass under
both ASan and TSan.

Bug: b/507384565