### PR TITLE
TP bitmap metadata support for heap graphs

### DIFF
--- a/src/trace_processor/importers/proto/heap_graph_module.cc
+++ b/src/trace_processor/importers/proto/heap_graph_module.cc
@@ -153,6 +153,19 @@ void HeapGraphModule::ParseHeapGraph(uint32_t seq_id,
           object.native_allocation_registry_size_field();
     }
 
+    if (object.has_bitmap_id_field()) {
+      obj.bitmap_id = object.bitmap_id_field();
+    }
+    if (object.has_bitmap_source_id_field()) {
+      obj.bitmap_source_id = object.bitmap_source_id_field();
+    }
+    if (object.has_bitmap_width_field()) {
+      obj.bitmap_width = object.bitmap_width_field();
+    }
+    if (object.has_bitmap_height_field()) {
+      obj.bitmap_height = object.bitmap_height_field();
+    }
+
     if (parse_error) {
       context_->storage->IncrementIndexedStats(
           stats::heap_graph_malformed_packet, static_cast<int>(upid));

--- a/src/trace_processor/importers/proto/heap_graph_tracker.cc
+++ b/src/trace_processor/importers/proto/heap_graph_tracker.cc
@@ -492,6 +492,48 @@ void HeapGraphTracker::AddObject(uint32_t seq_id,
     sequence_state.nar_size_by_obj_id[owner_id] =
         *obj.native_allocation_registry_size;
   }
+
+  bool has_bitmap_fields =
+      obj.bitmap_id.has_value() || obj.bitmap_source_id.has_value() ||
+      obj.bitmap_width.has_value() || obj.bitmap_height.has_value();
+
+  if (has_bitmap_fields) {
+    auto* prim_table = storage_->mutable_heap_graph_primitive_table();
+    uint32_t field_set_id = prim_table->row_count();
+
+    auto insert_primitive =
+        [&](const char* name, const char* type, auto value,
+            std::optional<int64_t> tables::HeapGraphPrimitiveTable::Row::*
+                column) {
+          if (value.has_value()) {
+            tables::HeapGraphPrimitiveTable::Row row;
+            row.field_set_id = field_set_id;
+            row.field_name = storage_->InternString(name);
+            row.field_type = storage_->InternString(type);
+            row.*column = static_cast<int64_t>(*value);
+            prim_table->Insert(row);
+          }
+        };
+
+    insert_primitive("android.graphics.Bitmap.mId", "long", obj.bitmap_id,
+                     &tables::HeapGraphPrimitiveTable::Row::long_value);
+    insert_primitive("android.graphics.Bitmap.mSourceId", "long",
+                     obj.bitmap_source_id,
+                     &tables::HeapGraphPrimitiveTable::Row::long_value);
+    insert_primitive("android.graphics.Bitmap.mWidth", "int", obj.bitmap_width,
+                     &tables::HeapGraphPrimitiveTable::Row::int_value);
+    insert_primitive("android.graphics.Bitmap.mHeight", "int",
+                     obj.bitmap_height,
+                     &tables::HeapGraphPrimitiveTable::Row::int_value);
+
+    // Link to object data
+    auto* data_table = storage_->mutable_heap_graph_object_data_table();
+    tables::HeapGraphObjectDataTable::Row data_row;
+    data_row.field_set_id = field_set_id;
+    auto data_id = data_table->Insert(data_row).id;
+
+    owner_row_ref.set_object_data_id(data_id.value);
+  }
 }
 
 void HeapGraphTracker::AddRoot(uint32_t seq_id,

--- a/src/trace_processor/importers/proto/heap_graph_tracker.h
+++ b/src/trace_processor/importers/proto/heap_graph_tracker.h
@@ -88,6 +88,12 @@ class HeapGraphTracker : public Destructible {
     // If this object is an instance of `libcore.util.NativeAllocationRegistry`,
     // this is the value of its `size` field.
     std::optional<int64_t> native_allocation_registry_size;
+
+    // Bitmap-specific fields
+    std::optional<int64_t> bitmap_id;
+    std::optional<int64_t> bitmap_source_id;
+    std::optional<uint32_t> bitmap_width;
+    std::optional<uint32_t> bitmap_height;
   };
 
   struct SourceRoot {

--- a/test/trace_processor/diff_tests/parser/profiling/tests_heap_graph.py
+++ b/test/trace_processor/diff_tests/parser/profiling/tests_heap_graph.py
@@ -47,6 +47,61 @@ class ProfilingHeapGraph(TestSuite):
         """,
         out=Path('heap_graph_flamegraph.out'))
 
+  def test_heap_graph_bitmap_fields(self):
+    return DiffTestBlueprint(
+        trace=TextProto(r"""
+        packet {
+          process_tree {
+            processes {
+              pid: 2
+              ppid: 1
+              cmdline: "system_server"
+              uid: 1000
+            }
+          }
+        }
+        packet {
+          trusted_packet_sequence_id: 999
+          timestamp: 10
+          heap_graph {
+            pid: 2
+            types {
+              id: 1
+              class_name: "android.graphics.Bitmap"
+            }
+            objects {
+              id: 1
+              type_id: 1
+              self_size: 64
+              bitmap_id_field: 123
+              bitmap_source_id_field: 456
+              bitmap_width_field: 100
+              bitmap_height_field: 200
+            }
+            continued: false
+            index: 0
+          }
+        }
+        """),
+        query="""
+        SELECT
+          p.field_name,
+          p.field_type,
+          p.long_value,
+          p.int_value
+        FROM heap_graph_object o
+          JOIN heap_graph_object_data d ON o.object_data_id = d.id
+          JOIN heap_graph_primitive p USING (field_set_id)
+        ORDER BY p.field_name;
+        """,
+        out=Csv('''
+          "field_name","field_type","long_value","int_value"
+          "android.graphics.Bitmap.mHeight","int","[NULL]",200
+          "android.graphics.Bitmap.mId","long",123,"[NULL]"
+          "android.graphics.Bitmap.mSourceId","long",456,"[NULL]"
+          "android.graphics.Bitmap.mWidth","int","[NULL]",100
+        '''))
+
   def test_heap_graph_object(self):
     return DiffTestBlueprint(
         trace=Path('heap_graph_baseapk.textproto'),


### PR DESCRIPTION
- trace processor can now parse the bitmap-specific metadata that were added in the platform.
- reusing the same data model leveraged for the hprof parsing (I confirmed that data flows into the heapdump explorer and bitmap specific views)

Bug: 493745993
