### PR TITLE
ui: Use Roboto typeface in Echarts-based chart widgets

### DIFF
--- a/ui/src/components/widgets/charts/chart_theme.ts
+++ b/ui/src/components/widgets/charts/chart_theme.ts
@@ -39,6 +39,7 @@ export interface ChartThemeColors {
   readonly backgroundColor: string;
   readonly accentColor: string;
   readonly chartColors: readonly string[];
+  readonly fontFamily: string;
 }
 
 /**
@@ -60,5 +61,7 @@ export function getChartThemeColors(el: Element): ChartThemeColors {
     backgroundColor: style.getPropertyValue('--pf-color-background').trim(),
     accentColor: style.getPropertyValue('--pf-color-accent').trim(),
     chartColors,
+    fontFamily:
+      style.getPropertyValue('--pf-font-compact').trim() || 'sans-serif',
   };
 }

--- a/ui/src/components/widgets/charts/echart_view.ts
+++ b/ui/src/components/widgets/charts/echart_view.ts
@@ -102,6 +102,7 @@ function buildEChartsTheme(colors: ChartThemeColors): Record<string, unknown> {
     backgroundColor: 'transparent',
     textStyle: {
       color: colors.textColor,
+      fontFamily: colors.fontFamily,
     },
     title: {
       textStyle: {color: colors.textColor},


### PR DESCRIPTION
Set 'Roboto' as the font theme for all echarts based chart widgets.