### PR TITLE
ui: Add yAxisMinInterval to LineChart

### DIFF
--- a/ui/src/components/widgets/charts/line_chart.ts
+++ b/ui/src/components/widgets/charts/line_chart.ts
@@ -124,6 +124,13 @@ export interface LineChartAttrs {
   readonly integerY?: boolean;
 
   /**
+   * Minimum interval between Y axis ticks. Use this to align ticks with a
+   * display unit — e.g. pass 1024 so ticks land on whole MB boundaries when
+   * data is in KB.
+   */
+  readonly yAxisMinInterval?: number;
+
+  /**
    * Show legend. Defaults to true when multiple series.
    */
   readonly showLegend?: boolean;
@@ -209,6 +216,7 @@ function buildLineOption(
     logScale = false,
     integerX = false,
     integerY = false,
+    yAxisMinInterval,
     showLegend,
     showPoints = true,
     lineWidth = 2,
@@ -269,7 +277,7 @@ function buildLineOption(
         formatYValue !== undefined
           ? (v) => formatYValue(v as number)
           : undefined,
-      minInterval: integerY ? 1 : undefined,
+      minInterval: yAxisMinInterval ?? (integerY ? 1 : undefined),
       scale: attrs.scaleAxes,
       showSplitLine: gridLines === 'horizontal' || gridLines === 'both',
     },


### PR DESCRIPTION
Lets callers force the Y axis tick step to be at least N — e.g. pass 1024 so ticks land on whole-MB boundaries when data is in KB.