### PR TITLE
tp: add 'ai' subcommand to list/search/install bundled skills

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1601,6 +1601,24 @@ cc_binary {
     ],
 }
 
+// GN: //ai/skills:skills
+genrule {
+    name: "perfetto_ai_skills_skills",
+    srcs: [
+        "ai/skills/perfetto-infra-getting-trace-processor/SKILL.md",
+        "ai/skills/perfetto-infra-querying-traces/SKILL.md",
+        "ai/skills/perfetto-workflow-android-heap-dump/SKILL.md",
+    ],
+    cmd: "$(location ai/skills/gen_skill_bundle.py) --output=$(out) --gen-dir=$(genDir) --namespace perfetto::trace_processor::ai_skills $(in)",
+    out: [
+        "ai/skills/skills.h",
+    ],
+    tool_files: [
+        "ai/skills/gen_skill_bundle.py",
+        "python/tools/cpp_blob_emitter.py",
+    ],
+}
+
 // GN: //src/base:perfetto_base_default_platform
 filegroup {
     name: "perfetto_base_default_platform",
@@ -17546,6 +17564,7 @@ filegroup {
 filegroup {
     name: "perfetto_src_trace_processor_shell_shell",
     srcs: [
+        "src/trace_processor/shell/ai_subcommand.cc",
         "src/trace_processor/shell/common_flags.cc",
         "src/trace_processor/shell/convert_subcommand.cc",
         "src/trace_processor/shell/export_subcommand.cc",
@@ -17968,6 +17987,7 @@ cc_library_static {
     ],
     host_supported: true,
     generated_headers: [
+        "perfetto_ai_skills_skills",
         "perfetto_protos_perfetto_common_cpp_gen_headers",
         "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",
@@ -18049,6 +18069,7 @@ cc_library_static {
         "perfetto_src_traceconv_gen_cc_winscope_descriptor",
     ],
     export_generated_headers: [
+        "perfetto_ai_skills_skills",
         "perfetto_protos_perfetto_common_cpp_gen_headers",
         "perfetto_protos_perfetto_common_semantic_type_zero_gen_headers",
         "perfetto_protos_perfetto_common_zero_gen_headers",

--- a/BUILD
+++ b/BUILD
@@ -729,6 +729,7 @@ perfetto_cc_library(
         ":include_perfetto_trace_processor_util",
     ],
     deps = [
+               ":ai_skills_skills",
                ":protos_perfetto_common_cpp",
                ":protos_perfetto_common_semantic_type_zero",
                ":protos_perfetto_common_zero",
@@ -1121,6 +1122,25 @@ perfetto_cc_library(
         ":src_protovm_protovm",
     ] + PERFETTO_CONFIG.deps.zlib,
     linkstatic = True,
+)
+
+# GN target: //ai/skills:skills
+perfetto_cpp_blob_header(
+    name = "ai_skills_skills",
+    script = ":ai_skills_gen_skill_bundle_py",
+    deps = [
+        "ai/skills/perfetto-infra-getting-trace-processor/SKILL.md",
+        "ai/skills/perfetto-infra-querying-traces/SKILL.md",
+        "ai/skills/perfetto-workflow-android-heap-dump/SKILL.md",
+    ],
+    outs = [
+        "ai/skills/skills.h",
+    ],
+    args = [
+        "--gen-dir=$(GENDIR)",
+        "--namespace",
+        "perfetto::trace_processor::ai_skills",
+    ],
 )
 
 # GN target: //include/perfetto/base:base
@@ -4468,6 +4488,8 @@ perfetto_filegroup(
 perfetto_filegroup(
     name = "src_trace_processor_shell_shell",
     srcs = [
+        "src/trace_processor/shell/ai_subcommand.cc",
+        "src/trace_processor/shell/ai_subcommand.h",
         "src/trace_processor/shell/common_flags.cc",
         "src/trace_processor/shell/common_flags.h",
         "src/trace_processor/shell/convert_subcommand.cc",
@@ -9782,6 +9804,16 @@ perfetto_build_config_cc_library(
     name = "build_config_hdr",
     hdrs = [build_config_dir_ + "/perfetto_build_flags.h"],
     includes = [build_config_dir_],
+)
+
+perfetto_py_binary(
+    name = "ai_skills_gen_skill_bundle_py",
+    srcs = [
+        "ai/skills/gen_skill_bundle.py",
+    ],
+    main = "ai/skills/gen_skill_bundle.py",
+    deps = [perfetto_label("python:cpp_blob_emitter")],
+    python_version = "PY3",
 )
 
 perfetto_py_binary(

--- a/BUILD.extras
+++ b/BUILD.extras
@@ -9,6 +9,16 @@ perfetto_build_config_cc_library(
 )
 
 perfetto_py_binary(
+    name = "ai_skills_gen_skill_bundle_py",
+    srcs = [
+        "ai/skills/gen_skill_bundle.py",
+    ],
+    main = "ai/skills/gen_skill_bundle.py",
+    deps = [perfetto_label("python:cpp_blob_emitter")],
+    python_version = "PY3",
+)
+
+perfetto_py_binary(
     name = "gen_amalgamated_sql_py",
     srcs = [
         "tools/gen_amalgamated_sql.py",

--- a/ai/skills/BUILD.gn
+++ b/ai/skills/BUILD.gn
@@ -1,0 +1,41 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../gn/perfetto_cpp_blob_header.gni")
+
+# Bundles every SKILL.md under ai/skills/ into a single gzip-compressed
+# constexpr std::array<uint8_t, N> embedded in the trace_processor
+# binary. Generated header: ai/skills/skills.h, exposing
+# `ai_skills::kSkills`. Decompress at runtime with
+# util::GzipDecompressor::DecompressFully and iterate the resulting
+# bytes with util::SqlBundle.
+#
+# This is intentionally a generic compressed-blob target rather than a
+# perfetto_amalgamated_sql_header (which is SQL-flavoured): SKILL.md
+# files are not SQL, and the "amalgamated SQL" template is a hack we
+# don't want to spread to non-SQL artifacts.
+perfetto_cpp_blob_header("skills") {
+  script = "gen_skill_bundle.py"
+  sources = [
+    "perfetto-infra-getting-trace-processor/SKILL.md",
+    "perfetto-infra-querying-traces/SKILL.md",
+    "perfetto-workflow-android-heap-dump/SKILL.md",
+  ]
+  generated_header = "${target_gen_dir}/skills.h"
+  pass_gen_dir = true
+  extra_args = [
+    "--namespace",
+    "perfetto::trace_processor::ai_skills",
+  ]
+}

--- a/ai/skills/README.md
+++ b/ai/skills/README.md
@@ -1,0 +1,105 @@
+# Perfetto Skills
+
+This directory holds **skills**: self-contained, model-agnostic
+instructions that teach an AI agent how to do something useful with
+Perfetto. Skills are how Perfetto and the teams that use it encode
+the knowledge an expert would share when sitting next to a colleague
+— what to look at, which tables to query, what good queries look
+like, and how to interpret the results.
+
+The format follows the [Agent Skills](https://agentskills.io)
+convention: each skill is a directory containing a `SKILL.md` with
+YAML frontmatter (`name`, `description`) and a markdown body. Any
+tool that implements the
+convention — Claude Code, Gemini CLI, OpenAI Codex — can load them.
+
+This is the **seed** of a much larger skill ecosystem described in
+[RFC-0025: AI in Perfetto](https://github.com/google/perfetto/discussions/5763).
+External teams will eventually contribute their own skills, either
+checked in here or served from extension servers.
+
+## Skills are designed to be copied
+
+A skill is portable. It will be vendored into agent contexts (e.g.
+`~/.claude/skills/`), pasted into other repos, and read by tools
+running without access to the Perfetto source tree. So:
+
+- **Never use repo-relative paths** like `src/trace_processor/...`
+  or `docs/analysis/...` — they don't resolve outside this checkout.
+  Link to [perfetto.dev](https://perfetto.dev/docs) instead.
+- **Don't refer to "this repo" or `tools/...` scripts** — assume
+  the reader only has a Perfetto build (`trace_processor`) and the
+  trace.
+- **Keep the skill self-sufficient.** If a skill needs a SQL helper
+  or example, ship it inside the skill directory next to `SKILL.md`.
+
+## Layout
+
+The directory is **flat**: every skill is a direct child of
+`ai/skills/`. This matches the discovery rules of every supported
+agent (`<root>/<slug>/SKILL.md`), so the same tree drops into
+`~/.claude/skills/`, `~/.gemini/skills/`, or `~/.agents/skills/`
+without any flattening step.
+
+```
+ai/skills/
+├── README.md
+├── perfetto-infra-querying-traces/
+│   └── SKILL.md
+├── perfetto-infra-getting-trace-processor/
+│   └── SKILL.md
+└── perfetto-workflow-android-heap-dump/
+    └── SKILL.md
+```
+
+The slug doubles as the taxonomy: `perfetto-` is the vendor prefix
+(so Perfetto skills don't collide with anything else the user has
+installed), then a category, then any sub-categories, then the
+skill name. Two categories today:
+
+- **`perfetto-infra-*`** — domain-agnostic mechanics of working with
+  Perfetto: how to query a trace, how to install the binary, etc.
+- **`perfetto-workflow-<domain>-*`** — domain-specific
+  investigation workflows: how to investigate a heap dump on
+  Android, jank on Chrome, etc.
+
+A workflow skill *uses* infra skills — it tells the agent "you'll
+need to query the trace; here's the bit specific to this problem."
+
+## Authoring a skill
+
+Create a directory under `ai/skills/` whose name follows the
+`perfetto-<category>-<name>` pattern, with a `SKILL.md` inside:
+
+```markdown
+---
+name: perfetto-infra-querying-traces
+description: Use when the user wants to load a Perfetto trace, run
+  a SQL query against it, or discover which tables and columns are
+  available. Covers trace_processor invocation and the PerfettoSQL
+  standard library.
+---
+
+# Body of the skill, written for an AI agent to follow.
+```
+
+Guidelines:
+
+- **`name`** must equal the directory slug. Agents key off the
+  frontmatter name and discovery is a single level deep.
+- **`description`** must clearly state *when* the skill should be
+  invoked. The agent uses this line to decide whether the skill is
+  relevant, so be specific about the trigger conditions, not just
+  the topic.
+- The body is regular markdown. Write it in the imperative ("run X",
+  "check Y"), the same way you would write a runbook.
+- **Always link to absolute URLs on
+  [perfetto.dev/docs](https://perfetto.dev/docs)**, not
+  repo-relative paths.
+- **Test your skill against a real trace** before checking it in.
+  Skills that have never been run end up with broken syntax and
+  wrong column names.
+- A skill directory can contain additional files (example scripts,
+  reference SQL). Reference them from `SKILL.md` by relative path.
+- Keep the body focused. If a skill grows past a couple of pages,
+  split it.

--- a/ai/skills/gen_skill_bundle.py
+++ b/ai/skills/gen_skill_bundle.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pack the SKILL.md files under ai/skills/ into a gzip-compressed blob
+embedded as a `constexpr std::array<uint8_t, N>` C++ header.
+
+The blob, after decompression with util::GzipDecompressor::DecompressFully,
+is an SqlBundle wire stream:
+
+  uint32_t count;
+  for (count) {
+    uint32_t path_size;       // excluding the trailing NUL.
+    char     path[path_size];
+    char     nul;             // 0x00.
+    uint32_t content_size;
+    char     content[content_size];
+  }
+
+The path is the file's location relative to ai/skills/ (e.g.
+'perfetto-infra-querying-traces/SKILL.md'); the directory portion is
+the skill slug used by `trace_processor ai install-skills` when
+writing the file out under the agent's discovery root.
+
+Inputs are positional file paths. As a convenience, any positional that
+ends with `.txt` is read as a newline-separated list of further input
+paths (the GN driver materialises this list at build time via
+`generated_file`).
+"""
+
+import argparse
+import gzip
+import os
+import struct
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.normpath(os.path.join(SCRIPT_DIR, '..', '..')))
+
+# pylint: disable=wrong-import-position
+from python.tools import cpp_blob_emitter  # noqa: E402
+# pylint: enable=wrong-import-position
+
+
+def expand_inputs(inputs):
+  out = []
+  for path in inputs:
+    if path.endswith('.txt'):
+      with open(path, 'r', encoding='utf-8') as f:
+        out.extend(line for line in f.read().splitlines() if line)
+    else:
+      out.append(path)
+  return out
+
+
+def pack(file_to_bytes):
+  """Pack {relpath: content_bytes} into the SqlBundle wire format."""
+  buf = bytearray()
+  buf += struct.pack('<I', len(file_to_bytes))
+  for path, content in file_to_bytes.items():
+    path_bytes = path.encode('utf-8')
+    buf += struct.pack('<I', len(path_bytes))
+    buf += path_bytes
+    buf += b'\0'
+    buf += struct.pack('<I', len(content))
+    buf += content
+  return bytes(buf)
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--output', required=True)
+  parser.add_argument('--namespace', required=True)
+  parser.add_argument('--gen-dir', default='')
+  parser.add_argument('--root-dir', default=None)
+  parser.add_argument('inputs', nargs='+')
+  args = parser.parse_args()
+
+  files = expand_inputs(args.inputs)
+
+  # Soong cannot pass a path to the source root, so without --root-dir we
+  # fall back to the longest common path. This relies on every input
+  # living under ai/skills/ which the GN driver guarantees.
+  root_dir = args.root_dir if args.root_dir else os.path.commonpath(files)
+
+  packed_files = {}
+  for path in files:
+    with open(path, 'rb') as f:
+      relpath = os.path.relpath(path, root_dir)
+      assert '..' not in relpath.split(os.sep), relpath
+      relpath = relpath.replace('\\', '/')
+      packed_files[relpath] = f.read()
+
+  blob = gzip.compress(pack(packed_files), compresslevel=9, mtime=0)
+  cpp_blob_emitter.emit_array(
+      blob,
+      args.output,
+      symbol=cpp_blob_emitter.derive_symbol(args.output),
+      namespace=args.namespace,
+      include_guard=cpp_blob_emitter.derive_include_guard(
+          args.output, args.gen_dir))
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/ai/skills/perfetto-infra-getting-trace-processor/SKILL.md
+++ b/ai/skills/perfetto-infra-getting-trace-processor/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: perfetto-infra-getting-trace-processor
+description: Use when the user does not yet have `trace_processor`
+  installed, or has not set up the Python `perfetto` client used to
+  drive the long-running RPC mode. Covers fetching the prebuilt binary
+  and an opinionated venv-based install for the Python client. This is
+  the OSS / public path; teams in restricted environments may have
+  their own version of this skill that overrides it.
+---
+
+# Getting `trace_processor` and the Python client
+
+This skill is one *answer* to the question "where does `trace_processor`
+come from?". It is intentionally **orthogonal** to the
+`querying-traces` skill: that one teaches what to do once you have a
+working `trace_processor`; this one teaches how to obtain it.
+
+There are many possible answers depending on the environment — Google
+internal users, OEM build environments, CI images, and other teams
+typically have their own preferred or mandatory path. **If the user is
+in such an environment, prefer their team-specific version of this
+skill.** Use this one when nothing more specific is available.
+
+## Part 1 — The `trace_processor` binary
+
+Fetch the official prebuilt binary. This is what 99% of users should
+do — a build from source is only needed when developing Perfetto
+itself.
+
+```sh
+curl -LO https://get.perfetto.dev/trace_processor
+chmod +x trace_processor
+./trace_processor --version    # smoke test
+```
+
+`get.perfetto.dev/trace_processor` is a small wrapper script that picks
+the right prebuilt binary for the host platform (Linux x86_64 / arm64,
+macOS, Windows) and caches it. Re-running the `curl -LO` (or just
+re-invoking `./trace_processor`) is the recommended way to stay
+current — the script is hash-idempotent, so it only re-downloads when
+the upstream binary actually changes. **Don't move it onto `PATH`** as
+a one-shot install: doing so encourages users to keep running a stale
+binary indefinitely.
+
+If a Perfetto source checkout *is* available, `tools/trace_processor`
+inside that checkout does the same fetch under the hood and
+additionally supports `--build` for a from-source build.
+
+## Part 2 — The Python client (for long-running RPC mode)
+
+The `querying-traces` skill recommends starting `trace_processor server
+http TRACE_FILE` once and connecting from Python so iteration doesn't
+re-parse the trace on every query. That requires the `perfetto` Python
+package (and `protobuf`).
+
+### Default: an isolated venv
+
+Modern macOS / Debian / Ubuntu Python installs (PEP 668) refuse global
+`pip install` by default, and even where they don't, mixing the
+Perfetto client into the system interpreter is a recipe for version
+conflicts. The opinionated path is a dedicated venv:
+
+```sh
+python3 -m venv ~/.venv/perfetto
+~/.venv/perfetto/bin/pip install -U perfetto protobuf
+# Optional: pandas, only if you want .as_pandas_dataframe() to work.
+~/.venv/perfetto/bin/pip install -U pandas
+
+# Sanity check.
+~/.venv/perfetto/bin/python -c \
+  "from perfetto.trace_processor import TraceProcessor; print('ok')"
+```
+
+Then invoke Python from the querying skill as
+`~/.venv/perfetto/bin/python`, or `source ~/.venv/perfetto/bin/activate`
+once per shell and use plain `python`.
+
+### When to override the default
+
+- **The user already has an environment manager** (`uv`, `pipx`,
+  `conda`, `poetry`, an existing project venv): install `perfetto` and
+  `protobuf` into that environment instead of creating a fresh
+  `~/.venv/perfetto`.
+- **The user explicitly wants a global install**: `pip install
+  --break-system-packages perfetto protobuf` is the escape hatch on
+  PEP-668 distros. Don't reach for it on the user's behalf — only
+  when they ask.
+- **The environment has its own packaging story** (Google internal,
+  CI images with pre-baked deps, locked-down corporate Python): defer
+  to that. This skill is the OSS default, not a mandate.
+
+## Verifying the full setup
+
+A one-shot end-to-end check that the binary and the client agree:
+
+```sh
+# Start the server on a small trace in the background, on a random port
+# to avoid clashing with any other trace_processor server / the UI.
+PORT=$((9100 + RANDOM % 900))
+trace_processor server http --port $PORT /path/to/some_trace.pftrace &
+SERVER_PID=$!
+sleep 1
+
+# Query via the Python client.
+~/.venv/perfetto/bin/python - "$PORT" <<'PY'
+import sys
+from perfetto.trace_processor import TraceProcessor
+tp = TraceProcessor(addr=f'127.0.0.1:{sys.argv[1]}')
+print(next(iter(tp.query('SELECT count(*) AS c FROM slice'))).c)
+tp.close()
+PY
+
+kill $SERVER_PID
+```
+
+If this prints a non-zero count and exits cleanly, the user is ready to
+follow the `querying-traces` skill.

--- a/ai/skills/perfetto-infra-querying-traces/SKILL.md
+++ b/ai/skills/perfetto-infra-querying-traces/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: perfetto-infra-querying-traces
+description: Use when the user wants to load a Perfetto trace, run a
+  PerfettoSQL query against it, or discover which tables, views, columns,
+  or stdlib modules are available. Covers trace_processor invocation, the
+  long-running RPC mode, and how to compose stdlib modules into a query.
+---
+
+# Querying Perfetto traces
+
+This skill teaches you how to extract data from a Perfetto trace file
+(`.pftrace`, `.perfetto-trace`, `.pb`) using `trace_processor` and
+PerfettoSQL.
+
+The `trace_processor` binary is what every other Perfetto analysis tool
+runs on top of, including the Perfetto UI. Reference docs:
+<https://perfetto.dev/docs/analysis/trace-processor>.
+
+> **Prerequisite — getting `trace_processor`.** This skill assumes
+> `trace_processor` is already on `PATH` (and, for the long-running RPC
+> mode below, that the Python client is installed). If neither is set
+> up, follow whatever skill the user's environment provides for
+> acquisition — typically `perfetto-infra-getting-trace-processor` for the
+> open-source path, or a team-specific variant inside Google or other
+> restricted environments. The rest of this skill is intentionally
+> orthogonal to *how* you got `trace_processor`.
+
+## Quickstart
+
+To run a single query and exit:
+
+```sh
+trace_processor query TRACE_FILE "SELECT ts, dur FROM slice LIMIT 10"
+```
+
+Multiple statements separated by `;` are supported in one invocation.
+
+## Long-running mode (preferred for iteration)
+
+Reparsing a trace on every query is slow — for a multi-GB trace it's tens
+of seconds, every time. When you expect to run more than a couple of
+queries, start the shell once as an HTTP RPC server and drive it from
+the Python client. (If the Python client is not installed yet, see the
+`getting-trace-processor` skill or the team-specific equivalent.)
+
+```sh
+# Terminal A: pick a random high port and start the server on it.
+# Always pass --port explicitly: the default (9001) is also used by
+# the Perfetto UI, and a fixed port collides with any other agent
+# already running a trace_processor server.
+PORT=$((9100 + RANDOM % 900))
+trace_processor server http --port $PORT TRACE_FILE
+```
+
+```python
+# Terminal B (or any Python process): connect to the running server.
+# PORT is the value chosen in Terminal A.
+from perfetto.trace_processor import TraceProcessor
+
+tp = TraceProcessor(addr='127.0.0.1:PORT')
+for row in tp.query('SELECT ts, dur, name FROM slice WHERE dur > 5e8 LIMIT 5'):
+    print(row.dur, row.name)
+
+# Pandas is also supported if the dependency is installed:
+df = tp.query('SELECT ts, dur, name FROM slice LIMIT 100').as_pandas_dataframe()
+
+tp.close()
+```
+
+The server keeps the trace parsed in memory; each `tp.query()` call is
+just a query against the existing session. This is the same RPC channel
+`ui.perfetto.dev` uses when you load a trace there.
+
+Notes:
+
+- Use `'127.0.0.1:PORT'`, not `'localhost:PORT'`. The server binds on
+  IPv4/IPv6 explicitly and `localhost` resolution can pick an interface
+  that isn't bound on macOS.
+- A quick liveness check from the shell:
+  `curl http://127.0.0.1:PORT/status` returns plain JSON-ish status
+  (loaded path, version) and is the fastest way to confirm the server
+  is up.
+- The on-the-wire `/query`, `/parse`, `/rpc` endpoints take protobuf-
+  encoded `QueryArgs`/`TraceProcessorRpc` payloads. **Do not hand-craft
+  HTTP calls with `curl`** — use the Python client (or the WASM
+  client embedded in the UI). Hand-crafted calls work for `/status` only.
+- If you want to stay in the C++ shell instead of Python, a one-shot
+  `trace_processor query TRACE_FILE "..."` is fine for a handful of
+  queries; the server is the right answer the moment iteration starts.
+
+## Discovering what's in the trace
+
+PerfettoSQL ships with **intrinsic table-functions** for browsing the
+loaded standard library — modules, tables/views, functions, macros. Use
+these to find what's available; use a plain `LIMIT 0` query to read the
+column schema of any specific table, view, or query result.
+
+> **Intrinsic surface — not stable API.** The `__intrinsic_*` names below
+> are an implementation detail of trace processor. They're fair game for
+> an agent to use during a session because this skill is loaded, but
+> **don't bake `__intrinsic_*` names into committed scripts, dashboards,
+> or stdlib modules** — they can change without notice.
+
+```sql
+-- 1. List every stdlib module currently available.
+SELECT package, module FROM __intrinsic_stdlib_modules ORDER BY 1, 2;
+
+-- 2. List the tables/views a specific module exposes
+--    (after INCLUDE PERFETTO MODULE).
+INCLUDE PERFETTO MODULE slices.with_context;
+SELECT name, type, exposed, description
+FROM __intrinsic_stdlib_tables('slices.with_context');
+
+-- 3. List functions / macros a module exposes.
+SELECT name, return_type, args
+FROM __intrinsic_stdlib_functions('slices.with_context');
+SELECT name, return_type, args
+FROM __intrinsic_stdlib_macros('android.memory.heap_graph.helpers');
+
+-- 4. Read the column schema of any table, view, or query.
+--    LIMIT 0 returns the result header with no row scan; trace_processor
+--    prints "column N = <name>" lines for each column.
+SELECT * FROM slice LIMIT 0;
+SELECT * FROM thread_or_process_slice LIMIT 0;
+SELECT * FROM (SELECT ts, dur, name FROM slice WHERE dur > 0) LIMIT 0;
+```
+
+Useful starting points for any trace:
+
+| View           | What's in it                                                    |
+| -------------- | --------------------------------------------------------------- |
+| `slice`        | Atrace slices, async slices, anything with a duration on a track |
+| `thread`       | One row per thread                                              |
+| `process`      | One row per process                                             |
+| `thread_state` | Scheduling state transitions (Running, Runnable, Sleeping, …)   |
+| `sched_slice`  | When threads were on-CPU                                        |
+| `counter`      | Time-series counter samples                                     |
+| `track`        | Every track in the trace; join on `track_id` to most other tables |
+
+Static reference for the public surface (does not require a running
+trace_processor): <https://perfetto.dev/docs/analysis/sql-tables>.
+
+## Using the standard library
+
+Most useful queries are *much* shorter when you build on stdlib modules
+instead of joining raw tables yourself. Generated stdlib reference:
+<https://perfetto.dev/docs/analysis/stdlib-docs>.
+
+Include a module before referencing the views, tables or macros it
+defines:
+
+```sql
+INCLUDE PERFETTO MODULE slices.with_context;
+
+SELECT name, dur, thread_name, process_name
+FROM thread_or_process_slice
+WHERE dur > 1e9                     -- slices longer than 1s
+ORDER BY dur DESC
+LIMIT 20;
+```
+
+A few commonly used modules to know:
+
+- `slices.with_context` — slice rows joined with their thread / process.
+- `sched.with_context` — `sched_slice` joined with thread / process.
+- `android.startup.startups` — one row per app startup.
+- `stacks.cpu_profiling` — flat samples and call-graph helpers.
+- `android.memory.heap_graph.dominator_tree` — retained-size analysis for
+  Java heap dumps (see the `perfetto-workflow-android-heap-dump`
+  skill for usage).
+
+The module name maps directly to the file path under the stdlib root:
+`foo.bar` lives at `foo/bar.sql`. Browse the full list at the stdlib
+reference linked above.
+
+## Tips for writing good PerfettoSQL
+
+- **Reach for stdlib first.** If you find yourself joining `slice` to
+  `thread_track` to `thread` to `process`, there is almost certainly a
+  stdlib module that already does it. Check the stdlib reference before
+  writing the join.
+- **Filter on `dur > 0` carefully.** Some slices have `dur = -1` (still
+  open at trace end) and some have `dur = 0` (instant events). Be explicit
+  about which you mean.
+- **Avoid `SELECT *` in saved queries.** Trace processor table schemas can
+  gain columns; pin the columns you actually use.
+- **Don't expose raw IDs in summaries.** Columns like `id`, `utid`, `upid`,
+  `track_id` are not stable across traces or even runs of trace_processor
+  on the same trace. They are fine to use *inside* a query as join keys,
+  but join out to a stable name (`thread.name`, `process.name`,
+  `slice.name`) before reporting results to the user.
+- **Use `EXPLAIN QUERY PLAN` if a query is slow.** It shows whether SQLite
+  is using indexes. Counter and slice tables have built-in indexes on `ts`
+  and `track_id`; queries that don't filter on either will scan the whole
+  table.
+- **Materialise expensive intermediate results.** `CREATE PERFETTO TABLE
+  foo AS SELECT ...` caches the result so subsequent queries don't redo
+  the work. Use `CREATE PERFETTO VIEW` if you want lazy evaluation.
+
+## Where to look for more
+
+- Language tour:
+  <https://perfetto.dev/docs/analysis/perfetto-sql-getting-started>
+- Trace processor reference:
+  <https://perfetto.dev/docs/analysis/trace-processor>
+- Generated table reference:
+  <https://perfetto.dev/docs/analysis/sql-tables>
+- Generated stdlib reference:
+  <https://perfetto.dev/docs/analysis/stdlib-docs>

--- a/ai/skills/perfetto-workflow-android-heap-dump/SKILL.md
+++ b/ai/skills/perfetto-workflow-android-heap-dump/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: perfetto-workflow-android-heap-dump
+description: Use when the user has an Android trace containing a Java heap
+  graph (heap dump) and wants to investigate memory usage, find leaks, or
+  understand what is retaining memory. Walks through a guided workflow
+  built on the heap_graph_* tables and the android.memory.heap_graph
+  stdlib.
+---
+
+# Investigating an Android Java heap dump
+
+This skill is the recommended first pass when the user asks "what's wrong
+with this heap dump?", "why is this process using so much memory?", or
+"what's leaking?". It assumes the trace was recorded with the ART perfetto
+data source and contains at least one Java heap graph.
+
+If the user has not yet loaded a trace into `trace_processor`, follow
+the `perfetto-infra-querying-traces` skill first, then come back here.
+Recording-side reference for heap dumps:
+<https://perfetto.dev/docs/data-sources/java-heap-profiler>.
+
+> All queries below use `$upid` and `$ts` as placeholders. Substitute the
+> values you picked in step 1 — `trace_processor` does not interpret `$`
+> variables.
+
+## Mental model
+
+A heap dump is a snapshot of every Java object alive in a process at a
+moment in time, plus the references between them. To find a leak you
+generally want to answer two questions:
+
+1. **What is taking up the most memory?** — sum object sizes by class or
+   by *retained* (dominated) size, not just by `self_size`. Retained size
+   is the memory that would be freed if the object went away.
+2. **Why isn't it getting GC'd?** — walk the dominator tree (or the
+   shortest path from a GC root) to find the chain of references keeping
+   it alive.
+
+The Perfetto stdlib has prebuilt views for both. Reach for those before
+joining `heap_graph_object` and `heap_graph_reference` by hand. Browse the
+modules under `android.memory.heap_graph.*` in the stdlib reference:
+<https://perfetto.dev/docs/analysis/stdlib-docs>.
+
+## Step 1 — Confirm the trace has a heap graph and orient
+
+```sql
+INCLUDE PERFETTO MODULE android.memory.heap_graph.heap_graph_stats;
+
+SELECT
+  upid,
+  graph_sample_ts,
+  total_heap_size,
+  reachable_heap_size,
+  total_obj_count,
+  reachable_obj_count,
+  anon_rss_and_swap_size,
+  oom_score_adj
+FROM android_heap_graph_stats
+ORDER BY graph_sample_ts;
+```
+
+Sanity checks at this point:
+
+- Did any rows come back? If not, the trace doesn't contain a heap graph
+  and you should stop and tell the user.
+- Is `reachable_heap_size` close to `total_heap_size`? A big gap means a
+  lot of memory is unreachable but not yet collected — interesting on its
+  own but not the typical "leak" pattern.
+- How does `total_heap_size` compare to `anon_rss_and_swap_size`? If RSS
+  is much larger than the Java heap, the bloat is probably not Java —
+  consider native allocations instead.
+- Pick the `upid` and `graph_sample_ts` you'll focus on for the rest of
+  the investigation. If there are multiple dumps, the earliest one
+  usually shows the steady state; later dumps show growth.
+
+Join with `process` to turn `upid` into a process name when reporting back
+to the user — never expose raw `upid` values.
+
+## Step 2 — Find the classes dominating retained size
+
+The `android_heap_graph_class_summary_tree` view aggregates the heap by
+the shortest-path tree from GC roots, grouped by class name. It's the
+fastest way to spot "this one class is holding most of the heap":
+
+```sql
+INCLUDE PERFETTO MODULE android.memory.heap_graph.class_summary_tree;
+
+SELECT
+  name AS class_name,
+  root_type,
+  self_count,
+  self_size,
+  cumulative_count,
+  cumulative_size
+FROM android_heap_graph_class_summary_tree
+WHERE upid = $upid AND graph_sample_ts = $ts
+ORDER BY cumulative_size DESC
+LIMIT 30;
+```
+
+`cumulative_size` is the size of all objects of this class plus everything
+they retain — this is what to sort by to find the dominant retainer.
+`self_size` only counts the objects of the class itself.
+
+Patterns that are usually worth flagging to the user:
+
+- A single class with a `cumulative_size` that's a large fraction of
+  `reachable_heap_size`.
+- An unexpectedly large `self_count` for a class that "should" only have
+  a handful of instances (Activities, Fragments, application singletons).
+- A `root_type` of `ROOT_JAVA_FRAME` or `ROOT_JNI_GLOBAL` retaining a lot
+  — these often indicate a native or JNI leak.
+
+## Step 3 — Use the dominator tree to find the retention chain
+
+Once a suspicious class is identified, the dominator tree tells you what
+is *uniquely* keeping its instances alive. An object's immediate
+dominator is the closest ancestor that *every* path from a GC root must
+pass through.
+
+```sql
+INCLUDE PERFETTO MODULE android.memory.heap_graph.dominator_tree;
+
+WITH suspect_objects AS (
+  SELECT o.id
+  FROM heap_graph_object o
+  JOIN heap_graph_class c ON o.type_id = c.id
+  WHERE o.upid = $upid
+    AND o.graph_sample_ts = $ts
+    AND c.name = 'com.example.LeakySingleton'
+)
+SELECT
+  d.id,
+  d.idom_id,
+  d.dominated_obj_count,
+  d.dominated_size_bytes,
+  d.depth
+FROM heap_graph_dominator_tree d
+JOIN suspect_objects s USING (id)
+ORDER BY dominated_size_bytes DESC;
+```
+
+To walk *up* from a leaked object to its GC root, follow `idom_id`
+recursively (it's NULL once you hit the super-root). Join each step
+through `heap_graph_object.type_id` → `heap_graph_class.name` to get a
+human-readable retention path.
+
+For a per-class rollup of the dominator tree (often easier to read than
+per-object), use `android.memory.heap_graph.dominator_class_tree`
+instead.
+
+## Step 4 — Inspect specific references when needed
+
+The dominator tree shows *one* retaining edge per object (the dominator).
+If you need the full set of incoming/outgoing references — e.g. to
+explain why an object can't be collected even though the dominator looks
+benign — query `heap_graph_reference` directly. Note that
+`heap_graph_reference.owner_id` is the source object id; you do not need
+to join through `reference_set_id`.
+
+```sql
+-- Outgoing references from a specific object.
+SELECT
+  r.field_name,
+  r.field_type_name,
+  oc.name AS owner_class,
+  r.owned_id AS referent_id,
+  rc.name AS referent_class,
+  ro.self_size AS referent_self_size
+FROM heap_graph_reference r
+JOIN heap_graph_object oo ON r.owner_id = oo.id
+JOIN heap_graph_class oc ON oo.type_id = oc.id
+LEFT JOIN heap_graph_object ro ON r.owned_id = ro.id
+LEFT JOIN heap_graph_class rc ON ro.type_id = rc.id
+WHERE r.owner_id = $object_id;
+```
+
+Common things to look for here:
+
+- An `ArrayList` / `HashMap` / `ConcurrentHashMap` whose internal array
+  has thousands of slots — the leaked container is the suspect.
+- A `WeakReference` or `SoftReference` chain that turns out not to be
+  weak in practice (a strong reference is also held).
+- An inner class (`Outer$Inner`) with a `this$0` field pinning an
+  Activity or Fragment — classic Android leak.
+
+## What to report back
+
+A good summary for the user contains:
+
+1. The process name and the timestamp of the heap dump.
+2. Total reachable heap size and the top retainers by `cumulative_size`,
+   with class names, not raw IDs.
+3. For the dominant retainer, the chain from a GC root to one example
+   object, expressed as `Class -> field -> Class -> field -> …`.
+4. A hypothesis stated as a hypothesis, not a fact ("this looks like a
+   leaked Activity retained via the inner Listener; the next step is to
+   confirm by …").
+
+Always keep the underlying SQL and object IDs available so the user can
+audit. Do not make claims about what the code is doing without inspecting
+the references.
+
+## Reference
+
+- Java heap profiler (recording side):
+  <https://perfetto.dev/docs/data-sources/java-heap-profiler>
+- PerfettoSQL language tour (with a heap-graph example):
+  <https://perfetto.dev/docs/analysis/perfetto-sql-getting-started>
+- Generated stdlib reference (browse `android.memory.heap_graph.*`):
+  <https://perfetto.dev/docs/analysis/stdlib-docs>

--- a/docs/ai/overview.md
+++ b/docs/ai/overview.md
@@ -1,0 +1,47 @@
+# AI in Perfetto
+
+This page is the landing for AI-related functionality in Perfetto.
+Today it all revolves around a bundled set of [Agent
+Skills](https://agentskills.io) that teach AI coding agents (Claude
+Code, Gemini CLI, OpenAI Codex, …) how to work with Perfetto traces.
+More AI features will land over time — see
+[RFC-0025: AI in Perfetto](https://github.com/google/perfetto/discussions/5763)
+for the longer-term direction.
+
+The skills themselves live in-tree at
+[`ai/skills/`](https://github.com/google/perfetto/tree/main/ai/skills);
+authoring conventions are in
+[`ai/skills/README.md`](https://github.com/google/perfetto/blob/main/ai/skills/README.md).
+
+## How to install Perfetto's skills into your AI coding agent
+
+You will need the `trace_processor` binary
+([download](https://get.perfetto.dev/trace_processor)) and one of the
+supported agents installed locally.
+
+```bash
+trace_processor ai install-skills claudecode  # → ~/.claude/skills/
+trace_processor ai install-skills geminicli   # → ~/.gemini/skills/
+trace_processor ai install-skills codex       # → ~/.agents/skills/
+```
+
+The agent picks the skills up on next launch.
+
+## How to inspect or filter the bundled skills
+
+```bash
+trace_processor ai list-skills
+trace_processor ai search-skills 'heap dump'
+```
+
+`--include` and `--exclude` take fnmatch globs against the skill's
+slug (e.g. `perfetto-infra-querying-traces`,
+`perfetto-workflow-android-heap-dump`). Both are repeatable; `*`
+matches across any character, so `perfetto-infra-*` matches the entire
+infra category.
+
+```bash
+trace_processor ai install-skills claudecode --include 'perfetto-infra-*'
+trace_processor ai install-skills claudecode --exclude 'perfetto-workflow-*'
+trace_processor ai install-skills claudecode --dest /tmp/x --dry-run
+```

--- a/docs/analysis/trace-processor.md
+++ b/docs/analysis/trace-processor.md
@@ -131,6 +131,7 @@ Commands:
   export        Export a trace to a database file.
   metrics       Run v1 metrics (deprecated; use 'summarize --metrics-v2').
   convert       Convert trace format.
+  ai            AI-related actions (today: list/search/install skills).
 
 Common flags (apply to all commands):
   -h, --help                  Show help (per-command if after a command).
@@ -248,6 +249,22 @@ Subcommand flags:
 
 Spec files are auto-detected as binary or text based on extension
 (`.pb` → binary, `.textproto` → text) with a content-sniffing fallback.
+
+#### {#subcommand-ai} `ai` — AI-related actions
+
+Umbrella for AI-related functionality. Today the actions under it
+list, search, and install Perfetto's bundled set of [Agent
+Skills](https://agentskills.io) into a coding agent's discovery
+directory:
+
+```bash
+trace_processor ai list-skills
+trace_processor ai search-skills 'heap dump'
+trace_processor ai install-skills claudecode
+```
+
+See [AI in Perfetto](/docs/ai/overview.md) for the full set of
+how-to guides.
 
 #### {#global-flags} Global flags (apply to every subcommand)
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -46,6 +46,10 @@
     - [Clock Synchronization](concepts/clock-sync.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome}
     - [Concurrent Sessions](concepts/concurrent-tracing-sessions.md) {.tag-android .tag-linux .tag-cpp-rust}
 
+  - [AI in Perfetto](#)
+
+    - [Overview](ai/overview.md) {.tag-android .tag-linux .tag-cpp-rust .tag-chrome .tag-perf}
+
   - [Recording](#)
 
     - [Tracing in Background](learning-more/tracing-in-background.md) {.tag-android .tag-linux}

--- a/include/perfetto/ext/trace_processor/trace_processor_shell.h
+++ b/include/perfetto/ext/trace_processor/trace_processor_shell.h
@@ -22,8 +22,10 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "perfetto/base/status.h"
+#include "perfetto/ext/base/status_or.h"
 #include "perfetto/trace_processor/basic_types.h"
 #include "perfetto/trace_processor/trace_processor.h"
 
@@ -31,6 +33,28 @@ namespace perfetto::trace_processor {
 
 // Forward declaration.
 class TraceProcessorShell_PlatformInterface;
+
+// Describes a coding agent that `trace_processor ai install-skills` can
+// target. Three agents are always built in (claudecode, geminicli, codex);
+// embedders that wrap trace_processor for restricted environments (e.g.
+// Google internal) can register additional agents — for instance one that
+// installs into an internal config root — by overriding
+// TraceProcessorShell_PlatformInterface::GetExtraAiAgents().
+struct AiAgentSpec {
+  // The token the user passes on the command line, e.g. "claudecode".
+  // Must be unique across builtins and embedder-supplied agents; if a
+  // collision occurs the embedder's spec wins.
+  std::string cli_name;
+
+  // Human-readable name shown in install logs and help text, e.g.
+  // "Anthropic Claude Code".
+  std::string description;
+
+  // Returns the absolute on-disk install root for this agent's skills,
+  // or an error if it cannot be resolved (e.g. $HOME unset). Called
+  // once when the agent is selected, before any files are written.
+  std::function<base::StatusOr<std::string>()> resolve_install_dir;
+};
 
 // Class for implementing a trace processor shell.
 //
@@ -87,6 +111,14 @@ class TraceProcessorShell_PlatformInterface {
       TraceProcessor* trace_processor,
       const std::string& path,
       std::function<void(size_t)> progress_callback) = 0;
+
+  // Additional agents the `trace_processor ai install-skills` subcommand
+  // should accept on top of the built-in claudecode/geminicli/codex set.
+  // Default returns empty; override to register environment-specific
+  // agents. cli_name collisions resolve in favour of the override (so
+  // embedders can also redirect a built-in agent to a different install
+  // path).
+  virtual std::vector<AiAgentSpec> GetExtraAiAgents() const { return {}; }
 };
 
 int PERFETTO_EXPORT_COMPONENT TraceProcessorShellMain(int argc, char** argv);

--- a/src/trace_processor/shell/BUILD.gn
+++ b/src/trace_processor/shell/BUILD.gn
@@ -16,6 +16,8 @@ import("../../../gn/perfetto.gni")
 
 source_set("shell") {
   sources = [
+    "ai_subcommand.cc",
+    "ai_subcommand.h",
     "common_flags.cc",
     "common_flags.h",
     "convert_subcommand.cc",
@@ -47,6 +49,7 @@ source_set("shell") {
   ]
   deps = [
     ":subcommands",
+    "../../../ai/skills",
     "../../../gn:default_deps",
     "../../../gn:protobuf_full",
     "../../../include/perfetto/ext/trace_processor:trace_processor_shell",
@@ -60,6 +63,8 @@ source_set("shell") {
     "../rpc:stdiod",
     "../trace_summary",
     "../trace_summary:gen_cc_trace_summary_descriptor",
+    "../util:gzip",
+    "../util:sql_bundle",
     "../util:stdlib",
     "../util/deobfuscation:deobfuscator",
     "../util/symbolizer",

--- a/src/trace_processor/shell/ai_subcommand.cc
+++ b/src/trace_processor/shell/ai_subcommand.cc
@@ -1,0 +1,462 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/trace_processor/shell/ai_subcommand.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "ai/skills/skills.h"
+#include "perfetto/base/build_config.h"
+#include "perfetto/base/logging.h"
+#include "perfetto/base/status.h"
+#include "perfetto/ext/base/file_utils.h"
+#include "perfetto/ext/base/scoped_file.h"
+#include "perfetto/ext/base/status_or.h"
+#include "perfetto/ext/base/string_utils.h"
+#include "perfetto/ext/trace_processor/trace_processor_shell.h"
+#include "src/trace_processor/shell/subcommand.h"
+#include "src/trace_processor/util/gzip_utils.h"
+#include "src/trace_processor/util/sql_bundle.h"
+
+namespace perfetto::trace_processor::shell {
+
+namespace {
+
+std::string HomeDir() {
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_WIN)
+  if (const char* p = std::getenv("USERPROFILE"); p && *p)
+    return p;
+  if (const char* p = std::getenv("APPDATA"); p && *p)
+    return p;
+#else
+  if (const char* p = std::getenv("HOME"); p && *p)
+    return p;
+#endif
+  return {};
+}
+
+std::function<base::StatusOr<std::string>()> HomeRelativeResolver(
+    std::string subdir) {
+  return [subdir = std::move(subdir)]() -> base::StatusOr<std::string> {
+    std::string home = HomeDir();
+    if (home.empty()) {
+      return base::ErrStatus(
+          "cannot resolve home directory; set HOME (or USERPROFILE on "
+          "Windows), or pass --dest explicitly.");
+    }
+    return home + "/" + subdir;
+  };
+}
+
+std::vector<AiAgentSpec> BuiltinAgents() {
+  std::vector<AiAgentSpec> out;
+  out.push_back({"claudecode", "Anthropic Claude Code",
+                 HomeRelativeResolver(".claude/skills")});
+  out.push_back({"geminicli", "Google Gemini CLI",
+                 HomeRelativeResolver(".gemini/skills")});
+  out.push_back(
+      {"codex", "OpenAI Codex CLI", HomeRelativeResolver(".agents/skills")});
+  return out;
+}
+
+std::vector<AiAgentSpec> RegisteredAgents(
+    TraceProcessorShell_PlatformInterface* platform) {
+  std::vector<AiAgentSpec> agents = BuiltinAgents();
+  if (platform) {
+    for (auto& extra : platform->GetExtraAiAgents()) {
+      auto it = std::find_if(
+          agents.begin(), agents.end(),
+          [&](const AiAgentSpec& a) { return a.cli_name == extra.cli_name; });
+      if (it != agents.end()) {
+        *it = std::move(extra);
+      } else {
+        agents.push_back(std::move(extra));
+      }
+    }
+  }
+  return agents;
+}
+
+const AiAgentSpec* LookupAgent(const std::vector<AiAgentSpec>& agents,
+                               const std::string& name) {
+  for (const auto& spec : agents) {
+    if (spec.cli_name == name)
+      return &spec;
+  }
+  return nullptr;
+}
+
+std::string AgentNameList(const std::vector<AiAgentSpec>& agents) {
+  std::string out;
+  for (size_t i = 0; i < agents.size(); ++i) {
+    if (i)
+      out += "|";
+    out += agents[i].cli_name;
+  }
+  return out;
+}
+
+base::Status MkdirParents(const std::string& path) {
+  if (path.empty() || path == "/" || path == ".")
+    return base::OkStatus();
+  if (base::FileExists(path))
+    return base::OkStatus();
+  std::string parent = base::Dirname(path);
+  if (parent != path) {
+    if (auto s = MkdirParents(parent); !s.ok())
+      return s;
+  }
+  if (!base::Mkdir(path)) {
+    if (base::FileExists(path))
+      return base::OkStatus();
+    return base::ErrStatus("failed to create directory '%s' (errno=%d)",
+                           path.c_str(), errno);
+  }
+  return base::OkStatus();
+}
+
+bool GlobMatch(std::string_view pattern, std::string_view text) {
+  size_t p = 0, t = 0;
+  size_t star_p = std::string_view::npos, star_t = 0;
+  while (t < text.size()) {
+    if (p < pattern.size() && pattern[p] == '*') {
+      star_p = p++;
+      star_t = t;
+    } else if (p < pattern.size() &&
+               (pattern[p] == '?' || pattern[p] == text[t])) {
+      ++p;
+      ++t;
+    } else if (star_p != std::string_view::npos) {
+      p = star_p + 1;
+      t = ++star_t;
+    } else {
+      return false;
+    }
+  }
+  while (p < pattern.size() && pattern[p] == '*')
+    ++p;
+  return p == pattern.size();
+}
+
+struct Skill {
+  std::string source_path;   // "perfetto-infra-querying-traces/SKILL.md"
+  std::string slug;          // "perfetto-infra-querying-traces"
+  std::string_view content;  // full file bytes; points into `bytes` storage
+};
+
+std::vector<Skill> LoadBundledSkills(std::vector<uint8_t>* bytes_out) {
+  *bytes_out = util::GzipDecompressor::DecompressFully(
+      ai_skills::kSkills.data(), ai_skills::kSkills.size());
+  std::vector<Skill> out;
+  for (const auto& entry : SqlBundle(bytes_out->data(), bytes_out->size())) {
+    Skill s;
+    s.source_path = entry.path;
+    s.slug = base::Dirname(s.source_path);
+    s.content = entry.sql;
+    out.push_back(std::move(s));
+  }
+  std::sort(out.begin(), out.end(), [](const Skill& a, const Skill& b) {
+    return a.source_path < b.source_path;
+  });
+  return out;
+}
+
+bool MatchesAnyGlob(std::string_view text,
+                    const std::vector<std::string>& globs) {
+  for (const auto& g : globs) {
+    if (GlobMatch(g, text))
+      return true;
+  }
+  return false;
+}
+
+bool ContainsCaseInsensitive(std::string_view haystack,
+                             std::string_view needle) {
+  if (needle.empty())
+    return true;
+  if (haystack.size() < needle.size())
+    return false;
+  for (size_t i = 0; i + needle.size() <= haystack.size(); ++i) {
+    bool match = true;
+    for (size_t j = 0; j < needle.size(); ++j) {
+      char a = haystack[i + j];
+      char b = needle[j];
+      if (a >= 'A' && a <= 'Z')
+        a = static_cast<char>(a - 'A' + 'a');
+      if (b >= 'A' && b <= 'Z')
+        b = static_cast<char>(b - 'A' + 'a');
+      if (a != b) {
+        match = false;
+        break;
+      }
+    }
+    if (match)
+      return true;
+  }
+  return false;
+}
+
+base::Status WriteFileAtomic(const std::string& path, std::string_view body) {
+  if (auto s = MkdirParents(base::Dirname(path)); !s.ok())
+    return s;
+  base::ScopedFile fd =
+      base::OpenFile(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  if (!fd) {
+    return base::ErrStatus("failed to open '%s' for write (errno=%d)",
+                           path.c_str(), errno);
+  }
+  ssize_t n = base::WriteAll(*fd, body.data(), body.size());
+  if (n < 0 || static_cast<size_t>(n) != body.size()) {
+    return base::ErrStatus("short write to '%s' (wrote %zd of %zu bytes)",
+                           path.c_str(), n, body.size());
+  }
+  return base::OkStatus();
+}
+
+std::vector<Skill> FilterSkills(std::vector<Skill> skills,
+                                const std::vector<std::string>& include_globs,
+                                const std::vector<std::string>& exclude_globs) {
+  std::vector<Skill> out;
+  for (auto& s : skills) {
+    if (!include_globs.empty() && !MatchesAnyGlob(s.slug, include_globs))
+      continue;
+    if (MatchesAnyGlob(s.slug, exclude_globs))
+      continue;
+    out.push_back(std::move(s));
+  }
+  return out;
+}
+
+base::Status InstallSkills(const AiAgentSpec& agent,
+                           const std::string& dest_root,
+                           bool dry_run,
+                           const std::vector<Skill>& selected) {
+  printf("Installing %zu Perfetto skill%s for %s into %s\n", selected.size(),
+         selected.size() == 1 ? "" : "s", agent.description.c_str(),
+         dest_root.c_str());
+  for (const auto& s : selected) {
+    std::string out_path = dest_root + "/" + s.slug + "/SKILL.md";
+    printf("  %s  %s\n", dry_run ? "DRY-RUN" : "WRITE  ", out_path.c_str());
+    if (!dry_run) {
+      if (auto st = WriteFileAtomic(out_path, s.content); !st.ok())
+        return st;
+    }
+  }
+  return base::OkStatus();
+}
+
+void PrintSkill(const Skill& s) {
+  printf("- %s\n", s.slug.c_str());
+}
+
+base::Status RunListSkills(const SubcommandContext& ctx,
+                           const std::vector<Skill>& skills) {
+  if (ctx.positional_args.size() > 1) {
+    return base::ErrStatus(
+        "ai list-skills: unexpected positional argument '%s'.",
+        ctx.positional_args[1].c_str());
+  }
+  printf("Bundled Perfetto skills (%zu):\n", skills.size());
+  for (const auto& s : skills)
+    PrintSkill(s);
+  return base::OkStatus();
+}
+
+base::Status RunSearchSkills(const SubcommandContext& ctx,
+                             const std::vector<Skill>& skills) {
+  if (ctx.positional_args.size() < 2) {
+    return base::ErrStatus(
+        "ai search-skills: missing query. "
+        "Usage: trace_processor ai search-skills <query>.");
+  }
+  if (ctx.positional_args.size() > 2) {
+    return base::ErrStatus(
+        "ai search-skills: unexpected extra positional argument '%s'. "
+        "Quote multi-word queries.",
+        ctx.positional_args[2].c_str());
+  }
+  const std::string& query = ctx.positional_args[1];
+  size_t hits = 0;
+  for (const auto& s : skills) {
+    if (ContainsCaseInsensitive(s.slug, query) ||
+        ContainsCaseInsensitive(s.content, query)) {
+      PrintSkill(s);
+      ++hits;
+    }
+  }
+  printf("\n%zu of %zu skill%s match '%s'.\n", hits, skills.size(),
+         skills.size() == 1 ? "" : "s", query.c_str());
+  return base::OkStatus();
+}
+
+base::Status RunInstallSkills(const SubcommandContext& ctx,
+                              const std::vector<Skill>& skills,
+                              const std::vector<AiAgentSpec>& agents,
+                              const std::string& agent_list,
+                              const std::string& dest_override,
+                              bool dry_run,
+                              const std::vector<std::string>& include_globs,
+                              const std::vector<std::string>& exclude_globs) {
+  if (ctx.positional_args.size() < 2) {
+    return base::ErrStatus("ai install-skills: missing agent. Pass one of %s.",
+                           agent_list.c_str());
+  }
+  if (ctx.positional_args.size() > 2) {
+    return base::ErrStatus(
+        "ai install-skills: unexpected extra positional argument '%s'.",
+        ctx.positional_args[2].c_str());
+  }
+  const std::string& agent_name = ctx.positional_args[1];
+  const AiAgentSpec* agent = LookupAgent(agents, agent_name);
+  if (!agent) {
+    return base::ErrStatus(
+        "ai install-skills: unknown agent '%s'. Try one of %s.",
+        agent_name.c_str(), agent_list.c_str());
+  }
+  std::vector<Skill> selected =
+      FilterSkills(skills, include_globs, exclude_globs);
+  if (selected.empty()) {
+    return base::ErrStatus(
+        "ai install-skills: --include/--exclude filters left no skills "
+        "to install. Run `trace_processor ai list-skills` to see what's "
+        "available.");
+  }
+  std::string dest = dest_override;
+  if (dest.empty()) {
+    if (!agent->resolve_install_dir) {
+      return base::ErrStatus(
+          "ai install-skills: agent '%s' has no install-dir resolver "
+          "and no --dest was given.",
+          agent_name.c_str());
+    }
+    base::StatusOr<std::string> resolved = agent->resolve_install_dir();
+    if (!resolved.ok()) {
+      return base::ErrStatus("ai install-skills: %s",
+                             resolved.status().c_message());
+    }
+    dest = *resolved;
+  }
+  return InstallSkills(*agent, dest, dry_run, selected);
+}
+
+}  // namespace
+
+const char* AiSubcommand::name() const {
+  return "ai";
+}
+
+const char* AiSubcommand::description() const {
+  return "AI-related actions (today: list/search/install skills).";
+}
+
+const char* AiSubcommand::usage_args() const {
+  return "<action> [args...]";
+}
+
+const char* AiSubcommand::detailed_help() const {
+  return R"(Umbrella subcommand for AI-related actions. Today the actions
+under it list, search, and install Perfetto's bundled set of
+[Agent Skills](https://agentskills.io) into a coding
+agent's discovery directory.
+
+Actions:
+  list-skills             Print every bundled SKILL.md.
+  search-skills <query>   Print bundled skills whose slug or content
+                          contains the case-insensitive substring.
+  install-skills <agent>  Copy bundled SKILL.md files into the on-disk
+                          discovery directory of an AI coding agent so
+                          the agent picks them up automatically.
+
+Built-in agents for `install-skills`:
+  claudecode              Anthropic Claude Code (~/.claude/skills/)
+  geminicli               Google Gemini CLI    (~/.gemini/skills/)
+  codex                   OpenAI Codex CLI     (~/.agents/skills/)
+
+Embedders that wrap trace_processor (e.g. Google internal builds) can
+register additional agents via TraceProcessorShell_PlatformInterface;
+those appear alongside the built-ins for that build.
+
+Glob filters (`--include` / `--exclude`, repeatable) match the skill's
+slug: `perfetto-infra-*`, `perfetto-workflow-android-*`, `*heap*`. With
+no filters, every bundled skill is installed.
+
+Examples:
+  trace_processor ai list-skills
+  trace_processor ai search-skills 'heap dump'
+  trace_processor ai install-skills claudecode
+  trace_processor ai install-skills geminicli --include 'perfetto-infra-*' --dry-run
+  trace_processor ai install-skills codex --exclude 'perfetto-workflow-*' --dest /tmp/x)";
+}
+
+std::vector<FlagSpec> AiSubcommand::GetFlags() {
+  return {
+      StringFlag("dest", '\0', "DIR",
+                 "(install-skills) Override the install root. Default "
+                 "is the agent's standard per-user skills directory.",
+                 &dest_),
+      BoolFlag("dry-run", '\0',
+               "(install-skills) Print what would be written without "
+               "touching the filesystem.",
+               &dry_run_),
+      FlagSpec{"include", '\0', true, "GLOB",
+               "(install-skills) Only install skills whose slug "
+               "matches GLOB. Repeatable. Default: install everything.",
+               [this](const char* v) { include_globs_.emplace_back(v); }},
+      FlagSpec{"exclude", '\0', true, "GLOB",
+               "(install-skills) Skip skills whose slug matches GLOB. "
+               "Repeatable. Applied after --include.",
+               [this](const char* v) { exclude_globs_.emplace_back(v); }},
+  };
+}
+
+base::Status AiSubcommand::Run(const SubcommandContext& ctx) {
+  if (ctx.positional_args.empty()) {
+    return base::ErrStatus(
+        "ai: missing action. Try `trace_processor help ai`.");
+  }
+  std::vector<uint8_t> bytes;
+  std::vector<Skill> skills = LoadBundledSkills(&bytes);
+  const std::string& action = ctx.positional_args[0];
+  if (action == "list-skills") {
+    return RunListSkills(ctx, skills);
+  }
+  if (action == "search-skills") {
+    return RunSearchSkills(ctx, skills);
+  }
+  if (action == "install-skills") {
+    std::vector<AiAgentSpec> agents = RegisteredAgents(ctx.platform);
+    std::string agent_list = AgentNameList(agents);
+    return RunInstallSkills(ctx, skills, agents, agent_list, dest_, dry_run_,
+                            include_globs_, exclude_globs_);
+  }
+  return base::ErrStatus(
+      "ai: unknown action '%s'. Supported actions: list-skills, "
+      "search-skills, install-skills.",
+      action.c_str());
+}
+
+}  // namespace perfetto::trace_processor::shell

--- a/src/trace_processor/shell/ai_subcommand.h
+++ b/src/trace_processor/shell/ai_subcommand.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_TRACE_PROCESSOR_SHELL_AI_SUBCOMMAND_H_
+#define SRC_TRACE_PROCESSOR_SHELL_AI_SUBCOMMAND_H_
+
+#include <string>
+#include <vector>
+
+#include "perfetto/base/status.h"
+#include "src/trace_processor/shell/subcommand.h"
+
+namespace perfetto::trace_processor::shell {
+
+class AiSubcommand : public Subcommand {
+ public:
+  const char* name() const override;
+  const char* description() const override;
+  const char* usage_args() const override;
+  const char* detailed_help() const override;
+  std::vector<FlagSpec> GetFlags() override;
+  base::Status Run(const SubcommandContext& ctx) override;
+
+ private:
+  std::string dest_;
+  bool dry_run_ = false;
+  std::vector<std::string> include_globs_;
+  std::vector<std::string> exclude_globs_;
+};
+
+}  // namespace perfetto::trace_processor::shell
+
+#endif  // SRC_TRACE_PROCESSOR_SHELL_AI_SUBCOMMAND_H_

--- a/src/trace_processor/trace_processor_shell.cc
+++ b/src/trace_processor/trace_processor_shell.cc
@@ -52,6 +52,7 @@
 #include "src/trace_processor/read_trace_internal.h"
 #include "src/trace_processor/rpc/rpc.h"
 #include "src/trace_processor/rpc/stdiod.h"
+#include "src/trace_processor/shell/ai_subcommand.h"
 #include "src/trace_processor/shell/common_flags.h"
 #include "src/trace_processor/shell/convert_subcommand.h"
 #include "src/trace_processor/shell/export_subcommand.h"
@@ -776,10 +777,11 @@ base::Status TraceProcessorShell::Run(int argc, char** argv) {
     shell::ExportSubcommand export_subcommand;
     shell::MetricsSubcommand metrics_subcommand;
     shell::ConvertSubcommand convert_subcommand;
+    shell::AiSubcommand ai_subcommand;
     std::vector<shell::Subcommand*> subcommands = {
         &query_subcommand,     &interactive_subcommand, &server_subcommand,
         &summarize_subcommand, &export_subcommand,      &metrics_subcommand,
-        &convert_subcommand,
+        &convert_subcommand,   &ai_subcommand,
     };
 
     // Handle "help" pseudo-subcommand: `tp help <command>` or bare `tp help`.

--- a/tools/gen_bazel
+++ b/tools/gen_bazel
@@ -703,6 +703,8 @@ def gen_cpp_blob_header(target: GnParser.Target):
   # bazel/rules.bzl prepends `PERFETTO_CONFIG.root` to make the label work in
   # both standalone and embedded builds.
   script_to_bazel_label = {
+      'ai/skills/gen_skill_bundle.py':
+          ':ai_skills_gen_skill_bundle_py',
       'python/tools/cpp_blob_emitter.py':
           'python:cpp_blob_emitter_bin',
       'src/trace_processor/plugins/wattson/gen_wattson_curves.py':


### PR DESCRIPTION
Bundle the `SKILL.md` files seeded under `ai/skills/` into the
`trace_processor` binary and add a new `ai` subcommand. `ai` is the
umbrella for AI-related actions; today the only ones are over the
skill bundle:

```
trace_processor ai list-skills
trace_processor ai search-skills <query>
trace_processor ai install-skills <agent>
                [--include GLOB]... [--exclude GLOB]...
                [--dest DIR] [--dry-run]
```

The agent is one of `claudecode` / `geminicli` / `codex` (all three
follow the [agentskills.io](https://agentskills.io) convention;
`install-skills` just copies the same bundle into `~/.claude/skills`,
`~/.gemini/skills` or `~/.agents/skills` respectively). Because the
in-tree layout is already flat — every skill lives at
`ai/skills/<slug>/SKILL.md` — `install-skills` now just decompresses
the bundle and writes each entry verbatim. A user without
`trace_processor` can get the same result with
`cp -r ai/skills/perfetto-* ~/.claude/skills/`.

`list-skills` prints what's available; `search-skills` is a
case-insensitive substring match over the slug and full `SKILL.md`
content; `install-skills`'s `--include` / `--exclude` take fnmatch-
style globs against the slug so partial installs ("just
`perfetto-infra-*`", "everything except `perfetto-workflow-*`") are
easy.

## Implementation

- `ai/skills/BUILD.gn` + `gen_skill_bundle.py` pack every `SKILL.md`
  into the `SqlBundle` path-keyed wire format, gzip-compress the
  result, and emit a `constexpr std::array<uint8_t, N>` via the
  existing generic `perfetto_cpp_blob_header` primitive. Intentionally
  **not** the SQL-flavoured `perfetto_amalgamated_sql_header` —
  skills are not SQL and that template is a hack we don't want
  spreading.
- `ai_subcommand.cc` decompresses the blob with `GzipDecompressor`,
  walks it with `SqlBundle`, and treats each entry as a `Skill` keyed
  by the directory portion of its source path (which is already the
  agent-facing slug, no further transformation needed). Helpers are
  tiny: an iterative-restart fnmatch for globs and a hand-rolled
  case-insensitive substring search; no regex/YAML dependencies are
  pulled in.

## Embedder hook for additional agents

- A new public `AiAgentSpec` struct in `trace_processor_shell.h`
  describes a single agent (`cli_name` + `description` + a callback
  that resolves the install root). Built-ins for
  `claudecode`/`geminicli`/`codex` are constructed with a
  `HomeDir`-relative resolver.
- `TraceProcessorShell_PlatformInterface` gains a virtual
  `GetExtraAiAgents()` hook that returns extra specs. `AiSubcommand`
  merges those with the built-ins (embedder wins on `cli_name`
  collision), so a Google-internal wrapper of `trace_processor` — or
  any other embedder — can register environment-specific agents
  without touching shared code.

## Docs

Adds a new "AI in Perfetto" section to the docs TOC under "Learning
More". For now it has a single overview page —
`docs/ai/overview.md` — that doubles as the section landing and
inline how-to guides (install skills, inspect / filter the bundle).
The section is set up to grow as more AI features land.
`docs/analysis/trace-processor.md` gets a brief `ai` subcommand
entry that cross-links to it.