### PR TITLE
tp: add macro for unparenthesizing a list of expressions

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -17259,6 +17259,14 @@ filegroup {
     ],
 }
 
+// GN: //src/trace_processor/perfetto_sql/stdlib/std/metasql:metasql
+filegroup {
+    name: "perfetto_src_trace_processor_perfetto_sql_stdlib_std_metasql_metasql",
+    srcs: [
+        "src/trace_processor/perfetto_sql/stdlib/std/metasql/unparenthesize.sql",
+    ],
+}
+
 // GN: //src/trace_processor/perfetto_sql/stdlib/std/traceinfo:traceinfo
 filegroup {
     name: "perfetto_src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
@@ -17299,6 +17307,7 @@ genrule {
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_stack_trace_stack_trace",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_stacks_stacks",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_gpu_gpu",
+        ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_metasql_metasql",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_std_trees_trees",
         ":perfetto_src_trace_processor_perfetto_sql_stdlib_time_time",

--- a/BUILD
+++ b/BUILD
@@ -4167,6 +4167,14 @@ perfetto_filegroup(
     ],
 )
 
+# GN target: //src/trace_processor/perfetto_sql/stdlib/std/metasql:metasql
+perfetto_filegroup(
+    name = "src_trace_processor_perfetto_sql_stdlib_std_metasql_metasql",
+    srcs = [
+        "src/trace_processor/perfetto_sql/stdlib/std/metasql/unparenthesize.sql",
+    ],
+)
+
 # GN target: //src/trace_processor/perfetto_sql/stdlib/std/traceinfo:traceinfo
 perfetto_filegroup(
     name = "src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
@@ -4292,6 +4300,7 @@ perfetto_cpp_blob_header(
         ":src_trace_processor_perfetto_sql_stdlib_stack_trace_stack_trace",
         ":src_trace_processor_perfetto_sql_stdlib_stacks_stacks",
         ":src_trace_processor_perfetto_sql_stdlib_std_gpu_gpu",
+        ":src_trace_processor_perfetto_sql_stdlib_std_metasql_metasql",
         ":src_trace_processor_perfetto_sql_stdlib_std_traceinfo_traceinfo",
         ":src_trace_processor_perfetto_sql_stdlib_std_trees_trees",
         ":src_trace_processor_perfetto_sql_stdlib_time_time",

--- a/python/generators/sql_processing/utils.py
+++ b/python/generators/sql_processing/utils.py
@@ -39,6 +39,7 @@ ALLOWED_PREFIXES = {
     'linux': ['cpu', 'memory'],
     'stacks': ['cpu_profiling'],
     'std/gpu': ['gpu'],
+    'std/metasql': ['metasql'],
 }
 
 # Allows for nonstandard object names.
@@ -72,6 +73,8 @@ COLUMN_TYPES = [
 MACRO_ARG_TYPES = [
     'TABLEORSUBQUERY',
     'EXPR',
+    'EXPRLIST',
+    'UNPARENEXPRLIST',
     'COLUMNNAME',
     'COLUMNNAMELIST',
     # Internal macro arg types for advanced use cases

--- a/src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.cc
+++ b/src/trace_processor/perfetto_sql/engine/perfetto_sql_engine.cc
@@ -299,9 +299,9 @@ base::StatusOr<std::vector<std::string>> GetColumnNamesFromSelectStatement(
   return column_names;
 }
 
-constexpr std::array<std::string_view, 6> kTokensAllowedInMacro{
-    "ColumnNameList", "_ProjectionFragment", "_TableNameList", "ColumnName",
-    "Expr",           "TableOrSubquery",
+constexpr std::array<std::string_view, 8> kTokensAllowedInMacro{
+    "ColumnNameList", "_ProjectionFragment", "_TableNameList",  "ColumnName",
+    "Expr",           "TableOrSubquery",     "UnparenExprList", "ExprList",
 };
 
 bool IsTokenAllowedInMacro(const std::string& str) {

--- a/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/BUILD.gn
@@ -36,6 +36,7 @@ perfetto_amalgamated_sql_header("stdlib") {
     "stack_trace",
     "stacks",
     "std/gpu",
+    "std/metasql",
     "std/traceinfo",
     "std/trees",
     "time",

--- a/src/trace_processor/perfetto_sql/stdlib/android/network_packets.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/android/network_packets.sql
@@ -13,6 +13,8 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+INCLUDE PERFETTO MODULE std.metasql.unparenthesize;
+
 -- Android network packet events (from android.network_packets data source).
 CREATE PERFETTO VIEW android_network_packets(
   -- Id of the slice.
@@ -80,13 +82,6 @@ SELECT
 FROM __intrinsic_android_network_packets
 JOIN slice USING (id);
 
--- This helper is used to unparenthesize a column list expression. Currently,
--- the the pre-processor is unable to do both steps in one macro, so this macro
--- must be passed to __intrinsic_token_apply at the callsite.
-CREATE PERFETTO MACRO _np_identity(x Expr)
-RETURNS Expr
-AS $x;
-
 -- Finds groups of overlapping slices and assigns them group ids.
 --
 -- An overlap group is a set of slices (or instants) that contiguously have >=1
@@ -112,12 +107,12 @@ AS (
     _max_endpoint AS (
       SELECT
         *,
-        max(ts + dur) OVER (PARTITION BY __intrinsic_token_apply!(_np_identity, $partition_columns) ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS max_end_so_far
+        max(ts + dur) OVER (PARTITION BY metasql_unparenthesize_exprlist!($partition_columns) ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS max_end_so_far
       FROM $src
     )
   SELECT
     *,
-    sum(coalesce(ts > max_end_so_far, TRUE)) OVER (PARTITION BY __intrinsic_token_apply!(_np_identity, $partition_columns) ORDER BY ts) AS group_id
+    sum(coalesce(ts > max_end_so_far, TRUE)) OVER (PARTITION BY metasql_unparenthesize_exprlist!($partition_columns) ORDER BY ts) AS group_id
   FROM _max_endpoint
 );
 
@@ -144,25 +139,25 @@ AS (
   WITH
     _quantized AS (
       SELECT
-        __intrinsic_token_apply!(_np_identity, $partition_columns),
+        metasql_unparenthesize_exprlist!($partition_columns),
         min(ts) AS ts,
         max(ts + dur + $timeout) - min(ts) AS dur,
         sum(packet_count) AS packet_count,
         sum(packet_length) AS packet_length
       FROM $src
       GROUP BY
-        __intrinsic_token_apply!(_np_identity, $partition_columns),
+        metasql_unparenthesize_exprlist!($partition_columns),
         CAST(ts / $timeout AS LONG)
     )
   SELECT
-    __intrinsic_token_apply!(_np_identity, $partition_columns),
+    metasql_unparenthesize_exprlist!($partition_columns),
     min(ts) AS ts,
     max(ts + dur) - min(ts) AS dur,
     sum(packet_count) AS packet_count,
     sum(packet_length) AS packet_length
   FROM _add_overlap_group_id!(_quantized, $partition_columns)
   GROUP BY
-    __intrinsic_token_apply!(_np_identity, $partition_columns),
+    metasql_unparenthesize_exprlist!($partition_columns),
     group_id
 );
 
@@ -219,7 +214,7 @@ AS (
         sum(packet_count) OVER group_window AS group_packets,
         max(ts + dur) OVER group_window - min(ts) OVER group_window AS group_dur
       FROM _add_overlap_group_id!($src, $partition_columns)
-      WINDOW group_window AS (PARTITION BY __intrinsic_token_apply!(_np_identity, $partition_columns), group_id)
+      WINDOW group_window AS (PARTITION BY metasql_unparenthesize_exprlist!($partition_columns), group_id)
     ),
     _cost_parts AS (
       SELECT

--- a/src/trace_processor/perfetto_sql/stdlib/intervals/overlap.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/intervals/overlap.sql
@@ -17,6 +17,8 @@ INCLUDE PERFETTO MODULE intervals.intersect;
 
 INCLUDE PERFETTO MODULE android.monitor_contention;
 
+INCLUDE PERFETTO MODULE std.metasql.unparenthesize;
+
 -- Compute the distribution of the overlap of the given intervals over time.
 --
 -- Each interval is a (ts, dur) pair and the overlap represented as a (ts, value)
@@ -521,11 +523,6 @@ AS (
     value = 0
 );
 
--- Helper to unparenthesize a column list with __intrinsic_token_apply.
-CREATE PERFETTO MACRO _imop_identity(col ColumnName)
-RETURNS Expr
-AS $col;
-
 -- Merge overlapping intervals within each partition group to generate a minimum
 -- covering set of intervals with no overlap within each partition.
 --
@@ -557,8 +554,8 @@ AS (
       SELECT
         ts,
         dur,
-        __intrinsic_token_apply!(_imop_identity, $partition_columns),
-        max(ts + dur) OVER (PARTITION BY __intrinsic_token_apply!(_imop_identity, $partition_columns) ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS max_endpoint_so_far
+        metasql_unparenthesize_exprlist!($partition_columns),
+        max(ts + dur) OVER (PARTITION BY metasql_unparenthesize_exprlist!($partition_columns) ORDER BY ts ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) AS max_endpoint_so_far
       FROM $intervals
       WHERE
         dur >= 0
@@ -566,15 +563,15 @@ AS (
     _numbered_groups AS (
       SELECT
         *,
-        sum(coalesce(ts > max_endpoint_so_far, TRUE)) OVER (PARTITION BY __intrinsic_token_apply!(_imop_identity, $partition_columns) ORDER BY ts) AS overlap_group_number
+        sum(coalesce(ts > max_endpoint_so_far, TRUE)) OVER (PARTITION BY metasql_unparenthesize_exprlist!($partition_columns) ORDER BY ts) AS overlap_group_number
       FROM _max_endpoint_so_far
     )
   SELECT
     min(ts) AS ts,
     max(ts + dur) - min(ts) AS dur,
-    __intrinsic_token_apply!(_imop_identity, $partition_columns)
+    metasql_unparenthesize_exprlist!($partition_columns)
   FROM _numbered_groups
   GROUP BY
-    __intrinsic_token_apply!(_imop_identity, $partition_columns),
+    metasql_unparenthesize_exprlist!($partition_columns),
     overlap_group_number
 );

--- a/src/trace_processor/perfetto_sql/stdlib/std/metasql/BUILD.gn
+++ b/src/trace_processor/perfetto_sql/stdlib/std/metasql/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("../../../../../../gn/perfetto_sql.gni")
+
+perfetto_sql_source_set("metasql") {
+  sources = [ "unparenthesize.sql" ]
+}

--- a/src/trace_processor/perfetto_sql/stdlib/std/metasql/unparenthesize.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/std/metasql/unparenthesize.sql
@@ -1,0 +1,30 @@
+--
+-- Copyright 2026 The Android Open Source Project
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE PERFETTO MACRO __unparenthesize_identity(x Expr)
+RETURNS Expr
+AS $x;
+
+-- Removes the surrounding parentheses from a parenthesised expression list,
+-- yielding a bare comma-separated expression list. Typically used when you
+-- already have something like `(a, b, c)` but need to splice it into a context
+-- (e.g. a `GROUP BY` clause or a `PARTITION BY` clause) that expects an
+-- unparenthesised list.
+CREATE PERFETTO MACRO metasql_unparenthesize_exprlist(
+  -- Parenthesised expression list to unparenthesise.
+  expr ExprList
+)
+RETURNS UnparenExprList
+AS __intrinsic_token_apply!(__unparenthesize_identity, $expr);

--- a/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
+++ b/src/trace_processor/perfetto_sql/stdlib/viz/flamegraph.sql
@@ -19,6 +19,8 @@
 
 INCLUDE PERFETTO MODULE graphs.scan;
 
+INCLUDE PERFETTO MODULE std.metasql.unparenthesize;
+
 CREATE PERFETTO MACRO _viz_flamegraph_hash_coalesce(col ColumnName)
 RETURNS Expr
 AS IFNULL($col, 0);
@@ -300,10 +302,6 @@ AS (
   ORDER BY hash
 );
 
-CREATE PERFETTO MACRO _col_list_id(a ColumnName)
-RETURNS Expr
-AS $a;
-
 -- Converts a table of hashes and paretn hashes into ids and parent
 -- ids, grouping all hashes together.
 CREATE PERFETTO MACRO _viz_flamegraph_merge_hashes(
@@ -326,8 +324,8 @@ AS (
     -- The grouping columns should be passed through as-is because the
     -- hash took them into account: we would not merged any nodes where
     -- the grouping columns were different.
-    __intrinsic_token_apply!(_col_list_id, $grouping),
-    __intrinsic_token_apply!(_col_list_id, $grouped_agged_exprs),
+    metasql_unparenthesize_exprlist!($grouping),
+    metasql_unparenthesize_exprlist!($grouped_agged_exprs),
     SUM(value) AS value,
     SUM(cumulativeValue) AS cumulativeValue
   FROM $hashed c

--- a/test/trace_processor/diff_tests/include_index.py
+++ b/test/trace_processor/diff_tests/include_index.py
@@ -153,6 +153,7 @@ from diff_tests.stdlib.intervals.tests import StdlibIntervals
 from diff_tests.stdlib.linux.cpu import LinuxCpu
 from diff_tests.stdlib.linux.memory import Memory
 from diff_tests.stdlib.linux.tests import LinuxTests
+from diff_tests.stdlib.metasql.tests import StdlibMetasql
 from diff_tests.stdlib.pixel.tests import PixelStdlib
 from diff_tests.stdlib.pkvm.tests import Pkvm
 from diff_tests.stdlib.prelude.args_functions_tests import ArgsFunctions
@@ -351,6 +352,7 @@ def fetch_all_diff_tests(
       Stacks,
       CreateIntervals,
       StdlibIntervals,
+      StdlibMetasql,
       SystemUICujs,
       IntervalsIntersect,
       Startups,

--- a/test/trace_processor/diff_tests/stdlib/metasql/tests.py
+++ b/test/trace_processor/diff_tests/stdlib/metasql/tests.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from python.generators.diff_tests.testing import Csv, TextProto
+from python.generators.diff_tests.testing import DiffTestBlueprint
+from python.generators.diff_tests.testing import TestSuite
+
+
+class StdlibMetasql(TestSuite):
+
+  def test_unparenthesize_exprlist(self):
+    return DiffTestBlueprint(
+        trace=TextProto(''),
+        query="""
+        INCLUDE PERFETTO MODULE std.metasql.unparenthesize;
+
+        CREATE PERFETTO TABLE data AS
+        SELECT 1 AS a, 10 AS b, 100 AS c
+        UNION ALL SELECT 1, 20, 200
+        UNION ALL SELECT 2, 30, 300
+        UNION ALL SELECT 2, 40, 400;
+
+        SELECT
+          a,
+          SUM(b) AS sum_b,
+          SUM(c) AS sum_c
+        FROM data
+        GROUP BY metasql_unparenthesize_exprlist!((a))
+        ORDER BY a;
+        """,
+        out=Csv("""
+        "a","sum_b","sum_c"
+        1,30,300
+        2,70,700
+        """))
+
+  def test_unparenthesize_exprlist_multiple(self):
+    return DiffTestBlueprint(
+        trace=TextProto(''),
+        query="""
+        INCLUDE PERFETTO MODULE std.metasql.unparenthesize;
+
+        CREATE PERFETTO TABLE data AS
+        SELECT 1 AS a, 'x' AS b, 100 AS c
+        UNION ALL SELECT 1, 'x', 200
+        UNION ALL SELECT 1, 'y', 300
+        UNION ALL SELECT 2, 'x', 400;
+
+        SELECT
+          a,
+          b,
+          SUM(c) AS sum_c
+        FROM data
+        GROUP BY metasql_unparenthesize_exprlist!((a, b))
+        ORDER BY a, b;
+        """,
+        out=Csv("""
+        "a","b","sum_c"
+        1,"x",300
+        1,"y",300
+        2,"x",400
+        """))


### PR DESCRIPTION
This is a very common pattern and people in G3 are starting to depend
on intrinsics which is not good. Add this as a constrained public API
to unblock them.
